### PR TITLE
fix(frontend): validate converted protocol requests

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -750,13 +750,8 @@ async fn handler_count_tokens(
             error.message(),
         ));
     }
-    if let Err(error) = validate_anthropic_tools(request.tools.as_deref()) {
-        return Err(anthropic_error(
-            error.status(),
-            error.anthropic_error_type(),
-            error.message(),
-        ));
-    }
+    // Count Tokens does not convert or execute tools, so keep tool definitions
+    // permissive here. TODO: Add validation when Anthropic server tools are supported.
     if state.strip_anthropic_preamble_enabled() {
         strip_billing_preamble(&mut request.system);
     }

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -145,6 +145,11 @@ fn validate_anthropic_messages(
         let AnthropicMessageContent::Blocks { content } = &message.content else {
             continue;
         };
+        if content.is_empty() {
+            return Err(invalid_argument(format!(
+                "messages[{message_index}].content: must contain at least one content block"
+            )));
+        }
         for (block_index, block) in content.iter().enumerate() {
             if let AnthropicContentBlock::Other(value) = block
                 && !value.is_object()

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -42,7 +42,7 @@ use crate::protocols::anthropic::stream_converter::AnthropicStreamConverter;
 use crate::protocols::anthropic::types::{
     AnthropicContentBlock, AnthropicCountTokensRequest, AnthropicCountTokensResponse,
     AnthropicCreateMessageRequest, AnthropicErrorBody, AnthropicErrorResponse, AnthropicMessage,
-    AnthropicMessageContent, SystemContent, chat_completion_to_anthropic_response,
+    AnthropicMessageContent, AnthropicTool, SystemContent, chat_completion_to_anthropic_response,
 };
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
@@ -134,12 +134,12 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 // ---------------------------------------------------------------------------
 
 #[derive(Debug)]
-enum AnthropicMessageValidationError {
+enum AnthropicRequestValidationError {
     InvalidArgument(String),
     NotImplemented(String),
 }
 
-impl AnthropicMessageValidationError {
+impl AnthropicRequestValidationError {
     fn status(&self) -> StatusCode {
         match self {
             Self::InvalidArgument(_) => StatusCode::BAD_REQUEST,
@@ -170,9 +170,9 @@ impl AnthropicMessageValidationError {
 
 fn validate_anthropic_messages(
     messages: &[AnthropicMessage],
-) -> Result<(), AnthropicMessageValidationError> {
+) -> Result<(), AnthropicRequestValidationError> {
     if messages.is_empty() {
-        return Err(AnthropicMessageValidationError::InvalidArgument(
+        return Err(AnthropicRequestValidationError::InvalidArgument(
             "messages: field required".to_string(),
         ));
     }
@@ -182,14 +182,14 @@ fn validate_anthropic_messages(
             continue;
         };
         if content.is_empty() {
-            return Err(AnthropicMessageValidationError::InvalidArgument(format!(
+            return Err(AnthropicRequestValidationError::InvalidArgument(format!(
                 "messages[{message_index}].content: must contain at least one content block"
             )));
         }
         for (block_index, block) in content.iter().enumerate() {
             if let AnthropicContentBlock::Other(value) = block {
                 if !value.is_object() {
-                    return Err(AnthropicMessageValidationError::InvalidArgument(format!(
+                    return Err(AnthropicRequestValidationError::InvalidArgument(format!(
                         "messages[{message_index}].content[{block_index}]: content blocks must be objects"
                     )));
                 }
@@ -198,12 +198,39 @@ fn validate_anthropic_messages(
                     .and_then(serde_json::Value::as_str)
                     .filter(|block_type| !block_type.is_empty())
                 else {
-                    return Err(AnthropicMessageValidationError::InvalidArgument(format!(
+                    return Err(AnthropicRequestValidationError::InvalidArgument(format!(
                         "messages[{message_index}].content[{block_index}].type: must be a non-empty string"
                     )));
                 };
-                return Err(AnthropicMessageValidationError::NotImplemented(format!(
+                return Err(AnthropicRequestValidationError::NotImplemented(format!(
                     "messages[{message_index}].content[{block_index}]: content block type \"{block_type}\" is not supported"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_anthropic_tools(
+    tools: Option<&[AnthropicTool]>,
+) -> Result<(), AnthropicRequestValidationError> {
+    for (tool_index, tool) in tools.unwrap_or_default().iter().enumerate() {
+        match tool.tool_type.as_deref() {
+            Some("") => {
+                return Err(AnthropicRequestValidationError::InvalidArgument(format!(
+                    "tools[{tool_index}].type: must be a non-empty string"
+                )));
+            }
+            Some("custom") | None => {
+                if tool.input_schema.is_none() {
+                    return Err(AnthropicRequestValidationError::InvalidArgument(format!(
+                        "tools[{tool_index}].input_schema: field required for client tools"
+                    )));
+                }
+            }
+            Some(tool_type) => {
+                return Err(AnthropicRequestValidationError::NotImplemented(format!(
+                    "tools[{tool_index}]: server tool type \"{tool_type}\" is not supported"
                 )));
             }
         }
@@ -233,6 +260,14 @@ async fn handler_anthropic_messages(
     );
 
     if let Err(error) = validate_anthropic_messages(&request.messages) {
+        inflight_guard.mark_error(error.metric_error_type());
+        return Err(anthropic_error(
+            error.status(),
+            error.anthropic_error_type(),
+            error.message(),
+        ));
+    }
+    if let Err(error) = validate_anthropic_tools(request.tools.as_deref()) {
         inflight_guard.mark_error(error.metric_error_type());
         return Err(anthropic_error(
             error.status(),
@@ -709,6 +744,13 @@ async fn handler_count_tokens(
     Json(mut request): Json<AnthropicCountTokensRequest>,
 ) -> Result<Response, Response> {
     if let Err(error) = validate_anthropic_messages(&request.messages) {
+        return Err(anthropic_error(
+            error.status(),
+            error.anthropic_error_type(),
+            error.message(),
+        ));
+    }
+    if let Err(error) = validate_anthropic_tools(request.tools.as_deref()) {
         return Err(anthropic_error(
             error.status(),
             error.anthropic_error_type(),

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -134,11 +134,48 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 
 const ANTHROPIC_MAX_TOOL_NAME_LENGTH: usize = 128;
 
+#[derive(Debug)]
+enum AnthropicMessageValidationError {
+    InvalidArgument(String),
+    NotImplemented(String),
+}
+
+impl AnthropicMessageValidationError {
+    fn status(&self) -> StatusCode {
+        match self {
+            Self::InvalidArgument(_) => StatusCode::BAD_REQUEST,
+            Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
+        }
+    }
+
+    fn metric_error_type(&self) -> ErrorType {
+        match self {
+            Self::InvalidArgument(_) => ErrorType::Validation,
+            Self::NotImplemented(_) => ErrorType::NotImplemented,
+        }
+    }
+
+    fn anthropic_error_type(&self) -> &'static str {
+        match self {
+            Self::InvalidArgument(_) => "invalid_request_error",
+            Self::NotImplemented(_) => "api_error",
+        }
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            Self::InvalidArgument(message) | Self::NotImplemented(message) => message,
+        }
+    }
+}
+
 fn validate_anthropic_messages(
     messages: &[AnthropicMessage],
-) -> Result<(), dynamo_runtime::error::DynamoError> {
+) -> Result<(), AnthropicMessageValidationError> {
     if messages.is_empty() {
-        return Err(invalid_argument("messages: field required"));
+        return Err(AnthropicMessageValidationError::InvalidArgument(
+            "messages: field required".to_string(),
+        ));
     }
 
     for (message_index, message) in messages.iter().enumerate() {
@@ -146,16 +183,28 @@ fn validate_anthropic_messages(
             continue;
         };
         if content.is_empty() {
-            return Err(invalid_argument(format!(
+            return Err(AnthropicMessageValidationError::InvalidArgument(format!(
                 "messages[{message_index}].content: must contain at least one content block"
             )));
         }
         for (block_index, block) in content.iter().enumerate() {
-            if let AnthropicContentBlock::Other(value) = block
-                && !value.is_object()
-            {
-                return Err(invalid_argument(format!(
-                    "messages[{message_index}].content[{block_index}]: content blocks must be objects"
+            if let AnthropicContentBlock::Other(value) = block {
+                if !value.is_object() {
+                    return Err(AnthropicMessageValidationError::InvalidArgument(format!(
+                        "messages[{message_index}].content[{block_index}]: content blocks must be objects"
+                    )));
+                }
+                let Some(block_type) = value
+                    .get("type")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|block_type| !block_type.is_empty())
+                else {
+                    return Err(AnthropicMessageValidationError::InvalidArgument(format!(
+                        "messages[{message_index}].content[{block_index}].type: must be a non-empty string"
+                    )));
+                };
+                return Err(AnthropicMessageValidationError::NotImplemented(format!(
+                    "messages[{message_index}].content[{block_index}]: content block type \"{block_type}\" is not supported"
                 )));
             }
         }
@@ -185,10 +234,10 @@ async fn handler_anthropic_messages(
     );
 
     if let Err(error) = validate_anthropic_messages(&request.messages) {
-        inflight_guard.mark_error(ErrorType::Validation);
+        inflight_guard.mark_error(error.metric_error_type());
         return Err(anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
+            error.status(),
+            error.anthropic_error_type(),
             error.message(),
         ));
     }
@@ -662,8 +711,8 @@ async fn handler_count_tokens(
 ) -> Result<Response, Response> {
     if let Err(error) = validate_anthropic_messages(&request.messages) {
         return Err(anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
+            error.status(),
+            error.anthropic_error_type(),
             error.message(),
         ));
     }

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -32,7 +32,7 @@ use super::{
     RouteDoc,
     disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
     metrics::{
-        CancellationLabels, Endpoint,
+        CancellationLabels, Endpoint, ErrorType, InflightGuard,
         process_chat_response_and_observe_metrics as process_response_and_observe_metrics,
     },
     service_v2,
@@ -40,7 +40,7 @@ use super::{
 use crate::protocols::anthropic::stream_converter::AnthropicStreamConverter;
 use crate::protocols::anthropic::types::{
     AnthropicContentBlock, AnthropicCountTokensRequest, AnthropicCountTokensResponse,
-    AnthropicCreateMessageRequest, AnthropicErrorBody, AnthropicErrorResponse,
+    AnthropicCreateMessageRequest, AnthropicErrorBody, AnthropicErrorResponse, AnthropicMessage,
     AnthropicMessageContent, SystemContent, chat_completion_to_anthropic_response,
 };
 use crate::protocols::common::extensions::{
@@ -59,7 +59,6 @@ use crate::types::Annotated;
 use super::error::{SanitizedError, invalid_argument};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
 use super::openai::{get_body_limit, get_or_create_request_id};
-use crate::engines::ValidateRequest;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -133,10 +132,16 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 // Handlers
 // ---------------------------------------------------------------------------
 
-fn validate_anthropic_content_blocks(
-    request: &AnthropicCreateMessageRequest,
+const ANTHROPIC_MAX_TOOL_NAME_LENGTH: usize = 128;
+
+fn validate_anthropic_messages(
+    messages: &[AnthropicMessage],
 ) -> Result<(), dynamo_runtime::error::DynamoError> {
-    for (message_index, message) in request.messages.iter().enumerate() {
+    if messages.is_empty() {
+        return Err(invalid_argument("messages: field required"));
+    }
+
+    for (message_index, message) in messages.iter().enumerate() {
         let AnthropicMessageContent::Blocks { content } = &message.content else {
             continue;
         };
@@ -159,45 +164,47 @@ async fn handler_anthropic_messages(
     headers: HeaderMap,
     Json(mut request): Json<AnthropicCreateMessageRequest>,
 ) -> Result<Response, Response> {
-    // Validate required fields
-    if request.messages.is_empty() {
-        return Err(anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            "messages: field required",
-        ));
-    }
-    if request.max_tokens == 0 {
-        return Err(anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            "max_tokens: must be greater than 0",
-        ));
-    }
-    if let Err(error) = validate_anthropic_content_blocks(&request) {
+    let request_id = get_or_create_request_id(&headers);
+    let streaming = request.stream;
+    let resolved_model = resolve_request_model(&request.model, template.as_ref());
+    let canonical_model = state.manager().resolve_canonical_name(resolved_model);
+    let metric_model = state
+        .manager()
+        .metric_model_for(&canonical_model)
+        .to_string();
+    let mut inflight_guard = state.metrics_clone().create_inflight_guard(
+        &metric_model,
+        Endpoint::AnthropicMessages,
+        streaming,
+        &request_id,
+    );
+
+    if let Err(error) = validate_anthropic_messages(&request.messages) {
+        inflight_guard.mark_error(ErrorType::Validation);
         return Err(anthropic_error(
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
             error.message(),
         ));
     }
+    if request.max_tokens == 0 {
+        inflight_guard.mark_error(ErrorType::Validation);
+        return Err(anthropic_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "max_tokens: must be greater than 0",
+        ));
+    }
     gate_anthropic_nvext(&mut request, state.nvext_enabled());
 
     // Create request context
-    let request_id = get_or_create_request_id(&headers);
-    let streaming = request.stream;
-    let resolved_model = resolve_request_model(&request.model, template.as_ref());
-    // Canonicalize alias → primary for the metric label (see anthropic_messages).
-    let canonical_model = state.manager().resolve_canonical_name(resolved_model);
     let cancellation_labels = CancellationLabels {
-        model: state
-            .manager()
-            .metric_model_for(&canonical_model)
-            .to_string(),
+        model: metric_model,
         endpoint: Endpoint::AnthropicMessages.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
     let metadata = extract_metadata_from_http(&headers).map_err(|err| {
+        inflight_guard.mark_error(ErrorType::Validation);
         anthropic_error(
             StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
             "invalid_request_error",
@@ -223,7 +230,15 @@ async fn handler_anthropic_messages(
     .await;
 
     let response = tokio::spawn(
-        anthropic_messages(state, template, request, headers, stream_handle).in_current_span(),
+        anthropic_messages(
+            state,
+            template,
+            request,
+            headers,
+            stream_handle,
+            inflight_guard,
+        )
+        .in_current_span(),
     )
     .await
     .map_err(|e| {
@@ -245,6 +260,7 @@ async fn anthropic_messages(
     mut request: Context<AnthropicCreateMessageRequest>,
     headers: HeaderMap,
     mut stream_handle: ConnectionHandle,
+    mut inflight_guard: InflightGuard,
 ) -> Result<Response, Response> {
     let streaming = request.stream;
     let request_id = request.id().to_string();
@@ -292,16 +308,22 @@ async fn anthropic_messages(
             // "overloaded_error" by `anthropic_error`). Reuses the OpenAI path's
             // canonical, customer-facing message so both APIs report the same
             // text. Anything else is a genuine missing model → 404.
-            crate::discovery::ModelManagerError::ModelUnavailable(_) => anthropic_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "overloaded_error",
-                &super::openai::model_not_ready_message(&model),
-            ),
-            _ => anthropic_error(
-                StatusCode::NOT_FOUND,
-                "not_found_error",
-                &format!("Model '{}' not found", model),
-            ),
+            crate::discovery::ModelManagerError::ModelUnavailable(_) => {
+                inflight_guard.mark_error(ErrorType::Unavailable);
+                anthropic_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "overloaded_error",
+                    &super::openai::model_not_ready_message(&model),
+                )
+            }
+            _ => {
+                inflight_guard.mark_error(ErrorType::NotFound);
+                anthropic_error(
+                    StatusCode::NOT_FOUND,
+                    "not_found_error",
+                    &format!("Model '{}' not found", model),
+                )
+            }
         })?;
 
     let (orig_request, context) = request.into_parts();
@@ -325,6 +347,7 @@ async fn anthropic_messages(
 
     // Convert Anthropic request -> UnifiedRequest -> Chat Completion request
     let unified_request: UnifiedRequest = orig_request.try_into().map_err(|e: anyhow::Error| {
+        inflight_guard.mark_error(ErrorType::Validation);
         tracing::error!(
             request_id,
             error = %e,
@@ -343,7 +366,8 @@ async fn anthropic_messages(
     let anthropic_ctx = unified_request.anthropic_context().cloned();
     let mut chat_request = unified_request.into_inner();
     apply_anthropic_header_routing_overrides(&mut chat_request, &headers, state.nvext_enabled());
-    if let Err(error) = chat_request.validate() {
+    if let Err(error) = chat_request.validate_with_tool_name_limit(ANTHROPIC_MAX_TOOL_NAME_LENGTH) {
+        inflight_guard.mark_error(ErrorType::Validation);
         let error = invalid_argument(error.to_string());
         return Err(anthropic_error(
             StatusCode::BAD_REQUEST,
@@ -397,14 +421,6 @@ async fn anthropic_messages(
     );
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
-
-    // Create inflight_guard early to ensure all errors are counted
-    let mut inflight_guard = state.metrics_clone().create_inflight_guard(
-        &model,
-        Endpoint::AnthropicMessages,
-        streaming,
-        request.id(),
-    );
 
     tracing::trace!("Issuing generate call for Anthropic messages");
 
@@ -639,6 +655,13 @@ async fn handler_count_tokens(
     State((state, _template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
     Json(mut request): Json<AnthropicCountTokensRequest>,
 ) -> Result<Response, Response> {
+    if let Err(error) = validate_anthropic_messages(&request.messages) {
+        return Err(anthropic_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            error.message(),
+        ));
+    }
     if state.strip_anthropic_preamble_enabled() {
         strip_billing_preamble(&mut request.system);
     }

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -39,9 +39,9 @@ use super::{
 };
 use crate::protocols::anthropic::stream_converter::AnthropicStreamConverter;
 use crate::protocols::anthropic::types::{
-    AnthropicCountTokensRequest, AnthropicCountTokensResponse, AnthropicCreateMessageRequest,
-    AnthropicErrorBody, AnthropicErrorResponse, SystemContent,
-    chat_completion_to_anthropic_response,
+    AnthropicContentBlock, AnthropicCountTokensRequest, AnthropicCountTokensResponse,
+    AnthropicCreateMessageRequest, AnthropicErrorBody, AnthropicErrorResponse,
+    AnthropicMessageContent, SystemContent, chat_completion_to_anthropic_response,
 };
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
@@ -56,9 +56,10 @@ use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 
 // Re-use helpers from the openai module (sibling under service/)
-use super::error::SanitizedError;
+use super::error::{SanitizedError, invalid_argument};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
 use super::openai::{get_body_limit, get_or_create_request_id};
+use crate::engines::ValidateRequest;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -132,6 +133,26 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 // Handlers
 // ---------------------------------------------------------------------------
 
+fn validate_anthropic_content_blocks(
+    request: &AnthropicCreateMessageRequest,
+) -> Result<(), dynamo_runtime::error::DynamoError> {
+    for (message_index, message) in request.messages.iter().enumerate() {
+        let AnthropicMessageContent::Blocks { content } = &message.content else {
+            continue;
+        };
+        for (block_index, block) in content.iter().enumerate() {
+            if let AnthropicContentBlock::Other(value) = block
+                && !value.is_object()
+            {
+                return Err(invalid_argument(format!(
+                    "messages[{message_index}].content[{block_index}]: content blocks must be objects"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Top-level HTTP handler for POST /v1/messages.
 async fn handler_anthropic_messages(
     State((state, template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
@@ -151,6 +172,13 @@ async fn handler_anthropic_messages(
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
             "max_tokens: must be greater than 0",
+        ));
+    }
+    if let Err(error) = validate_anthropic_content_blocks(&request) {
+        return Err(anthropic_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            error.message(),
         ));
     }
     gate_anthropic_nvext(&mut request, state.nvext_enabled());
@@ -315,6 +343,14 @@ async fn anthropic_messages(
     let anthropic_ctx = unified_request.anthropic_context().cloned();
     let mut chat_request = unified_request.into_inner();
     apply_anthropic_header_routing_overrides(&mut chat_request, &headers, state.nvext_enabled());
+    if let Err(error) = chat_request.validate() {
+        let error = invalid_argument(error.to_string());
+        return Err(anthropic_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            error.message(),
+        ));
+    }
     // When a reasoning parser is configured and the client hasn't explicitly
     // disabled thinking, assume the model's chat template will inject `<think>`.
     //

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -37,6 +37,7 @@ use super::{
     },
     service_v2,
 };
+use crate::engines::ValidateRequest;
 use crate::protocols::anthropic::stream_converter::AnthropicStreamConverter;
 use crate::protocols::anthropic::types::{
     AnthropicContentBlock, AnthropicCountTokensRequest, AnthropicCountTokensResponse,
@@ -131,8 +132,6 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
-
-const ANTHROPIC_MAX_TOOL_NAME_LENGTH: usize = 128;
 
 #[derive(Debug)]
 enum AnthropicMessageValidationError {
@@ -420,7 +419,7 @@ async fn anthropic_messages(
     let anthropic_ctx = unified_request.anthropic_context().cloned();
     let mut chat_request = unified_request.into_inner();
     apply_anthropic_header_routing_overrides(&mut chat_request, &headers, state.nvext_enabled());
-    if let Err(error) = chat_request.validate_with_tool_name_limit(ANTHROPIC_MAX_TOOL_NAME_LENGTH) {
+    if let Err(error) = chat_request.validate() {
         inflight_guard.mark_error(ErrorType::Validation);
         let error = invalid_argument(error.to_string());
         return Err(anthropic_error(

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -5,6 +5,7 @@ use std::sync::LazyLock;
 
 use axum::http::StatusCode;
 use dynamo_runtime::config::environment_names::llm as env_llm;
+use dynamo_runtime::error::{DynamoError, ErrorType as DynamoErrorType};
 use thiserror::Error;
 
 fn parse_overload_status_code(value: Option<&str>) -> StatusCode {
@@ -35,6 +36,15 @@ pub(crate) fn overload_status_code() -> StatusCode {
 pub struct HttpError {
     pub code: u16,
     pub message: String,
+}
+
+/// Construct a typed invalid-argument error for validation performed at an
+/// HTTP protocol adapter boundary.
+pub(crate) fn invalid_argument(message: impl Into<String>) -> DynamoError {
+    DynamoError::builder()
+        .error_type(DynamoErrorType::InvalidArgument)
+        .message(message)
+        .build()
 }
 
 /// Canonical sanitized error responses returned at the HTTP boundary.

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3063,6 +3063,11 @@ async fn responses(
     let (orig_request, context) = request.into_parts();
 
     let unified_request: UnifiedRequest = orig_request.try_into().map_err(|e: anyhow::Error| {
+        tracing::error!(
+            request_id,
+            error = %e,
+            "Failed to convert NvCreateResponse to UnifiedRequest",
+        );
         let err_response = ErrorMessage::from_anyhow(
             invalid_argument(format!("Failed to convert responses request: {e}")).into(),
             "Failed to convert responses request",

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -67,7 +67,10 @@ use crate::protocols::openai::{
         NvCreatePoolingRequest, NvCreatePoolingResponse, PoolingEmbedDType, PoolingEncodingFormat,
         PoolingEndianness, PoolingOutput,
     },
-    responses::{NvCreateResponse, NvResponse, ResponseParams, chat_completion_to_response},
+    responses::{
+        NvCreateResponse, NvResponse, ResponseParams, ResponsesConversionError,
+        chat_completion_to_response,
+    },
     videos::{NvCreateVideoRequest, NvVideosResponse},
 };
 use crate::protocols::unified::UnifiedRequest;
@@ -3068,11 +3071,18 @@ async fn responses(
             error = %e,
             "Failed to convert NvCreateResponse to UnifiedRequest",
         );
-        let err_response = ErrorMessage::from_anyhow(
-            invalid_argument(format!("Failed to convert responses request: {e}")).into(),
-            "Failed to convert responses request",
-        );
-        inflight_guard.mark_error(ErrorType::Validation);
+        let err_response = match e.downcast_ref::<ResponsesConversionError>() {
+            Some(ResponsesConversionError::NotImplemented(message)) => {
+                ErrorMessage::not_implemented_error(format!(
+                    "{VALIDATION_PREFIX}Failed to convert responses request: {message}"
+                ))
+            }
+            _ => ErrorMessage::from_anyhow(
+                invalid_argument(format!("Failed to convert responses request: {e}")).into(),
+                "Failed to convert responses request",
+            ),
+        };
+        inflight_guard.mark_error(extract_error_type_from_response(&err_response));
         err_response
     })?;
     // Extract the API context before consuming the UnifiedRequest — this

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use super::{
     RouteDoc,
     disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
-    error::HttpError,
+    error::{HttpError, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
     metrics::{
         CancellationLabels, Endpoint, ErrorType, EventConverter,
@@ -3063,15 +3063,9 @@ async fn responses(
     let (orig_request, context) = request.into_parts();
 
     let unified_request: UnifiedRequest = orig_request.try_into().map_err(|e: anyhow::Error| {
-        tracing::error!(
-            request_id,
-            error = %e,
-            "Failed to convert NvCreateResponse to UnifiedRequest",
-        );
-        let err_response = ErrorMessage::not_implemented_error(
-            VALIDATION_PREFIX.to_string()
-                + "Failed to convert responses request: "
-                + &e.to_string(),
+        let err_response = ErrorMessage::from_anyhow(
+            invalid_argument(format!("Failed to convert responses request: {e}")).into(),
+            "Failed to convert responses request",
         );
         inflight_guard.mark_error(extract_error_type_from_response(&err_response));
         err_response
@@ -3082,6 +3076,14 @@ async fn responses(
     let responses_ctx = unified_request.responses_context().cloned();
     let mut chat_request = unified_request.into_inner();
     if let Err(err_response) = normalize_chat_reasoning_template_args(&mut chat_request) {
+        inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+        return Err(err_response);
+    }
+    if let Err(error) = chat_request.validate() {
+        let err_response = ErrorMessage::from_anyhow(
+            invalid_argument(error.to_string()).into(),
+            "Invalid responses request",
+        );
         inflight_guard.mark_error(extract_error_type_from_response(&err_response));
         return Err(err_response);
     }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -176,6 +176,21 @@ fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
         .unwrap_or_else(|| classify_error_for_metrics(response.0, &response.1.message))
 }
 
+fn responses_conversion_error_response(error: anyhow::Error) -> ErrorResponse {
+    const CONTEXT: &str = "Failed to convert responses request";
+
+    match error.downcast_ref::<ResponsesConversionError>() {
+        Some(ResponsesConversionError::InvalidArgument(message)) => ErrorMessage::from_anyhow(
+            invalid_argument(format!("{CONTEXT}: {message}")).into(),
+            CONTEXT,
+        ),
+        Some(ResponsesConversionError::NotImplemented(message)) => {
+            ErrorMessage::not_implemented_error(format!("{VALIDATION_PREFIX}{CONTEXT}: {message}"))
+        }
+        None => ErrorMessage::from_anyhow(error, CONTEXT),
+    }
+}
+
 /// Match `InvalidArgument` at top-level OR under `Backend()`.
 /// `py_err_to_dynamo` wraps Python `ValueError`/`TypeError` as
 /// `Backend(InvalidArgument)`; both variants are 400-worthy.
@@ -3071,17 +3086,7 @@ async fn responses(
             error = %e,
             "Failed to convert NvCreateResponse to UnifiedRequest",
         );
-        let err_response = match e.downcast_ref::<ResponsesConversionError>() {
-            Some(ResponsesConversionError::NotImplemented(message)) => {
-                ErrorMessage::not_implemented_error(format!(
-                    "{VALIDATION_PREFIX}Failed to convert responses request: {message}"
-                ))
-            }
-            _ => ErrorMessage::from_anyhow(
-                invalid_argument(format!("Failed to convert responses request: {e}")).into(),
-                "Failed to convert responses request",
-            ),
-        };
+        let err_response = responses_conversion_error_response(e);
         inflight_guard.mark_error(extract_error_type_from_response(&err_response));
         err_response
     })?;
@@ -6313,6 +6318,20 @@ mod tests {
         assert_eq!(
             extract_error_type_from_response(&response),
             ErrorType::NotImplemented
+        );
+    }
+
+    #[test]
+    fn untyped_responses_conversion_errors_remain_internal() {
+        let response = responses_conversion_error_response(anyhow::anyhow!(
+            "internal response conversion details"
+        ));
+
+        assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.1.message, "Failed to convert responses request");
+        assert_eq!(
+            extract_error_type_from_response(&response),
+            ErrorType::Internal
         );
     }
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3067,7 +3067,7 @@ async fn responses(
             invalid_argument(format!("Failed to convert responses request: {e}")).into(),
             "Failed to convert responses request",
         );
-        inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+        inflight_guard.mark_error(ErrorType::Validation);
         err_response
     })?;
     // Extract the API context before consuming the UnifiedRequest — this
@@ -3084,7 +3084,7 @@ async fn responses(
             invalid_argument(error.to_string()).into(),
             "Invalid responses request",
         );
-        inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+        inflight_guard.mark_error(ErrorType::Validation);
         return Err(err_response);
     }
 

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -119,6 +119,7 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
         // Convert stop_sequences -> stop
         let stop = req
             .stop_sequences
+            .filter(|sequences| !sequences.is_empty())
             .map(dynamo_protocols::types::Stop::StringArray);
 
         Ok(NvCreateChatCompletionRequest {
@@ -935,6 +936,12 @@ mod tests {
             container: None,
             output_config: None,
         };
+
+        let mut empty_req = req.clone();
+        empty_req.stop_sequences = Some(vec![]);
+        let empty_chat_req: NvCreateChatCompletionRequest = empty_req.try_into().unwrap();
+        assert!(empty_chat_req.inner.stop.is_none());
+        crate::engines::ValidateRequest::validate(&empty_chat_req).unwrap();
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         assert!(chat_req.inner.stop.is_some());

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -111,7 +111,11 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
         }
 
         // Convert tools
-        let tools = req.tools.as_ref().map(|t| convert_anthropic_tools(t));
+        let tools = req
+            .tools
+            .as_deref()
+            .map(convert_anthropic_tools)
+            .transpose()?;
 
         // Convert tool_choice
         let tool_choice = req.tool_choice.as_ref().map(convert_anthropic_tool_choice);
@@ -466,22 +470,17 @@ fn convert_assistant_blocks(
 }
 
 /// Convert Anthropic tools to ChatCompletionTools.
-fn convert_anthropic_tools(tools: &[AnthropicTool]) -> Vec<ChatCompletionTool> {
+fn convert_anthropic_tools(
+    tools: &[AnthropicTool],
+) -> Result<Vec<ChatCompletionTool>, anyhow::Error> {
     tools
         .iter()
-        .filter_map(|tool| {
-            // Server tools (web_search, bash, etc.) don't have input_schema
-            // and can't be meaningfully converted to OpenAI function tools.
-            // They are backend-specific and handled separately.
-            let schema = tool.input_schema.clone().or_else(|| {
-                tracing::debug!(
-                    tool_name = %tool.name,
-                    tool_type = ?tool.tool_type,
-                    "Skipping server tool in OpenAI conversion (no input_schema)"
-                );
-                None
+        .enumerate()
+        .map(|(tool_index, tool)| {
+            let schema = tool.input_schema.clone().ok_or_else(|| {
+                anyhow::anyhow!("tools[{tool_index}].input_schema: field required for client tools")
             })?;
-            Some(ChatCompletionTool {
+            Ok(ChatCompletionTool {
                 r#type: ChatCompletionToolType::Function,
                 function: FunctionObject {
                     name: tool.name.clone(),

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -877,16 +877,31 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_accepts_positive_max_tokens() {
+    fn test_validate_accepts_max_tokens_at_upper_bound() {
         let request_json = json!({
             "model": "test-model",
             "messages": [{"role": "user", "content": "Hello"}],
-            "max_tokens": 1
+            "max_tokens": 1_048_576
         });
         let request: NvCreateChatCompletionRequest =
             serde_json::from_value(request_json).expect("Failed to deserialize request");
 
         assert!(ValidateRequest::validate(&request).is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_max_tokens_above_upper_bound() {
+        let request_json = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 1_048_577
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(request_json).expect("Failed to deserialize request");
+
+        let err = ValidateRequest::validate(&request)
+            .expect_err("max_tokens above the upper bound must be rejected");
+        assert!(err.to_string().contains("must not exceed 1048576"));
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -531,10 +531,12 @@ impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
     }
 }
 
-/// Implements `ValidateRequest` for `NvCreateChatCompletionRequest`,
-/// allowing us to validate the data.
-impl ValidateRequest for NvCreateChatCompletionRequest {
-    fn validate(&self) -> Result<(), anyhow::Error> {
+impl NvCreateChatCompletionRequest {
+    /// Validate the normalized chat request using the source protocol's tool-name limit.
+    pub(crate) fn validate_with_tool_name_limit(
+        &self,
+        max_tool_name_length: usize,
+    ) -> Result<(), anyhow::Error> {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
         validate::validate_chat_template_args(self.chat_template_args.as_ref())?;
         validate::validate_messages(&self.inner.messages)?;
@@ -568,7 +570,10 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
         // none for stream_options
         validate::validate_temperature(self.inner.temperature)?;
         validate::validate_top_p(self.inner.top_p)?;
-        validate::validate_tools(&self.inner.tools.as_deref())?;
+        validate::validate_tools_with_name_limit(
+            &self.inner.tools.as_deref(),
+            max_tool_name_length,
+        )?;
         validate::validate_tool_choice(&self.inner.tool_choice, self.inner.tools.as_deref())?;
         // none for parallel_tool_calls
         validate::validate_user(self.inner.user.as_deref())?;
@@ -582,6 +587,14 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
         validate::validate_n_with_temperature(self.inner.n, self.inner.temperature)?;
 
         Ok(())
+    }
+}
+
+/// Implements `ValidateRequest` for `NvCreateChatCompletionRequest`,
+/// allowing us to validate the data.
+impl ValidateRequest for NvCreateChatCompletionRequest {
+    fn validate(&self) -> Result<(), anyhow::Error> {
+        self.validate_with_tool_name_limit(validate::MAX_FUNCTION_NAME_LENGTH)
     }
 }
 

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -531,12 +531,10 @@ impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
     }
 }
 
-impl NvCreateChatCompletionRequest {
-    /// Validate the normalized chat request using the source protocol's tool-name limit.
-    pub(crate) fn validate_with_tool_name_limit(
-        &self,
-        max_tool_name_length: usize,
-    ) -> Result<(), anyhow::Error> {
+/// Implements `ValidateRequest` for `NvCreateChatCompletionRequest`,
+/// allowing us to validate the data.
+impl ValidateRequest for NvCreateChatCompletionRequest {
+    fn validate(&self) -> Result<(), anyhow::Error> {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
         validate::validate_chat_template_args(self.chat_template_args.as_ref())?;
         validate::validate_messages(&self.inner.messages)?;
@@ -570,10 +568,7 @@ impl NvCreateChatCompletionRequest {
         // none for stream_options
         validate::validate_temperature(self.inner.temperature)?;
         validate::validate_top_p(self.inner.top_p)?;
-        validate::validate_tools_with_name_limit(
-            &self.inner.tools.as_deref(),
-            max_tool_name_length,
-        )?;
+        validate::validate_tools(&self.inner.tools.as_deref())?;
         validate::validate_tool_choice(&self.inner.tool_choice, self.inner.tools.as_deref())?;
         // none for parallel_tool_calls
         validate::validate_user(self.inner.user.as_deref())?;
@@ -587,14 +582,6 @@ impl NvCreateChatCompletionRequest {
         validate::validate_n_with_temperature(self.inner.n, self.inner.temperature)?;
 
         Ok(())
-    }
-}
-
-/// Implements `ValidateRequest` for `NvCreateChatCompletionRequest`,
-/// allowing us to validate the data.
-impl ValidateRequest for NvCreateChatCompletionRequest {
-    fn validate(&self) -> Result<(), anyhow::Error> {
-        self.validate_with_tool_name_limit(validate::MAX_FUNCTION_NAME_LENGTH)
     }
 }
 

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -236,6 +236,14 @@ impl OpenAIStopConditionsProvider for NvCreateResponse {
 // Responses API -> Chat Completions conversion
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ResponsesConversionError {
+    #[error("{0}")]
+    InvalidArgument(String),
+    #[error("{0}")]
+    NotImplemented(String),
+}
+
 /// Convert a Responses API ImageDetail to the Chat Completions ImageDetail.
 /// The responses module re-exports an `ImageDetail` from the upstream async-openai
 /// crate which is distinct from `dynamo_protocols::types::ImageDetail` (chat).
@@ -276,17 +284,32 @@ fn convert_input_content_to_user_content(
                 ));
             }
             InputContent::InputImage(img) => {
-                if img.file_id.is_some() && img.image_url.is_none() {
-                    return Err(anyhow::anyhow!(
-                        "Image input by file_id is not yet supported"
-                    ));
-                }
-                let url_str = img
-                    .image_url
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("input_image requires image_url"))?;
-                let url = url::Url::parse(url_str)
-                    .map_err(|e| anyhow::anyhow!("Invalid image URL '{}': {}", url_str, e))?;
+                let url_str = match (img.file_id.as_deref(), img.image_url.as_deref()) {
+                    (None, None) | (Some(_), Some(_)) => {
+                        return Err(ResponsesConversionError::InvalidArgument(
+                            "input_image requires exactly one of file_id or image_url".to_string(),
+                        )
+                        .into());
+                    }
+                    (Some(file_id), None) if file_id.trim().is_empty() => {
+                        return Err(ResponsesConversionError::InvalidArgument(
+                            "input_image file_id must be non-empty".to_string(),
+                        )
+                        .into());
+                    }
+                    (Some(_), None) => {
+                        return Err(ResponsesConversionError::NotImplemented(
+                            "Image input by file_id is not yet supported".to_string(),
+                        )
+                        .into());
+                    }
+                    (None, Some(url_str)) => url_str,
+                };
+                let url = url::Url::parse(url_str).map_err(|error| {
+                    ResponsesConversionError::InvalidArgument(format!(
+                        "Invalid image URL '{url_str}': {error}"
+                    ))
+                })?;
                 let mut image_url = ImageUrl::from(url.to_string());
                 image_url.detail = Some(convert_image_detail_str(&img.detail));
                 let image_part = ChatCompletionRequestMessageContentPartImageArgs::default()
@@ -295,8 +318,41 @@ fn convert_input_content_to_user_content(
                 chat_parts.push(image_part.into());
             }
             // TODO: handle InputVideo / InputAudio when upstream adds them
-            InputContent::InputFile(_) => {
-                return Err(anyhow::anyhow!("File input content is not yet supported"));
+            InputContent::InputFile(file) => {
+                let (source_field, source_value) = match (
+                    file.file_data.as_deref(),
+                    file.file_id.as_deref(),
+                    file.file_url.as_deref(),
+                ) {
+                    (Some(file_data), None, None) => ("file_data", file_data),
+                    (None, Some(file_id), None) => ("file_id", file_id),
+                    (None, None, Some(file_url)) => ("file_url", file_url),
+                    _ => {
+                        return Err(ResponsesConversionError::InvalidArgument(
+                            "input_file requires exactly one of file_data, file_id, or file_url"
+                                .to_string(),
+                        )
+                        .into());
+                    }
+                };
+                if source_value.trim().is_empty() {
+                    return Err(ResponsesConversionError::InvalidArgument(format!(
+                        "input_file {source_field} must be non-empty"
+                    ))
+                    .into());
+                }
+                if source_field == "file_url" {
+                    url::Url::parse(source_value).map_err(|error| {
+                        ResponsesConversionError::InvalidArgument(format!(
+                            "Invalid file URL '{source_value}': {error}"
+                        ))
+                    })?;
+                }
+
+                return Err(ResponsesConversionError::NotImplemented(
+                    "File input content is not yet supported".to_string(),
+                )
+                .into());
             }
         }
     }

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -285,9 +285,9 @@ fn convert_input_content_to_user_content(
             }
             InputContent::InputImage(img) => {
                 let url_str = match (img.file_id.as_deref(), img.image_url.as_deref()) {
-                    (None, None) | (Some(_), Some(_)) => {
+                    (None, None) => {
                         return Err(ResponsesConversionError::InvalidArgument(
-                            "input_image requires exactly one of file_id or image_url".to_string(),
+                            "input_image requires file_id or image_url".to_string(),
                         )
                         .into());
                     }
@@ -303,7 +303,7 @@ fn convert_input_content_to_user_content(
                         )
                         .into());
                     }
-                    (None, Some(url_str)) => url_str,
+                    (_, Some(url_str)) => url_str,
                 };
                 let url = url::Url::parse(url_str).map_err(|error| {
                     ResponsesConversionError::InvalidArgument(format!(
@@ -1507,7 +1507,7 @@ mod tests {
     }
 
     #[test]
-    fn test_input_items_with_image() {
+    fn test_input_items_with_file_id_and_image_url_prefers_url() {
         let req = NvCreateResponse {
             inner: CreateResponse {
                 input: InputParam::Items(vec![InputItem::Item(Item::Message(MessageItem::Input(
@@ -1518,7 +1518,7 @@ mod tests {
                             }),
                             InputContent::InputImage(InputImageContent {
                                 detail: Default::default(), // ImageDetail::Auto
-                                file_id: None,
+                                file_id: Some("file_123".into()),
                                 image_url: Some("https://example.com/cat.jpg".into()),
                             }),
                         ],

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -90,8 +90,8 @@ pub const MAX_STOP_SEQUENCES: usize = 32;
 /// Maximum allowed number of tools.
 pub const MAX_TOOLS: usize = 1536;
 // Metadata validation constants removed - we are no longer restricting the metadata field char limits
-/// Maximum allowed length for function names
-pub const MAX_FUNCTION_NAME_LENGTH: usize = 96;
+/// Both `/v1/messages` and `/v1/responses` define a 128-character tool-name limit.
+pub const MAX_FUNCTION_NAME_LENGTH: usize = 128;
 /// Minimum allowed value for `repetition_penalty`
 pub const MIN_REPETITION_PENALTY: f32 = 0.0;
 /// Maximum allowed value for `repetition_penalty`
@@ -514,14 +514,6 @@ pub fn validate_top_logprobs(top_logprobs: Option<u8>) -> Result<(), anyhow::Err
 pub fn validate_tools(
     tools: &Option<&[dynamo_protocols::types::ChatCompletionTool]>,
 ) -> Result<(), anyhow::Error> {
-    validate_tools_with_name_limit(tools, MAX_FUNCTION_NAME_LENGTH)
-}
-
-/// Validates tools with a protocol-specific function-name length limit.
-pub fn validate_tools_with_name_limit(
-    tools: &Option<&[dynamo_protocols::types::ChatCompletionTool]>,
-    max_function_name_length: usize,
-) -> Result<(), anyhow::Error> {
     let tools = match tools {
         Some(val) => val,
         None => return Ok(()),
@@ -536,11 +528,11 @@ pub fn validate_tools_with_name_limit(
     }
 
     for (i, tool) in tools.iter().enumerate() {
-        if tool.function.name.len() > max_function_name_length {
+        if tool.function.name.len() > MAX_FUNCTION_NAME_LENGTH {
             anyhow::bail!(
                 "Function name at index {} exceeds {} character limit, got {} characters",
                 i,
-                max_function_name_length,
+                MAX_FUNCTION_NAME_LENGTH,
                 tool.function.name.len()
             );
         }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -772,12 +772,23 @@ pub fn validate_suffix(suffix: Option<&str>) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+const MAX_OUTPUT_TOKENS: u32 = 1_048_576;
+
 /// Validates max_tokens parameter
 pub fn validate_max_tokens(max_tokens: Option<u32>) -> Result<(), anyhow::Error> {
     if let Some(tokens) = max_tokens
         && tokens == 0
     {
         anyhow::bail!("Max tokens must be greater than 0, got {}", tokens);
+    }
+    if let Some(tokens) = max_tokens
+        && tokens > MAX_OUTPUT_TOKENS
+    {
+        anyhow::bail!(
+            "Max tokens must not exceed {}, got {}",
+            MAX_OUTPUT_TOKENS,
+            tokens
+        );
     }
     Ok(())
 }
@@ -791,6 +802,15 @@ pub fn validate_max_completion_tokens(
     {
         anyhow::bail!(
             "Max completion tokens must be greater than 0, got {}",
+            tokens
+        );
+    }
+    if let Some(tokens) = max_completion_tokens
+        && tokens > MAX_OUTPUT_TOKENS
+    {
+        anyhow::bail!(
+            "Max completion tokens must not exceed {}, got {}",
+            MAX_OUTPUT_TOKENS,
             tokens
         );
     }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -514,6 +514,14 @@ pub fn validate_top_logprobs(top_logprobs: Option<u8>) -> Result<(), anyhow::Err
 pub fn validate_tools(
     tools: &Option<&[dynamo_protocols::types::ChatCompletionTool]>,
 ) -> Result<(), anyhow::Error> {
+    validate_tools_with_name_limit(tools, MAX_FUNCTION_NAME_LENGTH)
+}
+
+/// Validates tools with a protocol-specific function-name length limit.
+pub fn validate_tools_with_name_limit(
+    tools: &Option<&[dynamo_protocols::types::ChatCompletionTool]>,
+    max_function_name_length: usize,
+) -> Result<(), anyhow::Error> {
     let tools = match tools {
         Some(val) => val,
         None => return Ok(()),
@@ -528,11 +536,11 @@ pub fn validate_tools(
     }
 
     for (i, tool) in tools.iter().enumerate() {
-        if tool.function.name.len() > MAX_FUNCTION_NAME_LENGTH {
+        if tool.function.name.len() > max_function_name_length {
             anyhow::bail!(
                 "Function name at index {} exceeds {} character limit, got {} characters",
                 i,
-                MAX_FUNCTION_NAME_LENGTH,
+                max_function_name_length,
                 tool.function.name.len()
             );
         }

--- a/lib/llm/tests/common/http_harness.rs
+++ b/lib/llm/tests/common/http_harness.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
-use dynamo_llm::http::service::service_v2::HttpService;
+use dynamo_llm::http::service::{Metrics, service_v2::HttpService};
 use dynamo_llm::model_card::ModelDeploymentCard;
 use dynamo_llm::protocols::codec::create_message_stream;
 use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
@@ -36,6 +36,8 @@ pub struct HarnessService {
     pub base_url: String,
     pub client: reqwest::Client,
     pub engine: Arc<ScriptedChatEngine>,
+    #[allow(dead_code)]
+    pub metrics: Arc<Metrics>,
     cancel: CancellationToken,
     join: Option<tokio::task::JoinHandle<Result<()>>>,
 }
@@ -68,6 +70,7 @@ impl HarnessService {
             .expect("failed to build harness HTTP service");
 
         let card = ModelDeploymentCard::with_name_only(MODEL);
+        let metrics = service.state_clone().metrics_clone();
         service
             .model_manager()
             .add_chat_completions_model(MODEL, card.mdcsum(), engine.clone())
@@ -82,6 +85,7 @@ impl HarnessService {
             base_url,
             client,
             engine,
+            metrics,
             cancel,
             join: Some(join),
         }

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -10,10 +10,12 @@ use dynamo_runtime::config::environment_names::llm::{
 use serde_json::{Value, json};
 use serial_test::serial;
 
+#[allow(dead_code)]
 #[path = "common/http_harness.rs"]
 mod http_harness;
 #[path = "common/ports.rs"]
 mod ports;
+#[allow(dead_code)]
 #[path = "common/scripted_chat_engine.rs"]
 mod scripted_chat_engine;
 

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -74,7 +74,8 @@ async fn assert_anthropic_501(response: reqwest::Response, message: &str) {
 async fn protocol_adapter_errors_are_returned_before_streaming_headers() {
     temp_env::async_with_vars(BASE_ENV, async {
         let valid_script = load_agent_fixture("text.sse").await.unwrap();
-        let svc = HarnessService::start([valid_script]).await;
+        let svc =
+            HarnessService::start([valid_script.clone(), valid_script.clone(), valid_script]).await;
 
         for stream in [false, true] {
             let response = svc
@@ -270,7 +271,7 @@ async fn protocol_adapter_errors_are_returned_before_streaming_headers() {
             );
         }
 
-        let anthropic_tool_name = "a".repeat(128);
+        let max_length_tool_name = "a".repeat(128);
         let response = svc
             .client
             .post(format!("{}/v1/messages", svc.base_url))
@@ -279,7 +280,7 @@ async fn protocol_adapter_errors_are_returned_before_streaming_headers() {
                 "max_tokens": 16,
                 "messages": [{"role": "user", "content": "ping"}],
                 "tools": [{
-                    "name": anthropic_tool_name,
+                    "name": max_length_tool_name.clone(),
                     "input_schema": {"type": "object", "properties": {}}
                 }]
             }))
@@ -288,25 +289,23 @@ async fn protocol_adapter_errors_are_returned_before_streaming_headers() {
             .unwrap();
         assert_eq!(response.status(), reqwest::StatusCode::OK);
 
-        let too_long_anthropic_tool_name = "a".repeat(129);
         let response = svc
             .client
-            .post(format!("{}/v1/messages", svc.base_url))
+            .post(format!("{}/v1/responses", svc.base_url))
             .json(&json!({
                 "model": MODEL,
-                "max_tokens": 16,
-                "messages": [{"role": "user", "content": "ping"}],
+                "input": "ping",
                 "tools": [{
-                    "name": too_long_anthropic_tool_name,
-                    "input_schema": {"type": "object", "properties": {}}
+                    "type": "function",
+                    "name": max_length_tool_name.clone(),
+                    "parameters": {"type": "object", "properties": {}}
                 }]
             }))
             .send()
             .await
             .unwrap();
-        assert_anthropic_400(response, "128 character limit").await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
 
-        let too_long_openai_tool_name = "a".repeat(97);
         let response = svc
             .client
             .post(format!("{}/v1/chat/completions", svc.base_url))
@@ -316,7 +315,7 @@ async fn protocol_adapter_errors_are_returned_before_streaming_headers() {
                 "tools": [{
                     "type": "function",
                     "function": {
-                        "name": too_long_openai_tool_name,
+                        "name": max_length_tool_name,
                         "parameters": {"type": "object", "properties": {}}
                     }
                 }]
@@ -324,9 +323,63 @@ async fn protocol_adapter_errors_are_returned_before_streaming_headers() {
             .send()
             .await
             .unwrap();
-        assert_openai_400(response, "96 character limit").await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
 
-        assert_eq!(svc.engine.take_requests().await.len(), 1);
+        let too_long_tool_name = "a".repeat(129);
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "name": too_long_tool_name.clone(),
+                    "input_schema": {"type": "object", "properties": {}}
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_anthropic_400(response, "128 character limit").await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "input": "ping",
+                "tools": [{
+                    "type": "function",
+                    "name": too_long_tool_name.clone(),
+                    "parameters": {"type": "object", "properties": {}}
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_openai_400(response, "128 character limit").await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/chat/completions", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": too_long_tool_name,
+                        "parameters": {"type": "object", "properties": {}}
+                    }
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_openai_400(response, "128 character limit").await;
+
+        assert_eq!(svc.engine.take_requests().await.len(), 3);
         svc.shutdown().await;
     })
     .await;

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -165,6 +165,115 @@ async fn responses_conversion_distinguishes_invalid_from_unsupported() {
 
 #[tokio::test]
 #[serial]
+async fn anthropic_tools_reject_unsupported_and_malformed_definitions() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+
+        for (stream, tool_choice) in [
+            (false, None),
+            (true, Some(json!({"type": "tool", "name": "web_search"}))),
+        ] {
+            let mut body = json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "stream": stream,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "type": "web_search_20260209",
+                    "name": "web_search"
+                }]
+            });
+            if let Some(tool_choice) = tool_choice {
+                body["tool_choice"] = tool_choice;
+            }
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .json(&body)
+                .send()
+                .await
+                .unwrap();
+            assert_anthropic_501(
+                response,
+                "server tool type \"web_search_20260209\" is not supported",
+            )
+            .await;
+        }
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "stream": stream,
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "tools": [{"name": "get_weather"}]
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_anthropic_400(response, "tools[0].input_schema: field required").await;
+        }
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages/count_tokens", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "type": "web_search_20260209",
+                    "name": "web_search"
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_anthropic_501(response, "server tool type \"web_search_20260209\"").await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages/count_tokens", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{"type": "custom", "name": "get_weather"}]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_anthropic_400(response, "tools[0].input_schema: field required").await;
+
+        for request_type in [RequestType::Unary, RequestType::Stream] {
+            for (error_type, expected) in [
+                (ErrorType::NotImplemented, 1),
+                (ErrorType::Validation, 1),
+                (ErrorType::Internal, 0),
+            ] {
+                assert_eq!(
+                    svc.metrics.get_request_counter(
+                        MODEL,
+                        &Endpoint::AnthropicMessages,
+                        &request_type,
+                        &Status::Error,
+                        &error_type,
+                    ),
+                    expected,
+                    "unexpected {error_type:?} count for {request_type}"
+                );
+            }
+        }
+
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
 // `reqwest::send` completes when response headers arrive. Asserting 4xx/5xx
 // status for `stream: true` proves the adapter rejected the request before
 // committing the HTTP 200 SSE response.

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -3,6 +3,7 @@
 
 //! HTTP regressions for validation performed by protocol adapters.
 
+use dynamo_llm::http::service::metrics::{Endpoint, ErrorType, RequestType, Status};
 use dynamo_runtime::config::environment_names::llm::{
     DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
     DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS,
@@ -57,7 +58,7 @@ async fn assert_anthropic_400(response: reqwest::Response, message: &str) {
 async fn protocol_adapter_validation_is_400_before_streaming_headers() {
     temp_env::async_with_vars(BASE_ENV, async {
         let valid_script = load_agent_fixture("text.sse").await.unwrap();
-        let svc = HarnessService::start([valid_script]).await;
+        let svc = HarnessService::start([valid_script.clone(), valid_script]).await;
 
         for stream in [false, true] {
             let response = svc
@@ -132,6 +133,45 @@ async fn protocol_adapter_validation_is_400_before_streaming_headers() {
 
         let response = svc
             .client
+            .post(format!("{}/v1/messages/count_tokens", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "messages": [{"role": "user", "content": ["hello"]}]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_anthropic_400(response, "content blocks must be objects").await;
+
+        for endpoint in [Endpoint::Responses, Endpoint::AnthropicMessages] {
+            for request_type in [RequestType::Unary, RequestType::Stream] {
+                assert_eq!(
+                    svc.metrics.get_request_counter(
+                        MODEL,
+                        &endpoint,
+                        &request_type,
+                        &Status::Error,
+                        &ErrorType::Validation,
+                    ),
+                    3,
+                    "validation errors were not metered for {endpoint}/{request_type}"
+                );
+                assert_eq!(
+                    svc.metrics.get_request_counter(
+                        MODEL,
+                        &endpoint,
+                        &request_type,
+                        &Status::Error,
+                        &ErrorType::Internal,
+                    ),
+                    0,
+                    "validation errors were misclassified for {endpoint}/{request_type}"
+                );
+            }
+        }
+
+        let response = svc
+            .client
             .post(format!("{}/v1/messages", svc.base_url))
             .json(&json!({
                 "model": MODEL,
@@ -149,7 +189,64 @@ async fn protocol_adapter_validation_is_400_before_streaming_headers() {
             .await
             .unwrap();
         assert_eq!(response.status(), reqwest::StatusCode::OK);
-        assert_eq!(svc.engine.take_requests().await.len(), 1);
+
+        let anthropic_tool_name = "a".repeat(128);
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "name": anthropic_tool_name,
+                    "input_schema": {"type": "object", "properties": {}}
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let too_long_anthropic_tool_name = "a".repeat(129);
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "name": too_long_anthropic_tool_name,
+                    "input_schema": {"type": "object", "properties": {}}
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_anthropic_400(response, "128 character limit").await;
+
+        let too_long_openai_tool_name = "a".repeat(97);
+        let response = svc
+            .client
+            .post(format!("{}/v1/chat/completions", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": too_long_openai_tool_name,
+                        "parameters": {"type": "object", "properties": {}}
+                    }
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_openai_400(response, "96 character limit").await;
+
+        assert_eq!(svc.engine.take_requests().await.len(), 2);
         svc.shutdown().await;
     })
     .await;

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -40,6 +40,18 @@ async fn assert_openai_400(response: reqwest::Response, message: &str) {
     );
 }
 
+async fn assert_openai_501(response: reqwest::Response, message: &str) {
+    assert_eq!(response.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["code"], 501);
+    assert!(
+        body["message"].as_str().is_some_and(|actual| actual
+            .to_ascii_lowercase()
+            .contains(&message.to_ascii_lowercase())),
+        "unexpected OpenAI error body: {body}"
+    );
+}
+
 async fn assert_anthropic_400(response: reqwest::Response, message: &str) {
     assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
     let body: Value = response.json().await.unwrap();
@@ -64,6 +76,91 @@ async fn assert_anthropic_501(response: reqwest::Response, message: &str) {
             .is_some_and(|actual| actual.contains(message)),
         "unexpected Anthropic error body: {body}"
     );
+}
+
+#[tokio::test]
+#[serial]
+async fn responses_conversion_distinguishes_invalid_from_unsupported() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+
+        for stream in [false, true] {
+            for (content, message) in [
+                (
+                    json!({"type": "input_image", "file_id": "file_123"}),
+                    "image input by file_id",
+                ),
+                (
+                    json!({
+                        "type": "input_file",
+                        "file_url": "https://example.com/report.pdf"
+                    }),
+                    "file input content",
+                ),
+            ] {
+                let response = svc
+                    .client
+                    .post(format!("{}/v1/responses", svc.base_url))
+                    .json(&json!({
+                        "model": MODEL,
+                        "stream": stream,
+                        "input": [{"role": "user", "content": [content]}]
+                    }))
+                    .send()
+                    .await
+                    .unwrap();
+                assert_openai_501(response, message).await;
+            }
+
+            for (content, message) in [
+                (
+                    json!({"type": "input_image"}),
+                    "requires exactly one of file_id or image_url",
+                ),
+                (
+                    json!({"type": "input_file"}),
+                    "requires exactly one of file_data, file_id, or file_url",
+                ),
+            ] {
+                let response = svc
+                    .client
+                    .post(format!("{}/v1/responses", svc.base_url))
+                    .json(&json!({
+                        "model": MODEL,
+                        "stream": stream,
+                        "input": [{"role": "user", "content": [content]}]
+                    }))
+                    .send()
+                    .await
+                    .unwrap();
+                assert_openai_400(response, message).await;
+            }
+        }
+
+        for request_type in [RequestType::Unary, RequestType::Stream] {
+            for (error_type, expected) in [
+                (ErrorType::NotImplemented, 2),
+                (ErrorType::Validation, 2),
+                (ErrorType::Internal, 0),
+            ] {
+                assert_eq!(
+                    svc.metrics.get_request_counter(
+                        MODEL,
+                        &Endpoint::Responses,
+                        &request_type,
+                        &Status::Error,
+                        &error_type,
+                    ),
+                    expected,
+                    "unexpected {error_type:?} count for {request_type}"
+                );
+            }
+        }
+
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
 }
 
 #[tokio::test]

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP regressions for validation performed by protocol adapters.
+
+use dynamo_runtime::config::environment_names::llm::{
+    DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
+    DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS,
+};
+use serde_json::{Value, json};
+use serial_test::serial;
+
+#[path = "common/http_harness.rs"]
+mod http_harness;
+#[path = "common/ports.rs"]
+mod ports;
+#[path = "common/scripted_chat_engine.rs"]
+mod scripted_chat_engine;
+
+use http_harness::{HarnessService, MODEL, load_agent_fixture};
+
+const BASE_ENV: [(&str, Option<&str>); 3] = [
+    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+    (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
+];
+
+async fn assert_openai_400(response: reqwest::Response, message: &str) {
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["code"], 400);
+    assert!(
+        body["message"].as_str().is_some_and(|actual| actual
+            .to_ascii_lowercase()
+            .contains(&message.to_ascii_lowercase())),
+        "unexpected OpenAI error body: {body}"
+    );
+}
+
+async fn assert_anthropic_400(response: reqwest::Response, message: &str) {
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["type"], "error");
+    assert_eq!(body["error"]["type"], "invalid_request_error");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|actual| actual.contains(message)),
+        "unexpected Anthropic error body: {body}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn protocol_adapter_validation_is_400_before_streaming_headers() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let valid_script = load_agent_fixture("text.sse").await.unwrap();
+        let svc = HarnessService::start([valid_script]).await;
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/responses", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "input": [],
+                    "max_tokens": 10,
+                    "stream": stream
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_openai_400(response, "messages").await;
+        }
+        for field in [json!({"temperature": 3.0}), json!({"top_p": 2.0})] {
+            for stream in [false, true] {
+                let mut body = json!({"model": MODEL, "input": "ping", "stream": stream});
+                body.as_object_mut()
+                    .unwrap()
+                    .extend(field.as_object().unwrap().clone());
+                let response = svc
+                    .client
+                    .post(format!("{}/v1/responses", svc.base_url))
+                    .json(&body)
+                    .send()
+                    .await
+                    .unwrap();
+                assert_openai_400(response, "must be").await;
+            }
+        }
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .header("x-api-key", "dummy")
+                .header("anthropic-version", "2023-06-01")
+                .json(&json!({
+                    "model": MODEL,
+                    "max_tokens": 10,
+                    "stream": stream,
+                    "messages": [{"role": "user", "content": ["hello"]}]
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_anthropic_400(response, "content blocks must be objects").await;
+        }
+        for field in [json!({"temperature": 3.0}), json!({"top_p": 2.0})] {
+            for stream in [false, true] {
+                let mut body = json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "stream": stream,
+                    "messages": [{"role": "user", "content": "ping"}]
+                });
+                body.as_object_mut()
+                    .unwrap()
+                    .extend(field.as_object().unwrap().clone());
+                let response = svc
+                    .client
+                    .post(format!("{}/v1/messages", svc.base_url))
+                    .json(&body)
+                    .send()
+                    .await
+                    .unwrap();
+                assert_anthropic_400(response, "must be").await;
+            }
+        }
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "stream": false,
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "future_block_type", "value": 1},
+                        {"type": "text", "text": "ping"}
+                    ]
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(svc.engine.take_requests().await.len(), 1);
+        svc.shutdown().await;
+    })
+    .await;
+}

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -115,7 +115,7 @@ async fn responses_conversion_distinguishes_invalid_from_unsupported() {
             for (content, message) in [
                 (
                     json!({"type": "input_image"}),
-                    "requires exactly one of file_id or image_url",
+                    "requires file_id or image_url",
                 ),
                 (
                     json!({"type": "input_file"}),

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -217,35 +217,6 @@ async fn anthropic_tools_reject_unsupported_and_malformed_definitions() {
             assert_anthropic_400(response, "tools[0].input_schema: field required").await;
         }
 
-        let response = svc
-            .client
-            .post(format!("{}/v1/messages/count_tokens", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "messages": [{"role": "user", "content": "ping"}],
-                "tools": [{
-                    "type": "web_search_20260209",
-                    "name": "web_search"
-                }]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_anthropic_501(response, "server tool type \"web_search_20260209\"").await;
-
-        let response = svc
-            .client
-            .post(format!("{}/v1/messages/count_tokens", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "messages": [{"role": "user", "content": "ping"}],
-                "tools": [{"type": "custom", "name": "get_weather"}]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_anthropic_400(response, "tools[0].input_schema: field required").await;
-
         for request_type in [RequestType::Unary, RequestType::Stream] {
             for (error_type, expected) in [
                 (ErrorType::NotImplemented, 1),

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -75,6 +75,22 @@ async fn protocol_adapter_validation_is_400_before_streaming_headers() {
                 .unwrap();
             assert_openai_400(response, "messages").await;
         }
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/responses", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "input": "ping",
+                    "stream": stream,
+                    "tools": [],
+                    "tool_choice": "required"
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_openai_400(response, "tool_choice is \"required\"").await;
+        }
         for field in [json!({"temperature": 3.0}), json!({"top_p": 2.0})] {
             for stream in [false, true] {
                 let mut body = json!({"model": MODEL, "input": "ping", "stream": stream});
@@ -108,6 +124,23 @@ async fn protocol_adapter_validation_is_400_before_streaming_headers() {
                 .await
                 .unwrap();
             assert_anthropic_400(response, "content blocks must be objects").await;
+        }
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .header("x-api-key", "dummy")
+                .header("anthropic-version", "2023-06-01")
+                .json(&json!({
+                    "model": MODEL,
+                    "max_tokens": 10,
+                    "stream": stream,
+                    "messages": [{"role": "user", "content": []}]
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_anthropic_400(response, "must contain at least one content block").await;
         }
         for field in [json!({"temperature": 3.0}), json!({"top_p": 2.0})] {
             for stream in [false, true] {
@@ -153,7 +186,7 @@ async fn protocol_adapter_validation_is_400_before_streaming_headers() {
                         &Status::Error,
                         &ErrorType::Validation,
                     ),
-                    3,
+                    4,
                     "validation errors were not metered for {endpoint}/{request_type}"
                 );
                 assert_eq!(

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -53,12 +53,28 @@ async fn assert_anthropic_400(response: reqwest::Response, message: &str) {
     );
 }
 
+async fn assert_anthropic_501(response: reqwest::Response, message: &str) {
+    assert_eq!(response.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["type"], "error");
+    assert_eq!(body["error"]["type"], "api_error");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|actual| actual.contains(message)),
+        "unexpected Anthropic error body: {body}"
+    );
+}
+
 #[tokio::test]
 #[serial]
-async fn protocol_adapter_validation_is_400_before_streaming_headers() {
+// `reqwest::send` completes when response headers arrive. Asserting 4xx/5xx
+// status for `stream: true` proves the adapter rejected the request before
+// committing the HTTP 200 SSE response.
+async fn protocol_adapter_errors_are_returned_before_streaming_headers() {
     temp_env::async_with_vars(BASE_ENV, async {
         let valid_script = load_agent_fixture("text.sse").await.unwrap();
-        let svc = HarnessService::start([valid_script.clone(), valid_script]).await;
+        let svc = HarnessService::start([valid_script]).await;
 
         for stream in [false, true] {
             let response = svc
@@ -203,25 +219,56 @@ async fn protocol_adapter_validation_is_400_before_streaming_headers() {
             }
         }
 
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "stream": stream,
+                    "messages": [{
+                        "role": "user",
+                        "content": [
+                            {"type": "future_block_type", "value": 1},
+                            {"type": "text", "text": "ping"}
+                        ]
+                    }]
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_anthropic_501(response, "content block type \"future_block_type\"").await;
+        }
+
         let response = svc
             .client
-            .post(format!("{}/v1/messages", svc.base_url))
+            .post(format!("{}/v1/messages/count_tokens", svc.base_url))
             .json(&json!({
                 "model": MODEL,
-                "max_tokens": 16,
-                "stream": false,
                 "messages": [{
                     "role": "user",
-                    "content": [
-                        {"type": "future_block_type", "value": 1},
-                        {"type": "text", "text": "ping"}
-                    ]
+                    "content": [{"type": "future_block_type", "value": 1}]
                 }]
             }))
             .send()
             .await
             .unwrap();
-        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_anthropic_501(response, "content block type \"future_block_type\"").await;
+
+        for request_type in [RequestType::Unary, RequestType::Stream] {
+            assert_eq!(
+                svc.metrics.get_request_counter(
+                    MODEL,
+                    &Endpoint::AnthropicMessages,
+                    &request_type,
+                    &Status::Error,
+                    &ErrorType::NotImplemented,
+                ),
+                1,
+                "unsupported content blocks were not metered for {request_type}"
+            );
+        }
 
         let anthropic_tool_name = "a".repeat(128);
         let response = svc
@@ -279,7 +326,7 @@ async fn protocol_adapter_validation_is_400_before_streaming_headers() {
             .unwrap();
         assert_openai_400(response, "96 character limit").await;
 
-        assert_eq!(svc.engine.take_requests().await.len(), 2);
+        assert_eq!(svc.engine.take_requests().await.len(), 1);
         svc.shutdown().await;
     })
     .await;

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -28,10 +28,42 @@ const BASE_ENV: [(&str, Option<&str>); 3] = [
     (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
 ];
 
-async fn assert_openai_400(response: reqwest::Response, message: &str) {
-    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+async fn post_json(svc: &HarnessService, path: &str, body: Value) -> reqwest::Response {
+    svc.client
+        .post(format!("{}{path}", svc.base_url))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+#[derive(Clone, Copy)]
+enum ExpectedError {
+    Validation,
+    NotImplemented,
+}
+
+impl ExpectedError {
+    fn status(self) -> reqwest::StatusCode {
+        match self {
+            Self::Validation => reqwest::StatusCode::BAD_REQUEST,
+            Self::NotImplemented => reqwest::StatusCode::NOT_IMPLEMENTED,
+        }
+    }
+
+    fn anthropic_type(self) -> &'static str {
+        match self {
+            Self::Validation => "invalid_request_error",
+            Self::NotImplemented => "api_error",
+        }
+    }
+}
+
+async fn assert_openai_error(response: reqwest::Response, expected: ExpectedError, message: &str) {
+    let status = expected.status();
+    assert_eq!(response.status(), status);
     let body: Value = response.json().await.unwrap();
-    assert_eq!(body["code"], 400);
+    assert_eq!(body["code"].as_u64(), Some(u64::from(status.as_u16())));
     assert!(
         body["message"].as_str().is_some_and(|actual| actual
             .to_ascii_lowercase()
@@ -40,23 +72,15 @@ async fn assert_openai_400(response: reqwest::Response, message: &str) {
     );
 }
 
-async fn assert_openai_501(response: reqwest::Response, message: &str) {
-    assert_eq!(response.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
-    let body: Value = response.json().await.unwrap();
-    assert_eq!(body["code"], 501);
-    assert!(
-        body["message"].as_str().is_some_and(|actual| actual
-            .to_ascii_lowercase()
-            .contains(&message.to_ascii_lowercase())),
-        "unexpected OpenAI error body: {body}"
-    );
-}
-
-async fn assert_anthropic_400(response: reqwest::Response, message: &str) {
-    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+async fn assert_anthropic_error(
+    response: reqwest::Response,
+    expected: ExpectedError,
+    message: &str,
+) {
+    assert_eq!(response.status(), expected.status());
     let body: Value = response.json().await.unwrap();
     assert_eq!(body["type"], "error");
-    assert_eq!(body["error"]["type"], "invalid_request_error");
+    assert_eq!(body["error"]["type"], expected.anthropic_type());
     assert!(
         body["error"]["message"]
             .as_str()
@@ -65,17 +89,71 @@ async fn assert_anthropic_400(response: reqwest::Response, message: &str) {
     );
 }
 
-async fn assert_anthropic_501(response: reqwest::Response, message: &str) {
-    assert_eq!(response.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
-    let body: Value = response.json().await.unwrap();
-    assert_eq!(body["type"], "error");
-    assert_eq!(body["error"]["type"], "api_error");
-    assert!(
-        body["error"]["message"]
-            .as_str()
-            .is_some_and(|actual| actual.contains(message)),
-        "unexpected Anthropic error body: {body}"
-    );
+fn assert_error_metrics(
+    svc: &HarnessService,
+    endpoint: &Endpoint,
+    request_type: &RequestType,
+    expected: &[(ErrorType, u64)],
+) {
+    for (error_type, expected) in expected {
+        assert_eq!(
+            svc.metrics.get_request_counter(
+                MODEL,
+                endpoint,
+                request_type,
+                &Status::Error,
+                error_type,
+            ),
+            *expected,
+            "unexpected {error_type:?} count for {endpoint}/{request_type}"
+        );
+    }
+}
+
+fn tool_name_requests(name: &str) -> [(&'static str, Value, bool); 3] {
+    [
+        (
+            "/v1/messages",
+            json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "name": name,
+                    "input_schema": {"type": "object", "properties": {}}
+                }]
+            }),
+            true,
+        ),
+        (
+            "/v1/responses",
+            json!({
+                "model": MODEL,
+                "input": "ping",
+                "tools": [{
+                    "type": "function",
+                    "name": name,
+                    "parameters": {"type": "object", "properties": {}}
+                }]
+            }),
+            false,
+        ),
+        (
+            "/v1/chat/completions",
+            json!({
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "parameters": {"type": "object", "properties": {}}
+                    }
+                }]
+            }),
+            false,
+        ),
+    ]
 }
 
 #[tokio::test]
@@ -84,77 +162,59 @@ async fn responses_conversion_distinguishes_invalid_from_unsupported() {
     temp_env::async_with_vars(BASE_ENV, async {
         let svc = HarnessService::start(Vec::new()).await;
 
-        for stream in [false, true] {
-            for (content, message) in [
-                (
-                    json!({"type": "input_image", "file_id": "file_123"}),
-                    "image input by file_id",
-                ),
-                (
-                    json!({
-                        "type": "input_file",
-                        "file_url": "https://example.com/report.pdf"
-                    }),
-                    "file input content",
-                ),
-            ] {
-                let response = svc
-                    .client
-                    .post(format!("{}/v1/responses", svc.base_url))
-                    .json(&json!({
-                        "model": MODEL,
-                        "stream": stream,
-                        "input": [{"role": "user", "content": [content]}]
-                    }))
-                    .send()
-                    .await
-                    .unwrap();
-                assert_openai_501(response, message).await;
-            }
-
-            for (content, message) in [
-                (
-                    json!({"type": "input_image"}),
-                    "requires file_id or image_url",
-                ),
-                (
-                    json!({"type": "input_file"}),
-                    "requires exactly one of file_data, file_id, or file_url",
-                ),
-            ] {
-                let response = svc
-                    .client
-                    .post(format!("{}/v1/responses", svc.base_url))
-                    .json(&json!({
-                        "model": MODEL,
-                        "stream": stream,
-                        "input": [{"role": "user", "content": [content]}]
-                    }))
-                    .send()
-                    .await
-                    .unwrap();
-                assert_openai_400(response, message).await;
-            }
+        for (stream, content, expected, message) in [
+            (
+                true,
+                json!({"type": "input_image", "file_id": "file_123"}),
+                ExpectedError::NotImplemented,
+                "image input by file_id",
+            ),
+            (
+                false,
+                json!({
+                    "type": "input_file",
+                    "file_url": "https://example.com/report.pdf"
+                }),
+                ExpectedError::NotImplemented,
+                "file input content",
+            ),
+            (
+                false,
+                json!({"type": "input_image"}),
+                ExpectedError::Validation,
+                "requires file_id or image_url",
+            ),
+            (
+                true,
+                json!({"type": "input_file"}),
+                ExpectedError::Validation,
+                "requires exactly one of file_data, file_id, or file_url",
+            ),
+        ] {
+            let response = post_json(
+                &svc,
+                "/v1/responses",
+                json!({
+                    "model": MODEL,
+                    "stream": stream,
+                    "input": [{"role": "user", "content": [content]}]
+                }),
+            )
+            .await;
+            assert_openai_error(response, expected, message).await;
         }
 
         for request_type in [RequestType::Unary, RequestType::Stream] {
-            for (error_type, expected) in [
-                (ErrorType::NotImplemented, 2),
-                (ErrorType::Validation, 2),
-                (ErrorType::Internal, 0),
-            ] {
-                assert_eq!(
-                    svc.metrics.get_request_counter(
-                        MODEL,
-                        &Endpoint::Responses,
-                        &request_type,
-                        &Status::Error,
-                        &error_type,
-                    ),
-                    expected,
-                    "unexpected {error_type:?} count for {request_type}"
-                );
-            }
+            assert_error_metrics(
+                &svc,
+                &Endpoint::Responses,
+                &request_type,
+                &[
+                    (ErrorType::NotImplemented, 1),
+                    (ErrorType::Validation, 1),
+                    (ErrorType::Internal, 0),
+                ],
+            );
         }
 
         assert!(svc.engine.take_requests().await.is_empty());
@@ -186,53 +246,101 @@ async fn anthropic_tools_reject_unsupported_and_malformed_definitions() {
             if let Some(tool_choice) = tool_choice {
                 body["tool_choice"] = tool_choice;
             }
-            let response = svc
-                .client
-                .post(format!("{}/v1/messages", svc.base_url))
-                .json(&body)
-                .send()
-                .await
-                .unwrap();
-            assert_anthropic_501(
+            let response = post_json(&svc, "/v1/messages", body).await;
+            assert_anthropic_error(
                 response,
+                ExpectedError::NotImplemented,
                 "server tool type \"web_search_20260209\" is not supported",
             )
             .await;
         }
 
-        for stream in [false, true] {
-            let response = svc
-                .client
-                .post(format!("{}/v1/messages", svc.base_url))
-                .json(&json!({
+        let response = post_json(
+            &svc,
+            "/v1/messages",
+            json!({
                     "model": MODEL,
                     "max_tokens": 16,
-                    "stream": stream,
+                    "stream": false,
                     "messages": [{"role": "user", "content": "ping"}],
                     "tools": [{"name": "get_weather"}]
-                }))
-                .send()
-                .await
-                .unwrap();
-            assert_anthropic_400(response, "tools[0].input_schema: field required").await;
-        }
+            }),
+        )
+        .await;
+        assert_anthropic_error(
+            response,
+            ExpectedError::Validation,
+            "tools[0].input_schema: field required",
+        )
+        .await;
 
         for request_type in [RequestType::Unary, RequestType::Stream] {
-            for (error_type, expected) in [
-                (ErrorType::NotImplemented, 1),
-                (ErrorType::Validation, 1),
-                (ErrorType::Internal, 0),
-            ] {
-                assert_eq!(
-                    svc.metrics.get_request_counter(
-                        MODEL,
-                        &Endpoint::AnthropicMessages,
-                        &request_type,
-                        &Status::Error,
-                        &error_type,
-                    ),
-                    expected,
-                    "unexpected {error_type:?} count for {request_type}"
+            let validation = match &request_type {
+                RequestType::Unary => 1,
+                RequestType::Stream => 0,
+            };
+            assert_error_metrics(
+                &svc,
+                &Endpoint::AnthropicMessages,
+                &request_type,
+                &[
+                    (ErrorType::NotImplemented, 1),
+                    (ErrorType::Validation, validation),
+                    (ErrorType::Internal, 0),
+                ],
+            );
+        }
+
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+// `reqwest::send` completes when response headers arrive. A 400 for `stream: true`
+// proves converted-request validation ran before the HTTP 200 SSE response was committed.
+#[tokio::test]
+#[serial]
+async fn converted_validation_errors_are_returned_before_streaming_headers() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+
+        for (stream, field) in [
+            (false, json!({"top_p": 2.0})),
+            (true, json!({"temperature": 3.0})),
+        ] {
+            let mut body = json!({"model": MODEL, "input": "ping", "stream": stream});
+            body.as_object_mut()
+                .unwrap()
+                .extend(field.as_object().unwrap().clone());
+            let response = post_json(&svc, "/v1/responses", body).await;
+            assert_openai_error(response, ExpectedError::Validation, "must be").await;
+        }
+
+        for (stream, field) in [
+            (false, json!({"temperature": 3.0})),
+            (true, json!({"top_p": 2.0})),
+        ] {
+            let mut body = json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "stream": stream,
+                "messages": [{"role": "user", "content": "ping"}]
+            });
+            body.as_object_mut()
+                .unwrap()
+                .extend(field.as_object().unwrap().clone());
+            let response = post_json(&svc, "/v1/messages", body).await;
+            assert_anthropic_error(response, ExpectedError::Validation, "must be").await;
+        }
+
+        for endpoint in [Endpoint::Responses, Endpoint::AnthropicMessages] {
+            for request_type in [RequestType::Unary, RequestType::Stream] {
+                assert_error_metrics(
+                    &svc,
+                    &endpoint,
+                    &request_type,
+                    &[(ErrorType::Validation, 1), (ErrorType::Internal, 0)],
                 );
             }
         }
@@ -245,166 +353,77 @@ async fn anthropic_tools_reject_unsupported_and_malformed_definitions() {
 
 #[tokio::test]
 #[serial]
-// `reqwest::send` completes when response headers arrive. Asserting 4xx/5xx
-// status for `stream: true` proves the adapter rejected the request before
-// committing the HTTP 200 SSE response.
-async fn protocol_adapter_errors_are_returned_before_streaming_headers() {
+async fn responses_reject_empty_input_and_required_tool_choice_without_tools() {
     temp_env::async_with_vars(BASE_ENV, async {
-        let valid_script = load_agent_fixture("text.sse").await.unwrap();
-        let svc =
-            HarnessService::start([valid_script.clone(), valid_script.clone(), valid_script]).await;
+        let svc = HarnessService::start(Vec::new()).await;
 
-        for stream in [false, true] {
-            let response = svc
-                .client
-                .post(format!("{}/v1/responses", svc.base_url))
-                .json(&json!({
-                    "model": MODEL,
-                    "input": [],
-                    "max_tokens": 10,
-                    "stream": stream
-                }))
-                .send()
-                .await
-                .unwrap();
-            assert_openai_400(response, "messages").await;
-        }
-        for stream in [false, true] {
-            let response = svc
-                .client
-                .post(format!("{}/v1/responses", svc.base_url))
-                .json(&json!({
+        for (body, message) in [
+            (
+                json!({"model": MODEL, "input": [], "max_tokens": 10}),
+                "messages",
+            ),
+            (
+                json!({
                     "model": MODEL,
                     "input": "ping",
-                    "stream": stream,
                     "tools": [],
                     "tool_choice": "required"
-                }))
-                .send()
-                .await
-                .unwrap();
-            assert_openai_400(response, "tool_choice is \"required\"").await;
-        }
-        for field in [json!({"temperature": 3.0}), json!({"top_p": 2.0})] {
-            for stream in [false, true] {
-                let mut body = json!({"model": MODEL, "input": "ping", "stream": stream});
-                body.as_object_mut()
-                    .unwrap()
-                    .extend(field.as_object().unwrap().clone());
-                let response = svc
-                    .client
-                    .post(format!("{}/v1/responses", svc.base_url))
-                    .json(&body)
-                    .send()
-                    .await
-                    .unwrap();
-                assert_openai_400(response, "must be").await;
-            }
+                }),
+                "tool_choice is \"required\"",
+            ),
+        ] {
+            let response = post_json(&svc, "/v1/responses", body).await;
+            assert_openai_error(response, ExpectedError::Validation, message).await;
         }
 
-        for stream in [false, true] {
-            let response = svc
-                .client
-                .post(format!("{}/v1/messages", svc.base_url))
-                .header("x-api-key", "dummy")
-                .header("anthropic-version", "2023-06-01")
-                .json(&json!({
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn anthropic_content_validation_applies_to_messages_and_count_tokens() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+
+        for (path, body, expected, message) in [
+            (
+                "/v1/messages",
+                json!({
                     "model": MODEL,
                     "max_tokens": 10,
-                    "stream": stream,
+                    "stream": true,
                     "messages": [{"role": "user", "content": ["hello"]}]
-                }))
-                .send()
-                .await
-                .unwrap();
-            assert_anthropic_400(response, "content blocks must be objects").await;
-        }
-        for stream in [false, true] {
-            let response = svc
-                .client
-                .post(format!("{}/v1/messages", svc.base_url))
-                .header("x-api-key", "dummy")
-                .header("anthropic-version", "2023-06-01")
-                .json(&json!({
+                }),
+                ExpectedError::Validation,
+                "content blocks must be objects",
+            ),
+            (
+                "/v1/messages",
+                json!({
                     "model": MODEL,
                     "max_tokens": 10,
-                    "stream": stream,
                     "messages": [{"role": "user", "content": []}]
-                }))
-                .send()
-                .await
-                .unwrap();
-            assert_anthropic_400(response, "must contain at least one content block").await;
-        }
-        for field in [json!({"temperature": 3.0}), json!({"top_p": 2.0})] {
-            for stream in [false, true] {
-                let mut body = json!({
+                }),
+                ExpectedError::Validation,
+                "must contain at least one content block",
+            ),
+            (
+                "/v1/messages/count_tokens",
+                json!({
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": ["hello"]}]
+                }),
+                ExpectedError::Validation,
+                "content blocks must be objects",
+            ),
+            (
+                "/v1/messages",
+                json!({
                     "model": MODEL,
                     "max_tokens": 16,
-                    "stream": stream,
-                    "messages": [{"role": "user", "content": "ping"}]
-                });
-                body.as_object_mut()
-                    .unwrap()
-                    .extend(field.as_object().unwrap().clone());
-                let response = svc
-                    .client
-                    .post(format!("{}/v1/messages", svc.base_url))
-                    .json(&body)
-                    .send()
-                    .await
-                    .unwrap();
-                assert_anthropic_400(response, "must be").await;
-            }
-        }
-
-        let response = svc
-            .client
-            .post(format!("{}/v1/messages/count_tokens", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "messages": [{"role": "user", "content": ["hello"]}]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_anthropic_400(response, "content blocks must be objects").await;
-
-        for endpoint in [Endpoint::Responses, Endpoint::AnthropicMessages] {
-            for request_type in [RequestType::Unary, RequestType::Stream] {
-                assert_eq!(
-                    svc.metrics.get_request_counter(
-                        MODEL,
-                        &endpoint,
-                        &request_type,
-                        &Status::Error,
-                        &ErrorType::Validation,
-                    ),
-                    4,
-                    "validation errors were not metered for {endpoint}/{request_type}"
-                );
-                assert_eq!(
-                    svc.metrics.get_request_counter(
-                        MODEL,
-                        &endpoint,
-                        &request_type,
-                        &Status::Error,
-                        &ErrorType::Internal,
-                    ),
-                    0,
-                    "validation errors were misclassified for {endpoint}/{request_type}"
-                );
-            }
-        }
-
-        for stream in [false, true] {
-            let response = svc
-                .client
-                .post(format!("{}/v1/messages", svc.base_url))
-                .json(&json!({
-                    "model": MODEL,
-                    "max_tokens": 16,
-                    "stream": stream,
                     "messages": [{
                         "role": "user",
                         "content": [
@@ -412,149 +431,75 @@ async fn protocol_adapter_errors_are_returned_before_streaming_headers() {
                             {"type": "text", "text": "ping"}
                         ]
                     }]
-                }))
-                .send()
-                .await
-                .unwrap();
-            assert_anthropic_501(response, "content block type \"future_block_type\"").await;
+                }),
+                ExpectedError::NotImplemented,
+                "content block type \"future_block_type\"",
+            ),
+            (
+                "/v1/messages/count_tokens",
+                json!({
+                    "model": MODEL,
+                    "messages": [{
+                        "role": "user",
+                        "content": [{"type": "future_block_type", "value": 1}]
+                    }]
+                }),
+                ExpectedError::NotImplemented,
+                "content block type \"future_block_type\"",
+            ),
+        ] {
+            let response = post_json(&svc, path, body).await;
+            assert_anthropic_error(response, expected, message).await;
         }
 
-        let response = svc
-            .client
-            .post(format!("{}/v1/messages/count_tokens", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "messages": [{
-                    "role": "user",
-                    "content": [{"type": "future_block_type", "value": 1}]
-                }]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_anthropic_501(response, "content block type \"future_block_type\"").await;
-
         for request_type in [RequestType::Unary, RequestType::Stream] {
-            assert_eq!(
-                svc.metrics.get_request_counter(
-                    MODEL,
-                    &Endpoint::AnthropicMessages,
-                    &request_type,
-                    &Status::Error,
-                    &ErrorType::NotImplemented,
-                ),
-                1,
-                "unsupported content blocks were not metered for {request_type}"
+            let not_implemented = match &request_type {
+                RequestType::Unary => 1,
+                RequestType::Stream => 0,
+            };
+            assert_error_metrics(
+                &svc,
+                &Endpoint::AnthropicMessages,
+                &request_type,
+                &[
+                    (ErrorType::Validation, 1),
+                    (ErrorType::NotImplemented, not_implemented),
+                    (ErrorType::Internal, 0),
+                ],
             );
         }
 
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn tool_name_limit_is_shared_across_protocols() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let valid_script = load_agent_fixture("text.sse").await.unwrap();
+        let svc =
+            HarnessService::start([valid_script.clone(), valid_script.clone(), valid_script]).await;
+
         let max_length_tool_name = "a".repeat(128);
-        let response = svc
-            .client
-            .post(format!("{}/v1/messages", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "max_tokens": 16,
-                "messages": [{"role": "user", "content": "ping"}],
-                "tools": [{
-                    "name": max_length_tool_name.clone(),
-                    "input_schema": {"type": "object", "properties": {}}
-                }]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(response.status(), reqwest::StatusCode::OK);
-
-        let response = svc
-            .client
-            .post(format!("{}/v1/responses", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "input": "ping",
-                "tools": [{
-                    "type": "function",
-                    "name": max_length_tool_name.clone(),
-                    "parameters": {"type": "object", "properties": {}}
-                }]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(response.status(), reqwest::StatusCode::OK);
-
-        let response = svc
-            .client
-            .post(format!("{}/v1/chat/completions", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "messages": [{"role": "user", "content": "ping"}],
-                "tools": [{
-                    "type": "function",
-                    "function": {
-                        "name": max_length_tool_name,
-                        "parameters": {"type": "object", "properties": {}}
-                    }
-                }]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        for (path, body, _) in tool_name_requests(&max_length_tool_name) {
+            let response = post_json(&svc, path, body).await;
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+        }
 
         let too_long_tool_name = "a".repeat(129);
-        let response = svc
-            .client
-            .post(format!("{}/v1/messages", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "max_tokens": 16,
-                "messages": [{"role": "user", "content": "ping"}],
-                "tools": [{
-                    "name": too_long_tool_name.clone(),
-                    "input_schema": {"type": "object", "properties": {}}
-                }]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_anthropic_400(response, "128 character limit").await;
-
-        let response = svc
-            .client
-            .post(format!("{}/v1/responses", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "input": "ping",
-                "tools": [{
-                    "type": "function",
-                    "name": too_long_tool_name.clone(),
-                    "parameters": {"type": "object", "properties": {}}
-                }]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_openai_400(response, "128 character limit").await;
-
-        let response = svc
-            .client
-            .post(format!("{}/v1/chat/completions", svc.base_url))
-            .json(&json!({
-                "model": MODEL,
-                "messages": [{"role": "user", "content": "ping"}],
-                "tools": [{
-                    "type": "function",
-                    "function": {
-                        "name": too_long_tool_name,
-                        "parameters": {"type": "object", "properties": {}}
-                    }
-                }]
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_openai_400(response, "128 character limit").await;
+        for (path, body, anthropic) in tool_name_requests(&too_long_tool_name) {
+            let response = post_json(&svc, path, body).await;
+            if anthropic {
+                assert_anthropic_error(response, ExpectedError::Validation, "128 character limit")
+                    .await;
+            } else {
+                assert_openai_error(response, ExpectedError::Validation, "128 character limit")
+                    .await;
+            }
+        }
 
         assert_eq!(svc.engine.take_requests().await.len(), 3);
         svc.shutdown().await;


### PR DESCRIPTION
## Stack

Independent — base: `main`

This PR is not part of the #12808 → #12810 stack.

## Summary

- Validate Responses and Anthropic requests after conversion to the shared Chat request.
- Reject empty converted message lists and existing shared Chat sampling validation failures.
- Reject malformed Anthropic content blocks with 400 and unsupported unknown object blocks with 501.
- Represent conversion and validation failures as typed invalid arguments.

## Fixed regressions

| Endpoint | Invalid request | Unary | Streaming |
|---|---|---:|---:|
| `/v1/responses` | `input: []` | 400 | 400 before SSE headers |
| `/v1/messages` | `content: ["hello"]` | 400 | 400 before SSE headers |
| Both adapters | Out-of-range `temperature` or `top_p` | 400 | 400 before SSE headers |

Unknown Anthropic object content blocks are rejected explicitly with 501 rather than silently discarded.

## Before/after validation matrix

The same 50 malformed or invalid HTTP requests were run against latest `main` at `c6985b44fd` and this PR worktree, including the 1,048,576 output-token ceiling. Intentional 501 responses represent unsupported features rather than internal errors.

| Endpoint | Cases | `main` | After this PR |
|---|---:|---|---|
| `/v1/chat/completions` | 13 | 10×400, 1×415, 2×500 | 12×400, 1×415 |
| `/v1/completions` | 7 | 5×400, 2×404 | 7×400 |
| `/v1/responses` | 12 | 1×400, 5×500, 6×501 | 10×400, 2×501 |
| `/v1/messages` | 13 | 4×400, 9×500 | 11×400, 2×501 |
| `/v1/messages/count_tokens` | 5 | 4×200, 1×400 | 4×400, 1×501 |
| **Total** | **50** | **4×200, 21×400, 2×404, 1×415, 16×500, 6×501** | **44×400, 1×415, 5×501** |

On `main`, 16 invalid requests reached the zero-response mock backend and consequently returned 500; the exact downstream status is backend-dependent. After this PR, none of the invalid requests reached the backend. The two `/v1/completions` 404s on `main` similarly show that the oversized requests passed frontend validation and reached model lookup.

<details>
<summary>Changed behavior</summary>

| Cases | `main` | After this PR |
|---|---|---|
| Chat `max_tokens: 1_048_577`, unary | 500; backend dispatched | 400; ceiling error |
| Chat `max_completion_tokens: 1_048_577`, streaming | 500; backend dispatched | 400 before streaming headers |
| Completions `max_tokens: 1_048_577`, unary/streaming | Passed validation; reached model lookup and returned 404 in the harness | 400; ceiling error |
| Chat function name length 129 | 400 citing the 96-character limit | 400 citing the shared 128-character limit |
| Responses empty input | 500; backend dispatched | 400; messages cannot be empty |
| Responses `max_output_tokens: 0` | 500; backend dispatched | 400; must be greater than zero |
| Responses `max_output_tokens: 1_048_577`, unary/streaming | 500; backend dispatched | 400; ceiling error |
| Responses image without a source | 501 unsupported | 400; requires `file_id` or `image_url` |
| Responses blank image `file_id` | 501 unsupported | 400; `file_id` must be non-empty |
| Responses file with multiple sources | 501 unsupported | 400; exactly one source required |
| Responses malformed file URL | 501 unsupported | 400 with URL parse cause |
| Responses required tool choice with no tools | 500; backend dispatched | 400; tools are empty |
| Messages empty content array | 500; backend dispatched | Indexed 400 |
| Messages primitive content block | 500; backend dispatched | Indexed 400 |
| Messages content block missing `type` | 500; backend dispatched | Indexed 400 |
| Messages unknown content block | 500; silently passed conversion and dispatched | Indexed 501 unsupported |
| Messages client tool missing `input_schema` | 500; backend dispatched | Indexed 400 |
| Messages server tool | 500; silently dropped and dispatched | Indexed 501 unsupported |
| Messages `max_tokens: 1_048_577`, unary/streaming | 500; backend dispatched | 400; ceiling error |
| Messages function name length 129 | 500; backend dispatched | 400 citing the 128-character limit |
| Count Tokens empty messages | 200, `input_tokens: 0` | 400 |
| Count Tokens empty content array | 200, `input_tokens: 1` | Indexed 400 |
| Count Tokens primitive content block | 200, `input_tokens: 1` | Indexed 400 |
| Count Tokens unknown content block | 200, `input_tokens: 14` | Indexed 501 unsupported |

</details>

## Validation

- Exact protocol HTTP regression: 1 passed, covering 13 request/control assertions
- `cargo check -p dynamo-llm`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

## Tracking

- [DYN-3788](https://linear.app/nvidia/issue/DYN-3788)
- [DYN-3789](https://linear.app/nvidia/issue/DYN-3789)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for OpenAI and Anthropic requests, including empty messages, invalid content blocks, metadata, and oversized tool names.
  * Invalid requests now return clearer validation errors instead of proceeding to generation.
  * Anthropic requests with empty stop-sequence lists are handled correctly without adding unnecessary stop configuration.
  * Unknown, object-shaped Anthropic content blocks return 501 instead of being silently discarded.

* **Reliability**
  * Request and validation metrics now more accurately reflect processing outcomes across streaming and non-streaming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->