### PR TITLE
fix(frontend): unify streamed HTTP error handling

### DIFF
--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -62,6 +62,17 @@ The Rust HTTP server also reads these environment variables, which are not expos
   Unset, `0`, invalid, or unrepresentable values disable keep-alive comments.
 </ParamField>
 
+<ParamField path="DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS" type="integer" default="unset">
+  Maximum time in milliseconds that the Frontend waits before committing streaming HTTP response
+  headers while inspecting the first non-annotation backend frame for an error. A positive value
+  enables the peek for Chat Completions, Completions, Responses, and Anthropic Messages streaming
+  requests. Unset, `0`, or invalid values disable it.
+
+  The Frontend reads the value for each streaming request, so changes apply without a restart.
+  Enabling the peek can delay response headers by up to the configured duration, but it stops
+  waiting as soon as the first non-annotation frame arrives.
+</ParamField>
+
 ## Router
 
 This section is the canonical CLI and environment-variable reference for the frontend's embedded

--- a/lib/bindings/python/rust/llm/frontend_routes.rs
+++ b/lib/bindings/python/rust/llm/frontend_routes.rs
@@ -241,7 +241,7 @@ async fn call_python_frontend_route(
     if extension_executor().try_send(job).is_err() {
         tracing::warn!("frontend extension pool saturated; shedding request");
         return extension_error_response(
-            dynamo_llm::http::service::error::SanitizedError::Overloaded.status(),
+            dynamo_llm::http::service::error::overload_status_code(),
             "frontend route extension busy",
         );
     }

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -30,7 +30,9 @@ use tracing::Instrument;
 
 use super::{
     RouteDoc,
-    disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
+    disconnect::{
+        ConnectionHandle, create_connection_monitor, monitor_for_disconnects_with_rendered_errors,
+    },
     metrics::{
         CancellationLabels, Endpoint, ErrorType, InflightGuard,
         process_chat_response_and_observe_metrics as process_response_and_observe_metrics,
@@ -57,7 +59,7 @@ use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 
 // Re-use helpers from the openai module (sibling under service/)
-use super::error::{SanitizedError, invalid_argument};
+use super::error::{ClassifiedHttpError, HttpErrorKind, invalid_argument};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
 use super::openai::{get_body_limit, get_or_create_request_id};
 
@@ -330,10 +332,11 @@ async fn handler_anthropic_messages(
     )
     .await
     .map_err(|e| {
-        anthropic_sanitized_error_with_details(
-            SanitizedError::Internal,
+        anthropic_problem(ClassifiedHttpError::internal(
+            "Internal server error",
             format!("Failed to await Anthropic messages task: {e:?}"),
-        )
+        ))
+        .0
     })?;
 
     connection_handle.disarm();
@@ -351,7 +354,6 @@ async fn anthropic_messages(
     mut inflight_guard: InflightGuard,
 ) -> Result<Response, Response> {
     let streaming = request.stream;
-    let request_id = request.id().to_string();
 
     // Apply template defaults before capturing model (must happen first so
     // engine lookup and metrics use the resolved model name).
@@ -413,7 +415,6 @@ async fn anthropic_messages(
                 )
             }
         })?;
-
     let (orig_request, context) = request.into_parts();
     let model_for_resp = orig_request.model.clone();
 
@@ -436,16 +437,8 @@ async fn anthropic_messages(
     // Convert Anthropic request -> UnifiedRequest -> Chat Completion request
     let unified_request: UnifiedRequest = orig_request.try_into().map_err(|e: anyhow::Error| {
         inflight_guard.mark_error(ErrorType::Validation);
-        tracing::error!(
-            request_id,
-            error = %e,
-            "Failed to convert AnthropicCreateMessageRequest to UnifiedRequest",
-        );
-        anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            &format!("Failed to convert request: {}", e),
-        )
+        let error = invalid_argument(format!("Failed to convert request: {e}"));
+        anthropic_error_from_anyhow(error.into(), "Failed to convert Anthropic request").0
     })?;
 
     // Extract the API context before consuming the UnifiedRequest — this
@@ -517,40 +510,11 @@ async fn anthropic_messages(
             state
                 .metrics_clone()
                 .inc_rejection(&model, super::metrics::Endpoint::AnthropicMessages);
-            inflight_guard.mark_error(super::metrics::ErrorType::Overload);
-            return anthropic_sanitized_error_with_details(
-                SanitizedError::Overloaded,
-                format!("{e:#}"),
-            );
         }
-        if super::metrics::request_was_unavailable(e.as_ref()) {
-            inflight_guard.mark_error(super::metrics::ErrorType::Unavailable);
-            return anthropic_sanitized_error_with_details(
-                SanitizedError::Unavailable,
-                format!("{e:#}"),
-            );
-        }
-        if let Some(dynamo_err) = find_invalid_argument_in_chain(e.as_ref()) {
-            inflight_guard.mark_error(super::metrics::ErrorType::Validation);
-            return anthropic_error(
-                StatusCode::BAD_REQUEST,
-                "invalid_request_error",
-                dynamo_err.message(),
-            );
-        }
-        // Check for cancelled request (client disconnected before response was sent)
-        if super::metrics::request_was_cancelled(e.as_ref()) {
-            inflight_guard.mark_error(super::metrics::ErrorType::Cancelled);
-            return anthropic_sanitized_error_with_details(
-                SanitizedError::Cancelled,
-                format!("{e:#}"),
-            );
-        }
-        inflight_guard.mark_error(super::metrics::ErrorType::Internal);
-        anthropic_sanitized_error_with_details(
-            SanitizedError::Internal,
-            format!("Failed to generate Anthropic completions: {e}"),
-        )
+        let (response, error_type) =
+            anthropic_error_from_anyhow(e, "Failed to generate Anthropic completions");
+        inflight_guard.mark_error(error_type);
+        response
     })?;
 
     let ctx = engine_stream.context();
@@ -576,6 +540,16 @@ async fn anthropic_messages(
     > = Box::pin(engine_stream);
 
     if streaming {
+        let engine_stream = match super::openai::pre_commit_error_peek_timeout() {
+            Some(duration) => super::openai::check_for_backend_error(engine_stream, Some(duration))
+                .await
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    anthropic_problem(problem).0
+                })?,
+            None => engine_stream,
+        };
+
         stream_handle.arm();
 
         let mut converter = match anthropic_ctx {
@@ -598,7 +572,6 @@ async fn anthropic_messages(
                 yield event.map_err(axum::Error::new);
             }
 
-            let mut saw_error = false;
             let mut cancelled = false;
 
             // Keep a single cancellation future alive across chunks — recreating
@@ -621,10 +594,22 @@ async fn anthropic_messages(
                             &mut http_queue_guard,
                         );
 
-                        let Some(stream_resp) = annotated_chunk.data else {
-                            if annotated_chunk.event.as_deref() == Some("error") {
-                                saw_error = true;
+                        if let Some(problem) = ClassifiedHttpError::from_annotated(&annotated_chunk) {
+                            converter.append_error_events(
+                                anthropic_problem_body(&problem),
+                                &mut events,
+                            );
+                            for event in events.drain(..) {
+                                yield event.map_err(axum::Error::new);
                             }
+                            // The native error event is terminal. Return the
+                            // classification to the monitor for metrics without
+                            // waiting for the backend transport to close.
+                            yield Err(axum::Error::new(problem));
+                            return;
+                        }
+
+                        let Some(stream_resp) = annotated_chunk.data else {
                             continue;
                         };
 
@@ -644,11 +629,7 @@ async fn anthropic_messages(
                 }
             }
 
-            if saw_error {
-                converter.append_error_events(&mut events);
-            } else {
-                converter.append_end_events(&mut events);
-            }
+            converter.append_end_events(&mut events);
             for event in events.drain(..) {
                 yield event.map_err(axum::Error::new);
             }
@@ -662,7 +643,12 @@ async fn anthropic_messages(
             }
         };
 
-        let stream = monitor_for_disconnects(full_stream, ctx, inflight_guard, stream_handle);
+        let stream = monitor_for_disconnects_with_rendered_errors(
+            full_stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+        );
 
         let mut sse_stream = Sse::new(stream);
         if let Some(keep_alive) = state.sse_keep_alive() {
@@ -672,38 +658,8 @@ async fn anthropic_messages(
         Ok(sse_stream.into_response())
     } else {
         // Non-streaming path: aggregate stream into single response
-
-        // Check first event for backend errors using the openai helper
-        let stream_with_check = super::openai::check_for_backend_error(engine_stream, None)
-            .await
-            .map_err(|(status, _json_err)| {
-                // check_for_backend_error has already sanitized the body and
-                // logged the backend detail; preserve its status when
-                // re-wrapping in Anthropic format. Status classification is
-                // delegated to SanitizedError::for_backend_status so the
-                // openai and anthropic surfaces stay aligned.
-                let details = format!("backend error event (status {})", status.as_u16());
-                match SanitizedError::for_backend_status(status) {
-                    Some(variant) => anthropic_sanitized_error_with_details(variant, details),
-                    // 4xx (non-499): preserve the client-error status; the
-                    // message is the canonical reason so we don't smuggle
-                    // backend text through. The "invalid_request_error"
-                    // argument is a fallback — anthropic_error remaps
-                    // 401/403/404/429 to their spec-correct types from the
-                    // status code itself.
-                    None => {
-                        tracing::error!(%status, "Anthropic backend error event");
-                        anthropic_error(
-                            status,
-                            "invalid_request_error",
-                            status.canonical_reason().unwrap_or("Client error"),
-                        )
-                    }
-                }
-            })?;
-
         let mut http_queue_guard = Some(http_queue_guard);
-        let stream = stream_with_check.inspect(move |response| {
+        let stream = engine_stream.inspect(move |response| {
             process_response_and_observe_metrics(
                 response,
                 &mut response_collector,
@@ -715,10 +671,10 @@ async fn anthropic_messages(
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
                 .map_err(|e| {
-                    anthropic_sanitized_error_with_details(
-                        SanitizedError::Internal,
-                        format!("Failed to fold messages stream: {e:?}"),
-                    )
+                    let (response, error_type) =
+                        anthropic_error_from_anyhow(e.into(), "Failed to fold messages stream");
+                    inflight_guard.mark_error(error_type);
+                    response
                 })?;
 
         let response = chat_completion_to_anthropic_response(
@@ -1024,82 +980,67 @@ fn apply_anthropic_header_routing_overrides(
     }
 }
 
-/// Build an Anthropic-formatted error response from a canonical
-/// [`SanitizedError`] variant. The status, public message, and Anthropic
-/// `error_type` all come from the variant; `details` are logged
-/// server-side but never reach the client.
-fn anthropic_sanitized_error_with_details(
-    err: SanitizedError,
-    details: impl std::fmt::Display,
-) -> Response {
-    let status = err.status();
-    if err.log_as_error() {
-        tracing::error!(status = %status, "Anthropic {err}: {details}");
-    } else {
-        tracing::debug!(status = %status, "Anthropic {err}: {details}");
-    }
+fn anthropic_error_from_anyhow(
+    err: anyhow::Error,
+    fallback: &str,
+) -> (Response, super::metrics::ErrorType) {
+    anthropic_problem(ClassifiedHttpError::from_error(err.as_ref(), fallback))
+}
+
+fn anthropic_problem(problem: ClassifiedHttpError) -> (Response, super::metrics::ErrorType) {
+    let metric_type = problem.metric_type();
+    let body = anthropic_problem_body(&problem);
     (
-        status,
-        Json(AnthropicErrorResponse {
-            object_type: "error".to_string(),
-            error: AnthropicErrorBody {
-                error_type: anthropic_sanitized_error_type(err).to_string(),
-                message: err.to_string(),
-            },
-        }),
+        (
+            problem.status(),
+            Json(AnthropicErrorResponse {
+                object_type: "error".to_string(),
+                error: body,
+            }),
+        )
+            .into_response(),
+        metric_type,
     )
-        .into_response()
 }
 
-fn anthropic_sanitized_error_type(error: SanitizedError) -> &'static str {
-    match error {
-        SanitizedError::Cancelled => "request_cancelled",
-        SanitizedError::Overloaded | SanitizedError::Unavailable => "overloaded_error",
-        SanitizedError::PreserveServerError(status) if matches!(status.as_u16(), 503 | 529) => {
-            "overloaded_error"
-        }
-        SanitizedError::Internal | SanitizedError::PreserveServerError(_) => "api_error",
+fn anthropic_problem_body(problem: &ClassifiedHttpError) -> AnthropicErrorBody {
+    if problem.status().is_server_error() {
+        tracing::error!(status = %problem.status(), "Anthropic error: {}", problem.diagnostic());
+    } else if problem.status().as_u16() == 499 {
+        tracing::debug!(status = %problem.status(), "Anthropic error: {}", problem.diagnostic());
+    }
+    let error_type = match problem.kind() {
+        HttpErrorKind::Validation => "invalid_request_error",
+        HttpErrorKind::Authentication => "authentication_error",
+        HttpErrorKind::Permission => "permission_error",
+        HttpErrorKind::NotFound => "not_found_error",
+        HttpErrorKind::RateLimit => "rate_limit_error",
+        HttpErrorKind::Cancelled => "request_cancelled",
+        HttpErrorKind::Overloaded | HttpErrorKind::Unavailable => "overloaded_error",
+        HttpErrorKind::NotImplemented | HttpErrorKind::Internal => "api_error",
+    };
+    AnthropicErrorBody {
+        error_type: error_type.to_string(),
+        message: problem.message().to_string(),
     }
 }
 
-/// Match `InvalidArgument` at top-level OR under `Backend()` anywhere in the
-/// error chain. Request validation surfaces `InvalidArgument`, while backends
-/// that reject bad input (e.g. Python `ValueError`/`TypeError` wrapped by
-/// `py_err_to_dynamo`) surface `Backend(InvalidArgument)`; both are client
-/// input errors and warrant an HTTP 400 rather than a generic 500.
-fn find_invalid_argument_in_chain<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a dynamo_runtime::error::DynamoError> {
-    use dynamo_runtime::error::{BackendError, ErrorType};
-
-    let mut current = Some(err);
-    while let Some(error) = current {
-        if let Some(dynamo_error) = error.downcast_ref::<dynamo_runtime::error::DynamoError>()
-            && matches!(
-                dynamo_error.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
-            )
-        {
-            return Some(dynamo_error);
-        }
-        current = error.source();
-    }
-    None
-}
-
-/// Build an Anthropic-formatted error response.
-/// Maps HTTP status codes to Anthropic error types following the Anthropic API spec.
-fn anthropic_error(status: StatusCode, error_type: &str, message: &str) -> Response {
-    let mapped_type = match status.as_u16() {
+fn anthropic_error_type(status: StatusCode, fallback: &str) -> &str {
+    match status.as_u16() {
         400 => "invalid_request_error",
         401 => "authentication_error",
         403 => "permission_error",
         404 => "not_found_error",
         429 => "rate_limit_error",
         503 | 529 => "overloaded_error",
-        // Use the caller-provided type for other codes (e.g. 500 → "api_error")
-        _ => error_type,
-    };
+        _ => fallback,
+    }
+}
+
+/// Build an Anthropic-formatted error response.
+/// Maps HTTP status codes to Anthropic error types following the Anthropic API spec.
+fn anthropic_error(status: StatusCode, error_type: &str, message: &str) -> Response {
+    let mapped_type = anthropic_error_type(status, error_type);
 
     (
         status,
@@ -1195,37 +1136,5 @@ mod tests {
 
         assert_eq!(nvext.backend_instance_id, None);
         assert_eq!(nvext.decode_worker_id, None);
-    }
-
-    #[test]
-    fn anthropic_invalid_argument_is_found_through_error_context() {
-        use dynamo_runtime::error::{DynamoError, ErrorType};
-
-        let error = anyhow::Error::new(
-            DynamoError::builder()
-                .error_type(ErrorType::InvalidArgument)
-                .message("invalid request")
-                .build(),
-        )
-        .context("request validation failed");
-
-        assert_eq!(
-            find_invalid_argument_in_chain(error.as_ref()).map(|error| error.message()),
-            Some("invalid request")
-        );
-    }
-
-    #[test]
-    fn sanitized_server_statuses_keep_anthropic_error_types() {
-        for (status, expected) in [
-            (StatusCode::SERVICE_UNAVAILABLE, "overloaded_error"),
-            (StatusCode::from_u16(529).unwrap(), "overloaded_error"),
-            (StatusCode::INTERNAL_SERVER_ERROR, "api_error"),
-        ] {
-            assert_eq!(
-                anthropic_sanitized_error_type(SanitizedError::PreserveServerError(status)),
-                expected
-            );
-        }
     }
 }

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -30,7 +30,9 @@ use tracing::Instrument;
 
 use super::{
     RouteDoc,
-    disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
+    disconnect::{
+        ConnectionHandle, create_connection_monitor, monitor_for_disconnects_with_rendered_errors,
+    },
     metrics::{
         CancellationLabels, Endpoint, ErrorType, InflightGuard,
         process_chat_response_and_observe_metrics as process_response_and_observe_metrics,
@@ -56,7 +58,7 @@ use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 
 // Re-use helpers from the openai module (sibling under service/)
-use super::error::{SanitizedError, invalid_argument};
+use super::error::{HttpProblem, HttpProblemKind, invalid_argument};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
 use super::openai::{get_body_limit, get_or_create_request_id};
 
@@ -242,10 +244,11 @@ async fn handler_anthropic_messages(
     )
     .await
     .map_err(|e| {
-        anthropic_sanitized_error_with_details(
-            SanitizedError::Internal,
+        anthropic_problem(HttpProblem::internal(
+            "Internal server error",
             format!("Failed to await Anthropic messages task: {e:?}"),
-        )
+        ))
+        .0
     })?;
 
     connection_handle.disarm();
@@ -263,7 +266,6 @@ async fn anthropic_messages(
     mut inflight_guard: InflightGuard,
 ) -> Result<Response, Response> {
     let streaming = request.stream;
-    let request_id = request.id().to_string();
 
     // Apply template defaults before capturing model (must happen first so
     // engine lookup and metrics use the resolved model name).
@@ -298,34 +300,6 @@ async fn anthropic_messages(
 
     tracing::trace!("Received Anthropic messages request: {:?}", &*request);
 
-    // Look up engine and parsing options early so we know whether a reasoning
-    // parser is configured before converting the request.
-    let (engine, parsing_options) = state
-        .manager()
-        .get_chat_completions_engine_with_parsing(&model)
-        .map_err(|e| match e {
-            // Registered but not ready to serve yet → retryable 503 (mapped to
-            // "overloaded_error" by `anthropic_error`). Reuses the OpenAI path's
-            // canonical, customer-facing message so both APIs report the same
-            // text. Anything else is a genuine missing model → 404.
-            crate::discovery::ModelManagerError::ModelUnavailable(_) => {
-                inflight_guard.mark_error(ErrorType::Unavailable);
-                anthropic_error(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "overloaded_error",
-                    &super::openai::model_not_ready_message(&model),
-                )
-            }
-            _ => {
-                inflight_guard.mark_error(ErrorType::NotFound);
-                anthropic_error(
-                    StatusCode::NOT_FOUND,
-                    "not_found_error",
-                    &format!("Model '{}' not found", model),
-                )
-            }
-        })?;
-
     let (orig_request, context) = request.into_parts();
     let model_for_resp = orig_request.model.clone();
 
@@ -348,16 +322,8 @@ async fn anthropic_messages(
     // Convert Anthropic request -> UnifiedRequest -> Chat Completion request
     let unified_request: UnifiedRequest = orig_request.try_into().map_err(|e: anyhow::Error| {
         inflight_guard.mark_error(ErrorType::Validation);
-        tracing::error!(
-            request_id,
-            error = %e,
-            "Failed to convert AnthropicCreateMessageRequest to UnifiedRequest",
-        );
-        anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            &format!("Failed to convert request: {}", e),
-        )
+        let error = invalid_argument(format!("Failed to convert request: {e}"));
+        anthropic_error_from_anyhow(error.into(), "Failed to convert Anthropic request").0
     })?;
 
     // Extract the API context before consuming the UnifiedRequest — this
@@ -368,13 +334,36 @@ async fn anthropic_messages(
     apply_anthropic_header_routing_overrides(&mut chat_request, &headers, state.nvext_enabled());
     if let Err(error) = chat_request.validate_with_tool_name_limit(ANTHROPIC_MAX_TOOL_NAME_LENGTH) {
         inflight_guard.mark_error(ErrorType::Validation);
-        let error = invalid_argument(error.to_string());
-        return Err(anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            error.message(),
-        ));
+        return Err(anthropic_error_from_anyhow(
+            invalid_argument(error.to_string()).into(),
+            "Invalid Anthropic request",
+        )
+        .0);
     }
+
+    // Resolve the engine only after the single conversion + validation
+    // pipeline succeeds, so invalid requests do not depend on model state.
+    let (engine, parsing_options) = state
+        .manager()
+        .get_chat_completions_engine_with_parsing(&model)
+        .map_err(|e| match e {
+            crate::discovery::ModelManagerError::ModelUnavailable(_) => {
+                inflight_guard.mark_error(ErrorType::Unavailable);
+                anthropic_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "overloaded_error",
+                    &super::openai::model_not_ready_message(&model),
+                )
+            }
+            _ => {
+                inflight_guard.mark_error(ErrorType::NotFound);
+                anthropic_error(
+                    StatusCode::NOT_FOUND,
+                    "not_found_error",
+                    &format!("Model '{}' not found", model),
+                )
+            }
+        })?;
     // When a reasoning parser is configured and the client hasn't explicitly
     // disabled thinking, assume the model's chat template will inject `<think>`.
     //
@@ -429,40 +418,11 @@ async fn anthropic_messages(
             state
                 .metrics_clone()
                 .inc_rejection(&model, super::metrics::Endpoint::AnthropicMessages);
-            inflight_guard.mark_error(super::metrics::ErrorType::Overload);
-            return anthropic_sanitized_error_with_details(
-                SanitizedError::Overloaded,
-                format!("{e:#}"),
-            );
         }
-        if super::metrics::request_was_unavailable(e.as_ref()) {
-            inflight_guard.mark_error(super::metrics::ErrorType::Unavailable);
-            return anthropic_sanitized_error_with_details(
-                SanitizedError::Unavailable,
-                format!("{e:#}"),
-            );
-        }
-        if let Some(dynamo_err) = find_invalid_argument_in_chain(e.as_ref()) {
-            inflight_guard.mark_error(super::metrics::ErrorType::Validation);
-            return anthropic_error(
-                StatusCode::BAD_REQUEST,
-                "invalid_request_error",
-                dynamo_err.message(),
-            );
-        }
-        // Check for cancelled request (client disconnected before response was sent)
-        if super::metrics::request_was_cancelled(e.as_ref()) {
-            inflight_guard.mark_error(super::metrics::ErrorType::Cancelled);
-            return anthropic_sanitized_error_with_details(
-                SanitizedError::Cancelled,
-                format!("{e:#}"),
-            );
-        }
-        inflight_guard.mark_error(super::metrics::ErrorType::Internal);
-        anthropic_sanitized_error_with_details(
-            SanitizedError::Internal,
-            format!("Failed to generate Anthropic completions: {e}"),
-        )
+        let (response, error_type) =
+            anthropic_error_from_anyhow(e, "Failed to generate Anthropic completions");
+        inflight_guard.mark_error(error_type);
+        response
     })?;
 
     let ctx = engine_stream.context();
@@ -488,6 +448,16 @@ async fn anthropic_messages(
     > = Box::pin(engine_stream);
 
     if streaming {
+        let engine_stream = match super::openai::pre_commit_error_peek_timeout() {
+            Some(duration) => super::openai::check_for_backend_error(engine_stream, Some(duration))
+                .await
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    anthropic_problem(problem).0
+                })?,
+            None => engine_stream,
+        };
+
         stream_handle.arm();
 
         let mut converter = match anthropic_ctx {
@@ -510,7 +480,6 @@ async fn anthropic_messages(
                 yield event.map_err(axum::Error::new);
             }
 
-            let mut saw_error = false;
             let mut cancelled = false;
 
             // Keep a single cancellation future alive across chunks — recreating
@@ -533,10 +502,22 @@ async fn anthropic_messages(
                             &mut http_queue_guard,
                         );
 
-                        let Some(stream_resp) = annotated_chunk.data else {
-                            if annotated_chunk.event.as_deref() == Some("error") {
-                                saw_error = true;
+                        if let Some(problem) = HttpProblem::from_annotated(&annotated_chunk) {
+                            converter.append_error_events(
+                                anthropic_problem_body(&problem),
+                                &mut events,
+                            );
+                            for event in events.drain(..) {
+                                yield event.map_err(axum::Error::new);
                             }
+                            // The native error event is terminal. Return the
+                            // classification to the monitor for metrics without
+                            // waiting for the backend transport to close.
+                            yield Err(axum::Error::new(problem));
+                            return;
+                        }
+
+                        let Some(stream_resp) = annotated_chunk.data else {
                             continue;
                         };
 
@@ -556,11 +537,7 @@ async fn anthropic_messages(
                 }
             }
 
-            if saw_error {
-                converter.append_error_events(&mut events);
-            } else {
-                converter.append_end_events(&mut events);
-            }
+            converter.append_end_events(&mut events);
             for event in events.drain(..) {
                 yield event.map_err(axum::Error::new);
             }
@@ -574,7 +551,12 @@ async fn anthropic_messages(
             }
         };
 
-        let stream = monitor_for_disconnects(full_stream, ctx, inflight_guard, stream_handle);
+        let stream = monitor_for_disconnects_with_rendered_errors(
+            full_stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+        );
 
         let mut sse_stream = Sse::new(stream);
         if let Some(keep_alive) = state.sse_keep_alive() {
@@ -584,38 +566,8 @@ async fn anthropic_messages(
         Ok(sse_stream.into_response())
     } else {
         // Non-streaming path: aggregate stream into single response
-
-        // Check first event for backend errors using the openai helper
-        let stream_with_check = super::openai::check_for_backend_error(engine_stream, None)
-            .await
-            .map_err(|(status, _json_err)| {
-                // check_for_backend_error has already sanitized the body and
-                // logged the backend detail; preserve its status when
-                // re-wrapping in Anthropic format. Status classification is
-                // delegated to SanitizedError::for_backend_status so the
-                // openai and anthropic surfaces stay aligned.
-                let details = format!("backend error event (status {})", status.as_u16());
-                match SanitizedError::for_backend_status(status) {
-                    Some(variant) => anthropic_sanitized_error_with_details(variant, details),
-                    // 4xx (non-499): preserve the client-error status; the
-                    // message is the canonical reason so we don't smuggle
-                    // backend text through. The "invalid_request_error"
-                    // argument is a fallback — anthropic_error remaps
-                    // 401/403/404/429 to their spec-correct types from the
-                    // status code itself.
-                    None => {
-                        tracing::error!(%status, "Anthropic backend error event");
-                        anthropic_error(
-                            status,
-                            "invalid_request_error",
-                            status.canonical_reason().unwrap_or("Client error"),
-                        )
-                    }
-                }
-            })?;
-
         let mut http_queue_guard = Some(http_queue_guard);
-        let stream = stream_with_check.inspect(move |response| {
+        let stream = engine_stream.inspect(move |response| {
             process_response_and_observe_metrics(
                 response,
                 &mut response_collector,
@@ -627,10 +579,10 @@ async fn anthropic_messages(
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
                 .map_err(|e| {
-                    anthropic_sanitized_error_with_details(
-                        SanitizedError::Internal,
-                        format!("Failed to fold messages stream: {e:?}"),
-                    )
+                    let (response, error_type) =
+                        anthropic_error_from_anyhow(e.into(), "Failed to fold messages stream");
+                    inflight_guard.mark_error(error_type);
+                    response
                 })?;
 
         let response = chat_completion_to_anthropic_response(
@@ -934,71 +886,67 @@ fn apply_anthropic_header_routing_overrides(
     }
 }
 
-/// Build an Anthropic-formatted error response from a canonical
-/// [`SanitizedError`] variant. The status, public message, and Anthropic
-/// `error_type` all come from the variant; `details` are logged
-/// server-side but never reach the client.
-fn anthropic_sanitized_error_with_details(
-    err: SanitizedError,
-    details: impl std::fmt::Display,
-) -> Response {
-    let status = err.status();
-    if err.log_as_error() {
-        tracing::error!(status = %status, "Anthropic {err}: {details}");
-    } else {
-        tracing::debug!(status = %status, "Anthropic {err}: {details}");
-    }
+fn anthropic_error_from_anyhow(
+    err: anyhow::Error,
+    fallback: &str,
+) -> (Response, super::metrics::ErrorType) {
+    anthropic_problem(HttpProblem::from_error(err.as_ref(), fallback))
+}
+
+fn anthropic_problem(problem: HttpProblem) -> (Response, super::metrics::ErrorType) {
+    let metric_type = problem.metric_type();
+    let body = anthropic_problem_body(&problem);
     (
-        status,
-        Json(AnthropicErrorResponse {
-            object_type: "error".to_string(),
-            error: AnthropicErrorBody {
-                error_type: err.anthropic_type().to_string(),
-                message: err.to_string(),
-            },
-        }),
+        (
+            problem.status(),
+            Json(AnthropicErrorResponse {
+                object_type: "error".to_string(),
+                error: body,
+            }),
+        )
+            .into_response(),
+        metric_type,
     )
-        .into_response()
 }
 
-/// Match `InvalidArgument` at top-level OR under `Backend()` anywhere in the
-/// error chain. Request validation surfaces `InvalidArgument`, while backends
-/// that reject bad input (e.g. Python `ValueError`/`TypeError` wrapped by
-/// `py_err_to_dynamo`) surface `Backend(InvalidArgument)`; both are client
-/// input errors and warrant an HTTP 400 rather than a generic 500.
-fn find_invalid_argument_in_chain<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a dynamo_runtime::error::DynamoError> {
-    use dynamo_runtime::error::{BackendError, ErrorType};
-
-    let mut current = Some(err);
-    while let Some(error) = current {
-        if let Some(dynamo_error) = error.downcast_ref::<dynamo_runtime::error::DynamoError>()
-            && matches!(
-                dynamo_error.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
-            )
-        {
-            return Some(dynamo_error);
-        }
-        current = error.source();
+fn anthropic_problem_body(problem: &HttpProblem) -> AnthropicErrorBody {
+    if problem.status().is_server_error() {
+        tracing::error!(status = %problem.status(), "Anthropic error: {}", problem.diagnostic());
+    } else if problem.status().as_u16() == 499 {
+        tracing::debug!(status = %problem.status(), "Anthropic error: {}", problem.diagnostic());
     }
-    None
+    let error_type = match problem.kind() {
+        HttpProblemKind::Validation => "invalid_request_error",
+        HttpProblemKind::Authentication => "authentication_error",
+        HttpProblemKind::Permission => "permission_error",
+        HttpProblemKind::NotFound => "not_found_error",
+        HttpProblemKind::RateLimit => "rate_limit_error",
+        HttpProblemKind::Cancelled => "request_cancelled",
+        HttpProblemKind::Overloaded | HttpProblemKind::Unavailable => "overloaded_error",
+        HttpProblemKind::NotImplemented | HttpProblemKind::Internal => "api_error",
+    };
+    AnthropicErrorBody {
+        error_type: error_type.to_string(),
+        message: problem.message().to_string(),
+    }
 }
 
-/// Build an Anthropic-formatted error response.
-/// Maps HTTP status codes to Anthropic error types following the Anthropic API spec.
-fn anthropic_error(status: StatusCode, error_type: &str, message: &str) -> Response {
-    let mapped_type = match status.as_u16() {
+fn anthropic_error_type(status: StatusCode, fallback: &str) -> &str {
+    match status.as_u16() {
         400 => "invalid_request_error",
         401 => "authentication_error",
         403 => "permission_error",
         404 => "not_found_error",
         429 => "rate_limit_error",
         503 | 529 => "overloaded_error",
-        // Use the caller-provided type for other codes (e.g. 500 → "api_error")
-        _ => error_type,
-    };
+        _ => fallback,
+    }
+}
+
+/// Build an Anthropic-formatted error response.
+/// Maps HTTP status codes to Anthropic error types following the Anthropic API spec.
+fn anthropic_error(status: StatusCode, error_type: &str, message: &str) -> Response {
+    let mapped_type = anthropic_error_type(status, error_type);
 
     (
         status,
@@ -1094,23 +1042,5 @@ mod tests {
 
         assert_eq!(nvext.backend_instance_id, None);
         assert_eq!(nvext.decode_worker_id, None);
-    }
-
-    #[test]
-    fn anthropic_invalid_argument_is_found_through_error_context() {
-        use dynamo_runtime::error::{DynamoError, ErrorType};
-
-        let error = anyhow::Error::new(
-            DynamoError::builder()
-                .error_type(ErrorType::InvalidArgument)
-                .message("invalid request")
-                .build(),
-        )
-        .context("request validation failed");
-
-        assert_eq!(
-            find_invalid_argument_in_chain(error.as_ref()).map(|error| error.message()),
-            Some("invalid request")
-        );
     }
 }

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -31,10 +31,11 @@
 use axum::response::sse::Event;
 use dynamo_runtime::engine::AsyncEngineContext;
 use futures::{Stream, StreamExt};
+use std::error::Error as _;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::http::service::error::SanitizedError;
+use crate::http::service::error::{ClassifiedHttpError, HttpErrorKind};
 use crate::http::service::metrics::{CancellationLabels, ErrorType, InflightGuard, Metrics};
 
 use dynamo_runtime::config::environment_names::llm::DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS as BACKEND_STREAM_TIMEOUT_ENV;
@@ -208,25 +209,63 @@ pub fn monitor_for_disconnects(
     )
 }
 
-fn openai_sanitized_error_type(error: SanitizedError) -> &'static str {
-    match error {
-        SanitizedError::Cancelled => "request_cancelled",
-        SanitizedError::Overloaded | SanitizedError::Unavailable => "service_unavailable",
-        SanitizedError::PreserveServerError(status) if matches!(status.as_u16(), 503 | 529) => {
-            "service_unavailable"
-        }
-        SanitizedError::Internal | SanitizedError::PreserveServerError(_) => {
-            "internal_server_error"
-        }
+/// Monitor a protocol stream that renders its own terminal error event before
+/// returning the classified [`ClassifiedHttpError`]. The monitor still owns metrics and
+/// stream finalization, but does not append an OpenAI error envelope.
+pub fn monitor_for_disconnects_with_rendered_errors(
+    stream: impl Stream<Item = Result<Event, axum::Error>>,
+    context: Arc<dyn AsyncEngineContext>,
+    inflight_guard: InflightGuard,
+    stream_handle: ConnectionHandle,
+) -> impl Stream<Item = Result<Event, axum::Error>> {
+    monitor_for_disconnects_impl(
+        stream,
+        context,
+        inflight_guard,
+        stream_handle,
+        backend_stream_timeout(),
+        false,
+    )
+}
+
+fn openai_stream_error_type(kind: HttpErrorKind) -> &'static str {
+    match kind {
+        HttpErrorKind::Validation => "invalid_request_error",
+        HttpErrorKind::Authentication => "authentication_error",
+        HttpErrorKind::Permission => "permission_error",
+        HttpErrorKind::NotFound => "not_found_error",
+        HttpErrorKind::RateLimit => "rate_limit_error",
+        HttpErrorKind::Cancelled => "request_cancelled",
+        HttpErrorKind::Overloaded | HttpErrorKind::Unavailable => "service_unavailable",
+        HttpErrorKind::NotImplemented => "not_implemented",
+        HttpErrorKind::Internal => "internal_server_error",
     }
 }
 
 fn monitor_for_disconnects_with_timeout(
     stream: impl Stream<Item = Result<Event, axum::Error>>,
     context: Arc<dyn AsyncEngineContext>,
+    inflight_guard: InflightGuard,
+    stream_handle: ConnectionHandle,
+    inactivity_timeout: Option<Duration>,
+) -> impl Stream<Item = Result<Event, axum::Error>> {
+    monitor_for_disconnects_impl(
+        stream,
+        context,
+        inflight_guard,
+        stream_handle,
+        inactivity_timeout,
+        true,
+    )
+}
+
+fn monitor_for_disconnects_impl(
+    stream: impl Stream<Item = Result<Event, axum::Error>>,
+    context: Arc<dyn AsyncEngineContext>,
     mut inflight_guard: InflightGuard,
     mut stream_handle: ConnectionHandle,
     inactivity_timeout: Option<Duration>,
+    render_openai_error: bool,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     stream_handle.arm();
 
@@ -255,27 +294,41 @@ fn monitor_for_disconnects_with_timeout(
                             yield event;
                         }
                         Some(Err(err)) => {
-                            // Mark error as internal since it's a streaming error
-                            inflight_guard.mark_error(ErrorType::Internal);
+                            let problem = err
+                                .source()
+                                .and_then(|source| source.downcast_ref::<ClassifiedHttpError>())
+                                .cloned()
+                                .unwrap_or_else(|| {
+                                    ClassifiedHttpError::internal(
+                                        "Internal server error",
+                                        err.to_string(),
+                                    )
+                                });
+                            inflight_guard.mark_error(problem.metric_type());
                             // We're terminating the stream intentionally here with a
                             // structured error + [DONE]; disarm so the stream handle
                             // doesn't later record this as ClosedUnexpectedly (which
                             // would mis-attribute the fault as a client disconnect).
                             stream_handle.disarm();
-                            tracing::error!("Streaming error: {err}");
-                            // Emit a structured OpenAI-style error frame + `data: [DONE]`
-                            // so naive `data:`-line parsers see both the error and a
-                            // stream terminator. Body derived from SanitizedError so
-                            // the sanitized message + status live in one place.
-                            let sanitized = SanitizedError::Internal;
-                            let err_json = serde_json::json!({
-                                "error": {
-                                    "message": sanitized.to_string(),
-                                    "type": openai_sanitized_error_type(sanitized),
-                                    "code": sanitized.status().as_u16(),
-                                }
-                            });
-                            yield Event::default().data(err_json.to_string());
+                            if problem.status().is_server_error() {
+                                tracing::error!("Streaming error: {}", problem.diagnostic());
+                            } else {
+                                tracing::debug!("Streaming error: {}", problem.diagnostic());
+                            }
+                            if render_openai_error {
+                                // HTTP status is already committed, so carry the
+                                // classification in an OpenAI inline envelope.
+                                let err_json = serde_json::json!({
+                                    "error": {
+                                        "message": problem.message(),
+                                        "type": openai_stream_error_type(problem.kind()),
+                                        "code": problem.status().as_u16(),
+                                    }
+                                });
+                                yield Event::default().data(err_json.to_string());
+                            }
+                            // Preserve the frontend's common SSE terminator after
+                            // either the default or protocol-native error frame.
                             yield Event::default().data("[DONE]");
                             // Break to prevent any subsequent mark_ok() from overwriting the error
                             break;
@@ -344,7 +397,6 @@ fn monitor_for_disconnects_with_timeout(
 mod tests {
     use super::*;
     use crate::http::service::metrics::{Endpoint, ErrorType, RequestType, Status};
-    use axum::http::StatusCode;
     use futures::StreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -727,8 +779,8 @@ mod tests {
             .get("error")
             .and_then(|v| v.as_object())
             .unwrap_or_else(|| panic!("[{case}] `error` field is not an object. Body:\n{text}"));
-        let expected = SanitizedError::Internal;
-        let expected_message = expected.to_string();
+        let expected = ClassifiedHttpError::internal("Internal server error", "test diagnostic");
+        let expected_message = expected.message().to_string();
         assert_eq!(
             error.get("message").and_then(|v| v.as_str()),
             Some(expected_message.as_str()),
@@ -736,7 +788,7 @@ mod tests {
         );
         assert_eq!(
             error.get("type").and_then(|v| v.as_str()),
-            Some(openai_sanitized_error_type(expected)),
+            Some(openai_stream_error_type(expected.kind())),
             "[{case}] structured error `type` mismatch. Body:\n{text}"
         );
         assert_eq!(
@@ -753,20 +805,6 @@ mod tests {
             "[{case}] SSE body leaked raw backend error detail to the client. \
              Expected `{leaked_detail}` to be absent. Body:\n{text}"
         );
-    }
-
-    #[test]
-    fn sanitized_server_statuses_keep_openai_error_types() {
-        for (status, expected) in [
-            (StatusCode::SERVICE_UNAVAILABLE, "service_unavailable"),
-            (StatusCode::from_u16(529).unwrap(), "service_unavailable"),
-            (StatusCode::INTERNAL_SERVER_ERROR, "internal_server_error"),
-        ] {
-            assert_eq!(
-                openai_sanitized_error_type(SanitizedError::PreserveServerError(status)),
-                expected
-            );
-        }
     }
 
     /// Upstream worker killed mid-stream → mpsc channel reports `Disconnected` to the

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -305,6 +305,9 @@ fn monitor_for_disconnects_impl(
                                     )
                                 });
                             inflight_guard.mark_error(problem.metric_type());
+                            // A terminal stream error abandons the source stream, so explicitly
+                            // kill linked backend work instead of relying on ResponseStream::drop().
+                            context.kill();
                             // We're terminating the stream intentionally here with a
                             // structured error + [DONE]; disarm so the stream handle
                             // doesn't later record this as ClosedUnexpectedly (which
@@ -474,7 +477,7 @@ mod tests {
     ) -> (
         Arc<Metrics>,
         InflightGuard,
-        Arc<dyn AsyncEngineContext>,
+        Arc<MockContext>,
         ConnectionHandle,
     ) {
         let metrics = Arc::new(Metrics::new());
@@ -482,7 +485,7 @@ mod tests {
             metrics
                 .clone()
                 .create_inflight_guard(model, Endpoint::ChatCompletions, true, req_id);
-        let context: Arc<dyn AsyncEngineContext> = Arc::new(MockContext::new());
+        let context = Arc::new(MockContext::with_kill_tracking());
         let (tx, _rx) = tokio::sync::oneshot::channel();
         let handle = ConnectionHandle::create_disabled(tx);
         (metrics, guard, context, handle)
@@ -814,9 +817,11 @@ mod tests {
         let (_metrics, guard, ctx, handle) = setup_test("worker-kill-model", "req-wk");
         let backend_detail = "Disconnected: Stream ended before generation completed";
         let stream = simulate_mid_stream_error(3, backend_detail);
+        let backend_ctx = ctx.clone();
         let monitored = monitor_for_disconnects_with_timeout(stream, ctx, guard, handle, None);
         let body = collect_sse_body(monitored).await;
         assert_fault_contract("worker_kill", &body, backend_detail);
+        assert!(backend_ctx.is_killed());
     }
 
     /// Python chat-processor raises mid-stream → Rust→Python `tx.send()` fails with

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -31,10 +31,11 @@
 use axum::response::sse::Event;
 use dynamo_runtime::engine::AsyncEngineContext;
 use futures::{Stream, StreamExt};
+use std::error::Error as _;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::http::service::error::SanitizedError;
+use crate::http::service::error::{HttpProblem, HttpProblemKind};
 use crate::http::service::metrics::{CancellationLabels, ErrorType, InflightGuard, Metrics};
 
 use dynamo_runtime::config::environment_names::llm::DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS as BACKEND_STREAM_TIMEOUT_ENV;
@@ -208,12 +209,63 @@ pub fn monitor_for_disconnects(
     )
 }
 
+/// Monitor a protocol stream that renders its own terminal error event before
+/// returning the classified [`HttpProblem`]. The monitor still owns metrics and
+/// stream finalization, but does not append an OpenAI error envelope.
+pub fn monitor_for_disconnects_with_rendered_errors(
+    stream: impl Stream<Item = Result<Event, axum::Error>>,
+    context: Arc<dyn AsyncEngineContext>,
+    inflight_guard: InflightGuard,
+    stream_handle: ConnectionHandle,
+) -> impl Stream<Item = Result<Event, axum::Error>> {
+    monitor_for_disconnects_impl(
+        stream,
+        context,
+        inflight_guard,
+        stream_handle,
+        backend_stream_timeout(),
+        false,
+    )
+}
+
+fn openai_stream_error_type(kind: HttpProblemKind) -> &'static str {
+    match kind {
+        HttpProblemKind::Validation => "invalid_request_error",
+        HttpProblemKind::Authentication => "authentication_error",
+        HttpProblemKind::Permission => "permission_error",
+        HttpProblemKind::NotFound => "not_found_error",
+        HttpProblemKind::RateLimit => "rate_limit_error",
+        HttpProblemKind::Cancelled => "request_cancelled",
+        HttpProblemKind::Overloaded | HttpProblemKind::Unavailable => "service_unavailable",
+        HttpProblemKind::NotImplemented => "not_implemented",
+        HttpProblemKind::Internal => "internal_server_error",
+    }
+}
+
 fn monitor_for_disconnects_with_timeout(
+    stream: impl Stream<Item = Result<Event, axum::Error>>,
+    context: Arc<dyn AsyncEngineContext>,
+    inflight_guard: InflightGuard,
+    stream_handle: ConnectionHandle,
+    inactivity_timeout: Option<Duration>,
+) -> impl Stream<Item = Result<Event, axum::Error>> {
+    monitor_for_disconnects_impl(
+        stream,
+        context,
+        inflight_guard,
+        stream_handle,
+        inactivity_timeout,
+        true,
+    )
+}
+
+fn monitor_for_disconnects_impl(
     stream: impl Stream<Item = Result<Event, axum::Error>>,
     context: Arc<dyn AsyncEngineContext>,
     mut inflight_guard: InflightGuard,
     mut stream_handle: ConnectionHandle,
     inactivity_timeout: Option<Duration>,
+    render_openai_error: bool,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     stream_handle.arm();
 
@@ -242,27 +294,38 @@ fn monitor_for_disconnects_with_timeout(
                             yield event;
                         }
                         Some(Err(err)) => {
-                            // Mark error as internal since it's a streaming error
-                            inflight_guard.mark_error(ErrorType::Internal);
+                            let problem = err
+                                .source()
+                                .and_then(|source| source.downcast_ref::<HttpProblem>())
+                                .cloned()
+                                .unwrap_or_else(|| {
+                                    HttpProblem::internal("Internal server error", err.to_string())
+                                });
+                            inflight_guard.mark_error(problem.metric_type());
                             // We're terminating the stream intentionally here with a
                             // structured error + [DONE]; disarm so the stream handle
                             // doesn't later record this as ClosedUnexpectedly (which
                             // would mis-attribute the fault as a client disconnect).
                             stream_handle.disarm();
-                            tracing::error!("Streaming error: {err}");
-                            // Emit a structured OpenAI-style error frame + `data: [DONE]`
-                            // so naive `data:`-line parsers see both the error and a
-                            // stream terminator. Body derived from SanitizedError so
-                            // the sanitized message + status live in one place.
-                            let sanitized = SanitizedError::Internal;
-                            let err_json = serde_json::json!({
-                                "error": {
-                                    "message": sanitized.to_string(),
-                                    "type": sanitized.openai_type_slug(),
-                                    "code": sanitized.status().as_u16(),
-                                }
-                            });
-                            yield Event::default().data(err_json.to_string());
+                            if problem.status().is_server_error() {
+                                tracing::error!("Streaming error: {}", problem.diagnostic());
+                            } else {
+                                tracing::debug!("Streaming error: {}", problem.diagnostic());
+                            }
+                            if render_openai_error {
+                                // HTTP status is already committed, so carry the
+                                // classification in an OpenAI inline envelope.
+                                let err_json = serde_json::json!({
+                                    "error": {
+                                        "message": problem.message(),
+                                        "type": openai_stream_error_type(problem.kind()),
+                                        "code": problem.status().as_u16(),
+                                    }
+                                });
+                                yield Event::default().data(err_json.to_string());
+                            }
+                            // Preserve the frontend's common SSE terminator after
+                            // either the default or protocol-native error frame.
                             yield Event::default().data("[DONE]");
                             // Break to prevent any subsequent mark_ok() from overwriting the error
                             break;
@@ -713,8 +776,8 @@ mod tests {
             .get("error")
             .and_then(|v| v.as_object())
             .unwrap_or_else(|| panic!("[{case}] `error` field is not an object. Body:\n{text}"));
-        let expected = SanitizedError::Internal;
-        let expected_message = expected.to_string();
+        let expected = HttpProblem::internal("Internal server error", "test diagnostic");
+        let expected_message = expected.message().to_string();
         assert_eq!(
             error.get("message").and_then(|v| v.as_str()),
             Some(expected_message.as_str()),
@@ -722,7 +785,7 @@ mod tests {
         );
         assert_eq!(
             error.get("type").and_then(|v| v.as_str()),
-            Some(expected.openai_type_slug()),
+            Some(openai_stream_error_type(expected.kind())),
             "[{case}] structured error `type` mismatch. Body:\n{text}"
         );
         assert_eq!(

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -32,7 +32,7 @@ fn parse_overload_status_code(value: Option<&str>) -> StatusCode {
 /// Overload / admission-control rejection status. Reads
 /// `DYN_HTTP_OVERLOAD_STATUS_CODE` (default 529) on first use; cached since the
 /// environment is fixed at runtime and this is on the rejection path.
-pub(crate) fn overload_status_code() -> StatusCode {
+pub fn overload_status_code() -> StatusCode {
     static CODE: LazyLock<StatusCode> = LazyLock::new(|| {
         let value = std::env::var(env_llm::DYN_HTTP_OVERLOAD_STATUS_CODE).ok();
         parse_overload_status_code(value.as_deref())

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -56,81 +56,7 @@ pub struct HttpError {
     pub message: String,
 }
 
-/// Compatibility model used by endpoint handlers that have not yet migrated
-/// to the shared classifier. The next PR in the stack removes this once every
-/// HTTP surface uses the shared classifier.
-#[derive(Debug, Clone, Copy)]
-pub enum SanitizedError {
-    Cancelled,
-    Overloaded,
-    Unavailable,
-    Internal,
-    PreserveServerError(StatusCode),
-}
-
-impl SanitizedError {
-    pub fn for_backend_status(status: StatusCode) -> Option<Self> {
-        if status.as_u16() == 499 {
-            Some(Self::Cancelled)
-        } else if status.is_client_error() {
-            None
-        } else if status.is_server_error() {
-            Some(Self::PreserveServerError(status))
-        } else {
-            Some(Self::Internal)
-        }
-    }
-
-    pub fn status(self) -> StatusCode {
-        match self {
-            Self::Cancelled => StatusCode::from_u16(499).expect("499 is a valid status code"),
-            Self::Overloaded => overload_status_code(),
-            Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-            Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::PreserveServerError(code) => code,
-        }
-    }
-
-    pub fn anthropic_type(self) -> &'static str {
-        match self {
-            Self::Cancelled => "request_cancelled",
-            Self::Overloaded | Self::Unavailable => "overloaded_error",
-            Self::PreserveServerError(status) if matches!(status.as_u16(), 503 | 529) => {
-                "overloaded_error"
-            }
-            Self::Internal | Self::PreserveServerError(_) => "api_error",
-        }
-    }
-
-    pub fn openai_type_slug(self) -> &'static str {
-        match self {
-            Self::Cancelled => "request_cancelled",
-            Self::Overloaded | Self::Unavailable => "service_unavailable",
-            Self::PreserveServerError(status) if matches!(status.as_u16(), 503 | 529) => {
-                "service_unavailable"
-            }
-            Self::Internal | Self::PreserveServerError(_) => "internal_server_error",
-        }
-    }
-
-    pub fn log_as_error(self) -> bool {
-        !matches!(self, Self::Cancelled)
-    }
-}
-
-impl std::fmt::Display for SanitizedError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Cancelled => f.write_str("Request cancelled"),
-            Self::Overloaded => f.write_str("Service temporarily overloaded"),
-            Self::Unavailable => f.write_str("Service temporarily unavailable"),
-            Self::Internal | Self::PreserveServerError(_) => f.write_str(INTERNAL_ERROR_MESSAGE),
-        }
-    }
-}
-
 /// Protocol-neutral error categories used for metrics and protocol rendering.
-#[allow(dead_code)] // Used by the endpoint-integration PR later in this stack.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HttpProblemKind {
     Validation,
@@ -151,7 +77,6 @@ pub(crate) enum HttpProblemKind {
 /// diagnostic. Protocol modules only translate this model into their wire
 /// envelope; they do not re-classify errors.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Used by the endpoint-integration PR later in this stack.
 pub(crate) struct HttpProblem {
     kind: HttpProblemKind,
     status: StatusCode,
@@ -162,7 +87,6 @@ pub(crate) struct HttpProblem {
 
 /// Construct a typed invalid-argument error for validation performed at an
 /// HTTP protocol adapter boundary.
-#[allow(dead_code)] // Used by the protocol-validation PR later in this stack.
 pub(crate) fn invalid_argument(message: impl Into<String>) -> DynamoError {
     DynamoError::builder()
         .error_type(DynamoErrorType::InvalidArgument)
@@ -176,7 +100,6 @@ enum ValidationScope {
     Outermost,
 }
 
-#[allow(dead_code)] // Used by the endpoint-integration PR later in this stack.
 impl HttpProblem {
     /// Classify an arbitrary error through the same logical nested-error flow
     /// used by `from_annotated`; generic callers retain chain-wide validation
@@ -540,7 +463,6 @@ fn find_dynamo_error_in_chain<'a>(
     None
 }
 
-#[allow(dead_code)] // Used by the endpoint-integration PR later in this stack.
 fn metric_type_for_kind(kind: HttpProblemKind) -> MetricErrorType {
     match kind {
         HttpProblemKind::Validation
@@ -563,7 +485,6 @@ impl std::fmt::Display for HttpProblem {
 
 impl std::error::Error for HttpProblem {}
 
-#[allow(dead_code)] // Used by the endpoint-integration PR later in this stack.
 fn kind_for_status(status: StatusCode) -> HttpProblemKind {
     match status {
         StatusCode::UNAUTHORIZED => HttpProblemKind::Authentication,
@@ -579,7 +500,6 @@ fn kind_for_status(status: StatusCode) -> HttpProblemKind {
     }
 }
 
-#[allow(dead_code)] // Used by the endpoint-integration PR later in this stack.
 fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
     let mut parts = Vec::new();
     let mut current = Some(err);
@@ -865,48 +785,5 @@ mod tests {
         let problem = HttpProblem::from_annotated(&Annotated::<()>::from_err(unknown)).unwrap();
         assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(problem.message(), INTERNAL_ERROR_MESSAGE);
-    }
-
-    #[test]
-    fn legacy_server_statuses_keep_protocol_error_types() {
-        for (status, anthropic_type, openai_type) in [
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                "overloaded_error",
-                "service_unavailable",
-            ),
-            (
-                StatusCode::from_u16(529).unwrap(),
-                "overloaded_error",
-                "service_unavailable",
-            ),
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "api_error",
-                "internal_server_error",
-            ),
-        ] {
-            let error = SanitizedError::PreserveServerError(status);
-            assert_eq!(error.anthropic_type(), anthropic_type);
-            assert_eq!(error.openai_type_slug(), openai_type);
-        }
-    }
-
-    #[test]
-    fn legacy_backend_status_classification_remains_compatible() {
-        assert!(matches!(
-            SanitizedError::for_backend_status(StatusCode::from_u16(499).unwrap()),
-            Some(SanitizedError::Cancelled)
-        ));
-        assert!(matches!(
-            SanitizedError::for_backend_status(StatusCode::SERVICE_UNAVAILABLE),
-            Some(SanitizedError::PreserveServerError(status))
-                if status == StatusCode::SERVICE_UNAVAILABLE
-        ));
-        assert!(SanitizedError::for_backend_status(StatusCode::BAD_REQUEST).is_none());
-        assert!(matches!(
-            SanitizedError::for_backend_status(StatusCode::from_u16(399).unwrap()),
-            Some(SanitizedError::Internal)
-        ));
     }
 }

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -50,66 +50,7 @@ pub struct HttpError {
     pub message: String,
 }
 
-/// Construct a typed invalid-argument error for validation performed at an
-/// HTTP protocol adapter boundary.
-pub(crate) fn invalid_argument(message: impl Into<String>) -> DynamoError {
-    DynamoError::builder()
-        .error_type(DynamoErrorType::InvalidArgument)
-        .message(message)
-        .build()
-}
-
-/// Sanitized HTTP error categories used by endpoint handlers.
-#[derive(Debug, Clone, Copy)]
-pub enum SanitizedError {
-    Cancelled,
-    Overloaded,
-    Unavailable,
-    Internal,
-    PreserveServerError(StatusCode),
-}
-
-impl SanitizedError {
-    pub fn for_backend_status(status: StatusCode) -> Option<Self> {
-        if status.as_u16() == 499 {
-            Some(Self::Cancelled)
-        } else if status.is_client_error() {
-            None
-        } else if status.is_server_error() {
-            Some(Self::PreserveServerError(status))
-        } else {
-            Some(Self::Internal)
-        }
-    }
-
-    pub fn status(self) -> StatusCode {
-        match self {
-            Self::Cancelled => StatusCode::from_u16(499).expect("499 is a valid status code"),
-            Self::Overloaded => overload_status_code(),
-            Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-            Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::PreserveServerError(code) => code,
-        }
-    }
-
-    pub fn log_as_error(self) -> bool {
-        !matches!(self, Self::Cancelled)
-    }
-}
-
-impl std::fmt::Display for SanitizedError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Cancelled => f.write_str("Request cancelled"),
-            Self::Overloaded => f.write_str("Service temporarily overloaded"),
-            Self::Unavailable => f.write_str("Service temporarily unavailable"),
-            Self::Internal | Self::PreserveServerError(_) => f.write_str(INTERNAL_ERROR_MESSAGE),
-        }
-    }
-}
-
 /// Protocol-neutral error categories used for metrics and protocol rendering.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HttpErrorKind {
     Validation,
@@ -130,7 +71,6 @@ pub(crate) enum HttpErrorKind {
 /// diagnostic. Protocol modules only translate this model into their wire
 /// envelope; they do not re-classify errors.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub(crate) struct ClassifiedHttpError {
     kind: HttpErrorKind,
     status: StatusCode,
@@ -139,13 +79,21 @@ pub(crate) struct ClassifiedHttpError {
     details: Option<Box<Value>>,
 }
 
+/// Construct a typed invalid-argument error for validation performed at an
+/// HTTP protocol adapter boundary.
+pub(crate) fn invalid_argument(message: impl Into<String>) -> DynamoError {
+    DynamoError::builder()
+        .error_type(DynamoErrorType::InvalidArgument)
+        .message(message)
+        .build()
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ValidationScope {
     Chain,
     Outermost,
 }
 
-#[allow(dead_code)]
 impl ClassifiedHttpError {
     /// Classify an arbitrary error through the same logical nested-error flow
     /// used by `from_annotated`; generic callers retain chain-wide validation
@@ -492,7 +440,6 @@ fn find_dynamo_error_in_chain<'a>(
     None
 }
 
-#[allow(dead_code)]
 fn metric_type_for_kind(kind: HttpErrorKind) -> MetricErrorType {
     match kind {
         HttpErrorKind::Validation | HttpErrorKind::Authentication | HttpErrorKind::Permission => {
@@ -515,7 +462,6 @@ impl std::fmt::Display for ClassifiedHttpError {
 
 impl std::error::Error for ClassifiedHttpError {}
 
-#[allow(dead_code)]
 fn kind_for_status(status: StatusCode) -> HttpErrorKind {
     match status {
         StatusCode::UNAUTHORIZED => HttpErrorKind::Authentication,
@@ -531,7 +477,6 @@ fn kind_for_status(status: StatusCode) -> HttpErrorKind {
     }
 }
 
-#[allow(dead_code)]
 fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
     let mut parts = Vec::new();
     let mut current = Some(err);
@@ -857,23 +802,5 @@ mod tests {
             ClassifiedHttpError::from_annotated(&Annotated::<()>::from_err(unknown)).unwrap();
         assert_eq!(classified.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(classified.message(), INTERNAL_ERROR_MESSAGE);
-    }
-
-    #[test]
-    fn backend_statuses_are_classified() {
-        assert!(matches!(
-            SanitizedError::for_backend_status(StatusCode::from_u16(499).unwrap()),
-            Some(SanitizedError::Cancelled)
-        ));
-        assert!(matches!(
-            SanitizedError::for_backend_status(StatusCode::SERVICE_UNAVAILABLE),
-            Some(SanitizedError::PreserveServerError(status))
-                if status == StatusCode::SERVICE_UNAVAILABLE
-        ));
-        assert!(SanitizedError::for_backend_status(StatusCode::BAD_REQUEST).is_none());
-        assert!(matches!(
-            SanitizedError::for_backend_status(StatusCode::from_u16(399).unwrap()),
-            Some(SanitizedError::Internal)
-        ));
     }
 }

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -14,12 +14,6 @@ use crate::types::Annotated;
 
 pub(crate) const INTERNAL_ERROR_MESSAGE: &str = "Internal server error";
 
-#[derive(serde::Deserialize)]
-struct LegacyBackendHttpPayload {
-    code: Option<u16>,
-    message: Option<String>,
-}
-
 fn parse_overload_status_code(value: Option<&str>) -> StatusCode {
     let default = StatusCode::from_u16(529).expect("529 is a valid HTTP status code");
     value
@@ -149,7 +143,8 @@ impl ClassifiedHttpError {
     /// Classify a backend stream event through the same logical nested-error
     /// flow as `from_error`; the event's outer typed validation is authoritative,
     /// while nested operational failures retain their retry/cancellation meaning.
-    /// Ordinary data is never interpreted as an error.
+    /// Ordinary data and tagged annotation metadata are never interpreted as
+    /// errors.
     pub(crate) fn from_annotated<T>(event: &Annotated<T>) -> Option<Self> {
         if event.is_error() {
             if let Some(error) = event.error.as_ref() {
@@ -167,38 +162,19 @@ impl ClassifiedHttpError {
                 .filter(|message| !message.trim().is_empty())
                 .unwrap_or_else(|| "unspecified error".to_string());
 
-            if let Some(classified) = Self::from_legacy_http_json(diagnostic.clone()) {
-                return Some(classified);
-            }
-
             return Some(Self::internal(INTERNAL_ERROR_MESSAGE, diagnostic));
         }
 
-        if let Some(comments) = event.comment.as_ref()
+        if event.data.is_none()
+            && event.event.is_none()
+            && let Some(comments) = event.comment.as_ref()
             && !comments.is_empty()
         {
             let diagnostic = comments.join(", ");
-            if let Some(classified) = Self::from_legacy_http_json(diagnostic.clone()) {
-                return Some(classified);
-            }
-
-            if event.data.is_none() && event.event.is_none() {
-                return Some(Self::internal(INTERNAL_ERROR_MESSAGE, diagnostic));
-            }
+            return Some(Self::internal(INTERNAL_ERROR_MESSAGE, diagnostic));
         }
 
         None
-    }
-
-    fn from_legacy_http_json(diagnostic: String) -> Option<Self> {
-        let payload = serde_json::from_str::<LegacyBackendHttpPayload>(&diagnostic).ok()?;
-        let code = payload.code?;
-        if code < 400 {
-            return None;
-        }
-        let status = StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-        let message = payload.message.unwrap_or_else(|| diagnostic.clone());
-        Some(Self::from_backend_status(status, message, diagnostic))
     }
 
     pub(crate) fn from_backend_status(
@@ -643,7 +619,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_untagged_comment_errors_remain_supported() {
+    fn http_json_in_annotation_metadata_is_not_classified_as_an_error() {
         let event = Annotated::<()> {
             data: None,
             id: None,
@@ -654,10 +630,7 @@ mod tests {
             error: None,
         };
 
-        let classified = ClassifiedHttpError::from_annotated(&event)
-            .expect("untagged comment must remain an error");
-        assert_eq!(classified.status(), StatusCode::BAD_REQUEST);
-        assert_eq!(classified.message(), "bad prompt");
+        assert!(ClassifiedHttpError::from_annotated(&event).is_none());
     }
 
     #[test]

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -149,7 +149,8 @@ impl ClassifiedHttpError {
     /// Classify a backend stream event through the same logical nested-error
     /// flow as `from_error`; the event's outer typed validation is authoritative,
     /// while nested operational failures retain their retry/cancellation meaning.
-    pub(crate) fn from_annotated<T: serde::Serialize>(event: &Annotated<T>) -> Option<Self> {
+    /// Ordinary data is never interpreted as an error.
+    pub(crate) fn from_annotated<T>(event: &Annotated<T>) -> Option<Self> {
         if event.is_error() {
             if let Some(error) = event.error.as_ref() {
                 return Some(Self::from_error_with_validation_scope(
@@ -171,13 +172,6 @@ impl ClassifiedHttpError {
             }
 
             return Some(Self::internal(INTERNAL_ERROR_MESSAGE, diagnostic));
-        }
-
-        if let Some(data) = event.data.as_ref()
-            && let Ok(diagnostic) = serde_json::to_string(data)
-            && let Some(classified) = Self::from_legacy_http_json(diagnostic)
-        {
-            return Some(classified);
         }
 
         if let Some(comments) = event.comment.as_ref()
@@ -649,51 +643,30 @@ mod tests {
     }
 
     #[test]
-    fn legacy_data_and_untagged_comment_errors_remain_supported() {
-        let cases = [
-            (
-                "data payload",
-                Annotated {
-                    data: Some(serde_json::json!({
-                        "code": 415,
-                        "message": "unsupported media type",
-                    })),
-                    id: None,
-                    event: None,
-                    comment: None,
-                    error: None,
-                },
-                StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                "unsupported media type",
-            ),
-            (
-                "untagged comment",
-                Annotated {
-                    data: None,
-                    id: None,
-                    event: Some("legacy.backend.annotation".to_string()),
-                    comment: Some(vec![
-                        r#"{"code":400,"message":"bad prompt","type":"Bad Request"}"#.to_string(),
-                    ]),
-                    error: None,
-                },
-                StatusCode::BAD_REQUEST,
-                "bad prompt",
-            ),
-        ];
+    fn legacy_untagged_comment_errors_remain_supported() {
+        let event = Annotated::<()> {
+            data: None,
+            id: None,
+            event: Some("legacy.backend.annotation".to_string()),
+            comment: Some(vec![
+                r#"{"code":400,"message":"bad prompt","type":"Bad Request"}"#.to_string(),
+            ]),
+            error: None,
+        };
 
-        for (shape, event, expected_status, expected_message) in cases {
-            let classified = ClassifiedHttpError::from_annotated(&event)
-                .unwrap_or_else(|| panic!("{shape} must remain an error"));
-            assert_eq!(classified.status(), expected_status, "{shape}");
-            assert_eq!(classified.message(), expected_message, "{shape}");
-        }
+        let classified = ClassifiedHttpError::from_annotated(&event)
+            .expect("untagged comment must remain an error");
+        assert_eq!(classified.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(classified.message(), "bad prompt");
+    }
 
-        let normal = Annotated::from_data(serde_json::json!({
-            "code": 200,
-            "message": "normal response",
+    #[test]
+    fn http_looking_data_is_not_classified_as_an_error() {
+        let data = Annotated::from_data(serde_json::json!({
+            "code": 415,
+            "message": "unsupported media type",
         }));
-        assert!(ClassifiedHttpError::from_annotated(&normal).is_none());
+        assert!(ClassifiedHttpError::from_annotated(&data).is_none());
     }
 
     #[test]

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -25,6 +25,7 @@ use serde::Serialize;
 use tracing::Instrument;
 
 use super::disconnect::create_connection_monitor;
+use super::error::{ClassifiedHttpError, HttpErrorKind};
 use super::metrics::{CancellationLabels, ErrorType};
 use super::openai::{
     check_model_serving_ready, check_ready, context_from_headers, get_body_limit,
@@ -90,6 +91,24 @@ fn generate_error_response(code: StatusCode, error_type: &str, message: String) 
         }),
     )
         .into_response()
+}
+
+fn generate_problem(problem: ClassifiedHttpError) -> Response {
+    if problem.status().is_server_error() {
+        tracing::error!(status = %problem.status(), "Generate error: {}", problem.diagnostic());
+    }
+    let error_type = match problem.kind() {
+        HttpErrorKind::Validation => "invalid_request_error",
+        HttpErrorKind::Authentication => "authentication_error",
+        HttpErrorKind::Permission => "permission_error",
+        HttpErrorKind::NotFound => "not_found_error",
+        HttpErrorKind::RateLimit => "rate_limit_error",
+        HttpErrorKind::Cancelled => "request_cancelled",
+        HttpErrorKind::Overloaded | HttpErrorKind::Unavailable => "service_unavailable",
+        HttpErrorKind::NotImplemented => "not_implemented",
+        HttpErrorKind::Internal => "internal_error",
+    };
+    generate_error_response(problem.status(), error_type, problem.message().to_string())
 }
 
 /// Resolve the request metadata that vLLM keeps outside the public JSON body.
@@ -423,32 +442,16 @@ async fn generate_dispatch(
     let stream = match generate_result {
         Ok(stream) => stream,
         Err(error) => {
-            let was_cancelled = request_context.is_killed()
-                || super::metrics::request_was_cancelled(error.as_ref());
             let was_rejected = super::metrics::request_was_rejected(error.as_ref());
-            inflight_guard.mark_error(if was_cancelled {
-                ErrorType::Cancelled
-            } else if was_rejected {
-                ErrorType::Unavailable
-            } else {
-                ErrorType::Internal
-            });
-            if was_cancelled {
-                return generate_cancelled_response();
-            }
             if was_rejected {
                 tracing::warn!(%request_id, error = %format!("{error:#}"), "engine rejected generate request");
                 state
                     .metrics_clone()
                     .inc_rejection(&model, super::metrics::Endpoint::Generate);
-                return generate_error_response(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "service_unavailable",
-                    "engine rejected the request".to_string(),
-                );
             }
-            tracing::error!(%request_id, error = %format!("{error:#}"), "engine generate call failed");
-            return generate_internal_error_response();
+            let problem = ClassifiedHttpError::from_error(error.as_ref(), "internal server error");
+            inflight_guard.mark_error(problem.metric_type());
+            return generate_problem(problem);
         }
     };
 
@@ -484,16 +487,13 @@ async fn generate_dispatch(
             Json(response).into_response()
         }
         Err(error) => {
-            if request_context.is_killed()
-                || engine_context.is_killed()
-                || super::metrics::request_was_cancelled(error.as_ref())
-            {
+            if request_context.is_killed() || engine_context.is_killed() {
                 inflight_guard.mark_error(ErrorType::Cancelled);
                 return generate_cancelled_response();
             }
-            inflight_guard.mark_error(ErrorType::Internal);
-            tracing::error!(%request_id, %error, "failed to fold generate stream");
-            generate_internal_error_response()
+            let problem = ClassifiedHttpError::from_error(error.as_ref(), "internal server error");
+            inflight_guard.mark_error(problem.metric_type());
+            generate_problem(problem)
         }
     }
 }
@@ -588,6 +588,44 @@ mod tests {
     struct TerminalEngine(crate::protocols::common::FinishReason);
 
     struct CancelledEngine;
+
+    struct InvalidArgumentEngine {
+        during_stream: bool,
+    }
+
+    fn backend_invalid_argument() -> dynamo_runtime::error::DynamoError {
+        dynamo_runtime::error::DynamoError::builder()
+            .error_type(dynamo_runtime::error::ErrorType::Backend(
+                dynamo_runtime::error::BackendError::InvalidArgument,
+            ))
+            .message("unsupported generate option")
+            .build()
+    }
+
+    #[async_trait::async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for InvalidArgumentEngine
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            if !self.during_stream {
+                return Err(backend_invalid_argument().into());
+            }
+            let event = Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(backend_invalid_argument()),
+            };
+            Ok(ResponseStream::new(
+                Box::pin(futures::stream::iter([event])),
+                request.context(),
+            ))
+        }
+    }
 
     #[async_trait::async_trait]
     impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
@@ -1129,6 +1167,47 @@ mod tests {
 
         assert_eq!(response.status().as_u16(), 499);
         assert_cancelled_dispatch_metrics(state.as_ref());
+    }
+
+    #[tokio::test]
+    async fn typed_validation_from_generate_or_stream_returns_400() {
+        for during_stream in [false, true] {
+            let engine: crate::types::openai::generate::GenerateStreamingEngine =
+                Arc::new(InvalidArgumentEngine { during_stream });
+            let service = HttpService::builder().build().unwrap();
+            let state = service.state_clone();
+            let response = generate_dispatch(
+                engine,
+                dispatch_test_context(),
+                "req-invalid-generate".to_string(),
+                "test-model".to_string(),
+                state.clone(),
+                GenerateResponseOptions::default(),
+            )
+            .await;
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("read validation response");
+            let body: serde_json::Value =
+                serde_json::from_slice(&body).expect("parse validation response");
+            assert_eq!(body["error"]["type"], "invalid_request_error");
+            assert_eq!(body["error"]["message"], "unsupported generate option");
+
+            let metric_model = state.manager().metric_model_for("test-model");
+            assert_eq!(state.metrics_clone().get_inflight_count(metric_model), 0);
+            assert_eq!(
+                state.metrics_clone().get_request_counter(
+                    metric_model,
+                    &Endpoint::Generate,
+                    &RequestType::Unary,
+                    &Status::Error,
+                    &ErrorType::Validation,
+                ),
+                1
+            );
+        }
     }
 
     #[test]

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -25,6 +25,7 @@ use serde::Serialize;
 use tracing::Instrument;
 
 use super::disconnect::create_connection_monitor;
+use super::error::{HttpProblem, HttpProblemKind};
 use super::metrics::{CancellationLabels, ErrorType};
 use super::openai::{
     check_model_serving_ready, check_ready, context_from_headers, get_body_limit,
@@ -90,6 +91,24 @@ fn generate_error_response(code: StatusCode, error_type: &str, message: String) 
         }),
     )
         .into_response()
+}
+
+fn generate_problem(problem: HttpProblem) -> Response {
+    if problem.status().is_server_error() {
+        tracing::error!(status = %problem.status(), "Generate error: {}", problem.diagnostic());
+    }
+    let error_type = match problem.kind() {
+        HttpProblemKind::Validation => "invalid_request_error",
+        HttpProblemKind::Authentication => "authentication_error",
+        HttpProblemKind::Permission => "permission_error",
+        HttpProblemKind::NotFound => "not_found_error",
+        HttpProblemKind::RateLimit => "rate_limit_error",
+        HttpProblemKind::Cancelled => "request_cancelled",
+        HttpProblemKind::Overloaded | HttpProblemKind::Unavailable => "service_unavailable",
+        HttpProblemKind::NotImplemented => "not_implemented",
+        HttpProblemKind::Internal => "internal_error",
+    };
+    generate_error_response(problem.status(), error_type, problem.message().to_string())
 }
 
 /// Resolve the request metadata that vLLM keeps outside the public JSON body.
@@ -423,32 +442,16 @@ async fn generate_dispatch(
     let stream = match generate_result {
         Ok(stream) => stream,
         Err(error) => {
-            let was_cancelled = request_context.is_killed()
-                || super::metrics::request_was_cancelled(error.as_ref());
             let was_rejected = super::metrics::request_was_rejected(error.as_ref());
-            inflight_guard.mark_error(if was_cancelled {
-                ErrorType::Cancelled
-            } else if was_rejected {
-                ErrorType::Unavailable
-            } else {
-                ErrorType::Internal
-            });
-            if was_cancelled {
-                return generate_cancelled_response();
-            }
             if was_rejected {
                 tracing::warn!(%request_id, error = %format!("{error:#}"), "engine rejected generate request");
                 state
                     .metrics_clone()
                     .inc_rejection(&model, super::metrics::Endpoint::Generate);
-                return generate_error_response(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "service_unavailable",
-                    "engine rejected the request".to_string(),
-                );
             }
-            tracing::error!(%request_id, error = %format!("{error:#}"), "engine generate call failed");
-            return generate_internal_error_response();
+            let problem = HttpProblem::from_error(error.as_ref(), "internal server error");
+            inflight_guard.mark_error(problem.metric_type());
+            return generate_problem(problem);
         }
     };
 
@@ -484,16 +487,13 @@ async fn generate_dispatch(
             Json(response).into_response()
         }
         Err(error) => {
-            if request_context.is_killed()
-                || engine_context.is_killed()
-                || super::metrics::request_was_cancelled(error.as_ref())
-            {
+            if request_context.is_killed() || engine_context.is_killed() {
                 inflight_guard.mark_error(ErrorType::Cancelled);
                 return generate_cancelled_response();
             }
-            inflight_guard.mark_error(ErrorType::Internal);
-            tracing::error!(%request_id, %error, "failed to fold generate stream");
-            generate_internal_error_response()
+            let problem = HttpProblem::from_error(error.as_ref(), "internal server error");
+            inflight_guard.mark_error(problem.metric_type());
+            generate_problem(problem)
         }
     }
 }
@@ -588,6 +588,44 @@ mod tests {
     struct TerminalEngine(crate::protocols::common::FinishReason);
 
     struct CancelledEngine;
+
+    struct InvalidArgumentEngine {
+        during_stream: bool,
+    }
+
+    fn backend_invalid_argument() -> dynamo_runtime::error::DynamoError {
+        dynamo_runtime::error::DynamoError::builder()
+            .error_type(dynamo_runtime::error::ErrorType::Backend(
+                dynamo_runtime::error::BackendError::InvalidArgument,
+            ))
+            .message("unsupported generate option")
+            .build()
+    }
+
+    #[async_trait::async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for InvalidArgumentEngine
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            if !self.during_stream {
+                return Err(backend_invalid_argument().into());
+            }
+            let event = Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(backend_invalid_argument()),
+            };
+            Ok(ResponseStream::new(
+                Box::pin(futures::stream::iter([event])),
+                request.context(),
+            ))
+        }
+    }
 
     #[async_trait::async_trait]
     impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
@@ -1129,6 +1167,47 @@ mod tests {
 
         assert_eq!(response.status().as_u16(), 499);
         assert_cancelled_dispatch_metrics(state.as_ref());
+    }
+
+    #[tokio::test]
+    async fn typed_validation_from_generate_or_stream_returns_400() {
+        for during_stream in [false, true] {
+            let engine: crate::types::openai::generate::GenerateStreamingEngine =
+                Arc::new(InvalidArgumentEngine { during_stream });
+            let service = HttpService::builder().build().unwrap();
+            let state = service.state_clone();
+            let response = generate_dispatch(
+                engine,
+                dispatch_test_context(),
+                "req-invalid-generate".to_string(),
+                "test-model".to_string(),
+                state.clone(),
+                GenerateResponseOptions::default(),
+            )
+            .await;
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("read validation response");
+            let body: serde_json::Value =
+                serde_json::from_slice(&body).expect("parse validation response");
+            assert_eq!(body["error"]["type"], "invalid_request_error");
+            assert_eq!(body["error"]["message"], "unsupported generate option");
+
+            let metric_model = state.manager().metric_model_for("test-model");
+            assert_eq!(state.metrics_clone().get_inflight_count(metric_model), 0);
+            assert_eq!(
+                state.metrics_clone().get_request_counter(
+                    metric_model,
+                    &Endpoint::Generate,
+                    &RequestType::Unary,
+                    &Status::Error,
+                    &ErrorType::Validation,
+                ),
+                1
+            );
+        }
     }
 
     #[test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -63,6 +63,7 @@ pub fn request_was_cancelled(err: &(dyn std::error::Error + 'static)) -> bool {
 pub use prometheus::Registry;
 
 use super::RouteDoc;
+use super::error::ClassifiedHttpError;
 
 /// Worker type label values for Prometheus timing metrics
 pub use crate::discovery::{WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
@@ -2048,6 +2049,10 @@ fn observe_annotation_metrics<T>(
 fn annotated_to_sse_event<T: Serialize>(
     annotated: crate::types::Annotated<T>,
 ) -> Result<Option<Event>, axum::Error> {
+    if let Some(problem) = ClassifiedHttpError::from_annotated(&annotated) {
+        return Err(axum::Error::new(problem));
+    }
+
     let mut event = Event::default();
 
     if let Some(ref data) = annotated.data {
@@ -2055,23 +2060,6 @@ fn annotated_to_sse_event<T: Serialize>(
     }
 
     if let Some(ref msg) = annotated.event {
-        if msg == "error" {
-            let error_message = if let Some(ref dynamo_err) = annotated.error
-                && !dynamo_err.message().is_empty()
-            {
-                dynamo_err.message().to_string()
-            } else if let Some(ref comments) = annotated.comment {
-                let joined = comments.join(" -- ");
-                if joined.trim().is_empty() {
-                    "unspecified error".to_string()
-                } else {
-                    joined
-                }
-            } else {
-                "unspecified error".to_string()
-            };
-            return Err(axum::Error::new(error_message));
-        }
         event = event.event(msg);
     }
 
@@ -3784,6 +3772,22 @@ mod tests {
         }
     }
 
+    fn assert_internal_problem(
+        result: Result<Option<Event>, axum::Error>,
+        expected_diagnostic: &str,
+    ) {
+        use std::error::Error as _;
+
+        let error = result.expect_err("error annotation must fail conversion");
+        let problem = error
+            .source()
+            .and_then(|source| source.downcast_ref::<ClassifiedHttpError>())
+            .expect("converter must preserve the classified HTTP problem");
+        assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(problem.message(), "Internal server error");
+        assert!(problem.diagnostic().contains(expected_diagnostic));
+    }
+
     #[test]
     fn test_error_event_uses_dynamo_error_message() {
         use dynamo_runtime::error::DynamoError;
@@ -3791,30 +3795,26 @@ mod tests {
             Some(DynamoError::msg("image load failed: 403 Forbidden")),
             None,
         ));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("403 Forbidden"));
+        assert_internal_problem(result, "403 Forbidden");
     }
 
     #[test]
     fn test_error_event_falls_back_to_comment() {
         let result =
             run_event_converter(error_annotated(None, Some(vec!["connection lost".into()])));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("connection lost"));
+        assert_internal_problem(result, "connection lost");
     }
 
     #[test]
     fn test_error_event_unspecified_when_no_message() {
         let result = run_event_converter(error_annotated(None, None));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "unspecified error");
+        assert_internal_problem(result, "unspecified error");
     }
 
     #[test]
     fn test_error_event_empty_comment_falls_through() {
         let result = run_event_converter(error_annotated(None, Some(vec!["".into()])));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "unspecified error");
+        assert_internal_problem(result, "unspecified error");
     }
 
     #[test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -58,6 +58,7 @@ pub fn request_was_cancelled(err: &(dyn std::error::Error + 'static)) -> bool {
 pub use prometheus::Registry;
 
 use super::RouteDoc;
+use super::error::HttpProblem;
 
 /// Worker type label values for Prometheus timing metrics
 pub use crate::discovery::{WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
@@ -2043,6 +2044,10 @@ fn observe_annotation_metrics<T>(
 fn annotated_to_sse_event<T: Serialize>(
     annotated: crate::types::Annotated<T>,
 ) -> Result<Option<Event>, axum::Error> {
+    if let Some(problem) = HttpProblem::from_annotated(&annotated) {
+        return Err(axum::Error::new(problem));
+    }
+
     let mut event = Event::default();
 
     if let Some(ref data) = annotated.data {
@@ -2050,23 +2055,6 @@ fn annotated_to_sse_event<T: Serialize>(
     }
 
     if let Some(ref msg) = annotated.event {
-        if msg == "error" {
-            let error_message = if let Some(ref dynamo_err) = annotated.error
-                && !dynamo_err.message().is_empty()
-            {
-                dynamo_err.message().to_string()
-            } else if let Some(ref comments) = annotated.comment {
-                let joined = comments.join(" -- ");
-                if joined.trim().is_empty() {
-                    "unspecified error".to_string()
-                } else {
-                    joined
-                }
-            } else {
-                "unspecified error".to_string()
-            };
-            return Err(axum::Error::new(error_message));
-        }
         event = event.event(msg);
     }
 
@@ -3779,6 +3767,22 @@ mod tests {
         }
     }
 
+    fn assert_internal_problem(
+        result: Result<Option<Event>, axum::Error>,
+        expected_diagnostic: &str,
+    ) {
+        use std::error::Error as _;
+
+        let error = result.expect_err("error annotation must fail conversion");
+        let problem = error
+            .source()
+            .and_then(|source| source.downcast_ref::<HttpProblem>())
+            .expect("converter must preserve the classified HTTP problem");
+        assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(problem.message(), "Internal server error");
+        assert!(problem.diagnostic().contains(expected_diagnostic));
+    }
+
     #[test]
     fn test_error_event_uses_dynamo_error_message() {
         use dynamo_runtime::error::DynamoError;
@@ -3786,30 +3790,26 @@ mod tests {
             Some(DynamoError::msg("image load failed: 403 Forbidden")),
             None,
         ));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("403 Forbidden"));
+        assert_internal_problem(result, "403 Forbidden");
     }
 
     #[test]
     fn test_error_event_falls_back_to_comment() {
         let result =
             run_event_converter(error_annotated(None, Some(vec!["connection lost".into()])));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("connection lost"));
+        assert_internal_problem(result, "connection lost");
     }
 
     #[test]
     fn test_error_event_unspecified_when_no_message() {
         let result = run_event_converter(error_annotated(None, None));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "unspecified error");
+        assert_internal_problem(result, "unspecified error");
     }
 
     #[test]
     fn test_error_event_empty_comment_falls_through() {
         let result = run_event_converter(error_annotated(None, Some(vec!["".into()])));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "unspecified error");
+        assert_internal_problem(result, "unspecified error");
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -92,7 +92,6 @@ pub const DYNAMO_REQUEST_ID_HEADER: &str = "x-dynamo-request-id";
 /// Dynamo Annotation for the request ID
 pub const ANNOTATION_REQUEST_ID: &str = "request_id";
 
-const VALIDATION_PREFIX: &str = "Validation: ";
 const BATCH_FILE_STORAGE_NOT_IMPLEMENTED: &str = "Batch file storage is not implemented yet.";
 const BATCH_JOB_STATE_NOT_IMPLEMENTED: &str =
     "Batch job lifecycle persistence is not implemented yet.";
@@ -1285,11 +1284,6 @@ async fn classify(
         &request_id,
     );
 
-    // Marked as `Validation` explicitly rather than through
-    // `extract_error_type_from_response`: that helper infers the type from the
-    // message, and only a `VALIDATION_PREFIX`-prefixed 400 maps to
-    // `Validation` (anything else falls back to `Internal`). These messages
-    // stay verbatim vLLM-compatible, so the prefix is not an option here.
     if let Err(err_response) = validate_pooling_cache_salt(request.cache_salt.as_deref()) {
         inflight.mark_error(ErrorType::Validation);
         return Err(err_response);
@@ -1558,11 +1552,6 @@ async fn pooling(
         &request_id,
     );
 
-    // Marked as `Validation` explicitly rather than through
-    // `extract_error_type_from_response`: that helper infers the type from the
-    // message, and only a `VALIDATION_PREFIX`-prefixed 400 maps to
-    // `Validation` (anything else falls back to `Internal`). These messages
-    // stay verbatim vLLM-compatible, so the prefix is not an option here.
     if let Err(err_response) = validate_pooling_cache_salt(request.cache_salt.as_deref()) {
         inflight.mark_error(ErrorType::Validation);
         return Err(err_response);
@@ -2458,15 +2447,13 @@ pub fn validate_chat_completion_unsupported_fields(
 
     if inner.function_call.is_some() {
         return Err(ErrorMessage::not_implemented_error(
-            VALIDATION_PREFIX.to_string()
-                + "`function_call` is deprecated. Please migrate to use `tool_choice` instead.",
+            "`function_call` is deprecated. Please migrate to use `tool_choice` instead.",
         ));
     }
 
     if inner.functions.is_some() {
         return Err(ErrorMessage::not_implemented_error(
-            VALIDATION_PREFIX.to_string()
-                + "`functions` is deprecated. Please migrate to use `tools` instead.",
+            "`functions` is deprecated. Please migrate to use `tools` instead.",
         ));
     }
 
@@ -2480,7 +2467,7 @@ fn normalize_chat_reasoning_template_args(
     request.normalize_reasoning_template_args().map_err(|e| {
         ErrorMessage::from_http_error(HttpError {
             code: 400,
-            message: VALIDATION_PREFIX.to_string() + &e.to_string(),
+            message: e.to_string(),
         })
     })
 }
@@ -2494,8 +2481,8 @@ pub fn validate_chat_completion_required_fields(
     if inner.messages.is_empty() {
         return Err(ErrorMessage::from_http_error(HttpError {
             code: 400,
-            message: VALIDATION_PREFIX.to_string()
-                + "The 'messages' field cannot be empty. At least one message is required.",
+            message: "The 'messages' field cannot be empty. At least one message is required."
+                .to_string(),
         }));
     }
 
@@ -2511,8 +2498,8 @@ pub fn validate_chat_completion_stream_options(
     if !streaming && inner.stream_options.is_some() {
         return Err(ErrorMessage::from_http_error(HttpError {
             code: 400,
-            message: VALIDATION_PREFIX.to_string()
-                + "The 'stream_options' field is only allowed when 'stream' is set to true.",
+            message: "The 'stream_options' field is only allowed when 'stream' is set to true."
+                .to_string(),
         }));
     }
     Ok(())
@@ -2528,7 +2515,7 @@ pub fn validate_chat_completion_fields_generic(
     request.validate().map_err(|e| {
         ErrorMessage::from_http_error(HttpError {
             code: 400,
-            message: VALIDATION_PREFIX.to_string() + &e.to_string(),
+            message: e.to_string(),
         })
     })
 }
@@ -2542,8 +2529,8 @@ pub fn validate_completion_stream_options(
     if !streaming && inner.stream_options.is_some() {
         return Err(ErrorMessage::from_http_error(HttpError {
             code: 400,
-            message: VALIDATION_PREFIX.to_string()
-                + "The 'stream_options' field is only allowed when 'stream' is set to true.",
+            message: "The 'stream_options' field is only allowed when 'stream' is set to true."
+                .to_string(),
         }));
     }
     Ok(())
@@ -2559,7 +2546,7 @@ pub fn validate_completion_fields_generic(
     request.validate().map_err(|e| {
         ErrorMessage::from_http_error(HttpError {
             code: 400,
-            message: VALIDATION_PREFIX.to_string() + &e.to_string(),
+            message: e.to_string(),
         })
     })
 }
@@ -2970,23 +2957,23 @@ pub fn validate_response_unsupported_fields(
         })
     {
         return Some(ErrorMessage::not_implemented_error(format!(
-            "{VALIDATION_PREFIX}`nvext.extra_fields=[\"{field}\"]` is not supported by the Responses API."
+            "`nvext.extra_fields=[\"{field}\"]` is not supported by the Responses API."
         )));
     }
 
     if inner.background == Some(true) {
         return Some(ErrorMessage::not_implemented_error(
-            VALIDATION_PREFIX.to_string() + "`background: true` is not supported.",
+            "`background: true` is not supported.",
         ));
     }
     if inner.previous_response_id.is_some() {
         return Some(ErrorMessage::not_implemented_error(
-            VALIDATION_PREFIX.to_string() + "`previous_response_id` is not supported.",
+            "`previous_response_id` is not supported.",
         ));
     }
     if inner.prompt.is_some() {
         return Some(ErrorMessage::not_implemented_error(
-            VALIDATION_PREFIX.to_string() + "`prompt` is not supported.",
+            "`prompt` is not supported.",
         ));
     }
     // Reject directive fields that change semantics if silently dropped.
@@ -3004,7 +2991,7 @@ pub fn validate_response_unsupported_fields(
     // makes receipt observable without needing a real backend.
     if inner.max_tool_calls.is_some() {
         return Some(ErrorMessage::not_implemented_error(
-            VALIDATION_PREFIX.to_string() + "`max_tool_calls` is not supported.",
+            "`max_tool_calls` is not supported.",
         ));
     }
     None
@@ -4745,7 +4732,7 @@ mod tests {
                 assert_eq!(
                     error.message,
                     format!(
-                        "{VALIDATION_PREFIX}`nvext.extra_fields=[\"{field}\"]` is not supported by the Responses API."
+                        "`nvext.extra_fields=[\"{field}\"]` is not supported by the Responses API."
                     )
                 );
             }
@@ -4870,9 +4857,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!(
-                    "{VALIDATION_PREFIX}The 'messages' field cannot be empty. At least one message is required."
-                )
+                "The 'messages' field cannot be empty. At least one message is required."
             );
         }
     }
@@ -4918,9 +4903,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!(
-                    "{VALIDATION_PREFIX}`thinking.type` must be `enabled`, `disabled`, or `adaptive`"
-                )
+                "`thinking.type` must be `enabled`, `disabled`, or `adaptive`"
             );
         }
     }
@@ -4966,7 +4949,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Frequency penalty must be between -2 and 2, got -3")
+                "Frequency penalty must be between -2 and 2, got -3"
             );
         }
 
@@ -4990,7 +4973,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Presence penalty must be between -2 and 2, got -3")
+                "Presence penalty must be between -2 and 2, got -3"
             );
         }
 
@@ -5014,7 +4997,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Temperature must be between 0 and 2, got -3")
+                "Temperature must be between 0 and 2, got -3"
             );
         }
 
@@ -5038,7 +5021,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Top_p must be between 0 and 1, got -3")
+                "Top_p must be between 0 and 1, got -3"
             );
         }
 
@@ -5064,7 +5047,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Repetition penalty must be between 0 and 2, got -3")
+                "Repetition penalty must be between 0 and 2, got -3"
             );
         }
 
@@ -5088,7 +5071,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Logprobs must be between 0 and 5, got 6")
+                "Logprobs must be between 0 and 5, got 6"
             );
         }
     }
@@ -5153,7 +5136,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Frequency penalty must be between -2 and 2, got -3")
+                "Frequency penalty must be between -2 and 2, got -3"
             );
         }
 
@@ -5184,7 +5167,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Presence penalty must be between -2 and 2, got -3")
+                "Presence penalty must be between -2 and 2, got -3"
             );
         }
 
@@ -5215,7 +5198,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Temperature must be between 0 and 2, got -3")
+                "Temperature must be between 0 and 2, got -3"
             );
         }
 
@@ -5246,7 +5229,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Top_p must be between 0 and 1, got -3")
+                "Top_p must be between 0 and 1, got -3"
             );
         }
 
@@ -5279,7 +5262,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Repetition penalty must be between 0 and 2, got -3")
+                "Repetition penalty must be between 0 and 2, got -3"
             );
         }
 
@@ -5310,7 +5293,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(
                 error_response.1.message,
-                format!("{VALIDATION_PREFIX}Top_logprobs must be between 0 and 20, got 25")
+                "Top_logprobs must be between 0 and 20, got 25"
             );
         }
     }
@@ -5656,7 +5639,7 @@ mod tests {
     fn test_extract_error_type_from_response_validation() {
         let response = ErrorMessage::from_http_error(HttpError {
             code: 400,
-            message: "Validation: bad input".to_string(),
+            message: "bad input".to_string(),
         });
         assert_eq!(
             extract_error_type_from_response(&response),

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1898,7 +1898,7 @@ pub(super) async fn check_for_backend_error<T>(
     timeout: Option<std::time::Duration>,
 ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<T>> + Send>>, ClassifiedHttpError>
 where
-    T: serde::Serialize + Send + 'static,
+    T: Send + 'static,
 {
     use futures::stream::StreamExt;
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1944,7 +1944,8 @@ where
 /// Read the pre-commit peek window from the environment.
 ///
 /// `Some(dur)` — poll for that duration before committing SSE.
-/// `None` — the peek is explicitly disabled with a value of `0`.
+/// `None` — the peek is disabled entirely (default). Set a positive value to
+/// enable it, or `0` to disable it explicitly.
 ///
 /// Read live per streaming request. Reading `std::env::var` is a hashmap
 /// lookup — sub-microsecond, negligible next to the peek window
@@ -1953,14 +1954,12 @@ where
 // FIXME: unify env-var initialization with the rest of `env_llm::*` once that
 // module gets a standard reader.
 pub(super) fn pre_commit_error_peek_timeout() -> Option<std::time::Duration> {
-    const DEFAULT_MS: u64 = 500;
     match std::env::var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS)
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_MS)
     {
-        0 => None,
-        ms => Some(std::time::Duration::from_millis(ms)),
+        Some(0) | None => None,
+        Some(ms) => Some(std::time::Duration::from_millis(ms)),
     }
 }
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -5384,29 +5384,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_check_for_backend_error_with_error_event() {
+    async fn test_check_for_backend_error_with_legacy_http_json_is_sanitized() {
         use crate::types::openai::chat_completions::NvCreateChatCompletionStreamResponse;
         use futures::stream;
 
-        // Create an error event
+        let legacy_payload = r#"{"message":"bad prompt","code":400}"#;
         let error_event = Annotated::<NvCreateChatCompletionStreamResponse> {
             data: None,
             id: None,
             event: Some("error".to_string()),
-            comment: Some(vec!["Backend service unavailable".to_string()]),
+            comment: Some(vec![legacy_payload.to_string()]),
             error: None,
         };
 
         let test_stream = stream::iter(vec![error_event]);
         let result = check_for_backend_error(test_stream, None).await;
 
-        // Should return an error
         assert!(result.is_err());
         if let Err(problem) = result {
             assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
-            // Backend-supplied 5xx text must not be forwarded to the client.
             assert_eq!(problem.message(), "Internal server error");
-            assert!(!problem.message().contains("Backend service unavailable"));
+            assert!(!problem.message().contains("bad prompt"));
         }
     }
 
@@ -5480,125 +5478,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_check_for_backend_error_with_json_error_and_code() {
-        use crate::types::openai::chat_completions::NvCreateChatCompletionStreamResponse;
-        use futures::stream;
-
-        // Create an error event with JSON payload containing error code in comment
-        let error_json =
-            r#"{"message":"prompt > max_seq_len","type":"Internal Server Error","code":500}"#;
-        let error_event = Annotated::<NvCreateChatCompletionStreamResponse> {
-            data: None,
-            id: None,
-            event: Some("error".to_string()),
-            comment: Some(vec![error_json.to_string()]),
-            error: None,
-        };
-
-        let test_stream = stream::iter(vec![error_event]);
-        let result = check_for_backend_error(test_stream, None).await;
-
-        // Should return an error with correct status code extracted from JSON
-        assert!(result.is_err());
-        if let Err(problem) = result {
-            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
-            // 500 backend JSON messages are sanitized to a static client
-            // message; the raw payload is only logged server-side.
-            assert_eq!(problem.message(), "Internal server error");
-            assert!(!problem.message().contains("prompt > max_seq_len"));
-        }
-    }
-
-    #[tokio::test]
-    async fn test_check_for_backend_error_with_non_client_error_code() {
-        use crate::types::openai::chat_completions::NvCreateChatCompletionStreamResponse;
-        use futures::stream;
-
-        // A backend asserting a non-4xx code (here 399) must not be able to
-        // smuggle a sensitive message through with a non-error status:
-        // anything outside the 4xx range is sanitized to 500.
-        let error_json =
-            r#"{"message":"panic at /srv/model.py:42","type":"Backend Error","code":399}"#;
-        let error_event = Annotated::<NvCreateChatCompletionStreamResponse> {
-            data: None,
-            id: None,
-            event: Some("error".to_string()),
-            comment: Some(vec![error_json.to_string()]),
-            error: None,
-        };
-
-        let test_stream = stream::iter(vec![error_event]);
-        let result = check_for_backend_error(test_stream, None).await;
-
-        assert!(result.is_err());
-        if let Err(problem) = result {
-            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
-            assert_eq!(problem.message(), "Internal server error");
-            assert!(!problem.message().contains("/srv/model.py"));
-            assert!(!problem.message().contains("panic"));
-        }
-    }
-
-    #[tokio::test]
-    async fn test_check_for_backend_error_with_503_preserves_status() {
-        use crate::types::openai::chat_completions::NvCreateChatCompletionStreamResponse;
-        use futures::stream;
-
-        // Backend 5xx status codes must round-trip so clients can distinguish
-        // retryable overload (503) from generic 500; only the body is sanitized.
-        let error_json = r#"{"message":"engine pool exhausted at /srv/engine.py:88","code":503}"#;
-        let error_event = Annotated::<NvCreateChatCompletionStreamResponse> {
-            data: None,
-            id: None,
-            event: Some("error".to_string()),
-            comment: Some(vec![error_json.to_string()]),
-            error: None,
-        };
-
-        let test_stream = stream::iter(vec![error_event]);
-        let result = check_for_backend_error(test_stream, None).await;
-
-        assert!(result.is_err());
-        if let Err(problem) = result {
-            assert_eq!(problem.status(), StatusCode::SERVICE_UNAVAILABLE);
-            assert_eq!(problem.message(), "Internal server error");
-            assert!(!problem.message().contains("engine pool"));
-            assert!(!problem.message().contains("/srv/engine.py"));
-        }
-    }
-
-    #[tokio::test]
-    async fn test_check_for_backend_error_with_499_sanitizes_cancellation() {
-        use crate::types::openai::chat_completions::NvCreateChatCompletionStreamResponse;
-        use futures::stream;
-
-        // 499 falls inside is_client_error(); ensure cancellation text from
-        // the backend (e.g. context IDs) cannot reach the client.
-        let error_json =
-            r#"{"message":"Context id abc-123 cancelled at /srv/queue.py:42","code":499}"#;
-        let error_event = Annotated::<NvCreateChatCompletionStreamResponse> {
-            data: None,
-            id: None,
-            event: Some("error".to_string()),
-            comment: Some(vec![error_json.to_string()]),
-            error: None,
-        };
-
-        let test_stream = stream::iter(vec![error_event]);
-        let result = check_for_backend_error(test_stream, None).await;
-
-        assert!(result.is_err());
-        if let Err(problem) = result {
-            assert_eq!(problem.status().as_u16(), 499);
-            assert_eq!(problem.message(), "Request cancelled");
-            assert!(!problem.message().contains("abc-123"));
-            assert!(!problem.message().contains("/srv/queue.py"));
-        }
-    }
-
-    #[tokio::test]
     async fn test_check_for_backend_error_skips_leading_annotation_frames() {
         use crate::types::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
         use futures::stream;
 
         // Streams prepend a request_id annotation before forwarding engine
@@ -5614,10 +5496,13 @@ mod tests {
             data: None,
             id: None,
             event: Some("error".to_string()),
-            comment: Some(vec![
-                r#"{"message":"bad input from client","code":400}"#.to_string(),
-            ]),
-            error: None,
+            comment: None,
+            error: Some(
+                DynamoError::builder()
+                    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                    .message("bad input from client")
+                    .build(),
+            ),
         };
 
         let test_stream = stream::iter(vec![annotation, error_event]);

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -33,8 +33,11 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use super::{
     RouteDoc,
-    disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
-    error::{HttpError, invalid_argument},
+    disconnect::{
+        ConnectionHandle, create_connection_monitor, monitor_for_disconnects,
+        monitor_for_disconnects_with_rendered_errors,
+    },
+    error::{ClassifiedHttpError, HttpError, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
     metrics::{
         CancellationLabels, Endpoint, ErrorType, EventConverter,
@@ -80,6 +83,7 @@ use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_protocols::types::ChatCompletionMessageToolCallChunk;
 use dynamo_protocols::types::ChatCompletionStreamResponseDelta;
 use dynamo_protocols::types::Choice;
+use dynamo_protocols::types::responses::ErrorObject;
 use dynamo_runtime::logging::get_distributed_tracing_context;
 use tracing::Instrument;
 
@@ -97,8 +101,6 @@ const BATCH_OUTPUT_RETRIEVAL_NOT_IMPLEMENTED: &str =
 
 static FORCE_INCLUDE_USAGE: LazyLock<bool> =
     LazyLock::new(|| env_is_truthy(env_llm::DYN_ENABLE_FORCE_INCLUDE_USAGE));
-
-use super::error::{SanitizedError, overload_status_code};
 
 pub(super) fn rl_router(
     drt: Arc<dynamo_runtime::DistributedRuntime>,
@@ -129,8 +131,9 @@ pub(crate) struct ErrorMessage {
     code: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
     details: Option<Box<serde_json::Value>>,
+    /// Preserve canonical classification for metrics without putting it on the wire.
     #[serde(skip)]
-    metric_error_type: Option<ErrorType>,
+    classification: Option<ErrorType>,
 }
 
 fn map_error_code_to_error_type(code: StatusCode) -> String {
@@ -144,36 +147,13 @@ fn map_error_code_to_error_type(code: StatusCode) -> String {
     }
 }
 
-/// Classify error for metrics based on status code and message
-fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
-    match code {
-        StatusCode::BAD_REQUEST => {
-            // 400
-            if message.starts_with("Validation:") {
-                ErrorType::Validation
-            } else {
-                ErrorType::Internal
-            }
-        }
-        StatusCode::NOT_FOUND => ErrorType::NotFound, // 404
-        StatusCode::NOT_IMPLEMENTED => ErrorType::NotImplemented, // 501
-        StatusCode::TOO_MANY_REQUESTS => ErrorType::Overload, // 429
-        StatusCode::SERVICE_UNAVAILABLE => ErrorType::Unavailable, // 503
-        StatusCode::INTERNAL_SERVER_ERROR => ErrorType::Internal, // 500
-        _ if code.as_u16() == 529 => ErrorType::Overload, // 529
-        _ if code.as_u16() == 499 => ErrorType::Cancelled, // 499 Client Closed Request
-        _ if code.is_client_error() => ErrorType::Validation, // other 4xx
-        _ => ErrorType::Internal,                     // everything else
-    }
-}
-
 /// Extract ErrorType from ErrorResponse for metrics
 fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
     response
         .1
-        .metric_error_type
+        .classification
         .clone()
-        .unwrap_or_else(|| classify_error_for_metrics(response.0, &response.1.message))
+        .unwrap_or_else(|| ClassifiedHttpError::metric_type_for_status(response.0))
 }
 
 fn responses_conversion_error_response(error: anyhow::Error) -> ErrorResponse {
@@ -191,41 +171,12 @@ fn responses_conversion_error_response(error: anyhow::Error) -> ErrorResponse {
     }
 }
 
-/// Match `InvalidArgument` at top-level OR under `Backend()`.
-/// `py_err_to_dynamo` wraps Python `ValueError`/`TypeError` as
-/// `Backend(InvalidArgument)`; both variants are 400-worthy.
-fn find_invalid_argument_in_chain<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a dynamo_runtime::error::DynamoError> {
-    use dynamo_runtime::error::{BackendError, ErrorType};
-    let mut current = Some(err);
-    while let Some(e) = current {
-        if let Some(dynamo_err) = e.downcast_ref::<dynamo_runtime::error::DynamoError>()
-            && matches!(
-                dynamo_err.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
-            )
-        {
-            return Some(dynamo_err);
-        }
-        current = e.source();
+fn responses_error_code(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::TOO_MANY_REQUESTS => "rate_limit_exceeded",
+        status if status.is_client_error() => "invalid_prompt",
+        _ => "server_error",
     }
-    None
-}
-
-fn find_queue_rejection_in_chain<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a dynamo_kv_router::scheduling::QueueRejection> {
-    let mut current = Some(err);
-    while let Some(error) = current {
-        if let Some(rejection) =
-            error.downcast_ref::<dynamo_kv_router::scheduling::QueueRejection>()
-        {
-            return Some(rejection);
-        }
-        current = error.source();
-    }
-    None
 }
 
 impl ErrorMessage {
@@ -240,7 +191,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -273,7 +224,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -291,7 +242,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -311,7 +262,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -335,34 +286,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
-            }),
-        )
-    }
-
-    /// Build a sanitized error response from a [`SanitizedError`] variant.
-    /// The status, public message, and protocol error_type all come from
-    /// the variant — call sites do not pass any of them as literals.
-    /// Server-side `details` are logged alongside the canonical category;
-    /// the client only ever sees the variant's public message.
-    pub fn sanitized_with_details(
-        err: SanitizedError,
-        details: impl std::fmt::Display,
-    ) -> ErrorResponse {
-        let status = err.status();
-        if err.log_as_error() {
-            tracing::error!(status = %status, "{err}: {details}");
-        } else {
-            tracing::debug!(status = %status, "{err}: {details}");
-        }
-        (
-            status,
-            Json(ErrorMessage {
-                message: err.to_string(),
-                error_type: map_error_code_to_error_type(status),
-                code: status.as_u16(),
-                details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -381,7 +305,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -396,117 +320,42 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
 
-    /// The OAI endpoints call an [`dynamo.runtime::engine::AsyncEngine`] which are specialized to return
-    /// an [`anyhow::Error`]. This method will convert the [`anyhow::Error`] into an [`HttpError`].
-    /// If successful, it will return the [`HttpError`] as an [`ErrorMessage::internal_server_error`]
-    /// with the details of the error.
+    pub(super) fn from_problem(problem: ClassifiedHttpError) -> ErrorResponse {
+        let status = problem.status();
+        let classification = problem.metric_type();
+        if status.is_server_error() {
+            tracing::error!(status = %status, "{}", problem.diagnostic());
+        } else if status.as_u16() == 499 {
+            tracing::debug!(status = %status, "{}", problem.diagnostic());
+        }
+        (
+            status,
+            Json(ErrorMessage {
+                message: problem.message().to_string(),
+                error_type: map_error_code_to_error_type(status),
+                code: status.as_u16(),
+                details: problem.details().cloned().map(Box::new),
+                classification: Some(classification),
+            }),
+        )
+    }
+
+    /// Convert an engine error into an OpenAI error envelope.
     pub fn from_anyhow(err: anyhow::Error, alt_msg: &str) -> ErrorResponse {
-        if let Some(rejection) = find_queue_rejection_in_chain(err.as_ref()) {
-            let code = overload_status_code();
-            return (
-                code,
-                Json(ErrorMessage {
-                    message: rejection.to_string(),
-                    error_type: map_error_code_to_error_type(code),
-                    code: code.as_u16(),
-                    details: serde_json::to_value(rejection).ok().map(Box::new),
-                    metric_error_type: None,
-                }),
-            );
-        }
-
-        // Check for ResourceExhausted anywhere in the error chain → HTTP 529
-        if super::metrics::request_was_rejected(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Overloaded,
-                format!("{err:#}"),
-            );
-        }
-
-        // No backend workers are currently routable → HTTP 503.
-        if super::metrics::request_was_unavailable(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Unavailable,
-                format!("{err:#}"),
-            );
-        }
-
-        // InvalidArgument (top-level OR Backend) → 400.
-        if let Some(dynamo_err) = find_invalid_argument_in_chain(err.as_ref()) {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorMessage {
-                    message: dynamo_err.message().to_string(),
-                    error_type: map_error_code_to_error_type(StatusCode::BAD_REQUEST),
-                    code: StatusCode::BAD_REQUEST.as_u16(),
-                    details: None,
-                    metric_error_type: Some(ErrorType::Validation),
-                }),
-            );
-        }
-
-        // Check for Cancelled anywhere in the error chain → HTTP 499 (Client Closed Request)
-        if super::metrics::request_was_cancelled(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Cancelled,
-                format!("{err:#}"),
-            );
-        }
-
-        // Then check for HttpError
-        match err.downcast::<HttpError>() {
-            Ok(http_error) => ErrorMessage::from_http_error(http_error),
-            Err(err) => {
-                ErrorMessage::internal_server_error_with_details(alt_msg, format!("{err:#}"))
-            }
-        }
+        Self::from_problem(ClassifiedHttpError::from_error(err.as_ref(), alt_msg))
     }
 
-    /// Implementers should only be able to throw 400-499 errors.
+    /// Implementers may explicitly return safe 4xx errors.
     pub fn from_http_error(err: HttpError) -> ErrorResponse {
-        // 499 is part of the 4xx range but its body can carry cancellation
-        // context (queue paths, context IDs) — sanitize separately.
-        if err.code == 499 {
-            return ErrorMessage::sanitized_with_details(SanitizedError::Cancelled, err.message);
-        }
-        // Backend-supplied messages are only forwarded for the documented 4xx
-        // range; for 5xx or codes outside the HTTP space the message may
-        // contain internal paths/details and is kept server-side only.
-        if err.code < 400 || err.code >= 500 {
-            return ErrorMessage::sanitized_with_details(SanitizedError::Internal, err.message);
-        }
-        match StatusCode::from_u16(err.code) {
-            Ok(code) => (
-                code,
-                Json(ErrorMessage {
-                    message: err.message,
-                    error_type: map_error_code_to_error_type(code),
-                    code: code.as_u16(),
-                    details: None,
-                    metric_error_type: None,
-                }),
-            ),
-            Err(_) => ErrorMessage::sanitized_with_details(SanitizedError::Internal, err.message),
-        }
-    }
-}
-
-impl From<HttpError> for ErrorMessage {
-    fn from(err: HttpError) -> Self {
-        ErrorMessage {
-            message: err.message,
-            error_type: map_error_code_to_error_type(
-                StatusCode::from_u16(err.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
-            ),
-            code: err.code,
-            details: None,
-            metric_error_type: None,
-        }
+        Self::from_problem(ClassifiedHttpError::from_error(
+            &err,
+            "Internal server error",
+        ))
     }
 }
 
@@ -529,7 +378,7 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
                 error_type: map_error_code_to_error_type(StatusCode::BAD_REQUEST),
                 code: StatusCode::BAD_REQUEST.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
             .into_response()
@@ -857,6 +706,19 @@ async fn completions_single(
     let stream = stream::iter(annotations).chain(stream);
 
     if streaming {
+        // Preserve streaming semantics after headers are committed, but give
+        // immediately available typed validation failures a bounded chance to
+        // become an HTTP 4xx first.
+        let stream = match pre_commit_error_peek_timeout() {
+            Some(dur) => check_for_backend_error(stream, Some(dur))
+                .await
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
+                })?,
+            None => Box::pin(stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>,
+        };
+
         // For streaming, we'll drop the http_queue_guard on the first token
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream
@@ -891,17 +753,6 @@ async fn completions_single(
 
         Ok(sse_stream.into_response())
     } else {
-        // Preserve typed backend errors before the completions aggregator turns
-        // them into strings. In particular, Python ValueError/TypeError arrives
-        // as Backend(InvalidArgument) and must remain an HTTP 400.
-        let stream = check_for_backend_error(stream, None)
-            .await
-            .map_err(|error_response| {
-                tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                error_response
-            })?;
-
         // Tap the stream to collect metrics for non-streaming requests without altering items
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.inspect(move |response| {
@@ -916,14 +767,10 @@ async fn completions_single(
         let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to fold completions stream for {}: {:?}",
-                    request_id,
-                    e
+                let err_response = ErrorMessage::from_anyhow(
+                    e.into(),
+                    &format!("Failed to fold completions stream for {request_id}"),
                 );
-                let err_response = ErrorMessage::internal_server_error(&format!(
-                    "Failed to fold completions stream for {request_id}"
-                ));
                 inflight_guard.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;
@@ -1016,28 +863,6 @@ fn aggregate_batch_completion_usage(
             yield response;
         }
     }
-}
-
-type BoxedCompletionResponseStream =
-    std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<NvCreateCompletionResponse>> + Send>>;
-
-/// Check each prompt stream before merging a non-streaming completion batch.
-///
-/// `select_all` cannot safely provide this check after merging because a normal
-/// event from one prompt may arrive before a typed backend error from another.
-/// Poll all streams concurrently so batch startup is not serialized.
-async fn check_completion_batch_streams<S>(
-    streams: Vec<S>,
-) -> Result<Vec<BoxedCompletionResponseStream>, ErrorResponse>
-where
-    S: futures::Stream<Item = Annotated<NvCreateCompletionResponse>> + Send + 'static,
-{
-    futures::future::try_join_all(
-        streams
-            .into_iter()
-            .map(|stream| check_for_backend_error(stream, None)),
-    )
-    .await
 }
 
 /// Handle batch prompt completions (multiple prompts with n choices each)
@@ -1142,23 +967,8 @@ async fn completions_batch(
         all_streams.push(remapped_stream);
     }
 
-    let all_streams: Vec<BoxedCompletionResponseStream> = if streaming {
-        all_streams
-            .into_iter()
-            .map(|stream| Box::pin(stream) as BoxedCompletionResponseStream)
-            .collect()
-    } else {
-        check_completion_batch_streams(all_streams)
-            .await
-            .map_err(|error_response| {
-                tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                error_response
-            })?
-    };
-
-    // Merge all streams after every non-streaming prompt has passed its own
-    // backend-error preflight.
+    // Merge all prompt streams. The unary aggregator preserves any typed error
+    // regardless of which prompt produces data first.
     let merged_stream = stream::select_all(all_streams);
     let merged_stream = aggregate_batch_completion_usage(merged_stream, request_id.clone());
 
@@ -1186,6 +996,18 @@ async fn completions_batch(
     let merged_stream = stream::iter(annotations_vec).chain(merged_stream);
 
     if streaming {
+        let merged_stream = match pre_commit_error_peek_timeout() {
+            Some(dur) => check_for_backend_error(merged_stream, Some(dur))
+                .await
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
+                })?,
+            None => {
+                Box::pin(merged_stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>
+            }
+        };
+
         // For streaming, we'll drop the http_queue_guard on the first token
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = merged_stream
@@ -1234,14 +1056,10 @@ async fn completions_batch(
         let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to fold completions stream for {}: {:?}",
-                    request_id,
-                    e
+                let err_response = ErrorMessage::from_anyhow(
+                    e.into(),
+                    &format!("Failed to fold completions stream for {request_id}"),
                 );
-                let err_response = ErrorMessage::internal_server_error(&format!(
-                    "Failed to fold completions stream for {request_id}"
-                ));
                 inflight_guard.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;
@@ -1362,13 +1180,8 @@ async fn embeddings(
     let mut response = NvCreateEmbeddingResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!(
-                "Failed to fold embeddings stream for {}: {:?}",
-                request_id,
-                e
-            );
             let err_response =
-                ErrorMessage::internal_server_error("Failed to fold embeddings stream");
+                ErrorMessage::from_anyhow(e.into(), "Failed to fold embeddings stream");
             inflight.mark_error(extract_error_type_from_response(&err_response));
             err_response
         })?;
@@ -1543,7 +1356,7 @@ fn pooling_or_classify_bad_request(message: String) -> ErrorResponse {
             error_type: map_error_code_to_error_type(code),
             code: code.as_u16(),
             details: None,
-            metric_error_type: None,
+            classification: None,
         }),
     )
 }
@@ -1964,7 +1777,7 @@ fn json_deserialize_error(error: serde_json::Error) -> ErrorResponse {
             error_type: map_error_code_to_error_type(code),
             code: code.as_u16(),
             details: None,
-            metric_error_type: None,
+            classification: None,
         }),
     )
 }
@@ -1993,7 +1806,7 @@ fn unsupported_media_type_error() -> ErrorResponse {
             error_type: map_error_code_to_error_type(code),
             code: code.as_u16(),
             details: None,
-            metric_error_type: None,
+            classification: None,
         }),
     )
 }
@@ -2047,128 +1860,6 @@ fn escape_json_string_control_chars(body: &[u8]) -> Option<Vec<u8>> {
     changed.then_some(out)
 }
 
-/// Checks if an Annotated event represents a backend error and extracts error information.
-/// Returns Some((message, status_code)) if it's an error, None otherwise.
-fn extract_backend_error_if_present<T: serde::Serialize>(
-    event: &Annotated<T>,
-) -> Option<(String, StatusCode)> {
-    #[derive(serde::Deserialize)]
-    struct ErrorPayload {
-        message: Option<String>,
-        code: Option<u16>,
-    }
-
-    // Check if event type is "error" (from postprocessor when FinishReason::Error is encountered)
-    if let Some(event_type) = &event.event
-        && event_type == "error"
-    {
-        use dynamo_runtime::error::{BackendError, ErrorType};
-
-        // Classify only this event's error, not its causes. An inner invalid
-        // argument must not override an outer unavailable or internal error.
-        let invalid_argument = event.error.as_ref().filter(|error| {
-            matches!(
-                error.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
-            )
-        });
-
-        // Extract error string: prefer DynamoError field, fallback to legacy comment.
-        // Use message() instead of to_string() for DynamoError to avoid prefixing
-        // the ErrorType (e.g., "Unknown: {...}"), which would break JSON parsing.
-        let error_str = if let Some(ref dynamo_err) = event.error {
-            let mut parts = Vec::new();
-            let mut current: Option<&dyn std::error::Error> = Some(dynamo_err);
-            while let Some(e) = current {
-                if let Some(de) = e.downcast_ref::<dynamo_runtime::error::DynamoError>() {
-                    parts.push(de.message().to_string());
-                } else {
-                    parts.push(e.to_string());
-                }
-                current = e.source();
-            }
-            parts.join(", ")
-        } else {
-            event
-                .comment
-                .as_ref()
-                .map(|c| c.join(", "))
-                .unwrap_or_else(|| "Unknown error".to_string())
-        };
-
-        // Parse the status-bearing node's own message. The diagnostic string
-        // above includes its causes and therefore is not necessarily JSON.
-        let status_message = event
-            .error
-            .as_ref()
-            .map(|error| error.message())
-            .unwrap_or(&error_str);
-        if let Ok(error_payload) = serde_json::from_str::<ErrorPayload>(status_message) {
-            // Preserve explicit HTTP-like statuses (for example 415); Python
-            // 4xx exceptions share the Backend(InvalidArgument) category.
-            let code = match error_payload.code {
-                Some(code) => {
-                    StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
-                }
-                None if invalid_argument.is_some() => StatusCode::BAD_REQUEST,
-                None => StatusCode::INTERNAL_SERVER_ERROR,
-            };
-            let message = error_payload
-                .message
-                .unwrap_or_else(|| status_message.to_string());
-            return Some((message, code));
-        }
-
-        if let Some(invalid_argument) = invalid_argument {
-            return Some((
-                invalid_argument.message().to_string(),
-                StatusCode::BAD_REQUEST,
-            ));
-        }
-
-        return Some((error_str, StatusCode::INTERNAL_SERVER_ERROR));
-    }
-
-    // Check if the data payload itself contains an error structure with code >= 400
-    if let Some(data) = &event.data
-        && let Ok(json_value) = serde_json::to_value(data)
-        && let Ok(error_payload) = serde_json::from_value::<ErrorPayload>(json_value.clone())
-        && let Some(code_num) = error_payload.code
-        && code_num >= 400
-    {
-        let code = StatusCode::from_u16(code_num).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-        let message = error_payload
-            .message
-            .unwrap_or_else(|| json_value.to_string());
-        return Some((message, code));
-    }
-
-    // Check if comment contains error information (without event: error)
-    if let Some(comments) = &event.comment
-        && !comments.is_empty()
-    {
-        let comment_str = comments.join(", ");
-
-        // Try to parse comment as error JSON with code >= 400
-        if let Ok(error_payload) = serde_json::from_str::<ErrorPayload>(&comment_str)
-            && let Some(code_num) = error_payload.code
-            && code_num >= 400
-        {
-            let code = StatusCode::from_u16(code_num).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            let message = error_payload.message.unwrap_or(comment_str);
-            return Some((message, code));
-        }
-
-        // Comments present with no data AND no event type indicates error
-        // (events with event types like "request_id" or "event.dynamo.test.sentinel" are annotations)
-        if event.data.is_none() && event.event.is_none() {
-            return Some((comment_str, StatusCode::INTERNAL_SERVER_ERROR));
-        }
-    }
-
-    None
-}
-
 /// Returns true for events that only carry an annotation tag (e.g. the
 /// `request_id` frame prepended to every stream): no data, no error, and
 /// an `event` field that is *not* the `"error"` marker. Annotations may
@@ -2194,18 +1885,18 @@ const MAX_LEADING_ANNOTATIONS: usize = 16;
 
 /// Inspect the first non-annotation event in the stream for a backend error.
 ///
-/// `timeout = None` — await stream events indefinitely (non-streaming preflight).
+/// `timeout = None` — await stream events indefinitely.
 /// `timeout = Some(dur)` — race against a single deadline captured at function
 /// entry (streaming pre-commit peek). If the deadline elapses before a
 /// non-annotation event arrives, return the buffered annotations chained with
 /// the remaining stream so downstream sees the original ordering.
 ///
-/// Returns `Err(ErrorResponse)` if the first non-annotation event is a backend
+/// Returns `Err(ClassifiedHttpError)` if the first non-annotation event is a backend
 /// error, `Ok(stream)` otherwise.
 pub(super) async fn check_for_backend_error<T>(
     stream: impl futures::Stream<Item = Annotated<T>> + Send + 'static,
     timeout: Option<std::time::Duration>,
-) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<T>> + Send>>, ErrorResponse>
+) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<T>> + Send>>, ClassifiedHttpError>
 where
     T: serde::Serialize + Send + 'static,
 {
@@ -2239,8 +1930,8 @@ where
             continue;
         }
 
-        if let Some((error_msg, status_code)) = extract_backend_error_if_present(&event) {
-            return Err(backend_error_response(error_msg, status_code));
+        if let Some(problem) = ClassifiedHttpError::from_annotated(&event) {
+            return Err(problem);
         }
 
         // First non-annotation, non-error event — hand back for downstream
@@ -2250,32 +1941,10 @@ where
     }
 }
 
-/// Convert an `(error_msg, status_code)` pair from `extract_backend_error_if_present`
-/// into the wire `ErrorResponse`. Shared between the non-streaming preflight
-/// (`check_for_backend_error`) and the streaming preflight so both paths speak
-/// the same sanitization + status contract to the client.
-fn backend_error_response(error_msg: String, status_code: StatusCode) -> ErrorResponse {
-    match SanitizedError::for_backend_status(status_code) {
-        Some(variant) => ErrorMessage::sanitized_with_details(variant, error_msg),
-        // 4xx (non-499): protocol contract — forward backend message as-is.
-        None => (
-            status_code,
-            Json(ErrorMessage {
-                message: error_msg,
-                error_type: map_error_code_to_error_type(status_code),
-                code: status_code.as_u16(),
-                details: None,
-                metric_error_type: None,
-            }),
-        ),
-    }
-}
-
 /// Read the pre-commit peek window from the environment.
 ///
 /// `Some(dur)` — poll for that duration before committing SSE.
-/// `None` — the peek is disabled entirely (default; matches pre-fix behavior
-/// where all backend errors surface as SSE frames post-HTTP-200).
+/// `None` — the peek is explicitly disabled with a value of `0`.
 ///
 /// Read live per streaming request. Reading `std::env::var` is a hashmap
 /// lookup — sub-microsecond, negligible next to the peek window
@@ -2283,13 +1952,15 @@ fn backend_error_response(error_msg: String, status_code: StatusCode) -> ErrorRe
 /// process restart.
 // FIXME: unify env-var initialization with the rest of `env_llm::*` once that
 // module gets a standard reader.
-fn pre_commit_error_peek_timeout() -> Option<std::time::Duration> {
+pub(super) fn pre_commit_error_peek_timeout() -> Option<std::time::Duration> {
+    const DEFAULT_MS: u64 = 500;
     match std::env::var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS)
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MS)
     {
-        Some(0) | None => None,
-        Some(ms) => Some(std::time::Duration::from_millis(ms)),
+        0 => None,
+        ms => Some(std::time::Duration::from_millis(ms)),
     }
 }
 
@@ -2646,18 +2317,12 @@ async fn chat_completions(
         let stream = match pre_commit_error_peek_timeout() {
             Some(dur) => check_for_backend_error(stream, Some(dur))
                 .await
-                .map_err(|err_response| {
-                    tracing::error!(request_id = %request_id, "Backend error detected: {:?}", err_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                    err_response
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
                 })?,
-            // Env var unset → skip peek, commit HTTP 200 immediately (pre-fix
-            // behavior). Backend errors will surface as SSE error frames via
-            // monitor_for_disconnects.
-            None => Box::pin(stream)
-                as std::pin::Pin<
-                    Box<dyn futures::Stream<Item = _> + Send>,
-                >,
+            // Explicit `0` skips the peek and commits HTTP 200 immediately.
+            None => Box::pin(stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>,
         };
 
         let mut http_queue_guard = Some(http_queue_guard);
@@ -2748,18 +2413,8 @@ async fn chat_completions(
 
         Ok(sse_stream.into_response())
     } else {
-        // Check first event for backend errors before aggregating (non-streaming only)
-        let stream_with_check =
-            check_for_backend_error(stream, None)
-                .await
-                .map_err(|error_response| {
-                    tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                    error_response
-                })?;
-
         let mut http_queue_guard = Some(http_queue_guard);
-        let stream = stream_with_check.inspect(move |response| {
+        let stream = stream.inspect(move |response| {
             // Calls observe_response() on each token - drops http_queue_guard on first token
             process_chat_response_and_observe_metrics(
                 response,
@@ -2772,12 +2427,8 @@ async fn chat_completions(
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
                 .map_err(|e| {
-                    tracing::error!(
-                        request_id,
-                        "Failed to parse chat completion response: {:?}",
-                        e
-                    );
-                    let err_response = ErrorMessage::internal_server_error(
+                    let err_response = ErrorMessage::from_anyhow(
+                        e.into(),
                         "Failed to parse chat completion response",
                     );
                     inflight_guard.mark_error(extract_error_type_from_response(&err_response));
@@ -3170,16 +2821,14 @@ async fn responses(
         let engine_stream = match pre_commit_error_peek_timeout() {
             Some(dur) => check_for_backend_error(engine_stream, Some(dur))
                 .await
-                .map_err(|err_response| {
-                    tracing::error!(request_id = %request_id, "Backend error detected: {:?}", err_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                    err_response
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
                 })?,
-            // Env var unset → skip peek, commit HTTP 200 immediately.
-            None => Box::pin(engine_stream)
-                as std::pin::Pin<
-                    Box<dyn futures::Stream<Item = _> + Send>,
-                >,
+            // Explicit `0` skips the peek and commits HTTP 200 immediately.
+            None => {
+                Box::pin(engine_stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>
+            }
         };
 
         // Streaming path: convert chat completion stream chunks to Responses API SSE events.
@@ -3202,9 +2851,6 @@ async fn responses(
                 yield event.map_err(axum::Error::new);
             }
 
-            // Track whether the backend sent an error event during the stream.
-            let mut saw_error = false;
-
             while let Some(annotated_chunk) = engine_stream.next().await {
                 process_chat_response_and_observe_metrics(
                     &annotated_chunk,
@@ -3212,9 +2858,21 @@ async fn responses(
                     &mut http_queue_guard,
                 );
 
-                if extract_backend_error_if_present(&annotated_chunk).is_some() {
-                    saw_error = true;
-                    continue;
+                if let Some(problem) = ClassifiedHttpError::from_annotated(&annotated_chunk) {
+                    converter.append_error_events(
+                        ErrorObject {
+                            code: responses_error_code(problem.status()).to_string(),
+                            message: problem.message().to_string(),
+                        },
+                        &mut events,
+                    );
+                    for event in events.drain(..) {
+                        yield event.map_err(axum::Error::new);
+                    }
+                    // response.failed is terminal. Return the classification to
+                    // the monitor for metrics without waiting for backend EOF.
+                    yield Err(axum::Error::new(problem));
+                    return;
                 }
 
                 let Some(stream_resp) = annotated_chunk.data else {
@@ -3227,11 +2885,7 @@ async fn responses(
                 }
             }
 
-            if saw_error {
-                converter.append_error_events(&mut events);
-            } else {
-                converter.append_end_events(&mut events);
-            }
+            converter.append_end_events(&mut events);
             for event in events.drain(..) {
                 yield event.map_err(axum::Error::new);
             }
@@ -3239,7 +2893,12 @@ async fn responses(
 
         // Wrap with disconnect monitoring: detects client disconnects, cancels generation,
         // and defers inflight_guard.mark_ok() until the stream completes.
-        let stream = monitor_for_disconnects(full_stream, ctx, inflight_guard, stream_handle);
+        let stream = monitor_for_disconnects_with_rendered_errors(
+            full_stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+        );
 
         let mut sse_stream = Sse::new(stream);
         if let Some(keep_alive) = state.sse_keep_alive() {
@@ -3249,19 +2908,8 @@ async fn responses(
         Ok(sse_stream.into_response())
     } else {
         // Non-streaming path: aggregate stream into single response
-
-        // Check first event for backend errors before aggregating (non-streaming only)
-        let stream_with_check =
-            check_for_backend_error(engine_stream, None)
-                .await
-                .map_err(|error_response| {
-                    tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                    error_response
-                })?;
-
         let mut http_queue_guard = Some(http_queue_guard);
-        let stream = stream_with_check.inspect(move |response| {
+        let stream = engine_stream.inspect(move |response| {
             process_chat_response_and_observe_metrics(
                 response,
                 &mut response_collector,
@@ -3273,9 +2921,8 @@ async fn responses(
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
                 .map_err(|e| {
-                    tracing::error!(request_id, "Failed to fold responses stream: {:?}", e);
                     let err_response =
-                        ErrorMessage::internal_server_error("Failed to fold responses stream");
+                        ErrorMessage::from_anyhow(e.into(), "Failed to fold responses stream");
                     inflight_guard.mark_error(extract_error_type_from_response(&err_response));
                     err_response
                 })?;
@@ -3886,8 +3533,7 @@ async fn images(
     let response = NvImagesResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to fold images stream for {}: {:?}", request_id, e);
-            let err_response = ErrorMessage::internal_server_error("Failed to fold images stream");
+            let err_response = ErrorMessage::from_anyhow(e.into(), "Failed to fold images stream");
             inflight.mark_error(extract_error_type_from_response(&err_response));
             err_response
         })?;
@@ -3911,7 +3557,7 @@ async fn images_edits(
                 error_type: map_error_code_to_error_type(code),
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         ));
     }
@@ -4041,9 +3687,8 @@ async fn videos(
         let response = NvVideosResponse::from_annotated_stream(stream)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to fold videos stream for {}: {:?}", request_id, e);
                 let err_response =
-                    ErrorMessage::internal_server_error("Failed to fold videos stream");
+                    ErrorMessage::from_anyhow(e.into(), "Failed to fold videos stream");
                 inflight.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;
@@ -4877,16 +4522,16 @@ mod tests {
 
     #[test]
     fn overload_errors_preserve_the_http_529_contract() {
-        use dynamo_runtime::error::{DynamoError, ErrorType};
+        use dynamo_runtime::error::{DynamoError, ErrorType as DynamoErrorType};
         use dynamo_runtime::pipeline::error::PipelineError;
 
         for (error_type, message) in [
             (
-                ErrorType::ResourceExhausted,
+                DynamoErrorType::ResourceExhausted,
                 "All workers are busy, please retry later",
             ),
             (
-                ErrorType::WorkerOverloaded,
+                DynamoErrorType::WorkerOverloaded,
                 "Selected worker is overloaded, please retry later",
             ),
         ] {
@@ -4902,6 +4547,10 @@ mod tests {
             assert_eq!(response.1.code, 529);
             assert_eq!(response.1.error_type, "Overloaded");
             assert_eq!(response.1.message, "Service temporarily overloaded");
+            assert_eq!(
+                extract_error_type_from_response(&response),
+                ErrorType::Overload
+            );
             assert!(
                 !response.1.message.contains(message),
                 "client response must not include the underlying engine message"
@@ -5038,7 +4687,7 @@ mod tests {
     fn test_cancelled_error_metrics_classification() {
         // HTTP 499 should be classified as Cancelled for metrics
         let error_type =
-            classify_error_for_metrics(StatusCode::from_u16(499).unwrap(), "cancelled request");
+            ClassifiedHttpError::metric_type_for_status(StatusCode::from_u16(499).unwrap());
         assert_eq!(
             error_type,
             ErrorType::Cancelled,
@@ -5753,16 +5402,11 @@ mod tests {
 
         // Should return an error
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
             // Backend-supplied 5xx text must not be forwarded to the client.
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(
-                !error_response
-                    .1
-                    .message
-                    .contains("Backend service unavailable")
-            );
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("Backend service unavailable"));
         }
     }
 
@@ -5791,14 +5435,16 @@ mod tests {
 
             let result = check_for_backend_error(stream::iter(vec![error_event]), None).await;
 
-            let error_response = match result {
-                Err(error_response) => error_response,
+            let problem = match result {
+                Err(problem) => problem,
                 Ok(_) => panic!("typed invalid argument must fail"),
             };
-            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-            assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-            assert_eq!(error_response.1.error_type, "Bad Request");
-            assert_eq!(error_response.1.message, "unsupported JSON schema keyword");
+            assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(
+                problem.kind(),
+                crate::http::service::error::HttpErrorKind::Validation
+            );
+            assert_eq!(problem.message(), "unsupported JSON schema keyword");
         }
     }
 
@@ -5820,62 +5466,17 @@ mod tests {
             ),
         };
 
-        let error_response =
-            match check_for_backend_error(stream::iter(vec![error_event]), None).await {
-                Ok(_) => panic!("typed completion error must fail"),
-                Err(error_response) => error_response,
-            };
+        let problem = match check_for_backend_error(stream::iter(vec![error_event]), None).await {
+            Ok(_) => panic!("typed completion error must fail"),
+            Err(problem) => problem,
+        };
 
-        assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert_eq!(error_response.1.error_type, "Bad Request");
+        assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
         assert!(
-            error_response
-                .1
-                .message
+            problem
+                .message()
                 .contains("does not currently support logprobs >= 1")
         );
-    }
-
-    #[tokio::test]
-    async fn test_batch_completion_checks_every_stream_for_backend_errors() {
-        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
-        use futures::stream;
-
-        let normal_event = Annotated::<NvCreateCompletionResponse> {
-            data: Some(make_completion_chunk("ok", None, None)),
-            id: None,
-            event: None,
-            comment: None,
-            error: None,
-        };
-        let error_event = Annotated::<NvCreateCompletionResponse> {
-            data: None,
-            id: None,
-            event: Some("error".to_string()),
-            comment: None,
-            error: Some(
-                DynamoError::builder()
-                    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
-                    .message("invalid second prompt")
-                    .build(),
-            ),
-        };
-
-        let result = check_completion_batch_streams(vec![
-            stream::iter(vec![normal_event]),
-            stream::iter(vec![error_event]),
-        ])
-        .await;
-
-        let error_response = match result {
-            Ok(_) => panic!("an error in any batch prompt must fail the request"),
-            Err(error_response) => error_response,
-        };
-        assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert_eq!(error_response.1.error_type, "Bad Request");
-        assert_eq!(error_response.1.message, "invalid second prompt");
     }
 
     #[tokio::test]
@@ -5899,13 +5500,12 @@ mod tests {
 
         // Should return an error with correct status code extracted from JSON
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
             // 500 backend JSON messages are sanitized to a static client
             // message; the raw payload is only logged server-side.
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert_eq!(error_response.1.code, 500);
-            assert!(!error_response.1.message.contains("prompt > max_seq_len"));
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("prompt > max_seq_len"));
         }
     }
 
@@ -5931,12 +5531,11 @@ mod tests {
         let result = check_for_backend_error(test_stream, None).await;
 
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
-            assert_eq!(error_response.1.code, 500);
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(!error_response.1.message.contains("/srv/model.py"));
-            assert!(!error_response.1.message.contains("panic"));
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("/srv/model.py"));
+            assert!(!problem.message().contains("panic"));
         }
     }
 
@@ -5960,12 +5559,11 @@ mod tests {
         let result = check_for_backend_error(test_stream, None).await;
 
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::SERVICE_UNAVAILABLE);
-            assert_eq!(error_response.1.code, 503);
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(!error_response.1.message.contains("engine pool"));
-            assert!(!error_response.1.message.contains("/srv/engine.py"));
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("engine pool"));
+            assert!(!problem.message().contains("/srv/engine.py"));
         }
     }
 
@@ -5990,12 +5588,11 @@ mod tests {
         let result = check_for_backend_error(test_stream, None).await;
 
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0.as_u16(), 499);
-            assert_eq!(error_response.1.code, 499);
-            assert_eq!(error_response.1.message, "Request cancelled");
-            assert!(!error_response.1.message.contains("abc-123"));
-            assert!(!error_response.1.message.contains("/srv/queue.py"));
+        if let Err(problem) = result {
+            assert_eq!(problem.status().as_u16(), 499);
+            assert_eq!(problem.message(), "Request cancelled");
+            assert!(!problem.message().contains("abc-123"));
+            assert!(!problem.message().contains("/srv/queue.py"));
         }
     }
 
@@ -6030,10 +5627,9 @@ mod tests {
             result.is_err(),
             "annotation followed by an error event must still be detected as an error"
         );
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-            assert_eq!(error_response.1.code, 400);
-            assert_eq!(error_response.1.message, "bad input from client");
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(problem.message(), "bad input from client");
         }
     }
 
@@ -6163,66 +5759,13 @@ mod tests {
 
         // Should return an error based on is_backend_error_event logic
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
             // Backend comment text falls under the 5xx default — must be
             // sanitized so it cannot leak internals to the client.
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(!error_response.1.message.contains("Connection timeout"));
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("Connection timeout"));
         }
-    }
-
-    #[test]
-    fn test_classify_error_for_metrics_validation() {
-        // 400 with "Validation:" prefix to validation
-        let error_type =
-            classify_error_for_metrics(StatusCode::BAD_REQUEST, "Validation: Invalid parameter");
-        assert_eq!(error_type, ErrorType::Validation);
-
-        // 400 WITHOUT "Validation:" to internal (fallback)
-        let error_type = classify_error_for_metrics(StatusCode::BAD_REQUEST, "Some other error");
-        assert_eq!(error_type, ErrorType::Internal);
-    }
-
-    #[test]
-    fn test_classify_error_for_metrics_status_codes() {
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::NOT_FOUND, "Model not found"),
-            ErrorType::NotFound
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::NOT_IMPLEMENTED, "Feature not supported"),
-            ErrorType::NotImplemented
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"),
-            ErrorType::Overload
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::SERVICE_UNAVAILABLE, "Unavailable"),
-            ErrorType::Unavailable
-        );
-        assert_eq!(
-            classify_error_for_metrics(overload_status_code(), "Overloaded"),
-            ErrorType::Overload
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::INTERNAL_SERVER_ERROR, "Panic"),
-            ErrorType::Internal
-        );
-    }
-
-    #[test]
-    fn test_classify_error_for_metrics_client_errors() {
-        // Other 4xx errors should be classified as validation
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::UNAUTHORIZED, "Unauthorized"),
-            ErrorType::Validation
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::FORBIDDEN, "Forbidden"),
-            ErrorType::Validation
-        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -37,7 +37,7 @@ use super::{
         ConnectionHandle, create_connection_monitor, monitor_for_disconnects,
         monitor_for_disconnects_with_rendered_errors,
     },
-    error::{ClassifiedHttpError, HttpError, invalid_argument},
+    error::{ClassifiedHttpError, HttpError, HttpErrorKind, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
     metrics::{
         CancellationLabels, Endpoint, ErrorType, EventConverter,
@@ -164,17 +164,24 @@ fn responses_conversion_error_response(error: anyhow::Error) -> ErrorResponse {
             CONTEXT,
         ),
         Some(ResponsesConversionError::NotImplemented(message)) => {
-            ErrorMessage::not_implemented_error(format!("{VALIDATION_PREFIX}{CONTEXT}: {message}"))
+            ErrorMessage::not_implemented_error(format!("{CONTEXT}: {message}"))
         }
         None => ErrorMessage::from_anyhow(error, CONTEXT),
     }
 }
 
-fn responses_error_code(status: StatusCode) -> &'static str {
-    match status {
-        StatusCode::TOO_MANY_REQUESTS => "rate_limit_exceeded",
-        status if status.is_client_error() => "invalid_prompt",
-        _ => "server_error",
+fn responses_error_code(kind: HttpErrorKind) -> &'static str {
+    match kind {
+        HttpErrorKind::Validation => "invalid_prompt",
+        HttpErrorKind::Authentication => "authentication_error",
+        HttpErrorKind::Permission => "permission_error",
+        HttpErrorKind::NotFound => "not_found_error",
+        HttpErrorKind::RateLimit => "rate_limit_exceeded",
+        HttpErrorKind::Cancelled => "request_cancelled",
+        HttpErrorKind::Overloaded
+        | HttpErrorKind::Unavailable
+        | HttpErrorKind::NotImplemented
+        | HttpErrorKind::Internal => "server_error",
     }
 }
 
@@ -2847,7 +2854,7 @@ async fn responses(
                 if let Some(problem) = ClassifiedHttpError::from_annotated(&annotated_chunk) {
                     converter.append_error_events(
                         ErrorObject {
-                            code: responses_error_code(problem.status()).to_string(),
+                            code: responses_error_code(problem.kind()).to_string(),
                             message: problem.message().to_string(),
                         },
                         &mut events,

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -33,8 +33,11 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use super::{
     RouteDoc,
-    disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
-    error::{HttpError, invalid_argument},
+    disconnect::{
+        ConnectionHandle, create_connection_monitor, monitor_for_disconnects,
+        monitor_for_disconnects_with_rendered_errors,
+    },
+    error::{HttpError, HttpProblem, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
     metrics::{
         CancellationLabels, Endpoint, ErrorType, EventConverter,
@@ -77,6 +80,7 @@ use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_protocols::types::ChatCompletionMessageToolCallChunk;
 use dynamo_protocols::types::ChatCompletionStreamResponseDelta;
 use dynamo_protocols::types::Choice;
+use dynamo_protocols::types::responses::ErrorObject;
 use dynamo_runtime::logging::get_distributed_tracing_context;
 use tracing::Instrument;
 
@@ -94,8 +98,6 @@ const BATCH_OUTPUT_RETRIEVAL_NOT_IMPLEMENTED: &str =
 
 static FORCE_INCLUDE_USAGE: LazyLock<bool> =
     LazyLock::new(|| env_is_truthy(env_llm::DYN_ENABLE_FORCE_INCLUDE_USAGE));
-
-use super::error::{SanitizedError, overload_status_code};
 
 pub(super) fn rl_router(
     drt: Arc<dynamo_runtime::DistributedRuntime>,
@@ -126,8 +128,9 @@ pub(crate) struct ErrorMessage {
     code: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
     details: Option<Box<serde_json::Value>>,
+    /// Preserve canonical classification for metrics without putting it on the wire.
     #[serde(skip)]
-    metric_error_type: Option<ErrorType>,
+    classification: Option<ErrorType>,
 }
 
 fn map_error_code_to_error_type(code: StatusCode) -> String {
@@ -141,73 +144,21 @@ fn map_error_code_to_error_type(code: StatusCode) -> String {
     }
 }
 
-/// Classify error for metrics based on status code and message
-fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
-    match code {
-        StatusCode::BAD_REQUEST => {
-            // 400
-            if message.starts_with("Validation:") {
-                ErrorType::Validation
-            } else {
-                ErrorType::Internal
-            }
-        }
-        StatusCode::NOT_FOUND => ErrorType::NotFound, // 404
-        StatusCode::NOT_IMPLEMENTED => ErrorType::NotImplemented, // 501
-        StatusCode::TOO_MANY_REQUESTS => ErrorType::Overload, // 429
-        StatusCode::SERVICE_UNAVAILABLE => ErrorType::Unavailable, // 503
-        StatusCode::INTERNAL_SERVER_ERROR => ErrorType::Internal, // 500
-        _ if code.as_u16() == 529 => ErrorType::Overload, // 529
-        _ if code.as_u16() == 499 => ErrorType::Cancelled, // 499 Client Closed Request
-        _ if code.is_client_error() => ErrorType::Validation, // other 4xx
-        _ => ErrorType::Internal,                     // everything else
-    }
-}
-
 /// Extract ErrorType from ErrorResponse for metrics
 fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
     response
         .1
-        .metric_error_type
+        .classification
         .clone()
-        .unwrap_or_else(|| classify_error_for_metrics(response.0, &response.1.message))
+        .unwrap_or_else(|| HttpProblem::metric_type_for_status(response.0))
 }
 
-/// Match `InvalidArgument` at top-level OR under `Backend()`.
-/// `py_err_to_dynamo` wraps Python `ValueError`/`TypeError` as
-/// `Backend(InvalidArgument)`; both variants are 400-worthy.
-fn find_invalid_argument_in_chain<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a dynamo_runtime::error::DynamoError> {
-    use dynamo_runtime::error::{BackendError, ErrorType};
-    let mut current = Some(err);
-    while let Some(e) = current {
-        if let Some(dynamo_err) = e.downcast_ref::<dynamo_runtime::error::DynamoError>()
-            && matches!(
-                dynamo_err.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
-            )
-        {
-            return Some(dynamo_err);
-        }
-        current = e.source();
+fn responses_error_code(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::TOO_MANY_REQUESTS => "rate_limit_exceeded",
+        status if status.is_client_error() => "invalid_prompt",
+        _ => "server_error",
     }
-    None
-}
-
-fn find_queue_rejection_in_chain<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a dynamo_kv_router::scheduling::QueueRejection> {
-    let mut current = Some(err);
-    while let Some(error) = current {
-        if let Some(rejection) =
-            error.downcast_ref::<dynamo_kv_router::scheduling::QueueRejection>()
-        {
-            return Some(rejection);
-        }
-        current = error.source();
-    }
-    None
 }
 
 impl ErrorMessage {
@@ -222,7 +173,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -255,7 +206,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -273,7 +224,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -293,7 +244,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -317,34 +268,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
-            }),
-        )
-    }
-
-    /// Build a sanitized error response from a [`SanitizedError`] variant.
-    /// The status, public message, and protocol error_type all come from
-    /// the variant — call sites do not pass any of them as literals.
-    /// Server-side `details` are logged alongside the canonical category;
-    /// the client only ever sees the variant's public message.
-    pub fn sanitized_with_details(
-        err: SanitizedError,
-        details: impl std::fmt::Display,
-    ) -> ErrorResponse {
-        let status = err.status();
-        if err.log_as_error() {
-            tracing::error!(status = %status, "{err}: {details}");
-        } else {
-            tracing::debug!(status = %status, "{err}: {details}");
-        }
-        (
-            status,
-            Json(ErrorMessage {
-                message: err.to_string(),
-                error_type: map_error_code_to_error_type(status),
-                code: status.as_u16(),
-                details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -363,7 +287,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
@@ -378,117 +302,39 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
     }
 
-    /// The OAI endpoints call an [`dynamo.runtime::engine::AsyncEngine`] which are specialized to return
-    /// an [`anyhow::Error`]. This method will convert the [`anyhow::Error`] into an [`HttpError`].
-    /// If successful, it will return the [`HttpError`] as an [`ErrorMessage::internal_server_error`]
-    /// with the details of the error.
+    pub(super) fn from_problem(problem: HttpProblem) -> ErrorResponse {
+        let status = problem.status();
+        let classification = problem.metric_type();
+        if status.is_server_error() {
+            tracing::error!(status = %status, "{}", problem.diagnostic());
+        } else if status.as_u16() == 499 {
+            tracing::debug!(status = %status, "{}", problem.diagnostic());
+        }
+        (
+            status,
+            Json(ErrorMessage {
+                message: problem.message().to_string(),
+                error_type: map_error_code_to_error_type(status),
+                code: status.as_u16(),
+                details: problem.details().cloned().map(Box::new),
+                classification: Some(classification),
+            }),
+        )
+    }
+
+    /// Convert an engine error into an OpenAI error envelope.
     pub fn from_anyhow(err: anyhow::Error, alt_msg: &str) -> ErrorResponse {
-        if let Some(rejection) = find_queue_rejection_in_chain(err.as_ref()) {
-            let code = overload_status_code();
-            return (
-                code,
-                Json(ErrorMessage {
-                    message: rejection.to_string(),
-                    error_type: map_error_code_to_error_type(code),
-                    code: code.as_u16(),
-                    details: serde_json::to_value(rejection).ok().map(Box::new),
-                    metric_error_type: None,
-                }),
-            );
-        }
-
-        // Check for ResourceExhausted anywhere in the error chain → HTTP 529
-        if super::metrics::request_was_rejected(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Overloaded,
-                format!("{err:#}"),
-            );
-        }
-
-        // No backend workers are currently routable → HTTP 503.
-        if super::metrics::request_was_unavailable(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Unavailable,
-                format!("{err:#}"),
-            );
-        }
-
-        // InvalidArgument (top-level OR Backend) → 400.
-        if let Some(dynamo_err) = find_invalid_argument_in_chain(err.as_ref()) {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorMessage {
-                    message: dynamo_err.message().to_string(),
-                    error_type: map_error_code_to_error_type(StatusCode::BAD_REQUEST),
-                    code: StatusCode::BAD_REQUEST.as_u16(),
-                    details: None,
-                    metric_error_type: Some(ErrorType::Validation),
-                }),
-            );
-        }
-
-        // Check for Cancelled anywhere in the error chain → HTTP 499 (Client Closed Request)
-        if super::metrics::request_was_cancelled(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Cancelled,
-                format!("{err:#}"),
-            );
-        }
-
-        // Then check for HttpError
-        match err.downcast::<HttpError>() {
-            Ok(http_error) => ErrorMessage::from_http_error(http_error),
-            Err(err) => {
-                ErrorMessage::internal_server_error_with_details(alt_msg, format!("{err:#}"))
-            }
-        }
+        Self::from_problem(HttpProblem::from_error(err.as_ref(), alt_msg))
     }
 
-    /// Implementers should only be able to throw 400-499 errors.
+    /// Implementers may explicitly return safe 4xx errors.
     pub fn from_http_error(err: HttpError) -> ErrorResponse {
-        // 499 is part of the 4xx range but its body can carry cancellation
-        // context (queue paths, context IDs) — sanitize separately.
-        if err.code == 499 {
-            return ErrorMessage::sanitized_with_details(SanitizedError::Cancelled, err.message);
-        }
-        // Backend-supplied messages are only forwarded for the documented 4xx
-        // range; for 5xx or codes outside the HTTP space the message may
-        // contain internal paths/details and is kept server-side only.
-        if err.code < 400 || err.code >= 500 {
-            return ErrorMessage::sanitized_with_details(SanitizedError::Internal, err.message);
-        }
-        match StatusCode::from_u16(err.code) {
-            Ok(code) => (
-                code,
-                Json(ErrorMessage {
-                    message: err.message,
-                    error_type: map_error_code_to_error_type(code),
-                    code: code.as_u16(),
-                    details: None,
-                    metric_error_type: None,
-                }),
-            ),
-            Err(_) => ErrorMessage::sanitized_with_details(SanitizedError::Internal, err.message),
-        }
-    }
-}
-
-impl From<HttpError> for ErrorMessage {
-    fn from(err: HttpError) -> Self {
-        ErrorMessage {
-            message: err.message,
-            error_type: map_error_code_to_error_type(
-                StatusCode::from_u16(err.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
-            ),
-            code: err.code,
-            details: None,
-            metric_error_type: None,
-        }
+        Self::from_problem(HttpProblem::from_error(&err, "Internal server error"))
     }
 }
 
@@ -511,7 +357,7 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
                 error_type: map_error_code_to_error_type(StatusCode::BAD_REQUEST),
                 code: StatusCode::BAD_REQUEST.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         )
             .into_response()
@@ -839,6 +685,19 @@ async fn completions_single(
     let stream = stream::iter(annotations).chain(stream);
 
     if streaming {
+        // Preserve streaming semantics after headers are committed, but give
+        // immediately available typed validation failures a bounded chance to
+        // become an HTTP 4xx first.
+        let stream = match pre_commit_error_peek_timeout() {
+            Some(dur) => check_for_backend_error(stream, Some(dur))
+                .await
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
+                })?,
+            None => Box::pin(stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>,
+        };
+
         // For streaming, we'll drop the http_queue_guard on the first token
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream
@@ -873,17 +732,6 @@ async fn completions_single(
 
         Ok(sse_stream.into_response())
     } else {
-        // Preserve typed backend errors before the completions aggregator turns
-        // them into strings. In particular, Python ValueError/TypeError arrives
-        // as Backend(InvalidArgument) and must remain an HTTP 400.
-        let stream = check_for_backend_error(stream, None)
-            .await
-            .map_err(|error_response| {
-                tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                error_response
-            })?;
-
         // Tap the stream to collect metrics for non-streaming requests without altering items
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.inspect(move |response| {
@@ -898,14 +746,10 @@ async fn completions_single(
         let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to fold completions stream for {}: {:?}",
-                    request_id,
-                    e
+                let err_response = ErrorMessage::from_anyhow(
+                    e.into(),
+                    &format!("Failed to fold completions stream for {request_id}"),
                 );
-                let err_response = ErrorMessage::internal_server_error(&format!(
-                    "Failed to fold completions stream for {request_id}"
-                ));
                 inflight_guard.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;
@@ -998,28 +842,6 @@ fn aggregate_batch_completion_usage(
             yield response;
         }
     }
-}
-
-type BoxedCompletionResponseStream =
-    std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<NvCreateCompletionResponse>> + Send>>;
-
-/// Check each prompt stream before merging a non-streaming completion batch.
-///
-/// `select_all` cannot safely provide this check after merging because a normal
-/// event from one prompt may arrive before a typed backend error from another.
-/// Poll all streams concurrently so batch startup is not serialized.
-async fn check_completion_batch_streams<S>(
-    streams: Vec<S>,
-) -> Result<Vec<BoxedCompletionResponseStream>, ErrorResponse>
-where
-    S: futures::Stream<Item = Annotated<NvCreateCompletionResponse>> + Send + 'static,
-{
-    futures::future::try_join_all(
-        streams
-            .into_iter()
-            .map(|stream| check_for_backend_error(stream, None)),
-    )
-    .await
 }
 
 /// Handle batch prompt completions (multiple prompts with n choices each)
@@ -1124,23 +946,8 @@ async fn completions_batch(
         all_streams.push(remapped_stream);
     }
 
-    let all_streams: Vec<BoxedCompletionResponseStream> = if streaming {
-        all_streams
-            .into_iter()
-            .map(|stream| Box::pin(stream) as BoxedCompletionResponseStream)
-            .collect()
-    } else {
-        check_completion_batch_streams(all_streams)
-            .await
-            .map_err(|error_response| {
-                tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                error_response
-            })?
-    };
-
-    // Merge all streams after every non-streaming prompt has passed its own
-    // backend-error preflight.
+    // Merge all prompt streams. The unary aggregator preserves any typed error
+    // regardless of which prompt produces data first.
     let merged_stream = stream::select_all(all_streams);
     let merged_stream = aggregate_batch_completion_usage(merged_stream, request_id.clone());
 
@@ -1168,6 +975,18 @@ async fn completions_batch(
     let merged_stream = stream::iter(annotations_vec).chain(merged_stream);
 
     if streaming {
+        let merged_stream = match pre_commit_error_peek_timeout() {
+            Some(dur) => check_for_backend_error(merged_stream, Some(dur))
+                .await
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
+                })?,
+            None => {
+                Box::pin(merged_stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>
+            }
+        };
+
         // For streaming, we'll drop the http_queue_guard on the first token
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = merged_stream
@@ -1216,14 +1035,10 @@ async fn completions_batch(
         let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to fold completions stream for {}: {:?}",
-                    request_id,
-                    e
+                let err_response = ErrorMessage::from_anyhow(
+                    e.into(),
+                    &format!("Failed to fold completions stream for {request_id}"),
                 );
-                let err_response = ErrorMessage::internal_server_error(&format!(
-                    "Failed to fold completions stream for {request_id}"
-                ));
                 inflight_guard.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;
@@ -1344,13 +1159,8 @@ async fn embeddings(
     let mut response = NvCreateEmbeddingResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!(
-                "Failed to fold embeddings stream for {}: {:?}",
-                request_id,
-                e
-            );
             let err_response =
-                ErrorMessage::internal_server_error("Failed to fold embeddings stream");
+                ErrorMessage::from_anyhow(e.into(), "Failed to fold embeddings stream");
             inflight.mark_error(extract_error_type_from_response(&err_response));
             err_response
         })?;
@@ -1525,7 +1335,7 @@ fn pooling_or_classify_bad_request(message: String) -> ErrorResponse {
             error_type: map_error_code_to_error_type(code),
             code: code.as_u16(),
             details: None,
-            metric_error_type: None,
+            classification: None,
         }),
     )
 }
@@ -1946,7 +1756,7 @@ fn json_deserialize_error(error: serde_json::Error) -> ErrorResponse {
             error_type: map_error_code_to_error_type(code),
             code: code.as_u16(),
             details: None,
-            metric_error_type: None,
+            classification: None,
         }),
     )
 }
@@ -1975,7 +1785,7 @@ fn unsupported_media_type_error() -> ErrorResponse {
             error_type: map_error_code_to_error_type(code),
             code: code.as_u16(),
             details: None,
-            metric_error_type: None,
+            classification: None,
         }),
     )
 }
@@ -2029,128 +1839,6 @@ fn escape_json_string_control_chars(body: &[u8]) -> Option<Vec<u8>> {
     changed.then_some(out)
 }
 
-/// Checks if an Annotated event represents a backend error and extracts error information.
-/// Returns Some((message, status_code)) if it's an error, None otherwise.
-fn extract_backend_error_if_present<T: serde::Serialize>(
-    event: &Annotated<T>,
-) -> Option<(String, StatusCode)> {
-    #[derive(serde::Deserialize)]
-    struct ErrorPayload {
-        message: Option<String>,
-        code: Option<u16>,
-    }
-
-    // Check if event type is "error" (from postprocessor when FinishReason::Error is encountered)
-    if let Some(event_type) = &event.event
-        && event_type == "error"
-    {
-        use dynamo_runtime::error::{BackendError, ErrorType};
-
-        // Classify only this event's error, not its causes. An inner invalid
-        // argument must not override an outer unavailable or internal error.
-        let invalid_argument = event.error.as_ref().filter(|error| {
-            matches!(
-                error.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
-            )
-        });
-
-        // Extract error string: prefer DynamoError field, fallback to legacy comment.
-        // Use message() instead of to_string() for DynamoError to avoid prefixing
-        // the ErrorType (e.g., "Unknown: {...}"), which would break JSON parsing.
-        let error_str = if let Some(ref dynamo_err) = event.error {
-            let mut parts = Vec::new();
-            let mut current: Option<&dyn std::error::Error> = Some(dynamo_err);
-            while let Some(e) = current {
-                if let Some(de) = e.downcast_ref::<dynamo_runtime::error::DynamoError>() {
-                    parts.push(de.message().to_string());
-                } else {
-                    parts.push(e.to_string());
-                }
-                current = e.source();
-            }
-            parts.join(", ")
-        } else {
-            event
-                .comment
-                .as_ref()
-                .map(|c| c.join(", "))
-                .unwrap_or_else(|| "Unknown error".to_string())
-        };
-
-        // Parse the status-bearing node's own message. The diagnostic string
-        // above includes its causes and therefore is not necessarily JSON.
-        let status_message = event
-            .error
-            .as_ref()
-            .map(|error| error.message())
-            .unwrap_or(&error_str);
-        if let Ok(error_payload) = serde_json::from_str::<ErrorPayload>(status_message) {
-            // Preserve explicit HTTP-like statuses (for example 415); Python
-            // 4xx exceptions share the Backend(InvalidArgument) category.
-            let code = match error_payload.code {
-                Some(code) => {
-                    StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
-                }
-                None if invalid_argument.is_some() => StatusCode::BAD_REQUEST,
-                None => StatusCode::INTERNAL_SERVER_ERROR,
-            };
-            let message = error_payload
-                .message
-                .unwrap_or_else(|| status_message.to_string());
-            return Some((message, code));
-        }
-
-        if let Some(invalid_argument) = invalid_argument {
-            return Some((
-                invalid_argument.message().to_string(),
-                StatusCode::BAD_REQUEST,
-            ));
-        }
-
-        return Some((error_str, StatusCode::INTERNAL_SERVER_ERROR));
-    }
-
-    // Check if the data payload itself contains an error structure with code >= 400
-    if let Some(data) = &event.data
-        && let Ok(json_value) = serde_json::to_value(data)
-        && let Ok(error_payload) = serde_json::from_value::<ErrorPayload>(json_value.clone())
-        && let Some(code_num) = error_payload.code
-        && code_num >= 400
-    {
-        let code = StatusCode::from_u16(code_num).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-        let message = error_payload
-            .message
-            .unwrap_or_else(|| json_value.to_string());
-        return Some((message, code));
-    }
-
-    // Check if comment contains error information (without event: error)
-    if let Some(comments) = &event.comment
-        && !comments.is_empty()
-    {
-        let comment_str = comments.join(", ");
-
-        // Try to parse comment as error JSON with code >= 400
-        if let Ok(error_payload) = serde_json::from_str::<ErrorPayload>(&comment_str)
-            && let Some(code_num) = error_payload.code
-            && code_num >= 400
-        {
-            let code = StatusCode::from_u16(code_num).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            let message = error_payload.message.unwrap_or(comment_str);
-            return Some((message, code));
-        }
-
-        // Comments present with no data AND no event type indicates error
-        // (events with event types like "request_id" or "event.dynamo.test.sentinel" are annotations)
-        if event.data.is_none() && event.event.is_none() {
-            return Some((comment_str, StatusCode::INTERNAL_SERVER_ERROR));
-        }
-    }
-
-    None
-}
-
 /// Returns true for events that only carry an annotation tag (e.g. the
 /// `request_id` frame prepended to every stream): no data, no error, and
 /// an `event` field that is *not* the `"error"` marker. Annotations may
@@ -2176,18 +1864,18 @@ const MAX_LEADING_ANNOTATIONS: usize = 16;
 
 /// Inspect the first non-annotation event in the stream for a backend error.
 ///
-/// `timeout = None` — await stream events indefinitely (non-streaming preflight).
+/// `timeout = None` — await stream events indefinitely.
 /// `timeout = Some(dur)` — race against a single deadline captured at function
 /// entry (streaming pre-commit peek). If the deadline elapses before a
 /// non-annotation event arrives, return the buffered annotations chained with
 /// the remaining stream so downstream sees the original ordering.
 ///
-/// Returns `Err(ErrorResponse)` if the first non-annotation event is a backend
+/// Returns `Err(HttpProblem)` if the first non-annotation event is a backend
 /// error, `Ok(stream)` otherwise.
 pub(super) async fn check_for_backend_error<T>(
     stream: impl futures::Stream<Item = Annotated<T>> + Send + 'static,
     timeout: Option<std::time::Duration>,
-) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<T>> + Send>>, ErrorResponse>
+) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<T>> + Send>>, HttpProblem>
 where
     T: serde::Serialize + Send + 'static,
 {
@@ -2221,8 +1909,8 @@ where
             continue;
         }
 
-        if let Some((error_msg, status_code)) = extract_backend_error_if_present(&event) {
-            return Err(backend_error_response(error_msg, status_code));
+        if let Some(problem) = HttpProblem::from_annotated(&event) {
+            return Err(problem);
         }
 
         // First non-annotation, non-error event — hand back for downstream
@@ -2232,32 +1920,10 @@ where
     }
 }
 
-/// Convert an `(error_msg, status_code)` pair from `extract_backend_error_if_present`
-/// into the wire `ErrorResponse`. Shared between the non-streaming preflight
-/// (`check_for_backend_error`) and the streaming preflight so both paths speak
-/// the same sanitization + status contract to the client.
-fn backend_error_response(error_msg: String, status_code: StatusCode) -> ErrorResponse {
-    match SanitizedError::for_backend_status(status_code) {
-        Some(variant) => ErrorMessage::sanitized_with_details(variant, error_msg),
-        // 4xx (non-499): protocol contract — forward backend message as-is.
-        None => (
-            status_code,
-            Json(ErrorMessage {
-                message: error_msg,
-                error_type: map_error_code_to_error_type(status_code),
-                code: status_code.as_u16(),
-                details: None,
-                metric_error_type: None,
-            }),
-        ),
-    }
-}
-
 /// Read the pre-commit peek window from the environment.
 ///
 /// `Some(dur)` — poll for that duration before committing SSE.
-/// `None` — the peek is disabled entirely (default; matches pre-fix behavior
-/// where all backend errors surface as SSE frames post-HTTP-200).
+/// `None` — the peek is explicitly disabled with a value of `0`.
 ///
 /// Read live per streaming request. Reading `std::env::var` is a hashmap
 /// lookup — sub-microsecond, negligible next to the peek window
@@ -2265,13 +1931,15 @@ fn backend_error_response(error_msg: String, status_code: StatusCode) -> ErrorRe
 /// process restart.
 // FIXME: unify env-var initialization with the rest of `env_llm::*` once that
 // module gets a standard reader.
-fn pre_commit_error_peek_timeout() -> Option<std::time::Duration> {
+pub(super) fn pre_commit_error_peek_timeout() -> Option<std::time::Duration> {
+    const DEFAULT_MS: u64 = 500;
     match std::env::var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS)
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MS)
     {
-        Some(0) | None => None,
-        Some(ms) => Some(std::time::Duration::from_millis(ms)),
+        0 => None,
+        ms => Some(std::time::Duration::from_millis(ms)),
     }
 }
 
@@ -2628,18 +2296,12 @@ async fn chat_completions(
         let stream = match pre_commit_error_peek_timeout() {
             Some(dur) => check_for_backend_error(stream, Some(dur))
                 .await
-                .map_err(|err_response| {
-                    tracing::error!(request_id = %request_id, "Backend error detected: {:?}", err_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                    err_response
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
                 })?,
-            // Env var unset → skip peek, commit HTTP 200 immediately (pre-fix
-            // behavior). Backend errors will surface as SSE error frames via
-            // monitor_for_disconnects.
-            None => Box::pin(stream)
-                as std::pin::Pin<
-                    Box<dyn futures::Stream<Item = _> + Send>,
-                >,
+            // Explicit `0` skips the peek and commits HTTP 200 immediately.
+            None => Box::pin(stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>,
         };
 
         let mut http_queue_guard = Some(http_queue_guard);
@@ -2730,18 +2392,8 @@ async fn chat_completions(
 
         Ok(sse_stream.into_response())
     } else {
-        // Check first event for backend errors before aggregating (non-streaming only)
-        let stream_with_check =
-            check_for_backend_error(stream, None)
-                .await
-                .map_err(|error_response| {
-                    tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                    error_response
-                })?;
-
         let mut http_queue_guard = Some(http_queue_guard);
-        let stream = stream_with_check.inspect(move |response| {
+        let stream = stream.inspect(move |response| {
             // Calls observe_response() on each token - drops http_queue_guard on first token
             process_chat_response_and_observe_metrics(
                 response,
@@ -2754,12 +2406,8 @@ async fn chat_completions(
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
                 .map_err(|e| {
-                    tracing::error!(
-                        request_id,
-                        "Failed to parse chat completion response: {:?}",
-                        e
-                    );
-                    let err_response = ErrorMessage::internal_server_error(
+                    let err_response = ErrorMessage::from_anyhow(
+                        e.into(),
                         "Failed to parse chat completion response",
                     );
                     inflight_guard.mark_error(extract_error_type_from_response(&err_response));
@@ -3150,16 +2798,14 @@ async fn responses(
         let engine_stream = match pre_commit_error_peek_timeout() {
             Some(dur) => check_for_backend_error(engine_stream, Some(dur))
                 .await
-                .map_err(|err_response| {
-                    tracing::error!(request_id = %request_id, "Backend error detected: {:?}", err_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                    err_response
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
                 })?,
-            // Env var unset → skip peek, commit HTTP 200 immediately.
-            None => Box::pin(engine_stream)
-                as std::pin::Pin<
-                    Box<dyn futures::Stream<Item = _> + Send>,
-                >,
+            // Explicit `0` skips the peek and commits HTTP 200 immediately.
+            None => {
+                Box::pin(engine_stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>
+            }
         };
 
         // Streaming path: convert chat completion stream chunks to Responses API SSE events.
@@ -3182,9 +2828,6 @@ async fn responses(
                 yield event.map_err(axum::Error::new);
             }
 
-            // Track whether the backend sent an error event during the stream.
-            let mut saw_error = false;
-
             while let Some(annotated_chunk) = engine_stream.next().await {
                 process_chat_response_and_observe_metrics(
                     &annotated_chunk,
@@ -3192,9 +2835,21 @@ async fn responses(
                     &mut http_queue_guard,
                 );
 
-                if extract_backend_error_if_present(&annotated_chunk).is_some() {
-                    saw_error = true;
-                    continue;
+                if let Some(problem) = HttpProblem::from_annotated(&annotated_chunk) {
+                    converter.append_error_events(
+                        ErrorObject {
+                            code: responses_error_code(problem.status()).to_string(),
+                            message: problem.message().to_string(),
+                        },
+                        &mut events,
+                    );
+                    for event in events.drain(..) {
+                        yield event.map_err(axum::Error::new);
+                    }
+                    // response.failed is terminal. Return the classification to
+                    // the monitor for metrics without waiting for backend EOF.
+                    yield Err(axum::Error::new(problem));
+                    return;
                 }
 
                 let Some(stream_resp) = annotated_chunk.data else {
@@ -3207,11 +2862,7 @@ async fn responses(
                 }
             }
 
-            if saw_error {
-                converter.append_error_events(&mut events);
-            } else {
-                converter.append_end_events(&mut events);
-            }
+            converter.append_end_events(&mut events);
             for event in events.drain(..) {
                 yield event.map_err(axum::Error::new);
             }
@@ -3219,7 +2870,12 @@ async fn responses(
 
         // Wrap with disconnect monitoring: detects client disconnects, cancels generation,
         // and defers inflight_guard.mark_ok() until the stream completes.
-        let stream = monitor_for_disconnects(full_stream, ctx, inflight_guard, stream_handle);
+        let stream = monitor_for_disconnects_with_rendered_errors(
+            full_stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+        );
 
         let mut sse_stream = Sse::new(stream);
         if let Some(keep_alive) = state.sse_keep_alive() {
@@ -3229,19 +2885,8 @@ async fn responses(
         Ok(sse_stream.into_response())
     } else {
         // Non-streaming path: aggregate stream into single response
-
-        // Check first event for backend errors before aggregating (non-streaming only)
-        let stream_with_check =
-            check_for_backend_error(engine_stream, None)
-                .await
-                .map_err(|error_response| {
-                    tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                    error_response
-                })?;
-
         let mut http_queue_guard = Some(http_queue_guard);
-        let stream = stream_with_check.inspect(move |response| {
+        let stream = engine_stream.inspect(move |response| {
             process_chat_response_and_observe_metrics(
                 response,
                 &mut response_collector,
@@ -3253,9 +2898,8 @@ async fn responses(
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
                 .map_err(|e| {
-                    tracing::error!(request_id, "Failed to fold responses stream: {:?}", e);
                     let err_response =
-                        ErrorMessage::internal_server_error("Failed to fold responses stream");
+                        ErrorMessage::from_anyhow(e.into(), "Failed to fold responses stream");
                     inflight_guard.mark_error(extract_error_type_from_response(&err_response));
                     err_response
                 })?;
@@ -3866,8 +3510,7 @@ async fn images(
     let response = NvImagesResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to fold images stream for {}: {:?}", request_id, e);
-            let err_response = ErrorMessage::internal_server_error("Failed to fold images stream");
+            let err_response = ErrorMessage::from_anyhow(e.into(), "Failed to fold images stream");
             inflight.mark_error(extract_error_type_from_response(&err_response));
             err_response
         })?;
@@ -3891,7 +3534,7 @@ async fn images_edits(
                 error_type: map_error_code_to_error_type(code),
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: None,
+                classification: None,
             }),
         ));
     }
@@ -4021,9 +3664,8 @@ async fn videos(
         let response = NvVideosResponse::from_annotated_stream(stream)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to fold videos stream for {}: {:?}", request_id, e);
                 let err_response =
-                    ErrorMessage::internal_server_error("Failed to fold videos stream");
+                    ErrorMessage::from_anyhow(e.into(), "Failed to fold videos stream");
                 inflight.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;
@@ -4273,10 +3915,7 @@ async fn audio_speech(
 
     let response = NvAudioSpeechResponse::from_annotated_stream(stream)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to fold audio stream for {}: {:?}", request_id, e);
-            ErrorMessage::internal_server_error("Failed to fold audio stream")
-        })?;
+        .map_err(|e| ErrorMessage::from_anyhow(e.into(), "Failed to fold audio stream"))?;
 
     // Check for failure before marking success
     if response.status == "failed" {
@@ -4846,14 +4485,14 @@ mod tests {
 
     #[test]
     fn test_resource_exhausted_error_response_from_anyhow() {
-        use dynamo_runtime::error::{DynamoError, ErrorType};
+        use dynamo_runtime::error::{DynamoError, ErrorType as DynamoErrorType};
         use dynamo_runtime::pipeline::error::PipelineError;
 
         let cause = PipelineError::ServiceOverloaded(
             "All workers are busy, please retry later".to_string(),
         );
         let err: anyhow::Error = DynamoError::builder()
-            .error_type(ErrorType::ResourceExhausted)
+            .error_type(DynamoErrorType::ResourceExhausted)
             .message("All workers are busy, please retry later")
             .cause(cause)
             .build()
@@ -4863,6 +4502,10 @@ mod tests {
         assert_eq!(response.1.code, 529);
         assert_eq!(response.1.error_type, "Overloaded");
         assert_eq!(response.1.message, "Service temporarily overloaded");
+        assert_eq!(
+            extract_error_type_from_response(&response),
+            ErrorType::Overload
+        );
         assert!(
             !response.1.message.contains("All workers are busy"),
             "client response must not include the underlying engine message"
@@ -4997,8 +4640,7 @@ mod tests {
     #[test]
     fn test_cancelled_error_metrics_classification() {
         // HTTP 499 should be classified as Cancelled for metrics
-        let error_type =
-            classify_error_for_metrics(StatusCode::from_u16(499).unwrap(), "cancelled request");
+        let error_type = HttpProblem::metric_type_for_status(StatusCode::from_u16(499).unwrap());
         assert_eq!(
             error_type,
             ErrorType::Cancelled,
@@ -5713,16 +5355,11 @@ mod tests {
 
         // Should return an error
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
             // Backend-supplied 5xx text must not be forwarded to the client.
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(
-                !error_response
-                    .1
-                    .message
-                    .contains("Backend service unavailable")
-            );
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("Backend service unavailable"));
         }
     }
 
@@ -5751,14 +5388,16 @@ mod tests {
 
             let result = check_for_backend_error(stream::iter(vec![error_event]), None).await;
 
-            let error_response = match result {
-                Err(error_response) => error_response,
+            let problem = match result {
+                Err(problem) => problem,
                 Ok(_) => panic!("typed invalid argument must fail"),
             };
-            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-            assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-            assert_eq!(error_response.1.error_type, "Bad Request");
-            assert_eq!(error_response.1.message, "unsupported JSON schema keyword");
+            assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(
+                problem.kind(),
+                crate::http::service::error::HttpProblemKind::Validation
+            );
+            assert_eq!(problem.message(), "unsupported JSON schema keyword");
         }
     }
 
@@ -5780,62 +5419,17 @@ mod tests {
             ),
         };
 
-        let error_response =
-            match check_for_backend_error(stream::iter(vec![error_event]), None).await {
-                Ok(_) => panic!("typed completion error must fail"),
-                Err(error_response) => error_response,
-            };
+        let problem = match check_for_backend_error(stream::iter(vec![error_event]), None).await {
+            Ok(_) => panic!("typed completion error must fail"),
+            Err(problem) => problem,
+        };
 
-        assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert_eq!(error_response.1.error_type, "Bad Request");
+        assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
         assert!(
-            error_response
-                .1
-                .message
+            problem
+                .message()
                 .contains("does not currently support logprobs >= 1")
         );
-    }
-
-    #[tokio::test]
-    async fn test_batch_completion_checks_every_stream_for_backend_errors() {
-        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
-        use futures::stream;
-
-        let normal_event = Annotated::<NvCreateCompletionResponse> {
-            data: Some(make_completion_chunk("ok", None, None)),
-            id: None,
-            event: None,
-            comment: None,
-            error: None,
-        };
-        let error_event = Annotated::<NvCreateCompletionResponse> {
-            data: None,
-            id: None,
-            event: Some("error".to_string()),
-            comment: None,
-            error: Some(
-                DynamoError::builder()
-                    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
-                    .message("invalid second prompt")
-                    .build(),
-            ),
-        };
-
-        let result = check_completion_batch_streams(vec![
-            stream::iter(vec![normal_event]),
-            stream::iter(vec![error_event]),
-        ])
-        .await;
-
-        let error_response = match result {
-            Ok(_) => panic!("an error in any batch prompt must fail the request"),
-            Err(error_response) => error_response,
-        };
-        assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert_eq!(error_response.1.error_type, "Bad Request");
-        assert_eq!(error_response.1.message, "invalid second prompt");
     }
 
     #[tokio::test]
@@ -5859,13 +5453,12 @@ mod tests {
 
         // Should return an error with correct status code extracted from JSON
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
             // 500 backend JSON messages are sanitized to a static client
             // message; the raw payload is only logged server-side.
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert_eq!(error_response.1.code, 500);
-            assert!(!error_response.1.message.contains("prompt > max_seq_len"));
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("prompt > max_seq_len"));
         }
     }
 
@@ -5891,12 +5484,11 @@ mod tests {
         let result = check_for_backend_error(test_stream, None).await;
 
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
-            assert_eq!(error_response.1.code, 500);
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(!error_response.1.message.contains("/srv/model.py"));
-            assert!(!error_response.1.message.contains("panic"));
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("/srv/model.py"));
+            assert!(!problem.message().contains("panic"));
         }
     }
 
@@ -5920,12 +5512,11 @@ mod tests {
         let result = check_for_backend_error(test_stream, None).await;
 
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::SERVICE_UNAVAILABLE);
-            assert_eq!(error_response.1.code, 503);
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(!error_response.1.message.contains("engine pool"));
-            assert!(!error_response.1.message.contains("/srv/engine.py"));
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("engine pool"));
+            assert!(!problem.message().contains("/srv/engine.py"));
         }
     }
 
@@ -5950,12 +5541,11 @@ mod tests {
         let result = check_for_backend_error(test_stream, None).await;
 
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0.as_u16(), 499);
-            assert_eq!(error_response.1.code, 499);
-            assert_eq!(error_response.1.message, "Request cancelled");
-            assert!(!error_response.1.message.contains("abc-123"));
-            assert!(!error_response.1.message.contains("/srv/queue.py"));
+        if let Err(problem) = result {
+            assert_eq!(problem.status().as_u16(), 499);
+            assert_eq!(problem.message(), "Request cancelled");
+            assert!(!problem.message().contains("abc-123"));
+            assert!(!problem.message().contains("/srv/queue.py"));
         }
     }
 
@@ -5990,10 +5580,9 @@ mod tests {
             result.is_err(),
             "annotation followed by an error event must still be detected as an error"
         );
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-            assert_eq!(error_response.1.code, 400);
-            assert_eq!(error_response.1.message, "bad input from client");
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(problem.message(), "bad input from client");
         }
     }
 
@@ -6123,66 +5712,13 @@ mod tests {
 
         // Should return an error based on is_backend_error_event logic
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
             // Backend comment text falls under the 5xx default — must be
             // sanitized so it cannot leak internals to the client.
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(!error_response.1.message.contains("Connection timeout"));
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("Connection timeout"));
         }
-    }
-
-    #[test]
-    fn test_classify_error_for_metrics_validation() {
-        // 400 with "Validation:" prefix to validation
-        let error_type =
-            classify_error_for_metrics(StatusCode::BAD_REQUEST, "Validation: Invalid parameter");
-        assert_eq!(error_type, ErrorType::Validation);
-
-        // 400 WITHOUT "Validation:" to internal (fallback)
-        let error_type = classify_error_for_metrics(StatusCode::BAD_REQUEST, "Some other error");
-        assert_eq!(error_type, ErrorType::Internal);
-    }
-
-    #[test]
-    fn test_classify_error_for_metrics_status_codes() {
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::NOT_FOUND, "Model not found"),
-            ErrorType::NotFound
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::NOT_IMPLEMENTED, "Feature not supported"),
-            ErrorType::NotImplemented
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"),
-            ErrorType::Overload
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::SERVICE_UNAVAILABLE, "Unavailable"),
-            ErrorType::Unavailable
-        );
-        assert_eq!(
-            classify_error_for_metrics(overload_status_code(), "Overloaded"),
-            ErrorType::Overload
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::INTERNAL_SERVER_ERROR, "Panic"),
-            ErrorType::Internal
-        );
-    }
-
-    #[test]
-    fn test_classify_error_for_metrics_client_errors() {
-        // Other 4xx errors should be classified as validation
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::UNAUTHORIZED, "Unauthorized"),
-            ErrorType::Validation
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::FORBIDDEN, "Forbidden"),
-            ErrorType::Validation
-        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -61,7 +61,7 @@ const REQUEST_CHANNEL_CAPACITY: usize = 64;
 /// half-broken peer from parking the connection indefinitely.
 const CLOSE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
-use super::{RouteDoc, error::SanitizedError, service_v2};
+use super::{RouteDoc, error::INTERNAL_ERROR_MESSAGE, service_v2};
 use crate::discovery::ModelManagerError;
 use crate::types::RealtimeBidirectionalEngine;
 use dynamo_protocols::types::realtime::{
@@ -169,10 +169,7 @@ async fn handle_socket(
         Ok(s) => s,
         Err(err) => {
             tracing::error!(%err, "/v1/realtime engine.generate() failed");
-            *close_reason.lock() = Some(close_message(
-                close_code::ERROR,
-                &SanitizedError::Internal.to_string(),
-            ));
+            *close_reason.lock() = Some(close_message(close_code::ERROR, INTERNAL_ERROR_MESSAGE));
             return;
         }
     };
@@ -190,13 +187,12 @@ async fn handle_socket(
                 event
             } else if let Some(err) = annotated.error {
                 tracing::error!("/v1/realtime engine error: {err}");
-                let sanitized = SanitizedError::Internal;
                 RealtimeServerEvent::Error(RealtimeServerEventError {
                     event_id: format!("event_{}", Uuid::new_v4()),
                     error: RealtimeAPIError {
                         r#type: "server_error".to_string(),
                         code: None,
-                        message: sanitized.to_string(),
+                        message: INTERNAL_ERROR_MESSAGE.to_string(),
                         param: None,
                         event_id: None,
                     },
@@ -485,7 +481,7 @@ where
                 send_error_event(
                     ws_tx,
                     "server_error",
-                    &SanitizedError::Internal.to_string(),
+                    INTERNAL_ERROR_MESSAGE,
                     Some(model_param),
                 )
                 .await;

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -574,20 +574,22 @@ impl AnthropicStreamConverter {
     }
 
     /// Emit error events when the stream ends due to a backend error.
-    pub fn emit_error_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
+    pub fn emit_error_events(
+        &mut self,
+        error: AnthropicErrorBody,
+    ) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::with_capacity(1);
-        self.append_error_events(&mut events);
+        self.append_error_events(error, &mut events);
         events
     }
 
     /// Append error events when the stream ends due to a backend error.
-    pub fn append_error_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
-        let error_event = AnthropicStreamEvent::Error {
-            error: AnthropicErrorBody {
-                error_type: "api_error".to_string(),
-                message: "An internal error occurred during generation.".to_string(),
-            },
-        };
+    pub fn append_error_events(
+        &mut self,
+        error: AnthropicErrorBody,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+    ) {
+        let error_event = AnthropicStreamEvent::Error { error };
         events.push(make_sse_event("error", &error_event));
     }
 }
@@ -1000,7 +1002,13 @@ mod tests {
         assert!(events.iter().all(Result::is_ok));
 
         events.clear();
-        conv.append_error_events(&mut events);
+        conv.append_error_events(
+            AnthropicErrorBody {
+                error_type: "api_error".to_string(),
+                message: "Internal server error".to_string(),
+            },
+            &mut events,
+        );
         assert_eq!(events.len(), 1);
         assert_eq!(events.capacity(), capacity);
         assert!(events.iter().all(Result::is_ok));

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -55,10 +55,37 @@ fn system_message_content(content: &AnthropicMessageContent) -> String {
             .join("\n"),
     }
 }
+
+fn validate_request(req: &AnthropicCreateMessageRequest) -> anyhow::Result<()> {
+    if req.messages.is_empty() {
+        anyhow::bail!("messages: field required");
+    }
+    if req.max_tokens == 0 {
+        anyhow::bail!("max_tokens: must be greater than 0");
+    }
+
+    for (message_index, message) in req.messages.iter().enumerate() {
+        let AnthropicMessageContent::Blocks { content } = &message.content else {
+            continue;
+        };
+        for (block_index, block) in content.iter().enumerate() {
+            if let AnthropicContentBlock::Other(value) = block
+                && !value.is_object()
+            {
+                anyhow::bail!(
+                    "messages[{message_index}].content[{block_index}]: content blocks must be objects"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
     type Error = anyhow::Error;
 
     fn try_from(req: AnthropicCreateMessageRequest) -> Result<Self, Self::Error> {
+        validate_request(&req)?;
         let mut messages = Vec::new();
 
         // Prepend system message if present
@@ -1282,6 +1309,22 @@ mod tests {
             }
             other => panic!("expected assistant message, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_scalar_content_block_is_rejected_during_conversion() {
+        let req: AnthropicCreateMessageRequest = serde_json::from_value(serde_json::json!({
+            "model": "test",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": ["hello"]}]
+        }))
+        .unwrap();
+
+        let error = NvCreateChatCompletionRequest::try_from(req).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "messages[0].content[0]: content blocks must be objects"
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -55,10 +55,37 @@ fn system_message_content(content: &AnthropicMessageContent) -> String {
             .join("\n"),
     }
 }
+
+fn validate_request(req: &AnthropicCreateMessageRequest) -> anyhow::Result<()> {
+    if req.messages.is_empty() {
+        anyhow::bail!("messages: field required");
+    }
+    if req.max_tokens == 0 {
+        anyhow::bail!("max_tokens: must be greater than 0");
+    }
+
+    for (message_index, message) in req.messages.iter().enumerate() {
+        let AnthropicMessageContent::Blocks { content } = &message.content else {
+            continue;
+        };
+        for (block_index, block) in content.iter().enumerate() {
+            if let AnthropicContentBlock::Other(value) = block
+                && !value.is_object()
+            {
+                anyhow::bail!(
+                    "messages[{message_index}].content[{block_index}]: content blocks must be objects"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
     type Error = anyhow::Error;
 
     fn try_from(req: AnthropicCreateMessageRequest) -> Result<Self, Self::Error> {
+        validate_request(&req)?;
         let mut messages = Vec::new();
 
         // Prepend system message if present
@@ -1283,6 +1310,22 @@ mod tests {
             }
             other => panic!("expected assistant message, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_scalar_content_block_is_rejected_during_conversion() {
+        let req: AnthropicCreateMessageRequest = serde_json::from_value(serde_json::json!({
+            "model": "test",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": ["hello"]}]
+        }))
+        .unwrap();
+
+        let error = NvCreateChatCompletionRequest::try_from(req).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "messages[0].content[0]: content blocks must be objects"
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -14,8 +14,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::response::sse::Event;
 use dynamo_protocols::types::responses::{
-    AssistantRole, FunctionToolCall, IncompleteDetails, InputTokenDetails, Instructions,
-    OutputContent, OutputItem, OutputMessage, OutputMessageContent, OutputStatus,
+    AssistantRole, ErrorObject, FunctionToolCall, IncompleteDetails, InputTokenDetails,
+    Instructions, OutputContent, OutputItem, OutputMessage, OutputMessageContent, OutputStatus,
     OutputTextContent, OutputTokenDetails, ReasoningItem, Response, ResponseCompletedEvent,
     ResponseContentPartAddedEvent, ResponseContentPartDoneEvent, ResponseCreatedEvent,
     ResponseFailedEvent, ResponseFunctionCallArgumentsDeltaEvent,
@@ -779,17 +779,23 @@ impl ResponseStreamConverter {
     }
 
     /// Emit error events when the stream ends due to a backend error.
-    pub fn emit_error_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
+    pub fn emit_error_events(&mut self, error: ErrorObject) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::new();
-        self.append_error_events(&mut events);
+        self.append_error_events(error, &mut events);
         events
     }
 
     /// Append error events when the stream ends due to a backend error.
-    pub fn append_error_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
+    pub fn append_error_events(
+        &mut self,
+        error: ErrorObject,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+    ) {
+        let mut response = self.make_response(Status::Failed, vec![]);
+        response.error = Some(error);
         let failed = ResponseStreamEvent::ResponseFailed(ResponseFailedEvent {
             sequence_number: self.next_seq(),
-            response: self.make_response(Status::Failed, vec![]),
+            response,
         });
         events.push(self.make_sse_event(&failed));
     }

--- a/lib/llm/tests/common/http_harness.rs
+++ b/lib/llm/tests/common/http_harness.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(dead_code)]
+
 //! Shared HTTP service and SSE helpers for agent-facing protocol tests.
 
 use std::collections::HashMap;
@@ -39,7 +41,6 @@ pub struct HarnessService {
     pub base_url: String,
     pub client: reqwest::Client,
     pub engine: Arc<ScriptedChatEngine>,
-    #[allow(dead_code)]
     pub metrics: Arc<Metrics>,
     pub completion_engine: Arc<ScriptedCompletionEngine>,
     cancel: CancellationToken,

--- a/lib/llm/tests/common/http_harness.rs
+++ b/lib/llm/tests/common/http_harness.rs
@@ -19,7 +19,10 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::ports::bind_random_port;
-use super::scripted_chat_engine::{Script, ScriptGate, ScriptedChatEngine};
+use super::scripted_chat_engine::{
+    AnnotatedScript, CompletionScript, Script, ScriptGate, ScriptedChatEngine,
+    ScriptedCompletionEngine,
+};
 
 pub const MODEL: &str = "harness-model";
 
@@ -38,6 +41,7 @@ pub struct HarnessService {
     pub engine: Arc<ScriptedChatEngine>,
     #[allow(dead_code)]
     pub metrics: Arc<Metrics>,
+    pub completion_engine: Arc<ScriptedCompletionEngine>,
     cancel: CancellationToken,
     join: Option<tokio::task::JoinHandle<Result<()>>>,
 }
@@ -45,15 +49,50 @@ pub struct HarnessService {
 impl HarnessService {
     pub async fn start(scripts: impl IntoIterator<Item = Script>) -> Self {
         let engine = Arc::new(ScriptedChatEngine::new(scripts));
-        Self::start_with_engine(engine).await
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new([]));
+        Self::start_with_engines(engine, completion_engine).await
+    }
+
+    pub async fn start_with_completion_scripts(
+        scripts: impl IntoIterator<Item = CompletionScript>,
+    ) -> Self {
+        let engine = Arc::new(ScriptedChatEngine::new([]));
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new(scripts));
+        Self::start_with_engines(engine, completion_engine).await
+    }
+
+    pub async fn start_with_scripts(
+        chat_scripts: impl IntoIterator<Item = AnnotatedScript>,
+        completion_scripts: impl IntoIterator<Item = CompletionScript>,
+    ) -> Self {
+        let engine = Arc::new(ScriptedChatEngine::new_annotated(chat_scripts));
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new(completion_scripts));
+        Self::start_with_engines(engine, completion_engine).await
+    }
+
+    pub async fn start_with_pending_annotated_scripts(
+        chat_scripts: impl IntoIterator<Item = AnnotatedScript>,
+    ) -> Self {
+        let engine = Arc::new(ScriptedChatEngine::new_pending_after_annotated(
+            chat_scripts,
+        ));
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new([]));
+        Self::start_with_engines(engine, completion_engine).await
     }
 
     pub async fn start_with_gated_tail(script: Script, split_at: usize) -> (Self, ScriptGate) {
         let (engine, gate) = ScriptedChatEngine::with_gated_tail(script, split_at);
-        (Self::start_with_engine(Arc::new(engine)).await, gate)
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new([]));
+        (
+            Self::start_with_engines(Arc::new(engine), completion_engine).await,
+            gate,
+        )
     }
 
-    async fn start_with_engine(engine: Arc<ScriptedChatEngine>) -> Self {
+    async fn start_with_engines(
+        engine: Arc<ScriptedChatEngine>,
+        completion_engine: Arc<ScriptedCompletionEngine>,
+    ) -> Self {
         let client = reqwest::Client::builder()
             .no_proxy()
             .build()
@@ -63,7 +102,7 @@ impl HarnessService {
             .port(port)
             .host("127.0.0.1")
             .enable_chat_endpoints(true)
-            .enable_cmpl_endpoints(false)
+            .enable_cmpl_endpoints(true)
             .enable_responses_endpoints(true)
             .enable_anthropic_endpoints(true)
             .build()
@@ -75,6 +114,10 @@ impl HarnessService {
             .model_manager()
             .add_chat_completions_model(MODEL, card.mdcsum(), engine.clone())
             .expect("failed to register scripted harness model");
+        service
+            .model_manager()
+            .add_completions_model(MODEL, card.mdcsum(), completion_engine.clone())
+            .expect("failed to register scripted harness completion model");
 
         let cancel = CancellationToken::new();
         let join = service.spawn_with_listener(cancel.clone(), listener).await;
@@ -86,6 +129,7 @@ impl HarnessService {
             client,
             engine,
             metrics,
+            completion_engine,
             cancel,
             join: Some(join),
         }

--- a/lib/llm/tests/common/scripted_chat_engine.rs
+++ b/lib/llm/tests/common/scripted_chat_engine.rs
@@ -11,6 +11,7 @@ use dynamo_llm::protocols::{
     openai::chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
     },
+    openai::completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
 };
 use dynamo_runtime::pipeline::{
     AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn, async_trait,
@@ -18,11 +19,14 @@ use dynamo_runtime::pipeline::{
 use tokio::sync::{Mutex, Semaphore};
 
 pub type Script = Vec<NvCreateChatCompletionStreamResponse>;
+pub type AnnotatedScript = Vec<Annotated<NvCreateChatCompletionStreamResponse>>;
+pub type CompletionScript = Vec<Annotated<NvCreateCompletionResponse>>;
 
 enum QueuedScript {
-    Immediate(Script),
+    Immediate(AnnotatedScript),
+    PendingAfter(AnnotatedScript),
     Gated {
-        chunks: Script,
+        chunks: AnnotatedScript,
         split_at: usize,
         release: std::sync::Arc<Semaphore>,
     },
@@ -47,7 +51,35 @@ pub struct ScriptedChatEngine {
 impl ScriptedChatEngine {
     pub fn new(scripts: impl IntoIterator<Item = Script>) -> Self {
         Self {
+            scripts: Mutex::new(
+                scripts
+                    .into_iter()
+                    .map(|script| {
+                        QueuedScript::Immediate(
+                            script.into_iter().map(Annotated::from_data).collect(),
+                        )
+                    })
+                    .collect(),
+            ),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn new_annotated(scripts: impl IntoIterator<Item = AnnotatedScript>) -> Self {
+        Self {
             scripts: Mutex::new(scripts.into_iter().map(QueuedScript::Immediate).collect()),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn new_pending_after_annotated(scripts: impl IntoIterator<Item = AnnotatedScript>) -> Self {
+        Self {
+            scripts: Mutex::new(
+                scripts
+                    .into_iter()
+                    .map(QueuedScript::PendingAfter)
+                    .collect(),
+            ),
             requests: Mutex::new(Vec::new()),
         }
     }
@@ -61,7 +93,7 @@ impl ScriptedChatEngine {
         (
             Self {
                 scripts: Mutex::new(VecDeque::from([QueuedScript::Gated {
-                    chunks: script,
+                    chunks: script.into_iter().map(Annotated::from_data).collect(),
                     split_at,
                     release: release.clone(),
                 }])),
@@ -108,8 +140,14 @@ impl
             match script {
                 QueuedScript::Immediate(chunks) => {
                     for chunk in chunks {
-                        yield Annotated::from_data(chunk);
+                        yield chunk;
                     }
+                }
+                QueuedScript::PendingAfter(chunks) => {
+                    for chunk in chunks {
+                        yield chunk;
+                    }
+                    std::future::pending::<()>().await;
                 }
                 QueuedScript::Gated {
                     chunks,
@@ -118,7 +156,7 @@ impl
                 } => {
                     let mut chunks = chunks.into_iter();
                     for chunk in chunks.by_ref().take(split_at) {
-                        yield Annotated::from_data(chunk);
+                        yield chunk;
                     }
                     let permit = release
                         .acquire()
@@ -126,11 +164,57 @@ impl
                         .expect("script gate semaphore was closed");
                     permit.forget();
                     for chunk in chunks {
-                        yield Annotated::from_data(chunk);
+                        yield chunk;
                     }
                 }
             }
         };
         Ok(ResponseStream::new(Box::pin(output), ctx))
+    }
+}
+
+/// Captures Completion requests and returns one annotated script per request.
+pub struct ScriptedCompletionEngine {
+    scripts: Mutex<VecDeque<CompletionScript>>,
+    requests: Mutex<Vec<NvCreateCompletionRequest>>,
+}
+
+impl ScriptedCompletionEngine {
+    pub fn new(scripts: impl IntoIterator<Item = CompletionScript>) -> Self {
+        Self {
+            scripts: Mutex::new(scripts.into_iter().collect()),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub async fn take_requests(&self) -> Vec<NvCreateCompletionRequest> {
+        std::mem::take(&mut *self.requests.lock().await)
+    }
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateCompletionRequest>,
+        ManyOut<Annotated<NvCreateCompletionResponse>>,
+        Error,
+    > for ScriptedCompletionEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateCompletionRequest>,
+    ) -> Result<ManyOut<Annotated<NvCreateCompletionResponse>>, Error> {
+        let (request, context) = request.transfer(());
+        let ctx = context.context();
+        self.requests.lock().await.push(request);
+        let script =
+            self.scripts.lock().await.pop_front().ok_or_else(|| {
+                anyhow!("ScriptedCompletionEngine received an unexpected request")
+            })?;
+
+        Ok(ResponseStream::new(
+            Box::pin(futures::stream::iter(script)),
+            ctx,
+        ))
     }
 }

--- a/lib/llm/tests/common/scripted_chat_engine.rs
+++ b/lib/llm/tests/common/scripted_chat_engine.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(dead_code)]
+
 //! A deterministic chat-completions engine for HTTP protocol integration tests.
 
 use std::collections::VecDeque;

--- a/lib/llm/tests/frontend_validation_http.rs
+++ b/lib/llm/tests/frontend_validation_http.rs
@@ -1,0 +1,421 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP regressions for validation failures shared by the frontend protocols.
+
+use std::time::Duration;
+
+use dynamo_llm::protocols::{
+    Annotated,
+    openai::{
+        chat_completions::NvCreateChatCompletionStreamResponse,
+        completions::NvCreateCompletionResponse,
+    },
+};
+use dynamo_runtime::{
+    config::environment_names::llm::{
+        DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
+        DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS,
+    },
+    error::{BackendError, DynamoError, ErrorType},
+};
+use serde_json::{Value, json};
+use serial_test::serial;
+
+#[path = "common/http_harness.rs"]
+mod http_harness;
+#[path = "common/ports.rs"]
+mod ports;
+#[path = "common/scripted_chat_engine.rs"]
+mod scripted_chat_engine;
+
+use http_harness::{HarnessService, MODEL, load_agent_fixture, parse_json_sse};
+use scripted_chat_engine::{AnnotatedScript, CompletionScript};
+
+const BASE_ENV: [(&str, Option<&str>); 3] = [
+    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+    (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
+];
+
+fn backend_error<T>(error_type: ErrorType, message: &str) -> Annotated<T> {
+    Annotated {
+        data: None,
+        id: None,
+        event: Some("error".to_string()),
+        comment: None,
+        error: Some(
+            DynamoError::builder()
+                .error_type(error_type)
+                .message(message)
+                .build(),
+        ),
+    }
+}
+
+async fn assert_openai_400(response: reqwest::Response, message: &str) {
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["code"], 400);
+    assert!(
+        body["message"].as_str().is_some_and(|actual| actual
+            .to_ascii_lowercase()
+            .contains(&message.to_ascii_lowercase())),
+        "unexpected OpenAI error body: {body}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn completions_backend_validation_is_400_for_unary_and_streaming() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let max_tokens_message = "max_tokens must be less than 2147483647";
+        let logprobs_message = "Dynamo's SGLang backend does not currently support logprobs >= 1";
+        let scripts: Vec<CompletionScript> = [
+            max_tokens_message,
+            max_tokens_message,
+            logprobs_message,
+            logprobs_message,
+        ]
+        .into_iter()
+        .map(|message| {
+            vec![backend_error::<NvCreateCompletionResponse>(
+                ErrorType::Backend(BackendError::InvalidArgument),
+                message,
+            )]
+        })
+        .collect();
+        let svc = HarnessService::start_with_completion_scripts(scripts).await;
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/completions", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "prompt": "test",
+                    "max_tokens": 2147483647_u32,
+                    "stream": stream
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_openai_400(response, "max_tokens").await;
+        }
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/completions", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "prompt": "hello",
+                    "max_tokens": 16,
+                    "logprobs": 1,
+                    "stream": stream
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_openai_400(response, "logprobs").await;
+        }
+
+        let requests = svc.completion_engine.take_requests().await;
+        assert_eq!(requests.len(), 4);
+        assert_eq!(requests[0].inner.max_tokens, Some(2147483647));
+        assert_eq!(requests[1].inner.max_tokens, Some(2147483647));
+        assert_eq!(requests[2].inner.logprobs, Some(1));
+        assert_eq!(requests[3].inner.logprobs, Some(1));
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+fn partial_then_error(
+    partial: &NvCreateChatCompletionStreamResponse,
+    error_type: ErrorType,
+    message: &str,
+) -> AnnotatedScript {
+    vec![
+        Annotated::from_data(partial.clone()),
+        backend_error(error_type, message),
+    ]
+}
+
+#[tokio::test]
+#[serial]
+async fn unary_and_late_stream_errors_keep_classification_and_envelopes() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let partial = load_agent_fixture("text.sse").await.unwrap()[0].clone();
+        let invalid = ErrorType::Backend(BackendError::InvalidArgument);
+        let scripts = vec![
+            partial_then_error(&partial, invalid, "invalid response input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/worker.py",
+            ),
+            partial_then_error(&partial, invalid, "invalid late response input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/late.py",
+            ),
+            partial_then_error(&partial, invalid, "invalid late Anthropic input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/anthropic.py",
+            ),
+            partial_then_error(&partial, invalid, "invalid late chat input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/chat.py",
+            ),
+        ];
+        let partial_completion: NvCreateCompletionResponse = serde_json::from_value(json!({
+            "id": "cmpl-partial",
+            "object": "text_completion",
+            "created": 0,
+            "model": MODEL,
+            "choices": [{
+                "text": "partial",
+                "index": 0,
+                "logprobs": null,
+                "finish_reason": null
+            }]
+        }))
+        .unwrap();
+        let completion_scripts = vec![
+            vec![
+                Annotated::from_data(partial_completion.clone()),
+                backend_error(invalid, "invalid late completion input"),
+            ],
+            vec![
+                Annotated::from_data(partial_completion),
+                backend_error(
+                    ErrorType::Backend(BackendError::Unknown),
+                    "secret /srv/completion.py",
+                ),
+            ],
+        ];
+        let svc = HarnessService::start_with_scripts(scripts, completion_scripts).await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({"model": MODEL, "input": "ping", "stream": false}))
+            .send()
+            .await
+            .unwrap();
+        assert_openai_400(response, "invalid response input").await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({"model": MODEL, "input": "ping", "stream": false}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let body: Value = response.json().await.unwrap();
+        assert_eq!(body["message"], "Failed to fold responses stream");
+        assert!(!body.to_string().contains("/srv/worker.py"));
+
+        for (error_code, expected_message) in [
+            ("invalid_prompt", "invalid late response input"),
+            ("server_error", "Internal server error"),
+        ] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/responses", svc.base_url))
+                .json(&json!({"model": MODEL, "input": "ping", "stream": true}))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            let events = parse_json_sse(&response.text().await.unwrap())
+                .await
+                .unwrap();
+            let failed = events
+                .iter()
+                .find(|event| event.event == "response.failed")
+                .expect("missing response.failed event");
+            assert_eq!(failed.data["response"]["error"]["code"], error_code);
+            assert_eq!(
+                failed.data["response"]["error"]["message"],
+                expected_message
+            );
+        }
+
+        for (error_type, expected_message) in [
+            ("invalid_request_error", "invalid late Anthropic input"),
+            ("api_error", "Internal server error"),
+        ] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "stream": true
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            let events = parse_json_sse(&response.text().await.unwrap())
+                .await
+                .unwrap();
+            let error = events
+                .iter()
+                .find(|event| event.event == "error")
+                .expect("missing Anthropic error event");
+            assert_eq!(error.data["error"]["type"], error_type);
+            assert_eq!(error.data["error"]["message"], expected_message);
+        }
+
+        for (endpoint, client_message) in [
+            ("chat/completions", "invalid late chat input"),
+            ("completions", "invalid late completion input"),
+        ] {
+            for (code, error_type, expected_message) in [
+                (400, "invalid_request_error", client_message.to_string()),
+                (
+                    500,
+                    "internal_server_error",
+                    "Internal server error".to_string(),
+                ),
+            ] {
+                let body = if endpoint == "chat/completions" {
+                    json!({
+                        "model": MODEL,
+                        "messages": [{"role": "user", "content": "ping"}],
+                        "stream": true
+                    })
+                } else {
+                    json!({"model": MODEL, "prompt": "ping", "stream": true})
+                };
+                let response = svc
+                    .client
+                    .post(format!("{}/v1/{endpoint}", svc.base_url))
+                    .json(&body)
+                    .send()
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), reqwest::StatusCode::OK);
+                let events = parse_json_sse(&response.text().await.unwrap())
+                    .await
+                    .unwrap();
+                let error = events
+                    .iter()
+                    .find_map(|event| event.data.get("error"))
+                    .expect("missing OpenAI inline error event");
+                assert_eq!(error["code"], code);
+                assert_eq!(error["type"], error_type);
+                assert_eq!(error["message"], expected_message);
+            }
+        }
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn native_stream_errors_are_terminal_and_recorded_as_failures() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let partial = load_agent_fixture("text.sse").await.unwrap()[0].clone();
+        let invalid = ErrorType::Backend(BackendError::InvalidArgument);
+        let svc = HarnessService::start_with_pending_annotated_scripts([
+            partial_then_error(&partial, invalid, "terminal Responses validation"),
+            partial_then_error(&partial, invalid, "terminal Anthropic validation"),
+        ])
+        .await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({"model": MODEL, "input": "ping", "stream": true}))
+            .send()
+            .await
+            .unwrap();
+        let body = tokio::time::timeout(Duration::from_secs(1), response.text())
+            .await
+            .expect("Responses stream waited for backend EOF")
+            .unwrap();
+        let events = parse_json_sse(&body).await.unwrap();
+        let failed = events
+            .iter()
+            .find(|event| event.event == "response.failed")
+            .expect("missing terminal response.failed event");
+        assert_eq!(
+            failed.data["response"]["error"]["message"],
+            "terminal Responses validation"
+        );
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+                "stream": true
+            }))
+            .send()
+            .await
+            .unwrap();
+        let body = tokio::time::timeout(Duration::from_secs(1), response.text())
+            .await
+            .expect("Anthropic stream waited for backend EOF")
+            .unwrap();
+        let events = parse_json_sse(&body).await.unwrap();
+        let error = events
+            .iter()
+            .find(|event| event.event == "error")
+            .expect("missing terminal Anthropic error event");
+        assert_eq!(
+            error.data["error"]["message"],
+            "terminal Anthropic validation"
+        );
+
+        let metrics = svc
+            .client
+            .get(format!("{}/metrics", svc.base_url))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        for endpoint in ["responses", "anthropic_messages"] {
+            let line = metrics
+                .lines()
+                .find(|line| {
+                    line.starts_with("dynamo_frontend_requests_total{")
+                        && line.contains(&format!("endpoint=\"{endpoint}\""))
+                        && line.contains("request_type=\"stream\"")
+                        && line.contains("status=\"error\"")
+                        && line.contains("error_type=\"validation\"")
+                })
+                .unwrap_or_else(|| panic!("missing validation failure metric for {endpoint}"));
+            assert!(line.ends_with(" 1"), "unexpected request metric: {line}");
+        }
+        assert!(
+            metrics.lines().any(|line| {
+                line == format!("dynamo_frontend_inflight_requests{{model=\"{MODEL}\"}} 0")
+            }),
+            "inflight gauge did not return to zero"
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}

--- a/lib/llm/tests/frontend_validation_http.rs
+++ b/lib/llm/tests/frontend_validation_http.rs
@@ -37,6 +37,11 @@ const BASE_ENV: [(&str, Option<&str>); 3] = [
     (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
     (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
 ];
+const PEEK_ENABLED_ENV: [(&str, Option<&str>); 3] = [
+    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+    (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, Some("500")),
+];
 
 fn backend_error<T>(error_type: ErrorType, message: &str) -> Annotated<T> {
     Annotated {
@@ -68,7 +73,7 @@ async fn assert_openai_400(response: reqwest::Response, message: &str) {
 #[tokio::test]
 #[serial]
 async fn completions_backend_validation_is_400_for_unary_and_streaming() {
-    temp_env::async_with_vars(BASE_ENV, async {
+    temp_env::async_with_vars(PEEK_ENABLED_ENV, async {
         const MAX_TOKENS_WITHIN_FRONTEND_LIMIT: u32 = 1_048_576;
         let max_tokens_message = "backend rejected max_tokens";
         let logprobs_message = "Dynamo's SGLang backend does not currently support logprobs >= 1";

--- a/lib/llm/tests/frontend_validation_http.rs
+++ b/lib/llm/tests/frontend_validation_http.rs
@@ -341,6 +341,109 @@ async fn unary_and_late_stream_errors_keep_classification_and_envelopes() {
 
 #[tokio::test]
 #[serial]
+async fn anthropic_overload_statuses_use_overloaded_error() {
+    temp_env::async_with_vars(PEEK_ENABLED_ENV, async {
+        let cases = [
+            (
+                ErrorType::Unavailable,
+                reqwest::StatusCode::SERVICE_UNAVAILABLE,
+                "Service temporarily unavailable",
+            ),
+            (
+                ErrorType::ResourceExhausted,
+                reqwest::StatusCode::from_u16(529).unwrap(),
+                "Service temporarily overloaded",
+            ),
+        ];
+        let scripts = cases.iter().map(|(error_type, _, _)| {
+            vec![backend_error(
+                *error_type,
+                "private backend overload detail",
+            )]
+        });
+        let svc = HarnessService::start_with_scripts(scripts, []).await;
+
+        for (_, expected_status, expected_message) in cases {
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "stream": true
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), expected_status);
+            let body: Value = response.json().await.unwrap();
+            assert_eq!(body["type"], "error");
+            assert_eq!(body["error"]["type"], "overloaded_error");
+            assert_eq!(body["error"]["message"], expected_message);
+            assert!(!body.to_string().contains("private backend overload detail"));
+        }
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn responses_overload_statuses_use_server_error_events() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let cases = [
+            (ErrorType::Unavailable, "Service temporarily unavailable"),
+            (
+                ErrorType::ResourceExhausted,
+                "Service temporarily overloaded",
+            ),
+        ];
+        let scripts = cases.iter().map(|(error_type, _)| {
+            vec![backend_error(
+                *error_type,
+                "private backend overload detail",
+            )]
+        });
+        let svc = HarnessService::start_with_scripts(scripts, []).await;
+
+        for (_, expected_message) in cases {
+            let response = svc
+                .client
+                .post(format!("{}/v1/responses", svc.base_url))
+                .json(&json!({"model": MODEL, "input": "ping", "stream": true}))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            let events = parse_json_sse(&response.text().await.unwrap())
+                .await
+                .unwrap();
+            let failed = events
+                .iter()
+                .find(|event| event.event == "response.failed")
+                .expect("missing response.failed event");
+            assert_eq!(failed.data["response"]["error"]["code"], "server_error");
+            assert_eq!(
+                failed.data["response"]["error"]["message"],
+                expected_message
+            );
+            assert!(
+                !failed
+                    .data
+                    .to_string()
+                    .contains("private backend overload detail")
+            );
+        }
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
 async fn native_stream_errors_are_terminal_and_recorded_as_failures() {
     temp_env::async_with_vars(BASE_ENV, async {
         let partial = load_agent_fixture("text.sse").await.unwrap()[0].clone();

--- a/lib/llm/tests/frontend_validation_http.rs
+++ b/lib/llm/tests/frontend_validation_http.rs
@@ -391,24 +391,31 @@ async fn anthropic_overload_statuses_use_overloaded_error() {
 
 #[tokio::test]
 #[serial]
-async fn responses_overload_statuses_use_server_error_events() {
+async fn responses_operational_error_kinds_use_protocol_codes() {
     temp_env::async_with_vars(BASE_ENV, async {
         let cases = [
-            (ErrorType::Unavailable, "Service temporarily unavailable"),
+            (
+                ErrorType::Unavailable,
+                "server_error",
+                "Service temporarily unavailable",
+            ),
             (
                 ErrorType::ResourceExhausted,
+                "server_error",
                 "Service temporarily overloaded",
             ),
+            (
+                ErrorType::Cancelled,
+                "request_cancelled",
+                "Request cancelled",
+            ),
         ];
-        let scripts = cases.iter().map(|(error_type, _)| {
-            vec![backend_error(
-                *error_type,
-                "private backend overload detail",
-            )]
+        let scripts = cases.iter().map(|(error_type, _, _)| {
+            vec![backend_error(*error_type, "private backend error detail")]
         });
         let svc = HarnessService::start_with_scripts(scripts, []).await;
 
-        for (_, expected_message) in cases {
+        for (_, expected_code, expected_message) in cases {
             let response = svc
                 .client
                 .post(format!("{}/v1/responses", svc.base_url))
@@ -424,7 +431,7 @@ async fn responses_overload_statuses_use_server_error_events() {
                 .iter()
                 .find(|event| event.event == "response.failed")
                 .expect("missing response.failed event");
-            assert_eq!(failed.data["response"]["error"]["code"], "server_error");
+            assert_eq!(failed.data["response"]["error"]["code"], expected_code);
             assert_eq!(
                 failed.data["response"]["error"]["message"],
                 expected_message
@@ -433,7 +440,7 @@ async fn responses_overload_statuses_use_server_error_events() {
                 !failed
                     .data
                     .to_string()
-                    .contains("private backend overload detail")
+                    .contains("private backend error detail")
             );
         }
 

--- a/lib/llm/tests/frontend_validation_http.rs
+++ b/lib/llm/tests/frontend_validation_http.rs
@@ -1,0 +1,428 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP regressions for validation failures shared by the frontend protocols.
+
+use std::time::Duration;
+
+use dynamo_llm::protocols::{
+    Annotated,
+    openai::{
+        chat_completions::NvCreateChatCompletionStreamResponse,
+        completions::NvCreateCompletionResponse,
+    },
+};
+use dynamo_runtime::{
+    config::environment_names::llm::{
+        DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
+        DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS,
+    },
+    error::{BackendError, DynamoError, ErrorType},
+};
+use serde_json::{Value, json};
+use serial_test::serial;
+
+#[path = "common/http_harness.rs"]
+mod http_harness;
+#[path = "common/ports.rs"]
+mod ports;
+#[path = "common/scripted_chat_engine.rs"]
+mod scripted_chat_engine;
+
+use http_harness::{HarnessService, MODEL, load_agent_fixture, parse_json_sse};
+use scripted_chat_engine::{AnnotatedScript, CompletionScript};
+
+const BASE_ENV: [(&str, Option<&str>); 3] = [
+    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+    (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
+];
+
+fn backend_error<T>(error_type: ErrorType, message: &str) -> Annotated<T> {
+    Annotated {
+        data: None,
+        id: None,
+        event: Some("error".to_string()),
+        comment: None,
+        error: Some(
+            DynamoError::builder()
+                .error_type(error_type)
+                .message(message)
+                .build(),
+        ),
+    }
+}
+
+async fn assert_openai_400(response: reqwest::Response, message: &str) {
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["code"], 400);
+    assert!(
+        body["message"].as_str().is_some_and(|actual| actual
+            .to_ascii_lowercase()
+            .contains(&message.to_ascii_lowercase())),
+        "unexpected OpenAI error body: {body}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn completions_backend_validation_is_400_for_unary_and_streaming() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        const MAX_TOKENS_WITHIN_FRONTEND_LIMIT: u32 = 1_048_576;
+        let max_tokens_message = "backend rejected max_tokens";
+        let logprobs_message = "Dynamo's SGLang backend does not currently support logprobs >= 1";
+        let scripts: Vec<CompletionScript> = [
+            max_tokens_message,
+            max_tokens_message,
+            logprobs_message,
+            logprobs_message,
+        ]
+        .into_iter()
+        .map(|message| {
+            vec![backend_error::<NvCreateCompletionResponse>(
+                ErrorType::Backend(BackendError::InvalidArgument),
+                message,
+            )]
+        })
+        .collect();
+        let svc = HarnessService::start_with_completion_scripts(scripts).await;
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/completions", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "prompt": "test",
+                    "max_tokens": MAX_TOKENS_WITHIN_FRONTEND_LIMIT,
+                    "stream": stream
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_openai_400(response, "max_tokens").await;
+        }
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/completions", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "prompt": "hello",
+                    "max_tokens": 16,
+                    "logprobs": 1,
+                    "stream": stream
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_openai_400(response, "logprobs").await;
+        }
+
+        let requests = svc.completion_engine.take_requests().await;
+        assert_eq!(requests.len(), 4);
+        assert_eq!(
+            requests[0].inner.max_tokens,
+            Some(MAX_TOKENS_WITHIN_FRONTEND_LIMIT)
+        );
+        assert_eq!(
+            requests[1].inner.max_tokens,
+            Some(MAX_TOKENS_WITHIN_FRONTEND_LIMIT)
+        );
+        assert_eq!(requests[2].inner.logprobs, Some(1));
+        assert_eq!(requests[3].inner.logprobs, Some(1));
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+fn partial_then_error(
+    partial: &NvCreateChatCompletionStreamResponse,
+    error_type: ErrorType,
+    message: &str,
+) -> AnnotatedScript {
+    vec![
+        Annotated::from_data(partial.clone()),
+        backend_error(error_type, message),
+    ]
+}
+
+#[tokio::test]
+#[serial]
+async fn unary_and_late_stream_errors_keep_classification_and_envelopes() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let partial = load_agent_fixture("text.sse").await.unwrap()[0].clone();
+        let invalid = ErrorType::Backend(BackendError::InvalidArgument);
+        let scripts = vec![
+            partial_then_error(&partial, invalid, "invalid response input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/worker.py",
+            ),
+            partial_then_error(&partial, invalid, "invalid late response input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/late.py",
+            ),
+            partial_then_error(&partial, invalid, "invalid late Anthropic input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/anthropic.py",
+            ),
+            partial_then_error(&partial, invalid, "invalid late chat input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/chat.py",
+            ),
+        ];
+        let partial_completion: NvCreateCompletionResponse = serde_json::from_value(json!({
+            "id": "cmpl-partial",
+            "object": "text_completion",
+            "created": 0,
+            "model": MODEL,
+            "choices": [{
+                "text": "partial",
+                "index": 0,
+                "logprobs": null,
+                "finish_reason": null
+            }]
+        }))
+        .unwrap();
+        let completion_scripts = vec![
+            vec![
+                Annotated::from_data(partial_completion.clone()),
+                backend_error(invalid, "invalid late completion input"),
+            ],
+            vec![
+                Annotated::from_data(partial_completion),
+                backend_error(
+                    ErrorType::Backend(BackendError::Unknown),
+                    "secret /srv/completion.py",
+                ),
+            ],
+        ];
+        let svc = HarnessService::start_with_scripts(scripts, completion_scripts).await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({"model": MODEL, "input": "ping", "stream": false}))
+            .send()
+            .await
+            .unwrap();
+        assert_openai_400(response, "invalid response input").await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({"model": MODEL, "input": "ping", "stream": false}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let body: Value = response.json().await.unwrap();
+        assert_eq!(body["message"], "Failed to fold responses stream");
+        assert!(!body.to_string().contains("/srv/worker.py"));
+
+        for (error_code, expected_message) in [
+            ("invalid_prompt", "invalid late response input"),
+            ("server_error", "Internal server error"),
+        ] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/responses", svc.base_url))
+                .json(&json!({"model": MODEL, "input": "ping", "stream": true}))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            let events = parse_json_sse(&response.text().await.unwrap())
+                .await
+                .unwrap();
+            let failed = events
+                .iter()
+                .find(|event| event.event == "response.failed")
+                .expect("missing response.failed event");
+            assert_eq!(failed.data["response"]["error"]["code"], error_code);
+            assert_eq!(
+                failed.data["response"]["error"]["message"],
+                expected_message
+            );
+        }
+
+        for (error_type, expected_message) in [
+            ("invalid_request_error", "invalid late Anthropic input"),
+            ("api_error", "Internal server error"),
+        ] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "stream": true
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            let events = parse_json_sse(&response.text().await.unwrap())
+                .await
+                .unwrap();
+            let error = events
+                .iter()
+                .find(|event| event.event == "error")
+                .expect("missing Anthropic error event");
+            assert_eq!(error.data["error"]["type"], error_type);
+            assert_eq!(error.data["error"]["message"], expected_message);
+        }
+
+        for (endpoint, client_message) in [
+            ("chat/completions", "invalid late chat input"),
+            ("completions", "invalid late completion input"),
+        ] {
+            for (code, error_type, expected_message) in [
+                (400, "invalid_request_error", client_message.to_string()),
+                (
+                    500,
+                    "internal_server_error",
+                    "Internal server error".to_string(),
+                ),
+            ] {
+                let body = if endpoint == "chat/completions" {
+                    json!({
+                        "model": MODEL,
+                        "messages": [{"role": "user", "content": "ping"}],
+                        "stream": true
+                    })
+                } else {
+                    json!({"model": MODEL, "prompt": "ping", "stream": true})
+                };
+                let response = svc
+                    .client
+                    .post(format!("{}/v1/{endpoint}", svc.base_url))
+                    .json(&body)
+                    .send()
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), reqwest::StatusCode::OK);
+                let events = parse_json_sse(&response.text().await.unwrap())
+                    .await
+                    .unwrap();
+                let error = events
+                    .iter()
+                    .find_map(|event| event.data.get("error"))
+                    .expect("missing OpenAI inline error event");
+                assert_eq!(error["code"], code);
+                assert_eq!(error["type"], error_type);
+                assert_eq!(error["message"], expected_message);
+            }
+        }
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn native_stream_errors_are_terminal_and_recorded_as_failures() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let partial = load_agent_fixture("text.sse").await.unwrap()[0].clone();
+        let invalid = ErrorType::Backend(BackendError::InvalidArgument);
+        let svc = HarnessService::start_with_pending_annotated_scripts([
+            partial_then_error(&partial, invalid, "terminal Responses validation"),
+            partial_then_error(&partial, invalid, "terminal Anthropic validation"),
+        ])
+        .await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({"model": MODEL, "input": "ping", "stream": true}))
+            .send()
+            .await
+            .unwrap();
+        let body = tokio::time::timeout(Duration::from_secs(1), response.text())
+            .await
+            .expect("Responses stream waited for backend EOF")
+            .unwrap();
+        let events = parse_json_sse(&body).await.unwrap();
+        let failed = events
+            .iter()
+            .find(|event| event.event == "response.failed")
+            .expect("missing terminal response.failed event");
+        assert_eq!(
+            failed.data["response"]["error"]["message"],
+            "terminal Responses validation"
+        );
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+                "stream": true
+            }))
+            .send()
+            .await
+            .unwrap();
+        let body = tokio::time::timeout(Duration::from_secs(1), response.text())
+            .await
+            .expect("Anthropic stream waited for backend EOF")
+            .unwrap();
+        let events = parse_json_sse(&body).await.unwrap();
+        let error = events
+            .iter()
+            .find(|event| event.event == "error")
+            .expect("missing terminal Anthropic error event");
+        assert_eq!(
+            error.data["error"]["message"],
+            "terminal Anthropic validation"
+        );
+
+        let metrics = svc
+            .client
+            .get(format!("{}/metrics", svc.base_url))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        for endpoint in ["responses", "anthropic_messages"] {
+            let line = metrics
+                .lines()
+                .find(|line| {
+                    line.starts_with("dynamo_frontend_requests_total{")
+                        && line.contains(&format!("endpoint=\"{endpoint}\""))
+                        && line.contains("request_type=\"stream\"")
+                        && line.contains("status=\"error\"")
+                        && line.contains("error_type=\"validation\"")
+                })
+                .unwrap_or_else(|| panic!("missing validation failure metric for {endpoint}"));
+            assert!(line.ends_with(" 1"), "unexpected request metric: {line}");
+        }
+        assert!(
+            metrics.lines().any(|line| {
+                line == format!("dynamo_frontend_inflight_requests{{model=\"{MODEL}\"}} 0")
+            }),
+            "inflight gauge did not return to zero"
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -21,7 +21,6 @@ use dynamo_llm::{
     },
     model_card::ModelDeploymentCard,
 };
-use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::metrics::prometheus_names::{frontend_service, name_prefix};
 use dynamo_runtime::{
     CancellationToken,
@@ -1457,29 +1456,8 @@ async fn test_nvext_disabled_strips_request_and_response() {
 /// the peek-before-200 helper with chat_completions, so an `InvalidArgument`
 /// frame at t=0 must land as HTTP 400, not HTTP 200 + generic 500 SSE.
 ///
-/// The pre-commit peek is opt-in via `DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS`
-/// (default: unset → peek disabled). Enable it here so the assertion
-/// exercises the fix path. `#[serial]` prevents the env var from bleeding
-/// into other tests that may run in parallel.
 #[tokio::test]
-#[serial_test::serial]
 async fn test_streaming_responses_returns_4xx_on_backend_invalid_argument() {
-    // SAFETY: single-threaded via `#[serial]`; no other test reads or writes
-    // this env var concurrently.
-    unsafe {
-        std::env::set_var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, "500");
-    }
-    // Guard to unset on any exit path from this test.
-    struct EnvGuard;
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                std::env::remove_var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS);
-            }
-        }
-    }
-    let _guard = EnvGuard;
-
     let (listener, port) = bind_random_port().await;
     let service = HttpService::builder()
         .port(port)

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -21,6 +21,7 @@ use dynamo_llm::{
     },
     model_card::ModelDeploymentCard,
 };
+use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::metrics::prometheus_names::{frontend_service, name_prefix};
 use dynamo_runtime::{
     CancellationToken,
@@ -1456,8 +1457,29 @@ async fn test_nvext_disabled_strips_request_and_response() {
 /// the peek-before-200 helper with chat_completions, so an `InvalidArgument`
 /// frame at t=0 must land as HTTP 400, not HTTP 200 + generic 500 SSE.
 ///
+/// The pre-commit peek is opt-in via `DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS`
+/// (default: unset → peek disabled). Enable it here so the assertion
+/// exercises the fix path. `#[serial]` prevents the env var from bleeding
+/// into other tests that may run in parallel.
 #[tokio::test]
+#[serial_test::serial]
 async fn test_streaming_responses_returns_4xx_on_backend_invalid_argument() {
+    // SAFETY: single-threaded via `#[serial]`; no other test reads or writes
+    // this env var concurrently.
+    unsafe {
+        std::env::set_var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, "500");
+    }
+    // Guard to unset on any exit path from this test.
+    struct EnvGuard;
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                std::env::remove_var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS);
+            }
+        }
+    }
+    let _guard = EnvGuard;
+
     let (listener, port) = bind_random_port().await;
     let service = HttpService::builder()
         .port(port)


### PR DESCRIPTION
## Stack

**2 of 2** — base: [#12808](https://github.com/ai-dynamo/dynamo/pull/12808)

Previous: [#12808](https://github.com/ai-dynamo/dynamo/pull/12808)

## Summary

- Route OpenAI, Responses, Anthropic, Generate, Embeddings, and shared HTTP surfaces through the common classifier.
- Remove endpoint-specific and non-streaming first-frame error workarounds.
- Return classified errors before response headers are committed.
- After SSE data commits HTTP 200, emit a protocol-correct inline client or sanitized server error and terminate immediately.
- Record late stream failures consistently in request metrics.

## Streaming rule

| Error timing | Result |
|---|---|
| Before response headers | Return the classified 4xx or sanitized 5xx |
| After SSE data commits HTTP 200 | Keep 200, emit the protocol-specific inline error, terminate the stream |

## Fixed regressions

- Completions `max_tokens: 2147483647`: 400 for unary and pre-header streaming.
- Different backend validation failures such as unsupported `logprobs`: 400.
- Typed validation after partial unary output: 400.
- Unknown runtime failures: sanitized 500.
- Late typed errors: inline protocol client error.
- Late unknown errors: sanitized inline server error.

## Validation

- `frontend_validation_http`: 3 passed
- Shared classifier tests: 10 passed
- Disconnect/stream error tests: 8 passed
- `cargo check -p dynamo-llm`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

## Tracking

- [DYN-3787](https://linear.app/nvidia/issue/DYN-3787)
- [DYN-3788](https://linear.app/nvidia/issue/DYN-3788)
- [DYN-3789](https://linear.app/nvidia/issue/DYN-3789)
