### PR TITLE
fix(llm): preserve explicit zero max_completion_tokens in chat template

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2433,7 +2433,7 @@ fn apply_chat_completions_request_template(
         if request.temperature.is_none() {
             request.temperature = Some(template.temperature);
         }
-        if request.max_completion_tokens.unwrap_or(0) == 0 {
+        if request.max_completion_tokens.is_none() {
             request.max_completion_tokens = Some(template.max_completion_tokens);
         }
     }
@@ -4474,6 +4474,27 @@ mod tests {
         request.temperature = None;
         apply_chat_completions_request_template(&mut request, Some(&template));
         assert_eq!(request.temperature, Some(0.7));
+    }
+
+    #[test]
+    fn test_chat_completions_template_preserves_explicit_zero_max_completion_tokens() {
+        let template = RequestTemplate {
+            model: "template-model".to_string(),
+            temperature: 0.7,
+            max_completion_tokens: 128,
+        };
+        let mut request = CreateChatCompletionRequest {
+            max_completion_tokens: Some(0),
+            ..Default::default()
+        };
+
+        apply_chat_completions_request_template(&mut request, Some(&template));
+
+        assert_eq!(request.max_completion_tokens, Some(0));
+
+        request.max_completion_tokens = None;
+        apply_chat_completions_request_template(&mut request, Some(&template));
+        assert_eq!(request.max_completion_tokens, Some(128));
     }
 
     #[test]


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Silent Validation Bypass: Explicit  `max_completion_tokens: 0`  Escapes Rejection When a Request Template Is Configured

## Details:

<!-- Describe the changes made in this PR. -->

When a client explicitly sent `max_completion_tokens: 0` ,  an illegal value that should be rejected  

the code `request.max_completion_tokens.unwrap_or(0) == 0` silently replaced it with the template's default value (e.g. 128 ). By the time validation ran, it saw 128, not 0. 

So the illegal input got laundered into a legal one, and the validation error never fired:

```
// lib/llm/src/protocols/openai/validate.rs:786
pub fn validate_max_completion_tokens(max_completion_tokens: Option<u32>) -> Result<(), anyhow::Error> {
    if let Some(tokens) = max_completion_tokens && tokens == 0 {
        anyhow::bail!("Max completion tokens must be greater than 0, got {}", tokens);
    }
    Ok(())
}
```

The `--template-file` feature should not turn an illegal input into a legal one. It exists to fill in omitted fields, not to override an explicit (even if invalid) value the client sent. 


Fix: `request.max_completion_tokens.is_none()`

This only fills in the template default when the field is truly absent (omitted).  An explicit 0 stays 0 , reaches validation, and is correctly rejected with "Max completion tokens must be greater than 0".


## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat completion requests now preserve an explicitly provided token limit of `0`.
  * Requests without a token limit continue to use the default value.

* **Tests**
  * Added regression coverage for both explicit zero values and default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->