### PR TITLE
fix(operator): reject unresolved checkpoint GMS client containers

### DIFF
--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/imdario/mergo"
 	corev1 "k8s.io/api/core/v1"
@@ -419,6 +420,13 @@ func prepareCheckpointGMSPodTemplate(
 	if err != nil {
 		return err
 	}
+
+	// Reject client names that no rendered checkpoint Job container declares so the
+	// Job never runs with GMS wiring silently missing from a requested client.
+	if err := checkpointGMSClientContainersError(gmsSpec.ExtraClientContainers, podTemplate.Spec.Containers); err != nil {
+		return err
+	}
+
 	ensureCheckpointGMSPodClaim(&podTemplate.Spec, checkpointGMSResourceClaimTemplateName(checkpointID))
 	checkpoint.EnsureIntraPodGPUMemoryService(
 		&podTemplate.Spec,
@@ -426,6 +434,36 @@ func prepareCheckpointGMSPodTemplate(
 		gmsSpec.ExtraClientContainers,
 	)
 	return nil
+}
+
+// checkpointGMSClientContainersError returns a deterministic error naming every
+// checkpoint.job.gmsClientContainers entry that no rendered Job container declares.
+func checkpointGMSClientContainersError(clientContainers []string, containers []corev1.Container) error {
+	if len(clientContainers) == 0 {
+		return nil
+	}
+
+	// Index rendered container names for constant-time client lookup.
+	containerNames := make(map[string]struct{}, len(containers))
+	for i := range containers {
+		containerNames[containers[i].Name] = struct{}{}
+	}
+
+	missingClients := make([]string, 0, len(clientContainers))
+	for _, name := range clientContainers {
+		if _, exists := containerNames[name]; !exists {
+			missingClients = append(missingClients, name)
+		}
+	}
+	if len(missingClients) == 0 {
+		return nil
+	}
+	slices.Sort(missingClients)
+
+	return fmt.Errorf(
+		"checkpoint.job.gmsClientContainers references unknown containers %q; every name must match a container in the rendered checkpoint job pod",
+		missingClients,
+	)
 }
 
 func ensureCheckpointGMSPodClaim(podSpec *corev1.PodSpec, claimTemplateName string) {

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -1637,3 +1637,125 @@ func TestDGDCheckpointsReconciler_DeleteAutoCheckpointsForDGD(t *testing.T) {
 		t.Fatalf("retained checkpoint should not keep DGD label after finalizer detach")
 	}
 }
+
+func TestDGDCheckpointsReconciler_RejectsUnresolvedCheckpointGMSClients(t *testing.T) {
+	tests := []struct {
+		name             string
+		clientContainers []string
+		jobContainers    []corev1.Container
+		wantErr          string
+		wantAbsentErr    string
+	}{
+		{
+			name:             "misspelled client is rejected",
+			clientContainers: []string{"gms-svaer"},
+			jobContainers: []corev1.Container{{
+				Name:  "gms-saver",
+				Image: "custom-saver:latest",
+			}},
+			wantErr:       `["gms-svaer"]`,
+			wantAbsentErr: "gms-saver",
+		},
+		{
+			name:             "client without any job pod template is rejected",
+			clientContainers: []string{"gms-saver"},
+			wantErr:          `["gms-saver"]`,
+		},
+		{
+			name:             "every unresolved client is named in sorted order",
+			clientContainers: []string{"z-client", "a-client"},
+			jobContainers: []corev1.Container{{
+				Name:  "gms-saver",
+				Image: "custom-saver:latest",
+			}},
+			wantErr: `["a-client" "z-client"]`,
+		},
+		{
+			name:             "target container is a resolvable client",
+			clientContainers: []string{commonconsts.MainContainerName},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build a GMS checkpoint component whose job declares the listed containers")
+			ctx := context.Background()
+			testScheme := newDynamoGraphDeploymentControllerTestScheme(t)
+			deviceClass := &resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: dra.DefaultDeviceClassName}}
+			reconciler := &DynamoGraphDeploymentReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(testScheme).
+					WithObjects(deviceClass).
+					Build(),
+				Config:   &configv1alpha1.OperatorConfiguration{},
+				Recorder: record.NewFakeRecorder(10),
+				RuntimeConfig: &controller_common.RuntimeConfig{
+					Gate: features.Gates{GMSSnapshot: true},
+				},
+			}
+			dgd := betaDGD(t, &v1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dgd",
+					Namespace: "default",
+					UID:       types.UID("dgd-uid"),
+				},
+			})
+
+			component := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: string(commonconsts.ComponentTypeWorker),
+				Resources: &v1alpha1.Resources{
+					Limits: &v1alpha1.ResourceItem{GPU: "1"},
+				},
+				GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    v1alpha1.GMSModeIntraPod,
+				},
+				Checkpoint: &v1alpha1.ServiceCheckpointConfig{
+					Enabled: true,
+					Mode:    v1alpha1.CheckpointModeAuto,
+					Identity: &v1alpha1.DynamoCheckpointIdentity{
+						Model:                "meta-llama/Llama-2-7b-hf",
+						BackendFramework:     "vllm",
+						TensorParallelSize:   1,
+						PipelineParallelSize: 1,
+						ExtraParameters:      map[string]string{},
+					},
+					Job: &v1alpha1.ServiceCheckpointJobConfig{
+						GMSClientContainers: tt.clientContainers,
+					},
+				},
+				ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+					MainContainer: &corev1.Container{
+						Name:  commonconsts.MainContainerName,
+						Image: "checkpoint-writer:latest",
+					},
+				},
+			}
+			if tt.jobContainers != nil {
+				component.Checkpoint.Job.PodTemplate = &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: tt.jobContainers},
+				}
+			}
+
+			t.Log("Create the GMS-backed checkpoint")
+			ckpt, err := newTestDGDCheckpointsReconciler(reconciler).createCheckpointCR(ctx, dgd, "worker", betaComponent(t, component))
+
+			if tt.wantErr == "" {
+				t.Log("Verify a resolvable client is wired instead of rejected")
+				require.NoError(t, err)
+				client := findContainer(ckpt.Spec.Job.PodTemplateSpec.Spec.Containers, tt.clientContainers[0])
+				require.NotNil(t, client)
+				assert.Contains(t, client.VolumeMounts, corev1.VolumeMount{Name: gms.SharedVolumeName, MountPath: gms.SharedMountPath})
+				return
+			}
+
+			t.Log("Verify the unresolved client fails checkpoint creation instead of being skipped")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "checkpoint.job.gmsClientContainers")
+			assert.Contains(t, err.Error(), tt.wantErr)
+			if tt.wantAbsentErr != "" {
+				assert.NotContains(t, err.Error(), tt.wantAbsentErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

fix(operator): reject unresolved checkpoint GMS client containers

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

Under  experimental.checkpoint.job , two fields must agree:

•  podTemplate.spec.containers[*].name  — the containers the user adds to the checkpoint Job pod
•  gmsClientContainers  — which of those containers get GMS client wiring

Nothing validates that the names in  gmsClientContainers  actually resolve to a container in the rendered checkpoint Job pod.

```
kind: DynamoGraphDeployment
metadata:
  name: my-llm
spec:
  components:
    - componentName: worker
      componentType: worker
      podTemplate:
        spec:
          containers:
            - name: main
              image: dynamo:latest
              resources:
                limits:
                  nvidia.com/gpu: 1

      experimental:
        gpuMemoryService:
          mode: IntraPod

        checkpoint:
          enabled: true
          targetContainerName: main
          job:
            podTemplate:
              spec:
                containers:
                  - name: gms-saver          # declared here
                    image: my-saver:v1
            gmsClientContainers:
              - gms-error                    # typo: does not match gms-saver
```

 gms-error  passes admission: the CRD schema only enforces the name pattern  `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, and the webhook only checks that  gpuMemoryService  is set and  mode: IntraPod . Neither checks that the name resolves.

At render time,  EnsureIntraPodGPUMemoryService  looks the name up in the pod spec and  continue s when it finds nothing — the unresolved client is skipped silently, with no error, no event, and no condition.

In result, the DGD is accepted, the Job is created, and the pod runs, but  gms-saver  never receives its GMS wiring:

```
containers:
  - name: main
    env: [{name: GMS_SOCKET_DIR, value: /gms-intrapod-control}]
    volumeMounts: [{name: gms-intrapod-control, mountPath: /gms-intrapod-control}]
    resources:
      claims: [{name: gpu-claim}]

  - name: gms-saver
    image: my-saver:v1
    # no GMS_SOCKET_DIR
    # no gms-intrapod-control volumeMount
    # no DRA claim
```

 main  is still wired because  EnsureServerSidecar  wires the target container directly, independently of  gmsClientContainers .

Every Kubernetes-level signal reports success: kubectl apply  succeeds, the DGD is  Ready , the Job is created, the pod is  Running .  
while the declared configuration and the rendered pod disagree. The failure only surfaces at runtime when  gms-saver  cannot reach the GMS socket, and the applied YAML gives no hint that the operator ignored the reference.


## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect checkpoint jobs that reference unavailable GMS client containers.
  * Checkpoint creation now reports all unresolved container names in a consistent, sorted order.
  * Prevented GMS wiring from being applied when referenced containers are invalid.
  * Valid GMS client containers continue to receive the shared-volume mount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->