### PR TITLE
docs: link CRD references to Full API Reference

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/dynamo-operator.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/dynamo-operator.md
@@ -136,7 +136,7 @@ Advanced and operator-owned resources:
 
 For the complete technical API reference for Dynamo Custom Resource Definitions, see:
 
-**📖 [Dynamo CRD API Reference](../../../../reference/kubernetes-api/additional-resources/api-reference-k8s.md)**
+**📖 [Dynamo CRD API Reference](../../../../reference/kubernetes-api/full-api-reference.mdx)**
 
 For user-focused workflows, see:
 

--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/managing-models-dynamomodel.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/managing-models-dynamomodel.md
@@ -125,7 +125,7 @@ spec:
 ```
 
 **For complete field specifications, validation rules, and all options, see:**
-📖 [DynamoModel API Reference](../../../../reference/kubernetes-api/additional-resources/api-reference-k8s.md#dynamomodel)
+📖 [DynamoModel API Reference](../../../../reference/kubernetes-api/full-api-reference.mdx#dynamomodel)
 
 ### Status Summary
 
@@ -664,7 +664,7 @@ The operator automatically handles all service discovery - you don't configure s
 
 For complete field specifications, validation rules, and detailed type definitions, see:
 
-**📖 [Dynamo CRD API Reference](../../../../reference/kubernetes-api/additional-resources/api-reference-k8s.md#dynamomodel)**
+**📖 [Dynamo CRD API Reference](../../../../reference/kubernetes-api/full-api-reference.mdx#dynamomodel)**
 
 ## Summary
 
@@ -678,4 +678,4 @@ DynamoModel provides declarative model management for Dynamo deployments:
 **Next Steps:**
 - Try the [Quick Start](#quick-start) example
 - Explore [Common Use Cases](#common-use-cases)
-- Check the [API Reference](../../../../reference/kubernetes-api/additional-resources/api-reference-k8s.md#dynamomodel) for advanced configuration
+- Check the [API Reference](../../../../reference/kubernetes-api/full-api-reference.mdx#dynamomodel) for advanced configuration

--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/shadow-engine-failover.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/shadow-engine-failover.md
@@ -168,7 +168,7 @@ experimental:
     mode: IntraPod
 ```
 
-See the [API reference](../../../../reference/kubernetes-api/additional-resources/api-reference-k8s.md) for the exact schema supported by your
+See the [API reference](../../../../reference/kubernetes-api/full-api-reference.mdx) for the exact schema supported by your
 CRD version.
 
 ## Basic Shadow Engine Failover Example
@@ -254,7 +254,7 @@ Working GMS-only examples:
 ## Related Documentation
 
 - [Snapshot](snapshot.md)
-- [API Reference](../../../../reference/kubernetes-api/additional-resources/api-reference-k8s.md)
+- [API Reference](../../../../reference/kubernetes-api/full-api-reference.mdx)
 - [vLLM failover example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/deploy/agg_failover.yaml)
 - [vLLM GMS example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/deploy/agg_gms.yaml)
 - [SGLang GMS example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/sglang/deploy/agg_gms.yaml)

--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/snapshot.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/snapshot.md
@@ -656,4 +656,4 @@ If the manifest already carries snapshot target metadata, it must agree with the
 
 - [Installation Guide](../../../../kubernetes/installation/install-dynamo.md)
 - [Shadow Engine Failover](shadow-engine-failover.md)
-- [API Reference](../../../../reference/kubernetes-api/additional-resources/api-reference-k8s.md)
+- [API Reference](../../../../reference/kubernetes-api/full-api-reference.mdx)

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
@@ -761,4 +761,4 @@ Ensure image pull secrets are configured in your namespace for the container reg
 - [Profiler README](overview.md) — Quick overview and feature matrix
 - [Profiler Examples](profiler-examples.md) — Complete DGDR YAML examples
 - [Planner Guide](../planner/planner-guide.md) — PlannerConfig reference and scaling modes
-- [DGDR API Reference](../../../../reference/kubernetes-api/additional-resources/api-reference-k8s.md) — Full DGDR specification
+- [DGDR API Reference](../../../../reference/kubernetes-api/full-api-reference.mdx) — Full DGDR specification

--- a/docs/fern/pages/kubernetes/auto-deployment/auto-deploy-with-dgdr.md
+++ b/docs/fern/pages/kubernetes/auto-deployment/auto-deploy-with-dgdr.md
@@ -417,4 +417,4 @@ For the complete merge, metadata, and validation rules, see
 | Author the deployment by hand instead | [DGD Guide](../model-deployment/deploy-with-dgd.md) |
 | Profiling algorithms and modes | [Profiler Guide](../../developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md) |
 | Runtime autoscaling details | [Planner Guide](../../developer-guide/knowledge-base/modular-components/planner/planner-guide.md) |
-| Full CRD reference | [API Reference](../../reference/kubernetes-api/additional-resources/api-reference-k8s.md) |
+| Full CRD reference | [API Reference](../../reference/kubernetes-api/full-api-reference.mdx) |

--- a/docs/fern/pages/kubernetes/model-deployment/deploy-with-dgd.md
+++ b/docs/fern/pages/kubernetes/model-deployment/deploy-with-dgd.md
@@ -20,7 +20,7 @@ Before authoring a DGD, make sure you have:
 - A **HuggingFace token** for gated or rate-limited models (you create the Secret in step 1).
 - New to Dynamo on Kubernetes? Run one model end to end with the [Kubernetes Quickstart](../getting-started/quickstart.mdx) first, then come back here to author your own spec.
 
-For the concepts behind the CRDs and the operator, see the [Model Deployment](introduction.mdx) and the [API Reference](../../reference/kubernetes-api/additional-resources/api-reference-k8s.md).
+For the concepts behind the CRDs and the operator, see the [Model Deployment](introduction.mdx) and the [API Reference](../../reference/kubernetes-api/full-api-reference.mdx).
 
 ## How a DGD is structured
 
@@ -751,4 +751,4 @@ These are independent capabilities you opt into per workload. None are required 
 </CardGroup>
 
 > [!IMPORTANT]
-> **The Planner is not part of the DGD spec.** SLA-driven autoscaling with the [Planner](../../developer-guide/knowledge-base/modular-components/planner/overview.md) is configured through a **DynamoGraphDeploymentRequest (DGDR)** — see [Auto Deploy with DGDR](../auto-deployment/auto-deploy-with-dgdr.md). For HPA/KEDA scaling of a DGD service, see [Autoscaling](../../developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md). For the full field reference, see the [API Reference](../../reference/kubernetes-api/additional-resources/api-reference-k8s.md).
+> **The Planner is not part of the DGD spec.** SLA-driven autoscaling with the [Planner](../../developer-guide/knowledge-base/modular-components/planner/overview.md) is configured through a **DynamoGraphDeploymentRequest (DGDR)** — see [Auto Deploy with DGDR](../auto-deployment/auto-deploy-with-dgdr.md). For HPA/KEDA scaling of a DGD service, see [Autoscaling](../../developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md). For the full field reference, see the [API Reference](../../reference/kubernetes-api/full-api-reference.mdx).

--- a/docs/fern/pages/kubernetes/model-deployment/expose-the-frontend.md
+++ b/docs/fern/pages/kubernetes/model-deployment/expose-the-frontend.md
@@ -46,7 +46,7 @@ spec:
 The operator creates the Ingress object; the controller provisions the actual address.
 
 > [!NOTE]
-> The `nvidia.com/v1alpha1` API had a convenience `ingress` field on the Frontend component that generated this Ingress (or a service-mesh VirtualService) for you. That field is **not** part of `nvidia.com/v1beta1` — author the Ingress directly as shown above, or use a LoadBalancer Service (Option 2). See the [API Reference](../../reference/kubernetes-api/additional-resources/api-reference-k8s.md#ingressspec) for the v1alpha1 field.
+> The `nvidia.com/v1alpha1` API had a convenience `ingress` field on the Frontend component that generated this Ingress (or a service-mesh VirtualService) for you. That field is **not** part of `nvidia.com/v1beta1` — author the Ingress directly as shown above, or use a LoadBalancer Service (Option 2). See the [API Reference](../../reference/kubernetes-api/full-api-reference.mdx#ingressspec) for the v1alpha1 field.
 
 ## Option 2: A LoadBalancer Service
 
@@ -74,4 +74,4 @@ The [Gateway API Inference Extension (GAIE)](../kv-aware-routing/gateway-api.mdx
 ## Related pages
 
 - [Inference Gateway (GAIE)](../kv-aware-routing/gateway-api.mdx) — Gateway API model-aware routing.
-- [API Reference — IngressSpec](../../reference/kubernetes-api/additional-resources/api-reference-k8s.md#ingressspec) — full field reference.
+- [API Reference — IngressSpec](../../reference/kubernetes-api/full-api-reference.mdx#ingressspec) — full field reference.

--- a/docs/fern/pages/kubernetes/operations/observability.mdx
+++ b/docs/fern/pages/kubernetes/operations/observability.mdx
@@ -364,7 +364,7 @@ defaults to `9090`:
 
 The worker startup probe allows approximately two hours for model download and engine warm-up.
 User-specified probes take precedence over these defaults. See the
-[API Reference](../../reference/kubernetes-api/additional-resources/api-reference-k8s.md) for defaults that vary by component type.
+[API Reference](../../reference/kubernetes-api/full-api-reference.mdx) for defaults that vary by component type.
 
 </Step>
 <Step title="Inspect a failing probe" id="inspect-a-failing-probe">

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -337,7 +337,7 @@ image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:x.y.z
 ## Related Documentation
 
 - **[Kubernetes Deployment Guide](../docs/fern/pages/kubernetes/getting-started/quickstart.mdx)** - Platform installation and concepts
-- **[API Reference](../docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md)** - DynamoGraphDeployment CRD specification
+- **[API Reference](../docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx)** - DynamoGraphDeployment CRD specification
 - **[vLLM Backend Guide](../docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/overview.md)** - vLLM-specific features
 - **[SGLang Backend Guide](../docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/overview.md)** - SGLang-specific features
 - **[TensorRT-LLM Backend Guide](../docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/overview.md)** - TensorRT-LLM features


### PR DESCRIPTION
## Overview:

Redirect user-facing Dynamo CRD API Reference links to the published Full API
Reference instead of the hidden raw generated Markdown page.

## Details:

- Replace 15 links across 9 Fern documentation pages and `recipes/README.md`
  with `full-api-reference.mdx`.
- Preserve the `#dynamomodel` and `#ingressspec` fragments used by existing
  links.
- Leave the hidden raw artifact, Fern navigation, and the separate missing MDX
  generation-path issue unchanged.

## Where should the reviewer start?

Review the canonical link replacements in
`docs/fern/pages/kubernetes/model-deployment/` and
`docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/`.

## Validation

- `python3 .github/workflows/detect_broken_links.py docs/fern/pages --format json`
  (198 Markdown files, 1,063 links, 0 broken links)
- `python3 .github/workflows/detect_broken_links.py recipes/README.md --format json`
  (1 Markdown file, 69 links, 0 broken links)
- Static target and anchor assertions for all 15 replacements
- `git diff --check`

`fern check` was not run locally because the Fern CLI is not installed; CI should
provide that coverage.

## Related Issues

- Closes #12748


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes and model deployment documentation links to the current full API reference.
  * Corrected API reference links across operator, observability, profiler, auto-deployment, and frontend exposure guides.
  * Replaced outdated documentation paths to help readers reach the appropriate API reference pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->