### PR TITLE
docs: fix Fern CLI guide link

### DIFF
--- a/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
+++ b/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
@@ -360,7 +360,7 @@ workflows. Authors never need to run it manually.
 ## Running Locally
 
 You can preview the documentation site on your machine using the
-[Fern CLI](https://buildwithfern.com/learn/docs/getting-started/overview/). This is useful
+[Fern CLI](https://buildwithfern.com/learn/cli-api-reference/cli-reference/overview). This is useful
 for verifying layout, navigation, and content before opening a PR.
 
 ### Prerequisites


### PR DESCRIPTION
## Overview:

Update the Fern CLI link in the documentation contribution guide to the current
CLI Reference page.

## Details:

- Replace the removed Fern Docs getting-started URL, which now returns HTTP 404.
- Point the guide to the current Fern CLI Reference overview URL.
- Leave lychee configuration and all unrelated documentation unchanged.

## Where should the reviewer start?

Review the single link replacement in
`docs/fern/pages/community/contributing/documentation/building-and-publishing.md`.

## Validation

- Verified the previous URL returns HTTP 404 and the replacement returns HTTP 200.
- `python3 .github/workflows/detect_broken_links.py docs/fern/pages --format json`
  (199 Markdown files, 0 broken local Markdown links)
- `git diff --check`

The local `lychee` CLI is not installed; the repository-wide external-link
check will run in CI.

## Related Issues

- Closes #12816


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Fern CLI documentation link in the “Running Locally” section to point to the current reference page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->