### PR TITLE
fix(sglang): put NIXL wheel libs on the loader path for E/PD frontend decoding (OPS-8072)

### DIFF
--- a/examples/backends/sglang/launch/agg_vision.sh
+++ b/examples/backends/sglang/launch/agg_vision.sh
@@ -93,19 +93,9 @@ if [ "$FRONTEND_DECODING" = true ]; then
     FD_ARGS+=(--frontend-decoding)
     BANNER_SUFFIX=" (Frontend Decoding)"
 
-    # The SGLang image inherits NIXL from the upstream lmsysorg/sglang runtime
-    # stack but does NOT add its native libs to LD_LIBRARY_PATH (cf.
-    # container/templates/dev.Dockerfile: "SGLang dev/local-dev inherit the
-    # upstream SGLang/NIXL runtime stack"). Without this, dynamo.frontend's Rust
-    # runtime hits "NIXL is not supported in stub mode" the moment it tries to
-    # build a media-fetching pipeline. Point the loader at the wheel-shipped .so
-    # files explicitly. We build cuda13 only, so the wheel is nixl_cu13, which
-    # stores its native libs under ".nixl_cu13.mesonpy.libs".
-    NIXL_WHEEL_LIBS="$(python3 -c 'import nixl_cu13, os; print(os.path.join(os.path.dirname(os.path.dirname(nixl_cu13.__file__)), ".nixl_cu13.mesonpy.libs"))' 2>/dev/null || true)"
-    if [ -d "$NIXL_WHEEL_LIBS" ]; then
-        export LD_LIBRARY_PATH="${NIXL_WHEEL_LIBS}:${NIXL_WHEEL_LIBS}/plugins:${LD_LIBRARY_PATH}"
-        export NIXL_PLUGIN_DIR="${NIXL_PLUGIN_DIR:-$NIXL_WHEEL_LIBS/plugins}"
-    fi
+    # The frontend decodes media itself and ships pixels over NIXL RDMA, so it
+    # needs the NIXL wheel's native libs on the loader path.
+    export_nixl_wheel_libs
 fi
 
 print_launch_banner --multimodal "Launching Aggregated Vision Serving${BANNER_SUFFIX}" "$MODEL" "$HTTP_PORT"

--- a/examples/backends/sglang/launch/multimodal_disagg.sh
+++ b/examples/backends/sglang/launch/multimodal_disagg.sh
@@ -122,6 +122,11 @@ fi
 
 if [[ "$FRONTEND_DECODING" == "true" ]]; then
     ENCODE_EXTRA_ARGS="$ENCODE_EXTRA_ARGS --frontend-decoding"
+    # The frontend decodes media itself and ships pixels over NIXL RDMA, so it
+    # needs the NIXL wheel's native libs on the loader path. Without this the
+    # frontend cannot build the media pipeline, so it never adds the model and
+    # /v1/models stays empty.
+    export_nixl_wheel_libs
 fi
 
 # Prevent port collisions: the test framework exports DYN_SYSTEM_PORT which all

--- a/examples/backends/sglang/launch/multimodal_epd.sh
+++ b/examples/backends/sglang/launch/multimodal_epd.sh
@@ -129,6 +129,11 @@ fi
 
 if [[ "$FRONTEND_DECODING" == "true" ]]; then
     ENCODE_EXTRA_ARGS="$ENCODE_EXTRA_ARGS --frontend-decoding"
+    # The frontend decodes media itself and ships pixels over NIXL RDMA, so it
+    # needs the NIXL wheel's native libs on the loader path. Without this the
+    # frontend cannot build the media pipeline, so it never adds the model and
+    # /v1/models stays empty.
+    export_nixl_wheel_libs
 fi
 
 if [[ "$SINGLE_GPU" == "true" ]]; then

--- a/examples/common/launch_utils.sh
+++ b/examples/common/launch_utils.sh
@@ -31,6 +31,8 @@
 #   print_launch_banner    Print startup banner with model info and example curl
 #   print_curl_footer      Print a custom curl example with standard framing (heredoc)
 #   wait_any_exit          Wait for any background process to exit, propagate its code
+#   export_nixl_wheel_libs Put the NIXL wheel's native libs on the loader path
+#                          (required before launching a frontend that decodes media)
 
 if [[ "${BASH_VERSINFO[0]}" -lt 4 || ( "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -lt 3 ) ]]; then
     echo "launch_utils.sh requires bash 4.3+ (for wait -n), found ${BASH_VERSION}" >&2
@@ -233,6 +235,34 @@ wait_for_ready() {
     done
     echo "WARNING: $_url not ready after ${_timeout}s" >&2
     return 1
+}
+
+# export_nixl_wheel_libs
+#
+# Put the NIXL wheel's native libraries on the dynamic-loader path. Call this
+# before launching `dynamo.frontend` in any deployment that passes
+# --frontend-decoding.
+#
+# The SGLang image inherits NIXL from the upstream lmsysorg/sglang runtime
+# stack but does NOT add its native libs to LD_LIBRARY_PATH (cf.
+# container/templates/dev.Dockerfile: "SGLang dev/local-dev inherit the
+# upstream SGLang/NIXL runtime stack"). nixl-sys resolves libnixl_capi.so with
+# a plain dlopen(), which then fails, and the frontend's Rust runtime reports
+# "NIXL is not supported in stub mode" the moment it builds a media-fetching
+# pipeline -- so the model is never added from discovery and /v1/models stays
+# empty forever. Point the loader at the wheel-shipped .so files explicitly.
+# We build cuda13 only, so the wheel is nixl_cu13, which stores its native libs
+# under ".nixl_cu13.mesonpy.libs".
+#
+# No-op (and silent) where the wheel layout does not match, e.g. images that
+# already expose NIXL on the default loader path.
+export_nixl_wheel_libs() {
+    local _libs
+    _libs="$(python3 -c 'import nixl_cu13, os; print(os.path.join(os.path.dirname(os.path.dirname(nixl_cu13.__file__)), ".nixl_cu13.mesonpy.libs"))' 2>/dev/null || true)"
+    if [ -d "$_libs" ]; then
+        export LD_LIBRARY_PATH="${_libs}:${_libs}/plugins:${LD_LIBRARY_PATH}"
+        export NIXL_PLUGIN_DIR="${NIXL_PLUGIN_DIR:-$_libs/plugins}"
+    fi
 }
 
 allocate_free_port() {

--- a/examples/common/launch_utils.sh
+++ b/examples/common/launch_utils.sh
@@ -260,7 +260,10 @@ export_nixl_wheel_libs() {
     local _libs
     _libs="$(python3 -c 'import nixl_cu13, os; print(os.path.join(os.path.dirname(os.path.dirname(nixl_cu13.__file__)), ".nixl_cu13.mesonpy.libs"))' 2>/dev/null || true)"
     if [ -d "$_libs" ]; then
-        export LD_LIBRARY_PATH="${_libs}:${_libs}/plugins:${LD_LIBRARY_PATH}"
+        # ${VAR:+:${VAR}} rather than a bare :${VAR}: an unset LD_LIBRARY_PATH
+        # would otherwise leave a trailing empty element, which the loader
+        # reads as the current directory.
+        export LD_LIBRARY_PATH="${_libs}:${_libs}/plugins${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
         export NIXL_PLUGIN_DIR="${NIXL_PLUGIN_DIR:-$_libs/plugins}"
     fi
 }

--- a/tests/test_frontend_decoding_launch_scripts.py
+++ b/tests/test_frontend_decoding_launch_scripts.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Every launch script that enables frontend decoding must put the NIXL wheel's
+native libs on the loader path.
+
+A frontend started with ``--frontend-decoding`` builds a media pipeline that
+needs a real NIXL agent. nixl-sys resolves ``libnixl_capi.so`` with a plain
+``dlopen()``, and the SGLang image keeps that library in the wheel's private
+directory rather than on the default loader path. Without
+``export_nixl_wheel_libs`` the frontend reports "NIXL is not supported in stub
+mode", never adds the model from discovery, and ``/v1/models`` stays empty
+forever -- a deployment that hangs at startup with no failing process.
+
+This shipped once: ``agg_vision.sh`` carried the setup inline, and when
+``--frontend-decoding`` was extended to the E/PD and disaggregated scripts they
+did not get it, so ``multimodal_e_pd_fd_qwen`` failed every post-merge run.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_EXAMPLES = _REPO_ROOT / "examples"
+_HELPER = "export_nixl_wheel_libs"
+
+
+def _scripts_enabling_frontend_decoding() -> list[Path]:
+    """Launch scripts that hand ``--frontend-decoding`` to a worker.
+
+    Matches the flag only where a script actually passes it on, so the shared
+    helper's own documentation does not count as a user.
+    """
+    hits = []
+    for path in sorted(_EXAMPLES.rglob("*.sh")):
+        text = path.read_text(encoding="utf-8")
+        if re.search(r"^[^#\n]*--frontend-decoding", text, re.MULTILINE):
+            hits.append(path)
+    return hits
+
+
+def test_frontend_decoding_scripts_export_nixl_wheel_libs():
+    scripts = _scripts_enabling_frontend_decoding()
+    # Guard the guard: if the flag is renamed this test must fail loudly rather
+    # than silently pass over an empty set.
+    assert scripts, "no launch script passes --frontend-decoding; update this test"
+
+    missing = [
+        str(p.relative_to(_REPO_ROOT))
+        for p in scripts
+        if _HELPER not in p.read_text(encoding="utf-8")
+    ]
+    assert not missing, (
+        f"launch scripts enable --frontend-decoding without calling {_HELPER}(): "
+        f"{missing}. Their frontend will fail with 'NIXL is not supported in "
+        f"stub mode' and never serve the model."
+    )
+
+
+def test_helper_is_defined_in_shared_launch_utils():
+    """The scripts above only source launch_utils.sh, so the helper must live
+    there -- otherwise they call an undefined function and, under `set -e`,
+    die at startup."""
+    utils = (_EXAMPLES / "common" / "launch_utils.sh").read_text(encoding="utf-8")
+    assert f"{_HELPER}()" in utils

--- a/tests/test_frontend_decoding_launch_scripts.py
+++ b/tests/test_frontend_decoding_launch_scripts.py
@@ -32,19 +32,40 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _EXAMPLES = _REPO_ROOT / "examples"
 _HELPER = "export_nixl_wheel_libs"
 
+# An uncommented call / definition. Matching bare text instead would accept a
+# commented-out call -- which is the likeliest way this regresses, and exactly
+# what this test exists to catch.
+_HELPER_CALL = re.compile(rf"^\s*{_HELPER}\b", re.MULTILINE)
+_HELPER_DEF = re.compile(rf"^\s*{_HELPER}\s*\(\)", re.MULTILINE)
+
+
+def _forwards_frontend_decoding(text: str) -> bool:
+    """Whether a script hands ``--frontend-decoding`` to a worker.
+
+    Skips the places the flag appears without being forwarded: comments, help
+    text, and the ``--frontend-decoding)`` case label (which parses the flag
+    rather than passing it on). A script that only documents the flag does not
+    launch a decoding frontend and so needs no library-path setup.
+    """
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("#", "echo", "printf")):
+            continue
+        if "--frontend-decoding" not in stripped:
+            continue
+        if re.fullmatch(r"--frontend-decoding\)", stripped):
+            continue
+        return True
+    return False
+
 
 def _scripts_enabling_frontend_decoding() -> list[Path]:
-    """Launch scripts that hand ``--frontend-decoding`` to a worker.
-
-    Matches the flag only where a script actually passes it on, so the shared
-    helper's own documentation does not count as a user.
-    """
-    hits = []
-    for path in sorted(_EXAMPLES.rglob("*.sh")):
-        text = path.read_text(encoding="utf-8")
-        if re.search(r"^[^#\n]*--frontend-decoding", text, re.MULTILINE):
-            hits.append(path)
-    return hits
+    """Launch scripts that hand ``--frontend-decoding`` to a worker."""
+    return [
+        path
+        for path in sorted(_EXAMPLES.rglob("*.sh"))
+        if _forwards_frontend_decoding(path.read_text(encoding="utf-8"))
+    ]
 
 
 def test_frontend_decoding_scripts_export_nixl_wheel_libs():
@@ -56,7 +77,7 @@ def test_frontend_decoding_scripts_export_nixl_wheel_libs():
     missing = [
         str(p.relative_to(_REPO_ROOT))
         for p in scripts
-        if _HELPER not in p.read_text(encoding="utf-8")
+        if not _HELPER_CALL.search(p.read_text(encoding="utf-8"))
     ]
     assert not missing, (
         f"launch scripts enable --frontend-decoding without calling {_HELPER}(): "
@@ -70,4 +91,4 @@ def test_helper_is_defined_in_shared_launch_utils():
     there -- otherwise they call an undefined function and, under `set -e`,
     die at startup."""
     utils = (_EXAMPLES / "common" / "launch_utils.sh").read_text(encoding="utf-8")
-    assert f"{_HELPER}()" in utils
+    assert _HELPER_DEF.search(utils), f"{_HELPER}() is not defined in launch_utils.sh"


### PR DESCRIPTION
## Summary

`test_sglang_deployment[multimodal_e_pd_fd_qwen-4]` has failed **every** post-merge run since #11880 added it (4/4 runs checked), while both siblings pass every time.

**Root cause.** A frontend started with `--frontend-decoding` registers a media decoder, so the Rust frontend builds `OpenAIPreprocessor` → `MediaLoader::new` → `get_nixl_agent()`. nixl-sys resolves `libnixl_capi.so` with a plain `dlopen()`, and the SGLang image keeps that library in the wheel's private directory (`.nixl_cu13.mesonpy.libs`) rather than on the default loader path. The dlopen fails, `is_stub()` returns true, and the frontend logs:

```
ERROR dynamo_llm::discovery::watcher: Error adding model from discovery
  model_name="Qwen/Qwen3-VL-2B-Instruct"
  error="OpenAIPreprocessor.new_with_parts: NIXL is not supported in stub mode"
```

The model is never added, `/v1/models` returns `{"data": []}` forever, and readiness polling spins until pytest-timeout kills it. Nothing crashes — VRAM sits flat at ~7.2 GiB (PD worker only), which is why it reads as a slow start rather than a hard failure.

`agg_vision.sh` already carried this setup inline, with a comment naming this exact error. #11880 extended `--frontend-decoding` to `multimodal_epd.sh` and `multimodal_disagg.sh` without it — that is the entire delta between the passing and failing variants. `multimodal_disagg.sh` is latently broken the same way (nothing exercises it with the flag yet).

**Fix.** Move the setup into `examples/common/launch_utils.sh` as `export_nixl_wheel_libs` and call it from all three scripts, so the next script to enable frontend decoding cannot miss it. Add a static test asserting exactly that invariant.

## Validation

Reproduced and verified on the GPU box (RTX 6000 Ada) against the **real** post-#11880 image `17c8f260a5...-sglang-runtime-test` — the same image and test CI runs, with only the patched launch scripts mounted over the image copies:

| Run | Before | After |
|---|---|---|
| `multimodal_e_pd_fd_qwen` | timeout; 6 stub-mode errors; 0 "Chat completions is ready" | **passed 46.7s**; 0 stub errors; pipeline built |
| `multimodal_agg_fd_qwen` (regression for the inline→shared refactor) | passed 51.7s | **passed 49.2s** |
| `multimodal_disagg_qwen` (non-FD, patched script) | — | **passed 53.7s** |

- The new static test was verified with a must-fail control: removing the call from `multimodal_epd.sh` fails it by name with the consequence spelled out.
- `pre-commit run --all-files` passes.
- The test's own `pytest.mark.timeout(180)` needs no change — the fixed deployment is ready in ~47s.

Linear: OPS-8072

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend decoding launch scripts to reliably load required NIXL native libraries.
  * Enhanced CUDA 13 wheel library detection and environment setup for smoother multimodal worker startup.

* **Tests**
  * Added coverage to verify all frontend decoding launch scripts configure NIXL libraries correctly.
  * Added validation that the shared library setup helper is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->