### PR TITLE
fix(frontend): return SGLang chat logprobs

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -1146,7 +1146,13 @@ class SglangStreamingPostProcessor:
         log_probs = engine_response.get("log_probs")
         top_logprobs = engine_response.get("top_logprobs")
         if finish_reason is not None:
+            raw_token_count = len(token_ids)
             token_ids = self._strip_trailing_eos_token_ids(list(token_ids))
+            retained_token_count = len(token_ids)
+            if log_probs is not None and len(log_probs) == raw_token_count:
+                log_probs = log_probs[:retained_token_count]
+            if top_logprobs is not None and len(top_logprobs) == raw_token_count:
+                top_logprobs = top_logprobs[:retained_token_count]
 
         delta_text = (
             self._incremental_decode(token_ids, flush=finish_reason is not None)

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -979,6 +979,7 @@ class SglangStreamingPostProcessor:
         # incomplete byte-fallback sequence.
         self._decode_context_ids = list((prompt_token_ids or [])[-5:])
         self._pending_decode_ids: list[int] = []
+        self._pending_logprobs_content: list[dict[str, Any]] = []
         self._has_emitted_role: bool = False
         # Tool call accumulation.  SGLang's streaming parser returns
         # deltas (name in one chunk, argument fragments across subsequent
@@ -1081,6 +1082,13 @@ class SglangStreamingPostProcessor:
 
         return {"content": content, "refusal": None} if content else None
 
+    def _take_pending_logprobs(self) -> dict[str, Any] | None:
+        if not self._pending_logprobs_content:
+            return None
+        content = self._pending_logprobs_content
+        self._pending_logprobs_content = []
+        return {"content": content, "refusal": None}
+
     def _parse_reasoning_delta(
         self, delta_text: str, finish_reason: str | None
     ) -> tuple[str | None, str]:
@@ -1164,6 +1172,8 @@ class SglangStreamingPostProcessor:
             openai_logprobs = self._build_openai_logprobs(
                 log_probs, top_logprobs, token_ids
             )
+            if openai_logprobs is not None:
+                self._pending_logprobs_content.extend(openai_logprobs["content"])
 
         if self._fast_plain_text:
             if delta_text:
@@ -1171,14 +1181,14 @@ class SglangStreamingPostProcessor:
                     "index": 0,
                     "delta": self._with_initial_role({"content": delta_text}),
                     "finish_reason": finish_reason,
-                    "logprobs": openai_logprobs,
+                    "logprobs": self._take_pending_logprobs(),
                 }
             elif finish_reason:
                 return {
                     "index": 0,
                     "delta": self._with_initial_role({}),
                     "finish_reason": finish_reason,
-                    "logprobs": openai_logprobs,
+                    "logprobs": self._take_pending_logprobs(),
                 }
             return None
 
@@ -1395,7 +1405,7 @@ class SglangStreamingPostProcessor:
                 "index": 0,
                 "delta": self._with_initial_role(delta),
                 "finish_reason": effective_finish,
-                "logprobs": openai_logprobs,
+                "logprobs": self._take_pending_logprobs(),
             }
 
         return None

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -979,6 +979,7 @@ class SglangStreamingPostProcessor:
         # incomplete byte-fallback sequence.
         self._decode_context_ids = list((prompt_token_ids or [])[-5:])
         self._pending_decode_ids: list[int] = []
+        self._logprob_context_ids: list[int] = []
         self._pending_logprobs_content: list[dict[str, Any]] = []
         self._has_emitted_role: bool = False
         # Tool call accumulation.  SGLang's streaming parser returns
@@ -1056,14 +1057,23 @@ class SglangStreamingPostProcessor:
 
         content: list[dict[str, Any]] = []
         for index, (token_id, logprob) in enumerate(zip(token_ids, log_probs)):
-            token = self.tokenizer.decode([token_id], skip_special_tokens=False)
+            context_token_ids = (self._logprob_context_ids + token_ids[:index])[-4:]
+            token = self._decode_logprob_token(token_id, None, context_token_ids)
             candidates = top_logprobs[index] if top_logprobs else []
             openai_top_logprobs = []
             for candidate in candidates:
-                candidate_token = candidate.get("token") or ""
+                candidate_token = self._decode_logprob_token(
+                    candidate.get("token_id"),
+                    candidate.get("token"),
+                    context_token_ids,
+                )
                 candidate_bytes = candidate.get("bytes")
-                if candidate_bytes is None and candidate_token:
-                    candidate_bytes = list(candidate_token.encode("utf-8"))
+                if candidate_bytes is None:
+                    candidate_bytes = (
+                        list(candidate_token.encode("utf-8"))
+                        if candidate_token
+                        else None
+                    )
                 openai_top_logprobs.append(
                     {
                         "token": candidate_token,
@@ -1081,6 +1091,57 @@ class SglangStreamingPostProcessor:
             )
 
         return {"content": content, "refusal": None} if content else None
+
+    def _decode_logprob_token(
+        self,
+        token_id: int | None,
+        token: str | None,
+        context_token_ids: list[int],
+    ) -> str:
+        if token is None:
+            if token_id is None:
+                return ""
+            token = self.tokenizer.decode([token_id], skip_special_tokens=False)
+
+        if not token.endswith("\ufffd") or token_id is None:
+            return token
+
+        for context_size in range(1, min(len(context_token_ids), 4) + 1):
+            context = context_token_ids[-context_size:]
+            decoded = self.tokenizer.decode(
+                context + [token_id], skip_special_tokens=False
+            )
+            if decoded.endswith("\ufffd"):
+                continue
+
+            clean_end = len(context)
+            for context_index in range(len(context) - 1, -1, -1):
+                context_token = self.tokenizer.decode(
+                    [context[context_index]], skip_special_tokens=False
+                )
+                if context_token.endswith("\ufffd"):
+                    clean_end = context_index
+                else:
+                    break
+
+            clean_prefix = (
+                self.tokenizer.decode(
+                    context[:clean_end], skip_special_tokens=False
+                )
+                if clean_end
+                else ""
+            )
+            if decoded.startswith(clean_prefix):
+                return decoded[len(clean_prefix) :]
+
+            common_prefix_length = 0
+            for prefix_char, decoded_char in zip(clean_prefix, decoded):
+                if prefix_char != decoded_char:
+                    break
+                common_prefix_length += 1
+            return decoded[common_prefix_length:]
+
+        return ""
 
     def _take_pending_logprobs(self) -> dict[str, Any] | None:
         if not self._pending_logprobs_content:
@@ -1174,6 +1235,7 @@ class SglangStreamingPostProcessor:
             )
             if openai_logprobs is not None:
                 self._pending_logprobs_content.extend(openai_logprobs["content"])
+        self._logprob_context_ids = (self._logprob_context_ids + token_ids)[-4:]
 
         if self._fast_plain_text:
             if delta_text:

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -1125,9 +1125,7 @@ class SglangStreamingPostProcessor:
                     break
 
             clean_prefix = (
-                self.tokenizer.decode(
-                    context[:clean_end], skip_special_tokens=False
-                )
+                self.tokenizer.decode(context[:clean_end], skip_special_tokens=False)
                 if clean_end
                 else ""
             )

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -1044,6 +1044,43 @@ class SglangStreamingPostProcessor:
         self._pending_decode_ids = []
         return delta_text
 
+    def _build_openai_logprobs(
+        self,
+        log_probs: list[float],
+        top_logprobs: list[list[dict[str, Any]]] | None,
+        token_ids: list[int],
+    ) -> dict[str, Any] | None:
+        if len(log_probs) != len(token_ids):
+            return None
+
+        content: list[dict[str, Any]] = []
+        for index, (token_id, logprob) in enumerate(zip(token_ids, log_probs)):
+            token = self.tokenizer.decode([token_id], skip_special_tokens=False)
+            candidates = top_logprobs[index] if top_logprobs else []
+            openai_top_logprobs = []
+            for candidate in candidates:
+                candidate_token = candidate.get("token") or ""
+                candidate_bytes = candidate.get("bytes")
+                if candidate_bytes is None and candidate_token:
+                    candidate_bytes = list(candidate_token.encode("utf-8"))
+                openai_top_logprobs.append(
+                    {
+                        "token": candidate_token,
+                        "logprob": float(candidate["logprob"]),
+                        "bytes": candidate_bytes,
+                    }
+                )
+            content.append(
+                {
+                    "token": token,
+                    "logprob": float(logprob),
+                    "bytes": list(token.encode("utf-8")) if token else None,
+                    "top_logprobs": openai_top_logprobs,
+                }
+            )
+
+        return {"content": content, "refusal": None} if content else None
+
     def _parse_reasoning_delta(
         self, delta_text: str, finish_reason: str | None
     ) -> tuple[str | None, str]:
@@ -1106,6 +1143,8 @@ class SglangStreamingPostProcessor:
         raw_ids = engine_response.get("token_ids")
         token_ids = raw_ids if isinstance(raw_ids, list) else list(raw_ids or [])
         finish_reason = engine_response.get("finish_reason")
+        log_probs = engine_response.get("log_probs")
+        top_logprobs = engine_response.get("top_logprobs")
         if finish_reason is not None:
             token_ids = self._strip_trailing_eos_token_ids(list(token_ids))
 
@@ -1114,6 +1153,11 @@ class SglangStreamingPostProcessor:
             if token_ids or finish_reason is not None
             else ""
         )
+        openai_logprobs = None
+        if log_probs is not None:
+            openai_logprobs = self._build_openai_logprobs(
+                log_probs, top_logprobs, token_ids
+            )
 
         if self._fast_plain_text:
             if delta_text:
@@ -1121,14 +1165,14 @@ class SglangStreamingPostProcessor:
                     "index": 0,
                     "delta": self._with_initial_role({"content": delta_text}),
                     "finish_reason": finish_reason,
-                    "logprobs": None,
+                    "logprobs": openai_logprobs,
                 }
             elif finish_reason:
                 return {
                     "index": 0,
                     "delta": self._with_initial_role({}),
                     "finish_reason": finish_reason,
-                    "logprobs": None,
+                    "logprobs": openai_logprobs,
                 }
             return None
 
@@ -1345,7 +1389,7 @@ class SglangStreamingPostProcessor:
                 "index": 0,
                 "delta": self._with_initial_role(delta),
                 "finish_reason": effective_finish,
-                "logprobs": None,
+                "logprobs": openai_logprobs,
             }
 
         return None

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -639,6 +639,91 @@ class SglangProcessor:
             video_count = len(_mm_counts.get("video_url", []))
             audio_count = len(_mm_counts.get("audio_url", []))
 
+            def flush_pending(
+                *,
+                finish_reason: str | None,
+                stop_reason: Any | None,
+                engine_data: Any | None,
+            ) -> dict[str, Any]:
+                nonlocal pending_token_ids
+                nonlocal pending_log_probs
+                nonlocal pending_top_logprobs
+                nonlocal pending_usage
+                nonlocal first_chunk
+                nonlocal post_proc_total_ms
+                nonlocal token_count
+
+                chunk_token_count = len(pending_token_ids)
+                usage_for_metrics = pending_usage
+                mapped_response = {
+                    "token_ids": pending_token_ids,
+                    "finish_reason": finish_reason,
+                }
+                if pending_log_probs is not None:
+                    mapped_response["log_probs"] = pending_log_probs
+                if pending_top_logprobs is not None:
+                    mapped_response["top_logprobs"] = pending_top_logprobs
+
+                if self.debug_perf:
+                    t_pp0 = time.monotonic()
+
+                choice = post.process_output(mapped_response)
+
+                if self.debug_perf:
+                    t_pp1 = time.monotonic()
+                    post_proc_total_ms += (t_pp1 - t_pp0) * 1000.0
+                    token_count += chunk_token_count
+
+                envelope: dict[str, Any] = {"_dynamo_annotated": True}
+                if choice:
+                    dynamo_out: dict[str, Any] = {
+                        "id": request_id,
+                        "choices": [choice],
+                        "created": created_ts,
+                        "model": request["model"],
+                        "object": "chat.completion.chunk",
+                    }
+                    if pending_usage:
+                        dynamo_out["usage"] = pending_usage
+                    response_nvext: dict[str, Any] = {}
+                    if stop_reason is not None and nvext_extra_field_requested(
+                        request, "stop_reason"
+                    ):
+                        response_nvext["stop_reason"] = stop_reason
+                    if engine_data is not None and nvext_extra_field_requested(
+                        request, "engine_data"
+                    ):
+                        response_nvext["engine_data"] = engine_data
+                    if response_nvext:
+                        dynamo_out["nvext"] = response_nvext
+
+                    envelope["data"] = dynamo_out
+
+                metrics: dict[str, Any] = {
+                    "input_tokens": input_tokens,
+                    "output_tokens": cumulative_output_tokens,
+                    "chunk_tokens": chunk_token_count,
+                }
+                # Include nonzero counts on every frame (text-only carries nothing).
+                if image_count:
+                    metrics["image_count"] = image_count
+                if video_count:
+                    metrics["video_count"] = video_count
+                if audio_count:
+                    metrics["audio_count"] = audio_count
+                cached_tokens = _cached_tokens_from_usage(usage_for_metrics)
+                if cached_tokens is not None:
+                    metrics["cached_tokens"] = cached_tokens
+                envelope["event"] = "llm_metrics"
+                envelope["comment"] = [json.dumps(metrics)]
+
+                pending_token_ids = []
+                pending_log_probs = None
+                pending_top_logprobs = None
+                pending_usage = None
+                first_chunk = False
+                return envelope
+
             async for dynamo_response in dynamo_stream:
                 if dynamo_response.is_error():
                     comments = dynamo_response.comments() or []
@@ -665,6 +750,25 @@ class SglangProcessor:
                     break
 
                 new_ids = engine_response["token_ids"]
+                log_probs = engine_response.get("log_probs")
+                top_logprobs = engine_response.get("top_logprobs")
+
+                if new_ids and pending_token_ids:
+                    pending_logprob_shape = (
+                        pending_log_probs is not None,
+                        pending_top_logprobs is not None,
+                    )
+                    chunk_logprob_shape = (
+                        log_probs is not None,
+                        top_logprobs is not None,
+                    )
+                    if pending_logprob_shape != chunk_logprob_shape:
+                        yield flush_pending(
+                            finish_reason=None,
+                            stop_reason=None,
+                            engine_data=None,
+                        )
+
                 chunk_tokens = len(new_ids)
                 cumulative_output_tokens += chunk_tokens
                 raw_finish = engine_response.get("finish_reason")
@@ -676,11 +780,11 @@ class SglangProcessor:
                 engine_data = engine_response.get("engine_data")
 
                 pending_token_ids.extend(new_ids)
-                if (log_probs := engine_response.get("log_probs")) is not None:
+                if log_probs is not None:
                     if pending_log_probs is None:
                         pending_log_probs = []
                     pending_log_probs.extend(log_probs)
-                if (top_logprobs := engine_response.get("top_logprobs")) is not None:
+                if top_logprobs is not None:
                     if pending_top_logprobs is None:
                         pending_top_logprobs = []
                     pending_top_logprobs.extend(top_logprobs)
@@ -689,77 +793,11 @@ class SglangProcessor:
                 # First chunk flushes immediately (si=1) to minimize TTFT.
                 flush_threshold = 1 if first_chunk else stream_interval
                 if finish_reason or len(pending_token_ids) >= flush_threshold:
-                    usage_for_metrics = pending_usage
-                    mapped_response = {
-                        "token_ids": pending_token_ids,
-                        "finish_reason": finish_reason,
-                    }
-                    if pending_log_probs is not None:
-                        mapped_response["log_probs"] = pending_log_probs
-                    if pending_top_logprobs is not None:
-                        mapped_response["top_logprobs"] = pending_top_logprobs
-
-                    if self.debug_perf:
-                        t_pp0 = time.monotonic()
-
-                    choice = post.process_output(mapped_response)
-
-                    if self.debug_perf:
-                        t_pp1 = time.monotonic()
-                        post_proc_total_ms += (t_pp1 - t_pp0) * 1000.0
-                        token_count += len(pending_token_ids)
-
-                    envelope: dict[str, Any] = {"_dynamo_annotated": True}
-                    if choice:
-                        dynamo_out: dict[str, Any] = {
-                            "id": request_id,
-                            "choices": [choice],
-                            "created": created_ts,
-                            "model": request["model"],
-                            "object": "chat.completion.chunk",
-                        }
-                        if pending_usage:
-                            dynamo_out["usage"] = pending_usage
-                            pending_usage = None
-                        response_nvext: dict[str, Any] = {}
-                        if stop_reason is not None and nvext_extra_field_requested(
-                            request, "stop_reason"
-                        ):
-                            response_nvext["stop_reason"] = stop_reason
-                        if engine_data is not None and (
-                            nvext_extra_field_requested(request, "engine_data")
-                        ):
-                            response_nvext["engine_data"] = engine_data
-                        if response_nvext:
-                            dynamo_out["nvext"] = response_nvext
-
-                        envelope["data"] = dynamo_out
-
-                    metrics: dict[str, Any] = {
-                        "input_tokens": input_tokens,
-                        "output_tokens": cumulative_output_tokens,
-                        "chunk_tokens": len(pending_token_ids),
-                    }
-                    # Include nonzero counts on every frame (text-only carries nothing).
-                    if image_count:
-                        metrics["image_count"] = image_count
-                    if video_count:
-                        metrics["video_count"] = video_count
-                    if audio_count:
-                        metrics["audio_count"] = audio_count
-                    cached_tokens = _cached_tokens_from_usage(usage_for_metrics)
-                    if cached_tokens is not None:
-                        metrics["cached_tokens"] = cached_tokens
-                    envelope["event"] = "llm_metrics"
-                    envelope["comment"] = [json.dumps(metrics)]
-
-                    yield envelope
-
-                    pending_token_ids = []
-                    pending_log_probs = None
-                    pending_top_logprobs = None
-                    pending_usage = None
-                    first_chunk = False
+                    yield flush_pending(
+                        finish_reason=finish_reason,
+                        stop_reason=stop_reason,
+                        engine_data=engine_data,
+                    )
         except Unknown:
             raise
         except Exception as e:

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -625,6 +625,8 @@ class SglangProcessor:
             # finish_reason.  Use si=1 for the first chunk to minimize
             # TTFT, then switch to the configured interval.
             pending_token_ids: list[int] = []
+            pending_log_probs: list[float] | None = None
+            pending_top_logprobs: list[list[dict[str, Any]]] | None = None
             pending_usage: dict[str, Any] | None = None
             first_chunk = True
             input_tokens = len(tokens)
@@ -674,6 +676,14 @@ class SglangProcessor:
                 engine_data = engine_response.get("engine_data")
 
                 pending_token_ids.extend(new_ids)
+                if (log_probs := engine_response.get("log_probs")) is not None:
+                    if pending_log_probs is None:
+                        pending_log_probs = []
+                    pending_log_probs.extend(log_probs)
+                if (top_logprobs := engine_response.get("top_logprobs")) is not None:
+                    if pending_top_logprobs is None:
+                        pending_top_logprobs = []
+                    pending_top_logprobs.extend(top_logprobs)
 
                 # Flush on finish or when we've accumulated enough tokens.
                 # First chunk flushes immediately (si=1) to minimize TTFT.
@@ -684,6 +694,10 @@ class SglangProcessor:
                         "token_ids": pending_token_ids,
                         "finish_reason": finish_reason,
                     }
+                    if pending_log_probs is not None:
+                        mapped_response["log_probs"] = pending_log_probs
+                    if pending_top_logprobs is not None:
+                        mapped_response["top_logprobs"] = pending_top_logprobs
 
                     if self.debug_perf:
                         t_pp0 = time.monotonic()
@@ -742,6 +756,8 @@ class SglangProcessor:
                     yield envelope
 
                     pending_token_ids = []
+                    pending_log_probs = None
+                    pending_top_logprobs = None
                     pending_usage = None
                     first_chunk = False
         except Unknown:

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -655,7 +655,7 @@ class SglangProcessor:
 
                 chunk_token_count = len(pending_token_ids)
                 usage_for_metrics = pending_usage
-                mapped_response = {
+                mapped_response: dict[str, Any] = {
                     "token_ids": pending_token_ids,
                     "finish_reason": finish_reason,
                 }

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -2890,6 +2890,73 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert content == "한"
         assert "\ufffd" not in content
 
+    def test_logprobs_reconstruct_split_multibyte_character(self):
+        """Logprob token strings use context to reconstruct split UTF-8."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=self.ByteTokenizer(),
+            tool_call_parser=None,
+            reasoning_parser=None,
+        )
+
+        encoded = list("한".encode("utf-8"))
+        choice = None
+        for index, token_id in enumerate(encoded):
+            choice = post.process_output(
+                {
+                    "token_ids": [token_id],
+                    "finish_reason": "stop" if index == len(encoded) - 1 else None,
+                    "log_probs": [-0.1 * (index + 1)],
+                    "top_logprobs": [
+                        [
+                            {
+                                "token_id": token_id,
+                                "token": "\ufffd",
+                                "logprob": -0.1 * (index + 1),
+                            }
+                        ]
+                    ],
+                }
+            )
+
+        assert choice is not None
+        assert choice["delta"]["content"] == "한"
+        logprob_content = choice["logprobs"]["content"]
+        assert [entry["token"] for entry in logprob_content] == ["", "", "한"]
+        assert [entry["bytes"] for entry in logprob_content] == [
+            None,
+            None,
+            list("한".encode("utf-8")),
+        ]
+        assert [
+            entry["top_logprobs"][0]["token"] for entry in logprob_content
+        ] == ["", "", "한"]
+
+    def test_logprobs_regular_token_is_unchanged(self):
+        """Ordinary tokens keep their decoded text and UTF-8 bytes."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=self.ByteTokenizer(),
+            tool_call_parser=None,
+            reasoning_parser=None,
+        )
+
+        choice = post.process_output(
+            {
+                "token_ids": [ord("A")],
+                "finish_reason": "stop",
+                "log_probs": [-0.3],
+            }
+        )
+
+        assert choice is not None
+        assert choice["logprobs"]["content"] == [
+            {
+                "token": "A",
+                "logprob": -0.3,
+                "bytes": [65],
+                "top_logprobs": [],
+            }
+        ]
+
     def test_byte_fallback_sequence_longer_than_six_tokens(
         self, byte_fallback_tokenizer
     ):

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -2959,6 +2959,85 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             }
         ]
 
+    def _run_logprob_stream(self, items):
+        processor = SglangProcessor(
+            tokenizer=self.ByteTokenizer(),
+            routed_engine=FakeRoutedEngine(items=items),
+            tool_call_parser_name=None,
+            reasoning_parser_name=None,
+            eos_token_ids=None,
+            stream_interval=20,
+        )
+        post = SglangStreamingPostProcessor(
+            tokenizer=self.ByteTokenizer(),
+            tool_call_parser=None,
+            reasoning_parser=None,
+        )
+
+        async def collect():
+            return [
+                item["data"]
+                async for item in processor._generate_and_stream(
+                    "req-logprobs", {"model": "test-model"}, {}, [], post
+                )
+                if "data" in item
+            ]
+
+        return asyncio.run(collect())
+
+    def test_missing_chunk_logprobs_do_not_drop_adjacent_logprobs(self):
+        """A missing-logprob chunk is isolated from adjacent valid chunks."""
+        chunks = self._run_logprob_stream(
+            [
+                {"token_ids": [ord("A")], "log_probs": [-0.1]},
+                {"token_ids": [ord("B")], "log_probs": [-0.2]},
+                {"token_ids": [ord("C")]},
+                {
+                    "token_ids": [ord("D")],
+                    "log_probs": [-0.4],
+                    "finish_reason": "stop",
+                },
+            ]
+        )
+
+        choices = [chunk["choices"][0] for chunk in chunks]
+        assert [choice["delta"]["content"] for choice in choices] == [
+            "A",
+            "B",
+            "C",
+            "D",
+        ]
+        assert [
+            choice["logprobs"]["content"][0]["logprob"]
+            if choice["logprobs"] is not None
+            else None
+            for choice in choices
+        ] == [-0.1, -0.2, None, -0.4]
+        assert choices[-1]["finish_reason"] == "stop"
+
+    def test_consistent_chunk_logprobs_keep_normal_batching(self):
+        """Consistent logprob chunks retain the configured stream interval."""
+        chunks = self._run_logprob_stream(
+            [
+                {"token_ids": [ord("A")], "log_probs": [-0.1]},
+                {"token_ids": [ord("B")], "log_probs": [-0.2]},
+                {"token_ids": [ord("C")], "log_probs": [-0.3]},
+                {
+                    "token_ids": [ord("D")],
+                    "log_probs": [-0.4],
+                    "finish_reason": "stop",
+                },
+            ]
+        )
+
+        choices = [chunk["choices"][0] for chunk in chunks]
+        assert [choice["delta"]["content"] for choice in choices] == ["A", "BCD"]
+        assert [entry["logprob"] for entry in choices[1]["logprobs"]["content"]] == [
+            -0.2,
+            -0.3,
+            -0.4,
+        ]
+
     def test_byte_fallback_sequence_longer_than_six_tokens(
         self, byte_fallback_tokenizer
     ):

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -2927,9 +2927,11 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             None,
             list("한".encode("utf-8")),
         ]
-        assert [
-            entry["top_logprobs"][0]["token"] for entry in logprob_content
-        ] == ["", "", "한"]
+        assert [entry["top_logprobs"][0]["token"] for entry in logprob_content] == [
+            "",
+            "",
+            "한",
+        ]
 
     def test_logprobs_regular_token_is_unchanged(self):
         """Ordinary tokens keep their decoded text and UTF-8 bytes."""


### PR DESCRIPTION
## Overview:

Fix SGLang chat-completion responses returning `logprobs.content: null` when logprobs were requested, including requests with `logprobs=true` and `top_logprobs=0`.

The SGLang backend calculated and returned token logprobs, but the frontend discarded them before postprocessing. The postprocessor also hardcoded the response’s `logprobs` field to `None`.

## Details:

- Preserve `log_probs` and `top_logprobs` while batching generated tokens in the SGLang frontend.
- Forward those values to the SGLang postprocessor.
- Convert backend logprobs into the OpenAI-compatible per-token format:
  - `token`
  - `logprob`
  - `bytes`
  - `top_logprobs`
- Return populated logprobs instead of hardcoded `null`.
- Preserve the existing behavior when logprobs are not requested.

## Where should the reviewer start?

- `components/src/dynamo/frontend/sglang_processor.py`
  - Preserves and forwards backend logprob data while batching tokens.
- `components/src/dynamo/frontend/sglang_prepost.py`
  - Converts backend logprob data into the OpenAI response contract.

## Related Issues

- Closes [DIS-2624](https://linear.app/nvidia/issue/DIS-2624/dynamorelease140frontend-sglang-processor-treats-top-logprobs0-as-1)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible log probability details to streamed responses.
  * Streaming output can include per-token scores, top candidate tokens, and UTF-8 byte values.
  * Log probability data is now preserved across streamed chunks and attached to text, completion, and parsed-output responses.

* **Bug Fixes**
  * Prevented incomplete or mismatched token probability data from being emitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->