### PR TITLE
docs: point the Fern CLI link at the CLI reference

### DIFF
--- a/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
+++ b/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
@@ -360,7 +360,7 @@ workflows. Authors never need to run it manually.
 ## Running Locally
 
 You can preview the documentation site on your machine using the
-[Fern CLI](https://buildwithfern.com/learn/docs/getting-started/overview). This is useful
+[Fern CLI](https://buildwithfern.com/learn/cli-api-reference/cli-reference/overview). This is useful
 for verifying layout, navigation, and content before opening a PR.
 
 ### Prerequisites

--- a/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
+++ b/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
@@ -360,7 +360,7 @@ workflows. Authors never need to run it manually.
 ## Running Locally
 
 You can preview the documentation site on your machine using the
-[Fern CLI](https://buildwithfern.com/learn/docs/getting-started/overview/). This is useful
+[Fern CLI](https://buildwithfern.com/learn/docs/getting-started/overview). This is useful
 for verifying layout, navigation, and content before opening a PR.
 
 ### Prerequisites


### PR DESCRIPTION
## Summary

The "Running Locally" section links the words "Fern CLI" at
`docs/fern/pages/community/contributing/documentation/building-and-publishing.md:363`.
Two things were wrong with the target.

It carried a trailing slash that now 404s. lychee reported that as a `308`
redirect until recently, so it passed; Fern has since made it a hard 404.

It also pointed at the general docs getting-started overview, not at the CLI
documentation the sentence is about. Dropping the slash alone would have left
the link pointing somewhere it does not belong.

Now points at the CLI reference, which is the right destination for the link
text and returns 200.

No `.lycheeignore` entry. The destination is live; only the target was wrong.

## Validation

```
/learn/docs/getting-started/overview/            404
/learn/docs/getting-started/overview             200, but not about the CLI
/learn/cli-api-reference/cli-reference/overview  200, the CLI reference
```

Checked without following redirects. An earlier `curl -L` on the no-slash URL
reported 200 by following a redirect, which hid that the slashed form was the
only broken one.

`git grep` confirms a single occurrence repo-wide. Pre-commit hooks pass.

## A caveat on the link check

This will not turn `lychee` green, and that is worth stating rather than
leaving as a surprise. `buildwithfern.com` answers 404 to the GitHub runner
for URLs that return 200 from an ordinary client, so the link check cannot
verify any link to that host in either direction.

`lychee` is advisory. It is not among the required status checks in the
`Required PR Checks` ruleset, and it is not in `pre-merge-status-check`'s
`needs`, so it does not gate merge.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Fern CLI documentation link in the “Running Locally” section to use the correct URL format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
