### PR TITLE
fix(aisimulate): send one synthetic load controller

### DIFF
--- a/aisimulate/src/aisimulate/spica/config.py
+++ b/aisimulate/src/aisimulate/spica/config.py
@@ -273,12 +273,15 @@ class Workload(BaseModel):
         return max(1, round((self.num_request_ratio or 0.0) * load))
 
     @property
-    def synthetic_arrival_interval_ms(self) -> float:
-        """Mean inter-arrival for a synthetic request-rate workload (1.0 default;
-        ignored in closed-loop / concurrency mode)."""
-        if self.request_rate:
-            return 1000.0 / self.request_rate
-        return 1.0
+    def synthetic_arrival_interval_ms(self) -> float | None:
+        """Mean inter-arrival for a synthetic request-rate workload.
+
+        Closed-loop workloads return ``None`` so Replay receives only their
+        ``replay_concurrency`` load controller.
+        """
+        if self.request_rate is None:
+            return None
+        return 1000.0 / self.request_rate
 
     @model_validator(mode="after")
     def _validate_workload(self) -> Workload:

--- a/aisimulate/src/aisimulate/spica/evaluator.py
+++ b/aisimulate/src/aisimulate/spica/evaluator.py
@@ -115,7 +115,7 @@ class ReplayEvaluator:
 
     def _synthetic_kwargs(self, concurrency_override: int | None = None) -> dict:
         """The synthetic-workload params ``run_synthetic_trace_replay`` takes
-        (``arrival_interval_ms`` is ignored in closed-loop mode).
+        (``arrival_interval_ms`` is ``None`` in closed-loop mode).
 
         ``request_count`` is derived from ``num_request_ratio`` and the effective load
         (the per-trial KV-load-derived ``concurrency_override``, else the workload's fixed

--- a/aisimulate/tests/spica/test_evaluator.py
+++ b/aisimulate/tests/spica/test_evaluator.py
@@ -260,6 +260,11 @@ def _syn_wl(**kw):
     return Workload(**base)
 
 
+def _assert_only_synthetic_load_controller(rec, expected):
+    controllers = ("replay_concurrency", "request_rate", "arrival_interval_ms")
+    assert [name for name in controllers if rec.get(name) is not None] == [expected]
+
+
 def test_synthetic_static_uses_run_synthetic_trace_replay(monkeypatch):
     # synthetic + static -> a single run_synthetic_trace_replay call with planner_config=None
     # (fixed-fleet replay, no scaling); goodput SLA threaded; in-flight cap = concurrency.
@@ -287,6 +292,7 @@ def test_synthetic_static_uses_run_synthetic_trace_replay(monkeypatch):
         and rec["request_count"] == 100
     )
     assert rec["replay_concurrency"] == 4  # closed-loop cap from concurrency
+    _assert_only_synthetic_load_controller(rec, "replay_concurrency")
     assert rec["sla_ttft_ms"] == 2000.0
     assert rec["planner_config"] is None  # static -> no planner in the loop
     assert rec["num_workers"] == 2
@@ -309,6 +315,7 @@ def test_concurrency_override_drives_cap_and_request_count(monkeypatch):
     goal = OptimizationGoal(target=OptimizationTarget.PARETO)  # no SLA needed
     ReplayEvaluator(wl, goal).evaluate(_agg_plan(static=True), concurrency_override=8)
     assert rec["replay_concurrency"] == 8  # cap = the candidate-derived concurrency
+    _assert_only_synthetic_load_controller(rec, "replay_concurrency")
     assert rec["request_count"] == 200  # num_request_ratio(25) * 8
     assert rec["planner_config"] is None
 
@@ -331,6 +338,7 @@ def test_synthetic_planner_threads_planner_config(monkeypatch):
     # request-rate workload -> open-loop (no cap); arrival_interval derived from the rate
     ReplayEvaluator(_syn_wl(request_rate=20.0), goal).evaluate(_agg_plan(static=False))
     assert rec["replay_concurrency"] is None
+    _assert_only_synthetic_load_controller(rec, "arrival_interval_ms")
     assert rec["input_tokens"] == 128 and rec["output_tokens"] == 64
     assert rec["arrival_interval_ms"] == 50.0  # 1000 / 20
     assert rec["planner_config"]["mode"] == "agg"


### PR DESCRIPTION
## Summary

- return `None` for synthetic arrival intervals in closed-loop Spica workloads so Replay receives only `replay_concurrency`
- assert the exactly-one-controller invariant for fixed concurrency, KV-load-derived concurrency, and request-rate workloads
- fix [DYN-3742](https://linear.app/nvidia/issue/DYN-3742/dynamorelease140spica-synthetic-closed-loop-searches-pass-two-load)

## Validation

- `python -m pytest aisimulate/tests/spica/test_evaluator.py -q` — 16 passed
- `python -m pytest aisimulate/tests/spica --ignore=aisimulate/tests/spica/test_replay_integration.py -q` — 244 passed
- `pre-commit run --files aisimulate/src/aisimulate/spica/config.py aisimulate/src/aisimulate/spica/evaluator.py aisimulate/tests/spica/test_evaluator.py` — passed

The four real-Replay integration tests were also attempted, but the local virtualenv has an older compiled `_core` binding than current `main`; it rejects the existing `capture_per_request` keyword before reaching this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Synthetic workloads without a configured request rate now support closed-loop operation using concurrency-based load control.
  - Request-rate workloads continue to calculate arrival intervals from the configured rate.

- **Documentation**
  - Updated synthetic replay guidance to clarify that closed-loop mode uses no arrival interval.

- **Tests**
  - Expanded coverage for closed-loop concurrency and open-loop arrival-rate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->