### PR TITLE
skills UAT feedback: resource envelope, correction protocol, agent-reported issues, capacity accounting

### DIFF
--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -104,6 +104,12 @@ Review the assigned DGD and any support manifests explicitly included in the han
 Stop before mutation if required namespace, CRDs, PVC prerequisites, secret names, storage class, images, or GPU
 capacity are missing.
 
+When checking GPU capacity, count every pod that is bound to a node (`spec.nodeName` set) and not in a terminal phase
+(`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in
+`ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes carrying taints beyond the
+standard GPU taint (tenant reservations) from schedulable capacity, and never add tolerations for them. Report free
+capacity as the largest schedulable per-node block, not a cluster-wide sum: a 4-GPU pod needs 4 free GPUs on one node.
+
 If a manifest must change only to work with the target cluster, such as resolving a storage class placeholder or adding
 a required node-taint toleration, update only the copy under `applied_manifests/`. Preserve the handed-off source
 and record the exact change and reason in `deployment_ledger.json`. Do not change performance knobs.

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -106,9 +106,11 @@ capacity are missing.
 
 When checking GPU capacity, count every pod that is bound to a node (`spec.nodeName` set) and not in a terminal phase
 (`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in
-`ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes carrying taints beyond the
-standard GPU taint (tenant reservations) from schedulable capacity, and never add tolerations for them. Report free
-capacity as the largest schedulable per-node block, not a cluster-wide sum: a 4-GPU pod needs 4 free GPUs on one node.
+`ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes whose taints the
+assigned manifest does not already tolerate, and never add new tolerations for other tenants' reservation taints.
+Evaluate fit per component pod — each pod's GPU request, node selectors, affinity, and tolerations against per-node
+free blocks — rather than a cluster-wide sum: a multi-component DGD schedules only if every one of its pods fits on
+some node.
 
 If a manifest must change only to work with the target cluster, such as resolving a storage class placeholder or adding
 a required node-taint toleration, update only the copy under `applied_manifests/`. Preserve the handed-off source

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -108,9 +108,11 @@ When checking GPU capacity, count every pod that is bound to a node (`spec.nodeN
 (`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in
 `ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes whose taints the
 assigned manifest does not already tolerate, and never add new tolerations for other tenants' reservation taints.
-Evaluate fit per component pod — each pod's GPU request, node selectors, affinity, and tolerations against per-node
-free blocks — rather than a cluster-wide sum: a multi-component DGD schedules only if every one of its pods fits on
-some node.
+Evaluate fit by expanding the DGD into its full multiset of pod demands (every component, every replica) and placing
+them against per-node free blocks while decrementing remaining capacity — two pods cannot count the same free GPUs.
+Honor each pod's node selectors, required affinity/anti-affinity, and tolerations during placement. If the DGD cannot
+be faithfully expanded into pod demands, report capacity as unknown, not sufficient. When `resources.gpu_ceiling` is
+set in the workload contract, also verify the run's total concurrent GPU holdings stay within it.
 
 If a manifest must change only to work with the target cluster, such as resolving a storage class placeholder or adding
 a required node-taint toleration, update only the copy under `applied_manifests/`. Preserve the handed-off source

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -61,6 +61,14 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - Accept natural-language answers; do not make the user author YAML.
 - Do not ask for secret values, kubeconfig contents, registry credentials, or Kubernetes Secret data.
 - Do not add a ceremonial confirmation round when the user's message already provides an unambiguous value.
+- Ask once for the resource envelope: the GPU floor and ceiling in play for this work, whether parallel experiments
+  are authorized within the ceiling, any knobs the user forbids changing, and any teardown deadline. Record the
+  answers in the contract's `resources` block. When capacity within the ceiling allows, downstream roles prefer
+  running approved candidates in parallel (one variable per slot, slot attribution in every ledger record) over
+  queueing them serially.
+- When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
+  numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
+  before recording it.
 
 If blocking facts remain, return the questions to the parent and stop without handing work to a downstream role.
 
@@ -118,6 +126,22 @@ Before finalizing:
 
 Do not overwrite the contract after handoff to `recipe-deployer`. A different performance question may use a new
 benchmark series within this contract; a material change to the user workload requires a new experiment root.
+
+## Contract Corrections
+
+A correction of fact is different from a material change: the user is not changing the workload, they are fixing a
+misreported description of the same workload (a wrong traffic number, a fleet-level figure that should have been
+per-replica, a mistaken SLO value). When the user corrects the contract:
+
+1. Append a correction annotation to the experiment ledger recording what changed, why, and when. Never rewrite or
+   delete prior records.
+2. Mark every run measured under the pre-correction contract as superseded, not invalid: those runs remain evidence
+   about the conditions they actually measured.
+3. Update the contract file in place with the correction noted inline, and recompute its SHA256.
+4. Re-establish the baseline under the corrected contract before proposing any new candidate.
+
+If the user is genuinely changing the workload rather than correcting its description, the existing rule applies:
+new experiment root.
 
 ## Return
 

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -61,11 +61,11 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - Accept natural-language answers; do not make the user author YAML.
 - Do not ask for secret values, kubeconfig contents, registry credentials, or Kubernetes Secret data.
 - Do not add a ceremonial confirmation round when the user's message already provides an unambiguous value.
-- Ask once for the resource envelope: the GPU floor and ceiling in play for this work, whether parallel experiments
-  are authorized within the ceiling, any knobs the user forbids changing, and any teardown deadline. Record the
-  answers in the contract's `resources` block. The envelope informs capacity planning; candidates still run serially
-  under the current iteration model (each iteration retires the previous deployment). Do not run candidates in
-  parallel unless artifact roots, DGD names, and teardown ownership are slot-isolated.
+- When the user supplies resource limits — a ceiling on total concurrent GPU use, or knobs they forbid changing —
+  record them in the contract's `resources` block. Ask about limits only when the run's scope makes them blocking
+  (for example, when architectural changes such as replica scaling or disaggregation are in scope and the ceiling
+  determines what may be proposed). Candidates run serially under the current iteration model; parallel candidate
+  execution is not supported.
 - When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
   numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
   before recording it.
@@ -129,22 +129,25 @@ benchmark series within this contract; a material change to the user workload re
 
 ## Contract Corrections
 
-A correction of fact is different from a material change: the user is not changing the workload, they are fixing a
-misreported description of the same workload (a wrong traffic number, a fleet-level figure that should have been
-per-replica, a mistaken SLO value). When the user corrects the contract:
+A correction of fact is the user fixing a misreported description of the same workload (a wrong traffic number, a
+fleet-level figure that should have been per-replica, a mistaken SLO value).
 
-1. Append a correction record to `<EXP_ROOT>/analysis/workload-corrections.jsonl` (append-only) stating what
-   changed, why, when, and which prior runs or iterations it supersedes. Never rewrite or delete prior records.
-2. Mark every run measured under the pre-correction contract as superseded, not invalid: those runs remain evidence
-   about the conditions they actually measured.
-3. Update the contract file in place with the correction noted inline, and recompute its SHA256.
-4. Return the corrected path and SHA256 to the parent for re-handoff: every downstream role holding the
-   pre-correction hash must receive the corrected pair before doing further work. This procedure is the only
-   sanctioned exception to the freeze rule above.
-5. Re-establish the baseline under the corrected contract before proposing any new candidate.
+**Before handoff to `recipe-deployer`**: the contract is still this skill's working file; amend it, note the
+correction inline, and recompute its SHA256.
 
-If the user is genuinely changing the workload rather than correcting its description, the existing rule applies:
-new experiment root.
+**After handoff**: the contract and its hash are frozen and historical artifacts reference them; do not mutate either.
+Instead:
+
+1. Start a new experiment root via this skill, carrying the corrected values forward and re-capturing the canonical
+   DGD copy there.
+2. Write one append-only supersedence marker in the old root, `<OLD_EXP_ROOT>/SUPERSEDED`, recording the corrected
+   field(s), the reason, the timestamp, and the new `EXP_ROOT`. Do not edit or delete any other artifact in the old
+   root: its runs remain valid evidence about the conditions they actually measured.
+3. Re-establish the baseline in the new root before proposing any candidate. Prior conclusions do not carry over;
+   they may be cited as evidence about the superseded conditions.
+
+This makes a post-handoff correction operationally identical to a material workload change (both open a new root);
+the distinction is recorded by the SUPERSEDED marker, not by editing frozen files.
 
 ## Return
 

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -63,9 +63,9 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - Do not add a ceremonial confirmation round when the user's message already provides an unambiguous value.
 - Ask once for the resource envelope: the GPU floor and ceiling in play for this work, whether parallel experiments
   are authorized within the ceiling, any knobs the user forbids changing, and any teardown deadline. Record the
-  answers in the contract's `resources` block. When capacity within the ceiling allows, downstream roles prefer
-  running approved candidates in parallel (one variable per slot, slot attribution in every ledger record) over
-  queueing them serially.
+  answers in the contract's `resources` block. The envelope informs capacity planning; candidates still run serially
+  under the current iteration model (each iteration retires the previous deployment). Do not run candidates in
+  parallel unless artifact roots, DGD names, and teardown ownership are slot-isolated.
 - When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
   numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
   before recording it.
@@ -133,12 +133,15 @@ A correction of fact is different from a material change: the user is not changi
 misreported description of the same workload (a wrong traffic number, a fleet-level figure that should have been
 per-replica, a mistaken SLO value). When the user corrects the contract:
 
-1. Append a correction annotation to the experiment ledger recording what changed, why, and when. Never rewrite or
-   delete prior records.
+1. Append a correction record to `<EXP_ROOT>/analysis/workload-corrections.jsonl` (append-only) stating what
+   changed, why, when, and which prior runs or iterations it supersedes. Never rewrite or delete prior records.
 2. Mark every run measured under the pre-correction contract as superseded, not invalid: those runs remain evidence
    about the conditions they actually measured.
 3. Update the contract file in place with the correction noted inline, and recompute its SHA256.
-4. Re-establish the baseline under the corrected contract before proposing any new candidate.
+4. Return the corrected path and SHA256 to the parent for re-handoff: every downstream role holding the
+   pre-correction hash must receive the corrected pair before doing further work. This procedure is the only
+   sanctioned exception to the freeze rule above.
+5. Re-establish the baseline under the corrected contract before proposing any new candidate.
 
 If the user is genuinely changing the workload rather than correcting its description, the existing rule applies:
 new experiment root.

--- a/.github/ISSUE_TEMPLATE/agent-reported.yml
+++ b/.github/ISSUE_TEMPLATE/agent-reported.yml
@@ -1,0 +1,29 @@
+name: Agent-reported instruction gap
+description: For AI agents using the optimization skills — report instructions that misled, blocked, or contradicted live verification.
+labels: ["agent-reported"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For AI agents. Search existing agent-reported issues before filing; one issue per
+        optimization session; sanitize all user/engagement specifics.
+  - type: input
+    id: agent-identity
+    attributes:
+      label: Agent identity
+      description: Driver model and the skills commit you were running.
+      placeholder: "claude-opus-4-8, skills @ abc1234"
+    validations:
+      required: true
+  - type: textarea
+    id: gap
+    attributes:
+      label: What the instructions said vs what you verified
+      description: Describe the instruction gap only. No user workload details, traffic numbers, cluster/namespace names, company names, or credentials.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested correction
+      description: Optional. The wording you would have needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,17 @@ exactly. All of this is enforced by `scripts/validate_skills.py` (pre-commit hoo
 `validate-skills`). Changes under `.agents/skills/` are also validated by NVSkills CI —
 a maintainer comments `/nvskills-ci` on the PR.
 
+## Improving These Instructions
+
+If these skills or instructions misled you, blocked you, or contradicted what you verified live, file an issue on
+this repository with the `agent-reported` label. Rules:
+
+1. Search existing `agent-reported` issues first; comment on a duplicate instead of filing a new one.
+2. File at most one issue per optimization session; batch findings into it.
+3. Identify yourself as an AI agent, including your driver model and the skills commit you were running.
+4. Sanitize completely: no user workload details, traffic numbers, cluster or namespace names, company names, or
+   credentials. Describe the instruction gap, not the engagement.
+
 ## Optimization Role Dispatch
 
 When the first user message starts a new Dynamo recipe optimization run, dispatch `user_interviewer` before any other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,14 +68,15 @@ a maintainer comments `/nvskills-ci` on the PR.
 
 ## Improving These Instructions
 
-If these skills or instructions misled you, blocked you, or contradicted what you verified live, file an issue on
-this repository with the `agent-reported` label. Rules:
+If these skills or instructions misled you, blocked you, or contradicted what you verified live, prepare an issue for
+this repository with the `agent-reported` label and ask your operator to approve filing it — filing is an external
+write and requires operator consent. Rules:
 
-1. Search existing `agent-reported` issues first; comment on a duplicate instead of filing a new one.
-2. File at most one issue per optimization session; batch findings into it.
+1. Search existing `agent-reported` issues first; propose commenting on a duplicate instead of filing a new one.
+2. Prepare at most one issue per optimization session; batch findings into it.
 3. Identify yourself as an AI agent, including your driver model and the skills commit you were running.
 4. Sanitize completely: no user workload details, traffic numbers, cluster or namespace names, company names, or
-   credentials. Describe the instruction gap, not the engagement.
+   credentials. Describe the instruction gap, not the engagement. Show the operator the full draft before filing.
 
 ## Optimization Role Dispatch
 

--- a/agent-docs/rules/execution/user-workload.md
+++ b/agent-docs/rules/execution/user-workload.md
@@ -66,11 +66,8 @@ preferences:
   mode: ""                         # agg, disagg
 
 resources:
-  gpu_floor: null                  # GPUs guaranteed available to this work
-  gpu_ceiling: null                # maximum GPUs the user authorizes, across all concurrent experiments
-  parallel_experiments: null      # user authorization for concurrent candidates (advisory until the loop supports slot isolation)
+  gpu_ceiling: null                # maximum total GPUs the user authorizes this run to hold at once
   pinned: []                       # configuration knobs the user forbids changing (e.g. ["mode", "precision"])
-  teardown_deadline: ""            # optional wall-clock bound by which all run resources must be gone
 
 objectives:
   ttft_ms_p95_max: null            # optional time to first token
@@ -100,8 +97,10 @@ created_at: ""
   `deployment.dgd_sha256` to match that file.
 - `kube_context` and `namespace` are required. The namespace must already exist.
 - Treat `resources.gpu_ceiling` as authorization, not entitlement: every GPU-consuming experiment still requires its
-  own evidence and adversarial review. Treat `resources.pinned` entries as hard constraints enforced at hypothesis
-  review and deploy preflight, not as style preferences.
+  own evidence and adversarial review. `hardware[]` describes what the workload serves on; `gpu_ceiling` bounds the
+  run's total concurrent GPU holdings and must be at least the assigned DGD's total request. When unset, the assigned
+  DGD's own footprint is the bound. `hypothesis-challenger` must reject candidates that change a `pinned` knob or
+  exceed `gpu_ceiling`; `deploy-dynamo-recipe` preflight must verify both before mutation.
 - `storage_class` is optional when the required PVC already exists or a suitable cluster default is known. If the run
   must create a PVC and no suitable class can be determined safely, return a focused question to the user.
 - Token lengths are optional customer-provided traffic hints, not required benchmark keys. Prefer real traces or

--- a/agent-docs/rules/execution/user-workload.md
+++ b/agent-docs/rules/execution/user-workload.md
@@ -65,6 +65,13 @@ preferences:
   framework: ""                    # vLLM, SGLang, or TRT-LLM
   mode: ""                         # agg, disagg
 
+resources:
+  gpu_floor: null                  # GPUs guaranteed available to this work
+  gpu_ceiling: null                # maximum GPUs the user authorizes, across all concurrent experiments
+  parallel_experiments: null      # whether the user authorizes concurrent candidate experiments within the ceiling
+  pinned: []                       # configuration knobs the user forbids changing (e.g. ["mode", "precision"])
+  teardown_deadline: ""            # optional wall-clock bound by which all run resources must be gone
+
 objectives:
   ttft_ms_p95_max: null            # optional time to first token
   itl_ms_p95_max: null             # optional inter-token-latency
@@ -92,6 +99,9 @@ created_at: ""
 - Require `deployment.dgd_path` to resolve to `<EXP_ROOT>/inputs/user_provided_dgd.yaml`, and require
   `deployment.dgd_sha256` to match that file.
 - `kube_context` and `namespace` are required. The namespace must already exist.
+- Treat `resources.gpu_ceiling` as authorization, not entitlement: every GPU-consuming experiment still requires its
+  own evidence and adversarial review. Treat `resources.pinned` entries as hard constraints enforced at hypothesis
+  review and deploy preflight, not as style preferences.
 - `storage_class` is optional when the required PVC already exists or a suitable cluster default is known. If the run
   must create a PVC and no suitable class can be determined safely, return a focused question to the user.
 - Token lengths are optional customer-provided traffic hints, not required benchmark keys. Prefer real traces or

--- a/agent-docs/rules/execution/user-workload.md
+++ b/agent-docs/rules/execution/user-workload.md
@@ -68,7 +68,7 @@ preferences:
 resources:
   gpu_floor: null                  # GPUs guaranteed available to this work
   gpu_ceiling: null                # maximum GPUs the user authorizes, across all concurrent experiments
-  parallel_experiments: null      # whether the user authorizes concurrent candidate experiments within the ceiling
+  parallel_experiments: null      # user authorization for concurrent candidates (advisory until the loop supports slot isolation)
   pinned: []                       # configuration knobs the user forbids changing (e.g. ["mode", "precision"])
   teardown_deadline: ""            # optional wall-clock bound by which all run resources must be gone
 


### PR DESCRIPTION
Four small changes from a hands-on UAT run of the optimization skills (clean environment, live cluster, overnight autonomous loop). Each fixes something observed, not hypothesized. Merges into `argupte/dynamo-work`.

**1. Resource envelope + contract corrections** (`synthesize-user-workload`, workload schema)
- Elicit once at bootstrap: GPU floor/ceiling, parallel-experiment authorization, pinned knobs, teardown deadline. Ceiling is authorization, not entitlement; every experiment still passes evidence + adversarial review. Observed: the loop under-used available capacity because no envelope was ever established, and the only alternative offered mid-run was an illegitimate one (which it correctly refused).
- Fleet-vs-unit load confirmation: observed a full overnight run answering the wrong question because fleet-level traffic numbers were applied to a single-replica test. The contract itself contained the contradiction. *Maintainers: this one bullet is severable if you think it over-constrains the interview.*
- Contract Corrections section: corrections-of-fact amend in place + annotate ledger + supersede prior runs + re-baseline; material changes keep the existing new-root rule. Observed: a strong driver model improvised exactly this correctly; codifying it makes the behavior survive weaker drivers.

**2. Agent-reported issue protocol** (`AGENTS.md` + issue template)
Agents that hit instructions contradicting live verification file a sanitized, deduplicated, once-per-session issue, self-identified as agents. Observed: three instruction-vs-reality divergences in one session, all resolved by the agent, none leaving any trace for maintainers. The `agent-reported` label count doubles as a transparent adoption signal. **Needs a maintainer to create the `agent-reported` label.**

**3. Binding-based capacity accounting** (`deploy-dynamo-recipe`)
Count bound non-terminal pods as holding their GPU requests; don't filter on `phase == Running` (ImagePullBackOff pods hold reservations); exclude tenant-reserved tainted nodes; report largest per-node block. Observed: Running-only accounting reported a fully-claimed node as 8/8 free; the agent diagnosed the method error itself, and this transcribes its fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->