### PR TITLE
test(ci): reclassify CPU-only vllm unit tests from gpu_1 to gpu_0 (OPS-8113)

### DIFF
--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -42,11 +42,14 @@ def _resolve_qwen3_tool_parser_class():
         return Qwen3CoderToolParser
 
 
-# Needs vllm packages (gpu_1 container), but does not allocate GPU VRAM.
+# Needs vllm packages, but never touches a GPU.
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
+    # Registers the tokenizer in the session predownload manifest (tests/conftest.py)
+    # so it stays fetchable after a worker's predownload test flips HF_HUB_OFFLINE.
+    pytest.mark.model("Qwen/Qwen3-0.6B"),
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -47,8 +47,10 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
     pytest.mark.gpu_0,
-    # Registers the tokenizer in the session predownload manifest (tests/conftest.py)
-    # so it stays fetchable after a worker's predownload test flips HF_HUB_OFFLINE.
+    # This file builds a real tokenizer. The marker declares it in the session
+    # predownload manifest (tests/conftest.py), which is what keeps it fetchable
+    # on a lane that predownloads and flips HF_HUB_OFFLINE; the CPU lane has no
+    # predownload consumer today, so there it is fetched live.
     pytest.mark.model("Qwen/Qwen3-0.6B"),
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,

--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -75,6 +75,44 @@ def pytest_ignore_collect(collection_path, config):
     return None
 
 
+@pytest.fixture
+def vllm_cpu_platform_when_no_accelerator():
+    """Pin vLLM's CpuPlatform on hosts with no accelerator.
+
+    Tests that build the vLLM engine argument parser hit
+    ``DeviceConfig.__post_init__``, which resolves ``current_platform`` when
+    ``device`` is left at ``"auto"``. On a host with no accelerator every
+    builtin platform plugin declines, ``resolve_current_platform_cls_qualname``
+    falls back to ``UnspecifiedPlatform`` (``device_type == ""``) and the
+    dataclass raises ``RuntimeError: Failed to infer device type``. The parser
+    instantiates each config dataclass to compute its argparse default, so this
+    fires while *building* the parser -- passing ``--device cpu`` cannot avoid
+    it.
+
+    ``vllm.platforms`` defines a module-level ``__setattr__`` whose whole job is
+    installing a platform object, so assigning through it is the supported way
+    in. Pin it only when torch reports no CUDA device, so GPU runners keep
+    exercising the real detection path. Save and restore the private
+    ``_current_platform`` rather than reading the public attribute, because
+    reading it would itself force lazy resolution and cache
+    ``UnspecifiedPlatform``; teardown then keeps a worker that ran these tests
+    from leaking a pinned platform into another module's tests.
+    """
+    import torch
+
+    if torch.cuda.is_available():
+        yield
+        return
+
+    import vllm.platforms as vllm_platforms
+    from vllm.platforms.cpu import CpuPlatform
+
+    previous = vllm_platforms._current_platform
+    vllm_platforms.current_platform = CpuPlatform()
+    yield
+    vllm_platforms.current_platform = previous
+
+
 def make_cli_args_fixture(module_name: str):
     """Create a pytest fixture for mocking CLI arguments for vllm backend."""
 

--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -75,42 +75,54 @@ def pytest_ignore_collect(collection_path, config):
     return None
 
 
+_PLATFORM_UNSET = object()
+
+
 @pytest.fixture
 def vllm_cpu_platform_when_no_accelerator():
-    """Pin vLLM's CpuPlatform on hosts with no accelerator.
+    """Pin vLLM's CpuPlatform on hosts where vLLM recognizes no accelerator.
 
-    Tests that build the vLLM engine argument parser hit
+    Tests that build the vLLM engine argument parser reach
     ``DeviceConfig.__post_init__``, which resolves ``current_platform`` when
-    ``device`` is left at ``"auto"``. On a host with no accelerator every
-    builtin platform plugin declines, ``resolve_current_platform_cls_qualname``
-    falls back to ``UnspecifiedPlatform`` (``device_type == ""``) and the
-    dataclass raises ``RuntimeError: Failed to infer device type``. The parser
-    instantiates each config dataclass to compute its argparse default, so this
-    fires while *building* the parser -- passing ``--device cpu`` cannot avoid
-    it.
+    ``device`` is left at ``"auto"`` and raises ``RuntimeError: Failed to infer
+    device type`` if the resolved platform has an empty ``device_type``. With no
+    accelerator every builtin platform plugin declines and the resolver falls
+    back to ``UnspecifiedPlatform``, whose ``device_type`` is exactly that. The
+    parser instantiates each config dataclass to compute its argparse default,
+    so this fires while *building* the parser -- passing ``--device cpu`` cannot
+    avoid it.
 
-    ``vllm.platforms`` defines a module-level ``__setattr__`` whose whole job is
-    installing a platform object, so assigning through it is the supported way
-    in. Pin it only when torch reports no CUDA device, so GPU runners keep
-    exercising the real detection path. Save and restore the private
-    ``_current_platform`` rather than reading the public attribute, because
-    reading it would itself force lazy resolution and cache
-    ``UnspecifiedPlatform``; teardown then keeps a worker that ran these tests
-    from leaking a pinned platform into another module's tests.
+    Gating on ``device_type`` rather than on ``torch.cuda`` makes this a no-op
+    wherever vLLM already recognizes the hardware, so both CUDA and XPU runners
+    keep exercising real detection (these modules are also marked ``xpu_1``).
+
+    ``vllm.platforms`` resolves ``current_platform`` lazily through a module
+    ``__getattr__``, and assigning the name writes a real module-dict entry that
+    shadows the hook. That entry, not the ``__setattr__`` the module also
+    defines, is what makes the pin visible: the interpreter never calls a
+    module-level ``__setattr__``, since PEP 562 covers only ``__getattr__`` and
+    ``__dir__``. Teardown therefore *deletes* the entry to re-arm the lazy hook
+    -- assigning the previous value back would leave the resolver shadowed for
+    every later test on this xdist worker.
     """
-    import torch
+    import vllm.platforms as vllm_platforms
+    from vllm.platforms import current_platform
 
-    if torch.cuda.is_available():
+    if current_platform.device_type:
         yield
         return
 
-    import vllm.platforms as vllm_platforms
     from vllm.platforms.cpu import CpuPlatform
 
-    previous = vllm_platforms._current_platform
+    previous = vllm_platforms.__dict__.get("current_platform", _PLATFORM_UNSET)
     vllm_platforms.current_platform = CpuPlatform()
-    yield
-    vllm_platforms.current_platform = previous
+    try:
+        yield
+    finally:
+        if previous is _PLATFORM_UNSET:
+            del vllm_platforms.current_platform
+        else:
+            vllm_platforms.current_platform = previous
 
 
 def make_cli_args_fixture(module_name: str):

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -20,7 +20,10 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
+    # Building the vLLM argument parser resolves a device; on an accelerator-less
+    # host that raises unless a platform is pinned first.
+    pytest.mark.usefixtures("vllm_cpu_platform_when_no_accelerator"),
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),

--- a/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
@@ -18,7 +18,7 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
@@ -19,7 +19,7 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
@@ -28,7 +28,7 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s

--- a/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
+++ b/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
@@ -20,7 +20,7 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -46,9 +46,10 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
     pytest.mark.core,
-    # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
-    # runners with "Failed to infer device type" even for mock tests.
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
+    # Building the vLLM argument parser resolves a device; on an accelerator-less
+    # host that raises unless a platform is pinned first.
+    pytest.mark.usefixtures("vllm_cpu_platform_when_no_accelerator"),
     pytest.mark.xpu_1,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -23,9 +23,7 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
     pytest.mark.core,
-    # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
-    # runners with "Failed to infer device type" even for mock tests.
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.xpu_1,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s


### PR DESCRIPTION
## Summary
**TLDR - shave 18 min from vllm PR test runtime**
Repeats [#12718](https://github.com/ai-dynamo/dynamo/pull/12718) (SGLang) for vLLM. Eight vLLM unit-test files carry `gpu_1`, which routes them into the VRAM-aware GPU stage. That orchestrator (`tests/utils/pytest_parallel_gpu.py`) launches **one subprocess per test**, so every zero-VRAM unit test pays a fresh `import vllm` + torch startup — a uniform ~36s each, with the GPU idle.

Measured on the amd64 `Test` job (run 31183861251, job 92889401992), those eight files are **12,024s of the stage's 19,562s cumulative subprocess time and 322 of its 381 tests**:

| file | tests | cumulative |
| -- | --: | --: |
| `vllm/tests/test_vllm_unit.py` | 120 | 3,998s |
| `vllm/tests/omni/test_output_formatter.py` | 44 | 2,006s |
| `frontend/tests/test_vllm_processor_unit.py` | 52 | 1,539s |
| `vllm/tests/omni/test_omni_stage_worker.py` | 30 | 1,376s |
| `vllm/tests/omni/test_omni_args.py` | 25 | 1,124s |
| `vllm/tests/test_vllm_worker_factory.py` | 27 | 958s |
| `vllm/tests/omni/test_omni_stage_router.py` | 13 | 594s |
| `vllm/tests/omni/test_omni_disagg_types.py` | 9 | 429s |

For context, that job runs 100 minutes against a 45-minute pre_merge step cap, while the CPU-only stage does 759 tests in 197s under `-n auto --dist=loadscope`.

### Why the marks were there, and what replaces them

Two files documented it: *"gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64 runners with 'Failed to infer device type' even for mock tests."* That is accurate — with no GPU, 52 of 122 tests in `test_vllm_unit.py` fail — but it was also blocking the other six files by association.

`DeviceConfig.__post_init__` resolves `current_platform` when `device == "auto"` and raises if the resolved platform has an empty `device_type`. With no accelerator every builtin platform plugin declines and the resolver falls back to `UnspecifiedPlatform`, whose `device_type` is exactly that. It fires while *building* the engine argument parser (`EngineArgs.add_cli_args` → `_compute_kwargs` instantiates each config dataclass to compute its argparse default), so passing `--device cpu` cannot avoid it.

The new `vllm_cpu_platform_when_no_accelerator` fixture pins `CpuPlatform` for the duration of such a test. Two details worth a reviewer's eye, both verified against vLLM's source in the image:

- **It gates on `current_platform.device_type` being empty, not on `torch.cuda`.** `torch.cuda.is_available()` is also False on an Intel XPU host, where vLLM resolves `XpuPlatform` perfectly well — and these modules carry `xpu_1`, so they run there. Gating on the exact condition `DeviceConfig` raises on keeps the fixture a no-op wherever vLLM recognizes the hardware.
- **Teardown deletes the module-dict entry rather than restoring it.** `vllm.platforms` defines a module-level `__setattr__`, but the interpreter never calls it — PEP 562 gives modules `__getattr__` and `__dir__` only. Assigning the name writes a plain module-dict entry, and that entry is what shadows the lazy resolver and makes the pin visible. Writing a value back would leave the resolver shadowed for every later test on the same xdist worker, so teardown removes the entry to re-arm the lazy hook.

It is opt-in via `usefixtures`, not autouse: only `test_vllm_unit.py` and `test_omni_args.py` need it. The other six files already pass with no GPU.

`test_vllm_processor_unit.py` also gains `pytest.mark.model("Qwen/Qwen3-0.6B")` — it builds a real tokenizer, matching its already-merged SGLang sibling.

### Deliberately not moved

- `omni/test_omni_nixl_connector.py` (4 tests, 170s) keeps `gpu_1`. Its `test_nixl_connector_object_roundtrip` **fails on the GPU-less arm64 lane on the exact image this CI run used** — a `torch.frombuffer` non-writable-buffer `UserWarning` promoted by `filterwarnings = error` — even though the same test passes on amd64. Moving it would turn the CPU lane red. Noted on OPS-8113; the test looks one torch release away from breaking on the GPU lane too.
- **All TensorRT-LLM unit tests.** Checked the same way: `import tensorrt_llm` fails with `ImportError: libcuda.so.1: cannot open shared object file` on the GPU-less lane (the driver, which the CUDA stubs dir does not supply), so all ten trtllm unit files already carry module-level skip guards and would *silently stop running* if marked `gpu_0`. Their GPU-stage cost is already small — the sequential stage runs 164 tests in 58.6s because those files intentionally omit `profiled_vram_gib` so the TRT-LLM import is shared. The only two trtllm tests in the VRAM-parallel stage genuinely use CUDA.

No `xpu_1` marks were touched; `xpu-ci.yaml` selects on `xpu_1` independently of `gpu_*`.

## Validation

Run against `…:17c8f260a5…-vllm-runtime-test` — the same image the referenced CI run used — selecting `pre_merge and vllm and gpu_0` over `components/src/dynamo/vllm` + `components/src/dynamo/frontend/tests`.

**On linux/arm64 with no GPU**, which is the only lane that is genuinely accelerator-less (the amd64 CPU-only stage is a step of the GPU job and does have a GPU):

| run | result |
| -- | -- |
| baseline | 741 passed, 6 skipped, 25.1s |
| patched | **1063 passed**, 6 skipped, 24.6s |

Also on amd64 (RTX 6000 Ada), both with the GPU masked and with it attached: 740 → **1062 passed**, 6 skipped either way, no wall-clock change. 322 tests move for no measurable CPU-lane cost — the stage is import-bound and already amortizes imports across xdist workers.

Collection confirms nothing was dropped: `gpu_0` 746 → 1068, `gpu_1` 326 → 4 (746 + 326 = 1068 + 4).

Fixture teardown was verified directly: after the pinned module finishes, the `vllm.platforms` module dict carries no `current_platform` entry and the lazy resolver still works.

`pre-commit run --all-files` passes.

Linear: OPS-8113

🤖 Generated with [Claude Code](https://claude.com/claude-code)