### PR TITLE
fix(profiler): propagate AIC database version (cherry-pick #12771)

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
@@ -15,6 +15,7 @@ try:
     from dynamo.profiler.utils.dgd_generation import (
         _build_planner_config,
         _inject_mocker_aic_args,
+        _load_latest_database_version,
         build_aic_interpolation_spec,
         build_aic_perf_model_spec,
         enable_vllm_benchmark_mode,
@@ -32,6 +33,39 @@ pytestmark = [
     pytest.mark.pre_merge,
     pytest.mark.unit,
 ]
+
+
+def test_aic_import_treats_missing_root_package_as_optional(monkeypatch):
+    def raise_missing_root(_):
+        raise ModuleNotFoundError(name="aiconfigurator_core")
+
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.dgd_generation.importlib.import_module",
+        raise_missing_root,
+    )
+
+    assert _load_latest_database_version() is None
+
+
+@pytest.mark.parametrize(
+    "missing_module",
+    ["aiconfigurator_core.sdk.operations.attention", "unrelated_dependency"],
+)
+def test_aic_import_propagates_internal_or_unrelated_missing_module(
+    monkeypatch, missing_module
+):
+    def raise_missing_dependency(_):
+        raise ModuleNotFoundError(name=missing_module)
+
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.dgd_generation.importlib.import_module",
+        raise_missing_dependency,
+    )
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        _load_latest_database_version()
+
+    assert exc_info.value.name == missing_module
 
 
 def _dgdr(
@@ -284,7 +318,17 @@ class TestBuildPlannerConfigEmbedsAicSpec:
         assert cfg.prefill_engine_num_gpu == 8
         assert cfg.decode_engine_num_gpu == 8
 
-    def test_aic_perf_model_threads_into_planner_config(self):
+    def test_aic_perf_model_threads_into_planner_config(self, monkeypatch):
+        resolved_versions = []
+
+        def resolve_backend_version(*, system, backend):
+            resolved_versions.append((system, backend))
+            return "0.24.0"
+
+        monkeypatch.setattr(
+            "dynamo.profiler.utils.dgd_generation.get_latest_database_version",
+            resolve_backend_version,
+        )
         planner = PlannerConfig(
             enable_throughput_scaling=True,
             enable_load_scaling=False,
@@ -313,8 +357,57 @@ class TestBuildPlannerConfigEmbedsAicSpec:
         assert cfg.aic_perf_model.hf_id == dgdr.model
         assert cfg.aic_perf_model.system == "h200_sxm"
         assert cfg.aic_perf_model.backend == "vllm"
+        assert cfg.aic_perf_model.backend_version == "0.24.0"
         assert cfg.aic_perf_model.prefill_pick == prefill_pick
         assert cfg.aic_perf_model.decode_pick == decode_pick
+        assert resolved_versions == [("h200_sxm", "vllm")]
+
+    def test_aic_perf_model_falls_back_when_database_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(
+            "dynamo.profiler.utils.dgd_generation.get_latest_database_version",
+            lambda **_: None,
+        )
+        planner = PlannerConfig(
+            enable_throughput_scaling=True,
+            enable_load_scaling=False,
+            optimization_target="sla",
+        )
+        dgdr = _dgdr(planner=planner)
+
+        spec = build_aic_perf_model_spec(
+            dgdr,
+            best_prefill_pick=PickedParallelConfig(tp=1),
+            best_decode_pick=PickedParallelConfig(tp=2),
+            resolved_backend="vllm",
+            system="unknown_system",
+        )
+
+        assert spec is None
+
+    def test_aic_perf_model_falls_back_when_sdk_is_unavailable(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(
+            "dynamo.profiler.utils.dgd_generation.get_latest_database_version",
+            None,
+        )
+        planner = PlannerConfig(
+            enable_throughput_scaling=True,
+            enable_load_scaling=False,
+            optimization_target="sla",
+        )
+        dgdr = _dgdr(planner=planner)
+
+        spec = build_aic_perf_model_spec(
+            dgdr,
+            best_prefill_pick=PickedParallelConfig(tp=1),
+            best_decode_pick=PickedParallelConfig(tp=2),
+            resolved_backend="vllm",
+            system="h200_sxm",
+        )
+
+        assert spec is None
+        assert "aiconfigurator-core is unavailable" in caplog.text
 
     @pytest.mark.parametrize(
         ("mode", "prefill_pick", "decode_pick"),

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import json
 import logging
 import os
 import uuid
+from collections.abc import Callable
 from typing import Any, Optional
 
 import numpy as np
@@ -51,6 +53,19 @@ logger = logging.getLogger(__name__)
 
 # Path to mocker disagg config relative to workspace
 MOCKER_DISAGG_CONFIG_PATH = "examples/backends/mocker/deploy/disagg.yaml"
+
+
+def _load_latest_database_version() -> Optional[Callable[..., Optional[str]]]:
+    try:
+        perf_database = importlib.import_module("aiconfigurator_core.sdk.perf_database")
+    except ModuleNotFoundError as e:
+        if e.name != "aiconfigurator_core":
+            raise
+        return None
+    return perf_database.get_latest_database_version
+
+
+get_latest_database_version = _load_latest_database_version()
 
 # ConfigMap name prefixes (a 4-char UUID suffix is appended at runtime
 # so that multiple deployments in the same namespace don't collide)
@@ -686,10 +701,31 @@ def build_aic_perf_model_spec(
     if mode in ("decode", "agg", "disagg") and best_decode_pick is None:
         return None
 
+    if get_latest_database_version is None:
+        logger.warning(
+            "aiconfigurator-core is unavailable; Planner will use FPM regression "
+            "instead of native AIC estimates."
+        )
+        return None
+
+    backend_version = get_latest_database_version(
+        system=system,
+        backend=resolved_backend,
+    )
+    if backend_version is None:
+        logger.warning(
+            "No AIC performance database is available for system=%s, backend=%s; "
+            "Planner will use FPM regression instead of native AIC estimates.",
+            system,
+            resolved_backend,
+        )
+        return None
+
     return AICPerfModelSpec(
         hf_id=dgdr.model,
         system=system,
         backend=resolved_backend,
+        backend_version=backend_version,
         prefill_pick=best_prefill_pick,
         decode_pick=best_decode_pick,
     )


### PR DESCRIPTION
## Summary

- Cherry-pick of #12771 to `release/1.4.0`.
- Populate the profiler-generated Planner AIC performance model with the packaged database version.
- Preserve FPM regression fallback when the AIC SDK or matching performance database is unavailable.

This fixes DYN-3777, where DGDR deployments report healthy and serve inference, but SLA throughput scaling silently skips every tick because `aic_perf_model.backend_version` is `null`.

## Original PR

- Main PR: #12771
- Main merge commit: `cd6b63b0cc318d21ee935e9b687ecb11f91508e5`
- Cherry-pick commit: `d7fe341af357d129e7e0bbe52340ad969fab2ef4`

## Release adaptation

The cherry-pick had one adjacent-context conflict in `dgd_generation.py`. The release branch keeps its service-schema mocker config constant, while the guarded AIC database loader from main was added unchanged. No functional behavior from unrelated main-branch DGD schema changes was brought into this backport.

## Validation

- 110 passed across the release branch profiler DGD/AIC, planner SLA, materialization, and profile SLA helper suites.
- Confirmed the pinned SDK resolves `h200_sxm` / `vllm` to database version `0.24.0`.
- Confirmed `dgd_generation` remains importable without the optional `aiconfigurator_core` package.
- Targeted mypy passed.
- isort, black, flake8, ruff, and `git diff --check` passed.
- Commit carries DCO sign-off, GPG signature, and the source merge SHA provenance trailer.

## Related Issues

- Linear: [DYN-3777](https://linear.app/nvidia/issue/DYN-3777/dynamo140dgdr-profiler-leaves-backend-version-unset-planners-aic)
- NVBug: 6566244
- [x] Confirmed — no related GitHub issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->