### PR TITLE
fix(frontend): reject informational overload status codes (cherry-pick #12738)

### DIFF
--- a/docs/fern/components/frontend/frontend-config-reference.mdx
+++ b/docs/fern/components/frontend/frontend-config-reference.mdx
@@ -52,8 +52,9 @@ The Rust HTTP server also reads these environment variables, which are not expos
 
 <ParamField path="DYN_HTTP_OVERLOAD_STATUS_CODE" type="integer" default="529">
   HTTP status returned for overload and admission-control rejection. Use `503` only for clients that
-  cannot handle 529. Invalid or out-of-range values fall back to 529. The value is read once and
-  cached when the HTTP service initializes.
+  cannot handle 529. Values from 200 through 999 are accepted. Informational values from 100 through
+  199, invalid values, and out-of-range values fall back to 529. The value is read and cached on
+  first use.
 </ParamField>
 
 ## Router

--- a/docs/fern/design-docs/request-rejection.md
+++ b/docs/fern/design-docs/request-rejection.md
@@ -38,8 +38,9 @@ The router distinguishes two failure classes:
   HTTP 529 by default.
 - **Unavailable** means no usable service path exists. The Frontend returns HTTP 503.
 
-`DYN_HTTP_OVERLOAD_STATUS_CODE` can change the overload response code for client compatibility. It is
-read once and cached; invalid or out-of-range values fall back to 529.
+`DYN_HTTP_OVERLOAD_STATUS_CODE` can change the overload response code for client compatibility. Values
+from 200 through 999 are accepted. Informational values from 100 through 199, invalid values, and
+out-of-range values fall back to 529. The value is read and cached on first use.
 
 ## Independently Enabled Signals
 

--- a/docs/fern/fault-tolerance/request-rejection.md
+++ b/docs/fern/fault-tolerance/request-rejection.md
@@ -213,8 +213,9 @@ def send_with_retry(request, max_retries=5):
 ```
 
 If an existing client only understands 503 retry semantics, set
-`DYN_HTTP_OVERLOAD_STATUS_CODE=503` on the Frontend. The variable accepts any valid HTTP status code;
-an invalid value falls back to 529.
+`DYN_HTTP_OVERLOAD_STATUS_CODE=503` on the Frontend. The variable accepts values from 200 through
+999. Informational values from 100 through 199, invalid values, and out-of-range values fall back to
+529. The value is read and cached on first use.
 
 ## Related Documentation
 

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -7,17 +7,22 @@ use axum::http::StatusCode;
 use dynamo_runtime::config::environment_names::llm as env_llm;
 use thiserror::Error;
 
+fn parse_overload_status_code(value: Option<&str>) -> StatusCode {
+    let default = StatusCode::from_u16(529).expect("529 is a valid HTTP status code");
+    value
+        .and_then(|s| s.trim().parse::<u16>().ok())
+        .and_then(|n| StatusCode::from_u16(n).ok())
+        .filter(|status| !status.is_informational())
+        .unwrap_or(default)
+}
+
 /// Overload / admission-control rejection status. Reads
-/// `DYN_HTTP_OVERLOAD_STATUS_CODE` (default 529); cached since env is fixed at
-/// runtime and this is on the rejection path.
+/// `DYN_HTTP_OVERLOAD_STATUS_CODE` (default 529) on first use; cached since the
+/// environment is fixed at runtime and this is on the rejection path.
 pub(crate) fn overload_status_code() -> StatusCode {
     static CODE: LazyLock<StatusCode> = LazyLock::new(|| {
-        let default = StatusCode::from_u16(529).expect("529 is a valid HTTP status code");
-        std::env::var(env_llm::DYN_HTTP_OVERLOAD_STATUS_CODE)
-            .ok()
-            .and_then(|s| s.trim().parse::<u16>().ok())
-            .and_then(|n| StatusCode::from_u16(n).ok())
-            .unwrap_or(default)
+        let value = std::env::var(env_llm::DYN_HTTP_OVERLOAD_STATUS_CODE).ok();
+        parse_overload_status_code(value.as_deref())
     });
     *CODE
 }
@@ -155,6 +160,34 @@ impl std::fmt::Display for SanitizedError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_configured_overload_status_code() {
+        for value in [
+            None,
+            Some(""),
+            Some("not-a-code"),
+            Some("99"),
+            Some("100"),
+            Some("199"),
+            Some("1000"),
+        ] {
+            assert_eq!(
+                parse_overload_status_code(value).as_u16(),
+                529,
+                "expected {value:?} to fall back to 529"
+            );
+        }
+
+        for value in [200_u16, 503, 529, 600, 999] {
+            let configured = value.to_string();
+            assert_eq!(
+                parse_overload_status_code(Some(&configured)).as_u16(),
+                value,
+                "expected {value} to be preserved"
+            );
+        }
+    }
 
     #[test]
     fn local_statuses_distinguish_overload_from_unavailable() {

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -302,9 +302,10 @@ pub mod llm {
 
     /// HTTP status code returned when the frontend rejects a request because
     /// all workers are overloaded. Defaults to 529 ("Site is overloaded"); set
-    /// to 503 for Service Unavailable retry semantics. Any valid HTTP status
-    /// code (100–999) is accepted; an unparseable or out-of-range value falls
-    /// back to 529.
+    /// to 503 for Service Unavailable retry semantics. Status codes from 200
+    /// through 999 are accepted; an informational value from 100 through 199,
+    /// an unparseable value, or an out-of-range value falls back to 529. The
+    /// value is read and cached on first use.
     pub const DYN_HTTP_OVERLOAD_STATUS_CODE: &str = "DYN_HTTP_OVERLOAD_STATUS_CODE";
 
     /// Enable LoRA adapter support (set to "true" to enable)


### PR DESCRIPTION
## Summary

- Cherry-pick #12738 to `release/1.4.0`.
- Reject informational HTTP status codes configured through `DYN_HTTP_OVERLOAD_STATUS_CODE` and fall back to 529.
- Preserve the existing 200–999 behavior, focused unit coverage, and configuration documentation.

Fixes DYN-3778

## Original PR

- Main PR: #12738
- Merge commit: `7ab0d6db75254c730d69320118e0d79a413ee306`
- Backport commit: `72dd1bebf2f7c41e1847af0ecc0b4c9f93c6656b`

## Validation

- `cargo test -p dynamo-llm http::service::error::tests --lib` (6 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-llm --lib -- -D warnings`
- `pre-commit run --files <changed files>`
- `fern check` (0 errors; 2 warnings)
- `fern docs broken-links`
- `git diff --check origin/release/1.4.0..HEAD`
