### PR TITLE
fix(vllm): shut down EngineCore on decode worker exit

### DIFF
--- a/components/src/dynamo/vllm/engine_monitor.py
+++ b/components/src/dynamo/vllm/engine_monitor.py
@@ -116,6 +116,14 @@ class VllmEngineMonitor:
                     await asyncio.sleep(self.health_config.interval)
 
             except (EngineDeadError, asyncio.TimeoutError) as e:
+                if self.shutdown_event and self.shutdown_event.is_set():
+                    logger.warning(
+                        "%s: %s while worker shutdown is in progress; "
+                        "stopping health monitoring.",
+                        self.__class__.__name__,
+                        type(e).__name__,
+                    )
+                    break
                 logger.error(f"Traceback: {traceback.format_exc()}")
                 logger.error(f"vLLM AsyncLLM health check failed: {e}")
                 logger.warning("Initiating Dynamo Runtime shutdown.")

--- a/components/src/dynamo/vllm/tests/test_vllm_engine_monitor_stats.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine_monitor_stats.py
@@ -7,6 +7,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo.common.engine_monitor import EngineHealthMonitorConfig
 from dynamo.vllm.engine_monitor import VllmEngineMonitor
@@ -193,3 +194,26 @@ async def test_run_health_check_times_out(mock_engine):
 
     with pytest.raises(asyncio.TimeoutError):
         await monitor._run_health_check()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("health_error", [EngineDeadError, asyncio.TimeoutError])
+async def test_health_failure_during_worker_shutdown_stops_monitor(
+    mock_engine, health_error
+):
+    shutdown_event = asyncio.Event()
+
+    async def fail_health_check_during_shutdown():
+        shutdown_event.set()
+        raise health_error()
+
+    mock_engine.check_health = fail_health_check_during_shutdown
+    monitor = _make_monitor(mock_engine, shutdown_event)
+    monitor._shutdown_engine = MagicMock()
+
+    with patch("dynamo.vllm.engine_monitor.os._exit") as exit_process:
+        await monitor._check_engine_health()
+
+    monitor._shutdown_engine.assert_not_called()
+    monitor.runtime.shutdown.assert_not_called()
+    exit_process.assert_not_called()

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -16,6 +16,7 @@ from dynamo.vllm.constants import DisaggregationMode
 from dynamo.vllm.worker_factory import (
     EngineSetupResult,
     WorkerFactory,
+    _DecodeWorkerLifecycle,
     _wait_and_load_benchmark,
 )
 
@@ -47,6 +48,203 @@ def _make_config(**overrides) -> Mock:
     }
     defaults.update(overrides)
     return Mock(**defaults)
+
+
+def _make_factory(**overrides) -> WorkerFactory:
+    defaults = {
+        "setup_vllm_engine_fn": Mock(),
+        "setup_kv_event_publisher_fn": Mock(return_value=None),
+        "register_vllm_model_fn": AsyncMock(),
+        "setup_fpm_relay_fn": Mock(return_value=None),
+        "setup_metrics_collection_fn": Mock(),
+    }
+    defaults.update(overrides)
+    return WorkerFactory(**defaults)
+
+
+def test_decode_worker_lifecycle_cleanup_in_reverse_construction_order():
+    calls = []
+    shutdown_event = asyncio.Event()
+    handler = Mock()
+    handler.cleanup.side_effect = lambda: calls.append("handler")
+    engine_client = Mock()
+    engine_client.shutdown.side_effect = lambda **_kwargs: calls.append("engine")
+    resources = _DecodeWorkerLifecycle(
+        engine_client=engine_client,
+        vllm_config=SimpleNamespace(shutdown_timeout=7.0),
+        handler=handler,
+        shutdown_event=shutdown_event,
+    )
+
+    resources.cleanup()
+
+    assert calls == ["handler", "engine"]
+    assert shutdown_event.is_set()
+    engine_client.shutdown.assert_called_once_with(timeout=7.0)
+
+
+def test_decode_worker_lifecycle_shutdown_engine_when_handler_cleanup_fails():
+    handler = Mock()
+    handler.cleanup.side_effect = RuntimeError("handler cleanup failed")
+    engine_client = Mock()
+    resources = _DecodeWorkerLifecycle(
+        engine_client=engine_client,
+        vllm_config=SimpleNamespace(shutdown_timeout=5.0),
+        handler=handler,
+    )
+
+    with pytest.raises(RuntimeError, match="handler cleanup failed"):
+        resources.cleanup()
+
+    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+
+
+def test_decode_worker_lifecycle_chains_handler_and_engine_cleanup_failures():
+    handler_error = RuntimeError("handler cleanup failed")
+    engine_error = RuntimeError("engine shutdown failed")
+    handler = Mock()
+    handler.cleanup.side_effect = handler_error
+    engine_client = Mock()
+    engine_client.shutdown.side_effect = engine_error
+    lifecycle = _DecodeWorkerLifecycle(
+        engine_client=engine_client,
+        vllm_config=SimpleNamespace(shutdown_timeout=5.0),
+        handler=handler,
+    )
+
+    with pytest.raises(RuntimeError, match="engine shutdown failed") as exc_info:
+        lifecycle.cleanup()
+
+    assert exc_info.value is engine_error
+    assert exc_info.value.__context__ is handler_error
+    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_custom_encoder_preserves_primary_error_when_cleanup_fails(caplog):
+    factory = _make_factory()
+    engine_client = Mock()
+    handler = Mock()
+    handler.cleanup.side_effect = RuntimeError("handler cleanup failed")
+    startup_error = ValueError("decode worker startup failed")
+
+    async def fail_after_resource_creation(*_args, lifecycle, **_kwargs):
+        lifecycle.engine_client = engine_client
+        lifecycle.vllm_config = SimpleNamespace(shutdown_timeout=5.0)
+        lifecycle.handler = handler
+        raise startup_error
+
+    factory._run_decode_worker = fail_after_resource_creation  # type: ignore[method-assign]
+    caplog.set_level(logging.ERROR)
+    config = SimpleNamespace(custom_encoder_class="encoder.Backend")
+
+    with pytest.raises(ValueError, match="decode worker startup failed") as exc_info:
+        await factory._create_decode_worker(Mock(), config, asyncio.Event(), [])
+
+    assert exc_info.value is startup_error
+    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+    assert "Failed to clean up decode worker after an earlier failure" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_decode_worker_without_custom_encoder_uses_lifecycle():
+    factory = _make_factory()
+    engine_client = Mock()
+    startup_error = ValueError("decode worker startup failed")
+
+    async def fail_after_engine_creation(*_args, lifecycle, **_kwargs):
+        lifecycle.engine_client = engine_client
+        lifecycle.vllm_config = SimpleNamespace(shutdown_timeout=5.0)
+        raise startup_error
+
+    factory._run_decode_worker = fail_after_engine_creation  # type: ignore[method-assign]
+    config = SimpleNamespace(custom_encoder_class=None)
+
+    with pytest.raises(ValueError, match="decode worker startup failed") as exc_info:
+        await factory._create_decode_worker(Mock(), config, asyncio.Event(), [])
+
+    assert exc_info.value is startup_error
+    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_stage", ["configure", "handler"])
+async def test_custom_encoder_shutdown_engine_on_startup_failure(
+    monkeypatch, failure_stage, tmp_path
+):
+    engine_client = Mock()
+    vllm_config = SimpleNamespace(
+        additional_config={},
+        cache_config=SimpleNamespace(num_gpu_blocks=1),
+        model_config=SimpleNamespace(max_model_len=1024),
+        shutdown_timeout=5.0,
+    )
+    engine_setup: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        str(tmp_path / "prometheus"),
+        Mock(),
+    )
+    factory = _make_factory(setup_vllm_engine_fn=Mock(return_value=engine_setup))
+    factory._maybe_create_failover_metrics = Mock(return_value=None)  # type: ignore[method-assign]
+    factory._maybe_get_encode_worker_client = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    stat_logger = Mock()
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.StatLoggerFactory",
+        Mock(return_value=stat_logger),
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.get_dp_range_for_worker", lambda _config: (0, 1)
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.per_rank_kv_blocks",
+        lambda _num_blocks, _dp_size: 1,
+    )
+
+    async def configure_block_size(*_args, **_kwargs):
+        if failure_stage == "configure":
+            raise ValueError("decode startup rejected")
+        return None
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.configure_kv_event_block_size",
+        configure_block_size,
+    )
+    handler_constructor = Mock(
+        side_effect=(
+            ValueError("decode startup rejected")
+            if failure_stage == "handler"
+            else None
+        )
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.DecodeWorkerHandler",
+        handler_constructor,
+    )
+
+    endpoint = Mock(connection_id=Mock(return_value="worker-id"))
+    runtime = Mock()
+    runtime.endpoint.return_value = endpoint
+    config = SimpleNamespace(
+        namespace="dynamo",
+        component="backend",
+        endpoint="generate",
+        enable_rl=False,
+        engine_args=SimpleNamespace(enable_lora=False),
+        enable_multimodal=True,
+        custom_encoder_class="encoder.Backend",
+        use_vllm_tokenizer=False,
+        frontend_decoding=False,
+    )
+
+    with pytest.raises(ValueError, match="decode startup rejected"):
+        await factory._create_decode_worker(runtime, config, asyncio.Event(), [])
+
+    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+    if failure_stage == "configure":
+        handler_constructor.assert_not_called()
 
 
 def _single_rank_benchmark_payload(

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -11,7 +11,9 @@ import math
 import os
 import time as _time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
+from types import TracebackType
 from typing import Any, Optional
 
 from vllm.config import VllmConfig
@@ -537,6 +539,44 @@ SetupFpmRelayFn = Callable[..., Optional[list]]
 SetupMetricsCollectionFn = Callable[..., None]
 
 
+@dataclass
+class _DecodeWorkerLifecycle:
+    engine_client: Optional[AsyncLLM] = None
+    vllm_config: Optional[VllmConfig] = None
+    handler: Optional[BaseWorkerHandler] = None
+    shutdown_event: asyncio.Event | None = None
+
+    def __enter__(self) -> "_DecodeWorkerLifecycle":
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        original_error: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        try:
+            self.cleanup()
+        except Exception:
+            if original_error is None:
+                raise
+            logger.exception(
+                "Failed to clean up decode worker after an earlier failure"
+            )
+
+    def cleanup(self) -> None:
+        """Release resources in reverse construction order."""
+        logger.debug("Cleaning up decode worker")
+        if self.shutdown_event is not None:
+            self.shutdown_event.set()
+        try:
+            if self.handler is not None:
+                self.handler.cleanup()
+        finally:
+            if self.engine_client is not None and self.vllm_config is not None:
+                self.engine_client.shutdown(timeout=self.vllm_config.shutdown_timeout)
+
+
 class WorkerFactory:
     """Factory for creating and initializing multimodal vLLM workers."""
 
@@ -941,6 +981,26 @@ class WorkerFactory:
         """
         Instantiate and serve
         """
+        with _DecodeWorkerLifecycle(shutdown_event=shutdown_event) as lifecycle:
+            await self._run_decode_worker(
+                runtime,
+                config,
+                shutdown_event,
+                shutdown_endpoints,
+                snapshot_engine=snapshot_engine,
+                lifecycle=lifecycle,
+            )
+
+    async def _run_decode_worker(
+        self,
+        runtime: DistributedRuntime,
+        config: Config,
+        shutdown_event: asyncio.Event,
+        shutdown_endpoints: list,  # mutated in place
+        snapshot_engine: Optional[EngineSetupResult],
+        lifecycle: _DecodeWorkerLifecycle,
+    ) -> None:
+        """Initialize and serve a decode worker."""
 
         generate_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
@@ -1016,6 +1076,8 @@ class WorkerFactory:
                 prometheus_temp_dir,
                 component_gauges,
             ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
+        lifecycle.engine_client = engine_client
+        lifecycle.vllm_config = vllm_config
         await configure_kv_event_block_size(engine_client, vllm_config)
 
         # TODO Hack to get data, move this to registering in TBD
@@ -1048,6 +1110,7 @@ class WorkerFactory:
             enable_frontend_decoding=config.frontend_decoding,
             encode_worker_client=encode_worker_client,
         )
+        lifecycle.handler = handler
         handler.add_temp_dir(prometheus_temp_dir)
 
         # Check if kv event consolidator is enabled (port was allocated in setup_vllm_engine)
@@ -1227,10 +1290,6 @@ class WorkerFactory:
         except Exception as e:
             logger.error(f"Failed to serve endpoints: {e}")
             raise
-        finally:
-            logger.debug("Cleaning up decode worker")
-            # Cleanup background tasks
-            handler.cleanup()
 
     async def _create_prefill_worker(
         self,


### PR DESCRIPTION
## Why

on current main, all listed operations happen:

```
  setup_vllm_engine()
      ↓ EngineCore is now running
  configure KV sizing
  connect to encode worker
  construct handler
  initialize publishers and metrics
  wait for optional `--benchmark-mode` results
  register model
      ↓
  existing serving try/finally begins
```

Decode workers start vLLM EngineCore before completing Dynamo-side handler, publisher, benchmark, and discovery initialization. An exception in that parent-side work can escape the main coroutine while EngineCore remains alive, so the process never terminates

**CustomEncoder validation is the concrete reproducer.**

Other post-engine failures can occur while configuring KV-event sizing, connecting to an encode worker, constructing the handler, initializing publishers or metrics, waiting for optional `--benchmark-mode` results, or registering the model with discovery. The existing serving-only cleanup does not cover those startup steps, and handler cleanup alone does not stop EngineCore.

## What Change

- Track partially constructed decode resources in one lifecycle context.
- Clean handler then EngineCore on every decode-worker exit.
- Preserve original failures and suppress the health-monitor shutdown race.

## Test Plan

- Run 46 focused lifecycle tests in the RC image.
- Verify CustomEncoder failure and normal SIGTERM shutdown on one GB200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved engine monitoring during shutdown so expected engine failures and health-check timeouts no longer trigger unnecessary runtime shutdown or forced process termination.
  * Improved decode-worker startup and cleanup reliability, including consistent resource cleanup when initialization, configuration, or handler creation fails.
  * Preserved the original startup error while still reporting cleanup failures and safely shutting down the engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->