### PR TITLE
fix(sglang): validate multimodal token IDs

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -993,10 +993,9 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
                     400,
                     f"nvext.token_data[{index}] must be an integer token ID",
                 )
-            # Some models, such as Phi-3, use negative multimodal sentinel IDs.
+            # Dynamo's Rust frontend uses u32 token IDs, so negatives are not expected.
             if (
-                token_id < 0
-                or (max_input_token_id is not None and token_id > max_input_token_id)
+                max_input_token_id is not None and token_id > max_input_token_id
             ) and token_id not in allowed_oov_ids:
                 raise HttpError(400, f"Token id {token_id} is out of vocabulary")
 

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -955,8 +955,9 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         if not isinstance(mm_data, dict):
             return frozenset()
 
-        tokenizer_manager = self.engine.tokenizer_manager
-        mm_tokens = getattr(tokenizer_manager.mm_processor, "mm_tokens", None)
+        tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+        mm_processor = getattr(tokenizer_manager, "mm_processor", None)
+        mm_tokens = getattr(mm_processor, "mm_tokens", None)
         token_ids = set()
 
         if mm_tokens is not None:
@@ -970,7 +971,8 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         # Some processors, including LLaVA's wrapper, expose only the image
         # token on ModelConfig. LLaVA also represents video frames as images.
         if mm_data.get("image_url") or mm_data.get("video_url"):
-            image_token_id = tokenizer_manager.model_config.image_token_id
+            model_config = getattr(tokenizer_manager, "model_config", None)
+            image_token_id = getattr(model_config, "image_token_id", None)
             if isinstance(image_token_id, int) and not isinstance(image_token_id, bool):
                 token_ids.add(image_token_id)
 
@@ -984,7 +986,7 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         if not isinstance(token_ids, list):
             raise HttpError(400, "nvext.token_data must resolve to a token ID list")
         if self._max_input_token_id is None:
-            raise HttpError(400, "Unable to validate nvext.token_data for this model")
+            return
 
         for index, token_id in enumerate(token_ids):
             if isinstance(token_id, bool) or not isinstance(token_id, int):
@@ -992,9 +994,8 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
                     400,
                     f"nvext.token_data[{index}] must be an integer token ID",
                 )
-            if token_id < 0 or (
-                token_id > self._max_input_token_id and token_id not in allowed_oov_ids
-            ):
+            # Some models, such as Phi-3, use negative multimodal sentinel IDs.
+            if token_id > self._max_input_token_id and token_id not in allowed_oov_ids:
                 raise HttpError(400, f"Token id {token_id} is out of vocabulary")
 
     def _validate_nvext_token_data(

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -995,7 +995,9 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
                     f"nvext.token_data[{index}] must be an integer token ID",
                 )
             # Some models, such as Phi-3, use negative multimodal sentinel IDs.
-            if token_id > self._max_input_token_id and token_id not in allowed_oov_ids:
+            if (
+                token_id < 0 or token_id > self._max_input_token_id
+            ) and token_id not in allowed_oov_ids:
                 raise HttpError(400, f"Token id {token_id} is out of vocabulary")
 
     def _validate_nvext_token_data(

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -924,6 +924,14 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         """Resolve the largest token ID accepted by the model embedding table."""
         tokenizer_manager = getattr(engine, "tokenizer_manager", None)
         model_config = getattr(tokenizer_manager, "model_config", None)
+        return BaseWorkerHandler._resolve_max_input_token_id_from_model_config(
+            model_config
+        )
+
+    @staticmethod
+    def _resolve_max_input_token_id_from_model_config(
+        model_config: Any,
+    ) -> Optional[int]:
         model_vocab_size: object = getattr(model_config, "vocab_size", None)
 
         # Compatibility fallback for SGLang model configs that expose the
@@ -940,6 +948,55 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
             return None
         return model_vocab_size - 1
 
+    def _resolve_request_multimodal_token_ids(
+        self, request: Dict[str, Any]
+    ) -> frozenset[int]:
+        mm_data = request.get("multi_modal_data")
+        if not isinstance(mm_data, dict):
+            return frozenset()
+
+        tokenizer_manager = self.engine.tokenizer_manager
+        mm_tokens = getattr(tokenizer_manager.mm_processor, "mm_tokens", None)
+        token_ids = set()
+
+        if mm_tokens is not None:
+            for modality in ("image", "video", "audio"):
+                if not mm_data.get(f"{modality}_url"):
+                    continue
+                token_id = getattr(mm_tokens, f"{modality}_token_id", None)
+                if isinstance(token_id, int) and not isinstance(token_id, bool):
+                    token_ids.add(token_id)
+
+        # Some processors, including LLaVA's wrapper, expose only the image
+        # token on ModelConfig. LLaVA also represents video frames as images.
+        if mm_data.get("image_url") or mm_data.get("video_url"):
+            image_token_id = tokenizer_manager.model_config.image_token_id
+            if isinstance(image_token_id, int) and not isinstance(image_token_id, bool):
+                token_ids.add(image_token_id)
+
+        return frozenset(token_ids)
+
+    def _validate_token_ids(
+        self,
+        token_ids: Any,
+        allowed_oov_ids: frozenset[int] = frozenset(),
+    ) -> None:
+        if not isinstance(token_ids, list):
+            raise HttpError(400, "nvext.token_data must resolve to a token ID list")
+        if self._max_input_token_id is None:
+            raise HttpError(400, "Unable to validate nvext.token_data for this model")
+
+        for index, token_id in enumerate(token_ids):
+            if isinstance(token_id, bool) or not isinstance(token_id, int):
+                raise HttpError(
+                    400,
+                    f"nvext.token_data[{index}] must be an integer token ID",
+                )
+            if token_id < 0 or (
+                token_id > self._max_input_token_id and token_id not in allowed_oov_ids
+            ):
+                raise HttpError(400, f"Token id {token_id} is out of vocabulary")
+
     def _validate_nvext_token_data(
         self,
         request: Dict[str, Any],
@@ -953,19 +1010,10 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         if not isinstance(nvext, dict) or nvext.get("token_in") is not True:
             return
 
-        if not isinstance(token_ids, list):
-            raise HttpError(400, "nvext.token_data must resolve to a token ID list")
-        if self._max_input_token_id is None:
-            raise HttpError(400, "Unable to validate nvext.token_data for this model")
-
-        for index, token_id in enumerate(token_ids):
-            if isinstance(token_id, bool) or not isinstance(token_id, int):
-                raise HttpError(
-                    400,
-                    f"nvext.token_data[{index}] must be an integer token ID",
-                )
-            if token_id < 0 or token_id > self._max_input_token_id:
-                raise HttpError(400, f"Token id {token_id} is out of vocabulary")
+        self._validate_token_ids(
+            token_ids,
+            self._resolve_request_multimodal_token_ids(request),
+        )
 
     @staticmethod
     def _get_guided_decoding_params(

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -985,9 +985,8 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
     ) -> None:
         if not isinstance(token_ids, list):
             raise HttpError(400, "nvext.token_data must resolve to a token ID list")
-        if self._max_input_token_id is None:
-            return
 
+        max_input_token_id = self._max_input_token_id
         for index, token_id in enumerate(token_ids):
             if isinstance(token_id, bool) or not isinstance(token_id, int):
                 raise HttpError(
@@ -996,7 +995,8 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
                 )
             # Some models, such as Phi-3, use negative multimodal sentinel IDs.
             if (
-                token_id < 0 or token_id > self._max_input_token_id
+                token_id < 0
+                or (max_input_token_id is not None and token_id > max_input_token_id)
             ) and token_id not in allowed_oov_ids:
                 raise HttpError(400, f"Token id {token_id} is out of vocabulary")
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -293,6 +293,9 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             dist_init_method="tcp://127.0.0.1:0",
             rank=0,
         )
+        self._max_input_token_id = self._resolve_max_input_token_id_from_model_config(
+            self.encoder.model_config
+        )
 
         # Let SGLang accept the NVDEC-backed decoder this handler builds, so it
         # keeps ownership of frame selection (see _install_load_video_passthrough).
@@ -951,6 +954,17 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         # Keep URL inputs on SGLang's existing loading path and materialize only
         # frontend-decoded images received through NIXL.
         image_items, video_urls = self._extract_media_inputs(raw_request)
+        preprocessed_request = PreprocessedRequest.model_validate(raw_request)
+        allowed_oov_ids = frozenset(
+            token_id
+            for media_inputs, token_id in (
+                (image_items, self.image_token_id),
+                (video_urls, self.video_token_id),
+            )
+            if media_inputs and token_id is not None
+        )
+        self._validate_token_ids(preprocessed_request.token_ids, allowed_oov_ids)
+
         (
             image_inputs,
             image_cache_keys,
@@ -977,7 +991,6 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             MultiModalGroup(multimodal_input=MultiModalInput(video_url=url))
             for url in video_urls
         ]
-        preprocessed_request = PreprocessedRequest.model_validate(raw_request)
 
         # Build SglangMultimodalRequest from the pre-tokenized request
         request = SglangMultimodalRequest(

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -294,7 +294,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             rank=0,
         )
         self._max_input_token_id = self._resolve_max_input_token_id_from_model_config(
-            getattr(self.encoder, "model_config", None)
+            self.encoder.model_config
         )
 
         # Let SGLang accept the NVDEC-backed decoder this handler builds, so it

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -294,7 +294,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             rank=0,
         )
         self._max_input_token_id = self._resolve_max_input_token_id_from_model_config(
-            self.encoder.model_config
+            getattr(self.encoder, "model_config", None)
         )
 
         # Let SGLang accept the NVDEC-backed decoder this handler builds, so it

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -316,6 +316,27 @@ def test_nvext_token_data_accepts_maximum_valid_token_id():
     assert handler._get_input_param(request) == {"input_ids": [1, 151935]}
 
 
+def test_nvext_token_data_allows_only_llava_image_token_with_image():
+    handler = _new_token_input_handler(maximum_input_token_id=31999)
+    handler.engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            mm_processor=SimpleNamespace(),
+            model_config=SimpleNamespace(image_token_id=32000),
+        )
+    )
+    request = {
+        "token_ids": [1, 32000],
+        "multi_modal_data": {"image_url": [{"Url": "https://example.com/image.png"}]},
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    assert handler._get_input_param(request) == {"input_ids": [1, 32000]}
+
+    request["token_ids"].append(2**32 - 1)
+    with pytest.raises(HttpError, match="4294967295"):
+        handler._get_input_param(request)
+
+
 @pytest.mark.parametrize("invalid_token_id", [151936, 2**32 - 1])
 def test_nvext_token_data_rejects_out_of_vocabulary_token_id(invalid_token_id):
     handler = _new_token_input_handler()

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -403,6 +403,23 @@ def test_nvext_token_data_skips_validation_when_model_bound_is_unavailable():
     assert handler._get_input_param(request) == {"input_ids": [2**32 - 1]}
 
 
+@pytest.mark.parametrize("invalid_token_id", [-1, True])
+def test_nvext_token_data_without_model_bound_rejects_locally_invalid_token_id(
+    invalid_token_id,
+):
+    handler = _new_token_input_handler()
+    handler._max_input_token_id = None
+    request = {
+        "token_ids": [invalid_token_id],
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    with pytest.raises(HttpError) as error:
+        handler._get_input_param(request)
+
+    assert error.value.code == 400
+
+
 @pytest.mark.parametrize("invalid_token_id", [-1, True, 1.5, "1"])
 def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
     handler = _new_token_input_handler()

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -403,7 +403,7 @@ def test_nvext_token_data_skips_validation_when_model_bound_is_unavailable():
     assert handler._get_input_param(request) == {"input_ids": [2**32 - 1]}
 
 
-@pytest.mark.parametrize("invalid_token_id", [True, 1.5, "1"])
+@pytest.mark.parametrize("invalid_token_id", [-1, True, 1.5, "1"])
 def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
     handler = _new_token_input_handler()
     request = {
@@ -417,10 +417,17 @@ def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
     assert error.value.code == 400
 
 
-def test_nvext_token_data_accepts_negative_multimodal_sentinel():
+def test_nvext_token_data_accepts_configured_negative_multimodal_sentinel():
     handler = _new_token_input_handler()
+    handler.engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            mm_processor=SimpleNamespace(mm_tokens=SimpleNamespace(image_token_id=-1)),
+            model_config=SimpleNamespace(image_token_id=None),
+        )
+    )
     request = {
         "token_ids": [-1],
+        "multi_modal_data": {"image_url": [{"Url": "https://example.com/image.png"}]},
         "extra_args": {"nvext": {"token_in": True}},
     }
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -337,6 +337,18 @@ def test_nvext_token_data_allows_only_llava_image_token_with_image():
         handler._get_input_param(request)
 
 
+def test_nvext_token_data_handles_missing_multimodal_metadata():
+    handler = _new_token_input_handler()
+    handler.engine = SimpleNamespace(tokenizer_manager=SimpleNamespace())
+    request = {
+        "token_ids": [1],
+        "multi_modal_data": {"image_url": [{"Url": "https://example.com/image.png"}]},
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    assert handler._get_input_param(request) == {"input_ids": [1]}
+
+
 @pytest.mark.parametrize("invalid_token_id", [151936, 2**32 - 1])
 def test_nvext_token_data_rejects_out_of_vocabulary_token_id(invalid_token_id):
     handler = _new_token_input_handler()
@@ -380,24 +392,18 @@ def test_nvext_token_data_rejects_marked_string_payload():
     assert error.value.code == 400
 
 
-def test_nvext_token_data_rejects_request_when_model_bound_is_unavailable():
+def test_nvext_token_data_skips_validation_when_model_bound_is_unavailable():
     handler = _new_token_input_handler()
     handler._max_input_token_id = None
     request = {
-        "token_ids": [1],
+        "token_ids": [2**32 - 1],
         "extra_args": {"nvext": {"token_in": True}},
     }
 
-    with pytest.raises(
-        HttpError,
-        match=r"Unable to validate nvext\.token_data for this model",
-    ) as error:
-        handler._get_input_param(request)
-
-    assert error.value.code == 400
+    assert handler._get_input_param(request) == {"input_ids": [2**32 - 1]}
 
 
-@pytest.mark.parametrize("invalid_token_id", [-1, True, 1.5, "1"])
+@pytest.mark.parametrize("invalid_token_id", [True, 1.5, "1"])
 def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
     handler = _new_token_input_handler()
     request = {
@@ -409,6 +415,16 @@ def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
         handler._get_input_param(request)
 
     assert error.value.code == 400
+
+
+def test_nvext_token_data_accepts_negative_multimodal_sentinel():
+    handler = _new_token_input_handler()
+    request = {
+        "token_ids": [-1],
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    assert handler._get_input_param(request) == {"input_ids": [-1]}
 
 
 def test_nvext_token_data_validation_skips_ordinary_token_input():

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -403,14 +403,11 @@ def test_nvext_token_data_skips_validation_when_model_bound_is_unavailable():
     assert handler._get_input_param(request) == {"input_ids": [2**32 - 1]}
 
 
-@pytest.mark.parametrize("invalid_token_id", [-1, True])
-def test_nvext_token_data_without_model_bound_rejects_locally_invalid_token_id(
-    invalid_token_id,
-):
+def test_nvext_token_data_without_model_bound_rejects_locally_invalid_token_id():
     handler = _new_token_input_handler()
     handler._max_input_token_id = None
     request = {
-        "token_ids": [invalid_token_id],
+        "token_ids": [True],
         "extra_args": {"nvext": {"token_in": True}},
     }
 
@@ -420,7 +417,7 @@ def test_nvext_token_data_without_model_bound_rejects_locally_invalid_token_id(
     assert error.value.code == 400
 
 
-@pytest.mark.parametrize("invalid_token_id", [-1, True, 1.5, "1"])
+@pytest.mark.parametrize("invalid_token_id", [True, 1.5, "1"])
 def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
     handler = _new_token_input_handler()
     request = {
@@ -432,23 +429,6 @@ def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
         handler._get_input_param(request)
 
     assert error.value.code == 400
-
-
-def test_nvext_token_data_accepts_configured_negative_multimodal_sentinel():
-    handler = _new_token_input_handler()
-    handler.engine = SimpleNamespace(
-        tokenizer_manager=SimpleNamespace(
-            mm_processor=SimpleNamespace(mm_tokens=SimpleNamespace(image_token_id=-1)),
-            model_config=SimpleNamespace(image_token_id=None),
-        )
-    )
-    request = {
-        "token_ids": [-1],
-        "multi_modal_data": {"image_url": [{"Url": "https://example.com/image.png"}]},
-        "extra_args": {"nvext": {"token_in": True}},
-    }
-
-    assert handler._get_input_param(request) == {"input_ids": [-1]}
 
 
 def test_nvext_token_data_validation_skips_ordinary_token_input():

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -19,6 +19,7 @@ from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
 from dynamo.common.multimodal import TransferRequest
+from dynamo.llm import HttpError
 from dynamo.sglang.backend_args import DynamoSGLangConfig
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
 from dynamo.sglang.request_handlers.multimodal.encode_worker_handler import (
@@ -151,6 +152,7 @@ async def test_encode_worker_caches_frontend_decoded_image(caplog):
     handler._embedding_cache = MultimodalEmbeddingCacheManager(1024 * 1024)
     handler.image_token_id = 42
     handler.video_token_id = None
+    handler._max_input_token_id = 41
 
     content_hash = "7a9bbcb11a898630"
     decoded_metadata = {
@@ -231,6 +233,27 @@ async def test_encode_worker_caches_frontend_decoded_image(caplog):
     assert pd_request["multimodal_inputs"][0]["image_grid_thw"] == [1, 2, 2]
     assert pd_request["multimodal_inputs"][0]["num_mm_tokens"] == 4
     assert "Decoded" not in json.dumps(pd_request)
+
+
+@pytest.mark.asyncio
+async def test_encode_worker_rejects_unknown_oov_token_before_loading_media():
+    handler = MultimodalEncodeWorkerHandler.__new__(MultimodalEncodeWorkerHandler)
+    handler.image_token_id = 32000
+    handler.video_token_id = None
+    handler._max_input_token_id = 31999
+    handler._prepare_image_inputs = AsyncMock()
+    raw_request = {
+        "token_ids": [1, 32000, 2**32 - 1],
+        "stop_conditions": {"max_tokens": 8},
+        "sampling_options": {"temperature": 0.0},
+        "multi_modal_data": {"image_url": [{"Url": "https://example.com/image.png"}]},
+    }
+
+    with pytest.raises(HttpError, match="4294967295"):
+        async for _ in handler.generate(raw_request, context=None):
+            pass
+
+    handler._prepare_image_inputs.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -315,6 +338,7 @@ async def test_encode_worker_releases_decoded_image_before_streaming():
     handler._embedding_cache = None
     handler.image_token_id = 42
     handler.video_token_id = None
+    handler._max_input_token_id = 41
 
     class _ImageLoader:
         image_ref = None

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -56,6 +56,7 @@ def cache_handler() -> MultimodalEncodeWorkerHandler:
 
     handler.set_token_ids_for_test = _set_token_ids_for_test
     handler.set_token_ids_for_test(151655, 151656)
+    handler._max_input_token_id = 151654
     handler._missing_video_cache_key_config_warned = False
     handler._decoded_content_hash_warning_emitted = False
     handler._image_loader = None


### PR DESCRIPTION
## Summary

- allow configured multimodal sentinel IDs outside the text vocabulary only when the request contains corresponding media
- validate dedicated multimodal encode requests before loading or encoding media
- continue rejecting arbitrary out-of-vocabulary IDs before they reach SGLang

## Root cause

The validation introduced by #12798 treats the text vocabulary as the complete set of valid input IDs and runs only on the request path that retains `extra_args.nvext.token_in`. Valid multimodal sentinels can sit outside the text vocabulary, while the dedicated multimodal request model does not retain that marker.

This change centralizes the token-range check, adds request-scoped multimodal exceptions, and calls it unconditionally at the dedicated encode boundary.

## Validation

- `108 passed` across:
  - `test_sglang_decode_handler.py`
  - `test_sglang_frontend_decoding.py`
  - `test_sglang_multimodal_embedding_cache.py`
- all touched-file pre-commit hooks passed
- validated with SGLang 0.5.16

## Tracking

- [DYN-3785](https://linear.app/nvidia/issue/DYN-3785/dynamorelease140psirt-single-request-dos-via-nvexttoken-data-integer)
- Stacked on #12798
