### PR TITLE
fix: reject nested non-progressing guided JSON cycles

### DIFF
--- a/components/src/dynamo/common/tests/test_guided_json.py
+++ b/components/src/dynamo/common/tests/test_guided_json.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 
-from dynamo.common.utils.guided_json import reject_cyclic_guided_json_ref_chain
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.llm import HttpError
 
 pytestmark = [
@@ -43,8 +43,38 @@ pytestmark = [
     ],
 )
 def test_rejects_cyclic_root_ref_chains(schema):
-    with pytest.raises(HttpError, match=r"circular local \$ref chain") as error:
-        reject_cyclic_guided_json_ref_chain(schema)
+    with pytest.raises(HttpError, match=r"non-progressing local \$ref cycle") as error:
+        reject_nonprogressing_guided_json_ref_cycles(schema)
+
+    assert error.value.code == 400
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        pytest.param(
+            {
+                "$defs": {
+                    "A": {"allOf": [{"$ref": "#/$defs/A"}]},
+                },
+                "$ref": "#/$defs/A",
+            },
+            id="allof",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {"value": {"$ref": "#/$defs/A"}},
+                "required": ["value"],
+                "$defs": {"A": {"$ref": "#/$defs/A"}},
+            },
+            id="required-property",
+        ),
+    ],
+)
+def test_rejects_nonprogressing_ref_cycles(schema):
+    with pytest.raises(HttpError, match=r"non-progressing local \$ref cycle") as error:
+        reject_nonprogressing_guided_json_ref_cycles(schema)
 
     assert error.value.code == 400
 
@@ -84,7 +114,7 @@ def test_rejects_cyclic_root_ref_chains(schema):
     ],
 )
 def test_allows_schemas_outside_cyclic_root_ref_chains(schema):
-    reject_cyclic_guided_json_ref_chain(schema)
+    reject_nonprogressing_guided_json_ref_cycles(schema)
 
 
 @pytest.mark.parametrize(
@@ -96,4 +126,4 @@ def test_allows_schemas_outside_cyclic_root_ref_chains(schema):
     ],
 )
 def test_leaves_unresolved_references_to_backend(schema):
-    reject_cyclic_guided_json_ref_chain(schema)
+    reject_nonprogressing_guided_json_ref_cycles(schema)

--- a/components/src/dynamo/common/utils/guided_json.py
+++ b/components/src/dynamo/common/utils/guided_json.py
@@ -4,6 +4,8 @@
 """Targeted checks for JSON schemas passed to constrained-decoding backends."""
 
 import json
+from collections import deque
+from collections.abc import Iterator
 from typing import Any
 from urllib.parse import unquote
 
@@ -65,11 +67,71 @@ def _resolve_local_pointer(
     return target, target_resource
 
 
-def reject_cyclic_guided_json_ref_chain(schema: Any) -> None:
-    """Reject root-reachable cycles made only of local ``$ref`` hops.
+def _child_resource(child: dict[str, Any], resource: dict[str, Any]) -> dict[str, Any]:
+    return child if isinstance(child.get("$id"), str) else resource
 
-    This intentionally does not interpret JSON Schema applicators. Productive
-    recursion and schemas outside this narrow failure mode remain backend-owned.
+
+def _iter_progressing_children(node: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    for keyword in (
+        "properties",
+        "patternProperties",
+        "dependentSchemas",
+        "dependencies",
+    ):
+        children = node.get(keyword)
+        if isinstance(children, dict):
+            for child in children.values():
+                if isinstance(child, dict):
+                    yield child
+
+    for keyword in (
+        "additionalProperties",
+        "unevaluatedProperties",
+        "propertyNames",
+        "items",
+        "additionalItems",
+        "prefixItems",
+        "contains",
+        "unevaluatedItems",
+        "contentSchema",
+    ):
+        children = node.get(keyword)
+        if isinstance(children, dict):
+            yield children
+        elif isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict):
+                    yield child
+
+
+def _has_cycle(
+    edges: dict[tuple[int, int], set[tuple[int, int]]],
+) -> bool:
+    in_degree = {node: 0 for node in edges}
+    for targets in edges.values():
+        for target in targets:
+            in_degree.setdefault(target, 0)
+            in_degree[target] += 1
+
+    ready = deque(node for node, degree in in_degree.items() if degree == 0)
+    visited = 0
+    while ready:
+        node = ready.popleft()
+        visited += 1
+        for target in edges.get(node, ()):
+            in_degree[target] -= 1
+            if in_degree[target] == 0:
+                ready.append(target)
+
+    return visited != len(in_degree)
+
+
+def reject_nonprogressing_guided_json_ref_cycles(schema: Any) -> None:
+    """Reject reachable local ``$ref`` cycles that cannot consume JSON.
+
+    ``allOf`` preserves the current JSON instance, while object properties and
+    array items cross a progress boundary. Choice applicators and schemas outside
+    this narrow failure mode remain backend-owned.
     """
     if isinstance(schema, str):
         try:
@@ -80,21 +142,40 @@ def reject_cyclic_guided_json_ref_chain(schema: Any) -> None:
     if not isinstance(schema, dict):
         return
 
-    resource = schema
-    node = schema
-    seen: set[int] = set()
+    pending = [(schema, schema)]
+    processed: set[tuple[int, int]] = set()
+    edges: dict[tuple[int, int], set[tuple[int, int]]] = {}
 
-    while True:
-        node_id = id(node)
-        if node_id in seen:
-            raise _schema_error("circular local $ref chain detected")
-        seen.add(node_id)
+    while pending:
+        node, resource = pending.pop()
+        node_key = (id(node), id(resource))
+        if node_key in processed:
+            continue
+        processed.add(node_key)
+        targets: set[tuple[int, int]] | None = None
 
         ref = node.get("$ref")
-        if not isinstance(ref, str) or not ref.startswith("#"):
-            return
-        resolved = _resolve_local_pointer(resource, ref)
-        if resolved is None:
-            return
+        if isinstance(ref, str) and ref.startswith("#"):
+            resolved = _resolve_local_pointer(resource, ref)
+            if resolved is not None:
+                target, target_resource = resolved
+                targets = edges.setdefault(node_key, set())
+                targets.add((id(target), id(target_resource)))
+                pending.append((target, target_resource))
 
-        node, resource = resolved
+        all_of = node.get("allOf")
+        if isinstance(all_of, list):
+            for child in all_of:
+                if not isinstance(child, dict):
+                    continue
+                child_resource = _child_resource(child, resource)
+                if targets is None:
+                    targets = edges.setdefault(node_key, set())
+                targets.add((id(child), id(child_resource)))
+                pending.append((child, child_resource))
+
+        for child in _iter_progressing_children(node):
+            pending.append((child, _child_resource(child, resource)))
+
+    if _has_cycle(edges):
+        raise _schema_error("non-progressing local $ref cycle detected")

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -28,7 +28,7 @@ from dynamo._core import Context
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.lora.manager import get_lora_manager
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
-from dynamo.common.utils.guided_json import reject_cyclic_guided_json_ref_chain
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import (
@@ -924,7 +924,7 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         if isinstance(guided_decoding, dict):
             json_schema = guided_decoding.get("json")
             if json_schema is not None:
-                reject_cyclic_guided_json_ref_chain(json_schema)
+                reject_nonprogressing_guided_json_ref_cycles(json_schema)
                 return {"json_schema": json.dumps(json_schema)}
             structural_tag = guided_decoding.get("structural_tag")
             if structural_tag is not None:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -64,7 +64,7 @@ from dynamo.common.rl import (
 )
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.engine_response import normalize_finish_reason
-from dynamo.common.utils.guided_json import reject_cyclic_guided_json_ref_chain
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.common.utils.time_section import time_and_log_code_section
@@ -720,7 +720,7 @@ def build_sampling_params(
     if guided_decoding is not None and isinstance(guided_decoding, dict):
         json_schema = guided_decoding.get("json")
         if json_schema is not None:
-            reject_cyclic_guided_json_ref_chain(json_schema)
+            reject_nonprogressing_guided_json_ref_cycles(json_schema)
         sampling_params.structured_outputs = StructuredOutputsParams(
             json=json_schema,
             regex=guided_decoding.get("regex"),


### PR DESCRIPTION
## Summary

* Follow up on ai-dynamo/dynamo#12795 by extending guided JSON validation beyond direct `$ref` chains.
* Model local `$ref` and mandatory `allOf` transitions as non-progressing graph edges.
* Inspect property and item child schemas without treating productive recursion as a cycle.
* Keep `$defs` resolution lazy and leave `anyOf`/`oneOf` alternatives backend-owned.

## Root cause

The validator stopped as soon as the current node lacked a direct `$ref`. Mandatory cycles hidden behind `allOf` or a property schema therefore reached XGrammar and produced matcher states with no terminating JSON value.

Fixes [DYN-3784](https://linear.app/nvidia/issue/DYN-3784/dynamorelease140psirt-single-request-dos-via-guided-json-self)<br>Fixes [DYN-3786](https://linear.app/nvidia/issue/DYN-3786/dynamorelease140psirt-single-request-dos-via-guided-json-circular)

## Validation

* Common guided JSON unit tests: 14 passed.
* XGrammar 0.2.5 assertions: nested dead cycles rejected; productive recursion accepted.
* 10,000-node cycle assertion passed without recursive traversal.
* Repository commit hooks passed: isort, black, flake8, codespell, ruff, marker validation, and file checks.