### PR TITLE
fix(frontend): return 4xx for backend request rejections on /v1/audio/speech

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -4277,10 +4277,16 @@ async fn audio_speech(
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
-    let stream = engine
-        .generate(request)
-        .await
-        .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate audio"))?;
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model, super::metrics::Endpoint::Audios);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to generate audio");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
 
     let mut http_queue_guard = Some(http_queue_guard);
     let stream = stream.inspect(move |response| {
@@ -4294,8 +4300,10 @@ async fn audio_speech(
     let response = NvAudioSpeechResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to fold audio stream for {}: {:?}", request_id, e);
-            ErrorMessage::internal_server_error("Failed to fold audio stream")
+            let err_response =
+                ErrorMessage::from_anyhow(anyhow::Error::new(e), "Failed to fold audio stream");
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
         })?;
 
     // Check for failure before marking success

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -4308,6 +4308,9 @@ async fn audio_speech(
 
     // Check for failure before marking success
     if response.status == "failed" {
+        // Without this the guard drops on its default and books this 400 as an
+        // internal error.
+        inflight.mark_error(ErrorType::Validation);
         return Ok((axum::http::StatusCode::BAD_REQUEST, Json(response)).into_response());
     }
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -4255,10 +4255,16 @@ async fn audio_speech(
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
-    let stream = engine
-        .generate(request)
-        .await
-        .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate audio"))?;
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model, super::metrics::Endpoint::Audios);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to generate audio");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
 
     let mut http_queue_guard = Some(http_queue_guard);
     let stream = stream.inspect(move |response| {
@@ -4272,8 +4278,10 @@ async fn audio_speech(
     let response = NvAudioSpeechResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to fold audio stream for {}: {:?}", request_id, e);
-            ErrorMessage::internal_server_error("Failed to fold audio stream")
+            let err_response =
+                ErrorMessage::from_anyhow(anyhow::Error::new(e), "Failed to fold audio stream");
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
         })?;
 
     // Check for failure before marking success

--- a/lib/llm/src/protocols/openai/audios/aggregator.rs
+++ b/lib/llm/src/protocols/openai/audios/aggregator.rs
@@ -3,8 +3,9 @@
 
 use futures::Stream;
 
-use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
+use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvAudioSpeechResponse;
 
@@ -22,7 +23,7 @@ impl NvAudioSpeechResponse {
     /// Aggregates an annotated stream of audio responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvAudioSpeechResponse>>,
-    ) -> Result<NvAudioSpeechResponse, String> {
-        aggregate_stream(stream).await
+    ) -> Result<NvAudioSpeechResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -38,3 +38,60 @@ where
 
     Ok(response.unwrap_or_else(T::empty))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_runtime::{
+        error::{BackendError, ErrorType},
+        protocols::maybe_error::MaybeError,
+    };
+    use futures::stream;
+    use serde::Deserialize;
+
+    #[derive(Debug, Default, PartialEq, Deserialize)]
+    struct Chunks(Vec<u32>);
+
+    impl StreamAggregable for Chunks {
+        fn empty() -> Self {
+            Self::default()
+        }
+
+        fn merge(&mut self, next: Self) {
+            self.0.extend(next.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn merges_data_and_falls_back_to_empty() {
+        let empty = aggregate_stream::<Chunks, _>(stream::empty())
+            .await
+            .unwrap();
+        assert_eq!(empty, Chunks(vec![]));
+
+        let stream = stream::iter(vec![
+            Annotated::from_data(Chunks(vec![1])),
+            Annotated::from_data(Chunks(vec![2])),
+        ]);
+        assert_eq!(aggregate_stream(stream).await.unwrap(), Chunks(vec![1, 2]));
+    }
+
+    /// The property every OpenAI endpoint depends on: a backend rejection keeps
+    /// its type, so the HTTP layer can answer 4xx rather than a blanket 500.
+    #[tokio::test]
+    async fn preserves_backend_error_type() {
+        let stream = stream::iter(vec![Annotated::<Chunks>::from_err(
+            DynamoError::builder()
+                .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                .message("invalid argument")
+                .build(),
+        )]);
+
+        let error = aggregate_stream(stream).await.unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid argument");
+    }
+}

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -43,6 +43,10 @@ where
 /// Aggregate a stream of [`Annotated<T>`] while preserving structured backend
 /// errors. Existing callers that expose string errors can continue to use
 /// [`aggregate_stream`].
+///
+/// The [`DynamoError`] is returned intact so the HTTP layer can classify a
+/// backend rejection — invalid argument, overload, cancellation — into the
+/// matching status code.
 pub async fn aggregate_typed_stream<T, S>(stream: S) -> Result<T, DynamoError>
 where
     T: StreamAggregable,
@@ -71,4 +75,63 @@ where
     }
 
     Ok(response.unwrap_or_else(T::empty))
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_runtime::{
+        error::{BackendError, ErrorType},
+        protocols::maybe_error::MaybeError,
+    };
+    use futures::stream;
+    use serde::Deserialize;
+
+    #[derive(Debug, Default, PartialEq, Deserialize)]
+    struct Chunks(Vec<u32>);
+
+    impl StreamAggregable for Chunks {
+        fn empty() -> Self {
+            Self::default()
+        }
+
+        fn merge(&mut self, next: Self) {
+            self.0.extend(next.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn merges_data_and_falls_back_to_empty() {
+        let empty = aggregate_typed_stream::<Chunks, _>(stream::empty())
+            .await
+            .unwrap();
+        assert_eq!(empty, Chunks(vec![]));
+
+        let stream = stream::iter(vec![
+            Annotated::from_data(Chunks(vec![1])),
+            Annotated::from_data(Chunks(vec![2])),
+        ]);
+        assert_eq!(
+            aggregate_typed_stream(stream).await.unwrap(),
+            Chunks(vec![1, 2])
+        );
+    }
+
+    /// The property every OpenAI endpoint depends on: a backend rejection keeps
+    /// its type, so the HTTP layer can answer 4xx rather than a blanket 500.
+    #[tokio::test]
+    async fn preserves_backend_error_type() {
+        let stream = stream::iter(vec![Annotated::<Chunks>::from_err(
+            DynamoError::builder()
+                .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                .message("invalid argument")
+                .build(),
+        )]);
+
+        let error = aggregate_typed_stream(stream).await.unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid argument");
+    }
 }

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -1541,6 +1541,125 @@ async fn test_streaming_responses_returns_4xx_on_backend_invalid_argument() {
     task.await.unwrap().unwrap();
 }
 
+/// Audio engine whose only response frame is a `Backend(InvalidArgument)`
+/// error — models a worker rejecting the request during deserialization
+/// (e.g. a `task_type` value outside the backend's accepted set).
+struct InvalidArgumentAudiosEngine {}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > for InvalidArgumentAudiosEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+    ) -> Result<
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > {
+        use dynamo_runtime::error::{BackendError, ErrorType as DynErrorType};
+        let (_request, context) = request.transfer(());
+        let ctx = context.context();
+        let stream = stream! {
+            yield Annotated::<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse> {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(
+                    DynamoError::builder()
+                        .error_type(DynErrorType::Backend(BackendError::InvalidArgument))
+                        .message(
+                            "ValidationError: 1 validation error for NvCreateAudioSpeechRequest \
+                             task_type Input should be 'CustomVoice', 'VoiceDesign', 'Base'",
+                        )
+                        .build(),
+                ),
+            };
+        };
+        Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
+
+/// The `/v1/audio/speech` request schema is looser in the frontend than in the
+/// worker (the worker constrains e.g. `task_type` to a model-specific set), so
+/// out-of-range values can only be rejected worker-side. That rejection must
+/// reach the caller as a 4xx carrying the backend's message, not as a 500
+/// about folding the audio stream.
+#[tokio::test]
+async fn test_audio_speech_backend_invalid_argument_returns_4xx() {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder().port(port).build().unwrap();
+    service.enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Audios, true);
+
+    let state = service.state_clone();
+    let manager = state.manager();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task =
+        tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+    wait_for_service_ready(port).await;
+
+    let registry = Registry::new();
+    let card = ModelDeploymentCard::with_name_only("tts-model");
+    manager
+        .add_audios_model(
+            "tts-model",
+            card.mdcsum(),
+            Arc::new(InvalidArgumentAudiosEngine {}),
+        )
+        .unwrap();
+
+    let metrics = state.metrics_clone();
+    metrics.register(&registry).unwrap();
+
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/v1/audio/speech"))
+        .json(&serde_json::json!({
+            "model": "tts-model",
+            "input": "The quick brown fox jumps over the lazy dog.",
+            "voice": "vivian",
+            "language": "English",
+            "task_type": "NotARealTaskType",
+        }))
+        .send()
+        .await
+        .expect("POST /v1/audio/speech");
+
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Backend(InvalidArgument) on /v1/audio/speech must land as HTTP 400; got {status}, body: {text}"
+    );
+    assert!(
+        text.contains("task_type"),
+        "expected the backend validation message to name the offending field; got: {text}"
+    );
+
+    // The 400 is a client error, so it must be metered as a validation
+    // failure rather than an internal one.
+    compare_counter(
+        &metrics,
+        "tts-model",
+        &Endpoint::Audios,
+        &RequestType::Unary,
+        &Status::Error,
+        &ErrorType::Validation,
+        1,
+    );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}
+
 /// Engine registered only so the classify/pooling routes resolve a model; the
 /// validation errors under test are rejected before the engine is reached.
 struct UncalledPoolingFamilyEngine {}

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -1660,6 +1660,100 @@ async fn test_audio_speech_backend_invalid_argument_returns_4xx() {
     task.await.unwrap().unwrap();
 }
 
+/// Audio engine that completes normally but reports `status: "failed"`, the
+/// shape a worker uses to signal it could not produce audio.
+struct FailedStatusAudiosEngine {}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > for FailedStatusAudiosEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+    ) -> Result<
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > {
+        use dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse;
+        let (_request, context) = request.transfer(());
+        let ctx = context.context();
+        let stream = stream! {
+            yield Annotated::from_data(NvAudioSpeechResponse {
+                status: "failed".to_string(),
+                error: Some("voice cloning failed".to_string()),
+                ..NvAudioSpeechResponse::empty()
+            });
+        };
+        Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
+
+/// A worker-reported `status: "failed"` returns 400, so it must meter as a
+/// client error too. The inflight guard defaults to `internal` when unmarked,
+/// which would book this 400 as a server fault.
+#[tokio::test]
+async fn test_audio_speech_failed_status_meters_as_client_error() {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder().port(port).build().unwrap();
+    service.enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Audios, true);
+
+    let state = service.state_clone();
+    let manager = state.manager();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task =
+        tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+    wait_for_service_ready(port).await;
+
+    let registry = Registry::new();
+    let card = ModelDeploymentCard::with_name_only("tts-model");
+    manager
+        .add_audios_model(
+            "tts-model",
+            card.mdcsum(),
+            Arc::new(FailedStatusAudiosEngine {}),
+        )
+        .unwrap();
+
+    let metrics = state.metrics_clone();
+    metrics.register(&registry).unwrap();
+
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/v1/audio/speech"))
+        .json(&serde_json::json!({"model": "tts-model", "input": "hello"}))
+        .send()
+        .await
+        .expect("POST /v1/audio/speech");
+
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {text}");
+    assert!(
+        text.contains("voice cloning failed"),
+        "the worker's failure reason must reach the caller; got: {text}"
+    );
+
+    compare_counter(
+        &metrics,
+        "tts-model",
+        &Endpoint::Audios,
+        &RequestType::Unary,
+        &Status::Error,
+        &ErrorType::Validation,
+        1,
+    );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}
+
 /// Engine registered only so the classify/pooling routes resolve a model; the
 /// validation errors under test are rejected before the engine is reached.
 struct UncalledPoolingFamilyEngine {}


### PR DESCRIPTION
## Summary

An invalid `task_type` on `/v1/audio/speech` returned HTTP 500 with
`"Failed to fold audio stream"` instead of a 4xx response naming the invalid
field.

The frontend request schema accepts `task_type` as `Option<String>`, while the
Python worker constrains it to the values supported by the deployed model.
Consequently, some invalid values can only be rejected by the worker. The
worker correctly reports these failures as `Backend(InvalidArgument)` error
frames.

On current `main`, audio stream aggregation preserves the resulting
`DynamoError`. However, the `audio_speech` handler replaced every aggregation
failure with a blanket internal-server-error response. This PR converts the
preserved error through `ErrorMessage::from_anyhow`, allowing the existing
error classification to:

- Return HTTP 400 for `Backend(InvalidArgument)`.
- Forward the backend validation message to the caller.
- Record the request as `error_type=validation` instead of `internal`.

The audio dispatch-error path is also aligned with the image and video
handlers:

- Recognized load-shedding errors increment `model_rejection_total`.
- The `InflightGuard` records the error classification derived from the
  response returned to the client.

This change is limited to `/v1/audio/speech`. It deliberately does not
hard-code backend- and model-specific `task_type` values in the Rust request
schema.

## Validation

`test_audio_speech_backend_invalid_argument_returns_4xx` drives a request
through the HTTP service against an audio engine that emits a
`Backend(InvalidArgument)` frame. It verifies:

- HTTP 400 is returned.
- The backend message identifies `task_type`.
- `requests_total` records `error_type=validation`.

The stream aggregator unit tests cover data merging, the empty-stream
fallback, and preservation of typed backend errors.

```text
cargo test -p dynamo-llm stream_aggregator::tests
cargo test -p dynamo-llm --test http-service \
  test_audio_speech_backend_invalid_argument_returns_4xx -- --exact
cargo fmt --all -- --check
cargo clippy -p dynamo-llm --no-deps --all-targets -- -D warnings
```

## Related Issues

- Fixes [DYN-3779](https://linear.app/nvidia/issue/DYN-3779/dynamorelease140vllm-omni-an-invalid-task-type-on-v1audiospeech)
- Tracks the underlying schema drift in ai-dynamo/dynamo#12833

## Review Focus

- `lib/llm/src/http/service/openai.rs`: audio error conversion and metrics
- `lib/llm/tests/http-service.rs`: endpoint-level regression coverage
- `lib/llm/src/protocols/openai/stream_aggregator.rs`: aggregator unit tests
