### PR TITLE
fix(aisimulate): send one synthetic load controller (cherry-pick #12824)

### DIFF
--- a/aisimulate/src/aisimulate/spica/config.py
+++ b/aisimulate/src/aisimulate/spica/config.py
@@ -273,12 +273,15 @@ class Workload(BaseModel):
         return max(1, round((self.num_request_ratio or 0.0) * load))
 
     @property
-    def synthetic_arrival_interval_ms(self) -> float:
-        """Mean inter-arrival for a synthetic request-rate workload (1.0 default;
-        ignored in closed-loop / concurrency mode)."""
-        if self.request_rate:
-            return 1000.0 / self.request_rate
-        return 1.0
+    def synthetic_arrival_interval_ms(self) -> float | None:
+        """Mean inter-arrival for a synthetic request-rate workload.
+
+        Closed-loop workloads return ``None`` so Replay receives only their
+        ``replay_concurrency`` load controller.
+        """
+        if self.request_rate is None:
+            return None
+        return 1000.0 / self.request_rate
 
     @model_validator(mode="after")
     def _validate_workload(self) -> Workload:

--- a/aisimulate/src/aisimulate/spica/evaluator.py
+++ b/aisimulate/src/aisimulate/spica/evaluator.py
@@ -121,7 +121,7 @@ class ReplayEvaluator:
 
     def _synthetic_kwargs(self, concurrency_override: int | None = None) -> dict:
         """The synthetic-workload params ``run_synthetic_trace_replay`` takes
-        (``arrival_interval_ms`` is ignored in closed-loop mode).
+        (``arrival_interval_ms`` is ``None`` in closed-loop mode).
 
         ``request_count`` is derived from ``num_request_ratio`` and the effective load
         (the per-trial KV-load-derived ``concurrency_override``, else the workload's fixed

--- a/aisimulate/tests/spica/test_evaluator.py
+++ b/aisimulate/tests/spica/test_evaluator.py
@@ -240,6 +240,11 @@ def _syn_wl(**kw):
     return Workload(**base)
 
 
+def _assert_only_synthetic_load_controller(rec, expected):
+    controllers = ("replay_concurrency", "request_rate", "arrival_interval_ms")
+    assert [name for name in controllers if rec.get(name) is not None] == [expected]
+
+
 def test_synthetic_static_uses_run_synthetic_trace_replay(monkeypatch):
     # synthetic + static -> a single run_synthetic_trace_replay call with planner_config=None
     # (fixed-fleet replay, no scaling); goodput SLA threaded; in-flight cap = concurrency.
@@ -265,6 +270,7 @@ def test_synthetic_static_uses_run_synthetic_trace_replay(monkeypatch):
         and rec["request_count"] == 100
     )
     assert rec["replay_concurrency"] == 4  # closed-loop cap from concurrency
+    _assert_only_synthetic_load_controller(rec, "replay_concurrency")
     assert rec["sla_ttft_ms"] == 2000.0
     assert rec["planner_config"] is None  # static -> no planner in the loop
     assert rec["num_workers"] == 2
@@ -285,6 +291,7 @@ def test_concurrency_override_drives_cap_and_request_count(monkeypatch):
     goal = OptimizationGoal(target=OptimizationTarget.PARETO)  # no SLA needed
     ReplayEvaluator(wl, goal).evaluate(_agg_plan(static=True), concurrency_override=8)
     assert rec["replay_concurrency"] == 8  # cap = the candidate-derived concurrency
+    _assert_only_synthetic_load_controller(rec, "replay_concurrency")
     assert rec["request_count"] == 200  # num_request_ratio(25) * 8
     assert rec["planner_config"] is None
 
@@ -305,6 +312,7 @@ def test_synthetic_planner_threads_planner_config(monkeypatch):
     # request-rate workload -> open-loop (no cap); arrival_interval derived from the rate
     ReplayEvaluator(_syn_wl(request_rate=20.0), goal).evaluate(_agg_plan(static=False))
     assert rec["replay_concurrency"] is None
+    _assert_only_synthetic_load_controller(rec, "arrival_interval_ms")
     assert rec["input_tokens"] == 128 and rec["output_tokens"] == 64
     assert rec["arrival_interval_ms"] == 50.0  # 1000 / 20
     assert rec["planner_config"]["mode"] == "agg"


### PR DESCRIPTION
## Summary

- cherry-pick [#12824](https://github.com/ai-dynamo/dynamo/pull/12824) onto `release/1.4.0`
- return no arrival interval for closed-loop Spica workloads so Replay receives only `replay_concurrency`
- preserve request-rate behavior and assert the exactly-one-controller invariant for all three synthetic workload shapes
- fix release blocker [DYN-3742](https://linear.app/nvidia/issue/DYN-3742/dynamorelease140spica-synthetic-closed-loop-searches-pass-two-load) / NVBUG 6556084

## Validation

- `python -m pytest aisimulate/tests/spica/test_evaluator.py aisimulate/tests/spica/test_config.py -q` — 78 passed
- `pre-commit run --files aisimulate/src/aisimulate/spica/config.py aisimulate/src/aisimulate/spica/evaluator.py aisimulate/tests/spica/test_evaluator.py` — passed
- `git diff --check origin/release/1.4.0..HEAD` — passed
- stable patch-id matches merged main commit `e91532121419c4113d91d665f56f3710214f719a`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->