### PR TITLE
test(ci): reclassify test_trtllm_main_init.py from gpu_1 to gpu_0 (OPS-8114)

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_trtllm_main_init.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_main_init.py
@@ -13,12 +13,16 @@ import pytest
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.trtllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
 
-# Intentionally unprofiled: these import-heavy, zero-VRAM tests run in the
-# sequential GPU stage so TensorRT-LLM initialization is shared.
+# gpu_0 despite the TensorRT-LLM test below: nothing is imported at module
+# scope, so this file collects on a host with no CUDA driver. The two
+# prometheus tests then run there, and the one test that does reach
+# tensorrt_llm skips itself, because importing its bindings raises
+# ImportError("libcuda.so.1: cannot open shared object file") -- which the
+# handler in that test already treats as a skip.
 
 
 def test_tensorrt_llm_metrics_collector_import():


### PR DESCRIPTION
## Summary

Follow-up to #12826 (vLLM) and #12718 (SGLang), but with an important difference: **this one buys essentially no runtime.** It is a marker-accuracy and coverage fix, and it is deliberately one file.

`test_trtllm_main_init.py` imports nothing at module scope, so it collects fine on a host with no CUDA driver. Two of its three tests only touch `prometheus_client` and `dynamo.common`. Only `test_tensorrt_llm_metrics_collector_import` reaches TensorRT-LLM, via a function-scope import whose existing `except ImportError -> pytest.skip` handler already covers the driver-less case. On GPU-less arm64, with no patching at all:

```
test_tensorrt_llm_metrics_collector_import SKIPPED (TensorRT-LLM not available: libcuda.so.1...)
test_prometheus_registry_import            PASSED
test_prometheus_metrics_integration        PASSED
```

### Runtime gain: ~17 ms

Not a typo. In the sequential GPU stage of run 31183861251 (job 92888922699) the three tests span `14:24:46.9978` → `14:24:47.0147`. The entire trtllm unit GPU stage is 164 tests in 58.6s, because this suite **already** got the optimization that mattered: these files intentionally omit `profiled_vram_gib` so they share one interpreter in the sequential stage rather than paying one subprocess per test. That per-test subprocess cost is precisely what #12826 removed from vLLM (12,024s); TRT-LLM had already sidestepped it.

What the change actually buys: the two prometheus tests start running on the arm64 lane, which they never have, and the file stops advertising a GPU requirement that most of it does not have.

### Why only this one file

I checked the whole trtllm suite rather than eyeballing it. To separate "the test uses a GPU" from "the test's import chain needs the driver", each trtllm `gpu_1` file was run on the GPU-less arm64 image with the module-level `torch.cuda.is_available()` guards defeated (a `-p` plugin monkeypatching it to `True`), forcing real imports instead of an early skip.

**Nine of the ten files in `components/src/dynamo/trtllm/tests/` fail collection even then**, with `ImportError: libcuda.so.1` — their module-scope imports reach `tensorrt_llm`, whose bindings link the driver. Their test bodies are mostly pure mocks, but that does not help: the module cannot be imported on a CPU-only runner, so marking them `gpu_0` would silently convert them into skips. The trtllm `gpu_1` files elsewhere are genuinely GPU-bound too — `test_consolidator_config_unit.py` and `test_trtllm_mm_hashes_protocol.py` hit NVML, `test_autodeploy_backend.py` launches a real server, and the rest are serve/fault-tolerance/router e2e.

## Validation

Against the trtllm runtime-test image:

| lane | baseline | patched |
| -- | -- | -- |
| arm64, no GPU (`pre_merge and trtllm and gpu_0`) | 246 passed, 21 skipped | **248 passed, 22 skipped** |
| amd64 + GPU, full `gpu_0` lane | — | **272 passed** |
| amd64 + GPU, this file alone | 3 passed | 3 passed |
| collection (amd64) | gpu_0 269 / gpu_1 162 | gpu_0 272 / gpu_1 159 |

The extra skip on arm64 is the TensorRT-LLM test opting out cleanly. The amd64 rows matter because that CPU-only stage is a step of the GPU job and does have a GPU, so all three tests keep running there exactly as they do today; exactly three tests move between selections, and none are lost.

Linear: OPS-8114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment compatibility by allowing collection without CUDA support.
  * Updated GPU test classification to better match the required execution environment.
  * Prometheus-related checks can now run on host systems, while TensorRT-LLM import checks are skipped when CUDA bindings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->