### PR TITLE
fix(vllm): filter infeasible EAGLE benchmark points

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -2577,6 +2577,16 @@ class InstrumentedScheduler(AsyncScheduler):
         except ValueError:
             return False
 
+        eagle_cache_drop_tokens = self._bench_eagle_cache_drop_tokens()
+        if eagle_cache_drop_tokens and any(
+            kv_read_tokens > 0 and new_tokens <= eagle_cache_drop_tokens
+            for new_tokens, kv_read_tokens in zip(new_token_lengths, kv_read_lengths)
+        ):
+            # EAGLE recomputes the last matched cache block. A request needs
+            # more than that block's tokens to reach the extra seeded block
+            # while preserving both benchmark axes.
+            return False
+
         prompt_lengths = [
             new_tokens + kv_read_tokens
             for new_tokens, kv_read_tokens in zip(new_token_lengths, kv_read_lengths)

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -2580,7 +2580,9 @@ class InstrumentedScheduler(AsyncScheduler):
         eagle_cache_drop_tokens = self._bench_eagle_cache_drop_tokens()
         if eagle_cache_drop_tokens and any(
             kv_read_tokens > 0 and new_tokens <= eagle_cache_drop_tokens
-            for new_tokens, kv_read_tokens in zip(new_token_lengths, kv_read_lengths)
+            for new_tokens, kv_read_tokens in zip(
+                new_token_lengths, kv_read_lengths, strict=True
+            )
         ):
             # EAGLE recomputes the last matched cache block. A request needs
             # more than that block's tokens to reach the extra seeded block
@@ -2589,7 +2591,9 @@ class InstrumentedScheduler(AsyncScheduler):
 
         prompt_lengths = [
             new_tokens + kv_read_tokens
-            for new_tokens, kv_read_tokens in zip(new_token_lengths, kv_read_lengths)
+            for new_tokens, kv_read_tokens in zip(
+                new_token_lengths, kv_read_lengths, strict=True
+            )
         ]
         max_model_len = self._bench_capacity_limit("max_model_len")
         if any(prompt_len + 1 > max_model_len for prompt_len in prompt_lengths):
@@ -2598,14 +2602,16 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_prefill_scheduled_tokens_per_req(prompt_len, kv_read_tokens)
             != new_tokens
             for prompt_len, kv_read_tokens, new_tokens in zip(
-                prompt_lengths, kv_read_lengths, new_token_lengths
+                prompt_lengths, kv_read_lengths, new_token_lengths, strict=True
             )
         ):
             return False
 
         required_blocks = sum(
             self._bench_prefill_blocks_per_req(prompt_len, kv_read_tokens)
-            for prompt_len, kv_read_tokens in zip(prompt_lengths, kv_read_lengths)
+            for prompt_len, kv_read_tokens in zip(
+                prompt_lengths, kv_read_lengths, strict=True
+            )
         )
         if total_kv_read_tokens > 0:
             seed_prompt_lengths = [
@@ -3029,7 +3035,7 @@ class InstrumentedScheduler(AsyncScheduler):
         allocation_failed = False
         try:
             for index, (prefix_tokens, cache_salt) in enumerate(
-                zip(prefix_lengths, cache_salts)
+                zip(prefix_lengths, cache_salts, strict=True)
             ):
                 req = Request(
                     request_id=f"__bench_fake_prefix_{self._bench_seq + index}",
@@ -3591,7 +3597,7 @@ class InstrumentedScheduler(AsyncScheduler):
                 prompt_lens=[
                     new_tokens + kv_read_tokens
                     for new_tokens, kv_read_tokens in zip(
-                        new_token_lengths, kv_read_lengths
+                        new_token_lengths, kv_read_lengths, strict=True
                     )
                 ],
                 max_tokens=1,

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -2776,7 +2776,13 @@ class InstrumentedScheduler(AsyncScheduler):
         kv_cache_manager = getattr(self, "kv_cache_manager", None)
         if self._bench_uses_per_group_cache_lookup():
             return 0
-        return self.block_size if getattr(kv_cache_manager, "use_eagle", False) else 0
+        if not getattr(kv_cache_manager, "use_eagle", False):
+            return 0
+        coordinator = getattr(kv_cache_manager, "coordinator", None)
+        if getattr(coordinator, "enable_partial_hash_hits", False):
+            # Hybrid align-mode cache lookup drops one fine-grained hash unit.
+            return self._bench_hash_block_size
+        return self.block_size
 
     def _bench_seed_prompt_len(self, kv_read_tokens: int) -> int:
         # EAGLE/MTP deliberately drops the last matched cache block. Seed one

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -2468,6 +2468,20 @@ def test_prefill_eagle_kv_read_requires_more_than_one_drop_block_per_request():
     assert InstrumentedScheduler._bench_prefill_point_feasible(stub, 18, 2, 16)
 
 
+def test_prefill_eagle_partial_hash_hit_uses_hash_drop_granularity():
+    stub = _prefill_grid_stub(block_size=16)
+    stub._bench_hash_block_size = 8
+    stub.kv_cache_manager = SimpleNamespace(
+        use_eagle=True,
+        coordinator=SimpleNamespace(enable_partial_hash_hits=True),
+    )
+
+    assert InstrumentedScheduler._bench_eagle_cache_drop_tokens(stub) == 8
+    assert InstrumentedScheduler._bench_seed_prompt_len(stub, 16) == 24
+    assert not InstrumentedScheduler._bench_prefill_point_feasible(stub, 8, 1, 8)
+    assert InstrumentedScheduler._bench_prefill_point_feasible(stub, 9, 1, 8)
+
+
 def test_prefill_fake_seed_feasibility_uses_uncapped_allocation():
     stub = _prefill_grid_stub(block_size=8)
     stub._bench_prefill_blocks_per_req = MagicMock(return_value=1)

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -2449,13 +2449,23 @@ def test_prefill_kv_read_grid_accounts_for_eagle_cache_block_drop():
     stub = _prefill_grid_stub(block_size=8)
     stub.kv_cache_manager = SimpleNamespace(use_eagle=True)
 
+    assert InstrumentedScheduler._bench_prefill_kv_read_points(stub, 8, 1) == [0]
+
     points = InstrumentedScheduler._bench_prefill_kv_read_points(stub, 40, 1)
     assert points[0] == 0
     assert all(point % 8 == 0 for point in points)
     assert InstrumentedScheduler._bench_seed_prompt_len(stub, 16) == 24
 
     # The extra seed block must also fit under max_model_len.
-    assert InstrumentedScheduler._bench_prefill_kv_read_points(stub, 1, 1)[-1] == 112
+    assert InstrumentedScheduler._bench_prefill_kv_read_points(stub, 9, 1)[-1] == 112
+
+
+def test_prefill_eagle_kv_read_requires_more_than_one_drop_block_per_request():
+    stub = _prefill_grid_stub(block_size=8)
+    stub.kv_cache_manager = SimpleNamespace(use_eagle=True)
+
+    assert not InstrumentedScheduler._bench_prefill_point_feasible(stub, 17, 2, 16)
+    assert InstrumentedScheduler._bench_prefill_point_feasible(stub, 18, 2, 16)
 
 
 def test_prefill_fake_seed_feasibility_uses_uncapped_allocation():


### PR DESCRIPTION
## Summary

- filter EAGLE prefill self-benchmark KV-read coordinates that cannot preserve both the requested scheduled-token and KV-read axes
- add regression coverage for the exact single-request block boundary and uneven batched partitions

## Root cause

The benchmark seeds one extra cache block because EAGLE deliberately recomputes the last matched block, but the measured request remains `new_tokens + kv_read_tokens`. vLLM bounds prefix lookup by that request length before dropping the EAGLE block. When per-request `new_tokens <= block_size`, the request cannot reach the extra seed block, so the measured KV hit is exactly one block below the grid target.

Extending the measured prompt would change the actual scheduled prefill workload from `n` to `n + block_size`, which violates the benchmark axis and shape validation. This change instead rejects those physically infeasible coordinates during feasibility/grid construction, before they can become skipped runtime points and invalidate the artifact.

Linear: [DYN-3796](https://linear.app/nvidia/issue/DYN-3796/dynamo140vllm-prefill-self-benchmark-seeds-one-block-short-of-the-kv)

## Validation

- `PYTHONPATH=/home/hongkuanz/Projects/dynamo/components/src .venv/bin/python -m pytest -q components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py components/src/dynamo/vllm/tests/test_benchmark_points.py components/src/dynamo/vllm/tests/test_vllm_worker_factory.py` — 178 passed
- `SKIP=pytest-marker-report .venv/bin/pre-commit run --files components/src/dynamo/vllm/instrumented_scheduler.py components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py` — passed; the repository-wide marker report is not runnable in this local environment because unrelated optional SGLang/KVBM dependencies are absent
- independent agentic code review — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prefill benchmarking with cached tokens by rejecting infeasible points when requests lack enough uncached tokens.
  * Corrected handling of cache-block requirements and model-length boundaries for Eagle-cache scenarios.

* **Tests**
  * Expanded validation for zero KV reads, block-aligned KV-read levels, and cache-block feasibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->