### PR TITLE
refactor(frontend): fold the remaining OpenAI streams with typed errors

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -4255,10 +4255,16 @@ async fn audio_speech(
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
-    let stream = engine
-        .generate(request)
-        .await
-        .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate audio"))?;
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model, super::metrics::Endpoint::Audios);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to generate audio");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
 
     let mut http_queue_guard = Some(http_queue_guard);
     let stream = stream.inspect(move |response| {
@@ -4272,8 +4278,10 @@ async fn audio_speech(
     let response = NvAudioSpeechResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to fold audio stream for {}: {:?}", request_id, e);
-            ErrorMessage::internal_server_error("Failed to fold audio stream")
+            let err_response =
+                ErrorMessage::from_anyhow(anyhow::Error::new(e), "Failed to fold audio stream");
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
         })?;
 
     // Check for failure before marking success

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1344,13 +1344,10 @@ async fn embeddings(
     let mut response = NvCreateEmbeddingResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!(
-                "Failed to fold embeddings stream for {}: {:?}",
-                request_id,
-                e
+            let err_response = ErrorMessage::from_anyhow(
+                anyhow::Error::new(e),
+                "Failed to fold embeddings stream",
             );
-            let err_response =
-                ErrorMessage::internal_server_error("Failed to fold embeddings stream");
             inflight.mark_error(extract_error_type_from_response(&err_response));
             err_response
         })?;
@@ -3864,8 +3861,8 @@ async fn images(
     let response = NvImagesResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to fold images stream for {}: {:?}", request_id, e);
-            let err_response = ErrorMessage::internal_server_error("Failed to fold images stream");
+            let err_response =
+                ErrorMessage::from_anyhow(anyhow::Error::new(e), "Failed to fold images stream");
             inflight.mark_error(extract_error_type_from_response(&err_response));
             err_response
         })?;
@@ -4019,9 +4016,10 @@ async fn videos(
         let response = NvVideosResponse::from_annotated_stream(stream)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to fold videos stream for {}: {:?}", request_id, e);
-                let err_response =
-                    ErrorMessage::internal_server_error("Failed to fold videos stream");
+                let err_response = ErrorMessage::from_anyhow(
+                    anyhow::Error::new(e),
+                    "Failed to fold videos stream",
+                );
                 inflight.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;

--- a/lib/llm/src/protocols/openai/audios/aggregator.rs
+++ b/lib/llm/src/protocols/openai/audios/aggregator.rs
@@ -3,8 +3,9 @@
 
 use futures::Stream;
 
-use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
+use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvAudioSpeechResponse;
 
@@ -22,7 +23,7 @@ impl NvAudioSpeechResponse {
     /// Aggregates an annotated stream of audio responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvAudioSpeechResponse>>,
-    ) -> Result<NvAudioSpeechResponse, String> {
-        aggregate_stream(stream).await
+    ) -> Result<NvAudioSpeechResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/embeddings/aggregator.rs
+++ b/lib/llm/src/protocols/openai/embeddings/aggregator.rs
@@ -6,10 +6,11 @@ use crate::protocols::{
     Annotated,
     codec::{Message, SseCodecError},
     convert_sse_stream,
-    openai::stream_aggregator::{StreamAggregable, aggregate_stream},
+    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
 };
 
 use dynamo_runtime::engine::DataStream;
+use dynamo_runtime::error::DynamoError;
 use futures::Stream;
 
 impl StreamAggregable for NvCreateEmbeddingResponse {
@@ -28,7 +29,7 @@ impl NvCreateEmbeddingResponse {
     /// Converts an SSE stream into a [`NvCreateEmbeddingResponse`].
     pub async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
-    ) -> Result<NvCreateEmbeddingResponse, String> {
+    ) -> Result<NvCreateEmbeddingResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateEmbeddingResponse>(stream);
         NvCreateEmbeddingResponse::from_annotated_stream(stream).await
     }
@@ -36,8 +37,8 @@ impl NvCreateEmbeddingResponse {
     /// Aggregates an annotated stream of embedding responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateEmbeddingResponse>>,
-    ) -> Result<NvCreateEmbeddingResponse, String> {
-        aggregate_stream(stream).await
+    ) -> Result<NvCreateEmbeddingResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
     }
 }
 
@@ -141,7 +142,7 @@ mod tests {
         let result = NvCreateEmbeddingResponse::from_annotated_stream(Box::pin(stream)).await;
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Test error"));
+        assert!(result.unwrap_err().to_string().contains("Test error"));
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/images/aggregator.rs
+++ b/lib/llm/src/protocols/openai/images/aggregator.rs
@@ -3,8 +3,9 @@
 
 use futures::Stream;
 
-use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
+use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvImagesResponse;
 
@@ -22,7 +23,7 @@ impl NvImagesResponse {
     /// Aggregates an annotated stream of image responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvImagesResponse>>,
-    ) -> Result<NvImagesResponse, String> {
-        aggregate_stream(stream).await
+    ) -> Result<NvImagesResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -43,6 +43,10 @@ where
 /// Aggregate a stream of [`Annotated<T>`] while preserving structured backend
 /// errors. Existing callers that expose string errors can continue to use
 /// [`aggregate_stream`].
+///
+/// The [`DynamoError`] is returned intact so the HTTP layer can classify a
+/// backend rejection — invalid argument, overload, cancellation — into the
+/// matching status code.
 pub async fn aggregate_typed_stream<T, S>(stream: S) -> Result<T, DynamoError>
 where
     T: StreamAggregable,
@@ -71,4 +75,63 @@ where
     }
 
     Ok(response.unwrap_or_else(T::empty))
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_runtime::{
+        error::{BackendError, ErrorType},
+        protocols::maybe_error::MaybeError,
+    };
+    use futures::stream;
+    use serde::Deserialize;
+
+    #[derive(Debug, Default, PartialEq, Deserialize)]
+    struct Chunks(Vec<u32>);
+
+    impl StreamAggregable for Chunks {
+        fn empty() -> Self {
+            Self::default()
+        }
+
+        fn merge(&mut self, next: Self) {
+            self.0.extend(next.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn merges_data_and_falls_back_to_empty() {
+        let empty = aggregate_typed_stream::<Chunks, _>(stream::empty())
+            .await
+            .unwrap();
+        assert_eq!(empty, Chunks(vec![]));
+
+        let stream = stream::iter(vec![
+            Annotated::from_data(Chunks(vec![1])),
+            Annotated::from_data(Chunks(vec![2])),
+        ]);
+        assert_eq!(
+            aggregate_typed_stream(stream).await.unwrap(),
+            Chunks(vec![1, 2])
+        );
+    }
+
+    /// The property every OpenAI endpoint depends on: a backend rejection keeps
+    /// its type, so the HTTP layer can answer 4xx rather than a blanket 500.
+    #[tokio::test]
+    async fn preserves_backend_error_type() {
+        let stream = stream::iter(vec![Annotated::<Chunks>::from_err(
+            DynamoError::builder()
+                .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                .message("invalid argument")
+                .build(),
+        )]);
+
+        let error = aggregate_typed_stream(stream).await.unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid argument");
+    }
 }

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -19,30 +19,6 @@ pub trait StreamAggregable: Sized {
 /// Aggregate a stream of [`Annotated<T>`] into a single `T`. The first error
 /// encountered short-circuits further merging and is returned; the remainder
 /// of the stream is dropped.
-pub async fn aggregate_stream<T, S>(stream: S) -> Result<T, String>
-where
-    T: StreamAggregable,
-    S: Stream<Item = Annotated<T>>,
-{
-    let mut stream = std::pin::pin!(stream);
-    let mut response: Option<T> = None;
-
-    while let Some(delta) = stream.next().await {
-        let delta = delta.ok()?;
-        if let Some(data) = delta.data {
-            match response.as_mut() {
-                Some(existing) => existing.merge(data),
-                None => response = Some(data),
-            }
-        }
-    }
-
-    Ok(response.unwrap_or_else(T::empty))
-}
-
-/// Aggregate a stream of [`Annotated<T>`] while preserving structured backend
-/// errors. Existing callers that expose string errors can continue to use
-/// [`aggregate_stream`].
 ///
 /// The [`DynamoError`] is returned intact so the HTTP layer can classify a
 /// backend rejection — invalid argument, overload, cancellation — into the
@@ -76,6 +52,7 @@ where
 
     Ok(response.unwrap_or_else(T::empty))
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/llm/src/protocols/openai/videos/aggregator.rs
+++ b/lib/llm/src/protocols/openai/videos/aggregator.rs
@@ -3,8 +3,9 @@
 
 use futures::Stream;
 
-use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
+use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvVideosResponse;
 
@@ -22,7 +23,7 @@ impl NvVideosResponse {
     /// Aggregates an annotated stream of video responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvVideosResponse>>,
-    ) -> Result<NvVideosResponse, String> {
-        aggregate_stream(stream).await
+    ) -> Result<NvVideosResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
     }
 }

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -1541,6 +1541,125 @@ async fn test_streaming_responses_returns_4xx_on_backend_invalid_argument() {
     task.await.unwrap().unwrap();
 }
 
+/// Audio engine whose only response frame is a `Backend(InvalidArgument)`
+/// error — models a worker rejecting the request during deserialization
+/// (e.g. a `task_type` value outside the backend's accepted set).
+struct InvalidArgumentAudiosEngine {}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > for InvalidArgumentAudiosEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+    ) -> Result<
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > {
+        use dynamo_runtime::error::{BackendError, ErrorType as DynErrorType};
+        let (_request, context) = request.transfer(());
+        let ctx = context.context();
+        let stream = stream! {
+            yield Annotated::<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse> {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(
+                    DynamoError::builder()
+                        .error_type(DynErrorType::Backend(BackendError::InvalidArgument))
+                        .message(
+                            "ValidationError: 1 validation error for NvCreateAudioSpeechRequest \
+                             task_type Input should be 'CustomVoice', 'VoiceDesign', 'Base'",
+                        )
+                        .build(),
+                ),
+            };
+        };
+        Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
+
+/// The `/v1/audio/speech` request schema is looser in the frontend than in the
+/// worker (the worker constrains e.g. `task_type` to a model-specific set), so
+/// out-of-range values can only be rejected worker-side. That rejection must
+/// reach the caller as a 4xx carrying the backend's message, not as a 500
+/// about folding the audio stream.
+#[tokio::test]
+async fn test_audio_speech_backend_invalid_argument_returns_4xx() {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder().port(port).build().unwrap();
+    service.enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Audios, true);
+
+    let state = service.state_clone();
+    let manager = state.manager();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task =
+        tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+    wait_for_service_ready(port).await;
+
+    let registry = Registry::new();
+    let card = ModelDeploymentCard::with_name_only("tts-model");
+    manager
+        .add_audios_model(
+            "tts-model",
+            card.mdcsum(),
+            Arc::new(InvalidArgumentAudiosEngine {}),
+        )
+        .unwrap();
+
+    let metrics = state.metrics_clone();
+    metrics.register(&registry).unwrap();
+
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/v1/audio/speech"))
+        .json(&serde_json::json!({
+            "model": "tts-model",
+            "input": "The quick brown fox jumps over the lazy dog.",
+            "voice": "vivian",
+            "language": "English",
+            "task_type": "NotARealTaskType",
+        }))
+        .send()
+        .await
+        .expect("POST /v1/audio/speech");
+
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Backend(InvalidArgument) on /v1/audio/speech must land as HTTP 400; got {status}, body: {text}"
+    );
+    assert!(
+        text.contains("task_type"),
+        "expected the backend validation message to name the offending field; got: {text}"
+    );
+
+    // The 400 is a client error, so it must be metered as a validation
+    // failure rather than an internal one.
+    compare_counter(
+        &metrics,
+        "tts-model",
+        &Endpoint::Audios,
+        &RequestType::Unary,
+        &Status::Error,
+        &ErrorType::Validation,
+        1,
+    );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}
+
 /// Engine registered only so the classify/pooling routes resolve a model; the
 /// validation errors under test are rejected before the engine is reached.
 struct UncalledPoolingFamilyEngine {}


### PR DESCRIPTION
> **Stacked on #12832.** Based on that branch, so this diff shows only the refactor. Retarget to `main` once #12832 merges.

## Summary

`aggregate_stream` flattens backend errors to `String`, so any handler using it must answer with a blanket 500 regardless of what the worker actually reported. #12832 moved `/v1/audio/speech` off it to fix a real bug (DYN-3779): a worker-side request rejection surfaced as HTTP 500 `"Failed to fold audio stream"` instead of a 4xx naming the offending field.

Images, videos, and embeddings are the last three callers and have the identical defect. This PR moves them to `aggregate_typed_stream`, routes their fold errors through `ErrorMessage::from_anyhow`, and deletes `aggregate_stream` so the lossy path cannot come back.

Classify and pooling were already on the typed path — this brings the remaining endpoints in line rather than introducing a new pattern.

## Behaviour change

**This changes status codes on three endpoints**, which is why it is split out of the bug fix rather than bundled with it.

Errors that carry no classification still land as the same 500 with the same public message. Only errors carrying a type change status:

| Backend error type | Before | After |
| -- | -- | -- |
| `Backend(InvalidArgument)` | 500 | 400, with the backend's message |
| `ResourceExhausted` | 500 | 529 |
| `Unavailable` | 500 | 503 |
| `Cancelled` | 500 | 499 |
| anything else | 500 | 500 (unchanged) |

`NvCreateEmbeddingResponse::from_sse_stream` and the four `from_annotated_stream` methods change their error type from `String` to `DynamoError`. There are no callers outside the HTTP handlers, and `lib/llm/CLAUDE.md` treats in-process Rust APIs as internal unless documented otherwise.

## Validation

```
cargo test -p dynamo-llm --lib                                1970 passed, 0 failed
cargo test -p dynamo-llm --test http-service                     12 passed, 0 failed
cargo test -p dynamo-llm --test aggregators                       8 passed, 0 failed
cargo test -p dynamo-llm --test http_metrics                      6 passed, 0 failed
cargo fmt --all
cargo clippy -p dynamo-llm --no-deps --all-targets -- -D warnings    clean
```

Behaviour is covered by the `aggregate_typed_stream` tests added in #12832 — the migration is a one-line change per endpoint onto an already-tested function, so no per-endpoint duplicates are added here.

## Related Issues

- Depends on #12832 (fixes DYN-3779)
- Related: #12833

## Where to start reviewing

`lib/llm/src/protocols/openai/stream_aggregator.rs` — the deletion is the point of the PR; the rest is the four call sites it forces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->