### PR TITLE
fix(vllm): preflight custom encoder before engine startup

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -4,7 +4,6 @@
 import asyncio
 import base64
 import functools
-import importlib
 import inspect
 import logging
 import math
@@ -94,8 +93,7 @@ from .lora_state import LoRAState
 from .multimodal_utils.custom_encoder import (
     AsyncVisionEncoder,
     CustomEncoderAdapter,
-    VisionEncoderBackend,
-    create_custom_encoder_adapter,
+    prepare_custom_encoder,
 )
 from .multimodal_utils.prefill_worker_utils import MultiModalEmbeddingLoader
 from .multimodal_utils.request_processor import (
@@ -1128,28 +1126,19 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     def _load_custom_encoder(self, config: Config) -> None:
         """Import, instantiate, and load the --custom-encoder-class encoder."""
         custom_encoder_class = config.custom_encoder_class
-        if not custom_encoder_class:
+        prepared = prepare_custom_encoder(
+            custom_encoder_class,
+            self.model_config,
+            config.engine_args,
+        )
+        if prepared is None:
             return
-        module_path, _, class_name = custom_encoder_class.rpartition(".")
-        backend_cls = getattr(importlib.import_module(module_path), class_name)
-        if not (
-            isinstance(backend_cls, type)
-            and issubclass(backend_cls, VisionEncoderBackend)
-        ):
-            raise TypeError(
-                f"--custom-encoder-class {custom_encoder_class!r} must resolve to a "
-                f"VisionEncoderBackend subclass, got {backend_cls!r}."
-            )
         # The author writes the VisionEncoderBackend; Dynamo wraps it in the
         # AsyncVisionEncoder glue, which owns the preprocess pool and
         # ThreadedMicroBatcher actor thread. load() runs backend.build() there
         # (the backend picks its own device) and cleans that thread up on failure.
-        backend = backend_cls()
-        adapter = create_custom_encoder_adapter(
-            backend,
-            self.model_config,
-            config.engine_args,
-        )
+        backend = prepared.backend
+        adapter = prepared.adapter
         encoder = AsyncVisionEncoder(backend)
         encoder.load(config.model)
         # Assign only after a successful load so a failed load (which already shut

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -65,6 +65,7 @@ from .kv_connector_protocols import (
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector,
 )
 from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
+from .multimodal_utils.custom_encoder import prepare_custom_encoder
 from .multimodal_utils.media_config import create_frontend_media_config
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
 from .snapshot import prepare_snapshot_engine
@@ -578,6 +579,15 @@ def setup_vllm_engine(
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(vllm_config)
     default_sampling_params = vllm_config.model_config.get_diff_sampling_param()
+
+    # Validate user-provided CustomEncoder setup before AsyncLLM starts its
+    # EngineCore child process. The handler prepares its owned instance again
+    # at the existing load point so its lifecycle remains unchanged.
+    prepare_custom_encoder(
+        getattr(config, "custom_encoder_class", None),
+        vllm_config.model_config,
+        engine_args,
+    )
 
     # Set up consolidator endpoints if KVBM (DynamoConnector) is enabled
     consolidator_endpoints = None

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/__init__.py
@@ -17,6 +17,10 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
     RawT,
     VisionEncoderBackend,
 )
+from dynamo.vllm.multimodal_utils.custom_encoder.loader import (
+    PreparedCustomEncoder,
+    prepare_custom_encoder,
+)
 
 __all__ = [
     "AsyncVisionEncoder",
@@ -26,6 +30,8 @@ __all__ = [
     "create_custom_encoder_adapter",
     "ItemT",
     "Preprocessed",
+    "PreparedCustomEncoder",
+    "prepare_custom_encoder",
     "Qwen3VLImageEncoding",
     "RawT",
     "VisionEncoderBackend",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/loader.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/loader.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve a user-provided custom encoder and its decoder adapter."""
+
+import importlib
+from dataclasses import dataclass
+from typing import Any
+
+from dynamo.vllm.multimodal_utils.custom_encoder.adapter import (
+    CustomEncoderAdapter,
+    create_custom_encoder_adapter,
+)
+from dynamo.vllm.multimodal_utils.custom_encoder.backend import VisionEncoderBackend
+
+
+@dataclass(frozen=True)
+class PreparedCustomEncoder:
+    """A resolved backend and its decoder-selected adapter."""
+
+    backend: VisionEncoderBackend[Any, Any, Any]
+    adapter: CustomEncoderAdapter[Any]
+
+
+def prepare_custom_encoder(
+    custom_encoder_class: str | None,
+    model_config: Any,
+    engine_args: Any,
+) -> PreparedCustomEncoder | None:
+    """Resolve and validate a CustomEncoder without starting its actor thread."""
+    if not custom_encoder_class:
+        return None
+
+    module_path, _, class_name = custom_encoder_class.rpartition(".")
+    backend_cls = getattr(importlib.import_module(module_path), class_name)
+    if not (
+        isinstance(backend_cls, type) and issubclass(backend_cls, VisionEncoderBackend)
+    ):
+        raise TypeError(
+            f"--custom-encoder-class {custom_encoder_class!r} must resolve to a "
+            f"VisionEncoderBackend subclass, got {backend_cls!r}."
+        )
+
+    backend = backend_cls()
+    adapter = create_custom_encoder_adapter(backend, model_config, engine_args)
+    return PreparedCustomEncoder(backend=backend, adapter=adapter)

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_loader.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_loader.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for resolving user-provided custom encoders."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.vllm.multimodal_utils.custom_encoder import prepare_custom_encoder
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+
+def test_preflight_rejects_non_backend_class():
+    with pytest.raises(TypeError, match="VisionEncoderBackend subclass"):
+        prepare_custom_encoder(
+            "json.JSONDecoder",
+            SimpleNamespace(),
+            SimpleNamespace(),
+        )

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -13,7 +13,7 @@ import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -550,6 +550,54 @@ def test_setup_vllm_engine_reuses_engine_config_model_config(monkeypatch):
     _, _, default_sampling_params, _, _ = vllm_main.setup_vllm_engine(config)
 
     assert default_sampling_params == {"temperature": 0.7}
+
+
+def test_setup_vllm_engine_preflights_custom_encoder_before_enginecore(monkeypatch):
+    vllm_main = _load_vllm_main()
+
+    class FakeModelConfig:
+        def get_diff_sampling_param(self):
+            return {}
+
+    vllm_config = SimpleNamespace(
+        additional_config={},
+        model_config=FakeModelConfig(),
+    )
+
+    class FakeEngineArgs:
+        enable_lora = False
+        load_format = "auto"
+
+        def create_engine_config(self, usage_context):
+            return vllm_config
+
+    engine_start = Mock(side_effect=AssertionError("EngineCore must not start"))
+    reject_encoder = Mock(side_effect=ValueError("bad encoder"))
+    monkeypatch.setattr(vllm_main, "setup_multiprocess_prometheus", lambda: None)
+    monkeypatch.setattr(vllm_main, "LLMBackendMetrics", lambda **_kwargs: None)
+    monkeypatch.setattr(vllm_main, "prepare_custom_encoder", reject_encoder)
+    monkeypatch.setattr(vllm_main.AsyncLLM, "from_vllm_config", engine_start)
+
+    config = SimpleNamespace(
+        component="backend",
+        namespace="dynamo",
+        engine_args=FakeEngineArgs(),
+        gms_shadow_mode=False,
+        multimodal_embedding_cache_capacity_gb=0,
+        route_to_encoder=False,
+        served_model_name="model",
+        custom_encoder_class="encoder.Backend",
+    )
+
+    with pytest.raises(ValueError, match="bad encoder"):
+        vllm_main.setup_vllm_engine(config)
+
+    reject_encoder.assert_called_once_with(
+        "encoder.Backend",
+        vllm_config.model_config,
+        config.engine_args,
+    )
+    engine_start.assert_not_called()
 
 
 # --disaggregation-mode tests


### PR DESCRIPTION
## Why

CustomEncoder adapter validation currently runs after vLLM starts EngineCore. Deterministic configuration errors escape the main coroutine but leave that child alive, so a misconfigured deployment never exits or restarts. Validating the resolved class and adapter before `AsyncLLM` starts prevents the orphan while preserving serving initialization at its existing handler location.

## What Change

- Resolve and validate CustomEncoder before EngineCore startup.
- Reuse shared preparation logic in the existing handler load path.
- Cover invalid classes and preflight ordering.

## Test Plan

- GB200 RC mismatch exited 1 in 21.3 seconds with no EngineCore.
- Focused CustomEncoder unit suites and all pre-commit hooks.