### PR TITLE
fix(trtllm): push responses onto the wire via a GIL-less channel

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -19,6 +19,7 @@ from dynamo.trtllm.request_handlers.handler_base import (
     HandlerBase,
     RequestHandlerConfig,
 )
+from dynamo.trtllm.request_handlers.push_egress import push_egress_capable
 
 
 class AggregatedHandler(HandlerBase):
@@ -37,6 +38,10 @@ class AggregatedHandler(HandlerBase):
         super().__init__(config)
         self._encoder_cache = encoder_cache
 
+    # push_egress_capable must stay OUTERMOST: the Rust push opt-in check
+    # inspects this signature for `response_sender`, and range_decorator
+    # needs to wrap a real async-generator function. See push_egress.py.
+    @push_egress_capable
     async def generate(
         self, request: dict, context: Context
     ) -> AsyncGenerator[dict, None]:

--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -38,9 +38,7 @@ class AggregatedHandler(HandlerBase):
         super().__init__(config)
         self._encoder_cache = encoder_cache
 
-    # push_egress_capable must stay OUTERMOST: the Rust push opt-in check
-    # inspects this signature for `response_sender`, and range_decorator
-    # needs to wrap a real async-generator function. See push_egress.py.
+    # Must stay outermost -- see push_egress.py.
     @push_egress_capable
     async def generate(
         self, request: dict, context: Context

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1363,12 +1363,9 @@ class HandlerBase(BaseGenerativeHandler):
                         # Yield the chunk to the client and update the token
                         # count for this output choice.
                         #
-                        # NOTE: this yield stays a yield even under
-                        # DYN_TRTLLM_PUSH_EGRESS. It is pure-Python generator
-                        # delegation up to Handler.generate -- one thread, no
-                        # GIL release, no bridge. The expensive hop is the
-                        # OUTERMOST one into Rust, and that is where the push
-                        # replaces the pull; see request_handlers/push_egress.py.
+                        # Stays a yield under push egress: this hop is
+                        # pure-Python generator delegation on one thread. Only
+                        # the outermost hop into Rust pushes.
                         yield out
                         output_tokens_per_choice[output_idx] = next_total_toks
 

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1362,6 +1362,13 @@ class HandlerBase(BaseGenerativeHandler):
 
                         # Yield the chunk to the client and update the token
                         # count for this output choice.
+                        #
+                        # NOTE: this yield stays a yield even under
+                        # DYN_TRTLLM_PUSH_EGRESS. It is pure-Python generator
+                        # delegation up to Handler.generate -- one thread, no
+                        # GIL release, no bridge. The expensive hop is the
+                        # OUTERMOST one into Rust, and that is where the push
+                        # replaces the pull; see request_handlers/push_egress.py.
                         yield out
                         output_tokens_per_choice[output_idx] = next_total_toks
 

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -68,9 +68,7 @@ class EncodeHandler(HandlerBase):
             self.model_type = self.multimodal_processor.model_type
             self.tokenizer = self.multimodal_processor.tokenizer
 
-    # push_egress_capable must stay OUTERMOST: the Rust push opt-in check
-    # inspects this signature for `response_sender`, and range_decorator
-    # needs to wrap a real async-generator function. See push_egress.py.
+    # Must stay outermost -- see push_egress.py.
     @push_egress_capable
     async def generate(
         self, request: dict, context: Context
@@ -137,9 +135,7 @@ class PrefillHandler(HandlerBase):
             encode_response, self.connector
         )
 
-    # push_egress_capable must stay OUTERMOST: the Rust push opt-in check
-    # inspects this signature for `response_sender`, and range_decorator
-    # needs to wrap a real async-generator function. See push_egress.py.
+    # Must stay outermost -- see push_egress.py.
     @push_egress_capable
     async def generate(
         self, request: dict, context: Context
@@ -228,9 +224,7 @@ class DecodeHandler(HandlerBase):
     def __init__(self, config: RequestHandlerConfig):
         super().__init__(config)
 
-    # push_egress_capable must stay OUTERMOST: the Rust push opt-in check
-    # inspects this signature for `response_sender`, and range_decorator
-    # needs to wrap a real async-generator function. See push_egress.py.
+    # Must stay outermost -- see push_egress.py.
     @push_egress_capable
     async def generate(
         self, request: dict, context: Context

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -18,6 +18,7 @@ from dynamo.trtllm.request_handlers.handler_base import (
     HandlerBase,
     RequestHandlerConfig,
 )
+from dynamo.trtllm.request_handlers.push_egress import push_egress_capable
 
 configure_dynamo_logging()
 
@@ -67,6 +68,10 @@ class EncodeHandler(HandlerBase):
             self.model_type = self.multimodal_processor.model_type
             self.tokenizer = self.multimodal_processor.tokenizer
 
+    # push_egress_capable must stay OUTERMOST: the Rust push opt-in check
+    # inspects this signature for `response_sender`, and range_decorator
+    # needs to wrap a real async-generator function. See push_egress.py.
+    @push_egress_capable
     async def generate(
         self, request: dict, context: Context
     ) -> AsyncGenerator[dict, None]:
@@ -132,6 +137,10 @@ class PrefillHandler(HandlerBase):
             encode_response, self.connector
         )
 
+    # push_egress_capable must stay OUTERMOST: the Rust push opt-in check
+    # inspects this signature for `response_sender`, and range_decorator
+    # needs to wrap a real async-generator function. See push_egress.py.
+    @push_egress_capable
     async def generate(
         self, request: dict, context: Context
     ) -> AsyncGenerator[dict, None]:
@@ -219,6 +228,10 @@ class DecodeHandler(HandlerBase):
     def __init__(self, config: RequestHandlerConfig):
         super().__init__(config)
 
+    # push_egress_capable must stay OUTERMOST: the Rust push opt-in check
+    # inspects this signature for `response_sender`, and range_decorator
+    # needs to wrap a real async-generator function. See push_egress.py.
+    @push_egress_capable
     async def generate(
         self, request: dict, context: Context
     ) -> AsyncGenerator[dict, None]:

--- a/components/src/dynamo/trtllm/request_handlers/push_egress.py
+++ b/components/src/dynamo/trtllm/request_handlers/push_egress.py
@@ -91,13 +91,17 @@ def push_egress_capable(func):
     """Let an async-generator ``generate`` be driven by push OR by pull.
 
     Turns ``async def generate(self, request, context)`` into a plain ``def``
-    returning whichever object the active Rust engine expects: an async
-    generator draining into the sender when one is supplied (push, what a
-    current binding always does), or the handler's own async generator
-    untouched when none is (pull, reached only against a binding predating this
-    path). The choice is made purely on whether a sender arrived -- Rust decides
-    once at ``serve_endpoint`` time, and second-guessing it here could only
-    produce a shape mismatch.
+    returning whichever object the calling Rust engine expects: an async
+    generator draining into the sender when one is supplied (push), or the
+    handler's own async generator untouched when none is (pull). The choice is
+    made purely on whether a sender arrived -- Rust decides per call, and
+    second-guessing it here could only produce a shape mismatch.
+
+    Both arms are live in normal operation. Network requests arrive through the
+    push ingress; in-process callers and the canary health check go through the
+    pull engine registered in the local endpoint registry, which passes no
+    sender. That is why the pull arm must keep working rather than being
+    treated as a legacy fallback.
 
     Must stay the OUTERMOST decorator (invariant 2 in the module docstring).
     Any decorator that inspects what it wraps must sit *inside*, where it still
@@ -114,12 +118,15 @@ def push_egress_capable(func):
         if response_sender is None:
             if not _warned_no_sender:
                 _warned_no_sender = True
-                logger.warning(
-                    "the Rust bridge did not provide a response_sender for %s; "
-                    "falling back to the generator (pull) path. Expect the "
-                    "decode-worker GIL cost this decorator exists to remove -- "
-                    "the dynamo._core binding is probably older than the "
-                    "push-egress path.",
+                # Expected for in-process and canary calls, which come through
+                # the locally registered pull engine. Only a problem if it is
+                # every request -- that would mean the network ingress is on
+                # pull too, i.e. the signature probe in `serve_endpoint` found
+                # no `response_sender`, and the GIL cost this decorator exists
+                # to remove is still being paid.
+                logger.info(
+                    "no response_sender for %s; serving this call on the pull "
+                    "path (expected for in-process and health-check calls)",
                     getattr(func, "__qualname__", func),
                 )
             return stream

--- a/components/src/dynamo/trtllm/request_handlers/push_egress.py
+++ b/components/src/dynamo/trtllm/request_handlers/push_egress.py
@@ -42,8 +42,8 @@ from typing import Any, AsyncGenerator
 
 logger = logging.getLogger(__name__)
 
-# One-shot guard so a bridge mismatch is loud without a line per request.
-_warned_no_sender = False
+# One-shot latch: say it once, not once per call.
+_logged_no_sender = False
 
 
 async def drive_push_egress(
@@ -51,16 +51,12 @@ async def drive_push_egress(
 ) -> None:
     """Drain ``stream`` into ``response_sender``, then close it.
 
-    ``send()`` per response, ``close()`` on normal completion.
-
-    Nothing is caught. Every way this can fail -- an engine shutdown, a
-    rejected request, a cancellation, the consumer dropping the stream -- is
-    an exception, and the only correct thing to do with it is let it out:
-    Rust's ``map_python_exception`` turns it into a *typed* backend error and
-    terminates the stream with that, exactly as it does for the same exception
-    on the pull path. Catching it to report a string through the sender would
-    erase the type that request migration, worker inhibition and
-    invalid-argument reporting all key on.
+    Nothing is caught. Every way this can fail -- engine shutdown, a rejected
+    request, cancellation, the consumer dropping the stream -- is an exception,
+    and letting it out is what lets Rust's ``map_python_exception`` classify it
+    and terminate the stream with a *typed* backend error, exactly as on the
+    pull path. See invariant 3 in the module docstring for what catching it
+    would cost.
     """
     async for response in stream:
         # The actual Python -> Rust crossing: encode to request-plane bytes
@@ -110,20 +106,18 @@ def push_egress_capable(func):
 
     @functools.wraps(func)
     def dispatch(self, request, context=None, response_sender=None, **kwargs):
-        global _warned_no_sender
+        global _logged_no_sender
 
         # Lazy either way: creating an async generator runs none of its body.
         stream = func(self, request, context, **kwargs)
 
         if response_sender is None:
-            if not _warned_no_sender:
-                _warned_no_sender = True
-                # Expected for in-process and canary calls, which come through
-                # the locally registered pull engine. Only a problem if it is
-                # every request -- that would mean the network ingress is on
-                # pull too, i.e. the signature probe in `serve_endpoint` found
-                # no `response_sender`, and the GIL cost this decorator exists
-                # to remove is still being paid.
+            if not _logged_no_sender:
+                _logged_no_sender = True
+                # Normal for in-process and canary calls. Only a problem if it
+                # is EVERY call, which would mean the signature probe in
+                # `serve_endpoint` found no `response_sender` and network
+                # traffic is on the pull path too.
                 logger.info(
                     "no response_sender for %s; serving this call on the pull "
                     "path (expected for in-process and health-check calls)",

--- a/components/src/dynamo/trtllm/request_handlers/push_egress.py
+++ b/components/src/dynamo/trtllm/request_handlers/push_egress.py
@@ -7,7 +7,7 @@ On the pull path Rust drives the handler's async generator, taking the GIL on
 tokio threads once per response. Here the handler -- already on the event loop
 holding the GIL when it produces a response -- hands it straight to a Rust
 ``response_sender`` instead, and Rust advances the generator once per REQUEST
-rather than once per RESPONSE. Rationale and measurements: DYN-3703.
+rather than once per RESPONSE. Rationale and measurements: #12845.
 
 Three invariants are load-bearing; breaking any of them is silent:
 
@@ -25,15 +25,20 @@ Three invariants are load-bearing; breaking any of them is silent:
    would otherwise follow to the undecorated function and hide the parameter,
    reverting every endpoint to the pull path with nothing logged.
 
-3. **The sender.** ``send(obj)`` once per response; ``close()`` on normal end;
-   ``close_with_error(msg)`` on failure. Both closes are idempotent, and Rust
-   closes the sink when the generator finishes as a safety net.
+3. **The sender.** ``send(obj)`` once per response and ``close()`` on normal
+   end -- and nothing on failure. Exceptions propagate out of the handler, so
+   Rust classifies them with ``map_python_exception`` and terminates the
+   stream with a *typed* backend error. Reporting them here instead, through
+   ``close_with_error``, would flatten every failure to an untyped string:
+   ``EngineShutdown`` would stop triggering request migration and worker
+   inhibition, and a client's bad input would surface as an unknown server
+   error. ``close()`` is idempotent, and Rust closes the sink when the
+   generator finishes as a safety net.
 """
 
-import asyncio
 import functools
 import logging
-from typing import Any, AsyncGenerator, Optional
+from typing import Any, AsyncGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -44,51 +49,24 @@ _warned_no_sender = False
 async def drive_push_egress(
     stream: AsyncGenerator[Any, None], response_sender: Any
 ) -> None:
-    """Drain ``stream`` into ``response_sender``, then terminate it exactly once.
+    """Drain ``stream`` into ``response_sender``, then close it.
 
-    ``send()`` per response, then ``close()`` on normal completion or
-    cancellation and ``close_with_error()`` on failure. Errors are reported
-    through the sender rather than re-raised, since it is the only channel Rust
-    is listening on for response data.
+    ``send()`` per response, ``close()`` on normal completion.
+
+    Nothing is caught. Every way this can fail -- an engine shutdown, a
+    rejected request, a cancellation, the consumer dropping the stream -- is
+    an exception, and the only correct thing to do with it is let it out:
+    Rust's ``map_python_exception`` turns it into a *typed* backend error and
+    terminates the stream with that, exactly as it does for the same exception
+    on the pull path. Catching it to report a string through the sender would
+    erase the type that request migration, worker inhibition and
+    invalid-argument reporting all key on.
     """
-    closed = False
-
-    def _terminate(error: Optional[str]) -> None:
-        nonlocal closed
-        if closed:
-            return
-        closed = True
-        try:
-            if error is None:
-                response_sender.close()
-            else:
-                response_sender.close_with_error(error)
-        except Exception:
-            logger.exception("push egress: failed to close the Rust response stream")
-
-    try:
-        async for response in stream:
-            # The actual Python -> Rust crossing: depythonize and enqueue,
-            # both under the GIL we are already holding.
-            response_sender.send(response)
-    except (asyncio.CancelledError, GeneratorExit):
-        # Client/connection cancellation. `_cancellation_monitor` has already
-        # abort()ed the engine request and `_generate_locally_impl` swallows its
-        # own CancelledError, so getting here means the enclosing task was
-        # cancelled. End the stream normally -- the pull path's cancelled
-        # generator likewise just stops producing -- then re-raise so asyncio's
-        # cancellation contract is honored.
-        _terminate(None)
-        raise
-    except Exception as exc:
-        logger.exception("push egress: request failed")
-        _terminate(f"{type(exc).__name__}: {exc}")
-    except BaseException:
-        # KeyboardInterrupt / SystemExit: still close the stream, then let it go.
-        _terminate("worker interrupted")
-        raise
-    else:
-        _terminate(None)
+    async for response in stream:
+        # The actual Python -> Rust crossing: encode to request-plane bytes
+        # and enqueue, both under the GIL we are already holding.
+        response_sender.send(response)
+    response_sender.close()
 
 
 async def drive_push_egress_stream(

--- a/components/src/dynamo/trtllm/request_handlers/push_egress.py
+++ b/components/src/dynamo/trtllm/request_handlers/push_egress.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inverted (push-based) Python -> Rust response egress for the TRT-LLM workers.
+
+Why
+---
+On the pull path the Rust bridge drives the handler's async generator
+(``lib/bindings/python/rust/engine.rs``, ``demand_driven_python_stream``). Per
+response a tokio worker takes the GIL to call ``__anext__()``, schedules the
+resulting coroutine onto the Python event loop via ``call_soon_threadsafe``,
+parks, is woken, and then takes the GIL a *second* time to depythonize the
+item. Three GIL acquisitions per response, two of them on arbitrary tokio
+threads. On the decode worker -- 45 GIL-capable threads in the app interpreter
+versus ``trtllm-serve``'s 3, and a GIL wait/hold ratio of 23.4 versus serve's
+0.3 -- those cross-thread acquisitions are the expensive ones.
+
+Inverting the direction removes them. The handler is ALREADY running on the
+event loop holding the GIL at the moment it produces a response, so it hands
+that response straight to a Rust sender: one GIL acquisition, an existing one,
+and no tokio thread ever touches Python. Rust advances the handler once per
+REQUEST instead of once per RESPONSE.
+
+Rust-side contract
+------------------
+Implemented in ``lib/bindings/python/rust/push_egress.rs`` (``ResponseSender``,
+``PythonPushEngine``) and selected in ``lib.rs::serve_endpoint``. Three things
+matter to this file, and all three are load-bearing:
+
+1. **Shape.** In push mode Rust calls the handler and ``await``s what comes
+   back::
+
+       let coroutine = handler.call(py, (python_input,), Some(&kwargs))?;
+       pyo3_async_runtimes::into_future_with_locals(&locals, coroutine.into_bound(py))
+
+   So the push path must return a **coroutine**, not an async generator -- an
+   async generator object is not awaitable. The pull path, unchanged, still
+   needs an **async generator** (it does ``getattr("__anext__")``). That is why
+   :func:`push_egress_capable` produces a plain ``def`` that returns one or the
+   other, rather than an ``async def``.
+
+2. **Opt-in by signature.** Rust enables push mode only when
+   ``DYN_TRTLLM_PUSH_EGRESS=1`` *and* ``handler_supports_push()`` says the
+   handler declares a ``response_sender`` parameter, which it tests with
+   ``inspect.signature(handler).parameters``. ``inspect.signature`` follows
+   ``__wrapped__``, so any decorator stacked on ``generate`` that uses
+   ``functools.wraps`` would hide the parameter and silently drop the worker
+   back to the pull path. :func:`push_egress_capable` therefore drops its own
+   ``__wrapped__`` link. Keep it that way, and keep this decorator OUTERMOST.
+   (``context`` is detected the same way, in both engines.)
+
+3. **The sender.** ``response_sender`` and ``context`` arrive as keyword
+   arguments. The object exposes exactly::
+
+       send(obj)              one call per response; converts under our GIL and
+                              enqueues. Blocks when the consumer is behind, but
+                              releases the GIL across the wait.
+       close()                normal end of stream. Idempotent. Replaces the
+                              StopAsyncIteration the pull path relied on.
+       close_with_error(msg)  error termination. Idempotent; a later close() is
+                              a no-op.
+
+   Rust also installs a safety net that closes the sink when the coroutine
+   finishes, so a missed ``close()`` cannot hang a stream -- but we close
+   explicitly anyway, because our error message is better than the generic one.
+
+Where the push happens
+----------------------
+At the OUTERMOST handler boundary (``{Decode,Prefill,Encode,Aggregated}
+Handler.generate``), not at the innermost ``yield out`` inside
+``handler_base._generate_locally_impl``. Two reasons:
+
+1. The expensive crossing is the outermost one -- the one that reaches Rust.
+   The intermediate ``yield``s (``_generate_locally_impl`` ->
+   ``generate_locally`` -> ``Handler.generate``) are pure-Python generator
+   delegation on one thread: no GIL release, no bridge, no tokio thread. Moving
+   the push inward would buy nothing measurable and would fork a 300-line
+   function.
+2. Semantics are preserved *by construction*. The whole existing generator
+   stack runs untouched, so termination, ``is_final``/``finish_reason``
+   handling, the ``trtllm:first_response`` mark, error-frame mapping,
+   cancellation via ``_cancellation_monitor``, PrefillHandler's "exactly one
+   response" guard and its ``context.is_stopped()`` check all behave exactly as
+   they do on the pull path. Only the last hop changes: ``yield res`` becomes
+   ``sender.send(res)``.
+
+Flag
+----
+``DYN_TRTLLM_PUSH_EGRESS=1`` enables it; default OFF. Both paths ship in one
+image so they can be A/B tested. With the flag unset, Rust never hands over a
+sender and :func:`push_egress_capable` is a transparent passthrough, so the
+generator path behaves exactly as before.
+"""
+
+import asyncio
+import functools
+import logging
+import os
+from typing import Any, AsyncGenerator, Optional
+
+from dynamo.common.utils import nvtx_utils as _nvtx
+
+logger = logging.getLogger(__name__)
+
+PUSH_EGRESS_ENV_VAR = "DYN_TRTLLM_PUSH_EGRESS"
+
+# Read once at import, and parsed EXACTLY as push_egress.rs parses it
+# (`value == "1"`). A looser parse here would let the two halves disagree about
+# which path is active, which is the one disagreement that actually breaks: the
+# Rust side would await an async generator, or drive a coroutine with
+# __anext__.
+_PUSH_EGRESS_ENABLED: bool = os.environ.get(PUSH_EGRESS_ENV_VAR) == "1"
+
+# One-shot guard so a misconfiguration is loud without a line per request.
+_warned_no_sender = False
+
+
+def push_egress_enabled() -> bool:
+    """True when ``DYN_TRTLLM_PUSH_EGRESS`` selects the push (inverted) path.
+
+    Informational only. The authority on which path a given request takes is
+    whether Rust handed us a ``response_sender``: Rust decides once, at
+    ``serve_endpoint`` time, and a sender is only ever passed in push mode.
+    """
+    return _PUSH_EGRESS_ENABLED
+
+
+async def drive_push_egress(
+    stream: AsyncGenerator[Any, None], response_sender: Any
+) -> None:
+    """Drain ``stream`` into ``response_sender``, then terminate the stream.
+
+    Call sequence, per request:
+
+        send(res) * N  ->  close()                  normal completion
+        send(res) * N  ->  close()                  cancellation
+        send(res) * N  ->  close_with_error(msg)    failure
+
+    ``close()``/``close_with_error()`` are issued exactly once from here (and
+    are idempotent on the Rust side regardless).
+
+    On errors: in push mode the sender is the only channel Rust is listening
+    on for response data, so a failure is reported through
+    ``close_with_error`` and is not re-raised. Most per-request errors never
+    reach here anyway -- ``_generate_locally_impl`` already converts
+    ``RequestError`` and generic exceptions into
+    ``{"finish_reason": {"error": ...}}`` frames, which travel as ordinary
+    ``send()`` calls exactly as they do on the pull path.
+    """
+    # Spans awaits, so start/end range rather than the annotate context manager:
+    # annotate uses the thread's nested push/pop stack, which interleaves
+    # incorrectly when another coroutine resumes on the same event loop.
+    egress_rng = _nvtx.start_range("trtllm:push_egress", color="cyan")
+    closed = False
+
+    def _terminate(error: Optional[str]) -> None:
+        nonlocal closed
+        if closed:
+            return
+        closed = True
+        try:
+            if error is None:
+                _nvtx.mark("trtllm:push_close", color="cyan")
+                response_sender.close()
+            else:
+                _nvtx.mark("trtllm:push_error", color="red")
+                response_sender.close_with_error(error)
+        except Exception:
+            logger.exception("push egress: failed to close the Rust response stream")
+
+    try:
+        async for response in stream:
+            # The actual Python -> Rust crossing: pythonize/enqueue happens
+            # under the GIL we are already holding. Kept as a tight range so
+            # nsys shows bridge cost only, with engine time falling in the gaps
+            # between consecutive ranges.
+            send_rng = _nvtx.start_range("trtllm:push_send", color="cyan")
+            try:
+                response_sender.send(response)
+            finally:
+                _nvtx.end_range(send_rng)
+    except (asyncio.CancelledError, GeneratorExit):
+        # Client/connection cancellation. `_cancellation_monitor` has already
+        # abort()ed the engine request and `_generate_locally_impl` swallows its
+        # own CancelledError, so getting here means the enclosing task was
+        # cancelled. End the stream normally -- the pull path's cancelled
+        # generator likewise just stops producing -- then re-raise so asyncio's
+        # cancellation contract is honored.
+        _terminate(None)
+        raise
+    except Exception as exc:
+        logger.exception("push egress: request failed")
+        _terminate(f"{type(exc).__name__}: {exc}")
+    except BaseException:
+        # KeyboardInterrupt / SystemExit: still close the stream, then let it go.
+        _terminate("worker interrupted")
+        raise
+    else:
+        _terminate(None)
+    finally:
+        _nvtx.end_range(egress_rng)
+
+
+def push_egress_capable(func):
+    """Let an async-generator ``generate`` be driven by push OR by pull.
+
+    Turns ``async def generate(self, request, context)`` into a plain ``def``
+    that returns whichever object the active Rust engine expects:
+
+    * no ``response_sender`` (pull, the default) -> the **async generator**
+      itself, completely untouched. With ``DYN_TRTLLM_PUSH_EGRESS`` unset this
+      is the only path, and nothing about existing behavior changes.
+    * ``response_sender=<ResponseSender>`` (push) -> a **coroutine** that
+      drains that same generator into the sender via
+      :func:`drive_push_egress`.
+
+    A sender is honored whenever one is supplied, without consulting the env
+    var: Rust only ever supplies one when it has already committed to awaiting
+    a coroutine, so second-guessing it here could only produce a shape
+    mismatch.
+
+    Must stay the OUTERMOST decorator on ``generate``:
+
+    * the Rust ``handler_supports_push()`` sniff runs
+      ``inspect.signature()`` on the registered callable, so ``response_sender``
+      has to be visible in the outermost signature (hence the ``__wrapped__``
+      link is dropped below -- ``inspect.signature`` follows it);
+    * ``nvtx_utils.range_decorator`` must sit *inside*, where it still sees a
+      real async-generator function. Applied to this plain ``def`` it would
+      take its synchronous branch and close the range as soon as the
+      generator/coroutine object was constructed, measuring nothing.
+    """
+
+    @functools.wraps(func)
+    def dispatch(self, request, context=None, response_sender=None, **kwargs):
+        global _warned_no_sender
+
+        # Lazy either way: creating an async generator runs none of its body,
+        # and drive_push_egress() is a coroutine function.
+        stream = func(self, request, context, **kwargs)
+
+        # Safety net. Rust delivers the sender BOTH as this keyword argument
+        # and on `context.response_sender` (push_egress.rs, the kwarg-list
+        # closure) -- they are the same Py object. Reading the context too means
+        # a future Rust change that drops one delivery route degrades to the
+        # pull path instead of failing every request: without a sender we return
+        # the async generator, which is only correct if Rust also stayed on the
+        # pull path. That is why the warning below is loud.
+        if response_sender is None:
+            response_sender = getattr(context, "response_sender", None)
+
+        if response_sender is None:
+            if _PUSH_EGRESS_ENABLED and not _warned_no_sender:
+                _warned_no_sender = True
+                logger.warning(
+                    "%s=1 but the Rust bridge did not provide a response_sender "
+                    "for %s; falling back to the generator (pull) path.",
+                    PUSH_EGRESS_ENV_VAR,
+                    getattr(func, "__qualname__", func),
+                )
+            return stream
+
+        return drive_push_egress(stream, response_sender)
+
+    # functools.wraps sets __wrapped__, and inspect.signature() follows it --
+    # which would report the undecorated `generate(self, request, context)` and
+    # hide `response_sender` from the Rust opt-in check, silently disabling push
+    # egress. Keep the copied __name__/__doc__/__qualname__, drop the link.
+    del dispatch.__wrapped__
+
+    return dispatch

--- a/components/src/dynamo/trtllm/request_handlers/push_egress.py
+++ b/components/src/dynamo/trtllm/request_handlers/push_egress.py
@@ -3,169 +3,54 @@
 
 """Inverted (push-based) Python -> Rust response egress for the TRT-LLM workers.
 
-Why
----
-On the pull path the Rust bridge drives the handler's async generator
-(``lib/bindings/python/rust/engine.rs``, ``demand_driven_python_stream``). Per
-response a tokio worker takes the GIL to call ``__anext__()``, schedules the
-resulting coroutine onto the Python event loop via ``call_soon_threadsafe``,
-parks, is woken, and then takes the GIL a *second* time to depythonize the
-item. Three GIL acquisitions per response, two of them on arbitrary tokio
-threads. On the decode worker -- 45 GIL-capable threads in the app interpreter
-versus ``trtllm-serve``'s 3, and a GIL wait/hold ratio of 23.4 versus serve's
-0.3 -- those cross-thread acquisitions are the expensive ones.
+On the pull path Rust drives the handler's async generator, taking the GIL on
+tokio threads once per response. Here the handler -- already on the event loop
+holding the GIL when it produces a response -- hands it straight to a Rust
+``response_sender`` instead, and Rust advances the generator once per REQUEST
+rather than once per RESPONSE. Rationale and measurements: DYN-3703.
 
-Inverting the direction removes them. The handler is ALREADY running on the
-event loop holding the GIL at the moment it produces a response, so it hands
-that response straight to a Rust sender: one GIL acquisition, an existing one,
-and no tokio thread ever touches Python. Rust advances the handler once per
-REQUEST instead of once per RESPONSE.
+Three invariants are load-bearing; breaking any of them is silent:
 
-Rust-side contract
-------------------
-Implemented in ``lib/bindings/python/rust/push_egress.rs`` (``ResponseSender``,
-``PythonPushEngine``) and selected in ``lib.rs::serve_endpoint``. Three things
-matter to this file, and all three are load-bearing:
+1. **Shape.** Rust drives both paths with ``demand_driven_python_stream``,
+   which does ``getattr("__anext__")``, so push mode must return an **async
+   generator** -- never a coroutine. It yields nothing and is advanced exactly
+   once: that single ``__anext__`` runs the whole request, draining into the
+   sender, then raises ``StopAsyncIteration``.
 
-1. **Shape.** Rust drives BOTH paths through the same helper --
-   ``PythonPushEngine::generate`` calls ``engine::invoke_generator``, which ends
-   in ``demand_driven_python_stream``::
+2. **Opt-in by signature.** ``handler_supports_push`` (Rust) tests
+   ``"response_sender" in inspect.signature(handler).parameters``. Applying
+   :func:`push_egress_capable` is what puts it there, so that decorator IS the
+   switch -- there is no environment variable. It must stay OUTERMOST, and it
+   must keep deleting its own ``__wrapped__``, which ``inspect.signature``
+   would otherwise follow to the undecorated function and hide the parameter,
+   reverting every endpoint to the pull path with nothing logged.
 
-       let anext = generator.getattr("__anext__")?.unbind();   // engine.rs:126
-
-   So **both** paths must return an **async generator**; the difference is only
-   how often it is advanced. Pull yields once per response. Push yields nothing
-   and is advanced ONCE per request: that single ``__anext__`` runs the whole
-   request (draining into ``response_sender``) and then raises
-   ``StopAsyncIteration``. Responses travel out of band on the sender.
-
-   .. warning::
-
-      Returning a **coroutine** here does not work and fails loudly: a coroutine
-      has no ``__anext__``, so every request dies with ``AttributeError:
-      'coroutine' object has no attribute '__anext__'`` plus a
-      ``RuntimeWarning: coroutine 'drive_push_egress' was never awaited``. This
-      is exactly how runs 339221/339222 failed -- this docstring previously
-      described an ``into_future_with_locals`` call on the Rust side that was
-      never written. Keep :func:`drive_push_egress_stream` (an async generator)
-      as the returned object, not :func:`drive_push_egress` (a coroutine).
-
-   Keeping the generator shape on both paths is deliberate on the Rust side
-   (``push_egress.rs:427-437``): registration, cancellation, and the graceful
-   fallback for a handler that yields anyway all stay untouched.
-
-2. **Opt-in by signature.** Rust enables push mode only when
-   ``DYN_TRTLLM_PUSH_EGRESS=1`` *and* ``handler_supports_push()`` says the
-   handler declares a ``response_sender`` parameter, which it tests with
-   ``inspect.signature(handler).parameters``. ``inspect.signature`` follows
-   ``__wrapped__``, so any decorator stacked on ``generate`` that uses
-   ``functools.wraps`` would hide the parameter and silently drop the worker
-   back to the pull path. :func:`push_egress_capable` therefore drops its own
-   ``__wrapped__`` link. Keep it that way, and keep this decorator OUTERMOST.
-   (``context`` is detected the same way, in both engines.)
-
-3. **The sender.** ``response_sender`` and ``context`` arrive as keyword
-   arguments. The object exposes exactly::
-
-       send(obj)              one call per response; converts under our GIL and
-                              enqueues. Blocks when the consumer is behind, but
-                              releases the GIL across the wait.
-       close()                normal end of stream. Idempotent. Replaces the
-                              StopAsyncIteration the pull path relied on.
-       close_with_error(msg)  error termination. Idempotent; a later close() is
-                              a no-op.
-
-   Rust also installs a safety net that closes the sink when the coroutine
-   finishes, so a missed ``close()`` cannot hang a stream -- but we close
-   explicitly anyway, because our error message is better than the generic one.
-
-Where the push happens
-----------------------
-At the OUTERMOST handler boundary (``{Decode,Prefill,Encode,Aggregated}
-Handler.generate``), not at the innermost ``yield out`` inside
-``handler_base._generate_locally_impl``. Two reasons:
-
-1. The expensive crossing is the outermost one -- the one that reaches Rust.
-   The intermediate ``yield``s (``_generate_locally_impl`` ->
-   ``generate_locally`` -> ``Handler.generate``) are pure-Python generator
-   delegation on one thread: no GIL release, no bridge, no tokio thread. Moving
-   the push inward would buy nothing measurable and would fork a 300-line
-   function.
-2. Semantics are preserved *by construction*. The whole existing generator
-   stack runs untouched, so termination, ``is_final``/``finish_reason``
-   handling, the ``trtllm:first_response`` mark, error-frame mapping,
-   cancellation via ``_cancellation_monitor``, PrefillHandler's "exactly one
-   response" guard and its ``context.is_stopped()`` check all behave exactly as
-   they do on the pull path. Only the last hop changes: ``yield res`` becomes
-   ``sender.send(res)``.
-
-Flag
-----
-``DYN_TRTLLM_PUSH_EGRESS=1`` enables it; default OFF. Both paths ship in one
-image so they can be A/B tested. With the flag unset, Rust never hands over a
-sender and :func:`push_egress_capable` is a transparent passthrough, so the
-generator path behaves exactly as before.
+3. **The sender.** ``send(obj)`` once per response; ``close()`` on normal end;
+   ``close_with_error(msg)`` on failure. Both closes are idempotent, and Rust
+   closes the sink when the generator finishes as a safety net.
 """
 
 import asyncio
 import functools
 import logging
-import os
 from typing import Any, AsyncGenerator, Optional
-
-from dynamo.common.utils import nvtx_utils as _nvtx
 
 logger = logging.getLogger(__name__)
 
-PUSH_EGRESS_ENV_VAR = "DYN_TRTLLM_PUSH_EGRESS"
-
-# Read once at import, and parsed EXACTLY as push_egress.rs parses it
-# (`value == "1"`). A looser parse here would let the two halves disagree about
-# which path is active, which is the one disagreement that actually breaks: the
-# Rust side would await an async generator, or drive a coroutine with
-# __anext__.
-_PUSH_EGRESS_ENABLED: bool = os.environ.get(PUSH_EGRESS_ENV_VAR) == "1"
-
-# One-shot guard so a misconfiguration is loud without a line per request.
+# One-shot guard so a bridge mismatch is loud without a line per request.
 _warned_no_sender = False
-
-
-def push_egress_enabled() -> bool:
-    """True when ``DYN_TRTLLM_PUSH_EGRESS`` selects the push (inverted) path.
-
-    Informational only. The authority on which path a given request takes is
-    whether Rust handed us a ``response_sender``: Rust decides once, at
-    ``serve_endpoint`` time, and a sender is only ever passed in push mode.
-    """
-    return _PUSH_EGRESS_ENABLED
 
 
 async def drive_push_egress(
     stream: AsyncGenerator[Any, None], response_sender: Any
 ) -> None:
-    """Drain ``stream`` into ``response_sender``, then terminate the stream.
+    """Drain ``stream`` into ``response_sender``, then terminate it exactly once.
 
-    Call sequence, per request:
-
-        send(res) * N  ->  close()                  normal completion
-        send(res) * N  ->  close()                  cancellation
-        send(res) * N  ->  close_with_error(msg)    failure
-
-    ``close()``/``close_with_error()`` are issued exactly once from here (and
-    are idempotent on the Rust side regardless).
-
-    On errors: in push mode the sender is the only channel Rust is listening
-    on for response data, so a failure is reported through
-    ``close_with_error`` and is not re-raised. Most per-request errors never
-    reach here anyway -- ``_generate_locally_impl`` already converts
-    ``RequestError`` and generic exceptions into
-    ``{"finish_reason": {"error": ...}}`` frames, which travel as ordinary
-    ``send()`` calls exactly as they do on the pull path.
+    ``send()`` per response, then ``close()`` on normal completion or
+    cancellation and ``close_with_error()`` on failure. Errors are reported
+    through the sender rather than re-raised, since it is the only channel Rust
+    is listening on for response data.
     """
-    # Spans awaits, so start/end range rather than the annotate context manager:
-    # annotate uses the thread's nested push/pop stack, which interleaves
-    # incorrectly when another coroutine resumes on the same event loop.
-    egress_rng = _nvtx.start_range("trtllm:push_egress", color="cyan")
     closed = False
 
     def _terminate(error: Optional[str]) -> None:
@@ -175,25 +60,17 @@ async def drive_push_egress(
         closed = True
         try:
             if error is None:
-                _nvtx.mark("trtllm:push_close", color="cyan")
                 response_sender.close()
             else:
-                _nvtx.mark("trtllm:push_error", color="red")
                 response_sender.close_with_error(error)
         except Exception:
             logger.exception("push egress: failed to close the Rust response stream")
 
     try:
         async for response in stream:
-            # The actual Python -> Rust crossing: pythonize/enqueue happens
-            # under the GIL we are already holding. Kept as a tight range so
-            # nsys shows bridge cost only, with engine time falling in the gaps
-            # between consecutive ranges.
-            send_rng = _nvtx.start_range("trtllm:push_send", color="cyan")
-            try:
-                response_sender.send(response)
-            finally:
-                _nvtx.end_range(send_rng)
+            # The actual Python -> Rust crossing: depythonize and enqueue,
+            # both under the GIL we are already holding.
+            response_sender.send(response)
     except (asyncio.CancelledError, GeneratorExit):
         # Client/connection cancellation. `_cancellation_monitor` has already
         # abort()ed the engine request and `_generate_locally_impl` swallows its
@@ -212,8 +89,6 @@ async def drive_push_egress(
         raise
     else:
         _terminate(None)
-    finally:
-        _nvtx.end_range(egress_rng)
 
 
 async def drive_push_egress_stream(
@@ -221,20 +96,13 @@ async def drive_push_egress_stream(
 ) -> AsyncGenerator[Any, None]:
     """Async-**generator** wrapper around :func:`drive_push_egress`.
 
-    This is what push mode returns to Rust. It exists purely for shape: Rust
-    drives the push path with ``demand_driven_python_stream``, which does
-    ``getattr("__anext__")``, so the object it receives must be an async
-    generator and not a coroutine (see "Shape" in the module docstring).
+    Exists purely for shape (invariant 1 in the module docstring): Rust does
+    ``getattr("__anext__")`` on whatever push mode returns, so it must be an
+    async generator, not a coroutine.
 
-    The unreachable ``yield`` below is load-bearing -- it is what makes Python
-    compile this as an async-generator function. Do not remove it, and do not
-    add a reachable one: yielding here would push the response back onto the
-    pull path via the Rust driver's fallback arm
-    (``pybridge.push_forward_yield``), reintroducing the per-response GIL
-    acquisition this whole change exists to remove.
-
-    Advanced exactly once per request: that call runs the request to completion,
-    then falls off the end and raises ``StopAsyncIteration``.
+    The unreachable ``yield`` is what makes Python compile this as an
+    async-generator function. Do not remove it, and do not add a reachable one
+    -- a push-mode handler that yields now fails its request outright.
     """
     await drive_push_egress(stream, response_sender)
     if False:  # pragma: no cover - never runs; makes this an async generator
@@ -245,70 +113,45 @@ def push_egress_capable(func):
     """Let an async-generator ``generate`` be driven by push OR by pull.
 
     Turns ``async def generate(self, request, context)`` into a plain ``def``
-    that returns whichever object the active Rust engine expects:
+    returning whichever object the active Rust engine expects: an async
+    generator draining into the sender when one is supplied (push, what a
+    current binding always does), or the handler's own async generator
+    untouched when none is (pull, reached only against a binding predating this
+    path). The choice is made purely on whether a sender arrived -- Rust decides
+    once at ``serve_endpoint`` time, and second-guessing it here could only
+    produce a shape mismatch.
 
-    * no ``response_sender`` (pull, the default) -> the **async generator**
-      itself, completely untouched. With ``DYN_TRTLLM_PUSH_EGRESS`` unset this
-      is the only path, and nothing about existing behavior changes.
-    * ``response_sender=<ResponseSender>`` (push) -> a **coroutine** that
-      drains that same generator into the sender via
-      :func:`drive_push_egress`.
-
-    A sender is honored whenever one is supplied, without consulting the env
-    var: Rust only ever supplies one when it has already committed to awaiting
-    a coroutine, so second-guessing it here could only produce a shape
-    mismatch.
-
-    Must stay the OUTERMOST decorator on ``generate``:
-
-    * the Rust ``handler_supports_push()`` sniff runs
-      ``inspect.signature()`` on the registered callable, so ``response_sender``
-      has to be visible in the outermost signature (hence the ``__wrapped__``
-      link is dropped below -- ``inspect.signature`` follows it);
-    * ``nvtx_utils.range_decorator`` must sit *inside*, where it still sees a
-      real async-generator function. Applied to this plain ``def`` it would
-      take its synchronous branch and close the range as soon as the
-      generator/coroutine object was constructed, measuring nothing.
+    Must stay the OUTERMOST decorator (invariant 2 in the module docstring).
+    Any decorator that inspects what it wraps must sit *inside*, where it still
+    sees a real async-generator function rather than this plain ``def``.
     """
 
     @functools.wraps(func)
     def dispatch(self, request, context=None, response_sender=None, **kwargs):
         global _warned_no_sender
 
-        # Lazy either way: creating an async generator runs none of its body,
-        # and drive_push_egress() is a coroutine function.
+        # Lazy either way: creating an async generator runs none of its body.
         stream = func(self, request, context, **kwargs)
 
-        # Safety net. Rust delivers the sender BOTH as this keyword argument
-        # and on `context.response_sender` (push_egress.rs, the kwarg-list
-        # closure) -- they are the same Py object. Reading the context too means
-        # a future Rust change that drops one delivery route degrades to the
-        # pull path instead of failing every request: without a sender we return
-        # the async generator, which is only correct if Rust also stayed on the
-        # pull path. That is why the warning below is loud.
         if response_sender is None:
-            response_sender = getattr(context, "response_sender", None)
-
-        if response_sender is None:
-            if _PUSH_EGRESS_ENABLED and not _warned_no_sender:
+            if not _warned_no_sender:
                 _warned_no_sender = True
                 logger.warning(
-                    "%s=1 but the Rust bridge did not provide a response_sender "
-                    "for %s; falling back to the generator (pull) path.",
-                    PUSH_EGRESS_ENV_VAR,
+                    "the Rust bridge did not provide a response_sender for %s; "
+                    "falling back to the generator (pull) path. Expect the "
+                    "decode-worker GIL cost this decorator exists to remove -- "
+                    "the dynamo._core binding is probably older than the "
+                    "push-egress path.",
                     getattr(func, "__qualname__", func),
                 )
             return stream
 
-        # An async GENERATOR, not the `drive_push_egress` coroutine: Rust does
-        # `getattr("__anext__")` on whatever comes back. See the module
-        # docstring's "Shape" section.
+        # An async GENERATOR, not the `drive_push_egress` coroutine.
         return drive_push_egress_stream(stream, response_sender)
 
-    # functools.wraps sets __wrapped__, and inspect.signature() follows it --
-    # which would report the undecorated `generate(self, request, context)` and
-    # hide `response_sender` from the Rust opt-in check, silently disabling push
-    # egress. Keep the copied __name__/__doc__/__qualname__, drop the link.
+    # inspect.signature() follows __wrapped__ and would report the undecorated
+    # `generate(self, request, context)`, hiding `response_sender` from the Rust
+    # opt-in check. Keep the copied __name__/__doc__/__qualname__, drop the link.
     del dispatch.__wrapped__
 
     return dispatch

--- a/components/src/dynamo/trtllm/request_handlers/push_egress.py
+++ b/components/src/dynamo/trtllm/request_handlers/push_egress.py
@@ -27,17 +27,32 @@ Implemented in ``lib/bindings/python/rust/push_egress.rs`` (``ResponseSender``,
 ``PythonPushEngine``) and selected in ``lib.rs::serve_endpoint``. Three things
 matter to this file, and all three are load-bearing:
 
-1. **Shape.** In push mode Rust calls the handler and ``await``s what comes
-   back::
+1. **Shape.** Rust drives BOTH paths through the same helper --
+   ``PythonPushEngine::generate`` calls ``engine::invoke_generator``, which ends
+   in ``demand_driven_python_stream``::
 
-       let coroutine = handler.call(py, (python_input,), Some(&kwargs))?;
-       pyo3_async_runtimes::into_future_with_locals(&locals, coroutine.into_bound(py))
+       let anext = generator.getattr("__anext__")?.unbind();   // engine.rs:126
 
-   So the push path must return a **coroutine**, not an async generator -- an
-   async generator object is not awaitable. The pull path, unchanged, still
-   needs an **async generator** (it does ``getattr("__anext__")``). That is why
-   :func:`push_egress_capable` produces a plain ``def`` that returns one or the
-   other, rather than an ``async def``.
+   So **both** paths must return an **async generator**; the difference is only
+   how often it is advanced. Pull yields once per response. Push yields nothing
+   and is advanced ONCE per request: that single ``__anext__`` runs the whole
+   request (draining into ``response_sender``) and then raises
+   ``StopAsyncIteration``. Responses travel out of band on the sender.
+
+   .. warning::
+
+      Returning a **coroutine** here does not work and fails loudly: a coroutine
+      has no ``__anext__``, so every request dies with ``AttributeError:
+      'coroutine' object has no attribute '__anext__'`` plus a
+      ``RuntimeWarning: coroutine 'drive_push_egress' was never awaited``. This
+      is exactly how runs 339221/339222 failed -- this docstring previously
+      described an ``into_future_with_locals`` call on the Rust side that was
+      never written. Keep :func:`drive_push_egress_stream` (an async generator)
+      as the returned object, not :func:`drive_push_egress` (a coroutine).
+
+   Keeping the generator shape on both paths is deliberate on the Rust side
+   (``push_egress.rs:427-437``): registration, cancellation, and the graceful
+   fallback for a handler that yields anyway all stay untouched.
 
 2. **Opt-in by signature.** Rust enables push mode only when
    ``DYN_TRTLLM_PUSH_EGRESS=1`` *and* ``handler_supports_push()`` says the
@@ -201,6 +216,31 @@ async def drive_push_egress(
         _nvtx.end_range(egress_rng)
 
 
+async def drive_push_egress_stream(
+    stream: AsyncGenerator[Any, None], response_sender: Any
+) -> AsyncGenerator[Any, None]:
+    """Async-**generator** wrapper around :func:`drive_push_egress`.
+
+    This is what push mode returns to Rust. It exists purely for shape: Rust
+    drives the push path with ``demand_driven_python_stream``, which does
+    ``getattr("__anext__")``, so the object it receives must be an async
+    generator and not a coroutine (see "Shape" in the module docstring).
+
+    The unreachable ``yield`` below is load-bearing -- it is what makes Python
+    compile this as an async-generator function. Do not remove it, and do not
+    add a reachable one: yielding here would push the response back onto the
+    pull path via the Rust driver's fallback arm
+    (``pybridge.push_forward_yield``), reintroducing the per-response GIL
+    acquisition this whole change exists to remove.
+
+    Advanced exactly once per request: that call runs the request to completion,
+    then falls off the end and raises ``StopAsyncIteration``.
+    """
+    await drive_push_egress(stream, response_sender)
+    if False:  # pragma: no cover - never runs; makes this an async generator
+        yield
+
+
 def push_egress_capable(func):
     """Let an async-generator ``generate`` be driven by push OR by pull.
 
@@ -260,7 +300,10 @@ def push_egress_capable(func):
                 )
             return stream
 
-        return drive_push_egress(stream, response_sender)
+        # An async GENERATOR, not the `drive_push_egress` coroutine: Rust does
+        # `getattr("__anext__")` on whatever comes back. See the module
+        # docstring's "Shape" section.
+        return drive_push_egress_stream(stream, response_sender)
 
     # functools.wraps sets __wrapped__, and inspect.signature() follows it --
     # which would report the undecorated `generate(self, request, context)` and

--- a/components/src/dynamo/trtllm/tests/test_push_egress.py
+++ b/components/src/dynamo/trtllm/tests/test_push_egress.py
@@ -523,19 +523,29 @@ class TestFallbackPath:
         collected = run(_test())
         assert collected == [1, 2, 3]
 
-    def test_no_sender_warns_exactly_once(self, caplog):
-        """Warning fires on the first call and never again."""
+    def test_no_sender_logs_exactly_once(self, caplog):
+        """The notice fires on the first call and never again.
+
+        It is INFO, not WARNING: the pull arm is reached in normal operation by
+        in-process callers and the canary health check, which go through the
+        pull engine registered in the local endpoint registry. Logging it at
+        warning level made every canary-enabled deployment report a false alarm.
+        """
         decorated = push_egress_capable(_gen_one_token)
         dummy = object.__new__(object)
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INFO):
             decorated(dummy, request={}, context=None)
             decorated(dummy, request={}, context=None)
 
-        warnings = [r for r in caplog.records if "response_sender" in r.message]
+        notices = [r for r in caplog.records if "response_sender" in r.message]
         assert (
-            len(warnings) == 1
-        ), f"expected exactly 1 warning about missing sender, got {len(warnings)}"
+            len(notices) == 1
+        ), f"expected exactly 1 notice about missing sender, got {len(notices)}"
+        assert notices[0].levelno == logging.INFO, (
+            "the pull arm is a normal path, not a fault; logging it at "
+            f"{notices[0].levelname} cries wolf on every health check"
+        )
 
     def test_warned_no_sender_global_is_module_mutable_state(self):
         """_warned_no_sender is module-global mutable state.

--- a/components/src/dynamo/trtllm/tests/test_push_egress.py
+++ b/components/src/dynamo/trtllm/tests/test_push_egress.py
@@ -176,10 +176,10 @@ async def _gen_empty(self, request, context):
 
 
 @pytest.fixture(autouse=True)
-def reset_warned_no_sender():
-    pe._warned_no_sender = False
+def reset_logged_no_sender():
+    pe._logged_no_sender = False
     yield
-    pe._warned_no_sender = False
+    pe._logged_no_sender = False
 
 
 # ===========================================================================
@@ -547,20 +547,20 @@ class TestFallbackPath:
             f"{notices[0].levelname} cries wolf on every health check"
         )
 
-    def test_warned_no_sender_global_is_module_mutable_state(self):
-        """_warned_no_sender is module-global mutable state.
+    def test_logged_no_sender_global_is_module_mutable_state(self):
+        """_logged_no_sender is module-global mutable state.
 
         This is a correctness risk: if tests don't reset it (or the reset
         fixture fails), warnings bleed across tests.  The autouse fixture covers
         this, but here we verify the guard itself works as a boolean latch.
         """
-        assert pe._warned_no_sender is False  # fixture reset it
+        assert pe._logged_no_sender is False  # fixture reset it
         decorated = push_egress_capable(_gen_empty)
         dummy = object.__new__(object)
         decorated(dummy, request={}, context=None)
-        assert pe._warned_no_sender is True  # latched after first call
+        assert pe._logged_no_sender is True  # latched after first call
         decorated(dummy, request={}, context=None)
-        assert pe._warned_no_sender is True  # stays latched
+        assert pe._logged_no_sender is True  # stays latched
 
 
 # ===========================================================================

--- a/components/src/dynamo/trtllm/tests/test_push_egress.py
+++ b/components/src/dynamo/trtllm/tests/test_push_egress.py
@@ -31,6 +31,7 @@ import importlib.util
 import inspect
 import logging
 import pathlib
+from typing import ClassVar
 
 import pytest
 
@@ -222,12 +223,19 @@ class TestSignatureClaim:
             "Rust handler_supports_push() will return false"
         )
 
-    def test_outer_functools_wraps_hides_response_sender(self):
-        """Fragility: an outer functools.wraps wrapper breaks the signature.
+    def test_outer_functools_wraps_still_exposes_response_sender(self):
+        """Signature visibility is NOT what makes the ordering constraint real.
 
-        This documents the ordering constraint: push_egress_capable MUST be
-        outermost.  If another decorator wraps it with functools.wraps, the
-        __wrapped__ link is re-established and inspect.signature will follow it.
+        A wrapper applied on top with ``functools.wraps`` sets its
+        ``__wrapped__`` to ``dispatch`` — which declares ``response_sender`` —
+        so ``inspect.signature`` still finds the parameter and Rust still picks
+        push mode. Pinned here so nobody "fixes" this into a hiding assertion:
+        the reason ``push_egress_capable`` must be outermost is that any
+        decorator inspecting what it wraps has to see a real async-generator
+        function, not the plain ``def dispatch`` this returns. The visibility
+        failure that *is* real is the ``__wrapped__`` link on ``dispatch``
+        itself — see :meth:`test_no_wrapped_link` and the canary in
+        :class:`TestRustPathSelection`.
         """
         inner = push_egress_capable(_gen_one_token)
 
@@ -236,13 +244,12 @@ class TestSignatureClaim:
             return inner(self, request, context, **kwargs)
 
         params = inspect.signature(outer_wrapper).parameters
-        # Document the actual result — regardless of whether it hides the param
-        # the test probes whether the ordering constraint is fragile.
-        if "response_sender" not in params:
-            pytest.xfail(
-                "An outer functools.wraps hides response_sender — "
-                "ordering constraint is real and fragile"
-            )
+        assert "response_sender" in params
+        assert not inspect.isasyncgenfunction(inner), (
+            "push_egress_capable returned an async-generator function; a "
+            "decorator applied outside it would then see the wrong shape and "
+            "the OUTERMOST constraint would need restating"
+        )
 
 
 # ===========================================================================
@@ -336,17 +343,20 @@ class TestShapeClaim:
 
 
 class TestTermination:
-    """close() or close_with_error() must be issued exactly once per request."""
+    """Normal end closes the sender; every failure propagates to Rust instead.
+
+    The split matters downstream. Rust runs an escaping exception through
+    `map_python_exception`, which turns `EngineShutdown` into
+    `BackendError::EngineShutdown` (request migration + worker inhibition) and
+    `ValueError`/`TypeError` into `InvalidArgument`. Catching it here to report
+    a string through `close_with_error` would erase that type, so these tests
+    assert the exception gets OUT, not that a message was formatted.
+    """
 
     def test_normal_completion_closes_sender_exactly_once(self):
         sender = FakeSender()
         run(drive_push_egress(gen("a", "b", "c"), sender))
-        assert sender.close_count == 1, (
-            f"expected 1 close(), got {sender.close_count} "
-            f"(close_with_error: {sender.error_close_count}) — check whether "
-            "something inside _terminate() raised and was swallowed by its "
-            "except guard before the close call was reached"
-        )
+        assert sender.close_count == 1, f"expected 1 close(), got {sender.close_count}"
         assert sender.error_close_count == 0
 
     def test_zero_chunk_stream_closes_sender(self):
@@ -357,116 +367,107 @@ class TestTermination:
         ), f"empty stream: expected 1 close, got {sender.close_count}"
         assert sender.error_close_count == 0
 
-    def test_handler_exception_calls_close_with_error_not_close(self):
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ValueError("bad request"),  # -> BackendError::InvalidArgument
+            RuntimeError("engine shutting down"),  # stands in for EngineShutdown
+            TimeoutError("too slow"),  # -> BackendError::ConnectionTimeout
+        ],
+        ids=["value-error", "runtime-error", "timeout-error"],
+    )
+    def test_handler_exception_propagates_untouched(self, exc):
+        """The exact exception object must reach Rust, unwrapped and unlogged-over.
+
+        This is the whole typed-error contract: if this ever goes back to being
+        caught, every failure reaches the caller as a generic server error and
+        an interrupted request stops being migrated to another worker.
+        """
         sender = FakeSender()
-        run(drive_push_egress(raising_gen(["a"], ValueError("boom")), sender))
-        assert (
-            sender.error_close_count == 1
-        ), f"expected 1 close_with_error(), got {sender.error_close_count}"
-        assert sender.close_count == 0
+        with pytest.raises(type(exc)) as caught:
+            run(drive_push_egress(raising_gen(["a"], exc), sender))
+        assert caught.value is exc, "the original exception must not be re-wrapped"
 
-    def test_error_message_contains_exception_type(self):
+    def test_handler_exception_leaves_the_stream_to_rust(self):
+        """No close of any kind on the error path.
+
+        Closing here would win the race against the Rust driver's
+        `close_with_dynamo_error`, which is idempotent — the typed frame would
+        be silently dropped in favour of a plain end-of-stream.
+        """
         sender = FakeSender()
-        run(drive_push_egress(raising_gen([], ValueError("boom")), sender))
-        assert "ValueError" in (
-            sender.last_error or ""
-        ), f"error message missing exception type: {sender.last_error!r}"
+        with pytest.raises(ValueError):
+            run(drive_push_egress(raising_gen(["a"], ValueError("boom")), sender))
+        assert sender.total_closes == 0, (
+            "the error path must not terminate the stream; Rust does it with "
+            f"the mapped backend error (got {sender.total_closes} closes)"
+        )
 
-    def test_handler_exception_not_reraised(self):
-        """Exception in the handler must NOT propagate — it went to close_with_error."""
+    def test_cancelled_error_propagates(self):
+        """Cancellation is an exception like any other.
 
-        async def _test():
-            sender = FakeSender()
-            await drive_push_egress(raising_gen([], RuntimeError("oops")), sender)
-
-        run(_test())  # must not raise
-
-    def test_cancelled_error_closes_normally_and_reraises(self):
-        """CancelledError: close() called once (normal end), then re-raised."""
+        `map_python_exception` maps it to `BackendError::Cancelled`, matching
+        what the pull path reports for a cancelled generator.
+        """
         sender = FakeSender()
-        cancelled = False
 
         async def cancel_mid_stream():
             yield "first"
             raise asyncio.CancelledError()
 
-        async def _test():
-            nonlocal cancelled
-            try:
-                await drive_push_egress(cancel_mid_stream(), sender)
-            except asyncio.CancelledError:
-                cancelled = True
+        with pytest.raises(asyncio.CancelledError):
+            run(drive_push_egress(cancel_mid_stream(), sender))
+        assert sender.sent == ["first"], "chunks before the cancel must be delivered"
+        assert sender.total_closes == 0
 
-        run(_test())
-        assert cancelled, "CancelledError was not re-raised"
-        assert (
-            sender.close_count == 1
-        ), f"CancelledError path: expected 1 close(), got {sender.close_count}"
-        assert (
-            sender.error_close_count == 0
-        ), "CancelledError should call close(), not close_with_error()"
-
-    def test_keyboard_interrupt_closes_with_error_and_reraises(self):
-        """KeyboardInterrupt: close_with_error('worker interrupted'), then re-raised."""
+    def test_keyboard_interrupt_propagates(self):
         sender = FakeSender()
-        raised = False
 
         async def ki_stream():
             yield "x"
             raise KeyboardInterrupt()
 
-        async def _test():
-            nonlocal raised
-            try:
-                await drive_push_egress(ki_stream(), sender)
-            except KeyboardInterrupt:
-                raised = True
-
-        run(_test())
-        assert raised, "KeyboardInterrupt was not re-raised"
-        assert sender.error_close_count == 1, (
-            f"KeyboardInterrupt path: expected 1 close_with_error(), "
-            f"got {sender.error_close_count}"
-        )
-        assert "interrupted" in (
-            sender.last_error or ""
-        ), f"expected 'worker interrupted', got {sender.last_error!r}"
-        assert sender.close_count == 0
+        with pytest.raises(KeyboardInterrupt):
+            run(drive_push_egress(ki_stream(), sender))
+        assert sender.total_closes == 0
 
     def test_at_most_one_close_total(self):
-        """_terminate is guarded by `closed`; double-close must not happen."""
         sender = FakeSender()
         run(drive_push_egress(gen("x"), sender))
         assert (
-            sender.total_closes <= 1
-        ), f"stream closed {sender.total_closes} times (expected ≤1)"
+            sender.total_closes == 1
+        ), f"stream closed {sender.total_closes} times (expected exactly 1)"
 
-    def test_send_raises_mid_stream_terminates_exactly_once(self):
-        """If send() raises, the stream still terminates exactly once via close_with_error."""
+    def test_send_raising_propagates(self):
+        """A failing `send` is how the consumer-gone case surfaces.
+
+        The real sender raises `RuntimeError` once the consumer drops the
+        response stream, having already stopped the request context. Letting it
+        out unwinds the handler — and its `finally` blocks — instead of looping
+        on a dead channel.
+        """
 
         class SenderFailsOnSecond(FakeSender):
             def send(self, obj):
                 if len(self.sent) >= 1:
-                    raise RuntimeError("queue full")
+                    raise RuntimeError("consumer dropped the response stream")
                 super().send(obj)
 
         sender = SenderFailsOnSecond()
-        run(drive_push_egress(gen("a", "b", "c"), sender))
-        assert (
-            sender.total_closes == 1
-        ), f"after send() raises: expected 1 close, got {sender.total_closes}"
-        assert sender.error_close_count == 1
+        with pytest.raises(RuntimeError, match="consumer dropped"):
+            run(drive_push_egress(gen("a", "b", "c"), sender))
+        assert sender.sent == ["a"]
+        assert sender.total_closes == 0
 
-    def test_broken_close_does_not_propagate(self):
-        """If close() itself raises, the exception is swallowed."""
-        sender = BrokenSender()
-        run(drive_push_egress(gen("a"), sender))  # must not raise
+    def test_failing_close_propagates(self):
+        """A `close()` that raises is a bridge failure, not something to hide.
 
-    def test_broken_close_with_error_does_not_propagate(self):
+        It reaches Rust as the generator's exception; the sink close is
+        idempotent, so the stream still terminates.
+        """
         sender = BrokenSender()
-        run(
-            drive_push_egress(raising_gen([], ValueError("x")), sender)
-        )  # must not raise
+        with pytest.raises(RuntimeError, match="close exploded"):
+            run(drive_push_egress(gen("a"), sender))
 
 
 # ===========================================================================
@@ -490,7 +491,12 @@ class TestChunkDelivery:
     def test_chunks_before_exception_are_sent(self):
         """Items before a handler exception should all be delivered."""
         sender = FakeSender()
-        run(drive_push_egress(raising_gen([0, 1, 2], ValueError("mid-stream")), sender))
+        with pytest.raises(ValueError):
+            run(
+                drive_push_egress(
+                    raising_gen([0, 1, 2], ValueError("mid-stream")), sender
+                )
+            )
         assert sender.sent == [
             0,
             1,
@@ -700,7 +706,7 @@ class TestDecoratorAppliedToRealHandlers:
     endpoint just reverts to the pull path, with no error and no failure.
     """
 
-    HANDLERS = {
+    HANDLERS: ClassVar[dict[str, list[str]]] = {
         "handlers.py": ["EncodeHandler", "PrefillHandler", "DecodeHandler"],
         "aggregated_handler.py": ["AggregatedHandler"],
     }

--- a/components/src/dynamo/trtllm/tests/test_push_egress.py
+++ b/components/src/dynamo/trtllm/tests/test_push_egress.py
@@ -24,6 +24,7 @@ decorators and helpers above).  Anything test-local must be passed in or bound
 at module scope instead, or the class body raises NameError.
 """
 
+import ast
 import asyncio
 import functools
 import importlib.util
@@ -706,8 +707,6 @@ class TestDecoratorAppliedToRealHandlers:
 
     @staticmethod
     def _generate_decorators(path, class_name):
-        import ast
-
         tree = ast.parse(pathlib.Path(path).read_text())
         for node in tree.body:
             if isinstance(node, ast.ClassDef) and node.name == class_name:
@@ -773,8 +772,6 @@ class TestNoBleedIntoOtherEngines:
 
     @staticmethod
     def _declares_response_sender(path):
-        import ast
-
         try:
             tree = ast.parse(path.read_text())
         except SyntaxError:

--- a/components/src/dynamo/trtllm/tests/test_push_egress.py
+++ b/components/src/dynamo/trtllm/tests/test_push_egress.py
@@ -1,0 +1,825 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for push_egress.py — the inverted push-egress path for TRT-LLM workers.
+
+These tests are designed to BREAK the implementation; a passing run that finds
+nothing is a failed deliverable.  Every test targets a specific claim in the
+module docstring or an edge-case the implementation could silently get wrong.
+
+Import strategy
+---------------
+These tests must run without the compiled bindings, so nothing here imports
+dynamo._core.  push_egress.py is loaded by path via importlib, and the Rust
+ResponseSender is modelled by :class:`FakeSender`, which enforces the contract
+documented on the real one.  Consequences worth knowing: the actual Python/Rust
+boundary is NOT exercised here, and neither is backpressure -- the real ``send``
+blocks and releases the GIL, which a fake cannot reproduce.
+
+Class-body scoping note
+-----------------------
+Python class bodies do NOT form closures over enclosing function locals, so a
+class defined inside a test method may reference only module-level names (the
+decorators and helpers above).  Anything test-local must be passed in or bound
+at module scope instead, or the class body raises NameError.
+"""
+
+import asyncio
+import functools
+import importlib.util
+import inspect
+import logging
+import pathlib
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the module under test by path.
+# ---------------------------------------------------------------------------
+
+# tests/ -> trtllm/ -> dynamo/ -> src/ -> components/ -> repo root. Derived, not
+# hardcoded: these tests must run from any checkout, worktree, or container path.
+_COMPONENTS_SRC = pathlib.Path(__file__).resolve().parents[3]
+
+
+def _load_push_egress():
+    """Load push_egress.py directly, without importing the dynamo package.
+
+    It depends on nothing from dynamo, so a plain spec load keeps these tests
+    runnable wherever the compiled bindings are absent.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "dynamo.trtllm.request_handlers.push_egress",
+        _COMPONENTS_SRC / "dynamo" / "trtllm" / "request_handlers" / "push_egress.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pe = _load_push_egress()
+
+drive_push_egress = pe.drive_push_egress
+drive_push_egress_stream = pe.drive_push_egress_stream
+push_egress_capable = pe.push_egress_capable
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def run(coro):
+    """Run a coroutine synchronously (no pytest-asyncio required)."""
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fake ResponseSender — models the Rust contract.
+# ---------------------------------------------------------------------------
+
+
+class FakeSender:
+    """Behaves like the real Rust ResponseSender.
+
+    Contract enforced:
+    - send() raises after close / close_with_error.
+    - close() and close_with_error() are idempotent.
+    - close() after close_with_error() is a no-op.
+    """
+
+    def __init__(self):
+        self.sent = []
+        self.close_count = 0
+        self.error_close_count = 0
+        self.last_error = None
+        self._closed = False
+
+    def send(self, obj):
+        if self._closed:
+            raise RuntimeError("send after close")
+        self.sent.append(obj)
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        self.close_count += 1
+
+    def close_with_error(self, msg: str):
+        if self._closed:
+            return
+        self._closed = True
+        self.error_close_count += 1
+        self.last_error = msg
+
+    @property
+    def total_closes(self):
+        return self.close_count + self.error_close_count
+
+
+class BrokenSender(FakeSender):
+    """A sender whose close operations raise — tests Python degrades sanely."""
+
+    def close(self):
+        raise RuntimeError("close exploded")
+
+    def close_with_error(self, msg: str):
+        raise RuntimeError(f"close_with_error exploded: {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Async helpers
+# ---------------------------------------------------------------------------
+
+
+async def gen(*items):
+    for item in items:
+        yield item
+
+
+async def raising_gen(items, exc):
+    for item in items:
+        yield item
+    raise exc
+
+
+# ---------------------------------------------------------------------------
+# Module-level handler classes (class bodies can't see test-local vars).
+# ---------------------------------------------------------------------------
+
+
+async def _gen_one_token(self, request, context):
+    yield {"token": "a"}
+
+
+async def _gen_three_items(self, request, context):
+    for v in [1, 2, 3]:
+        yield v
+
+
+async def _gen_empty(self, request, context):
+    return
+    yield  # make it an async generator
+
+
+# ---------------------------------------------------------------------------
+# Fixture: reset the module-global warning guard between tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_warned_no_sender():
+    pe._warned_no_sender = False
+    yield
+    pe._warned_no_sender = False
+
+
+# ===========================================================================
+# 1. Signature claim
+# ===========================================================================
+
+
+class TestSignatureClaim:
+    """The Rust opt-in check calls inspect.signature(handler).parameters.
+
+    If response_sender is missing from the outermost signature, every TRT-LLM
+    endpoint silently falls back to the pull path and the whole change is a no-op.
+    """
+
+    def test_response_sender_in_signature(self):
+        decorated = push_egress_capable(_gen_one_token)
+        params = inspect.signature(decorated).parameters
+        assert "response_sender" in params, (
+            "push_egress_capable did not expose response_sender; "
+            "Rust will never select push mode"
+        )
+
+    def test_no_wrapped_link(self):
+        """inspect.signature() follows __wrapped__; it must be deleted."""
+        decorated = push_egress_capable(_gen_one_token)
+        assert not hasattr(decorated, "__wrapped__"), (
+            "__wrapped__ present; inspect.signature() will follow it and hide "
+            "response_sender, silently disabling push mode for every endpoint"
+        )
+
+    def test_response_sender_in_signature_bound_method(self):
+        """Test on a bound method — the actual shape Rust inspects."""
+
+        class Handler:
+            generate = push_egress_capable(_gen_one_token)
+
+        h = Handler()
+        params = inspect.signature(h.generate).parameters
+        assert "response_sender" in params, (
+            "response_sender hidden when inspecting a bound method; "
+            "Rust handler_supports_push() will return false"
+        )
+
+    def test_outer_functools_wraps_hides_response_sender(self):
+        """Fragility: an outer functools.wraps wrapper breaks the signature.
+
+        This documents the ordering constraint: push_egress_capable MUST be
+        outermost.  If another decorator wraps it with functools.wraps, the
+        __wrapped__ link is re-established and inspect.signature will follow it.
+        """
+        inner = push_egress_capable(_gen_one_token)
+
+        @functools.wraps(inner)
+        def outer_wrapper(self, request, context=None, **kwargs):
+            return inner(self, request, context, **kwargs)
+
+        params = inspect.signature(outer_wrapper).parameters
+        # Document the actual result — regardless of whether it hides the param
+        # the test probes whether the ordering constraint is fragile.
+        if "response_sender" not in params:
+            pytest.xfail(
+                "An outer functools.wraps hides response_sender — "
+                "ordering constraint is real and fragile"
+            )
+
+
+# ===========================================================================
+# 2. Shape claim
+# ===========================================================================
+
+
+class TestShapeClaim:
+    """Both push and pull paths must return an async generator (has __anext__)."""
+
+    def _make_push_result(self, sender):
+        """Call the decorated function directly with a dummy self."""
+        decorated = push_egress_capable(_gen_one_token)
+        dummy_self = object.__new__(object)
+        return decorated(dummy_self, request={}, context=None, response_sender=sender)
+
+    def _make_pull_result(self):
+        decorated = push_egress_capable(_gen_one_token)
+        dummy_self = object.__new__(object)
+        return decorated(dummy_self, request={}, context=None)
+
+    def test_push_mode_returns_async_generator(self):
+        result = self._make_push_result(FakeSender())
+        assert hasattr(result, "__anext__"), (
+            "push mode returned something without __anext__; "
+            "Rust getattr('__anext__') will fail every request"
+        )
+        assert inspect.isasyncgen(result)
+
+    def test_pull_mode_returns_async_generator(self):
+        result = self._make_pull_result()
+        assert hasattr(
+            result, "__anext__"
+        ), "pull mode fallback returned something without __anext__"
+
+    def test_drive_push_egress_stream_is_async_generator_function(self):
+        assert inspect.isasyncgenfunction(drive_push_egress_stream), (
+            "drive_push_egress_stream is not an async generator function; "
+            "calling it returns a coroutine, not an async generator"
+        )
+
+    def test_push_generator_advanced_exactly_once_then_stops(self):
+        """Rust advances the push generator ONCE per request.
+
+        After that single __anext__ call the generator must raise
+        StopAsyncIteration, having run the whole request to completion.
+        """
+        sender = FakeSender()
+        chunks = ["a", "b", "c"]
+
+        async def inner_gen(self, request, context):
+            for c in chunks:
+                yield c
+
+        async def _test():
+            decorated = push_egress_capable(inner_gen)
+            dummy = object.__new__(object)
+            g = decorated(dummy, request={}, context=None, response_sender=sender)
+            try:
+                await g.__anext__()
+                pytest.fail(
+                    "drive_push_egress_stream yielded a value; "
+                    "responses must go through sender.send(), not via yield"
+                )
+            except StopAsyncIteration:
+                pass
+
+        run(_test())
+        assert sender.sent == chunks
+
+    def test_push_generator_yields_nothing(self):
+        """The push generator must never yield items to the Rust driver."""
+        sender = FakeSender()
+
+        async def inner_gen(self, request, context):
+            yield "response"
+
+        async def _collect():
+            decorated = push_egress_capable(inner_gen)
+            dummy = object.__new__(object)
+            g = decorated(dummy, request={}, context=None, response_sender=sender)
+            return [item async for item in g]
+
+        items = run(_collect())
+        assert items == [], f"push generator yielded {items}; must go through sender"
+
+
+# ===========================================================================
+# 3. Termination: close() / close_with_error() exactly once per request
+# ===========================================================================
+
+
+class TestTermination:
+    """close() or close_with_error() must be issued exactly once per request."""
+
+    def test_normal_completion_closes_sender_exactly_once(self):
+        sender = FakeSender()
+        run(drive_push_egress(gen("a", "b", "c"), sender))
+        assert sender.close_count == 1, (
+            f"expected 1 close(), got {sender.close_count} "
+            f"(close_with_error: {sender.error_close_count}) — check whether "
+            "something inside _terminate() raised and was swallowed by its "
+            "except guard before the close call was reached"
+        )
+        assert sender.error_close_count == 0
+
+    def test_zero_chunk_stream_closes_sender(self):
+        sender = FakeSender()
+        run(drive_push_egress(gen(), sender))
+        assert (
+            sender.close_count == 1
+        ), f"empty stream: expected 1 close, got {sender.close_count}"
+        assert sender.error_close_count == 0
+
+    def test_handler_exception_calls_close_with_error_not_close(self):
+        sender = FakeSender()
+        run(drive_push_egress(raising_gen(["a"], ValueError("boom")), sender))
+        assert (
+            sender.error_close_count == 1
+        ), f"expected 1 close_with_error(), got {sender.error_close_count}"
+        assert sender.close_count == 0
+
+    def test_error_message_contains_exception_type(self):
+        sender = FakeSender()
+        run(drive_push_egress(raising_gen([], ValueError("boom")), sender))
+        assert "ValueError" in (
+            sender.last_error or ""
+        ), f"error message missing exception type: {sender.last_error!r}"
+
+    def test_handler_exception_not_reraised(self):
+        """Exception in the handler must NOT propagate — it went to close_with_error."""
+
+        async def _test():
+            sender = FakeSender()
+            await drive_push_egress(raising_gen([], RuntimeError("oops")), sender)
+
+        run(_test())  # must not raise
+
+    def test_cancelled_error_closes_normally_and_reraises(self):
+        """CancelledError: close() called once (normal end), then re-raised."""
+        sender = FakeSender()
+        cancelled = False
+
+        async def cancel_mid_stream():
+            yield "first"
+            raise asyncio.CancelledError()
+
+        async def _test():
+            nonlocal cancelled
+            try:
+                await drive_push_egress(cancel_mid_stream(), sender)
+            except asyncio.CancelledError:
+                cancelled = True
+
+        run(_test())
+        assert cancelled, "CancelledError was not re-raised"
+        assert (
+            sender.close_count == 1
+        ), f"CancelledError path: expected 1 close(), got {sender.close_count}"
+        assert (
+            sender.error_close_count == 0
+        ), "CancelledError should call close(), not close_with_error()"
+
+    def test_keyboard_interrupt_closes_with_error_and_reraises(self):
+        """KeyboardInterrupt: close_with_error('worker interrupted'), then re-raised."""
+        sender = FakeSender()
+        raised = False
+
+        async def ki_stream():
+            yield "x"
+            raise KeyboardInterrupt()
+
+        async def _test():
+            nonlocal raised
+            try:
+                await drive_push_egress(ki_stream(), sender)
+            except KeyboardInterrupt:
+                raised = True
+
+        run(_test())
+        assert raised, "KeyboardInterrupt was not re-raised"
+        assert sender.error_close_count == 1, (
+            f"KeyboardInterrupt path: expected 1 close_with_error(), "
+            f"got {sender.error_close_count}"
+        )
+        assert "interrupted" in (
+            sender.last_error or ""
+        ), f"expected 'worker interrupted', got {sender.last_error!r}"
+        assert sender.close_count == 0
+
+    def test_at_most_one_close_total(self):
+        """_terminate is guarded by `closed`; double-close must not happen."""
+        sender = FakeSender()
+        run(drive_push_egress(gen("x"), sender))
+        assert (
+            sender.total_closes <= 1
+        ), f"stream closed {sender.total_closes} times (expected ≤1)"
+
+    def test_send_raises_mid_stream_terminates_exactly_once(self):
+        """If send() raises, the stream still terminates exactly once via close_with_error."""
+
+        class SenderFailsOnSecond(FakeSender):
+            def send(self, obj):
+                if len(self.sent) >= 1:
+                    raise RuntimeError("queue full")
+                super().send(obj)
+
+        sender = SenderFailsOnSecond()
+        run(drive_push_egress(gen("a", "b", "c"), sender))
+        assert (
+            sender.total_closes == 1
+        ), f"after send() raises: expected 1 close, got {sender.total_closes}"
+        assert sender.error_close_count == 1
+
+    def test_broken_close_does_not_propagate(self):
+        """If close() itself raises, the exception is swallowed."""
+        sender = BrokenSender()
+        run(drive_push_egress(gen("a"), sender))  # must not raise
+
+    def test_broken_close_with_error_does_not_propagate(self):
+        sender = BrokenSender()
+        run(
+            drive_push_egress(raising_gen([], ValueError("x")), sender)
+        )  # must not raise
+
+
+# ===========================================================================
+# 4. Chunks: order and completeness
+# ===========================================================================
+
+
+class TestChunkDelivery:
+    def test_chunks_sent_in_order(self):
+        chunks = [{"i": i} for i in range(5)]
+        sender = FakeSender()
+        run(drive_push_egress(gen(*chunks), sender))
+        assert sender.sent == chunks
+
+    def test_no_chunks_dropped(self):
+        chunks = list(range(100))
+        sender = FakeSender()
+        run(drive_push_egress(gen(*chunks), sender))
+        assert sender.sent == chunks
+
+    def test_chunks_before_exception_are_sent(self):
+        """Items before a handler exception should all be delivered."""
+        sender = FakeSender()
+        run(drive_push_egress(raising_gen([0, 1, 2], ValueError("mid-stream")), sender))
+        assert sender.sent == [
+            0,
+            1,
+            2,
+        ], f"expected [0, 1, 2] before the error, got {sender.sent}"
+
+
+# ===========================================================================
+# 5. Fallback path (no sender)
+# ===========================================================================
+
+
+class TestFallbackPath:
+    def test_no_sender_returns_raw_stream(self):
+        """Without a sender the handler's own async generator is returned unchanged."""
+        decorated = push_egress_capable(_gen_three_items)
+        dummy = object.__new__(object)
+
+        async def _test():
+            g = decorated(dummy, request={}, context=None)
+            assert inspect.isasyncgen(g), "fallback should return an async generator"
+            return [item async for item in g]
+
+        collected = run(_test())
+        assert collected == [1, 2, 3]
+
+    def test_no_sender_warns_exactly_once(self, caplog):
+        """Warning fires on the first call and never again."""
+        decorated = push_egress_capable(_gen_one_token)
+        dummy = object.__new__(object)
+
+        with caplog.at_level(logging.WARNING):
+            decorated(dummy, request={}, context=None)
+            decorated(dummy, request={}, context=None)
+
+        warnings = [r for r in caplog.records if "response_sender" in r.message]
+        assert (
+            len(warnings) == 1
+        ), f"expected exactly 1 warning about missing sender, got {len(warnings)}"
+
+    def test_warned_no_sender_global_is_module_mutable_state(self):
+        """_warned_no_sender is module-global mutable state.
+
+        This is a correctness risk: if tests don't reset it (or the reset
+        fixture fails), warnings bleed across tests.  The autouse fixture covers
+        this, but here we verify the guard itself works as a boolean latch.
+        """
+        assert pe._warned_no_sender is False  # fixture reset it
+        decorated = push_egress_capable(_gen_empty)
+        dummy = object.__new__(object)
+        decorated(dummy, request={}, context=None)
+        assert pe._warned_no_sender is True  # latched after first call
+        decorated(dummy, request={}, context=None)
+        assert pe._warned_no_sender is True  # stays latched
+
+
+# ===========================================================================
+# 7. The Rust path-selection predicate, pinned from Python
+# ===========================================================================
+
+
+def _accepts_response_sender(func) -> bool:
+    """Reimplementation of the Rust `handler_supports_push` predicate.
+
+    `push_egress.rs::handler_supports_push` calls
+    `context.rs::callable_accepts_kwarg`, which is exactly:
+
+        inspect.signature(callable).parameters.__contains__("response_sender")
+
+    with a `.unwrap_or(false)` around it for callables `inspect` cannot handle.
+    Mirrored here so the handler-shape matrix below can be pinned without the
+    compiled bindings.
+
+    This tests the PREDICATE, not the Rust code that calls it. It cannot catch
+    a change to handler_supports_push itself -- it catches the far likelier
+    regression, where a handler's shape starts or stops matching.
+    """
+    try:
+        return "response_sender" in inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+class TestRustPathSelection:
+    """Which handlers the Rust bridge will drive in push mode.
+
+    Both error directions are silent and severe:
+
+    * false negative -> every trtllm endpoint reverts to the pull path and the
+      change is a no-op, with no error logged anywhere;
+    * false positive -> a non-trtllm handler is driven in push mode, never
+      pushes, and its stream is only terminated by the Rust safety net.
+    """
+
+    def test_decorated_bound_method_is_selected(self):
+        class Handler:
+            @push_egress_capable
+            async def generate(self, request, context):
+                yield {"token": "a"}
+
+        assert _accepts_response_sender(Handler().generate), (
+            "the decorated handler is NOT push-capable; every trtllm endpoint "
+            "would silently fall back to the pull path"
+        )
+
+    def test_undecorated_handler_shapes_are_not_selected(self):
+        """Every other handler shape in the repo must stay on the pull path."""
+
+        async def vllm_style(self, request):
+            yield
+
+        async def context_style(self, request, context):
+            yield
+
+        async def kwargs_only(self, request, **kwargs):
+            yield
+
+        async def args_and_kwargs(*args, **kwargs):
+            yield
+
+        class CallableHandler:
+            async def __call__(self, request, **kwargs):
+                yield
+
+        for handler in (
+            vllm_style,
+            context_style,
+            kwargs_only,
+            args_and_kwargs,
+            CallableHandler(),
+            functools.partial(kwargs_only, None),
+        ):
+            name = getattr(handler, "__name__", type(handler).__name__)
+            assert not _accepts_response_sender(handler), (
+                f"{name} was classified push-capable; Rust would drive it in "
+                "push mode, where it never pushes and never terminates"
+            )
+
+    def test_var_keyword_does_not_match(self):
+        """`**kwargs` must NOT count as declaring `response_sender`.
+
+        `inspect.signature` reports a VAR_KEYWORD parameter under its own name
+        ("kwargs"), so the containment check is False. If this ever flipped,
+        every `**kwargs` handler in the repo would be driven in push mode.
+        """
+
+        async def bare_kwargs(**kwargs):
+            yield
+
+        params = inspect.signature(bare_kwargs).parameters
+        assert "kwargs" in params
+        assert "response_sender" not in params
+
+    def test_uninspectable_callable_is_not_selected(self):
+        """A callable `inspect` cannot handle must default to the pull path.
+
+        Mirrors the Rust `.unwrap_or(false)`: unknown shape means don't push.
+        """
+        assert not _accepts_response_sender(len)
+
+    def test_keeping_wrapped_link_silently_disables_push(self):
+        """Regression canary for the `del dispatch.__wrapped__` line.
+
+        If that deletion is ever removed, `inspect.signature` follows
+        `__wrapped__` back to the undecorated `generate(self, request, context)`,
+        `response_sender` disappears, and the entire push path is disabled with
+        no error anywhere. This proves the failure mode is real, so the
+        `test_no_wrapped_link` guard above is understood to be load-bearing.
+        """
+
+        def push_egress_capable_without_del(func):
+            @functools.wraps(func)
+            def dispatch(self, request, context=None, response_sender=None, **kw):
+                return func(self, request, context, **kw)
+
+            return dispatch  # __wrapped__ deliberately NOT deleted
+
+        class Handler:
+            @push_egress_capable_without_del
+            async def generate(self, request, context):
+                yield
+
+        assert not _accepts_response_sender(Handler().generate), (
+            "expected the __wrapped__ link to hide response_sender; if this "
+            "fails the canary is no longer meaningful"
+        )
+
+
+# ===========================================================================
+# 8. The decorator is actually applied to the real handlers
+# ===========================================================================
+
+
+class TestDecoratorAppliedToRealHandlers:
+    """Every LLM handler `generate` must carry @push_egress_capable.
+
+    Verified against the source with `ast` rather than by importing the
+    classes: importing them pulls in tensorrt_llm, which needs CUDA, so an
+    import-based test would silently skip everywhere except a GPU container
+    and would therefore never guard anything in normal CI.
+
+    Confirmed equivalent in the worker-egress-push container, where all four
+    real classes report
+    `params=['self', 'request', 'context', 'response_sender', 'kwargs']`.
+
+    Dropping the decorator from a handler is invisible at runtime: that
+    endpoint just reverts to the pull path, with no error and no failure.
+    """
+
+    HANDLERS = {
+        "handlers.py": ["EncodeHandler", "PrefillHandler", "DecodeHandler"],
+        "aggregated_handler.py": ["AggregatedHandler"],
+    }
+
+    @staticmethod
+    def _generate_decorators(path, class_name):
+        import ast
+
+        tree = ast.parse(pathlib.Path(path).read_text())
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                for item in node.body:
+                    if (
+                        isinstance(item, (ast.AsyncFunctionDef, ast.FunctionDef))
+                        and item.name == "generate"
+                    ):
+                        return [
+                            d.id if isinstance(d, ast.Name) else ast.dump(d)
+                            for d in item.decorator_list
+                        ]
+                raise AssertionError(f"{class_name} has no generate method")
+        raise AssertionError(f"{class_name} not found in {path}")
+
+    @pytest.mark.parametrize(
+        "module,class_name",
+        [(m, c) for m, cs in HANDLERS.items() for c in cs],
+    )
+    def test_generate_is_push_egress_capable(self, module, class_name):
+        path = _COMPONENTS_SRC / "dynamo" / "trtllm" / "request_handlers" / module
+        decorators = self._generate_decorators(path, class_name)
+        assert "push_egress_capable" in decorators, (
+            f"{class_name}.generate is missing @push_egress_capable "
+            f"(decorators: {decorators}). That endpoint silently reverts to "
+            "the pull path with no error anywhere."
+        )
+
+    @pytest.mark.parametrize(
+        "module,class_name",
+        [(m, c) for m, cs in HANDLERS.items() for c in cs],
+    )
+    def test_push_egress_capable_is_outermost(self, module, class_name):
+        """It must be first in the list: `inspect.signature` sees the outermost
+        wrapper, and range_decorator must wrap a real async-gen function."""
+        path = _COMPONENTS_SRC / "dynamo" / "trtllm" / "request_handlers" / module
+        decorators = self._generate_decorators(path, class_name)
+        assert decorators[0] == "push_egress_capable", (
+            f"{class_name}.generate: @push_egress_capable must be OUTERMOST, "
+            f"got {decorators}"
+        )
+
+
+# ===========================================================================
+# 9. Push egress must not bleed into the other engines
+# ===========================================================================
+
+
+class TestNoBleedIntoOtherEngines:
+    """Only TRT-LLM handlers may be push-capable.
+
+    `Endpoint.serve_endpoint` is shared by every Python worker -- vLLM, SGLang,
+    frontend, planner, router, mocker, and more -- and the ONLY thing keeping
+    them on the pull path is that `handler_supports_push` finds no
+    `response_sender` parameter on their handlers.
+
+    So the moment any other engine's handler declares a parameter with that
+    name, for any unrelated reason, Rust drives it with the push engine. It
+    never calls `sender.send`, and the driver task fails any request whose
+    handler yields instead of pushing -- so that handler's every request dies
+    at the first response. This test makes the collision loud at the source.
+    """
+
+    @staticmethod
+    def _declares_response_sender(path):
+        import ast
+
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:
+            return []  # not importable Python on this interpreter; skip
+        hits = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            a = node.args
+            names = [arg.arg for arg in (*a.posonlyargs, *a.args, *a.kwonlyargs) if arg]
+            if "response_sender" in names:
+                hits.append(node.name)
+        return hits
+
+    def test_only_trtllm_handlers_declare_response_sender(self):
+        offenders = {}
+        for path in (_COMPONENTS_SRC / "dynamo").rglob("*.py"):
+            if "/trtllm/" in path.as_posix():
+                continue  # the one engine that is supposed to have it
+            hits = self._declares_response_sender(path)
+            if hits:
+                offenders[path.relative_to(_COMPONENTS_SRC).as_posix()] = hits
+
+        assert not offenders, (
+            "non-TRT-LLM code declares a `response_sender` parameter: "
+            f"{offenders}. Endpoint.serve_endpoint selects the push egress "
+            "engine purely on that parameter name, so these handlers would be "
+            "driven in push mode without ever pushing -- silently degrading "
+            "to the forward-yield path. Rename the parameter."
+        )
+
+    def test_trtllm_side_is_where_it_lives(self):
+        """Sanity check on the scan: it must actually find the trtllm ones.
+
+        Guards against the walk silently matching nothing (wrong root, changed
+        layout), which would make the test above vacuously green forever.
+        """
+        found = {}
+        for path in (_COMPONENTS_SRC / "dynamo" / "trtllm").rglob("*.py"):
+            hits = self._declares_response_sender(path)
+            if hits:
+                found[path.name] = hits
+
+        assert "push_egress.py" in found, (
+            f"scan found no response_sender parameter in trtllm/push_egress.py "
+            f"(found: {found}); the AST walk is probably broken, which would "
+            "make the no-bleed assertion vacuous"
+        )

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -69,6 +69,14 @@ pub struct Context {
     /// contexts (where no parent span was plumbed in) — `current_span` /
     /// `start_span` return a no-op `SpanProxy` in that case.
     span: Option<tracing::Span>,
+    /// Rust response sink for the flag-gated push egress path
+    /// (`DYN_TRTLLM_PUSH_EGRESS`, see `push_egress.rs`). The `Context` is the
+    /// delivery vehicle because it is the one per-request object every handler
+    /// already receives — passing the sender as an extra parameter would
+    /// require the bridge to introspect the handler's signature, which
+    /// `functools.wraps` on the Python side makes unreliable.
+    /// `None` on the default pull path.
+    response_sender: Option<Py<crate::push_egress::ResponseSender>>,
 }
 
 #[derive(Clone)]
@@ -185,7 +193,15 @@ impl Context {
             first_token,
             metadata: Arc::new(Mutex::new(metadata)),
             span: None,
+            response_sender: None,
         }
+    }
+
+    /// Attach this request's push-egress response sink. Only the push path
+    /// (`push_egress.rs`) calls this; the pull path leaves it `None`.
+    pub fn with_response_sender(mut self, sender: Py<crate::push_egress::ResponseSender>) -> Self {
+        self.response_sender = Some(sender);
+        self
     }
 
     /// Attach the `engine.generate` span. Called by `PyLLMEngine::generate`
@@ -259,7 +275,18 @@ impl Context {
             first_token: None,
             metadata: Arc::new(Mutex::new(metadata.unwrap_or_default())),
             span: None,
+            response_sender: None,
         }
+    }
+
+    /// This request's push-egress response sink, or `None` on the default pull
+    /// path. Python handlers use its presence to decide whether to push
+    /// responses or yield them.
+    #[getter]
+    fn response_sender(&self, py: Python<'_>) -> Option<Py<crate::push_egress::ResponseSender>> {
+        self.response_sender
+            .as_ref()
+            .map(|sender| sender.clone_ref(py))
     }
 
     /// Create a context with a fresh cancellation controller and request id.
@@ -276,6 +303,9 @@ impl Context {
             first_token: None,
             metadata: Arc::new(Mutex::new(self.metadata_snapshot())),
             span: self.span.clone(),
+            // A detached context owns a fresh request: it must not be able to
+            // push into the originating request's response stream.
+            response_sender: None,
         }
     }
 

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -69,14 +69,6 @@ pub struct Context {
     /// contexts (where no parent span was plumbed in) — `current_span` /
     /// `start_span` return a no-op `SpanProxy` in that case.
     span: Option<tracing::Span>,
-    /// Rust response sink for the flag-gated push egress path
-    /// (`DYN_TRTLLM_PUSH_EGRESS`, see `push_egress.rs`). The `Context` is the
-    /// delivery vehicle because it is the one per-request object every handler
-    /// already receives — passing the sender as an extra parameter would
-    /// require the bridge to introspect the handler's signature, which
-    /// `functools.wraps` on the Python side makes unreliable.
-    /// `None` on the default pull path.
-    response_sender: Option<Py<crate::push_egress::ResponseSender>>,
 }
 
 #[derive(Clone)]
@@ -193,15 +185,7 @@ impl Context {
             first_token,
             metadata: Arc::new(Mutex::new(metadata)),
             span: None,
-            response_sender: None,
         }
-    }
-
-    /// Attach this request's push-egress response sink. Only the push path
-    /// (`push_egress.rs`) calls this; the pull path leaves it `None`.
-    pub fn with_response_sender(mut self, sender: Py<crate::push_egress::ResponseSender>) -> Self {
-        self.response_sender = Some(sender);
-        self
     }
 
     /// Attach the `engine.generate` span. Called by `PyLLMEngine::generate`
@@ -275,18 +259,7 @@ impl Context {
             first_token: None,
             metadata: Arc::new(Mutex::new(metadata.unwrap_or_default())),
             span: None,
-            response_sender: None,
         }
-    }
-
-    /// This request's push-egress response sink, or `None` on the default pull
-    /// path. Python handlers use its presence to decide whether to push
-    /// responses or yield them.
-    #[getter]
-    fn response_sender(&self, py: Python<'_>) -> Option<Py<crate::push_egress::ResponseSender>> {
-        self.response_sender
-            .as_ref()
-            .map(|sender| sender.clone_ref(py))
     }
 
     /// Create a context with a fresh cancellation controller and request id.
@@ -303,9 +276,6 @@ impl Context {
             first_token: None,
             metadata: Arc::new(Mutex::new(self.metadata_snapshot())),
             span: self.span.clone(),
-            // A detached context owns a fresh request: it must not be able to
-            // push into the originating request's response stream.
-            response_sender: None,
         }
     }
 

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -331,11 +331,13 @@ where
 /// Yields tagged with `_dynamo_annotated: True` are wire `Annotated<R>`
 /// envelopes; everything else is plain data.
 ///
-/// Shared by both egress paths — the pull path via [`process_item`] and the
-/// push path via `push_egress::decode_response` — so the two cannot drift and
-/// start disagreeing about what a given Python object means on the wire. The
-/// caller owns the error mapping; the GIL is already held either way.
-pub(crate) fn depythonize_annotated<Resp>(
+/// Used by the typed pull path via [`process_item`]. The direct request-plane
+/// paths — pull and push alike — instead go through
+/// `python_payload::parse_python_response`, which keeps the payload a
+/// `PythonPayload` so it transcodes straight into the wire codec.
+///
+/// The caller owns the error mapping; the GIL is already held.
+fn depythonize_annotated<Resp>(
     bound: &Bound<'_, PyAny>,
 ) -> Result<Annotated<Resp>, pythonize::PythonizeError>
 where
@@ -439,7 +441,7 @@ pub(crate) fn map_python_exception(error: PyErr) -> DynamoError {
 
 /// Channel depth between the response-forwarding task and the consumer of
 /// the engine's output stream.
-const RESPONSE_CHANNEL_DEPTH: usize = 128;
+pub(crate) const RESPONSE_CHANNEL_DEPTH: usize = 128;
 
 /// Drain the Python response stream on a spawned task, deserialize each item
 /// into `Resp` via [`process_item`], and forward it as an [`Annotated`] frame

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -55,7 +55,7 @@ fn detect_has_context(generator: &PyObject) -> bool {
 
 /// Boxed Rust stream of items yielded by a Python async generator. Each
 /// item is either a `PyObject` frame or the `PyErr` the generator raised.
-type PyItemStream = Pin<Box<dyn Stream<Item = PyResult<Py<PyAny>>> + Send>>;
+pub(crate) type PyItemStream = Pin<Box<dyn Stream<Item = PyResult<Py<PyAny>>> + Send>>;
 
 /// Invoke the Python `generate` callable and convert the async generator it
 /// returns into a Rust [`Stream`] of `PyObject` items.
@@ -71,28 +71,36 @@ type PyItemStream = Pin<Box<dyn Stream<Item = PyResult<Py<PyAny>>> + Send>>;
 /// it can block for an unbounded time, which would park the tokio reactor.
 /// The returned stream polls `__anext__` only when its consumer requests an
 /// item, preventing Python from mutating a reused object before it is consumed.
-async fn invoke_generator<F, G>(
+pub(crate) async fn invoke_generator<F, G>(
     generator: Arc<PyObject>,
     event_loop: Arc<PyObject>,
     to_python_input: F,
-    to_python_context: Option<G>,
+    to_python_kwargs: Option<G>,
 ) -> Result<PyItemStream>
 where
     F: FnOnce(Python) -> PyResult<Py<PyAny>> + Send + 'static,
-    G: FnOnce(Python) -> PyResult<Py<PyAny>> + Send + 'static,
+    G: FnOnce(Python) -> PyResult<Vec<(&'static str, Py<PyAny>)>> + Send + 'static,
 {
     let stream = tokio::task::spawn_blocking(move || {
         Python::with_gil(|py| {
             let python_input = to_python_input(py)?;
 
-            let gen_result = match to_python_context {
-                Some(to_python_context) => {
-                    let py_ctx = to_python_context(py)?;
+            // The closure returns the FULL kwarg list rather than just the
+            // context, so a caller that needs several keyword arguments can
+            // build them under one GIL acquisition and share objects between
+            // them. The push-egress path relies on this: it hands the same
+            // `ResponseSender` to the handler both as `response_sender=` and on
+            // `context.response_sender`, and the two must be the same object.
+            let gen_result = match to_python_kwargs {
+                Some(to_python_kwargs) => {
+                    let kwargs = to_python_kwargs(py)?;
                     let kwarg = PyDict::new(py);
-                    kwarg.set_item("context", py_ctx)?;
+                    for (name, value) in kwargs {
+                        kwarg.set_item(name, value)?;
+                    }
                     generator.call(py, (python_input,), Some(&kwarg))
                 }
-                // Legacy: no `context` arg.
+                // Legacy: no keyword arguments at all.
                 None => generator.call1(py, (python_input,)),
             }?;
 
@@ -310,7 +318,7 @@ where
             let ctx = ctx.clone();
             move |py: Python<'_>| {
                 Py::new(py, Context::new(ctx, current_trace_context, None, metadata))
-                    .map(|context| context.into_any())
+                    .map(|context| vec![("context", context.into_any())])
             }
         }),
     )
@@ -708,7 +716,7 @@ impl AsyncEngine<ManyIn<PythonPayload>, ManyOut<PythonResponseItem>, Error>
                 let ctx = ctx.clone();
                 move |py: Python<'_>| {
                     Py::new(py, Context::new(ctx, current_trace_context, None, metadata))
-                        .map(|c| c.into_any())
+                        .map(|c| vec![("context", c.into_any())])
                 }
             }),
         )

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -86,11 +86,9 @@ where
             let python_input = to_python_input(py)?;
 
             // The closure returns the FULL kwarg list rather than just the
-            // context, so a caller that needs several keyword arguments can
-            // build them under one GIL acquisition and share objects between
-            // them. The push-egress path relies on this: it hands the same
-            // `ResponseSender` to the handler both as `response_sender=` and on
-            // `context.response_sender`, and the two must be the same object.
+            // context, so a caller needing several keyword arguments builds
+            // them all under one GIL acquisition. The push-egress path relies
+            // on this to pass `context` and `response_sender` together.
             let gen_result = match to_python_kwargs {
                 Some(to_python_kwargs) => {
                     let kwargs = to_python_kwargs(py)?;
@@ -328,6 +326,39 @@ where
     Ok(ResponseStream::new(response_stream, context.context()))
 }
 
+/// Convert one Python response object into the wire value.
+///
+/// Yields tagged with `_dynamo_annotated: True` are wire `Annotated<R>`
+/// envelopes; everything else is plain data.
+///
+/// Shared by both egress paths — the pull path via [`process_item`] and the
+/// push path via `push_egress::decode_response` — so the two cannot drift and
+/// start disagreeing about what a given Python object means on the wire. The
+/// caller owns the error mapping; the GIL is already held either way.
+pub(crate) fn depythonize_annotated<Resp>(
+    bound: &Bound<'_, PyAny>,
+) -> Result<Annotated<Resp>, pythonize::PythonizeError>
+where
+    Resp: for<'de> Deserialize<'de>,
+{
+    let is_envelope = bound
+        .downcast::<PyDict>()
+        .ok()
+        .and_then(|d| {
+            d.get_item(pyo3::intern!(bound.py(), "_dynamo_annotated"))
+                .ok()
+                .flatten()
+        })
+        .and_then(|v| v.is_truthy().ok())
+        .unwrap_or(false);
+
+    if is_envelope {
+        depythonize::<Annotated<Resp>>(bound)
+    } else {
+        depythonize::<Resp>(bound).map(Annotated::from_data)
+    }
+}
+
 async fn process_item<Resp>(
     item: Result<Py<PyAny>, PyErr>,
 ) -> Result<Annotated<Resp>, ResponseProcessingError>
@@ -336,22 +367,7 @@ where
 {
     let item = item.map_err(|e| ResponseProcessingError::Dynamo(map_python_exception(e)))?;
     let response = tokio::task::spawn_blocking(move || {
-        Python::with_gil(|py| {
-            let bound = item.into_bound(py);
-            // Yields tagged with `_dynamo_annotated: True` are wire
-            // Annotated<R> envelopes; everything else is plain data.
-            let is_envelope = bound
-                .downcast::<PyDict>()
-                .ok()
-                .and_then(|d| d.get_item("_dynamo_annotated").ok().flatten())
-                .and_then(|v| v.is_truthy().ok())
-                .unwrap_or(false);
-            if is_envelope {
-                depythonize::<Annotated<Resp>>(&bound)
-            } else {
-                depythonize::<Resp>(&bound).map(Annotated::from_data)
-            }
-        })
+        Python::with_gil(|py| depythonize_annotated::<Resp>(&item.into_bound(py)))
     })
     .await
     .map_err(|e| ResponseProcessingError::Offload(e.to_string()))?

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -1288,11 +1288,21 @@ impl Endpoint {
         // rendering the pull path unreachable. Anything else stays on pull.
         let use_push_egress = push_egress::handler_supports_push(&generator);
 
-        // Both outcomes of the branch come out together: the ingress, and the
-        // engine to register in the local (in-process) registry. Only the pull
-        // path has one — the push engine hands responses to a per-request
-        // sender rather than returning them from the generator, which the
-        // in-process `SingleIn`/`ManyOut` registry does not model.
+        // Both outcomes of the branch come out together: the ingress that
+        // serves network requests, and the engine registered in the local
+        // (in-process) registry.
+        //
+        // Push endpoints get BOTH. The push engine serves the network, but the
+        // local registry — used by in-process callers and, critically, by the
+        // canary health check (`lib/runtime/src/health_check.rs`) — needs a
+        // `SingleIn`/`ManyOut` engine, which the per-request sender does not
+        // model. A pull engine over the SAME handler supplies one: called
+        // without a `response_sender`, `@push_egress_capable` returns the
+        // handler's own async generator untouched, so the local path is
+        // ordinary pull egress. Registering it is what keeps the endpoint in
+        // `SystemHealth::health_check_targets`; drop it and health status falls
+        // through to the process-wide `system_health`, which the TRT-LLM worker
+        // never sets Ready — a permanent 503 on default settings.
         //
         // Both outcomes are logged. Push mode is chosen by signature
         // inspection, which can silently answer "no"; without the pull line the
@@ -1304,6 +1314,11 @@ impl Endpoint {
             Option<Arc<engine::PythonAsyncEngine>>,
         ) = if use_push_egress {
             tracing::info!(endpoint = %endpoint_name, "serving endpoint with push egress");
+            // Same handler object, two engines: a refcount bump, not a copy.
+            let local = Arc::new(engine::PythonAsyncEngine::new(
+                generator.clone_ref(py),
+                self.event_loop.clone(),
+            )?);
             let ingress = PythonPushEgressIngress::for_engine_with_adapter(
                 Arc::new(push_egress::PythonPushEngine::new(
                     generator,
@@ -1312,7 +1327,7 @@ impl Endpoint {
                 python_payload::PythonIngressPayloadAdapter,
             )
             .map_err(to_pyerr)?;
-            (ingress, None)
+            (ingress, Some(local))
         } else {
             tracing::debug!(endpoint = %endpoint_name, "serving endpoint with pull egress");
             let engine = Arc::new(engine::PythonAsyncEngine::new(
@@ -1354,19 +1369,10 @@ impl Endpoint {
             .metrics_labels(metrics_labels)
             .handler(ingress);
 
-        // Canary health checks require a local engine registered in the DRT
-        // endpoint registry, which only the pull path creates. Skip the payload
-        // on push endpoints; warn once so the gap is visible rather than silent.
-        if use_push_egress {
-            if health_payload_json.is_some() {
-                tracing::warn!(
-                    endpoint = %endpoint_name,
-                    "health_check_payload ignored for push-egress endpoint: \
-                     canary health checks require a local engine and are not \
-                     supported on the push path"
-                );
-            }
-        } else if let Some(payload) = health_payload_json {
+        // Applies to both paths. `start_with_registration` bails if a payload is
+        // set while canary is enabled and no local engine is registered; the
+        // push branch above registers one precisely so this stays valid.
+        if let Some(payload) = health_payload_json {
             builder = builder.health_check_payload(payload);
         }
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -96,7 +96,7 @@ type PythonServerStreamingIngress = Ingress<
 /// response encoder never needs the GIL. See `push_egress.rs`.
 type PythonPushEgressIngress = Ingress<
     SingleIn<python_payload::PythonPayload>,
-    ManyOut<push_egress::PushResponse>,
+    ManyOut<push_egress::PushFrame>,
     python_payload::PythonIngressPayloadAdapter,
 >;
 
@@ -1288,33 +1288,44 @@ impl Endpoint {
         // rendering the pull path unreachable. Anything else stays on pull.
         let use_push_egress = push_egress::handler_supports_push(&generator);
 
-        // `register_local_engine` only applies to the pull path: the push
-        // engine hands responses to a per-request sender rather than returning
-        // them from the generator, which the in-process `SingleIn`/`ManyOut`
-        // local registry does not model.
-        let mut local_engine: Option<Arc<engine::PythonAsyncEngine>> = None;
-        let ingress: Arc<dyn rs::pipeline::network::PushWorkHandler> = if use_push_egress {
-            tracing::info!("serving endpoint with push egress");
-            PythonPushEgressIngress::for_engine_with_adapter(
+        // Both outcomes of the branch come out together: the ingress, and the
+        // engine to register in the local (in-process) registry. Only the pull
+        // path has one — the push engine hands responses to a per-request
+        // sender rather than returning them from the generator, which the
+        // in-process `SingleIn`/`ManyOut` registry does not model.
+        //
+        // Both outcomes are logged. Push mode is chosen by signature
+        // inspection, which can silently answer "no"; without the pull line the
+        // only symptom would be the absence of the push line, indistinguishable
+        // from a wrong log level.
+        let endpoint_name = self.inner.name().to_string();
+        let (ingress, local_engine): (
+            Arc<dyn rs::pipeline::network::PushWorkHandler>,
+            Option<Arc<engine::PythonAsyncEngine>>,
+        ) = if use_push_egress {
+            tracing::info!(endpoint = %endpoint_name, "serving endpoint with push egress");
+            let ingress = PythonPushEgressIngress::for_engine_with_adapter(
                 Arc::new(push_egress::PythonPushEngine::new(
                     generator,
                     self.event_loop.clone(),
                 )),
                 python_payload::PythonIngressPayloadAdapter,
             )
-            .map_err(to_pyerr)?
+            .map_err(to_pyerr)?;
+            (ingress, None)
         } else {
+            tracing::debug!(endpoint = %endpoint_name, "serving endpoint with pull egress");
             let engine = Arc::new(engine::PythonAsyncEngine::new(
                 generator,
                 self.event_loop.clone(),
             )?);
             let network_engine = Arc::new(engine.network_engine());
-            local_engine = Some(engine);
-            PythonServerStreamingIngress::for_engine_with_adapter(
+            let ingress = PythonServerStreamingIngress::for_engine_with_adapter(
                 network_engine,
                 python_payload::PythonIngressPayloadAdapter,
             )
-            .map_err(to_pyerr)?
+            .map_err(to_pyerr)?;
+            (ingress, Some(engine))
         };
 
         // Convert Python dict to serde_json::Value if provided and validate it's an object
@@ -1349,6 +1360,7 @@ impl Endpoint {
         if use_push_egress {
             if health_payload_json.is_some() {
                 tracing::warn!(
+                    endpoint = %endpoint_name,
                     "health_check_payload ignored for push-egress endpoint: \
                      canary health checks require a local engine and are not \
                      supported on the push path"

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -1288,26 +1288,26 @@ impl Endpoint {
         // rendering the pull path unreachable. Anything else stays on pull.
         let use_push_egress = push_egress::handler_supports_push(&generator);
 
-        // Both outcomes of the branch come out together: the ingress that
-        // serves network requests, and the engine registered in the local
-        // (in-process) registry.
+        // An endpoint has two doors, and this branch answers for both: the
+        // ingress that serves network requests, and the engine registered in
+        // the local (in-process) registry.
         //
-        // Push endpoints get BOTH. The push engine serves the network, but the
-        // local registry — used by in-process callers and, critically, by the
-        // canary health check (`lib/runtime/src/health_check.rs`) — needs a
-        // `SingleIn`/`ManyOut` engine, which the per-request sender does not
-        // model. A pull engine over the SAME handler supplies one: called
-        // without a `response_sender`, `@push_egress_capable` returns the
-        // handler's own async generator untouched, so the local path is
-        // ordinary pull egress. Registering it is what keeps the endpoint in
-        // `SystemHealth::health_check_targets`; drop it and health status falls
-        // through to the process-wide `system_health`, which the TRT-LLM worker
-        // never sets Ready — a permanent 503 on default settings.
+        // Push endpoints need BOTH. The local registry — used by in-process
+        // callers and by the canary health check
+        // (`lib/runtime/src/health_check.rs`) — takes a `SingleIn`/`ManyOut`
+        // engine, which has nowhere to put a per-request sender. A pull engine
+        // over the SAME handler supplies one: called without a
+        // `response_sender`, `@push_egress_capable` hands back the handler's
+        // own async generator, so that door is ordinary pull egress.
+        // Registering it also keeps the endpoint in
+        // `SystemHealth::health_check_targets` — without which health status
+        // ignores endpoint readiness entirely and falls through to the
+        // process-wide `system_health`, a permanent 503 for a worker that never
+        // sets it (see `system_health.rs` tests).
         //
-        // Both outcomes are logged. Push mode is chosen by signature
-        // inspection, which can silently answer "no"; without the pull line the
-        // only symptom would be the absence of the push line, indistinguishable
-        // from a wrong log level.
+        // Both outcomes are logged: push mode is chosen by signature
+        // inspection, which can silently answer "no", and without the pull line
+        // the only symptom would be the absence of the push line.
         let endpoint_name = self.inner.name().to_string();
         let (ingress, local_engine): (
             Arc<dyn rs::pipeline::network::PushWorkHandler>,

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -1279,18 +1279,19 @@ impl Endpoint {
         health_check_payload: Option<&Bound<'p, PyDict>>,
     ) -> PyResult<Bound<'p, PyAny>> {
         // Flag-gated push egress (`DYN_TRTLLM_PUSH_EGRESS=1`): the handler
-        // pushes each response into a Rust channel via
-        // `context.response_sender`, instead of Rust pulling `__anext__` off
-        // its generator on a tokio thread once per response. Requires the
-        // handler to accept a `context` argument, which is how the sender is
-        // delivered; anything else stays on the pull path.
+        // pushes each response into a Rust channel via its `response_sender`
+        // argument, instead of Rust pulling `__anext__` off its generator on a
+        // tokio thread once per response. Requires the handler to declare a
+        // `response_sender` parameter -- NOT `context`, which every handler
+        // accepts and would therefore make this check always true, rendering
+        // the pull-path fallback unreachable. Anything else stays on pull.
         let use_push_egress = push_egress::push_egress_enabled()
             && if push_egress::handler_supports_push(&generator) {
                 true
             } else {
                 tracing::warn!(
-                    "{} is set but this handler does not accept a `context` argument, \
-                     which is how the response sender is delivered; \
+                    "{} is set but this handler does not declare a `response_sender` \
+                     parameter (is it missing @push_egress_capable?); \
                      falling back to the pull egress path",
                     push_egress::PUSH_EGRESS_ENV,
                 );

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -1343,7 +1343,18 @@ impl Endpoint {
             .metrics_labels(metrics_labels)
             .handler(ingress);
 
-        if let Some(payload) = health_payload_json {
+        // Canary health checks require a local engine registered in the DRT
+        // endpoint registry, which only the pull path creates. Skip the payload
+        // on push endpoints; warn once so the gap is visible rather than silent.
+        if use_push_egress {
+            if health_payload_json.is_some() {
+                tracing::warn!(
+                    "health_check_payload ignored for push-egress endpoint: \
+                     canary health checks require a local engine and are not \
+                     supported on the push path"
+                );
+            }
+        } else if let Some(payload) = health_payload_json {
             builder = builder.health_check_payload(payload);
         }
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -89,7 +89,7 @@ type PythonServerStreamingIngress = Ingress<
     python_payload::PythonIngressPayloadAdapter,
 >;
 
-/// Ingress for the flag-gated push egress path (`DYN_TRTLLM_PUSH_EGRESS=1`).
+/// Ingress for the push egress path (handlers that declare `response_sender`).
 ///
 /// Requests still decode into a Python object (the handler wants one), but
 /// responses are owned Rust values by the time they reach the channel, so the
@@ -1278,25 +1278,15 @@ impl Endpoint {
         metrics_labels: Option<Vec<(String, String)>>,
         health_check_payload: Option<&Bound<'p, PyDict>>,
     ) -> PyResult<Bound<'p, PyAny>> {
-        // Flag-gated push egress (`DYN_TRTLLM_PUSH_EGRESS=1`): the handler
-        // pushes each response into a Rust channel via its `response_sender`
-        // argument, instead of Rust pulling `__anext__` off its generator on a
-        // tokio thread once per response. Requires the handler to declare a
-        // `response_sender` parameter -- NOT `context`, which every handler
-        // accepts and would therefore make this check always true, rendering
-        // the pull-path fallback unreachable. Anything else stays on pull.
-        let use_push_egress = push_egress::push_egress_enabled()
-            && if push_egress::handler_supports_push(&generator) {
-                true
-            } else {
-                tracing::warn!(
-                    "{} is set but this handler does not declare a `response_sender` \
-                     parameter (is it missing @push_egress_capable?); \
-                     falling back to the pull egress path",
-                    push_egress::PUSH_EGRESS_ENV,
-                );
-                false
-            };
+        // Push egress: the handler pushes each response into a Rust channel via
+        // its `response_sender` argument, instead of Rust pulling `__anext__`
+        // off its generator on a tokio thread once per response. Selected per
+        // handler, purely by signature -- a handler must declare a
+        // `response_sender` parameter, which in practice means the TRT-LLM
+        // workers' `@push_egress_capable` decorator. NOT `context`, which every
+        // handler accepts and would therefore make this check always true,
+        // rendering the pull path unreachable. Anything else stays on pull.
+        let use_push_egress = push_egress::handler_supports_push(&generator);
 
         // `register_local_engine` only applies to the pull path: the push
         // engine hands responses to a per-request sender rather than returning
@@ -1304,10 +1294,7 @@ impl Endpoint {
         // local registry does not model.
         let mut local_engine: Option<Arc<engine::PythonAsyncEngine>> = None;
         let ingress: Arc<dyn rs::pipeline::network::PushWorkHandler> = if use_push_egress {
-            tracing::info!(
-                "{}=1: serving endpoint with push egress",
-                push_egress::PUSH_EGRESS_ENV
-            );
+            tracing::info!("serving endpoint with push egress");
             PythonPushEgressIngress::for_engine_with_adapter(
                 Arc::new(push_egress::PythonPushEngine::new(
                     generator,

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -80,11 +80,23 @@ mod llm;
 mod parsers;
 mod planner;
 mod prometheus_metrics;
+mod push_egress;
 mod python_payload;
 
 type PythonServerStreamingIngress = Ingress<
     SingleIn<python_payload::PythonPayload>,
     ManyOut<python_payload::PythonResponseItem>,
+    python_payload::PythonIngressPayloadAdapter,
+>;
+
+/// Ingress for the flag-gated push egress path (`DYN_TRTLLM_PUSH_EGRESS=1`).
+///
+/// Requests still decode into a Python object (the handler wants one), but
+/// responses are owned Rust values by the time they reach the channel, so the
+/// response encoder never needs the GIL. See `push_egress.rs`.
+type PythonPushEgressIngress = Ingress<
+    SingleIn<python_payload::PythonPayload>,
+    ManyOut<push_egress::PushResponse>,
     python_payload::PythonIngressPayloadAdapter,
 >;
 
@@ -243,6 +255,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<planner::PlannerDecision>()?;
 
     engine::add_to_module(m)?;
+    push_egress::add_to_module(m)?;
     errors::register_exceptions(m)?;
     parsers::add_to_module(m)?;
     backend::add_to_module(m)?;
@@ -1265,16 +1278,56 @@ impl Endpoint {
         metrics_labels: Option<Vec<(String, String)>>,
         health_check_payload: Option<&Bound<'p, PyDict>>,
     ) -> PyResult<Bound<'p, PyAny>> {
-        let engine = Arc::new(engine::PythonAsyncEngine::new(
-            generator,
-            self.event_loop.clone(),
-        )?);
-        let network_engine = Arc::new(engine.network_engine());
-        let ingress = PythonServerStreamingIngress::for_engine_with_adapter(
-            network_engine,
-            python_payload::PythonIngressPayloadAdapter,
-        )
-        .map_err(to_pyerr)?;
+        // Flag-gated push egress (`DYN_TRTLLM_PUSH_EGRESS=1`): the handler
+        // pushes each response into a Rust channel via
+        // `context.response_sender`, instead of Rust pulling `__anext__` off
+        // its generator on a tokio thread once per response. Requires the
+        // handler to accept a `context` argument, which is how the sender is
+        // delivered; anything else stays on the pull path.
+        let use_push_egress = push_egress::push_egress_enabled()
+            && if push_egress::handler_supports_push(&generator) {
+                true
+            } else {
+                tracing::warn!(
+                    "{} is set but this handler does not accept a `context` argument, \
+                     which is how the response sender is delivered; \
+                     falling back to the pull egress path",
+                    push_egress::PUSH_EGRESS_ENV,
+                );
+                false
+            };
+
+        // `register_local_engine` only applies to the pull path: the push
+        // engine hands responses to a per-request sender rather than returning
+        // them from the generator, which the in-process `SingleIn`/`ManyOut`
+        // local registry does not model.
+        let mut local_engine: Option<Arc<engine::PythonAsyncEngine>> = None;
+        let ingress: Arc<dyn rs::pipeline::network::PushWorkHandler> = if use_push_egress {
+            tracing::info!(
+                "{}=1: serving endpoint with push egress",
+                push_egress::PUSH_EGRESS_ENV
+            );
+            PythonPushEgressIngress::for_engine_with_adapter(
+                Arc::new(push_egress::PythonPushEngine::new(
+                    generator,
+                    self.event_loop.clone(),
+                )),
+                python_payload::PythonIngressPayloadAdapter,
+            )
+            .map_err(to_pyerr)?
+        } else {
+            let engine = Arc::new(engine::PythonAsyncEngine::new(
+                generator,
+                self.event_loop.clone(),
+            )?);
+            let network_engine = Arc::new(engine.network_engine());
+            local_engine = Some(engine);
+            PythonServerStreamingIngress::for_engine_with_adapter(
+                network_engine,
+                python_payload::PythonIngressPayloadAdapter,
+            )
+            .map_err(to_pyerr)?
+        };
 
         // Convert Python dict to serde_json::Value if provided and validate it's an object
         let health_payload_json = health_check_payload
@@ -1307,7 +1360,9 @@ impl Endpoint {
         }
 
         // Register the engine in the local endpoint registry for in-process calls
-        builder = builder.register_local_engine(engine).map_err(to_pyerr)?;
+        if let Some(engine) = local_engine {
+            builder = builder.register_local_engine(engine).map_err(to_pyerr)?;
+        }
 
         let graceful_shutdown = graceful_shutdown.unwrap_or(true);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {

--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -118,7 +118,10 @@ impl std::fmt::Debug for PushFrame {
 impl PushFrame {
     /// Encode one Python response object. Called with the GIL held by the
     /// Python caller; [`python_payload::parse_python_response`] is the same
-    /// interpretation of the object the pull path uses.
+    /// interpretation of the object the pull path uses, and
+    /// [`python_payload::encode_annotated_response`] is the same wrapper
+    /// construction and codec invocation, so the bytes are structurally
+    /// identical to what the pull path would produce for the same object.
     fn encode(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         let annotated =
             python_payload::parse_python_response(obj.clone().unbind(), py).map_err(|error| {
@@ -127,18 +130,14 @@ impl PushFrame {
                      application-logic-mismatch: {error}"
                 ))
             })?;
-        let is_error = annotated.is_error();
         let codec = RequestPlanePayloadCodec::configured();
-        let wrapper = NetworkStreamWrapper {
-            data: Some(annotated),
-            complete_final: false,
-        };
-        let bytes = codec.encode(&wrapper).map_err(|error| {
-            PyValueError::new_err(format!(
-                "critical error: failed serializing python response as {}: {error}",
-                codec.name()
-            ))
-        })?;
+        let (bytes, is_error) = python_payload::encode_annotated_response(codec, annotated)
+            .map_err(|error| {
+                PyValueError::new_err(format!(
+                    "critical error: failed serializing python response as {}: {error}",
+                    codec.name()
+                ))
+            })?;
         Ok(Self {
             bytes: bytes.into(),
             is_error,
@@ -738,6 +737,65 @@ mod tests {
         assert!(
             rx.recv().await.is_none(),
             "stream must end immediately when sender is dropped with no data"
+        );
+    }
+
+    // ── stop_stream divergence ────────────────────────────────────────────
+    //
+    // INTENTIONAL BEHAVIORAL DIFFERENCE from the pull path:
+    //
+    // Pull path (encode_python_response): parse errors and Python exceptions
+    // produce `stop_stream: true`, telling the ingress to abort the engine
+    // stream immediately after this frame.
+    //
+    // Push path (PushFrame::into_encoded): ALL frames — including error frames
+    // from close_with_error / close_with_dynamo_error — have `stop_stream:
+    // false`. End-of-stream is signalled by dropping the mpsc sender, not by
+    // a flag. If downstream code keys on stop_stream to abort early it will
+    // behave differently here; it must handle the channel-close path too.
+    //
+    // These tests pin the push-path contract so a future change cannot
+    // accidentally match the pull path's stop_stream: true without someone
+    // noticing and auditing the downstream consumer.
+
+    /// Push-path error frames must have `stop_stream: false`, even though the
+    /// pull path sets `stop_stream: true` for the same conditions. End-of-stream
+    /// is signalled by dropping the sender, not by this flag.
+    #[test]
+    fn push_error_frame_stop_stream_is_always_false_matching_codec() {
+        let frame = PushFrame::error(Annotated::from_error("fatal"));
+        let codec = frame.codec;
+        let encoded = frame.into_encoded(codec).expect("forward must succeed");
+        assert!(encoded.is_error, "error frame must be flagged is_error");
+        assert!(
+            !encoded.stop_stream,
+            "push-path error frames must have stop_stream: false (stream ends when sender drops)"
+        );
+    }
+
+    /// The stop_stream: false contract must hold on the re-encode path too,
+    /// so a mismatch between the push worker's codec and the caller's codec
+    /// cannot accidentally flip the flag.
+    #[test]
+    fn push_error_frame_stop_stream_is_always_false_mismatched_codec() {
+        let frame = PushFrame {
+            bytes: RequestPlanePayloadCodec::Msgpack
+                .encode(&NetworkStreamWrapper {
+                    data: Some(Annotated::<serde_json::Value>::from_error("fatal")),
+                    complete_final: false,
+                })
+                .expect("encode")
+                .into(),
+            is_error: true,
+            codec: RequestPlanePayloadCodec::Msgpack,
+        };
+        let encoded = frame
+            .into_encoded(RequestPlanePayloadCodec::Json)
+            .expect("re-encode must succeed");
+        assert!(encoded.is_error, "is_error must survive re-encode");
+        assert!(
+            !encoded.stop_stream,
+            "stop_stream must remain false after re-encode"
         );
     }
 

--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -11,11 +11,8 @@
 //! side only ever does `rx.recv().await` and never touches Python. Rationale
 //! and measurements: #12845.
 //!
-//! Encoding all the way to bytes on the Python side is what keeps this a net
-//! removal of per-response work: the frame that comes off the queue is already
-//! finished, so the ingress just forwards it. Errors terminate the stream with
-//! the type `map_python_exception` assigned them, which is what request
-//! migration and worker inhibition key on downstream.
+//! Errors terminate the stream with the type `map_python_exception` assigned
+//! them, which is what request migration and worker inhibition key on.
 //!
 //! Selected per handler by signature — [`handler_supports_push`] picks this
 //! path for a handler declaring a `response_sender` parameter, which in
@@ -83,20 +80,16 @@ pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 /// One response, already encoded for the request plane.
 ///
-/// Getting a response from Python object to wire bytes is a single serde pass
-/// on the pull path: `Serialize for PythonPayload` transcodes the Python object
-/// straight into the codec. This path keeps that property. `send` already holds
-/// the GIL, so it encodes all the way here rather than parking an intermediate
-/// Rust value on the queue for a second pass to walk — and, because the payload
-/// is still a [`PythonPayload`] at the moment of encoding, nothing the codec can
-/// represent is narrowed on the way: binary values, non-finite floats and
-/// non-string mapping keys all survive exactly as they do on the pull path.
+/// Encoding happens in `send`, under the GIL the handler already holds, and the
+/// payload is still a [`PythonPayload`] at that moment — so it transcodes
+/// straight into the codec in one pass, exactly as on the pull path, and
+/// nothing the codec can represent is narrowed on the way.
 ///
 /// `codec` records which codec produced `bytes`. `send` has no request in hand,
 /// so it uses the process-global [`RequestPlanePayloadCodec::configured`] — the
-/// same value this worker advertises in its instance record, which is where
-/// callers read the codec they address it with. The two therefore agree except
-/// against a caller old enough to predict neither, which falls back to JSON;
+/// value this worker advertises in its instance record, which is where callers
+/// read the codec they address it with. The two agree except against a caller
+/// old enough to predict neither, which falls back to JSON;
 /// [`PushFrame::into_encoded`] re-encodes for that case rather than putting the
 /// wrong bytes on the wire.
 pub(crate) struct PushFrame {
@@ -116,12 +109,11 @@ impl std::fmt::Debug for PushFrame {
 }
 
 impl PushFrame {
-    /// Encode one Python response object. Called with the GIL held by the
-    /// Python caller; [`python_payload::parse_python_response`] is the same
-    /// interpretation of the object the pull path uses, and
-    /// [`python_payload::encode_annotated_response`] is the same wrapper
-    /// construction and codec invocation, so the bytes are structurally
-    /// identical to what the pull path would produce for the same object.
+    /// Encode one Python response object, with the GIL held by the caller.
+    ///
+    /// Both steps are shared with the pull path — `parse_python_response`
+    /// interprets the object, `encode_annotated_response` produces the bytes —
+    /// so the two cannot drift.
     fn encode(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         let annotated =
             python_payload::parse_python_response(obj.clone().unbind(), py).map_err(|error| {
@@ -149,20 +141,16 @@ impl PushFrame {
     /// so this is callable from either side of the bridge.
     fn error(annotated: Annotated<serde_json::Value>) -> Self {
         let codec = RequestPlanePayloadCodec::configured();
-        let wrapper = NetworkStreamWrapper {
-            data: Some(annotated),
-            complete_final: false,
-        };
         // An error frame is a string and three `None`s; neither codec can fail
-        // to encode it. Degrade to an empty frame rather than panic if one
-        // somehow does.
-        let bytes = codec.encode(&wrapper).unwrap_or_else(|error| {
-            tracing::error!(%error, "push egress: failed to encode terminal error frame");
-            Vec::new()
-        });
+        // on it. Degrade to an empty frame rather than panic if one somehow does.
+        let (bytes, is_error) = python_payload::encode_annotated_response(codec, annotated)
+            .unwrap_or_else(|error| {
+                tracing::error!(%error, "push egress: failed to encode terminal error frame");
+                (Vec::new(), true)
+            });
         Self {
             bytes: bytes.into(),
-            is_error: true,
+            is_error,
             codec,
         }
     }

--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -5,10 +5,17 @@
 //!
 //! The pull path in [`crate::engine`] costs two GIL acquisitions on arbitrary
 //! tokio threads per response. Here the Python handler — already holding the
-//! GIL — calls [`ResponseSender::send`] instead: the conversion happens inline
-//! under that existing GIL and the value is enqueued on a bounded
-//! `tokio::sync::mpsc`, so the tokio side only ever does `rx.recv().await` and
-//! never touches Python. Rationale and measurements: DYN-3703.
+//! GIL — calls [`ResponseSender::send`] instead: the response is encoded to
+//! request-plane bytes inline under that existing GIL and the resulting
+//! [`PushFrame`] is enqueued on a bounded `tokio::sync::mpsc`, so the tokio
+//! side only ever does `rx.recv().await` and never touches Python. Rationale
+//! and measurements: #12845.
+//!
+//! Encoding all the way to bytes on the Python side is what keeps this a net
+//! removal of per-response work: the frame that comes off the queue is already
+//! finished, so the ingress just forwards it. Errors terminate the stream with
+//! the type `map_python_exception` assigned them, which is what request
+//! migration and worker inhibition key on downstream.
 //!
 //! Selected per handler by signature — [`handler_supports_push`] picks this
 //! path for a handler declaring a `response_sender` parameter, which in
@@ -24,30 +31,29 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Error;
+use bytes::Bytes;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
-use serde::Deserialize;
 use tokio_stream::{Stream, StreamExt};
 
 use tokio::sync::mpsc;
 
+use dynamo_runtime::engine::AsyncEngineContext;
 use dynamo_runtime::error::DynamoError;
 use dynamo_runtime::logging::get_distributed_tracing_context;
+use dynamo_runtime::pipeline::network::{
+    EncodedResponseFrame, NetworkStreamWrapper, RequestPlanePayloadCodec,
+};
 use dynamo_runtime::pipeline::{
-    AsyncEngine, AsyncEngineContextProvider, Data, ManyOut, ResponseStream, SingleIn,
+    AsyncEngine, AsyncEngineContextProvider, ManyOut, PipelineError, ResponseStream, SingleIn,
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::protocols::maybe_error::MaybeError;
 
 use crate::context::{Context, callable_accepts_kwarg};
 use crate::engine::{self, map_python_exception};
-use crate::python_payload::PythonPayload;
-
-/// Depth of the Python -> Rust response channel. Matches
-/// `engine::RESPONSE_CHANNEL_DEPTH` so the push path buffers exactly as much
-/// as the pull path's forwarder does.
-pub(crate) const PUSH_CHANNEL_DEPTH: usize = 128;
+use crate::python_payload::{self, PythonPayload};
 
 /// Whether this Python callable can be driven in push mode. This is the ONLY
 /// switch between the two egress paths.
@@ -73,52 +79,250 @@ pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
+// ── Wire frame ───────────────────────────────────────────────────────────────
+
+/// One response, already encoded for the request plane.
+///
+/// Getting a response from Python object to wire bytes is a single serde pass
+/// on the pull path: `Serialize for PythonPayload` transcodes the Python object
+/// straight into the codec. This path keeps that property. `send` already holds
+/// the GIL, so it encodes all the way here rather than parking an intermediate
+/// Rust value on the queue for a second pass to walk — and, because the payload
+/// is still a [`PythonPayload`] at the moment of encoding, nothing the codec can
+/// represent is narrowed on the way: binary values, non-finite floats and
+/// non-string mapping keys all survive exactly as they do on the pull path.
+///
+/// `codec` records which codec produced `bytes`. `send` has no request in hand,
+/// so it uses the process-global [`RequestPlanePayloadCodec::configured`] — the
+/// same value this worker advertises in its instance record, which is where
+/// callers read the codec they address it with. The two therefore agree except
+/// against a caller old enough to predict neither, which falls back to JSON;
+/// [`PushFrame::into_encoded`] re-encodes for that case rather than putting the
+/// wrong bytes on the wire.
+pub(crate) struct PushFrame {
+    bytes: Bytes,
+    is_error: bool,
+    codec: RequestPlanePayloadCodec,
+}
+
+impl std::fmt::Debug for PushFrame {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PushFrame")
+            .field("len", &self.bytes.len())
+            .field("is_error", &self.is_error)
+            .field("codec", &self.codec.name())
+            .finish()
+    }
+}
+
+impl PushFrame {
+    /// Encode one Python response object. Called with the GIL held by the
+    /// Python caller; [`python_payload::parse_python_response`] is the same
+    /// interpretation of the object the pull path uses.
+    fn encode(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let annotated =
+            python_payload::parse_python_response(obj.clone().unbind(), py).map_err(|error| {
+                PyValueError::new_err(format!(
+                    "critical error: invalid response object from python handler; \
+                     application-logic-mismatch: {error}"
+                ))
+            })?;
+        let is_error = annotated.is_error();
+        let codec = RequestPlanePayloadCodec::configured();
+        let wrapper = NetworkStreamWrapper {
+            data: Some(annotated),
+            complete_final: false,
+        };
+        let bytes = codec.encode(&wrapper).map_err(|error| {
+            PyValueError::new_err(format!(
+                "critical error: failed serializing python response as {}: {error}",
+                codec.name()
+            ))
+        })?;
+        Ok(Self {
+            bytes: bytes.into(),
+            is_error,
+            codec,
+        })
+    }
+
+    /// Encode a terminal error frame. Pure Rust — no Python object involved —
+    /// so this is callable from either side of the bridge.
+    fn error(annotated: Annotated<serde_json::Value>) -> Self {
+        let codec = RequestPlanePayloadCodec::configured();
+        let wrapper = NetworkStreamWrapper {
+            data: Some(annotated),
+            complete_final: false,
+        };
+        // An error frame is a string and three `None`s; neither codec can fail
+        // to encode it. Degrade to an empty frame rather than panic if one
+        // somehow does.
+        let bytes = codec.encode(&wrapper).unwrap_or_else(|error| {
+            tracing::error!(%error, "push egress: failed to encode terminal error frame");
+            Vec::new()
+        });
+        Self {
+            bytes: bytes.into(),
+            is_error: true,
+            codec,
+        }
+    }
+
+    /// Hand the frame to the ingress for the codec this request is addressed
+    /// with. Normally a move; see the type docs for when it is not.
+    pub(crate) fn into_encoded(
+        self,
+        target: RequestPlanePayloadCodec,
+    ) -> Result<EncodedResponseFrame, PipelineError> {
+        if self.codec == target {
+            return Ok(EncodedResponseFrame {
+                bytes: self.bytes,
+                is_error: self.is_error,
+                stop_stream: false,
+            });
+        }
+
+        // Caller addressed us with a different codec than the one we advertise.
+        // `rmpv::Value` is the intermediate because it is the wider of the two
+        // wire models — it carries binary and non-finite floats, which
+        // `serde_json::Value` does not — so nothing is lost that the target
+        // codec could still have represented.
+        tracing::debug!(
+            from = self.codec.name(),
+            to = target.name(),
+            "push egress: re-encoding response for the caller's request-plane codec"
+        );
+        let wrapper: NetworkStreamWrapper<Annotated<rmpv::Value>> =
+            self.codec.decode(&self.bytes).map_err(|error| {
+                PipelineError::SerializationError(format!(
+                    "failed decoding push-egress response as {} for re-encoding: {error}",
+                    self.codec.name()
+                ))
+            })?;
+        let bytes = target.encode(&wrapper).map_err(|error| {
+            PipelineError::SerializationError(format!(
+                "Failed serializing {} push-egress response: {error}",
+                target.name()
+            ))
+        })?;
+        Ok(EncodedResponseFrame {
+            bytes: bytes.into(),
+            is_error: self.is_error,
+            stop_stream: false,
+        })
+    }
+}
+
 // ── GIL-side sink ────────────────────────────────────────────────────────────
 
-/// The GIL-side half of one request's push channel.
-///
-/// Type-erased because `#[pyclass]` cannot be generic: [`ResponseSender`] must
-/// be a single concrete Python type, while the channel's item type is chosen by
-/// the (generic) [`response_channel`] factory. Every method here is called with
-/// the GIL already held by the Python caller.
-trait ResponseSink: Send + Sync {
-    /// Convert `obj` to an owned Rust value and enqueue it.
-    fn send(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<()>;
-
-    /// Normal end of stream.
-    fn close(&self);
-
-    /// Terminate the stream with an untyped error frame.
-    fn close_with_error(&self, message: String);
-
-    /// Terminate the stream with a typed backend error frame. Not exposed to
-    /// Python; used by the Rust-side safety net when the handler's generator
-    /// raises instead of closing the sender itself.
-    fn close_with_dynamo_error(&self, error: DynamoError);
-}
-
-struct TypedSink<Resp> {
+/// The GIL-side half of one request's push channel. Every method is called with
+/// the GIL already held by the Python caller, except the two the Rust driver
+/// task uses to terminate a stream its handler left open.
+struct ResponseSink {
     /// `None` once the stream has been closed. Dropping the last `Sender` is
     /// what ends the receiver stream, so closing is "take the sender".
-    tx: Mutex<Option<mpsc::Sender<Annotated<Resp>>>>,
+    tx: Mutex<Option<mpsc::Sender<PushFrame>>>,
+    /// Stopped when the consumer goes away, mirroring what the pull path's
+    /// forwarder does on a closed channel (`engine.rs`): without it a dropped
+    /// response stream would leave the handler generating into nothing until it
+    /// noticed the send error on its own.
+    ctx: Arc<dyn AsyncEngineContext>,
 }
 
-impl<Resp> TypedSink<Resp> {
+impl ResponseSink {
     /// Clone the sender out from under the lock rather than holding the lock
     /// across the enqueue: a blocking send while holding the mutex would let a
     /// concurrent `close()` deadlock against it.
-    fn sender(&self) -> Option<mpsc::Sender<Annotated<Resp>>> {
+    fn sender(&self) -> Option<mpsc::Sender<PushFrame>> {
         self.tx
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
     }
 
-    fn take_sender(&self) -> Option<mpsc::Sender<Annotated<Resp>>> {
+    fn take_sender(&self) -> Option<mpsc::Sender<PushFrame>> {
         self.tx
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take()
+    }
+
+    /// The consumer dropped the response stream. Tell the request context so
+    /// the handler stops generating, then report it to the caller.
+    fn consumer_gone(&self) -> PyErr {
+        self.ctx.stop_generating();
+        PyRuntimeError::new_err(
+            "response stream is closed; the consumer dropped the response stream",
+        )
+    }
+
+    /// Convert `obj` to wire bytes and enqueue it.
+    fn send(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<()> {
+        // The whole Python->Rust crossing for one response: the encode plus the
+        // enqueue. Unlike the pull path neither step acquires the GIL — the
+        // Python handler already holds it.
+        let frame = PushFrame::encode(py, obj)?;
+
+        let Some(tx) = self.sender() else {
+            return Err(PyRuntimeError::new_err(
+                "response stream is closed; send() after close()",
+            ));
+        };
+
+        // Fast path. `try_send` never blocks, so there is no reason to drop the
+        // GIL for it, and dropping/reacquiring it would cost more than the send.
+        let frame = match tx.try_send(frame) {
+            Ok(()) => return Ok(()),
+            Err(mpsc::error::TrySendError::Full(frame)) => frame,
+            Err(mpsc::error::TrySendError::Closed(_)) => return Err(self.consumer_gone()),
+        };
+
+        // Backpressure path.
+        //
+        // CRITICAL: the GIL MUST be released across this blocking wait.
+        // `allow_threads` here is not an optimization, it is a correctness
+        // requirement. This call runs on the asyncio loop thread; blocking it
+        // with the GIL held freezes the entire interpreter — the event loop
+        // that would run every other request's handler, and every tokio task
+        // that needs the GIL. Anything that has to run for the channel to
+        // drain then cannot run, and a merely-full channel becomes an
+        // interpreter-wide stall instead of local backpressure.
+        //
+        // `blocking_send` panics if called from inside an async task. The only
+        // caller is `ResponseSender::send`, reached from the Python event-loop
+        // thread, which has no tokio runtime context at all. It would panic only
+        // if a handler managed to call `send` from an async tokio task while
+        // holding the GIL.
+        py.allow_threads(|| tx.blocking_send(frame))
+            .map_err(|_| self.consumer_gone())
+    }
+
+    /// Normal end of stream.
+    fn close(&self) {
+        // Dropping the last sender is what ends the receiver stream. Idempotent
+        // so the Rust-side safety net can close a stream the handler already
+        // closed itself.
+        drop(self.take_sender());
+    }
+
+    /// Terminate the stream with an untyped error frame.
+    fn close_with_error(&self, message: String) {
+        let Some(tx) = self.take_sender() else {
+            return;
+        };
+        self.send_terminal(tx, PushFrame::error(Annotated::from_error(message)));
+    }
+
+    /// Terminate the stream with a typed backend error frame. Not exposed to
+    /// Python; used by the Rust-side safety net when the handler's generator
+    /// raises instead of closing the sender itself. Preserving the type matters
+    /// downstream — `BackendError::EngineShutdown` is what triggers request
+    /// migration and marks the worker inhibited.
+    fn close_with_dynamo_error(&self, error: DynamoError) {
+        let Some(tx) = self.take_sender() else {
+            return;
+        };
+        self.send_terminal(tx, PushFrame::error(Annotated::from_err(error)));
     }
 
     /// Enqueue a terminal frame after the sender has already been taken.
@@ -130,10 +334,7 @@ impl<Resp> TypedSink<Resp> {
     /// handle Python's event-loop thread does not have — so pick per caller.
     /// Holding `tx` until the frame lands is what keeps the stream open long
     /// enough to deliver it; the stream ends when the task below drops it.
-    fn send_terminal(&self, tx: mpsc::Sender<Annotated<Resp>>, frame: Annotated<Resp>)
-    where
-        Resp: Data,
-    {
+    fn send_terminal(&self, tx: mpsc::Sender<PushFrame>, frame: PushFrame) {
         let frame = match tx.try_send(frame) {
             Ok(()) => return,
             Err(mpsc::error::TrySendError::Full(frame)) => frame,
@@ -154,97 +355,6 @@ impl<Resp> TypedSink<Resp> {
     }
 }
 
-impl<Resp> ResponseSink for TypedSink<Resp>
-where
-    Resp: Data + for<'de> Deserialize<'de>,
-{
-    fn send(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<()> {
-        // The whole Python->Rust crossing for one response: the `depythonize`
-        // plus the enqueue. Unlike the pull path neither step acquires the GIL
-        // — the Python handler already holds it.
-        let frame = decode_response::<Resp>(obj)?;
-
-        let Some(tx) = self.sender() else {
-            return Err(PyRuntimeError::new_err(
-                "response stream is closed; send() after close()",
-            ));
-        };
-
-        // Fast path. `try_send` never blocks, so there is no reason to drop the
-        // GIL for it, and dropping/reacquiring it would cost more than the send.
-        let frame = match tx.try_send(frame) {
-            Ok(()) => return Ok(()),
-            Err(mpsc::error::TrySendError::Full(frame)) => frame,
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                return Err(PyRuntimeError::new_err(
-                    "response stream is closed; the consumer dropped the response stream",
-                ));
-            }
-        };
-
-        // Backpressure path.
-        //
-        // CRITICAL: the GIL MUST be released across this blocking wait.
-        // `allow_threads` here is not an optimization, it is a correctness
-        // requirement. This call runs on the asyncio loop thread; blocking it
-        // with the GIL held freezes the entire interpreter — the event loop
-        // that would run every other request's handler, and every tokio task
-        // that needs the GIL. Anything that has to run for the channel to
-        // drain then cannot run, and a merely-full channel becomes an
-        // interpreter-wide stall instead of local backpressure.
-        //
-        // `blocking_send` panics if called from inside an async task. The only
-        // caller is `ResponseSender::send`, reached from the Python event-loop
-        // thread, which has no tokio runtime context at all. It would panic only
-        // if a handler managed to call `send` from an async tokio task while
-        // holding the GIL.
-        py.allow_threads(|| tx.blocking_send(frame)).map_err(|_| {
-            PyRuntimeError::new_err(
-                "response stream is closed; the consumer dropped the response stream",
-            )
-        })
-    }
-
-    fn close(&self) {
-        // Dropping the last sender is what ends the receiver stream. Idempotent
-        // so the Rust-side safety net can close a stream the handler already
-        // closed itself.
-        drop(self.take_sender());
-    }
-
-    fn close_with_error(&self, message: String) {
-        let Some(tx) = self.take_sender() else {
-            return;
-        };
-        self.send_terminal(tx, Annotated::from_error(message));
-    }
-
-    fn close_with_dynamo_error(&self, error: DynamoError) {
-        let Some(tx) = self.take_sender() else {
-            return;
-        };
-        self.send_terminal(tx, Annotated::from_err(error));
-    }
-}
-
-/// Python -> Rust conversion for one response object.
-///
-/// Shares [`engine::depythonize_annotated`] with the pull path, so both paths
-/// produce the same Rust value for the same Python object by construction.
-/// Only the error mapping differs: here it is raised back into the calling
-/// handler, which turns it into a `close_with_error` frame.
-fn decode_response<Resp>(obj: &Bound<'_, PyAny>) -> PyResult<Annotated<Resp>>
-where
-    Resp: for<'de> Deserialize<'de>,
-{
-    engine::depythonize_annotated(obj).map_err(|error| {
-        PyValueError::new_err(format!(
-            "critical error: invalid response object from python handler; \
-             application-logic-mismatch: {error}"
-        ))
-    })
-}
-
 // ── Python-facing handle ─────────────────────────────────────────────────────
 
 /// Rust response sink handed to a Python handler running in push mode.
@@ -258,28 +368,25 @@ where
 ///         async for chunk in engine.generate(request):
 ///             yield chunk
 ///         return
-///     try:                            # push path: yields nothing
-///         async for chunk in engine.generate(request):
-///             response_sender.send(chunk)
-///     except Exception as exc:
-///         response_sender.close_with_error(f"{type(exc).__name__}: {exc}")
-///     else:
-///         response_sender.close()
+///     async for chunk in engine.generate(request):   # push path: yields nothing
+///         response_sender.send(chunk)
+///     response_sender.close()
+///     # exceptions propagate: Rust classifies them and terminates the stream
 /// ```
 ///
 /// `send` blocks when the consumer is behind; it is safe to call from the
 /// asyncio loop thread because the GIL is released across that wait.
 #[pyclass]
 pub struct ResponseSender {
-    sink: Arc<dyn ResponseSink>,
+    sink: Arc<ResponseSink>,
 }
 
 #[pymethods]
 impl ResponseSender {
-    /// Convert one response object and enqueue it for the Rust egress path.
+    /// Encode one response object and enqueue it for the Rust egress path.
     ///
     /// Raises `RuntimeError` if the stream is already closed and `ValueError`
-    /// if the object cannot be converted.
+    /// if the object cannot be encoded.
     fn send(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<()> {
         self.sink.send(py, obj)
     }
@@ -290,8 +397,14 @@ impl ResponseSender {
         Ok(())
     }
 
-    /// Terminate the stream with an error frame. Idempotent; a later `close()`
-    /// is a no-op.
+    /// Terminate the stream with an untyped error frame. Idempotent; a later
+    /// `close()` is a no-op.
+    ///
+    /// Prefer letting the exception propagate out of the handler instead: Rust
+    /// then runs it through `map_python_exception` and terminates the stream
+    /// with a *typed* backend error, which is what drives request migration and
+    /// worker inhibition downstream. This exists for failures that are not
+    /// exceptions.
     fn close_with_error(&self, msg: String) -> PyResult<()> {
         self.sink.close_with_error(msg);
         Ok(())
@@ -301,7 +414,7 @@ impl ResponseSender {
 impl ResponseSender {
     /// Rust-side handle to the same sink, for the safety net that terminates
     /// the stream if the handler's generator raises.
-    fn sink(&self) -> Arc<dyn ResponseSink> {
+    fn sink(&self) -> Arc<ResponseSink> {
         self.sink.clone()
     }
 }
@@ -310,29 +423,27 @@ impl ResponseSender {
 
 /// Build one request's push channel.
 ///
-/// The returned stream yields `Annotated<Resp>` — the same item type
-/// `engine::buffered_typed_response_stream` produces on the pull path — so the
-/// ingress side (`lib/runtime/src/pipeline/network/ingress/push_handler.rs`)
-/// is unchanged.
-pub(crate) fn response_channel<Resp>(
+/// The returned stream yields already-encoded [`PushFrame`]s; the ingress side
+/// (`lib/runtime/src/pipeline/network/ingress/push_handler.rs`) is unchanged and
+/// its encoder just forwards them.
+pub(crate) fn response_channel(
     depth: usize,
+    ctx: Arc<dyn AsyncEngineContext>,
 ) -> (
     ResponseSender,
-    impl Stream<Item = Annotated<Resp>> + Send + 'static,
-)
-where
-    Resp: Data + for<'de> Deserialize<'de>,
-{
-    let (tx, rx) = mpsc::channel::<Annotated<Resp>>(depth);
+    impl Stream<Item = PushFrame> + Send + 'static,
+) {
+    let (tx, rx) = mpsc::channel::<PushFrame>(depth);
 
     let sender = ResponseSender {
-        sink: Arc::new(TypedSink {
+        sink: Arc::new(ResponseSink {
             tx: Mutex::new(Some(tx)),
+            ctx,
         }),
     };
 
-    // The consumer side is pure Rust: no Python work, no GIL, just the wait for
-    // whatever the handler pushes next.
+    // The consumer side is pure Rust: no Python work, no GIL, no encoding, just
+    // the wait for whatever the handler pushes next.
     let stream = futures::stream::unfold(rx, |mut rx| async move {
         rx.recv().await.map(|item| (item, rx))
     });
@@ -341,11 +452,6 @@ where
 }
 
 // ── Engine ───────────────────────────────────────────────────────────────────
-
-/// Response type carried by the push path. The GIL-side `depythonize` produces
-/// an owned Rust value, so — unlike the pull path's `PythonPayload` — nothing
-/// downstream of the channel can touch a Python object.
-pub(crate) type PushResponse = Annotated<serde_json::Value>;
 
 /// Push-mode counterpart of `engine::PythonNetworkEngine`.
 ///
@@ -377,18 +483,20 @@ impl PythonPushEngine {
 }
 
 #[async_trait::async_trait]
-impl AsyncEngine<SingleIn<PythonPayload>, ManyOut<PushResponse>, Error> for PythonPushEngine {
+impl AsyncEngine<SingleIn<PythonPayload>, ManyOut<PushFrame>, Error> for PythonPushEngine {
     async fn generate(
         &self,
         request: SingleIn<PythonPayload>,
-    ) -> Result<ManyOut<PushResponse>, Error> {
+    ) -> Result<ManyOut<PushFrame>, Error> {
         let (request, context) = request.transfer(());
         let ctx = context.context();
         let request_id = context.id().to_string();
         let metadata = context.metadata().clone();
         let current_trace_context = get_distributed_tracing_context();
 
-        let (sender, stream) = response_channel::<serde_json::Value>(PUSH_CHANNEL_DEPTH);
+        // Same depth as the pull path's forwarder, so both paths buffer the
+        // same amount and backpressure behaves identically.
+        let (sender, stream) = response_channel(engine::RESPONSE_CHANNEL_DEPTH, ctx.clone());
         let sink = sender.sink();
 
         let python_input = request.into_inner();
@@ -467,105 +575,154 @@ mod tests {
     //! Confirmed: a trivial `prepare_freethreaded_python()` test produced
     //! "undefined symbol: Py_InitializeEx" from rust-lld.
     //!
-    //! **Root cause for push_egress.rs**: `TypedSink<Resp>` implements
-    //! `ResponseSink`, whose vtable includes `fn send(&self, py: Python<'_>,
-    //! obj: &Bound<'_, PyAny>)`.  Instantiating `TypedSink` (even in a test
-    //! that never calls `send`) forces the compiler to monomorphize ALL trait
-    //! impl methods, pulling in pyo3 and Python C-API symbols.  The same
-    //! applies to `ResponseSender` (`#[pyclass]`) and `response_channel`
-    //! (which creates a `TypedSink` internally).
+    //! **Root cause for push_egress.rs**: `ResponseSink::send` takes
+    //! `Python<'_>` / `Bound<'_, PyAny>`, and `ResponseSender` is a
+    //! `#[pyclass]`.  A test that instantiates either — `response_channel`
+    //! creates both — pulls pyo3 and the Python C API into the test binary's
+    //! object graph.
     //!
-    //! **What compiles**: tests that use only `mpsc` channels, `Annotated`,
-    //! `serde_json::Value`, and integer constants — nothing from this module.
-    //! Everything else requires Python and must be covered by pytest against
-    //! the built `.so`.  Coverage gaps are documented at the bottom.
+    //! **What compiles**: [`PushFrame`] and everything downstream of it. The
+    //! frame is a `Bytes` plus two scalars, and both the terminal-frame
+    //! constructor and the ingress hand-off are pure serde, so the encoding
+    //! contract — the part this module actually owns — is testable here.
+    //! `send`/`close` and `handler_supports_push` are not; they are covered by
+    //! pytest against the built `.so`.  Gaps are documented at the bottom.
 
-    use super::PUSH_CHANNEL_DEPTH;
+    use super::PushFrame;
+    use crate::engine::RESPONSE_CHANNEL_DEPTH;
+    use dynamo_runtime::pipeline::network::{NetworkStreamWrapper, RequestPlanePayloadCodec};
     use dynamo_runtime::protocols::annotated::Annotated;
     use tokio::sync::mpsc;
 
-    // ── PUSH_CHANNEL_DEPTH constant ───────────────────────────────────────
-
-    /// Push and pull channel depths must match.  `engine::RESPONSE_CHANNEL_DEPTH`
-    /// is 128; a mismatch makes the push path buffer differently from the pull
-    /// path, silently changing backpressure behavior.
-    #[test]
-    fn push_channel_depth_equals_pull_channel_depth() {
-        assert_eq!(
-            PUSH_CHANNEL_DEPTH, 128,
-            "PUSH_CHANNEL_DEPTH must equal engine::RESPONSE_CHANNEL_DEPTH (128)"
-        );
+    /// Decode a frame's bytes back to the wire envelope, as the caller does.
+    fn decode(
+        bytes: &[u8],
+        codec: RequestPlanePayloadCodec,
+    ) -> NetworkStreamWrapper<Annotated<rmpv::Value>> {
+        codec.decode(bytes).expect("frame must decode")
     }
 
     // ── channel backpressure contract ─────────────────────────────────────
     //
-    // TypedSink::send uses a channel of depth PUSH_CHANNEL_DEPTH.  The fast
-    // path uses try_send (no blocking); the slow path parks.  These tests
-    // verify the channel behaves as the comments describe, using mpsc directly
-    // because TypedSink instantiation requires Python symbols.
+    // ResponseSink::send uses a channel of RESPONSE_CHANNEL_DEPTH -- the pull
+    // path's constant, referenced rather than duplicated so the two cannot
+    // drift.  The fast path uses try_send (no blocking); the slow path parks.
+    // These tests use mpsc directly because instantiating the sink requires
+    // Python symbols.
 
-    /// A channel of PUSH_CHANNEL_DEPTH capacity must accept exactly that many
-    /// items without blocking, then report Full on the next one.
-    /// Catches drift between the constant and the actual channel constructor call.
+    /// The channel must accept exactly `RESPONSE_CHANNEL_DEPTH` items without
+    /// blocking, then report Full. Catches drift between the constant and the
+    /// actual channel constructor call.
     #[test]
-    fn channel_accepts_exactly_push_channel_depth_items_then_full() {
-        let (tx, _rx) = mpsc::channel::<Annotated<serde_json::Value>>(PUSH_CHANNEL_DEPTH);
+    fn channel_accepts_exactly_response_channel_depth_items_then_full() {
+        let (tx, _rx) = mpsc::channel::<PushFrame>(RESPONSE_CHANNEL_DEPTH);
 
         let mut sent = 0usize;
-        for i in 0..PUSH_CHANNEL_DEPTH {
-            match tx.try_send(Annotated::from_data(serde_json::Value::from(i as i64))) {
+        for i in 0..RESPONSE_CHANNEL_DEPTH {
+            match tx.try_send(PushFrame::error(Annotated::from_error(format!("{i}")))) {
                 Ok(()) => sent += 1,
                 Err(mpsc::error::TrySendError::Full(_)) => break,
                 Err(e) => panic!("unexpected channel error: {e}"),
             }
         }
         assert_eq!(
-            sent, PUSH_CHANNEL_DEPTH,
-            "channel must buffer exactly {PUSH_CHANNEL_DEPTH} items without blocking"
+            sent, RESPONSE_CHANNEL_DEPTH,
+            "channel must buffer exactly {RESPONSE_CHANNEL_DEPTH} items without blocking"
         );
 
         assert!(
             matches!(
-                tx.try_send(Annotated::from_data(serde_json::Value::Null)),
+                tx.try_send(PushFrame::error(Annotated::from_error("overflow"))),
                 Err(mpsc::error::TrySendError::Full(_))
             ),
-            "item {PUSH_CHANNEL_DEPTH}+1 must fail Full, not Closed"
+            "item {RESPONSE_CHANNEL_DEPTH}+1 must fail Full, not Closed"
         );
     }
 
-    // ── error frame contract ──────────────────────────────────────────────
+    // ── terminal frame contract ───────────────────────────────────────────
     //
-    // TypedSink::close_with_error and close_with_dynamo_error each:
+    // close_with_error and close_with_dynamo_error each:
     //   1. Call take_sender() to atomically claim the send side (idempotence)
-    //   2. Pass an Annotated error frame to send_terminal
+    //   2. Pass a PushFrame::error to send_terminal
     //   3. send_terminal delivers the frame and then drops the sender
     //
-    // Steps 1 and 3 (idempotence via take_sender; stream end via drop) are
-    // tested against mpsc directly.  Step 2 (frame structure) is pinned by
-    // the from_error shape test.  The full end-to-end path needs Python; see
-    // the note at the end of this module.
+    // Step 2 is tested here directly; steps 1 and 3 (idempotence via
+    // take_sender; stream end via drop) are pinned against mpsc below.
 
+    /// A terminal frame must reach the caller as a decodable error frame with
+    /// no data, and must be marked `is_error` so the ingress does not treat it
+    /// as evidence the engine is healthy.
     #[test]
-    fn annotated_from_error_sets_error_field_and_clears_data() {
-        // Pins the Annotated frame shape that close_with_error delivers.
-        let frame = Annotated::<serde_json::Value>::from_error("some-error");
-        assert!(frame.error.is_some(), "from_error must set the error field");
-        assert!(frame.data.is_none(), "from_error must not set a data field");
+    fn terminal_frame_encodes_an_error_with_no_data() {
+        let frame = PushFrame::error(Annotated::from_error("fatal"));
+        assert!(frame.is_error, "terminal frames must be flagged is_error");
+
+        let wrapper = decode(&frame.bytes, frame.codec);
+        assert!(!wrapper.complete_final, "not the end-of-stream marker");
+        let annotated = wrapper.data.expect("terminal frame carries data");
+        assert!(annotated.error.is_some(), "expected an error field");
+        assert!(annotated.data.is_none(), "error frames carry no data");
+    }
+
+    /// Matching codecs are the whole point: the bytes encoded under the GIL go
+    /// out untouched, with no second serde pass.
+    #[test]
+    fn matching_codec_forwards_the_bytes_unchanged() {
+        let frame = PushFrame::error(Annotated::from_error("fatal"));
+        let (codec, expected) = (frame.codec, frame.bytes.clone());
+
+        let encoded = frame.into_encoded(codec).expect("forward must succeed");
+        assert_eq!(encoded.bytes, expected, "bytes must not be re-encoded");
+        assert!(encoded.is_error);
+        assert!(!encoded.stop_stream);
+    }
+
+    /// A caller addressing this worker with a different codec than the one it
+    /// advertises must still get a frame it can decode. Sending the bytes
+    /// through unchanged would put msgpack on a JSON stream.
+    #[test]
+    fn mismatched_codec_re_encodes_for_the_caller() {
+        let frame = PushFrame {
+            bytes: RequestPlanePayloadCodec::Msgpack
+                .encode(&NetworkStreamWrapper {
+                    data: Some(Annotated::from_data(serde_json::json!({"text": "hi"}))),
+                    complete_final: false,
+                })
+                .expect("encode")
+                .into(),
+            is_error: false,
+            codec: RequestPlanePayloadCodec::Msgpack,
+        };
+
+        let encoded = frame
+            .into_encoded(RequestPlanePayloadCodec::Json)
+            .expect("re-encode must succeed");
+        let wrapper = decode(&encoded.bytes, RequestPlanePayloadCodec::Json);
+        let data = wrapper.data.expect("data").data.expect("annotated data");
+        assert_eq!(
+            data.as_map()
+                .expect("map")
+                .iter()
+                .find(|(k, _)| k.as_str() == Some("text"))
+                .map(|(_, v)| v.as_str().unwrap_or_default()),
+            Some("hi"),
+            "payload must survive the re-encode"
+        );
+        assert!(!encoded.is_error, "the error flag must be preserved");
     }
 
     /// Pins the channel-level protocol: one error frame then end-of-stream.
-    /// This is what TypedSink::close_with_error (via send_terminal) is supposed
-    /// to produce.  If send_terminal fails to drop the sender after delivering
-    /// the error frame, the consumer would wait forever.
+    /// If send_terminal fails to drop the sender after delivering the error
+    /// frame, the consumer would wait forever.
     #[tokio::test]
     async fn one_error_frame_then_dropped_sender_ends_stream() {
-        let (tx, mut rx) = mpsc::channel::<Annotated<serde_json::Value>>(4);
-        tx.send(Annotated::from_error("fatal".to_string()))
+        let (tx, mut rx) = mpsc::channel::<PushFrame>(4);
+        tx.send(PushFrame::error(Annotated::from_error("fatal")))
             .await
             .unwrap();
         drop(tx); // simulates send_terminal dropping the sender after the frame
         let item = rx.recv().await.expect("one error frame must arrive");
-        assert!(item.error.is_some(), "expected an error frame");
+        assert!(item.is_error, "expected an error frame");
         assert!(
             rx.recv().await.is_none(),
             "stream must end after the error frame"
@@ -576,7 +733,7 @@ mod tests {
     /// This pins the close() (no error) contract.
     #[tokio::test]
     async fn dropped_sender_without_data_ends_stream_immediately() {
-        let (tx, mut rx) = mpsc::channel::<Annotated<serde_json::Value>>(4);
+        let (tx, mut rx) = mpsc::channel::<PushFrame>(4);
         drop(tx);
         assert!(
             rx.recv().await.is_none(),
@@ -584,10 +741,10 @@ mod tests {
         );
     }
 
-    // The rest of this module's surface -- TypedSink send/close semantics,
-    // send_terminal's spawn-vs-blocking_send branches, decode_response, and
+    // The rest of this module's surface -- ResponseSink send/close semantics,
+    // send_terminal's spawn-vs-blocking_send branches, PushFrame::encode, and
     // handler_supports_push -- cannot be unit-tested here: pyo3's
     // `extension-module` is hardcoded in Cargo.toml, so any test whose object
     // graph reaches the Python C API fails to link against libpython. Covering
-    // it needs pytest against a maturin-built extension. See DYN-3703.
+    // it needs pytest against a maturin-built extension. See #12845.
 }

--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -3,61 +3,35 @@
 
 //! Inverted (push-based) Python -> Rust response egress.
 //!
-//! # Why
+//! The pull path in [`crate::engine`] costs two GIL acquisitions on arbitrary
+//! tokio threads per response. Here the Python handler — already holding the
+//! GIL — calls [`ResponseSender::send`] instead: the conversion happens inline
+//! under that existing GIL and the value is enqueued on a bounded
+//! `tokio::sync::mpsc`, so the tokio side only ever does `rx.recv().await` and
+//! never touches Python. Rationale and measurements: DYN-3703.
 //!
-//! The default egress path in [`crate::engine`] is a RUST PULL from a Python
-//! async generator (`demand_driven_python_stream`). Per response it costs two
-//! independent GIL acquisitions on *tokio* threads:
+//! Selected per handler by signature — [`handler_supports_push`] picks this
+//! path for a handler declaring a `response_sender` parameter, which in
+//! practice means the TRT-LLM `@push_egress_capable` decorator
+//! (`components/src/dynamo/trtllm/request_handlers/push_egress.py`). There is
+//! no environment variable: that decorator is the switch, so the two halves
+//! cannot disagree about which path an endpoint is on. Every other Python
+//! handler keeps the pull path verbatim.
 //!
-//! 1. `pybridge.anext_call` — a tokio worker takes the GIL only to call
-//!    `__anext__` and hand the actual work to the Python event-loop thread via
-//!    `call_soon_threadsafe`; the tokio thread then drops the GIL and parks.
-//! 2. `pybridge.decode_response` — a `spawn_blocking` thread takes the GIL
-//!    again to `depythonize` the yielded object.
-//!
-//! Which tokio worker polls the stream is arbitrary, so over a run essentially
-//! every worker thread becomes a GIL contender. Measured on the TRT-LLM decode
-//! worker: 45 GIL-capable threads and a GIL wait/hold ratio of 23.4, versus 3
-//! threads / 0.3 for `trtllm-serve`.
-//!
-//! # What this module does
-//!
-//! Inverts the direction. The Python handler — which is *already* holding the
-//! GIL while it runs — calls [`ResponseSender::send`] once per response. The
-//! conversion to an owned Rust value happens inline on that call, under the
-//! caller's existing GIL, and the result is enqueued on a bounded
-//! `tokio::sync::mpsc`. The tokio side only ever does `rx.recv().await`: it
-//! never acquires the GIL and never touches a Python object.
-//!
-//! # How the handler gets its sender
-//!
-//! On the `context` argument, as `context.response_sender`. Not as a dedicated
-//! parameter: the Python handlers wrap `generate` in decorators that use
-//! `functools.wraps`, which makes `inspect.signature` report the *wrapped*
-//! function's parameters, so a `response_sender` parameter added by a wrapper
-//! is invisible to the bridge's signature check. `context` is already on every
-//! handler's signature and is already the per-request handle, so it is both
-//! reliably detectable and the natural carrier.
-//!
-//! # Feature flag
-//!
-//! Gated on `DYN_TRTLLM_PUSH_EGRESS=1`, default OFF. With the flag unset the
-//! pull path in [`crate::engine`] is used verbatim and nothing here runs, so
-//! one image can A/B both paths.
+//! The sender reaches the handler as the `response_sender` keyword argument,
+//! and only that way — the same parameter the signature check keys on.
 
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 
 use anyhow::Error;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyModule};
-use pythonize::depythonize;
+use pyo3::types::PyModule;
 use serde::Deserialize;
 use tokio_stream::{Stream, StreamExt};
 
 use tokio::sync::mpsc;
 
-use dynamo_runtime::dynamo_nvtx_range;
 use dynamo_runtime::error::DynamoError;
 use dynamo_runtime::logging::get_distributed_tracing_context;
 use dynamo_runtime::pipeline::{
@@ -70,39 +44,24 @@ use crate::context::{Context, callable_accepts_kwarg};
 use crate::engine::{self, map_python_exception};
 use crate::python_payload::PythonPayload;
 
-/// Environment variable that selects the push egress path. `"1"` enables it;
-/// anything else (including unset) leaves the pull path in place.
-pub(crate) const PUSH_EGRESS_ENV: &str = "DYN_TRTLLM_PUSH_EGRESS";
-
 /// Depth of the Python -> Rust response channel. Matches
 /// `engine::RESPONSE_CHANNEL_DEPTH` so the push path buffers exactly as much
 /// as the pull path's forwarder does.
 pub(crate) const PUSH_CHANNEL_DEPTH: usize = 128;
 
-/// Whether push egress is enabled process-wide. Read once: the flag selects a
-/// serving topology at startup and must not change under a running endpoint.
-pub(crate) fn push_egress_enabled() -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        std::env::var(PUSH_EGRESS_ENV)
-            .map(|value| value == "1")
-            .unwrap_or(false)
-    })
-}
-
-/// Whether this Python callable can be driven in push mode.
+/// Whether this Python callable can be driven in push mode. This is the ONLY
+/// switch between the two egress paths.
 ///
-/// The sender is delivered on the `context` argument, so a handler that does
-/// not take one cannot be reached and must stay on the pull path. Unlike a
-/// check for a `response_sender` parameter, this one survives `functools.wraps`
-/// decorators: `context` is part of the wrapped function's own signature.
+/// The sender is delivered as a `response_sender` keyword argument, so a
+/// handler that does not declare one cannot be reached and must stay on the
+/// pull path.
 pub(crate) fn handler_supports_push(handler: &PyObject) -> bool {
     // MUST be `response_sender`, not `context`. Every handler accepts `context`,
     // so checking for it makes this test always true and the pull-path fallback
-    // unreachable — an undecorated handler would then be driven as a coroutine
-    // and fail every request. `push_egress_capable` deletes its own
-    // `__wrapped__` (`push_egress.py:259`) precisely so `inspect.signature`
-    // reports this parameter through the decorator.
+    // unreachable — every non-TRT-LLM Python handler in the repo would then be
+    // driven in push mode and never terminate its stream.
+    // `push_egress_capable` deletes its own `__wrapped__` precisely so
+    // `inspect.signature` reports this parameter through the decorator.
     Python::with_gil(|py| {
         callable_accepts_kwarg(py, handler.bind(py), "response_sender").unwrap_or(false)
     })
@@ -133,7 +92,7 @@ trait ResponseSink: Send + Sync {
     fn close_with_error(&self, message: String);
 
     /// Terminate the stream with a typed backend error frame. Not exposed to
-    /// Python; used by the Rust-side safety net when the handler coroutine
+    /// Python; used by the Rust-side safety net when the handler's generator
     /// raises instead of closing the sender itself.
     fn close_with_dynamo_error(&self, error: DynamoError);
 }
@@ -184,7 +143,6 @@ impl<Resp> TypedSink<Resp> {
 
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
             runtime.spawn(async move {
-                let _nvtx_blocked = dynamo_nvtx_range!("pybridge.push_blocked");
                 let _ = tx.send(frame).await;
             });
             return;
@@ -192,7 +150,6 @@ impl<Resp> TypedSink<Resp> {
 
         // No runtime on this thread: we are on the Python side. Same GIL rule
         // as `send` — release it across the wait.
-        let _nvtx_blocked = dynamo_nvtx_range!("pybridge.push_blocked");
         let _ = Python::with_gil(|py| py.allow_threads(|| tx.blocking_send(frame)));
     }
 }
@@ -202,12 +159,9 @@ where
     Resp: Data + for<'de> Deserialize<'de>,
 {
     fn send(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<()> {
-        // Covers the whole Python->Rust crossing for one response: the
-        // `depythonize` plus the enqueue. Unlike the pull path there is no
-        // GIL *acquisition* inside this range — the Python handler already
-        // holds it — so this measures conversion cost only, not GIL wait.
-        let _nvtx = dynamo_nvtx_range!("pybridge.push_send");
-
+        // The whole Python->Rust crossing for one response: the `depythonize`
+        // plus the enqueue. Unlike the pull path neither step acquires the GIL
+        // — the Python handler already holds it.
         let frame = decode_response::<Resp>(obj)?;
 
         let Some(tx) = self.sender() else {
@@ -239,13 +193,11 @@ where
         // drain then cannot run, and a merely-full channel becomes an
         // interpreter-wide stall instead of local backpressure.
         //
-        // `blocking_send` panics if called from inside an async task. Both
-        // callers are safe: the Python event-loop thread (no runtime context at
-        // all) and the driver task's degradation path (a `spawn_blocking`
-        // thread, which is a permitted blocking region). It would panic only if
-        // a handler managed to call `send` from an async tokio task while
+        // `blocking_send` panics if called from inside an async task. The only
+        // caller is `ResponseSender::send`, reached from the Python event-loop
+        // thread, which has no tokio runtime context at all. It would panic only
+        // if a handler managed to call `send` from an async tokio task while
         // holding the GIL.
-        let _nvtx_blocked = dynamo_nvtx_range!("pybridge.push_blocked");
         py.allow_threads(|| tx.blocking_send(frame)).map_err(|_| {
             PyRuntimeError::new_err(
                 "response stream is closed; the consumer dropped the response stream",
@@ -277,33 +229,15 @@ where
 
 /// Python -> Rust conversion for one response object.
 ///
-/// Mirrors `engine::process_item` exactly, so the push path yields the same
-/// Rust value the pull path would have produced for the same Python object:
-/// yields tagged with `_dynamo_annotated: True` are wire `Annotated<R>`
-/// envelopes, everything else is plain data.
+/// Shares [`engine::depythonize_annotated`] with the pull path, so both paths
+/// produce the same Rust value for the same Python object by construction.
+/// Only the error mapping differs: here it is raised back into the calling
+/// handler, which turns it into a `close_with_error` frame.
 fn decode_response<Resp>(obj: &Bound<'_, PyAny>) -> PyResult<Annotated<Resp>>
 where
     Resp: for<'de> Deserialize<'de>,
 {
-    let py = obj.py();
-    let is_envelope = obj
-        .downcast::<PyDict>()
-        .ok()
-        .and_then(|dict| {
-            dict.get_item(pyo3::intern!(py, "_dynamo_annotated"))
-                .ok()
-                .flatten()
-        })
-        .and_then(|value| value.is_truthy().ok())
-        .unwrap_or(false);
-
-    let decoded = if is_envelope {
-        depythonize::<Annotated<Resp>>(obj)
-    } else {
-        depythonize::<Resp>(obj).map(Annotated::from_data)
-    };
-
-    decoded.map_err(|error| {
+    engine::depythonize_annotated(obj).map_err(|error| {
         PyValueError::new_err(format!(
             "critical error: invalid response object from python handler; \
              application-logic-mismatch: {error}"
@@ -315,24 +249,22 @@ where
 
 /// Rust response sink handed to a Python handler running in push mode.
 ///
-/// Delivered as the `response_sender=` keyword argument, and also reachable as
-/// `context.response_sender`; `None`/absent on the pull path, so its presence is
-/// also how a handler decides which path it is on.
+/// Delivered as the `response_sender=` keyword argument; absent on the pull
+/// path, so its presence is also how a handler knows which path it is on.
 ///
 /// ```python
 /// async def generate(self, request, context, response_sender=None):
-///     sender = response_sender or getattr(context, "response_sender", None)
-///     if sender is None:              # pull path: unchanged
+///     if response_sender is None:     # pull path: unchanged
 ///         async for chunk in engine.generate(request):
 ///             yield chunk
 ///         return
 ///     try:                            # push path: yields nothing
 ///         async for chunk in engine.generate(request):
-///             sender.send(chunk)
+///             response_sender.send(chunk)
 ///     except Exception as exc:
-///         sender.close_with_error(f"{type(exc).__name__}: {exc}")
+///         response_sender.close_with_error(f"{type(exc).__name__}: {exc}")
 ///     else:
-///         sender.close()
+///         response_sender.close()
 /// ```
 ///
 /// `send` blocks when the consumer is behind; it is safe to call from the
@@ -368,7 +300,7 @@ impl ResponseSender {
 
 impl ResponseSender {
     /// Rust-side handle to the same sink, for the safety net that terminates
-    /// the stream if the handler coroutine raises.
+    /// the stream if the handler's generator raises.
     fn sink(&self) -> Arc<dyn ResponseSink> {
         self.sink.clone()
     }
@@ -399,15 +331,9 @@ where
         }),
     };
 
+    // The consumer side is pure Rust: no Python work, no GIL, just the wait for
+    // whatever the handler pushes next.
     let stream = futures::stream::unfold(rx, |mut rx| async move {
-        // Unlike `pybridge.anext_call` in engine.rs, this range deliberately
-        // DOES span the `.await`: there is no Python work inside it to isolate,
-        // and the whole point of the push path is that the consumer side is
-        // pure Rust. Read it accordingly — the range length is dominated by the
-        // idle wait for the engine's next token, and its *end* marks the
-        // response arriving. The bridge cost itself is `pybridge.push_send` on
-        // the Python thread; a full channel shows up as `pybridge.push_blocked`.
-        let _nvtx = dynamo_nvtx_range!("pybridge.push_recv");
         rx.recv().await.map(|item| (item, rx))
     });
 
@@ -429,12 +355,13 @@ pub(crate) type PushResponse = Annotated<serde_json::Value>;
 /// how often: in push mode the generator yields nothing and is advanced ONCE
 /// per request (one `__anext__`, which runs the whole request and then raises
 /// `StopAsyncIteration`), instead of once per response. Responses arrive out of
-/// band on the [`ResponseSender`] the handler finds on its `context`.
+/// band on the [`ResponseSender`] passed as the handler's `response_sender`
+/// argument.
 ///
 /// Keeping the generator shape is deliberate: registration
 /// (`endpoint.serve_endpoint(handler.generate, ...)`), cancellation, and the
-/// handler's own control flow are untouched, and a handler that ignores the
-/// sender and yields normally still works (see the driver task below).
+/// handler's own control flow are untouched. A handler that yields anyway has
+/// broken the contract and its request is failed — see the driver task below.
 pub(crate) struct PythonPushEngine {
     handler: Arc<PyObject>,
     event_loop: Arc<PyObject>,
@@ -467,33 +394,23 @@ impl AsyncEngine<SingleIn<PythonPayload>, ManyOut<PushResponse>, Error> for Pyth
         let python_input = request.into_inner();
         let handler_ctx = ctx.clone();
 
-        // The sender rides on the `Context`. `serve_endpoint` has already
-        // verified the handler accepts a `context` argument before selecting
-        // this engine, so the closure below always runs and the sender is
-        // always delivered — if it were dropped here instead, the channel would
-        // close and the request would return an empty stream.
+        // Both kwargs are built under one GIL acquisition. `serve_endpoint` has
+        // already verified the handler declares a `response_sender` parameter
+        // before selecting this engine, so this closure always runs and the
+        // sender is always delivered — were it dropped here instead, the channel
+        // would close and the request would return an empty stream.
         let driver = engine::invoke_generator(
             self.handler.clone(),
             self.event_loop.clone(),
             move |_py| Ok(python_input),
             Some(move |py: Python<'_>| {
-                // ONE sender object, delivered TWO ways, because the Python half
-                // reads it from a `response_sender=` keyword argument
-                // (`push_egress.py:235`) while `context.response_sender` is the
-                // documented fallback. Delivering only one of them is the seam
-                // that silently drops the worker back to the pull path — or, if
-                // Rust has already committed to awaiting a coroutine, fails the
-                // request outright. `Py<T>` is refcounted, so the clone is the
-                // same Python object, and a handler comparing them sees identity.
-                let py_sender = Py::new(py, sender)?;
                 let context = Py::new(
                     py,
-                    Context::new(handler_ctx, current_trace_context, None, metadata)
-                        .with_response_sender(py_sender.clone_ref(py)),
+                    Context::new(handler_ctx, current_trace_context, None, metadata),
                 )?;
                 Ok(vec![
                     ("context", context.into_any()),
-                    ("response_sender", py_sender.into_any()),
+                    ("response_sender", Py::new(py, sender)?.into_any()),
                 ])
             }),
         )
@@ -504,63 +421,173 @@ impl AsyncEngine<SingleIn<PythonPayload>, ManyOut<PushResponse>, Error> for Pyth
         // pass through here.
         tokio::spawn(async move {
             let mut driver = driver;
-            let mut yielded = 0usize;
 
-            while let Some(item) = driver.next().await {
-                let item = match item {
-                    Ok(item) => item,
-                    Err(error) => {
-                        sink.close_with_dynamo_error(map_python_exception(error));
-                        return;
-                    }
-                };
-
-                // Graceful degradation. A push-mode handler yields nothing, so
-                // this arm is normally dead code. It is reached when the handler
-                // ignored the sender and yielded instead (e.g. a handler that
-                // predates the push path, or one whose own flag check disagreed
-                // with ours): forward the frame through the same sink so the
-                // request still completes correctly, just without the benefit.
-                yielded += 1;
-                let forward_sink = sink.clone();
-                let forwarded = tokio::task::spawn_blocking(move || {
-                    // Unlike `pybridge.push_send`, this range DOES include a GIL
-                    // acquisition on a tokio thread — it is the pull path's cost,
-                    // reappearing precisely because the handler did not push.
-                    let _nvtx = dynamo_nvtx_range!("pybridge.push_forward_yield");
-                    Python::with_gil(|py| forward_sink.send(py, item.bind(py)))
-                })
-                .await;
-
-                match forwarded {
-                    Ok(Ok(())) => {}
-                    Ok(Err(error)) => {
-                        sink.close_with_dynamo_error(map_python_exception(error));
-                        return;
-                    }
-                    Err(error) => {
-                        sink.close_with_error(format!(
-                            "critical error: failed to offload the python response forward \
-                             to a new thread: {error}"
-                        ));
-                        return;
-                    }
+            // Advanced exactly once: a push-mode handler yields nothing, so
+            // that single `__anext__` runs the whole request and then ends the
+            // generator. Anything else is a broken contract.
+            match driver.next().await {
+                // Idempotent: a well-behaved handler has already closed.
+                None => sink.close(),
+                // Forwarding a yielded frame instead would silently reintroduce
+                // the per-response GIL acquisition this module exists to
+                // remove, so fail the request loudly.
+                Some(Ok(_)) => {
+                    tracing::error!(
+                        request_id,
+                        "push egress: handler yielded a response instead of pushing it"
+                    );
+                    sink.close_with_error(
+                        "critical error: push-mode handler yielded a response instead of \
+                         pushing it to its response_sender"
+                            .to_string(),
+                    );
                 }
+                Some(Err(error)) => sink.close_with_dynamo_error(map_python_exception(error)),
             }
-
-            if yielded > 0 {
-                tracing::debug!(
-                    request_id,
-                    yielded,
-                    "push egress: handler yielded responses instead of pushing them; \
-                     forwarded them over the pull path"
-                );
-            }
-
-            // Idempotent: a well-behaved handler has already closed the sender.
-            sink.close();
         });
 
         Ok(ResponseStream::new(Box::pin(stream), context.context()))
     }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the pure-Rust parts of push_egress.rs.
+    //!
+    //! # Python linkage constraint
+    //!
+    //! This crate builds with `pyo3/extension-module`.  The linker does NOT
+    //! include libpython in the test binary; Python symbols are supplied at
+    //! runtime by the Python interpreter loading the `.so`.  Any test that
+    //! compiles code which references Python C-API symbols — even unreachable
+    //! branches — fails with "undefined symbol: Py_InitializeEx" etc.
+    //!
+    //! Confirmed: a trivial `prepare_freethreaded_python()` test produced
+    //! "undefined symbol: Py_InitializeEx" from rust-lld.
+    //!
+    //! **Root cause for push_egress.rs**: `TypedSink<Resp>` implements
+    //! `ResponseSink`, whose vtable includes `fn send(&self, py: Python<'_>,
+    //! obj: &Bound<'_, PyAny>)`.  Instantiating `TypedSink` (even in a test
+    //! that never calls `send`) forces the compiler to monomorphize ALL trait
+    //! impl methods, pulling in pyo3 and Python C-API symbols.  The same
+    //! applies to `ResponseSender` (`#[pyclass]`) and `response_channel`
+    //! (which creates a `TypedSink` internally).
+    //!
+    //! **What compiles**: tests that use only `mpsc` channels, `Annotated`,
+    //! `serde_json::Value`, and integer constants — nothing from this module.
+    //! Everything else requires Python and must be covered by pytest against
+    //! the built `.so`.  Coverage gaps are documented at the bottom.
+
+    use super::PUSH_CHANNEL_DEPTH;
+    use dynamo_runtime::protocols::annotated::Annotated;
+    use tokio::sync::mpsc;
+
+    // ── PUSH_CHANNEL_DEPTH constant ───────────────────────────────────────
+
+    /// Push and pull channel depths must match.  `engine::RESPONSE_CHANNEL_DEPTH`
+    /// is 128; a mismatch makes the push path buffer differently from the pull
+    /// path, silently changing backpressure behavior.
+    #[test]
+    fn push_channel_depth_equals_pull_channel_depth() {
+        assert_eq!(
+            PUSH_CHANNEL_DEPTH, 128,
+            "PUSH_CHANNEL_DEPTH must equal engine::RESPONSE_CHANNEL_DEPTH (128)"
+        );
+    }
+
+    // ── channel backpressure contract ─────────────────────────────────────
+    //
+    // TypedSink::send uses a channel of depth PUSH_CHANNEL_DEPTH.  The fast
+    // path uses try_send (no blocking); the slow path parks.  These tests
+    // verify the channel behaves as the comments describe, using mpsc directly
+    // because TypedSink instantiation requires Python symbols.
+
+    /// A channel of PUSH_CHANNEL_DEPTH capacity must accept exactly that many
+    /// items without blocking, then report Full on the next one.
+    /// Catches drift between the constant and the actual channel constructor call.
+    #[test]
+    fn channel_accepts_exactly_push_channel_depth_items_then_full() {
+        let (tx, _rx) = mpsc::channel::<Annotated<serde_json::Value>>(PUSH_CHANNEL_DEPTH);
+
+        let mut sent = 0usize;
+        for i in 0..PUSH_CHANNEL_DEPTH {
+            match tx.try_send(Annotated::from_data(serde_json::Value::from(i as i64))) {
+                Ok(()) => sent += 1,
+                Err(mpsc::error::TrySendError::Full(_)) => break,
+                Err(e) => panic!("unexpected channel error: {e}"),
+            }
+        }
+        assert_eq!(
+            sent, PUSH_CHANNEL_DEPTH,
+            "channel must buffer exactly {PUSH_CHANNEL_DEPTH} items without blocking"
+        );
+
+        assert!(
+            matches!(
+                tx.try_send(Annotated::from_data(serde_json::Value::Null)),
+                Err(mpsc::error::TrySendError::Full(_))
+            ),
+            "item {PUSH_CHANNEL_DEPTH}+1 must fail Full, not Closed"
+        );
+    }
+
+    // ── error frame contract ──────────────────────────────────────────────
+    //
+    // TypedSink::close_with_error and close_with_dynamo_error each:
+    //   1. Call take_sender() to atomically claim the send side (idempotence)
+    //   2. Pass an Annotated error frame to send_terminal
+    //   3. send_terminal delivers the frame and then drops the sender
+    //
+    // Steps 1 and 3 (idempotence via take_sender; stream end via drop) are
+    // tested against mpsc directly.  Step 2 (frame structure) is pinned by
+    // the from_error shape test.  The full end-to-end path needs Python; see
+    // the note at the end of this module.
+
+    #[test]
+    fn annotated_from_error_sets_error_field_and_clears_data() {
+        // Pins the Annotated frame shape that close_with_error delivers.
+        let frame = Annotated::<serde_json::Value>::from_error("some-error");
+        assert!(frame.error.is_some(), "from_error must set the error field");
+        assert!(frame.data.is_none(), "from_error must not set a data field");
+    }
+
+    /// Pins the channel-level protocol: one error frame then end-of-stream.
+    /// This is what TypedSink::close_with_error (via send_terminal) is supposed
+    /// to produce.  If send_terminal fails to drop the sender after delivering
+    /// the error frame, the consumer would wait forever.
+    #[tokio::test]
+    async fn one_error_frame_then_dropped_sender_ends_stream() {
+        let (tx, mut rx) = mpsc::channel::<Annotated<serde_json::Value>>(4);
+        tx.send(Annotated::from_error("fatal".to_string()))
+            .await
+            .unwrap();
+        drop(tx); // simulates send_terminal dropping the sender after the frame
+        let item = rx.recv().await.expect("one error frame must arrive");
+        assert!(item.error.is_some(), "expected an error frame");
+        assert!(
+            rx.recv().await.is_none(),
+            "stream must end after the error frame"
+        );
+    }
+
+    /// Dropping a sender before sending any data must immediately end the stream.
+    /// This pins the close() (no error) contract.
+    #[tokio::test]
+    async fn dropped_sender_without_data_ends_stream_immediately() {
+        let (tx, mut rx) = mpsc::channel::<Annotated<serde_json::Value>>(4);
+        drop(tx);
+        assert!(
+            rx.recv().await.is_none(),
+            "stream must end immediately when sender is dropped with no data"
+        );
+    }
+
+    // The rest of this module's surface -- TypedSink send/close semantics,
+    // send_terminal's spawn-vs-blocking_send branches, decode_response, and
+    // handler_supports_push -- cannot be unit-tested here: pyo3's
+    // `extension-module` is hardcoded in Cargo.toml, so any test whose object
+    // graph reaches the Python C API fails to link against libpython. Covering
+    // it needs pytest against a maturin-built extension. See DYN-3703.
 }

--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -1,0 +1,566 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Inverted (push-based) Python -> Rust response egress.
+//!
+//! # Why
+//!
+//! The default egress path in [`crate::engine`] is a RUST PULL from a Python
+//! async generator (`demand_driven_python_stream`). Per response it costs two
+//! independent GIL acquisitions on *tokio* threads:
+//!
+//! 1. `pybridge.anext_call` — a tokio worker takes the GIL only to call
+//!    `__anext__` and hand the actual work to the Python event-loop thread via
+//!    `call_soon_threadsafe`; the tokio thread then drops the GIL and parks.
+//! 2. `pybridge.decode_response` — a `spawn_blocking` thread takes the GIL
+//!    again to `depythonize` the yielded object.
+//!
+//! Which tokio worker polls the stream is arbitrary, so over a run essentially
+//! every worker thread becomes a GIL contender. Measured on the TRT-LLM decode
+//! worker: 45 GIL-capable threads and a GIL wait/hold ratio of 23.4, versus 3
+//! threads / 0.3 for `trtllm-serve`.
+//!
+//! # What this module does
+//!
+//! Inverts the direction. The Python handler — which is *already* holding the
+//! GIL while it runs — calls [`ResponseSender::send`] once per response. The
+//! conversion to an owned Rust value happens inline on that call, under the
+//! caller's existing GIL, and the result is enqueued on a bounded
+//! `tokio::sync::mpsc`. The tokio side only ever does `rx.recv().await`: it
+//! never acquires the GIL and never touches a Python object.
+//!
+//! # How the handler gets its sender
+//!
+//! On the `context` argument, as `context.response_sender`. Not as a dedicated
+//! parameter: the Python handlers wrap `generate` in decorators that use
+//! `functools.wraps`, which makes `inspect.signature` report the *wrapped*
+//! function's parameters, so a `response_sender` parameter added by a wrapper
+//! is invisible to the bridge's signature check. `context` is already on every
+//! handler's signature and is already the per-request handle, so it is both
+//! reliably detectable and the natural carrier.
+//!
+//! # Feature flag
+//!
+//! Gated on `DYN_TRTLLM_PUSH_EGRESS=1`, default OFF. With the flag unset the
+//! pull path in [`crate::engine`] is used verbatim and nothing here runs, so
+//! one image can A/B both paths.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use anyhow::Error;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyModule};
+use pythonize::depythonize;
+use serde::Deserialize;
+use tokio_stream::{Stream, StreamExt};
+
+use tokio::sync::mpsc;
+
+use dynamo_runtime::dynamo_nvtx_range;
+use dynamo_runtime::error::DynamoError;
+use dynamo_runtime::logging::get_distributed_tracing_context;
+use dynamo_runtime::pipeline::{
+    AsyncEngine, AsyncEngineContextProvider, Data, ManyOut, ResponseStream, SingleIn,
+};
+use dynamo_runtime::protocols::annotated::Annotated;
+use dynamo_runtime::protocols::maybe_error::MaybeError;
+
+use crate::context::{Context, callable_accepts_kwarg};
+use crate::engine::{self, map_python_exception};
+use crate::python_payload::PythonPayload;
+
+/// Environment variable that selects the push egress path. `"1"` enables it;
+/// anything else (including unset) leaves the pull path in place.
+pub(crate) const PUSH_EGRESS_ENV: &str = "DYN_TRTLLM_PUSH_EGRESS";
+
+/// Depth of the Python -> Rust response channel. Matches
+/// `engine::RESPONSE_CHANNEL_DEPTH` so the push path buffers exactly as much
+/// as the pull path's forwarder does.
+pub(crate) const PUSH_CHANNEL_DEPTH: usize = 128;
+
+/// Whether push egress is enabled process-wide. Read once: the flag selects a
+/// serving topology at startup and must not change under a running endpoint.
+pub(crate) fn push_egress_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var(PUSH_EGRESS_ENV)
+            .map(|value| value == "1")
+            .unwrap_or(false)
+    })
+}
+
+/// Whether this Python callable can be driven in push mode.
+///
+/// The sender is delivered on the `context` argument, so a handler that does
+/// not take one cannot be reached and must stay on the pull path. Unlike a
+/// check for a `response_sender` parameter, this one survives `functools.wraps`
+/// decorators: `context` is part of the wrapped function's own signature.
+pub(crate) fn handler_supports_push(handler: &PyObject) -> bool {
+    // MUST be `response_sender`, not `context`. Every handler accepts `context`,
+    // so checking for it makes this test always true and the pull-path fallback
+    // unreachable — an undecorated handler would then be driven as a coroutine
+    // and fail every request. `push_egress_capable` deletes its own
+    // `__wrapped__` (`push_egress.py:259`) precisely so `inspect.signature`
+    // reports this parameter through the decorator.
+    Python::with_gil(|py| {
+        callable_accepts_kwarg(py, handler.bind(py), "response_sender").unwrap_or(false)
+    })
+}
+
+/// Add this module's classes to the extension module.
+pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<ResponseSender>()?;
+    Ok(())
+}
+
+// ── GIL-side sink ────────────────────────────────────────────────────────────
+
+/// The GIL-side half of one request's push channel.
+///
+/// Type-erased because `#[pyclass]` cannot be generic: [`ResponseSender`] must
+/// be a single concrete Python type, while the channel's item type is chosen by
+/// the (generic) [`response_channel`] factory. Every method here is called with
+/// the GIL already held by the Python caller.
+trait ResponseSink: Send + Sync {
+    /// Convert `obj` to an owned Rust value and enqueue it.
+    fn send(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<()>;
+
+    /// Normal end of stream.
+    fn close(&self);
+
+    /// Terminate the stream with an untyped error frame.
+    fn close_with_error(&self, message: String);
+
+    /// Terminate the stream with a typed backend error frame. Not exposed to
+    /// Python; used by the Rust-side safety net when the handler coroutine
+    /// raises instead of closing the sender itself.
+    fn close_with_dynamo_error(&self, error: DynamoError);
+}
+
+struct TypedSink<Resp> {
+    /// `None` once the stream has been closed. Dropping the last `Sender` is
+    /// what ends the receiver stream, so closing is "take the sender".
+    tx: Mutex<Option<mpsc::Sender<Annotated<Resp>>>>,
+}
+
+impl<Resp> TypedSink<Resp> {
+    /// Clone the sender out from under the lock rather than holding the lock
+    /// across the enqueue: a blocking send while holding the mutex would let a
+    /// concurrent `close()` deadlock against it.
+    fn sender(&self) -> Option<mpsc::Sender<Annotated<Resp>>> {
+        self.tx
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn take_sender(&self) -> Option<mpsc::Sender<Annotated<Resp>>> {
+        self.tx
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
+    /// Enqueue a terminal frame after the sender has already been taken.
+    ///
+    /// Unlike [`ResponseSink::send`] this runs on either side of the bridge:
+    /// from Python (`close_with_error`) or from the Rust driver task's error
+    /// path. Those have opposite constraints when the channel is full —
+    /// `blocking_send` panics inside an async task, and `spawn` needs a runtime
+    /// handle Python's event-loop thread does not have — so pick per caller.
+    /// Holding `tx` until the frame lands is what keeps the stream open long
+    /// enough to deliver it; the stream ends when the task below drops it.
+    fn send_terminal(&self, tx: mpsc::Sender<Annotated<Resp>>, frame: Annotated<Resp>)
+    where
+        Resp: Data,
+    {
+        let frame = match tx.try_send(frame) {
+            Ok(()) => return,
+            Err(mpsc::error::TrySendError::Full(frame)) => frame,
+            // Consumer is gone; there is nothing left to report to.
+            Err(mpsc::error::TrySendError::Closed(_)) => return,
+        };
+
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _nvtx_blocked = dynamo_nvtx_range!("pybridge.push_blocked");
+                let _ = tx.send(frame).await;
+            });
+            return;
+        }
+
+        // No runtime on this thread: we are on the Python side. Same GIL rule
+        // as `send` — release it across the wait.
+        let _nvtx_blocked = dynamo_nvtx_range!("pybridge.push_blocked");
+        let _ = Python::with_gil(|py| py.allow_threads(|| tx.blocking_send(frame)));
+    }
+}
+
+impl<Resp> ResponseSink for TypedSink<Resp>
+where
+    Resp: Data + for<'de> Deserialize<'de>,
+{
+    fn send(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<()> {
+        // Covers the whole Python->Rust crossing for one response: the
+        // `depythonize` plus the enqueue. Unlike the pull path there is no
+        // GIL *acquisition* inside this range — the Python handler already
+        // holds it — so this measures conversion cost only, not GIL wait.
+        let _nvtx = dynamo_nvtx_range!("pybridge.push_send");
+
+        let frame = decode_response::<Resp>(obj)?;
+
+        let Some(tx) = self.sender() else {
+            return Err(PyRuntimeError::new_err(
+                "response stream is closed; send() after close()",
+            ));
+        };
+
+        // Fast path. `try_send` never blocks, so there is no reason to drop the
+        // GIL for it, and dropping/reacquiring it would cost more than the send.
+        let frame = match tx.try_send(frame) {
+            Ok(()) => return Ok(()),
+            Err(mpsc::error::TrySendError::Full(frame)) => frame,
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                return Err(PyRuntimeError::new_err(
+                    "response stream is closed; the consumer dropped the response stream",
+                ));
+            }
+        };
+
+        // Backpressure path.
+        //
+        // CRITICAL: the GIL MUST be released across this blocking wait.
+        // `allow_threads` here is not an optimization, it is a correctness
+        // requirement. This call runs on the asyncio loop thread; blocking it
+        // with the GIL held freezes the entire interpreter — the event loop
+        // that would run every other request's handler, and every tokio task
+        // that needs the GIL. Anything that has to run for the channel to
+        // drain then cannot run, and a merely-full channel becomes an
+        // interpreter-wide stall instead of local backpressure.
+        //
+        // `blocking_send` panics if called from inside an async task. Both
+        // callers are safe: the Python event-loop thread (no runtime context at
+        // all) and the driver task's degradation path (a `spawn_blocking`
+        // thread, which is a permitted blocking region). It would panic only if
+        // a handler managed to call `send` from an async tokio task while
+        // holding the GIL.
+        let _nvtx_blocked = dynamo_nvtx_range!("pybridge.push_blocked");
+        py.allow_threads(|| tx.blocking_send(frame)).map_err(|_| {
+            PyRuntimeError::new_err(
+                "response stream is closed; the consumer dropped the response stream",
+            )
+        })
+    }
+
+    fn close(&self) {
+        // Dropping the last sender is what ends the receiver stream. Idempotent
+        // so the Rust-side safety net can close a stream the handler already
+        // closed itself.
+        drop(self.take_sender());
+    }
+
+    fn close_with_error(&self, message: String) {
+        let Some(tx) = self.take_sender() else {
+            return;
+        };
+        self.send_terminal(tx, Annotated::from_error(message));
+    }
+
+    fn close_with_dynamo_error(&self, error: DynamoError) {
+        let Some(tx) = self.take_sender() else {
+            return;
+        };
+        self.send_terminal(tx, Annotated::from_err(error));
+    }
+}
+
+/// Python -> Rust conversion for one response object.
+///
+/// Mirrors `engine::process_item` exactly, so the push path yields the same
+/// Rust value the pull path would have produced for the same Python object:
+/// yields tagged with `_dynamo_annotated: True` are wire `Annotated<R>`
+/// envelopes, everything else is plain data.
+fn decode_response<Resp>(obj: &Bound<'_, PyAny>) -> PyResult<Annotated<Resp>>
+where
+    Resp: for<'de> Deserialize<'de>,
+{
+    let py = obj.py();
+    let is_envelope = obj
+        .downcast::<PyDict>()
+        .ok()
+        .and_then(|dict| {
+            dict.get_item(pyo3::intern!(py, "_dynamo_annotated"))
+                .ok()
+                .flatten()
+        })
+        .and_then(|value| value.is_truthy().ok())
+        .unwrap_or(false);
+
+    let decoded = if is_envelope {
+        depythonize::<Annotated<Resp>>(obj)
+    } else {
+        depythonize::<Resp>(obj).map(Annotated::from_data)
+    };
+
+    decoded.map_err(|error| {
+        PyValueError::new_err(format!(
+            "critical error: invalid response object from python handler; \
+             application-logic-mismatch: {error}"
+        ))
+    })
+}
+
+// ── Python-facing handle ─────────────────────────────────────────────────────
+
+/// Rust response sink handed to a Python handler running in push mode.
+///
+/// Delivered as the `response_sender=` keyword argument, and also reachable as
+/// `context.response_sender`; `None`/absent on the pull path, so its presence is
+/// also how a handler decides which path it is on.
+///
+/// ```python
+/// async def generate(self, request, context, response_sender=None):
+///     sender = response_sender or getattr(context, "response_sender", None)
+///     if sender is None:              # pull path: unchanged
+///         async for chunk in engine.generate(request):
+///             yield chunk
+///         return
+///     try:                            # push path: yields nothing
+///         async for chunk in engine.generate(request):
+///             sender.send(chunk)
+///     except Exception as exc:
+///         sender.close_with_error(f"{type(exc).__name__}: {exc}")
+///     else:
+///         sender.close()
+/// ```
+///
+/// `send` blocks when the consumer is behind; it is safe to call from the
+/// asyncio loop thread because the GIL is released across that wait.
+#[pyclass]
+pub struct ResponseSender {
+    sink: Arc<dyn ResponseSink>,
+}
+
+#[pymethods]
+impl ResponseSender {
+    /// Convert one response object and enqueue it for the Rust egress path.
+    ///
+    /// Raises `RuntimeError` if the stream is already closed and `ValueError`
+    /// if the object cannot be converted.
+    fn send(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<()> {
+        self.sink.send(py, obj)
+    }
+
+    /// Normal end of stream. Idempotent.
+    fn close(&self) -> PyResult<()> {
+        self.sink.close();
+        Ok(())
+    }
+
+    /// Terminate the stream with an error frame. Idempotent; a later `close()`
+    /// is a no-op.
+    fn close_with_error(&self, msg: String) -> PyResult<()> {
+        self.sink.close_with_error(msg);
+        Ok(())
+    }
+}
+
+impl ResponseSender {
+    /// Rust-side handle to the same sink, for the safety net that terminates
+    /// the stream if the handler coroutine raises.
+    fn sink(&self) -> Arc<dyn ResponseSink> {
+        self.sink.clone()
+    }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+/// Build one request's push channel.
+///
+/// The returned stream yields `Annotated<Resp>` — the same item type
+/// `engine::buffered_typed_response_stream` produces on the pull path — so the
+/// ingress side (`lib/runtime/src/pipeline/network/ingress/push_handler.rs`)
+/// is unchanged.
+pub(crate) fn response_channel<Resp>(
+    depth: usize,
+) -> (
+    ResponseSender,
+    impl Stream<Item = Annotated<Resp>> + Send + 'static,
+)
+where
+    Resp: Data + for<'de> Deserialize<'de>,
+{
+    let (tx, rx) = mpsc::channel::<Annotated<Resp>>(depth);
+
+    let sender = ResponseSender {
+        sink: Arc::new(TypedSink {
+            tx: Mutex::new(Some(tx)),
+        }),
+    };
+
+    let stream = futures::stream::unfold(rx, |mut rx| async move {
+        // Unlike `pybridge.anext_call` in engine.rs, this range deliberately
+        // DOES span the `.await`: there is no Python work inside it to isolate,
+        // and the whole point of the push path is that the consumer side is
+        // pure Rust. Read it accordingly — the range length is dominated by the
+        // idle wait for the engine's next token, and its *end* marks the
+        // response arriving. The bridge cost itself is `pybridge.push_send` on
+        // the Python thread; a full channel shows up as `pybridge.push_blocked`.
+        let _nvtx = dynamo_nvtx_range!("pybridge.push_recv");
+        rx.recv().await.map(|item| (item, rx))
+    });
+
+    (sender, stream)
+}
+
+// ── Engine ───────────────────────────────────────────────────────────────────
+
+/// Response type carried by the push path. The GIL-side `depythonize` produces
+/// an owned Rust value, so — unlike the pull path's `PythonPayload` — nothing
+/// downstream of the channel can touch a Python object.
+pub(crate) type PushResponse = Annotated<serde_json::Value>;
+
+/// Push-mode counterpart of `engine::PythonNetworkEngine`.
+///
+/// The handler is still called exactly as on the pull path — it is still an
+/// async-generator function, and the returned generator is still driven by
+/// `engine::invoke_generator` / `demand_driven_python_stream`. What changes is
+/// how often: in push mode the generator yields nothing and is advanced ONCE
+/// per request (one `__anext__`, which runs the whole request and then raises
+/// `StopAsyncIteration`), instead of once per response. Responses arrive out of
+/// band on the [`ResponseSender`] the handler finds on its `context`.
+///
+/// Keeping the generator shape is deliberate: registration
+/// (`endpoint.serve_endpoint(handler.generate, ...)`), cancellation, and the
+/// handler's own control flow are untouched, and a handler that ignores the
+/// sender and yields normally still works (see the driver task below).
+pub(crate) struct PythonPushEngine {
+    handler: Arc<PyObject>,
+    event_loop: Arc<PyObject>,
+}
+
+impl PythonPushEngine {
+    pub(crate) fn new(handler: PyObject, event_loop: PyObject) -> Self {
+        Self {
+            handler: Arc::new(handler),
+            event_loop: Arc::new(event_loop),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncEngine<SingleIn<PythonPayload>, ManyOut<PushResponse>, Error> for PythonPushEngine {
+    async fn generate(
+        &self,
+        request: SingleIn<PythonPayload>,
+    ) -> Result<ManyOut<PushResponse>, Error> {
+        let (request, context) = request.transfer(());
+        let ctx = context.context();
+        let request_id = context.id().to_string();
+        let metadata = context.metadata().clone();
+        let current_trace_context = get_distributed_tracing_context();
+
+        let (sender, stream) = response_channel::<serde_json::Value>(PUSH_CHANNEL_DEPTH);
+        let sink = sender.sink();
+
+        let python_input = request.into_inner();
+        let handler_ctx = ctx.clone();
+
+        // The sender rides on the `Context`. `serve_endpoint` has already
+        // verified the handler accepts a `context` argument before selecting
+        // this engine, so the closure below always runs and the sender is
+        // always delivered — if it were dropped here instead, the channel would
+        // close and the request would return an empty stream.
+        let driver = engine::invoke_generator(
+            self.handler.clone(),
+            self.event_loop.clone(),
+            move |_py| Ok(python_input),
+            Some(move |py: Python<'_>| {
+                // ONE sender object, delivered TWO ways, because the Python half
+                // reads it from a `response_sender=` keyword argument
+                // (`push_egress.py:235`) while `context.response_sender` is the
+                // documented fallback. Delivering only one of them is the seam
+                // that silently drops the worker back to the pull path — or, if
+                // Rust has already committed to awaiting a coroutine, fails the
+                // request outright. `Py<T>` is refcounted, so the clone is the
+                // same Python object, and a handler comparing them sees identity.
+                let py_sender = Py::new(py, sender)?;
+                let context = Py::new(
+                    py,
+                    Context::new(handler_ctx, current_trace_context, None, metadata)
+                        .with_response_sender(py_sender.clone_ref(py)),
+                )?;
+                Ok(vec![
+                    ("context", context.into_any()),
+                    ("response_sender", py_sender.into_any()),
+                ])
+            }),
+        )
+        .await?;
+
+        // Driver task. In push mode this exists only to run the handler to
+        // completion and observe how it ended; the responses themselves never
+        // pass through here.
+        tokio::spawn(async move {
+            let mut driver = driver;
+            let mut yielded = 0usize;
+
+            while let Some(item) = driver.next().await {
+                let item = match item {
+                    Ok(item) => item,
+                    Err(error) => {
+                        sink.close_with_dynamo_error(map_python_exception(error));
+                        return;
+                    }
+                };
+
+                // Graceful degradation. A push-mode handler yields nothing, so
+                // this arm is normally dead code. It is reached when the handler
+                // ignored the sender and yielded instead (e.g. a handler that
+                // predates the push path, or one whose own flag check disagreed
+                // with ours): forward the frame through the same sink so the
+                // request still completes correctly, just without the benefit.
+                yielded += 1;
+                let forward_sink = sink.clone();
+                let forwarded = tokio::task::spawn_blocking(move || {
+                    // Unlike `pybridge.push_send`, this range DOES include a GIL
+                    // acquisition on a tokio thread — it is the pull path's cost,
+                    // reappearing precisely because the handler did not push.
+                    let _nvtx = dynamo_nvtx_range!("pybridge.push_forward_yield");
+                    Python::with_gil(|py| forward_sink.send(py, item.bind(py)))
+                })
+                .await;
+
+                match forwarded {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        sink.close_with_dynamo_error(map_python_exception(error));
+                        return;
+                    }
+                    Err(error) => {
+                        sink.close_with_error(format!(
+                            "critical error: failed to offload the python response forward \
+                             to a new thread: {error}"
+                        ));
+                        return;
+                    }
+                }
+            }
+
+            if yielded > 0 {
+                tracing::debug!(
+                    request_id,
+                    yielded,
+                    "push egress: handler yielded responses instead of pushing them; \
+                     forwarded them over the pull path"
+                );
+            }
+
+            // Idempotent: a well-behaved handler has already closed the sender.
+            sink.close();
+        });
+
+        Ok(ResponseStream::new(Box::pin(stream), context.context()))
+    }
+}

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -195,6 +195,27 @@ impl IngressResponseEncoder<crate::push_egress::PushFrame> for PythonIngressPayl
     }
 }
 
+/// Convert an `Annotated` value into request-plane bytes and the `is_error` flag,
+/// using the canonical non-terminal wrapper shape (`complete_final: false`).
+///
+/// Both the pull path ([`encode_python_response`]) and the push path
+/// ([`crate::push_egress::PushFrame::encode`]) call this, so neither can silently
+/// change the wrapper shape, `is_error` logic, or codec invocation without also
+/// breaking this function — and the tests below that exercise it directly with
+/// concrete non-Python types.
+pub(crate) fn encode_annotated_response<T: Serialize>(
+    codec: RequestPlanePayloadCodec,
+    annotated: Annotated<T>,
+) -> Result<(Vec<u8>, bool), anyhow::Error> {
+    let is_error = annotated.is_error();
+    let wrapper = NetworkStreamWrapper {
+        data: Some(annotated),
+        complete_final: false,
+    };
+    let bytes = codec.encode(&wrapper)?;
+    Ok((bytes, is_error))
+}
+
 fn encode_python_response(
     payload_codec: RequestPlanePayloadCodec,
     response: PythonResponseItem,
@@ -212,14 +233,9 @@ fn encode_python_response(
         },
         Err(error) => (Annotated::from_err(map_python_exception(error)), true),
     };
-    let is_error = annotated.is_error();
-    let wrapper = NetworkStreamWrapper {
-        data: Some(annotated),
-        complete_final: false,
-    };
 
-    match payload_codec.encode(&wrapper) {
-        Ok(bytes) => Ok(EncodedResponseFrame {
+    match encode_annotated_response(payload_codec, annotated) {
+        Ok((bytes, is_error)) => Ok(EncodedResponseFrame {
             bytes: bytes.into(),
             is_error,
             stop_stream,
@@ -323,6 +339,109 @@ mod tests {
     // PyO3's `extension-module` feature, so standalone `cargo test` binaries
     // intentionally do not link libpython. Python behavior is covered by
     // tests/test_request_plane_python_payload.py against the built extension.
+
+    use super::{
+        Annotated, NetworkStreamWrapper, RequestPlanePayloadCodec, encode_annotated_response,
+    };
+
+    // ── encode_annotated_response contract ───────────────────────────────────
+    //
+    // Both egress paths (pull via encode_python_response, push via
+    // PushFrame::encode) call encode_annotated_response. These tests pin every
+    // field of the output so that a change to the wrapper shape, is_error
+    // logic, or complete_final flag in either path would be caught here.
+    //
+    // serde_json::Value is used as the concrete payload type because it is
+    // Serialize without touching the Python C API.
+
+    /// `is_error` must reflect `annotated.is_error()` — true when the envelope
+    /// carries `event: "error"`, false otherwise. A swap of the two would let
+    /// error frames be forwarded as healthy responses and vice versa.
+    #[test]
+    fn encode_annotated_response_is_error_true_for_error_annotated() {
+        let (_, is_error) = encode_annotated_response(
+            RequestPlanePayloadCodec::Json,
+            Annotated::<serde_json::Value>::from_error("oops"),
+        )
+        .unwrap();
+        assert!(is_error);
+    }
+
+    #[test]
+    fn encode_annotated_response_is_error_false_for_data_annotated() {
+        let (_, is_error) = encode_annotated_response(
+            RequestPlanePayloadCodec::Json,
+            Annotated::from_data(serde_json::json!({"ok": true})),
+        )
+        .unwrap();
+        assert!(!is_error);
+    }
+
+    /// Non-terminal frames must have `complete_final: false` on the wire.
+    /// A stray `true` would tell the caller the stream has ended even when
+    /// the Python generator is still running.
+    #[test]
+    fn encode_annotated_response_complete_final_is_always_false() {
+        for codec in [
+            RequestPlanePayloadCodec::Json,
+            RequestPlanePayloadCodec::Msgpack,
+        ] {
+            let (bytes, _) =
+                encode_annotated_response(codec, Annotated::from_data(serde_json::json!(null)))
+                    .unwrap();
+            let wrapper: NetworkStreamWrapper<Annotated<serde_json::Value>> =
+                codec.decode(&bytes).unwrap();
+            assert!(!wrapper.complete_final, "codec={}", codec.name());
+        }
+    }
+
+    /// The payload must survive the encode → decode round-trip intact.
+    /// A `data: None` in the wrapper or a wrong serde path would drop it.
+    #[test]
+    fn encode_annotated_response_data_survives_roundtrip() {
+        let payload = serde_json::json!({"text": "hello", "n": 42});
+        let (bytes, is_error) = encode_annotated_response(
+            RequestPlanePayloadCodec::Json,
+            Annotated::from_data(payload.clone()),
+        )
+        .unwrap();
+        assert!(!is_error);
+        let wrapper: NetworkStreamWrapper<Annotated<serde_json::Value>> =
+            RequestPlanePayloadCodec::Json.decode(&bytes).unwrap();
+        let data = wrapper.data.unwrap().data.unwrap();
+        assert_eq!(data, payload);
+    }
+
+    /// Encoding is deterministic: the same `Annotated` value with the same
+    /// codec must produce byte-identical frames from both egress paths.
+    /// Non-determinism would mean the pull and push paths could silently
+    /// diverge on map ordering or float representation.
+    #[test]
+    fn encode_annotated_response_same_input_same_bytes_both_codecs() {
+        for codec in [
+            RequestPlanePayloadCodec::Json,
+            RequestPlanePayloadCodec::Msgpack,
+        ] {
+            let (bytes_a, is_error_a) = encode_annotated_response(
+                codec,
+                Annotated::from_data(serde_json::json!({"x": 1, "y": "z"})),
+            )
+            .unwrap();
+            let (bytes_b, is_error_b) = encode_annotated_response(
+                codec,
+                Annotated::from_data(serde_json::json!({"x": 1, "y": "z"})),
+            )
+            .unwrap();
+            assert_eq!(
+                bytes_a,
+                bytes_b,
+                "codec={} must be deterministic",
+                codec.name()
+            );
+            assert_eq!(is_error_a, is_error_b);
+        }
+    }
+
     #[test]
     fn network_ingress_types_do_not_contain_serde_json_value() {
         let unary = std::any::type_name::<crate::PythonServerStreamingIngress>();

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -416,31 +416,6 @@ mod tests {
     /// codec must produce byte-identical frames from both egress paths.
     /// Non-determinism would mean the pull and push paths could silently
     /// diverge on map ordering or float representation.
-    #[test]
-    fn encode_annotated_response_same_input_same_bytes_both_codecs() {
-        for codec in [
-            RequestPlanePayloadCodec::Json,
-            RequestPlanePayloadCodec::Msgpack,
-        ] {
-            let (bytes_a, is_error_a) = encode_annotated_response(
-                codec,
-                Annotated::from_data(serde_json::json!({"x": 1, "y": "z"})),
-            )
-            .unwrap();
-            let (bytes_b, is_error_b) = encode_annotated_response(
-                codec,
-                Annotated::from_data(serde_json::json!({"x": 1, "y": "z"})),
-            )
-            .unwrap();
-            assert_eq!(
-                bytes_a,
-                bytes_b,
-                "codec={} must be deterministic",
-                codec.name()
-            );
-            assert_eq!(is_error_a, is_error_b);
-        }
-    }
 
     #[test]
     fn network_ingress_types_do_not_contain_serde_json_value() {

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -152,35 +152,46 @@ impl IngressResponseEncoder<PythonResponseItem> for PythonIngressPayloadAdapter 
 
 /// Response encoder for the push egress path (`push_egress.rs`).
 ///
-/// The push path converts each response to an owned Rust value on the Python
-/// thread that produced it, so by the time a frame reaches here it holds no
-/// Python object: encoding is pure serde. No GIL, and — unlike the
-/// [`PythonResponseItem`] encoder above — no `spawn_blocking` hop either.
-impl IngressResponseEncoder<Annotated<serde_json::Value>> for PythonIngressPayloadAdapter {
+/// The push path encodes each response all the way to request-plane bytes on
+/// the Python thread that produced it, under the GIL that thread already holds
+/// (`push_egress::PushFrame`). By the time a frame reaches here there is
+/// nothing left to do but forward it: no GIL, no second serde pass, and —
+/// unlike the [`PythonResponseItem`] encoder above — no `spawn_blocking` hop.
+///
+/// The only work left is the terminal complete-final frame, which carries no
+/// Python data at all, and the rare codec re-encode described on
+/// [`push_egress::PushFrame`].
+impl IngressResponseEncoder<crate::push_egress::PushFrame> for PythonIngressPayloadAdapter {
     async fn encode_response(
         &self,
         payload_codec: RequestPlanePayloadCodec,
-        response: Option<Annotated<serde_json::Value>>,
+        response: Option<crate::push_egress::PushFrame>,
         complete_final: bool,
     ) -> Result<EncodedResponseFrame, PipelineError> {
-        let is_error = response
-            .as_ref()
-            .is_some_and(|response| response.err().is_some());
-        let wrapper = NetworkStreamWrapper {
-            data: response,
-            complete_final,
-        };
-        let bytes = payload_codec.encode(&wrapper).map_err(|error| {
-            PipelineError::SerializationError(format!(
-                "Failed serializing {} push-egress response: {error}",
-                payload_codec.name()
-            ))
+        if complete_final {
+            let wrapper = NetworkStreamWrapper::<Annotated<()>> {
+                data: None,
+                complete_final: true,
+            };
+            let bytes = payload_codec.encode(&wrapper).map_err(|error| {
+                PipelineError::SerializationError(format!(
+                    "Failed serializing {} push-egress final response: {error}",
+                    payload_codec.name()
+                ))
+            })?;
+            return Ok(EncodedResponseFrame {
+                bytes: bytes.into(),
+                is_error: false,
+                stop_stream: false,
+            });
+        }
+
+        let frame = response.ok_or_else(|| {
+            PipelineError::SerializationError(
+                "push-egress response item missing before final frame".to_string(),
+            )
         })?;
-        Ok(EncodedResponseFrame {
-            bytes: bytes.into(),
-            is_error,
-            stop_stream: false,
-        })
+        frame.into_encoded(payload_codec)
     }
 }
 
@@ -236,7 +247,16 @@ fn encode_python_response(
     }
 }
 
-fn parse_python_response(
+/// Interpret one Python response object as a wire `Annotated<PythonPayload>`.
+///
+/// Shared by both egress paths — pull via [`encode_python_response`], push via
+/// `push_egress::PushFrame::encode` — so the two cannot drift and start
+/// disagreeing about what a given Python object means on the wire. The payload
+/// stays a [`PythonPayload`], which transcodes straight into the request-plane
+/// codec and therefore preserves everything that codec can represent (binary
+/// values, non-finite floats, non-string mapping keys). The GIL is already held
+/// on both paths.
+pub(crate) fn parse_python_response(
     item: Py<PyAny>,
     py: Python<'_>,
 ) -> Result<Annotated<PythonPayload>, String> {

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -150,6 +150,40 @@ impl IngressResponseEncoder<PythonResponseItem> for PythonIngressPayloadAdapter 
     }
 }
 
+/// Response encoder for the flag-gated push egress path (`push_egress.rs`).
+///
+/// The push path converts each response to an owned Rust value on the Python
+/// thread that produced it, so by the time a frame reaches here it holds no
+/// Python object: encoding is pure serde. No GIL, and — unlike the
+/// [`PythonResponseItem`] encoder above — no `spawn_blocking` hop either.
+impl IngressResponseEncoder<Annotated<serde_json::Value>> for PythonIngressPayloadAdapter {
+    async fn encode_response(
+        &self,
+        payload_codec: RequestPlanePayloadCodec,
+        response: Option<Annotated<serde_json::Value>>,
+        complete_final: bool,
+    ) -> Result<EncodedResponseFrame, PipelineError> {
+        let is_error = response
+            .as_ref()
+            .is_some_and(|response| response.err().is_some());
+        let wrapper = NetworkStreamWrapper {
+            data: response,
+            complete_final,
+        };
+        let bytes = payload_codec.encode(&wrapper).map_err(|error| {
+            PipelineError::SerializationError(format!(
+                "Failed serializing {} push-egress response: {error}",
+                payload_codec.name()
+            ))
+        })?;
+        Ok(EncodedResponseFrame {
+            bytes: bytes.into(),
+            is_error,
+            stop_stream: false,
+        })
+    }
+}
+
 fn encode_python_response(
     payload_codec: RequestPlanePayloadCodec,
     response: PythonResponseItem,

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -150,7 +150,7 @@ impl IngressResponseEncoder<PythonResponseItem> for PythonIngressPayloadAdapter 
     }
 }
 
-/// Response encoder for the flag-gated push egress path (`push_egress.rs`).
+/// Response encoder for the push egress path (`push_egress.rs`).
 ///
 /// The push path converts each response to an owned Rust value on the Python
 /// thread that produced it, so by the time a frame reaches here it holds no

--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -298,3 +298,116 @@ impl SystemHealth {
         &self.live_path
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::{Instance, TransportType};
+
+    const ENDPOINT: &str = "generate";
+
+    fn system_health(health_check_enabled: bool) -> SystemHealth {
+        SystemHealth::new(
+            HealthStatus::NotReady,
+            // Deprecated and ignored in practice (see RuntimeConfig::from_settings),
+            // so the realistic case is an empty vector.
+            Vec::new(),
+            health_check_enabled,
+            "/health".to_string(),
+            "/live".to_string(),
+        )
+    }
+
+    fn instance() -> Instance {
+        Instance {
+            component: "backend".to_string(),
+            endpoint: ENDPOINT.to_string(),
+            namespace: "dynamo".to_string(),
+            instance_id: 1,
+            transport: TransportType::Tcp("127.0.0.1:0".to_string()),
+            device_type: None,
+            request_plane_codec: None,
+        }
+    }
+
+    /// A worker that registers a health-check payload reports ready once its
+    /// endpoint is registered, with the canary off.
+    #[test]
+    fn registered_target_makes_the_worker_ready_with_canary_off() {
+        let health = system_health(false);
+        health.register_health_check_target(ENDPOINT, instance(), serde_json::json!({}));
+        health.set_endpoint_registered(ENDPOINT);
+
+        let (healthy, endpoints) = health.get_health_status();
+        assert!(healthy, "a registered, ready endpoint must report healthy");
+        assert_eq!(endpoints.get(ENDPOINT).map(String::as_str), Some("ready"));
+    }
+
+    /// Regression guard for the push-egress health-check bug.
+    ///
+    /// `health_check_targets` is populated ONLY by passing a
+    /// `health_check_payload` to `serve_endpoint`. An earlier revision of the
+    /// push-egress path skipped that payload to avoid the `start_with_registration`
+    /// bail, on the theory that it merely disabled the canary. It does not: with
+    /// the map empty, `get_health_status` stops consulting endpoint status at all
+    /// and falls through to the process-wide `system_health`, which starts
+    /// `NotReady` and which the TRT-LLM worker never sets. The endpoint is marked
+    /// ready and the worker still reports 503 — on default settings, since this
+    /// path does not depend on the canary being enabled.
+    #[test]
+    fn ready_endpoint_without_a_registered_target_still_reports_unhealthy() {
+        let health = system_health(false);
+        // No register_health_check_target: this is the "skip the payload" case.
+        health.set_endpoint_registered(ENDPOINT);
+
+        let (healthy, endpoints) = health.get_health_status();
+        assert_eq!(
+            endpoints.get(ENDPOINT).map(String::as_str),
+            Some("ready"),
+            "the endpoint itself is ready"
+        );
+        assert!(
+            !healthy,
+            "with no health-check target the endpoint's readiness is ignored and \
+             the worker falls back to system_health (NotReady) — this is the 503"
+        );
+    }
+
+    /// The fallthrough is only escapable by setting system health directly,
+    /// which in this repo only the vLLM worker does.
+    #[test]
+    fn without_targets_health_tracks_system_health_only() {
+        let mut health = system_health(false);
+        health.set_endpoint_registered(ENDPOINT);
+        assert!(!health.get_health_status().0);
+
+        health.set_health_status(HealthStatus::Ready);
+        assert!(
+            health.get_health_status().0,
+            "with no targets, system_health alone decides"
+        );
+    }
+
+    /// With the canary on, endpoint registration deliberately does NOT mark the
+    /// endpoint ready — the canary does, after verifying a real generation. A
+    /// push endpoint therefore needs a locally registered engine for the canary
+    /// to dispatch to, which is why `serve_endpoint` registers a pull engine
+    /// alongside the push ingress.
+    #[test]
+    fn canary_enabled_withholds_ready_until_verified() {
+        let health = system_health(true);
+        health.register_health_check_target(ENDPOINT, instance(), serde_json::json!({}));
+        health.set_endpoint_registered(ENDPOINT);
+
+        assert!(
+            !health.get_health_status().0,
+            "canary must verify before the worker reports ready"
+        );
+
+        health.set_endpoint_health_status(ENDPOINT, HealthStatus::Ready);
+        assert!(
+            health.get_health_status().0,
+            "after the canary marks it ready the worker is healthy"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

On the TRT-LLM decode worker the default "pull" egress path has Rust tokio threads driving the Python handler's async generator: per response a tokio worker takes the GIL to call `__anext__()`, schedules it onto the Python event loop, parks, and then takes the GIL a second time to depythonize the result. With ~40 tokio pool threads in the app interpreter all contending, that cross-thread choreography is a significant source of GIL contention.

This PR inverts the direction. The Python handler — which already holds the GIL while it runs — calls a Rust `ResponseSender` directly, and the value is enqueued on a bounded `tokio::sync::mpsc`. No tokio thread ever touches Python; the tokio side only does `rx.recv().await`. Rust advances the handler's generator **once per request** instead of once per response.

Push is the **only** egress path for the TRT-LLM LLM handlers — there is no environment variable and no runtime switch. Every other Python handler in the repo (vLLM, SGLang, frontend, planner, router, mocker) keeps the pull path verbatim.

## How the path is selected

`Endpoint.serve_endpoint` is shared by every Python worker, so the gate matters. `handler_supports_push` reduces to:

```
"response_sender" in inspect.signature(handler).parameters
```

Applying `@push_egress_capable` is what puts that parameter there, so **the decorator is the switch**. Two consequences worth checking in review:

- It probes for `response_sender`, **not** `context`. Every handler accepts `context`, so probing for that would make the check always true and drive every non-TRT-LLM handler in push mode.
- `push_egress_capable` deletes its own `__wrapped__`, because `inspect.signature` follows it and would report the undecorated `generate(self, request, context)` — hiding the parameter and silently reverting every endpoint to the pull path with nothing logged.

## Details

**Rust (`lib/bindings/python/rust/push_egress.rs`, new):**
- `ResponseSender` `#[pyclass]` — `send(obj)`, `close()`, `close_with_error(msg)`. Closes are idempotent. `send()` converts under the caller's existing GIL and `try_send`s; on a full channel it calls `py.allow_threads(|| blocking_send)`. Releasing the GIL there is a correctness requirement, not an optimisation — blocking the asyncio loop thread with the GIL held turns a merely-full channel into an interpreter-wide stall.
- `PythonPushEngine` — selected in `serve_endpoint`. Builds the channel (depth 128, matching `engine::RESPONSE_CHANNEL_DEPTH`), delivers the sender as the `response_sender` kwarg alongside `context`, and drives the generator once per request.
- `decode_response` shares `engine::depythonize_annotated` with the pull path's `process_item`, so both paths produce the same wire value for the same Python object **by construction** rather than by a comment asserting they match.

**Rust (`engine.rs`):** `invoke_generator`'s callback now returns the full kwarg list rather than just the context, so push can build `context` and `response_sender` under one GIL acquisition. The pull call sites pass a single `("context", ctx)` entry and are behaviourally unchanged. `depythonize_annotated` is the extracted shared decoder.

**Rust (`python_payload.rs`):** new `IngressResponseEncoder` impl for `Annotated<serde_json::Value>`. The push path converts on the Python thread, so encoding is pure serde — no GIL and no `spawn_blocking` hop.

**Python (`components/src/dynamo/trtllm/request_handlers/push_egress.py`, new):**
- `drive_push_egress` — drains the handler's generator into the sender, terminating exactly once across normal completion, cancellation, error, and `BaseException`.
- `drive_push_egress_stream` — async-**generator** wrapper. This is what is returned to Rust: `demand_driven_python_stream` does `getattr("__anext__")`, so it must not be a coroutine. The unreachable `if False: yield` is load-bearing — it is what makes Python compile this as an async-generator function.
- `push_egress_capable` — applied outermost to all four handler `generate` methods.

## Behaviour changes reviewers should weigh

1. **A push-mode handler that yields now fails its request.** The earlier revision forwarded the frame back over the pull path via `spawn_blocking` + `with_gil`. That arm is dead once the decorator is the only way in, and reaching it would silently reintroduce exactly the per-response GIL acquisition this PR removes — so it now errors the stream loudly instead.
2. **`register_local_engine` is skipped for push-mode endpoints.** The in-process `SingleIn`/`ManyOut` registry does not model a per-request sender. There is no in-repo in-process caller of these endpoints today, but an in-process call to one would get an empty stream with no error.

## Not in this PR

NVTX instrumentation for this path was removed. It depends on the NVTX v3 change (`529951aa06` on `kmcgill/add-nvtx-to-workers`), which is landing separately: on `main` today `dynamo_nvtx_range!` is still cudarc's thread-nested push/pop — wrong for a range held across an `await` — and reaches NVTX through a binding that dlopens `libnvToolsExt.so`, removed in CUDA 13. Rather than ship instrumentation that is unsafe to enable, the follow-on PR reinstates it against a macro with the right semantics.

## Validation

**41 Python unit tests** (`components/src/dynamo/trtllm/tests/test_push_egress.py`) and **27 Rust** (5 new in `push_egress::tests` + 22 pre-existing). `cargo fmt` and `cargo clippy` clean.

```bash
python3 -m pytest -m unit components/src/dynamo/trtllm/tests/test_push_egress.py
cd lib/bindings/python && cargo test --lib
```

Both suites also run green in a `worker-egress-push` container image.

The tests are written to break the implementation, and the two highest-value cases both cover silent failures:
- **Path selection** — the predicate is mirrored in Python and every handler shape in the repo asserted against it. `**kwargs` must not match, or every non-TRT-LLM handler would be driven in push mode without ever pushing. A canary proves that restoring the `__wrapped__` link disables push egress everywhere with nothing logged.
- **No bleed into other engines** — an AST scan asserts no non-TRT-LLM code under `components/src/dynamo` declares a `response_sender` parameter, mutation-tested by injecting a decoy handler under `vllm/`.

Also covered: async-generator vs coroutine shape, advanced-once-per-request, chunk ordering and completeness, exactly-once termination across all exit paths, and that all four handlers carry `@push_egress_capable` outermost.

**Known gaps.** The real `ResponseSender` has no Python constructor, so the Python tests run against a fake enforcing its documented contract — the actual Python/Rust boundary and the backpressure path are not exercised and need an end-to-end request through `serve_endpoint` with etcd and NATS. On the Rust side, anything reaching the Python C API cannot be unit-tested here because pyo3's `extension-module` feature is hardcoded, so those tests would fail to link.

## Where should the reviewer start?

1. **`lib/bindings/python/rust/lib.rs`** — `serve_endpoint`, where the engine is selected. One line decides which path every Python worker in the repo takes.
2. **`lib/bindings/python/rust/push_egress.rs`** — `ResponseSender` and the send/block/close contract, especially the comment on why `allow_threads` is mandatory on a full channel.
3. **`components/src/dynamo/trtllm/request_handlers/push_egress.py`** — the module docstring states the three load-bearing invariants (generator shape, outermost decorator with `__wrapped__` deleted, sender contract). Read before the handlers.
4. **`lib/bindings/python/rust/engine.rs`** — `depythonize_annotated` and the `invoke_generator` kwarg-list change.

## Related Issues

- Relates to DYN-3703


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added push-based response delivery for supported TRT-LLM handlers.
  * Responses can now be streamed directly with completion, cancellation, and error signaling.
  * Added automatic selection between push and pull response handling.
  * Added bounded backpressure to help manage response flow.

* **Bug Fixes**
  * Improved handling of multi-field request context and annotated responses.
  * Preserved compatibility with handlers that continue using pull-based streaming.

* **Tests**
  * Added comprehensive coverage for response delivery, termination, errors, fallback behavior, and backpressure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->