### PR TITLE
fix(sweeper): close non-blocking review follow-ups

### DIFF
--- a/aisimulate/tests/sweeper/test_packaging.py
+++ b/aisimulate/tests/sweeper/test_packaging.py
@@ -24,6 +24,7 @@ def test_aisimulate_distribution_publishes_aisimulate_sweeper_package():
     # Planner CI, assert the artifact contains the canonical package and no alias.
     if any(path.startswith("aisimulate/") for path in packaged_files):
         assert any(path.startswith("aisimulate/sweeper/") for path in packaged_files)
+        assert not any(path.startswith("aisimulate/spica/") for path in packaged_files)
         assert not any(path.startswith("sweeper/") for path in packaged_files)
 
 

--- a/components/src/dynamo/planner/simulation/provider.py
+++ b/components/src/dynamo/planner/simulation/provider.py
@@ -182,6 +182,16 @@ def _plain(value: Any) -> Any:
 
 def _planner_optimization_target(goal: Mapping[str, JSONValue]) -> str:
     target = str(_plain(goal.get("target", "throughput")))
+    if target == "pareto":
+        raw_objectives = goal.get("pareto_objectives")
+        objectives = (
+            {str(_plain(objective)) for objective in raw_objectives}
+            if isinstance(raw_objectives, list)
+            else set()
+        )
+        if objectives.intersection({"goodput", "goodput_per_gpu"}):
+            return "sla"
+        return "throughput"
     return {
         "throughput": "throughput",
         "throughput_per_gpu": "throughput",
@@ -189,7 +199,6 @@ def _planner_optimization_target(goal: Mapping[str, JSONValue]) -> str:
         "e2e_latency": "latency",
         "goodput": "sla",
         "goodput_per_gpu": "sla",
-        "pareto": "throughput",
     }[target]
 
 

--- a/components/src/dynamo/planner/tests/unit/test_planner_sweep_config_provider.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_sweep_config_provider.py
@@ -99,6 +99,60 @@ def test_non_goodput_filters_predictive_throughput_policies() -> None:
     assert plan.potential_runtime_hooks[0].provider == "dynamo.planner"
 
 
+def test_pareto_goodput_uses_sla_planner_target() -> None:
+    adapter = create_provider()
+    context = replace(
+        _sweep_context(target="pareto"),
+        goal={
+            "target": "pareto",
+            "pareto_objectives": ["goodput_per_gpu", "throughput_per_user"],
+            "sla": {"ttft_ms": 2000.0, "itl_ms": 30.0},
+        },
+    )
+
+    plan = adapter.generate_search_space(
+        {
+            "scaling_policy": ["throughput_180_5"],
+            "fpm_sampling": ["default"],
+            "load_sensitivity": ["default"],
+            "load_predictor_candidates": ["constant_last"],
+        },
+        context,
+    )
+    replay_spec = adapter.materialize_replay(
+        plan,
+        {
+            "scaling_policy": "throughput_180_5",
+            "fpm_sampling": "default",
+            "load_sensitivity": "default",
+        },
+        _candidate_context(),
+    )
+
+    assert isinstance(plan.state, dict)
+    assert plan.state["optimization_target"] == "sla"
+    planner_config = replay_spec.runtime_hooks[0].config["planner_config"]
+    assert isinstance(planner_config, dict)
+    assert planner_config["optimization_target"] == "sla"
+    assert planner_config["ttft_ms"] == 2000.0
+    assert planner_config["itl_ms"] == 30.0
+
+
+def test_default_pareto_keeps_throughput_planner_target() -> None:
+    context = replace(
+        _sweep_context(target="pareto"),
+        goal={"target": "pareto", "pareto_objectives": None, "sla": None},
+    )
+
+    plan = create_provider().generate_search_space(
+        {"scaling_policy": ["disabled"]},
+        context,
+    )
+
+    assert isinstance(plan.state, dict)
+    assert plan.state["optimization_target"] == "throughput"
+
+
 def test_disabled_policy_materializes_no_runtime_hook() -> None:
     adapter = create_provider()
     plan = adapter.generate_search_space(

--- a/components/src/dynamo/replay/tests/test_simulation_integration.py
+++ b/components/src/dynamo/replay/tests/test_simulation_integration.py
@@ -224,6 +224,7 @@ def test_real_static_path_preserves_goodput() -> None:
     assert "planner_total_ticks" not in report.metrics
 
 
+@pytest.mark.pre_merge
 @pytest.mark.post_merge
 @pytest.mark.timeout(300)
 def test_sweeper_runs_real_dynamo_replay_in_spawned_workers() -> None:


### PR DESCRIPTION
## Summary

- map Pareto goals containing `goodput` or `goodput_per_gpu` to the Planner's SLA optimization target while preserving the default throughput-based Pareto behavior
- assert that the built AI Simulate wheel contains `aisimulate.sweeper` and no legacy `aisimulate.spica` package
- run the existing real two-worker `DynamoReplayRunnerFactory` integration test in both pre-merge and post-merge suites

## Why

PR #12446 deliberately keeps a large architectural refactor focused. These are non-blocking follow-ups from its final review:

- the Planner mapping previously inspected only `goal.target`, so every Pareto goal became `throughput` even when one objective was goodput and required SLA-aware scaling
- the wheel test checked for a top-level `sweeper/` alias but did not verify that `aisimulate/spica/` was absent
- the strongest spawned-worker integration test existed only in the post-merge suite and therefore did not gate pull requests

This PR is stacked on #12446 and should merge after it.

## Validation

- repository pre-commit hooks on all four changed files
- two focused Planner provider regression tests
- built-wheel packaging test in a clean Python 3.12 environment
- `git diff --check`

The real spawned Replay integration requires the Planner image and native bindings; this change makes that exact test run in PR CI.