### PR TITLE
fix(vllm): filter infeasible EAGLE benchmark points (cherry-pick #12836)

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -2144,9 +2144,23 @@ class InstrumentedScheduler(AsyncScheduler):
         except ValueError:
             return False
 
+        eagle_cache_drop_tokens = self._bench_eagle_cache_drop_tokens()
+        if eagle_cache_drop_tokens and any(
+            kv_read_tokens > 0 and new_tokens <= eagle_cache_drop_tokens
+            for new_tokens, kv_read_tokens in zip(
+                new_token_lengths, kv_read_lengths, strict=True
+            )
+        ):
+            # EAGLE recomputes the last matched cache block. A request needs
+            # more than that block's tokens to reach the extra seeded block
+            # while preserving both benchmark axes.
+            return False
+
         prompt_lengths = [
             new_tokens + kv_read_tokens
-            for new_tokens, kv_read_tokens in zip(new_token_lengths, kv_read_lengths)
+            for new_tokens, kv_read_tokens in zip(
+                new_token_lengths, kv_read_lengths, strict=True
+            )
         ]
         if any(prompt_len + 1 > self.max_model_len for prompt_len in prompt_lengths):
             return False
@@ -2154,14 +2168,16 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_prefill_scheduled_tokens_per_req(prompt_len, kv_read_tokens)
             != new_tokens
             for prompt_len, kv_read_tokens, new_tokens in zip(
-                prompt_lengths, kv_read_lengths, new_token_lengths
+                prompt_lengths, kv_read_lengths, new_token_lengths, strict=True
             )
         ):
             return False
 
         required_blocks = sum(
             self._bench_prefill_blocks_per_req(prompt_len, kv_read_tokens)
-            for prompt_len, kv_read_tokens in zip(prompt_lengths, kv_read_lengths)
+            for prompt_len, kv_read_tokens in zip(
+                prompt_lengths, kv_read_lengths, strict=True
+            )
         )
         if total_kv_read_tokens > 0:
             seed_prompt_lengths = [
@@ -2329,7 +2345,13 @@ class InstrumentedScheduler(AsyncScheduler):
         kv_cache_manager = getattr(self, "kv_cache_manager", None)
         if self._bench_uses_per_group_cache_lookup():
             return 0
-        return self.block_size if getattr(kv_cache_manager, "use_eagle", False) else 0
+        if not getattr(kv_cache_manager, "use_eagle", False):
+            return 0
+        coordinator = getattr(kv_cache_manager, "coordinator", None)
+        if getattr(coordinator, "enable_partial_hash_hits", False):
+            # Hybrid align-mode cache lookup drops one fine-grained hash unit.
+            return self._bench_hash_block_size
+        return self.block_size
 
     def _bench_seed_prompt_len(self, kv_read_tokens: int) -> int:
         # EAGLE/MTP deliberately drops the last matched cache block. Seed one
@@ -2526,7 +2548,7 @@ class InstrumentedScheduler(AsyncScheduler):
         allocation_failed = False
         try:
             for index, (prefix_tokens, cache_salt) in enumerate(
-                zip(prefix_lengths, cache_salts)
+                zip(prefix_lengths, cache_salts, strict=True)
             ):
                 req = Request(
                     request_id=f"__bench_fake_prefix_{self._bench_seq + index}",
@@ -3072,7 +3094,7 @@ class InstrumentedScheduler(AsyncScheduler):
                 prompt_lens=[
                     new_tokens + kv_read_tokens
                     for new_tokens, kv_read_tokens in zip(
-                        new_token_lengths, kv_read_lengths
+                        new_token_lengths, kv_read_lengths, strict=True
                     )
                 ],
                 max_tokens=1,

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -2018,13 +2018,37 @@ def test_prefill_kv_read_grid_accounts_for_eagle_cache_block_drop():
     stub = _prefill_grid_stub(block_size=8)
     stub.kv_cache_manager = SimpleNamespace(use_eagle=True)
 
+    assert InstrumentedScheduler._bench_prefill_kv_read_points(stub, 8, 1) == [0]
+
     points = InstrumentedScheduler._bench_prefill_kv_read_points(stub, 40, 1)
     assert points[0] == 0
     assert all(point % 8 == 0 for point in points)
     assert InstrumentedScheduler._bench_seed_prompt_len(stub, 16) == 24
 
     # The extra seed block must also fit under max_model_len.
-    assert InstrumentedScheduler._bench_prefill_kv_read_points(stub, 1, 1)[-1] == 112
+    assert InstrumentedScheduler._bench_prefill_kv_read_points(stub, 9, 1)[-1] == 112
+
+
+def test_prefill_eagle_kv_read_requires_more_than_one_drop_block_per_request():
+    stub = _prefill_grid_stub(block_size=8)
+    stub.kv_cache_manager = SimpleNamespace(use_eagle=True)
+
+    assert not InstrumentedScheduler._bench_prefill_point_feasible(stub, 17, 2, 16)
+    assert InstrumentedScheduler._bench_prefill_point_feasible(stub, 18, 2, 16)
+
+
+def test_prefill_eagle_partial_hash_hit_uses_hash_drop_granularity():
+    stub = _prefill_grid_stub(block_size=16)
+    stub._bench_hash_block_size = 8
+    stub.kv_cache_manager = SimpleNamespace(
+        use_eagle=True,
+        coordinator=SimpleNamespace(enable_partial_hash_hits=True),
+    )
+
+    assert InstrumentedScheduler._bench_eagle_cache_drop_tokens(stub) == 8
+    assert InstrumentedScheduler._bench_seed_prompt_len(stub, 16) == 24
+    assert not InstrumentedScheduler._bench_prefill_point_feasible(stub, 8, 1, 8)
+    assert InstrumentedScheduler._bench_prefill_point_feasible(stub, 9, 1, 8)
 
 
 def test_prefill_fake_seed_feasibility_uses_uncapped_allocation():


### PR DESCRIPTION
## Summary

- Cherry-pick of #12836 to `release/1.4.0`.
- Filter EAGLE prefill self-benchmark KV-read coordinates that cannot preserve both requested benchmark axes.
- Use the fine-grained hash unit for hybrid partial-hash cache lookup and the scheduler block otherwise.
- Preserve the AI-review follow-up that makes parallel request partitions strict.

This fixes [DYN-3796](https://linear.app/nvidia/issue/DYN-3796/dynamo140vllm-prefill-self-benchmark-seeds-one-block-short-of-the-kv) / NVBug 6569436, where the vLLM prefill self-benchmark reports a KV read exactly one block below the requested grid target for EAGLE boundary points.

## Original PR

- Main PR: #12836
- Main merge commit: `1d0faad164ab0883653d7947ed05601d92533b5b`
- Cherry-pick commit: `3d4d09aa33dee6455a320a45779f3859dbd8437c`

## Release adaptation

The merge commit cherry-picked cleanly with no manual conflict resolution. The release branch retains its existing direct `self.max_model_len` feasibility check, while main has since wrapped that value through `_bench_capacity_limit("max_model_len")`; `git range-diff` confirms the backported changes themselves are equivalent.

## Validation

- `PYTHONPATH=components/src .venv/bin/python -m pytest -q components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py components/src/dynamo/vllm/tests/test_benchmark_points.py components/src/dynamo/vllm/tests/test_vllm_worker_factory.py --disable-warnings` — 158 passed
- `SKIP=pytest-marker-report .venv/bin/pre-commit run --files components/src/dynamo/vllm/instrumented_scheduler.py components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py` — passed
- `.venv/bin/ruff check components/src/dynamo/vllm/instrumented_scheduler.py --select B905` — passed
- `git diff --check origin/release/1.4.0..HEAD` — passed
- Commit carries DCO sign-off, a valid GPG signature, and the source merge SHA provenance trailer.

## Related Issues

- Linear: [DYN-3796](https://linear.app/nvidia/issue/DYN-3796/dynamo140vllm-prefill-self-benchmark-seeds-one-block-short-of-the-kv)
- NVBug: 6569436
- [x] Confirmed — no related GitHub issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->