### PR TITLE
fix: backport guided JSON validation to release/1.4.0

### DIFF
--- a/components/src/dynamo/common/tests/test_guided_json.py
+++ b/components/src/dynamo/common/tests/test_guided_json.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
+from dynamo.llm import HttpError
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+]
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"$ref": "#"},
+        json.dumps({"$ref": "#"}),
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/A"},
+            },
+            "$ref": "#/$defs/A",
+        },
+        {
+            "$defs": {
+                "A": {"$id": "urn:example:A", "$ref": "#"},
+            },
+            "$ref": "#/$defs/A",
+        },
+        {
+            "$defs": {
+                "a/b": {"$ref": "#/$defs/c~0d"},
+                "c~d": {"$ref": "#/$defs/a~1b"},
+            },
+            "$ref": "#/$defs/a~1b",
+        },
+    ],
+)
+def test_rejects_cyclic_root_ref_chains(schema):
+    with pytest.raises(HttpError, match=r"non-progressing local \$ref cycle") as error:
+        reject_nonprogressing_guided_json_ref_cycles(schema)
+
+    assert error.value.code == 400
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        pytest.param(
+            {
+                "$defs": {
+                    "A": {"allOf": [{"$ref": "#/$defs/A"}]},
+                },
+                "$ref": "#/$defs/A",
+            },
+            id="allof",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {"value": {"$ref": "#/$defs/A"}},
+                "required": ["value"],
+                "$defs": {"A": {"$ref": "#/$defs/A"}},
+            },
+            id="required-property",
+        ),
+    ],
+)
+def test_rejects_nonprogressing_ref_cycles(schema):
+    with pytest.raises(HttpError, match=r"non-progressing local \$ref cycle") as error:
+        reject_nonprogressing_guided_json_ref_cycles(schema)
+
+    assert error.value.code == 400
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {
+            "type": "string",
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/A"},
+            },
+        },
+        {
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "next": {"$ref": "#/$defs/Node"},
+                    },
+                }
+            },
+            "$ref": "#/$defs/Node",
+        },
+        {"anyOf": [{"type": "string"}, {"$ref": "#"}]},
+        {
+            "$defs": {
+                "A": {
+                    "$id": "urn:example:A",
+                    "$defs": {"B": {"type": "string"}},
+                    "$ref": "#/$defs/B",
+                }
+            },
+            "$ref": "#/$defs/A",
+        },
+    ],
+)
+def test_allows_schemas_outside_cyclic_root_ref_chains(schema):
+    reject_nonprogressing_guided_json_ref_cycles(schema)
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"$ref": "#/$defs/Missing"},
+        {"$ref": "https://example.com/schema.json"},
+        {"$ref": 123},
+    ],
+)
+def test_leaves_unresolved_references_to_backend(schema):
+    reject_nonprogressing_guided_json_ref_cycles(schema)

--- a/components/src/dynamo/common/utils/guided_json.py
+++ b/components/src/dynamo/common/utils/guided_json.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Targeted checks for JSON schemas passed to constrained-decoding backends."""
+
+import json
+from collections import deque
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import unquote
+
+from dynamo.llm import HttpError
+
+
+def _schema_error(message: str) -> HttpError:
+    return HttpError(400, f"Invalid guided_json schema: {message}")
+
+
+def _decode_pointer_token(token: str) -> str | None:
+    decoded = []
+    index = 0
+    while index < len(token):
+        char = token[index]
+        if char != "~":
+            decoded.append(char)
+            index += 1
+            continue
+        if index + 1 >= len(token) or token[index + 1] not in ("0", "1"):
+            return None
+        decoded.append("~" if token[index + 1] == "0" else "/")
+        index += 2
+    return "".join(decoded)
+
+
+def _resolve_local_pointer(
+    resource: dict[str, Any], ref: str
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    fragment = unquote(ref[1:])
+    if not fragment:
+        return resource, resource
+    if not fragment.startswith("/"):
+        return None
+
+    target: Any = resource
+    target_resource = resource
+    for encoded_token in fragment[1:].split("/"):
+        token = _decode_pointer_token(encoded_token)
+        if token is None:
+            return None
+        if isinstance(target, dict):
+            if token not in target:
+                return None
+            target = target[token]
+        elif isinstance(target, list) and token.isdecimal():
+            item_index = int(token)
+            if item_index >= len(target):
+                return None
+            target = target[item_index]
+        else:
+            return None
+
+        if isinstance(target, dict) and isinstance(target.get("$id"), str):
+            target_resource = target
+
+    if not isinstance(target, dict):
+        return None
+    return target, target_resource
+
+
+def _child_resource(child: dict[str, Any], resource: dict[str, Any]) -> dict[str, Any]:
+    return child if isinstance(child.get("$id"), str) else resource
+
+
+def _iter_progressing_children(node: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    for keyword in (
+        "properties",
+        "patternProperties",
+        "dependentSchemas",
+        "dependencies",
+    ):
+        children = node.get(keyword)
+        if isinstance(children, dict):
+            for child in children.values():
+                if isinstance(child, dict):
+                    yield child
+
+    for keyword in (
+        "additionalProperties",
+        "unevaluatedProperties",
+        "propertyNames",
+        "items",
+        "additionalItems",
+        "prefixItems",
+        "contains",
+        "unevaluatedItems",
+        "contentSchema",
+    ):
+        children = node.get(keyword)
+        if isinstance(children, dict):
+            yield children
+        elif isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict):
+                    yield child
+
+
+def _has_cycle(
+    edges: dict[tuple[int, int], set[tuple[int, int]]],
+) -> bool:
+    in_degree = {node: 0 for node in edges}
+    for targets in edges.values():
+        for target in targets:
+            in_degree.setdefault(target, 0)
+            in_degree[target] += 1
+
+    ready = deque(node for node, degree in in_degree.items() if degree == 0)
+    visited = 0
+    while ready:
+        node = ready.popleft()
+        visited += 1
+        for target in edges.get(node, ()):
+            in_degree[target] -= 1
+            if in_degree[target] == 0:
+                ready.append(target)
+
+    return visited != len(in_degree)
+
+
+def reject_nonprogressing_guided_json_ref_cycles(schema: Any) -> None:
+    """Reject reachable local ``$ref`` cycles that cannot consume JSON.
+
+    ``allOf`` preserves the current JSON instance, while object properties and
+    array items cross a progress boundary. Choice applicators and schemas outside
+    this narrow failure mode remain backend-owned.
+    """
+    if isinstance(schema, str):
+        try:
+            schema = json.loads(schema)
+        except json.JSONDecodeError:
+            return
+
+    if not isinstance(schema, dict):
+        return
+
+    pending = [(schema, schema)]
+    processed: set[tuple[int, int]] = set()
+    edges: dict[tuple[int, int], set[tuple[int, int]]] = {}
+
+    while pending:
+        node, resource = pending.pop()
+        node_key = (id(node), id(resource))
+        if node_key in processed:
+            continue
+        processed.add(node_key)
+        targets: set[tuple[int, int]] | None = None
+
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#"):
+            resolved = _resolve_local_pointer(resource, ref)
+            if resolved is not None:
+                target, target_resource = resolved
+                targets = edges.setdefault(node_key, set())
+                targets.add((id(target), id(target_resource)))
+                pending.append((target, target_resource))
+
+        all_of = node.get("allOf")
+        if isinstance(all_of, list):
+            for child in all_of:
+                if not isinstance(child, dict):
+                    continue
+                child_resource = _child_resource(child, resource)
+                if targets is None:
+                    targets = edges.setdefault(node_key, set())
+                targets.add((id(child), id(child_resource)))
+                pending.append((child, child_resource))
+
+        for child in _iter_progressing_children(node):
+            pending.append((child, _child_resource(child, resource)))
+
+    if _has_cycle(edges):
+        raise _schema_error("non-progressing local $ref cycle detected")

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -30,6 +30,7 @@ from dynamo._core import Context
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.lora.manager import get_lora_manager
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import (
@@ -1025,6 +1026,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         if isinstance(guided_decoding, dict):
             json_schema = guided_decoding.get("json")
             if json_schema is not None:
+                reject_nonprogressing_guided_json_ref_cycles(json_schema)
                 return {"json_schema": json.dumps(json_schema)}
             structural_tag = guided_decoding.get("structural_tag")
             if structural_tag is not None:

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from dynamo.common.metadata_upload import MetadataUploader
+from dynamo.llm import HttpError
 from dynamo.sglang.request_handlers.llm.decode_handler import (
     DecodeWorkerHandler,
     _extract_sglang_stop_reason,
@@ -295,6 +296,33 @@ def test_build_sampling_params_maps_guided_decoding_to_json_schema():
     assert sampling_params["json_schema"] == (
         '{"type": "object", "properties": {"city": {"type": "string"}}}'
     )
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"$ref": "#"},
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/A"},
+            },
+            "$ref": "#/$defs/A",
+        },
+    ],
+)
+def test_build_sampling_params_rejects_guided_json_reference_cycles(schema):
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+
+    with pytest.raises(HttpError) as error:
+        handler._build_sampling_params(
+            {
+                "sampling_options": {"guided_decoding": {"json": schema}},
+                "stop_conditions": {"max_tokens": 8},
+            }
+        )
+
+    assert error.value.code == 400
 
 
 def test_build_sampling_params_passes_n_for_sglang_tokenizer_requests():

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -63,6 +63,7 @@ from dynamo.common.rl import (
 )
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.engine_response import normalize_finish_reason
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.common.utils.time_section import time_and_log_code_section
@@ -716,8 +717,11 @@ def build_sampling_params(
             sampling_options.update(passthrough_sampling_options)
     guided_decoding = sampling_options.get("guided_decoding")
     if guided_decoding is not None and isinstance(guided_decoding, dict):
+        json_schema = guided_decoding.get("json")
+        if json_schema is not None:
+            reject_nonprogressing_guided_json_ref_cycles(json_schema)
         sampling_params.structured_outputs = StructuredOutputsParams(
-            json=guided_decoding.get("json"),
+            json=json_schema,
             regex=guided_decoding.get("regex"),
             choice=guided_decoding.get("choice"),
             grammar=guided_decoding.get("grammar"),
@@ -3272,14 +3276,15 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # the per-request deferred guard so engine_client.abort() never fires in
         # the unsafe pre-first-token window, and the admin abort_request route can
         # reach this request via self._deferred_aborts.
-        async with _deferred_abort_guard(
-            self.engine_client,
-            request_id,
-            is_decode_only,
-            self._deferred_aborts,
-            self._shutdown_on_engine_dead,
-        ) as abort_guard, self._abort_monitor(
-            context, request_id, abort_guard=abort_guard
+        async with (
+            _deferred_abort_guard(
+                self.engine_client,
+                request_id,
+                is_decode_only,
+                self._deferred_aborts,
+                self._shutdown_on_engine_dead,
+            ) as abort_guard,
+            self._abort_monitor(context, request_id, abort_guard=abort_guard),
         ):
             try:
                 gen = self.engine_client.generate(

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1204,6 +1204,66 @@ def test_build_sampling_params_maps_guided_decoding(constraint_name, constraint_
         assert getattr(sp.structured_outputs, field) == expected
 
 
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"$ref": "#"},
+        json.dumps({"$ref": "#"}),
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/A"},
+            },
+            "$ref": "#/$defs/A",
+        },
+    ],
+)
+def test_build_sampling_params_rejects_guided_json_reference_cycles(schema):
+    from dynamo.llm import HttpError
+    from dynamo.vllm.handlers import build_sampling_params
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {"guided_decoding": {"json": schema}},
+        "stop_conditions": {},
+        "output_options": {},
+    }
+
+    with pytest.raises(HttpError) as error:
+        build_sampling_params(request, default_sampling_params={})
+
+    assert error.value.code == 400
+
+
+def test_build_sampling_params_accepts_productive_recursive_guided_json():
+    from dynamo.vllm.handlers import build_sampling_params
+
+    schema = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "children": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/Node"},
+                    }
+                },
+            }
+        },
+        "$ref": "#/$defs/Node",
+    }
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {"guided_decoding": {"json": schema}},
+        "stop_conditions": {},
+        "output_options": {},
+    }
+
+    sampling_params = build_sampling_params(request, default_sampling_params={})
+
+    assert sampling_params.structured_outputs.json == schema
+
+
 def test_build_sampling_params_caps_omitted_max_tokens_to_generation_default():
     from dynamo.vllm.handlers import build_sampling_params
 


### PR DESCRIPTION
## Summary
- Cherry-pick #12795 to `release/1.4.0`.
- Reject non-progressing guided JSON reference cycles before SGLang or vLLM grammar processing.
- Add the `HttpError` test import required on the release branch.

Fixes DYN-3784
Fixes DYN-3786

## Original PR
- Main PR: #12795
- Merge commit: `4f32fc6831f4ba00bd46e0b4872a6d91bab94d37`
- Backport commit: `68f09630b14ebf7c3f57eed618e5f22afb7f7689`

## Validation
- [x] `pre-commit run --from-ref HEAD^ --to-ref HEAD`
- [x] Common guided JSON unit tests: 14 passed
- [ ] Release CI
