### PR TITLE
docs: fix dead Fern CLI link breaking the link check

### DIFF
--- a/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
+++ b/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
@@ -360,7 +360,7 @@ workflows. Authors never need to run it manually.
 ## Running Locally
 
 You can preview the documentation site on your machine using the
-[Fern CLI](https://buildwithfern.com/learn/docs/getting-started/overview/). This is useful
+[Fern CLI](https://buildwithfern.com/learn/cli-api-reference/cli-reference/overview). This is useful
 for verifying layout, navigation, and content before opening a PR.
 
 ### Prerequisites


### PR DESCRIPTION
## Problem

`https://buildwithfern.com/learn/docs/getting-started/overview/` now returns **404**. It fails the `lychee` job in **Docs link check**, which is currently red on `main` and therefore on every open PR:

```
[404] https://buildwithfern.com/learn/docs/getting-started/overview/ (at 363:1)
      | Rejected status code: 404 Not Found
```

## Fix

Repoints it at the Fern CLI reference, which is what the surrounding sentence is about — *"preview the documentation site on your machine using the Fern CLI"* — and which returns 200:

```
https://buildwithfern.com/learn/cli-api-reference/cli-reference/overview
```

## Test

- [ ] `Docs link check` / `lychee` passes
- [x] Replacement URL verified live (200); the old one verified 404

## Notes

One line, docs only. Found while working on an unrelated PR (#12759) whose `lychee` check was red for this reason; keeping it separate rather than bundling it there.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the local preview instructions to link to the current Fern CLI API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->