### PR TITLE
fix(sglang): apply MiniMax M3 guided tool grammar immediately

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -768,6 +768,16 @@ impl OpenAIPreprocessor {
                 None => true,
             }
         });
+
+        // MiniMax M3 uses adaptive reasoning. For required/named tool choices,
+        // SGLang must apply the guided tool grammar from the first generated
+        // token; gating that grammar behind a reasoning end marker allows the
+        // model's native tool-call namespace to bypass the JSON constraint.
+        // Structured responses retain their existing reasoning behavior.
+        if is_guided_tool_choice && matches!(reasoning_parser, Some("minimax_m3" | "minimax-m3")) {
+            return false;
+        }
+
         let is_structured_response = Self::has_structured_response_format(request);
         let structured_response_requires_reasoning = is_structured_response
             && Self::structured_response_supports_sglang_reasoning_gate(reasoning_parser);
@@ -5333,6 +5343,24 @@ mod tests {
             Some("deepseek_v4")
         ));
 
+        // MiniMax M3 remains an adaptive-thinking model for normal/auto
+        // requests, but required/named tool choices must constrain JSON from
+        // token zero instead of waiting for a reasoning boundary.
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
+            &request(serde_json::json!("required"), None),
+            Some("minimax_m3")
+        ));
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
+            &request(
+                serde_json::json!({
+                    "type": "function",
+                    "function": {"name": "lookup"}
+                }),
+                Some(true)
+            ),
+            Some("minimax-m3")
+        ));
+
         let structured_request = |enable_thinking: bool| {
             serde_json::from_value::<NvCreateChatCompletionRequest>(serde_json::json!({
                 "model": "test-model",
@@ -5380,6 +5408,10 @@ mod tests {
         assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
             &structured_request(false),
             Some("gpt_oss")
+        ));
+        assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
+            &structured_request(true),
+            Some("minimax_m3")
         ));
         assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
             &request(serde_json::json!("required"), None),

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -770,6 +770,16 @@ impl OpenAIPreprocessor {
                 None => true,
             }
         });
+
+        // MiniMax M3 uses adaptive reasoning. For required/named tool choices,
+        // SGLang must apply the guided tool grammar from the first generated
+        // token; gating that grammar behind a reasoning end marker allows the
+        // model's native tool-call namespace to bypass the JSON constraint.
+        // Structured responses retain their existing reasoning behavior.
+        if is_guided_tool_choice && matches!(reasoning_parser, Some("minimax_m3" | "minimax-m3")) {
+            return false;
+        }
+
         let is_structured_response = Self::has_structured_response_format(request);
         let structured_response_requires_reasoning = is_structured_response
             && Self::structured_response_supports_sglang_reasoning_gate(reasoning_parser);
@@ -5372,6 +5382,24 @@ mod tests {
             Some("deepseek_v4")
         ));
 
+        // MiniMax M3 remains an adaptive-thinking model for normal/auto
+        // requests, but required/named tool choices must constrain JSON from
+        // token zero instead of waiting for a reasoning boundary.
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
+            &request(serde_json::json!("required"), None),
+            Some("minimax_m3")
+        ));
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
+            &request(
+                serde_json::json!({
+                    "type": "function",
+                    "function": {"name": "lookup"}
+                }),
+                Some(true)
+            ),
+            Some("minimax-m3")
+        ));
+
         let structured_request = |enable_thinking: bool| {
             serde_json::from_value::<NvCreateChatCompletionRequest>(serde_json::json!({
                 "model": "test-model",
@@ -5419,6 +5447,10 @@ mod tests {
         assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
             &structured_request(false),
             Some("gpt_oss")
+        ));
+        assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
+            &structured_request(true),
+            Some("minimax_m3")
         ));
         assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
             &request(serde_json::json!("required"), None),


### PR DESCRIPTION
## Overview:

Ensure MiniMax M3 required and named tool choices apply SGLang guided decoding from the first generated token.

## Details:

- Do not set `require_reasoning` for MiniMax M3 required or named tool choices.
- Preserve existing reasoning behavior for normal chat, automatic tool choice, and structured responses.
- Add regression assertions for both MiniMax M3 parser aliases and structured-response behavior.

Validation:

- `cargo test -p dynamo-llm --no-default-features preprocessor::tests::test_guided_output_requires_reasoning --lib`
- `cargo test -p dynamo-llm --no-default-features tool_choice_minimax_m3 --test postprocessor_parsing_stream`

## Where should the reviewer start?

`OpenAIPreprocessor::guided_output_requires_reasoning` in `lib/llm/src/preprocessor.rs`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue