### PR TITLE
test(efa): add EFA packaging checks to the nightly -efa image jobs

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -913,6 +913,79 @@ jobs:
     secrets: inherit
 
   # ============================================================================
+  # EFA IMAGE TEST JOBS
+  #
+  # The -efa images are built here but nothing verified their EFA packaging.
+  # These jobs run only the efa_image checks (tests/container/test_efa_image.py):
+  # no GPU, no EFA device and no cluster, a few seconds per image. EFA changes
+  # are sparse, so nightly is the right cadence -- per-commit would spend far
+  # more than the risk warrants.
+  # ============================================================================
+
+  vllm-efa-test:
+    name: vllm-runtime-efa
+    needs: [vllm-efa-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: vllm-efa
+      test_type: CPU Test
+      amd_runner: prod-tester-amd-gpu-4-v2
+      target_tag_plain: ${{ needs.vllm-efa-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64", "arm64"]'
+      run_cpu_only_tests: true
+      cpu_only_test_markers: efa_image and gpu_0
+      run_gpu_tests: false
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
+  sglang-efa-test:
+    name: sglang-runtime-efa
+    needs: [sglang-efa-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: sglang-efa
+      test_type: CPU Test
+      amd_runner: prod-tester-amd-gpu-4-v2
+      target_tag_plain: ${{ needs.sglang-efa-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64", "arm64"]'
+      run_cpu_only_tests: true
+      cpu_only_test_markers: efa_image and gpu_0
+      run_gpu_tests: false
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
+  trtllm-efa-test:
+    name: trtllm-runtime-efa
+    needs: [trtllm-efa-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: trtllm-efa
+      test_type: CPU Test
+      amd_runner: prod-tester-amd-gpu-4-v2
+      target_tag_plain: ${{ needs.trtllm-efa-build.outputs.target_tag_plain }}
+      cuda_version: '["13.1"]'
+      platform: '["amd64", "arm64"]'
+      run_cpu_only_tests: true
+      cpu_only_test_markers: efa_image and gpu_0
+      run_gpu_tests: false
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
+  # ============================================================================
   # XPU TEST JOBS
   # ============================================================================
 

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -492,9 +492,7 @@ jobs:
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]'
       run_cpu_only_tests: true
-      # efa_image adds the EFA packaging checks (tests/container/test_efa_image.py),
-      # which are what makes this job differ from the non-EFA vllm-test.
-      cpu_only_test_markers: '(pre_merge or post_merge) and (vllm or efa_image) and gpu_0'
+      cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
       run_gpu_tests: false
     secrets: inherit
 
@@ -562,25 +560,6 @@ jobs:
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
-  sglang-efa-test:
-    name: sglang-runtime-efa
-    needs: [sglang-efa-build]
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      dd_env: post-merge
-      test_suite_name: sglang-efa
-      test_type: CPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
-      target_tag_plain: ${{ needs.sglang-efa-build.outputs.target_tag_plain }}
-      cuda_version: '["13.0"]'
-      platform: '["amd64", "arm64"]'
-      run_cpu_only_tests: true
-      # efa_image adds the EFA packaging checks (tests/container/test_efa_image.py),
-      # which are what makes this job differ from the non-EFA sglang-test.
-      cpu_only_test_markers: '(pre_merge or post_merge) and (sglang or efa_image) and gpu_0'
-      run_gpu_tests: false
-    secrets: inherit
-
   trtllm-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build]
@@ -634,9 +613,7 @@ jobs:
       cuda_version: '["13.1"]'
       platform: '["amd64", "arm64"]'
       run_cpu_only_tests: true
-      # efa_image adds the EFA packaging checks (tests/container/test_efa_image.py),
-      # which are what makes this job differ from the non-EFA trtllm-test.
-      cpu_only_test_markers: '(pre_merge or post_merge) and (trtllm or efa_image) and gpu_0'
+      cpu_only_test_markers: '(pre_merge or post_merge) and trtllm and gpu_0'
       run_gpu_tests: false
     secrets: inherit
 

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -492,7 +492,9 @@ jobs:
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]'
       run_cpu_only_tests: true
-      cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
+      # efa_image adds the EFA packaging checks (tests/container/test_efa_image.py),
+      # which are what makes this job differ from the non-EFA vllm-test.
+      cpu_only_test_markers: '(pre_merge or post_merge) and (vllm or efa_image) and gpu_0'
       run_gpu_tests: false
     secrets: inherit
 
@@ -560,6 +562,25 @@ jobs:
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
+  sglang-efa-test:
+    name: sglang-runtime-efa
+    needs: [sglang-efa-build]
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      dd_env: post-merge
+      test_suite_name: sglang-efa
+      test_type: CPU Test
+      amd_runner: prod-tester-amd-gpu-4-v2
+      target_tag_plain: ${{ needs.sglang-efa-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64", "arm64"]'
+      run_cpu_only_tests: true
+      # efa_image adds the EFA packaging checks (tests/container/test_efa_image.py),
+      # which are what makes this job differ from the non-EFA sglang-test.
+      cpu_only_test_markers: '(pre_merge or post_merge) and (sglang or efa_image) and gpu_0'
+      run_gpu_tests: false
+    secrets: inherit
+
   trtllm-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build]
@@ -613,7 +634,9 @@ jobs:
       cuda_version: '["13.1"]'
       platform: '["amd64", "arm64"]'
       run_cpu_only_tests: true
-      cpu_only_test_markers: '(pre_merge or post_merge) and trtllm and gpu_0'
+      # efa_image adds the EFA packaging checks (tests/container/test_efa_image.py),
+      # which are what makes this job differ from the non-EFA trtllm-test.
+      cpu_only_test_markers: '(pre_merge or post_merge) and (trtllm or efa_image) and gpu_0'
       run_gpu_tests: false
     secrets: inherit
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,7 @@ markers = [
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
     "wheel_smoke: marks tests that validate wheels copied from runtime images",
+    "efa_image: marks tests that validate EFA packaging inside an -efa runtime image (no GPU or EFA device required)",
     "installs_extra_dependencies: marks tests that pip-install a package the runtime image intentionally omits (via DYN_TEST_ONLY_PIP_INSTALL). The feature under test may not work in an unmodified shipped image",
     "stress: marks tests as stress tests",
     "performance: marks tests as performance tests",

--- a/tests/container/test_efa_image.py
+++ b/tests/container/test_efa_image.py
@@ -20,8 +20,9 @@ that a functional test could not see until it reached a p5/GB200 cluster:
 Each of those turns into a *silent* fallback to UCX at inference time, which is
 why these are hard assertions rather than warnings.
 
-Selected by the ``efa_image`` marker; the non-EFA image test jobs never collect
-them.
+Selected by the ``efa_image`` marker, from the nightly ``*-efa-test`` jobs. EFA
+changes are sparse, so nightly is the cadence that matches the risk; nothing
+else collects these.
 """
 
 import os
@@ -32,8 +33,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.efa_image,
-    pytest.mark.pre_merge,
-    pytest.mark.post_merge,
+    pytest.mark.nightly,
     pytest.mark.unit,
     pytest.mark.gpu_0,
 ]

--- a/tests/container/test_efa_image.py
+++ b/tests/container/test_efa_image.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""EFA packaging checks for the ``-efa`` runtime images.
+
+These run *inside* an EFA-tagged runtime image and assert the properties that
+make NIXL able to reach Elastic Fabric Adapter at runtime. They need no GPU, no
+EFA device and no cluster, so they run in the existing ``*-efa-test`` CI jobs on
+both amd64 and arm64.
+
+They exist because every EFA regression so far has been a packaging regression
+that a functional test could not see until it reached a p5/GB200 cluster:
+
+* the TRT-LLM EFA image shipped a NIXL plugin directory with no LIBFABRIC plugin
+* NIXL was linked against the generic from-source libfabric instead of the EFA
+  SDK's, so HMEM/CUDA dmabuf descriptors did not match at runtime
+* the arm64 image put plugins under ``lib/aarch64-linux-gnu`` while
+  ``NIXL_PLUGIN_DIR`` still pointed at ``lib64``
+
+Each of those turns into a *silent* fallback to UCX at inference time, which is
+why these are hard assertions rather than warnings.
+
+Selected by the ``efa_image`` marker; the non-EFA image test jobs never collect
+them.
+"""
+
+import os
+import re
+import subprocess
+
+import pytest
+
+pytestmark = [
+    pytest.mark.efa_image,
+    pytest.mark.pre_merge,
+    pytest.mark.post_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+]
+
+EFA_SDK_ROOT = "/opt/amazon/efa"
+FI_INFO = os.path.join(EFA_SDK_ROOT, "bin", "fi_info")
+LIBFABRIC_PLUGIN = "libplugin_LIBFABRIC.so"
+
+# The EFA image build (container/templates/aws.Dockerfile) normalizes NIXL into
+# a single arch-agnostic layout and points NIXL_PLUGIN_DIR at it. Every value
+# below is read from the environment rather than hardcoded, so an image that
+# moves the layout but keeps the env consistent still passes.
+NIXL_PLUGIN_DIR = os.environ.get("NIXL_PLUGIN_DIR", "")
+NIXL_LIB_DIR = os.environ.get("NIXL_LIB_DIR", "")
+
+
+def _run(cmd: list[str]) -> str:
+    """Run a command and return stdout+stderr, failing the test on OSError."""
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except OSError as exc:
+        pytest.fail(f"could not execute {' '.join(cmd)}: {exc}")
+    return proc.stdout + proc.stderr
+
+
+def test_efa_sdk_installed() -> None:
+    """The AWS EFA installer's SDK must be present at its canonical prefix."""
+    assert os.path.isdir(EFA_SDK_ROOT), (
+        f"{EFA_SDK_ROOT} is missing — this image was not built with make_efa=true, "
+        "or the EFA installer stage did not run."
+    )
+    assert os.access(FI_INFO, os.X_OK), f"{FI_INFO} is missing or not executable"
+
+    libs = []
+    for lib_dir in (
+        os.path.join(EFA_SDK_ROOT, "lib"),
+        os.path.join(EFA_SDK_ROOT, "lib64"),
+    ):
+        if os.path.isdir(lib_dir):
+            libs += [f for f in os.listdir(lib_dir) if f.startswith("libfabric.so")]
+    assert libs, f"no libfabric.so* under {EFA_SDK_ROOT}/lib*"
+
+
+def test_efa_version_recorded() -> None:
+    """The image must record which EFA installer it was built from.
+
+    Without this there is no way to tell a patched libfabric from a stock one
+    after the fact, which is exactly the ambiguity that made the GB200
+    VRAM-registration failure expensive to diagnose.
+    """
+    version = os.environ.get("EFA_VERSION", "")
+    assert version, "EFA_VERSION is not set in the image environment"
+    assert re.match(
+        r"^\d+\.\d+", version
+    ), f"EFA_VERSION={version!r} does not look like a version"
+
+
+def test_efa_provider_compiled_in() -> None:
+    """libfabric must actually have the EFA provider built in.
+
+    ``fi_info -l`` lists compiled-in providers and needs no EFA hardware, so a
+    CPU-only runner can still catch a libfabric built without EFA support.
+    """
+    output = _run([FI_INFO, "-l"])
+    providers = {
+        line.rstrip(":")
+        for line in output.splitlines()
+        if line and not line[0].isspace()
+    }
+    assert "efa" in providers, (
+        "libfabric has no 'efa' provider. Providers found: "
+        f"{sorted(providers) or '<none>'}\n{output}"
+    )
+
+
+def test_nixl_plugin_dir_contains_libfabric_plugin() -> None:
+    """NIXL_PLUGIN_DIR must exist and hold the LIBFABRIC backend plugin.
+
+    A plugin directory that resolves but has no LIBFABRIC plugin is the TRT-LLM
+    failure mode: NIXL loads, finds only UCX, and silently uses it.
+    """
+    assert NIXL_PLUGIN_DIR, "NIXL_PLUGIN_DIR is not set in the image environment"
+    assert os.path.isdir(
+        NIXL_PLUGIN_DIR
+    ), f"NIXL_PLUGIN_DIR={NIXL_PLUGIN_DIR} does not exist (wrong arch path?)"
+
+    plugins = sorted(os.listdir(NIXL_PLUGIN_DIR))
+    assert LIBFABRIC_PLUGIN in plugins, (
+        f"{LIBFABRIC_PLUGIN} missing from NIXL_PLUGIN_DIR={NIXL_PLUGIN_DIR}. "
+        f"Present: {plugins}"
+    )
+
+
+def test_libfabric_plugin_links_efa_sdk() -> None:
+    """NIXL's LIBFABRIC plugin must link against the EFA SDK's libfabric.
+
+    Linking against a generic from-source libfabric builds a plugin whose
+    HMEM/CUDA dmabuf descriptors do not match the EFA provider at runtime.
+    """
+    plugin = os.path.join(NIXL_PLUGIN_DIR, LIBFABRIC_PLUGIN)
+    if not os.path.isfile(plugin):
+        pytest.skip("LIBFABRIC plugin absent; covered by the plugin-dir test")
+
+    # Only the libfabric line matters. CUDA libs legitimately resolve to
+    # "not found" here because CI runs this on a CPU-only runner.
+    resolved = [
+        line.strip()
+        for line in _run(["ldd", plugin]).splitlines()
+        if "libfabric.so" in line
+    ]
+    assert (
+        resolved
+    ), f"{plugin} does not link libfabric at all:\n{_run(['ldd', plugin])}"
+
+    for line in resolved:
+        _, _, target = line.partition("=>")
+        target = target.strip()
+        assert target.startswith(EFA_SDK_ROOT), (
+            f"{LIBFABRIC_PLUGIN} resolves libfabric to {target or line!r}, expected it "
+            f"under {EFA_SDK_ROOT}. NIXL was built against the wrong libfabric — see "
+            "the -Dlibfabric_path meson flag in container/templates/wheel_builder.Dockerfile."
+        )
+
+
+def test_nixl_runtime_libs_resolvable() -> None:
+    """libnixl.so must sit alongside the plugins, and any LD_PRELOAD must resolve.
+
+    The EFA image sets LD_PRELOAD so the Dynamo-built NIXL wins over any
+    framework-bundled copy (see the trtllm branch of aws.Dockerfile); a stale
+    path there breaks every worker at startup rather than at transfer time.
+
+    NIXL_LIB_DIR is only exported by some of the runtime stages, so fall back to
+    the plugin directory's parent — plugins always live at ``<libdir>/plugins``,
+    and a libnixl that does not sit next to its plugins is the bug we care about.
+    """
+    lib_dir = NIXL_LIB_DIR or os.path.dirname(NIXL_PLUGIN_DIR.rstrip("/"))
+    assert lib_dir, "neither NIXL_LIB_DIR nor NIXL_PLUGIN_DIR is set in the image"
+    assert os.path.isdir(lib_dir), f"NIXL lib dir {lib_dir} does not exist"
+    assert "libnixl.so" in os.listdir(
+        lib_dir
+    ), f"libnixl.so missing from NIXL lib dir {lib_dir}"
+
+    for entry in os.environ.get("LD_PRELOAD", "").replace(":", " ").split():
+        assert os.path.isfile(entry), f"LD_PRELOAD entry {entry} does not exist"


### PR DESCRIPTION
## Summary

Nightly and post-merge both build **six** `-efa` runtime image variants (vllm/sglang/trtllm × amd64/arm64), and nothing verifies the EFA packaging of any of them. The existing `vllm-efa-test` / `trtllm-efa-test` post-merge jobs run `'(pre_merge or post_merge) and <framework> and gpu_0'` — character-for-character the same markers as their non-EFA counterparts, touching nothing EFA-specific. Nightly has no EFA test jobs at all.

Every EFA regression we have hit was a *packaging* regression that no functional test could see until it reached a p5/GB200 cluster, and each degrades to a **silent UCX fallback** rather than a hard failure:

- an image shipping a NIXL plugin directory with no LIBFABRIC plugin
- NIXL linked against the generic from-source libfabric instead of the EFA SDK's, so HMEM/CUDA dmabuf descriptors do not match at runtime
- arm64 putting plugins somewhere other than where `NIXL_PLUGIN_DIR` points

### Changes

- **`tests/container/test_efa_image.py`** (new, marker `efa_image`) — six checks: EFA SDK installed · `EFA_VERSION` recorded · `efa` provider compiled into libfabric (`fi_info -l`) · `NIXL_PLUGIN_DIR` holds `libplugin_LIBFABRIC.so` · that plugin's `ldd` resolves libfabric under `/opt/amazon/efa` · `libnixl.so` sits beside the plugins and every `LD_PRELOAD` entry resolves. No GPU, no EFA device, no cluster; a few seconds per image.
- **`pyproject.toml`** — register the `efa_image` marker.
- **`.github/workflows/nightly-ci.yml`** — add `vllm-efa-test`, `sglang-efa-test`, `trtllm-efa-test`, each running only `efa_image and gpu_0` against its nightly `-efa` image on amd64 and arm64.

**Cadence:** nightly, not per-commit. EFA changes are sparse, so paying for these on every push to `main` costs more CI than the risk warrants. `post-merge-ci.yml` is deliberately left untouched by this PR.

Paths are read from the environment rather than hardcoded, because they genuinely differ: `vllm-runtime:1.3.1-efa` uses `NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins` on amd64 but `/opt/dynamo/nixl/plugins` on **arm64**. A hardcoded `lib64` assertion would have failed on arm64 — which is the very bug class this test exists to catch. `NIXL_LIB_DIR` is also not exported by every runtime stage (`trtllm_runtime.Dockerfile` sets only `NIXL_PLUGIN_DIR` and `LD_PRELOAD`), so the libnixl check falls back to the plugin directory's parent rather than going vacuous.

## Validation

**Executed in CI-built EFA images.** Before the switch to nightly, this branch's post-merge variant was dispatched on `pull-request/12868` ([run 31238756257](https://github.com/ai-dynamo/dynamo/actions/runs/31238756257)); `vllm-runtime-efa` built and both CPU Test jobs passed:

| Job | Summary |
|---|---|
| amd64 | 1110 passed, 9 skipped — 0 failed, 0 errors |
| arm64 | 1110 passed, 10 skipped — 0 failed, 0 errors |

All six tests appear by name in both logs with zero FAILED/ERROR lines. Only the wiring changed afterwards; the test file's assertions are unchanged.

**Executed in released images on the AWS dev clusters** (mounted at `/workspace/tests/container`, run with the image's own Python, in pods holding **no GPU and no EFA device** — the same condition as the CI runner):

| Image | Result |
|---|---|
| `vllm-runtime:1.3.1-efa` — amd64 | **6 passed** |
| `vllm-runtime:1.3.1-efa` — **arm64** | **6 passed** |
| `sglang-runtime:1.3.1-efa` — amd64 | **6 passed** |
| `sglang-runtime:1.3.1` (non-EFA, negative control) | **5 failed, 1 skipped** |
| `vllm-runtime:1.3.1` (non-EFA, negative control) | **4 failed** — including the libfabric-linkage check |

Repo-level: `pytest --collect-only` under `--strict-markers` collects 6, and `-m 'efa_image and gpu_0'` selects all 6; `tests/report_pytest_markers.py` reports **`Missing sets: 0`** across 4660 tests; isort / black / flake8 / ruff / codespell / check-yaml / check-toml pass; both workflow files parse.

### Known gaps

- `nvcr.io/nvidia/ai-dynamo/trtllm-runtime` is not publicly pullable, so the TRT-LLM EFA image was not exercised directly. By inspection, `aws.Dockerfile`'s trtllm branch sets `NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins` and `LD_PRELOAD=/opt/nvidia/nvda_nixl/lib64/libnixl.so`, which both checks handle — worth watching the first nightly `trtllm-efa-test`.
- These checks cover *packaging*, not function: no RDMA, no memory registration, no KV transfer. Functional EFA validation on real p5/GB200 clusters is the follow-up.
- The `pytest-marker-report` pre-commit hook was skipped at commit time: its hook venv runs on this machine's Python 3.9, which cannot import `tests/utils/collection_env_guard.py` (`str | None`). The same script was run under Python 3.12 — `Missing sets: 0`.

An internal Linear ticket also tracks this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
