### PR TITLE
feat(operator): support two intra-pod shadow engines

### DIFF
--- a/components/src/dynamo/vllm/engine_monitor.py
+++ b/components/src/dynamo/vllm/engine_monitor.py
@@ -51,6 +51,10 @@ class VllmEngineMonitor:
         )
 
     def __del__(self):
+        self.cancel()
+
+    def cancel(self) -> None:
+        """Cancel background tasks when monitor ownership cannot be transferred."""
         self._monitor_task.cancel()
         self._stats_task.cancel()
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -17,6 +17,7 @@ from collections import deque
 from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Callable,
@@ -106,6 +107,9 @@ from .multimodal_utils.request_processor import (
     MissingMultimodalHandoffError,
     VllmMultimodalRequestProcessor,
 )
+
+if TYPE_CHECKING:
+    from gpu_memory_service.failover_lock.interface import FailoverLock
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
@@ -1090,6 +1094,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     _benchmark_results: Optional[dict] = None
     _scale_ep_in_progress: bool = False
+    _failover_lock: "FailoverLock | None" = None
 
     @property
     def loaded_loras(self) -> dict[str, LoRAInfo]:
@@ -1114,6 +1119,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         shutdown_event: asyncio.Event | None = None,
         enable_frontend_decoding: bool = False,
         encode_worker_client: Optional[Client] = None,
+        engine_monitor: VllmEngineMonitor | None = None,
     ):
         self.runtime = runtime
         self.engine_client = engine
@@ -1122,7 +1128,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self.fpm_relays: list | None = None
         self.generate_endpoint = generate_endpoint
         self.config = config
-        self.engine_monitor = VllmEngineMonitor(runtime, engine, shutdown_event)
+        self.engine_monitor = (
+            engine_monitor
+            if engine_monitor is not None
+            else VllmEngineMonitor(runtime, engine, shutdown_event)
+        )
         self.temp_dirs: list[tempfile.TemporaryDirectory] = []
         self.model_max_len = model_max_len
         self.model_config = model_config
@@ -2675,6 +2685,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     def cleanup(self):
         """Clean up resources including temporary directories."""
+        self.engine_monitor.cancel()
         if self._custom_encoder is not None:
             # Run backend.close() on the actor thread, then stop it — executor
             # GC would only end the thread, never call close().
@@ -3078,36 +3089,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
 
 class DecodeWorkerHandler(BaseWorkerHandler):
-    def __init__(
-        self,
-        runtime,
-        config: Config,
-        engine,
-        default_sampling_params,
-        model_max_len: int | None = None,
-        model_config: ModelConfig | None = None,
-        enable_multimodal: bool = False,
-        generate_endpoint=None,
-        use_vllm_tokenizer: bool = False,
-        shutdown_event: asyncio.Event | None = None,
-        enable_frontend_decoding: bool = False,
-        encode_worker_client: Client | None = None,
-    ):
-        super().__init__(
-            runtime,
-            config,
-            engine,
-            default_sampling_params,
-            model_max_len=model_max_len,
-            model_config=model_config,
-            enable_multimodal=enable_multimodal,
-            generate_endpoint=generate_endpoint,
-            use_vllm_tokenizer=use_vllm_tokenizer,
-            shutdown_event=shutdown_event,
-            enable_frontend_decoding=enable_frontend_decoding,
-            encode_worker_client=encode_worker_client,
-        )
-
     async def generate(self, request, context):
         # Use context ID for request tracking and correlation
         request_id = context.id()
@@ -3554,6 +3535,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         shutdown_event: asyncio.Event | None = None,
         enable_frontend_decoding: bool = False,
         encode_worker_client: Client | None = None,
+        engine_monitor: VllmEngineMonitor | None = None,
     ):
         super().__init__(
             runtime,
@@ -3568,6 +3550,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             shutdown_event=shutdown_event,
             enable_frontend_decoding=enable_frontend_decoding,
             encode_worker_client=encode_worker_client,
+            engine_monitor=engine_monitor,
         )
 
         self._multimodal_request_processor.initialize_prefill_handoff()

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -27,9 +27,11 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
         endpoint: Endpoint,
         dp_rank: int = 0,
         component_gauges: Optional[LLMBackendMetrics] = None,
+        publication_gate: Optional[asyncio.Event] = None,
     ) -> None:
         self.inner = WorkerMetricsPublisher()
         self._endpoint = endpoint
+        self._publication_gate = publication_gate
         self.dp_rank = dp_rank
         self.component_gauges = component_gauges or LLMBackendMetrics()
         self.num_gpu_block = 1
@@ -39,6 +41,8 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
     async def _create_endpoint(self) -> None:
         """Create the NATS endpoint asynchronously."""
         try:
+            if self._publication_gate is not None:
+                await self._publication_gate.wait()
             await self.inner.create_endpoint(self._endpoint)
             logging.debug("vLLM metrics publisher endpoint created")
         except Exception:
@@ -137,10 +141,14 @@ class StatLoggerFactory:
         endpoint: Endpoint,
         component_gauges: Optional[LLMBackendMetrics] = None,
         embedding_worker: bool = False,
+        defer_publication: bool = False,
     ) -> None:
         self.endpoint = endpoint
         self.component_gauges = component_gauges
         self.embedding_worker = embedding_worker
+        self.publication_gate = asyncio.Event()
+        if not defer_publication:
+            self.publication_gate.set()
         self.created_logger: Optional[DynamoStatLoggerPublisher] = None
 
     def create_stat_logger(self, dp_rank: int) -> StatLoggerBase:
@@ -158,6 +166,7 @@ class StatLoggerFactory:
             endpoint=self.endpoint,
             dp_rank=dp_rank,
             component_gauges=self.component_gauges,
+            publication_gate=self.publication_gate,
         )
         self.created_logger = logger
 
@@ -174,3 +183,7 @@ class StatLoggerFactory:
     def init_publish(self) -> None:
         if self.created_logger:
             self.created_logger.init_publish()
+
+    def enable_publication(self) -> None:
+        """Allow created stat loggers to register their metrics endpoints."""
+        self.publication_gate.set()

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -11,8 +11,9 @@ so it is also the seam where the embedding worker must short-circuit
 the chat-shaped pipeline.
 """
 
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -125,3 +126,27 @@ def test_factory_default_is_chat_path(monkeypatch):
     assert constructed[0]["endpoint"] is endpoint
     assert constructed[0]["dp_rank"] == 3
     assert constructed[0]["component_gauges"] is component_gauges
+    assert constructed[0]["publication_gate"] is factory.publication_gate
+    assert factory.publication_gate.is_set()
+
+
+@pytest.mark.asyncio
+async def test_factory_can_defer_publication(monkeypatch):
+    inner = Mock(create_endpoint=AsyncMock())
+    monkeypatch.setattr(
+        publisher_mod, "WorkerMetricsPublisher", Mock(return_value=inner)
+    )
+    factory = StatLoggerFactory(
+        endpoint=SimpleNamespace(),
+        component_gauges=SimpleNamespace(),
+        defer_publication=True,
+    )
+
+    logger = factory.create_stat_logger(dp_rank=0)
+    await asyncio.sleep(0)
+    inner.create_endpoint.assert_not_awaited()
+
+    factory.enable_publication()
+    await logger._endpoint_task
+
+    inner.create_endpoint.assert_awaited_once_with(factory.endpoint)

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -7,17 +7,24 @@ import asyncio
 import json
 import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from gpu_memory_service.failover_lock import FailoverLockError
+from gpu_memory_service.failover_lock.flock import FlockFailoverLock
+from vllm.v1.engine.exceptions import EngineDeadError
 
+import dynamo.vllm.handlers as handlers_mod
+import dynamo.vllm.worker_factory as worker_factory_mod
+from dynamo.common.engine_monitor import EngineHealthMonitorConfig
 from dynamo.llm import ModelInput, ModelType, WorkerType
 from dynamo.vllm.constants import DisaggregationMode
+from dynamo.vllm.engine_monitor import VllmEngineMonitor
 from dynamo.vllm.worker_factory import (
     EngineSetupResult,
     WorkerFactory,
-    _DecodeWorkerLifecycle,
     _wait_and_load_benchmark,
+    _WorkerLifecycle,
 )
 
 pytestmark = [
@@ -40,6 +47,7 @@ def _make_config(**overrides) -> Mock:
         "route_to_encoder": False,
         "disaggregation_mode": DisaggregationMode.AGGREGATED,
         "embedding_worker": False,
+        "endpoint_types": "chat",
         # Pin to the real Config default: an auto-created Mock attribute is
         # truthy, which enables the GMS shadow-mode path and imports the
         # optional gpu_memory_service package (absent in some test images).
@@ -69,7 +77,7 @@ def test_decode_worker_lifecycle_cleanup_in_reverse_construction_order():
     handler.cleanup.side_effect = lambda: calls.append("handler")
     engine_client = Mock()
     engine_client.shutdown.side_effect = lambda **_kwargs: calls.append("engine")
-    resources = _DecodeWorkerLifecycle(
+    resources = _WorkerLifecycle(
         engine_client=engine_client,
         vllm_config=SimpleNamespace(shutdown_timeout=7.0),
         handler=handler,
@@ -87,7 +95,7 @@ def test_decode_worker_lifecycle_shutdown_engine_when_handler_cleanup_fails():
     handler = Mock()
     handler.cleanup.side_effect = RuntimeError("handler cleanup failed")
     engine_client = Mock()
-    resources = _DecodeWorkerLifecycle(
+    resources = _WorkerLifecycle(
         engine_client=engine_client,
         vllm_config=SimpleNamespace(shutdown_timeout=5.0),
         handler=handler,
@@ -106,7 +114,7 @@ def test_decode_worker_lifecycle_chains_handler_and_engine_cleanup_failures():
     handler.cleanup.side_effect = handler_error
     engine_client = Mock()
     engine_client.shutdown.side_effect = engine_error
-    lifecycle = _DecodeWorkerLifecycle(
+    lifecycle = _WorkerLifecycle(
         engine_client=engine_client,
         vllm_config=SimpleNamespace(shutdown_timeout=5.0),
         handler=handler,
@@ -143,7 +151,7 @@ async def test_custom_encoder_preserves_primary_error_when_cleanup_fails(caplog)
 
     assert exc_info.value is startup_error
     engine_client.shutdown.assert_called_once_with(timeout=5.0)
-    assert "Failed to clean up decode worker after an earlier failure" in caplog.text
+    assert "Failed to clean up worker after an earlier failure" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -232,6 +240,7 @@ async def test_custom_encoder_shutdown_engine_on_startup_failure(
         component="backend",
         endpoint="generate",
         enable_rl=False,
+        gms_shadow_mode=False,
         engine_args=SimpleNamespace(enable_lora=False),
         enable_multimodal=True,
         custom_encoder_class="encoder.Backend",
@@ -245,6 +254,273 @@ async def test_custom_encoder_shutdown_engine_on_startup_failure(
     engine_client.shutdown.assert_called_once_with(timeout=5.0)
     if failure_stage == "configure":
         handler_constructor.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_failover_election_retains_real_lock_through_wake(monkeypatch, tmp_path):
+    lock_path = str(tmp_path / "failover.lock")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", lock_path)
+    monkeypatch.setenv("ENGINE_ID", "2")
+    pause_controller = Mock()
+    pause_controller.pause = AsyncMock()
+    during_resume, after_return = (FlockFailoverLock(lock_path) for _ in range(2))
+    owner = None
+
+    async def resume():
+        with pytest.raises(FailoverLockError, match="Timed out acquiring flock"):
+            await during_resume.acquire(
+                "during-resume", poll_interval=0.005, timeout=0.02
+            )
+
+    pause_controller.resume = resume
+    factory = WorkerFactory(Mock(), Mock(), AsyncMock(), Mock(), Mock())
+    try:
+        was_failover, owner = await factory._wake_with_failover_lock(
+            pause_controller,
+            Mock(),
+            SimpleNamespace(gms_shadow_mode=True),
+        )
+
+        assert was_failover is False
+        assert isinstance(owner, FlockFailoverLock)
+        pause_controller.pause.assert_awaited_once_with(1)
+        pause_controller.mark_resumed.assert_called_once_with()
+        with pytest.raises(FailoverLockError, match="Timed out acquiring flock"):
+            await after_return.acquire(
+                "after-return", poll_interval=0.005, timeout=0.02
+            )
+
+        await owner.release()
+        owner = None
+        await after_return.acquire("after-release", timeout=0.1)
+    finally:
+        if owner is not None:
+            await owner.release()
+        await during_resume.release()
+        await after_return.release()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "handler_type", "create_method"),
+    [
+        ("decode", handlers_mod.DecodeWorkerHandler, "_create_decode_worker"),
+        ("prefill", handlers_mod.PrefillWorkerHandler, "_create_prefill_worker"),
+    ],
+)
+@pytest.mark.parametrize("failure_stage", ["before_transfer", "after_transfer"])
+async def test_shadow_monitor_cleanup_has_exactly_one_owner(
+    monkeypatch, mode, handler_type, create_method, failure_stage
+):
+    election_entered = asyncio.Event()
+    release_election = asyncio.Event()
+
+    async def blocked_election(*_args, **_kwargs):
+        election_entered.set()
+        await release_election.wait()
+        return True, Mock()
+
+    vllm_config = SimpleNamespace(
+        additional_config={},
+        cache_config=SimpleNamespace(num_gpu_blocks=1),
+        model_config=SimpleNamespace(max_model_len=1024),
+        shutdown_timeout=5.0,
+    )
+    engine_client = Mock(vllm_config=vllm_config)
+    prometheus_temp_dir = Mock()
+    engine_setup: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        prometheus_temp_dir,
+        Mock(),
+    )
+    early_monitor = Mock()
+    monitor_constructor = Mock(return_value=early_monitor)
+    monkeypatch.setattr(worker_factory_mod, "VllmEngineMonitor", monitor_constructor)
+    monkeypatch.setattr(handlers_mod, "VllmEngineMonitor", monitor_constructor)
+    monkeypatch.setattr(handlers_mod, "get_dp_range_for_worker", lambda _config: (0, 1))
+    monkeypatch.setattr(handlers_mod, "VllmMultimodalRequestProcessor", Mock())
+    monkeypatch.setattr(handlers_mod, "InputParamManager", Mock())
+    monkeypatch.setattr(handlers_mod, "RLRouteRegistry", Mock())
+    monkeypatch.setattr(worker_factory_mod, "get_dp_range_for_worker", lambda _: (0, 1))
+    monkeypatch.setattr(
+        worker_factory_mod, "configure_kv_event_block_size", AsyncMock()
+    )
+
+    factory = WorkerFactory(
+        Mock(return_value=engine_setup),
+        Mock(return_value=None),
+        AsyncMock(),
+        Mock(return_value=None),
+        Mock(),
+    )
+    factory._wake_with_failover_lock = blocked_election  # type: ignore[assignment]
+    factory._maybe_create_failover_metrics = Mock()  # type: ignore[assignment]
+    factory._maybe_get_encode_worker_client = AsyncMock(return_value=None)  # type: ignore[assignment]
+    created_handlers = []
+
+    def fail_after_transfer(_runtime, handler, **_kwargs):
+        created_handlers.append(handler)
+        raise RuntimeError("post-transfer setup failed")
+
+    factory.register_engine_routes = fail_after_transfer  # type: ignore[assignment]
+
+    endpoint = Mock(connection_id=Mock(return_value="cid"))
+    endpoint.serve_endpoint = AsyncMock()
+    runtime = Mock(endpoint=Mock(return_value=endpoint))
+    config = _make_config(
+        gms_shadow_mode=True,
+        namespace="dyn",
+        component=mode,
+        endpoint="generate",
+        enable_rl=False,
+        engine_args=SimpleNamespace(enable_lora=False, trust_remote_code=False),
+        model="model",
+        served_model_name=None,
+        served_model_aliases=[],
+        custom_encoder_class=None,
+        use_vllm_tokenizer=False,
+        frontend_decoding=False,
+        endpoint_types="chat",
+        custom_jinja_template=None,
+    )
+    shutdown_event = asyncio.Event()
+    task = asyncio.create_task(
+        getattr(factory, create_method)(runtime, config, shutdown_event, [])
+    )
+
+    await asyncio.wait_for(election_entered.wait(), timeout=1)
+    monitor_constructor.assert_called_once_with(runtime, engine_client, shutdown_event)
+    assert created_handlers == []
+    factory.register_vllm_model.assert_not_awaited()
+    endpoint.serve_endpoint.assert_not_called()
+
+    if failure_stage == "before_transfer":
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert created_handlers == []
+        prometheus_temp_dir.cleanup.assert_not_called()
+    else:
+        release_election.set()
+        with pytest.raises(RuntimeError, match="post-transfer setup failed"):
+            await task
+        assert len(created_handlers) == 1
+        assert type(created_handlers[0]) is handler_type
+        assert created_handlers[0].engine_monitor is early_monitor
+        prometheus_temp_dir.cleanup.assert_called_once_with()
+
+    assert shutdown_event.is_set()
+    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+    assert monitor_constructor.call_count == 1
+    early_monitor.cancel.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_monitor_detects_engine_death_while_wake_is_pending(
+    monkeypatch, tmp_path
+):
+    wake_started = asyncio.Event()
+    finish_wake = asyncio.Event()
+
+    async def pending_wake():
+        wake_started.set()
+        await finish_wake.wait()
+
+    async def fail_health_check_during_wake():
+        await wake_started.wait()
+        raise EngineDeadError("engine died during wake")
+
+    vllm_config = SimpleNamespace(
+        additional_config={},
+        cache_config=SimpleNamespace(num_gpu_blocks=1),
+        model_config=SimpleNamespace(max_model_len=1024),
+        shutdown_timeout=5.0,
+    )
+    engine_client = Mock(
+        vllm_config=vllm_config,
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=pending_wake,
+        resume_generation=AsyncMock(),
+        check_health=fail_health_check_during_wake,
+    )
+    engine_setup: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        Mock(),
+        Mock(),
+    )
+    monitor_created = asyncio.Event()
+    monitor_holder = {}
+
+    def create_monitor(runtime, engine, shutdown_event):
+        monitor = object.__new__(VllmEngineMonitor)
+        monitor.runtime = runtime
+        monitor.engine_client = engine
+        monitor.shutdown_event = shutdown_event
+        monitor.health_config = EngineHealthMonitorConfig(
+            interval=60,
+            check_timeout=0,
+            shutdown_timeout=0,
+        )
+        monitor._shutdown_engine = MagicMock()
+        monitor._monitor_task = asyncio.create_task(monitor._check_engine_health())
+        monitor._stats_task = asyncio.get_running_loop().create_future()
+        monitor_holder["monitor"] = monitor
+        monitor_created.set()
+        return monitor
+
+    monkeypatch.setattr(worker_factory_mod, "VllmEngineMonitor", create_monitor)
+    monkeypatch.setattr(
+        worker_factory_mod,
+        "configure_kv_event_block_size",
+        AsyncMock(side_effect=RuntimeError("stop after wake")),
+    )
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", str(tmp_path / "failover.lock"))
+    factory = WorkerFactory(
+        Mock(return_value=engine_setup),
+        Mock(),
+        AsyncMock(),
+        Mock(),
+        Mock(),
+    )
+    factory._maybe_create_failover_metrics = Mock()  # type: ignore[assignment]
+    endpoint = Mock(connection_id=Mock(return_value="cid"))
+    runtime = Mock(endpoint=Mock(return_value=endpoint))
+    config = _make_config(
+        gms_shadow_mode=True,
+        namespace="dyn",
+        component="decode",
+        endpoint="generate",
+        enable_rl=False,
+        engine_args=SimpleNamespace(enable_lora=False),
+    )
+    with patch(
+        "dynamo.vllm.engine_monitor.os._exit",
+        side_effect=RuntimeError("process exit"),
+    ) as exit_process:
+        worker_task = asyncio.create_task(
+            factory._create_decode_worker(runtime, config, asyncio.Event(), [])
+        )
+        await asyncio.wait_for(monitor_created.wait(), timeout=1)
+        await asyncio.wait_for(wake_started.wait(), timeout=1)
+        monitor = monitor_holder["monitor"]
+
+        with pytest.raises(RuntimeError, match="process exit"):
+            await monitor._monitor_task
+
+        assert not worker_task.done()
+        monitor._shutdown_engine.assert_called_once_with()
+        runtime.shutdown.assert_called_once_with()
+        exit_process.assert_called_once_with(1)
+
+        finish_wake.set()
+        with pytest.raises(RuntimeError, match="stop after wake"):
+            await worker_task
+        assert monitor._stats_task.cancelled()
 
 
 def _single_rank_benchmark_payload(
@@ -851,7 +1127,9 @@ class TestPrefillRegistrationContract:
             setup_metrics_collection_fn=Mock(),
         )
         factory._maybe_get_encode_worker_client = AsyncMock(return_value=None)  # type: ignore[assignment]
-        factory._maybe_wait_for_failover_lock = AsyncMock()  # type: ignore[assignment]
+        factory._wake_with_failover_lock = AsyncMock(  # type: ignore[assignment]
+            return_value=(False, None)
+        )
         factory.register_engine_routes = Mock()  # type: ignore[assignment]
 
         # embedding_cache_manager=None skips register_embedding_cache_metrics.
@@ -935,7 +1213,9 @@ async def test_prefill_serves_lora_lifecycle_endpoints_when_enabled(
         setup_metrics_collection_fn=Mock(),
     )
     factory._maybe_get_encode_worker_client = AsyncMock(return_value=None)  # type: ignore[assignment]
-    factory._maybe_wait_for_failover_lock = AsyncMock()  # type: ignore[assignment]
+    factory._wake_with_failover_lock = AsyncMock(  # type: ignore[assignment]
+        return_value=(False, None)
+    )
     factory.register_engine_routes = Mock()  # type: ignore[assignment]
 
     handler = Mock(embedding_cache_manager=None)

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -33,11 +33,13 @@ from .args import Config
 from .cache_info import configure_kv_event_block_size
 from .capacity import per_rank_kv_blocks
 from .constants import DisaggregationMode
+from .engine_monitor import VllmEngineMonitor
 from .handlers import (
     BaseWorkerHandler,
     DecodeWorkerHandler,
     EmbeddingWorkerHandler,
     PrefillWorkerHandler,
+    VllmEnginePauseController,
     get_dp_range_for_worker,
 )
 from .health_check import (
@@ -540,13 +542,14 @@ SetupMetricsCollectionFn = Callable[..., None]
 
 
 @dataclass
-class _DecodeWorkerLifecycle:
+class _WorkerLifecycle:
     engine_client: Optional[AsyncLLM] = None
     vllm_config: Optional[VllmConfig] = None
+    engine_monitor: Optional[VllmEngineMonitor] = None
     handler: Optional[BaseWorkerHandler] = None
     shutdown_event: asyncio.Event | None = None
 
-    def __enter__(self) -> "_DecodeWorkerLifecycle":
+    def __enter__(self) -> "_WorkerLifecycle":
         return self
 
     def __exit__(
@@ -560,18 +563,18 @@ class _DecodeWorkerLifecycle:
         except Exception:
             if original_error is None:
                 raise
-            logger.exception(
-                "Failed to clean up decode worker after an earlier failure"
-            )
+            logger.exception("Failed to clean up worker after an earlier failure")
 
     def cleanup(self) -> None:
         """Release resources in reverse construction order."""
-        logger.debug("Cleaning up decode worker")
+        logger.debug("Cleaning up worker")
         if self.shutdown_event is not None:
             self.shutdown_event.set()
         try:
             if self.handler is not None:
                 self.handler.cleanup()
+            elif self.engine_monitor is not None:
+                self.engine_monitor.cancel()
         finally:
             if self.engine_client is not None and self.vllm_config is not None:
                 self.engine_client.shutdown(timeout=self.vllm_config.shutdown_timeout)
@@ -930,19 +933,18 @@ class WorkerFactory:
         failover_metrics.set_state("init")
         return failover_metrics
 
-    async def _maybe_wait_for_failover_lock(
+    async def _wake_with_failover_lock(
         self,
-        handler,
+        pause_controller,
         runtime: DistributedRuntime,
         config: Config,
         failover_metrics=None,
-    ) -> bool:
-        # Shadow mode: sleep → probe → block on lock → wake. True only for a real
-        # (contended) failover, not the initial bootup.
+    ) -> tuple[bool, Any | None]:
+        """Pause, elect the active shadow, and wake it while retaining the lock."""
         if config.gms_shadow_mode is not True:
-            return False
+            return False, None
 
-        await handler._pause_controller.pause(1)
+        await pause_controller.pause(1)
         if failover_metrics is not None:
             failover_metrics.set_state("standby")
 
@@ -959,16 +961,32 @@ class WorkerFactory:
         await lock.acquire(engine_id=f"engine-{engine_id}")
         was_failover = lock.was_contended
         logger.info("[Shadow] Lock acquired, waking engine")
-        if failover_metrics is not None:
-            failover_metrics.set_state("waking")
-            if was_failover:
-                # Only a contended acquire is a failover; a bootup is not a switch.
-                failover_metrics.record_switch_attempt()
+        resume_started = False
+        try:
+            if failover_metrics is not None:
+                failover_metrics.set_state("waking")
+                if was_failover:
+                    # Only a contended acquire is a failover; a bootup is not a switch.
+                    failover_metrics.record_switch_attempt()
 
-        await handler._pause_controller.resume()
-        handler._pause_controller.mark_resumed()
+            resume_started = True
+            await pause_controller.resume()
+            pause_controller.mark_resumed()
+        except BaseException:
+            if not resume_started:
+                await lock.release()
+            else:
+                # resume() can fail after partially waking vLLM. Keep the lock
+                # until process termination closes the fd; releasing it could
+                # let another engine wake concurrently.
+                logger.critical(
+                    "[Shadow] Engine wake failed after lock acquisition; "
+                    "terminating process while retaining the lock"
+                )
+                os._exit(1)
+            raise
         logger.info("[Shadow] Engine awake, registering with discovery")
-        return was_failover
+        return was_failover, lock
 
     async def _create_decode_worker(
         self,
@@ -981,7 +999,7 @@ class WorkerFactory:
         """
         Instantiate and serve
         """
-        with _DecodeWorkerLifecycle(shutdown_event=shutdown_event) as lifecycle:
+        with _WorkerLifecycle(shutdown_event=shutdown_event) as lifecycle:
             await self._run_decode_worker(
                 runtime,
                 config,
@@ -998,7 +1016,7 @@ class WorkerFactory:
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
         snapshot_engine: Optional[EngineSetupResult],
-        lifecycle: _DecodeWorkerLifecycle,
+        lifecycle: _WorkerLifecycle,
     ) -> None:
         """Initialize and serve a decode worker."""
 
@@ -1061,6 +1079,7 @@ class WorkerFactory:
             factory = StatLoggerFactory(
                 endpoint=generate_endpoint,
                 component_gauges=component_gauges,
+                defer_publication=config.gms_shadow_mode is True,
             )
         else:
             # Factory is created without component_gauges; setup_vllm_engine() will
@@ -1068,6 +1087,7 @@ class WorkerFactory:
             # on the factory before vLLM calls create_stat_logger().
             factory = StatLoggerFactory(
                 endpoint=generate_endpoint,
+                defer_publication=config.gms_shadow_mode is True,
             )
             (
                 engine_client,
@@ -1078,6 +1098,15 @@ class WorkerFactory:
             ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
         lifecycle.engine_client = engine_client
         lifecycle.vllm_config = vllm_config
+        engine_monitor = None
+        if config.gms_shadow_mode is True:
+            engine_monitor = VllmEngineMonitor(runtime, engine_client, shutdown_event)
+            lifecycle.engine_monitor = engine_monitor
+        pause_controller = VllmEnginePauseController(engine_client)
+        was_failover, failover_lock = await self._wake_with_failover_lock(
+            pause_controller, runtime, config, failover_metrics
+        )
+        factory.enable_publication()
         await configure_kv_event_block_size(engine_client, vllm_config)
 
         # TODO Hack to get data, move this to registering in TBD
@@ -1109,8 +1138,13 @@ class WorkerFactory:
             shutdown_event=shutdown_event,
             enable_frontend_decoding=config.frontend_decoding,
             encode_worker_client=encode_worker_client,
+            engine_monitor=engine_monitor,
         )
         lifecycle.handler = handler
+        lifecycle.engine_monitor = None
+        if config.gms_shadow_mode is True:
+            handler._pause_controller = pause_controller
+            handler._failover_lock = failover_lock
         handler.add_temp_dir(prometheus_temp_dir)
 
         # Check if kv event consolidator is enabled (port was allocated in setup_vllm_engine)
@@ -1155,9 +1189,6 @@ class WorkerFactory:
                 component_name=config.component,
             )
 
-        # Register engine routes
-        self.register_engine_routes(runtime, handler, lora_enabled=lora_enabled)
-
         # Parse endpoint types from --endpoint-types flag
         model_type = parse_endpoint_types(config.endpoint_types)
         logger.info(f"Registering model with endpoint types: {config.endpoint_types}")
@@ -1173,9 +1204,7 @@ class WorkerFactory:
                 "The chat template will be loaded but the /v1/chat/completions endpoint will not be available."
             )
 
-        was_failover = await self._maybe_wait_for_failover_lock(
-            handler, runtime, config, failover_metrics
-        )
+        self.register_engine_routes(runtime, handler, lora_enabled=lora_enabled)
 
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
@@ -1299,6 +1328,25 @@ class WorkerFactory:
         shutdown_endpoints: list,  # mutated in place
         snapshot_engine: Optional[EngineSetupResult] = None,
     ) -> None:
+        with _WorkerLifecycle(shutdown_event=shutdown_event) as lifecycle:
+            await self._run_prefill_worker(
+                runtime,
+                config,
+                shutdown_event,
+                shutdown_endpoints,
+                snapshot_engine=snapshot_engine,
+                lifecycle=lifecycle,
+            )
+
+    async def _run_prefill_worker(
+        self,
+        runtime: DistributedRuntime,
+        config: Config,
+        shutdown_event: asyncio.Event,
+        shutdown_endpoints: list,  # mutated in place
+        lifecycle: _WorkerLifecycle,
+        snapshot_engine: Optional[EngineSetupResult] = None,
+    ) -> None:
         """
         Instantiate and serve
         """
@@ -1353,6 +1401,16 @@ class WorkerFactory:
                 prometheus_temp_dir,
                 _component_gauges,
             ) = self.setup_vllm_engine(config, fpm_worker_id=fpm_worker_id)
+        lifecycle.engine_client = engine_client
+        lifecycle.vllm_config = vllm_config
+        engine_monitor = None
+        if config.gms_shadow_mode is True:
+            engine_monitor = VllmEngineMonitor(runtime, engine_client, shutdown_event)
+            lifecycle.engine_monitor = engine_monitor
+        pause_controller = VllmEnginePauseController(engine_client)
+        was_failover, failover_lock = await self._wake_with_failover_lock(
+            pause_controller, runtime, config, failover_metrics
+        )
         await configure_kv_event_block_size(engine_client, vllm_config)
 
         encode_worker_client = await self._maybe_get_encode_worker_client(
@@ -1372,7 +1430,13 @@ class WorkerFactory:
             shutdown_event=shutdown_event,
             enable_frontend_decoding=config.frontend_decoding,
             encode_worker_client=encode_worker_client,
+            engine_monitor=engine_monitor,
         )
+        lifecycle.handler = handler
+        lifecycle.engine_monitor = None
+        if config.gms_shadow_mode is True:
+            handler._pause_controller = pause_controller
+            handler._failover_lock = failover_lock
         handler.add_temp_dir(prometheus_temp_dir)
 
         # Check if kv event consolidator is enabled (port was allocated in setup_vllm_engine)
@@ -1420,10 +1484,6 @@ class WorkerFactory:
         # Register engine routes
         self.register_engine_routes(
             runtime, handler, lora_enabled=config.engine_args.enable_lora
-        )
-
-        was_failover = await self._maybe_wait_for_failover_lock(
-            handler, runtime, config, failover_metrics
         )
 
         # Wait for self-benchmark to complete before registering.
@@ -1538,9 +1598,6 @@ class WorkerFactory:
         except Exception as e:
             logger.error(f"Failed to serve endpoints: {e}")
             raise
-        finally:
-            logger.debug("Cleaning up prefill worker")
-            handler.cleanup()
 
     async def _maybe_get_encode_worker_client(
         self, runtime: DistributedRuntime, config: Config

--- a/deploy/operator/api/v1alpha1/common.go
+++ b/deploy/operator/api/v1alpha1/common.go
@@ -229,7 +229,9 @@ type GMSClientPodSpec struct {
 
 // FailoverSpec configures active-passive failover for a worker component.
 // For intraPod mode: requires gpuMemoryService.enabled; the main container is cloned
-// into engine containers (active + standby) within the same pod.
+// into one active and one or two standby engine containers within the same pod.
+// The second shadow currently requires a single-node direct vLLM launch without
+// Ray or data parallel.
 // For interPod mode: the operator creates a dedicated GMS weight server pod and
 // multiple engine pods per rank that share GPUs via DRA resource claims.
 type FailoverSpec struct {
@@ -242,12 +244,10 @@ type FailoverSpec struct {
 	// +kubebuilder:validation:Enum=intraPod;interPod
 	// +optional
 	Mode GPUMemoryServiceMode `json:"mode,omitempty"`
-	// NumShadows is the number of shadow (standby) engine pods per rank.
-	// Total engine pods per rank = NumShadows + 1 (1 primary + NumShadows shadows).
-	//
-	// NumShadows is only meaningful for mode=interPod; intraPod uses a fixed
-	// 1 primary + 1 shadow sidecar layout and any value other than 1 is
-	// rejected at admission time.
+	// NumShadows is the number of shadow (standby) engines per rank.
+	// In intraPod mode, one or two shadows are supported; the second shadow
+	// currently requires a single-node direct vLLM launch without Ray or data
+	// parallel. InterPod mode supports one or more shadows.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1
 	// +optional

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_test.go
@@ -675,8 +675,9 @@ func TestDCD_ExperimentalModeValuesAreValidForIntermediateVersion(t *testing.T) 
 					Mode:    GMSModeInterPod,
 				},
 				Failover: &FailoverSpec{
-					Enabled: true,
-					Mode:    GMSModeIntraPod,
+					Enabled:    true,
+					Mode:       GMSModeIntraPod,
+					NumShadows: 2,
 				},
 				Checkpoint: &ServiceCheckpointConfig{
 					Enabled: true,
@@ -699,6 +700,9 @@ func TestDCD_ExperimentalModeValuesAreValidForIntermediateVersion(t *testing.T) 
 	if got := hub.Spec.Experimental.Failover.Mode; got != v1beta1.GMSModeIntraPod {
 		t.Fatalf("hub failover mode = %q, want %q", got, v1beta1.GMSModeIntraPod)
 	}
+	if got := hub.Spec.Experimental.Failover.NumShadows; got != 2 {
+		t.Fatalf("hub failover numShadows = %d, want 2", got)
+	}
 	if got := hub.Spec.Experimental.Checkpoint.Mode; got != v1beta1.CheckpointModeManual {
 		t.Fatalf("hub checkpoint mode = %q, want %q", got, v1beta1.CheckpointModeManual)
 	}
@@ -709,7 +713,7 @@ func TestDCD_ExperimentalModeValuesAreValidForIntermediateVersion(t *testing.T) 
 			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
 				Experimental: &v1beta1.ExperimentalSpec{
 					GPUMemoryService: &v1beta1.GPUMemoryServiceSpec{Mode: v1beta1.GMSModeIntraPod},
-					Failover:         &v1beta1.FailoverSpec{Mode: v1beta1.GMSModeInterPod},
+					Failover:         &v1beta1.FailoverSpec{Mode: v1beta1.GMSModeInterPod, NumShadows: 2},
 					Checkpoint: &v1beta1.ComponentCheckpointConfig{
 						Enabled: true,
 						Mode:    v1beta1.CheckpointModeAuto,
@@ -731,6 +735,9 @@ func TestDCD_ExperimentalModeValuesAreValidForIntermediateVersion(t *testing.T) 
 	}
 	if got := spoke.Spec.Failover.Mode; got != GMSModeInterPod {
 		t.Fatalf("spoke failover mode = %q, want %q", got, GMSModeInterPod)
+	}
+	if got := spoke.Spec.Failover.NumShadows; got != 2 {
+		t.Fatalf("spoke failover numShadows = %d, want 2", got)
 	}
 	if got := spoke.Spec.Checkpoint.Mode; got != CheckpointModeAuto {
 		t.Fatalf("spoke checkpoint mode = %q, want %q", got, CheckpointModeAuto)

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -187,7 +187,9 @@ type DynamoComponentDeploymentSharedSpec struct {
 	GPUMemoryService *GPUMemoryServiceSpec `json:"gpuMemoryService,omitempty"`
 
 	// Failover configures GMS (GPU Memory Service) failover for this service.
-	// For intraPod mode: the main container is cloned into two engine containers (active + standby).
+	// For intraPod mode: the main container is cloned into one active and one or
+	// two standby engine containers. The second shadow currently requires a
+	// single-node direct vLLM launch without Ray or data parallel.
 	// For interPod mode: the operator creates a dedicated GMS weight server pod and
 	// multiple engine pods per rank that share GPUs via DRA resource claims.
 	// +optional

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
@@ -641,7 +641,7 @@ func TestDGD_RoundTrip_Experimental(t *testing.T) {
 						},
 						Failover: &v1beta1.FailoverSpec{
 							Mode:       v1beta1.GMSModeIntraPod,
-							NumShadows: 1,
+							NumShadows: 2,
 						},
 						Checkpoint: &v1beta1.ComponentCheckpointConfig{
 							Enabled:             true,

--- a/deploy/operator/api/v1beta1/common.go
+++ b/deploy/operator/api/v1beta1/common.go
@@ -269,11 +269,14 @@ type GMSClientPodSpec struct {
 }
 
 // FailoverSpec configures active-passive failover for a worker component.
-// The main container is cloned into two engine containers (active + standby)
-// sharing GPUs via DRA, and the standby acquires the flock when the active
-// engine fails. Failover requires that gpuMemoryService is also set, and that
-// failover.mode matches gpuMemoryService.mode. Also requires the
-// `nvidia.com/dynamo-kube-discovery-mode: container` annotation on the DGD.
+// In IntraPod mode, the main container is cloned into one active and one or two
+// standby engine containers sharing GPUs via DRA. InterPod mode supports one
+// standby. Standbys acquire the flock after the active engine fails. Failover
+// with a second IntraPod shadow currently requires a single-node direct vLLM
+// launch without Ray or data parallel. Failover requires that gpuMemoryService
+// is also set, and that failover.mode matches gpuMemoryService.mode. Also
+// requires the `nvidia.com/dynamo-kube-discovery-mode: container` annotation on
+// the DGD.
 // See ExperimentalSpec for the stability caveat.
 type FailoverSpec struct {
 	// mode selects the failover deployment topology. Must match
@@ -284,13 +287,12 @@ type FailoverSpec struct {
 	// +kubebuilder:default=IntraPod
 	// +kubebuilder:validation:Enum=IntraPod;InterPod
 	Mode GPUMemoryServiceMode `json:"mode,omitempty"`
-	// numShadows is the number of shadow (standby) engine containers per
-	// rank. Reserved for future use; the operator currently creates exactly
-	// one shadow.
+	// numShadows is the number of shadow (standby) engines per rank. IntraPod
+	// mode supports 1 or 2; the second shadow currently requires a single-node
+	// direct vLLM launch without Ray or data parallel. InterPod mode supports 1.
 	// +optional
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=1
 	NumShadows int32 `json:"numShadows,omitempty"`
 }
 

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -10694,7 +10694,9 @@ spec:
                 failover:
                   description: |-
                     Failover configures GMS (GPU Memory Service) failover for this service.
-                    For intraPod mode: the main container is cloned into two engine containers (active + standby).
+                    For intraPod mode: the main container is cloned into one active and one or
+                    two standby engine containers. The second shadow currently requires a
+                    single-node direct vLLM launch without Ray or data parallel.
                     For interPod mode: the operator creates a dedicated GMS weight server pod and
                     multiple engine pods per rank that share GPUs via DRA resource claims.
                   properties:
@@ -10714,12 +10716,10 @@ spec:
                     numShadows:
                       default: 1
                       description: |-
-                        NumShadows is the number of shadow (standby) engine pods per rank.
-                        Total engine pods per rank = NumShadows + 1 (1 primary + NumShadows shadows).
-
-                        NumShadows is only meaningful for mode=interPod; intraPod uses a fixed
-                        1 primary + 1 shadow sidecar layout and any value other than 1 is
-                        rejected at admission time.
+                        NumShadows is the number of shadow (standby) engines per rank.
+                        In intraPod mode, one or two shadows are supported; the second shadow
+                        currently requires a single-node direct vLLM launch without Ray or data
+                        parallel. InterPod mode supports one or more shadows.
                       format: int32
                       minimum: 1
                       type: integer
@@ -12115,11 +12115,10 @@ spec:
                         numShadows:
                           default: 1
                           description: |-
-                            numShadows is the number of shadow (standby) engine containers per
-                            rank. Reserved for future use; the operator currently creates exactly
-                            one shadow.
+                            numShadows is the number of shadow (standby) engines per rank. IntraPod
+                            mode supports 1 or 2; the second shadow currently requires a single-node
+                            direct vLLM launch without Ray or data parallel. InterPod mode supports 1.
                           format: int32
-                          maximum: 1
                           minimum: 1
                           type: integer
                       type: object

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -10994,7 +10994,9 @@ spec:
                       failover:
                         description: |-
                           Failover configures GMS (GPU Memory Service) failover for this service.
-                          For intraPod mode: the main container is cloned into two engine containers (active + standby).
+                          For intraPod mode: the main container is cloned into one active and one or
+                          two standby engine containers. The second shadow currently requires a
+                          single-node direct vLLM launch without Ray or data parallel.
                           For interPod mode: the operator creates a dedicated GMS weight server pod and
                           multiple engine pods per rank that share GPUs via DRA resource claims.
                         properties:
@@ -11014,12 +11016,10 @@ spec:
                           numShadows:
                             default: 1
                             description: |-
-                              NumShadows is the number of shadow (standby) engine pods per rank.
-                              Total engine pods per rank = NumShadows + 1 (1 primary + NumShadows shadows).
-
-                              NumShadows is only meaningful for mode=interPod; intraPod uses a fixed
-                              1 primary + 1 shadow sidecar layout and any value other than 1 is
-                              rejected at admission time.
+                              NumShadows is the number of shadow (standby) engines per rank.
+                              In intraPod mode, one or two shadows are supported; the second shadow
+                              currently requires a single-node direct vLLM launch without Ray or data
+                              parallel. InterPod mode supports one or more shadows.
                             format: int32
                             minimum: 1
                             type: integer
@@ -12573,11 +12573,10 @@ spec:
                               numShadows:
                                 default: 1
                                 description: |-
-                                  numShadows is the number of shadow (standby) engine containers per
-                                  rank. Reserved for future use; the operator currently creates exactly
-                                  one shadow.
+                                  numShadows is the number of shadow (standby) engines per rank. IntraPod
+                                  mode supports 1 or 2; the second shadow currently requires a single-node
+                                  direct vLLM launch without Ray or data parallel. InterPod mode supports 1.
                                 format: int32
-                                maximum: 1
                                 minimum: 1
                                 type: integer
                             type: object

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -154,7 +154,7 @@ func (r *dgdCheckpointsReconciler) Reconcile(
 			info.RestoreTargetContainers = []string{alphaCheckpointConfig.TargetContainerName}
 		}
 		if dynamo.IsIntraPodFailoverEnabled(component) {
-			info.RestoreTargetContainers = dynamo.IntraPodFailoverEngineContainerNames()
+			info.RestoreTargetContainers = dynamo.IntraPodFailoverEngineContainerNames(component)
 		}
 		if err := gms.OverlayClients(&info.GPUMemoryService, info.CheckpointName, info.Exists, dynamo.GetGPUMemoryService(component)); err != nil {
 			return dgdCheckpointsResult{}, fmt.Errorf("failed to apply checkpoint gpuMemoryService config for component %s: %w", componentName, err)

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
@@ -196,7 +196,9 @@ func (r *dcdWorkloadRenderer) generatePodTemplateSpec(
 			return nil, errors.Wrap(err, "failed to resolve checkpoint")
 		}
 		if dynamo.IsIntraPodFailoverEnabled(&dcd.Spec.DynamoComponentDeploymentSharedSpec) {
-			info.RestoreTargetContainers = dynamo.IntraPodFailoverEngineContainerNames()
+			info.RestoreTargetContainers = dynamo.IntraPodFailoverEngineContainerNames(
+				&dcd.Spec.DynamoComponentDeploymentSharedSpec,
+			)
 		}
 		if err := gms.OverlayClients(
 			&info.GPUMemoryService,

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -387,8 +387,8 @@ func gmsResourceSharingEntries(serviceName string, roles []ServiceRole) []grovev
 // ──────────────────────────────────────────────────────────────────────────────
 // Intra-pod GMS failover (Mode: intraPod)
 //
-// The main container is cloned into two engine containers (active + standby)
-// within the same pod. GPU access is shared via DRA and a GMS sidecar
+// The main container is cloned into one active and one or two standby engine
+// containers within the same pod. GPU access is shared via DRA and a GMS sidecar
 // injects weights via the shared emptyDir volume.
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -413,12 +413,63 @@ func IsIntraPodFailoverEnabled(component *v1beta1.DynamoComponentDeploymentShare
 	return mode == "" || mode == v1beta1.GMSModeIntraPod
 }
 
-func IntraPodFailoverEngineContainerNames() []string {
-	names := make([]string, 0, failoverEngineCount)
-	for i := 0; i < failoverEngineCount; i++ {
+func IntraPodFailoverEngineContainerNames(component *v1beta1.DynamoComponentDeploymentSharedSpec) []string {
+	if !IsIntraPodFailoverEnabled(component) {
+		return nil
+	}
+	engineCount := failoverEngineCount
+	if component.Experimental.Failover.NumShadows == 2 {
+		engineCount = 3
+	}
+	names := make([]string, 0, engineCount)
+	for i := 0; i < engineCount; i++ {
 		names = append(names, fmt.Sprintf("engine-%d", i))
 	}
 	return names
+}
+
+// buildFailoverPodWithComponent preserves the historical one-shadow transform
+// and adds the narrow, transactional two-shadow transform.
+func buildFailoverPodWithComponent(
+	podSpec *corev1.PodSpec,
+	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+	numberOfNodes int32,
+	backendFramework BackendFramework,
+) error {
+	numShadows := component.Experimental.Failover.NumShadows
+	if numShadows <= 1 {
+		return buildFailoverPod(podSpec, numberOfNodes, backendFramework)
+	}
+	if numShadows > 2 {
+		return fmt.Errorf("intra-pod failover supports one or two shadows")
+	}
+	if len(podSpec.Containers) == 0 {
+		return fmt.Errorf("pod spec must have at least one container for failover transformation")
+	}
+	if err := TwoShadowIntraPodFailoverProfileError(
+		&podSpec.Containers[0],
+		numberOfNodes,
+		string(backendFramework),
+		GetPodTemplateAnnotations(component)[commonconsts.KubeAnnotationVLLMDistributedExecutorBackend],
+	); err != nil {
+		return err
+	}
+
+	ports, err := threeEngineVLLMPorts(&podSpec.Containers[0])
+	if err != nil {
+		return err
+	}
+	updated := podSpec.DeepCopy()
+	mainContainer := updated.Containers[0]
+	sidecars := updated.Containers[1:]
+	engines := make([]corev1.Container, len(ports))
+	for i := range ports {
+		engines[i] = buildEngineContainer(mainContainer, i, ports[i].system)
+	}
+	updated.Containers = append(engines, sidecars...)
+	applyThreeEngineVLLMOverrides(updated, ports)
+	*podSpec = *updated
+	return nil
 }
 
 // buildFailoverPod clones the main container into two engine containers (active + standby).

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -597,14 +597,110 @@ func intraPodFailoverPodSpec() corev1.PodSpec {
 
 func TestBuildFailoverPod_TwoEnginesPlusSidecar(t *testing.T) {
 	ps := intraPodFailoverPodSpec()
-	err := buildFailoverPod(&ps, 1, BackendFrameworkVLLM)
+	want := ps.DeepCopy()
+	require.NoError(t, buildFailoverPod(want, 1, BackendFrameworkVLLM))
+	component := &v1beta1.DynamoComponentDeploymentSharedSpec{
+		Experimental: &v1beta1.ExperimentalSpec{
+			Failover: &v1beta1.FailoverSpec{NumShadows: 1},
+		},
+	}
+	err := buildFailoverPodWithComponent(&ps, component, 1, BackendFrameworkVLLM)
 	require.NoError(t, err)
+	assert.Equal(t, want, &ps)
 
 	// 2 engines + 1 preserved sidecar
 	assert.Len(t, ps.Containers, 3)
 	assert.Equal(t, "engine-0", ps.Containers[0].Name)
 	assert.Equal(t, "engine-1", ps.Containers[1].Name)
 	assert.Equal(t, "frontend-sidecar", ps.Containers[2].Name)
+}
+
+func TestBuildFailoverPodWithComponent_ThreeDirectEngines(t *testing.T) {
+	ps := intraPodFailoverPodSpec()
+	ps.Containers[0].Command = []string{"python3", "-m", "dynamo.vllm", vllmMasterPortFlag}
+	ps.Containers[0].Args = []string{"30000"}
+	component := &v1beta1.DynamoComponentDeploymentSharedSpec{
+		Experimental: &v1beta1.ExperimentalSpec{
+			Failover: &v1beta1.FailoverSpec{NumShadows: 2},
+		},
+	}
+
+	require.NoError(t, buildFailoverPodWithComponent(&ps, component, 1, BackendFrameworkVLLM))
+	require.Len(t, ps.Containers, 4)
+
+	used := map[int]bool{}
+	for i := range 3 {
+		engine := ps.Containers[i]
+		assert.Equal(t, fmt.Sprintf("engine-%d", i), engine.Name)
+		master, found, err := tokenizedVLLMMasterPort(&engine)
+		require.NoError(t, err)
+		require.True(t, found)
+		env := envToMap(engine.Env)
+		for _, port := range []int{
+			master,
+			mustAtoi(t, env["DYN_SYSTEM_PORT"]),
+			mustAtoi(t, env["DYN_FORWARDPASS_METRIC_PORT"]),
+			mustAtoi(t, env["VLLM_NIXL_SIDE_CHANNEL_PORT"]),
+			mustAtoi(t, env["DYN_VLLM_KV_EVENT_PORT"]),
+		} {
+			assert.False(t, used[port], "port %d is duplicated", port)
+			used[port] = true
+		}
+	}
+	assert.Equal(t, "frontend-sidecar", ps.Containers[3].Name)
+}
+
+func TestBuildFailoverPodWithComponent_RollsBackInvalidPorts(t *testing.T) {
+	component := &v1beta1.DynamoComponentDeploymentSharedSpec{
+		Experimental: &v1beta1.ExperimentalSpec{
+			Failover: &v1beta1.FailoverSpec{NumShadows: 2},
+		},
+	}
+	for _, tt := range []struct {
+		name string
+		port string
+	}{
+		{name: "collision", port: strconv.Itoa(commonconsts.DynamoSystemPort)},
+		{name: "range", port: "65500"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ps := intraPodFailoverPodSpec()
+			ps.Containers[0].Args = []string{vllmMasterPortFlag, tt.port}
+			before := ps.DeepCopy()
+
+			err := buildFailoverPodWithComponent(&ps, component, 1, BackendFrameworkVLLM)
+			require.Error(t, err)
+			assert.Equal(t, before, &ps)
+		})
+	}
+}
+
+func TestTwoShadowIntraPodFailoverProfileError(t *testing.T) {
+	direct := corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}}
+	require.NoError(t, TwoShadowIntraPodFailoverProfileError(&direct, 1, "", ""))
+
+	for _, tt := range []struct {
+		name                string
+		container           corev1.Container
+		nodes               int32
+		backend             string
+		vllmExecutorBackend string
+	}{
+		{name: "shell", container: corev1.Container{Command: []string{"sh", "-c"}, Args: []string{"python3 -m dynamo.vllm"}}, nodes: 1, backend: "vllm"},
+		{name: "ray", container: corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", "--distributed-executor-backend", "ray"}}, nodes: 1, backend: "vllm"},
+		{name: "data parallel", container: corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", "--data-parallel-size", "2"}}, nodes: 1, backend: "vllm"},
+		{name: "multinode", container: direct, nodes: 2, backend: "vllm"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := TwoShadowIntraPodFailoverProfileError(
+				&tt.container,
+				tt.nodes,
+				tt.backend,
+				tt.vllmExecutorBackend,
+			)
+			require.ErrorContains(t, err, twoShadowIntraPodFailoverProfileMessage)
+		})
+	}
 }
 
 func TestBuildFailoverPod_EmptyContainers(t *testing.T) {
@@ -744,7 +840,10 @@ func TestIsIntraPodFailoverEnabled(t *testing.T) {
 }
 
 func TestIntraPodFailoverEngineContainerNames(t *testing.T) {
-	assert.Equal(t, []string{"engine-0", "engine-1"}, IntraPodFailoverEngineContainerNames())
+	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		Failover: &v1alpha1.FailoverSpec{Enabled: true, Mode: v1alpha1.GMSModeIntraPod},
+	})
+	assert.Equal(t, []string{"engine-0", "engine-1"}, IntraPodFailoverEngineContainerNames(component))
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -804,4 +903,11 @@ func envToMap(envs []corev1.EnvVar) map[string]string {
 		m[e.Name] = e.Value
 	}
 	return m
+}
+
+func mustAtoi(t *testing.T, value string) int {
+	t.Helper()
+	port, err := strconv.Atoi(value)
+	require.NoError(t, err)
+	return port
 }

--- a/deploy/operator/internal/dynamo/failover_vllm.go
+++ b/deploy/operator/internal/dynamo/failover_vllm.go
@@ -6,16 +6,209 @@
 package dynamo
 
 import (
+	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	vllmMasterPortFlag   = "--master-port"
 	vllmMasterPortStride = 100
+
+	twoShadowIntraPodFailoverProfileMessage = "two shadows currently require a single-node direct vLLM launch without Ray or data parallel"
 )
+
+type vllmEnginePorts struct {
+	master int
+	system int
+	fpm    int
+	nixl   int
+	kv     int
+}
+
+// TwoShadowIntraPodFailoverProfileError validates the deliberately narrow
+// launch profile whose listeners the operator can isolate across three engines.
+func TwoShadowIntraPodFailoverProfileError(
+	container *corev1.Container,
+	numberOfNodes int32,
+	backendFramework string,
+	vllmExecutorBackend string,
+) error {
+	if backendFramework == "" && isDirectVLLMLaunch(container) {
+		backendFramework = string(BackendFrameworkVLLM)
+	}
+	if numberOfNodes != 1 ||
+		!strings.EqualFold(backendFramework, string(BackendFrameworkVLLM)) ||
+		!isDirectVLLMLaunch(container) ||
+		strings.EqualFold(vllmExecutorBackend, "ray") {
+		return fmt.Errorf("%s", twoShadowIntraPodFailoverProfileMessage)
+	}
+
+	tokens := append(append([]string{}, container.Command...), container.Args...)
+	for i, token := range tokens {
+		if token == enableElasticEPFlag || strings.HasPrefix(token, enableElasticEPFlag+"=") ||
+			strings.HasPrefix(token, "--data-parallel-") {
+			return fmt.Errorf("%s", twoShadowIntraPodFailoverProfileMessage)
+		}
+		if token == distributedExecutorFlag {
+			if i+1 < len(tokens) && strings.EqualFold(tokens[i+1], "ray") {
+				return fmt.Errorf("%s", twoShadowIntraPodFailoverProfileMessage)
+			}
+		} else if strings.EqualFold(token, distributedExecutorFlag+"=ray") {
+			return fmt.Errorf("%s", twoShadowIntraPodFailoverProfileMessage)
+		}
+	}
+	return nil
+}
+
+func isDirectVLLMLaunch(container *corev1.Container) bool {
+	if container == nil {
+		return false
+	}
+	tokens := append(append([]string{}, container.Command...), container.Args...)
+	return len(tokens) >= 3 &&
+		isPythonExecutable(tokens[0]) &&
+		tokens[1] == "-m" &&
+		tokens[2] == "dynamo.vllm"
+}
+
+func isPythonExecutable(command string) bool {
+	name := filepath.Base(command)
+	if !strings.HasPrefix(name, "python") {
+		return false
+	}
+	suffix := strings.TrimPrefix(name, "python")
+	if suffix == "" {
+		return true
+	}
+	for _, part := range strings.Split(suffix, ".") {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func threeEngineVLLMPorts(container *corev1.Container) ([]vllmEnginePorts, error) {
+	masterBase, found, err := tokenizedVLLMMasterPort(container)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		masterBase = 29500
+	}
+
+	const engineCount = 3
+	ports := make([]vllmEnginePorts, engineCount)
+	used := make(map[int]string, engineCount*5)
+	for i := range ports {
+		ports[i] = vllmEnginePorts{
+			master: masterBase + i*vllmMasterPortStride,
+			system: commonconsts.DynamoSystemPort + i,
+			fpm:    commonconsts.DynamoFPMBasePort + i,
+			nixl:   5600 + i,
+			kv:     20080 + i,
+		}
+		for _, candidate := range []struct {
+			name string
+			port int
+		}{
+			{name: "master", port: ports[i].master},
+			{name: "system", port: ports[i].system},
+			{name: "FPM", port: ports[i].fpm},
+			{name: "NIXL", port: ports[i].nixl},
+			{name: "KV", port: ports[i].kv},
+		} {
+			if candidate.port < 1 || candidate.port > 65535 {
+				return nil, fmt.Errorf("invalid vLLM %s port %d for engine-%d: must be between 1 and 65535", candidate.name, candidate.port, i)
+			}
+			if owner, exists := used[candidate.port]; exists {
+				return nil, fmt.Errorf("vLLM port %d for engine-%d %s collides with %s", candidate.port, i, candidate.name, owner)
+			}
+			used[candidate.port] = fmt.Sprintf("engine-%d %s", i, candidate.name)
+		}
+	}
+	return ports, nil
+}
+
+func tokenizedVLLMMasterPort(container *corev1.Container) (int, bool, error) {
+	if container == nil {
+		return 0, false, fmt.Errorf("container is nil")
+	}
+	var values []string
+	tokens := append(append([]string{}, container.Command...), container.Args...)
+	for i, token := range tokens {
+		switch {
+		case token == vllmMasterPortFlag:
+			if i+1 >= len(tokens) {
+				return 0, false, fmt.Errorf("%s requires a value", vllmMasterPortFlag)
+			}
+			values = append(values, tokens[i+1])
+		case strings.HasPrefix(token, vllmMasterPortFlag+"="):
+			values = append(values, strings.TrimPrefix(token, vllmMasterPortFlag+"="))
+		}
+	}
+	if len(values) == 0 {
+		return 0, false, nil
+	}
+	if len(values) > 1 {
+		return 0, false, fmt.Errorf("%s appears more than once", vllmMasterPortFlag)
+	}
+	port, err := strconv.Atoi(values[0])
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid vLLM %s value %q: %w", vllmMasterPortFlag, values[0], err)
+	}
+	return port, true, nil
+}
+
+func setTokenizedVLLMMasterPort(container *corev1.Container, port int) {
+	value := strconv.Itoa(port)
+	for i, token := range container.Command {
+		switch {
+		case token == vllmMasterPortFlag && i+1 < len(container.Command):
+			container.Command[i+1] = value
+			return
+		case token == vllmMasterPortFlag:
+			container.Args[0] = value
+			return
+		case strings.HasPrefix(token, vllmMasterPortFlag+"="):
+			container.Command[i] = vllmMasterPortFlag + "=" + value
+			return
+		}
+	}
+	for i, token := range container.Args {
+		switch {
+		case token == vllmMasterPortFlag:
+			container.Args[i+1] = value
+			return
+		case strings.HasPrefix(token, vllmMasterPortFlag+"="):
+			container.Args[i] = vllmMasterPortFlag + "=" + value
+			return
+		}
+	}
+	container.Args = append(container.Args, vllmMasterPortFlag, value)
+}
+
+func applyThreeEngineVLLMOverrides(podSpec *corev1.PodSpec, ports []vllmEnginePorts) {
+	for i := range ports {
+		engine := &podSpec.Containers[i]
+		setTokenizedVLLMMasterPort(engine, ports[i].master)
+		engine.Env = MergeEnvs(engine.Env, []corev1.EnvVar{
+			{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "true"},
+			{Name: "VLLM_NIXL_SIDE_CHANNEL_PORT", Value: strconv.Itoa(ports[i].nixl)},
+			{Name: "DYN_VLLM_KV_EVENT_PORT", Value: strconv.Itoa(ports[i].kv)},
+		})
+	}
+}
 
 // applyVLLMOverrides injects vLLM-specific env vars into all engine containers.
 // Port staggering (NIXL side channel, KV event, master port) prevents collisions

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1699,10 +1699,10 @@ func GenerateBasePodSpec(
 		}
 	}
 
-	// Clone main container into two engine containers (active + standby) for failover.
+	// Clone main into active and standby engine containers for failover.
 	// Runs after GMS so the main container already has DRA claims and shared volume.
 	if IsIntraPodFailoverEnabled(component) {
-		if err := buildFailoverPod(&podSpec, numberOfNodes, backendFramework); err != nil {
+		if err := buildFailoverPodWithComponent(&podSpec, component, numberOfNodes, backendFramework); err != nil {
 			return nil, fmt.Errorf("failed to build failover pod: %w", err)
 		}
 	}

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -6449,6 +6449,59 @@ func TestGenerateBasePodSpec_GPUMemoryServiceExtraClientContainers(t *testing.T)
 	assertGMSClientContainer(t, metricsClient)
 }
 
+func TestTwoShadowIntraPodFailoverRendersForDCDAndDGD(t *testing.T) {
+	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		ComponentType: commonconsts.ComponentTypeWorker,
+		Resources:     &v1alpha1.Resources{Limits: &v1alpha1.ResourceItem{GPU: "1"}},
+		ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+			MainContainer: &corev1.Container{
+				Command: []string{"python3"},
+				Args:    []string{"-m", "dynamo.vllm"},
+			},
+		},
+		GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{Enabled: true, Mode: v1alpha1.GMSModeIntraPod},
+		Failover:         &v1alpha1.FailoverSpec{Enabled: true, Mode: v1alpha1.GMSModeIntraPod, NumShadows: 2},
+	})
+	config := &configv1alpha1.OperatorConfiguration{}
+
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: "default"},
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: *component.DeepCopy(),
+		},
+	}
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "graph", Namespace: "default"},
+	}
+	renderers := map[string]func() (*corev1.PodSpec, error){
+		"DCD": func() (*corev1.PodSpec, error) {
+			return GenerateBasePodSpecForController(
+				dcd, nil, config, RoleMain, commonconsts.MultinodeDeploymentTypeLWS, nil,
+				GenerateBasePodSpecForControllerOptions{},
+			)
+		},
+		"DGD": func() (*corev1.PodSpec, error) {
+			return GeneratePodSpecForComponent(
+				component, BackendFrameworkVLLM, nil, dgd, RoleMain, 1, config,
+				commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			)
+		},
+	}
+
+	for name, render := range renderers {
+		t.Run(name, func(t *testing.T) {
+			podSpec, err := render()
+			require.NoError(t, err)
+			require.Len(t, podSpec.Containers, 3)
+			assert.Equal(t, []string{"engine-0", "engine-1", "engine-2"}, []string{
+				podSpec.Containers[0].Name,
+				podSpec.Containers[1].Name,
+				podSpec.Containers[2].Name,
+			})
+		})
+	}
+}
+
 func TestGenerateBasePodSpec_GPUMemoryServiceRejectsMissingExtraClientContainers(t *testing.T) {
 	t.Log("Set up intra-pod GMS with two unresolved extra clients")
 	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{
@@ -8606,7 +8659,7 @@ func TestGenerateGrovePodCliqueSet_IntraPodFailoverCheckpointTargets(t *testing.
 			Ready:                   true,
 			Hash:                    "abc123def4567890",
 			CheckpointName:          "decode-checkpoint",
-			RestoreTargetContainers: IntraPodFailoverEngineContainerNames(),
+			RestoreTargetContainers: []string{"engine-0", "engine-1"},
 		},
 	}
 
@@ -8624,7 +8677,7 @@ func TestGenerateGrovePodCliqueSet_IntraPodFailoverCheckpointTargets(t *testing.
 			"clique %q must carry snapshot-target-containers=engine-0,engine-1", clique.Name)
 		assert.Equal(t, "true", clique.Annotations[commonconsts.CheckpointRestoreCandidateAnnotation],
 			"clique %q must carry the restore-candidate annotation for the pod-create webhook", clique.Name)
-		for _, engineName := range IntraPodFailoverEngineContainerNames() {
+		for _, engineName := range []string{"engine-0", "engine-1"} {
 			c := findContainerInClique(t, clique, engineName)
 			assert.NotEqual(t, []string{"sleep", "infinity"}, c.Command,
 				"%s in clique %q must stay cold-start-shaped in Immediate startup", engineName, clique.Name)

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -58,6 +59,7 @@ func (v *DynamoComponentDeploymentValidator) validate(
 		sharedValidation: sharedValidation{
 			ctx:                                ctx,
 			runtimeVersionSource:               runtimeVersionSource,
+			requestVersionSource:               runtimeVersionSource,
 			allowMissingRuntimeVersionOverride: true,
 		},
 	}
@@ -85,6 +87,7 @@ func (v *DynamoComponentDeploymentValidator) ValidateUpdate(
 		sharedValidation: sharedValidation{
 			ctx:                                ctx,
 			runtimeVersionSource:               runtimeVersionSourceDisabled,
+			requestVersionSource:               runtimeVersionSource,
 			allowMissingRuntimeVersionOverride: true,
 		},
 	}
@@ -118,7 +121,27 @@ func (v *DynamoComponentDeploymentValidator) ValidateUpdate(
 func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeployment(
 	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
 ) field.ErrorList {
-	return v.validateDynamoComponentDeploymentSpec(&dcd.Spec, field.NewPath("spec"))
+	allErrs := v.validateDynamoComponentDeploymentSpec(&dcd.Spec, field.NewPath("spec"))
+	if v.requestVersionSource != runtimeVersionSourceV1Beta1 {
+		return allErrs
+	}
+	failover := failoverFor(&dcd.Spec.DynamoComponentDeploymentSharedSpec)
+	if failover == nil {
+		return allErrs
+	}
+	if effectiveGMSMode(failover.Mode) != nvidiacomv1beta1.GMSModeIntraPod {
+		return allErrs
+	}
+	return append(allErrs, twoShadowIntraPodFailoverProfileErrors(
+		effectiveNumShadows(failover),
+		dynamo.GetMainContainer(&dcd.Spec.DynamoComponentDeploymentSharedSpec),
+		dcd.Spec.GetNumberOfNodes(),
+		dcd.Spec.BackendFramework,
+		effectiveVLLMExecutorBackend(
+			dynamo.GetPodTemplateAnnotations(&dcd.Spec.DynamoComponentDeploymentSharedSpec),
+		),
+		field.NewPath("spec", "experimental", "failover"),
+	)...)
 }
 
 // validateDynamoComponentDeploymentSpec validates spec. spec and fldPath must not be nil.

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_v1alpha1.go
@@ -19,6 +19,7 @@ package validation
 
 import (
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -43,9 +44,45 @@ func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeploymentS
 	fldPath *field.Path,
 	dynamoNamespace string,
 ) field.ErrorList {
-	return v.validateDynamoComponentDeploymentSharedSpecV1alpha1(
+	allErrs := v.validateDynamoComponentDeploymentSharedSpecV1alpha1(
 		&spec.DynamoComponentDeploymentSharedSpec,
 		fldPath,
 		dynamoNamespace,
 	)
+	if v.requestVersionSource != runtimeVersionSourceV1Alpha1 ||
+		spec.Failover == nil || !spec.Failover.Enabled ||
+		spec.Failover.Mode != nvidiacomv1alpha1.GMSModeIntraPod {
+		return allErrs
+	}
+	return append(allErrs, twoShadowIntraPodFailoverProfileErrors(
+		spec.Failover.NumShadows,
+		alphaMainContainer(&spec.DynamoComponentDeploymentSharedSpec),
+		alphaNumberOfNodes(&spec.DynamoComponentDeploymentSharedSpec),
+		spec.BackendFramework,
+		effectiveVLLMExecutorBackend(
+			alphaPodAnnotations(&spec.DynamoComponentDeploymentSharedSpec),
+		),
+		fldPath.Child("failover"),
+	)...)
+}
+
+func alphaMainContainer(spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec) *corev1.Container {
+	if spec.ExtraPodSpec == nil {
+		return nil
+	}
+	return spec.ExtraPodSpec.MainContainer
+}
+
+func alphaNumberOfNodes(spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec) int32 {
+	if spec.Multinode == nil {
+		return 1
+	}
+	return spec.Multinode.NodeCount
+}
+
+func alphaPodAnnotations(spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec) map[string]string {
+	if spec.ExtraPodMetadata == nil {
+		return nil
+	}
+	return spec.ExtraPodMetadata.Annotations
 }

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -452,6 +452,23 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
+			name: "alpha intra-pod failover rejects more than two shadows",
+			deployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Resources:     workerGPU,
+				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+				},
+				Failover: &nvidiacomv1alpha1.FailoverSpec{
+					Enabled:    true,
+					Mode:       nvidiacomv1alpha1.GMSModeIntraPod,
+					NumShadows: 3,
+				},
+			}),
+			wantWebhookErrs: []string{`spec.failover.numShadows: Invalid value: 3: is invalid for mode="intraPod": supported values are 1 and 2`},
+		},
+		{
 			name: "v1beta1 checkpoint with inter-pod GMS and failover reports both errors",
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				enableBetaInterPodGMS(&dcd.Spec.DynamoComponentDeploymentSharedSpec)
@@ -809,7 +826,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				Failover: &nvidiacomv1alpha1.FailoverSpec{
 					Enabled:    true,
 					Mode:       nvidiacomv1alpha1.GMSModeInterPod,
-					NumShadows: 1,
+					NumShadows: 2,
 				},
 			}),
 			wantWebhookErrs: []string{`spec.experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "InterPod"`},
@@ -860,10 +877,39 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
-			name: "intra-pod failover rejects multiple shadows",
+			name: "beta two-shadow direct vLLM with omitted backend is accepted",
+			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.Spec.BackendFramework = ""
+				enableBetaTwoShadowIntraPod(
+					&dcd.Spec.DynamoComponentDeploymentSharedSpec,
+					[]string{"python3"},
+					[]string{"-m", "dynamo.vllm"},
+				)
+			}),
+		},
+		{
+			name: "beta two-shadow shell launch is rejected",
+			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				enableBetaTwoShadowIntraPod(
+					&dcd.Spec.DynamoComponentDeploymentSharedSpec,
+					[]string{"sh", "-c"},
+					[]string{"python3 -m dynamo.vllm"},
+				)
+			}),
+			wantWebhookErrs: []string{"spec.experimental.failover: Forbidden: two shadows currently require a single-node direct vLLM launch without Ray or data parallel"},
+		},
+		{
+			name: "two-shadow direct vLLM failover is accepted",
 			deployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				ComponentType: consts.ComponentTypeWorker,
 				Resources:     workerGPU,
+				ExtraPodSpec: &nvidiacomv1alpha1.ExtraPodSpec{
+					MainContainer: &corev1.Container{
+						Image:   "registry.example/runtime:1.1.0",
+						Command: []string{"python3"},
+						Args:    []string{"-m", "dynamo.vllm"},
+					},
+				},
 				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
 					Enabled: true,
 					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
@@ -874,7 +920,6 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					NumShadows: 2,
 				},
 			}),
-			wantWebhookErrs: []string{`spec.failover.numShadows: Invalid value: 2: is invalid for mode="intraPod": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode="interPod" to configure numShadows`},
 		},
 		{
 			name: "single-shadow intra-pod failover is accepted",

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -78,8 +78,22 @@ func (v *DynamoGraphDeploymentValidator) Validate(
 	deployment *nvidiacomv1beta1.DynamoGraphDeployment,
 	runtimeVersionSource runtimeVersionValidationSource,
 ) (admission.Warnings, error) {
+	return v.validate(ctx, deployment, runtimeVersionSource, runtimeVersionSource)
+}
+
+func (v *DynamoGraphDeploymentValidator) validate(
+	ctx context.Context,
+	deployment *nvidiacomv1beta1.DynamoGraphDeployment,
+	runtimeVersionSource runtimeVersionValidationSource,
+	requestVersionSource runtimeVersionValidationSource,
+) (admission.Warnings, error) {
 	validation := &dynamoGraphDeploymentValidation{
-		sharedValidation: sharedValidation{ctx: ctx, mgr: v.mgr, runtimeVersionSource: runtimeVersionSource},
+		sharedValidation: sharedValidation{
+			ctx:                  ctx,
+			mgr:                  v.mgr,
+			runtimeVersionSource: runtimeVersionSource,
+			requestVersionSource: requestVersionSource,
+		},
 	}
 
 	allErrs := validation.validateDynamoGraphDeployment(deployment)
@@ -104,7 +118,12 @@ func (v *DynamoGraphDeploymentValidator) ValidateUpdate(
 	runtimeVersionSource runtimeVersionValidationSource,
 ) (admission.Warnings, error) {
 	validation := &dynamoGraphDeploymentValidation{
-		sharedValidation:  sharedValidation{ctx: ctx, mgr: v.mgr, runtimeVersionSource: runtimeVersionSource},
+		sharedValidation: sharedValidation{
+			ctx:                  ctx,
+			mgr:                  v.mgr,
+			runtimeVersionSource: runtimeVersionSource,
+			requestVersionSource: runtimeVersionSource,
+		},
 		userInfo:          userInfo,
 		operatorPrincipal: operatorPrincipal,
 	}
@@ -148,7 +167,34 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeployment(
 		grovePathwayRequirement: grovePathwayRequirement,
 	}
 	allErrs = append(allErrs, v.validateDynamoGraphDeploymentSpec(&dgd.Spec, field.NewPath("spec"), specOpts)...)
+	if v.requestVersionSource == runtimeVersionSourceV1Beta1 {
+		allErrs = append(allErrs, validateTwoShadowProfiles(dgd)...)
+	}
 
+	return allErrs
+}
+
+func validateTwoShadowProfiles(dgd *nvidiacomv1beta1.DynamoGraphDeployment) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		failover := failoverFor(component)
+		if failover == nil || effectiveGMSMode(failover.Mode) != nvidiacomv1beta1.GMSModeIntraPod {
+			continue
+		}
+		allErrs = append(allErrs, twoShadowIntraPodFailoverProfileErrors(
+			effectiveNumShadows(failover),
+			dynamo.GetMainContainer(component),
+			component.GetNumberOfNodes(),
+			dgd.Spec.BackendFramework,
+			effectiveVLLMExecutorBackend(
+				dynamo.GetPodTemplateAnnotations(component),
+				dgd.Annotations,
+				dgd.Spec.Annotations,
+			),
+			field.NewPath("spec", "components").Index(i).Child("experimental", "failover"),
+		)...)
+	}
 	return allErrs
 }
 

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
@@ -133,7 +133,12 @@ func (h *DynamoGraphDeploymentHandler) validateUpdate(
 	// Create validator with manager for API group detection and perform validation.
 	validator := NewDynamoGraphDeploymentValidator(h.mgr)
 	runtimeVersionSource := runtimeVersionValidationSourceForRequest(ctx, expectedGVK)
-	warnings, err := validator.Validate(ctx, newDeployment, runtimeVersionSourceDisabled)
+	warnings, err := validator.validate(
+		ctx,
+		newDeployment,
+		runtimeVersionSourceDisabled,
+		runtimeVersionSource,
+	)
 	if err != nil {
 		return warnings, err
 	}

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
@@ -35,6 +35,7 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentV1alpha1(
 		field.NewPath("spec"),
 		dgd.Name,
 		dgd.Namespace,
+		dgd.Annotations,
 	)
 }
 
@@ -44,6 +45,7 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecV1alp
 	fldPath *field.Path,
 	dgdName string,
 	dgdNamespace string,
+	dgdAnnotations map[string]string,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 	pvcsPath := fldPath.Child("pvcs")
@@ -61,6 +63,22 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecV1alp
 			servicePath,
 			dynamoNamespace,
 		)...)
+		if v.requestVersionSource == runtimeVersionSourceV1Alpha1 &&
+			service.Failover != nil && service.Failover.Enabled &&
+			service.Failover.Mode == nvidiacomv1alpha1.GMSModeIntraPod {
+			allErrs = append(allErrs, twoShadowIntraPodFailoverProfileErrors(
+				service.Failover.NumShadows,
+				alphaMainContainer(service),
+				alphaNumberOfNodes(service),
+				spec.BackendFramework,
+				effectiveVLLMExecutorBackend(
+					alphaPodAnnotations(service),
+					dgdAnnotations,
+					spec.Annotations,
+				),
+				servicePath.Child("failover"),
+			)...)
+		}
 	}
 	return allErrs
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1125,17 +1125,47 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{`spec.components[1].experimental.failover.mode: Invalid value: "InterPod": must match gpuMemoryService.mode "IntraPod"`},
 		},
 		{
-			name: "intra-pod failover shadow maximum is validated by the schema",
+			name: "two-shadow direct vLLM DGD is accepted",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaContainerDiscovery(dgd)
+				worker := betaWorkerComponent(dgd)
+				enableBetaTwoShadowIntraPod(worker, []string{"python3"}, []string{"-m", "dynamo.vllm"})
+			}),
+		},
+		{
+			name: "two-shadow vLLM data parallel DGD is rejected",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaContainerDiscovery(dgd)
+				worker := betaWorkerComponent(dgd)
+				enableBetaTwoShadowIntraPod(
+					worker,
+					[]string{"python3"},
+					[]string{"-m", "dynamo.vllm", "--data-parallel-size", "2"},
+				)
+			}),
+			wantWebhookErrs: []string{"spec.components[1].experimental.failover: Forbidden: two shadows currently require a single-node direct vLLM launch without Ray or data parallel"},
+		},
+		{
+			name: "beta intra-pod failover rejects more than two shadows",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				enableBetaContainerDiscovery(dgd)
 				worker := betaWorkerComponent(dgd)
 				enableBetaIntraPodGMS(worker)
 				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
 					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
-					NumShadows: 2,
+					NumShadows: 3,
 				}
 			}),
-			wantSchemaErr: "spec.components[1].experimental.failover.numShadows: Invalid value: 2: spec.components[1].experimental.failover.numShadows in body should be less than or equal to 1",
+			wantWebhookErrs: []string{`spec.components[1].experimental.failover.numShadows: Invalid value: 3: is invalid for mode="IntraPod": supported values are 1 and 2`},
+		},
+		{
+			name: "beta inter-pod failover preserves one-shadow maximum",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaInterPodGMS(worker)
+				enableBetaInterPodFailover(worker, 2)
+			}),
+			wantWebhookErrs: []string{`spec.components[1].experimental.failover.numShadows: Invalid value: 2: is invalid for mode="InterPod": supported value is 1`},
 		},
 		{
 			name: "inter-pod failover requires GMS",
@@ -1246,19 +1276,25 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Forbidden: exactly one of configMapRef or config is required"},
 		},
 		{
-			name: "alpha intra-pod failover shadow maximum is preserved structurally",
+			name: "alpha two-shadow direct vLLM DGD is accepted",
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].Failover = &nvidiacomv1alpha1.FailoverSpec{
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "container"}
+				worker := dgd.Spec.Services["worker"]
+				worker.Resources = &nvidiacomv1alpha1.Resources{
+					Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"},
+				}
+				worker.ExtraPodSpec.MainContainer.Command = []string{"python3"}
+				worker.ExtraPodSpec.MainContainer.Args = []string{"-m", "dynamo.vllm"}
+				worker.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+				}
+				worker.Failover = &nvidiacomv1alpha1.FailoverSpec{
 					Enabled:    true,
 					Mode:       nvidiacomv1alpha1.GMSModeIntraPod,
 					NumShadows: 2,
 				}
 			}),
-			wantWebhookErrs: []string{
-				`metadata.annotations[nvidia.com/dynamo-kube-discovery-mode]: Invalid value: "": must be "container" when intra-pod failover is configured`,
-				`spec.components[0].experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "IntraPod"`,
-				`spec.services[worker].failover.numShadows: Invalid value: 2: is invalid for mode="intraPod": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode="interPod" to configure numShadows`,
-			},
 		},
 		{
 			name: "alpha frontend sidecar rejects generated container name conflict",
@@ -2554,6 +2590,19 @@ func enableBetaIntraPodGMS(component *nvidiacomv1beta1.DynamoComponentDeployment
 			}},
 		},
 	}
+}
+
+func enableBetaTwoShadowIntraPod(
+	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	command, args []string,
+) {
+	enableBetaIntraPodGMS(component)
+	component.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
+		Mode:       nvidiacomv1beta1.GMSModeIntraPod,
+		NumShadows: 2,
+	}
+	component.PodTemplate.Spec.Containers[0].Command = command
+	component.PodTemplate.Spec.Containers[0].Args = args
 }
 
 func enableBetaInterPodFailover(

--- a/deploy/operator/internal/webhook/validation/shared_helpers.go
+++ b/deploy/operator/internal/webhook/validation/shared_helpers.go
@@ -25,6 +25,7 @@ import (
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/runtimeversion"
@@ -149,6 +150,39 @@ func invalidVLLMDistributedExecutorBackendAnnotation(annotations map[string]stri
 	default:
 		return value, true
 	}
+}
+
+func twoShadowIntraPodFailoverProfileErrors(
+	numShadows int32,
+	mainContainer *corev1.Container,
+	numberOfNodes int32,
+	backendFramework string,
+	vllmExecutorBackend string,
+	failoverPath *field.Path,
+) field.ErrorList {
+	if numShadows != 2 {
+		return nil
+	}
+	if err := dynamo.TwoShadowIntraPodFailoverProfileError(
+		mainContainer,
+		numberOfNodes,
+		backendFramework,
+		vllmExecutorBackend,
+	); err != nil {
+		return field.ErrorList{field.Forbidden(failoverPath, err.Error())}
+	}
+	return nil
+}
+
+// effectiveVLLMExecutorBackend follows pod rendering precedence: the first
+// (most specific) annotation set containing the key wins.
+func effectiveVLLMExecutorBackend(annotationSets ...map[string]string) string {
+	for _, annotations := range annotationSets {
+		if value, exists := annotations[consts.KubeAnnotationVLLMDistributedExecutorBackend]; exists {
+			return value
+		}
+	}
+	return ""
 }
 
 // inferencePoolAvailabilityError checks the InferencePool API.

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -73,7 +73,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
 			fmt.Sprintf("cannot inject frontend sidecar: a container named %q already exists in extraPodSpec.containers", consts.FrontendSidecarContainerName),
 		))
 	}
-	if spec.Failover != nil {
+	if spec.Failover != nil && v.requestVersionSource == runtimeVersionSourceV1Alpha1 {
 		allErrs = append(allErrs, v.validateFailoverSpecV1alpha1(spec.Failover, fldPath.Child("failover"))...)
 	}
 
@@ -167,12 +167,13 @@ func (v *sharedValidation) validateFailoverSpecV1alpha1(
 	fldPath *field.Path,
 ) field.ErrorList {
 	if !failover.Enabled || failover.Mode != nvidiacomv1alpha1.GMSModeIntraPod ||
-		failover.NumShadows == 0 || failover.NumShadows == 1 {
+		failover.NumShadows == 0 ||
+		(failover.NumShadows >= 1 && failover.NumShadows <= 2) {
 		return nil
 	}
 	return field.ErrorList{field.Invalid(
 		fldPath.Child("numShadows"),
 		failover.NumShadows,
-		fmt.Sprintf("is invalid for mode=%q: intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode=%q to configure numShadows", nvidiacomv1alpha1.GMSModeIntraPod, nvidiacomv1alpha1.GMSModeInterPod),
+		fmt.Sprintf("is invalid for mode=%q: supported values are 1 and 2", nvidiacomv1alpha1.GMSModeIntraPod),
 	)}
 }

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -41,6 +41,7 @@ type sharedValidation struct {
 	mgr                                ctrl.Manager
 	warnings                           admission.Warnings
 	runtimeVersionSource               runtimeVersionValidationSource
+	requestVersionSource               runtimeVersionValidationSource
 	allowMissingRuntimeVersionOverride bool
 }
 
@@ -319,6 +320,23 @@ func (v *sharedValidation) validateFailoverSpec(
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 	failoverMode := effectiveGMSMode(failover.Mode)
+	if v.requestVersionSource == runtimeVersionSourceV1Beta1 &&
+		failoverMode == nvidiacomv1beta1.GMSModeIntraPod &&
+		effectiveNumShadows(failover) > 2 {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("numShadows"),
+			failover.NumShadows,
+			`is invalid for mode="IntraPod": supported values are 1 and 2`,
+		))
+	} else if v.requestVersionSource == runtimeVersionSourceV1Beta1 &&
+		failoverMode == nvidiacomv1beta1.GMSModeInterPod &&
+		effectiveNumShadows(failover) > 1 {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("numShadows"),
+			failover.NumShadows,
+			`is invalid for mode="InterPod": supported value is 1`,
+		))
+	}
 	if gms == nil {
 		allErrs = append(allErrs, field.Forbidden(
 			fldPath,

--- a/deploy/snapshot/internal/criu/restore.go
+++ b/deploy/snapshot/internal/criu/restore.go
@@ -38,14 +38,20 @@ func ExecuteRestore(
 	// and unlock. That keeps the window where the restored process runs with CUDA
 	// still locked as short as possible. cleanup is called on the error paths below.
 	var openFiles, inheritedFiles []*os.File
+	imageDirPath, removeImageDir, err := prepareRestoreImageDir(checkpointPath)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to prepare CRIU image directory: %w", err)
+	}
 	cleanup := func() {
 		closeFiles(inheritedFiles)
 		closeFiles(openFiles)
+		removeImageDir()
 	}
 
 	// Open image dir FD
-	imageDir, imageDirFD, err := openPathForCRIU(checkpointPath)
+	imageDir, imageDirFD, err := openPathForCRIU(imageDirPath)
 	if err != nil {
+		cleanup()
 		return 0, nil, fmt.Errorf("failed to open image directory: %w", err)
 	}
 	openFiles = append(openFiles, imageDir)
@@ -87,7 +93,7 @@ func ExecuteRestore(
 	log.V(1).Info("Executing go-criu Restore call")
 	if err := c.Restore(criuOpts, notify); err != nil {
 		log.Error(err, "go-criu Restore returned error")
-		logging.LogRestoreErrors(checkpointPath, settings.WorkDir, log)
+		logging.LogRestoreErrors(imageDirPath, settings.WorkDir, log)
 		cleanup()
 		return 0, nil, fmt.Errorf("CRIU restore failed: %w", err)
 	}

--- a/deploy/snapshot/internal/criu/restore_images.go
+++ b/deploy/snapshot/internal/criu/restore_images.go
@@ -1,0 +1,459 @@
+package criu
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/checkpoint-restore/go-criu/v8/crit"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fdinfo"
+	sk_inet "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-inet"
+	sk_unix "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-unix"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	filesImageFilename            = "files.img"
+	placeholderMountNamespacePath = "/proc/self/ns/mnt"
+	cudaSocketNameStart           = "\x00cuda-uvmfd-"
+	// CRIU records an unconnected AF_UNIX socket with Linux's CLOSE state value.
+	linuxUnixSocketStateClose = 7
+	linuxTCPStateEstablished  = 1
+	linuxTCPStateListen       = 10
+)
+
+type tcpPortRewrite struct {
+	client *sk_inet.InetSkEntry
+	server *sk_inet.InetSkEntry
+}
+
+func prepareRestoreImageDir(checkpointPath string) (string, func(), error) {
+	// The placeholder mount namespace remains container-specific with shareProcessNamespace,
+	// so its inode uniquely scopes names that would collide in the shared network namespace.
+	var stat unix.Stat_t
+	if err := unix.Stat(placeholderMountNamespacePath, &stat); err != nil {
+		return "", nil, fmt.Errorf("failed to stat placeholder mount namespace at %s: %w", placeholderMountNamespacePath, err)
+	}
+	return prepareRestoreImageDirForSocketScope(checkpointPath, stat.Ino)
+}
+
+func prepareRestoreImageDirForSocketScope(checkpointPath string, restoreSocketScope uint64) (string, func(), error) {
+	checkpointPath, err := filepath.Abs(checkpointPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to resolve checkpoint path: %w", err)
+	}
+
+	filesImage, err := os.Open(filepath.Join(checkpointPath, filesImageFilename))
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to open %s: %w", filesImageFilename, err)
+	}
+
+	image, err := crit.New(filesImage, nil, "", false, false).Decode(&fdinfo.FileEntry{})
+	closeErr := filesImage.Close()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to decode %s: %w", filesImageFilename, err)
+	}
+	if closeErr != nil {
+		return "", nil, fmt.Errorf("failed to close %s: %w", filesImageFilename, closeErr)
+	}
+
+	tcpRewrite, forbiddenPorts := planTCPPortRewrite(image, checkpointPath)
+	reservationFD := -1
+	var restorePort uint32
+	if tcpRewrite != nil {
+		restorePort, reservationFD, err = reserveDualStackTCPPort(forbiddenPorts)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to reserve restore TCP port: %w", err)
+		}
+	}
+
+	rewritten := false
+	for _, entry := range image.Entries {
+		fileEntry := entry.Message.(*fdinfo.FileEntry)
+		if fileEntry.GetType() != fdinfo.FdTypes_UNIXSK || fileEntry.Usk == nil {
+			continue
+		}
+		if name, ok := rewriteCUDASocketName(fileEntry.Usk.Name, restoreSocketScope); ok {
+			fileEntry.Usk.Name = name
+			rewritten = true
+		}
+		if rewriteLinuxAutobindDatagramSocketName(fileEntry.Usk, restoreSocketScope) {
+			rewritten = true
+		}
+	}
+	if tcpRewrite != nil {
+		*tcpRewrite.client.SrcPort = restorePort
+		*tcpRewrite.server.DstPort = restorePort
+		rewritten = true
+	}
+	if !rewritten {
+		return checkpointPath, func() {}, nil
+	}
+
+	privateDir, err := os.MkdirTemp(filepath.Dir(checkpointPath), ".dynamo-criu-restore-*")
+	if err != nil {
+		if reservationFD >= 0 {
+			_ = unix.Close(reservationFD)
+		}
+		return "", nil, fmt.Errorf("failed to create private CRIU image directory: %w", err)
+	}
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		cleanupOnce.Do(func() {
+			if reservationFD >= 0 {
+				_ = unix.Close(reservationFD)
+			}
+			_ = os.RemoveAll(privateDir)
+		})
+	}
+	fail := func(err error) (string, func(), error) {
+		cleanup()
+		return "", nil, err
+	}
+
+	entries, err := os.ReadDir(checkpointPath)
+	if err != nil {
+		return fail(fmt.Errorf("failed to read checkpoint directory: %w", err))
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == filesImageFilename || !strings.HasSuffix(name, ".img") {
+			continue
+		}
+		// CRIU does not modify restore images; hard links keep them visible after it
+		// enters the restored mount namespace without copying large page images.
+		if err := os.Link(filepath.Join(checkpointPath, name), filepath.Join(privateDir, name)); err != nil {
+			return fail(fmt.Errorf("failed to hard-link CRIU image %s: %w", name, err))
+		}
+	}
+
+	privateFilesImage, err := os.OpenFile(filepath.Join(privateDir, filesImageFilename), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return fail(fmt.Errorf("failed to create private %s: %w", filesImageFilename, err))
+	}
+	if err := crit.New(nil, privateFilesImage, "", false, false).Encode(image); err != nil {
+		_ = privateFilesImage.Close()
+		return fail(fmt.Errorf("failed to encode private %s: %w", filesImageFilename, err))
+	}
+	if err := privateFilesImage.Close(); err != nil {
+		return fail(fmt.Errorf("failed to close private %s: %w", filesImageFilename, err))
+	}
+
+	return privateDir, cleanup, nil
+}
+
+func planTCPPortRewrite(image *crit.CriuImage, checkpointPath string) (*tcpPortRewrite, map[uint32]struct{}) {
+	var files []*fdinfo.FileEntry
+	idOwners := make(map[uint32]int)
+	inodeOwners := make(map[uint32]int)
+	forbiddenPorts := make(map[uint32]struct{})
+
+	for _, entry := range image.Entries {
+		file, ok := entry.Message.(*fdinfo.FileEntry)
+		if !ok {
+			continue
+		}
+		if file.GetType() != fdinfo.FdTypes_INETSK {
+			continue
+		}
+		files = append(files, file)
+		if id := file.GetId(); id != 0 {
+			idOwners[id]++
+		}
+		if file.Isk == nil {
+			continue
+		}
+		if id := file.Isk.GetId(); id != 0 && id != file.GetId() {
+			idOwners[id]++
+		}
+		if inode := file.Isk.GetIno(); inode != 0 {
+			inodeOwners[inode]++
+		}
+		if port := file.Isk.GetSrcPort(); port != 0 {
+			forbiddenPorts[port] = struct{}{}
+		}
+		if port := file.Isk.GetDstPort(); port != 0 {
+			forbiddenPorts[port] = struct{}{}
+		}
+	}
+
+	var rewrites []tcpPortRewrite
+	for _, endpoint := range files {
+		if !isEligibleEstablished(endpoint, idOwners, inodeOwners, checkpointPath) {
+			continue
+		}
+		peer, ok := soleReciprocal(endpoint.Isk, files)
+		if !ok || endpoint.GetId() > peer.GetId() {
+			continue
+		}
+		if !isEligibleEstablished(peer, idOwners, inodeOwners, checkpointPath) {
+			continue
+		}
+		reverse, ok := soleReciprocal(peer.Isk, files)
+		if !ok || reverse != endpoint {
+			continue
+		}
+		endpointRole := listenerRole(endpoint.Isk, files, idOwners, inodeOwners)
+		peerRole := listenerRole(peer.Isk, files, idOwners, inodeOwners)
+		switch {
+		case endpointRole == 0 && peerRole == 1:
+			rewrites = append(rewrites, tcpPortRewrite{client: endpoint.Isk, server: peer.Isk})
+		case endpointRole == 1 && peerRole == 0:
+			rewrites = append(rewrites, tcpPortRewrite{client: peer.Isk, server: endpoint.Isk})
+		}
+	}
+	if len(rewrites) != 1 {
+		return nil, forbiddenPorts
+	}
+	return &rewrites[0], forbiddenPorts
+}
+
+func isEligibleINET(
+	file *fdinfo.FileEntry,
+	idOwners, inodeOwners map[uint32]int,
+) bool {
+	if file == nil {
+		return false
+	}
+	socket := file.Isk
+	return file.GetType() == fdinfo.FdTypes_INETSK &&
+		file.GetId() != 0 &&
+		socket != nil &&
+		socket.GetId() != 0 &&
+		file.GetId() == socket.GetId() &&
+		socket.GetIno() != 0 &&
+		socket.SrcPort != nil &&
+		socket.DstPort != nil &&
+		socket.V6Only != nil &&
+		socket.NsId != nil &&
+		socket.GetFamily() == uint32(unix.AF_INET6) &&
+		socket.GetType() == uint32(unix.SOCK_STREAM) &&
+		socket.GetProto() == uint32(unix.IPPROTO_TCP) &&
+		!socket.GetV6Only() &&
+		idOwners[socket.GetId()] == 1 &&
+		inodeOwners[socket.GetIno()] == 1
+}
+
+func isEligibleEstablished(
+	file *fdinfo.FileEntry,
+	idOwners, inodeOwners map[uint32]int,
+	checkpointPath string,
+) bool {
+	socket := file.Isk
+	return isEligibleINET(file, idOwners, inodeOwners) &&
+		isIPv4MappedEstablished(socket) &&
+		hasRegularTCPStreamImage(checkpointPath, socket.GetIno())
+}
+
+func isIPv4MappedEstablished(socket *sk_inet.InetSkEntry) bool {
+	return socket != nil &&
+		socket.GetFamily() == uint32(unix.AF_INET6) &&
+		socket.GetType() == uint32(unix.SOCK_STREAM) &&
+		socket.GetProto() == uint32(unix.IPPROTO_TCP) &&
+		socket.GetState() == linuxTCPStateEstablished &&
+		socket.GetSrcPort() > 0 &&
+		socket.GetSrcPort() <= 65535 &&
+		socket.GetDstPort() > 0 &&
+		socket.GetDstPort() <= 65535 &&
+		ipv4MappedAddress(socket.SrcAddr) &&
+		ipv4MappedAddress(socket.DstAddr)
+}
+
+func hasRegularTCPStreamImage(checkpointPath string, inode uint32) bool {
+	info, err := os.Lstat(filepath.Join(checkpointPath, fmt.Sprintf("tcp-stream-%x.img", inode)))
+	return err == nil && info.Mode().IsRegular()
+}
+
+func soleReciprocal(
+	endpoint *sk_inet.InetSkEntry,
+	files []*fdinfo.FileEntry,
+) (*fdinfo.FileEntry, bool) {
+	var peer *fdinfo.FileEntry
+	for _, candidate := range files {
+		socket := candidate.Isk
+		if !isIPv4MappedEstablished(socket) ||
+			endpoint == socket ||
+			endpoint.GetNsId() != socket.GetNsId() ||
+			endpoint.GetSrcPort() != socket.GetDstPort() ||
+			endpoint.GetDstPort() != socket.GetSrcPort() ||
+			!slices.Equal(endpoint.SrcAddr, socket.DstAddr) ||
+			!slices.Equal(endpoint.DstAddr, socket.SrcAddr) {
+			continue
+		}
+		if peer != nil {
+			return nil, false
+		}
+		peer = candidate
+	}
+	return peer, peer != nil
+}
+
+func listenerRole(
+	endpoint *sk_inet.InetSkEntry,
+	files []*fdinfo.FileEntry,
+	idOwners, inodeOwners map[uint32]int,
+) int {
+	role := 0
+	for _, file := range files {
+		socket := file.Isk
+		if socket == nil ||
+			socket.GetType() != uint32(unix.SOCK_STREAM) ||
+			socket.GetProto() != uint32(unix.IPPROTO_TCP) ||
+			socket.GetState() != linuxTCPStateListen ||
+			socket.GetNsId() != endpoint.GetNsId() ||
+			socket.GetSrcPort() != endpoint.GetSrcPort() {
+			continue
+		}
+		if role != 0 || !isEligibleWildcardListener(file, idOwners, inodeOwners) {
+			return -1
+		}
+		role = 1
+	}
+	return role
+}
+
+func isEligibleWildcardListener(
+	file *fdinfo.FileEntry,
+	idOwners, inodeOwners map[uint32]int,
+) bool {
+	socket := file.Isk
+	return isEligibleINET(file, idOwners, inodeOwners) &&
+		socket.GetState() == linuxTCPStateListen &&
+		socket.GetSrcPort() > 0 &&
+		socket.GetSrcPort() <= 65535 &&
+		socket.GetDstPort() == 0 &&
+		!socket.GetV6Only() &&
+		slices.Equal(socket.SrcAddr, []uint32{0, 0, 0, 0}) &&
+		slices.Equal(socket.DstAddr, []uint32{0, 0, 0, 0})
+}
+
+func ipv4MappedAddress(address []uint32) bool {
+	return len(address) == 4 &&
+		address[0] == 0 &&
+		address[1] == 0 &&
+		address[2] == 0xffff0000
+}
+
+func reserveDualStackTCPPort(forbidden map[uint32]struct{}) (uint32, int, error) {
+	var rejected []int
+	defer func() {
+		for _, fd := range rejected {
+			_ = unix.Close(fd)
+		}
+	}()
+
+	for {
+		fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, unix.IPPROTO_TCP)
+		if err != nil {
+			return 0, -1, err
+		}
+		if err := unix.SetsockoptInt(fd, unix.IPPROTO_IPV6, unix.IPV6_V6ONLY, 0); err != nil {
+			_ = unix.Close(fd)
+			return 0, -1, err
+		}
+		if err := unix.Bind(fd, &unix.SockaddrInet6{}); err != nil {
+			_ = unix.Close(fd)
+			return 0, -1, err
+		}
+
+		boundAddress, err := unix.Getsockname(fd)
+		if err != nil {
+			_ = unix.Close(fd)
+			return 0, -1, err
+		}
+		address, ok := boundAddress.(*unix.SockaddrInet6)
+		if !ok {
+			_ = unix.Close(fd)
+			return 0, -1, fmt.Errorf("unexpected bound socket address %T", boundAddress)
+		}
+		port := uint32(address.Port)
+		if port == 0 || port > 65535 {
+			_ = unix.Close(fd)
+			return 0, -1, fmt.Errorf("kernel selected invalid TCP port %d", port)
+		}
+		if _, exists := forbidden[port]; exists {
+			// Keep the bind until selection finishes so port 0 cannot immediately
+			// return the same forbidden port.
+			rejected = append(rejected, fd)
+			continue
+		}
+		if err := unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil {
+			_ = unix.Close(fd)
+			return 0, -1, err
+		}
+		return port, fd, nil
+	}
+}
+
+func rewriteCUDASocketName(name []byte, restoreSocketScope uint64) ([]byte, bool) {
+	if !bytes.HasPrefix(name, []byte(cudaSocketNameStart)) {
+		return nil, false
+	}
+
+	end := len(name)
+	for end > len(cudaSocketNameStart) && name[end-1] == 0 {
+		end--
+	}
+	numericFields := name[len(cudaSocketNameStart):end]
+	separator := bytes.IndexByte(numericFields, '-')
+	if separator <= 0 ||
+		separator == len(numericFields)-1 ||
+		!decimalDigits(numericFields[:separator]) ||
+		!decimalDigits(numericFields[separator+1:]) {
+		return nil, false
+	}
+
+	rewritten := make([]byte, 0, len(name)+20)
+	rewritten = append(rewritten, cudaSocketNameStart...)
+	rewritten = strconv.AppendUint(rewritten, restoreSocketScope, 10)
+	rewritten = append(rewritten, numericFields[separator:]...)
+	rewritten = append(rewritten, name[end:]...)
+	return rewritten, true
+}
+
+func rewriteLinuxAutobindDatagramSocketName(entry *sk_unix.UnixSkEntry, restoreSocketScope uint64) bool {
+	if entry == nil ||
+		entry.Type == nil ||
+		entry.State == nil ||
+		entry.Peer == nil ||
+		entry.Backlog == nil ||
+		entry.Uflags == nil ||
+		*entry.Type != uint32(unix.SOCK_DGRAM) ||
+		*entry.State != linuxUnixSocketStateClose ||
+		*entry.Peer != 0 ||
+		*entry.Backlog != 0 ||
+		*entry.Uflags != 0 ||
+		entry.FilePerms != nil ||
+		entry.NameDir != nil ||
+		(entry.Deleted != nil && *entry.Deleted) ||
+		len(entry.Name) != 6 ||
+		entry.Name[0] != 0 {
+		return false
+	}
+	for _, digit := range entry.Name[1:] {
+		if (digit < '0' || digit > '9') && (digit < 'a' || digit > 'f') {
+			return false
+		}
+	}
+
+	rewritten := make([]byte, 0, len(entry.Name)+1+20)
+	rewritten = append(rewritten, entry.Name...)
+	rewritten = append(rewritten, '-')
+	rewritten = strconv.AppendUint(rewritten, restoreSocketScope, 10)
+	entry.Name = rewritten
+	return true
+}
+
+func decimalDigits(value []byte) bool {
+	for _, digit := range value {
+		if digit < '0' || digit > '9' {
+			return false
+		}
+	}
+	return len(value) > 0
+}

--- a/deploy/snapshot/internal/criu/restore_images_test.go
+++ b/deploy/snapshot/internal/criu/restore_images_test.go
@@ -1,0 +1,528 @@
+package criu
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/checkpoint-restore/go-criu/v8/crit"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fdinfo"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fown"
+	sk_inet "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-inet"
+	sk_opts "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-opts"
+	sk_unix "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-unix"
+	"golang.org/x/sys/unix"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestRewriteCUDASocketName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want []byte
+	}{
+		{
+			name: "abstract with trailing nulls",
+			in:   []byte("\x00cuda-uvmfd-4026543509-855\x00\x00"),
+			want: []byte("\x00cuda-uvmfd-987654321-855\x00\x00"),
+		},
+		{name: "pathname", in: []byte("cuda-uvmfd-4026543509-855")},
+		{name: "unnamed", in: nil},
+		{name: "extra suffix", in: []byte("\x00cuda-uvmfd-4026543509-855-extra")},
+		{name: "nonnumeric namespace", in: []byte("\x00cuda-uvmfd-source-855")},
+		{name: "nonnumeric pid", in: []byte("\x00cuda-uvmfd-4026543509-main")},
+		{name: "missing pid", in: []byte("\x00cuda-uvmfd-4026543509-")},
+		{name: "embedded null", in: []byte("\x00cuda-uvmfd-4026543509\x00-855")},
+		{name: "similar prefix", in: []byte("\x00cuda-uvmfdx-4026543509-855")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, rewritten := rewriteCUDASocketName(test.in, 987654321)
+			if test.want == nil {
+				if rewritten {
+					t.Fatalf("rewriteCUDASocketName(%q) unexpectedly rewrote to %q", test.in, got)
+				}
+				return
+			}
+			if !rewritten {
+				t.Fatalf("rewriteCUDASocketName(%q) did not rewrite", test.in)
+			}
+			if !bytes.Equal(got, test.want) {
+				t.Fatalf("rewriteCUDASocketName(%q) = %q, want %q", test.in, got, test.want)
+			}
+		})
+	}
+}
+
+func TestPrepareRestoreImageDir(t *testing.T) {
+	checkpointPath := t.TempDir()
+	entries := []*fdinfo.FileEntry{
+		newUnixSocketEntry(1, []byte("\x00cuda-uvmfd-4026543509-1\x00"), 101, 202),
+		newUnixSocketEntry(2, []byte("\x00other-4026543509-1\x00"), 202, 101),
+		newUnixSocketEntry(3, []byte("/tmp/cuda-uvmfd-4026543509-3"), 303, 0),
+		newAutobindSocketEntry(4, []byte("\x000a1b2"), 404, uint32(unix.SOCK_DGRAM), linuxUnixSocketStateClose, 0),
+		newAutobindSocketEntry(5, []byte("\x00abcde"), 505, uint32(unix.SOCK_DGRAM), linuxUnixSocketStateClose, 0),
+		newAutobindSocketEntry(6, []byte("\x0012345"), 606, uint32(unix.SOCK_DGRAM), linuxUnixSocketStateClose, 404),
+		newAutobindSocketEntry(7, []byte("\x00f00ba"), 707, uint32(unix.SOCK_STREAM), linuxUnixSocketStateClose, 0),
+	}
+	originalEntries := make([]*fdinfo.FileEntry, len(entries))
+	for i, entry := range entries {
+		originalEntries[i] = proto.Clone(entry).(*fdinfo.FileEntry)
+	}
+	canonicalFilesImage := writeFilesImage(t, checkpointPath, entries)
+	pageImage := []byte("large page image stand-in")
+	if err := os.WriteFile(filepath.Join(checkpointPath, "pages-1.img"), pageImage, 0600); err != nil {
+		t.Fatalf("write pages image: %v", err)
+	}
+
+	imageDir, cleanup, err := prepareRestoreImageDirForSocketScope(checkpointPath, 987654321)
+	if err != nil {
+		t.Fatalf("prepareRestoreImageDirForSocketScope: %v", err)
+	}
+	defer cleanup()
+	if imageDir == checkpointPath {
+		t.Fatal("matching CUDA socket should use a private image directory")
+	}
+	if got, want := filepath.Dir(imageDir), filepath.Dir(checkpointPath); got != want {
+		t.Fatalf("private image directory parent = %q, want %q", got, want)
+	}
+
+	privateEntries := readFilesImage(t, imageDir)
+	originalEntries[0].Usk.Name = []byte("\x00cuda-uvmfd-987654321-1\x00")
+	originalEntries[3].Usk.Name = []byte("\x000a1b2-987654321")
+	originalEntries[4].Usk.Name = []byte("\x00abcde-987654321")
+	for i, want := range originalEntries {
+		if !proto.Equal(privateEntries[i], want) {
+			t.Errorf("private entry %d changed outside the expected name rewrite:\n got: %v\nwant: %v", i, privateEntries[i], want)
+		}
+	}
+
+	canonicalPageInfo, err := os.Lstat(filepath.Join(checkpointPath, "pages-1.img"))
+	if err != nil {
+		t.Fatalf("lstat canonical pages image: %v", err)
+	}
+	linkInfo, err := os.Lstat(filepath.Join(imageDir, "pages-1.img"))
+	if err != nil {
+		t.Fatalf("lstat private pages image: %v", err)
+	}
+	if linkInfo.Mode()&os.ModeSymlink != 0 || !linkInfo.Mode().IsRegular() {
+		t.Fatalf("private pages image mode = %v, want regular non-symlink", linkInfo.Mode())
+	}
+	if !os.SameFile(canonicalPageInfo, linkInfo) {
+		t.Fatal("private pages image is not a hard link to the canonical image")
+	}
+	gotPageImage, err := os.ReadFile(filepath.Join(imageDir, "pages-1.img"))
+	if err != nil {
+		t.Fatalf("read private pages image: %v", err)
+	}
+	if !bytes.Equal(gotPageImage, pageImage) {
+		t.Fatalf("private pages image = %q, want %q", gotPageImage, pageImage)
+	}
+
+	gotCanonicalFilesImage, err := os.ReadFile(filepath.Join(checkpointPath, filesImageFilename))
+	if err != nil {
+		t.Fatalf("read canonical files image: %v", err)
+	}
+	if !bytes.Equal(gotCanonicalFilesImage, canonicalFilesImage) {
+		t.Fatal("canonical files.img was modified")
+	}
+
+	cleanup()
+	if _, err := os.Stat(imageDir); !os.IsNotExist(err) {
+		t.Fatalf("private image directory still exists after cleanup: %v", err)
+	}
+}
+
+func TestPrepareRestoreImageDirWithoutCUDASocketsUsesCheckpoint(t *testing.T) {
+	checkpointPath := t.TempDir()
+	writeFilesImage(t, checkpointPath, []*fdinfo.FileEntry{
+		newUnixSocketEntry(1, []byte("\x00other-123-1"), 101, 0),
+	})
+
+	imageDir, cleanup, err := prepareRestoreImageDirForSocketScope(checkpointPath, 987654321)
+	if err != nil {
+		t.Fatalf("prepareRestoreImageDirForSocketScope: %v", err)
+	}
+	defer cleanup()
+	if imageDir != checkpointPath {
+		t.Fatalf("image directory = %q, want canonical checkpoint %q", imageDir, checkpointPath)
+	}
+}
+
+func TestPrepareRestoreImageDirConcurrentSocketScopesAreIndependent(t *testing.T) {
+	checkpointPath := t.TempDir()
+	canonicalFilesImage := writeFilesImage(t, checkpointPath, []*fdinfo.FileEntry{
+		newUnixSocketEntry(1, []byte("\x00cuda-uvmfd-4026543509-855"), 101, 0),
+	})
+
+	type result struct {
+		socketScope uint64
+		path        string
+		cleanup     func()
+		err         error
+	}
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	for _, socketScope := range []uint64{111111, 222222} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			path, cleanup, err := prepareRestoreImageDirForSocketScope(checkpointPath, socketScope)
+			results <- result{socketScope: socketScope, path: path, cleanup: cleanup, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var paths []string
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("prepare restore view for socket scope %d: %v", result.socketScope, result.err)
+		}
+		t.Cleanup(result.cleanup)
+		paths = append(paths, result.path)
+		entries := readFilesImage(t, result.path)
+		want := []byte("\x00cuda-uvmfd-" + strconv.FormatUint(result.socketScope, 10) + "-855")
+		if got := entries[0].Usk.Name; !bytes.Equal(got, want) {
+			t.Fatalf("socket name for scope %d = %q, want %q", result.socketScope, got, want)
+		}
+	}
+	if paths[0] == paths[1] {
+		t.Fatalf("concurrent restores shared private image directory %q", paths[0])
+	}
+
+	gotCanonicalFilesImage, err := os.ReadFile(filepath.Join(checkpointPath, filesImageFilename))
+	if err != nil {
+		t.Fatalf("read canonical files image: %v", err)
+	}
+	if !bytes.Equal(gotCanonicalFilesImage, canonicalFilesImage) {
+		t.Fatal("canonical files.img was modified by concurrent restores")
+	}
+}
+
+func TestPrepareRestoreImageDirRewritesEstablishedIPv6ClientPort(t *testing.T) {
+	checkpointPath := t.TempDir()
+	entries := newTCPRestoreTopology()
+	other := newIPv6TCPSocketEntry(4, 104, 40001, 40002)
+	other.Isk.State = proto.Uint32(7)
+	other.Isk.Family = proto.Uint32(unix.AF_INET)
+	other.Isk.SrcAddr, other.Isk.DstAddr = []uint32{0}, []uint32{0}
+	entries = append(entries, other)
+	canonicalFilesImage := writeFilesImage(t, checkpointPath, entries)
+	writeTCPStreamImages(t, checkpointPath, 102, 103)
+
+	imageDir, cleanup, err := prepareRestoreImageDirForSocketScope(checkpointPath, 987654321)
+	if err != nil {
+		t.Fatalf("prepareRestoreImageDirForSocketScope: %v", err)
+	}
+	defer cleanup()
+	if imageDir == checkpointPath {
+		t.Fatal("established TCP pair should use a private image directory")
+	}
+
+	privateEntries := readFilesImage(t, imageDir)
+	clientPort := privateEntries[1].Isk.GetSrcPort()
+	if clientPort == 0 || clientPort > 65535 {
+		t.Fatalf("rewritten client port = %d, want 1..65535", clientPort)
+	}
+	for _, forbidden := range []uint32{46730, 52103, 40001, 40002} {
+		if clientPort == forbidden {
+			t.Fatalf("rewritten client port = %d, matches canonical port %d", clientPort, forbidden)
+		}
+	}
+	if got := privateEntries[2].Isk.GetDstPort(); got != clientPort {
+		t.Fatalf("rewritten server destination port = %d, want client port %d", got, clientPort)
+	}
+
+	for i, original := range entries {
+		want := proto.Clone(original).(*fdinfo.FileEntry)
+		if i == 1 {
+			want.Isk.SrcPort = proto.Uint32(clientPort)
+		}
+		if i == 2 {
+			want.Isk.DstPort = proto.Uint32(clientPort)
+		}
+		if !proto.Equal(privateEntries[i], want) {
+			t.Errorf("private entry %d changed outside the expected port rewrite:\n got: %v\nwant: %v", i, privateEntries[i], want)
+		}
+	}
+	gotCanonical, err := os.ReadFile(filepath.Join(checkpointPath, filesImageFilename))
+	if err != nil || !bytes.Equal(gotCanonical, canonicalFilesImage) {
+		t.Fatalf("canonical files image changed: %v", err)
+	}
+
+	if fd, err := bindDualStackTCPPort(clientPort, false); err == nil {
+		_ = unix.Close(fd)
+		t.Fatalf("strict bind to reserved TCP port %d unexpectedly succeeded", clientPort)
+	}
+	reuseFD, err := bindDualStackTCPPort(clientPort, true)
+	if err != nil {
+		t.Fatalf("CRIU-like bind to reserved TCP port %d: %v", clientPort, err)
+	}
+	_ = unix.Close(reuseFD)
+
+	cleanup()
+	fd, err := bindDualStackTCPPort(clientPort, false)
+	if err != nil {
+		t.Fatalf("bind to released TCP port %d: %v", clientPort, err)
+	}
+	cleanup()
+	if _, err := unix.Getsockname(fd); err != nil {
+		t.Fatalf("repeated cleanup closed reused socket FD: %v", err)
+	}
+	_ = unix.Close(fd)
+}
+
+func TestPrepareRestoreImageDirTCPRewriteFailsClosed(t *testing.T) {
+	wildcard := []uint32{0, 0, 0, 0}
+	for _, name := range []string{"nonreciprocal", "ambiguous", "indeterminate roles"} {
+		t.Run(name, func(t *testing.T) {
+			entries := newTCPRestoreTopology()
+			switch name {
+			case "nonreciprocal":
+				entries = entries[:2]
+			case "ambiguous":
+				duplicate := proto.Clone(entries[2]).(*fdinfo.FileEntry)
+				duplicate.Id = proto.Uint32(4)
+				duplicate.Isk.Id = proto.Uint32(4)
+				duplicate.Isk.Ino = proto.Uint32(104)
+				entries = append(entries, duplicate)
+			case "indeterminate roles":
+				listener := newIPv6TCPSocketEntry(4, 104, 46730, 0)
+				listener.Isk.State = proto.Uint32(linuxTCPStateListen)
+				listener.Isk.SrcAddr, listener.Isk.DstAddr = wildcard, wildcard
+				entries = append(entries, listener)
+			}
+			checkpointPath := t.TempDir()
+			writeFilesImage(t, checkpointPath, entries)
+			for _, entry := range entries {
+				if entry.Isk.GetState() == linuxTCPStateEstablished {
+					writeTCPStreamImages(t, checkpointPath, entry.Isk.GetIno())
+				}
+			}
+
+			imageDir, cleanup, err := prepareRestoreImageDirForSocketScope(checkpointPath, 987654321)
+			if err != nil {
+				t.Fatalf("prepareRestoreImageDirForSocketScope: %v", err)
+			}
+			defer cleanup()
+			if imageDir != checkpointPath {
+				t.Fatalf("unsupported TCP graph used private image directory %q", imageDir)
+			}
+		})
+	}
+}
+
+func TestPrepareRestoreImageDirConcurrentTCPPortsAreIndependent(t *testing.T) {
+	checkpointPath := t.TempDir()
+	writeFilesImage(t, checkpointPath, newTCPRestoreTopology())
+	writeTCPStreamImages(t, checkpointPath, 102, 103)
+
+	type result struct {
+		path    string
+		cleanup func()
+		err     error
+	}
+	results := make(chan result, 3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			path, cleanup, err := prepareRestoreImageDirForSocketScope(checkpointPath, 987654321)
+			results <- result{path, cleanup, err}
+		}()
+	}
+
+	ports := make(map[uint32]struct{})
+	for range 3 {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("prepare restore view: %v", result.err)
+		}
+		t.Cleanup(result.cleanup)
+		port := readFilesImage(t, result.path)[1].Isk.GetSrcPort()
+		if _, exists := ports[port]; exists {
+			t.Fatalf("concurrent restore views shared rewritten TCP port %d", port)
+		}
+		ports[port] = struct{}{}
+	}
+	if len(ports) != 3 {
+		t.Fatalf("concurrent restores used %d TCP ports, want 3", len(ports))
+	}
+}
+
+func newAutobindSocketEntry(id uint32, name []byte, inode, socketType, state, peer uint32) *fdinfo.FileEntry {
+	entry := newUnixSocketEntry(id, name, inode, peer)
+	entry.Usk.Type = proto.Uint32(socketType)
+	entry.Usk.State = proto.Uint32(state)
+	return entry
+}
+
+func newUnixSocketEntry(id uint32, name []byte, inode, peer uint32) *fdinfo.FileEntry {
+	zero32 := uint32(0)
+	zero64 := uint64(0)
+	socketType := uint32(1)
+	socketState := uint32(10)
+	return &fdinfo.FileEntry{
+		Type: fdinfo.FdTypes_UNIXSK.Enum(),
+		Id:   proto.Uint32(id),
+		Usk: &sk_unix.UnixSkEntry{
+			Id:      proto.Uint32(id),
+			Ino:     proto.Uint32(inode),
+			Type:    &socketType,
+			State:   &socketState,
+			Flags:   &zero32,
+			Uflags:  &zero32,
+			Backlog: &zero32,
+			Peer:    proto.Uint32(peer),
+			Fown: &fown.FownEntry{
+				Uid:     &zero32,
+				Euid:    &zero32,
+				Signum:  &zero32,
+				PidType: &zero32,
+				Pid:     &zero32,
+			},
+			Opts: &sk_opts.SkOptsEntry{
+				SoSndbuf:     &zero32,
+				SoRcvbuf:     &zero32,
+				SoSndTmoSec:  &zero64,
+				SoSndTmoUsec: &zero64,
+				SoRcvTmoSec:  &zero64,
+				SoRcvTmoUsec: &zero64,
+				SoMark:       proto.Uint32(77),
+			},
+			Name: name,
+			NsId: proto.Uint32(9),
+		},
+	}
+}
+
+func newTCPRestoreTopology() []*fdinfo.FileEntry {
+	wildcard := []uint32{0, 0, 0, 0}
+	podAddress := []uint32{0, 0, 0xffff0000, 0x0100007f}
+	entries := []*fdinfo.FileEntry{
+		newIPv6TCPSocketEntry(1, 101, 52103, 0),
+		newIPv6TCPSocketEntry(2, 102, 46730, 52103),
+		newIPv6TCPSocketEntry(3, 103, 52103, 46730),
+	}
+	entries[0].Isk.State = proto.Uint32(linuxTCPStateListen)
+	entries[0].Isk.SrcAddr, entries[0].Isk.DstAddr = wildcard, wildcard
+	entries[1].Isk.SrcAddr, entries[1].Isk.DstAddr = podAddress, podAddress
+	entries[2].Isk.SrcAddr, entries[2].Isk.DstAddr = podAddress, podAddress
+	return entries
+}
+
+func newIPv6TCPSocketEntry(id, inode, srcPort, dstPort uint32) *fdinfo.FileEntry {
+	base := newUnixSocketEntry(id, nil, inode, 0).Usk
+	return &fdinfo.FileEntry{
+		Type: fdinfo.FdTypes_INETSK.Enum(),
+		Id:   proto.Uint32(id),
+		Isk: &sk_inet.InetSkEntry{
+			Id:      proto.Uint32(id),
+			Ino:     proto.Uint32(inode),
+			Family:  proto.Uint32(uint32(unix.AF_INET6)),
+			Type:    proto.Uint32(uint32(unix.SOCK_STREAM)),
+			Proto:   proto.Uint32(uint32(unix.IPPROTO_TCP)),
+			State:   proto.Uint32(linuxTCPStateEstablished),
+			SrcPort: proto.Uint32(srcPort),
+			DstPort: proto.Uint32(dstPort),
+			Flags:   base.Flags,
+			Backlog: base.Backlog,
+			Fown:    base.Fown,
+			Opts:    base.Opts,
+			V6Only:  proto.Bool(false),
+			NsId:    proto.Uint32(9),
+		},
+	}
+}
+
+func writeTCPStreamImages(t *testing.T, dir string, inodes ...uint32) {
+	t.Helper()
+	for _, inode := range inodes {
+		name := filepath.Join(dir, "tcp-stream-"+strconv.FormatUint(uint64(inode), 16)+".img")
+		if err := os.WriteFile(name, []byte("tcp stream"), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+}
+
+func bindDualStackTCPPort(port uint32, reuse bool) (int, error) {
+	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, unix.IPPROTO_TCP)
+	if err != nil {
+		return -1, err
+	}
+	if err := unix.SetsockoptInt(fd, unix.IPPROTO_IPV6, unix.IPV6_V6ONLY, 0); err != nil {
+		_ = unix.Close(fd)
+		return -1, err
+	}
+	address := &unix.SockaddrInet6{Port: int(port)}
+	if reuse {
+		for _, option := range []int{unix.SO_REUSEADDR, unix.SO_REUSEPORT} {
+			if err := unix.SetsockoptInt(fd, unix.SOL_SOCKET, option, 1); err != nil {
+				_ = unix.Close(fd)
+				return -1, err
+			}
+		}
+		address.Addr = [16]byte{10: 0xff, 11: 0xff, 12: 127, 15: 1}
+	}
+	if err := unix.Bind(fd, address); err != nil {
+		_ = unix.Close(fd)
+		return -1, err
+	}
+	return fd, nil
+}
+
+func writeFilesImage(t *testing.T, dir string, entries []*fdinfo.FileEntry) []byte {
+	t.Helper()
+
+	file, err := os.OpenFile(filepath.Join(dir, filesImageFilename), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		t.Fatalf("create files image: %v", err)
+	}
+	imageEntries := make([]*crit.CriuEntry, len(entries))
+	for i, entry := range entries {
+		imageEntries[i] = &crit.CriuEntry{Message: entry}
+	}
+	image := &crit.CriuImage{
+		Magic:     "FILES",
+		Entries:   imageEntries,
+		EntryType: &fdinfo.FileEntry{},
+	}
+	if err := crit.New(nil, file, "", false, false).Encode(image); err != nil {
+		_ = file.Close()
+		t.Fatalf("encode files image: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close files image: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, filesImageFilename))
+	if err != nil {
+		t.Fatalf("read files image: %v", err)
+	}
+	return data
+}
+
+func readFilesImage(t *testing.T, dir string) []*fdinfo.FileEntry {
+	t.Helper()
+
+	file, err := os.Open(filepath.Join(dir, filesImageFilename))
+	if err != nil {
+		t.Fatalf("open files image: %v", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			t.Errorf("close files image: %v", err)
+		}
+	}()
+	image, err := crit.New(file, nil, "", false, false).Decode(&fdinfo.FileEntry{})
+	if err != nil {
+		t.Fatalf("decode files image: %v", err)
+	}
+	entries := make([]*fdinfo.FileEntry, len(image.Entries))
+	for i, entry := range image.Entries {
+		entries[i] = entry.Message.(*fdinfo.FileEntry)
+	}
+	return entries
+}

--- a/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
+++ b/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
@@ -450,7 +450,7 @@ _Appears in:_
 | `checkpoint` _[ServiceCheckpointConfig](#servicecheckpointconfig)_ | Checkpoint configures container checkpointing for this service.<br />When enabled, pods can be restored from a checkpoint files for faster cold start. |  | Optional: \{\} <br /> |
 | `topologyConstraint` _[TopologyConstraint](#topologyconstraint)_ | TopologyConstraint for this service. packDomain is required.<br />When both this and spec.topologyConstraint.packDomain are set, packDomain<br />must be narrower than or equal to the spec-level packDomain. |  | Optional: \{\} <br /> |
 | `gpuMemoryService` _[GPUMemoryServiceSpec](#gpumemoryservicespec)_ | GPUMemoryService configures the GPU Memory Service (GMS) sidecar.<br />When enabled, a GMS sidecar is injected and GPU access is managed via DRA. |  | Optional: \{\} <br /> |
-| `failover` _[FailoverSpec](#failoverspec)_ | Failover configures GMS (GPU Memory Service) failover for this service.<br />For intraPod mode: the main container is cloned into two engine containers (active + standby).<br />For interPod mode: the operator creates a dedicated GMS weight server pod and<br />multiple engine pods per rank that share GPUs via DRA resource claims. |  | Optional: \{\} <br /> |
+| `failover` _[FailoverSpec](#failoverspec)_ | Failover configures GMS (GPU Memory Service) failover for this service.<br />For intraPod mode: the main container is cloned into one active and one or<br />two standby engine containers. The second shadow currently requires a<br />single-node direct vLLM launch without Ray or data parallel.<br />For interPod mode: the operator creates a dedicated GMS weight server pod and<br />multiple engine pods per rank that share GPUs via DRA resource claims. |  | Optional: \{\} <br /> |
 
 
 #### DynamoComponentDeploymentSpec
@@ -495,7 +495,7 @@ _Appears in:_
 | `checkpoint` _[ServiceCheckpointConfig](#servicecheckpointconfig)_ | Checkpoint configures container checkpointing for this service.<br />When enabled, pods can be restored from a checkpoint files for faster cold start. |  | Optional: \{\} <br /> |
 | `topologyConstraint` _[TopologyConstraint](#topologyconstraint)_ | TopologyConstraint for this service. packDomain is required.<br />When both this and spec.topologyConstraint.packDomain are set, packDomain<br />must be narrower than or equal to the spec-level packDomain. |  | Optional: \{\} <br /> |
 | `gpuMemoryService` _[GPUMemoryServiceSpec](#gpumemoryservicespec)_ | GPUMemoryService configures the GPU Memory Service (GMS) sidecar.<br />When enabled, a GMS sidecar is injected and GPU access is managed via DRA. |  | Optional: \{\} <br /> |
-| `failover` _[FailoverSpec](#failoverspec)_ | Failover configures GMS (GPU Memory Service) failover for this service.<br />For intraPod mode: the main container is cloned into two engine containers (active + standby).<br />For interPod mode: the operator creates a dedicated GMS weight server pod and<br />multiple engine pods per rank that share GPUs via DRA resource claims. |  | Optional: \{\} <br /> |
+| `failover` _[FailoverSpec](#failoverspec)_ | Failover configures GMS (GPU Memory Service) failover for this service.<br />For intraPod mode: the main container is cloned into one active and one or<br />two standby engine containers. The second shadow currently requires a<br />single-node direct vLLM launch without Ray or data parallel.<br />For interPod mode: the operator creates a dedicated GMS weight server pod and<br />multiple engine pods per rank that share GPUs via DRA resource claims. |  | Optional: \{\} <br /> |
 
 
 #### DynamoGraphDeployment
@@ -881,7 +881,9 @@ _Appears in:_
 
 FailoverSpec configures active-passive failover for a worker component.
 For intraPod mode: requires gpuMemoryService.enabled; the main container is cloned
-into engine containers (active + standby) within the same pod.
+into one active and one or two standby engine containers within the same pod.
+The second shadow currently requires a single-node direct vLLM launch without
+Ray or data parallel.
 For interPod mode: the operator creates a dedicated GMS weight server pod and
 multiple engine pods per rank that share GPUs via DRA resource claims.
 
@@ -895,7 +897,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enabled activates failover mode. |  |  |
 | `mode` _[GPUMemoryServiceMode](#gpumemoryservicemode)_ | Mode selects the failover deployment topology.<br />intraPod: engine containers run within the same pod (requires gpuMemoryService.enabled).<br />interPod: a dedicated GMS weight server pod + engine pods per rank (requires Grove). | intraPod | Enum: [intraPod interPod] <br />Optional: \{\} <br /> |
-| `numShadows` _integer_ | NumShadows is the number of shadow (standby) engine pods per rank.<br />Total engine pods per rank = NumShadows + 1 (1 primary + NumShadows shadows).<br />NumShadows is only meaningful for mode=interPod; intraPod uses a fixed<br />1 primary + 1 shadow sidecar layout and any value other than 1 is<br />rejected at admission time. | 1 | Minimum: 1 <br />Optional: \{\} <br /> |
+| `numShadows` _integer_ | NumShadows is the number of shadow (standby) engines per rank.<br />In intraPod mode, one or two shadows are supported; the second shadow<br />currently requires a single-node direct vLLM launch without Ray or data<br />parallel. InterPod mode supports one or more shadows. | 1 | Minimum: 1 <br />Optional: \{\} <br /> |
 
 
 #### FrontendSidecarSpec
@@ -2477,11 +2479,14 @@ _Appears in:_
 
 
 FailoverSpec configures active-passive failover for a worker component.
-The main container is cloned into two engine containers (active + standby)
-sharing GPUs via DRA, and the standby acquires the flock when the active
-engine fails. Failover requires that gpuMemoryService is also set, and that
-failover.mode matches gpuMemoryService.mode. Also requires the
-`nvidia.com/dynamo-kube-discovery-mode: container` annotation on the DGD.
+In IntraPod mode, the main container is cloned into one active and one or two
+standby engine containers sharing GPUs via DRA. InterPod mode supports one
+standby. Standbys acquire the flock after the active engine fails. Failover
+with a second IntraPod shadow currently requires a single-node direct vLLM
+launch without Ray or data parallel. Failover requires that gpuMemoryService
+is also set, and that failover.mode matches gpuMemoryService.mode. Also
+requires the `nvidia.com/dynamo-kube-discovery-mode: container` annotation on
+the DGD.
 See ExperimentalSpec for the stability caveat.
 
 
@@ -2492,7 +2497,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `mode` _[GPUMemoryServiceMode](#gpumemoryservicemode)_ | mode selects the failover deployment topology. Must match<br />`spec.experimental.gpuMemoryService.mode` (or<br />`spec.components[*].experimental.gpuMemoryService.mode` inside a<br />DynamoGraphDeployment). | IntraPod | Enum: [IntraPod InterPod] <br />Optional: \{\} <br /> |
-| `numShadows` _integer_ | numShadows is the number of shadow (standby) engine containers per<br />rank. Reserved for future use; the operator currently creates exactly<br />one shadow. | 1 | Maximum: 1 <br />Minimum: 1 <br />Optional: \{\} <br /> |
+| `numShadows` _integer_ | numShadows is the number of shadow (standby) engines per rank. IntraPod<br />mode supports 1 or 2; the second shadow currently requires a single-node<br />direct vLLM launch without Ray or data parallel. InterPod mode supports 1. | 1 | Minimum: 1 <br />Optional: \{\} <br /> |
 
 
 #### FeaturesSpec

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-component-deployment.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-component-deployment.mdx
@@ -214,7 +214,7 @@ Groups opt-in preview features for a component. Referenced by `experimental`. Ne
 </Indent>
 
 <ParamField path="failover" type="FailoverSpec">
-  Configures active-passive GPU failover for a worker component. The `main` container is cloned into two engine containers (active + standby) sharing GPUs via DRA, and the standby acquires the flock when the active engine fails. Requires `gpuMemoryService` to be set, `failover.mode` to match `gpuMemoryService.mode`, and the `nvidia.com/dynamo-kube-discovery-mode: container` annotation on the DGD.
+  Configures active-passive GPU failover for a worker component. In `IntraPod` mode, the `main` container is cloned into one active and one or two standby engine containers sharing GPUs through DRA. The second shadow currently requires a single-node direct vLLM launch without Ray or data parallel. `InterPod` mode supports one standby. Standbys acquire the flock after the active engine fails. Requires `gpuMemoryService` to be set, `failover.mode` to match `gpuMemoryService.mode`, and the `nvidia.com/dynamo-kube-discovery-mode: container` annotation on the DGD.
 </ParamField>
 
 <Indent>
@@ -224,7 +224,7 @@ Groups opt-in preview features for a component. Referenced by `experimental`. Ne
     <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>IntraPod</Badge> <Badge intent="note" minimal>InterPod</Badge></span>
   </ParamField>
   <ParamField path="numShadows" type="integer" default="1">
-    Number of shadow (standby) engine containers per rank. Reserved for future use; the operator currently creates exactly one shadow. Minimum `1`, maximum `1`.
+    Number of shadow (standby) engines per rank. `IntraPod` mode supports `1` or `2`; the second shadow currently requires a single-node direct vLLM launch without Ray or data parallel. `InterPod` mode supports `1`.
   </ParamField>
 </Indent>
 

--- a/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
@@ -656,7 +656,7 @@ See [GPUMemoryServiceSpec](#gpumemoryservicespec).
 </ParamField>
 
 <ParamField path="failover" type="FailoverSpec">
-Failover configures GMS (GPU Memory Service) failover for this service.&lt;br /&gt;For intraPod mode: the main container is cloned into two engine containers (active + standby).&lt;br /&gt;For interPod mode: the operator creates a dedicated GMS weight server pod and&lt;br /&gt;multiple engine pods per rank that share GPUs via DRA resource claims.
+Failover configures GMS (GPU Memory Service) failover for this service.&lt;br /&gt;For intraPod mode: the main container is cloned into one active and one or&lt;br /&gt;two standby engine containers. The second shadow currently requires a&lt;br /&gt;single-node direct vLLM launch without Ray or data parallel.&lt;br /&gt;For interPod mode: the operator creates a dedicated GMS weight server pod and&lt;br /&gt;multiple engine pods per rank that share GPUs via DRA resource claims.
 See [FailoverSpec](#failoverspec).
 **Validation:** Optional: \&#123;\&#125; &lt;br /&gt;
 </ParamField>
@@ -812,7 +812,7 @@ See [GPUMemoryServiceSpec](#gpumemoryservicespec).
 </ParamField>
 
 <ParamField path="failover" type="FailoverSpec">
-Failover configures GMS (GPU Memory Service) failover for this service.&lt;br /&gt;For intraPod mode: the main container is cloned into two engine containers (active + standby).&lt;br /&gt;For interPod mode: the operator creates a dedicated GMS weight server pod and&lt;br /&gt;multiple engine pods per rank that share GPUs via DRA resource claims.
+Failover configures GMS (GPU Memory Service) failover for this service.&lt;br /&gt;For intraPod mode: the main container is cloned into one active and one or&lt;br /&gt;two standby engine containers. The second shadow currently requires a&lt;br /&gt;single-node direct vLLM launch without Ray or data parallel.&lt;br /&gt;For interPod mode: the operator creates a dedicated GMS weight server pod and&lt;br /&gt;multiple engine pods per rank that share GPUs via DRA resource claims.
 See [FailoverSpec](#failoverspec).
 **Validation:** Optional: \&#123;\&#125; &lt;br /&gt;
 </ParamField>
@@ -1376,7 +1376,9 @@ See [Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1
 <Accordion id="failoverspec" title="FailoverSpec">
 FailoverSpec configures active-passive failover for a worker component.
 For intraPod mode: requires gpuMemoryService.enabled; the main container is cloned
-into engine containers (active + standby) within the same pod.
+into one active and one or two standby engine containers within the same pod.
+The second shadow currently requires a single-node direct vLLM launch without
+Ray or data parallel.
 For interPod mode: the operator creates a dedicated GMS weight server pod and
 multiple engine pods per rank that share GPUs via DRA resource claims.
 
@@ -1395,7 +1397,7 @@ See [GPUMemoryServiceMode](#gpumemoryservicemode).
 </ParamField>
 
 <ParamField path="numShadows" type="integer" default="1">
-NumShadows is the number of shadow (standby) engine pods per rank.&lt;br /&gt;Total engine pods per rank = NumShadows + 1 (1 primary + NumShadows shadows).&lt;br /&gt;NumShadows is only meaningful for mode=interPod; intraPod uses a fixed&lt;br /&gt;1 primary + 1 shadow sidecar layout and any value other than 1 is&lt;br /&gt;rejected at admission time.
+NumShadows is the number of shadow (standby) engines per rank.&lt;br /&gt;In intraPod mode, one or two shadows are supported; the second shadow&lt;br /&gt;currently requires a single-node direct vLLM launch without Ray or data&lt;br /&gt;parallel. InterPod mode supports one or more shadows.
 **Validation:** Minimum: 1 &lt;br /&gt;Optional: \&#123;\&#125; &lt;br /&gt;
 </ParamField>
 </Accordion>
@@ -3527,10 +3529,13 @@ See [ComponentCheckpointConfig](#componentcheckpointconfig).
 
 <Accordion id="v1beta1-failoverspec" title="FailoverSpec">
 FailoverSpec configures active-passive failover for a worker component.
-The main container is cloned into two engine containers (active + standby)
-sharing GPUs via DRA, and the standby acquires the flock when the active
-engine fails. Failover requires that gpuMemoryService is also set, and that
-failover.mode matches gpuMemoryService.mode. Also requires the
+In IntraPod mode, the main container is cloned into one active and one or two
+standby engine containers sharing GPUs via DRA. InterPod mode supports one
+standby. Standbys acquire the flock after the active engine fails. Failover
+with a second IntraPod shadow currently requires a single-node direct vLLM
+launch without Ray or data parallel. Failover requires that gpuMemoryService
+is also set, and that failover.mode matches
+gpuMemoryService.mode. Also requires the
 `nvidia.com/dynamo-kube-discovery-mode: container` annotation on the DGD.
 See ExperimentalSpec for the stability caveat.
 
@@ -3545,8 +3550,8 @@ See [GPUMemoryServiceMode](#v1beta1-gpumemoryservicemode).
 </ParamField>
 
 <ParamField path="numShadows" type="integer" default="1">
-numShadows is the number of shadow (standby) engine containers per&lt;br /&gt;rank. Reserved for future use; the operator currently creates exactly&lt;br /&gt;one shadow.
-**Validation:** Maximum: 1 &lt;br /&gt;Minimum: 1 &lt;br /&gt;Optional: \&#123;\&#125; &lt;br /&gt;
+numShadows is the number of shadow (standby) engines per rank. IntraPod&lt;br /&gt;mode supports 1 or 2; the second shadow currently requires a single-node&lt;br /&gt;direct vLLM launch without Ray or data parallel. InterPod mode supports 1.
+**Validation:** Minimum: 1 &lt;br /&gt;Optional: \&#123;\&#125; &lt;br /&gt;
 </ParamField>
 </Accordion>
 


### PR DESCRIPTION
## Summary

This is the third layer of the seven-PR stack for [DEP #12671](https://github.com/ai-dynamo/dynamo/issues/12671). It extends IntraPod failover from one shadow to at most two:

```text
engine-0  active candidate
engine-1  shadow candidate
engine-2  optional second shadow candidate
```

All engine containers share one Pod network namespace. The operator therefore assigns and validates distinct master, Dynamo system, forward-pass metrics, NIXL side-channel, and KV-event ports before committing the Pod transformation.

```mermaid
flowchart LR
    M["main container"] --> E0["engine-0<br/>ENGINE_ID=0"]
    M --> E1["engine-1<br/>ENGINE_ID=1"]
    M --> E2["engine-2<br/>ENGINE_ID=2"]
```

The existing one-shadow path remains unchanged. The new two-shadow case is deliberately narrow: it requires a single-node, direct/tokenized vLLM launch without a shell wrapper, Ray, Elastic-Ray, or vLLM data parallel. Unsupported profiles fail during DCD/DGD admission and again during rendering rather than producing colliding listeners.

The API, conversion behavior, webhooks, CRDs, and generated references consistently describe the one-or-two-shadow limit. Historical InterPod conversion behavior remains unchanged.

This PR only adds generic failover topology and port safety. It does not enable Snapshot-backed failover.

## Validation

- exact-commit API, conversion, Dynamo rendering, admission, and controller tests passed
- DCD/DGD tests cover direct two-shadow acceptance and shell/Ray/DP/multinode rejection
- three-engine port uniqueness, range, collision, and transactional rollback tests passed
- all non-e2e operator packages built independently at this stack layer
- CRD and API-reference generation completed with zero drift
- `go vet`, `gofmt`, DCO, signature, and diff-hygiene checks passed

### Rewritten seven-PR chain validation

- Operator checkpoint/controller/webhook validation passed with `go test ./internal/checkpoint ./internal/controller ./internal/webhook/validation -count=1`.
- Operator lint passed with `make lint`, invoking `golangci-lint v1.64.8`.
- Snapshot validation passed with `make lint`, `go test ./internal/criu -count=1`, `go test -race ./internal/criu -count=1`, `go test ./... -count=1`, and `go vet ./...` from `deploy/snapshot`.
- Python formatting/lint hooks passed with repository-pinned isort 5.12.0, Black 23.1.0, flake8 7.3.0, and Ruff 0.5.2.
- Independent reviews approved the rewritten local chain.
- No live AKS E2E is claimed for the rewritten heads.

Full CI is not claimed.

## Stack

GitHub Stack: [#12911](https://github.com/ai-dynamo/dynamo/stacks/12911)

| Order | PR | Change |
| ---: | --- | --- |
| 1 | [#12887](https://github.com/ai-dynamo/dynamo/pull/12887) | Remap clone-unsafe sockets during restore |
| 2 | [#12869](https://github.com/ai-dynamo/dynamo/pull/12869) | Elect the failover owner before worker publication |
| 3 | **[#12870](https://github.com/ai-dynamo/dynamo/pull/12870)** | **Support a second IntraPod shadow** |
| 4 | [#12871](https://github.com/ai-dynamo/dynamo/pull/12871) | Retain restored engines paused |
| 5 | [#12872](https://github.com/ai-dynamo/dynamo/pull/12872) | Verify automatic checkpoint provenance |
| 6 | [#12873](https://github.com/ai-dynamo/dynamo/pull/12873) | Bind workloads to verified checkpoints |
| 7 | [#12874](https://github.com/ai-dynamo/dynamo/pull/12874) | Enable Snapshot-backed IntraPod failover |
