### PR TITLE
feat(snapshot): retain restored engines for external wake

### DIFF
--- a/components/src/dynamo/common/snapshot/constants.py
+++ b/components/src/dynamo/common/snapshot/constants.py
@@ -17,6 +17,7 @@ SNAPSHOT_CONTROL_DIR_ENV = "DYN_SNAPSHOT_CONTROL_DIR"
 SNAPSHOT_CONTROL_DIR = "/snapshot-control"
 SNAPSHOT_RESTORE_CONTEXT_FILE = "restore-context.json"
 SNAPSHOT_RESTORE_STANDBY_ENV = "DYN_SNAPSHOT_RESTORE_STANDBY"
+SNAPSHOT_RESTORE_PAUSED_ENV = "DYN_SNAPSHOT_RESTORE_PAUSED"
 
 # Must match snapshotprotocol.{SnapshotCompleteFile,RestoreCompleteFile,
 # ReadyForSnapshotFile}.
@@ -44,6 +45,11 @@ RESTORE_RUNTIME_ENV_NAMES = {
     # Kubernetes discovery mode env read when the restored runtime registers.
     "DYN_KUBE_DISCOVERY_MODE",
     "CONTAINER_NAME",
+    # Target identity and pause policy consumed after engine construction.
+    "ENGINE_ID",
+    "FAILOVER_LOCK_PATH",
+    "DYN_VLLM_GMS_SHADOW_MODE",
+    SNAPSHOT_RESTORE_PAUSED_ENV,
     # Optional non-secret platform endpoints that may be consumed after restore.
     "MODEL_EXPRESS_URL",
     "PROMETHEUS_ENDPOINT",

--- a/components/src/dynamo/common/snapshot/lifecycle.py
+++ b/components/src/dynamo/common/snapshot/lifecycle.py
@@ -16,6 +16,7 @@ from dynamo.common.snapshot.constants import (
     SNAPSHOT_COMPLETE_FILE,
     SNAPSHOT_CONTROL_DIR_ENV,
 )
+from dynamo.common.snapshot.restore_context import _restore_should_remain_paused
 
 logger = logging.getLogger(__name__)
 EngineT = TypeVar("EngineT")
@@ -35,6 +36,11 @@ class SnapshotConfig:
     def __init__(self, control_dir: str):
         self.control_dir = control_dir
         self.ready_file = os.path.join(control_dir, READY_FOR_SNAPSHOT_FILE)
+        self._restore_paused = False
+
+    @property
+    def restore_paused(self) -> bool:
+        return self._restore_paused
 
     @classmethod
     def from_env(cls) -> "SnapshotConfig | None":
@@ -68,6 +74,11 @@ class SnapshotConfig:
 
         if event == "restore":
             logger.info("Restore sentinel detected")
+            self._restore_paused = _restore_should_remain_paused()
+            if self._restore_paused:
+                logger.info("Keeping restored model application-paused")
+                os.environ.pop("HF_HUB_OFFLINE", None)
+                return True
             logger.info("Resuming model after restore")
             await pause_controller.resume()
             pause_controller.mark_resumed()

--- a/components/src/dynamo/common/snapshot/restore_context.py
+++ b/components/src/dynamo/common/snapshot/restore_context.py
@@ -17,6 +17,7 @@ from dynamo.common.snapshot.constants import (
     SNAPSHOT_CONTROL_DIR,
     SNAPSHOT_CONTROL_DIR_ENV,
     SNAPSHOT_RESTORE_CONTEXT_FILE,
+    SNAPSHOT_RESTORE_PAUSED_ENV,
     SNAPSHOT_RESTORE_STANDBY_ENV,
 )
 
@@ -116,9 +117,25 @@ def parse_snapshot_restore_runtime_config(argv: list[str] | None) -> object:
 def apply_snapshot_restore_env() -> dict[str, str | None]:
     """Load restore-context JSON and apply its runtime env to ``os.environ``."""
 
-    # Load the restore-context JSON captured by the restore standby process. It
-    # contains the target container's actual restore-time env after Kubernetes
-    # resolved literals, Downward API values, ConfigMaps, and Secrets.
+    env_config, source = _load_snapshot_restore_env()
+    return _apply_restore_env(env_config, source=source)
+
+
+def _restore_should_remain_paused() -> bool:
+    """Return whether the target remains application-paused after restore."""
+
+    env_config, _ = _load_snapshot_restore_env()
+    value = env_config.get(SNAPSHOT_RESTORE_PAUSED_ENV)
+    if value in (None, "0"):
+        return False
+    if value == "1":
+        return True
+    raise RuntimeError(
+        f"snapshot restore context {SNAPSHOT_RESTORE_PAUSED_ENV} must be 0, 1, or null"
+    )
+
+
+def _load_snapshot_restore_env() -> tuple[Mapping[str, object], str]:
     control_dir = os.environ.get(SNAPSHOT_CONTROL_DIR_ENV, SNAPSHOT_CONTROL_DIR)
     context_path = Path(control_dir) / SNAPSHOT_RESTORE_CONTEXT_FILE
     if not context_path.is_file():
@@ -137,7 +154,7 @@ def apply_snapshot_restore_env() -> dict[str, str | None]:
     env_config = restore_context.get("env")
     if not isinstance(env_config, dict):
         raise RuntimeError("snapshot restore context requires an object env field")
-    return _apply_restore_env(env_config, source=source)
+    return env_config, source
 
 
 def write_snapshot_restore_context(control_dir: str | None = None) -> None:

--- a/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
+++ b/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import json
 import os
 
 import pytest
@@ -10,10 +11,17 @@ from dynamo.common.snapshot.constants import (
     READY_FOR_SNAPSHOT_FILE,
     RESTORE_COMPLETE_FILE,
     SNAPSHOT_CONTROL_DIR_ENV,
+    SNAPSHOT_RESTORE_CONTEXT_FILE,
+    SNAPSHOT_RESTORE_PAUSED_ENV,
 )
 from dynamo.common.snapshot.lifecycle import SnapshotConfig
 
-pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.timeout(30),
+    pytest.mark.pre_merge,
+]
 
 
 class _PauseController:
@@ -31,8 +39,17 @@ class _PauseController:
         pass
 
 
+def _write_restore_context(tmp_path, *, restore_paused: bool = False) -> None:
+    env = {SNAPSHOT_RESTORE_PAUSED_ENV: "1"} if restore_paused else {}
+    (tmp_path / SNAPSHOT_RESTORE_CONTEXT_FILE).write_text(
+        json.dumps({"env": env}),
+        encoding="utf-8",
+    )
+
+
 async def test_snapshot_lifecycle_resumes_after_restore_sentinel(monkeypatch, tmp_path):
     monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
+    _write_restore_context(tmp_path)
     controller = _PauseController()
     config = SnapshotConfig.from_env()
     assert config is not None
@@ -60,11 +77,38 @@ async def test_snapshot_lifecycle_resumes_after_restore_sentinel(monkeypatch, tm
                 await lifecycle
 
 
+async def test_snapshot_lifecycle_preserves_requested_pause(monkeypatch, tmp_path):
+    monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
+    _write_restore_context(tmp_path, restore_paused=True)
+    controller = _PauseController()
+    config = SnapshotConfig.from_env()
+    assert config is not None
+
+    lifecycle = asyncio.create_task(config.run_lifecycle(controller))
+    try:
+        for _ in range(100):
+            if (tmp_path / READY_FOR_SNAPSHOT_FILE).exists():
+                break
+            await asyncio.sleep(0.01)
+        (tmp_path / RESTORE_COMPLETE_FILE).write_text("done", encoding="utf-8")
+
+        assert await lifecycle is True
+        assert config.restore_paused is True
+        assert controller.paused is True
+        assert controller.resumed is False
+    finally:
+        if not lifecycle.done():
+            lifecycle.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await lifecycle
+
+
 async def test_snapshot_lifecycle_clears_capture_only_env_after_restore(
     monkeypatch, tmp_path
 ):
     monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    _write_restore_context(tmp_path)
     assert os.environ["HF_HUB_OFFLINE"] == "1"
 
     controller = _PauseController()

--- a/components/src/dynamo/common/tests/test_snapshot_restore_context.py
+++ b/components/src/dynamo/common/tests/test_snapshot_restore_context.py
@@ -13,11 +13,14 @@ from dynamo.common.snapshot.constants import (
     RESTORE_RUNTIME_ENV_NAMES,
     SNAPSHOT_CONTROL_DIR_ENV,
     SNAPSHOT_RESTORE_CONTEXT_FILE,
+    SNAPSHOT_RESTORE_PAUSED_ENV,
     SNAPSHOT_RESTORE_STANDBY_ENV,
 )
 from dynamo.common.snapshot.restore_context import (
+    _restore_should_remain_paused,
     apply_snapshot_restore_env,
     refresh_snapshot_restore_config,
+    write_snapshot_restore_context,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
@@ -67,6 +70,46 @@ def test_apply_snapshot_restore_env_applies_and_clears_values(monkeypatch, tmp_p
     assert os.environ["DYN_DISCOVERY_BACKEND"] == "etcd"
     assert "DYN_REQUEST_PLANE" not in os.environ
     assert "UNSUPPORTED_ENV" not in os.environ
+
+
+def test_write_restore_context_is_allowlisted(monkeypatch, tmp_path):
+    monkeypatch.setenv("ENGINE_ID", "2")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/gms/failover.lock")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv(SNAPSHOT_RESTORE_PAUSED_ENV, "1")
+    monkeypatch.setenv("SECRET_TOKEN", "do-not-copy")
+
+    write_snapshot_restore_context(str(tmp_path))
+
+    context_path = tmp_path / SNAPSHOT_RESTORE_CONTEXT_FILE
+    captured = json.loads(context_path.read_text(encoding="utf-8"))["env"]
+    assert captured["ENGINE_ID"] == "2"
+    assert captured["FAILOVER_LOCK_PATH"] == "/gms/failover.lock"
+    assert captured["DYN_VLLM_GMS_SHADOW_MODE"] == "true"
+    assert captured[SNAPSHOT_RESTORE_PAUSED_ENV] == "1"
+    assert "SECRET_TOKEN" not in captured
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, False), ("0", False), ("1", True)],
+)
+def test_restore_paused_marker_is_strict(monkeypatch, tmp_path, value, expected):
+    env = {} if value is None else {SNAPSHOT_RESTORE_PAUSED_ENV: value}
+    write_restore_context(monkeypatch, tmp_path, env)
+
+    assert _restore_should_remain_paused() is expected
+
+
+def test_restore_paused_marker_rejects_other_values(monkeypatch, tmp_path):
+    write_restore_context(
+        monkeypatch,
+        tmp_path,
+        {SNAPSHOT_RESTORE_PAUSED_ENV: "true"},
+    )
+
+    with pytest.raises(RuntimeError, match="must be 0, 1, or null"):
+        _restore_should_remain_paused()
 
 
 async def test_refresh_snapshot_restore_config_reparses_runtime_fields(

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -25,10 +25,6 @@ from vllm.v1.metrics.prometheus import setup_multiprocess_prometheus
 
 from dynamo.common.config_dump import dump_config
 from dynamo.common.model_fetch import fetch_model
-from dynamo.common.snapshot.restore_context import (
-    parse_snapshot_restore_runtime_config,
-    refresh_snapshot_restore_config,
-)
 from dynamo.common.utils.graceful_shutdown import install_signal_handlers
 from dynamo.common.utils.prometheus import (
     EMBEDDING_CACHE_METRIC_PREFIX,
@@ -68,7 +64,7 @@ from .kv_connector_protocols import (
 from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
 from .multimodal_utils.media_config import create_frontend_media_config
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
-from .snapshot import prepare_snapshot_engine
+from .snapshot import prepare_snapshot_engine, refresh_vllm_snapshot_restore_config
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
@@ -149,12 +145,11 @@ async def worker(argv: list[str] | None = None) -> None:
         setup_vllm_engine,
     )
 
-    snapshot_engine = None
     if snapshot_controller is not None:
-        snapshot_engine = snapshot_controller.engine
-        config = await refresh_snapshot_restore_config(
+        config = await refresh_vllm_snapshot_restore_config(
             config,
-            lambda: parse_snapshot_restore_runtime_config(argv),
+            argv,
+            restore_paused=snapshot_controller.snapshot_config.restore_paused,
         )
 
     # HEADLESS MODE: bypass DistributedRuntime entirely.
@@ -187,7 +182,7 @@ async def worker(argv: list[str] | None = None) -> None:
         config,
         shutdown_event,
         shutdown_endpoints,
-        snapshot_engine=snapshot_engine,
+        snapshot_controller=snapshot_controller,
     )
 
     logger.debug("Worker function completed, exiting...")

--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -11,12 +11,32 @@ from dynamo.common.snapshot.lifecycle import (
     SnapshotConfig,
     configure_snapshot_capture_env,
 )
+from dynamo.common.snapshot.restore_context import (
+    parse_snapshot_restore_runtime_config,
+    refresh_snapshot_restore_config,
+)
+from dynamo.common.utils.env import env_bool
 
 from .args import Config
 from .handlers import VllmEnginePauseController
 from .worker_factory import EngineSetupResult
 
 logger = logging.getLogger(__name__)
+
+
+async def refresh_vllm_snapshot_restore_config(
+    config: Config,
+    argv: list[str] | None,
+    *,
+    restore_paused: bool,
+) -> Config:
+    config = await refresh_snapshot_restore_config(
+        config,
+        lambda: parse_snapshot_restore_runtime_config(argv),
+    )
+    if restore_paused:
+        config.gms_shadow_mode = env_bool("DYN_VLLM_GMS_SHADOW_MODE")
+    return config
 
 
 async def prepare_snapshot_engine(

--- a/components/src/dynamo/vllm/tests/test_vllm_snapshot.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_snapshot.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import dynamo.vllm.snapshot as snapshot_mod
+from dynamo.vllm.args import parse_args
+from dynamo.vllm.worker_factory import WorkerFactory
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.fault_tolerance,
+    pytest.mark.gpu_1,
+    pytest.mark.xpu_1,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),
+    pytest.mark.pre_merge,
+]
+
+_BASE_ARGS = [
+    "--model",
+    "Qwen/Qwen3-0.6B",
+    "--load-format",
+    "gms",
+    "--request-plane",
+    "tcp",
+]
+
+
+@pytest.mark.asyncio
+async def test_paused_restore_rejects_resumed_engine():
+    factory = WorkerFactory(Mock(), Mock(), AsyncMock(), Mock(), Mock())
+
+    with pytest.raises(RuntimeError, match="snapshot restore engine is not paused"):
+        await factory._wake_with_failover_lock(
+            Mock(is_paused=False),
+            Mock(),
+            SimpleNamespace(gms_shadow_mode=True),
+            restore_paused=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_restore_refresh_sets_shadow_mode_before_election(monkeypatch):
+    config = parse_args(_BASE_ARGS)
+    assert config.gms_shadow_mode is False
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "1")
+    monkeypatch.setattr(
+        snapshot_mod,
+        "refresh_snapshot_restore_config",
+        AsyncMock(return_value=config),
+    )
+
+    config = await snapshot_mod.refresh_vllm_snapshot_restore_config(
+        config,
+        _BASE_ARGS,
+        restore_paused=True,
+    )
+
+    election = AsyncMock(return_value=(False, Mock()))
+    factory = WorkerFactory(Mock(), Mock(), AsyncMock(), Mock(), Mock())
+    factory._wake_with_failover_lock = election  # type: ignore[assignment]
+    await factory._wake_with_failover_lock(Mock(), Mock(), config)
+    election.assert_awaited_once()
+    assert election.await_args.args[2].gms_shadow_mode is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "create_method"),
+    [
+        ("decode", "_create_decode_worker"),
+        ("prefill", "_create_prefill_worker"),
+    ],
+)
+async def test_paused_restore_reuses_pause_controller_without_repausing(
+    monkeypatch, mode, create_method
+):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    election_call = {}
+
+    async def blocked_election(*args, **kwargs):
+        election_call["args"] = args
+        election_call["kwargs"] = kwargs
+        entered.set()
+        await release.wait()
+        return True, Mock()
+
+    engine_config = SimpleNamespace(
+        additional_config={},
+        cache_config=SimpleNamespace(num_gpu_blocks=1),
+        model_config=SimpleNamespace(max_model_len=1024),
+        shutdown_timeout=5.0,
+    )
+    controller = SimpleNamespace(
+        engine=(Mock(), engine_config, Mock(), "/tmp/prom", Mock()),
+        pause_controller=Mock(is_paused=True, needs_resume_recovery=True),
+        snapshot_config=Mock(restore_paused=True),
+    )
+    kv_setup = AsyncMock()
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.configure_kv_event_block_size", kv_setup
+    )
+    engine_monitor = Mock()
+    monitor_constructor = Mock(return_value=engine_monitor)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.VllmEngineMonitor", monitor_constructor
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.get_dp_range_for_worker", lambda _config: (0, 1)
+    )
+    kv_publisher, fpm_relay, routes = Mock(), Mock(), Mock()
+    model_registration, model_discovery = (
+        AsyncMock(),
+        AsyncMock(side_effect=RuntimeError("stop-after-election")),
+    )
+    factory = WorkerFactory(Mock(), kv_publisher, model_registration, fpm_relay, Mock())
+    factory._wake_with_failover_lock = blocked_election  # type: ignore[assignment]
+    factory._maybe_create_failover_metrics = Mock()  # type: ignore[assignment]
+    factory._maybe_get_encode_worker_client = model_discovery  # type: ignore[assignment]
+    factory.register_engine_routes = routes  # type: ignore[assignment]
+    endpoint = Mock(connection_id=Mock(return_value="cid"), serve_endpoint=Mock())
+    runtime = Mock(endpoint=Mock(return_value=endpoint))
+    pause_controller = controller.pause_controller
+    pause_controller.pause = AsyncMock()
+    args = [*_BASE_ARGS, "--gms-shadow-mode"]
+    if mode == "prefill":
+        args.extend(
+            [
+                "--disaggregation-mode",
+                "prefill",
+                "--kv-transfer-config",
+                '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+            ]
+        )
+    config = parse_args(args)
+    task = asyncio.create_task(
+        getattr(factory, create_method)(
+            runtime, config, asyncio.Event(), [], snapshot_controller=controller
+        )
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    assert election_call["args"][0] is pause_controller
+    assert election_call["kwargs"]["restore_paused"] is True
+    pause_controller.pause.assert_not_awaited()
+    blocked = (
+        kv_setup,
+        model_discovery,
+        kv_publisher,
+        fpm_relay,
+        routes,
+        model_registration,
+        endpoint.serve_endpoint,
+    )
+    for publisher in blocked:
+        publisher.assert_not_called()
+    release.set()
+    with pytest.raises(RuntimeError, match="stop-after-election"):
+        await task
+    monitor_constructor.assert_called_once()
+    engine_monitor.cancel.assert_called_once_with()
+    model_discovery.assert_awaited_once()

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -1017,13 +1017,14 @@ class TestCreate:
         shutdown_event = asyncio.Event()
         shutdown_endpoints = []
         snapshot_engine = Mock()
+        snapshot_controller = Mock(engine=snapshot_engine)
 
         await factory.create(
             runtime,
             config,
             shutdown_event,
             shutdown_endpoints,
-            snapshot_engine=snapshot_engine,
+            snapshot_controller=snapshot_controller,
         )
 
         factory._create_realtime_worker.assert_awaited_once_with(  # type: ignore[union-attr]
@@ -1038,8 +1039,20 @@ class TestCreate:
         factory._create_prefill_worker.assert_not_called()  # type: ignore[union-attr]
         factory._create_multimodal_encode_worker.assert_not_called()  # type: ignore[union-attr]
 
-    async def test_passes_snapshot_engine(self, factory: WorkerFactory) -> None:
-        config = _make_config(enable_multimodal=True)
+    @pytest.mark.parametrize(
+        ("mode", "method_name"),
+        [
+            (DisaggregationMode.AGGREGATED, "_create_decode_worker"),
+            (DisaggregationMode.PREFILL, "_create_prefill_worker"),
+        ],
+    )
+    async def test_passes_snapshot_controller(
+        self,
+        factory: WorkerFactory,
+        mode: DisaggregationMode,
+        method_name: str,
+    ) -> None:
+        config = _make_config(disaggregation_mode=mode)
         runtime = Mock()
         shutdown_event = asyncio.Event()
         shutdown_endpoints: list = []
@@ -1050,21 +1063,22 @@ class TestCreate:
             "/tmp/prometheus",
             Mock(),
         )
+        snapshot_controller = Mock(engine=snapshot_engine)
 
         await factory.create(
             runtime,
             config,
             shutdown_event,
             shutdown_endpoints,
-            snapshot_engine=snapshot_engine,
+            snapshot_controller=snapshot_controller,
         )
 
-        factory._create_decode_worker.assert_called_once_with(  # type: ignore[union-attr]
+        getattr(factory, method_name).assert_called_once_with(
             runtime,
             config,
             shutdown_event,
             shutdown_endpoints,
-            snapshot_engine=snapshot_engine,
+            snapshot_controller=snapshot_controller,
         )
 
 

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -21,6 +21,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 from dynamo import prometheus_names
 from dynamo.common.rl import first_endpoint_response, register_rl_routes
+from dynamo.common.snapshot.lifecycle import EngineSnapshotController
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.common.utils.prometheus import (
     LLMBackendMetrics,
@@ -65,6 +66,7 @@ BENCHMARK_SOFT_TIMEOUT_GRACE_SECONDS = 90
 # have no KV cache / scheduler gauges, so setup_vllm_engine() skips the
 # LLMBackendMetrics registration there.
 EngineSetupResult = tuple[AsyncLLM, VllmConfig, Any, Any, Optional[LLMBackendMetrics]]
+_SnapshotController = EngineSnapshotController[EngineSetupResult]
 
 
 def _benchmark_rank_path(base_path: Path, dp_rank: int) -> Path:
@@ -603,9 +605,13 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,
-        snapshot_engine: Optional[EngineSetupResult] = None,
+        snapshot_controller: _SnapshotController | None = None,
     ) -> None:
         """Create the appropriate multimodal worker based on config flags."""
+
+        snapshot_engine = (
+            snapshot_controller.engine if snapshot_controller is not None else None
+        )
 
         if config.realtime:
             await self._create_realtime_worker(
@@ -640,7 +646,7 @@ class WorkerFactory:
                 config,
                 shutdown_event,
                 shutdown_endpoints,
-                snapshot_engine=snapshot_engine,
+                snapshot_controller=snapshot_controller,
             )
         else:
             # AGGREGATED or DECODE
@@ -649,7 +655,7 @@ class WorkerFactory:
                 config,
                 shutdown_event,
                 shutdown_endpoints,
-                snapshot_engine=snapshot_engine,
+                snapshot_controller=snapshot_controller,
             )
         return
 
@@ -939,12 +945,17 @@ class WorkerFactory:
         runtime: DistributedRuntime,
         config: Config,
         failover_metrics=None,
+        restore_paused: bool = False,
     ) -> tuple[bool, Any | None]:
         """Pause, elect the active shadow, and wake it while retaining the lock."""
         if config.gms_shadow_mode is not True:
             return False, None
 
-        await pause_controller.pause(1)
+        if restore_paused:
+            if not pause_controller.is_paused:
+                raise RuntimeError("snapshot restore engine is not paused")
+        else:
+            await pause_controller.pause(1)
         if failover_metrics is not None:
             failover_metrics.set_state("standby")
 
@@ -977,8 +988,8 @@ class WorkerFactory:
                 await lock.release()
             else:
                 # resume() can fail after partially waking vLLM. Keep the lock
-                # until process termination closes the fd; releasing it could
-                # let another engine wake concurrently.
+                # until process termination closes the fd;
+                # releasing here could let another engine wake concurrently.
                 logger.critical(
                     "[Shadow] Engine wake failed after lock acquisition; "
                     "terminating process while retaining the lock"
@@ -994,7 +1005,7 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
-        snapshot_engine: Optional[EngineSetupResult] = None,
+        snapshot_controller: _SnapshotController | None = None,
     ) -> None:
         """
         Instantiate and serve
@@ -1005,7 +1016,7 @@ class WorkerFactory:
                 config,
                 shutdown_event,
                 shutdown_endpoints,
-                snapshot_engine=snapshot_engine,
+                snapshot_controller=snapshot_controller,
                 lifecycle=lifecycle,
             )
 
@@ -1015,10 +1026,18 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
-        snapshot_engine: Optional[EngineSetupResult],
+        snapshot_controller: _SnapshotController | None,
         lifecycle: _WorkerLifecycle,
     ) -> None:
         """Initialize and serve a decode worker."""
+
+        snapshot_engine = (
+            snapshot_controller.engine if snapshot_controller is not None else None
+        )
+        restore_paused = (
+            snapshot_controller is not None
+            and snapshot_controller.snapshot_config.restore_paused
+        )
 
         generate_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
@@ -1102,9 +1121,18 @@ class WorkerFactory:
         if config.gms_shadow_mode is True:
             engine_monitor = VllmEngineMonitor(runtime, engine_client, shutdown_event)
             lifecycle.engine_monitor = engine_monitor
-        pause_controller = VllmEnginePauseController(engine_client)
+
+        if restore_paused:
+            assert snapshot_controller is not None
+            pause_controller = snapshot_controller.pause_controller
+        else:
+            pause_controller = VllmEnginePauseController(engine_client)
         was_failover, failover_lock = await self._wake_with_failover_lock(
-            pause_controller, runtime, config, failover_metrics
+            pause_controller,
+            runtime,
+            config,
+            failover_metrics,
+            restore_paused=restore_paused,
         )
         factory.enable_publication()
         await configure_kv_event_block_size(engine_client, vllm_config)
@@ -1326,7 +1354,7 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
-        snapshot_engine: Optional[EngineSetupResult] = None,
+        snapshot_controller: _SnapshotController | None = None,
     ) -> None:
         with _WorkerLifecycle(shutdown_event=shutdown_event) as lifecycle:
             await self._run_prefill_worker(
@@ -1334,7 +1362,7 @@ class WorkerFactory:
                 config,
                 shutdown_event,
                 shutdown_endpoints,
-                snapshot_engine=snapshot_engine,
+                snapshot_controller=snapshot_controller,
                 lifecycle=lifecycle,
             )
 
@@ -1345,11 +1373,18 @@ class WorkerFactory:
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
         lifecycle: _WorkerLifecycle,
-        snapshot_engine: Optional[EngineSetupResult] = None,
+        snapshot_controller: _SnapshotController | None = None,
     ) -> None:
         """
         Instantiate and serve
         """
+        snapshot_engine = (
+            snapshot_controller.engine if snapshot_controller is not None else None
+        )
+        restore_paused = (
+            snapshot_controller is not None
+            and snapshot_controller.snapshot_config.restore_paused
+        )
         generate_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
         )
@@ -1407,9 +1442,17 @@ class WorkerFactory:
         if config.gms_shadow_mode is True:
             engine_monitor = VllmEngineMonitor(runtime, engine_client, shutdown_event)
             lifecycle.engine_monitor = engine_monitor
-        pause_controller = VllmEnginePauseController(engine_client)
+        if restore_paused:
+            assert snapshot_controller is not None
+            pause_controller = snapshot_controller.pause_controller
+        else:
+            pause_controller = VllmEnginePauseController(engine_client)
         was_failover, failover_lock = await self._wake_with_failover_lock(
-            pause_controller, runtime, config, failover_metrics
+            pause_controller,
+            runtime,
+            config,
+            failover_metrics,
+            restore_paused=restore_paused,
         )
         await configure_kv_event_block_size(engine_client, vllm_config)
 

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -606,27 +607,40 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, []string{"run"}, podSpec.Containers[1].Args)
 	})
 
-	t.Run("failover targets shape every engine container", func(t *testing.T) {
+	t.Run("paused restore shapes only named target containers", func(t *testing.T) {
 		podSpec := &corev1.PodSpec{
 			Containers: []corev1.Container{
 				{Name: "engine-0", Image: "main:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
 				{Name: "engine-1", Image: "main:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
-				{Name: "sidecar", Image: "sidecar:latest", Command: []string{"sidecar"}, Args: []string{"run"}},
+				{Name: "engine-2", Image: "main:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
+				{Name: "gms-server", Image: "gms:latest", Command: []string{"gms-server"}, Args: []string{"--serve"}, Env: []corev1.EnvVar{{Name: "GMS", Value: "server"}}},
+				{Name: "gms-loader", Image: "gms:latest", Command: []string{"gms-loader"}, Args: []string{"--load"}, Env: []corev1.EnvVar{{Name: "GMS", Value: "loader"}}},
+				{Name: "user-helper", Image: "helper:latest", Command: []string{"helper"}, Args: []string{"run"}, Env: []corev1.EnvVar{{Name: "HELPER", Value: "true"}}},
 			},
 		}
+		nonTargets := make(map[string]corev1.Container)
+		for _, name := range []string{"gms-server", "gms-loader", "user-helper"} {
+			nonTargets[name] = *findContainer(podSpec, name).DeepCopy()
+		}
 		info := &CheckpointInfo{
-			Enabled:                 true,
-			Ready:                   true,
-			Hash:                    testHash,
-			RestoreTargetContainers: []string{"engine-0", "engine-1"},
+			Enabled: true,
+			Ready:   true,
+			Hash:    testHash,
+			GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+				Enabled: true,
+				Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+			},
+			RestoreTargetContainers: []string{"engine-0", "engine-1", "engine-2"},
+			RestorePaused:           true,
 		}
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
 
 		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
-		for _, name := range []string{"engine-0", "engine-1"} {
+		for _, name := range info.RestoreTargetContainers {
 			c := findContainer(podSpec, name)
 			require.NotNil(t, c, "container %q not found", name)
 			assertRestoreStandbyMode(t, c, []string{"python3"}, []string{"-m", "dynamo.vllm"})
+			assert.Contains(t, c.Env, corev1.EnvVar{Name: snapshotRestorePausedEnv, Value: "1"})
 			gotSubPath := ""
 			for _, m := range c.VolumeMounts {
 				if m.Name == snapshotprotocol.SnapshotControlVolumeName {
@@ -635,9 +649,36 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			}
 			assert.Equal(t, name, gotSubPath, "engine %s control-volume subPath", name)
 		}
-		sidecar := findContainer(podSpec, "sidecar")
-		require.NotNil(t, sidecar)
-		assert.Equal(t, []string{"sidecar"}, sidecar.Command, "sidecar must not be rewritten")
+		for name, before := range nonTargets {
+			after := findContainer(podSpec, name)
+			require.NotNil(t, after)
+			assert.True(t, equality.Semantic.DeepEqual(before, *after), "%s must cold-start unchanged", name)
+		}
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
+		count := 0
+		for i := range podSpec.InitContainers {
+			if podSpec.InitContainers[i].Name == gms.ServerContainerName {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("paused restore rejects unsupported GMS mode", func(t *testing.T) {
+		podSpec := testPodSpec()
+		info := &CheckpointInfo{
+			Enabled:       true,
+			Ready:         true,
+			Hash:          testHash,
+			RestorePaused: true,
+			GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+				Enabled: true,
+				Mode:    nvidiacomv1alpha1.GMSModeInterPod,
+			},
+		}
+		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
+
+		require.ErrorContains(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile), `mode "interPod" is not implemented`)
 	})
 
 	t.Run("ready checkpoint uses configured PVC storage without daemonset discovery", func(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -30,6 +30,8 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const snapshotRestorePausedEnv = "DYN_SNAPSHOT_RESTORE_PAUSED"
+
 func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]string, checkpointInfo *CheckpointInfo) {
 	_ = ApplyRestorePodMetadataWithStorageConfig(
 		labels,
@@ -37,6 +39,16 @@ func ApplyRestorePodMetadata(labels map[string]string, annotations map[string]st
 		checkpointInfo,
 		configv1alpha1.CheckpointStorageConfiguration{},
 	)
+}
+
+func setLiteralEnv(env []corev1.EnvVar, name, value string) []corev1.EnvVar {
+	for i := range env {
+		if env[i].Name == name {
+			env[i] = corev1.EnvVar{Name: name, Value: value}
+			return env
+		}
+	}
+	return append(env, corev1.EnvVar{Name: name, Value: value})
 }
 
 func ApplyRestorePodMetadataWithStorageConfig(
@@ -277,6 +289,9 @@ func InjectResolvedCheckpointIntoPodSpec(
 		}
 		if container == nil {
 			return fmt.Errorf("checkpoint restore target %q does not exist in pod spec", name)
+		}
+		if restore.info.RestorePaused {
+			container.Env = setLiteralEnv(container.Env, snapshotRestorePausedEnv, "1")
 		}
 		targetContainers = append(targetContainers, container)
 	}

--- a/deploy/operator/internal/checkpoint/resolve.go
+++ b/deploy/operator/internal/checkpoint/resolve.go
@@ -38,6 +38,8 @@ type CheckpointInfo struct {
 	StartupPolicy    nvidiacomv1alpha1.CheckpointStartupPolicy
 	// Empty means the restore pod targets the default main container.
 	RestoreTargetContainers []string
+	// RestorePaused keeps restored targets paused for owner election.
+	RestorePaused bool
 }
 
 func checkpointInfoFromObject(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (*CheckpointInfo, error) {


### PR DESCRIPTION
## Summary

This is the fourth layer of the seven-PR stack for [DEP #12671](https://github.com/ai-dynamo/dynamo/issues/12671). It adds a generic Snapshot handoff that can return a restored engine while it is still application-paused.

An ordinary Snapshot restore resumes the engine immediately. Failover needs a different order: restore first, then let the engine compete for ownership, and wake only the winner.

This layer depends on repaired [#12869](https://github.com/ai-dynamo/dynamo/pull/12869): its pre-election `EngineCore` monitor owns startup until the same monitor is transferred to the restored worker handler.

```mermaid
flowchart TD
    R["CRIU restore completes"] --> P{"Remain paused?"}
    P -- No --> A["Resume immediately<br/>existing behavior"]
    P -- Yes --> H["Return restored engine and<br/>original pause controller"]
    H --> L["External flock election"]
    L --> W["Winner resumes"]
```

The restore context now carries the target container's runtime environment, including target identity and the remain-paused policy. Both prefill and decode workers receive the complete Snapshot controller and reuse the original pause controller, avoiding a second pause operation.

The default remains resume-after-restore. GMS mode validation also remains active; the pause bit cannot bypass unsupported-mode checks.

This PR creates the lifecycle seam but does not select workloads that use it.

## Validation

- 13 common Snapshot lifecycle and restore-context tests passed
- focused paused-restore tests cover default resume and retained-paused behavior
- prefill/decode tests verify reuse of the original pause controller without re-pausing
- operator checkpoint tests passed
- changed Python compiled; Black and Ruff passed
- exact-commit operator build, DCO, signature, and diff-hygiene checks passed

### Rewritten seven-PR chain validation

- Operator checkpoint/controller/webhook validation passed with `go test ./internal/checkpoint ./internal/controller ./internal/webhook/validation -count=1`.
- Operator lint passed with `make lint`, invoking `golangci-lint v1.64.8`.
- Snapshot validation passed with `make lint`, `go test ./internal/criu -count=1`, `go test -race ./internal/criu -count=1`, `go test ./... -count=1`, and `go vet ./...` from `deploy/snapshot`.
- Python formatting/lint hooks passed with repository-pinned isort 5.12.0, Black 23.1.0, flake8 7.3.0, and Ruff 0.5.2.
- Independent reviews approved the rewritten local chain.
- No live AKS E2E is claimed for the rewritten heads.

Full CI is not claimed.

## Stack

GitHub Stack: [#12911](https://github.com/ai-dynamo/dynamo/stacks/12911)

| Order | PR | Change |
| ---: | --- | --- |
| 1 | [#12887](https://github.com/ai-dynamo/dynamo/pull/12887) | Remap clone-unsafe sockets during restore |
| 2 | [#12869](https://github.com/ai-dynamo/dynamo/pull/12869) | Elect the failover owner before worker publication |
| 3 | [#12870](https://github.com/ai-dynamo/dynamo/pull/12870) | Support a second IntraPod shadow |
| 4 | **[#12871](https://github.com/ai-dynamo/dynamo/pull/12871)** | **Retain restored engines paused** |
| 5 | [#12872](https://github.com/ai-dynamo/dynamo/pull/12872) | Verify automatic checkpoint provenance |
| 6 | [#12873](https://github.com/ai-dynamo/dynamo/pull/12873) | Bind workloads to verified checkpoints |
| 7 | [#12874](https://github.com/ai-dynamo/dynamo/pull/12874) | Enable Snapshot-backed IntraPod failover |
