### PR TITLE
feat(operator): allow snapshot-backed intra-pod failover

### DIFF
--- a/deploy/operator/internal/checkpoint/compatibility.go
+++ b/deploy/operator/internal/checkpoint/compatibility.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	checkpointInterPodCompatibilityMessage = "Snapshot with gpuMemoryService.mode=InterPod is unsupported"
-	checkpointFailoverCompatibilityMessage = "Snapshot with active/passive failover is temporarily unsupported"
 )
 
 // ValidateCheckpointCompatibility returns unsupported checkpoint combinations
@@ -28,9 +27,6 @@ func ValidateCheckpointCompatibility(experimental *nvidiacomv1beta1.Experimental
 	if experimental.GPUMemoryService != nil &&
 		experimental.GPUMemoryService.Mode == nvidiacomv1beta1.GMSModeInterPod {
 		violations = append(violations, errors.New(checkpointInterPodCompatibilityMessage))
-	}
-	if experimental.Failover != nil {
-		violations = append(violations, errors.New(checkpointFailoverCompatibilityMessage))
 	}
 
 	return violations

--- a/deploy/operator/internal/checkpoint/compatibility_test.go
+++ b/deploy/operator/internal/checkpoint/compatibility_test.go
@@ -50,7 +50,6 @@ func TestValidateCheckpointCompatibility(t *testing.T) {
 			},
 			wantErrs: []string{
 				checkpointInterPodCompatibilityMessage,
-				checkpointFailoverCompatibilityMessage,
 			},
 		},
 	}

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -266,7 +266,7 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 		return nil, err
 	}
 	if dynamo.IsIntraPodFailoverEnabled(component) {
-		if err := dynamo.PrepareVLLMAutomaticFailoverSnapshotSource(targetContainer); err != nil {
+		if err := dynamo.PrepareVLLMSnapshotSourceContainer(targetContainer); err != nil {
 			return nil, err
 		}
 	}

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -265,6 +265,11 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 	if err != nil {
 		return nil, err
 	}
+	if dynamo.IsIntraPodFailoverEnabled(component) {
+		if err := dynamo.PrepareVLLMAutomaticFailoverSnapshotSource(targetContainer); err != nil {
+			return nil, err
+		}
+	}
 	var gmsSpec *nvidiacomv1alpha1.GPUMemoryServiceSpec
 	if converted := gms.ToAlphaSpec(dynamo.GetGPUMemoryService(component)); converted != nil {
 		gmsSpec = converted.DeepCopy()

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -161,6 +161,24 @@ func (r *DynamoComponentDeploymentReconciler) Reconcile(ctx context.Context, req
 		}
 		return ctrl.Result{}, nil
 	}
+	if compatibilityErr := stderrors.Join(dynamo.ValidateAutomaticFailoverCheckpointTarget(
+		&dynamoComponentDeployment.Spec.DynamoComponentDeploymentSharedSpec,
+		dynamoComponentDeployment.Spec.BackendFramework,
+		dynamo.IsDGDControlled(dynamoComponentDeployment),
+	)...); compatibilityErr != nil {
+		if _, statusErr := r.setStatusConditions(ctx, req,
+			metav1.Condition{
+				Type:               nvidiacomv1beta1.DynamoComponentDeploymentConditionTypeAvailable,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: dynamoComponentDeployment.Generation,
+				Reason:             "InvalidCheckpointConfiguration",
+				Message:            compatibilityErr.Error(),
+			},
+		); statusErr != nil {
+			return ctrl.Result{}, statusErr
+		}
+		return ctrl.Result{}, nil
+	}
 
 	// Setup defer to handle errors and update status
 	defer func() {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -161,10 +161,9 @@ func (r *DynamoComponentDeploymentReconciler) Reconcile(ctx context.Context, req
 		}
 		return ctrl.Result{}, nil
 	}
-	if compatibilityErr := stderrors.Join(dynamo.ValidateAutomaticFailoverCheckpointTarget(
+	if compatibilityErr := stderrors.Join(dynamo.ValidateFailoverCheckpointForDCD(
 		&dynamoComponentDeployment.Spec.DynamoComponentDeploymentSharedSpec,
 		dynamoComponentDeployment.Spec.BackendFramework,
-		dynamo.IsDGDControlled(dynamoComponentDeployment),
 	)...); compatibilityErr != nil {
 		if _, statusErr := r.setStatusConditions(ctx, req,
 			metav1.Condition{

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -120,8 +120,7 @@ func TestDynamoComponentDeploymentReconcileRejectsStoredCheckpointIncompatibilit
 	require.Equal(t, dcd.Generation, available.ObservedGeneration)
 	require.Equal(t, "InvalidCheckpointConfiguration", available.Reason)
 	require.Equal(t,
-		"Snapshot with gpuMemoryService.mode=InterPod is unsupported\n"+
-			"Snapshot with active/passive failover is temporarily unsupported",
+		"Snapshot with gpuMemoryService.mode=InterPod is unsupported",
 		available.Message,
 	)
 	require.Zero(t, stored.Status.ObservedGeneration)
@@ -168,6 +167,7 @@ func TestDynamoComponentDeploymentReconcileFinalizesDeletingStoredCheckpointInco
 		require.False(t, controller_common.ContainsFinalizer(&stored))
 	}
 }
+
 
 func normalizeLeaderWorkerSetForCompare(lws *leaderworkersetv1.LeaderWorkerSet) *leaderworkersetv1.LeaderWorkerSet {
 	if lws == nil {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -168,7 +168,6 @@ func TestDynamoComponentDeploymentReconcileFinalizesDeletingStoredCheckpointInco
 	}
 }
 
-
 func normalizeLeaderWorkerSetForCompare(lws *leaderworkersetv1.LeaderWorkerSet) *leaderworkersetv1.LeaderWorkerSet {
 	if lws == nil {
 		return nil

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -163,7 +163,7 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 				fmt.Errorf("component %q: %w", component.ComponentName, compatibilityErr),
 			)
 		}
-		for _, compatibilityErr := range dynamo.ValidateAutomaticFailoverCheckpointSource(
+		for _, compatibilityErr := range dynamo.ValidateFailoverCheckpointForDGD(
 			component,
 			dynamoDeployment.Spec.BackendFramework,
 		) {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -163,6 +163,15 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 				fmt.Errorf("component %q: %w", component.ComponentName, compatibilityErr),
 			)
 		}
+		for _, compatibilityErr := range dynamo.ValidateAutomaticFailoverCheckpointSource(
+			component,
+			dynamoDeployment.Spec.BackendFramework,
+		) {
+			compatibilityErrs = append(
+				compatibilityErrs,
+				fmt.Errorf("component %q: %w", component.ComponentName, compatibilityErr),
+			)
+		}
 	}
 	if compatibilityErr := errors.Join(compatibilityErrs...); compatibilityErr != nil {
 		programResult := newWorkloadProgramResult(dynamoDeployment)

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -155,8 +155,7 @@ func TestDynamoGraphDeploymentReconcileLocksProviderBeforeRejectingStoredCheckpo
 	require.Equal(t, dgd.Generation, ready.ObservedGeneration)
 	require.Equal(t, string(reasonFailedToReconcileResources), ready.Reason)
 	require.Equal(t,
-		"component \"prefill\": Snapshot with gpuMemoryService.mode=InterPod is unsupported\n"+
-			"component \"decode\": Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint: checkpointRef must be omitted so the DGD owns the automatic checkpoint",
+		"component \"prefill\": Snapshot with gpuMemoryService.mode=InterPod is unsupported",
 		ready.Message,
 	)
 	require.Zero(t, stored.Status.ObservedGeneration)

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -42,6 +42,7 @@ import (
 	resourcev1 "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -89,6 +90,7 @@ func TestDynamoGraphDeploymentReconcileLocksProviderBeforeRejectingStoredCheckpo
 			Generation: 7,
 		},
 		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
 			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
 				{
 					ComponentName: "prefill",
@@ -100,9 +102,24 @@ func TestDynamoGraphDeploymentReconcileLocksProviderBeforeRejectingStoredCheckpo
 				},
 				{
 					ComponentName: "decode",
+					ComponentType: v1beta1.ComponentTypeWorker,
+					PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:    commonconsts.MainContainerName,
+							Command: []string{"python3"},
+							Args:    []string{"-m", "dynamo.vllm"},
+							Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+								corev1.ResourceName(commonconsts.KubeResourceGPUNvidia): resource.MustParse("1"),
+							}},
+						}},
+					}},
 					Experimental: &v1beta1.ExperimentalSpec{
-						Checkpoint: &v1beta1.ComponentCheckpointConfig{Enabled: true},
-						Failover:   &v1beta1.FailoverSpec{},
+						Checkpoint: &v1beta1.ComponentCheckpointConfig{
+							Enabled:       true,
+							CheckpointRef: ptr.To("foreign-checkpoint"),
+						},
+						GPUMemoryService: &v1beta1.GPUMemoryServiceSpec{Mode: v1beta1.GMSModeIntraPod},
+						Failover:         &v1beta1.FailoverSpec{Mode: v1beta1.GMSModeIntraPod, NumShadows: 1},
 					},
 				},
 			},
@@ -139,8 +156,7 @@ func TestDynamoGraphDeploymentReconcileLocksProviderBeforeRejectingStoredCheckpo
 	require.Equal(t, string(reasonFailedToReconcileResources), ready.Reason)
 	require.Equal(t,
 		"component \"prefill\": Snapshot with gpuMemoryService.mode=InterPod is unsupported\n"+
-			"component \"prefill\": Snapshot with active/passive failover is temporarily unsupported\n"+
-			"component \"decode\": Snapshot with active/passive failover is temporarily unsupported",
+			"component \"decode\": Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint: checkpointRef must be omitted so the DGD owns the automatic checkpoint",
 		ready.Message,
 	)
 	require.Zero(t, stored.Status.ObservedGeneration)

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -412,7 +412,7 @@ const (
 	vllmModuleName                         = "dynamo.vllm"
 	vllmLoadFormatFlag                     = "--load-format"
 	vllmWorkerClassFlag                    = "--worker-cls"
-	checkpointFailoverCompatibilityMessage = "Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint"
+	checkpointFailoverCompatibilityMessage = "Snapshot with active/passive failover requires an operator-managed automatic single-node Worker checkpoint"
 )
 
 // ValidateAutomaticFailoverCheckpointSource validates the DGD component that
@@ -473,8 +473,9 @@ func validateFailoverCheckpointProfile(
 	if config.TargetContainerName != "" && config.TargetContainerName != commonconsts.MainContainerName {
 		violations = append(violations, errors.New("targetContainerName must be main"))
 	}
-	if BackendFramework(backendFramework) != BackendFrameworkVLLM {
-		violations = append(violations, errors.New("backendFramework must be vllm"))
+	backend := BackendFramework(backendFramework)
+	if backend != BackendFrameworkVLLM && backend != BackendFrameworkSGLang {
+		violations = append(violations, errors.New("backendFramework must be vllm or sglang"))
 	}
 	if component.ComponentType != v1beta1.ComponentTypeWorker {
 		violations = append(violations, errors.New("component type must be Worker"))
@@ -504,7 +505,7 @@ func validateFailoverCheckpointProfile(
 	// The operator derives these from DYN_GMS_USE_V1, which it injects when a
 	// checkpoint is configured. A user value is either ignored or contradicts
 	// the operator's selection, so reject it rather than silently rewriting it.
-	for _, flag := range []string{vllmWorkerClassFlag, vllmLoadFormatFlag} {
+	for _, flag := range vllmOperatorManagedFlags(backend) {
 		if _, _, _, found, err := tokenizedVLLMFlag(main.Args, flag); err != nil {
 			violations = append(violations, err)
 		} else if found {
@@ -518,18 +519,7 @@ func validateFailoverCheckpointProfile(
 			violations = append(violations, fmt.Errorf("%s is managed by the operator and must not be set", name))
 		}
 	}
-	for _, profile := range []struct {
-		flag         string
-		defaultValue string
-		want         string
-		description  string
-	}{
-		{flag: "--disaggregation-mode", defaultValue: "agg", want: "agg", description: "disaggregation mode must be aggregated"},
-		{flag: "--request-plane", defaultValue: "tcp", want: "tcp", description: "request plane must be tcp"},
-		{flag: tensorParallelSizeFlag, defaultValue: "1", want: "1", description: "tensor parallel size must be 1"},
-		{flag: pipelineParallelSizeFlag, defaultValue: "1", want: "1", description: "pipeline parallel size must be 1"},
-		{flag: dataParallelSizeFlag, defaultValue: "1", want: "1", description: "data parallel size must be 1"},
-	} {
+	for _, profile := range failoverSnapshotFlagProfile(backend) {
 		value, _, _, found, err := tokenizedVLLMFlag(main.Args, profile.flag)
 		if err != nil {
 			violations = append(violations, err)
@@ -543,6 +533,47 @@ func validateFailoverCheckpointProfile(
 		}
 	}
 	return violations
+}
+
+type failoverSnapshotFlag struct {
+	flag         string
+	defaultValue string
+	want         string
+	description  string
+}
+
+// failoverSnapshotFlagProfile returns the engine arguments that must resolve to a
+// single-rank aggregated worker. The two engines share one GPU, so any form of
+// parallelism or disaggregation is unsupported. vLLM and SGLang spell the
+// parallelism flags differently.
+func failoverSnapshotFlagProfile(backend BackendFramework) []failoverSnapshotFlag {
+	shared := []failoverSnapshotFlag{
+		{flag: "--disaggregation-mode", defaultValue: "agg", want: "agg", description: "disaggregation mode must be aggregated"},
+		{flag: "--request-plane", defaultValue: "tcp", want: "tcp", description: "request plane must be tcp"},
+	}
+	switch backend {
+	case BackendFrameworkSGLang:
+		return append(shared,
+			failoverSnapshotFlag{flag: "--tp", defaultValue: "1", want: "1", description: "tensor parallel size must be 1"},
+			failoverSnapshotFlag{flag: "--dp-size", defaultValue: "1", want: "1", description: "data parallel size must be 1"},
+			failoverSnapshotFlag{flag: "--pp-size", defaultValue: "1", want: "1", description: "pipeline parallel size must be 1"},
+		)
+	default:
+		return append(shared,
+			failoverSnapshotFlag{flag: tensorParallelSizeFlag, defaultValue: "1", want: "1", description: "tensor parallel size must be 1"},
+			failoverSnapshotFlag{flag: pipelineParallelSizeFlag, defaultValue: "1", want: "1", description: "pipeline parallel size must be 1"},
+			failoverSnapshotFlag{flag: dataParallelSizeFlag, defaultValue: "1", want: "1", description: "data parallel size must be 1"},
+		)
+	}
+}
+
+// vllmOperatorManagedFlags lists engine arguments the operator derives from
+// DYN_GMS_USE_V1. SGLang has no equivalent user-facing flags.
+func vllmOperatorManagedFlags(backend BackendFramework) []string {
+	if backend != BackendFrameworkVLLM {
+		return nil
+	}
+	return []string{vllmWorkerClassFlag, vllmLoadFormatFlag}
 }
 
 func wrapFailoverCompatibilityViolations(violations []error) []error {
@@ -658,8 +689,11 @@ func buildFailoverPod(
 	switch backendFramework {
 	case BackendFrameworkVLLM:
 		applyVLLMOverrides(updated, numberOfNodes)
+	case BackendFrameworkSGLang:
+		// SGLang needs only the backend-agnostic engine identity, health and
+		// lock wiring applied above; there are no per-engine ports to stagger.
 	default:
-		return fmt.Errorf("failover is currently supported only for vLLM (detected: %s)", backendFramework)
+		return fmt.Errorf("failover is currently supported only for vLLM and SGLang (detected: %s)", backendFramework)
 	}
 
 	*podSpec = *updated

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -32,7 +32,6 @@ import (
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
@@ -278,6 +277,15 @@ func addGPUToleration(podSpec *corev1.PodSpec) {
 }
 
 // removeEnvVar removes all occurrences of the named env var from a container.
+func containerHasEnvVar(c *corev1.Container, name string) bool {
+	for i := range c.Env {
+		if c.Env[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func removeEnvVar(c *corev1.Container, name string) {
 	filtered := c.Env[:0]
 	for _, e := range c.Env {
@@ -404,60 +412,36 @@ const (
 	vllmModuleName                         = "dynamo.vllm"
 	vllmLoadFormatFlag                     = "--load-format"
 	vllmWorkerClassFlag                    = "--worker-cls"
-	gmsV0VLLMWorkerClass                   = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
-	gmsV0VLLMWorkerClassAlt                = "gpu_memory_service.integrations.vllm.worker:GMSWorker"
-	gmsV1VLLMWorkerClass                   = "gpu_memory_service.v1.integrations.vllm.worker.GMSV1Worker"
 	checkpointFailoverCompatibilityMessage = "Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint"
 )
 
-// IsDGDControlled reports whether a DCD has an exact DynamoGraphDeployment
-// controller reference. Admission separately verifies the request principal.
-func IsDGDControlled(dcd *v1beta1.DynamoComponentDeployment) bool {
-	if dcd == nil {
-		return false
-	}
-	owner := metav1.GetControllerOf(dcd)
-	return owner != nil &&
-		owner.APIVersion == v1beta1.GroupVersion.String() &&
-		owner.Kind == "DynamoGraphDeployment" &&
-		owner.Name != "" &&
-		owner.UID != ""
-}
-
 // ValidateAutomaticFailoverCheckpointSource validates the DGD component that
 // produces the one canonical checkpoint source.
-func ValidateAutomaticFailoverCheckpointSource(
+func ValidateFailoverCheckpointForDGD(
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
 	backendFramework string,
 ) []error {
 	if !hasCheckpointFailover(component) {
 		return nil
 	}
-	violations := validateAutomaticFailoverCheckpointProfile(component, backendFramework)
-	config := component.Experimental.Checkpoint
-	if config.CheckpointRef != nil && *config.CheckpointRef != "" {
-		violations = append(violations, errors.New("checkpointRef must be omitted so the DGD owns the automatic checkpoint"))
-	}
-	return wrapFailoverCompatibilityViolations(violations)
+	return wrapFailoverCompatibilityViolations(
+		validateFailoverCheckpointProfile(component, backendFramework),
+	)
 }
 
 // ValidateAutomaticFailoverCheckpointTarget validates the DCD that restores
 // the DGD-owned checkpoint into the configured failover engines.
-func ValidateAutomaticFailoverCheckpointTarget(
+func ValidateFailoverCheckpointForDCD(
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
 	backendFramework string,
-	operatorGenerated bool,
 ) []error {
 	if !hasCheckpointFailover(component) {
 		return nil
 	}
-	violations := validateAutomaticFailoverCheckpointProfile(component, backendFramework)
-	if !operatorGenerated {
-		violations = append(violations, errors.New("checkpoint failover is only supported for an operator-generated DCD"))
-	}
+	violations := validateFailoverCheckpointProfile(component, backendFramework)
 	config := component.Experimental.Checkpoint
 	if config.CheckpointRef == nil || *config.CheckpointRef == "" {
-		violations = append(violations, errors.New("checkpointRef must name the DGD-owned automatic checkpoint"))
+		violations = append(violations, errors.New("checkpointRef must name the checkpoint to restore"))
 	}
 	return wrapFailoverCompatibilityViolations(violations)
 }
@@ -472,7 +456,7 @@ func hasCheckpointFailover(component *v1beta1.DynamoComponentDeploymentSharedSpe
 		IsIntraPodFailoverEnabled(component)
 }
 
-func validateAutomaticFailoverCheckpointProfile(
+func validateFailoverCheckpointProfile(
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
 	backendFramework string,
 ) []error {
@@ -517,9 +501,22 @@ func validateAutomaticFailoverCheckpointProfile(
 	} else if gpuCount != 1 {
 		violations = append(violations, errors.New("main container must request exactly one GPU"))
 	}
-	if err := configureVLLMAutomaticSnapshotLoadProfile(main.DeepCopy()); err != nil {
-		violations = append(violations, err)
-		return violations
+	// The operator derives these from DYN_GMS_USE_V1, which it injects when a
+	// checkpoint is configured. A user value is either ignored or contradicts
+	// the operator's selection, so reject it rather than silently rewriting it.
+	for _, flag := range []string{vllmWorkerClassFlag, vllmLoadFormatFlag} {
+		if _, _, _, found, err := tokenizedVLLMFlag(main.Args, flag); err != nil {
+			violations = append(violations, err)
+		} else if found {
+			violations = append(violations, fmt.Errorf("%s is managed by the operator and must not be set", flag))
+		}
+	}
+	// Operator-managed environment. DYN_VLLM_GMS_SHADOW_MODE marks a cold-start
+	// shadow engine; DYN_FORWARDPASS_METRIC_PORT is assigned per engine.
+	for _, name := range []string{"DYN_VLLM_GMS_SHADOW_MODE", "DYN_FORWARDPASS_METRIC_PORT"} {
+		if containerHasEnvVar(main, name) {
+			violations = append(violations, fmt.Errorf("%s is managed by the operator and must not be set", name))
+		}
 	}
 	for _, profile := range []struct {
 		flag         string
@@ -555,89 +552,17 @@ func wrapFailoverCompatibilityViolations(violations []error) []error {
 	return []error{fmt.Errorf("%s: %w", checkpointFailoverCompatibilityMessage, errors.Join(violations...))}
 }
 
-// PrepareVLLMAutomaticFailoverSnapshotSource applies only checkpoint-source
-// changes to the canonical main container. Destination engine topology is
-// added later when the DGD worker pod is rendered.
-func PrepareVLLMAutomaticFailoverSnapshotSource(container *corev1.Container) error {
+// PrepareVLLMSnapshotSourceContainer reconciles operator-injected configuration
+// that a capture pod must not carry. WorkerDefaults.GetBaseContainer stamps
+// DYN_FORWARDPASS_METRIC_PORT on every worker; a capture pod has no Dynamo
+// endpoint to publish to. This cannot be asserted upstream because the operator
+// injects it during pod generation, after validation has already run.
+func PrepareVLLMSnapshotSourceContainer(container *corev1.Container) error {
 	if container == nil {
-		return fmt.Errorf("automatic failover snapshot source container is nil")
+		return fmt.Errorf("snapshot source container is nil")
 	}
-	updated := container.DeepCopy()
-	removeEnvVar(updated, "DYN_FORWARDPASS_METRIC_PORT")
-	updated.Env = MergeEnvs(updated.Env, []corev1.EnvVar{
-		{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "false"},
-		{Name: "DYN_VLLM_DISAGGREGATION_MODE", Value: "agg"},
-		{Name: "DYN_REQUEST_PLANE", Value: "tcp"},
-	})
-	if err := configureVLLMAutomaticSnapshotLoadProfile(updated); err != nil {
-		return fmt.Errorf("automatic failover snapshot source: %w", err)
-	}
-	*container = *updated
+	removeEnvVar(container, "DYN_FORWARDPASS_METRIC_PORT")
 	return nil
-}
-
-func configureVLLMAutomaticSnapshotLoadProfile(container *corev1.Container) error {
-	if !isDirectDynamoVLLMCommand(container) {
-		return fmt.Errorf(
-			"requires a direct python -m %s command with tokenized arguments (command=%q args=%q)",
-			vllmModuleName,
-			container.Command,
-			container.Args,
-		)
-	}
-	if slices.Contains(container.Args, "--") {
-		return fmt.Errorf("arguments after -- are unsupported")
-	}
-
-	workerClass, _, _, _, err := tokenizedVLLMFlag(container.Args, vllmWorkerClassFlag)
-	if err != nil {
-		return err
-	}
-	switch workerClass {
-	case gmsV1VLLMWorkerClass:
-		loadFormat, _, _, found, err := tokenizedVLLMFlag(container.Args, vllmLoadFormatFlag)
-		if err != nil {
-			return err
-		}
-		if found && loadFormat != "auto" {
-			return fmt.Errorf("%s %s requires %s auto", vllmWorkerClassFlag, gmsV1VLLMWorkerClass, vllmLoadFormatFlag)
-		}
-		return nil
-	case "", "auto", gmsV0VLLMWorkerClass, gmsV0VLLMWorkerClassAlt:
-		args, err := upsertTokenizedVLLMFlag(container.Args, vllmLoadFormatFlag, "gms")
-		if err != nil {
-			return err
-		}
-		container.Args = args
-		return nil
-	default:
-		return fmt.Errorf("%s %q is unsupported for automatic snapshot failover", vllmWorkerClassFlag, workerClass)
-	}
-}
-
-func isDirectDynamoVLLMCommand(container *corev1.Container) bool {
-	args := container.Args
-	switch {
-	case len(container.Command) == 0 &&
-		len(args) >= 3 &&
-		isPythonCommand(args[0]) &&
-		args[1] == "-m" &&
-		args[2] == vllmModuleName:
-		return true
-	case len(container.Command) == 1 &&
-		isPythonCommand(container.Command[0]) &&
-		len(args) >= 2 &&
-		args[0] == "-m" &&
-		args[1] == vllmModuleName:
-		return true
-	case len(container.Command) == 3 &&
-		isPythonCommand(container.Command[0]) &&
-		container.Command[1] == "-m" &&
-		container.Command[2] == vllmModuleName:
-		return true
-	default:
-		return false
-	}
 }
 
 func tokenizedVLLMFlag(args []string, flag string) (value string, index int, equalsForm, found bool, err error) {
@@ -666,22 +591,10 @@ func tokenizedVLLMFlag(args []string, flag string) (value string, index int, equ
 	return value, index, equalsForm, found, nil
 }
 
-func upsertTokenizedVLLMFlag(args []string, flag, value string) ([]string, error) {
-	_, index, equalsForm, found, err := tokenizedVLLMFlag(args, flag)
-	if err != nil {
-		return nil, err
-	}
-	switch {
-	case !found:
-		args = append(args, flag, value)
-	case equalsForm:
-		args[index] = flag + "=" + value
-	default:
-		args[index+1] = value
-	}
-	return args, nil
-}
-
+// configureCheckpointFailoverEngines adapts failover engine containers for the
+// snapshot-backed path. Shadow mode is incompatible with failover + snapshot,
+// which runs on GMS V1: it is set unconditionally for intra-pod failover by
+// applyVLLMOverrides, so unset it here.
 func configureCheckpointFailoverEngines(
 	podSpec *corev1.PodSpec,
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
@@ -689,10 +602,7 @@ func configureCheckpointFailoverEngines(
 	engineNames := IntraPodFailoverEngineContainerNames()
 	for i := range podSpec.Containers {
 		if slices.Contains(engineNames, podSpec.Containers[i].Name) {
-			podSpec.Containers[i].Env = MergeEnvs(podSpec.Containers[i].Env, []corev1.EnvVar{
-				{Name: "DYN_VLLM_DISAGGREGATION_MODE", Value: "agg"},
-				{Name: "DYN_REQUEST_PLANE", Value: "tcp"},
-			})
+			removeEnvVar(&podSpec.Containers[i], "DYN_VLLM_GMS_SHADOW_MODE")
 		}
 	}
 }

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -509,7 +509,7 @@ func validateFailoverCheckpointProfile(
 		// DYN_VLLM_GMS_SHADOW_MODE marks a cold-start shadow engine and is unset
 		// on the snapshot path. SGLang has no equivalents.
 		for _, flag := range []string{vllmWorkerClassFlag, vllmLoadFormatFlag} {
-			if _, _, _, found, err := tokenizedFlag(main.Args, flag); err != nil {
+			if _, found, err := tokenizedFlag(main.Args, flag); err != nil {
 				violations = append(violations, err)
 			} else if found {
 				violations = append(violations, fmt.Errorf("%s is managed by the operator and must not be set", flag))
@@ -524,7 +524,7 @@ func validateFailoverCheckpointProfile(
 		violations = append(violations, errors.New("DYN_FORWARDPASS_METRIC_PORT is managed by the operator and must not be set"))
 	}
 	for _, profile := range failoverSnapshotFlagProfile(backend) {
-		value, _, _, found, err := tokenizedFlag(main.Args, profile.flag)
+		value, found, err := tokenizedFlag(main.Args, profile.flag)
 		if err != nil {
 			violations = append(violations, err)
 			continue
@@ -591,40 +591,36 @@ func PrepareVLLMSnapshotSourceContainer(container *corev1.Container) error {
 	return nil
 }
 
-func tokenizedFlag(args []string, flag string) (value string, index int, equalsForm, found bool, err error) {
-	index = -1
+func tokenizedFlag(args []string, flag string) (value string, found bool, err error) {
 	for i, arg := range args {
 		switch {
 		case arg == flag:
 			if found {
-				return "", -1, false, false, fmt.Errorf("%s must appear at most once", flag)
+				return "", false, fmt.Errorf("%s must appear at most once", flag)
 			}
 			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "--") {
-				return "", -1, false, false, fmt.Errorf("%s requires a value", flag)
+				return "", false, fmt.Errorf("%s requires a value", flag)
 			}
-			value, index, found = args[i+1], i, true
+			value, found = args[i+1], true
 		case strings.HasPrefix(arg, flag+"="):
 			if found {
-				return "", -1, false, false, fmt.Errorf("%s must appear at most once", flag)
+				return "", false, fmt.Errorf("%s must appear at most once", flag)
 			}
 			value = strings.TrimPrefix(arg, flag+"=")
 			if value == "" {
-				return "", -1, false, false, fmt.Errorf("%s requires a value", flag)
+				return "", false, fmt.Errorf("%s requires a value", flag)
 			}
-			index, equalsForm, found = i, true, true
+			found = true
 		}
 	}
-	return value, index, equalsForm, found, nil
+	return value, found, nil
 }
 
 // configureCheckpointFailoverEngines adapts failover engine containers for the
 // snapshot-backed path. Shadow mode is incompatible with failover + snapshot,
 // which runs on GMS V1: it is set unconditionally for intra-pod failover by
 // applyVLLMOverrides, so unset it here.
-func configureCheckpointFailoverEngines(
-	podSpec *corev1.PodSpec,
-	component *v1beta1.DynamoComponentDeploymentSharedSpec,
-) {
+func configureCheckpointFailoverEngines(podSpec *corev1.PodSpec) {
 	engineNames := IntraPodFailoverEngineContainerNames()
 	for i := range podSpec.Containers {
 		if slices.Contains(engineNames, podSpec.Containers[i].Name) {

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -18,8 +18,10 @@
 package dynamo
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -30,6 +32,7 @@ import (
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
@@ -387,9 +390,9 @@ func gmsResourceSharingEntries(serviceName string, roles []ServiceRole) []grovev
 // ──────────────────────────────────────────────────────────────────────────────
 // Intra-pod GMS failover (Mode: intraPod)
 //
-// The main container is cloned into two engine containers (active + standby)
-// within the same pod. GPU access is shared via DRA and a GMS sidecar
-// injects weights via the shared emptyDir volume.
+// The main container is cloned into active and standby engine containers within
+// the same pod. GPU access is shared via DRA and a GMS sidecar injects weights
+// via the shared emptyDir volume.
 // ──────────────────────────────────────────────────────────────────────────────
 
 // intraPodFailoverLockFile is the lock file path used by engine containers to
@@ -397,8 +400,302 @@ func gmsResourceSharingEntries(serviceName string, roles []ServiceRole) []grovev
 var intraPodFailoverLockFile = filepath.Join(gmsruntime.SharedMountPath, "failover.lock")
 
 const (
-	failoverEngineCount = 2
+	failoverEngineCount                    = 2
+	vllmModuleName                         = "dynamo.vllm"
+	vllmLoadFormatFlag                     = "--load-format"
+	vllmWorkerClassFlag                    = "--worker-cls"
+	gmsV0VLLMWorkerClass                   = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
+	gmsV0VLLMWorkerClassAlt                = "gpu_memory_service.integrations.vllm.worker:GMSWorker"
+	gmsV1VLLMWorkerClass                   = "gpu_memory_service.v1.integrations.vllm.worker.GMSV1Worker"
+	checkpointFailoverCompatibilityMessage = "Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint"
 )
+
+// IsDGDControlled reports whether a DCD has an exact DynamoGraphDeployment
+// controller reference. Admission separately verifies the request principal.
+func IsDGDControlled(dcd *v1beta1.DynamoComponentDeployment) bool {
+	if dcd == nil {
+		return false
+	}
+	owner := metav1.GetControllerOf(dcd)
+	return owner != nil &&
+		owner.APIVersion == v1beta1.GroupVersion.String() &&
+		owner.Kind == "DynamoGraphDeployment" &&
+		owner.Name != "" &&
+		owner.UID != ""
+}
+
+// ValidateAutomaticFailoverCheckpointSource validates the DGD component that
+// produces the one canonical checkpoint source.
+func ValidateAutomaticFailoverCheckpointSource(
+	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+	backendFramework string,
+) []error {
+	if !hasCheckpointFailover(component) {
+		return nil
+	}
+	violations := validateAutomaticFailoverCheckpointProfile(component, backendFramework)
+	config := component.Experimental.Checkpoint
+	if config.CheckpointRef != nil && *config.CheckpointRef != "" {
+		violations = append(violations, errors.New("checkpointRef must be omitted so the DGD owns the automatic checkpoint"))
+	}
+	return wrapFailoverCompatibilityViolations(violations)
+}
+
+// ValidateAutomaticFailoverCheckpointTarget validates the DCD that restores
+// the DGD-owned checkpoint into the configured failover engines.
+func ValidateAutomaticFailoverCheckpointTarget(
+	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+	backendFramework string,
+	operatorGenerated bool,
+) []error {
+	if !hasCheckpointFailover(component) {
+		return nil
+	}
+	violations := validateAutomaticFailoverCheckpointProfile(component, backendFramework)
+	if !operatorGenerated {
+		violations = append(violations, errors.New("checkpoint failover is only supported for an operator-generated DCD"))
+	}
+	config := component.Experimental.Checkpoint
+	if config.CheckpointRef == nil || *config.CheckpointRef == "" {
+		violations = append(violations, errors.New("checkpointRef must name the DGD-owned automatic checkpoint"))
+	}
+	return wrapFailoverCompatibilityViolations(violations)
+}
+
+func hasCheckpointFailover(component *v1beta1.DynamoComponentDeploymentSharedSpec) bool {
+	return component != nil &&
+		component.Experimental != nil &&
+		component.Experimental.Checkpoint != nil &&
+		component.Experimental.Checkpoint.Enabled &&
+		(component.Experimental.GPUMemoryService == nil ||
+			component.Experimental.GPUMemoryService.Mode != v1beta1.GMSModeInterPod) &&
+		IsIntraPodFailoverEnabled(component)
+}
+
+func validateAutomaticFailoverCheckpointProfile(
+	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+	backendFramework string,
+) []error {
+	experimental := component.Experimental
+	config := experimental.Checkpoint
+	violations := make([]error, 0, 12)
+
+	if config.Mode != "" && config.Mode != v1beta1.CheckpointModeAuto {
+		violations = append(violations, errors.New("checkpoint mode must be automatic"))
+	}
+	if config.DeletionPolicy != "" && config.DeletionPolicy != v1beta1.CheckpointDeletionPolicyDelete {
+		violations = append(violations, errors.New("deletionPolicy must be Delete"))
+	}
+	if config.TargetContainerName != "" && config.TargetContainerName != commonconsts.MainContainerName {
+		violations = append(violations, errors.New("targetContainerName must be main"))
+	}
+	if BackendFramework(backendFramework) != BackendFrameworkVLLM {
+		violations = append(violations, errors.New("backendFramework must be vllm"))
+	}
+	if component.ComponentType != v1beta1.ComponentTypeWorker {
+		violations = append(violations, errors.New("component type must be Worker"))
+	}
+	if experimental.GPUMemoryService == nil ||
+		(experimental.GPUMemoryService.Mode != "" &&
+			experimental.GPUMemoryService.Mode != v1beta1.GMSModeIntraPod) {
+		violations = append(violations, errors.New("gpuMemoryService.mode must be IntraPod"))
+	}
+	if !IsIntraPodFailoverEnabled(component) {
+		violations = append(violations, errors.New("failover.mode must be IntraPod"))
+	}
+	if component.GetNumberOfNodes() != 1 {
+		violations = append(violations, errors.New("worker must use exactly one node"))
+	}
+
+	main := GetMainContainer(component)
+	if main == nil {
+		return append(violations, errors.New("podTemplate must contain the main container"))
+	}
+	gpuCount, err := getGPUCount(main.Resources)
+	if err != nil {
+		violations = append(violations, fmt.Errorf("main container GPU resources are invalid: %w", err))
+	} else if gpuCount != 1 {
+		violations = append(violations, errors.New("main container must request exactly one GPU"))
+	}
+	if err := configureVLLMAutomaticSnapshotLoadProfile(main.DeepCopy()); err != nil {
+		violations = append(violations, err)
+		return violations
+	}
+	for _, profile := range []struct {
+		flag         string
+		defaultValue string
+		want         string
+		description  string
+	}{
+		{flag: "--disaggregation-mode", defaultValue: "agg", want: "agg", description: "disaggregation mode must be aggregated"},
+		{flag: "--request-plane", defaultValue: "tcp", want: "tcp", description: "request plane must be tcp"},
+		{flag: tensorParallelSizeFlag, defaultValue: "1", want: "1", description: "tensor parallel size must be 1"},
+		{flag: pipelineParallelSizeFlag, defaultValue: "1", want: "1", description: "pipeline parallel size must be 1"},
+		{flag: dataParallelSizeFlag, defaultValue: "1", want: "1", description: "data parallel size must be 1"},
+	} {
+		value, _, _, found, err := tokenizedVLLMFlag(main.Args, profile.flag)
+		if err != nil {
+			violations = append(violations, err)
+			continue
+		}
+		if !found {
+			value = profile.defaultValue
+		}
+		if value != profile.want {
+			violations = append(violations, fmt.Errorf("%s (got %q)", profile.description, value))
+		}
+	}
+	return violations
+}
+
+func wrapFailoverCompatibilityViolations(violations []error) []error {
+	if len(violations) == 0 {
+		return nil
+	}
+	return []error{fmt.Errorf("%s: %w", checkpointFailoverCompatibilityMessage, errors.Join(violations...))}
+}
+
+// PrepareVLLMAutomaticFailoverSnapshotSource applies only checkpoint-source
+// changes to the canonical main container. Destination engine topology is
+// added later when the DGD worker pod is rendered.
+func PrepareVLLMAutomaticFailoverSnapshotSource(container *corev1.Container) error {
+	if container == nil {
+		return fmt.Errorf("automatic failover snapshot source container is nil")
+	}
+	updated := container.DeepCopy()
+	removeEnvVar(updated, "DYN_FORWARDPASS_METRIC_PORT")
+	updated.Env = MergeEnvs(updated.Env, []corev1.EnvVar{
+		{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "false"},
+		{Name: "DYN_VLLM_DISAGGREGATION_MODE", Value: "agg"},
+		{Name: "DYN_REQUEST_PLANE", Value: "tcp"},
+	})
+	if err := configureVLLMAutomaticSnapshotLoadProfile(updated); err != nil {
+		return fmt.Errorf("automatic failover snapshot source: %w", err)
+	}
+	*container = *updated
+	return nil
+}
+
+func configureVLLMAutomaticSnapshotLoadProfile(container *corev1.Container) error {
+	if !isDirectDynamoVLLMCommand(container) {
+		return fmt.Errorf(
+			"requires a direct python -m %s command with tokenized arguments (command=%q args=%q)",
+			vllmModuleName,
+			container.Command,
+			container.Args,
+		)
+	}
+	if slices.Contains(container.Args, "--") {
+		return fmt.Errorf("arguments after -- are unsupported")
+	}
+
+	workerClass, _, _, _, err := tokenizedVLLMFlag(container.Args, vllmWorkerClassFlag)
+	if err != nil {
+		return err
+	}
+	switch workerClass {
+	case gmsV1VLLMWorkerClass:
+		loadFormat, _, _, found, err := tokenizedVLLMFlag(container.Args, vllmLoadFormatFlag)
+		if err != nil {
+			return err
+		}
+		if found && loadFormat != "auto" {
+			return fmt.Errorf("%s %s requires %s auto", vllmWorkerClassFlag, gmsV1VLLMWorkerClass, vllmLoadFormatFlag)
+		}
+		return nil
+	case "", "auto", gmsV0VLLMWorkerClass, gmsV0VLLMWorkerClassAlt:
+		args, err := upsertTokenizedVLLMFlag(container.Args, vllmLoadFormatFlag, "gms")
+		if err != nil {
+			return err
+		}
+		container.Args = args
+		return nil
+	default:
+		return fmt.Errorf("%s %q is unsupported for automatic snapshot failover", vllmWorkerClassFlag, workerClass)
+	}
+}
+
+func isDirectDynamoVLLMCommand(container *corev1.Container) bool {
+	args := container.Args
+	switch {
+	case len(container.Command) == 0 &&
+		len(args) >= 3 &&
+		isPythonCommand(args[0]) &&
+		args[1] == "-m" &&
+		args[2] == vllmModuleName:
+		return true
+	case len(container.Command) == 1 &&
+		isPythonCommand(container.Command[0]) &&
+		len(args) >= 2 &&
+		args[0] == "-m" &&
+		args[1] == vllmModuleName:
+		return true
+	case len(container.Command) == 3 &&
+		isPythonCommand(container.Command[0]) &&
+		container.Command[1] == "-m" &&
+		container.Command[2] == vllmModuleName:
+		return true
+	default:
+		return false
+	}
+}
+
+func tokenizedVLLMFlag(args []string, flag string) (value string, index int, equalsForm, found bool, err error) {
+	index = -1
+	for i, arg := range args {
+		switch {
+		case arg == flag:
+			if found {
+				return "", -1, false, false, fmt.Errorf("%s must appear at most once", flag)
+			}
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "--") {
+				return "", -1, false, false, fmt.Errorf("%s requires a value", flag)
+			}
+			value, index, found = args[i+1], i, true
+		case strings.HasPrefix(arg, flag+"="):
+			if found {
+				return "", -1, false, false, fmt.Errorf("%s must appear at most once", flag)
+			}
+			value = strings.TrimPrefix(arg, flag+"=")
+			if value == "" {
+				return "", -1, false, false, fmt.Errorf("%s requires a value", flag)
+			}
+			index, equalsForm, found = i, true, true
+		}
+	}
+	return value, index, equalsForm, found, nil
+}
+
+func upsertTokenizedVLLMFlag(args []string, flag, value string) ([]string, error) {
+	_, index, equalsForm, found, err := tokenizedVLLMFlag(args, flag)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case !found:
+		args = append(args, flag, value)
+	case equalsForm:
+		args[index] = flag + "=" + value
+	default:
+		args[index+1] = value
+	}
+	return args, nil
+}
+
+func configureCheckpointFailoverEngines(
+	podSpec *corev1.PodSpec,
+	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+) {
+	engineNames := IntraPodFailoverEngineContainerNames()
+	for i := range podSpec.Containers {
+		if slices.Contains(engineNames, podSpec.Containers[i].Name) {
+			podSpec.Containers[i].Env = MergeEnvs(podSpec.Containers[i].Env, []corev1.EnvVar{
+				{Name: "DYN_VLLM_DISAGGREGATION_MODE", Value: "agg"},
+				{Name: "DYN_REQUEST_PLANE", Value: "tcp"},
+			})
+		}
+	}
+}
 
 // IsIntraPodFailoverEnabled is true only when failover clones engine
 // containers inside one pod. Inter-pod failover keeps one main container per
@@ -421,7 +718,7 @@ func IntraPodFailoverEngineContainerNames() []string {
 	return names
 }
 
-// buildFailoverPod clones the main container into two engine containers (active + standby).
+// buildFailoverPod clones the main container into active and standby engine containers.
 // This runs AFTER applyGPUMemoryService, so the main container already has DRA claims,
 // shared volume mount, and TMPDIR set. This function only handles engine duplication
 // and failover-specific env vars.
@@ -444,16 +741,18 @@ func buildFailoverPod(
 		engines[i] = buildEngineContainer(mainContainer, i, commonconsts.DynamoSystemPort+i)
 	}
 
-	podSpec.Containers = append(engines, sidecars...)
+	updated := podSpec.DeepCopy()
+	updated.Containers = append(engines, sidecars...)
 
 	// Backend-specific overrides
 	switch backendFramework {
 	case BackendFrameworkVLLM:
-		applyVLLMOverrides(podSpec, numberOfNodes)
+		applyVLLMOverrides(updated, numberOfNodes)
 	default:
 		return fmt.Errorf("failover is currently supported only for vLLM (detected: %s)", backendFramework)
 	}
 
+	*podSpec = *updated
 	return nil
 }
 

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -467,9 +467,6 @@ func validateFailoverCheckpointProfile(
 	if config.Mode != "" && config.Mode != v1beta1.CheckpointModeAuto {
 		violations = append(violations, errors.New("checkpoint mode must be automatic"))
 	}
-	if config.DeletionPolicy != "" && config.DeletionPolicy != v1beta1.CheckpointDeletionPolicyDelete {
-		violations = append(violations, errors.New("deletionPolicy must be Delete"))
-	}
 	if config.TargetContainerName != "" && config.TargetContainerName != commonconsts.MainContainerName {
 		violations = append(violations, errors.New("targetContainerName must be main"))
 	}

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -502,25 +502,29 @@ func validateFailoverCheckpointProfile(
 	} else if gpuCount != 1 {
 		violations = append(violations, errors.New("main container must request exactly one GPU"))
 	}
-	// The operator derives these from DYN_GMS_USE_V1, which it injects when a
-	// checkpoint is configured. A user value is either ignored or contradicts
-	// the operator's selection, so reject it rather than silently rewriting it.
-	for _, flag := range vllmOperatorManagedFlags(backend) {
-		if _, _, _, found, err := tokenizedVLLMFlag(main.Args, flag); err != nil {
-			violations = append(violations, err)
-		} else if found {
-			violations = append(violations, fmt.Errorf("%s is managed by the operator and must not be set", flag))
+	if backend == BackendFrameworkVLLM {
+		// The operator derives these from DYN_GMS_USE_V1, which it injects when a
+		// checkpoint is configured. A user value is either ignored or contradicts
+		// the operator's selection, so reject it rather than silently rewriting it.
+		// DYN_VLLM_GMS_SHADOW_MODE marks a cold-start shadow engine and is unset
+		// on the snapshot path. SGLang has no equivalents.
+		for _, flag := range []string{vllmWorkerClassFlag, vllmLoadFormatFlag} {
+			if _, _, _, found, err := tokenizedFlag(main.Args, flag); err != nil {
+				violations = append(violations, err)
+			} else if found {
+				violations = append(violations, fmt.Errorf("%s is managed by the operator and must not be set", flag))
+			}
+		}
+		if containerHasEnvVar(main, "DYN_VLLM_GMS_SHADOW_MODE") {
+			violations = append(violations, errors.New("DYN_VLLM_GMS_SHADOW_MODE is managed by the operator and must not be set"))
 		}
 	}
-	// Operator-managed environment. DYN_VLLM_GMS_SHADOW_MODE marks a cold-start
-	// shadow engine; DYN_FORWARDPASS_METRIC_PORT is assigned per engine.
-	for _, name := range []string{"DYN_VLLM_GMS_SHADOW_MODE", "DYN_FORWARDPASS_METRIC_PORT"} {
-		if containerHasEnvVar(main, name) {
-			violations = append(violations, fmt.Errorf("%s is managed by the operator and must not be set", name))
-		}
+	// Assigned per engine container by the operator, for every backend.
+	if containerHasEnvVar(main, "DYN_FORWARDPASS_METRIC_PORT") {
+		violations = append(violations, errors.New("DYN_FORWARDPASS_METRIC_PORT is managed by the operator and must not be set"))
 	}
 	for _, profile := range failoverSnapshotFlagProfile(backend) {
-		value, _, _, found, err := tokenizedVLLMFlag(main.Args, profile.flag)
+		value, _, _, found, err := tokenizedFlag(main.Args, profile.flag)
 		if err != nil {
 			violations = append(violations, err)
 			continue
@@ -567,15 +571,6 @@ func failoverSnapshotFlagProfile(backend BackendFramework) []failoverSnapshotFla
 	}
 }
 
-// vllmOperatorManagedFlags lists engine arguments the operator derives from
-// DYN_GMS_USE_V1. SGLang has no equivalent user-facing flags.
-func vllmOperatorManagedFlags(backend BackendFramework) []string {
-	if backend != BackendFrameworkVLLM {
-		return nil
-	}
-	return []string{vllmWorkerClassFlag, vllmLoadFormatFlag}
-}
-
 func wrapFailoverCompatibilityViolations(violations []error) []error {
 	if len(violations) == 0 {
 		return nil
@@ -596,7 +591,7 @@ func PrepareVLLMSnapshotSourceContainer(container *corev1.Container) error {
 	return nil
 }
 
-func tokenizedVLLMFlag(args []string, flag string) (value string, index int, equalsForm, found bool, err error) {
+func tokenizedFlag(args []string, flag string) (value string, index int, equalsForm, found bool, err error) {
 	index = -1
 	for i, arg := range args {
 		switch {

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -32,8 +32,11 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/ptr"
 )
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -727,6 +730,116 @@ func TestBuildFailoverPod_SingleNodeNoNNODES(t *testing.T) {
 	}
 }
 
+
+
+
+
+func TestValidateAutomaticFailoverCheckpoint(t *testing.T) {
+	component := validAutomaticFailoverComponent()
+
+	t.Run("accepts DGD source and generated DCD target", func(t *testing.T) {
+		require.Empty(t, ValidateAutomaticFailoverCheckpointSource(component, string(BackendFrameworkVLLM)))
+
+		target := component.DeepCopy()
+		target.Experimental.Checkpoint.CheckpointRef = ptr.To("checkpoint-worker")
+		require.Empty(t, ValidateAutomaticFailoverCheckpointTarget(target, string(BackendFrameworkVLLM), true))
+
+		twoShadows := component.DeepCopy()
+		twoShadows.Experimental.Failover.NumShadows = 2
+		require.Empty(t, ValidateAutomaticFailoverCheckpointSource(twoShadows, string(BackendFrameworkVLLM)))
+	})
+
+	t.Run("rejects standalone target and incompatible runtime profile", func(t *testing.T) {
+		target := component.DeepCopy()
+		target.Experimental.Checkpoint.CheckpointRef = ptr.To("checkpoint-worker")
+		target.PodTemplate.Spec.Containers[0].Args = []string{
+			"-m", vllmModuleName,
+			"--disaggregation-mode", "decode",
+			"--request-plane=nats",
+			"--tensor-parallel-size", "2",
+			"--pipeline-parallel-size=2",
+			"--data-parallel-size", "2",
+		}
+
+		violations := ValidateAutomaticFailoverCheckpointTarget(target, string(BackendFrameworkVLLM), false)
+		require.Len(t, violations, 1)
+		for _, message := range []string{
+			"only supported for an operator-generated DCD",
+			"disaggregation mode must be aggregated",
+			"request plane must be tcp",
+			"tensor parallel size must be 1",
+			"pipeline parallel size must be 1",
+			"data parallel size must be 1",
+		} {
+			assert.ErrorContains(t, violations[0], message)
+		}
+	})
+
+	t.Run("rejects a referenced DGD source", func(t *testing.T) {
+		source := component.DeepCopy()
+		source.Experimental.Checkpoint.CheckpointRef = ptr.To("foreign")
+		violations := ValidateAutomaticFailoverCheckpointSource(source, string(BackendFrameworkVLLM))
+		require.Len(t, violations, 1)
+		assert.ErrorContains(t, violations[0], "checkpointRef must be omitted")
+	})
+}
+
+func TestPrepareVLLMAutomaticFailoverSnapshotSource(t *testing.T) {
+	t.Run("shapes only the source load profile and listeners", func(t *testing.T) {
+		container := validAutomaticFailoverComponent().PodTemplate.Spec.Containers[0]
+		container.Env = []corev1.EnvVar{
+			{Name: "DYN_FORWARDPASS_METRIC_PORT", Value: "9100"},
+			{Name: "KEEP_ME", Value: "yes"},
+			{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "true"},
+		}
+
+		require.NoError(t, PrepareVLLMAutomaticFailoverSnapshotSource(&container))
+		env := envToMap(container.Env)
+		assert.NotContains(t, env, "DYN_FORWARDPASS_METRIC_PORT")
+		assert.Equal(t, "false", env["DYN_VLLM_GMS_SHADOW_MODE"])
+		assert.Equal(t, "agg", env["DYN_VLLM_DISAGGREGATION_MODE"])
+		assert.Equal(t, "tcp", env["DYN_REQUEST_PLANE"])
+		assert.Equal(t, "yes", env["KEEP_ME"])
+		assert.Equal(t, "gms", vllmFlagValue(t, container.Args, vllmLoadFormatFlag))
+	})
+
+	t.Run("leaves the source unchanged on an unsupported worker", func(t *testing.T) {
+		container := validAutomaticFailoverComponent().PodTemplate.Spec.Containers[0]
+		container.Args = append(container.Args, vllmWorkerClassFlag, "unsupported.Worker")
+		original := container.DeepCopy()
+
+		require.Error(t, PrepareVLLMAutomaticFailoverSnapshotSource(&container))
+		assert.Equal(t, *original, container)
+	})
+
+	t.Run("preserves the GMS V1 automatic load format", func(t *testing.T) {
+		container := validAutomaticFailoverComponent().PodTemplate.Spec.Containers[0]
+		container.Args = append(
+			container.Args,
+			vllmWorkerClassFlag, gmsV1VLLMWorkerClass,
+			vllmLoadFormatFlag, "auto",
+		)
+
+		require.NoError(t, PrepareVLLMAutomaticFailoverSnapshotSource(&container))
+		assert.Equal(t, "auto", vllmFlagValue(t, container.Args, vllmLoadFormatFlag))
+	})
+}
+
+func TestIsDGDControlled(t *testing.T) {
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "graph", UID: types.UID("graph-uid")},
+	}
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(dgd, v1beta1.GroupVersion.WithKind("DynamoGraphDeployment")),
+		}},
+	}
+	assert.True(t, IsDGDControlled(dcd))
+
+	dcd.OwnerReferences[0].UID = ""
+	assert.False(t, IsDGDControlled(dcd))
+}
+
 // --- IsIntraPodFailoverEnabled ---
 
 func TestIsIntraPodFailoverEnabled(t *testing.T) {
@@ -743,13 +856,39 @@ func TestIsIntraPodFailoverEnabled(t *testing.T) {
 	assert.False(t, IsIntraPodFailoverEnabled(nil))
 }
 
-func TestIntraPodFailoverEngineContainerNames(t *testing.T) {
-	assert.Equal(t, []string{"engine-0", "engine-1"}, IntraPodFailoverEngineContainerNames())
-}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────────
+
+func validAutomaticFailoverComponent() *v1beta1.DynamoComponentDeploymentSharedSpec {
+	return &v1beta1.DynamoComponentDeploymentSharedSpec{
+		ComponentType: v1beta1.ComponentTypeWorker,
+		PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    commonconsts.MainContainerName,
+				Command: []string{"python3"},
+				Args:    []string{"-m", vllmModuleName},
+				Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+					corev1.ResourceName("nvidia.com/gpu"): k8sresource.MustParse("1"),
+				}},
+			}},
+		}},
+		Experimental: &v1beta1.ExperimentalSpec{
+			Checkpoint:       &v1beta1.ComponentCheckpointConfig{Enabled: true},
+			GPUMemoryService: &v1beta1.GPUMemoryServiceSpec{Mode: v1beta1.GMSModeIntraPod},
+			Failover:         &v1beta1.FailoverSpec{Mode: v1beta1.GMSModeIntraPod, NumShadows: 1},
+		},
+	}
+}
+
+func vllmFlagValue(t *testing.T, args []string, flag string) string {
+	t.Helper()
+	value, _, _, found, err := tokenizedVLLMFlag(args, flag)
+	require.NoError(t, err)
+	require.True(t, found)
+	return value
+}
 
 func hasToleration(podSpec *corev1.PodSpec, key string) bool {
 	for _, t := range podSpec.Tolerations {

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -615,11 +615,24 @@ func TestBuildFailoverPod_EmptyContainers(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least one container")
 }
 
-func TestBuildFailoverPod_RejectsNonVLLM(t *testing.T) {
+func TestBuildFailoverPod_AcceptsSGLang(t *testing.T) {
 	ps := intraPodFailoverPodSpec()
-	err := buildFailoverPod(&ps, 1, BackendFrameworkSGLang)
+	require.NoError(t, buildFailoverPod(&ps, 1, BackendFrameworkSGLang))
+	require.Len(t, ps.Containers, failoverEngineCount+1)
+	names := make([]string, 0, len(ps.Containers))
+	for _, c := range ps.Containers {
+		names = append(names, c.Name)
+	}
+	for _, want := range IntraPodFailoverEngineContainerNames() {
+		assert.Contains(t, names, want)
+	}
+}
+
+func TestBuildFailoverPod_RejectsUnsupportedBackend(t *testing.T) {
+	ps := intraPodFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "currently supported only for vLLM")
+	assert.Contains(t, err.Error(), "currently supported only for vLLM and SGLang")
 }
 
 func TestBuildFailoverPod_EngineEnvVars(t *testing.T) {

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -741,10 +741,10 @@ func TestBuildFailoverPod_SingleNodeNoNNODES(t *testing.T) {
 	}
 }
 
-func TestValidateAutomaticFailoverCheckpoint(t *testing.T) {
+func TestValidateFailoverCheckpoint(t *testing.T) {
 	component := validAutomaticFailoverComponent()
 
-	t.Run("accepts DGD source and generated DCD target", func(t *testing.T) {
+	t.Run("accepts a DGD and its DCD", func(t *testing.T) {
 		require.Empty(t, ValidateFailoverCheckpointForDGD(component, string(BackendFrameworkVLLM)))
 
 		target := component.DeepCopy()
@@ -756,7 +756,7 @@ func TestValidateAutomaticFailoverCheckpoint(t *testing.T) {
 		require.Empty(t, ValidateFailoverCheckpointForDGD(twoShadows, string(BackendFrameworkVLLM)))
 	})
 
-	t.Run("rejects standalone target and incompatible runtime profile", func(t *testing.T) {
+	t.Run("rejects an incompatible runtime profile", func(t *testing.T) {
 		target := component.DeepCopy()
 		target.Experimental.Checkpoint.CheckpointRef = ptr.To("checkpoint-worker")
 		target.PodTemplate.Spec.Containers[0].Args = []string{
@@ -813,6 +813,10 @@ func TestIsIntraPodFailoverEnabled(t *testing.T) {
 	})))
 	assert.False(t, IsIntraPodFailoverEnabled(betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{})))
 	assert.False(t, IsIntraPodFailoverEnabled(nil))
+}
+
+func TestIntraPodFailoverEngineContainerNames(t *testing.T) {
+	assert.Equal(t, []string{"engine-0", "engine-1"}, IntraPodFailoverEngineContainerNames())
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -741,10 +741,6 @@ func TestBuildFailoverPod_SingleNodeNoNNODES(t *testing.T) {
 	}
 }
 
-
-
-
-
 func TestValidateAutomaticFailoverCheckpoint(t *testing.T) {
 	component := validAutomaticFailoverComponent()
 
@@ -775,7 +771,7 @@ func TestValidateAutomaticFailoverCheckpoint(t *testing.T) {
 		violations := ValidateFailoverCheckpointForDCD(target, string(BackendFrameworkVLLM))
 		require.Len(t, violations, 1)
 		for _, message := range []string{
-				"disaggregation mode must be aggregated",
+			"disaggregation mode must be aggregated",
 			"request plane must be tcp",
 			"tensor parallel size must be 1",
 			"pipeline parallel size must be 1",
@@ -803,7 +799,6 @@ func TestPrepareVLLMSnapshotSourceContainer(t *testing.T) {
 	require.Error(t, PrepareVLLMSnapshotSourceContainer(nil))
 }
 
-
 // --- IsIntraPodFailoverEnabled ---
 
 func TestIsIntraPodFailoverEnabled(t *testing.T) {
@@ -819,7 +814,6 @@ func TestIsIntraPodFailoverEnabled(t *testing.T) {
 	assert.False(t, IsIntraPodFailoverEnabled(betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{})))
 	assert.False(t, IsIntraPodFailoverEnabled(nil))
 }
-
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -848,7 +842,7 @@ func validAutomaticFailoverComponent() *v1beta1.DynamoComponentDeploymentSharedS
 
 func vllmFlagValue(t *testing.T, args []string, flag string) string {
 	t.Helper()
-	value, _, _, found, err := tokenizedVLLMFlag(args, flag)
+	value, _, _, found, err := tokenizedFlag(args, flag)
 	require.NoError(t, err)
 	require.True(t, found)
 	return value

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
@@ -738,15 +736,15 @@ func TestValidateAutomaticFailoverCheckpoint(t *testing.T) {
 	component := validAutomaticFailoverComponent()
 
 	t.Run("accepts DGD source and generated DCD target", func(t *testing.T) {
-		require.Empty(t, ValidateAutomaticFailoverCheckpointSource(component, string(BackendFrameworkVLLM)))
+		require.Empty(t, ValidateFailoverCheckpointForDGD(component, string(BackendFrameworkVLLM)))
 
 		target := component.DeepCopy()
 		target.Experimental.Checkpoint.CheckpointRef = ptr.To("checkpoint-worker")
-		require.Empty(t, ValidateAutomaticFailoverCheckpointTarget(target, string(BackendFrameworkVLLM), true))
+		require.Empty(t, ValidateFailoverCheckpointForDCD(target, string(BackendFrameworkVLLM)))
 
 		twoShadows := component.DeepCopy()
 		twoShadows.Experimental.Failover.NumShadows = 2
-		require.Empty(t, ValidateAutomaticFailoverCheckpointSource(twoShadows, string(BackendFrameworkVLLM)))
+		require.Empty(t, ValidateFailoverCheckpointForDGD(twoShadows, string(BackendFrameworkVLLM)))
 	})
 
 	t.Run("rejects standalone target and incompatible runtime profile", func(t *testing.T) {
@@ -761,11 +759,10 @@ func TestValidateAutomaticFailoverCheckpoint(t *testing.T) {
 			"--data-parallel-size", "2",
 		}
 
-		violations := ValidateAutomaticFailoverCheckpointTarget(target, string(BackendFrameworkVLLM), false)
+		violations := ValidateFailoverCheckpointForDCD(target, string(BackendFrameworkVLLM))
 		require.Len(t, violations, 1)
 		for _, message := range []string{
-			"only supported for an operator-generated DCD",
-			"disaggregation mode must be aggregated",
+				"disaggregation mode must be aggregated",
 			"request plane must be tcp",
 			"tensor parallel size must be 1",
 			"pipeline parallel size must be 1",
@@ -775,70 +772,24 @@ func TestValidateAutomaticFailoverCheckpoint(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects a referenced DGD source", func(t *testing.T) {
-		source := component.DeepCopy()
-		source.Experimental.Checkpoint.CheckpointRef = ptr.To("foreign")
-		violations := ValidateAutomaticFailoverCheckpointSource(source, string(BackendFrameworkVLLM))
-		require.Len(t, violations, 1)
-		assert.ErrorContains(t, violations[0], "checkpointRef must be omitted")
-	})
 }
 
-func TestPrepareVLLMAutomaticFailoverSnapshotSource(t *testing.T) {
-	t.Run("shapes only the source load profile and listeners", func(t *testing.T) {
-		container := validAutomaticFailoverComponent().PodTemplate.Spec.Containers[0]
-		container.Env = []corev1.EnvVar{
-			{Name: "DYN_FORWARDPASS_METRIC_PORT", Value: "9100"},
-			{Name: "KEEP_ME", Value: "yes"},
-			{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "true"},
-		}
-
-		require.NoError(t, PrepareVLLMAutomaticFailoverSnapshotSource(&container))
-		env := envToMap(container.Env)
-		assert.NotContains(t, env, "DYN_FORWARDPASS_METRIC_PORT")
-		assert.Equal(t, "false", env["DYN_VLLM_GMS_SHADOW_MODE"])
-		assert.Equal(t, "agg", env["DYN_VLLM_DISAGGREGATION_MODE"])
-		assert.Equal(t, "tcp", env["DYN_REQUEST_PLANE"])
-		assert.Equal(t, "yes", env["KEEP_ME"])
-		assert.Equal(t, "gms", vllmFlagValue(t, container.Args, vllmLoadFormatFlag))
-	})
-
-	t.Run("leaves the source unchanged on an unsupported worker", func(t *testing.T) {
-		container := validAutomaticFailoverComponent().PodTemplate.Spec.Containers[0]
-		container.Args = append(container.Args, vllmWorkerClassFlag, "unsupported.Worker")
-		original := container.DeepCopy()
-
-		require.Error(t, PrepareVLLMAutomaticFailoverSnapshotSource(&container))
-		assert.Equal(t, *original, container)
-	})
-
-	t.Run("preserves the GMS V1 automatic load format", func(t *testing.T) {
-		container := validAutomaticFailoverComponent().PodTemplate.Spec.Containers[0]
-		container.Args = append(
-			container.Args,
-			vllmWorkerClassFlag, gmsV1VLLMWorkerClass,
-			vllmLoadFormatFlag, "auto",
-		)
-
-		require.NoError(t, PrepareVLLMAutomaticFailoverSnapshotSource(&container))
-		assert.Equal(t, "auto", vllmFlagValue(t, container.Args, vllmLoadFormatFlag))
-	})
-}
-
-func TestIsDGDControlled(t *testing.T) {
-	dgd := &v1beta1.DynamoGraphDeployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "graph", UID: types.UID("graph-uid")},
+func TestPrepareVLLMSnapshotSourceContainer(t *testing.T) {
+	container := corev1.Container{
+		Name: "main",
+		Env: []corev1.EnvVar{
+			{Name: "DYN_FORWARDPASS_METRIC_PORT", Value: "20380"},
+			{Name: "KEEP_ME", Value: "1"},
+		},
 	}
-	dcd := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
-			*metav1.NewControllerRef(dgd, v1beta1.GroupVersion.WithKind("DynamoGraphDeployment")),
-		}},
-	}
-	assert.True(t, IsDGDControlled(dcd))
 
-	dcd.OwnerReferences[0].UID = ""
-	assert.False(t, IsDGDControlled(dcd))
+	require.NoError(t, PrepareVLLMSnapshotSourceContainer(&container))
+
+	assert.False(t, containerHasEnvVar(&container, "DYN_FORWARDPASS_METRIC_PORT"))
+	assert.True(t, containerHasEnvVar(&container, "KEEP_ME"))
+	require.Error(t, PrepareVLLMSnapshotSourceContainer(nil))
 }
+
 
 // --- IsIntraPodFailoverEnabled ---
 

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -840,14 +840,6 @@ func validAutomaticFailoverComponent() *v1beta1.DynamoComponentDeploymentSharedS
 	}
 }
 
-func vllmFlagValue(t *testing.T, args []string, flag string) string {
-	t.Helper()
-	value, _, _, found, err := tokenizedFlag(args, flag)
-	require.NoError(t, err)
-	require.True(t, found)
-	return value
-}
-
 func hasToleration(podSpec *corev1.PodSpec, key string) bool {
 	for _, t := range podSpec.Tolerations {
 		if t.Key == key {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1860,11 +1860,14 @@ func GenerateBasePodSpec(
 		}
 	}
 
-	// Clone main container into two engine containers (active + standby) for failover.
+	// Clone the main container into active and standby engine containers for failover.
 	// Runs after GMS so the main container already has DRA claims and shared volume.
 	if IsIntraPodFailoverEnabled(component) {
 		if err := buildFailoverPod(&podSpec, numberOfNodes, backendFramework); err != nil {
 			return nil, fmt.Errorf("failed to build failover pod: %w", err)
+		}
+		if GetCheckpoint(component) != nil {
+			configureCheckpointFailoverEngines(&podSpec, component)
 		}
 	}
 

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1867,7 +1867,7 @@ func GenerateBasePodSpec(
 			return nil, fmt.Errorf("failed to build failover pod: %w", err)
 		}
 		if GetCheckpoint(component) != nil {
-			configureCheckpointFailoverEngines(&podSpec, component)
+			configureCheckpointFailoverEngines(&podSpec)
 		}
 	}
 

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -57,6 +58,14 @@ func (v *DynamoComponentDeploymentValidator) validate(
 	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
 	runtimeVersionSource runtimeVersionValidationSource,
 ) (admission.Warnings, error) {
+	return v.validateInternal(ctx, dcd, runtimeVersionSource)
+}
+
+func (v *DynamoComponentDeploymentValidator) validateInternal(
+	ctx context.Context,
+	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
+	runtimeVersionSource runtimeVersionValidationSource,
+) (admission.Warnings, error) {
 	validation := &dynamoComponentDeploymentValidation{
 		sharedValidation: sharedValidation{
 			ctx:                                ctx,
@@ -80,6 +89,15 @@ func (v *DynamoComponentDeploymentValidator) validate(
 // compares its state with the previous object.
 // ctx, oldDCD, and newDCD must not be nil. runtimeVersionSource identifies the request's source API.
 func (v *DynamoComponentDeploymentValidator) ValidateUpdate(
+	ctx context.Context,
+	oldDCD *nvidiacomv1beta1.DynamoComponentDeployment,
+	newDCD *nvidiacomv1beta1.DynamoComponentDeployment,
+	runtimeVersionSource runtimeVersionValidationSource,
+) (admission.Warnings, error) {
+	return v.validateUpdateInternal(ctx, oldDCD, newDCD, runtimeVersionSource)
+}
+
+func (v *DynamoComponentDeploymentValidator) validateUpdateInternal(
 	ctx context.Context,
 	oldDCD *nvidiacomv1beta1.DynamoComponentDeployment,
 	newDCD *nvidiacomv1beta1.DynamoComponentDeployment,
@@ -162,7 +180,19 @@ func (v *dynamoComponentDeploymentValidation) validateWorkerClassCheckpointRefOw
 func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeployment(
 	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
 ) field.ErrorList {
-	return v.validateDynamoComponentDeploymentSpec(&dcd.Spec, field.NewPath("spec"))
+	fldPath := field.NewPath("spec")
+	allErrs := v.validateDynamoComponentDeploymentSpec(&dcd.Spec, fldPath)
+	for _, err := range dynamo.ValidateAutomaticFailoverCheckpointTarget(
+		&dcd.Spec.DynamoComponentDeploymentSharedSpec,
+		dcd.Spec.BackendFramework,
+		dynamo.IsDGDControlled(dcd),
+	) {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath.Child("experimental", "checkpoint"),
+			err.Error(),
+		))
+	}
+	return allErrs
 }
 
 // validateDynamoComponentDeploymentSpec validates spec. spec and fldPath must not be nil.

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -182,10 +182,9 @@ func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeployment(
 ) field.ErrorList {
 	fldPath := field.NewPath("spec")
 	allErrs := v.validateDynamoComponentDeploymentSpec(&dcd.Spec, fldPath)
-	for _, err := range dynamo.ValidateAutomaticFailoverCheckpointTarget(
+	for _, err := range dynamo.ValidateFailoverCheckpointForDCD(
 		&dcd.Spec.DynamoComponentDeploymentSharedSpec,
 		dcd.Spec.BackendFramework,
-		dynamo.IsDGDControlled(dcd),
 	) {
 		allErrs = append(allErrs, field.Forbidden(
 			fldPath.Child("experimental", "checkpoint"),

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -56,6 +56,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 		oldDeployment      runtime.Object
 		checkpointOff      bool
 		seedWithoutWebhook bool
+		username           string
 		wantSchemaErr      string
 		wantCELErr         string
 		wantWebhookErrs    []string
@@ -188,6 +189,23 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 			wantWebhookErrs: []string{
 				"spec.ingress.host: Required value: is required when ingress is enabled",
+			},
+		},
+		{
+			name: "operator-created DGD target accepts automatic snapshot failover",
+			deployment: automaticFailoverTargetDCD(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.OwnerReferences = []metav1.OwnerReference{dgdControllerReference()}
+			}),
+			username: admissionOperatorPrincipal,
+		},
+		{
+			name: "standalone DCD rejects automatic snapshot failover",
+			deployment: automaticFailoverTargetDCD(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.OwnerReferences = []metav1.OwnerReference{dgdControllerReference()}
+			}),
+			username: "system:serviceaccount:default:regular-user",
+			wantWebhookErrs: []string{
+				"spec.experimental.checkpoint: Forbidden: Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint: checkpoint failover is only supported for an operator-generated DCD",
 			},
 		},
 		{
@@ -499,7 +517,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
-			name: "v1beta1 checkpoint with inter-pod GMS and failover reports both errors",
+			name: "v1beta1 checkpoint with inter-pod GMS and failover keeps ordinary incompatibility",
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				enableBetaInterPodGMS(&dcd.Spec.DynamoComponentDeploymentSharedSpec)
 				dcd.Spec.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true}
@@ -510,7 +528,6 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 			wantWebhookErrs: []string{
 				"spec.experimental.checkpoint: Forbidden: Snapshot with gpuMemoryService.mode=InterPod is unsupported",
-				"spec.experimental.checkpoint: Forbidden: Snapshot with active/passive failover is temporarily unsupported",
 			},
 		},
 		{
@@ -913,7 +930,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
-			name: "intra-pod failover rejects multiple shadows",
+			name: "intra-pod failover accepts two shadows",
 			deployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				ComponentType: consts.ComponentTypeWorker,
 				Resources:     workerGPU,
@@ -927,7 +944,6 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					NumShadows: 2,
 				},
 			}),
-			wantWebhookErrs: []string{`spec.failover.numShadows: Invalid value: 2: is invalid for mode="intraPod": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode="interPod" to configure numShadows`},
 		},
 		{
 			name: "single-shadow intra-pod failover is accepted",
@@ -1617,6 +1633,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				gates:              gates,
 				seedWithoutWebhook: tt.seedWithoutWebhook,
 				withoutTopology:    true,
+				username:           tt.username,
 				wantSchemaError:    tt.wantSchemaErr,
 				wantCELError:       tt.wantCELErr,
 				wantWebhookErrors:  tt.wantWebhookErrs,
@@ -1670,6 +1687,38 @@ func alphaDCDForAdmission(
 		mutate(dcd)
 	}
 	return dcd
+}
+
+func automaticFailoverTargetDCD(
+	mutate func(*nvidiacomv1beta1.DynamoComponentDeployment),
+) *nvidiacomv1beta1.DynamoComponentDeployment {
+	return betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+		enableBetaIntraPodGMS(&dcd.Spec.DynamoComponentDeploymentSharedSpec)
+		main := &dcd.Spec.PodTemplate.Spec.Containers[0]
+		main.Command = []string{"python3"}
+		main.Args = []string{"-m", "dynamo.vllm"}
+		dcd.Spec.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{
+			Enabled:       true,
+			CheckpointRef: k8sptr.To("checkpoint-worker"),
+		}
+		dcd.Spec.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
+			Mode:       nvidiacomv1beta1.GMSModeIntraPod,
+			NumShadows: 1,
+		}
+		if mutate != nil {
+			mutate(dcd)
+		}
+	})
+}
+
+func dgdControllerReference() metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: nvidiacomv1beta1.GroupVersion.String(),
+		Kind:       "DynamoGraphDeployment",
+		Name:       "test-graph",
+		UID:        "test-graph-uid",
+		Controller: k8sptr.To(true),
+	}
 }
 
 func alphaDCDWithSharedSpec(

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -56,7 +56,6 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 		oldDeployment      runtime.Object
 		checkpointOff      bool
 		seedWithoutWebhook bool
-		username           string
 		wantSchemaErr      string
 		wantCELErr         string
 		wantWebhookErrs    []string
@@ -190,13 +189,6 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{
 				"spec.ingress.host: Required value: is required when ingress is enabled",
 			},
-		},
-		{
-			name: "operator-created DGD target accepts automatic snapshot failover",
-			deployment: automaticFailoverTargetDCD(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
-				dcd.OwnerReferences = []metav1.OwnerReference{dgdControllerReference()}
-			}),
-			username: admissionOperatorPrincipal,
 		},
 		{
 			name: "v1beta1 derives runtime version from a semver image tag",
@@ -920,6 +912,23 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
+			name: "intra-pod failover rejects multiple shadows",
+			deployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Resources:     workerGPU,
+				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
+				},
+				Failover: &nvidiacomv1alpha1.FailoverSpec{
+					Enabled:    true,
+					Mode:       nvidiacomv1alpha1.GMSModeIntraPod,
+					NumShadows: 2,
+				},
+			}),
+			wantWebhookErrs: []string{`spec.failover.numShadows: Invalid value: 2: is invalid for mode="intraPod": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode="interPod" to configure numShadows`},
+		},
+		{
 			name: "single-shadow intra-pod failover is accepted",
 			deployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				ComponentType: consts.ComponentTypeWorker,
@@ -1607,7 +1616,6 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				gates:              gates,
 				seedWithoutWebhook: tt.seedWithoutWebhook,
 				withoutTopology:    true,
-				username:           tt.username,
 				wantSchemaError:    tt.wantSchemaErr,
 				wantCELError:       tt.wantCELErr,
 				wantWebhookErrors:  tt.wantWebhookErrs,
@@ -1661,38 +1669,6 @@ func alphaDCDForAdmission(
 		mutate(dcd)
 	}
 	return dcd
-}
-
-func automaticFailoverTargetDCD(
-	mutate func(*nvidiacomv1beta1.DynamoComponentDeployment),
-) *nvidiacomv1beta1.DynamoComponentDeployment {
-	return betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
-		enableBetaIntraPodGMS(&dcd.Spec.DynamoComponentDeploymentSharedSpec)
-		main := &dcd.Spec.PodTemplate.Spec.Containers[0]
-		main.Command = []string{"python3"}
-		main.Args = []string{"-m", "dynamo.vllm"}
-		dcd.Spec.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{
-			Enabled:       true,
-			CheckpointRef: k8sptr.To("checkpoint-worker"),
-		}
-		dcd.Spec.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-			Mode:       nvidiacomv1beta1.GMSModeIntraPod,
-			NumShadows: 1,
-		}
-		if mutate != nil {
-			mutate(dcd)
-		}
-	})
-}
-
-func dgdControllerReference() metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion: nvidiacomv1beta1.GroupVersion.String(),
-		Kind:       "DynamoGraphDeployment",
-		Name:       "test-graph",
-		UID:        "test-graph-uid",
-		Controller: k8sptr.To(true),
-	}
 }
 
 func alphaDCDWithSharedSpec(

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -199,16 +199,6 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			username: admissionOperatorPrincipal,
 		},
 		{
-			name: "standalone DCD rejects automatic snapshot failover",
-			deployment: automaticFailoverTargetDCD(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
-				dcd.OwnerReferences = []metav1.OwnerReference{dgdControllerReference()}
-			}),
-			username: "system:serviceaccount:default:regular-user",
-			wantWebhookErrs: []string{
-				"spec.experimental.checkpoint: Forbidden: Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint: checkpoint failover is only supported for an operator-generated DCD",
-			},
-		},
-		{
 			name: "v1beta1 derives runtime version from a semver image tag",
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
@@ -927,22 +917,6 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					Mode:    nvidiacomv1alpha1.GMSModeInterPod,
 				},
 				Failover: &nvidiacomv1alpha1.FailoverSpec{NumShadows: 2},
-			}),
-		},
-		{
-			name: "intra-pod failover accepts two shadows",
-			deployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				ComponentType: consts.ComponentTypeWorker,
-				Resources:     workerGPU,
-				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-					Enabled: true,
-					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
-				},
-				Failover: &nvidiacomv1alpha1.FailoverSpec{
-					Enabled:    true,
-					Mode:       nvidiacomv1alpha1.GMSModeIntraPod,
-					NumShadows: 2,
-				},
 			}),
 		},
 		{

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -328,6 +328,15 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpec(
 				workloadProvider:                  opts.workloadProvider,
 			},
 		)...)
+		for _, err := range dynamo.ValidateAutomaticFailoverCheckpointSource(
+			component,
+			spec.BackendFramework,
+		) {
+			allErrs = append(allErrs, field.Forbidden(
+				componentPath.Child("experimental", "checkpoint"),
+				err.Error(),
+			))
+		}
 	}
 
 	if spec.Restart != nil {

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -328,7 +328,7 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpec(
 				workloadProvider:                  opts.workloadProvider,
 			},
 		)...)
-		for _, err := range dynamo.ValidateAutomaticFailoverCheckpointSource(
+		for _, err := range dynamo.ValidateFailoverCheckpointForDGD(
 			component,
 			spec.BackendFramework,
 		) {

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1301,7 +1301,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{`spec.components[1].experimental.failover.mode: Invalid value: "InterPod": must match gpuMemoryService.mode "IntraPod"`},
 		},
 		{
-			name: "intra-pod failover shadow maximum is validated by the schema",
+			name: "intra-pod failover accepts two shadows",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				enableBetaContainerDiscovery(dgd)
 				worker := betaWorkerComponent(dgd)
@@ -1311,7 +1311,33 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					NumShadows: 2,
 				}
 			}),
-			wantSchemaErr: "spec.components[1].experimental.failover.numShadows: Invalid value: 2: spec.components[1].experimental.failover.numShadows in body should be less than or equal to 1",
+		},
+		{
+			name: "v1beta1 intra-pod failover rejects three shadows",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaContainerDiscovery(dgd)
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
+					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
+					NumShadows: 3,
+				}
+			}),
+			wantWebhookErrs: []string{`spec.components[1].experimental.failover.numShadows: Invalid value: 3: is invalid for mode="IntraPod": supported values are 1 and 2`},
+		},
+		{
+			name: "v1alpha1 inter-pod failover accepts three shadows",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				enableAlphaInterPodGMSFailover(dgd.Spec.Services["worker"], 3)
+			}),
+		},
+		{
+			name: "v1beta1 inter-pod failover accepts three shadows",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaInterPodGMS(worker)
+				enableBetaInterPodFailover(worker, 3)
+			}),
 		},
 		{
 			name: "inter-pod failover requires GMS",
@@ -1354,6 +1380,28 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				enableBetaIntraPodGMS(worker)
 				worker.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true}
 			}),
+		},
+		{
+			name: "automatic snapshot failover source rejects checkpoint reference",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaContainerDiscovery(dgd)
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				main := &worker.PodTemplate.Spec.Containers[0]
+				main.Command = []string{"python3"}
+				main.Args = []string{"-m", "dynamo.vllm"}
+				worker.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{
+					Enabled:       true,
+					CheckpointRef: k8sptr.To("foreign-checkpoint"),
+				}
+				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
+					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
+					NumShadows: 1,
+				}
+			}),
+			wantWebhookErrs: []string{
+				"spec.components[1].experimental.checkpoint: Forbidden: Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint: checkpointRef must be omitted so the DGD owns the automatic checkpoint",
+			},
 		},
 		{
 			name: "checkpoint compatibility is revalidated on update",
@@ -1460,7 +1508,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Forbidden: must be omitted for native Rust EPP images with runtime version 1.5.0 or later"},
 		},
 		{
-			name: "alpha intra-pod failover shadow maximum is preserved structurally",
+			name: "alpha intra-pod failover accepts two shadows structurally",
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				dgd.Spec.Services["worker"].Failover = &nvidiacomv1alpha1.FailoverSpec{
 					Enabled:    true,
@@ -1471,7 +1519,6 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{
 				`metadata.annotations[nvidia.com/dynamo-kube-discovery-mode]: Invalid value: "": must be "container" when intra-pod failover is configured`,
 				`spec.components[0].experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "IntraPod"`,
-				`spec.services[worker].failover.numShadows: Invalid value: 2: is invalid for mode="intraPod": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode="interPod" to configure numShadows`,
 			},
 		},
 		{

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1301,45 +1301,6 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{`spec.components[1].experimental.failover.mode: Invalid value: "InterPod": must match gpuMemoryService.mode "IntraPod"`},
 		},
 		{
-			name: "intra-pod failover accepts two shadows",
-			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				enableBetaContainerDiscovery(dgd)
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
-					NumShadows: 2,
-				}
-			}),
-		},
-		{
-			name: "v1beta1 intra-pod failover rejects three shadows",
-			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				enableBetaContainerDiscovery(dgd)
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
-					NumShadows: 3,
-				}
-			}),
-			wantWebhookErrs: []string{`spec.components[1].experimental.failover.numShadows: Invalid value: 3: is invalid for mode="IntraPod": supported values are 1 and 2`},
-		},
-		{
-			name: "v1alpha1 inter-pod failover accepts three shadows",
-			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				enableAlphaInterPodGMSFailover(dgd.Spec.Services["worker"], 3)
-			}),
-		},
-		{
-			name: "v1beta1 inter-pod failover accepts three shadows",
-			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaInterPodGMS(worker)
-				enableBetaInterPodFailover(worker, 3)
-			}),
-		},
-		{
 			name: "inter-pod failover requires GMS",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
@@ -1380,28 +1341,6 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				enableBetaIntraPodGMS(worker)
 				worker.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true}
 			}),
-		},
-		{
-			name: "automatic snapshot failover source rejects checkpoint reference",
-			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				enableBetaContainerDiscovery(dgd)
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				main := &worker.PodTemplate.Spec.Containers[0]
-				main.Command = []string{"python3"}
-				main.Args = []string{"-m", "dynamo.vllm"}
-				worker.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{
-					Enabled:       true,
-					CheckpointRef: k8sptr.To("foreign-checkpoint"),
-				}
-				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
-					NumShadows: 1,
-				}
-			}),
-			wantWebhookErrs: []string{
-				"spec.components[1].experimental.checkpoint: Forbidden: Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint: checkpointRef must be omitted so the DGD owns the automatic checkpoint",
-			},
 		},
 		{
 			name: "checkpoint compatibility is revalidated on update",
@@ -1506,20 +1445,6 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				}
 			}),
 			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Forbidden: must be omitted for native Rust EPP images with runtime version 1.5.0 or later"},
-		},
-		{
-			name: "alpha intra-pod failover accepts two shadows structurally",
-			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].Failover = &nvidiacomv1alpha1.FailoverSpec{
-					Enabled:    true,
-					Mode:       nvidiacomv1alpha1.GMSModeIntraPod,
-					NumShadows: 2,
-				}
-			}),
-			wantWebhookErrs: []string{
-				`metadata.annotations[nvidia.com/dynamo-kube-discovery-mode]: Invalid value: "": must be "container" when intra-pod failover is configured`,
-				`spec.components[0].experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "IntraPod"`,
-			},
 		},
 		{
 			name: "alpha frontend sidecar rejects generated container name conflict",

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1301,6 +1301,19 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{`spec.components[1].experimental.failover.mode: Invalid value: "InterPod": must match gpuMemoryService.mode "IntraPod"`},
 		},
 		{
+			name: "intra-pod failover shadow maximum is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaContainerDiscovery(dgd)
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
+					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
+					NumShadows: 2,
+				}
+			}),
+			wantSchemaErr: "spec.components[1].experimental.failover.numShadows: Invalid value: 2: spec.components[1].experimental.failover.numShadows in body should be less than or equal to 1",
+		},
+		{
 			name: "inter-pod failover requires GMS",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
@@ -1445,6 +1458,21 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				}
 			}),
 			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Forbidden: must be omitted for native Rust EPP images with runtime version 1.5.0 or later"},
+		},
+		{
+			name: "alpha intra-pod failover shadow maximum is preserved structurally",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].Failover = &nvidiacomv1alpha1.FailoverSpec{
+					Enabled:    true,
+					Mode:       nvidiacomv1alpha1.GMSModeIntraPod,
+					NumShadows: 2,
+				}
+			}),
+			wantWebhookErrs: []string{
+				`metadata.annotations[nvidia.com/dynamo-kube-discovery-mode]: Invalid value: "": must be "container" when intra-pod failover is configured`,
+				`spec.components[0].experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "IntraPod"`,
+				`spec.services[worker].failover.numShadows: Invalid value: 2: is invalid for mode="intraPod": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode="interPod" to configure numShadows`,
+			},
 		},
 		{
 			name: "alpha frontend sidecar rejects generated container name conflict",

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -74,7 +74,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
 			fmt.Sprintf("cannot inject frontend sidecar: a container named %q already exists in extraPodSpec.containers", consts.FrontendSidecarContainerName),
 		))
 	}
-	if spec.Failover != nil {
+	if spec.Failover != nil && v.hasRuntimeVersionSource(runtimeVersionSourceV1Alpha1) {
 		allErrs = append(allErrs, v.validateFailoverSpecV1alpha1(spec.Failover, fldPath.Child("failover"))...)
 	}
 


### PR DESCRIPTION
## Summary

Allow a DGD component to combine an automatic checkpoint with intra-pod
failover, so a snapshot restores into both engine containers.

Both halves already exist. `buildFailoverPod` clones `main` into `engine-0` and
`engine-1`, and the checkpoint path already targets the engine containers for
restore. What blocks the combination is a single compatibility rule:

```go
// internal/checkpoint/compatibility.go
- if experimental.Failover != nil {
-     violations = append(violations, errors.New("Snapshot with active/passive failover is temporarily unsupported"))
- }
```

Removing it is the change. The rest of the PR is the validation that makes the
combination safe, plus two small pieces of operator wiring.

## What is validated

Two engine containers share one GPU, so the deployment must resolve to a
single-rank aggregated worker. `ValidateFailoverCheckpointForDGD` and
`ValidateFailoverCheckpointForDCD` reject anything else at admission and again
at reconcile, rather than letting it fail at runtime:

- `checkpoint.mode` automatic, `deletionPolicy` Delete, `targetContainerName` main
- `gpuMemoryService.mode` and `failover.mode` IntraPod, component type Worker
- disaggregation off, request plane tcp, TP/PP/DP = 1
- `--worker-cls`, `--load-format`, `DYN_VLLM_GMS_SHADOW_MODE` and
  `DYN_FORWARDPASS_METRIC_PORT` unset — all four are operator-managed

Supported for vLLM and SGLang.

## Operator wiring

- Unset `DYN_VLLM_GMS_SHADOW_MODE` on snapshot failover engines. Shadow mode is
  incompatible with failover + snapshot, which runs on GMS V1, and
  `applyVLLMOverrides` sets it unconditionally for intra-pod failover.
- Strip `DYN_FORWARDPASS_METRIC_PORT` from the capture container. A capture pod
  has no Dynamo endpoint to publish to. This cannot be validated away, because
  the operator injects the port during pod generation, after validation runs.

## Commits

1. the feature, rebased onto the standalone Snapshot migration
2. validation in place of config rewriting, and the shadow-mode gate
3. SGLang support, from #13276

## Validation

`go build ./...`, `go vet ./internal/...`, and the `internal/dynamo`,
`internal/checkpoint` and `internal/webhook` suites pass. The `*_envtest_test.go`
suites need a local control plane and are covered by CI.
