### PR TITLE
fix(frontend): backport vLLM tool-call constraints to release/1.4.0

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -6,11 +6,15 @@ from __future__ import annotations
 import os
 from collections.abc import Awaitable, Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Protocol
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionRequest,
+)
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
@@ -21,7 +25,10 @@ from vllm.renderers import ChatParams, merge_kwargs
 from vllm.sampling_params import SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser
+from vllm.tool_parsers.utils import get_json_schema_from_tools
 from vllm.utils.async_utils import make_async
+
+from dynamo.llm.exceptions import InvalidArgument
 
 from .thinking import apply_default_thinking_mode_to_template_kwargs
 
@@ -42,10 +49,262 @@ class PreprocessResult:
     chat_template_kwargs: dict[str, Any]
     engine_prompt: dict[str, Any]
     prompt_token_ids: list[int]
+    guided_decoding: dict[str, Any] | None = None
 
 
 _ASYNC_TOKENIZER_POOL: dict[int, Callable[..., Awaitable[Any]]] = {}
 SKIP_REQUEST_VALIDATION = os.getenv("DYN_VLLM_SKIP_REQUEST_VALIDATION", "1") == "1"
+
+
+def _is_named_tool_choice(tool_choice: Any) -> bool:
+    """True only for a well-formed named tool choice.
+
+    tool_choice arrives either validated (ChatCompletionNamedToolChoiceParam) or,
+    on the DYN_VLLM_SKIP_REQUEST_VALIDATION fast path, as the raw client dict, so
+    both shapes are checked. Testing only `not isinstance(tool_choice, str)` would
+    classify malformed values such as {} or {"type": "function"} as a forced tool
+    choice, which then gates the conflict check below.
+    """
+    if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam):
+        return bool(tool_choice.function.name)
+    if isinstance(tool_choice, dict):
+        function = tool_choice.get("function")
+        return (
+            tool_choice.get("type") == "function"
+            and isinstance(function, dict)
+            and bool(function.get("name"))
+        )
+    return False
+
+
+def _is_forced_tool_choice(tool_choice: Any) -> bool:
+    return tool_choice == "required" or _is_named_tool_choice(tool_choice)
+
+
+def _has_explicit_output_constraint(request: ChatCompletionRequest) -> bool:
+    """Whether the caller set a constraint over the whole generated token stream.
+
+    CONTENT response_format variants (json_object, json_schema) are deliberately
+    excluded. The OpenAI spec scopes those to the message the model returns to the
+    user, "rather than when the model calls a tool", so a forced tool choice makes
+    them unenforceable rather than contradictory -- vLLM drops them for exactly
+    this case in ToolParser.adjust_request (response_format = None).
+
+    response_format={"type": "structural_tag"} is NOT a content format: vLLM
+    normalizes it into structured_outputs.structural_tag, a grammar over the whole
+    token stream, which is the same slot the tool grammar needs. It is counted
+    here so a forced choice rejects it instead of silently discarding it.
+
+    guided_* and an explicit structured_outputs have no content scoping either.
+    """
+    if request.structured_outputs is not None:
+        return True
+    # Reads response_format too, so this catches the structural_tag variant
+    # regardless of which field the caller used to express it.
+    extracted = request.extract_structured_outputs()
+    if extracted is not None and extracted.structural_tag is not None:
+        return True
+    request_extra = request.model_extra or {}
+    if request_extra.get("guided_choice"):
+        return True
+    return any(
+        request_extra.get(key) is not None
+        for key in ("guided_json", "guided_regex", "guided_grammar")
+    )
+
+
+def _tool_is_strict(tool: Any) -> bool:
+    return tool.function.strict is True
+
+
+def _should_build_tool_call_guidance(
+    request: ChatCompletionRequest,
+    *,
+    structural_tag_mode: str,
+    structural_tag_scope: str,
+) -> bool:
+    tool_choice = request.tool_choice or "auto"
+    # TODO: a forced tool_choice with no tools is unsatisfiable and should be a
+    # 400, not an unconstrained request. preprocessor/tool_choice.rs rejects it
+    # (ToolChoiceError::EmptyTools via get_json_schema_from_tools); here and in
+    # sglang_prepost.py it returns no constraint and the caller gets a plausible
+    # answer that can never contain the tool call they required. vLLM's own
+    # "when using tool_choice, tools must be set" validator does not run because
+    # the DYN_VLLM_SKIP_REQUEST_VALIDATION fast path uses model_construct.
+    if not request.tools:
+        return False
+
+    # TODO: preprocessor/structural_tag.rs installs a tool-call BAN structural tag
+    # for tool_choice="none" when the mode is on and
+    # exclude_tools_when_tool_choice_none is false (apply_tool_call_ban). Neither
+    # Python path does. When tools stay in the rendered prompt the model can still
+    # see them, so "none" is only a prompt-level suggestion here rather than an
+    # enforced guarantee. sglang_prepost.py has the same gap.
+    if tool_choice == "none":
+        return False
+    if _is_forced_tool_choice(tool_choice):
+        return True
+    if structural_tag_mode != "on":
+        return False
+    if tool_choice != "auto":
+        return False
+    if structural_tag_scope == "always":
+        return True
+    # TODO: parallel_tool_calls only decides whether a structural tag is attempted;
+    # it does not bound call count in the forced-choice JSON fallback below.
+    # get_json_schema_from_tools emits {"type": "array", "minItems": 1} with no
+    # maxItems, matching build_required_schema in protocols/openai/tools.rs, so
+    # parallel_tool_calls=false can still produce several calls. sglang_prepost.py
+    # is the only path that forwards the flag into its schema builder.
+    explicit_single_call = (
+        "parallel_tool_calls" in request.model_fields_set
+        and request.parallel_tool_calls is False
+    )
+    return explicit_single_call or any(_tool_is_strict(tool) for tool in request.tools)
+
+
+def _request_for_vllm_structural_tag(
+    request: ChatCompletionRequest,
+    *,
+    structural_tag_schema: str,
+) -> ChatCompletionRequest:
+    strict_schema = structural_tag_schema == "strict"
+    tools = [
+        tool.model_copy(
+            update={
+                "function": tool.function.model_copy(
+                    update={
+                        "strict": True if strict_schema else tool.function.strict,
+                    }
+                )
+            }
+        )
+        for tool in request.tools or []
+    ]
+    return request.model_copy(update={"tools": tools})
+
+
+def build_tool_call_guided_decoding(
+    request: ChatCompletionRequest,
+    tool_parser: ToolParser | None,
+    *,
+    parser_guided_decoding: dict[str, Any] | None = None,
+    structural_tag_mode: str = "off",
+    structural_tag_scope: str = "auto",
+    structural_tag_schema: str = "auto",
+) -> dict[str, Any] | None:
+    """Build tool-call guidance through vLLM's configured tool parser."""
+    if not _should_build_tool_call_guidance(
+        request,
+        structural_tag_mode=structural_tag_mode,
+        structural_tag_scope=structural_tag_scope,
+    ):
+        return None
+
+    if structural_tag_mode == "on" and tool_parser is not None:
+        request_for_tag = _request_for_vllm_structural_tag(
+            request,
+            structural_tag_schema=structural_tag_schema,
+        )
+        structural_tag = tool_parser.get_structural_tag(request_for_tag)
+        if structural_tag is not None:
+            tag_value = (
+                structural_tag.model_dump()
+                if hasattr(structural_tag, "model_dump")
+                else structural_tag
+            )
+            return {"structural_tag": tag_value}
+
+    if parser_guided_decoding is not None:
+        return parser_guided_decoding
+
+    tool_choice = request.tool_choice or "auto"
+    if _is_forced_tool_choice(tool_choice):
+        # Parsers that require native tool syntax (e.g. Gemma4Engine, PoolsideV1)
+        # leave structured_outputs unset for required/named choices on purpose;
+        # forcing a JSON schema conflicts with their wire format and can crash
+        # EngineCore under speculative decoding. Only fall back for parsers that
+        # advertise JSON support (or when no parser is active).
+        if tool_parser is not None and not getattr(
+            tool_parser, "supports_required_and_named", True
+        ):
+            return None
+        json_schema = get_json_schema_from_tools(tool_choice, request.tools)
+        if json_schema is not None:
+            return {"json": json_schema}
+    return None
+
+
+# Convert vLLM structured-output parameters into Dynamo guided-decoding options.
+def _guided_decoding_from_structured_outputs(
+    structured_outputs: Any,
+) -> dict[str, Any] | None:
+    if structured_outputs is None:
+        return None
+
+    guided_decoding: dict[str, Any]
+    if structured_outputs.json is not None:
+        guided_decoding = {"json": structured_outputs.json}
+    elif structured_outputs.regex is not None:
+        guided_decoding = {"regex": structured_outputs.regex}
+    elif structured_outputs.choice is not None:
+        guided_decoding = {"choice": structured_outputs.choice}
+    elif structured_outputs.grammar is not None:
+        guided_decoding = {"grammar": structured_outputs.grammar}
+    elif structured_outputs.json_object:
+        guided_decoding = {"json": {"type": "object"}}
+    elif structured_outputs.structural_tag is not None:
+        guided_decoding = {"structural_tag": structured_outputs.structural_tag}
+    else:
+        return None
+
+    if structured_outputs.whitespace_pattern is not None:
+        guided_decoding["whitespace_pattern"] = structured_outputs.whitespace_pattern
+    return guided_decoding
+
+
+# Explicit assistant constraints take precedence over automatic tool guidance.
+def _build_assistant_guided_decoding(
+    request: ChatCompletionRequest,
+) -> dict[str, Any] | None:
+    guided_decoding = _guided_decoding_from_structured_outputs(
+        request.extract_structured_outputs()
+    )
+
+    request_extra = request.model_extra or {}
+    # Pick a single legacy guided_* constraint by precedence rather than merging
+    # several keys into one dict, because guided_decoding carries exactly one
+    # constraint and the elif chain above already honors that for
+    # structured_outputs.
+    #
+    # TODO: first-match-wins silently discards the other constraints the caller
+    # explicitly set, with no error and no annotation.
+    # GuidedDecodingOptions::validate in protocols/common.rs rejects the same
+    # request outright, so `guided_json` + `guided_regex` is a 400 through the Rust
+    # frontend and a silent single-constraint request here. Rejecting is the
+    # correct behavior; it is left as-is only to avoid adding a second new 400 to
+    # this change. Note that validate() also counts whitespace_pattern toward its
+    # exclusivity limit, so the {"json": ..., "whitespace_pattern": ...} pair built
+    # below is accepted here and rejected there -- whitespace_pattern modifies a
+    # grammar rather than being one, so that counter is the side that is wrong.
+    legacy_guidance: dict[str, Any] = {}
+    for key, value in (
+        ("json", request_extra.get("guided_json")),
+        ("regex", request_extra.get("guided_regex")),
+        ("grammar", request_extra.get("guided_grammar")),
+        ("choice", request_extra.get("guided_choice") or None),
+    ):
+        if value is not None:
+            legacy_guidance = {key: value}
+            break
+    if legacy_guidance:
+        # Legacy guided_* takes precedence over structured_outputs (prior
+        # behavior), but as a single constraint.
+        guided_decoding = legacy_guidance
+        whitespace_pattern = request_extra.get("guided_whitespace_pattern")
+        if whitespace_pattern is not None:
+            guided_decoding["whitespace_pattern"] = whitespace_pattern
+    return guided_decoding
 
 
 def _get_async_tokenizer(tokenizer: TokenizerLike) -> Callable[..., Awaitable[Any]]:
@@ -88,6 +347,28 @@ def _materialize_assistant_tool_calls(
     return normalized
 
 
+# Fully validate nested fields only when the fast path leaves raw dictionaries.
+def _validate_chat_completion_request(
+    request: dict[str, Any] | ChatCompletionRequest,
+) -> ChatCompletionRequest:
+    if isinstance(request, ChatCompletionRequest):
+        return request
+    if not SKIP_REQUEST_VALIDATION:
+        return ChatCompletionRequest.model_validate(request)
+
+    validated_request = ChatCompletionRequest.model_construct(**request)
+    has_unvalidated_tools = validated_request.tools and any(
+        not hasattr(tool, "model_dump") for tool in validated_request.tools
+    )
+    if (
+        has_unvalidated_tools
+        or isinstance(validated_request.response_format, dict)
+        or isinstance(validated_request.structured_outputs, dict)
+    ):
+        return ChatCompletionRequest.model_validate(request)
+    return validated_request
+
+
 def _prepare_request(
     request: dict[str, Any] | ChatCompletionRequest,
     *,
@@ -97,8 +378,16 @@ def _prepare_request(
     enable_auto_tool_choice: bool = False,
     default_chat_template_kwargs: dict[str, Any] | None = None,
     default_thinking_mode: str | None = None,
+    validated_request: ChatCompletionRequest | None = None,
 ) -> tuple[ChatCompletionRequest, ToolParser | None, dict[str, Any], Any, ChatParams]:
     """Validate request and build arguments for template rendering.
+
+    Args:
+        request: The raw request. Keep it as the caller received it (a dict on
+            the pythonized path) so transport-only aliases below are readable.
+        validated_request: A pre-validated model when the caller already built
+            one (avoids re-validating); semantic fields are read from it while
+            transport-only aliases still come from the raw ``request`` dict.
 
     Returns:
         request_for_sampling: Validated ChatCompletionRequest.
@@ -107,17 +396,11 @@ def _prepare_request(
         messages_for_render: Messages to pass as first arg to render_messages.
         chat_params: ChatParams for render_messages / render_messages_async.
     """
-    if isinstance(request, ChatCompletionRequest):
-        request_for_sampling = request
-    elif SKIP_REQUEST_VALIDATION:
-        # Trusted fast path; caller must provide OpenAI-compatible payload.
-        request_for_sampling = ChatCompletionRequest.model_construct(**request)
-        if request_for_sampling.tools and any(
-            not hasattr(tool, "model_dump") for tool in request_for_sampling.tools
-        ):
-            request_for_sampling = ChatCompletionRequest.model_validate(request)
-    else:
-        request_for_sampling = ChatCompletionRequest.model_validate(request)
+    request_for_sampling = (
+        validated_request
+        if validated_request is not None
+        else _validate_chat_completion_request(request)
+    )
 
     tool_parser: ToolParser | None = None
     # With enable_auto_tool_choice the model may emit tool calls even when the
@@ -215,7 +498,23 @@ async def preprocess_chat_request(
     enable_auto_tool_choice: bool = False,
     default_chat_template_kwargs: dict[str, Any] | None = None,
     default_thinking_mode: str | None = None,
+    structural_tag_mode: str = "off",
+    structural_tag_scope: str = "auto",
+    structural_tag_schema: str = "auto",
 ) -> PreprocessResult:
+    validated_request = _validate_chat_completion_request(request)
+    assistant_guided_decoding = _build_assistant_guided_decoding(validated_request)
+    client_structured_guidance = deepcopy(
+        _guided_decoding_from_structured_outputs(
+            validated_request.extract_structured_outputs()
+        )
+    )
+    is_forced_tool_choice = _is_forced_tool_choice(validated_request.tool_choice)
+    # Must be read BEFORE _prepare_request: it calls ToolParser.adjust_request(),
+    # which mutates this same request object in place and can set
+    # structured_outputs itself. Reading it afterwards would treat a
+    # parser-generated constraint as one the caller sent and reject the request.
+    has_explicit_output_constraint = _has_explicit_output_constraint(validated_request)
     (
         request_for_sampling,
         tool_parser,
@@ -230,6 +529,47 @@ async def preprocess_chat_request(
         enable_auto_tool_choice=enable_auto_tool_choice,
         default_chat_template_kwargs=default_chat_template_kwargs,
         default_thinking_mode=default_thinking_mode,
+        validated_request=validated_request,
+    )
+
+    adjusted_structured_guidance = _guided_decoding_from_structured_outputs(
+        request_for_sampling.structured_outputs
+    )
+    parser_guided_decoding = (
+        adjusted_structured_guidance
+        if tool_parser is not None
+        and adjusted_structured_guidance != client_structured_guidance
+        else None
+    )
+    tool_guided_decoding = build_tool_call_guided_decoding(
+        request_for_sampling,
+        tool_parser,
+        parser_guided_decoding=parser_guided_decoding,
+        structural_tag_mode=structural_tag_mode,
+        structural_tag_scope=structural_tag_scope,
+        structural_tag_schema=structural_tag_schema,
+    )
+    # A forced tool choice already claims the decoder's single grammar slot, so a
+    # caller-set guided_*/structured_outputs constraint over the same token stream
+    # cannot also be honored. Reject it (InvalidArgument -> 400) rather than
+    # silently drop it, matching has_explicit_guided_decoding in
+    # preprocessor/tool_choice.rs.
+    #
+    # response_format is NOT part of that test: it is scoped to the message the
+    # model returns to the user, not to tool calls, so it is dropped for a forced
+    # choice instead of rejected. That matches both preprocessor/tool_choice.rs
+    # (which clears gd.json) and vLLM's own ToolParser.adjust_request (which sets
+    # response_format = None), and it keeps a request both the OpenAI spec and
+    # vLLM accept from returning 400 here.
+    if is_forced_tool_choice and has_explicit_output_constraint:
+        raise InvalidArgument(
+            "tool_choice forces a tool call and cannot be combined with an "
+            "explicit guided_* or structured_outputs constraint."
+        )
+    guided_decoding = (
+        assistant_guided_decoding
+        if assistant_guided_decoding is not None and not is_forced_tool_choice
+        else tool_guided_decoding
     )
 
     _, engine_prompt = await renderer.render_messages_async(messages, chat_params)
@@ -250,6 +590,7 @@ async def preprocess_chat_request(
         chat_template_kwargs=chat_template_kwargs,
         engine_prompt=engine_prompt,
         prompt_token_ids=tokens,
+        guided_decoding=guided_decoding,
     )
 
 

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -594,6 +594,17 @@ def build_tool_call_guided_decoding(
                 parallel_tool_calls=parallel_tool_calls,
             ),
         )
+    # TODO: this applies a structural-tag constraint for tool_choice="auto"
+    # whenever a tool-call parser is configured, and reads NONE of
+    # structural_tag_mode / structural_tag_scope / structural_tag_schema. Those
+    # knobs are accepted on the CLI and published into the model card by
+    # sglang/register.py, so an operator setting the mode to "off" still gets a
+    # constraint on this path. prepost.py requires structural_tag_mode == "on"
+    # (_should_build_tool_call_guidance) and preprocessor/structural_tag.rs
+    # requires StructuralTagMode != Off, so at the default mode ("off") the same
+    # request is unconstrained on both of those paths and constrained here.
+    # Also unlike them, "auto" is never gated on scope/strict, so this behaves as
+    # scope="always" with no way to narrow it.
     elif tool_call_parser_name:
         tool_call_parser_name = _normalize_sglang_parser_name(tool_call_parser_name)
         parser = FunctionCallParser(
@@ -815,6 +826,18 @@ def preprocess_chat_request(
         tool_call_parser_name=tool_call_parser_name,
         sglang_tools=sglang_tools,
     )
+    # TODO: response_format wins here even when tool_choice is "required" or names
+    # a function, so a request that demanded a tool call can come back with none
+    # -- the tool constraint is dropped and only logged. The other two paths do
+    # the opposite: preprocessor/tool_choice.rs clears the response_format JSON
+    # and keeps the tool constraint, and prepost.py does the same after narrowing
+    # its conflict check. response_format is scoped by the OpenAI spec to the
+    # message the model returns to the user, not to tool calls, so the tool
+    # constraint is the one that must survive.
+    #
+    # This path also never reads the legacy guided_json / guided_regex /
+    # guided_grammar / guided_choice fields at all, so those are dropped silently
+    # while both other paths honor them (and reject them against a forced choice).
     if (
         response_format_guided_decoding is not None
         and tool_call_guided_decoding is not None

--- a/components/src/dynamo/frontend/tests/_tool_guidance_parity.py
+++ b/components/src/dynamo/frontend/tests/_tool_guidance_parity.py
@@ -1,0 +1,110 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+"""Shared behavioral cases for backend tool-guidance tests."""
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+GuidanceSource = Literal["none", "assistant", "tool"]
+ToolChoice = Literal["auto", "none", "required", "named"]
+
+
+@dataclass(frozen=True)
+class ToolGuidanceParityCase:
+    name: str
+    tool_choice: ToolChoice
+    has_tools: bool
+    has_assistant_constraint: bool
+    expected: GuidanceSource
+    # Backends known to disagree with `expected` today, mapped to what they
+    # actually produce. The row still states the correct answer; a listed backend
+    # asserts against its recorded value instead, so the code under test still
+    # runs and any OTHER change in its behavior fails loudly. Fixing a backend
+    # means deleting its entry here, not editing `expected`.
+    known_divergent: tuple[tuple[str, GuidanceSource], ...] = ()
+
+    def divergent_source(self, backend: str) -> GuidanceSource | None:
+        for name, source in self.known_divergent:
+            if name == backend:
+                return source
+        return None
+
+
+TOOL_GUIDANCE_PARITY_CASES = (
+    ToolGuidanceParityCase("no-tools", "auto", False, False, "none"),
+    ToolGuidanceParityCase("tool-choice-none", "none", True, False, "none"),
+    ToolGuidanceParityCase("tool-choice-required", "required", True, False, "tool"),
+    ToolGuidanceParityCase("named-tool-choice", "named", True, False, "tool"),
+    ToolGuidanceParityCase("automatic-tool-choice", "auto", True, False, "tool"),
+    ToolGuidanceParityCase(
+        "response-format-precedence",
+        "auto",
+        True,
+        True,
+        "assistant",
+    ),
+    # response_format is scoped to the message returned to the user, not to tool
+    # calls, so a forced choice keeps the tool constraint and drops it. SGLang
+    # instead lets response_format win and can return no tool call at all --
+    # see the TODO above `guided_decoding = response_format_guided_decoding or ...`
+    # in sglang_prepost.py.
+    ToolGuidanceParityCase(
+        "forced-choice-with-response-format",
+        "required",
+        True,
+        True,
+        "tool",
+        known_divergent=(("sglang", "assistant"),),
+    ),
+    ToolGuidanceParityCase(
+        "named-choice-with-response-format",
+        "named",
+        True,
+        True,
+        "tool",
+        known_divergent=(("sglang", "assistant"),),
+    ),
+)
+
+
+def parity_tool() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "strict": True,
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def tool_choice_value(tool_choice: ToolChoice) -> str | dict[str, Any]:
+    if tool_choice == "named":
+        return {
+            "type": "function",
+            "function": {"name": "get_weather"},
+        }
+    return tool_choice
+
+
+def assistant_response_format() -> dict[str, str]:
+    return {"type": "json_object"}
+
+
+def classify_guidance_source(
+    guided_decoding: dict[str, Any] | None,
+    *,
+    has_assistant_constraint: bool,
+) -> GuidanceSource:
+    if guided_decoding is None:
+        return "none"
+    if has_assistant_constraint and guided_decoding == {"json": {"type": "object"}}:
+        return "assistant"
+    return "tool"

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -17,6 +17,13 @@ import types
 
 import pytest
 from _routed_engine_fakes import FakeRoutedEngine, FakeRoutedItem
+from _tool_guidance_parity import (
+    TOOL_GUIDANCE_PARITY_CASES,
+    assistant_response_format,
+    classify_guidance_source,
+    parity_tool,
+    tool_choice_value,
+)
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
@@ -1096,6 +1103,43 @@ class TestBuildResponseFormatGuidedDecoding:
 
 
 class TestBuildToolCallGuidedDecoding:  # FRONTEND.3 — guided-decoding setup for tool_choice
+    # Keep SGLang's guidance decisions aligned with the shared backend matrix.
+    @pytest.mark.parametrize(
+        "case",
+        TOOL_GUIDANCE_PARITY_CASES,
+        ids=lambda case: case.name,
+    )
+    def test_shared_tool_guidance_policy(self, tokenizer, case):
+        # A divergent case still runs the backend and asserts its RECORDED current
+        # answer, so an exception or any other behavior change fails here rather
+        # than being absorbed. Fixing SGLang makes this fail with "expected
+        # assistant, got tool", which is the signal to drop the entry.
+        expected = case.divergent_source("sglang") or case.expected
+        request = {
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        if case.has_tools:
+            request["tools"] = [parity_tool()]
+            request["tool_choice"] = tool_choice_value(case.tool_choice)
+        if case.has_assistant_constraint:
+            request["response_format"] = assistant_response_format()
+
+        result = preprocess_chat_request(
+            request,
+            tokenizer=tokenizer,
+            tool_call_parser_name="kimi_k2",
+            reasoning_parser_name=None,
+        )
+
+        assert (
+            classify_guidance_source(
+                result.guided_decoding,
+                has_assistant_constraint=case.has_assistant_constraint,
+            )
+            == expected
+        )
+
     def test_none_when_no_tools(self):
         assert (
             build_tool_call_guided_decoding(

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -14,9 +14,19 @@ from unittest.mock import AsyncMock
 
 import pytest
 from _routed_engine_fakes import FakeRoutedEngine as _FakeRoutedEngine
+from _tool_guidance_parity import (
+    TOOL_GUIDANCE_PARITY_CASES,
+    assistant_response_format,
+    classify_guidance_source,
+    parity_tool,
+    tool_choice_value,
+)
 from transformers import AutoTokenizer
+from vllm.sampling_params import StructuredOutputsParams
 
-from dynamo.frontend.prepost import _prepare_request
+from dynamo.frontend import prepost as prepost_module
+from dynamo.frontend.prepost import _prepare_request, build_tool_call_guided_decoding
+from dynamo.llm.exceptions import InvalidArgument
 
 # NOTE: dynamo.frontend.vllm_processor is imported lazily inside the tests that
 # need it (and via the vllm_processor_module fixture). Importing it at module
@@ -747,6 +757,7 @@ async def test_generator_preserves_zero_top_logprobs(
                 chat_template_kwargs={},
                 engine_prompt={"prompt": "Hello"},
                 prompt_token_ids=[1],
+                guided_decoding=None,
             )
         ),
     )
@@ -1015,6 +1026,574 @@ class TestSchemaAwareToolParser:
         assert args["profile"] == {"name": "Alice", "age": 30}
 
 
+class _FakeStructuralTag:
+    def __init__(self, value):
+        self.value = value
+
+    def model_dump(self):
+        return self.value
+
+
+class _FakeStructuralTagParser:
+    structural_tag_model = None
+
+    def __init__(self):
+        self.requests = []
+
+    def get_structural_tag(self, request, *, reasoning=False):
+        self.requests.append(request)
+        strict = [tool.function.strict for tool in request.tools]
+        return _FakeStructuralTag({"format": {"strict": strict}})
+
+
+class _FakeGrammarToolParser:
+    def get_structural_tag(self, request, *, reasoning=False):
+        return None
+
+
+class _FakeAdjustRequestGrammarToolParser(_FakeGrammarToolParser):
+    def __init__(self, tokenizer, tools):
+        del tokenizer, tools
+
+    def adjust_request(self, request):
+        request.structured_outputs = StructuredOutputsParams(
+            grammar='root ::= "<tool_call>"'
+        )
+        return request
+
+
+class _FakePassthroughToolParser(_FakeGrammarToolParser):
+    def __init__(self, tokenizer, tools):
+        del tokenizer, tools
+
+    def adjust_request(self, request):
+        return request
+
+
+class _FakeResponseFormatConsumingToolParser(_FakeAdjustRequestGrammarToolParser):
+    def adjust_request(self, request):
+        request.response_format = None
+        return super().adjust_request(request)
+
+
+class _FakeNativeSyntaxToolParser(_FakeGrammarToolParser):
+    # Mirrors parsers like Gemma4Engine/PoolsideV1 that emit native tool syntax
+    # and decline a forced JSON constraint for required/named choices.
+    supports_required_and_named = False
+
+
+class TestPreprocessRawRequestControls:
+    """Transport-only controls must survive the preprocess_chat_request boundary.
+
+    Regression: preprocess_chat_request passed the validated model into
+    _prepare_request, making its dict-only reads of chat_template_args and root
+    thinking unreachable. Direct _prepare_request tests do not cover this path.
+    """
+
+    @staticmethod
+    def _renderer():
+        return SimpleNamespace(
+            render_messages_async=AsyncMock(
+                return_value=(None, {"prompt_token_ids": [1]})
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_template_args_survive_preprocess(self, tokenizer):
+        result = await prepost_module.preprocess_chat_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "chat_template_args": {"enable_thinking": False},
+            },
+            tokenizer=tokenizer,
+            renderer=self._renderer(),
+            tool_parser_class=None,
+        )
+        assert result.chat_template_kwargs.get("enable_thinking") is False
+
+    @pytest.mark.asyncio
+    async def test_root_thinking_suppresses_deployment_default(self, tokenizer):
+        # An explicit root thinking control must block the deployment default
+        # from injecting its own thinking_mode.
+        result = await prepost_module.preprocess_chat_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "thinking": True,
+            },
+            tokenizer=tokenizer,
+            renderer=self._renderer(),
+            tool_parser_class=None,
+            default_thinking_mode="disabled",
+        )
+        assert "thinking_mode" not in result.chat_template_kwargs
+
+
+class TestToolCallGuidedDecoding:
+    def _request(self, tokenizer, **overrides):
+        raw_request = {**TOOL_REQUEST, "tool_choice": "auto", **overrides}
+        request, _, _, _, _ = _prepare_request(
+            raw_request,
+            tokenizer=tokenizer,
+            tool_parser_class=None,
+        )
+        return request
+
+    def test_mode_off_emits_no_guidance(self, tokenizer):
+        parser = _FakeStructuralTagParser()
+        guided = build_tool_call_guided_decoding(
+            self._request(tokenizer),
+            parser,
+            structural_tag_mode="off",
+            structural_tag_scope="always",
+            structural_tag_schema="strict",
+        )
+
+        assert guided is None
+        assert parser.requests == []
+
+    # Forced choices need a JSON constraint even when structural tags are disabled.
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [
+            "required",
+            {"type": "function", "function": {"name": "get_weather"}},
+        ],
+    )
+    def test_forced_choice_uses_json_guidance_when_mode_off(
+        self, tokenizer, tool_choice
+    ):
+        parser = _FakeStructuralTagParser()
+        guided = build_tool_call_guided_decoding(
+            self._request(tokenizer, tool_choice=tool_choice),
+            parser,
+            structural_tag_mode="off",
+        )
+
+        assert guided is not None
+        assert set(guided) == {"json"}
+        assert parser.requests == []
+
+    # Parsers that require native tool syntax must not get a forced JSON schema.
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [
+            "required",
+            {"type": "function", "function": {"name": "get_weather"}},
+        ],
+    )
+    def test_forced_choice_skips_json_for_native_syntax_parser(
+        self, tokenizer, tool_choice
+    ):
+        guided = build_tool_call_guided_decoding(
+            self._request(tokenizer, tool_choice=tool_choice),
+            _FakeNativeSyntaxToolParser(),
+            structural_tag_mode="off",
+        )
+
+        assert guided is None
+
+    def test_strict_schema_uses_copy(self, tokenizer):
+        request = self._request(tokenizer)
+        parser = _FakeStructuralTagParser()
+        guided = build_tool_call_guided_decoding(
+            request,
+            parser,
+            structural_tag_mode="on",
+            structural_tag_scope="always",
+            structural_tag_schema="strict",
+        )
+
+        assert guided == {"structural_tag": {"format": {"strict": [True]}}}
+        assert request.tools[0].function.strict is None
+        assert parser.requests[0].messages is request.messages
+
+    # Auto schema mode must preserve an omitted strict flag as unset.
+    def test_auto_schema_preserves_unset_strict(self, tokenizer):
+        parser = _FakeStructuralTagParser()
+        guided = build_tool_call_guided_decoding(
+            self._request(tokenizer),
+            parser,
+            structural_tag_mode="on",
+            structural_tag_scope="always",
+            structural_tag_schema="auto",
+        )
+
+        assert guided == {"structural_tag": {"format": {"strict": [None]}}}
+
+    # Parser-created grammar must survive preprocessing as guided decoding.
+    @pytest.mark.asyncio
+    async def test_parser_adjust_request_generated_grammar_is_forwarded(
+        self, tokenizer
+    ):
+        result = await prepost_module.preprocess_chat_request(
+            {**TOOL_REQUEST, "tool_choice": "required"},
+            tokenizer=tokenizer,
+            renderer=SimpleNamespace(
+                render_messages_async=AsyncMock(
+                    return_value=(None, {"prompt_token_ids": [1]})
+                )
+            ),
+            tool_parser_class=_FakeAdjustRequestGrammarToolParser,
+            structural_tag_mode="on",
+            structural_tag_scope="auto",
+            structural_tag_schema="strict",
+        )
+
+        assert result.guided_decoding == {"grammar": 'root ::= "<tool_call>"'}
+
+    # Explicit assistant constraints must override automatic tool-call guidance.
+    @pytest.mark.parametrize(
+        "assistant_constraint, expected",
+        [
+            (
+                {"response_format": {"type": "json_object"}},
+                {"json": {"type": "object"}},
+            ),
+            ({"guided_regex": "yes|no"}, {"regex": "yes|no"}),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_assistant_guidance_takes_precedence_over_auto_tool_guidance(
+        self, tokenizer, assistant_constraint, expected
+    ):
+        result = await prepost_module.preprocess_chat_request(
+            {
+                **TOOL_REQUEST,
+                "tool_choice": "auto",
+                **assistant_constraint,
+            },
+            tokenizer=tokenizer,
+            renderer=SimpleNamespace(
+                render_messages_async=AsyncMock(
+                    return_value=(None, {"prompt_token_ids": [1]})
+                )
+            ),
+            tool_parser_class=_FakeResponseFormatConsumingToolParser,
+            structural_tag_mode="on",
+            structural_tag_scope="always",
+        )
+
+        assert result.guided_decoding == expected
+
+    # A forced tool choice with a client-provided structured_outputs constraint
+    # is a conflict: reject it rather than silently reuse or replace it. (The
+    # parser-generated case is covered by the test above, which is not rejected.)
+    @pytest.mark.asyncio
+    async def test_forced_choice_with_client_structured_outputs_is_rejected(
+        self, tokenizer
+    ):
+        with pytest.raises(InvalidArgument):
+            await prepost_module.preprocess_chat_request(
+                {
+                    **TOOL_REQUEST,
+                    "tool_choice": "required",
+                    "structured_outputs": {"grammar": 'root ::= "not_a_tool_call"'},
+                },
+                tokenizer=tokenizer,
+                renderer=SimpleNamespace(
+                    render_messages_async=AsyncMock(
+                        return_value=(None, {"prompt_token_ids": [1]})
+                    )
+                ),
+                tool_parser_class=_FakePassthroughToolParser,
+                structural_tag_mode="on",
+            )
+
+    # A forced tool choice plus an explicit constraint is a client error (400),
+    # matching the Rust path, not a silently dropped constraint.
+    @pytest.mark.asyncio
+    async def test_forced_choice_with_explicit_constraint_is_rejected(self, tokenizer):
+        with pytest.raises(InvalidArgument):
+            await prepost_module.preprocess_chat_request(
+                {
+                    **TOOL_REQUEST,
+                    "tool_choice": "required",
+                    "guided_regex": "yes|no",
+                },
+                tokenizer=tokenizer,
+                renderer=SimpleNamespace(
+                    render_messages_async=AsyncMock(
+                        return_value=(None, {"prompt_token_ids": [1]})
+                    )
+                ),
+                tool_parser_class=_FakePassthroughToolParser,
+                structural_tag_mode="on",
+            )
+
+    # response_format is scoped to the message returned to the user, not to tool
+    # calls, so a forced tool choice drops it and keeps the tool constraint -- it
+    # is NOT the 400 that guided_*/structured_outputs get. This matches
+    # preprocessor/tool_choice.rs (clears gd.json) and vLLM's own
+    # ToolParser.adjust_request (sets response_format = None).
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [
+            "required",
+            {"type": "function", "function": {"name": "get_weather"}},
+        ],
+        ids=["required", "named"],
+    )
+    @pytest.mark.parametrize(
+        "response_format",
+        [
+            {"type": "json_object"},
+            {
+                "type": "json_schema",
+                "json_schema": {"name": "answer", "schema": {"type": "object"}},
+            },
+        ],
+        ids=["json_object", "json_schema"],
+    )
+    @pytest.mark.asyncio
+    async def test_forced_choice_with_response_format_keeps_tool_guidance(
+        self, tokenizer, tool_choice, response_format
+    ):
+        result = await prepost_module.preprocess_chat_request(
+            {
+                **TOOL_REQUEST,
+                "tool_choice": tool_choice,
+                "response_format": response_format,
+            },
+            tokenizer=tokenizer,
+            renderer=SimpleNamespace(
+                render_messages_async=AsyncMock(
+                    return_value=(None, {"prompt_token_ids": [1]})
+                )
+            ),
+            tool_parser_class=_FakeResponseFormatConsumingToolParser,
+            structural_tag_mode="on",
+        )
+
+        # The parser's tool grammar survives; response_format is dropped rather
+        # than rejected or allowed to win.
+        assert result.guided_decoding == {"grammar": 'root ::= "<tool_call>"'}
+
+    # response_format={"type": "structural_tag"} is not a content format -- vLLM
+    # normalizes it into structured_outputs.structural_tag, a grammar over the
+    # whole token stream. A forced choice must reject it rather than silently
+    # discard it the way the json_object/json_schema variants are dropped.
+    @pytest.mark.asyncio
+    async def test_forced_choice_with_structural_tag_response_format_is_rejected(
+        self, tokenizer
+    ):
+        with pytest.raises(InvalidArgument):
+            await prepost_module.preprocess_chat_request(
+                {
+                    **TOOL_REQUEST,
+                    "tool_choice": "required",
+                    "response_format": {
+                        "type": "structural_tag",
+                        "format": {"type": "any_text"},
+                    },
+                },
+                tokenizer=tokenizer,
+                renderer=SimpleNamespace(
+                    render_messages_async=AsyncMock(
+                        return_value=(None, {"prompt_token_ids": [1]})
+                    )
+                ),
+                tool_parser_class=_FakePassthroughToolParser,
+                structural_tag_mode="on",
+            )
+
+    # A malformed tool_choice object is not a named tool choice, so it must not be
+    # treated as forced and must not trigger the forced-choice conflict check.
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [{}, {"type": "function"}, {"type": "function", "function": {}}],
+        ids=["empty", "no_function", "no_name"],
+    )
+    def test_malformed_tool_choice_is_not_forced(self, tool_choice):
+        assert prepost_module._is_named_tool_choice(tool_choice) is False
+        assert prepost_module._is_forced_tool_choice(tool_choice) is False
+
+    # Legacy guided_* must resolve to a single constraint, not a merged dict.
+    @pytest.mark.asyncio
+    async def test_legacy_guided_fields_yield_single_constraint(self, tokenizer):
+        result = await prepost_module.preprocess_chat_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "guided_json": {"type": "object"},
+                "guided_regex": "\\d+",
+            },
+            tokenizer=tokenizer,
+            renderer=SimpleNamespace(
+                render_messages_async=AsyncMock(
+                    return_value=(None, {"prompt_token_ids": [1]})
+                )
+            ),
+            tool_parser_class=None,
+        )
+        assert result.guided_decoding == {"json": {"type": "object"}}
+
+    # Keep vLLM's guidance decisions aligned with the shared backend matrix.
+    @pytest.mark.parametrize(
+        "case",
+        TOOL_GUIDANCE_PARITY_CASES,
+        ids=lambda case: case.name,
+    )
+    @pytest.mark.asyncio
+    async def test_shared_tool_guidance_policy(self, tokenizer, case):
+        request = {
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        if case.has_tools:
+            request["tools"] = [parity_tool()]
+            request["tool_choice"] = tool_choice_value(case.tool_choice)
+        if case.has_assistant_constraint:
+            request["response_format"] = assistant_response_format()
+
+        result = await prepost_module.preprocess_chat_request(
+            request,
+            tokenizer=tokenizer,
+            renderer=SimpleNamespace(
+                render_messages_async=AsyncMock(
+                    return_value=(None, {"prompt_token_ids": [1]})
+                )
+            ),
+            tool_parser_class=_FakeResponseFormatConsumingToolParser,
+            structural_tag_mode="on",
+            structural_tag_scope="always",
+        )
+
+        assert (
+            classify_guidance_source(
+                result.guided_decoding,
+                has_assistant_constraint=case.has_assistant_constraint,
+            )
+            == case.expected
+        )
+
+    def test_tool_choice_none_does_not_request_vllm_guidance(self, tokenizer):
+        parser = _FakeStructuralTagParser()
+        guided = build_tool_call_guided_decoding(
+            self._request(tokenizer, tool_choice="none"),
+            parser,
+            structural_tag_mode="on",
+            structural_tag_scope="always",
+            structural_tag_schema="strict",
+        )
+
+        assert guided is None
+        assert parser.requests == []
+
+    @pytest.mark.parametrize(
+        "schema_mode, expects_unconstrained_schema",
+        [("auto", True), ("strict", False)],
+    )
+    def test_vllm_parser_receives_schema_mode(
+        self, tokenizer, schema_mode, expects_unconstrained_schema
+    ):
+        tools = [
+            TOOL_REQUEST["tools"][0],
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_temperature",
+                    "description": "Get the temperature for a location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                    "strict": False,
+                },
+            },
+        ]
+        tools[0] = {
+            **tools[0],
+            "function": {**tools[0]["function"], "strict": True},
+        }
+        request = self._request(tokenizer, tools=tools)
+        parser = _FakeStructuralTagParser()
+
+        guided = build_tool_call_guided_decoding(
+            request,
+            parser,
+            structural_tag_mode="on",
+            structural_tag_scope="always",
+            structural_tag_schema=schema_mode,
+        )
+
+        assert guided is not None
+        strict_values = guided["structural_tag"]["format"]["strict"]
+        assert strict_values == [True, not expects_unconstrained_schema]
+
+    def test_auto_scope_requires_parallel_tool_calls_to_be_explicit(self, tokenizer):
+        explicit_request = self._request(tokenizer, parallel_tool_calls=False)
+        request = type(explicit_request).model_construct(
+            _fields_set=explicit_request.model_fields_set - {"parallel_tool_calls"},
+            **explicit_request.__dict__,
+        )
+
+        assert request.parallel_tool_calls is False
+        assert "parallel_tool_calls" not in request.model_fields_set
+        assert not prepost_module._should_build_tool_call_guidance(
+            request,
+            structural_tag_mode="on",
+            structural_tag_scope="auto",
+        )
+
+    @pytest.mark.parametrize(
+        "mode, tool_choice, scope, strict, parallel, expected",
+        [
+            ("off", "auto", "always", False, None, False),
+            ("off", "none", "always", False, None, False),
+            (
+                "on",
+                {"type": "function", "function": {"name": "get_weather"}},
+                "auto",
+                False,
+                None,
+                True,
+            ),
+            ("on", "none", "auto", False, None, False),
+            ("on", "required", "auto", False, None, True),
+            ("on", "auto", "always", False, None, True),
+            ("on", "auto", "auto", True, None, True),
+            ("on", "auto", "auto", False, False, True),
+            ("on", "auto", "auto", False, None, False),
+        ],
+    )
+    def test_runtime_policy_matrix(
+        self,
+        tokenizer,
+        mode,
+        tool_choice,
+        scope,
+        strict,
+        parallel,
+        expected,
+    ):
+        request = self._request(
+            tokenizer,
+            tool_choice=tool_choice,
+            parallel_tool_calls=parallel,
+            tools=[
+                {
+                    **TOOL_REQUEST["tools"][0],
+                    "function": {
+                        **TOOL_REQUEST["tools"][0]["function"],
+                        "strict": strict,
+                    },
+                }
+            ],
+        )
+
+        assert (
+            prepost_module._should_build_tool_call_guidance(
+                request,
+                structural_tag_mode=mode,
+                structural_tag_scope=scope,
+            )
+            is expected
+        )
+
+
 # ---------------------------------------------------------------------------
 # _prepare_request: chat_template_kwargs forwarding
 # ---------------------------------------------------------------------------
@@ -1174,6 +1753,22 @@ def test_runtime_config_context_length(vllm_processor_module, runtime_config, ex
     mdc = SimpleNamespace(runtime_config=lambda: runtime_config)
 
     assert vllm_processor_module._runtime_config_context_length(mdc) == expected
+
+
+def test_runtime_config_structural_tag_options(vllm_processor_module):
+    mdc = SimpleNamespace(
+        runtime_config=lambda: {
+            "structural_tag_mode": "on",
+            "structural_tag_scope": "always",
+            "structural_tag_schema": "strict",
+        }
+    )
+
+    assert vllm_processor_module._runtime_config_structural_tag_options(mdc) == (
+        "on",
+        "always",
+        "strict",
+    )
 
 
 # Regression: MistralTokenizer (--tokenizer-mode mistral) has no chat_template

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -88,6 +88,19 @@ def _runtime_config_context_length(mdc: ModelDeploymentCard) -> int | None:
     return context_length
 
 
+def _runtime_config_structural_tag_options(
+    mdc: ModelDeploymentCard,
+) -> tuple[str, str, str]:
+    runtime_config = mdc.runtime_config()
+    if not isinstance(runtime_config, dict):
+        return "off", "auto", "auto"
+    return (
+        runtime_config.get("structural_tag_mode", "off"),
+        runtime_config.get("structural_tag_scope", "auto"),
+        runtime_config.get("structural_tag_schema", "auto"),
+    )
+
+
 def _ensure_chat_template(
     tokenizer: Any, local_dir: str, chat_template_flag: str | None
 ) -> None:
@@ -265,6 +278,9 @@ class VllmProcessor:
         enable_auto_tool_choice: bool = False,
         default_chat_template_kwargs: dict[str, Any] | None = None,
         default_thinking_mode: str | None = None,
+        structural_tag_mode: str = "off",
+        structural_tag_scope: str = "auto",
+        structural_tag_schema: str = "auto",
     ):
         self.tokenizer = tokenizer
         self.input_processor = input_processor
@@ -277,6 +293,9 @@ class VllmProcessor:
         self.enable_auto_tool_choice = enable_auto_tool_choice
         self.default_chat_template_kwargs = default_chat_template_kwargs
         self.default_thinking_mode = default_thinking_mode
+        self.structural_tag_mode = structural_tag_mode
+        self.structural_tag_scope = structural_tag_scope
+        self.structural_tag_schema = structural_tag_schema
         # Sender for mm_kwargs transfer — instantiated lazily on first MM request.
         # MmKwargsShmSender for same-node transfers (default), MmKwargsNixlSender
         # for cross-node RDMA. Controlled by DYNAMO_MM_TRANSFER env var.
@@ -482,6 +501,9 @@ class VllmProcessor:
                 enable_auto_tool_choice=self.enable_auto_tool_choice,
                 default_chat_template_kwargs=self.default_chat_template_kwargs,
                 default_thinking_mode=self.default_thinking_mode,
+                structural_tag_mode=self.structural_tag_mode,
+                structural_tag_scope=self.structural_tag_scope,
+                structural_tag_schema=self.structural_tag_schema,
             )
 
         request_for_sampling = pre.request_for_sampling
@@ -489,6 +511,7 @@ class VllmProcessor:
         chat_template_kwargs = pre.chat_template_kwargs
         engine_prompt = pre.engine_prompt
         tokens = pre.prompt_token_ids
+        guided_decoding = pre.guided_decoding
 
         if request_for_sampling.max_completion_tokens is not None:
             max_tokens = request_for_sampling.max_completion_tokens
@@ -611,6 +634,8 @@ class VllmProcessor:
             "annotations": [],
             "routing": request.get("routing"),
         }
+        if guided_decoding is not None:
+            dynamo_preproc["sampling_options"]["guided_decoding"] = guided_decoding
         if reasoning_ended is not None:
             dynamo_preproc["reasoning_ended"] = reasoning_ended
         if reasoning_parser_kwargs is not None:
@@ -1046,6 +1071,11 @@ class EngineFactory:
         else:
             reasoning_parser_class = None
         default_thinking_mode = runtime_default_thinking_mode(mdc.runtime_config())
+        (
+            structural_tag_mode,
+            structural_tag_scope,
+            structural_tag_schema,
+        ) = _runtime_config_structural_tag_options(mdc)
 
         block_size = self.config.kv_cache_block_size or 16
 
@@ -1062,6 +1092,9 @@ class EngineFactory:
                 self.flags, "default_chat_template_kwargs", None
             ),
             default_thinking_mode=default_thinking_mode,
+            structural_tag_mode=structural_tag_mode,
+            structural_tag_scope=structural_tag_scope,
+            structural_tag_schema=structural_tag_schema,
         )
         gen.exclude_tools_when_tool_choice_none = (
             self.config.exclude_tools_when_tool_choice_none

--- a/tests/frontend/test_vllm_prepost_integration.py
+++ b/tests/frontend/test_vllm_prepost_integration.py
@@ -248,6 +248,14 @@ def test_vllm_chat_processor_tokenizes_and_streams_tool_calls(
     assert captured["model"] == TEST_MODEL
     assert isinstance(captured["token_ids"], list) and captured["token_ids"]
 
+    guided_decoding = captured["sampling_options"].get("guided_decoding")
+    assert isinstance(guided_decoding, dict)
+    structural_tag = guided_decoding.get("structural_tag")
+    assert isinstance(structural_tag, dict)
+    serialized_tag = json.dumps(structural_tag)
+    assert "search_gutenberg_books" in serialized_tag
+    assert "search_terms" in serialized_tag
+
     decoded_prompt = captured["decoded_prompt"]
     assert "What are the titles of some James Joyce books?" in decoded_prompt
     assert "search_gutenberg_books" in decoded_prompt

--- a/tests/frontend/vllm_prepost_worker.py
+++ b/tests/frontend/vllm_prepost_worker.py
@@ -14,7 +14,13 @@ from typing import Any
 import uvloop
 from transformers import AutoTokenizer
 
-from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
+from dynamo.llm import (
+    ModelInput,
+    ModelRuntimeConfig,
+    ModelType,
+    WorkerType,
+    register_model,
+)
 from dynamo.runtime import DistributedRuntime
 from tests.frontend.test_prepost import OUTPUTS_INTERVAL_20
 from tests.frontend.test_vllm_prepost_integration import CAPTURE_PATH_ENV
@@ -69,12 +75,17 @@ async def main():
 
     runtime = DistributedRuntime(asyncio.get_running_loop(), "etcd", "tcp")
     endpoint = runtime.endpoint("test.vllm-prepost.generate")
+    runtime_config = ModelRuntimeConfig()
+    runtime_config.set_structural_tag_mode("on")
+    runtime_config.set_structural_tag_scope("always")
+    runtime_config.set_structural_tag_schema("strict")
     await register_model(
         ModelInput.Tokens,
         ModelType.Chat,
         endpoint,
         QWEN,
         model_name=QWEN,
+        runtime_config=runtime_config,
         worker_type=WorkerType.Aggregated,
     )
 

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -241,6 +241,7 @@ STUB_MODULES = [
     "vllm.tool_parsers.hermes_tool_parser",
     "vllm.tool_parsers.mistral_tool_parser",
     "vllm.tool_parsers.qwen3_engine_tool_parser",
+    "vllm.tool_parsers.utils",
     "vllm.utils",
     "vllm.utils.async_utils",
     "vllm.utils.hashing",


### PR DESCRIPTION
## Summary

- Backport #12684 to `release/1.4.0`.
- Forward vLLM tool-call and structured-output constraints from the frontend to workers.
- Preserve parser-native tool syntax while adding guided decoding for supported forced tool choices.

## Tracking

Fixes DIS-2645

Source issue: [DIS-2625](https://linear.app/nvidia/issue/DIS-2625/dynamorelease140frontend-vllmprocessor-does-not-pass-guided-decoding)

## Original PR

- Main PR: #12684
- Merge commit: `a765194ef665395a4dd0f266e63066944f7e64fd`

## Validation

- [x] Cherry-pick applied without conflicts
- [x] Source and backport patch IDs match
- [x] `git diff --check`
- [x] vLLM processor unit tests: 97 passed
- [x] SGLang processor unit tests: 198 passed
- [x] Changed-file pre-commit hooks passed
- [ ] CI