### PR TITLE
fix(frontend): patch #12684 to normalize a raw named tool_choice at the validation boundary

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -12,6 +12,7 @@ from typing import Any, Protocol
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedFunction,
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
 )
@@ -79,6 +80,25 @@ def _is_named_tool_choice(tool_choice: Any) -> bool:
 
 def _is_forced_tool_choice(tool_choice: Any) -> bool:
     return tool_choice == "required" or _is_named_tool_choice(tool_choice)
+
+
+def _typed_tool_choice(tool_choice: Any) -> Any:
+    """Normalize a raw named tool choice into the type vLLM's helpers expect.
+
+    vLLM's get_json_schema_from_tools only recognizes a typed
+    ChatCompletionNamedToolChoiceParam. On the DYN_VLLM_SKIP_REQUEST_VALIDATION
+    fast path tool_choice can still be the raw client dict when the request
+    already carries typed tools, and that helper silently returns None for it --
+    leaving a named forced tool call with no constraint at all, which is the
+    defect this whole path exists to fix. Callers reach this only after
+    _is_named_tool_choice has confirmed the shape, so the name is present.
+    """
+    if isinstance(tool_choice, dict):
+        return ChatCompletionNamedToolChoiceParam(
+            type="function",
+            function=ChatCompletionNamedFunction(name=tool_choice["function"]["name"]),
+        )
+    return tool_choice
 
 
 def _has_explicit_output_constraint(request: ChatCompletionRequest) -> bool:
@@ -229,6 +249,8 @@ def build_tool_call_guided_decoding(
             tool_parser, "supports_required_and_named", True
         ):
             return None
+        # tool_choice is already the typed named param by here; see
+        # _validate_chat_completion_request.
         json_schema = get_json_schema_from_tools(tool_choice, request.tools)
         if json_schema is not None:
             return {"json": json_schema}
@@ -366,6 +388,15 @@ def _validate_chat_completion_request(
         or isinstance(validated_request.structured_outputs, dict)
     ):
         return ChatCompletionRequest.model_validate(request)
+    # model_construct leaves tool_choice as the raw client dict. Normalize it
+    # here, once, rather than at each consumer: vLLM's helpers branch on the
+    # typed ChatCompletionNamedToolChoiceParam, and a dict makes
+    # get_json_schema_from_tools silently return None while
+    # get_structural_tag raises AttributeError on .model_dump().
+    if _is_named_tool_choice(validated_request.tool_choice):
+        validated_request.tool_choice = _typed_tool_choice(
+            validated_request.tool_choice
+        )
     return validated_request
 
 

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -1403,6 +1403,56 @@ class TestToolCallGuidedDecoding:
                 structural_tag_mode="on",
             )
 
+    # On the DYN_VLLM_SKIP_REQUEST_VALIDATION fast path, an already-typed `tools`
+    # list means the request is never re-validated, so `tool_choice` stays a raw
+    # dict. vLLM branches on the typed named param: get_json_schema_from_tools
+    # returns None for a dict (no constraint at all) and get_structural_tag raises
+    # AttributeError on .model_dump(). Normalize once at the validation boundary.
+    def _fast_path_named_request(self, tokenizer):
+        typed_tools = _prepare_request(
+            TOOL_REQUEST, tokenizer=tokenizer, tool_parser_class=None
+        )[0].tools
+        return prepost_module._validate_chat_completion_request(
+            {
+                **TOOL_REQUEST,
+                "tools": typed_tools,
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                },
+            }
+        )
+
+    def test_raw_named_tool_choice_is_normalized_at_the_boundary(self, tokenizer):
+        request = self._fast_path_named_request(tokenizer)
+        assert not isinstance(request.tool_choice, dict)
+        assert request.tool_choice.function.name == "get_weather"
+
+    def test_normalized_named_choice_still_builds_json_schema(self, tokenizer):
+        guided = build_tool_call_guided_decoding(
+            self._fast_path_named_request(tokenizer), None
+        )
+        assert guided is not None, "named forced choice must still be constrained"
+        assert "json" in guided
+
+    def test_normalized_named_choice_does_not_break_structural_tag(self, tokenizer):
+        # Regression: a raw dict reached vLLM's structural-tag registry and raised
+        # AttributeError on .model_dump(), surfacing as a 500 rather than a
+        # constraint. Uses the REAL hermes parser -- a fake never reaches the
+        # registry, so it cannot reproduce this.
+        from vllm.tool_parsers import ToolParserManager
+
+        hermes_cls = ToolParserManager.get_tool_parser("hermes")
+        request = self._fast_path_named_request(tokenizer)
+        parser = hermes_cls(tokenizer, request.tools)
+
+        guided = build_tool_call_guided_decoding(
+            request, parser, structural_tag_mode="on"
+        )
+
+        assert guided is not None
+        assert "structural_tag" in guided
+
     # A malformed tool_choice object is not a named tool choice, so it must not be
     # treated as forced and must not trigger the forced-choice conflict check.
     @pytest.mark.parametrize(

--- a/docs/fern/pages/reference/api/python/frontend.mdx
+++ b/docs/fern/pages/reference/api/python/frontend.mdx
@@ -130,7 +130,7 @@ from dynamo.frontend.prepost import PreprocessResult
 PreprocessResult(request_for_sampling: ChatCompletionRequest, tool_parser: ToolParser | None, chat_template_kwargs: dict[str, Any], engine_prompt: dict[str, Any], prompt_token_ids: list[int], guided_decoding: dict[str, Any] | None = None) -> None
 ```
 
-[`components/src/dynamo/frontend/prepost.py#L45`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L45)
+[`components/src/dynamo/frontend/prepost.py#L46`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L46)
 
 **Public methods**
 
@@ -331,7 +331,7 @@ from dynamo.frontend.prepost import StreamingPostProcessor
 StreamingPostProcessor(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionRequest, sampling_params: SamplingParams, prompt_token_ids: Sequence[int], tool_parser: ToolParser | None, reasoning_parser_class: type[ReasoningParser] | None, chat_template_kwargs: dict[str, Any], stream_response: bool = True) -> None
 ```
 
-[`components/src/dynamo/frontend/prepost.py#L597`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L597)
+[`components/src/dynamo/frontend/prepost.py#L628`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L628)
 
 **Public methods**
 
@@ -343,7 +343,7 @@ __init__(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionReques
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L598)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L629)
 
 <h4 id="api-dynamo-frontend-prepost-streamingpostprocessor-process-output">process_output</h4>
 
@@ -353,7 +353,7 @@ process_output(output: Any) -> dict[str, Any] | None
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L894)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L925)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-vllm-processor-vllmprocessor" title="VllmProcessor (class)">
@@ -448,7 +448,7 @@ from dynamo.frontend.prepost import build_tool_call_guided_decoding
 build_tool_call_guided_decoding(request: ChatCompletionRequest, tool_parser: ToolParser | None, *, parser_guided_decoding: dict[str, Any] | None = None, structural_tag_mode: str = 'off', structural_tag_scope: str = 'auto', structural_tag_schema: str = 'auto') -> dict[str, Any] | None
 ```
 
-[`components/src/dynamo/frontend/prepost.py#L187`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L187)
+[`components/src/dynamo/frontend/prepost.py#L207`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L207)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-sglang-prepost-build-tool-call-guided-decoding" title="build_tool_call_guided_decoding (function)">
@@ -700,7 +700,7 @@ from dynamo.frontend.prepost import preprocess_chat_request
 preprocess_chat_request(request: dict[str, Any] | ChatCompletionRequest, *, tokenizer: TokenizerLike, renderer: _Renderer, tool_parser_class: type[ToolParser] | None, exclude_tools_when_tool_choice_none: bool = True, enable_auto_tool_choice: bool = False, default_chat_template_kwargs: dict[str, Any] | None = None, default_thinking_mode: str | None = None, structural_tag_mode: str = 'off', structural_tag_scope: str = 'auto', structural_tag_schema: str = 'auto') -> PreprocessResult
 ```
 
-[`components/src/dynamo/frontend/prepost.py#L491`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L491)
+[`components/src/dynamo/frontend/prepost.py#L522`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L522)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-sglang-prepost-preprocess-chat-request" title="preprocess_chat_request (function)">


### PR DESCRIPTION
## Overview

Follow-up to #12684 ([DIS-2625](https://linear.app/nvidia/issue/DIS-2625)), found by CodeRabbit's review after that PR merged.

A named `tool_choice` arriving as a raw dict silently gets **no** guided-decoding constraint, which is the defect #12684 set out to fix, reached through a different door. `tool_choice: "required"` is unaffected — only the named form.

## Details

`get_json_schema_from_tools` only recognizes a typed `ChatCompletionNamedToolChoiceParam`. With `DYN_VLLM_SKIP_REQUEST_VALIDATION=1` (the default), a request that already carries typed `tools` is never re-validated, so `tool_choice` stays the raw client dict. Measured on vLLM 0.26.0:

```
typed tool_choice -> ChatCompletionNamedToolChoiceParam => schema built
dict  tool_choice -> dict                               => None
```

`_is_named_tool_choice` correctly accepts the dict, so the request takes the forced branch and then gets nothing back. With `--dyn-enable-structural-tag` on it is worse: `get_structural_tag` raises `AttributeError` on `.model_dump()` (`structural_tag_registry.py:191`), i.e. a 500 rather than a missing constraint.

The conversion happens once in `_validate_chat_completion_request`, so `tool_choice` is typed for every consumer rather than being converted at individual call sites. SGLang converts for the same reason where it calls `get_json_schema_constraint`.

## Validation

- Three regression tests, each verified red without the fix: boundary normalization, the JSON fallback, and the structural-tag path (the last uses the real hermes parser — a fake never reaches vLLM's registry and cannot reproduce the AttributeError).
- Processor unit tests: vLLM 100 passed, SGLang 220 passed.
- Pre-commit hooks passed.

## Where should the reviewer start?

`components/src/dynamo/frontend/prepost.py` — `_typed_tool_choice()` and the single call in `_validate_chat_completion_request`.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed forced tool selections so they consistently generate the expected structured output guidance.
  * Improved compatibility when tool definitions and selected tools use different representations.

* **Tests**
  * Added regression coverage to verify that forced named tool calls remain properly constrained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
