### PR TITLE
fix(vllm): advertise native generate capability

### DIFF
--- a/components/src/dynamo/vllm/engine_generate.py
+++ b/components/src/dynamo/vllm/engine_generate.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime capability metadata for vLLM's native Generate API."""
+
+import json
+
+from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, WorkerType
+
+VLLM_GENERATE_CAPABILITY = "vllm_inference_v1_generate"
+
+
+def publish_engine_generate_capability(
+    runtime_config: ModelRuntimeConfig,
+    model_input: ModelInput,
+    model_type: ModelType,
+    worker_type: WorkerType,
+) -> bool:
+    """Publish native Generate support when the worker accepts token input."""
+    if model_input != ModelInput.Tokens:
+        return False
+    if worker_type == WorkerType.Prefill:
+        supported = model_type == ModelType.Prefill
+    else:
+        supported = worker_type in (WorkerType.Decode, WorkerType.Aggregated) and (
+            model_type.supports_chat() or model_type == ModelType.Completions
+        )
+    if not supported:
+        return False
+
+    runtime_config.set_engine_specific(
+        VLLM_GENERATE_CAPABILITY,
+        json.dumps(True),
+    )
+    return True

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -59,6 +59,7 @@ from .capacity import (
     per_rank_kv_blocks,
     publish_vllm_token_budget,
 )
+from .engine_generate import publish_engine_generate_capability
 from .handlers import apply_data_parallel_runtime_config, get_dp_range_for_worker
 from .headless import run_dynamo_headless
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
@@ -689,6 +690,10 @@ async def register_vllm_model(
         runtime_config, config.engine_args, worker_type, dp_range
     )
     runtime_config.context_length = vllm_config.model_config.max_model_len
+    if publish_engine_generate_capability(
+        runtime_config, model_input, model_type, worker_type
+    ):
+        logging.info("Published vLLM engine-native generate capability")
     if model_type != ModelType.Embedding:
         publish_vllm_token_budget(
             runtime_config, vllm_config.model_config.max_model_len

--- a/components/src/dynamo/vllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/vllm/tests/test_runtime_metadata.py
@@ -8,7 +8,12 @@ from unittest.mock import Mock
 import pytest
 
 from dynamo.common.token_budget import TOKEN_BUDGET_RUNTIME_KEY
+from dynamo.llm import ModelInput, ModelType, WorkerType
 from dynamo.vllm.capacity import get_metrics_model_name, get_spec_decode_runtime_data
+from dynamo.vllm.engine_generate import (
+    VLLM_GENERATE_CAPABILITY,
+    publish_engine_generate_capability,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -61,6 +66,36 @@ def test_vllm_token_budget_matches_rejection_policy():
         "reject_prompt_overflow": True,
         "reject_total_overflow": True,
     }
+
+
+@pytest.mark.parametrize(
+    ("model_input", "model_type", "worker_type", "expected"),
+    [
+        (ModelInput.Tokens, ModelType.Prefill, WorkerType.Prefill, True),
+        (ModelInput.Tokens, ModelType.Chat, WorkerType.Decode, True),
+        (ModelInput.Tokens, ModelType.Completions, WorkerType.Aggregated, True),
+        (ModelInput.Tokens, ModelType.Empty, WorkerType.Prefill, False),
+        (ModelInput.Tokens, ModelType.Empty, WorkerType.Decode, False),
+        (ModelInput.Text, ModelType.Chat, WorkerType.Aggregated, False),
+        (ModelInput.Tokens, ModelType.Embedding, WorkerType.Aggregated, False),
+    ],
+)
+def test_vllm_generate_capability_publication(
+    model_input, model_type, worker_type, expected
+):
+    runtime_config = SimpleNamespace(set_engine_specific=Mock())
+
+    published = publish_engine_generate_capability(
+        runtime_config, model_input, model_type, worker_type
+    )
+
+    assert published is expected
+    if expected:
+        runtime_config.set_engine_specific.assert_called_once_with(
+            VLLM_GENERATE_CAPABILITY, json.dumps(True)
+        )
+    else:
+        runtime_config.set_engine_specific.assert_not_called()
 
 
 def test_spec_decode_runtime_data_falls_back_to_engine_args_json():


### PR DESCRIPTION
## Summary

Follow-up to #12466. Token-input vLLM prefill, decode, and aggregated workers publish `runtime_data["vllm_inference_v1_generate"] = true`; text-input, embedding, and incompatible role/type combinations do not.

## Before/after regression evidence

Live one-B200 aggregate deployment in `warnold-dynamo`, model `Qwen/Qwen3-0.6B`, frontend opt-in `DYN_VLLM_ENABLE_INFERENCE_V1_GENERATE=1`, shared cache mounted at `/shared`. Test image: `docker.io/aphoh/not-sglang-dynamo:vllm-generate-pr12881-b54c27bab@sha256:43252f0a0b25e97b04e21e434b9656fa56ab44e7811f1db2f75b7b71f01e45d3`. It packages complete `origin/main` and PR source trees over the same runtime base.

- Before: worker ran checksum-verified `origin/main` `main.py` (`87e6e0b409fa33545750127746089e5579d897e695970fca3fb6e3acab062991`), with no capability in its model-card metadata. `/v1/models` listed `Qwen/Qwen3-0.6B`; valid `POST /inference/v1/generate` body `{"model":"Qwen/Qwen3-0.6B","token_ids":[9707,11],"sampling_params":{"max_tokens":8,"temperature":0}}` returned `404 {"error":{"message":"Model not found: Qwen/Qwen3-0.6B"...}}`.
- After: PR `main.py` checksum `447a86433091347927e5e07cb3135e5906117fcbd2f87e4f2b76638154c75560` and `engine_generate.py` checksum `55fe1aeece3bd733ef2d19a3c12c24927ef4da68cd6c14da3be3f1352aac9fcc` were verified inside the worker. Its metadata contained `vllm_inference_v1_generate`; explicit-model and omitted-model Generate calls both returned `200` with token outputs.
- Request ID: header `x-request-id=11111111-1111-4111-8111-111111111111` overrode body `request_id=22222222-2222-4222-8222-222222222222`; the response echoed the header ID.
- Streaming: `stream=true` returned intended `501 not_implemented` (`streaming ... is not implemented`).

## Validation

- Live B200 before/after validation above.
- `cargo test -p dynamo-llm generate_requires_enabled_matching_worker_capability --lib`: passed (1 passed, 0 failed).
- Python syntax compilation and isolated seven-case capability matrix: passed.
- `git diff --check origin/main...HEAD`: passed.

## Review guide

1. `engine_generate.py` is the narrow capability predicate/publisher.
2. `main.py` publishes it during vLLM registration.
3. `test_runtime_metadata.py` covers supported and unsupported combinations.

Only the three vLLM files are included; no SGLang or older passthrough work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime capability reporting for native vLLM generation support.
  * Capability information is advertised automatically during supported model registrations.

* **Bug Fixes**
  * Prevented capability reporting for unsupported input formats and model or worker configurations.

* **Tests**
  * Added coverage for supported and unsupported capability combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->