### PR TITLE
fix(mocker): align replay ITL and per-user throughput with AIPerf semantics

### DIFF
--- a/components/src/dynamo/replay/reporting.py
+++ b/components/src/dynamo/replay/reporting.py
@@ -63,6 +63,7 @@ def _build_rows(report: dict[str, object]) -> list[list[str]]:
     _append_stat_row(rows, report, "Time to Second Token (ms)", "ttst_ms")
     _append_stat_row(rows, report, "Request Latency (ms)", "e2e_latency_ms")
     _append_stat_row(rows, report, "Inter Token Latency (ms)", "itl_ms")
+    _append_stat_row(rows, report, "Token Gap (ms)", "token_gap_ms")
     _append_stat_row(
         rows,
         report,

--- a/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
+++ b/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
@@ -346,8 +346,15 @@ The report — and the equivalent Python APIs `dynamo.replay.run_trace_replay(..
 - virtual duration and wall-clock runtime
 - request and token throughput
 - prefix cache reuse ratio
-- TTFT, TTST, TPOT, ITL, and end-to-end latency summaries
+- TTFT, TTST, TPOT, ITL, token-gap, and end-to-end latency summaries
 - output-token-throughput-per-user summaries
+
+ITL and output-token-throughput-per-user follow AIPerf's request-level definitions so the report can
+be compared field-for-field with an AIPerf run: `itl = (request_latency - ttft) /
+(output_sequence_length - 1)` per request, and `output_token_throughput_per_user = 1000 / itl_ms`
+per request. The `token_gap` summary keeps the raw distribution over individual consecutive-token
+gaps pooled across requests — its tail exposes engine stalls (for example chunked-prefill
+interference) that request-level averaging smooths out.
 
 ## Related pages
 

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -108,8 +108,17 @@ pub struct TraceLatencyStats {
     pub ttft: TraceDistributionStats,
     pub ttst: TraceDistributionStats,
     pub tpot: TraceDistributionStats,
+    /// Per-request average inter-token latency, matching AIPerf's
+    /// `inter_token_latency` definition:
+    /// `(request_latency - ttft) / (output_sequence_length - 1)`.
     pub itl: TraceInterTokenLatencyStats,
+    /// Distribution over individual consecutive-token gaps (all requests
+    /// pooled). This is the stricter per-gap view previously published as
+    /// `itl`; it has no AIPerf counterpart.
+    pub token_gap: TraceInterTokenLatencyStats,
     pub e2e: TraceDistributionStats,
+    /// Per-request `1000 / itl_ms`, matching AIPerf's
+    /// `output_token_throughput_per_user` definition (`1 / ITL`).
     pub output_token_throughput_per_user: TraceDistributionStats,
 }
 
@@ -278,6 +287,8 @@ impl Serialize for TraceSimulationReport {
         serialize_distribution(&mut map, "tpot", &self.latency.tpot)?;
         serialize_distribution(&mut map, "itl", &self.latency.itl.distribution)?;
         map.serialize_entry("max_itl_ms", &self.latency.itl.max_ms)?;
+        serialize_distribution(&mut map, "token_gap", &self.latency.token_gap.distribution)?;
+        map.serialize_entry("max_token_gap_ms", &self.latency.token_gap.max_ms)?;
         serialize_distribution(&mut map, "e2e_latency", &self.latency.e2e)?;
         serialize_rate_distribution(
             &mut map,
@@ -657,8 +668,7 @@ pub(crate) struct TraceCollector {
     requests: FxHashMap<Uuid, TraceRequestStats>,
     /// Global per-token distributions are folded in as requests terminate, so
     /// completed requests no longer retain one timestamp per emitted token.
-    itl_distribution: StreamingDistribution,
-    output_token_throughput_per_user: StreamingDistribution,
+    token_gap_distribution: StreamingDistribution,
     /// Keep completed token timelines until `finish()` instead of folding them
     /// synchronously in `on_terminal`.
     defer_token_timeline_finalization: bool,
@@ -735,8 +745,7 @@ impl TraceRequestStats {
     fn finalize_token_timeline(
         &mut self,
         include_in_distributions: bool,
-        itl_distribution: &mut StreamingDistribution,
-        output_token_throughput_per_user: &mut StreamingDistribution,
+        token_gap_distribution: &mut StreamingDistribution,
     ) {
         let TokenTimeline::Recording(times) = &self.token_timeline else {
             return;
@@ -744,11 +753,8 @@ impl TraceRequestStats {
 
         if include_in_distributions {
             for window in times.windows(2) {
-                let itl_ms = (window[1] - window[0]).max(0.0);
-                itl_distribution.add(itl_ms);
-                if itl_ms > 0.0 {
-                    output_token_throughput_per_user.add(1000.0 / itl_ms);
-                }
+                let gap_ms = (window[1] - window[0]).max(0.0);
+                token_gap_distribution.add(gap_ms);
             }
         }
 
@@ -1092,8 +1098,7 @@ impl TraceCollector {
     ) {
         let Self {
             requests,
-            itl_distribution,
-            output_token_throughput_per_user,
+            token_gap_distribution,
             defer_token_timeline_finalization,
             ..
         } = self;
@@ -1105,8 +1110,7 @@ impl TraceCollector {
             if !*defer_token_timeline_finalization {
                 stats.finalize_token_timeline(
                     status == ReplayTerminalStatus::Completed && stats.first_admit_ms.is_some(),
-                    itl_distribution,
-                    output_token_throughput_per_user,
+                    token_gap_distribution,
                 );
             }
         }
@@ -1176,16 +1180,14 @@ impl TraceCollector {
     pub(crate) fn finish(mut self) -> TraceSimulationReport {
         let Self {
             requests,
-            itl_distribution,
-            output_token_throughput_per_user,
+            token_gap_distribution,
             ..
         } = &mut self;
         for stats in requests.values_mut() {
             stats.finalize_token_timeline(
                 stats.terminal_status == Some(ReplayTerminalStatus::Completed)
                     && stats.first_admit_ms.is_some(),
-                itl_distribution,
-                output_token_throughput_per_user,
+                token_gap_distribution,
             );
         }
 
@@ -1205,13 +1207,14 @@ impl TraceCollector {
         let accumulated_decode_worker_seconds = self.decode_worker_seconds;
         let prefill_gpus_per_worker = self.prefill_gpus_per_worker;
         let decode_gpus_per_worker = self.decode_gpus_per_worker;
-        let itl_distribution = self.itl_distribution.finish();
-        let output_token_throughput_per_user = self.output_token_throughput_per_user.finish();
+        let token_gap_max_ms = self.token_gap_distribution.max;
+        let token_gap_distribution = self.token_gap_distribution.finish();
         let requests = self.requests;
         let request_count = requests.len();
         let mut ttfts = Vec::with_capacity(request_count);
         let mut ttsts = Vec::with_capacity(request_count);
         let mut tpots = Vec::with_capacity(request_count);
+        let mut output_tokens_per_s_per_user = Vec::with_capacity(request_count);
         let mut e2e_latencies = Vec::with_capacity(request_count);
         let mut duration_ms = 0.0_f64;
         let mut total_input_tokens = 0usize;
@@ -1269,6 +1272,9 @@ impl TraceCollector {
 
             if let Some(tpot_ms) = stats.mean_tpot_ms() {
                 tpots.push(tpot_ms);
+                if tpot_ms > 0.0 {
+                    output_tokens_per_s_per_user.push(1000.0 / tpot_ms);
+                }
             }
         }
 
@@ -1327,13 +1333,26 @@ impl TraceCollector {
             latency: TraceLatencyStats {
                 ttft: build_distribution_stats(ttfts),
                 ttst: build_distribution_stats(ttsts),
-                tpot: build_distribution_stats(tpots),
-                itl: TraceInterTokenLatencyStats {
-                    max_ms: itl_distribution.max_ms,
-                    distribution: itl_distribution,
+                tpot: build_distribution_stats(tpots.clone()),
+                itl: {
+                    let distribution = build_distribution_stats(tpots);
+                    TraceInterTokenLatencyStats {
+                        max_ms: distribution.max_ms,
+                        distribution,
+                    }
+                },
+                token_gap: TraceInterTokenLatencyStats {
+                    max_ms: if token_gap_max_ms.is_finite() {
+                        token_gap_max_ms
+                    } else {
+                        0.0
+                    },
+                    distribution: token_gap_distribution,
                 },
                 e2e: build_distribution_stats(e2e_latencies),
-                output_token_throughput_per_user,
+                output_token_throughput_per_user: build_distribution_stats(
+                    output_tokens_per_s_per_user,
+                ),
             },
             goodput,
             per_request,
@@ -2122,8 +2141,14 @@ mod tests {
         assert_eq!(collector.retained_token_timestamps(), 3);
 
         let report = collector.finish();
+        // Request-level ITL (AIPerf semantics): (15 - 10) / 2 gaps = 2.5.
         assert_eq!(report.latency.itl.distribution.mean_ms, 2.5);
-        assert_eq!(report.latency.itl.distribution.min_ms, 2.0);
-        assert_eq!(report.latency.itl.distribution.max_ms, 3.0);
+        assert_eq!(report.latency.itl.distribution.min_ms, 2.5);
+        assert_eq!(report.latency.itl.distribution.max_ms, 2.5);
+        // Raw per-gap view: gaps of 2 ms and 3 ms.
+        assert_eq!(report.latency.token_gap.distribution.mean_ms, 2.5);
+        assert_eq!(report.latency.token_gap.distribution.min_ms, 2.0);
+        assert_eq!(report.latency.token_gap.distribution.max_ms, 3.0);
+        assert_eq!(report.latency.token_gap.max_ms, 3.0);
     }
 }

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -228,7 +228,7 @@ mod tests {
     use uuid::Uuid;
 
     #[test]
-    fn test_replay_itl_uses_per_token_gaps() {
+    fn test_replay_itl_matches_aiperf_request_semantics() {
         fn assert_ddsketch_relative_error(actual: f64, expected: f64) {
             assert!((actual - expected).abs() <= expected.abs() * 0.001 + f64::EPSILON);
         }
@@ -246,22 +246,26 @@ mod tests {
 
         let report = collector.finish();
 
+        // Request-level ITL matches AIPerf: (last - first) / (osl - 1) = 100/3.
         assert!((report.latency.tpot.mean_ms - (100.0 / 3.0)).abs() < 1e-9);
         assert!((report.latency.itl.distribution.mean_ms - (100.0 / 3.0)).abs() < 1e-9);
-        assert_ddsketch_relative_error(report.latency.itl.distribution.median_ms, 1.0);
-        assert_ddsketch_relative_error(report.latency.itl.distribution.p75_ms, 98.0);
-        assert_ddsketch_relative_error(report.latency.itl.distribution.p90_ms, 98.0);
-        assert_ddsketch_relative_error(report.latency.itl.distribution.p95_ms, 98.0);
-        assert_eq!(report.latency.itl.max_ms, 98.0);
+        assert!((report.latency.itl.distribution.median_ms - (100.0 / 3.0)).abs() < 1e-9);
+        assert!((report.latency.itl.max_ms - (100.0 / 3.0)).abs() < 1e-9);
+        // The raw per-gap distribution keeps the individual 1/1/98 ms gaps.
+        assert!((report.latency.token_gap.distribution.mean_ms - (100.0 / 3.0)).abs() < 1e-9);
+        assert_ddsketch_relative_error(report.latency.token_gap.distribution.median_ms, 1.0);
+        assert_ddsketch_relative_error(report.latency.token_gap.distribution.p75_ms, 98.0);
+        assert_ddsketch_relative_error(report.latency.token_gap.distribution.p90_ms, 98.0);
+        assert_ddsketch_relative_error(report.latency.token_gap.distribution.p95_ms, 98.0);
+        assert_eq!(report.latency.token_gap.max_ms, 98.0);
         assert_eq!(report.latency.ttst.min_ms, 1.0);
         assert_eq!(report.latency.ttst.max_ms, 1.0);
-        assert_eq!(
-            report.latency.output_token_throughput_per_user.min_ms,
-            1000.0 / 98.0
+        // Per-user throughput matches AIPerf: 1 / request-level ITL.
+        assert!(
+            (report.latency.output_token_throughput_per_user.min_ms - 30.0).abs() < 1e-9
         );
-        assert_eq!(
-            report.latency.output_token_throughput_per_user.max_ms,
-            1000.0
+        assert!(
+            (report.latency.output_token_throughput_per_user.max_ms - 30.0).abs() < 1e-9
         );
     }
 


### PR DESCRIPTION
## Overview

The replay report prints an AIPerf-style metrics table, but its **Inter Token Latency** and **Output Token Throughput Per User** rows were computed over *individual consecutive-token gaps pooled across all requests*, while AIPerf defines both metrics **per request**:

```
itl  = (request_latency - ttft) / (output_sequence_length - 1)   # one value per request
otpu = 1 / itl                                                   # one value per request
```

Since DynoSim's headline use case is comparing a simulated report against a real AIPerf run field-for-field, the like-named metrics should use the same definition. With the per-gap definition, percentile rows are dominated by clean decode steps: rare-but-large scheduler stalls (e.g. a chunked prefill blocking decode for ~200 ms) sit just above p99 and disappear from the table, while on the AIPerf side each such stall is smeared into every affected request's average and shifts the whole distribution.

## What changed

- `itl_*` summary fields and the "Inter Token Latency" table row now follow AIPerf's request-level definition (identical to the existing per-request `itl_ms` in `--per-request-jsonl`)
- `output_token_throughput_per_user_*` now follows AIPerf (`1 / itl` per request)
- the raw per-gap distribution is preserved under new `token_gap_*` summary fields and a "Token Gap (ms)" table row — its tail is the only place engine-level stalls such as chunked-prefill interference remain visible before request-level averaging smooths them out
- docs: report-schema section states the definitions explicitly
- tests updated; `test_replay_itl_uses_per_token_gaps` renamed to `test_replay_itl_matches_aiperf_request_semantics`, covering both metrics

## Validation against silicon

Setup: Qwen3-32B (bf16), 4x SGLang TP2 workers on GB200 behind `dynamo.frontend --router-mode kv` (this repo @ main), replaying the public Mooncake FAST25 `conversation_trace.jsonl` (first 20 min, filtered to input+output <= 40704, 3440 requests, `ignore_eos`) with AIPerf 0.9.0 in fixed-schedule mode; DynoSim replaying the identical trace with `--router-mode kv_router --num-workers 4` and AIC gb200/sglang timing, KV capacity pinned to the measured `max_total_num_tokens`.

| metric | silicon (AIPerf) | sim, old per-gap "ITL" | sim, request-level ITL (this PR) |
|---|---|---|---|
| ITL p50 (ms) | 12.1 | 8.0 (-34%) | 9.6 (-21%) |
| ITL p90 (ms) | 21.4 | 8.6 (-60%) | 14.8 (-31%) |
| ITL p99 (ms) | 237 | 24.2 (-90%) | 129.8 (-45%) |
| TTFT p50/p90/p99 (ms) | 357 / 1180 / 2021 | 388 / 1026 / 1683 | unchanged |
| request throughput | 2.832 rps | 2.838 rps | unchanged |

The old rows made the simulator look 60-90% optimistic on decode latency; the apples-to-apples comparison shows the actual model error is 21-45%, which matches the physical accounting (engine logs show a 15.7% chunked-prefill duty cycle; the mocker reproduces ~104 s of blocked stream-time vs ~145 s on silicon, plus AIC's GB200 decode entries running ~7% fast).

## Breaking change note

`mean/median/p*/max_itl_ms` and `*_output_token_throughput_per_user` change meaning (per-gap -> per-request). Consumers that want the old data should read the new `*_token_gap_ms` fields.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Replay reports now include a **Token Gap (ms)** metric, showing pooled gaps between consecutive generated tokens.
  - Latency reports now distinguish request-level ITL from raw token-gap statistics for clearer performance analysis.
  - Per-user output-token throughput and related latency calculations now follow consistent request-level definitions.

- **Documentation**
  - Updated the replay CLI reference with token-gap reporting and clarified definitions for ITL and output-token throughput.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->