### PR TITLE
fix(mocker): model SGLang prefill-priority scheduling in the sglang core

### DIFF
--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -661,32 +661,65 @@ impl SglangCore {
         let prefill_time =
             simulate_prefill_duration(batch_size, mean_isl, mean_prefix, &self.config, true)?;
 
+        let mut newly_prefilled = Vec::new();
         for mut req in admit.can_run {
             if req.materialized_tokens < req.current_sequence_len() {
                 cache_materialized_prefix(&mut req, &mut self.kv_manager, &self.config);
                 self.waiting.push_front(req);
             } else {
-                self.running.push(req);
+                newly_prefilled.push(req);
             }
         }
 
-        // Capture scheduled decode data before the decode step modifies running.
-        let scheduled_decode_lens: Vec<u64> = self
-            .running
-            .iter()
-            .filter(|req| req.remaining_output_tokens() > 0)
-            .map(|req| req.current_sequence_len() as u64)
-            .collect();
+        // SGLang schedules extend (prefill) batches ahead of decode: as long as
+        // a prefill batch can form, requests already in the running set get no
+        // forward pass (`enable_mixed_chunk` is off by default). Mirror that
+        // priority here. An extend pass advances only the requests whose
+        // prefill completed within it — their first token is produced by the
+        // extend forward itself — while every other running request waits for
+        // the next pass with no admissions, which runs a normal decode step.
+        // This is what lets a long multi-chunk prompt starve decode for
+        // several consecutive passes, exactly as observed on silicon.
+        let is_extend_pass = batch_size > 0;
+
+        // Capture scheduled decode data before the decode step modifies its pool.
+        let scheduled_decode_lens: Vec<u64> = if is_extend_pass {
+            newly_prefilled
+                .iter()
+                .filter(|req| req.remaining_output_tokens() > 0)
+                .map(|req| req.current_sequence_len() as u64)
+                .collect()
+        } else {
+            self.running
+                .iter()
+                .filter(|req| req.remaining_output_tokens() > 0)
+                .map(|req| req.current_sequence_len() as u64)
+                .collect()
+        };
 
         let decode_start_ms = now_ms + prefill_time.as_secs_f64() * 1000.0;
-        let mut decode = simulate_decode_step_with_sampler(
-            &mut self.running,
-            &mut self.kv_manager,
-            &self.config,
-            self.speculative_sampler.as_mut(),
-            decode_start_ms,
-            true,
-        )?;
+        let mut decode = if is_extend_pass {
+            let decode = simulate_decode_step_with_sampler(
+                &mut newly_prefilled,
+                &mut self.kv_manager,
+                &self.config,
+                self.speculative_sampler.as_mut(),
+                decode_start_ms,
+                true,
+            )?;
+            self.running.append(&mut newly_prefilled);
+            decode
+        } else {
+            debug_assert!(newly_prefilled.is_empty());
+            simulate_decode_step_with_sampler(
+                &mut self.running,
+                &mut self.kv_manager,
+                &self.config,
+                self.speculative_sampler.as_mut(),
+                decode_start_ms,
+                true,
+            )?
+        };
 
         for request in decode.completed_requests.drain(..) {
             self.complete_source(request);

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -2239,17 +2239,33 @@ mod forward_pass_metrics {
             ..Default::default()
         });
 
-        // Pass 2: r2 prefill + decode step runs on all running (r1 + r2)
+        // Pass 2: r2 forms an extend batch, which SGLang schedules ahead of
+        // decode. Only r2 advances (its first token comes from the extend
+        // forward); r1 is starved for this pass.
         let pass2 = core.execute_pass(&mut collector, 1.0);
         let fpm2 = pass2.fpm.expect("FPM should be present");
         assert_eq!(fpm2.num_prefill_requests, 1, "r2 is prefilling");
-        // In SGLang, after r2 prefill completes it joins running alongside r1,
-        // so the decode step sees both.
-        assert_eq!(fpm2.num_decode_requests, 2, "r1 + r2 both in decode step");
+        assert_eq!(
+            fpm2.num_decode_requests, 1,
+            "extend pass advances only the newly prefilled r2; r1 waits"
+        );
         assert!(
             fpm2.sum_decode_kv_tokens > 0,
             "decode requests should have KV context"
         );
+        assert!(
+            pass2
+                .output_signals
+                .iter()
+                .all(|signal| signal.uuid == Uuid::from_u128(2)),
+            "starved r1 must not emit a token during the extend pass"
+        );
+
+        // Pass 3: no admissions pending, so a normal decode step covers both.
+        let pass3 = core.execute_pass(&mut collector, pass2.end_ms);
+        let fpm3 = pass3.fpm.expect("FPM should be present");
+        assert_eq!(fpm3.num_prefill_requests, 0);
+        assert_eq!(fpm3.num_decode_requests, 2, "r1 + r2 both decode now");
     }
 
     #[test]


### PR DESCRIPTION
## Overview

SGLang schedules extend (prefill) batches **ahead of** decode: while a prefill batch can form, requests in the running set receive no forward pass (`enable_mixed_chunk` is off by default, and was off in our silicon runs). The sglang mocker core instead ran one decode step in *every* engine pass — including passes that executed a prefill chunk — so during a long multi-chunk prompt, every running request still received one token per chunk.

The consequence is that the simulator cannot reproduce the decode-starvation trains that dominate the ITL tail on real hardware: a 40k-token prompt runs ~5 consecutive 8192-token chunks back-to-back, and decode requests on that worker stall for the whole train.

## What changed

In `try_execute_pass_internal`:

- a pass that admitted a prefill batch (an *extend pass*) now advances only the requests whose prefill completed within it — their first token is produced by the extend forward itself, which is exactly what the AIC/profile prefill timing measures
- every other running request waits; the next pass with no admissions runs a normal decode step over the full running set
- chunk continuations re-enter the waiting-queue front, so a long prompt forms the same back-to-back extend-pass train as the real scheduler

This is a gap-*shape* correction: total simulated prefill-blocking time is unchanged (the old code already charged running requests the chunk duration, just one token at a time), so medians and throughput are stable while the tail becomes physical.

## Validation against silicon

Qwen3-32B (bf16), 4x SGLang TP2 workers on GB200 behind `dynamo.frontend --router-mode kv`, replaying the public Mooncake FAST25 `conversation_trace.jsonl` (first 20 min, filtered to input+output <= 40704, 3440 requests, `ignore_eos`) with AIPerf 0.9.0 fixed-schedule; DynoSim on the identical trace, AIC gb200/sglang timing, KV capacity pinned to measured `max_total_num_tokens`. ITL below is request-level (AIPerf definition, see #12883 — this branch is independent but was validated together with it).

| | sim before | sim after | silicon |
|---|---|---|---|
| max token gap (ms) | 392 | **2102** | ~3000 (longest observed stall) |
| ITL p99 (ms) | 129.8 | **152.0** | 237 |
| ITL max (ms) | 277 | **1125** | 4253 (smoke), short-output request behind a chunk train |
| ITL p50 (ms) | 9.59 | 9.72 | 12.1 |
| TTFT p50 / p99 (ms) | 384 / 1702 | 389 / 1675 | 357 / 2021 |
| request throughput (rps) | 2.84 | 2.84 | 2.83 |

Engine-log cross-check on silicon: 319 prefill batches in 303 s (chunk p50 7.9k tokens, ~248 ms each), decode fully idle during each chunk train — matching the new pass semantics.

The remaining p50/p90 deficit is AIC database calibration (GB200 decode entries ~7% fast, prefill entries ~14% fast vs this silicon/SGLang 0.5.16), not scheduler structure: with `speedup_ratio 0.877` + `decode_speedup_ratio 1.041` compensating those measured offsets, the same run lands at ITL p50 11.03 / p90 17.30 / p99 149.4 vs silicon 12.1 / 21.4 / 237.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mixed prefill and decode scheduling to ensure newly prefilling requests are processed immediately.
  * Existing decoding requests now wait appropriately during extend passes, preventing premature output.

* **Tests**
  * Updated scheduling coverage to verify correct output across mixed prefill and decode passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->