### PR TITLE
fix(snapshot): remap clone-conflicting sockets during restore

### DIFF
--- a/deploy/snapshot/internal/criu/restore.go
+++ b/deploy/snapshot/internal/criu/restore.go
@@ -39,18 +39,24 @@ func ExecuteRestore(
 	// and unlock. That keeps the window where the restored process runs with CUDA
 	// still locked as short as possible. cleanup is called on the error paths below.
 	var openFiles, inheritedFiles []*os.File
+	imageDirPath, removeImageDir, err := prepareRestoreImageDir(checkpointPath)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to prepare CRIU image directory: %w", err)
+	}
 	var confTmpDir string
 	cleanup := func() {
 		closeFiles(inheritedFiles)
 		closeFiles(openFiles)
+		removeImageDir()
 		if err := os.RemoveAll(confTmpDir); err != nil {
 			log.Error(err, "failed to remove criu config temp dir", "path", confTmpDir)
 		}
 	}
 
 	// Open image dir FD
-	imageDir, imageDirFD, err := openPathForCRIU(checkpointPath)
+	imageDir, imageDirFD, err := openPathForCRIU(imageDirPath)
 	if err != nil {
+		cleanup()
 		return 0, nil, fmt.Errorf("failed to open image directory: %w", err)
 	}
 	openFiles = append(openFiles, imageDir)
@@ -100,7 +106,7 @@ func ExecuteRestore(
 	log.V(1).Info("Executing go-criu Restore call")
 	if err := c.Restore(criuOpts, notify); err != nil {
 		log.Error(err, "go-criu Restore returned error")
-		logging.LogRestoreErrors(checkpointPath, settings.WorkDir, log)
+		logging.LogRestoreErrors(imageDirPath, settings.WorkDir, log)
 		cleanup()
 		return 0, nil, fmt.Errorf("CRIU restore failed: %w", err)
 	}

--- a/deploy/snapshot/internal/criu/restore_images.go
+++ b/deploy/snapshot/internal/criu/restore_images.go
@@ -1,0 +1,367 @@
+package criu
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/checkpoint-restore/go-criu/v8/crit"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fdinfo"
+	sk_inet "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-inet"
+	sk_unix "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-unix"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	filesImageFilename            = "files.img"
+	placeholderMountNamespacePath = "/proc/self/ns/mnt"
+	cudaUVMFDSocketNamePrefix     = "\x00cuda-uvmfd-"
+	linuxUnixSocketStateListen    = 10
+	linuxTCPStateEstablished      = 1
+	linuxTCPStateClose            = 7
+	linuxTCPStateListen           = 10
+)
+
+type tcpPortRewrite struct {
+	socket *sk_inet.InetSkEntry
+	peers  []*sk_inet.InetSkEntry
+	port   uint32
+}
+
+func prepareRestoreImageDir(checkpointPath string) (string, func(), error) {
+	// The placeholder mount namespace remains container-specific with shareProcessNamespace.
+	var stat unix.Stat_t
+	if err := unix.Stat(placeholderMountNamespacePath, &stat); err != nil {
+		return "", nil, fmt.Errorf("failed to stat placeholder mount namespace at %s: %w", placeholderMountNamespacePath, err)
+	}
+	return prepareRestoreImageDirForRestoreID(checkpointPath, stat.Ino)
+}
+
+func prepareRestoreImageDirForRestoreID(checkpointPath string, restoreID uint64) (string, func(), error) {
+	checkpointPath, err := filepath.Abs(checkpointPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to resolve checkpoint path: %w", err)
+	}
+
+	filesImage, err := os.Open(filepath.Join(checkpointPath, filesImageFilename))
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to open %s: %w", filesImageFilename, err)
+	}
+
+	image, err := crit.New(filesImage, nil, "", false, false).Decode(&fdinfo.FileEntry{})
+	closeErr := filesImage.Close()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to decode %s: %w", filesImageFilename, err)
+	}
+	if closeErr != nil {
+		return "", nil, fmt.Errorf("failed to close %s: %w", filesImageFilename, closeErr)
+	}
+
+	// CRIU recreates bound sockets from files.img. Give each clone a private
+	// view so containers sharing a Pod network namespace get unique identities.
+	tcpRewrites, tcpDisconnects, forbiddenPorts := planTCPPortRewrites(image)
+	var reservationFDs []int
+	for i := range tcpRewrites {
+		var reservationFD int
+		tcpRewrites[i].port, reservationFD, err = reserveDualStackTCPPort(forbiddenPorts)
+		if err != nil {
+			closeFDs(reservationFDs)
+			return "", nil, fmt.Errorf("failed to reserve replacement TCP port: %w", err)
+		}
+		reservationFDs = append(reservationFDs, reservationFD)
+		forbiddenPorts[tcpRewrites[i].port] = struct{}{}
+	}
+
+	rewritten := false
+	for _, entry := range image.Entries {
+		fileEntry := entry.Message.(*fdinfo.FileEntry)
+		if fileEntry.GetType() != fdinfo.FdTypes_UNIXSK || fileEntry.Usk == nil {
+			continue
+		}
+		if rewriteCloneConflictingUnixSocketAddress(fileEntry.Usk, restoreID) {
+			rewritten = true
+		}
+	}
+	for _, rewrite := range tcpRewrites {
+		*rewrite.socket.SrcPort = rewrite.port
+		for _, peer := range rewrite.peers {
+			*peer.DstPort = rewrite.port
+		}
+		rewritten = true
+	}
+	for _, socket := range tcpDisconnects {
+		// A remote peer cannot follow a cloned connection to its new tuple.
+		// Preserve the FD, but restore it as an unconnected TCP socket.
+		*socket.State = linuxTCPStateClose
+		*socket.SrcPort = 0
+		*socket.DstPort = 0
+		clear(socket.SrcAddr)
+		clear(socket.DstAddr)
+		rewritten = true
+	}
+	if !rewritten {
+		return checkpointPath, func() {}, nil
+	}
+
+	privateDir, err := os.MkdirTemp(filepath.Dir(checkpointPath), ".dynamo-criu-restore-*")
+	if err != nil {
+		closeFDs(reservationFDs)
+		return "", nil, fmt.Errorf("failed to create private CRIU image directory: %w", err)
+	}
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		cleanupOnce.Do(func() {
+			closeFDs(reservationFDs)
+			_ = os.RemoveAll(privateDir)
+		})
+	}
+	fail := func(err error) (string, func(), error) {
+		cleanup()
+		return "", nil, err
+	}
+
+	entries, err := os.ReadDir(checkpointPath)
+	if err != nil {
+		return fail(fmt.Errorf("failed to read checkpoint directory: %w", err))
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == filesImageFilename || !strings.HasSuffix(name, ".img") {
+			continue
+		}
+		// CRIU does not modify restore images; hard links keep them visible after it
+		// enters the restored mount namespace without copying large page images.
+		if err := os.Link(filepath.Join(checkpointPath, name), filepath.Join(privateDir, name)); err != nil {
+			return fail(fmt.Errorf("failed to hard-link CRIU image %s: %w", name, err))
+		}
+	}
+
+	privateFilesImage, err := os.OpenFile(filepath.Join(privateDir, filesImageFilename), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return fail(fmt.Errorf("failed to create private %s: %w", filesImageFilename, err))
+	}
+	if err := crit.New(nil, privateFilesImage, "", false, false).Encode(image); err != nil {
+		_ = privateFilesImage.Close()
+		return fail(fmt.Errorf("failed to encode private %s: %w", filesImageFilename, err))
+	}
+	if err := privateFilesImage.Close(); err != nil {
+		return fail(fmt.Errorf("failed to close private %s: %w", filesImageFilename, err))
+	}
+
+	return privateDir, cleanup, nil
+}
+
+func planTCPPortRewrites(image *crit.CriuImage) (
+	[]tcpPortRewrite,
+	[]*sk_inet.InetSkEntry,
+	map[uint32]struct{},
+) {
+	var sockets []*sk_inet.InetSkEntry
+	forbiddenPorts := make(map[uint32]struct{})
+
+	for _, entry := range image.Entries {
+		file, ok := entry.Message.(*fdinfo.FileEntry)
+		if !ok || file.GetType() != fdinfo.FdTypes_INETSK || file.Isk == nil {
+			continue
+		}
+		sockets = append(sockets, file.Isk)
+		if port := file.Isk.GetSrcPort(); port != 0 {
+			forbiddenPorts[port] = struct{}{}
+		}
+		if port := file.Isk.GetDstPort(); port != 0 {
+			forbiddenPorts[port] = struct{}{}
+		}
+	}
+
+	var rewrites []tcpPortRewrite
+	var disconnects []*sk_inet.InetSkEntry
+	// Keep listener ports stable. Only rewrite connections whose reciprocal
+	// endpoint is also in the image, so both halves retain a valid TCP tuple.
+	for _, socket := range sockets {
+		if !isEstablishedTCP(socket) || !hasSupportedTCPAddresses(socket) {
+			continue
+		}
+		rewrite := tcpPortRewrite{socket: socket}
+		for _, peer := range sockets {
+			if reciprocalTCPPair(socket, peer) {
+				rewrite.peers = append(rewrite.peers, peer)
+			}
+		}
+		if len(rewrite.peers) == 0 {
+			disconnects = append(disconnects, socket)
+		} else if len(rewrite.peers) == 1 && !hasTCPListener(socket, sockets) {
+			rewrites = append(rewrites, rewrite)
+		}
+	}
+	return rewrites, disconnects, forbiddenPorts
+}
+
+func isTCPSocket(socket *sk_inet.InetSkEntry) bool {
+	return socket != nil &&
+		socket.SrcPort != nil &&
+		socket.DstPort != nil &&
+		socket.NsId != nil &&
+		(socket.GetFamily() == uint32(unix.AF_INET) ||
+			socket.GetFamily() == uint32(unix.AF_INET6)) &&
+		socket.GetType() == uint32(unix.SOCK_STREAM) &&
+		socket.GetProto() == uint32(unix.IPPROTO_TCP)
+}
+
+func isEstablishedTCP(socket *sk_inet.InetSkEntry) bool {
+	return isTCPSocket(socket) &&
+		socket.GetState() == linuxTCPStateEstablished &&
+		socket.GetSrcPort() > 0 &&
+		socket.GetDstPort() > 0
+}
+
+func reciprocalTCPPair(a, b *sk_inet.InetSkEntry) bool {
+	aSrc, aSrcOK := normalizedIPAddress(a.GetFamily(), a.SrcAddr)
+	aDst, aDstOK := normalizedIPAddress(a.GetFamily(), a.DstAddr)
+	bSrc, bSrcOK := normalizedIPAddress(b.GetFamily(), b.SrcAddr)
+	bDst, bDstOK := normalizedIPAddress(b.GetFamily(), b.DstAddr)
+	return a != b &&
+		isEstablishedTCP(a) &&
+		isEstablishedTCP(b) &&
+		aSrcOK && aDstOK && bSrcOK && bDstOK &&
+		a.GetNsId() == b.GetNsId() &&
+		a.GetSrcPort() == b.GetDstPort() &&
+		a.GetDstPort() == b.GetSrcPort() &&
+		aSrc == bDst &&
+		aDst == bSrc
+}
+
+func hasSupportedTCPAddresses(socket *sk_inet.InetSkEntry) bool {
+	_, srcOK := normalizedIPAddress(socket.GetFamily(), socket.SrcAddr)
+	_, dstOK := normalizedIPAddress(socket.GetFamily(), socket.DstAddr)
+	return srcOK && dstOK
+}
+
+func normalizedIPAddress(family uint32, words []uint32) (netip.Addr, bool) {
+	switch family {
+	case unix.AF_INET:
+		if len(words) != 1 {
+			return netip.Addr{}, false
+		}
+		var address [4]byte
+		binary.LittleEndian.PutUint32(address[:], words[0])
+		return netip.AddrFrom4(address), true
+	case unix.AF_INET6:
+		if len(words) != 4 {
+			return netip.Addr{}, false
+		}
+		var address [16]byte
+		for i, word := range words {
+			binary.LittleEndian.PutUint32(address[i*4:], word)
+		}
+		return netip.AddrFrom16(address).Unmap(), true
+	default:
+		return netip.Addr{}, false
+	}
+}
+
+func hasTCPListener(
+	endpoint *sk_inet.InetSkEntry,
+	sockets []*sk_inet.InetSkEntry,
+) bool {
+	for _, socket := range sockets {
+		if !isTCPSocket(socket) ||
+			socket.GetState() != linuxTCPStateListen ||
+			socket.GetFamily() != endpoint.GetFamily() ||
+			socket.GetNsId() != endpoint.GetNsId() ||
+			socket.GetSrcPort() != endpoint.GetSrcPort() ||
+			socket.GetDstPort() != 0 {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func reserveDualStackTCPPort(forbidden map[uint32]struct{}) (uint32, int, error) {
+	var rejected []int
+	defer func() {
+		for _, fd := range rejected {
+			_ = unix.Close(fd)
+		}
+	}()
+
+	for {
+		fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, unix.IPPROTO_TCP)
+		if err != nil {
+			return 0, -1, err
+		}
+		if err := unix.SetsockoptInt(fd, unix.IPPROTO_IPV6, unix.IPV6_V6ONLY, 0); err != nil {
+			_ = unix.Close(fd)
+			return 0, -1, err
+		}
+		if err := unix.Bind(fd, &unix.SockaddrInet6{}); err != nil {
+			_ = unix.Close(fd)
+			return 0, -1, err
+		}
+
+		boundAddress, err := unix.Getsockname(fd)
+		if err != nil {
+			_ = unix.Close(fd)
+			return 0, -1, err
+		}
+		address, ok := boundAddress.(*unix.SockaddrInet6)
+		if !ok {
+			_ = unix.Close(fd)
+			return 0, -1, fmt.Errorf("unexpected bound socket address %T", boundAddress)
+		}
+		port := uint32(address.Port)
+		if port == 0 || port > 65535 {
+			_ = unix.Close(fd)
+			return 0, -1, fmt.Errorf("kernel selected invalid TCP port %d", port)
+		}
+		if _, exists := forbidden[port]; exists {
+			// Keep the bind until selection finishes so port 0 cannot immediately
+			// return the same forbidden port.
+			rejected = append(rejected, fd)
+			continue
+		}
+		if err := unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil {
+			_ = unix.Close(fd)
+			return 0, -1, err
+		}
+		return port, fd, nil
+	}
+}
+
+func closeFDs(fds []int) {
+	for _, fd := range fds {
+		_ = unix.Close(fd)
+	}
+}
+
+func rewriteCloneConflictingUnixSocketAddress(entry *sk_unix.UnixSkEntry, restoreID uint64) bool {
+	if !isCUDAUVMFDListener(entry) {
+		return false
+	}
+
+	// CUDA retains this listener's FD, so only its clone-private address changes.
+	input := make([]byte, 8+len(entry.Name))
+	binary.BigEndian.PutUint64(input, restoreID)
+	copy(input[8:], entry.Name)
+	digest := sha256.Sum256(input)
+	entry.Name = hex.AppendEncode([]byte("\x00dynamo-"), digest[:])
+	return true
+}
+
+func isCUDAUVMFDListener(entry *sk_unix.UnixSkEntry) bool {
+	return entry != nil &&
+		entry.Type != nil &&
+		entry.State != nil &&
+		entry.Peer != nil &&
+		*entry.Type == uint32(unix.SOCK_SEQPACKET) &&
+		*entry.State == linuxUnixSocketStateListen &&
+		*entry.Peer == 0 &&
+		bytes.HasPrefix(entry.Name, []byte(cudaUVMFDSocketNamePrefix))
+}

--- a/deploy/snapshot/internal/criu/restore_images_test.go
+++ b/deploy/snapshot/internal/criu/restore_images_test.go
@@ -1,0 +1,277 @@
+package criu
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/checkpoint-restore/go-criu/v8/crit"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fdinfo"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fown"
+	sk_inet "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-inet"
+	sk_opts "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-opts"
+	sk_unix "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-unix"
+	"golang.org/x/sys/unix"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestPrepareRestoreImageDirRewritesObservedSocketTopology(t *testing.T) {
+	checkpointPath := t.TempDir()
+	entries := observedSocketTopology()
+	canonical := writeFilesImage(t, checkpointPath, entries)
+
+	imageDir, cleanup, err := prepareRestoreImageDirForRestoreID(checkpointPath, 987654321)
+	if err != nil {
+		t.Fatalf("prepare restore image directory: %v", err)
+	}
+	defer cleanup()
+	if imageDir == checkpointPath {
+		t.Fatal("socket conflicts did not produce a private restore image")
+	}
+
+	restored := readFilesImage(t, imageDir)
+	if got := restored[0].Usk.Name; !bytes.HasPrefix(got, []byte("\x00dynamo-")) {
+		t.Fatalf("CUDA listener address = %q, want Dynamo abstract address", got)
+	}
+	clientPort := restored[5].Isk.GetSrcPort()
+	if clientPort == entries[5].Isk.GetSrcPort() {
+		t.Fatalf("TCP client port was not rewritten")
+	}
+	if got := restored[6].Isk.GetDstPort(); got != clientPort {
+		t.Fatalf("TCP server peer port = %d, want %d", got, clientPort)
+	}
+	dualStackClientPort := restored[9].Isk.GetSrcPort()
+	if dualStackClientPort == entries[9].Isk.GetSrcPort() {
+		t.Fatalf("dual-stack TCP client port was not rewritten")
+	}
+	if got := restored[10].Isk.GetDstPort(); got != dualStackClientPort {
+		t.Fatalf("dual-stack TCP server peer port = %d, want %d", got, dualStackClientPort)
+	}
+	if outbound := restored[7].Isk; outbound.GetState() != linuxTCPStateClose ||
+		outbound.GetSrcPort() != 0 ||
+		outbound.GetDstPort() != 0 {
+		t.Fatalf("outbound TCP socket was not disconnected: %v", outbound)
+	}
+	for i, original := range entries {
+		want := proto.Clone(original).(*fdinfo.FileEntry)
+		switch i {
+		case 0:
+			want.Usk.Name = restored[i].Usk.Name
+		case 5:
+			want.Isk.SrcPort = proto.Uint32(clientPort)
+		case 6:
+			want.Isk.DstPort = proto.Uint32(clientPort)
+		case 7:
+			want.Isk.State = proto.Uint32(linuxTCPStateClose)
+			want.Isk.SrcPort = proto.Uint32(0)
+			want.Isk.DstPort = proto.Uint32(0)
+			clear(want.Isk.SrcAddr)
+			clear(want.Isk.DstAddr)
+		case 9:
+			want.Isk.SrcPort = proto.Uint32(dualStackClientPort)
+		case 10:
+			want.Isk.DstPort = proto.Uint32(dualStackClientPort)
+		}
+		if !proto.Equal(restored[i], want) {
+			t.Errorf("restore entry %d changed unexpectedly:\n got: %v\nwant: %v", i, restored[i], want)
+		}
+	}
+
+	gotCanonical, err := os.ReadFile(filepath.Join(checkpointPath, filesImageFilename))
+	if err != nil {
+		t.Fatalf("read canonical image: %v", err)
+	}
+	if !bytes.Equal(gotCanonical, canonical) {
+		t.Fatal("canonical files.img was modified")
+	}
+}
+
+func TestPrepareRestoreImageDirConcurrentRestoresAreIndependent(t *testing.T) {
+	checkpointPath := t.TempDir()
+	writeFilesImage(t, checkpointPath, observedSocketTopology())
+
+	type result struct {
+		path    string
+		cleanup func()
+		err     error
+	}
+	results := make(chan result, 2)
+	var wait sync.WaitGroup
+	for _, restoreID := range []uint64{111, 222} {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			path, cleanup, err := prepareRestoreImageDirForRestoreID(checkpointPath, restoreID)
+			results <- result{path: path, cleanup: cleanup, err: err}
+		}()
+	}
+	wait.Wait()
+	close(results)
+
+	addresses := make(map[string]struct{})
+	ports := make(map[uint32]struct{})
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("prepare restore image directory: %v", result.err)
+		}
+		t.Cleanup(result.cleanup)
+		entries := readFilesImage(t, result.path)
+		addresses[string(entries[0].Usk.Name)] = struct{}{}
+		ports[entries[5].Isk.GetSrcPort()] = struct{}{}
+	}
+	if len(addresses) != 2 {
+		t.Fatalf("concurrent restores used %d CUDA socket addresses, want 2", len(addresses))
+	}
+	if len(ports) != 2 {
+		t.Fatalf("concurrent restores used %d TCP client ports, want 2", len(ports))
+	}
+}
+
+func observedSocketTopology() []*fdinfo.FileEntry {
+	wildcard := []uint32{0, 0, 0, 0}
+	podAddress := []uint32{0, 0, 0xffff0000, 0x0100007f}
+	podIPv4Address := []uint32{0x0100007f}
+	remoteIPv4Address := []uint32{0x66d95434}
+	listener := newTCPSocketEntry(5, 105, 52103, 0, linuxTCPStateListen, wildcard, wildcard)
+	client := newTCPSocketEntry(6, 106, 46730, 52103, linuxTCPStateEstablished, podAddress, podAddress)
+	server := newTCPSocketEntry(7, 107, 52103, 46730, linuxTCPStateEstablished, podAddress, podAddress)
+	outbound := newTCPSocketEntry(8, 108, 45336, 443, linuxTCPStateEstablished, podIPv4Address, remoteIPv4Address)
+	outbound.Isk.Family = proto.Uint32(unix.AF_INET)
+	outbound.Isk.V6Only = nil
+	dualStackListener := newTCPSocketEntry(9, 109, 53103, 0, linuxTCPStateListen, wildcard, wildcard)
+	dualStackClient := newTCPSocketEntry(10, 110, 47730, 53103, linuxTCPStateEstablished, podIPv4Address, podIPv4Address)
+	dualStackClient.Isk.Family = proto.Uint32(unix.AF_INET)
+	dualStackClient.Isk.V6Only = nil
+	dualStackServer := newTCPSocketEntry(11, 111, 53103, 47730, linuxTCPStateEstablished, podAddress, podAddress)
+	return []*fdinfo.FileEntry{
+		newUnixSocketEntry(1, []byte("\x00cuda-uvmfd-4026554902-1195\x00"), 101, unix.SOCK_SEQPACKET, linuxUnixSocketStateListen),
+		newUnixSocketEntry(2, []byte("/tmp/4c85f2c6-ea0e-45cb-b7ee-fd519aba82d0\x00"), 102, unix.SOCK_STREAM, linuxUnixSocketStateListen),
+		newUnixSocketEntry(3, []byte("\x00047f9"), 103, unix.SOCK_DGRAM, 7),
+		newUnixSocketEntry(4, []byte("\x00047ff"), 104, unix.SOCK_DGRAM, 7),
+		listener,
+		client,
+		server,
+		outbound,
+		dualStackListener,
+		dualStackClient,
+		dualStackServer,
+	}
+}
+
+func newUnixSocketEntry(id uint32, name []byte, inode uint32, socketType int, state uint32) *fdinfo.FileEntry {
+	zero32 := uint32(0)
+	zero64 := uint64(0)
+	return &fdinfo.FileEntry{
+		Type: fdinfo.FdTypes_UNIXSK.Enum(),
+		Id:   proto.Uint32(id),
+		Usk: &sk_unix.UnixSkEntry{
+			Id:      proto.Uint32(id),
+			Ino:     proto.Uint32(inode),
+			Type:    proto.Uint32(uint32(socketType)),
+			State:   proto.Uint32(state),
+			Flags:   &zero32,
+			Uflags:  &zero32,
+			Backlog: &zero32,
+			Peer:    &zero32,
+			Fown: &fown.FownEntry{
+				Uid:     &zero32,
+				Euid:    &zero32,
+				Signum:  &zero32,
+				PidType: &zero32,
+				Pid:     &zero32,
+			},
+			Opts: &sk_opts.SkOptsEntry{
+				SoSndbuf:     &zero32,
+				SoRcvbuf:     &zero32,
+				SoSndTmoSec:  &zero64,
+				SoSndTmoUsec: &zero64,
+				SoRcvTmoSec:  &zero64,
+				SoRcvTmoUsec: &zero64,
+			},
+			Name: name,
+			NsId: proto.Uint32(9),
+		},
+	}
+}
+
+func newTCPSocketEntry(
+	id, inode, srcPort, dstPort, state uint32,
+	srcAddr, dstAddr []uint32,
+) *fdinfo.FileEntry {
+	socketMetadata := newUnixSocketEntry(id, nil, inode, unix.SOCK_STREAM, state).Usk
+	return &fdinfo.FileEntry{
+		Type: fdinfo.FdTypes_INETSK.Enum(),
+		Id:   proto.Uint32(id),
+		Isk: &sk_inet.InetSkEntry{
+			Id:      proto.Uint32(id),
+			Ino:     proto.Uint32(inode),
+			Family:  proto.Uint32(unix.AF_INET6),
+			Type:    proto.Uint32(unix.SOCK_STREAM),
+			Proto:   proto.Uint32(unix.IPPROTO_TCP),
+			State:   proto.Uint32(state),
+			SrcPort: proto.Uint32(srcPort),
+			DstPort: proto.Uint32(dstPort),
+			SrcAddr: srcAddr,
+			DstAddr: dstAddr,
+			Flags:   socketMetadata.Flags,
+			Backlog: socketMetadata.Backlog,
+			Fown:    socketMetadata.Fown,
+			Opts:    socketMetadata.Opts,
+			V6Only:  proto.Bool(false),
+			NsId:    proto.Uint32(9),
+		},
+	}
+}
+
+func writeFilesImage(t *testing.T, dir string, entries []*fdinfo.FileEntry) []byte {
+	t.Helper()
+	file, err := os.Create(filepath.Join(dir, filesImageFilename))
+	if err != nil {
+		t.Fatalf("create files image: %v", err)
+	}
+	imageEntries := make([]*crit.CriuEntry, len(entries))
+	for i, entry := range entries {
+		imageEntries[i] = &crit.CriuEntry{Message: entry}
+	}
+	image := &crit.CriuImage{
+		Magic:     "FILES",
+		Entries:   imageEntries,
+		EntryType: &fdinfo.FileEntry{},
+	}
+	if err := crit.New(nil, file, "", false, false).Encode(image); err != nil {
+		_ = file.Close()
+		t.Fatalf("encode files image: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close files image: %v", err)
+	}
+	data, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatalf("read files image: %v", err)
+	}
+	return data
+}
+
+func readFilesImage(t *testing.T, dir string) []*fdinfo.FileEntry {
+	t.Helper()
+	file, err := os.Open(filepath.Join(dir, filesImageFilename))
+	if err != nil {
+		t.Fatalf("open files image: %v", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			t.Errorf("close files image: %v", err)
+		}
+	}()
+	image, err := crit.New(file, nil, "", false, false).Decode(&fdinfo.FileEntry{})
+	if err != nil {
+		t.Fatalf("decode files image: %v", err)
+	}
+	entries := make([]*fdinfo.FileEntry, len(image.Entries))
+	for i, entry := range image.Entries {
+		entries[i] = entry.Message.(*fdinfo.FileEntry)
+	}
+	return entries
+}


### PR DESCRIPTION
## Summary

Enable repeated restores of one CRIU checkpoint into sibling engine containers that share a Pod network namespace.

For each restore, this change creates a private `files.img` view and deconflicts only the two socket identities observed in real Snapshot checkpoints:

- a CUDA UVM `SOCK_SEQPACKET` listener is rebound to an abstract address of the form `\0dynamo-<sha256>`, derived from the target container restore ID and original address; and
- one unique reciprocal internal TCP client/server pair gets a kernel-selected free client port.

The canonical checkpoint remains unchanged and reusable. Unrelated, unsupported, or ambiguous socket records are left untouched. The TCP port is reserved until restore cleanup so concurrent restores select distinct ports.

## Validation

From `deploy/snapshot`:

- `go test -race ./...`
- `go vet ./internal/criu`
- `git diff --check`

## Stack

| Order | PR | Scope |
| ---: | --- | --- |
| 1 | **#12887** | **Restore-time socket deconfliction** |
| 2 | #12869 | Shared Snapshot/GMS failover runtime |
| 3 | #12874 | Operator orchestration |
