### PR TITLE
refactor(discovery): reconcile models through desired state [DYN-3847]

### DIFF
--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -18,6 +18,8 @@ pub use kv_source_watch::KvSourceMembershipWatch;
 mod model_manager;
 pub use model_manager::{ModelManager, ModelManagerError, UNKNOWN_METRIC_MODEL};
 
+mod controller;
+
 mod worker_set;
 pub use worker_set::WorkerSet;
 

--- a/lib/llm/src/discovery/controller.rs
+++ b/lib/llm/src/discovery/controller.rs
@@ -202,6 +202,7 @@ pub(crate) struct ModelDiscoveryController<H: ControllerHost> {
     reconciliations: JoinSet<ReconciliationResult>,
     active_builds: usize,
     max_concurrent_builds: usize,
+    next_build_generation: u64,
 }
 
 impl<H: ControllerHost> ModelDiscoveryController<H> {
@@ -221,6 +222,7 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
             reconciliations: JoinSet::new(),
             active_builds: 0,
             max_concurrent_builds: max_concurrent_builds.max(1),
+            next_build_generation: 1,
         }
     }
 
@@ -641,15 +643,17 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
             };
 
             let cancellation = CancellationToken::new();
+            let generation = self.next_build_generation;
+            self.next_build_generation = self.next_build_generation.wrapping_add(1).max(1);
             let spec = GroupSpec {
                 key: key.clone(),
                 fingerprint: fingerprint.clone(),
-                generation: group.generation,
+                generation,
                 representative,
             };
             group.status = GroupStatus::Building {
                 fingerprint,
-                generation: group.generation,
+                generation,
                 cancellation: cancellation.clone(),
             };
 
@@ -1299,6 +1303,34 @@ mod tests {
 
         assert!(host.members(&group_key()).is_empty());
         assert_eq!(host.removed_groups.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn recreated_group_rejects_prepared_result_from_prior_lifetime() {
+        let (host, mut starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let first = instance(1, "same");
+
+        controller.apply_added(first.clone());
+        controller.start_queued_builds();
+        let first_spec = starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        let stale = controller.builds.join_next().await.unwrap().unwrap();
+        controller.active_builds -= 1;
+
+        controller.apply_removed(&first.key);
+        controller.apply_added(first.clone());
+        controller.start_queued_builds();
+        let replacement_spec = starts.recv().await.unwrap();
+        assert_ne!(first_spec.generation, replacement_spec.generation);
+
+        controller.apply_build_result(stale);
+        assert!(host.members(&group_key()).is_empty());
+        assert_eq!(host.discarded.load(Ordering::SeqCst), 1);
+
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert_eq!(host.members(&group_key()), BTreeSet::from([first.key]));
     }
 
     #[tokio::test]

--- a/lib/llm/src/discovery/controller.rs
+++ b/lib/llm/src/discovery/controller.rs
@@ -23,6 +23,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{model_card::ModelDeploymentCard, namespace::NamespaceFilter};
 
 const DEFAULT_MAX_CONCURRENT_BUILDS: usize = 8;
+const RECONCILIATION_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub(crate) struct GroupKey {
@@ -83,15 +84,24 @@ pub(crate) trait ControllerHost: Send + Sync + 'static {
         spec: &GroupSpec,
         prepared: Self::Prepared,
         members: &[DesiredInstance],
+        adapters: &[DesiredInstance],
     ) -> anyhow::Result<()>;
 
     fn add_group_member(&self, key: &GroupKey, member: &DesiredInstance) -> anyhow::Result<()>;
 
     fn remove_group_member(&self, key: &GroupKey, instance_key: &str) -> anyhow::Result<()>;
 
+    fn sync_group_adapters(
+        &self,
+        key: &GroupKey,
+        adapters: &[DesiredInstance],
+    ) -> anyhow::Result<()>;
+
     fn remove_group(&self, key: &GroupKey);
 
     fn discard_prepared(&self, prepared: Self::Prepared);
+
+    async fn list_instances(&self) -> anyhow::Result<Vec<DiscoveryInstance>>;
 
     fn project_lora(
         &self,
@@ -123,6 +133,7 @@ enum GroupStatus {
     Conflict,
     Blocked {
         fingerprint: String,
+        deadline: Instant,
     },
 }
 
@@ -175,12 +186,20 @@ struct BuildResult<P> {
     outcome: BuildOutcome<P>,
 }
 
+struct ReconciliationResult {
+    revision: u64,
+    instances: anyhow::Result<Vec<DiscoveryInstance>>,
+}
+
 pub(crate) struct ModelDiscoveryController<H: ControllerHost> {
     host: Arc<H>,
     desired: HashMap<String, DesiredInstance>,
     groups: HashMap<GroupKey, DesiredGroup>,
     endpoint_workers: HashMap<EndpointId, HashSet<u64>>,
+    revision: u64,
+    instance_revisions: HashMap<String, u64>,
     builds: JoinSet<BuildResult<H::Prepared>>,
+    reconciliations: JoinSet<ReconciliationResult>,
     active_builds: usize,
     max_concurrent_builds: usize,
 }
@@ -196,7 +215,10 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
             desired: HashMap::new(),
             groups: HashMap::new(),
             endpoint_workers: HashMap::new(),
+            revision: 0,
+            instance_revisions: HashMap::new(),
             builds: JoinSet::new(),
+            reconciliations: JoinSet::new(),
             active_builds: 0,
             max_concurrent_builds: max_concurrent_builds.max(1),
         }
@@ -207,6 +229,11 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
         mut discovery_stream: DiscoveryStream,
         namespace_filter: NamespaceFilter,
     ) {
+        let mut reconciliation_interval = tokio::time::interval_at(
+            Instant::now() + RECONCILIATION_INTERVAL,
+            RECONCILIATION_INTERVAL,
+        );
+        reconciliation_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             self.start_queued_builds();
             let retry_deadline = self.next_retry_deadline();
@@ -232,6 +259,16 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                         None => {}
                     }
                 }
+                _ = reconciliation_interval.tick(), if self.reconciliations.is_empty() => {
+                    self.start_reconciliation();
+                }
+                result = self.reconciliations.join_next(), if !self.reconciliations.is_empty() => {
+                    match result {
+                        Some(Ok(result)) => self.apply_reconciliation(result, &namespace_filter),
+                        Some(Err(error)) => tracing::error!(%error, "Model reconciliation task failed"),
+                        None => {}
+                    }
+                }
                 _ = wait_for_deadline(retry_deadline), if retry_deadline.is_some() => {
                     self.release_due_retries();
                 }
@@ -242,7 +279,7 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
     }
 
     fn apply_event(&mut self, event: DiscoveryEvent, namespace_filter: &NamespaceFilter) {
-        let changed = match event {
+        match event {
             DiscoveryEvent::Added(instance) => {
                 match self.host.normalize(instance, namespace_filter) {
                     Ok(Some(instance)) => self.apply_added(instance),
@@ -264,10 +301,6 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                 false
             }
         };
-
-        if changed {
-            self.requeue_blocked_groups();
-        }
     }
 
     fn apply_added(&mut self, instance: DesiredInstance) -> bool {
@@ -288,6 +321,8 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
 
         let group_key = instance.group_key.clone();
         let endpoint_id = instance.endpoint_id.clone();
+        let instance_id = instance.mcid.instance_id;
+        let instance_key = instance.key.clone();
         let materializes_worker_set = instance.materializes_worker_set();
         if materializes_worker_set {
             self.groups
@@ -296,23 +331,37 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                 .insert(&instance);
         }
         self.desired.insert(instance.key.clone(), instance);
+        self.record_mutation(instance_key);
 
         if materializes_worker_set {
             self.reconcile_group(&group_key, true);
+        } else {
+            for key in self.materialization_groups_for(&endpoint_id, instance_id) {
+                self.reconcile_group(&key, true);
+            }
         }
         self.project_lora_for(HashSet::from([endpoint_id]));
         true
     }
 
     fn apply_removed(&mut self, instance_key: &str) -> bool {
-        let Some(instance) = self.desired.remove(instance_key) else {
+        let removed = self.desired.remove(instance_key);
+        self.record_mutation(instance_key.to_string());
+        let Some(instance) = removed else {
             return false;
         };
-        if instance.materializes_worker_set() {
-            if let Some(group) = self.groups.get_mut(&instance.group_key) {
-                group.remove(&instance);
-            }
-            self.reconcile_group(&instance.group_key, true);
+        let affected_groups = if instance.materializes_worker_set() {
+            vec![instance.group_key.clone()]
+        } else {
+            self.materialization_groups_for(&instance.endpoint_id, instance.mcid.instance_id)
+        };
+        if instance.materializes_worker_set()
+            && let Some(group) = self.groups.get_mut(&instance.group_key)
+        {
+            group.remove(&instance);
+        }
+        for key in affected_groups {
+            self.reconcile_group(&key, true);
         }
         self.project_lora_for(HashSet::from([instance.endpoint_id]));
         true
@@ -390,12 +439,26 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                         sync_failed = true;
                     }
                 }
+                if !sync_failed {
+                    let adapters = self.adapters_for_members(&current_members);
+                    if let Err(error) = self.host.sync_group_adapters(key, &adapters) {
+                        tracing::warn!(
+                            group = %key.id(),
+                            error = format!("{error:#}"),
+                            "Failed to synchronize committed LoRA adapter surfaces"
+                        );
+                        sync_failed = true;
+                    }
+                }
                 if sync_failed {
                     group.admission_tx.send_replace(Vec::new());
                     self.host.remove_group(key);
                     group.generation = group.generation.wrapping_add(1);
-                    group.retry_attempt = 0;
-                    GroupStatus::Queued { fingerprint }
+                    group.retry_attempt = group.retry_attempt.saturating_add(1);
+                    GroupStatus::Blocked {
+                        fingerprint,
+                        deadline: Instant::now() + retry_delay(group.retry_attempt),
+                    }
                 } else {
                     GroupStatus::Ready {
                         fingerprint,
@@ -424,9 +487,11 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
             },
             GroupStatus::Blocked {
                 fingerprint: blocked_fingerprint,
-            } if blocked_fingerprint == fingerprint && !desired_changed => {
-                GroupStatus::Blocked { fingerprint }
-            }
+                deadline,
+            } if blocked_fingerprint == fingerprint && !desired_changed => GroupStatus::Blocked {
+                fingerprint,
+                deadline,
+            },
             previous => {
                 cancel_build(&previous);
                 if matches!(previous, GroupStatus::Ready { .. }) {
@@ -449,12 +514,78 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
             .collect()
     }
 
+    fn adapters_for_members(&self, member_keys: &BTreeSet<String>) -> Vec<DesiredInstance> {
+        let physical_members = member_keys
+            .iter()
+            .filter_map(|key| self.desired.get(key))
+            .map(|member| (member.endpoint_id.clone(), member.mcid.instance_id))
+            .collect::<HashSet<_>>();
+        let mut adapters = self
+            .desired
+            .values()
+            .filter(|instance| {
+                !instance.materializes_worker_set()
+                    && physical_members
+                        .contains(&(instance.endpoint_id.clone(), instance.mcid.instance_id))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        adapters.sort_by(|left, right| left.key.cmp(&right.key));
+        adapters
+    }
+
+    fn materialization_groups_for(
+        &self,
+        endpoint_id: &EndpointId,
+        instance_id: u64,
+    ) -> Vec<GroupKey> {
+        self.desired
+            .values()
+            .filter(|instance| {
+                instance.materializes_worker_set()
+                    && &instance.endpoint_id == endpoint_id
+                    && instance.mcid.instance_id == instance_id
+            })
+            .map(|instance| instance.group_key.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn record_mutation(&mut self, instance_key: String) {
+        self.revision = self.revision.wrapping_add(1);
+        self.instance_revisions.insert(instance_key, self.revision);
+    }
+
     fn project_lora_for(&mut self, endpoint_ids: HashSet<EndpointId>) {
         for endpoint_id in endpoint_ids {
+            let committed_bases = self
+                .desired
+                .values()
+                .filter(|instance| {
+                    instance.materializes_worker_set()
+                        && instance.endpoint_id == endpoint_id
+                        && self.groups.get(&instance.group_key).is_some_and(|group| {
+                            matches!(
+                                &group.status,
+                                GroupStatus::Ready { committed_members, .. }
+                                    if committed_members.contains(&instance.key)
+                            )
+                        })
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            let committed_workers = committed_bases
+                .iter()
+                .map(|instance| instance.mcid.instance_id)
+                .collect::<HashSet<_>>();
             let desired = self
                 .desired
                 .values()
-                .filter(|instance| instance.endpoint_id == endpoint_id)
+                .filter(|instance| {
+                    instance.endpoint_id == endpoint_id
+                        && committed_workers.contains(&instance.mcid.instance_id)
+                })
                 .map(|instance| (instance.mcid.clone(), instance.card.clone()))
                 .collect::<Vec<_>>();
             let current_workers = desired
@@ -471,19 +602,6 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
             if !current_workers.is_empty() {
                 self.endpoint_workers.insert(endpoint_id, current_workers);
             }
-        }
-    }
-
-    fn requeue_blocked_groups(&mut self) {
-        for group in self.groups.values_mut() {
-            let GroupStatus::Blocked { fingerprint } = &group.status else {
-                continue;
-            };
-            group.generation = group.generation.wrapping_add(1);
-            group.retry_attempt = 0;
-            group.status = GroupStatus::Queued {
-                fingerprint: fingerprint.clone(),
-            };
         }
     }
 
@@ -598,8 +716,12 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                     .cloned()
                     .unwrap_or_default();
                 let members = self.members(&member_keys);
+                let adapters = self.adapters_for_members(&member_keys);
                 group.admission_tx.send_replace(admitted_ids(&members));
-                match self.host.commit_group(&result.spec, prepared, &members) {
+                match self
+                    .host
+                    .commit_group(&result.spec, prepared, &members, &adapters)
+                {
                     Ok(()) => {
                         group.retry_attempt = 0;
                         group.status = GroupStatus::Ready {
@@ -614,8 +736,10 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                             error = format!("{error:#}"),
                             "Model materialization is blocked at commit"
                         );
+                        group.retry_attempt = group.retry_attempt.saturating_add(1);
                         group.status = GroupStatus::Blocked {
                             fingerprint: result.spec.fingerprint,
+                            deadline: Instant::now() + retry_delay(group.retry_attempt),
                         };
                     }
                 }
@@ -641,14 +765,24 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                 };
             }
         }
+        let affected_endpoints = group
+            .cohorts
+            .values()
+            .flatten()
+            .filter_map(|key| self.desired.get(key))
+            .map(|instance| instance.endpoint_id.clone())
+            .collect::<HashSet<_>>();
         self.groups.insert(result.spec.key, group);
+        self.project_lora_for(affected_endpoints);
     }
 
     fn next_retry_deadline(&self) -> Option<Instant> {
         self.groups
             .values()
             .filter_map(|group| match group.status {
-                GroupStatus::Retrying { deadline, .. } => Some(deadline),
+                GroupStatus::Retrying { deadline, .. } | GroupStatus::Blocked { deadline, .. } => {
+                    Some(deadline)
+                }
                 _ => None,
             })
             .min()
@@ -657,12 +791,16 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
     fn release_due_retries(&mut self) {
         let now = Instant::now();
         for group in self.groups.values_mut() {
-            let GroupStatus::Retrying {
-                fingerprint,
-                deadline,
-            } = &group.status
-            else {
-                continue;
+            let (fingerprint, deadline) = match &group.status {
+                GroupStatus::Retrying {
+                    fingerprint,
+                    deadline,
+                }
+                | GroupStatus::Blocked {
+                    fingerprint,
+                    deadline,
+                } => (fingerprint, deadline),
+                _ => continue,
             };
             if *deadline <= now {
                 group.status = GroupStatus::Queued {
@@ -679,6 +817,80 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
         }
         self.builds.abort_all();
         while self.builds.join_next().await.is_some() {}
+        self.reconciliations.abort_all();
+        while self.reconciliations.join_next().await.is_some() {}
+    }
+
+    fn start_reconciliation(&mut self) {
+        let host = self.host.clone();
+        let revision = self.revision;
+        self.reconciliations.spawn(async move {
+            ReconciliationResult {
+                revision,
+                instances: host.list_instances().await,
+            }
+        });
+    }
+
+    fn apply_reconciliation(
+        &mut self,
+        result: ReconciliationResult,
+        namespace_filter: &NamespaceFilter,
+    ) {
+        let instances = match result.instances {
+            Ok(instances) => instances,
+            Err(error) => {
+                tracing::warn!(error = format!("{error:#}"), "Model reconciliation failed");
+                return;
+            }
+        };
+        let mut observed = HashSet::new();
+        let mut normalized = Vec::new();
+        for instance in instances {
+            let DiscoveryInstanceId::Model(mcid) = instance.id() else {
+                continue;
+            };
+            let key = mcid.to_path();
+            observed.insert(key.clone());
+            if self
+                .instance_revisions
+                .get(&key)
+                .is_some_and(|revision| *revision > result.revision)
+            {
+                continue;
+            }
+            match self.host.normalize(instance, namespace_filter) {
+                Ok(Some(instance)) => normalized.push(instance),
+                Ok(None) => {}
+                Err(error) => tracing::warn!(
+                    instance = key,
+                    error = format!("{error:#}"),
+                    "Rejected model from reconciliation snapshot"
+                ),
+            }
+        }
+
+        for instance in normalized {
+            self.apply_added(instance);
+        }
+        let removals = self
+            .desired
+            .keys()
+            .filter(|key| {
+                !observed.contains(*key)
+                    && self
+                        .instance_revisions
+                        .get(*key)
+                        .is_none_or(|revision| *revision <= result.revision)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for key in removals {
+            self.apply_removed(&key);
+        }
+        self.instance_revisions.retain(|key, revision| {
+            self.desired.contains_key(key) || observed.contains(key) || *revision > result.revision
+        });
     }
 }
 
@@ -731,9 +943,11 @@ mod tests {
     struct FakeHost {
         starts: AtomicUsize,
         failures: AtomicUsize,
+        commit_failures: AtomicUsize,
         start_tx: mpsc::UnboundedSender<GroupSpec>,
         release: Semaphore,
         committed: Mutex<HashMap<String, BTreeSet<String>>>,
+        adapters: Mutex<HashMap<String, BTreeSet<String>>>,
         removed_groups: AtomicUsize,
         discarded: AtomicUsize,
     }
@@ -745,9 +959,11 @@ mod tests {
                 Arc::new(Self {
                     starts: AtomicUsize::new(0),
                     failures: AtomicUsize::new(0),
+                    commit_failures: AtomicUsize::new(0),
                     start_tx,
                     release: Semaphore::new(0),
                     committed: Mutex::new(HashMap::new()),
+                    adapters: Mutex::new(HashMap::new()),
                     removed_groups: AtomicUsize::new(0),
                     discarded: AtomicUsize::new(0),
                 }),
@@ -763,6 +979,15 @@ mod tests {
                 .cloned()
                 .unwrap_or_default()
         }
+
+        fn adapters(&self, key: &GroupKey) -> BTreeSet<String> {
+            self.adapters
+                .lock()
+                .unwrap()
+                .get(&key.id())
+                .cloned()
+                .unwrap_or_default()
+        }
     }
 
     #[async_trait]
@@ -771,10 +996,43 @@ mod tests {
 
         fn normalize(
             &self,
-            _instance: DiscoveryInstance,
-            _namespace_filter: &NamespaceFilter,
+            instance: DiscoveryInstance,
+            namespace_filter: &NamespaceFilter,
         ) -> anyhow::Result<Option<DesiredInstance>> {
-            unreachable!("controller tests inject normalized desired instances")
+            let DiscoveryInstance::Model {
+                namespace,
+                component,
+                endpoint,
+                instance_id,
+                card_json,
+                model_suffix,
+            } = instance
+            else {
+                return Ok(None);
+            };
+            if !namespace_filter.matches(&namespace) {
+                return Ok(None);
+            }
+            let card: ModelDeploymentCard = serde_json::from_value(card_json)?;
+            let mcid = ModelCardInstanceId {
+                namespace: namespace.clone(),
+                component: component.clone(),
+                endpoint: endpoint.clone(),
+                instance_id,
+                model_suffix,
+            };
+            Ok(Some(DesiredInstance {
+                key: mcid.to_path(),
+                mcid,
+                endpoint_id: EndpointId {
+                    namespace,
+                    component,
+                    name: endpoint,
+                },
+                group_key: group_key(),
+                card,
+                fingerprint: "spec".to_string(),
+            }))
         }
 
         async fn prepare(
@@ -803,11 +1061,25 @@ mod tests {
             spec: &GroupSpec,
             prepared: Self::Prepared,
             members: &[DesiredInstance],
+            adapters: &[DesiredInstance],
         ) -> anyhow::Result<()> {
             let Prepared(_build) = prepared;
+            if self
+                .commit_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                anyhow::bail!("injected commit conflict");
+            }
             self.committed.lock().unwrap().insert(
                 spec.key.id(),
                 members.iter().map(|member| member.key.clone()).collect(),
+            );
+            self.adapters.lock().unwrap().insert(
+                spec.key.id(),
+                adapters.iter().map(|adapter| adapter.key.clone()).collect(),
             );
             Ok(())
         }
@@ -832,14 +1104,31 @@ mod tests {
             Ok(())
         }
 
+        fn sync_group_adapters(
+            &self,
+            key: &GroupKey,
+            adapters: &[DesiredInstance],
+        ) -> anyhow::Result<()> {
+            self.adapters.lock().unwrap().insert(
+                key.id(),
+                adapters.iter().map(|adapter| adapter.key.clone()).collect(),
+            );
+            Ok(())
+        }
+
         fn remove_group(&self, key: &GroupKey) {
             self.committed.lock().unwrap().remove(&key.id());
+            self.adapters.lock().unwrap().remove(&key.id());
             self.removed_groups.fetch_add(1, Ordering::SeqCst);
         }
 
         fn discard_prepared(&self, prepared: Self::Prepared) {
             let Prepared(_build) = prepared;
             self.discarded.fetch_add(1, Ordering::SeqCst);
+        }
+
+        async fn list_instances(&self) -> anyhow::Result<Vec<DiscoveryInstance>> {
+            Ok(Vec::new())
         }
 
         fn project_lora(
@@ -877,6 +1166,17 @@ mod tests {
             card: ModelDeploymentCard::with_name_only("model"),
             group_key: group_key(),
             fingerprint: fingerprint.to_string(),
+        }
+    }
+
+    fn discovery_instance(instance: &DesiredInstance) -> DiscoveryInstance {
+        DiscoveryInstance::Model {
+            namespace: instance.mcid.namespace.clone(),
+            component: instance.mcid.component.clone(),
+            endpoint: instance.mcid.endpoint.clone(),
+            instance_id: instance.mcid.instance_id,
+            card_json: serde_json::to_value(&instance.card).unwrap(),
+            model_suffix: instance.mcid.model_suffix.clone(),
         }
     }
 
@@ -1023,9 +1323,22 @@ mod tests {
             host.members(&group_key()),
             BTreeSet::from([base.key.clone()])
         );
+        assert_eq!(
+            host.adapters(&group_key()),
+            BTreeSet::from([adapter.key.clone()])
+        );
+        controller.apply_removed(&adapter.key);
+        assert!(host.adapters(&group_key()).is_empty());
+        controller.apply_added(adapter.clone());
+        assert_eq!(
+            host.adapters(&group_key()),
+            BTreeSet::from([adapter.key.clone()])
+        );
+        assert_eq!(host.starts.load(Ordering::SeqCst), 1);
 
         controller.apply_removed(&base.key);
         assert!(host.members(&group_key()).is_empty());
+        assert!(host.adapters(&group_key()).is_empty());
         assert!(controller.desired.contains_key(&adapter.key));
         assert_eq!(host.removed_groups.load(Ordering::SeqCst), 1);
     }
@@ -1082,6 +1395,68 @@ mod tests {
         host.release.add_permits(1);
         finish_build(&mut controller).await;
         assert_eq!(host.members(&group_key()), BTreeSet::from([desired.key]));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn blocked_group_retries_on_its_deadline_not_unrelated_churn() {
+        let (host, mut starts) = FakeHost::new();
+        host.commit_failures.store(1, Ordering::SeqCst);
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let desired = instance(1, "spec");
+        controller.apply_added(desired.clone());
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+
+        let mut unrelated_adapter = instance(99, "spec");
+        unrelated_adapter.mcid.model_suffix = Some("unrelated-adapter".to_string());
+        unrelated_adapter.key = unrelated_adapter.mcid.to_path();
+        controller.apply_added(unrelated_adapter);
+        controller.start_queued_builds();
+        assert!(starts.try_recv().is_err());
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        controller.release_due_retries();
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert_eq!(host.members(&group_key()), BTreeSet::from([desired.key]));
+    }
+
+    #[tokio::test]
+    async fn reconciliation_repairs_missed_state_without_undoing_newer_events() {
+        let (host, _starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host);
+        let first = instance(1, "spec");
+        let second = instance(2, "spec");
+
+        controller.apply_added(first.clone());
+        let snapshot_revision = controller.revision;
+        controller.apply_removed(&first.key);
+        controller.apply_added(second.clone());
+        controller.apply_reconciliation(
+            ReconciliationResult {
+                revision: snapshot_revision,
+                instances: Ok(vec![discovery_instance(&first)]),
+            },
+            &NamespaceFilter::Global,
+        );
+
+        assert!(!controller.desired.contains_key(&first.key));
+        assert!(controller.desired.contains_key(&second.key));
+
+        let repair_revision = controller.revision;
+        controller.apply_reconciliation(
+            ReconciliationResult {
+                revision: repair_revision,
+                instances: Ok(vec![discovery_instance(&first)]),
+            },
+            &NamespaceFilter::Global,
+        );
+        assert!(controller.desired.contains_key(&first.key));
+        assert!(!controller.desired.contains_key(&second.key));
     }
 
     #[test]

--- a/lib/llm/src/discovery/controller.rs
+++ b/lib/llm/src/discovery/controller.rs
@@ -1,0 +1,1092 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    panic::AssertUnwindSafe,
+    sync::Arc,
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use dynamo_runtime::{
+    discovery::{
+        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryStream,
+        ModelCardInstanceId,
+    },
+    protocols::EndpointId,
+};
+use futures::{FutureExt, StreamExt};
+use tokio::{sync::watch, task::JoinSet, time::Instant};
+use tokio_util::sync::CancellationToken;
+
+use crate::{model_card::ModelDeploymentCard, namespace::NamespaceFilter};
+
+const DEFAULT_MAX_CONCURRENT_BUILDS: usize = 8;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+pub(crate) struct GroupKey {
+    pub(crate) model_name: String,
+    pub(crate) worker_set_key: String,
+}
+
+impl GroupKey {
+    pub(crate) fn id(&self) -> String {
+        serde_json::to_string(&(&self.model_name, &self.worker_set_key))
+            .expect("serializing discovery group keys cannot fail")
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DesiredInstance {
+    pub(crate) key: String,
+    pub(crate) mcid: ModelCardInstanceId,
+    pub(crate) endpoint_id: EndpointId,
+    pub(crate) card: ModelDeploymentCard,
+    pub(crate) group_key: GroupKey,
+    pub(crate) fingerprint: String,
+}
+
+impl DesiredInstance {
+    fn materializes_worker_set(&self) -> bool {
+        self.mcid.model_suffix.is_none()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct GroupSpec {
+    pub(crate) key: GroupKey,
+    pub(crate) fingerprint: String,
+    pub(crate) generation: u64,
+    pub(crate) representative: DesiredInstance,
+}
+
+#[async_trait]
+pub(crate) trait ControllerHost: Send + Sync + 'static {
+    type Prepared: Send + 'static;
+
+    fn normalize(
+        &self,
+        instance: DiscoveryInstance,
+        namespace_filter: &NamespaceFilter,
+    ) -> anyhow::Result<Option<DesiredInstance>>;
+
+    async fn prepare(
+        &self,
+        spec: GroupSpec,
+        admitted_ids: watch::Receiver<Vec<u64>>,
+        cancellation: CancellationToken,
+    ) -> anyhow::Result<Self::Prepared>;
+
+    fn commit_group(
+        &self,
+        spec: &GroupSpec,
+        prepared: Self::Prepared,
+        members: &[DesiredInstance],
+    ) -> anyhow::Result<()>;
+
+    fn add_group_member(&self, key: &GroupKey, member: &DesiredInstance) -> anyhow::Result<()>;
+
+    fn remove_group_member(&self, key: &GroupKey, instance_key: &str) -> anyhow::Result<()>;
+
+    fn remove_group(&self, key: &GroupKey);
+
+    fn discard_prepared(&self, prepared: Self::Prepared);
+
+    fn project_lora(
+        &self,
+        endpoint_id: &EndpointId,
+        reset_worker_ids: &HashSet<u64>,
+        desired: &[(ModelCardInstanceId, ModelDeploymentCard)],
+    );
+}
+
+#[derive(Clone)]
+enum GroupStatus {
+    Idle,
+    Queued {
+        fingerprint: String,
+    },
+    Building {
+        fingerprint: String,
+        generation: u64,
+        cancellation: CancellationToken,
+    },
+    Ready {
+        fingerprint: String,
+        committed_members: BTreeSet<String>,
+    },
+    Retrying {
+        fingerprint: String,
+        deadline: Instant,
+    },
+    Conflict,
+    Blocked {
+        fingerprint: String,
+    },
+}
+
+struct DesiredGroup {
+    generation: u64,
+    retry_attempt: u32,
+    cohorts: HashMap<String, BTreeSet<String>>,
+    admission_tx: watch::Sender<Vec<u64>>,
+    status: GroupStatus,
+}
+
+impl DesiredGroup {
+    fn new() -> Self {
+        let (admission_tx, _) = watch::channel(Vec::new());
+        Self {
+            generation: 0,
+            retry_attempt: 0,
+            cohorts: HashMap::new(),
+            admission_tx,
+            status: GroupStatus::Idle,
+        }
+    }
+
+    fn insert(&mut self, instance: &DesiredInstance) {
+        self.cohorts
+            .entry(instance.fingerprint.clone())
+            .or_default()
+            .insert(instance.key.clone());
+    }
+
+    fn remove(&mut self, instance: &DesiredInstance) {
+        let Some(cohort) = self.cohorts.get_mut(&instance.fingerprint) else {
+            return;
+        };
+        cohort.remove(&instance.key);
+        if cohort.is_empty() {
+            self.cohorts.remove(&instance.fingerprint);
+        }
+    }
+}
+
+enum BuildOutcome<P> {
+    Prepared(P),
+    Failed(anyhow::Error),
+    Cancelled,
+}
+
+struct BuildResult<P> {
+    spec: GroupSpec,
+    outcome: BuildOutcome<P>,
+}
+
+pub(crate) struct ModelDiscoveryController<H: ControllerHost> {
+    host: Arc<H>,
+    desired: HashMap<String, DesiredInstance>,
+    groups: HashMap<GroupKey, DesiredGroup>,
+    endpoint_workers: HashMap<EndpointId, HashSet<u64>>,
+    builds: JoinSet<BuildResult<H::Prepared>>,
+    active_builds: usize,
+    max_concurrent_builds: usize,
+}
+
+impl<H: ControllerHost> ModelDiscoveryController<H> {
+    pub(crate) fn new(host: Arc<H>) -> Self {
+        Self::with_max_concurrent_builds(host, DEFAULT_MAX_CONCURRENT_BUILDS)
+    }
+
+    fn with_max_concurrent_builds(host: Arc<H>, max_concurrent_builds: usize) -> Self {
+        Self {
+            host,
+            desired: HashMap::new(),
+            groups: HashMap::new(),
+            endpoint_workers: HashMap::new(),
+            builds: JoinSet::new(),
+            active_builds: 0,
+            max_concurrent_builds: max_concurrent_builds.max(1),
+        }
+    }
+
+    pub(crate) async fn run(
+        mut self,
+        mut discovery_stream: DiscoveryStream,
+        namespace_filter: NamespaceFilter,
+    ) {
+        loop {
+            self.start_queued_builds();
+            let retry_deadline = self.next_retry_deadline();
+
+            tokio::select! {
+                event = discovery_stream.next() => {
+                    let Some(event) = event else {
+                        tracing::warn!(
+                            "Model discovery stream ended; retaining committed serving state"
+                        );
+                        break;
+                    };
+                    match event {
+                        Ok(event) => self.apply_event(event, &namespace_filter),
+                        Err(error) => tracing::error!(%error, "Error in model discovery stream"),
+                    }
+                }
+                result = self.builds.join_next(), if !self.builds.is_empty() => {
+                    self.active_builds = self.active_builds.saturating_sub(1);
+                    match result {
+                        Some(Ok(result)) => self.apply_build_result(result),
+                        Some(Err(error)) => tracing::error!(%error, "Model materialization task failed"),
+                        None => {}
+                    }
+                }
+                _ = wait_for_deadline(retry_deadline), if retry_deadline.is_some() => {
+                    self.release_due_retries();
+                }
+            }
+        }
+
+        self.shutdown_builds().await;
+    }
+
+    fn apply_event(&mut self, event: DiscoveryEvent, namespace_filter: &NamespaceFilter) {
+        let changed = match event {
+            DiscoveryEvent::Added(instance) => {
+                match self.host.normalize(instance, namespace_filter) {
+                    Ok(Some(instance)) => self.apply_added(instance),
+                    Ok(None) => false,
+                    Err(error) => {
+                        tracing::error!(
+                            error = format!("{error:#}"),
+                            "Rejected model discovery update; preserving last valid desired state"
+                        );
+                        false
+                    }
+                }
+            }
+            DiscoveryEvent::Removed(DiscoveryInstanceId::Model(mcid)) => {
+                self.apply_removed(&mcid.to_path())
+            }
+            DiscoveryEvent::Removed(_) => {
+                tracing::error!("Unexpected non-model removal in model discovery stream");
+                false
+            }
+        };
+
+        if changed {
+            self.requeue_blocked_groups();
+        }
+    }
+
+    fn apply_added(&mut self, instance: DesiredInstance) -> bool {
+        if let Some(existing) = self.desired.get(&instance.key) {
+            if existing.group_key == instance.group_key
+                && existing.fingerprint == instance.fingerprint
+            {
+                return false;
+            }
+            tracing::error!(
+                instance = instance.key,
+                existing_group = %existing.group_key.id(),
+                candidate_group = %instance.group_key.id(),
+                "Rejected an in-place model-card mutation; worker instance paths identify immutable incarnations"
+            );
+            return false;
+        }
+
+        let group_key = instance.group_key.clone();
+        let endpoint_id = instance.endpoint_id.clone();
+        let materializes_worker_set = instance.materializes_worker_set();
+        if materializes_worker_set {
+            self.groups
+                .entry(group_key.clone())
+                .or_insert_with(DesiredGroup::new)
+                .insert(&instance);
+        }
+        self.desired.insert(instance.key.clone(), instance);
+
+        if materializes_worker_set {
+            self.reconcile_group(&group_key, true);
+        }
+        self.project_lora_for(HashSet::from([endpoint_id]));
+        true
+    }
+
+    fn apply_removed(&mut self, instance_key: &str) -> bool {
+        let Some(instance) = self.desired.remove(instance_key) else {
+            return false;
+        };
+        if instance.materializes_worker_set() {
+            if let Some(group) = self.groups.get_mut(&instance.group_key) {
+                group.remove(&instance);
+            }
+            self.reconcile_group(&instance.group_key, true);
+        }
+        self.project_lora_for(HashSet::from([instance.endpoint_id]));
+        true
+    }
+
+    fn reconcile_group(&mut self, key: &GroupKey, desired_changed: bool) {
+        let Some(mut group) = self.groups.remove(key) else {
+            return;
+        };
+        let old_status = std::mem::replace(&mut group.status, GroupStatus::Idle);
+
+        if group.cohorts.is_empty() {
+            group.admission_tx.send_replace(Vec::new());
+            cancel_build(&old_status);
+            if matches!(old_status, GroupStatus::Ready { .. }) {
+                self.host.remove_group(key);
+            }
+            return;
+        }
+
+        if group.cohorts.len() > 1 {
+            group.admission_tx.send_replace(Vec::new());
+            cancel_build(&old_status);
+            if matches!(old_status, GroupStatus::Ready { .. }) {
+                self.host.remove_group(key);
+            }
+            if !matches!(old_status, GroupStatus::Conflict) {
+                group.generation = group.generation.wrapping_add(1);
+                group.retry_attempt = 0;
+            }
+            group.status = GroupStatus::Conflict;
+            self.groups.insert(key.clone(), group);
+            return;
+        }
+
+        let (fingerprint, member_keys) = group
+            .cohorts
+            .iter()
+            .next()
+            .map(|(fingerprint, members)| (fingerprint.clone(), members.clone()))
+            .expect("non-empty group has one cohort");
+        let members = self.members(&member_keys);
+        let admitted = admitted_ids(&members);
+        group.admission_tx.send_replace(admitted);
+
+        group.status = match old_status {
+            GroupStatus::Ready {
+                fingerprint: ready_fingerprint,
+                committed_members,
+            } if ready_fingerprint == fingerprint => {
+                let current_members = member_keys;
+                let mut sync_failed = false;
+                for removed in committed_members.difference(&current_members) {
+                    if let Err(error) = self.host.remove_group_member(key, removed) {
+                        tracing::error!(
+                            group = %key.id(),
+                            instance = removed,
+                            error = format!("{error:#}"),
+                            "Failed to remove a committed discovery-group member"
+                        );
+                        sync_failed = true;
+                    }
+                }
+                for added in current_members.difference(&committed_members) {
+                    let Some(member) = self.desired.get(added) else {
+                        continue;
+                    };
+                    if let Err(error) = self.host.add_group_member(key, member) {
+                        tracing::error!(
+                            group = %key.id(),
+                            instance = added,
+                            error = format!("{error:#}"),
+                            "Failed to add a committed discovery-group member"
+                        );
+                        sync_failed = true;
+                    }
+                }
+                if sync_failed {
+                    group.admission_tx.send_replace(Vec::new());
+                    self.host.remove_group(key);
+                    group.generation = group.generation.wrapping_add(1);
+                    group.retry_attempt = 0;
+                    GroupStatus::Queued { fingerprint }
+                } else {
+                    GroupStatus::Ready {
+                        fingerprint,
+                        committed_members: current_members,
+                    }
+                }
+            }
+            GroupStatus::Building {
+                fingerprint: building_fingerprint,
+                generation,
+                cancellation,
+            } if building_fingerprint == fingerprint => GroupStatus::Building {
+                fingerprint,
+                generation,
+                cancellation,
+            },
+            GroupStatus::Queued {
+                fingerprint: queued_fingerprint,
+            } if queued_fingerprint == fingerprint => GroupStatus::Queued { fingerprint },
+            GroupStatus::Retrying {
+                fingerprint: retry_fingerprint,
+                deadline,
+            } if retry_fingerprint == fingerprint && !desired_changed => GroupStatus::Retrying {
+                fingerprint,
+                deadline,
+            },
+            GroupStatus::Blocked {
+                fingerprint: blocked_fingerprint,
+            } if blocked_fingerprint == fingerprint && !desired_changed => {
+                GroupStatus::Blocked { fingerprint }
+            }
+            previous => {
+                cancel_build(&previous);
+                if matches!(previous, GroupStatus::Ready { .. }) {
+                    group.admission_tx.send_replace(Vec::new());
+                    self.host.remove_group(key);
+                    group.admission_tx.send_replace(admitted_ids(&members));
+                }
+                group.generation = group.generation.wrapping_add(1);
+                group.retry_attempt = 0;
+                GroupStatus::Queued { fingerprint }
+            }
+        };
+        self.groups.insert(key.clone(), group);
+    }
+
+    fn members(&self, member_keys: &BTreeSet<String>) -> Vec<DesiredInstance> {
+        member_keys
+            .iter()
+            .filter_map(|key| self.desired.get(key).cloned())
+            .collect()
+    }
+
+    fn project_lora_for(&mut self, endpoint_ids: HashSet<EndpointId>) {
+        for endpoint_id in endpoint_ids {
+            let desired = self
+                .desired
+                .values()
+                .filter(|instance| instance.endpoint_id == endpoint_id)
+                .map(|instance| (instance.mcid.clone(), instance.card.clone()))
+                .collect::<Vec<_>>();
+            let current_workers = desired
+                .iter()
+                .map(|(mcid, _)| mcid.instance_id)
+                .collect::<HashSet<_>>();
+            let mut reset_workers = self
+                .endpoint_workers
+                .remove(&endpoint_id)
+                .unwrap_or_default();
+            reset_workers.extend(current_workers.iter().copied());
+            self.host
+                .project_lora(&endpoint_id, &reset_workers, &desired);
+            if !current_workers.is_empty() {
+                self.endpoint_workers.insert(endpoint_id, current_workers);
+            }
+        }
+    }
+
+    fn requeue_blocked_groups(&mut self) {
+        for group in self.groups.values_mut() {
+            let GroupStatus::Blocked { fingerprint } = &group.status else {
+                continue;
+            };
+            group.generation = group.generation.wrapping_add(1);
+            group.retry_attempt = 0;
+            group.status = GroupStatus::Queued {
+                fingerprint: fingerprint.clone(),
+            };
+        }
+    }
+
+    fn start_queued_builds(&mut self) {
+        if self.active_builds >= self.max_concurrent_builds {
+            return;
+        }
+        let mut queued = self
+            .groups
+            .iter()
+            .filter_map(|(key, group)| {
+                matches!(group.status, GroupStatus::Queued { .. }).then_some(key.clone())
+            })
+            .collect::<Vec<_>>();
+        queued.sort();
+
+        for key in queued {
+            if self.active_builds >= self.max_concurrent_builds {
+                break;
+            }
+            let Some(group) = self.groups.get_mut(&key) else {
+                continue;
+            };
+            let GroupStatus::Queued { fingerprint } = &group.status else {
+                continue;
+            };
+            let fingerprint = fingerprint.clone();
+            let Some(member_key) = group
+                .cohorts
+                .get(&fingerprint)
+                .and_then(|members| members.first())
+            else {
+                continue;
+            };
+            let Some(representative) = self.desired.get(member_key).cloned() else {
+                continue;
+            };
+
+            let cancellation = CancellationToken::new();
+            let spec = GroupSpec {
+                key: key.clone(),
+                fingerprint: fingerprint.clone(),
+                generation: group.generation,
+                representative,
+            };
+            group.status = GroupStatus::Building {
+                fingerprint,
+                generation: group.generation,
+                cancellation: cancellation.clone(),
+            };
+
+            let host = self.host.clone();
+            let admitted_ids = group.admission_tx.subscribe();
+            let task_spec = spec.clone();
+            self.builds.spawn(async move {
+                let future = AssertUnwindSafe(async {
+                    tokio::select! {
+                        biased;
+                        _ = cancellation.cancelled() => BuildOutcome::Cancelled,
+                        result = host.prepare(task_spec.clone(), admitted_ids, cancellation.clone()) => {
+                            match result {
+                                Ok(prepared) => BuildOutcome::Prepared(prepared),
+                                Err(error) => BuildOutcome::Failed(error),
+                            }
+                        }
+                    }
+                });
+                let outcome = match future.catch_unwind().await {
+                    Ok(outcome) => outcome,
+                    Err(_) => BuildOutcome::Failed(anyhow::anyhow!(
+                        "model materialization panicked"
+                    )),
+                };
+                BuildResult {
+                    spec: task_spec,
+                    outcome,
+                }
+            });
+            self.active_builds += 1;
+        }
+    }
+
+    fn apply_build_result(&mut self, result: BuildResult<H::Prepared>) {
+        let Some(mut group) = self.groups.remove(&result.spec.key) else {
+            if let BuildOutcome::Prepared(prepared) = result.outcome {
+                self.host.discard_prepared(prepared);
+            }
+            return;
+        };
+        let is_current = matches!(
+            &group.status,
+            GroupStatus::Building {
+                fingerprint,
+                generation,
+                ..
+            } if fingerprint == &result.spec.fingerprint && *generation == result.spec.generation
+        ) && group.cohorts.len() == 1
+            && group.cohorts.contains_key(&result.spec.fingerprint);
+        if !is_current {
+            if let BuildOutcome::Prepared(prepared) = result.outcome {
+                self.host.discard_prepared(prepared);
+            }
+            self.groups.insert(result.spec.key, group);
+            return;
+        }
+
+        match result.outcome {
+            BuildOutcome::Prepared(prepared) => {
+                let member_keys = group
+                    .cohorts
+                    .get(&result.spec.fingerprint)
+                    .cloned()
+                    .unwrap_or_default();
+                let members = self.members(&member_keys);
+                group.admission_tx.send_replace(admitted_ids(&members));
+                match self.host.commit_group(&result.spec, prepared, &members) {
+                    Ok(()) => {
+                        group.retry_attempt = 0;
+                        group.status = GroupStatus::Ready {
+                            fingerprint: result.spec.fingerprint,
+                            committed_members: member_keys,
+                        };
+                    }
+                    Err(error) => {
+                        group.admission_tx.send_replace(Vec::new());
+                        tracing::warn!(
+                            group = %result.spec.key.id(),
+                            error = format!("{error:#}"),
+                            "Model materialization is blocked at commit"
+                        );
+                        group.status = GroupStatus::Blocked {
+                            fingerprint: result.spec.fingerprint,
+                        };
+                    }
+                }
+            }
+            BuildOutcome::Failed(error) => {
+                group.retry_attempt = group.retry_attempt.saturating_add(1);
+                let delay = retry_delay(group.retry_attempt);
+                tracing::warn!(
+                    group = %result.spec.key.id(),
+                    attempt = group.retry_attempt,
+                    retry_ms = delay.as_millis(),
+                    error = format!("{error:#}"),
+                    "Model materialization failed; scheduling retry"
+                );
+                group.status = GroupStatus::Retrying {
+                    fingerprint: result.spec.fingerprint,
+                    deadline: Instant::now() + delay,
+                };
+            }
+            BuildOutcome::Cancelled => {
+                group.status = GroupStatus::Queued {
+                    fingerprint: result.spec.fingerprint,
+                };
+            }
+        }
+        self.groups.insert(result.spec.key, group);
+    }
+
+    fn next_retry_deadline(&self) -> Option<Instant> {
+        self.groups
+            .values()
+            .filter_map(|group| match group.status {
+                GroupStatus::Retrying { deadline, .. } => Some(deadline),
+                _ => None,
+            })
+            .min()
+    }
+
+    fn release_due_retries(&mut self) {
+        let now = Instant::now();
+        for group in self.groups.values_mut() {
+            let GroupStatus::Retrying {
+                fingerprint,
+                deadline,
+            } = &group.status
+            else {
+                continue;
+            };
+            if *deadline <= now {
+                group.status = GroupStatus::Queued {
+                    fingerprint: fingerprint.clone(),
+                };
+            }
+        }
+    }
+
+    async fn shutdown_builds(&mut self) {
+        for group in self.groups.values_mut() {
+            group.admission_tx.send_replace(Vec::new());
+            cancel_build(&group.status);
+        }
+        self.builds.abort_all();
+        while self.builds.join_next().await.is_some() {}
+    }
+}
+
+fn admitted_ids(members: &[DesiredInstance]) -> Vec<u64> {
+    let mut ids = members
+        .iter()
+        .map(|member| member.mcid.instance_id)
+        .collect::<Vec<_>>();
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
+
+fn cancel_build(status: &GroupStatus) {
+    if let GroupStatus::Building { cancellation, .. } = status {
+        cancellation.cancel();
+    }
+}
+
+async fn wait_for_deadline(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
+fn retry_delay(attempt: u32) -> Duration {
+    let base_seconds = match attempt {
+        0 | 1 => 1,
+        2 => 2,
+        3 => 4,
+        4 => 8,
+        5 => 16,
+        _ => 30,
+    };
+    Duration::from_secs(base_seconds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use tokio::sync::{Semaphore, mpsc};
+
+    struct Prepared(u64);
+
+    struct FakeHost {
+        starts: AtomicUsize,
+        failures: AtomicUsize,
+        start_tx: mpsc::UnboundedSender<GroupSpec>,
+        release: Semaphore,
+        committed: Mutex<HashMap<String, BTreeSet<String>>>,
+        removed_groups: AtomicUsize,
+        discarded: AtomicUsize,
+    }
+
+    impl FakeHost {
+        fn new() -> (Arc<Self>, mpsc::UnboundedReceiver<GroupSpec>) {
+            let (start_tx, start_rx) = mpsc::unbounded_channel();
+            (
+                Arc::new(Self {
+                    starts: AtomicUsize::new(0),
+                    failures: AtomicUsize::new(0),
+                    start_tx,
+                    release: Semaphore::new(0),
+                    committed: Mutex::new(HashMap::new()),
+                    removed_groups: AtomicUsize::new(0),
+                    discarded: AtomicUsize::new(0),
+                }),
+                start_rx,
+            )
+        }
+
+        fn members(&self, key: &GroupKey) -> BTreeSet<String> {
+            self.committed
+                .lock()
+                .unwrap()
+                .get(&key.id())
+                .cloned()
+                .unwrap_or_default()
+        }
+    }
+
+    #[async_trait]
+    impl ControllerHost for FakeHost {
+        type Prepared = Prepared;
+
+        fn normalize(
+            &self,
+            _instance: DiscoveryInstance,
+            _namespace_filter: &NamespaceFilter,
+        ) -> anyhow::Result<Option<DesiredInstance>> {
+            unreachable!("controller tests inject normalized desired instances")
+        }
+
+        async fn prepare(
+            &self,
+            spec: GroupSpec,
+            _admitted_ids: watch::Receiver<Vec<u64>>,
+            _cancellation: CancellationToken,
+        ) -> anyhow::Result<Self::Prepared> {
+            let build = self.starts.fetch_add(1, Ordering::SeqCst) as u64;
+            self.start_tx.send(spec).unwrap();
+            self.release.acquire().await.unwrap().forget();
+            if self
+                .failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                anyhow::bail!("injected materialization failure");
+            }
+            Ok(Prepared(build))
+        }
+
+        fn commit_group(
+            &self,
+            spec: &GroupSpec,
+            prepared: Self::Prepared,
+            members: &[DesiredInstance],
+        ) -> anyhow::Result<()> {
+            let Prepared(_build) = prepared;
+            self.committed.lock().unwrap().insert(
+                spec.key.id(),
+                members.iter().map(|member| member.key.clone()).collect(),
+            );
+            Ok(())
+        }
+
+        fn add_group_member(&self, key: &GroupKey, member: &DesiredInstance) -> anyhow::Result<()> {
+            self.committed
+                .lock()
+                .unwrap()
+                .get_mut(&key.id())
+                .unwrap()
+                .insert(member.key.clone());
+            Ok(())
+        }
+
+        fn remove_group_member(&self, key: &GroupKey, instance_key: &str) -> anyhow::Result<()> {
+            self.committed
+                .lock()
+                .unwrap()
+                .get_mut(&key.id())
+                .unwrap()
+                .remove(instance_key);
+            Ok(())
+        }
+
+        fn remove_group(&self, key: &GroupKey) {
+            self.committed.lock().unwrap().remove(&key.id());
+            self.removed_groups.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn discard_prepared(&self, prepared: Self::Prepared) {
+            let Prepared(_build) = prepared;
+            self.discarded.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn project_lora(
+            &self,
+            _endpoint_id: &EndpointId,
+            _reset_worker_ids: &HashSet<u64>,
+            _desired: &[(ModelCardInstanceId, ModelDeploymentCard)],
+        ) {
+        }
+    }
+
+    fn group_key() -> GroupKey {
+        GroupKey {
+            model_name: "model".to_string(),
+            worker_set_key: "group".to_string(),
+        }
+    }
+
+    fn instance(id: u64, fingerprint: &str) -> DesiredInstance {
+        let mcid = ModelCardInstanceId {
+            namespace: "namespace".to_string(),
+            component: "worker".to_string(),
+            endpoint: "generate".to_string(),
+            instance_id: id,
+            model_suffix: None,
+        };
+        DesiredInstance {
+            key: mcid.to_path(),
+            mcid,
+            endpoint_id: EndpointId {
+                namespace: "namespace".to_string(),
+                component: "worker".to_string(),
+                name: "generate".to_string(),
+            },
+            card: ModelDeploymentCard::with_name_only("model"),
+            group_key: group_key(),
+            fingerprint: fingerprint.to_string(),
+        }
+    }
+
+    async fn finish_build(controller: &mut ModelDiscoveryController<FakeHost>) {
+        let result = controller.builds.join_next().await.unwrap().unwrap();
+        controller.active_builds -= 1;
+        controller.apply_build_result(result);
+    }
+
+    #[tokio::test]
+    async fn membership_churn_keeps_one_build_and_commits_latest_members() {
+        let (host, mut starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let first = instance(1, "same");
+        let second = instance(2, "same");
+
+        controller.apply_added(first.clone());
+        controller.apply_added(second.clone());
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+
+        controller.apply_removed(&first.key);
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+
+        assert_eq!(host.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            host.members(&group_key()),
+            BTreeSet::from([second.key.clone()])
+        );
+
+        let third = instance(3, "same");
+        controller.apply_added(third.clone());
+        assert_eq!(
+            host.members(&group_key()),
+            BTreeSet::from([second.key.clone(), third.key.clone()])
+        );
+        controller.apply_removed(&third.key);
+        assert_eq!(host.members(&group_key()), BTreeSet::from([second.key]));
+        assert_eq!(host.starts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn duplicate_and_in_place_mutation_preserve_first_valid_incarnation() {
+        let (host, mut starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let first = instance(1, "first-spec");
+        let mutation = instance(1, "different-spec");
+
+        assert!(controller.apply_added(first.clone()));
+        assert!(!controller.apply_added(first.clone()));
+        assert!(!controller.apply_added(mutation));
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+
+        assert_eq!(host.members(&group_key()), BTreeSet::from([first.key]));
+        assert_eq!(host.starts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn conflict_fails_ready_group_closed_and_recovers_after_clear() {
+        let (host, mut starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let compatible = instance(1, "first-spec");
+        controller.apply_added(compatible.clone());
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert!(!host.members(&group_key()).is_empty());
+
+        let conflicting = instance(2, "second-spec");
+        controller.apply_added(conflicting.clone());
+        assert!(host.members(&group_key()).is_empty());
+        assert_eq!(host.removed_groups.load(Ordering::SeqCst), 1);
+
+        controller.apply_removed(&conflicting.key);
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert_eq!(host.members(&group_key()), BTreeSet::from([compatible.key]));
+    }
+
+    #[tokio::test]
+    async fn conflict_during_build_cancels_without_publishing_either_cohort() {
+        let (host, mut starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let first = instance(1, "first-spec");
+        let conflicting = instance(2, "second-spec");
+        controller.apply_added(first.clone());
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+
+        controller.apply_added(conflicting.clone());
+        finish_build(&mut controller).await;
+        assert!(host.members(&group_key()).is_empty());
+
+        controller.apply_removed(&conflicting.key);
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert_eq!(host.members(&group_key()), BTreeSet::from([first.key]));
+    }
+
+    #[tokio::test]
+    async fn final_removal_cancels_build_without_late_publication() {
+        let (host, mut starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let only = instance(1, "spec");
+        controller.apply_added(only.clone());
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+
+        controller.apply_removed(&only.key);
+        finish_build(&mut controller).await;
+
+        assert!(host.members(&group_key()).is_empty());
+        assert_eq!(host.removed_groups.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn adapter_cards_neither_start_nor_keep_worker_sets_alive() {
+        let (host, mut starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let mut adapter = instance(1, "adapter-spec");
+        adapter.mcid.model_suffix = Some("adapter".to_string());
+        adapter.key = adapter.mcid.to_path();
+
+        controller.apply_added(adapter.clone());
+        controller.start_queued_builds();
+        assert!(starts.try_recv().is_err());
+
+        let base = instance(1, "base-spec");
+        controller.apply_added(base.clone());
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert_eq!(
+            host.members(&group_key()),
+            BTreeSet::from([base.key.clone()])
+        );
+
+        controller.apply_removed(&base.key);
+        assert!(host.members(&group_key()).is_empty());
+        assert!(controller.desired.contains_key(&adapter.key));
+        assert_eq!(host.removed_groups.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn desired_change_retries_a_failed_build_immediately() {
+        let (host, mut starts) = FakeHost::new();
+        host.failures.store(1, Ordering::SeqCst);
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let desired = instance(1, "spec");
+        controller.apply_added(desired.clone());
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert!(host.members(&group_key()).is_empty());
+
+        let joined = instance(2, "spec");
+        controller.apply_added(joined.clone());
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+
+        assert_eq!(
+            host.members(&group_key()),
+            BTreeSet::from([desired.key, joined.key])
+        );
+        assert_eq!(host.starts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn failed_build_remains_unpublished_until_its_retry_succeeds() {
+        let (host, mut starts) = FakeHost::new();
+        host.failures.store(1, Ordering::SeqCst);
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let desired = instance(1, "spec");
+        controller.apply_added(desired.clone());
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert!(host.members(&group_key()).is_empty());
+
+        tokio::time::advance(Duration::from_millis(999)).await;
+        controller.release_due_retries();
+        controller.start_queued_builds();
+        assert!(starts.try_recv().is_err());
+
+        tokio::time::advance(Duration::from_millis(1)).await;
+        controller.release_due_retries();
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert_eq!(host.members(&group_key()), BTreeSet::from([desired.key]));
+    }
+
+    #[test]
+    fn retry_delay_follows_the_capped_schedule() {
+        let delays = (1..=7).map(retry_delay).collect::<Vec<_>>();
+        assert_eq!(delays, [1, 2, 4, 8, 16, 30, 30].map(Duration::from_secs));
+    }
+}

--- a/lib/llm/src/discovery/controller.rs
+++ b/lib/llm/src/discovery/controller.rs
@@ -46,6 +46,7 @@ pub(crate) struct DesiredInstance {
     pub(crate) card: ModelDeploymentCard,
     pub(crate) group_key: GroupKey,
     pub(crate) fingerprint: String,
+    pub(crate) projection_fingerprint: String,
 }
 
 impl DesiredInstance {
@@ -87,13 +88,10 @@ pub(crate) trait ControllerHost: Send + Sync + 'static {
         adapters: &[DesiredInstance],
     ) -> anyhow::Result<()>;
 
-    fn add_group_member(&self, key: &GroupKey, member: &DesiredInstance) -> anyhow::Result<()>;
-
-    fn remove_group_member(&self, key: &GroupKey, instance_key: &str) -> anyhow::Result<()>;
-
-    fn sync_group_adapters(
+    fn replace_group(
         &self,
         key: &GroupKey,
+        members: &[DesiredInstance],
         adapters: &[DesiredInstance],
     ) -> anyhow::Result<()>;
 
@@ -102,13 +100,6 @@ pub(crate) trait ControllerHost: Send + Sync + 'static {
     fn discard_prepared(&self, prepared: Self::Prepared);
 
     async fn list_instances(&self) -> anyhow::Result<Vec<DiscoveryInstance>>;
-
-    fn project_lora(
-        &self,
-        endpoint_id: &EndpointId,
-        reset_worker_ids: &HashSet<u64>,
-        desired: &[(ModelCardInstanceId, ModelDeploymentCard)],
-    );
 }
 
 #[derive(Clone)]
@@ -133,6 +124,11 @@ enum GroupStatus {
     Conflict,
     Blocked {
         fingerprint: String,
+        deadline: Instant,
+    },
+    BlockedReady {
+        fingerprint: String,
+        committed_members: BTreeSet<String>,
         deadline: Instant,
     },
 }
@@ -195,7 +191,6 @@ pub(crate) struct ModelDiscoveryController<H: ControllerHost> {
     host: Arc<H>,
     desired: HashMap<String, DesiredInstance>,
     groups: HashMap<GroupKey, DesiredGroup>,
-    endpoint_workers: HashMap<EndpointId, HashSet<u64>>,
     revision: u64,
     instance_revisions: HashMap<String, u64>,
     builds: JoinSet<BuildResult<H::Prepared>>,
@@ -215,7 +210,6 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
             host,
             desired: HashMap::new(),
             groups: HashMap::new(),
-            endpoint_workers: HashMap::new(),
             revision: 0,
             instance_revisions: HashMap::new(),
             builds: JoinSet::new(),
@@ -307,18 +301,23 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
 
     fn apply_added(&mut self, instance: DesiredInstance) -> bool {
         if let Some(existing) = self.desired.get(&instance.key) {
-            if existing.group_key == instance.group_key
-                && existing.fingerprint == instance.fingerprint
+            if existing.fingerprint == instance.fingerprint
+                && existing.projection_fingerprint == instance.projection_fingerprint
             {
                 return false;
             }
-            tracing::error!(
-                instance = instance.key,
-                existing_group = %existing.group_key.id(),
-                candidate_group = %instance.group_key.id(),
-                "Rejected an in-place model-card mutation; worker instance paths identify immutable incarnations"
-            );
-            return false;
+            if existing.materializes_worker_set()
+                && (existing.group_key != instance.group_key
+                    || existing.fingerprint != instance.fingerprint)
+            {
+                tracing::error!(
+                    instance = instance.key,
+                    existing_group = %existing.group_key.id(),
+                    candidate_group = %instance.group_key.id(),
+                    "Rejected an in-place materialization change; worker instance paths identify immutable incarnations"
+                );
+                return false;
+            }
         }
 
         let group_key = instance.group_key.clone();
@@ -342,7 +341,6 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                 self.reconcile_group(&key, true);
             }
         }
-        self.project_lora_for(HashSet::from([endpoint_id]));
         true
     }
 
@@ -365,7 +363,6 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
         for key in affected_groups {
             self.reconcile_group(&key, true);
         }
-        self.project_lora_for(HashSet::from([instance.endpoint_id]));
         true
     }
 
@@ -378,7 +375,7 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
         if group.cohorts.is_empty() {
             group.admission_tx.send_replace(Vec::new());
             cancel_build(&old_status);
-            if matches!(old_status, GroupStatus::Ready { .. }) {
+            if status_has_commit(&old_status) {
                 self.host.remove_group(key);
             }
             return;
@@ -387,7 +384,7 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
         if group.cohorts.len() > 1 {
             group.admission_tx.send_replace(Vec::new());
             cancel_build(&old_status);
-            if matches!(old_status, GroupStatus::Ready { .. }) {
+            if status_has_commit(&old_status) {
                 self.host.remove_group(key);
             }
             if !matches!(old_status, GroupStatus::Conflict) {
@@ -407,64 +404,74 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
             .expect("non-empty group has one cohort");
         let members = self.members(&member_keys);
         let admitted = admitted_ids(&members);
-        group.admission_tx.send_replace(admitted);
+        if !matches!(
+            &old_status,
+            GroupStatus::Ready { .. } | GroupStatus::BlockedReady { .. }
+        ) {
+            group.admission_tx.send_replace(admitted);
+        }
 
         group.status = match old_status {
             GroupStatus::Ready {
                 fingerprint: ready_fingerprint,
                 committed_members,
+            }
+            | GroupStatus::BlockedReady {
+                fingerprint: ready_fingerprint,
+                committed_members,
+                ..
             } if ready_fingerprint == fingerprint => {
                 let current_members = member_keys;
-                let mut sync_failed = false;
-                for removed in committed_members.difference(&current_members) {
-                    if let Err(error) = self.host.remove_group_member(key, removed) {
-                        tracing::error!(
-                            group = %key.id(),
-                            instance = removed,
-                            error = format!("{error:#}"),
-                            "Failed to remove a committed discovery-group member"
-                        );
-                        sync_failed = true;
+                let old_admitted = group.admission_tx.borrow().clone();
+                let new_admitted = admitted_ids(&members);
+                let new_admitted_set = new_admitted.iter().copied().collect::<HashSet<_>>();
+                group.admission_tx.send_replace(
+                    old_admitted
+                        .iter()
+                        .copied()
+                        .filter(|id| new_admitted_set.contains(id))
+                        .collect(),
+                );
+                let adapters = self.adapters_for_members(&current_members);
+                match self.host.replace_group(key, &members, &adapters) {
+                    Ok(()) => {
+                        group.admission_tx.send_replace(new_admitted);
+                        group.retry_attempt = 0;
+                        GroupStatus::Ready {
+                            fingerprint,
+                            committed_members: current_members,
+                        }
                     }
-                }
-                for added in current_members.difference(&committed_members) {
-                    let Some(member) = self.desired.get(added) else {
-                        continue;
-                    };
-                    if let Err(error) = self.host.add_group_member(key, member) {
-                        tracing::error!(
-                            group = %key.id(),
-                            instance = added,
-                            error = format!("{error:#}"),
-                            "Failed to add a committed discovery-group member"
-                        );
-                        sync_failed = true;
-                    }
-                }
-                if !sync_failed {
-                    let adapters = self.adapters_for_members(&current_members);
-                    if let Err(error) = self.host.sync_group_adapters(key, &adapters) {
+                    Err(error) if current_members == committed_members => {
+                        group.admission_tx.send_replace(old_admitted);
+                        group.retry_attempt = group.retry_attempt.saturating_add(1);
+                        let delay = retry_delay(group.retry_attempt);
                         tracing::warn!(
                             group = %key.id(),
                             error = format!("{error:#}"),
-                            "Failed to synchronize committed LoRA adapter surfaces"
+                            retry_ms = delay.as_millis(),
+                            "Discovery-group replacement blocked; retaining the last safe commit"
                         );
-                        sync_failed = true;
+                        GroupStatus::BlockedReady {
+                            fingerprint,
+                            committed_members,
+                            deadline: Instant::now() + delay,
+                        }
                     }
-                }
-                if sync_failed {
-                    group.admission_tx.send_replace(Vec::new());
-                    self.host.remove_group(key);
-                    group.generation = group.generation.wrapping_add(1);
-                    group.retry_attempt = group.retry_attempt.saturating_add(1);
-                    GroupStatus::Blocked {
-                        fingerprint,
-                        deadline: Instant::now() + retry_delay(group.retry_attempt),
-                    }
-                } else {
-                    GroupStatus::Ready {
-                        fingerprint,
-                        committed_members: current_members,
+                    Err(error) => {
+                        group.admission_tx.send_replace(Vec::new());
+                        self.host.remove_group(key);
+                        group.generation = group.generation.wrapping_add(1);
+                        group.retry_attempt = group.retry_attempt.saturating_add(1);
+                        tracing::warn!(
+                            group = %key.id(),
+                            error = format!("{error:#}"),
+                            "Discovery-group membership replacement failed; withdrawing stale commit"
+                        );
+                        GroupStatus::Blocked {
+                            fingerprint,
+                            deadline: Instant::now() + retry_delay(group.retry_attempt),
+                        }
                     }
                 }
             }
@@ -496,7 +503,7 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
             },
             previous => {
                 cancel_build(&previous);
-                if matches!(previous, GroupStatus::Ready { .. }) {
+                if status_has_commit(&previous) {
                     group.admission_tx.send_replace(Vec::new());
                     self.host.remove_group(key);
                     group.admission_tx.send_replace(admitted_ids(&members));
@@ -557,57 +564,6 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
     fn record_mutation(&mut self, instance_key: String) {
         self.revision = self.revision.wrapping_add(1);
         self.instance_revisions.insert(instance_key, self.revision);
-    }
-
-    fn project_lora_for(&mut self, endpoint_ids: HashSet<EndpointId>) {
-        for endpoint_id in endpoint_ids {
-            let committed_bases = self
-                .desired
-                .values()
-                .filter(|instance| {
-                    instance.materializes_worker_set()
-                        && instance.endpoint_id == endpoint_id
-                        && self.groups.get(&instance.group_key).is_some_and(|group| {
-                            matches!(
-                                &group.status,
-                                GroupStatus::Ready { committed_members, .. }
-                                    if committed_members.contains(&instance.key)
-                            )
-                        })
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            let committed_workers = committed_bases
-                .iter()
-                .map(|instance| instance.mcid.instance_id)
-                .collect::<HashSet<_>>();
-            let desired = self
-                .desired
-                .values()
-                .filter(|instance| {
-                    instance.endpoint_id == endpoint_id
-                        && committed_workers.contains(&instance.mcid.instance_id)
-                })
-                .map(|instance| (instance.mcid.clone(), instance.card.clone()))
-                .collect::<Vec<_>>();
-            let current_workers = desired
-                .iter()
-                .map(|(mcid, _)| mcid.instance_id)
-                .collect::<HashSet<_>>();
-            let previous_workers = self
-                .endpoint_workers
-                .remove(&endpoint_id)
-                .unwrap_or_default();
-            let removed_workers = previous_workers
-                .difference(&current_workers)
-                .copied()
-                .collect::<HashSet<_>>();
-            self.host
-                .project_lora(&endpoint_id, &removed_workers, &desired);
-            if !current_workers.is_empty() {
-                self.endpoint_workers.insert(endpoint_id, current_workers);
-            }
-        }
     }
 
     fn start_queued_builds(&mut self) {
@@ -772,24 +728,16 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                 };
             }
         }
-        let affected_endpoints = group
-            .cohorts
-            .values()
-            .flatten()
-            .filter_map(|key| self.desired.get(key))
-            .map(|instance| instance.endpoint_id.clone())
-            .collect::<HashSet<_>>();
         self.groups.insert(result.spec.key, group);
-        self.project_lora_for(affected_endpoints);
     }
 
     fn next_retry_deadline(&self) -> Option<Instant> {
         self.groups
             .values()
             .filter_map(|group| match group.status {
-                GroupStatus::Retrying { deadline, .. } | GroupStatus::Blocked { deadline, .. } => {
-                    Some(deadline)
-                }
+                GroupStatus::Retrying { deadline, .. }
+                | GroupStatus::Blocked { deadline, .. }
+                | GroupStatus::BlockedReady { deadline, .. } => Some(deadline),
                 _ => None,
             })
             .min()
@@ -797,7 +745,8 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
 
     fn release_due_retries(&mut self) {
         let now = Instant::now();
-        for group in self.groups.values_mut() {
+        let mut retained_retries = Vec::new();
+        for (key, group) in &mut self.groups {
             let (fingerprint, deadline) = match &group.status {
                 GroupStatus::Retrying {
                     fingerprint,
@@ -807,6 +756,18 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                     fingerprint,
                     deadline,
                 } => (fingerprint, deadline),
+                GroupStatus::BlockedReady {
+                    fingerprint,
+                    committed_members,
+                    deadline,
+                } if *deadline <= now => {
+                    group.status = GroupStatus::Ready {
+                        fingerprint: fingerprint.clone(),
+                        committed_members: committed_members.clone(),
+                    };
+                    retained_retries.push(key.clone());
+                    continue;
+                }
                 _ => continue,
             };
             if *deadline <= now {
@@ -814,6 +775,9 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                     fingerprint: fingerprint.clone(),
                 };
             }
+        }
+        for key in retained_retries {
+            self.reconcile_group(&key, false);
         }
     }
 
@@ -917,6 +881,13 @@ fn cancel_build(status: &GroupStatus) {
     }
 }
 
+fn status_has_commit(status: &GroupStatus) -> bool {
+    matches!(
+        status,
+        GroupStatus::Ready { .. } | GroupStatus::BlockedReady { .. }
+    )
+}
+
 async fn wait_for_deadline(deadline: Option<Instant>) {
     match deadline {
         Some(deadline) => tokio::time::sleep_until(deadline).await,
@@ -951,10 +922,12 @@ mod tests {
         starts: AtomicUsize,
         failures: AtomicUsize,
         commit_failures: AtomicUsize,
+        replace_failures: AtomicUsize,
         start_tx: mpsc::UnboundedSender<GroupSpec>,
         release: Semaphore,
         committed: Mutex<HashMap<String, BTreeSet<String>>>,
         adapters: Mutex<HashMap<String, BTreeSet<String>>>,
+        adapter_projections: Mutex<HashMap<String, HashMap<String, String>>>,
         removed_groups: AtomicUsize,
         discarded: AtomicUsize,
     }
@@ -967,10 +940,12 @@ mod tests {
                     starts: AtomicUsize::new(0),
                     failures: AtomicUsize::new(0),
                     commit_failures: AtomicUsize::new(0),
+                    replace_failures: AtomicUsize::new(0),
                     start_tx,
                     release: Semaphore::new(0),
                     committed: Mutex::new(HashMap::new()),
                     adapters: Mutex::new(HashMap::new()),
+                    adapter_projections: Mutex::new(HashMap::new()),
                     removed_groups: AtomicUsize::new(0),
                     discarded: AtomicUsize::new(0),
                 }),
@@ -994,6 +969,29 @@ mod tests {
                 .get(&key.id())
                 .cloned()
                 .unwrap_or_default()
+        }
+
+        fn adapter_projection(&self, key: &GroupKey, adapter_key: &str) -> Option<String> {
+            self.adapter_projections
+                .lock()
+                .unwrap()
+                .get(&key.id())
+                .and_then(|adapters| adapters.get(adapter_key))
+                .cloned()
+        }
+
+        fn store_adapters(&self, key: &GroupKey, adapters: &[DesiredInstance]) {
+            self.adapters.lock().unwrap().insert(
+                key.id(),
+                adapters.iter().map(|adapter| adapter.key.clone()).collect(),
+            );
+            self.adapter_projections.lock().unwrap().insert(
+                key.id(),
+                adapters
+                    .iter()
+                    .map(|adapter| (adapter.key.clone(), adapter.projection_fingerprint.clone()))
+                    .collect(),
+            );
         }
     }
 
@@ -1039,6 +1037,7 @@ mod tests {
                 group_key: group_key(),
                 card,
                 fingerprint: "spec".to_string(),
+                projection_fingerprint: "projection".to_string(),
             }))
         }
 
@@ -1084,48 +1083,37 @@ mod tests {
                 spec.key.id(),
                 members.iter().map(|member| member.key.clone()).collect(),
             );
-            self.adapters.lock().unwrap().insert(
-                spec.key.id(),
-                adapters.iter().map(|adapter| adapter.key.clone()).collect(),
-            );
+            self.store_adapters(&spec.key, adapters);
             Ok(())
         }
 
-        fn add_group_member(&self, key: &GroupKey, member: &DesiredInstance) -> anyhow::Result<()> {
-            self.committed
-                .lock()
-                .unwrap()
-                .get_mut(&key.id())
-                .unwrap()
-                .insert(member.key.clone());
-            Ok(())
-        }
-
-        fn remove_group_member(&self, key: &GroupKey, instance_key: &str) -> anyhow::Result<()> {
-            self.committed
-                .lock()
-                .unwrap()
-                .get_mut(&key.id())
-                .unwrap()
-                .remove(instance_key);
-            Ok(())
-        }
-
-        fn sync_group_adapters(
+        fn replace_group(
             &self,
             key: &GroupKey,
+            members: &[DesiredInstance],
             adapters: &[DesiredInstance],
         ) -> anyhow::Result<()> {
-            self.adapters.lock().unwrap().insert(
+            if self
+                .replace_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                anyhow::bail!("injected replacement conflict");
+            }
+            self.committed.lock().unwrap().insert(
                 key.id(),
-                adapters.iter().map(|adapter| adapter.key.clone()).collect(),
+                members.iter().map(|member| member.key.clone()).collect(),
             );
+            self.store_adapters(key, adapters);
             Ok(())
         }
 
         fn remove_group(&self, key: &GroupKey) {
             self.committed.lock().unwrap().remove(&key.id());
             self.adapters.lock().unwrap().remove(&key.id());
+            self.adapter_projections.lock().unwrap().remove(&key.id());
             self.removed_groups.fetch_add(1, Ordering::SeqCst);
         }
 
@@ -1136,14 +1124,6 @@ mod tests {
 
         async fn list_instances(&self) -> anyhow::Result<Vec<DiscoveryInstance>> {
             Ok(Vec::new())
-        }
-
-        fn project_lora(
-            &self,
-            _endpoint_id: &EndpointId,
-            _reset_worker_ids: &HashSet<u64>,
-            _desired: &[(ModelCardInstanceId, ModelDeploymentCard)],
-        ) {
         }
     }
 
@@ -1173,6 +1153,7 @@ mod tests {
             card: ModelDeploymentCard::with_name_only("model"),
             group_key: group_key(),
             fingerprint: fingerprint.to_string(),
+            projection_fingerprint: fingerprint.to_string(),
         }
     }
 
@@ -1371,11 +1352,59 @@ mod tests {
         );
         assert_eq!(host.starts.load(Ordering::SeqCst), 1);
 
+        let mut updated_adapter = adapter.clone();
+        updated_adapter.projection_fingerprint = "updated-projection".to_string();
+        assert!(controller.apply_added(updated_adapter));
+        assert_eq!(
+            host.adapter_projection(&group_key(), &adapter.key),
+            Some("updated-projection".to_string())
+        );
+        assert_eq!(host.starts.load(Ordering::SeqCst), 1);
+
         controller.apply_removed(&base.key);
         assert!(host.members(&group_key()).is_empty());
         assert!(host.adapters(&group_key()).is_empty());
         assert!(controller.desired.contains_key(&adapter.key));
         assert_eq!(host.removed_groups.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn failed_adapter_replacement_retains_safe_commit_and_retries_projection() {
+        let (host, mut starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let base = instance(1, "base-spec");
+        let mut adapter = instance(1, "adapter-spec");
+        adapter.mcid.model_suffix = Some("adapter".to_string());
+        adapter.key = adapter.mcid.to_path();
+
+        controller.apply_added(adapter.clone());
+        controller.apply_added(base);
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        assert_eq!(
+            host.adapter_projection(&group_key(), &adapter.key),
+            Some("adapter-spec".to_string())
+        );
+
+        host.replace_failures.store(1, Ordering::SeqCst);
+        let mut updated = adapter.clone();
+        updated.projection_fingerprint = "updated".to_string();
+        controller.apply_added(updated);
+        assert_eq!(
+            host.adapter_projection(&group_key(), &adapter.key),
+            Some("adapter-spec".to_string())
+        );
+        assert_eq!(host.members(&group_key()).len(), 1);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        controller.release_due_retries();
+        assert_eq!(
+            host.adapter_projection(&group_key(), &adapter.key),
+            Some("updated".to_string())
+        );
+        assert_eq!(host.starts.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/llm/src/discovery/controller.rs
+++ b/lib/llm/src/discovery/controller.rs
@@ -594,13 +594,16 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                 .iter()
                 .map(|(mcid, _)| mcid.instance_id)
                 .collect::<HashSet<_>>();
-            let mut reset_workers = self
+            let previous_workers = self
                 .endpoint_workers
                 .remove(&endpoint_id)
                 .unwrap_or_default();
-            reset_workers.extend(current_workers.iter().copied());
+            let removed_workers = previous_workers
+                .difference(&current_workers)
+                .copied()
+                .collect::<HashSet<_>>();
             self.host
-                .project_lora(&endpoint_id, &reset_workers, &desired);
+                .project_lora(&endpoint_id, &removed_workers, &desired);
             if !current_workers.is_empty() {
                 self.endpoint_workers.insert(endpoint_id, current_workers);
             }

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -296,6 +296,21 @@ impl Model {
             .collect()
     }
 
+    /// Build an immutable membership snapshot for request-plane publication.
+    ///
+    /// WorkerSets themselves are shared because their engines and routing lifecycle are
+    /// long-lived. The membership map is copied so later discovery mutations cannot leak
+    /// through an older published catalog.
+    pub(crate) fn snapshot(&self) -> Self {
+        let snapshot = Self::new(self.name.clone());
+        for entry in &self.worker_sets {
+            snapshot
+                .worker_sets
+                .insert(entry.key().clone(), entry.value().clone());
+        }
+        snapshot
+    }
+
     /// Check if this model has any decode engine (chat or completions) across any WorkerSet.
     pub fn has_decode_engine(&self) -> bool {
         self.worker_sets

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -77,26 +77,6 @@ pub struct ModelReadiness {
     pub namespaces: std::collections::BTreeMap<String, NamespaceReadiness>,
 }
 
-/// More than one endpoint leaf for a P/D role is trying to use the
-/// namespace-level prefill rendezvous.
-///
-/// DynamoGraphDeployment convention gives one model topology a namespace and
-/// advertises one prefill endpoint plus one decode endpoint within it.
-/// [`EndpointId`](dynamo_runtime::protocols::EndpointId) identifies each leaf;
-/// it is deliberately not also treated as implicit pairing metadata. Multiple
-/// endpoint leaves for either role are therefore ambiguous, rather than being
-/// paired by discovery arrival order.
-#[derive(Debug, thiserror::Error)]
-#[error(
-    "model {model:?} namespace {namespace:?} has ambiguous endpoint-scoped P/D topology (prefill={prefill_endpoints:?}, decode={decode_endpoints:?})"
-)]
-pub(crate) struct AmbiguousPrefillRouterTopology {
-    model: String,
-    namespace: String,
-    prefill_endpoints: Vec<String>,
-    decode_endpoints: Vec<String>,
-}
-
 /// Readiness facts for one namespace, from [`Model::evaluate_namespace`].
 /// Shared by the serving gate and the `/ready` endpoint so they can't diverge.
 struct NamespaceReadinessEval {
@@ -105,6 +85,7 @@ struct NamespaceReadinessEval {
     legacy_live_workers: usize,
     present: std::collections::HashSet<crate::worker_type::WorkerType>,
     missing: std::collections::HashSet<crate::worker_type::WorkerType>,
+    ambiguous: std::collections::HashSet<crate::worker_type::WorkerType>,
 }
 
 /// A named model backed by one or more WorkerSets.
@@ -165,117 +146,6 @@ impl Model {
         self.worker_sets
             .get(namespace)
             .map(|entry| entry.value().clone())
-    }
-
-    /// Return the decode WorkerSet for the only complete typed P/D topology in
-    /// a namespace.
-    ///
-    /// The rendezvous remains intentionally keyed by `(model, namespace)`: a
-    /// namespace denotes one P/D topology, while exact EndpointIds denote its
-    /// leaves. More than one typed Prefill endpoint or more than one
-    /// typed Decode endpoint is ambiguous, whether or not its prefill router
-    /// has already been attached. Aggregated and Encode WorkerSets do not
-    /// participate and continue serving normally.
-    pub(crate) fn unique_prefill_routed_worker_set_in_namespace(
-        &self,
-        namespace: &str,
-    ) -> Result<Option<Arc<WorkerSet>>, AmbiguousPrefillRouterTopology> {
-        self.prefill_router_topology_in_namespace(namespace, None)
-    }
-
-    pub(crate) fn prefill_router_topology_with_decode_candidate(
-        &self,
-        namespace: &str,
-        decode_endpoint: &dynamo_runtime::protocols::EndpointId,
-    ) -> Result<Option<Arc<WorkerSet>>, AmbiguousPrefillRouterTopology> {
-        self.prefill_router_topology_in_namespace(namespace, Some(decode_endpoint))
-    }
-
-    fn prefill_router_topology_in_namespace(
-        &self,
-        namespace: &str,
-        decode_candidate: Option<&dynamo_runtime::protocols::EndpointId>,
-    ) -> Result<Option<Arc<WorkerSet>>, AmbiguousPrefillRouterTopology> {
-        use crate::worker_type::WorkerType;
-
-        let mut prefill_endpoints = self
-            .worker_sets
-            .iter()
-            .filter(|entry| {
-                entry.value().namespace() == namespace
-                    && entry.value().card().worker_type == Some(WorkerType::Prefill)
-            })
-            .map(|entry| Self::worker_set_identity(entry.key(), entry.value()))
-            .collect::<Vec<_>>();
-        prefill_endpoints.sort();
-
-        let mut decode_worker_sets = self
-            .worker_sets
-            .iter()
-            .filter(|entry| {
-                entry.value().namespace() == namespace
-                    && entry.value().card().worker_type == Some(WorkerType::Decode)
-            })
-            .map(|entry| {
-                let identity = Self::worker_set_identity(entry.key(), entry.value());
-                (identity, entry.value().clone())
-            })
-            .collect::<Vec<_>>();
-        decode_worker_sets.sort_by(|(left, _), (right, _)| left.cmp(right));
-
-        let mut decode_endpoints = decode_worker_sets
-            .iter()
-            .map(|(identity, _)| identity.clone())
-            .collect::<Vec<_>>();
-        if let Some(candidate) = decode_candidate
-            && !decode_endpoints
-                .iter()
-                .any(|identity| identity == &candidate.to_string())
-        {
-            decode_endpoints.push(candidate.to_string());
-        }
-        decode_endpoints.sort();
-
-        if prefill_endpoints.len() > 1 || decode_endpoints.len() > 1 {
-            return Err(AmbiguousPrefillRouterTopology {
-                model: self.name.clone(),
-                namespace: namespace.to_string(),
-                prefill_endpoints,
-                decode_endpoints,
-            });
-        }
-
-        if prefill_endpoints.len() == 1 && decode_endpoints.len() == 1 {
-            Ok(decode_worker_sets.pop().and_then(|(_, worker_set)| {
-                worker_set.prefill_router.is_some().then_some(worker_set)
-            }))
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn worker_set_identity(key: &str, worker_set: &WorkerSet) -> String {
-        worker_set
-            .endpoint_id()
-            .map(ToString::to_string)
-            .unwrap_or_else(|| format!("worker-set-key={key}"))
-    }
-
-    pub(crate) fn prefill_routed_decode_worker_sets_in_namespace(
-        &self,
-        namespace: &str,
-    ) -> Vec<Arc<WorkerSet>> {
-        use crate::worker_type::WorkerType;
-
-        self.worker_sets
-            .iter()
-            .filter(|entry| {
-                entry.value().namespace() == namespace
-                    && entry.value().card().worker_type == Some(WorkerType::Decode)
-                    && entry.value().prefill_router.is_some()
-            })
-            .map(|entry| entry.value().clone())
-            .collect()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -492,6 +362,7 @@ impl Model {
         let mut has_legacy = false;
         let mut legacy_live_workers = 0usize;
         let mut has_live_worker = false;
+        let mut live_sets_by_type = std::collections::HashMap::new();
 
         // First pass: which worker types have a live worker (+ legacy detection).
         for ws in wsets {
@@ -503,6 +374,7 @@ impl Model {
                 Some((wt, _needs)) => {
                     if count > 0 {
                         present.insert(wt);
+                        *live_sets_by_type.entry(wt).or_insert(0usize) += 1;
                     }
                 }
                 // No declared worker_type → legacy card.
@@ -523,8 +395,17 @@ impl Model {
                 legacy_live_workers,
                 present,
                 missing,
+                ambiguous: std::collections::HashSet::new(),
             };
         }
+
+        let ambiguous = live_sets_by_type
+            .into_iter()
+            .filter_map(|(worker_type, count)| {
+                (worker_type != crate::worker_type::WorkerType::Aggregated && count > 1)
+                    .then_some(worker_type)
+            })
+            .collect::<std::collections::HashSet<_>>();
 
         // Strict path: a registered worker type with no live worker anywhere is
         // missing; a *live* WorkerSet whose `needs` DNF is unsatisfied flags its
@@ -554,11 +435,12 @@ impl Model {
         }
 
         NamespaceReadinessEval {
-            ready: has_live_worker && missing.is_empty(),
+            ready: has_live_worker && missing.is_empty() && ambiguous.is_empty(),
             has_legacy,
             legacy_live_workers,
             present,
             missing,
+            ambiguous,
         }
     }
 
@@ -641,6 +523,14 @@ impl Model {
                 }
             } else if eval.has_legacy {
                 Some("legacy worker(s) present but no live worker".to_string())
+            } else if !eval.ambiguous.is_empty() {
+                let mut roles = eval
+                    .ambiguous
+                    .iter()
+                    .map(|worker_type| worker_type.as_str())
+                    .collect::<Vec<_>>();
+                roles.sort_unstable();
+                Some(format!("ambiguous worker types: {}", roles.join(", ")))
             } else {
                 Some(format!("missing worker types: {}", missing_vec.join(", ")))
             };
@@ -1238,90 +1128,9 @@ mod tests {
             dynamo_runtime::pipeline::RouterMode::RoundRobin,
             None,
         );
-        pr.mark_active_for_test();
-        pr.deactivate();
+        pr.set_target(None);
         ws.prefill_router = Some(pr);
         Arc::new(ws)
-    }
-
-    fn endpoint_id(
-        namespace: &str,
-        component: &str,
-        name: &str,
-    ) -> dynamo_runtime::protocols::EndpointId {
-        dynamo_runtime::protocols::EndpointId {
-            namespace: namespace.to_string(),
-            component: component.to_string(),
-            name: name.to_string(),
-        }
-    }
-
-    fn make_endpoint_worker_set(
-        namespace: &str,
-        component: &str,
-        endpoint: &str,
-        worker_type: crate::worker_type::WorkerType,
-        with_prefill_router: bool,
-    ) -> Arc<WorkerSet> {
-        let mut card = ModelDeploymentCard::default();
-        card.worker_type = Some(worker_type);
-        let mut worker_set = WorkerSet::new(
-            namespace.to_string(),
-            format!("{component}-{endpoint}"),
-            card,
-        );
-        worker_set.set_endpoint_id(endpoint_id(namespace, component, endpoint));
-        if with_prefill_router {
-            let router = PrefillRouter::disabled(
-                Arc::new(crate::discovery::ModelManager::new()),
-                dynamo_runtime::pipeline::RouterMode::RoundRobin,
-                None,
-            );
-            router.mark_active_for_test();
-            worker_set.prefill_router = Some(router);
-        }
-        Arc::new(worker_set)
-    }
-
-    #[test]
-    fn one_endpoint_scoped_prefill_decode_pair_is_unambiguous() {
-        use crate::worker_type::WorkerType;
-
-        let model = Model::new("llama".to_string());
-        let decode = make_endpoint_worker_set(
-            "deployment-a",
-            "decode",
-            "generate",
-            WorkerType::Decode,
-            true,
-        );
-        model.add_worker_set("decode-leaf".to_string(), decode.clone());
-        model.add_worker_set(
-            "prefill-leaf".to_string(),
-            make_endpoint_worker_set(
-                "deployment-a",
-                "prefill",
-                "generate",
-                WorkerType::Prefill,
-                false,
-            ),
-        );
-        model.add_worker_set(
-            "unrelated-aggregated".to_string(),
-            make_endpoint_worker_set(
-                "deployment-a",
-                "aggregated",
-                "generate",
-                WorkerType::Aggregated,
-                false,
-            ),
-        );
-
-        let selected = model
-            .unique_prefill_routed_worker_set_in_namespace("deployment-a")
-            .expect("one P/D pair is unambiguous")
-            .expect("decode leaf is present");
-        assert!(Arc::ptr_eq(&selected, &decode));
     }
 
     /// Baseline: a WorkerSet without a PrefillRouter is always displayable

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -461,8 +461,10 @@ impl Model {
     /// and old aggregated workers are indistinguishable on the wire. Rather than
     /// hide the model, we fall back to legacy behavior and report ready as long
     /// as some worker is live. Strict worker-type readiness gating resumes automatically once
-    /// every worker in the namespace carries a `worker_type`. Remove this branch
-    /// when the compat shim is retired.
+    /// every worker in the namespace carries a `worker_type`.
+    ///
+    /// TODO(v1.5): Remove this branch with the legacy MDC topology shims after
+    /// the v1.2 compatibility window expires.
     pub fn is_workers_ready(&self, namespace: &str) -> bool {
         let wsets: Vec<Arc<WorkerSet>> = self
             .worker_sets

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -329,8 +329,10 @@ impl ModelManager {
     }
 
     /// Remove a Model if it has no remaining WorkerSets.
+    ///
+    /// The caller holds `reservation_lock` and publishes the resulting catalog update.
     /// Uses atomic remove_if to avoid TOCTOU race between checking is_empty and removing.
-    pub fn remove_model_if_empty(&self, model_name: &str) {
+    fn remove_model_if_empty(&self, model_name: &str) {
         if self
             .models
             .remove_if(model_name, |_, model| model.is_empty())
@@ -534,6 +536,10 @@ impl ModelManager {
         removed
     }
 
+    /// Commit a complete discovery group atomically.
+    ///
+    /// `before_publish` runs while `reservation_lock` is held and must not call methods that
+    /// acquire that lock.
     pub(crate) fn commit_discovery_group<F>(
         &self,
         group_id: &str,
@@ -783,6 +789,10 @@ impl ModelManager {
             .unwrap_or_default()
     }
 
+    /// Remove a complete discovery group atomically.
+    ///
+    /// `before_publish` runs while `reservation_lock` is held and must not call methods that
+    /// acquire that lock.
     pub(crate) fn remove_discovery_group<F>(
         &self,
         group_id: &str,

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -9,6 +9,7 @@ use std::{
     },
 };
 
+use arc_swap::ArcSwap;
 use dashmap::{DashMap, mapref::entry::Entry};
 use dynamo_kv_router::{
     PrefillLoadEstimator,
@@ -25,7 +26,7 @@ use super::{
 };
 
 use dynamo_runtime::{
-    component::{Endpoint, build_transport_type},
+    component::{Client, Endpoint, build_transport_type},
     discovery::{Discovery, DiscoverySpec},
     pipeline::network::RequestPlanePayloadCodec,
     prelude::DistributedRuntimeProvider,
@@ -132,6 +133,27 @@ pub enum ModelManagerError {
 /// implausible while keeping the value readable in Grafana dropdowns.
 pub const UNKNOWN_METRIC_MODEL: &str = "unknown_model";
 
+#[derive(Default)]
+struct CommittedCatalog {
+    models: HashMap<String, Arc<Model>>,
+    cards: HashMap<String, ModelDeploymentCard>,
+    aliases: HashMap<String, String>,
+}
+
+struct CommittedDiscoveryGroup {
+    primary: String,
+    namespace: String,
+    worker_set_key: String,
+    aliases: Vec<String>,
+    cards: HashMap<String, ModelDeploymentCard>,
+}
+
+pub(crate) struct RemovedDiscoveryGroup {
+    pub(crate) namespace: String,
+    pub(crate) representative: ModelDeploymentCard,
+    pub(crate) cards: Vec<ModelDeploymentCard>,
+}
+
 /// Central manager for model engines, routing, and configuration.
 ///
 /// Models are stored hierarchically: ModelManager → Model → WorkerSet.
@@ -142,8 +164,15 @@ pub struct ModelManager {
     /// Model name → Model (which contains WorkerSets with engines)
     models: DashMap<String, Arc<Model>>,
 
+    /// Atomically published request-plane view. Discovery lifecycle changes are assembled in the
+    /// mutable maps above and become visible with one pointer swap.
+    catalog: ArcSwap<CommittedCatalog>,
+
     /// Per-instance model cards, keyed by instance path. Used for cleanup on worker removal.
     cards: DashMap<String, ModelDeploymentCard>,
+
+    /// Controller-owned committed groups, keyed by the controller's stable GroupKey encoding.
+    discovery_groups: DashMap<String, CommittedDiscoveryGroup>,
 
     /// Prefill router activation rendezvous, keyed by "model_name:namespace".
     prefill_router_activators: DashMap<String, PrefillActivationState>,
@@ -193,7 +222,9 @@ impl ModelManager {
     pub fn new() -> Self {
         Self {
             models: DashMap::new(),
+            catalog: ArcSwap::from_pointee(CommittedCatalog::default()),
             cards: DashMap::new(),
+            discovery_groups: DashMap::new(),
             prefill_router_activators: DashMap::new(),
             encoder_router_activators: DashMap::new(),
             runtime_configs: DashMap::new(),
@@ -209,6 +240,29 @@ impl ModelManager {
         }
     }
 
+    fn publish_catalog_locked(&self) {
+        let models = self
+            .models
+            .iter()
+            .map(|entry| (entry.key().clone(), Arc::new(entry.value().snapshot())))
+            .collect();
+        let cards = self
+            .cards
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+        let aliases = self
+            .alias_to_primary
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+        self.catalog.store(Arc::new(CommittedCatalog {
+            models,
+            cards,
+            aliases,
+        }));
+    }
+
     // -- Model access --
 
     /// Get or create a Model for the given name.
@@ -221,6 +275,10 @@ impl ModelManager {
 
     /// Get an existing Model, if it exists.
     pub fn get_model(&self, model_name: &str) -> Option<Arc<Model>> {
+        self.catalog.load().models.get(model_name).cloned()
+    }
+
+    fn get_model_internal(&self, model_name: &str) -> Option<Arc<Model>> {
         self.models
             .get(model_name)
             .map(|entry| entry.value().clone())
@@ -276,6 +334,7 @@ impl ModelManager {
         if let Some(topology_namespace) = topology_namespace {
             self.reconcile_prefill_router_topology(model_name, &topology_namespace);
         }
+        self.publish_catalog_locked();
         true
     }
 
@@ -291,6 +350,7 @@ impl ModelManager {
         namespace: &str,
         worker_set: Arc<WorkerSet>,
     ) -> bool {
+        let _reservation = self.reservation_lock.lock();
         // Collision check: if `model_name` already exists as a primary (i.e.
         // already has worker sets AND is not currently an alias), refuse to
         // clobber it. The two facts are read one map at a time — the `models`
@@ -313,6 +373,7 @@ impl ModelManager {
 
         let model = self.get_or_create_model(model_name);
         model.add_worker_set(namespace.to_string(), worker_set);
+        self.publish_catalog_locked();
         true
     }
 
@@ -364,6 +425,7 @@ impl ModelManager {
             }
             Entry::Vacant(slot) => {
                 slot.insert(primary.to_string());
+                self.publish_catalog_locked();
                 true
             }
         }
@@ -371,6 +433,7 @@ impl ModelManager {
 
     /// Remove a previously registered alias mapping once the alias has no WorkerSets.
     pub fn unregister_alias_if_empty(&self, alias: &str, primary: &str) {
+        let _reservation = self.reservation_lock.lock();
         if self
             .models
             .get(alias)
@@ -381,14 +444,17 @@ impl ModelManager {
 
         self.alias_to_primary
             .remove_if(alias, |_, existing| existing == primary);
+        self.publish_catalog_locked();
     }
 
     /// Return the primary (canonical) model name for `model`, resolving aliases.
     /// Returns `model` unchanged if it is not an alias.
     pub fn resolve_canonical_name(&self, model: &str) -> String {
-        self.alias_to_primary
+        self.catalog
+            .load()
+            .aliases
             .get(model)
-            .map(|v| v.value().clone())
+            .cloned()
             .unwrap_or_else(|| model.to_string())
     }
 
@@ -402,6 +468,7 @@ impl ModelManager {
 
     /// Remove a WorkerSet from a Model. Removes the Model if it becomes empty.
     pub fn remove_worker_set(&self, model_name: &str, namespace: &str) -> Option<Arc<WorkerSet>> {
+        let _reservation = self.reservation_lock.lock();
         let model = self.models.get(model_name)?;
         let removed = model.remove_worker_set(namespace);
         let topology_namespace = removed.as_ref().and_then(|worker_set| {
@@ -419,50 +486,221 @@ impl ModelManager {
             self.reconcile_prefill_router_topology(model_name, &topology_namespace);
         }
         self.remove_model_if_empty(model_name);
+        self.publish_catalog_locked();
         removed
+    }
+
+    pub(crate) fn commit_discovery_group<F>(
+        &self,
+        group_id: &str,
+        worker_set_key: &str,
+        worker_set: WorkerSet,
+        members: Vec<(String, ModelDeploymentCard)>,
+        before_publish: F,
+    ) -> anyhow::Result<()>
+    where
+        F: FnOnce(),
+    {
+        let representative = members
+            .first()
+            .map(|(_, card)| card)
+            .ok_or_else(|| anyhow::anyhow!("cannot commit an empty discovery group"))?;
+        let primary = representative.name().to_string();
+        let aliases = representative
+            .aliases
+            .iter()
+            .filter(|alias| alias.as_str() != primary)
+            .cloned()
+            .collect::<Vec<_>>();
+        let namespace = worker_set.namespace().to_string();
+
+        let _reservation = self.reservation_lock.lock();
+        anyhow::ensure!(
+            !self.discovery_groups.contains_key(group_id),
+            "discovery group {group_id:?} is already committed"
+        );
+        if let Some(owner) = self.alias_to_primary.get(&primary) {
+            anyhow::bail!(
+                "model name {primary:?} is reserved as an alias of {:?}",
+                owner.value()
+            );
+        }
+
+        for alias in &aliases {
+            if let Some(owner) = self.alias_to_primary.get(alias)
+                && owner.value() != &primary
+            {
+                anyhow::bail!("alias {alias:?} is already reserved by {:?}", owner.value());
+            }
+            let is_other_primary = self
+                .models
+                .get(alias)
+                .is_some_and(|model| !model.is_empty())
+                && self
+                    .alias_to_primary
+                    .get(alias)
+                    .is_none_or(|owner| owner.value() != &primary);
+            anyhow::ensure!(
+                !is_other_primary,
+                "alias {alias:?} collides with a registered primary model"
+            );
+        }
+
+        let worker_set = Arc::new(worker_set);
+        self.get_or_create_model(&primary)
+            .add_worker_set(worker_set_key.to_string(), worker_set.clone());
+        for alias in &aliases {
+            self.alias_to_primary.insert(alias.clone(), primary.clone());
+            self.get_or_create_model(alias)
+                .add_worker_set(worker_set_key.to_string(), worker_set.clone());
+        }
+
+        let cards = members.into_iter().collect::<HashMap<_, _>>();
+        for (key, card) in &cards {
+            self.cards.insert(key.clone(), card.clone());
+        }
+        self.discovery_groups.insert(
+            group_id.to_string(),
+            CommittedDiscoveryGroup {
+                primary: primary.clone(),
+                namespace: namespace.clone(),
+                worker_set_key: worker_set_key.to_string(),
+                aliases,
+                cards,
+            },
+        );
+        before_publish();
+        self.reconcile_prefill_router_topology(&primary, &namespace);
+        self.publish_catalog_locked();
+        Ok(())
+    }
+
+    pub(crate) fn add_discovery_group_member(
+        &self,
+        group_id: &str,
+        key: String,
+        card: ModelDeploymentCard,
+    ) -> anyhow::Result<()> {
+        let _reservation = self.reservation_lock.lock();
+        let mut group = self
+            .discovery_groups
+            .get_mut(group_id)
+            .ok_or_else(|| anyhow::anyhow!("committed discovery group {group_id:?} not found"))?;
+        group.cards.insert(key.clone(), card.clone());
+        self.cards.insert(key, card);
+        drop(group);
+        self.publish_catalog_locked();
+        Ok(())
+    }
+
+    pub(crate) fn remove_discovery_group_member(
+        &self,
+        group_id: &str,
+        key: &str,
+    ) -> Option<ModelDeploymentCard> {
+        let _reservation = self.reservation_lock.lock();
+        let mut group = self.discovery_groups.get_mut(group_id)?;
+        let removed = group.cards.remove(key)?;
+        self.cards.remove(key);
+        drop(group);
+        self.publish_catalog_locked();
+        Some(removed)
+    }
+
+    pub(crate) fn remove_discovery_group<F>(
+        &self,
+        group_id: &str,
+        before_publish: F,
+    ) -> Option<RemovedDiscoveryGroup>
+    where
+        F: FnOnce(&RemovedDiscoveryGroup),
+    {
+        let _reservation = self.reservation_lock.lock();
+        let (_, group) = self.discovery_groups.remove(group_id)?;
+        let representative = group.cards.values().next()?.clone();
+        let topology_namespace = group.namespace.clone();
+
+        for key in group.cards.keys() {
+            self.cards.remove(key);
+        }
+        if let Some(model) = self.models.get(&group.primary) {
+            model.remove_worker_set(&group.worker_set_key);
+        }
+        self.remove_model_if_empty(&group.primary);
+        for alias in &group.aliases {
+            if let Some(model) = self.models.get(alias) {
+                model.remove_worker_set(&group.worker_set_key);
+            }
+            self.remove_model_if_empty(alias);
+            if self.models.get(alias).is_none_or(|model| model.is_empty()) {
+                self.alias_to_primary
+                    .remove_if(alias, |_, owner| owner == &group.primary);
+            }
+        }
+        let cards = group.cards.into_values().collect();
+        let removed = RemovedDiscoveryGroup {
+            namespace: group.namespace,
+            representative,
+            cards,
+        };
+        before_publish(&removed);
+        self.reconcile_prefill_router_topology(&group.primary, &topology_namespace);
+        self.publish_catalog_locked();
+        Some(removed)
     }
 
     // -- Model cards --
 
     pub fn get_model_cards(&self) -> Vec<ModelDeploymentCard> {
-        self.cards.iter().map(|r| r.value().clone()).collect()
+        self.catalog.load().cards.values().cloned().collect()
     }
 
-    /// Return owned discovery instance keys for the locally recorded cards.
-    /// Reconciliation must not hold DashMap guards while it performs
-    /// asynchronous cleanup.
+    /// Return owned keys for cards in the published catalog.
     pub fn get_model_card_keys(&self) -> Vec<String> {
-        self.cards.iter().map(|r| r.key().clone()).collect()
+        self.catalog.load().cards.keys().cloned().collect()
     }
 
-    /// Save a ModelDeploymentCard from an instance's key so we can fetch it later when the key is
-    /// deleted.
+    /// Compatibility path for explicit in-process callers. Discovery uses the atomic group
+    /// lifecycle methods above and never publishes a card independently.
     pub fn save_model_card(&self, key: &str, card: ModelDeploymentCard) -> anyhow::Result<()> {
+        let _reservation = self.reservation_lock.lock();
         self.cards.insert(key.to_string(), card);
+        self.publish_catalog_locked();
         Ok(())
     }
 
     /// Remove and return model card for this instance's key. We do this when the instance stops.
     pub fn get_model_card(&self, key: &str) -> Option<ModelDeploymentCard> {
-        self.cards.get(key).map(|r| r.value().clone())
+        self.catalog.load().cards.get(key).cloned()
     }
 
     pub fn remove_model_card(&self, key: &str) -> Option<ModelDeploymentCard> {
-        self.cards.remove(key).map(|(_, v)| v)
+        let _reservation = self.reservation_lock.lock();
+        let removed = self.cards.remove(key).map(|(_, value)| value);
+        if removed.is_some() {
+            self.publish_catalog_locked();
+        }
+        removed
     }
 
     // -- Engine accessors (delegate through Model → WorkerSet) --
 
     /// Check if a decode model (chat or completions) is registered
     pub fn has_decode_model(&self, model: &str) -> bool {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .is_some_and(|m| m.has_decode_engine())
     }
 
     /// Check if a prefill model is registered
     pub fn has_prefill_model(&self, model: &str) -> bool {
-        self.models.get(model).is_some_and(|m| m.has_prefill())
+        self.catalog
+            .load()
+            .models
+            .get(model)
+            .is_some_and(|m| m.has_prefill())
     }
 
     /// Check if any model (decode or prefill) is registered.
@@ -475,7 +713,7 @@ impl ModelManager {
     /// [`has_model_any`](Self::has_model_any), which checks specifically for a
     /// decode or prefill engine.
     pub fn has_registered_model(&self, model: &str) -> bool {
-        self.models.contains_key(model)
+        self.catalog.load().models.contains_key(model)
     }
 
     /// Resolve the model name to use in frontend Prometheus metrics.
@@ -496,7 +734,9 @@ impl ModelManager {
     /// Whether `model` has at least one WorkerSet that can serve an inference
     /// request right now. See [`Model::is_ready_to_serve`].
     pub fn is_model_ready_to_serve(&self, model: &str) -> bool {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .is_some_and(|m| m.is_ready_to_serve())
     }
@@ -504,16 +744,20 @@ impl ModelManager {
     /// Whether any registered model can serve at least one inference request
     /// right now. See [`Model::is_ready_to_serve`].
     pub fn has_any_ready_model(&self) -> bool {
-        self.models
-            .iter()
-            .any(|entry| entry.value().is_ready_to_serve())
+        self.catalog
+            .load()
+            .models
+            .values()
+            .any(|model| model.is_ready_to_serve())
     }
 
     pub fn model_display_names(&self) -> HashSet<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().is_displayable())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.is_displayable())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
@@ -524,118 +768,143 @@ impl ModelManager {
     /// deployment (e.g. decode-only with no prefill peer) is neither advertised
     /// nor chosen as an implicit default.
     pub fn serving_ready_display_names(&self) -> HashSet<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| {
-                let model = entry.value();
-                model.is_displayable() && model.has_ready_workers()
-            })
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.is_displayable() && model.has_ready_workers())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_chat_completions_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_chat_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_chat_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_completions_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_completions_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_completions_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_embeddings_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_embeddings_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_embeddings_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_classify_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_classify_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_classify_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_pooling_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_pooling_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_pooling_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_tensor_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_tensor_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_tensor_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_images_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_images_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_images_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_audios_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_audios_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_audios_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_videos_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_videos_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_videos_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_realtime_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_realtime_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_realtime_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_generate_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_generate_engine())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_generate_engine())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     /// List Generate models with an engine that advertises `capability`.
     pub fn list_generate_models_for_capability(&self, capability: &str) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_generate_engine_for_capability(capability))
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_generate_engine_for_capability(capability))
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
     pub fn list_prefill_models(&self) -> Vec<String> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .iter()
-            .filter(|entry| entry.value().has_prefill())
-            .map(|entry| entry.key().clone())
+            .filter(|(_, model)| model.has_prefill())
+            .map(|(name, _)| name.clone())
             .collect()
     }
 
@@ -643,7 +912,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIEmbeddingsStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_embeddings_engine()
@@ -653,7 +924,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIClassifyStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_classify_engine()
@@ -663,7 +936,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIPoolingStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_pooling_engine()
@@ -673,7 +948,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAICompletionsStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_completions_engine()
@@ -683,7 +960,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIChatCompletionsStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_chat_engine()
@@ -693,7 +972,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<TensorStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_tensor_engine()
@@ -703,7 +984,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIImagesStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_images_engine()
@@ -713,7 +996,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIVideosStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_videos_engine()
@@ -723,7 +1008,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAIAudiosStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_audios_engine()
@@ -733,7 +1020,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<RealtimeBidirectionalEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_realtime_engine()
@@ -743,7 +1032,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<GenerateStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_generate_engine()
@@ -754,7 +1045,9 @@ impl ModelManager {
         model: &str,
         capability: &str,
     ) -> Result<GenerateStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_generate_engine_for_capability(capability)
@@ -772,7 +1065,9 @@ impl ModelManager {
         ),
         ModelManagerError,
     > {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_chat_engine_with_parsing()
@@ -788,7 +1083,9 @@ impl ModelManager {
         ),
         ModelManagerError,
     > {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_completions_engine_with_parsing()
@@ -804,7 +1101,9 @@ impl ModelManager {
         ),
         ModelManagerError,
     > {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_generate_engine_with_parsing()
@@ -834,6 +1133,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: OpenAIChatCompletionsStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_chat_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -846,6 +1146,7 @@ impl ModelManager {
         );
         ws.chat_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -855,6 +1156,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: OpenAICompletionsStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_completions_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -867,6 +1169,7 @@ impl ModelManager {
         );
         ws.completions_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -876,6 +1179,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: OpenAIEmbeddingsStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_embeddings_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -888,6 +1192,7 @@ impl ModelManager {
         );
         ws.embeddings_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -897,6 +1202,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: OpenAIClassifyStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_classify_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -909,6 +1215,7 @@ impl ModelManager {
         );
         ws.classify_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -918,6 +1225,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: OpenAIPoolingStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_pooling_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -930,6 +1238,7 @@ impl ModelManager {
         );
         ws.pooling_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -939,6 +1248,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: TensorStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_tensor_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -951,6 +1261,7 @@ impl ModelManager {
         );
         ws.tensor_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -960,6 +1271,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: OpenAIImagesStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_images_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -972,6 +1284,7 @@ impl ModelManager {
         );
         ws.images_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -981,6 +1294,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: OpenAIVideosStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_videos_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -993,6 +1307,7 @@ impl ModelManager {
         );
         ws.videos_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -1002,6 +1317,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: OpenAIAudiosStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_audios_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -1014,6 +1330,7 @@ impl ModelManager {
         );
         ws.audios_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -1023,6 +1340,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: RealtimeBidirectionalEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_realtime_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -1035,6 +1353,7 @@ impl ModelManager {
         );
         ws.realtime_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -1044,6 +1363,7 @@ impl ModelManager {
         card_checksum: &str,
         engine: GenerateStreamingEngine,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_generate_engine() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -1057,6 +1377,7 @@ impl ModelManager {
         let mut ws = WorkerSet::new(namespace.clone(), card_checksum.to_string(), card);
         ws.generate_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -1065,6 +1386,7 @@ impl ModelManager {
         model: &str,
         card_checksum: &str,
     ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
         let model_entry = self.get_or_create_model(model);
         if model_entry.has_prefill() {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
@@ -1075,6 +1397,7 @@ impl ModelManager {
         card.needs = vec![vec![crate::worker_type::WorkerType::Decode]];
         let ws = WorkerSet::new(namespace.clone(), card_checksum.to_string(), card);
         model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
         Ok(())
     }
 
@@ -1083,7 +1406,12 @@ impl ModelManager {
     /// Remove a model entirely (all its WorkerSets).
     /// Returns the removed Model, or None if not found.
     pub fn remove_model(&self, model: &str) -> Option<Arc<Model>> {
-        self.models.remove(model).map(|(_, m)| m)
+        let _reservation = self.reservation_lock.lock();
+        let removed = self.models.remove(model).map(|(_, value)| value);
+        if removed.is_some() {
+            self.publish_catalog_locked();
+        }
+        removed
     }
 
     // Per-type remove methods for in-process models (used by Python bindings).
@@ -1280,6 +1608,38 @@ impl ModelManager {
         Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
     {
         let client = endpoint.client().await?;
+        self.kv_chooser_for_with_selector_and_client(
+            endpoint,
+            client,
+            kv_cache_block_size,
+            selector,
+            kv_router_config,
+            prefill_load_estimator,
+            worker_role,
+            metric_worker_type,
+            model_name,
+            is_eagle,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn kv_chooser_for_with_selector_and_client<Sel>(
+        &self,
+        endpoint: &Endpoint,
+        client: Client,
+        kv_cache_block_size: u32,
+        selector: Sel,
+        kv_router_config: Option<KvRouterConfig>,
+        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
+        worker_role: Option<WorkerType>,
+        metric_worker_type: &'static str,
+        model_name: Option<String>,
+        is_eagle: bool,
+    ) -> anyhow::Result<Arc<KvRouter<Sel>>>
+    where
+        Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
+    {
         let lora_domain = self.lora_domain(&endpoint.id());
 
         // Register router via discovery mechanism.
@@ -1511,7 +1871,7 @@ impl ModelManager {
         namespace: &str,
         decode_endpoint: &EndpointId,
     ) -> anyhow::Result<Option<oneshot::Receiver<Endpoint>>> {
-        if let Some(model) = self.get_model(model_name)
+        if let Some(model) = self.get_model_internal(model_name)
             && let Err(error) =
                 model.prefill_router_topology_with_decode_candidate(namespace, decode_endpoint)
         {
@@ -1569,7 +1929,7 @@ impl ModelManager {
     }
 
     fn deactivate_prefill_router_topology(&self, model_name: &str, namespace: &str) {
-        let Some(model) = self.get_model(model_name) else {
+        let Some(model) = self.get_model_internal(model_name) else {
             return;
         };
         for worker_set in model.prefill_routed_decode_worker_sets_in_namespace(namespace) {
@@ -1580,7 +1940,7 @@ impl ModelManager {
     }
 
     fn reconcile_prefill_router_topology(&self, model_name: &str, namespace: &str) {
-        let Some(model) = self.get_model(model_name) else {
+        let Some(model) = self.get_model_internal(model_name) else {
             return;
         };
         let worker_set = match model.unique_prefill_routed_worker_set_in_namespace(namespace) {
@@ -1650,7 +2010,7 @@ impl ModelManager {
         // state. Endpoint-scoped WorkerSets are leaves, but a model namespace
         // supports only one P/D pairing; discovery order must not choose among
         // multiple prefill-routed decode endpoints.
-        let reactivation_target = if let Some(model) = self.get_model(model_name) {
+        let reactivation_target = if let Some(model) = self.get_model_internal(model_name) {
             match model.unique_prefill_routed_worker_set_in_namespace(namespace) {
                 Ok(worker_set) => worker_set,
                 Err(error) => {
@@ -1769,7 +2129,7 @@ impl ModelManager {
     /// Called by the watcher when all prefill workers in a namespace are removed.
     /// After deactivation, requests fall back to aggregated mode.
     pub fn deactivate_prefill_router_for_decode(&self, model_name: &str, namespace: &str) {
-        let Some(model) = self.get_model(model_name) else {
+        let Some(model) = self.get_model_internal(model_name) else {
             return;
         };
 
@@ -1793,7 +2153,7 @@ impl ModelManager {
     /// The cached endpoint remains usable when that removal resolves a
     /// duplicate leaf; it is dropped only after the final prefill leaf leaves.
     pub fn remove_prefill_activator(&self, model_name: &str, namespace: &str) {
-        if self.get_model(model_name).is_some_and(|model| {
+        if self.get_model_internal(model_name).is_some_and(|model| {
             model.worker_sets().into_iter().any(|worker_set| {
                 worker_set.namespace() == namespace
                     && worker_set.card().worker_type
@@ -1953,7 +2313,7 @@ impl ModelManager {
     }
 
     fn reactivate_encoder_routers(&self, model_name: &str, namespace: &str) {
-        if let Some(model) = self.get_model(model_name) {
+        if let Some(model) = self.get_model_internal(model_name) {
             for ws in model.worker_sets() {
                 if ws.namespace() == namespace
                     && let Some(ref router) = ws.encoder_router
@@ -1981,7 +2341,7 @@ impl ModelManager {
     }
 
     pub fn deactivate_encoder_router_for_consumers(&self, model_name: &str, namespace: &str) {
-        if let Some(model) = self.get_model(model_name) {
+        if let Some(model) = self.get_model_internal(model_name) {
             for ws in model.worker_sets() {
                 if ws.namespace() == namespace
                     && let Some(ref router) = ws.encoder_router
@@ -2875,6 +3235,63 @@ mod tests {
     fn test_remove_model_card_nonexistent() {
         let mm = ModelManager::new();
         assert!(mm.remove_model_card("nonexistent").is_none());
+    }
+
+    #[test]
+    fn discovery_group_commit_is_all_or_nothing_across_aliases_and_cards() {
+        let manager = ModelManager::new();
+        manager.add_worker_set("taken", "existing", make_worker_set("existing", "old"));
+
+        let mut blocked_card = ModelDeploymentCard::with_name_only("candidate");
+        blocked_card.aliases = vec!["taken".to_string()];
+        let blocked_worker_set = WorkerSet::new(
+            "deployment".to_string(),
+            blocked_card.mdcsum().to_string(),
+            blocked_card.clone(),
+        );
+        let error = manager
+            .commit_discovery_group(
+                "blocked-group",
+                "candidate-workers",
+                blocked_worker_set,
+                vec![("instance-1".to_string(), blocked_card)],
+                || {},
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("collides"));
+        assert!(manager.get_model("candidate").is_none());
+        assert!(manager.get_model_cards().is_empty());
+        assert!(manager.get_model("taken").is_some());
+
+        let mut card = ModelDeploymentCard::with_name_only("committed");
+        card.aliases = vec!["alias".to_string()];
+        let worker_set = WorkerSet::new(
+            "deployment".to_string(),
+            card.mdcsum().to_string(),
+            card.clone(),
+        );
+        manager
+            .commit_discovery_group(
+                "ready-group",
+                "committed-workers",
+                worker_set,
+                vec![("instance-2".to_string(), card)],
+                || {},
+            )
+            .unwrap();
+
+        assert_eq!(manager.get_model_cards().len(), 1);
+        assert!(manager.get_model("committed").is_some());
+        assert!(manager.get_model("alias").is_some());
+        assert_eq!(manager.resolve_canonical_name("alias"), "committed");
+
+        manager
+            .remove_discovery_group("ready-group", |_| {})
+            .unwrap();
+        assert!(manager.get_model_cards().is_empty());
+        assert!(manager.get_model("committed").is_none());
+        assert!(manager.get_model("alias").is_none());
+        assert_eq!(manager.resolve_canonical_name("alias"), "alias");
     }
 
     // -- Prefill router rendezvous tests --

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -17,7 +17,6 @@ use dynamo_kv_router::{
     protocols::{KvTransferEnforcement, RoutingConstraints, WorkerId},
     selector::WorkerSelector,
 };
-use tokio::sync::oneshot;
 
 use super::worker_monitor::LoadThresholdConfig;
 use super::{
@@ -58,35 +57,6 @@ use crate::{
     },
     worker_type::WorkerType,
 };
-
-/// State for prefill router activation rendezvous.
-///
-/// Once a prefill endpoint has been observed for a (model, namespace) pair,
-/// `PrefillReady` is left in the activator map indefinitely (until prefill
-/// workers all disappear). This survives `register_prefill_router` consuming
-/// the entry — that consumer hands out a fresh `oneshot::Receiver` synthesized
-/// from the cached endpoint, then re-inserts `PrefillReady` so future decode
-/// WorkerSet rebuilds (e.g., decode pod restarts) can find it and activate
-/// immediately without waiting for prefill workers to re-register.
-enum PrefillActivationState {
-    /// Decode model registered, waiting for prefill endpoint
-    DecodeWaiting(oneshot::Sender<Endpoint>),
-    /// Prefill endpoint observed and cached for this (model, namespace).
-    /// Anyone calling `register_prefill_router` synthesizes a fresh
-    /// `oneshot::Receiver` from this and re-inserts the cached endpoint.
-    ///
-    /// Boxed to keep the enum variant sizes balanced (`Endpoint` is much
-    /// larger than `oneshot::Sender`). Satisfies `clippy::large_enum_variant`.
-    PrefillReady(Box<Endpoint>),
-}
-
-/// State for the optional Encode endpoint / token-pipeline rendezvous.
-#[derive(Default)]
-struct EncoderActivationState {
-    consumer: Option<oneshot::Sender<Endpoint>>,
-    endpoint: Option<Box<Endpoint>>,
-    routing_enabled: bool,
-}
 
 struct LoraEndpointDomain {
     routing_table: LoraRoutingTable,
@@ -151,7 +121,6 @@ struct CommittedDiscoveryGroup {
 }
 
 pub(crate) struct RemovedDiscoveryGroup {
-    pub(crate) namespace: String,
     pub(crate) representative: ModelDeploymentCard,
     pub(crate) cards: Vec<ModelDeploymentCard>,
 }
@@ -175,12 +144,6 @@ pub struct ModelManager {
 
     /// Controller-owned committed groups, keyed by the controller's stable GroupKey encoding.
     discovery_groups: DashMap<String, CommittedDiscoveryGroup>,
-
-    /// Prefill router activation rendezvous, keyed by "model_name:namespace".
-    prefill_router_activators: DashMap<String, PrefillActivationState>,
-
-    /// Encode router activation rendezvous, keyed by "model_name:namespace".
-    encoder_router_activators: DashMap<String, EncoderActivationState>,
 
     /// Per-endpoint runtime config watchers. Keyed by EndpointId (includes namespace).
     runtime_configs: DashMap<EndpointId, RuntimeConfigWatch>,
@@ -227,8 +190,6 @@ impl ModelManager {
             catalog: ArcSwap::from_pointee(CommittedCatalog::default()),
             cards: DashMap::new(),
             discovery_groups: DashMap::new(),
-            prefill_router_activators: DashMap::new(),
-            encoder_router_activators: DashMap::new(),
             runtime_configs: DashMap::new(),
             hicache_caches: DashMap::new(),
             kv_source_memberships: DashMap::new(),
@@ -371,15 +332,9 @@ impl ModelManager {
             return false;
         }
         let model = self.get_or_create_model(model_name);
-        let topology_namespace = (matches!(
-            worker_set.card().worker_type,
-            Some(crate::worker_type::WorkerType::Prefill | crate::worker_type::WorkerType::Decode)
-        ))
-        .then(|| worker_set.namespace().to_string());
+        let topology_namespace = worker_set.namespace().to_string();
         model.add_worker_set(namespace.to_string(), Arc::new(worker_set));
-        if let Some(topology_namespace) = topology_namespace {
-            self.reconcile_prefill_router_topology(model_name, &topology_namespace);
-        }
+        self.reconcile_discovery_topology(model_name, &topology_namespace);
         self.publish_catalog_locked();
         true
     }
@@ -517,19 +472,15 @@ impl ModelManager {
         let _reservation = self.reservation_lock.lock();
         let model = self.models.get(model_name)?;
         let removed = model.remove_worker_set(namespace);
-        let topology_namespace = removed.as_ref().and_then(|worker_set| {
-            matches!(
-                worker_set.card().worker_type,
-                Some(
-                    crate::worker_type::WorkerType::Prefill
-                        | crate::worker_type::WorkerType::Decode
-                )
-            )
-            .then(|| worker_set.namespace().to_string())
-        });
+        let topology_namespace = removed
+            .as_ref()
+            .map(|worker_set| worker_set.namespace().to_string());
+        if let Some(worker_set) = &removed {
+            Self::clear_worker_set_targets(worker_set);
+        }
         drop(model);
         if let Some(topology_namespace) = topology_namespace {
-            self.reconcile_prefill_router_topology(model_name, &topology_namespace);
+            self.reconcile_discovery_topology(model_name, &topology_namespace);
         }
         self.remove_model_if_empty(model_name);
         self.publish_catalog_locked();
@@ -538,20 +489,14 @@ impl ModelManager {
 
     /// Commit a complete discovery group atomically.
     ///
-    /// `before_publish` runs while `reservation_lock` is held and must not call methods that
-    /// acquire that lock.
-    pub(crate) fn commit_discovery_group<F>(
+    pub(crate) fn commit_discovery_group(
         &self,
         group_id: &str,
         worker_set_key: &str,
         worker_set: WorkerSet,
         members: Vec<(String, ModelDeploymentCard)>,
         adapters: Vec<(String, ModelDeploymentCard)>,
-        before_publish: F,
-    ) -> anyhow::Result<()>
-    where
-        F: FnOnce(),
-    {
+    ) -> anyhow::Result<()> {
         let representative = members
             .first()
             .map(|(_, card)| card)
@@ -639,8 +584,7 @@ impl ModelManager {
                 representative,
             },
         );
-        before_publish();
-        self.reconcile_prefill_router_topology(&primary, &namespace);
+        self.reconcile_discovery_topology(&primary, &namespace);
         self.publish_catalog_locked();
         Ok(())
     }
@@ -791,16 +735,7 @@ impl ModelManager {
 
     /// Remove a complete discovery group atomically.
     ///
-    /// `before_publish` runs while `reservation_lock` is held and must not call methods that
-    /// acquire that lock.
-    pub(crate) fn remove_discovery_group<F>(
-        &self,
-        group_id: &str,
-        before_publish: F,
-    ) -> Option<RemovedDiscoveryGroup>
-    where
-        F: FnOnce(&RemovedDiscoveryGroup),
-    {
+    pub(crate) fn remove_discovery_group(&self, group_id: &str) -> Option<RemovedDiscoveryGroup> {
         let _reservation = self.reservation_lock.lock();
         let (_, group) = self.discovery_groups.remove(group_id)?;
         let representative = group.representative.clone();
@@ -812,8 +747,10 @@ impl ModelManager {
         for key in group.adapters.keys() {
             self.cards.remove(key);
         }
-        if let Some(model) = self.models.get(&group.primary) {
-            model.remove_worker_set(&group.worker_set_key);
+        if let Some(model) = self.models.get(&group.primary)
+            && let Some(worker_set) = model.remove_worker_set(&group.worker_set_key)
+        {
+            Self::clear_worker_set_targets(&worker_set);
         }
         self.remove_model_if_empty(&group.primary);
         for alias in &group.aliases {
@@ -838,12 +775,10 @@ impl ModelManager {
             .chain(group.adapters.into_values())
             .collect();
         let removed = RemovedDiscoveryGroup {
-            namespace: group.namespace,
             representative,
             cards,
         };
-        before_publish(&removed);
-        self.reconcile_prefill_router_topology(&group.primary, &topology_namespace);
+        self.reconcile_discovery_topology(&group.primary, &topology_namespace);
         self.publish_catalog_locked();
         Some(removed)
     }
@@ -1985,16 +1920,6 @@ impl ModelManager {
         Ok(Arc::new(chooser))
     }
 
-    // -- Prefill router coordination --
-    // Keyed by "model_name:namespace" so each namespace's decode WorkerSet gets its own
-    // prefill router activated by same-namespace prefill workers.
-
-    /// Build a key for a (model, namespace) pair. Used for prefill router activators
-    /// and registration guards.
-    pub(crate) fn model_namespace_key(model_name: &str, namespace: &str) -> String {
-        format!("{}:{}", model_name, namespace)
-    }
-
     // ── LoRA allocation accessors ───────────────────────────────────────
 
     fn lora_domain(&self, endpoint_id: &EndpointId) -> Arc<LoraEndpointDomain> {
@@ -2070,502 +1995,80 @@ impl ModelManager {
         })
     }
 
-    /// Register a prefill router for a decode WorkerSet. Returns a receiver that will be
-    /// activated when the corresponding prefill model in the same namespace is discovered.
-    /// Returns None if a decode WorkerSet in this namespace was already registered.
-    pub fn register_prefill_router(
-        &self,
-        model_name: &str,
-        namespace: &str,
-        decode_endpoint: &EndpointId,
-    ) -> anyhow::Result<Option<oneshot::Receiver<Endpoint>>> {
-        if let Some(model) = self.get_model_internal(model_name)
-            && let Err(error) =
-                model.prefill_router_topology_with_decode_candidate(namespace, decode_endpoint)
-        {
-            self.deactivate_prefill_router_topology(model_name, namespace);
-            return Err(error.into());
-        }
+    fn supports_encoder_result_handoff(card: &ModelDeploymentCard) -> bool {
+        card.runtime_config
+            .runtime_data
+            .get("encoder_result_handoff")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+    }
 
-        let key = Self::model_namespace_key(model_name, namespace);
-        // Use the entry API so the activator state mutation is atomic per-key:
-        // a concurrent `remove_prefill_activator` (called by the watcher on
-        // prefill-component teardown) can't slip into the gap between a
-        // `remove`-then-`insert` pair and miss the cleanup, leaving a stale
-        // PrefillReady cached for a prefill that's already gone.
-        match self.prefill_router_activators.entry(key) {
-            Entry::Occupied(o) => match o.get() {
-                PrefillActivationState::PrefillReady(endpoint) => {
-                    // Read the cached endpoint without removing the entry — its
-                    // shard lock is held for the duration of the OccupiedEntry,
-                    // so any concurrent prefill teardown serializes after us
-                    // and observes the entry it needs to clear.
-                    let endpoint_clone = (**endpoint).clone();
-                    let (tx, rx) = oneshot::channel();
-                    let _ = tx.send(endpoint_clone);
-                    tracing::debug!(
-                        model_name = %model_name,
-                        namespace = %namespace,
-                        "Prefill endpoint cached; returning fresh receiver"
-                    );
-                    Ok(Some(rx))
-                }
-                PrefillActivationState::DecodeWaiting(_) => {
-                    // Decode already registered — entry stays in place so the
-                    // existing live waiter isn't disturbed. Return None to
-                    // signal the caller that this shouldn't have happened.
-                    tracing::error!(
-                        model_name = %model_name,
-                        namespace = %namespace,
-                        "Decode WorkerSet already registered for this prefill router"
-                    );
-                    Ok(None)
-                }
-            },
-            Entry::Vacant(v) => {
-                // New registration: create tx/rx pair, store sender, return receiver.
-                let (tx, rx) = oneshot::channel();
-                v.insert(PrefillActivationState::DecodeWaiting(tx));
-                tracing::debug!(
-                    model_name = %model_name,
-                    namespace = %namespace,
-                    "No prefill endpoint for namespace yet, storing sender for future activation"
-                );
-                Ok(Some(rx))
-            }
+    fn clear_worker_set_targets(worker_set: &WorkerSet) {
+        if let Some(router) = &worker_set.prefill_router {
+            router.set_target(None);
+        }
+        if let Some(router) = &worker_set.encoder_router {
+            router.set_target(None);
         }
     }
 
-    fn deactivate_prefill_router_topology(&self, model_name: &str, namespace: &str) {
+    /// Derive routing targets exclusively from committed WorkerSets. The
+    /// caller holds `reservation_lock`; target clearing is synchronous and
+    /// happens before the catalog pointer is published.
+    fn reconcile_discovery_topology(&self, model_name: &str, namespace: &str) {
         let Some(model) = self.get_model_internal(model_name) else {
             return;
         };
-        for worker_set in model.prefill_routed_decode_worker_sets_in_namespace(namespace) {
-            if let Some(ref prefill_router) = worker_set.prefill_router {
-                prefill_router.deactivate();
+        let worker_sets = model
+            .worker_sets()
+            .into_iter()
+            .filter(|worker_set| worker_set.namespace() == namespace)
+            .collect::<Vec<_>>();
+
+        let prefill_providers = worker_sets
+            .iter()
+            .filter(|worker_set| worker_set.card().worker_type == Some(WorkerType::Prefill))
+            .filter_map(|worker_set| worker_set.topology_endpoint().cloned())
+            .collect::<Vec<_>>();
+        let decode_consumers = worker_sets
+            .iter()
+            .filter(|worker_set| worker_set.card().worker_type == Some(WorkerType::Decode))
+            .collect::<Vec<_>>();
+        let prefill_target = (prefill_providers.len() == 1 && decode_consumers.len() == 1)
+            .then(|| prefill_providers[0].clone());
+        for worker_set in &decode_consumers {
+            if let Some(router) = &worker_set.prefill_router {
+                router.set_target(prefill_target.clone());
             }
         }
-    }
 
-    fn reconcile_prefill_router_topology(&self, model_name: &str, namespace: &str) {
-        let Some(model) = self.get_model_internal(model_name) else {
-            return;
-        };
-        let worker_set = match model.unique_prefill_routed_worker_set_in_namespace(namespace) {
-            Ok(Some(worker_set)) => worker_set,
-            Ok(None) => {
-                self.deactivate_prefill_router_topology(model_name, namespace);
-                return;
-            }
-            Err(error) => {
-                tracing::error!(
-                    model_name,
-                    namespace,
-                    %error,
-                    "P/D routing is disabled until endpoint membership is unique"
-                );
-                self.deactivate_prefill_router_topology(model_name, namespace);
-                return;
-            }
-        };
-
-        let key = Self::model_namespace_key(model_name, namespace);
-        let selected_prefill = model.worker_sets().into_iter().find_map(|worker_set| {
-            (worker_set.namespace() == namespace
-                && worker_set.card().worker_type == Some(crate::worker_type::WorkerType::Prefill))
-            .then(|| worker_set.endpoint_id().cloned())
-            .flatten()
-        });
-        let cached_prefill_matches =
-            self.prefill_router_activators
-                .get(&key)
-                .is_some_and(|state| {
-                    matches!(
-                        state.value(),
-                        PrefillActivationState::PrefillReady(endpoint)
-                            if Some(endpoint.id()) == selected_prefill
-                    )
-                });
-        if !cached_prefill_matches {
-            tracing::error!(
-                model_name,
-                namespace,
-                ?selected_prefill,
-                "P/D routing remains disabled because the sole prefill endpoint does not match the cached activation"
-            );
-            self.deactivate_prefill_router_topology(model_name, namespace);
-            return;
-        }
-
-        if let Some(prefill_router) = worker_set.prefill_router.as_ref()
-            && prefill_router.is_deactivated()
-        {
-            prefill_router.reactivate();
-        }
-    }
-
-    /// Activate a prefill router by sending the endpoint through the oneshot channel.
-    /// The namespace must match the decode WorkerSet's namespace.
-    pub fn activate_prefill_router(
-        &self,
-        model_name: &str,
-        namespace: &str,
-        endpoint: Endpoint,
-    ) -> anyhow::Result<()> {
-        let key = Self::model_namespace_key(model_name, namespace);
-
-        // Resolve the namespace-level topology before mutating rendezvous
-        // state. Endpoint-scoped WorkerSets are leaves, but a model namespace
-        // supports only one P/D pairing; discovery order must not choose among
-        // multiple prefill-routed decode endpoints.
-        let reactivation_target = if let Some(model) = self.get_model_internal(model_name) {
-            match model.unique_prefill_routed_worker_set_in_namespace(namespace) {
-                Ok(worker_set) => worker_set,
-                Err(error) => {
-                    self.deactivate_prefill_router_topology(model_name, namespace);
-                    return Err(error.into());
-                }
-            }
-        } else {
-            None
-        };
-
-        // Reactivate any existing deactivated decode-side `PrefillRouter`. Used
-        // by the PrefillReady-refresh and Vacant arms — the rebuilding case
-        // for prefill workers that previously died and now rejoin.
-        let reactivate_if_needed = || {
-            if let Some(ws) = reactivation_target.as_ref()
-                && let Some(ref pr) = ws.prefill_router
-                && pr.is_deactivated()
-            {
-                pr.reactivate();
-                true
-            } else {
-                false
-            }
-        };
-
-        // Atomic per-key state transition via the entry API. Replaces the
-        // previous `remove → process → insert` pattern, which left a window in
-        // which a concurrent `remove_prefill_activator` (prefill teardown via
-        // the watcher) could slip in, observe an empty map, and skip the
-        // cleanup — letting a stale `PrefillReady` get resurrected here.
-        match self.prefill_router_activators.entry(key) {
-            Entry::Occupied(mut o) => {
-                // Atomically swap the value to a fresh PrefillReady. The old
-                // value tells us which transition we just performed.
-                let new_value = PrefillActivationState::PrefillReady(Box::new(endpoint.clone()));
-                let old = o.insert(new_value);
-                // Drop the OccupiedEntry to release the shard lock before any
-                // potentially-non-trivial work (e.g. nested DashMap accesses
-                // via reactivate_if_needed). The state transition above is
-                // already committed.
-                drop(o);
-
-                match old {
-                    PrefillActivationState::DecodeWaiting(sender) => {
-                        // Cold-start (or post-rebuild) handshake: decode
-                        // registered first. Wake the waiting receiver.
-                        sender.send(endpoint).map_err(|_| {
-                            anyhow::anyhow!(
-                                "Failed to send endpoint to prefill router activator for {}:{}",
-                                model_name,
-                                namespace
-                            )
-                        })?;
-                        // Structural reconciliation deactivates an incomplete P/D
-                        // topology while this waiter is pending. The now-unique
-                        // prefill leaf makes it eligible again.
-                        reactivate_if_needed();
-                        tracing::info!(
-                            model_name = %model_name,
-                            namespace = %namespace,
-                            "Activated prefill router for decode WorkerSet"
-                        );
-                    }
-                    PrefillActivationState::PrefillReady(_) => {
-                        // Stale PrefillReady from a prior handshake. Two cases:
-                        //   (a) Duplicate activate_prefill_router call (e.g.,
-                        //       the same prefill instance re-publishes its
-                        //       endpoint) — just refresh, no router action.
-                        //   (b) Prefill rejoin after a transient absence —
-                        //       reactivate any deactivated decode-side router.
-                        if reactivate_if_needed() {
-                            tracing::info!(
-                                model_name = %model_name,
-                                namespace = %namespace,
-                                "Reactivated existing prefill router for decode WorkerSet (prefill rejoin)"
-                            );
-                        } else {
-                            tracing::debug!(
-                                model_name = %model_name,
-                                namespace = %namespace,
-                                "Refreshed cached prefill endpoint for future decode WorkerSet rebuild"
-                            );
-                        }
-                    }
-                }
-                Ok(())
-            }
-            Entry::Vacant(v) => {
-                // No prior handshake state. Insert a fresh PrefillReady so a
-                // future decode rebuild's register_prefill_router finds the
-                // cache and activates immediately.
-                v.insert(PrefillActivationState::PrefillReady(Box::new(endpoint)));
-
-                // Then handle the prefill-rejoin case: an existing decode-side
-                // PrefillRouter that was deactivated when prefill went away.
-                if reactivate_if_needed() {
-                    tracing::info!(
-                        model_name = %model_name,
-                        namespace = %namespace,
-                        "Reactivated existing prefill router for decode WorkerSet (prefill rejoin)"
-                    );
-                } else {
-                    tracing::info!(
-                        model_name = %model_name,
-                        namespace = %namespace,
-                        "Stored prefill endpoint for future decode WorkerSet registration"
-                    );
-                }
-                Ok(())
-            }
-        }
-    }
-
-    /// Deactivate the prefill router on the decode WorkerSet for the given model/namespace.
-    /// Called by the watcher when all prefill workers in a namespace are removed.
-    /// After deactivation, requests fall back to aggregated mode.
-    pub fn deactivate_prefill_router_for_decode(&self, model_name: &str, namespace: &str) {
-        let Some(model) = self.get_model_internal(model_name) else {
-            return;
-        };
-
-        if let Err(error) = model.unique_prefill_routed_worker_set_in_namespace(namespace) {
-            tracing::error!(
-                model_name,
-                namespace,
-                %error,
-                "Deactivating every prefill router in ambiguous endpoint-scoped topology"
-            );
-        }
-
-        for worker_set in model.prefill_routed_decode_worker_sets_in_namespace(namespace) {
-            if let Some(ref prefill_router) = worker_set.prefill_router {
-                prefill_router.deactivate();
-            }
-        }
-    }
-
-    /// Reconcile the prefill activator after one prefill WorkerSet is removed.
-    /// The cached endpoint remains usable when that removal resolves a
-    /// duplicate leaf; it is dropped only after the final prefill leaf leaves.
-    pub fn remove_prefill_activator(&self, model_name: &str, namespace: &str) {
-        if self.get_model_internal(model_name).is_some_and(|model| {
-            model.worker_sets().into_iter().any(|worker_set| {
-                worker_set.namespace() == namespace
-                    && worker_set.card().worker_type
-                        == Some(crate::worker_type::WorkerType::Prefill)
+        let encode_providers = worker_sets
+            .iter()
+            .filter(|worker_set| {
+                worker_set.card().worker_type == Some(WorkerType::Encode)
+                    && worker_set.card().model_type.is_empty()
             })
-        }) {
-            self.reconcile_prefill_router_topology(model_name, namespace);
-            return;
-        }
+            .filter_map(|worker_set| worker_set.topology_endpoint().cloned())
+            .collect::<Vec<_>>();
+        let unique_encode = (encode_providers.len() == 1).then(|| encode_providers[0].clone());
+        let capable_prefill = (prefill_providers.len() == 1)
+            && worker_sets.iter().any(|worker_set| {
+                worker_set.card().worker_type == Some(WorkerType::Prefill)
+                    && Self::supports_encoder_result_handoff(worker_set.card())
+            });
 
-        let key = Self::model_namespace_key(model_name, namespace);
-        if self.prefill_router_activators.remove(&key).is_some() {
-            tracing::debug!(
-                model_name = %model_name,
-                namespace = %namespace,
-                "Cleaned up prefill router activator for removed WorkerSet"
-            );
-        }
-    }
-
-    /// Remove a stale `DecodeWaiting(sender)` entry on decode WorkerSet teardown,
-    /// while preserving any `PrefillReady(endpoint)` cache.
-    ///
-    /// When a decode WorkerSet is torn down, the `DecodeWaiting` entry's sender
-    /// targets a `oneshot::Receiver` held by the now-dropped `PrefillRouter`. If
-    /// we leave it in the map:
-    ///   - the next decode rebuild's `register_prefill_router` finds the stale
-    ///     `DecodeWaiting`, hits the `Some(DecodeWaiting)` arm, and returns
-    ///     `None` — so the rebuilt WorkerSet has no `PrefillRouter` at all;
-    ///   - when prefill finally registers, `activate_prefill_router` wakes the
-    ///     orphaned receiver and activates a router that's about to be dropped,
-    ///     producing log lines that look like success while the rebuilt
-    ///     WorkerSet still has nothing.
-    ///
-    /// `PrefillReady` must be left intact — it's a cache of the prefill endpoint
-    /// that survives decode rebuilds (PR 8965's primary contribution).
-    pub fn remove_decode_prefill_waiter(&self, model_name: &str, namespace: &str) {
-        let key = Self::model_namespace_key(model_name, namespace);
-        // Atomic remove-if-stale: only drop the entry if it's `DecodeWaiting`,
-        // leaving `PrefillReady` cache entries untouched.
-        let removed = self.prefill_router_activators.remove_if(&key, |_, v| {
-            matches!(v, PrefillActivationState::DecodeWaiting(_))
-        });
-        if removed.is_some() {
-            tracing::debug!(
-                model_name = %model_name,
-                namespace = %namespace,
-                "Removed stale DecodeWaiting activator on decode WorkerSet teardown"
-            );
-        }
-    }
-
-    /// Register the optional encoder hop for a token-serving WorkerSet.
-    /// A cached Encode endpoint activates rebuilt consumers immediately.
-    pub fn register_encoder_router(
-        &self,
-        model_name: &str,
-        namespace: &str,
-    ) -> Option<oneshot::Receiver<Endpoint>> {
-        let key = Self::model_namespace_key(model_name, namespace);
-        match self.encoder_router_activators.entry(key) {
-            Entry::Occupied(mut o) => {
-                if o.get().consumer.is_some() {
-                    tracing::error!(
-                        model_name = %model_name,
-                        namespace = %namespace,
-                        "Token WorkerSet already registered for this encoder router"
-                    );
-                    return None;
-                }
-                let (tx, rx) = oneshot::channel();
-                let state = o.get_mut();
-                if state.routing_enabled {
-                    if let Some(endpoint) = state.endpoint.as_ref() {
-                        let _ = tx.send((**endpoint).clone());
-                    } else {
-                        state.consumer = Some(tx);
-                    }
-                } else {
-                    state.consumer = Some(tx);
-                }
-                Some(rx)
-            }
-            Entry::Vacant(v) => {
-                let (tx, rx) = oneshot::channel();
-                v.insert(EncoderActivationState {
-                    consumer: Some(tx),
-                    ..Default::default()
-                });
-                Some(rx)
-            }
-        }
-    }
-
-    /// Mark the model namespace as explicitly depending on an Encode worker.
-    /// Activation waits for both this signal and an Encode endpoint so worker
-    /// discovery order does not change routing behavior.
-    pub fn enable_encoder_routing(&self, model_name: &str, namespace: &str) {
-        let key = Self::model_namespace_key(model_name, namespace);
-        // Option::zip would eagerly evaluate consumer.take(), dropping the
-        // waiter when the Encode endpoint has not arrived yet.
-        #[allow(clippy::manual_option_zip)]
-        let sender_and_endpoint = match self.encoder_router_activators.entry(key) {
-            Entry::Occupied(mut o) => {
-                let state = o.get_mut();
-                state.routing_enabled = true;
-                state
-                    .endpoint
-                    .as_ref()
-                    .map(|endpoint| (**endpoint).clone())
-                    .and_then(|endpoint| state.consumer.take().map(|sender| (sender, endpoint)))
-            }
-            Entry::Vacant(v) => {
-                v.insert(EncoderActivationState {
-                    routing_enabled: true,
-                    ..Default::default()
-                });
-                None
-            }
-        };
-        if let Some((sender, endpoint)) = sender_and_endpoint {
-            let _ = sender.send(endpoint);
-        }
-    }
-
-    /// Publish an Encode endpoint and activate any waiting token pipeline.
-    pub fn activate_encoder_router(&self, model_name: &str, namespace: &str, endpoint: Endpoint) {
-        let key = Self::model_namespace_key(model_name, namespace);
-        let sender = match self.encoder_router_activators.entry(key) {
-            Entry::Occupied(mut o) => {
-                let state = o.get_mut();
-                state.endpoint = Some(Box::new(endpoint.clone()));
-                state
-                    .routing_enabled
-                    .then(|| state.consumer.take())
-                    .flatten()
-            }
-            Entry::Vacant(v) => {
-                v.insert(EncoderActivationState {
-                    endpoint: Some(Box::new(endpoint.clone())),
-                    ..Default::default()
-                });
-                None
-            }
-        };
-        if let Some(sender) = sender {
-            if sender.send(endpoint).is_err() {
-                tracing::warn!(
-                    model_name = %model_name,
-                    namespace = %namespace,
-                    "Encoder router consumer disappeared before activation; endpoint remains cached"
-                );
-            }
-        } else {
-            self.reactivate_encoder_routers(model_name, namespace);
-        }
-    }
-
-    fn reactivate_encoder_routers(&self, model_name: &str, namespace: &str) {
-        if let Some(model) = self.get_model_internal(model_name) {
-            for ws in model.worker_sets() {
-                if ws.namespace() == namespace
-                    && let Some(ref router) = ws.encoder_router
-                    && router.is_deactivated()
-                {
-                    router.reactivate();
-                }
-            }
-        }
-    }
-
-    /// Drop a stale Encode endpoint and make existing token pipelines bypass it.
-    pub fn remove_encoder_activator(&self, model_name: &str, namespace: &str) {
-        let key = Self::model_namespace_key(model_name, namespace);
-        if let Entry::Occupied(mut o) = self.encoder_router_activators.entry(key) {
-            let should_remove = {
-                let state = o.get_mut();
-                state.endpoint = None;
-                state.consumer.is_none()
+        for worker_set in &worker_sets {
+            let Some(router) = &worker_set.encoder_router else {
+                continue;
             };
-            if should_remove {
-                o.remove();
-            }
-        }
-    }
-
-    pub fn deactivate_encoder_router_for_consumers(&self, model_name: &str, namespace: &str) {
-        if let Some(model) = self.get_model_internal(model_name) {
-            for ws in model.worker_sets() {
-                if ws.namespace() == namespace
-                    && let Some(ref router) = ws.encoder_router
-                {
-                    router.deactivate();
+            let routing_enabled = match worker_set.card().worker_type {
+                Some(WorkerType::Decode) => capable_prefill && decode_consumers.len() == 1,
+                Some(WorkerType::Prefill) => false,
+                Some(WorkerType::Aggregated | WorkerType::Encode) | None => {
+                    Self::supports_encoder_result_handoff(worker_set.card())
                 }
-            }
-        }
-    }
-
-    /// Remove a waiter owned by a token WorkerSet that failed or was removed,
-    /// while preserving a cached live Encode endpoint for rebuilds.
-    pub fn remove_consumer_encoder_waiter(&self, model_name: &str, namespace: &str) {
-        let key = Self::model_namespace_key(model_name, namespace);
-        if let Some(mut state) = self.encoder_router_activators.get_mut(&key) {
-            state.consumer = None;
+            };
+            router.set_target(routing_enabled.then(|| unique_encode.clone()).flatten());
         }
     }
 
@@ -2798,6 +2301,7 @@ mod tests {
         DistributedRuntime, Runtime,
         discovery::{Discovery, DiscoverySpec, MockDiscovery, SharedMockRegistry},
         distributed::DistributedConfig,
+        pipeline::RouterMode,
         transports::event_plane::EventScope,
     };
 
@@ -3476,7 +2980,6 @@ mod tests {
                 blocked_worker_set,
                 vec![("instance-1".to_string(), blocked_card)],
                 Vec::new(),
-                || {},
             )
             .unwrap_err();
         assert!(error.to_string().contains("collides"));
@@ -3498,7 +3001,6 @@ mod tests {
                 worker_set,
                 vec![("instance-2".to_string(), card)],
                 Vec::new(),
-                || {},
             )
             .unwrap();
 
@@ -3507,9 +3009,7 @@ mod tests {
         assert!(manager.get_model("alias").is_some());
         assert_eq!(manager.resolve_canonical_name("alias"), "committed");
 
-        manager
-            .remove_discovery_group("ready-group", |_| {})
-            .unwrap();
+        manager.remove_discovery_group("ready-group").unwrap();
         assert!(manager.get_model_cards().is_empty());
         assert!(manager.get_model("committed").is_none());
         assert!(manager.get_model("alias").is_none());
@@ -3538,7 +3038,6 @@ mod tests {
                 worker_set,
                 vec![("base-instance".to_string(), base)],
                 vec![("adapter-instance".to_string(), adapter)],
-                || {},
             )
             .unwrap();
 
@@ -3549,514 +3048,200 @@ mod tests {
                 .is_some_and(|model| model.has_worker_set("base-workers"))
         );
 
-        manager
-            .remove_discovery_group("adapter-group", |_| {})
-            .unwrap();
+        manager.remove_discovery_group("adapter-group").unwrap();
         assert!(manager.get_model_cards().is_empty());
         assert!(manager.get_committed_model("adapter").is_none());
     }
 
-    // -- Prefill router rendezvous tests --
-    // Note: activate_prefill_router requires an Endpoint (needs DistributedRuntime),
-    // so we test the registration state machine and cleanup only.
-
-    fn decode_endpoint_id(namespace: &str) -> EndpointId {
-        EndpointId {
-            namespace: namespace.to_string(),
-            component: "decode".to_string(),
-            name: "generate".to_string(),
+    fn topology_card(role: WorkerType) -> ModelDeploymentCard {
+        let mut card = ModelDeploymentCard::with_name_only("topology-model");
+        card.worker_type = Some(role);
+        card.model_type = match role {
+            WorkerType::Decode => crate::model_type::ModelType::Chat,
+            _ => crate::model_type::ModelType::empty(),
+        };
+        card.needs = match role {
+            WorkerType::Prefill => vec![vec![WorkerType::Decode, WorkerType::Encode]],
+            WorkerType::Decode => vec![vec![WorkerType::Prefill]],
+            WorkerType::Encode => vec![vec![WorkerType::Prefill]],
+            WorkerType::Aggregated => Vec::new(),
+        };
+        if role == WorkerType::Prefill {
+            card.runtime_config
+                .set_engine_specific("encoder_result_handoff", true)
+                .unwrap();
         }
+        card
     }
 
-    #[test]
-    fn test_prefill_router_register_new() {
-        let mm = ModelManager::new();
+    fn topology_worker_set(
+        manager: Arc<ModelManager>,
+        role: WorkerType,
+        endpoint: Endpoint,
+    ) -> (
+        WorkerSet,
+        Option<Arc<crate::kv_router::PrefillRouter>>,
+        Option<Arc<crate::kv_router::EncoderRouter>>,
+    ) {
+        let card = topology_card(role);
+        let mut worker_set =
+            WorkerSet::new(endpoint.id().namespace, card.mdcsum().to_string(), card);
+        worker_set.set_topology_endpoint(endpoint);
+        if role != WorkerType::Decode {
+            return (worker_set, None, None);
+        }
 
-        // First registration for a (model, namespace) returns Some(rx)
-        let rx = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        assert!(rx.is_some());
-    }
-
-    #[test]
-    fn test_prefill_router_double_register_returns_none() {
-        let mm = ModelManager::new();
-
-        let rx1 = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        assert!(rx1.is_some());
-
-        // Second registration for the same (model, namespace) returns None
-        let rx2 = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        assert!(rx2.is_none());
-    }
-
-    #[test]
-    fn test_prefill_router_different_namespaces_independent() {
-        let mm = ModelManager::new();
-
-        // Different namespaces should be independent
-        let rx1 = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        let rx2 = mm
-            .register_prefill_router("llama", "ns2", &decode_endpoint_id("ns2"))
-            .unwrap();
-        assert!(rx1.is_some());
-        assert!(rx2.is_some());
-    }
-
-    #[test]
-    fn test_prefill_router_different_models_independent() {
-        let mm = ModelManager::new();
-
-        // Different models should be independent
-        let rx1 = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        let rx2 = mm
-            .register_prefill_router("gpt", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        assert!(rx1.is_some());
-        assert!(rx2.is_some());
-    }
-
-    #[test]
-    fn test_prefill_router_remove_allows_reregister() {
-        let mm = ModelManager::new();
-
-        let rx = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        assert!(rx.is_some());
-
-        // Remove the activator
-        mm.remove_prefill_activator("llama", "ns1");
-
-        // Should be able to register again
-        let rx2 = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        assert!(rx2.is_some());
-    }
-
-    #[test]
-    fn test_prefill_router_remove_nonexistent_noop() {
-        let mm = ModelManager::new();
-        // Should not panic
-        mm.remove_prefill_activator("llama", "ns1");
-    }
-
-    #[test]
-    fn test_encoder_router_registration_and_waiter_cleanup() {
-        let mm = ModelManager::new();
-        let rx = mm.register_encoder_router("llama", "ns1");
-        assert!(rx.is_some());
-        assert!(mm.register_encoder_router("llama", "ns1").is_none());
-
-        drop(rx);
-        mm.remove_consumer_encoder_waiter("llama", "ns1");
-        assert!(mm.register_encoder_router("llama", "ns1").is_some());
-    }
-
-    #[test]
-    fn test_encoder_router_different_namespaces_are_independent() {
-        let mm = ModelManager::new();
-        assert!(mm.register_encoder_router("llama", "ns1").is_some());
-        assert!(mm.register_encoder_router("llama", "ns2").is_some());
-    }
-
-    #[test]
-    fn test_remove_encoder_activator_drops_stale_state_without_waiter() {
-        let mm = ModelManager::new();
-        let key = ModelManager::model_namespace_key("llama", "ns1");
-        mm.encoder_router_activators.insert(
-            key.clone(),
-            EncoderActivationState {
-                routing_enabled: true,
-                ..Default::default()
-            },
+        let (_activation_tx, activation_rx) = tokio::sync::oneshot::channel();
+        let prefill = crate::kv_router::PrefillRouter::new(
+            activation_rx,
+            manager,
+            RouterMode::RoundRobin,
+            1,
+            None,
+            None,
+            None,
+            None,
+            "topology-model".to_string(),
+            worker_set.namespace().to_string(),
+            false,
+            None,
         );
-
-        mm.remove_encoder_activator("llama", "ns1");
-
-        assert!(!mm.encoder_router_activators.contains_key(&key));
-        let _receiver = mm
-            .register_encoder_router("llama", "ns1")
-            .expect("registration after cleanup must succeed");
-        let state = mm.encoder_router_activators.get(&key).unwrap();
-        assert!(!state.routing_enabled);
-        assert!(state.consumer.is_some());
-    }
-
-    #[test]
-    fn test_remove_encoder_activator_preserves_waiting_consumer() {
-        let mm = ModelManager::new();
-        let key = ModelManager::model_namespace_key("llama", "ns1");
-        let _receiver = mm
-            .register_encoder_router("llama", "ns1")
-            .expect("consumer registration must succeed");
-        mm.enable_encoder_routing("llama", "ns1");
-
-        mm.remove_encoder_activator("llama", "ns1");
-
-        let state = mm.encoder_router_activators.get(&key).unwrap();
-        assert!(state.consumer.is_some());
-        assert!(state.endpoint.is_none());
-        assert!(state.routing_enabled);
-    }
-
-    #[derive(Clone, Copy)]
-    enum EncoderActivationSignal {
-        Register,
-        Enable,
-        Activate,
+        let encoder = crate::kv_router::EncoderRouter::new(
+            "topology-model".to_string(),
+            worker_set.namespace().to_string(),
+        );
+        worker_set.prefill_router = Some(prefill.clone());
+        worker_set.encoder_router = Some(encoder.clone());
+        (worker_set, Some(prefill), Some(encoder))
     }
 
     #[tokio::test]
-    async fn test_encoder_router_activates_in_every_signal_order() {
-        use EncoderActivationSignal::{Activate, Enable, Register};
-
+    async fn committed_topology_converges_for_every_epd_startup_order() {
         let runtime = Runtime::from_current().unwrap();
         let distributed =
             DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
                 .await
                 .unwrap();
-        let endpoint = distributed
-            .namespace("encoder-activation-orders".to_string())
-            .unwrap()
-            .component("encoder".to_string())
-            .unwrap()
-            .endpoint("generate".to_string());
         let orders = [
-            [Register, Enable, Activate],
-            [Register, Activate, Enable],
-            [Enable, Register, Activate],
-            [Enable, Activate, Register],
-            [Activate, Register, Enable],
-            [Activate, Enable, Register],
+            [WorkerType::Encode, WorkerType::Prefill, WorkerType::Decode],
+            [WorkerType::Encode, WorkerType::Decode, WorkerType::Prefill],
+            [WorkerType::Prefill, WorkerType::Encode, WorkerType::Decode],
+            [WorkerType::Prefill, WorkerType::Decode, WorkerType::Encode],
+            [WorkerType::Decode, WorkerType::Encode, WorkerType::Prefill],
+            [WorkerType::Decode, WorkerType::Prefill, WorkerType::Encode],
         ];
 
-        for order in orders {
-            let mm = ModelManager::new();
-            let mut receiver = None;
-            for signal in order {
-                match signal {
-                    Register => {
-                        receiver = mm.register_encoder_router("llama", "ns1");
-                    }
-                    Enable => mm.enable_encoder_routing("llama", "ns1"),
-                    Activate => {
-                        mm.activate_encoder_router("llama", "ns1", endpoint.clone());
-                    }
+        for (index, order) in orders.into_iter().enumerate() {
+            let manager = Arc::new(ModelManager::new());
+            let namespace = format!("epd-order-{index}");
+            let component = distributed
+                .namespace(namespace.clone())
+                .unwrap()
+                .component("workers".to_string())
+                .unwrap();
+            let prefill_endpoint = component.endpoint("prefill".to_string());
+            let encode_endpoint = component.endpoint("encode".to_string());
+            let decode_endpoint = component.endpoint("decode".to_string());
+            let mut prefill_router = None;
+            let mut encoder_router = None;
+
+            for (step, role) in order.into_iter().enumerate() {
+                let endpoint = match role {
+                    WorkerType::Prefill => prefill_endpoint.clone(),
+                    WorkerType::Encode => encode_endpoint.clone(),
+                    WorkerType::Decode => decode_endpoint.clone(),
+                    WorkerType::Aggregated => unreachable!(),
+                };
+                let (worker_set, prefill, encoder) =
+                    topology_worker_set(manager.clone(), role, endpoint);
+                prefill_router = prefill.or(prefill_router);
+                encoder_router = encoder.or(encoder_router);
+                let card = worker_set.card().clone();
+                manager
+                    .commit_discovery_group(
+                        &format!("{namespace}-{role:?}"),
+                        &format!("{role:?}"),
+                        worker_set,
+                        vec![(format!("{namespace}-{role:?}"), card)],
+                        Vec::new(),
+                    )
+                    .unwrap();
+                if step < 2 {
+                    assert!(
+                        !manager
+                            .get_committed_model("topology-model")
+                            .unwrap()
+                            .namespace_readiness()
+                            .ready
+                    );
                 }
             }
 
-            let activated = receiver
-                .expect("every order registers a consumer")
-                .await
-                .expect("all three signals must activate the consumer");
-            assert_eq!(activated, endpoint);
+            assert!(
+                manager
+                    .get_committed_model("topology-model")
+                    .unwrap()
+                    .namespace_readiness()
+                    .ready
+            );
+            let prefill_router = prefill_router.unwrap();
+            let encoder_router = encoder_router.unwrap();
+            assert_eq!(
+                prefill_router.target_endpoint_id(),
+                Some(prefill_endpoint.id())
+            );
+            assert_eq!(
+                encoder_router.target_endpoint_id(),
+                Some(encode_endpoint.id())
+            );
+
+            if index < 2 {
+                let duplicate_endpoint = component.endpoint("prefill-duplicate".to_string());
+                let (duplicate, _, _) = topology_worker_set(
+                    manager.clone(),
+                    WorkerType::Prefill,
+                    duplicate_endpoint.clone(),
+                );
+                let duplicate_card = duplicate.card().clone();
+                manager
+                    .commit_discovery_group(
+                        &format!("{namespace}-prefill-duplicate"),
+                        "PrefillDuplicate",
+                        duplicate,
+                        vec![(format!("{namespace}-prefill-duplicate"), duplicate_card)],
+                        Vec::new(),
+                    )
+                    .unwrap();
+                assert!(
+                    !manager
+                        .get_committed_model("topology-model")
+                        .unwrap()
+                        .namespace_readiness()
+                        .ready
+                );
+                assert_eq!(prefill_router.target_endpoint_id(), None);
+
+                let removed_group = if index == 0 {
+                    format!("{namespace}-prefill-duplicate")
+                } else {
+                    format!("{namespace}-Prefill")
+                };
+                manager.remove_discovery_group(&removed_group).unwrap();
+                let expected = if index == 0 {
+                    prefill_endpoint.id()
+                } else {
+                    duplicate_endpoint.id()
+                };
+                assert!(
+                    manager
+                        .get_committed_model("topology-model")
+                        .unwrap()
+                        .namespace_readiness()
+                        .ready
+                );
+                assert_eq!(prefill_router.target_endpoint_id(), Some(expected));
+            }
         }
-
-        runtime.shutdown();
-    }
-
-    #[tokio::test]
-    async fn test_encoder_router_repeated_enable_preserves_waiter() {
-        let runtime = Runtime::from_current().unwrap();
-        let distributed =
-            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
-                .await
-                .unwrap();
-        let endpoint = distributed
-            .namespace("encoder-repeated-enable".to_string())
-            .unwrap()
-            .component("encoder".to_string())
-            .unwrap()
-            .endpoint("generate".to_string());
-        let mm = ModelManager::new();
-        let receiver = mm
-            .register_encoder_router("llama", "ns1")
-            .expect("consumer registration must succeed");
-
-        mm.enable_encoder_routing("llama", "ns1");
-        mm.enable_encoder_routing("llama", "ns1");
-        mm.activate_encoder_router("llama", "ns1", endpoint.clone());
-
-        assert_eq!(receiver.await.unwrap(), endpoint);
-        runtime.shutdown();
-    }
-
-    #[test]
-    fn test_encoder_router_reactivates_every_matching_worker_set() {
-        let router_a = crate::kv_router::EncoderRouter::disabled();
-        let router_b = crate::kv_router::EncoderRouter::disabled();
-        let mm = ModelManager::new();
-        let mut ws_a = make_worker_set("ns1", "checksum-a");
-        ws_a.encoder_router = Some(router_a.clone());
-        let mut ws_b = make_worker_set("ns1", "checksum-b");
-        ws_b.encoder_router = Some(router_b.clone());
-        mm.add_worker_set("llama", "ns1:chat:decode", ws_a);
-        mm.add_worker_set("llama", "ns1:completions:decode", ws_b);
-
-        mm.deactivate_encoder_router_for_consumers("llama", "ns1");
-        assert!(router_a.is_deactivated());
-        assert!(router_b.is_deactivated());
-
-        mm.reactivate_encoder_routers("llama", "ns1");
-
-        assert!(!router_a.is_deactivated());
-        assert!(!router_b.is_deactivated());
-    }
-
-    // -- remove_decode_prefill_waiter tests (stale-DecodeWaiting cleanup) --
-
-    /// Decode WorkerSet teardown while still in DecodeWaiting must drop the
-    /// stale waiter so a subsequent decode rebuild can register fresh.
-    #[test]
-    fn test_remove_decode_prefill_waiter_clears_decodewaiting() {
-        let mm = ModelManager::new();
-
-        // Decode registers first → DecodeWaiting in map.
-        let rx1 = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        assert!(rx1.is_some());
-
-        // Decode WorkerSet is removed before prefill registers. Drop the
-        // receiver to mirror PrefillRouter being dropped along with the
-        // WorkerSet.
-        drop(rx1);
-
-        // Watcher's decode-teardown path calls this:
-        mm.remove_decode_prefill_waiter("llama", "ns1");
-
-        // Rebuild path: a new register_prefill_router must succeed.
-        let rx2 = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        assert!(
-            rx2.is_some(),
-            "after stale-DecodeWaiting cleanup, decode rebuild must get a fresh rx"
-        );
-    }
-
-    /// Removing the waiter when the activator is already empty must not panic.
-    #[test]
-    fn test_remove_decode_prefill_waiter_empty_noop() {
-        let mm = ModelManager::new();
-        mm.remove_decode_prefill_waiter("llama", "ns1");
-        // And the next register must still work.
-        let rx = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap();
-        assert!(rx.is_some());
-    }
-
-    #[test]
-    fn test_model_namespace_key_format() {
-        assert_eq!(
-            ModelManager::model_namespace_key("llama", "ns1"),
-            "llama:ns1"
-        );
-        assert_eq!(
-            ModelManager::model_namespace_key("gpt-4", "default-abc"),
-            "gpt-4:default-abc"
-        );
-    }
-
-    // -- deactivate_prefill_router_for_decode tests --
-
-    use crate::kv_router::PrefillRouter;
-
-    /// Helper: make a WorkerSet with an activated PrefillRouter attached.
-    fn make_worker_set_with_prefill_router(namespace: &str, mdcsum: &str) -> WorkerSet {
-        let mut card = ModelDeploymentCard::default();
-        card.worker_type = Some(crate::worker_type::WorkerType::Decode);
-        let mut ws = WorkerSet::new(namespace.to_string(), mdcsum.to_string(), card);
-        let pr = PrefillRouter::disabled(
-            std::sync::Arc::new(ModelManager::new()),
-            dynamo_runtime::pipeline::RouterMode::RoundRobin,
-            None,
-        );
-        pr.mark_active_for_test();
-        ws.prefill_router = Some(pr);
-        ws
-    }
-
-    fn make_endpoint_worker_set_with_prefill_router(namespace: &str, component: &str) -> WorkerSet {
-        let mut worker_set = make_worker_set_with_prefill_router(namespace, component);
-        worker_set.set_endpoint_id(EndpointId {
-            namespace: namespace.to_string(),
-            component: component.to_string(),
-            name: "generate".to_string(),
-        });
-        worker_set
-    }
-
-    fn make_typed_endpoint_worker_set(
-        namespace: &str,
-        component: &str,
-        worker_type: crate::worker_type::WorkerType,
-    ) -> WorkerSet {
-        let mut card = ModelDeploymentCard::default();
-        card.worker_type = Some(worker_type);
-        let mut worker_set = WorkerSet::new(namespace.to_string(), component.to_string(), card);
-        worker_set.set_endpoint_id(EndpointId {
-            namespace: namespace.to_string(),
-            component: component.to_string(),
-            name: "generate".to_string(),
-        });
-        worker_set
-    }
-
-    /// Calling deactivate on a non-existent model must not panic.
-    #[test]
-    fn test_deactivate_prefill_router_for_decode_noop_missing_model() {
-        let mm = ModelManager::new();
-        mm.deactivate_prefill_router_for_decode("nonexistent", "ns1");
-    }
-
-    /// Calling deactivate on a WorkerSet without a prefill_router must not panic.
-    #[test]
-    fn test_deactivate_prefill_router_for_decode_noop_no_router() {
-        let mm = ModelManager::new();
-        mm.add_worker_set("llama", "ns1", make_worker_set("ns1", "abc"));
-        mm.deactivate_prefill_router_for_decode("llama", "ns1");
-    }
-
-    /// Deactivation updates routing lifecycle but does not add a second visibility policy on top
-    /// of registered worker topology.
-    #[test]
-    fn test_deactivate_prefill_router_for_decode_keeps_model_visible() {
-        let mm = ModelManager::new();
-        mm.add_worker_set(
-            "llama",
-            "ns1",
-            make_worker_set_with_prefill_router("ns1", "abc"),
-        );
-
-        // Model is visible before deactivation.
-        assert!(mm.model_display_names().contains("llama"));
-
-        mm.deactivate_prefill_router_for_decode("llama", "ns1");
-
-        assert!(mm.model_display_names().contains("llama"));
-        let router = mm
-            .get_model("llama")
-            .and_then(|model| model.get_worker_set("ns1"))
-            .and_then(|ws| ws.prefill_router.clone())
-            .expect("prefill router");
-        assert!(router.is_deactivated());
-
-        // Idempotent: calling again must not panic.
-        mm.deactivate_prefill_router_for_decode("llama", "ns1");
-        assert!(mm.model_display_names().contains("llama"));
-    }
-
-    #[tokio::test]
-    async fn ambiguous_decode_leaf_disables_only_pd_and_recovers_on_removal() {
-        use crate::worker_type::WorkerType;
-
-        let runtime = Runtime::from_current().unwrap();
-        let distributed =
-            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
-                .await
-                .unwrap();
-        let mm = ModelManager::new();
-        mm.add_worker_set(
-            "llama",
-            "decode-a",
-            make_endpoint_worker_set_with_prefill_router("ns1", "decode-a"),
-        );
-        mm.add_worker_set(
-            "llama",
-            "prefill",
-            make_typed_endpoint_worker_set("ns1", "prefill", WorkerType::Prefill),
-        );
-        mm.add_worker_set("llama", "ordinary", make_worker_set("ns1", "ordinary"));
-
-        let endpoint = distributed
-            .namespace("ns1".to_string())
-            .unwrap()
-            .component("prefill".to_string())
-            .unwrap()
-            .endpoint("generate".to_string());
-        mm.prefill_router_activators.insert(
-            ModelManager::model_namespace_key("llama", "ns1"),
-            PrefillActivationState::PrefillReady(Box::new(endpoint)),
-        );
-        let router = mm
-            .get_model("llama")
-            .and_then(|model| model.get_worker_set("decode-a"))
-            .and_then(|worker_set| worker_set.prefill_router.clone())
-            .expect("decode router");
-
-        mm.add_worker_set(
-            "llama",
-            "decode-b",
-            make_typed_endpoint_worker_set("ns1", "decode-b", WorkerType::Decode),
-        );
-
-        assert!(router.is_deactivated());
-        assert_eq!(mm.get_model("llama").unwrap().worker_set_count(), 4);
-        assert!(mm.get_model("llama").unwrap().has_worker_set("ordinary"));
-
-        mm.remove_worker_set("llama", "decode-b");
-        assert!(!router.is_deactivated());
-        assert_eq!(mm.get_model("llama").unwrap().worker_set_count(), 3);
-        assert!(mm.get_model("llama").unwrap().has_worker_set("ordinary"));
-        runtime.shutdown();
-    }
-
-    #[tokio::test]
-    async fn completing_initial_pd_handshake_reactivates_decode_router() {
-        use crate::worker_type::WorkerType;
-
-        let runtime = Runtime::from_current().unwrap();
-        let distributed =
-            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
-                .await
-                .unwrap();
-        let mm = ModelManager::new();
-        let activation = mm
-            .register_prefill_router("llama", "ns1", &decode_endpoint_id("ns1"))
-            .unwrap()
-            .expect("decode activation receiver");
-
-        mm.add_worker_set(
-            "llama",
-            "decode",
-            make_endpoint_worker_set_with_prefill_router("ns1", "decode"),
-        );
-        let router = mm
-            .get_model("llama")
-            .and_then(|model| model.get_worker_set("decode"))
-            .and_then(|worker_set| worker_set.prefill_router.clone())
-            .expect("decode router");
-        assert!(router.is_deactivated());
-
-        mm.add_worker_set(
-            "llama",
-            "prefill",
-            make_typed_endpoint_worker_set("ns1", "prefill", WorkerType::Prefill),
-        );
-        let endpoint = distributed
-            .namespace("ns1".to_string())
-            .unwrap()
-            .component("prefill".to_string())
-            .unwrap()
-            .endpoint("generate".to_string());
-        mm.activate_prefill_router("llama", "ns1", endpoint)
-            .unwrap();
-
-        assert!(!router.is_deactivated());
-        drop(activation);
         runtime.shutdown();
     }
 

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -169,6 +169,10 @@ pub struct ModelManager {
     discovery_groups: DashMap<String, CommittedDiscoveryGroup>,
 
     /// Per-endpoint runtime config watchers. Keyed by EndpointId (includes namespace).
+    ///
+    /// NOTE: These shared receivers currently live for the manager lifetime. Rebinding to a new
+    /// endpoint therefore leaves the previous watcher cached; safe eviction requires shared
+    /// ownership tracking because multiple routers may consume the same endpoint watch.
     runtime_configs: DashMap<EndpointId, RuntimeConfigWatch>,
 
     /// Per-endpoint HiCache state and its one Mooncake event subscriber.

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -135,9 +135,9 @@ pub const UNKNOWN_METRIC_MODEL: &str = "unknown_model";
 
 #[derive(Default)]
 struct CommittedCatalog {
-    models: HashMap<String, Arc<Model>>,
-    cards: HashMap<String, ModelDeploymentCard>,
-    aliases: HashMap<String, String>,
+    models: Arc<HashMap<String, Arc<Model>>>,
+    cards: Arc<HashMap<String, Arc<ModelDeploymentCard>>>,
+    aliases: Arc<HashMap<String, String>>,
 }
 
 struct CommittedDiscoveryGroup {
@@ -146,6 +146,8 @@ struct CommittedDiscoveryGroup {
     worker_set_key: String,
     aliases: Vec<String>,
     cards: HashMap<String, ModelDeploymentCard>,
+    adapters: HashMap<String, ModelDeploymentCard>,
+    representative: ModelDeploymentCard,
 }
 
 pub(crate) struct RemovedDiscoveryGroup {
@@ -169,7 +171,7 @@ pub struct ModelManager {
     catalog: ArcSwap<CommittedCatalog>,
 
     /// Per-instance model cards, keyed by instance path. Used for cleanup on worker removal.
-    cards: DashMap<String, ModelDeploymentCard>,
+    cards: DashMap<String, Arc<ModelDeploymentCard>>,
 
     /// Controller-owned committed groups, keyed by the controller's stable GroupKey encoding.
     discovery_groups: DashMap<String, CommittedDiscoveryGroup>,
@@ -257,9 +259,45 @@ impl ModelManager {
             .map(|entry| (entry.key().clone(), entry.value().clone()))
             .collect();
         self.catalog.store(Arc::new(CommittedCatalog {
-            models,
-            cards,
-            aliases,
+            models: Arc::new(models),
+            cards: Arc::new(cards),
+            aliases: Arc::new(aliases),
+        }));
+    }
+
+    fn publish_cards_locked(&self) {
+        let current = self.catalog.load_full();
+        let cards = self
+            .cards
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+        self.catalog.store(Arc::new(CommittedCatalog {
+            models: current.models.clone(),
+            cards: Arc::new(cards),
+            aliases: current.aliases.clone(),
+        }));
+    }
+
+    fn publish_models_and_cards_locked(&self, changed_models: &HashSet<String>) {
+        let current = self.catalog.load_full();
+        let mut models = (*current.models).clone();
+        for name in changed_models {
+            if let Some(model) = self.models.get(name) {
+                models.insert(name.clone(), Arc::new(model.snapshot()));
+            } else {
+                models.remove(name);
+            }
+        }
+        let cards = self
+            .cards
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+        self.catalog.store(Arc::new(CommittedCatalog {
+            models: Arc::new(models),
+            cards: Arc::new(cards),
+            aliases: current.aliases.clone(),
         }));
     }
 
@@ -275,6 +313,12 @@ impl ModelManager {
 
     /// Get an existing Model, if it exists.
     pub fn get_model(&self, model_name: &str) -> Option<Arc<Model>> {
+        self.models
+            .get(model_name)
+            .map(|entry| entry.value().clone())
+    }
+
+    pub(crate) fn get_committed_model(&self, model_name: &str) -> Option<Arc<Model>> {
         self.catalog.load().models.get(model_name).cloned()
     }
 
@@ -496,6 +540,7 @@ impl ModelManager {
         worker_set_key: &str,
         worker_set: WorkerSet,
         members: Vec<(String, ModelDeploymentCard)>,
+        adapters: Vec<(String, ModelDeploymentCard)>,
         before_publish: F,
     ) -> anyhow::Result<()>
     where
@@ -513,6 +558,7 @@ impl ModelManager {
             .cloned()
             .collect::<Vec<_>>();
         let namespace = worker_set.namespace().to_string();
+        let representative = representative.clone();
 
         let _reservation = self.reservation_lock.lock();
         anyhow::ensure!(
@@ -525,6 +571,13 @@ impl ModelManager {
                 owner.value()
             );
         }
+        anyhow::ensure!(
+            !self.discovery_groups.iter().any(|entry| entry
+                .adapters
+                .values()
+                .any(|adapter| adapter.name() == primary)),
+            "model name {primary:?} is reserved by a LoRA adapter"
+        );
 
         for alias in &aliases {
             if let Some(owner) = self.alias_to_primary.get(alias)
@@ -545,6 +598,7 @@ impl ModelManager {
                 "alias {alias:?} collides with a registered primary model"
             );
         }
+        self.validate_adapter_claims(&primary, adapters.iter().map(|(_, card)| card))?;
 
         let worker_set = Arc::new(worker_set);
         self.get_or_create_model(&primary)
@@ -554,10 +608,18 @@ impl ModelManager {
             self.get_or_create_model(alias)
                 .add_worker_set(worker_set_key.to_string(), worker_set.clone());
         }
+        for (_, adapter) in &adapters {
+            self.get_or_create_model(adapter.name())
+                .add_worker_set(worker_set_key.to_string(), worker_set.clone());
+        }
 
         let cards = members.into_iter().collect::<HashMap<_, _>>();
         for (key, card) in &cards {
-            self.cards.insert(key.clone(), card.clone());
+            self.cards.insert(key.clone(), Arc::new(card.clone()));
+        }
+        let adapters = adapters.into_iter().collect::<HashMap<_, _>>();
+        for (key, card) in &adapters {
+            self.cards.insert(key.clone(), Arc::new(card.clone()));
         }
         self.discovery_groups.insert(
             group_id.to_string(),
@@ -567,11 +629,45 @@ impl ModelManager {
                 worker_set_key: worker_set_key.to_string(),
                 aliases,
                 cards,
+                adapters,
+                representative,
             },
         );
         before_publish();
         self.reconcile_prefill_router_topology(&primary, &namespace);
         self.publish_catalog_locked();
+        Ok(())
+    }
+
+    fn validate_adapter_claims<'a>(
+        &self,
+        primary: &str,
+        adapters: impl Iterator<Item = &'a ModelDeploymentCard>,
+    ) -> anyhow::Result<()> {
+        for adapter in adapters {
+            let name = adapter.name();
+            anyhow::ensure!(
+                name != primary,
+                "LoRA adapter name {name:?} collides with its base model"
+            );
+            anyhow::ensure!(
+                !self.alias_to_primary.contains_key(name),
+                "LoRA adapter name {name:?} collides with a registered alias"
+            );
+            let owned_by_same_base = self.discovery_groups.iter().any(|entry| {
+                entry.primary == primary
+                    && entry
+                        .adapters
+                        .values()
+                        .any(|existing| existing.name() == name)
+            });
+            let collides_with_primary =
+                self.models.get(name).is_some_and(|model| !model.is_empty()) && !owned_by_same_base;
+            anyhow::ensure!(
+                !collides_with_primary,
+                "LoRA adapter name {name:?} collides with a registered model"
+            );
+        }
         Ok(())
     }
 
@@ -587,9 +683,9 @@ impl ModelManager {
             .get_mut(group_id)
             .ok_or_else(|| anyhow::anyhow!("committed discovery group {group_id:?} not found"))?;
         group.cards.insert(key.clone(), card.clone());
-        self.cards.insert(key, card);
+        self.cards.insert(key, Arc::new(card));
         drop(group);
-        self.publish_catalog_locked();
+        self.publish_cards_locked();
         Ok(())
     }
 
@@ -603,8 +699,88 @@ impl ModelManager {
         let removed = group.cards.remove(key)?;
         self.cards.remove(key);
         drop(group);
-        self.publish_catalog_locked();
+        self.publish_cards_locked();
         Some(removed)
+    }
+
+    pub(crate) fn sync_discovery_group_adapters(
+        &self,
+        group_id: &str,
+        desired: Vec<(String, ModelDeploymentCard)>,
+    ) -> anyhow::Result<()> {
+        let _reservation = self.reservation_lock.lock();
+        let group = self
+            .discovery_groups
+            .get(group_id)
+            .ok_or_else(|| anyhow::anyhow!("committed discovery group {group_id:?} not found"))?;
+        let primary = group.primary.clone();
+        let worker_set_key = group.worker_set_key.clone();
+        drop(group);
+
+        self.validate_adapter_claims(&primary, desired.iter().map(|(_, card)| card))?;
+        let worker_set = self
+            .models
+            .get(&primary)
+            .and_then(|model| model.get_worker_set(&worker_set_key))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "committed discovery group {group_id:?} lost WorkerSet {worker_set_key:?}"
+                )
+            })?;
+        let desired = desired.into_iter().collect::<HashMap<_, _>>();
+        let desired_names = desired
+            .values()
+            .map(|card| card.name().to_string())
+            .collect::<HashSet<_>>();
+        let mut group = self
+            .discovery_groups
+            .get_mut(group_id)
+            .ok_or_else(|| anyhow::anyhow!("committed discovery group {group_id:?} not found"))?;
+        let removed_names = group
+            .adapters
+            .iter()
+            .filter(|(key, _)| !desired.contains_key(*key))
+            .map(|(_, card)| card.name().to_string())
+            .collect::<HashSet<_>>();
+        for key in group
+            .adapters
+            .keys()
+            .filter(|key| !desired.contains_key(*key))
+            .cloned()
+            .collect::<Vec<_>>()
+        {
+            group.adapters.remove(&key);
+            self.cards.remove(&key);
+        }
+        for (key, card) in desired {
+            self.cards.insert(key.clone(), Arc::new(card.clone()));
+            group.adapters.insert(key, card);
+        }
+        drop(group);
+
+        for name in &desired_names {
+            self.get_or_create_model(name)
+                .add_worker_set(worker_set_key.clone(), worker_set.clone());
+        }
+        for name in removed_names.difference(&desired_names) {
+            if let Some(model) = self.models.get(name) {
+                model.remove_worker_set(&worker_set_key);
+            }
+            self.remove_model_if_empty(name);
+        }
+        let changed_models = desired_names
+            .union(&removed_names)
+            .cloned()
+            .collect::<HashSet<_>>();
+        self.publish_models_and_cards_locked(&changed_models);
+        Ok(())
+    }
+
+    pub(crate) fn discovery_group_adapter_cards(&self, group_id: &str) -> Vec<ModelDeploymentCard> {
+        self.discovery_groups
+            .get(group_id)
+            .map(|group| group.adapters.values().cloned().collect())
+            .unwrap_or_default()
     }
 
     pub(crate) fn remove_discovery_group<F>(
@@ -617,10 +793,13 @@ impl ModelManager {
     {
         let _reservation = self.reservation_lock.lock();
         let (_, group) = self.discovery_groups.remove(group_id)?;
-        let representative = group.cards.values().next()?.clone();
+        let representative = group.representative.clone();
         let topology_namespace = group.namespace.clone();
 
         for key in group.cards.keys() {
+            self.cards.remove(key);
+        }
+        for key in group.adapters.keys() {
             self.cards.remove(key);
         }
         if let Some(model) = self.models.get(&group.primary) {
@@ -637,7 +816,17 @@ impl ModelManager {
                     .remove_if(alias, |_, owner| owner == &group.primary);
             }
         }
-        let cards = group.cards.into_values().collect();
+        for adapter in group.adapters.values() {
+            if let Some(model) = self.models.get(adapter.name()) {
+                model.remove_worker_set(&group.worker_set_key);
+            }
+            self.remove_model_if_empty(adapter.name());
+        }
+        let cards = group
+            .cards
+            .into_values()
+            .chain(group.adapters.into_values())
+            .collect();
         let removed = RemovedDiscoveryGroup {
             namespace: group.namespace,
             representative,
@@ -652,7 +841,12 @@ impl ModelManager {
     // -- Model cards --
 
     pub fn get_model_cards(&self) -> Vec<ModelDeploymentCard> {
-        self.catalog.load().cards.values().cloned().collect()
+        self.catalog
+            .load()
+            .cards
+            .values()
+            .map(|card| (**card).clone())
+            .collect()
     }
 
     /// Return owned keys for cards in the published catalog.
@@ -664,19 +858,23 @@ impl ModelManager {
     /// lifecycle methods above and never publishes a card independently.
     pub fn save_model_card(&self, key: &str, card: ModelDeploymentCard) -> anyhow::Result<()> {
         let _reservation = self.reservation_lock.lock();
-        self.cards.insert(key.to_string(), card);
+        self.cards.insert(key.to_string(), Arc::new(card));
         self.publish_catalog_locked();
         Ok(())
     }
 
     /// Remove and return model card for this instance's key. We do this when the instance stops.
     pub fn get_model_card(&self, key: &str) -> Option<ModelDeploymentCard> {
-        self.catalog.load().cards.get(key).cloned()
+        self.catalog
+            .load()
+            .cards
+            .get(key)
+            .map(|card| (**card).clone())
     }
 
     pub fn remove_model_card(&self, key: &str) -> Option<ModelDeploymentCard> {
         let _reservation = self.reservation_lock.lock();
-        let removed = self.cards.remove(key).map(|(_, value)| value);
+        let removed = self.cards.remove(key).map(|(_, value)| (*value).clone());
         if removed.is_some() {
             self.publish_catalog_locked();
         }
@@ -3088,6 +3286,18 @@ mod tests {
         assert!(Arc::ptr_eq(&m1, &m2));
     }
 
+    #[test]
+    fn public_get_model_retains_live_mutation_semantics() {
+        let manager = ModelManager::new();
+        manager.add_worker_set("llama", "first", make_worker_set("first", "same"));
+        let model = manager.get_model("llama").unwrap();
+
+        manager.add_worker_set("llama", "second", make_worker_set("second", "same"));
+
+        assert!(model.has_worker_set("second"));
+        assert!(Arc::ptr_eq(&model, &manager.get_model("llama").unwrap()));
+    }
+
     // -- Model listing and filtering tests --
 
     #[test]
@@ -3255,6 +3465,7 @@ mod tests {
                 "candidate-workers",
                 blocked_worker_set,
                 vec![("instance-1".to_string(), blocked_card)],
+                Vec::new(),
                 || {},
             )
             .unwrap_err();
@@ -3276,6 +3487,7 @@ mod tests {
                 "committed-workers",
                 worker_set,
                 vec![("instance-2".to_string(), card)],
+                Vec::new(),
                 || {},
             )
             .unwrap();
@@ -3292,6 +3504,46 @@ mod tests {
         assert!(manager.get_model("committed").is_none());
         assert!(manager.get_model("alias").is_none());
         assert_eq!(manager.resolve_canonical_name("alias"), "alias");
+    }
+
+    #[test]
+    fn discovery_group_projects_adapter_cards_onto_the_base_worker_set() {
+        let manager = ModelManager::new();
+        let base = ModelDeploymentCard::with_name_only("base");
+        let mut adapter = ModelDeploymentCard::with_name_only("adapter");
+        adapter.lora = Some(crate::model_card::LoraInfo {
+            name: "adapter".to_string(),
+            max_gpu_lora_count: Some(4),
+        });
+        let worker_set = WorkerSet::new(
+            "deployment".to_string(),
+            base.mdcsum().to_string(),
+            base.clone(),
+        );
+
+        manager
+            .commit_discovery_group(
+                "adapter-group",
+                "base-workers",
+                worker_set,
+                vec![("base-instance".to_string(), base)],
+                vec![("adapter-instance".to_string(), adapter)],
+                || {},
+            )
+            .unwrap();
+
+        assert_eq!(manager.get_model_cards().len(), 2);
+        assert!(
+            manager
+                .get_committed_model("adapter")
+                .is_some_and(|model| model.has_worker_set("base-workers"))
+        );
+
+        manager
+            .remove_discovery_group("adapter-group", |_| {})
+            .unwrap();
+        assert!(manager.get_model_cards().is_empty());
+        assert!(manager.get_committed_model("adapter").is_none());
     }
 
     // -- Prefill router rendezvous tests --

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -14,7 +14,7 @@ use dashmap::{DashMap, mapref::entry::Entry};
 use dynamo_kv_router::{
     PrefillLoadEstimator,
     config::KvRouterConfig,
-    protocols::{KvTransferEnforcement, RoutingConstraints, WorkerId},
+    protocols::{KvTransferEnforcement, RoutingConstraints, WorkerId, WorkerWithDpRank},
     selector::WorkerSelector,
 };
 
@@ -26,7 +26,7 @@ use super::{
 
 use dynamo_runtime::{
     component::{Client, Endpoint, build_transport_type},
-    discovery::{Discovery, DiscoverySpec},
+    discovery::{Discovery, DiscoverySpec, ModelCardInstanceId},
     pipeline::network::RequestPlanePayloadCodec,
     prelude::DistributedRuntimeProvider,
     protocols::EndpointId,
@@ -41,8 +41,9 @@ use crate::{
         DisaggregatedEndpoint, ModelRuntimeConfig, VLLM_INFERENCE_V1_GENERATE_CAPABILITY,
         topology_taint,
     },
+    lora::state_tracker::LoraWorkerProjection,
     lora::{LoraFilter, LoraRoutingTable, LoraStateTracker, load_estimator::LoadEstimator},
-    model_card::ModelDeploymentCard,
+    model_card::{LoraInfo, ModelDeploymentCard},
     types::{
         RealtimeBidirectionalEngine,
         generic::tensor::TensorStreamingEngine,
@@ -64,6 +65,7 @@ struct LoraEndpointDomain {
     load_estimator: Arc<LoadEstimator>,
     filter: Arc<LoraFilter>,
     controller_started: AtomicBool,
+    controller_cancel: parking_lot::Mutex<Option<tokio_util::sync::CancellationToken>>,
 }
 
 impl LoraEndpointDomain {
@@ -80,7 +82,19 @@ impl LoraEndpointDomain {
             load_estimator: Arc::new(LoadEstimator::new()),
             filter,
             controller_started: AtomicBool::new(false),
+            controller_cancel: parking_lot::Mutex::new(None),
         }
+    }
+
+    fn shutdown(&self) {
+        if let Some(cancel) = self.controller_cancel.lock().take() {
+            cancel.cancel();
+        }
+        self.controller_started.store(false, Ordering::Release);
+        self.routing_table.clear();
+        self.load_estimator.reset();
+        self.state_tracker
+            .replace_endpoint_projection(HashMap::new());
     }
 }
 
@@ -118,7 +132,16 @@ struct CommittedDiscoveryGroup {
     cards: HashMap<String, ModelDeploymentCard>,
     adapters: HashMap<String, ModelDeploymentCard>,
     representative: ModelDeploymentCard,
+    worker_set: Arc<WorkerSet>,
 }
+
+#[derive(Default)]
+struct PendingLoraProjection {
+    base_capacities: Vec<u32>,
+    adapters: HashMap<String, LoraInfo>,
+}
+
+type EndpointLoraProjection = HashMap<EndpointId, HashMap<WorkerWithDpRank, LoraWorkerProjection>>;
 
 pub(crate) struct RemovedDiscoveryGroup {
     pub(crate) representative: ModelDeploymentCard,
@@ -157,13 +180,13 @@ pub struct ModelManager {
 
     /// Exact endpoint → independent LoRA allocation and load domain.
     lora_domains: DashMap<EndpointId, Arc<LoraEndpointDomain>>,
+    committed_lora_endpoints: parking_lot::Mutex<HashSet<EndpointId>>,
     lora_enabled: bool,
     /// Per-decode-endpoint LoRA load-feed subscription handles, so we start exactly one feed
     /// per endpoint and can restart it if the previous one exited (avoids double counting on
     /// rebuilds while keeping the feed durable).
     lora_load_feeds: DashMap<String, tokio::task::JoinHandle<()>>,
     lora_controller_cancel: parking_lot::Mutex<Option<tokio_util::sync::CancellationToken>>,
-    lora_controller_handles: parking_lot::Mutex<Vec<tokio::task::JoinHandle<()>>>,
 
     /// Alias → primary model name mapping. Used to normalize metrics labels.
     alias_to_primary: DashMap<String, String>,
@@ -194,10 +217,10 @@ impl ModelManager {
             hicache_caches: DashMap::new(),
             kv_source_memberships: DashMap::new(),
             lora_domains: DashMap::new(),
+            committed_lora_endpoints: parking_lot::Mutex::new(HashSet::new()),
             lora_enabled: crate::lora::lora_serving_enabled(),
             lora_load_feeds: DashMap::new(),
             lora_controller_cancel: parking_lot::Mutex::new(None),
-            lora_controller_handles: parking_lot::Mutex::new(Vec::new()),
             alias_to_primary: DashMap::new(),
             reservation_lock: parking_lot::Mutex::new(()),
         }
@@ -226,40 +249,162 @@ impl ModelManager {
         }));
     }
 
-    fn publish_cards_locked(&self) {
-        let current = self.catalog.load_full();
-        let cards = self
-            .cards
-            .iter()
-            .map(|entry| (entry.key().clone(), entry.value().clone()))
-            .collect();
-        self.catalog.store(Arc::new(CommittedCatalog {
-            models: current.models.clone(),
-            cards: Arc::new(cards),
-            aliases: current.aliases.clone(),
-        }));
-    }
+    fn lora_projection_locked(&self) -> EndpointLoraProjection {
+        let mut pending: HashMap<EndpointId, HashMap<WorkerWithDpRank, PendingLoraProjection>> =
+            HashMap::new();
+        for group in self.discovery_groups.iter() {
+            for (key, card) in &group.cards {
+                let Ok(mcid) = ModelCardInstanceId::from_path(key) else {
+                    continue;
+                };
+                let endpoint_id = EndpointId {
+                    namespace: mcid.namespace.clone(),
+                    component: mcid.component.clone(),
+                    name: mcid.endpoint.clone(),
+                };
+                let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
+                let worker_projection = pending
+                    .entry(endpoint_id)
+                    .or_default()
+                    .entry(worker)
+                    .or_default();
+                if let Some(capacity) = card.runtime_config.max_gpu_lora_count {
+                    worker_projection.base_capacities.push(capacity);
+                }
 
-    fn publish_models_and_cards_locked(&self, changed_models: &HashSet<String>) {
-        let current = self.catalog.load_full();
-        let mut models = (*current.models).clone();
-        for name in changed_models {
-            if let Some(model) = self.models.get(name) {
-                models.insert(name.clone(), Arc::new(model.snapshot()));
-            } else {
-                models.remove(name);
+                for (adapter_key, adapter_card) in &group.adapters {
+                    let Ok(adapter_mcid) = ModelCardInstanceId::from_path(adapter_key) else {
+                        continue;
+                    };
+                    if adapter_mcid.namespace != mcid.namespace
+                        || adapter_mcid.component != mcid.component
+                        || adapter_mcid.endpoint != mcid.endpoint
+                        || adapter_mcid.instance_id != mcid.instance_id
+                    {
+                        continue;
+                    }
+                    if let Some(lora) = &adapter_card.lora {
+                        worker_projection
+                            .adapters
+                            .insert(lora.name.clone(), lora.clone());
+                    }
+                }
             }
         }
-        let cards = self
-            .cards
+
+        pending
+            .into_iter()
+            .map(|(endpoint_id, workers)| {
+                let workers = workers
+                    .into_iter()
+                    .filter_map(|(worker, mut projection)| {
+                        projection.base_capacities.sort_unstable();
+                        projection.base_capacities.dedup();
+                        if projection.base_capacities.len() > 1 {
+                            tracing::warn!(
+                                endpoint = %endpoint_id,
+                                worker_id = worker.worker_id,
+                                capacities = ?projection.base_capacities,
+                                "Base MDCs disagree on LoRA capacity; using the conservative minimum"
+                            );
+                        }
+                        let mut loras = projection.adapters.into_values().collect::<Vec<_>>();
+                        loras.sort_by(|left, right| left.name.cmp(&right.name));
+                        let mut adapter_capacities = loras
+                            .iter()
+                            .filter_map(|lora| lora.max_gpu_lora_count)
+                            .collect::<Vec<_>>();
+                        adapter_capacities.sort_unstable();
+                        adapter_capacities.dedup();
+                        if adapter_capacities.len() > 1 {
+                            tracing::warn!(
+                                endpoint = %endpoint_id,
+                                worker_id = worker.worker_id,
+                                capacities = ?adapter_capacities,
+                                "Adapter MDCs disagree on LoRA capacity; using the conservative minimum"
+                            );
+                        }
+                        let capacity = projection
+                            .base_capacities
+                            .first()
+                            .copied()
+                            .or_else(|| adapter_capacities.first().copied())
+                            .or_else(|| (!loras.is_empty()).then_some(4))?;
+                        Some((worker, LoraWorkerProjection { capacity, loras }))
+                    })
+                    .collect();
+                (endpoint_id, workers)
+            })
+            .collect()
+    }
+
+    fn union_lora_projection(
+        before: &EndpointLoraProjection,
+        after: &EndpointLoraProjection,
+    ) -> EndpointLoraProjection {
+        let mut union = before.clone();
+        for (endpoint, workers) in after {
+            let endpoint_union = union.entry(endpoint.clone()).or_default();
+            for (worker, projection) in workers {
+                let Some(existing) = endpoint_union.get_mut(worker) else {
+                    endpoint_union.insert(*worker, projection.clone());
+                    continue;
+                };
+                existing.capacity = existing.capacity.min(projection.capacity);
+                let mut loras = existing
+                    .loras
+                    .iter()
+                    .chain(&projection.loras)
+                    .map(|lora| (lora.name.clone(), lora.clone()))
+                    .collect::<HashMap<_, _>>()
+                    .into_values()
+                    .collect::<Vec<_>>();
+                loras.sort_by(|left, right| left.name.cmp(&right.name));
+                existing.loras = loras;
+            }
+        }
+        union
+    }
+
+    fn publish_lora_projection_locked(&self, projection: EndpointLoraProjection) {
+        let mut endpoints = self.committed_lora_endpoints.lock();
+        let next_endpoints = projection.keys().cloned().collect::<HashSet<_>>();
+        for endpoint_id in endpoints.union(&next_endpoints) {
+            let workers = projection.get(endpoint_id).cloned().unwrap_or_default();
+            if let Some(domain) = self.lora_domains.get(endpoint_id) {
+                domain.state_tracker.replace_endpoint_projection(workers);
+            } else if !workers.is_empty() {
+                self.lora_domain(endpoint_id)
+                    .state_tracker
+                    .replace_endpoint_projection(workers);
+            }
+        }
+        *endpoints = next_endpoints;
+        drop(endpoints);
+        self.prune_idle_lora_domains();
+    }
+
+    fn prune_idle_lora_domains(&self) {
+        let committed = self.committed_lora_endpoints.lock().clone();
+        let removable = self
+            .lora_domains
             .iter()
-            .map(|entry| (entry.key().clone(), entry.value().clone()))
-            .collect();
-        self.catalog.store(Arc::new(CommittedCatalog {
-            models: Arc::new(models),
-            cards: Arc::new(cards),
-            aliases: current.aliases.clone(),
-        }));
+            .filter_map(|entry| {
+                (!committed.contains(entry.key())
+                    && entry.state_tracker.is_empty()
+                    && Arc::strong_count(&entry.filter) == 1)
+                    .then(|| entry.key().clone())
+            })
+            .collect::<Vec<_>>();
+        for endpoint_id in removable {
+            let Some((_, domain)) = self.lora_domains.remove(&endpoint_id) else {
+                continue;
+            };
+            domain.shutdown();
+            if let Some((_, feed)) = self.lora_load_feeds.remove(&endpoint_id.to_string()) {
+                feed.abort();
+            }
+        }
     }
 
     // -- Model access --
@@ -512,6 +657,7 @@ impl ModelManager {
         let representative = representative.clone();
 
         let _reservation = self.reservation_lock.lock();
+        let lora_before = self.lora_projection_locked();
         anyhow::ensure!(
             !self.discovery_groups.contains_key(group_id),
             "discovery group {group_id:?} is already committed"
@@ -560,8 +706,9 @@ impl ModelManager {
                 .add_worker_set(worker_set_key.to_string(), worker_set.clone());
         }
         for (_, adapter) in &adapters {
+            let adapter_view = Arc::new(worker_set.adapter_view(adapter.clone()));
             self.get_or_create_model(adapter.name())
-                .add_worker_set(worker_set_key.to_string(), worker_set.clone());
+                .add_worker_set(worker_set_key.to_string(), adapter_view);
         }
 
         let cards = members.into_iter().collect::<HashMap<_, _>>();
@@ -582,10 +729,14 @@ impl ModelManager {
                 cards,
                 adapters,
                 representative,
+                worker_set,
             },
         );
+        let lora_after = self.lora_projection_locked();
+        self.publish_lora_projection_locked(Self::union_lora_projection(&lora_before, &lora_after));
         self.reconcile_discovery_topology(&primary, &namespace);
         self.publish_catalog_locked();
+        self.publish_lora_projection_locked(lora_after);
         Ok(())
     }
 
@@ -595,6 +746,11 @@ impl ModelManager {
         adapters: impl Iterator<Item = &'a ModelDeploymentCard>,
     ) -> anyhow::Result<()> {
         for adapter in adapters {
+            let lora = adapter
+                .lora
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("adapter card is missing LoRA metadata"))?;
+            anyhow::ensure!(!lora.name.is_empty(), "LoRA adapter name cannot be empty");
             let name = adapter.name();
             anyhow::ensure!(
                 name != primary,
@@ -621,42 +777,11 @@ impl ModelManager {
         Ok(())
     }
 
-    pub(crate) fn add_discovery_group_member(
+    pub(crate) fn replace_discovery_group(
         &self,
         group_id: &str,
-        key: String,
-        card: ModelDeploymentCard,
-    ) -> anyhow::Result<()> {
-        let _reservation = self.reservation_lock.lock();
-        let mut group = self
-            .discovery_groups
-            .get_mut(group_id)
-            .ok_or_else(|| anyhow::anyhow!("committed discovery group {group_id:?} not found"))?;
-        group.cards.insert(key.clone(), card.clone());
-        self.cards.insert(key, Arc::new(card));
-        drop(group);
-        self.publish_cards_locked();
-        Ok(())
-    }
-
-    pub(crate) fn remove_discovery_group_member(
-        &self,
-        group_id: &str,
-        key: &str,
-    ) -> Option<ModelDeploymentCard> {
-        let _reservation = self.reservation_lock.lock();
-        let mut group = self.discovery_groups.get_mut(group_id)?;
-        let removed = group.cards.remove(key)?;
-        self.cards.remove(key);
-        drop(group);
-        self.publish_cards_locked();
-        Some(removed)
-    }
-
-    pub(crate) fn sync_discovery_group_adapters(
-        &self,
-        group_id: &str,
-        desired: Vec<(String, ModelDeploymentCard)>,
+        members: Vec<(String, ModelDeploymentCard)>,
+        adapters: Vec<(String, ModelDeploymentCard)>,
     ) -> anyhow::Result<()> {
         let _reservation = self.reservation_lock.lock();
         let group = self
@@ -665,64 +790,77 @@ impl ModelManager {
             .ok_or_else(|| anyhow::anyhow!("committed discovery group {group_id:?} not found"))?;
         let primary = group.primary.clone();
         let worker_set_key = group.worker_set_key.clone();
-        drop(group);
-
-        self.validate_adapter_claims(&primary, desired.iter().map(|(_, card)| card))?;
-        let worker_set = self
-            .models
-            .get(&primary)
-            .and_then(|model| model.get_worker_set(&worker_set_key))
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "committed discovery group {group_id:?} lost WorkerSet {worker_set_key:?}"
-                )
-            })?;
-        let desired = desired.into_iter().collect::<HashMap<_, _>>();
-        let desired_names = desired
+        let worker_set = group.worker_set.clone();
+        let previous_member_keys = group.cards.keys().cloned().collect::<HashSet<_>>();
+        let previous_adapter_keys = group.adapters.keys().cloned().collect::<HashSet<_>>();
+        let previous_adapter_names = group
+            .adapters
             .values()
             .map(|card| card.name().to_string())
             .collect::<HashSet<_>>();
+        drop(group);
+
+        anyhow::ensure!(
+            !members.is_empty(),
+            "cannot replace with an empty discovery group"
+        );
+        self.validate_adapter_claims(&primary, adapters.iter().map(|(_, card)| card))?;
+        let members = members.into_iter().collect::<HashMap<_, _>>();
+        let adapters = adapters.into_iter().collect::<HashMap<_, _>>();
+        let desired_member_keys = members.keys().cloned().collect::<HashSet<_>>();
+        let desired_adapter_keys = adapters.keys().cloned().collect::<HashSet<_>>();
+        let desired_adapter_names = adapters
+            .values()
+            .map(|card| card.name().to_string())
+            .collect::<HashSet<_>>();
+        let adapter_views = adapters
+            .values()
+            .map(|card| {
+                (
+                    card.name().to_string(),
+                    Arc::new(worker_set.adapter_view(card.clone())),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        let lora_before = self.lora_projection_locked();
+
+        for key in previous_member_keys.difference(&desired_member_keys) {
+            self.cards.remove(key);
+        }
+        for key in previous_adapter_keys.difference(&desired_adapter_keys) {
+            self.cards.remove(key);
+        }
+        for (key, card) in members.iter().chain(adapters.iter()) {
+            self.cards.insert(key.clone(), Arc::new(card.clone()));
+        }
+
         let mut group = self
             .discovery_groups
             .get_mut(group_id)
             .ok_or_else(|| anyhow::anyhow!("committed discovery group {group_id:?} not found"))?;
-        let removed_names = group
-            .adapters
-            .iter()
-            .filter(|(key, _)| !desired.contains_key(*key))
-            .map(|(_, card)| card.name().to_string())
-            .collect::<HashSet<_>>();
-        for key in group
-            .adapters
-            .keys()
-            .filter(|key| !desired.contains_key(*key))
+        group.representative = members
+            .values()
+            .next()
             .cloned()
-            .collect::<Vec<_>>()
-        {
-            group.adapters.remove(&key);
-            self.cards.remove(&key);
-        }
-        for (key, card) in desired {
-            self.cards.insert(key.clone(), Arc::new(card.clone()));
-            group.adapters.insert(key, card);
-        }
+            .expect("non-empty members checked above");
+        group.cards = members;
+        group.adapters = adapters;
         drop(group);
 
-        for name in &desired_names {
-            self.get_or_create_model(name)
-                .add_worker_set(worker_set_key.clone(), worker_set.clone());
+        for (name, adapter_view) in adapter_views {
+            self.get_or_create_model(&name)
+                .add_worker_set(worker_set_key.clone(), adapter_view);
         }
-        for name in removed_names.difference(&desired_names) {
+        for name in previous_adapter_names.difference(&desired_adapter_names) {
             if let Some(model) = self.models.get(name) {
                 model.remove_worker_set(&worker_set_key);
             }
             self.remove_model_if_empty(name);
         }
-        let changed_models = desired_names
-            .union(&removed_names)
-            .cloned()
-            .collect::<HashSet<_>>();
-        self.publish_models_and_cards_locked(&changed_models);
+        let lora_after = self.lora_projection_locked();
+        self.publish_lora_projection_locked(Self::union_lora_projection(&lora_before, &lora_after));
+        self.publish_catalog_locked();
+        self.publish_lora_projection_locked(lora_after);
         Ok(())
     }
 
@@ -737,6 +875,7 @@ impl ModelManager {
     ///
     pub(crate) fn remove_discovery_group(&self, group_id: &str) -> Option<RemovedDiscoveryGroup> {
         let _reservation = self.reservation_lock.lock();
+        let lora_before = self.lora_projection_locked();
         let (_, group) = self.discovery_groups.remove(group_id)?;
         let representative = group.representative.clone();
         let topology_namespace = group.namespace.clone();
@@ -778,8 +917,11 @@ impl ModelManager {
             representative,
             cards,
         };
+        let lora_after = self.lora_projection_locked();
+        self.publish_lora_projection_locked(Self::union_lora_projection(&lora_before, &lora_after));
         self.reconcile_discovery_topology(&group.primary, &topology_namespace);
         self.publish_catalog_locked();
+        self.publish_lora_projection_locked(lora_after);
         Some(removed)
     }
 
@@ -1953,18 +2095,20 @@ impl ModelManager {
                 ema_alpha: config.ema_alpha,
                 ..Default::default()
             });
-        let handle = crate::lora::LoraController::start_for_endpoint(
+        let domain_cancel = cancel_token.child_token();
+        *domain.controller_cancel.lock() = Some(domain_cancel.clone());
+        let _handle = crate::lora::LoraController::start_for_endpoint(
             endpoint_id.clone(),
             config,
             domain.routing_table.clone(),
             domain.state_tracker.clone(),
             domain.load_estimator.clone(),
-            cancel_token,
+            domain_cancel,
         );
-        self.lora_controller_handles.lock().push(handle);
     }
 
-    pub fn lora_state_tracker_for(&self, endpoint_id: &EndpointId) -> LoraStateTracker {
+    #[cfg(test)]
+    pub(crate) fn lora_state_tracker_for(&self, endpoint_id: &EndpointId) -> LoraStateTracker {
         self.lora_domain(endpoint_id).state_tracker.clone()
     }
 
@@ -3017,40 +3161,72 @@ mod tests {
     }
 
     #[test]
-    fn discovery_group_projects_adapter_cards_onto_the_base_worker_set() {
+    fn discovery_group_derives_adapter_model_and_lora_projection() {
         let manager = ModelManager::new();
-        let base = ModelDeploymentCard::with_name_only("base");
+        let mut base = ModelDeploymentCard::with_name_only("base");
+        base.runtime_config.max_gpu_lora_count = Some(6);
         let mut adapter = ModelDeploymentCard::with_name_only("adapter");
         adapter.lora = Some(crate::model_card::LoraInfo {
             name: "adapter".to_string(),
-            max_gpu_lora_count: Some(4),
+            max_gpu_lora_count: None,
         });
         let worker_set = WorkerSet::new(
             "deployment".to_string(),
             base.mdcsum().to_string(),
             base.clone(),
         );
+        let base_mcid = ModelCardInstanceId {
+            namespace: "namespace".to_string(),
+            component: "worker".to_string(),
+            endpoint: "generate".to_string(),
+            instance_id: 17,
+            model_suffix: None,
+        };
+        let adapter_mcid = ModelCardInstanceId {
+            model_suffix: Some("adapter".to_string()),
+            ..base_mcid.clone()
+        };
 
         manager
             .commit_discovery_group(
                 "adapter-group",
                 "base-workers",
                 worker_set,
-                vec![("base-instance".to_string(), base)],
-                vec![("adapter-instance".to_string(), adapter)],
+                vec![(base_mcid.to_path(), base)],
+                vec![(adapter_mcid.to_path(), adapter)],
             )
             .unwrap();
 
         assert_eq!(manager.get_model_cards().len(), 2);
-        assert!(
-            manager
-                .get_committed_model("adapter")
-                .is_some_and(|model| model.has_worker_set("base-workers"))
+        let base_worker_set = manager
+            .get_committed_model("base")
+            .and_then(|model| model.get_worker_set("base-workers"))
+            .unwrap();
+        let adapter_worker_set = manager
+            .get_committed_model("adapter")
+            .and_then(|model| model.get_worker_set("base-workers"))
+            .unwrap();
+        assert!(!Arc::ptr_eq(&base_worker_set, &adapter_worker_set));
+        assert_eq!(adapter_worker_set.card().name(), "adapter");
+        assert_eq!(
+            adapter_worker_set
+                .card()
+                .lora
+                .as_ref()
+                .map(|lora| lora.name.as_str()),
+            Some("adapter")
         );
+
+        let endpoint_id = EndpointId::from("namespace.worker.generate");
+        let tracker = manager.lora_state_tracker_for(&endpoint_id);
+        let worker = WorkerWithDpRank::new(17, 0);
+        assert!(tracker.is_loaded("adapter", &worker));
+        assert_eq!(tracker.total_lora_slots(), 6);
 
         manager.remove_discovery_group("adapter-group").unwrap();
         assert!(manager.get_model_cards().is_empty());
         assert!(manager.get_committed_model("adapter").is_none());
+        assert!(tracker.is_empty());
     }
 
     fn topology_card(role: WorkerType) -> ModelDeploymentCard {

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -15,7 +15,6 @@ use dynamo_kv_router::{
 };
 use dynamo_runtime::{
     DistributedRuntime,
-    component::Endpoint,
     discovery::{DiscoveryInstance, DiscoveryQuery, DiscoveryStream, ModelCardInstanceId},
     pipeline::{
         ManyOut, Operator, RouterMode, SegmentSource, ServiceBackend, SingleIn, Source,
@@ -151,17 +150,6 @@ fn supports_enabled_engine_generate(card: &ModelDeploymentCard, capabilities: &[
         .any(|capability| supports_generate_capability(card, capability))
 }
 
-const ENCODER_RESULT_HANDOFF_CAPABILITY: &str = "encoder_result_handoff";
-
-fn supports_encoder_result_handoff(card: &ModelDeploymentCard) -> bool {
-    matches!(
-        card.runtime_config
-            .runtime_data
-            .get(ENCODER_RESULT_HANDOFF_CAPABILITY),
-        Some(serde_json::Value::Bool(true))
-    )
-}
-
 // Generate's opaque request state is not yet verified for migration replay.
 const GENERATE_MIGRATION_LIMIT: u32 = 0;
 
@@ -242,64 +230,9 @@ where
     worker_selector_factory: WorkerSelectorFactory<Sel>,
 }
 
-enum PreparedActivation {
-    None,
-    Prefill {
-        endpoint: Endpoint,
-        enable_encoder_routing: bool,
-    },
-    Encoder {
-        endpoint: Endpoint,
-    },
-}
-
-struct PreparationLease {
-    manager: Arc<ModelManager>,
-    model_name: String,
-    namespace: String,
-    remove_prefill_waiter: bool,
-    remove_encoder_waiter: bool,
-    armed: bool,
-}
-
-impl PreparationLease {
-    fn new(manager: Arc<ModelManager>, model_name: String, namespace: String) -> Self {
-        Self {
-            manager,
-            model_name,
-            namespace,
-            remove_prefill_waiter: false,
-            remove_encoder_waiter: false,
-            armed: true,
-        }
-    }
-
-    fn disarm(&mut self) {
-        self.armed = false;
-    }
-}
-
-impl Drop for PreparationLease {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        if self.remove_prefill_waiter {
-            self.manager
-                .remove_decode_prefill_waiter(&self.model_name, &self.namespace);
-        }
-        if self.remove_encoder_waiter {
-            self.manager
-                .remove_consumer_encoder_waiter(&self.model_name, &self.namespace);
-        }
-    }
-}
-
 pub(crate) struct PreparedWorkerSet {
     worker_set: Option<WorkerSet>,
     card: ModelDeploymentCard,
-    activation: PreparedActivation,
-    lease: PreparationLease,
 }
 
 const ALL_MODEL_TYPES: &[ModelType] = &[
@@ -532,14 +465,9 @@ where
         );
         let checksum = card.mdcsum();
         let namespace = mcid.namespace.clone();
-        let mut lease = PreparationLease::new(
-            self.manager.clone(),
-            card.name().to_string(),
-            namespace.clone(),
-        );
         // Build the WorkerSet with all applicable engines
         let mut worker_set = WorkerSet::new(namespace.clone(), checksum.to_string(), card.clone());
-        worker_set.set_endpoint_id(endpoint.id());
+        worker_set.set_topology_endpoint(endpoint.clone());
         worker_set.set_instance_watcher(instance_watcher);
 
         // A surface-less Encode worker is reached only through EncoderRouter.
@@ -557,10 +485,6 @@ where
             return Ok(PreparedWorkerSet {
                 worker_set: Some(worker_set),
                 card: card.clone(),
-                activation: PreparedActivation::Encoder {
-                    endpoint: component.endpoint(&mcid.endpoint),
-                },
-                lease,
             });
         }
 
@@ -598,11 +522,6 @@ where
             return Ok(PreparedWorkerSet {
                 worker_set: Some(worker_set),
                 card: card.clone(),
-                activation: PreparedActivation::Prefill {
-                    endpoint: component.endpoint(&mcid.endpoint),
-                    enable_encoder_routing: supports_encoder_result_handoff(card),
-                },
-                lease,
             });
         }
 
@@ -700,39 +619,15 @@ where
             // P/D rendezvous. Aggregated and Encode endpoints are independent
             // serving leaves and must not claim or perturb that pairing.
             let model_name = card.name().to_string();
-            let prefill_receiver = if needs_preprocessed_routing
+            let prefill_chooser = if needs_preprocessed_routing
                 && effective_worker_type(card.worker_type, card.model_type) == WorkerType::Decode
             {
-                lease.remove_prefill_waiter = true;
-                match self
-                    .manager
-                    .register_prefill_router(&model_name, &namespace, &endpoint.id())
-                {
-                    Ok(receiver) => receiver,
-                    Err(error) => {
-                        tracing::error!(
-                            model_name,
-                            namespace,
-                            %error,
-                            "Refusing ambiguous endpoint-scoped P/D topology; ordinary serving remains enabled"
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-            // Chat and completions on this decode endpoint share one prefill chooser.
-            let prefill_chooser = prefill_receiver.map(|rx| {
-                // Create prefill-specific config with track_active_blocks disabled
                 let mut prefill_config = router_config.kv_router_config.clone();
                 prefill_config.router_track_active_blocks = false;
-                // Prefill KV events are emitted by prefill workers; do not inherit
-                // decode-only speculative hash mode.
                 let prefill_enable_eagle = false;
 
-                PrefillRouter::new_with_selector_factory(
-                    rx,
+                Some(PrefillRouter::new_with_selector_factory(
+                    None,
                     self.manager.clone(),
                     router_config.router_mode,
                     card.kv_cache_block_size,
@@ -744,17 +639,14 @@ where
                     model_name.clone(),
                     namespace.clone(),
                     prefill_enable_eagle,
-                    // Hand the monitor directly so the prefill Client can be attached
-                    // to it on activation (no namespace lookup).
                     worker_monitor.clone(),
-                )
-            });
+                ))
+            } else {
+                None
+            };
 
             let encoder_chooser = if needs_preprocessed_routing {
-                lease.remove_encoder_waiter = true;
-                self.manager
-                    .register_encoder_router(&model_name, &namespace)
-                    .map(|rx| EncoderRouter::new(rx, model_name.clone(), namespace.clone()))
+                Some(EncoderRouter::new(model_name.clone(), namespace.clone()))
             } else {
                 None
             };
@@ -1089,8 +981,6 @@ where
         Ok(PreparedWorkerSet {
             worker_set: Some(worker_set),
             card: card.clone(),
-            activation: PreparedActivation::None,
-            lease,
         })
     }
 
@@ -1189,41 +1079,7 @@ where
                 .iter()
                 .map(|adapter| (adapter.key.clone(), adapter.card.clone()))
                 .collect(),
-            || {
-                let namespace = &spec.representative.mcid.namespace;
-                match &prepared.activation {
-                    PreparedActivation::None => {}
-                    PreparedActivation::Prefill {
-                        endpoint,
-                        enable_encoder_routing,
-                    } => {
-                        if *enable_encoder_routing {
-                            self.manager
-                                .enable_encoder_routing(prepared.card.name(), namespace);
-                        }
-                        if let Err(error) = self.manager.activate_prefill_router(
-                            prepared.card.name(),
-                            namespace,
-                            endpoint.clone(),
-                        ) {
-                            tracing::warn!(
-                                model_name = prepared.card.name(),
-                                %error,
-                                "Prefill group committed but router activation was already satisfied"
-                            );
-                        }
-                    }
-                    PreparedActivation::Encoder { endpoint } => {
-                        self.manager.activate_encoder_router(
-                            prepared.card.name(),
-                            namespace,
-                            endpoint.clone(),
-                        );
-                    }
-                }
-            },
         )?;
-        prepared.lease.disarm();
         self.emit_update(ModelUpdate::Added(prepared.card.clone()));
         let mut adapter_names = HashSet::new();
         for adapter in adapters {
@@ -1316,34 +1172,7 @@ where
     }
 
     fn remove_group(&self, key: &GroupKey) {
-        let Some(removed) = self.manager.remove_discovery_group(&key.id(), |removed| {
-            let card = &removed.representative;
-            let namespace = &removed.namespace;
-            match effective_worker_type(card.worker_type, card.model_type) {
-                WorkerType::Prefill => {
-                    self.manager
-                        .remove_prefill_activator(card.name(), namespace);
-                    self.manager
-                        .deactivate_prefill_router_for_decode(card.name(), namespace);
-                }
-                WorkerType::Encode if card.model_type.is_empty() => {
-                    self.manager
-                        .remove_encoder_activator(card.name(), namespace);
-                    self.manager
-                        .deactivate_encoder_router_for_consumers(card.name(), namespace);
-                }
-                WorkerType::Decode => {
-                    self.manager
-                        .remove_decode_prefill_waiter(card.name(), namespace);
-                    self.manager
-                        .remove_consumer_encoder_waiter(card.name(), namespace);
-                }
-                WorkerType::Aggregated | WorkerType::Encode => {
-                    self.manager
-                        .remove_consumer_encoder_waiter(card.name(), namespace);
-                }
-            }
-        }) else {
+        let Some(removed) = self.manager.remove_discovery_group(&key.id()) else {
             return;
         };
         let removed_members = removed.cards.len();
@@ -1535,23 +1364,6 @@ mod tests {
             &card,
             &[OTHER_GENERATE_CAPABILITY]
         ));
-    }
-
-    #[test]
-    fn encoder_result_handoff_requires_explicit_worker_capability() {
-        let mut card = ModelDeploymentCard::with_name_only("model");
-        card.needs = vec![vec![WorkerType::Encode]];
-        assert!(!supports_encoder_result_handoff(&card));
-
-        card.runtime_config
-            .set_engine_specific(ENCODER_RESULT_HANDOFF_CAPABILITY, true)
-            .unwrap();
-        assert!(supports_encoder_result_handoff(&card));
-
-        card.runtime_config
-            .set_engine_specific(ENCODER_RESULT_HANDOFF_CAPABILITY, false)
-            .unwrap();
-        assert!(!supports_encoder_result_handoff(&card));
     }
 
     #[tokio::test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1013,12 +1013,17 @@ where
         normalize_legacy_prefill_topology(&mut card);
         self.apply_tokenizer_backend_override(&mut card);
         validate_card_shape(&card)?;
+        anyhow::ensure!(
+            mcid.model_suffix.is_some() == card.lora.is_some(),
+            "LoRA discovery identity and card metadata disagree"
+        );
         let endpoint_id = model_card_endpoint_id(&mcid);
         let group_key = GroupKey {
             model_name: card.name().to_string(),
             worker_set_key: worker_set_key(&endpoint_id, card.model_type, card.worker_type),
         };
         let fingerprint = materialization_fingerprint(&card, &self.router_config)?;
+        let projection_fingerprint = lora_projection_fingerprint(&card)?;
         Ok(Some(DesiredInstance {
             key: mcid.to_path(),
             mcid,
@@ -1026,6 +1031,7 @@ where
             card,
             group_key,
             fingerprint,
+            projection_fingerprint,
         }))
     }
 
@@ -1105,26 +1111,10 @@ where
         Ok(())
     }
 
-    fn add_group_member(&self, key: &GroupKey, member: &DesiredInstance) -> anyhow::Result<()> {
-        self.manager
-            .add_discovery_group_member(&key.id(), member.key.clone(), member.card.clone())
-    }
-
-    fn remove_group_member(&self, key: &GroupKey, instance_key: &str) -> anyhow::Result<()> {
-        self.manager
-            .remove_discovery_group_member(&key.id(), instance_key)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "instance {instance_key:?} missing from committed group {:?}",
-                    key.id()
-                )
-            })?;
-        Ok(())
-    }
-
-    fn sync_group_adapters(
+    fn replace_group(
         &self,
         key: &GroupKey,
+        members: &[DesiredInstance],
         adapters: &[DesiredInstance],
     ) -> anyhow::Result<()> {
         let group_id = key.id();
@@ -1148,8 +1138,12 @@ where
                 )
             })
             .collect::<HashMap<_, _>>();
-        self.manager.sync_discovery_group_adapters(
+        self.manager.replace_discovery_group(
             &group_id,
+            members
+                .iter()
+                .map(|member| (member.key.clone(), member.card.clone()))
+                .collect(),
             adapters
                 .iter()
                 .map(|adapter| (adapter.key.clone(), adapter.card.clone()))
@@ -1207,36 +1201,6 @@ where
 
     async fn list_instances(&self) -> anyhow::Result<Vec<DiscoveryInstance>> {
         self.drt.discovery().list(DiscoveryQuery::AllModels).await
-    }
-
-    fn project_lora(
-        &self,
-        endpoint_id: &EndpointId,
-        removed_worker_ids: &HashSet<u64>,
-        desired: &[(ModelCardInstanceId, ModelDeploymentCard)],
-    ) {
-        use crate::kv_router::protocols::WorkerWithDpRank;
-
-        let tracker = self.manager.lora_state_tracker_for(endpoint_id);
-        for worker_id in removed_worker_ids {
-            tracker.handle_worker_removal(WorkerWithDpRank::new(*worker_id, 0));
-        }
-
-        let mut projections = HashMap::new();
-        for (mcid, card) in desired {
-            let projection = projections
-                .entry(WorkerWithDpRank::new(mcid.instance_id, 0))
-                .or_insert_with(|| (None, Vec::new()));
-            if let Some(lora) = card.lora.as_ref() {
-                projection.1.push(lora.clone());
-            } else if let Some(capacity) = card.runtime_config.max_gpu_lora_count {
-                projection.0 = Some(capacity);
-            }
-        }
-        for (worker, (base_capacity, mut loras)) in projections {
-            loras.sort_by(|left, right| left.name.cmp(&right.name));
-            tracker.replace_worker_projection(worker, base_capacity, &loras);
-        }
     }
 }
 
@@ -1297,6 +1261,17 @@ fn materialization_fingerprint(
     Ok(blake3::hash(&bytes).to_string())
 }
 
+fn lora_projection_fingerprint(card: &ModelDeploymentCard) -> anyhow::Result<String> {
+    let mut value = serde_json::json!({
+        "display_name": &card.display_name,
+        "aliases": &card.aliases,
+        "lora": &card.lora,
+        "base_capacity": card.runtime_config.max_gpu_lora_count,
+    });
+    canonicalize_json(&mut value);
+    Ok(blake3::hash(&serde_json::to_vec(&value)?).to_string())
+}
+
 fn canonicalize_json(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(object) => {
@@ -1313,32 +1288,6 @@ fn canonicalize_json(value: &mut serde_json::Value) {
             }
         }
         _ => {}
-    }
-}
-
-/// Seed the LoRA state tracker from a worker's MDC.
-///
-/// - Adapter card (`card.lora` is `Some`): register the loaded adapter and worker capacity.
-/// - Base worker card advertising `runtime_config.max_gpu_lora_count`: seed capacity-only (no
-///   phantom adapter) so the controller sees idle-but-LoRA-capable workers before the first
-///   adapter load. Returns `None`.
-/// - Otherwise (non-LoRA worker): no-op, returns `None`.
-///
-/// Used by focused unit tests for the individual MDC projections consumed by the controller.
-#[cfg(test)]
-fn seed_lora_state_from_card(
-    state_tracker: &crate::lora::LoraStateTracker,
-    worker: crate::kv_router::protocols::WorkerWithDpRank,
-    card: &ModelDeploymentCard,
-) -> Option<String> {
-    if let Some(lora_info) = card.lora.as_ref() {
-        state_tracker.handle_mdc_addition(worker, lora_info);
-        Some(lora_info.name.clone())
-    } else if let Some(capacity) = card.runtime_config.max_gpu_lora_count {
-        state_tracker.set_worker_capacity(worker, capacity);
-        None
-    } else {
-        None
     }
 }
 
@@ -1421,6 +1370,7 @@ mod tests {
             mcid,
             endpoint_id,
             fingerprint: materialization_fingerprint(&card, &RouterConfig::default()).unwrap(),
+            projection_fingerprint: lora_projection_fingerprint(&card).unwrap(),
             card,
             group_key: key.clone(),
         };
@@ -1443,64 +1393,6 @@ mod tests {
         assert!(model.has_chat_engine());
         assert!(model.has_classify_engine());
         assert!(model.has_pooling_engine());
-    }
-
-    #[test]
-    fn base_card_with_capacity_seeds_idle_lora_capable_worker() {
-        // jh-nv (watcher base-card seeding): a base worker card (lora=None) carrying
-        // runtime_config.max_gpu_lora_count must seed capacity-only so the controller sees the
-        // idle LoRA-capable worker before any adapter loads. Pins the base-card -> capacity flow
-        // that the discovery loop relies on.
-        let st = crate::lora::LoraStateTracker::new();
-        let worker = crate::kv_router::protocols::WorkerWithDpRank::new(7, 0);
-        let mut card = ModelDeploymentCard::with_name_only("base-model");
-        card.runtime_config.max_gpu_lora_count = Some(4);
-        assert!(card.lora.is_none());
-
-        let adapter = seed_lora_state_from_card(&st, worker, &card);
-        assert_eq!(adapter, None, "a base card registers no adapter name");
-        assert_eq!(
-            st.list_workers(),
-            vec![worker],
-            "idle LoRA-capable worker must be visible to the controller"
-        );
-        assert_eq!(st.total_lora_slots(), 4);
-    }
-
-    #[test]
-    fn base_card_without_capacity_seeds_nothing() {
-        // A non-LoRA base card must not seed any worker capacity.
-        let st = crate::lora::LoraStateTracker::new();
-        let card = ModelDeploymentCard::with_name_only("base-model");
-        assert!(card.runtime_config.max_gpu_lora_count.is_none());
-
-        let adapter = seed_lora_state_from_card(
-            &st,
-            crate::kv_router::protocols::WorkerWithDpRank::new(1, 0),
-            &card,
-        );
-        assert_eq!(adapter, None);
-        assert!(
-            st.list_workers().is_empty(),
-            "a non-LoRA base card must not seed capacity"
-        );
-    }
-
-    #[test]
-    fn adapter_card_registers_adapter_and_returns_name() {
-        // An adapter card registers the loaded adapter and its capacity in the desired ledger.
-        let st = crate::lora::LoraStateTracker::new();
-        let worker = crate::kv_router::protocols::WorkerWithDpRank::new(3, 0);
-        let mut card = ModelDeploymentCard::with_name_only("base-model");
-        card.lora = Some(crate::model_card::LoraInfo {
-            name: "adapter-x".to_string(),
-            max_gpu_lora_count: Some(2),
-        });
-
-        let adapter = seed_lora_state_from_card(&st, worker, &card);
-        assert_eq!(adapter.as_deref(), Some("adapter-x"));
-        assert!(st.is_loaded("adapter-x", &worker));
-        assert_eq!(st.total_lora_slots(), 2);
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -456,7 +456,7 @@ where
         let client = endpoint
             .client()
             .await?
-            .with_admitted_instances_and_cancellation(admitted_ids, cancellation);
+            .with_admitted_instances_and_cancellation(admitted_ids, cancellation.clone());
         let instance_watcher = client.instance_avail_watcher();
         tracing::debug!(
             model_name = card.name(),
@@ -467,6 +467,7 @@ where
         let namespace = mcid.namespace.clone();
         // Build the WorkerSet with all applicable engines
         let mut worker_set = WorkerSet::new(namespace.clone(), checksum.to_string(), card.clone());
+        worker_set.set_lifecycle_cancellation(cancellation);
         worker_set.set_topology_endpoint(endpoint.clone());
         worker_set.set_instance_watcher(instance_watcher);
 
@@ -1211,19 +1212,30 @@ where
     fn project_lora(
         &self,
         endpoint_id: &EndpointId,
-        reset_worker_ids: &HashSet<u64>,
+        removed_worker_ids: &HashSet<u64>,
         desired: &[(ModelCardInstanceId, ModelDeploymentCard)],
     ) {
         use crate::kv_router::protocols::WorkerWithDpRank;
 
         let tracker = self.manager.lora_state_tracker_for(endpoint_id);
-        for worker_id in reset_worker_ids {
+        for worker_id in removed_worker_ids {
             tracker.handle_worker_removal(WorkerWithDpRank::new(*worker_id, 0));
         }
-        let mut desired = desired.to_vec();
-        desired.sort_by_key(|(mcid, _)| (mcid.model_suffix.is_some(), mcid.to_path()));
+
+        let mut projections = HashMap::new();
         for (mcid, card) in desired {
-            seed_lora_state_from_card(&tracker, WorkerWithDpRank::new(mcid.instance_id, 0), &card);
+            let projection = projections
+                .entry(WorkerWithDpRank::new(mcid.instance_id, 0))
+                .or_insert_with(|| (None, Vec::new()));
+            if let Some(lora) = card.lora.as_ref() {
+                projection.1.push(lora.clone());
+            } else if let Some(capacity) = card.runtime_config.max_gpu_lora_count {
+                projection.0 = Some(capacity);
+            }
+        }
+        for (worker, (base_capacity, mut loras)) in projections {
+            loras.sort_by(|left, right| left.name.cmp(&right.name));
+            tracker.replace_worker_projection(worker, base_capacity, &loras);
         }
     }
 }
@@ -1312,8 +1324,8 @@ fn canonicalize_json(value: &mut serde_json::Value) {
 ///   adapter load. Returns `None`.
 /// - Otherwise (non-LoRA worker): no-op, returns `None`.
 ///
-/// The controller clears and rebuilds an endpoint's desired projection on every source-card
-/// change, so removals do not depend on separately remembered pending additions.
+/// Used by focused unit tests for the individual MDC projections consumed by the controller.
+#[cfg(test)]
 fn seed_lora_state_from_card(
     state_tracker: &crate::lora::LoraStateTracker,
     worker: crate::kv_router::protocols::WorkerWithDpRank,

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -16,7 +16,7 @@ use dynamo_kv_router::{
 use dynamo_runtime::{
     DistributedRuntime,
     component::Endpoint,
-    discovery::{DiscoveryInstance, DiscoveryStream, ModelCardInstanceId},
+    discovery::{DiscoveryInstance, DiscoveryQuery, DiscoveryStream, ModelCardInstanceId},
     pipeline::{
         ManyOut, Operator, RouterMode, SegmentSource, ServiceBackend, SingleIn, Source,
         network::egress::push_router::PushRouter,
@@ -734,9 +734,6 @@ where
             });
 
             let encoder_chooser = if needs_preprocessed_routing {
-                if supports_encoder_result_handoff(card) {
-                    self.manager.enable_encoder_routing(&model_name, &namespace);
-                }
                 lease.remove_encoder_waiter = true;
                 self.manager
                     .register_encoder_router(&model_name, &namespace)
@@ -1138,7 +1135,19 @@ where
         spec: &GroupSpec,
         mut prepared: Self::Prepared,
         members: &[DesiredInstance],
+        adapters: &[DesiredInstance],
     ) -> anyhow::Result<()> {
+        let adapter_was_available = adapters
+            .iter()
+            .map(|adapter| {
+                (
+                    adapter.card.name().to_string(),
+                    self.manager
+                        .get_committed_model(adapter.card.name())
+                        .is_some(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
         let worker_set = prepared
             .worker_set
             .take()
@@ -1158,6 +1167,10 @@ where
             &spec.key.worker_set_key,
             worker_set,
             committed_members,
+            adapters
+                .iter()
+                .map(|adapter| (adapter.key.clone(), adapter.card.clone()))
+                .collect(),
             || {
                 let namespace = &spec.representative.mcid.namespace;
                 match &prepared.activation {
@@ -1194,6 +1207,17 @@ where
         )?;
         prepared.lease.disarm();
         self.emit_update(ModelUpdate::Added(prepared.card.clone()));
+        let mut adapter_names = HashSet::new();
+        for adapter in adapters {
+            if adapter_names.insert(adapter.card.name().to_string())
+                && !adapter_was_available
+                    .get(adapter.card.name())
+                    .copied()
+                    .unwrap_or(false)
+            {
+                self.emit_update(ModelUpdate::Added(adapter.card.clone()));
+            }
+        }
         if prepared.card.model_type.supports_chat() {
             self.notify_on_model.notify_waiters();
         }
@@ -1220,6 +1244,56 @@ where
                     key.id()
                 )
             })?;
+        Ok(())
+    }
+
+    fn sync_group_adapters(
+        &self,
+        key: &GroupKey,
+        adapters: &[DesiredInstance],
+    ) -> anyhow::Result<()> {
+        let group_id = key.id();
+        let previous = self
+            .manager
+            .discovery_group_adapter_cards(&group_id)
+            .into_iter()
+            .map(|card| (card.name().to_string(), card))
+            .collect::<HashMap<_, _>>();
+        let desired = adapters
+            .iter()
+            .map(|adapter| (adapter.card.name().to_string(), adapter.card.clone()))
+            .collect::<HashMap<_, _>>();
+        let was_available = previous
+            .keys()
+            .chain(desired.keys())
+            .map(|name| {
+                (
+                    name.clone(),
+                    self.manager.get_committed_model(name).is_some(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        self.manager.sync_discovery_group_adapters(
+            &group_id,
+            adapters
+                .iter()
+                .map(|adapter| (adapter.key.clone(), adapter.card.clone()))
+                .collect(),
+        )?;
+        for (name, card) in &desired {
+            if !was_available.get(name).copied().unwrap_or(false)
+                && self.manager.get_committed_model(name).is_some()
+            {
+                self.emit_update(ModelUpdate::Added(card.clone()));
+            }
+        }
+        for (name, card) in previous {
+            if was_available.get(&name).copied().unwrap_or(false)
+                && self.manager.get_committed_model(&name).is_none()
+            {
+                self.emit_update(ModelUpdate::Removed(card));
+            }
+        }
         Ok(())
     }
 
@@ -1255,6 +1329,18 @@ where
             return;
         };
         let removed_members = removed.cards.len();
+        let mut removed_adapter_names = HashSet::new();
+        for removed_card in &removed.cards {
+            if removed_card.lora.is_some()
+                && removed_adapter_names.insert(removed_card.name().to_string())
+                && self
+                    .manager
+                    .get_committed_model(removed_card.name())
+                    .is_none()
+            {
+                self.emit_update(ModelUpdate::Removed(removed_card.clone()));
+            }
+        }
         let card = removed.representative;
         for removed_card in removed_model_cards(&self.manager, &card) {
             self.emit_update(ModelUpdate::Removed(removed_card));
@@ -1269,6 +1355,10 @@ where
 
     fn discard_prepared(&self, prepared: Self::Prepared) {
         drop(prepared);
+    }
+
+    async fn list_instances(&self) -> anyhow::Result<Vec<DiscoveryInstance>> {
+        self.drt.discovery().list(DiscoveryQuery::AllModels).await
     }
 
     fn project_lora(
@@ -1329,13 +1419,42 @@ fn materialization_fingerprint(
     card: &ModelDeploymentCard,
     default_router_config: &RouterConfig,
 ) -> anyhow::Result<String> {
-    let mut normalized = card.clone();
-    normalized.worker_type = Some(effective_worker_type(card.worker_type, card.model_type));
-    if normalized.router_config.is_none() {
-        normalized.router_config = Some(default_router_config.clone());
-    }
-    let bytes = serde_json::to_vec(&normalized)?;
+    let effective_router = card.router_config.as_ref().unwrap_or(default_router_config);
+    let mut value = serde_json::to_value(card)?;
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("model card must serialize as an object"))?;
+    object.insert(
+        "worker_type".to_string(),
+        serde_json::to_value(effective_worker_type(card.worker_type, card.model_type))?,
+    );
+    object.remove("router_config");
+    let normalized: ModelDeploymentCard = serde_json::from_value(value)?;
+
+    let mut bytes = normalized.mdcsum().as_bytes().to_vec();
+    let mut router_value = serde_json::to_value(effective_router)?;
+    canonicalize_json(&mut router_value);
+    bytes.extend(serde_json::to_vec(&router_value)?);
     Ok(blake3::hash(&bytes).to_string())
+}
+
+fn canonicalize_json(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(object) => {
+            let mut entries = std::mem::take(object).into_iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            for (key, mut value) in entries {
+                canonicalize_json(&mut value);
+                object.insert(key, value);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                canonicalize_json(value);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Seed the LoRA state tracker from a worker's MDC.
@@ -1474,7 +1593,9 @@ mod tests {
             .prepare_worker_set(&spec, admission_rx, CancellationToken::new())
             .await
             .unwrap();
-        watcher.commit_group(&spec, prepared, &[desired]).unwrap();
+        watcher
+            .commit_group(&spec, prepared, &[desired], &[])
+            .unwrap();
 
         let model = manager.get_model("mixed-text-model").unwrap();
         assert!(model.has_chat_engine());
@@ -1790,9 +1911,28 @@ mod tests {
         );
 
         current.runtime_config.max_gpu_lora_count = Some(4);
+        current.runtime_config.kv_event_publishing_enabled = Some(true);
+        current.runtime_config.data_parallel_start_rank = 4;
+        assert_eq!(
+            materialization_fingerprint(&legacy, &RouterConfig::default()).unwrap(),
+            materialization_fingerprint(&current, &RouterConfig::default()).unwrap()
+        );
+
+        current.aliases.push("new-serving-name".to_string());
         assert_ne!(
             materialization_fingerprint(&legacy, &RouterConfig::default()).unwrap(),
             materialization_fingerprint(&current, &RouterConfig::default()).unwrap()
+        );
+
+        let mut legacy_wire = serde_json::to_value(&legacy).unwrap();
+        legacy_wire["context_length"] = serde_json::json!(8_192);
+        let legacy_wire: ModelDeploymentCard = serde_json::from_value(legacy_wire).unwrap();
+        let mut current_wire = legacy.clone();
+        current_wire.worker_type = Some(WorkerType::Prefill);
+        current_wire.runtime_config.context_length = Some(8_192);
+        assert_eq!(
+            materialization_fingerprint(&legacy_wire, &RouterConfig::default()).unwrap(),
+            materialization_fingerprint(&current_wire, &RouterConfig::default()).unwrap()
         );
     }
 

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -165,6 +165,23 @@ fn supports_encoder_result_handoff(card: &ModelDeploymentCard) -> bool {
 // Generate's opaque request state is not yet verified for migration replay.
 const GENERATE_MIGRATION_LIMIT: u32 = 0;
 
+/// Project the topology implicit in a pre-`worker_type` prefill card into the
+/// explicit contract used by current workers.
+///
+/// TODO(v1.5): Remove this projection together with the missing-role fallback
+/// in `effective_worker_type` and the legacy readiness bypass after the v1.2
+/// MDC compatibility window expires.
+fn normalize_legacy_prefill_topology(card: &mut ModelDeploymentCard) {
+    if card.worker_type.is_some() || !card.model_type.supports_prefill() {
+        return;
+    }
+
+    card.worker_type = Some(WorkerType::Prefill);
+    if card.needs.is_empty() {
+        card.needs = vec![vec![WorkerType::Decode]];
+    }
+}
+
 /// Resolve the effective [`WorkerType`] for a card during the
 /// cross-version rollout.
 ///
@@ -1102,6 +1119,7 @@ where
         }
 
         let mut card = instance.deserialize_model::<ModelDeploymentCard>()?;
+        normalize_legacy_prefill_topology(&mut card);
         self.apply_tokenizer_backend_override(&mut card);
         validate_card_shape(&card)?;
         let endpoint_id = model_card_endpoint_id(&mcid);
@@ -1899,11 +1917,16 @@ mod tests {
     }
 
     #[test]
-    fn materialization_fingerprint_normalizes_legacy_worker_role() {
+    fn materialization_fingerprint_normalizes_legacy_prefill_topology() {
         let mut legacy = ModelDeploymentCard::with_name_only("model");
         legacy.model_type = ModelType::Prefill;
         let mut current = legacy.clone();
         current.worker_type = Some(WorkerType::Prefill);
+        current.needs = vec![vec![WorkerType::Decode]];
+
+        normalize_legacy_prefill_topology(&mut legacy);
+        assert_eq!(legacy.worker_type, Some(WorkerType::Prefill));
+        assert_eq!(legacy.needs, vec![vec![WorkerType::Decode]]);
 
         assert_eq!(
             materialization_fingerprint(&legacy, &RouterConfig::default()).unwrap(),
@@ -1924,16 +1947,85 @@ mod tests {
             materialization_fingerprint(&current, &RouterConfig::default()).unwrap()
         );
 
-        let mut legacy_wire = serde_json::to_value(&legacy).unwrap();
+        let mut legacy_wire = ModelDeploymentCard::with_name_only("model");
+        legacy_wire.model_type = ModelType::Prefill;
+        let mut legacy_wire = serde_json::to_value(&legacy_wire).unwrap();
+        let object = legacy_wire.as_object_mut().unwrap();
+        object.remove("worker_type");
+        object.remove("needs");
         legacy_wire["context_length"] = serde_json::json!(8_192);
-        let legacy_wire: ModelDeploymentCard = serde_json::from_value(legacy_wire).unwrap();
-        let mut current_wire = legacy.clone();
+        let mut legacy_wire: ModelDeploymentCard = serde_json::from_value(legacy_wire).unwrap();
+        normalize_legacy_prefill_topology(&mut legacy_wire);
+        let mut current_wire = ModelDeploymentCard::with_name_only("model");
+        current_wire.model_type = ModelType::Prefill;
         current_wire.worker_type = Some(WorkerType::Prefill);
+        current_wire.needs = vec![vec![WorkerType::Decode]];
         current_wire.runtime_config.context_length = Some(8_192);
         assert_eq!(
             materialization_fingerprint(&legacy_wire, &RouterConfig::default()).unwrap(),
             materialization_fingerprint(&current_wire, &RouterConfig::default()).unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn discovery_normalization_joins_v12_and_current_prefill() {
+        use dynamo_runtime::{Runtime, distributed::DistributedConfig};
+
+        let runtime = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(runtime, DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let watcher = ModelWatcher::new(
+            drt,
+            Arc::new(ModelManager::new()),
+            RouterConfig::default(),
+            0,
+            None,
+            None,
+            None,
+            Arc::new(Metrics::new_with_prefix(Some(
+                "watcher_v12_prefill_compat_test".to_string(),
+            ))),
+        );
+
+        let mut legacy_card = ModelDeploymentCard::with_name_only("model");
+        legacy_card.model_type = ModelType::Prefill;
+        legacy_card.model_input = ModelInput::Tokens;
+        let mut legacy_json = serde_json::to_value(legacy_card).unwrap();
+        let legacy_object = legacy_json.as_object_mut().unwrap();
+        legacy_object.remove("worker_type");
+        legacy_object.remove("needs");
+
+        let mut current_card = ModelDeploymentCard::with_name_only("model");
+        current_card.model_type = ModelType::Prefill;
+        current_card.model_input = ModelInput::Tokens;
+        current_card.worker_type = Some(WorkerType::Prefill);
+        current_card.needs = vec![vec![WorkerType::Decode]];
+
+        let instance = |instance_id, card_json| DiscoveryInstance::Model {
+            namespace: "ns1".to_string(),
+            component: "workers".to_string(),
+            endpoint: "generate".to_string(),
+            instance_id,
+            card_json,
+            model_suffix: None,
+        };
+        let legacy = watcher
+            .normalize(instance(1, legacy_json), &NamespaceFilter::Global)
+            .unwrap()
+            .unwrap();
+        let current = watcher
+            .normalize(
+                instance(2, serde_json::to_value(current_card).unwrap()),
+                &NamespaceFilter::Global,
+            )
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(legacy.card.worker_type, Some(WorkerType::Prefill));
+        assert_eq!(legacy.card.needs, vec![vec![WorkerType::Decode]]);
+        assert_eq!(legacy.group_key, current.group_key);
+        assert_eq!(legacy.fingerprint, current.fingerprint);
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -3,28 +3,20 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
-};
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{Mutex, Notify, mpsc::Sender};
-use tokio::task::{JoinHandle, JoinSet};
+use tokio::sync::{Notify, mpsc::Sender};
 
 use anyhow::Context as _;
-use dashmap::{DashMap, DashSet};
+use async_trait::async_trait;
 use dynamo_kv_router::{
     DEFAULT_ROUTING_GROUP, PrefillLoadEstimator, RoutingPartitionRef,
     selector::{DefaultWorkerSelector, WorkerSelector},
 };
-use futures::StreamExt;
-
 use dynamo_runtime::{
     DistributedRuntime,
-    discovery::{
-        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery, DiscoveryStream,
-        ModelCardInstanceId,
-    },
+    component::Endpoint,
+    discovery::{DiscoveryInstance, DiscoveryStream, ModelCardInstanceId},
     pipeline::{
         ManyOut, Operator, RouterMode, SegmentSource, ServiceBackend, SingleIn, Source,
         network::egress::push_router::PushRouter,
@@ -68,10 +60,12 @@ use crate::{
     worker_type::WorkerType,
 };
 
-use super::ModelManager;
+use super::{
+    ModelManager,
+    controller::{ControllerHost, DesiredInstance, GroupKey, GroupSpec, ModelDiscoveryController},
+};
 use crate::namespace::NamespaceFilter;
-
-const RECONCILIATION_INTERVAL: Duration = Duration::from_secs(30);
+use tokio_util::sync::CancellationToken;
 
 /// Constructs a collision-free WorkerSet storage key from its exact endpoint,
 /// model type, and worker role.
@@ -112,16 +106,6 @@ fn model_card_endpoint_id(mcid: &ModelCardInstanceId) -> EndpointId {
     }
 }
 
-fn has_live_endpoint_card(
-    cards: &[(EndpointId, ModelDeploymentCard)],
-    namespace: &str,
-    component: &str,
-) -> bool {
-    cards
-        .iter()
-        .any(|(endpoint, _)| endpoint.namespace == namespace && endpoint.component == component)
-}
-
 fn model_card_instance_id(instance: &DiscoveryInstance) -> anyhow::Result<ModelCardInstanceId> {
     match instance {
         DiscoveryInstance::Model {
@@ -140,28 +124,6 @@ fn model_card_instance_id(instance: &DiscoveryInstance) -> anyhow::Result<ModelC
         }),
         _ => anyhow::bail!("Unexpected discovery instance type (expected ModelCard)"),
     }
-}
-
-/// A source card is fully represented locally only after both the per-instance
-/// card and the shared WorkerSet have been recorded. `handle_put` can save the
-/// card before later pipeline construction fails, so either check alone would
-/// allow a failed registration to escape reconciliation.
-fn is_registration_complete(
-    manager: &ModelManager,
-    mcid: &ModelCardInstanceId,
-    card: &ModelDeploymentCard,
-) -> bool {
-    let ws_key = worker_set_key(
-        &model_card_endpoint_id(mcid),
-        card.model_type,
-        card.worker_type,
-    );
-    manager
-        .get_model_card(&mcid.to_path())
-        .is_some_and(|saved| saved.name() == card.name() && saved.mdcsum() == card.mdcsum())
-        && manager.get_model(card.name()).is_some_and(|model| {
-            model.has_worker_set(&ws_key) && model.is_checksum_compatible(&ws_key, card.mdcsum())
-        })
 }
 
 fn uses_multimodal_cache_routing(card: &ModelDeploymentCard) -> bool {
@@ -246,26 +208,11 @@ where
     migration_max_seq_len: Option<u32>,
     notify_on_model: Notify,
     model_update_tx: Option<Sender<ModelUpdate>>,
+    model_update_dispatch:
+        parking_lot::Mutex<Option<tokio::sync::mpsc::UnboundedSender<ModelUpdate>>>,
     chat_engine_factory: Option<ChatEngineFactoryCallback>,
     prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
     metrics: Arc<Metrics>,
-    /// Guards against concurrent pipeline construction for the same (model, namespace).
-    registering_worker_sets: DashSet<String>,
-    /// Wakes tasks blocked in `recover_concurrent_registration` when a
-    /// `RegistrationGuard` drops (i.e. a registration completes or panics).
-    registration_notify: Notify,
-    /// Tracks in-flight `handle_put` tasks by instance path so a later operation
-    /// can cancel a superseded registration.
-    pending_puts: DashMap<String, PendingPut>,
-    /// Serializes state changes for one model-card instance. The generation
-    /// fence preserves discovery-event order even when spawned tasks acquire
-    /// the per-instance lock in a different order.
-    instance_operations: DashMap<String, Arc<InstanceOperation>>,
-    /// Maps an MDC instance path to the LoRA adapter name recorded in the pre-spawn state-tracker
-    /// addition, so a removal whose model card was never durably saved (handle_put failed before
-    /// save) can still remove exactly that adapter from the tracker instead of leaving phantom
-    /// state or wiping a live worker (R4-2 / RR3-3).
-    pending_lora_adds: DashMap<String, String>,
     /// Frontend's `--model-path`. Threaded into `download_config` so
     /// `file://` slots can fall back here when the worker's path is
     /// unreachable on this host.
@@ -276,6 +223,66 @@ where
     /// Keep raw pipelines out of default-off and backend-mismatched paths.
     generate_engine_capabilities: Vec<&'static str>,
     worker_selector_factory: WorkerSelectorFactory<Sel>,
+}
+
+enum PreparedActivation {
+    None,
+    Prefill {
+        endpoint: Endpoint,
+        enable_encoder_routing: bool,
+    },
+    Encoder {
+        endpoint: Endpoint,
+    },
+}
+
+struct PreparationLease {
+    manager: Arc<ModelManager>,
+    model_name: String,
+    namespace: String,
+    remove_prefill_waiter: bool,
+    remove_encoder_waiter: bool,
+    armed: bool,
+}
+
+impl PreparationLease {
+    fn new(manager: Arc<ModelManager>, model_name: String, namespace: String) -> Self {
+        Self {
+            manager,
+            model_name,
+            namespace,
+            remove_prefill_waiter: false,
+            remove_encoder_waiter: false,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PreparationLease {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if self.remove_prefill_waiter {
+            self.manager
+                .remove_decode_prefill_waiter(&self.model_name, &self.namespace);
+        }
+        if self.remove_encoder_waiter {
+            self.manager
+                .remove_consumer_encoder_waiter(&self.model_name, &self.namespace);
+        }
+    }
+}
+
+pub(crate) struct PreparedWorkerSet {
+    worker_set: Option<WorkerSet>,
+    card: ModelDeploymentCard,
+    activation: PreparedActivation,
+    lease: PreparationLease,
 }
 
 const ALL_MODEL_TYPES: &[ModelType] = &[
@@ -338,63 +345,6 @@ fn removed_model_cards(
         .collect()
 }
 
-/// RAII guard that removes a key from a `DashSet` on drop and wakes any tasks
-/// waiting for the registration to finish via the shared [`Notify`].
-/// Ensures `registering_worker_sets` is cleaned up even if the registration
-/// task panics, preventing permanent poisoning of the registration key.
-struct RegistrationGuard<'a> {
-    set: &'a DashSet<String>,
-    key: String,
-    notify: &'a Notify,
-}
-
-struct PendingPut {
-    generation: u64,
-    handle: JoinHandle<()>,
-}
-
-#[derive(Default)]
-struct InstanceOperation {
-    generation: AtomicU64,
-    lock: Mutex<()>,
-}
-
-impl InstanceOperation {
-    fn current_generation(&self) -> u64 {
-        self.generation.load(Ordering::Acquire)
-    }
-
-    fn begin(&self) -> u64 {
-        self.generation
-            .fetch_add(1, Ordering::AcqRel)
-            .wrapping_add(1)
-    }
-
-    fn reserve_after(&self, expected: u64) -> Option<u64> {
-        let next = expected.wrapping_add(1);
-        self.generation
-            .compare_exchange(expected, next, Ordering::AcqRel, Ordering::Acquire)
-            .ok()
-            .map(|_| next)
-    }
-
-    fn is_current(&self, generation: u64) -> bool {
-        self.current_generation() == generation
-    }
-}
-
-enum DeleteOutcome {
-    Superseded,
-    Processed(Option<String>),
-}
-
-impl Drop for RegistrationGuard<'_> {
-    fn drop(&mut self) {
-        self.set.remove(&self.key);
-        self.notify.notify_waiters();
-    }
-}
-
 impl ModelWatcher<DefaultWorkerSelector> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -447,14 +397,10 @@ where
             migration_max_seq_len,
             notify_on_model: Notify::new(),
             model_update_tx: None,
+            model_update_dispatch: parking_lot::Mutex::new(None),
             chat_engine_factory,
             prefill_load_estimator,
             metrics,
-            registering_worker_sets: DashSet::new(),
-            registration_notify: Notify::new(),
-            pending_puts: DashMap::new(),
-            instance_operations: DashMap::new(),
-            pending_lora_adds: DashMap::new(),
             local_model_path: None,
             tokenizer_backend: None,
             generate_engine_capabilities: Vec::new(),
@@ -491,59 +437,6 @@ where
         }
     }
 
-    fn instance_operation(&self, key: &str) -> Arc<InstanceOperation> {
-        self.instance_operations
-            .entry(key.to_string())
-            .or_insert_with(|| Arc::new(InstanceOperation::default()))
-            .clone()
-    }
-
-    fn begin_instance_operation(&self, key: &str) -> (Arc<InstanceOperation>, u64) {
-        let operation = self.instance_operation(key);
-        let generation = operation.begin();
-        (operation, generation)
-    }
-
-    fn observe_instance_operation(&self, key: &str) -> (Arc<InstanceOperation>, u64) {
-        let operation = self.instance_operation(key);
-        let generation = operation.current_generation();
-        (operation, generation)
-    }
-
-    fn prune_instance_operation(&self, key: &str, operation: &Arc<InstanceOperation>) {
-        self.instance_operations.remove_if(key, |_, current| {
-            Arc::ptr_eq(current, operation) && Arc::strong_count(current) == 2
-        });
-    }
-
-    fn seed_lora_state_for_put(&self, mcid: &ModelCardInstanceId, card: &ModelDeploymentCard) {
-        use crate::kv_router::protocols::WorkerWithDpRank;
-
-        let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
-        let state_tracker = self
-            .manager
-            .lora_state_tracker_for(&model_card_endpoint_id(mcid));
-        if let Some(adapter_name) = seed_lora_state_from_card(&state_tracker, worker, card) {
-            self.pending_lora_adds.insert(mcid.to_path(), adapter_name);
-        }
-    }
-
-    async fn handle_put_if_current(
-        &self,
-        mcid: &ModelCardInstanceId,
-        card: &mut ModelDeploymentCard,
-        operation: &InstanceOperation,
-        generation: u64,
-    ) -> Option<anyhow::Result<()>> {
-        let _guard = operation.lock.lock().await;
-        if !operation.is_current(generation) {
-            return None;
-        }
-
-        self.seed_lora_state_for_put(mcid, card);
-        Some(self.handle_put(mcid, card).await)
-    }
-
     /// Wait until we have at least one chat completions model and return it's name.
     pub async fn wait_for_chat_model(&self) -> String {
         // Loop in case it gets added and immediately deleted
@@ -555,949 +448,48 @@ where
         }
     }
 
-    /// Common watch logic with optional namespace filtering.
-    ///
-    /// Takes `Arc<Self>` so that each `handle_put` call can be spawned into its own
-    /// tokio task, preventing a slow HuggingFace config download for one model from
-    /// blocking discovery events for all subsequent models.
+    /// Run the ordered desired-state controller for model discovery.
     pub async fn watch(
         self: Arc<Self>,
-        mut discovery_stream: DiscoveryStream,
+        discovery_stream: DiscoveryStream,
         namespace_filter: NamespaceFilter,
     ) {
-        let mut reconciliation = tokio::time::interval(RECONCILIATION_INTERVAL);
-        reconciliation.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        // list_and_watch supplies the initial snapshot. Consume the immediate
-        // first tick so reconciliation begins after one complete interval.
-        reconciliation.tick().await;
-        let mut reconciliation_tasks = JoinSet::new();
-
-        loop {
-            let result = tokio::select! {
-                result = discovery_stream.next() => {
-                    let Some(result) = result else {
+        let dispatch_handle = self.model_update_tx.clone().map(|external_tx| {
+            let (dispatch_tx, mut dispatch_rx) = tokio::sync::mpsc::unbounded_channel();
+            *self.model_update_dispatch.lock() = Some(dispatch_tx);
+            tokio::spawn(async move {
+                while let Some(update) = dispatch_rx.recv().await {
+                    if external_tx.send(update).await.is_err() {
                         break;
-                    };
-                    result
-                }
-                _ = reconciliation.tick(), if reconciliation_tasks.is_empty() => {
-                    let watcher = Arc::clone(&self);
-                    let namespace_filter = namespace_filter.clone();
-                    reconciliation_tasks.spawn(async move {
-                        if let Err(err) = watcher.reconcile(&namespace_filter).await {
-                            tracing::warn!(
-                                error = format!("{err:#}"),
-                                "Frontend model registration reconciliation failed"
-                            );
-                        }
-                    });
-                    continue;
-                }
-                result = reconciliation_tasks.join_next(), if !reconciliation_tasks.is_empty() => {
-                    if let Some(Err(err)) = result {
-                        tracing::warn!(
-                            error = %err,
-                            "Frontend model registration reconciliation task failed"
-                        );
-                    }
-                    continue;
-                }
-            };
-            let event = match result {
-                Ok(event) => event,
-                Err(err) => {
-                    tracing::error!(%err, "Error in discovery stream");
-                    continue;
-                }
-            };
-
-            match event {
-                DiscoveryEvent::Added(instance) => {
-                    // Extract ModelCardInstanceId and card from the discovery instance
-                    let (mcid, mut card) = match &instance {
-                        DiscoveryInstance::Model {
-                            namespace,
-                            component,
-                            endpoint,
-                            instance_id,
-                            model_suffix,
-                            ..
-                        } => {
-                            let mcid = ModelCardInstanceId {
-                                namespace: namespace.clone(),
-                                component: component.clone(),
-                                endpoint: endpoint.clone(),
-                                instance_id: *instance_id,
-                                model_suffix: model_suffix.clone(),
-                            };
-
-                            match instance.deserialize_model::<ModelDeploymentCard>() {
-                                Ok(card) => (mcid, card),
-                                Err(err) => {
-                                    tracing::error!(%err, instance_id, "Failed to deserialize model card");
-                                    continue;
-                                }
-                            }
-                        }
-                        _ => {
-                            tracing::error!(
-                                "Unexpected discovery instance type (expected ModelCard)"
-                            );
-                            continue;
-                        }
-                    };
-
-                    // Filter by namespace using the configured filter
-                    if !namespace_filter.matches(&mcid.namespace) {
-                        tracing::debug!(
-                            model_namespace = mcid.namespace,
-                            namespace_filter = ?namespace_filter,
-                            "Skipping model due to namespace filter"
-                        );
-                        continue;
-                    }
-
-                    self.apply_tokenizer_backend_override(&mut card);
-
-                    // If a WorkerSet already exists for this (model, namespace, type),
-                    // validate that the new worker's checksum matches. Different
-                    // WorkerSets (different namespaces) are allowed to have different checksums to support rolling updates.
-                    let ws_key = worker_set_key(
-                        &model_card_endpoint_id(&mcid),
-                        card.model_type,
-                        card.worker_type,
-                    );
-                    if let Some(model) = self.manager.get_model(card.name())
-                        && !model.is_checksum_compatible(&ws_key, card.mdcsum())
-                    {
-                        tracing::error!(
-                            model_name = card.name(),
-                            namespace = mcid.namespace,
-                            new_checksum = card.mdcsum(),
-                            "Checksum for new worker does not match existing WorkerSet's checksum. \
-                             Drain all old workers in this namespace before deploying a new version."
-                        );
-                        // TODO: mark that instance down in clients
-                        // Not obvious how to do that given the current design
-                        // Instances come from an `InstanceSource` in a `Client` in a `PushRouter`.
-                        // Calling `report_instance_down` on the Client should do it (although
-                        // needs more testing).
-                        // The `PushRouter` is in `ModelMananger` (`self.manager` here), but inside
-                        // interface `AsyncEngine` which only has a `generate` method.
-                        continue;
-                    }
-
-                    // Spawn each handle_put into its own task so that a slow
-                    // HuggingFace config download for one model cannot block
-                    // discovery events for all subsequent models.
-                    //
-                    // The per-instance operation generation preserves event
-                    // order if this task is scheduled after a later operation.
-                    let instance_key = mcid.to_path();
-                    let task_key = instance_key.clone();
-                    let (operation, generation) = self.begin_instance_operation(&instance_key);
-                    let watcher = Arc::clone(&self);
-                    let handle = tokio::spawn(async move {
-                        match watcher
-                            .handle_put_if_current(&mcid, &mut card, &operation, generation)
-                            .await
-                        {
-                            Some(Ok(())) => {
-                                tracing::info!(
-                                    model_name = card.name(),
-                                    namespace = mcid.namespace,
-                                    "added model"
-                                );
-                                watcher.notify_on_model.notify_waiters();
-                            }
-                            Some(Err(err)) => {
-                                tracing::error!(
-                                    model_name = card.name(),
-                                    namespace = mcid.namespace,
-                                    error = format!("{err:#}"),
-                                    "Error adding model from discovery",
-                                );
-                            }
-                            None => {
-                                tracing::debug!(
-                                    key = %task_key,
-                                    generation,
-                                    "Skipping superseded model registration"
-                                );
-                            }
-                        }
-                        watcher.prune_instance_operation(&task_key, &operation);
-                        // Note: we intentionally do NOT remove from pending_puts here.
-                        // Only the watch loop (on duplicate events) and handle_delete
-                        // manage pending_puts, avoiding a race where a completed task's
-                        // cleanup could remove a newer task's entry.
-                    });
-                    // If a duplicate Added event arrives while the first task is still
-                    // in-flight, abort the old task to cancel redundant work.
-                    //
-                    // `instance_key` is `mcid.to_path()` = "{ns}/{component}/{endpoint}/{instance_id:x}",
-                    // so this is keyed per-worker-instance, NOT per-model. Two different workers
-                    // registering the same model produce two different keys and run independently.
-                    // The only case that hits this branch is the etcd watch replaying the same
-                    // worker's Added event (reconnect or re-sync) — where cancelling the earlier
-                    // redundant task is exactly what we want.
-                    if let Some((_, old_put)) = self.pending_puts.remove(&instance_key) {
-                        old_put.handle.abort();
-                    }
-                    self.pending_puts
-                        .insert(instance_key, PendingPut { generation, handle });
-                }
-                DiscoveryEvent::Removed(id) => {
-                    // Extract ModelCardInstanceId from the removal event
-                    let model_card_instance_id = match &id {
-                        DiscoveryInstanceId::Model(mcid) => mcid,
-                        DiscoveryInstanceId::Endpoint(_)
-                        | DiscoveryInstanceId::EventChannel(_)
-                        | DiscoveryInstanceId::EventSource(_) => {
-                            tracing::error!(
-                                "Unexpected discovery instance type in removal (expected Model)"
-                            );
-                            continue;
-                        }
-                    };
-
-                    let instance_key = model_card_instance_id.to_path();
-                    let (operation, generation) = self.begin_instance_operation(&instance_key);
-                    match self
-                        .handle_delete(
-                            model_card_instance_id,
-                            &namespace_filter,
-                            operation,
-                            generation,
-                        )
-                        .await
-                    {
-                        Ok(DeleteOutcome::Processed(Some(model_name))) => {
-                            tracing::info!(model_name, "removed model");
-                        }
-                        Ok(DeleteOutcome::Processed(None)) => {
-                            // There are other instances running this model, nothing to do
-                        }
-                        Ok(DeleteOutcome::Superseded) => {}
-                        Err(e) => {
-                            tracing::error!(error = %e, "error removing model");
-                        }
                     }
                 }
-            }
-        }
-
-        reconciliation_tasks.abort_all();
-        while reconciliation_tasks.join_next().await.is_some() {}
-    }
-
-    /// Compare the local frontend registry with a fresh discovery snapshot.
-    /// Missing or incomplete source cards are retried through `handle_put`; a
-    /// locally recorded card absent from the snapshot is removed through
-    /// `handle_delete`. The snapshot is sorted so repeated failures are logged
-    /// and retried in a deterministic order.
-    async fn reconcile(self: &Arc<Self>, namespace_filter: &NamespaceFilter) -> anyhow::Result<()> {
-        // Snapshot local keys and their operation generations before awaiting
-        // discovery. A registration that starts after this point advances its
-        // generation and prevents this snapshot from deleting the fresh card.
-        let local_entries = self
-            .manager
-            .get_model_card_keys()
-            .into_iter()
-            .map(|key| {
-                let (operation, generation) = self.observe_instance_operation(&key);
-                (key, operation, generation)
             })
-            .collect::<Vec<_>>();
-
-        let mut instances = self.drt.discovery().list(DiscoveryQuery::AllModels).await?;
-        instances.sort_by_key(|instance| {
-            model_card_instance_id(instance)
-                .map(|mcid| mcid.to_path())
-                .unwrap_or_default()
         });
 
-        let mut desired_keys = HashSet::with_capacity(instances.len());
-        let mut retry_count = 0usize;
+        ModelDiscoveryController::new(Arc::clone(&self))
+            .run(discovery_stream, namespace_filter)
+            .await;
 
-        for instance in instances {
-            let mcid = match model_card_instance_id(&instance) {
-                Ok(mcid) => mcid,
-                Err(err) => {
-                    tracing::error!(
-                        error = format!("{err:#}"),
-                        "Unexpected discovery entry during model reconciliation"
-                    );
-                    continue;
-                }
-            };
-            if !namespace_filter.matches(&mcid.namespace) {
-                continue;
-            }
-
-            // Record the source key before deserializing the card. A malformed
-            // source entry must not cause a valid local entry with the same key
-            // to be treated as stale and deleted.
-            desired_keys.insert(mcid.to_path());
-
-            let mut card = match instance.deserialize_model::<ModelDeploymentCard>() {
-                Ok(card) => card,
-                Err(err) => {
-                    tracing::error!(
-                        %err,
-                        instance_id = mcid.instance_id,
-                        "Failed to deserialize model card during reconciliation"
-                    );
-                    continue;
-                }
-            };
-            self.apply_tokenizer_backend_override(&mut card);
-
-            if !is_registration_complete(&self.manager, &mcid, &card)
-                && self.retry_model_registration(mcid, card).await
-            {
-                retry_count += 1;
-            }
-        }
-
-        let mut stale_entries = Vec::new();
-        for (key, operation, generation) in local_entries {
-            let mcid = match ModelCardInstanceId::from_path(&key) {
-                Ok(mcid) => mcid,
-                Err(err) => {
-                    tracing::warn!(%err, key, "Ignoring malformed local model-card key");
-                    continue;
-                }
-            };
-            if namespace_filter.matches(&mcid.namespace) && !desired_keys.contains(&key) {
-                stale_entries.push((key, mcid, operation, generation));
-            }
-        }
-        stale_entries.sort_by(|left, right| left.0.cmp(&right.0));
-        let stale_entry_count = stale_entries.len();
-
-        let mut removed_stale_count = 0usize;
-        let mut superseded_stale_count = 0usize;
-        for (key, mcid, operation, snapshot_generation) in stale_entries {
-            let Some(delete_generation) = operation.reserve_after(snapshot_generation) else {
-                superseded_stale_count += 1;
-                tracing::debug!(
-                    key = %key,
-                    snapshot_generation,
-                    current_generation = operation.current_generation(),
-                    "Skipping stale cleanup superseded after reconciliation snapshot"
-                );
-                continue;
-            };
-            match self
-                .handle_delete(&mcid, namespace_filter, operation, delete_generation)
+        self.model_update_dispatch.lock().take();
+        if let Some(mut dispatch_handle) = dispatch_handle
+            && tokio::time::timeout(Duration::from_secs(1), &mut dispatch_handle)
                 .await
-            {
-                Ok(DeleteOutcome::Processed(_)) => removed_stale_count += 1,
-                Ok(DeleteOutcome::Superseded) => superseded_stale_count += 1,
-                Err(err) => {
-                    tracing::error!(
-                        key = %key,
-                        error = format!("{err:#}"),
-                        "Error removing stale model during reconciliation"
-                    );
-                }
-            }
+                .is_err()
+        {
+            dispatch_handle.abort();
         }
-
-        tracing::debug!(
-            expected_model_cards = desired_keys.len(),
-            retried_model_cards = retry_count,
-            removed_stale_model_cards = removed_stale_count,
-            superseded_stale_model_cards = superseded_stale_count,
-            failed_stale_model_cards =
-                stale_entry_count.saturating_sub(removed_stale_count + superseded_stale_count),
-            "Completed frontend model registration reconciliation"
-        );
-        Ok(())
     }
 
-    /// Start one reconciliation retry unless the original event-driven
-    /// registration for this instance is still running. Completed failed tasks
-    /// remain in `pending_puts`, so they are replaced here by the retry task.
-    async fn retry_model_registration(
-        self: &Arc<Self>,
-        mcid: ModelCardInstanceId,
-        mut card: ModelDeploymentCard,
-    ) -> bool {
-        let instance_key = mcid.to_path();
-        if self
-            .pending_puts
-            .get(&instance_key)
-            .is_some_and(|pending| !pending.handle.is_finished())
-        {
-            return false;
-        }
-
-        let ws_key = worker_set_key(
-            &model_card_endpoint_id(&mcid),
-            card.model_type,
-            card.worker_type,
-        );
-        if let Some(model) = self.manager.get_model(card.name())
-            && !model.is_checksum_compatible(&ws_key, card.mdcsum())
-        {
-            tracing::error!(
-                model_name = card.name(),
-                namespace = mcid.namespace,
-                new_checksum = card.mdcsum(),
-                "Reconciliation found a model-card checksum that does not match the existing WorkerSet. \
-                 Drain all old workers in this namespace before deploying a new version."
-            );
-            return false;
-        }
-
-        tracing::warn!(
-            model_name = card.name(),
-            namespace = mcid.namespace,
-            instance_key,
-            "Retrying incomplete frontend model registration from discovery snapshot"
-        );
-
-        let task_key = instance_key.clone();
-        let (operation, generation) = self.begin_instance_operation(&instance_key);
-        let watcher = Arc::clone(self);
-        let handle = tokio::spawn(async move {
-            match watcher
-                .handle_put_if_current(&mcid, &mut card, &operation, generation)
-                .await
-            {
-                Some(Ok(())) => {
-                    tracing::info!(
-                        model_name = card.name(),
-                        namespace = mcid.namespace,
-                        "Reconciled model registration"
-                    );
-                    watcher.notify_on_model.notify_waiters();
-                }
-                Some(Err(err)) => {
-                    tracing::error!(
-                        model_name = card.name(),
-                        namespace = mcid.namespace,
-                        error = format!("{err:#}"),
-                        "Model registration reconciliation retry failed"
-                    );
-                }
-                None => {
-                    tracing::debug!(
-                        key = %task_key,
-                        generation,
-                        "Skipping superseded model registration retry"
-                    );
-                }
-            }
-            watcher.prune_instance_operation(&task_key, &operation);
-        });
-
-        if let Some((_, old_put)) = self.pending_puts.remove(&instance_key) {
-            old_put.handle.abort();
-        }
-        self.pending_puts
-            .insert(instance_key, PendingPut { generation, handle });
-        true
-    }
-
-    /// Handle a worker removal. Cleans up per-namespace WorkerSets and the Model itself
-    /// when no instances remain. Returns the model name if the entire Model was removed.
-    async fn handle_delete(
+    /// Build a complete WorkerSet off-side. The controller is the only caller that may publish it.
+    async fn prepare_worker_set(
         &self,
-        mcid: &ModelCardInstanceId,
-        namespace_filter: &NamespaceFilter,
-        operation: Arc<InstanceOperation>,
-        generation: u64,
-    ) -> anyhow::Result<DeleteOutcome> {
-        let key = mcid.to_path();
-
-        let operation_guard = match tokio::time::timeout(
-            Duration::from_secs(60),
-            operation.lock.lock(),
-        )
-        .await
-        {
-            Ok(guard) => guard,
-            Err(_) => {
-                if !operation.is_current(generation) {
-                    self.prune_instance_operation(&key, &operation);
-                    return Ok(DeleteOutcome::Superseded);
-                }
-
-                if let Some((_, pending)) = self
-                    .pending_puts
-                    .remove_if(&key, |_, pending| pending.generation < generation)
-                {
-                    pending.handle.abort();
-                    let _ = pending.handle.await;
-                }
-                tracing::warn!(
-                    key = %key,
-                    "Timed out waiting for an earlier model registration; aborted it before delete"
-                );
-                operation.lock.lock().await
-            }
-        };
-
-        if !operation.is_current(generation) {
-            drop(operation_guard);
-            self.prune_instance_operation(&key, &operation);
-            tracing::debug!(
-                key = %key,
-                generation,
-                current_generation = operation.current_generation(),
-                "Skipping superseded model removal"
-            );
-            return Ok(DeleteOutcome::Superseded);
-        }
-
-        // An earlier put either released the operation lock or is waiting on
-        // it with an obsolete generation. Cancel its task before mutating the
-        // local card and WorkerSet state.
-        if let Some((_, pending)) = self
-            .pending_puts
-            .remove_if(&key, |_, pending| pending.generation < generation)
-        {
-            pending.handle.abort();
-            let _ = pending.handle.await;
-        }
-
-        let result = self.handle_delete_serialized(mcid, namespace_filter).await;
-        drop(operation_guard);
-        self.prune_instance_operation(&key, &operation);
-        result.map(DeleteOutcome::Processed)
-    }
-
-    async fn handle_delete_serialized(
-        &self,
-        mcid: &ModelCardInstanceId,
-        namespace_filter: &NamespaceFilter,
-    ) -> anyhow::Result<Option<String>> {
-        let key = mcid.to_path();
-
-        let card = match self.manager.get_model_card(&key) {
-            Some(card) => card,
-            None => {
-                // The card was never durably saved (e.g. an Added event whose handle_put failed
-                // before save, after the pre-spawn tracker addition). Reconcile tracker state at
-                // the right granularity:
-                //   - base worker card (`model_suffix == None`): the worker instance is gone, so
-                //     clear it entirely;
-                //   - LoRA-adapter card (`model_suffix == Some`): remove ONLY that adapter, using
-                //     the name recorded in `pending_lora_adds`, so a still-live worker's other
-                //     adapters/capacity are untouched (RR3-3 / R4-2).
-                use crate::kv_router::protocols::WorkerWithDpRank;
-                let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
-                let state_tracker = self
-                    .manager
-                    .lora_state_tracker_for(&model_card_endpoint_id(mcid));
-                if mcid.model_suffix.is_none() {
-                    state_tracker.handle_worker_removal(worker);
-                    // Sweep any pending fallback entries for this worker's LoRA cards so they
-                    // can't linger if their own remove events never arrive (RF-2).
-                    let prefix = format!("{}/", mcid.to_path());
-                    self.pending_lora_adds
-                        .retain(|k, _| !k.starts_with(&prefix));
-                } else if let Some((_, lora_name)) = self.pending_lora_adds.remove(&key) {
-                    state_tracker.handle_mdc_removal(worker, &lora_name);
-                }
-                tracing::warn!(
-                    key = %key,
-                    "ModelDeploymentCard absent during removal; reconciled LoRA tracker state from pending add"
-                );
-                return Ok(None);
-            }
-        };
-        let model_name = card.name().to_string();
-
-        // Complete the only fallible discovery query before removing local
-        // state. If discovery is temporarily unavailable, retaining the card
-        // lets the next reconciliation pass retry this stale entry instead of
-        // losing the key while leaving its WorkerSet behind.
-        let all_cards = self.all_cards().await.with_context(|| model_name.clone())?;
-        let active_instances = all_cards
-            .iter()
-            .filter(|(endpoint_id, card)| {
-                card.name() == model_name && namespace_filter.matches(&endpoint_id.namespace)
-            })
-            .collect::<Vec<_>>();
-        let card = match self.manager.remove_model_card(&key) {
-            Some(card) => card,
-            None => {
-                tracing::debug!(
-                    key = %key,
-                    "ModelDeploymentCard was removed by concurrent cleanup"
-                );
-                return Ok(None);
-            }
-        };
-
-        // Feed the LoRA state tracker now that any in-flight handle_put has completed and the
-        // card is available (N2 — avoids the race where a Removed event outran the add). A LoRA
-        // adapter card unregisters just that adapter; the base worker card means the worker
-        // instance is gone, so drop its capacity + all loaded-LoRA bookkeeping (F4/F5).
-        {
-            use crate::kv_router::protocols::WorkerWithDpRank;
-            let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
-            let state_tracker = self
-                .manager
-                .lora_state_tracker_for(&model_card_endpoint_id(mcid));
-            match card.lora {
-                Some(ref lora_info) => state_tracker.handle_mdc_removal(worker, &lora_info.name),
-                None => state_tracker.handle_worker_removal(worker),
-            }
-        }
-        // The card-based cleanup above is authoritative; drop the pending fallback entry for a
-        // LoRA card, or sweep all of this worker's suffixed entries for a base card (RF-2).
-        if card.lora.is_some() {
-            self.pending_lora_adds.remove(&key);
-        } else {
-            let prefix = format!("{}/", mcid.to_path());
-            self.pending_lora_adds
-                .retain(|k, _| !k.starts_with(&prefix));
-        }
-
-        let worker_namespace = &mcid.namespace;
-        let worker_component = &mcid.component;
-        let ws_key = worker_set_key(
-            &model_card_endpoint_id(mcid),
-            card.model_type,
-            card.worker_type,
-        );
-
-        // Check if instances of the SAME role and component remain in
-        // this namespace. In disaggregated deployments, prefill and
-        // decode are different components in the same namespace -- so
-        // checking only (ns, component) is necessary but not sufficient.
-        // Encode workers can share a (ns, component) with Aggregated, so
-        // we ALSO require the remaining instance to map to the same
-        // computed `ws_key` (which folds in worker_type for Encode). If
-        // we used only (ns, component), removing the last Encode
-        // instance from a namespace that still has an Aggregated worker
-        // in the same component would see "instances exist" and skip
-        // remove_worker_set, leaking the Encode WorkerSet forever.
-        let component_has_instances = active_instances.iter().any(|(eid, other_card)| {
-            eid.namespace == *worker_namespace
-                && eid.component == *worker_component
-                && worker_set_key(eid, other_card.model_type, other_card.worker_type) == ws_key
-        });
-
-        let endpoint_has_instances =
-            has_live_endpoint_card(&all_cards, worker_namespace, worker_component);
-
-        if !component_has_instances {
-            // No more workers of this component in this namespace — remove its WorkerSet
-            let removed = self.manager.remove_worker_set(&model_name, &ws_key);
-            if removed.is_some() {
-                tracing::info!(
-                    model_name,
-                    namespace = %worker_namespace,
-                    "Removed WorkerSet (no remaining instances in namespace)"
-                );
-                // Remove alias mirrors, but only ones this deployment owns — a
-                // declared alias that lost its reservation belongs to another model.
-                for alias in &card.aliases {
-                    if alias != &model_name && self.manager.alias_belongs_to(alias, &model_name) {
-                        self.manager.remove_worker_set(alias, &ws_key);
-                        self.manager.remove_model_if_empty(alias);
-                        self.manager.unregister_alias_if_empty(alias, &model_name);
-                    }
-                }
-            }
-
-            if !endpoint_has_instances {
-                self.manager
-                    .remove_hicache_caches(worker_namespace, worker_component);
-            }
-
-            // Activator-state cleanup depends on which component just went away.
-            //
-            // PREFILL teardown (cached endpoint is stale): drop everything for
-            // this key and deactivate the decode-side router so requests fall
-            // back to aggregated mode.
-            //
-            // DECODE teardown: keep `PrefillReady` (the cached endpoint is still
-            // valid for future decode rebuilds — that's PR 8965's primary
-            // contribution) but DO drop any stale `DecodeWaiting(sender)`. The
-            // sender pointed at a `oneshot::Receiver` held by the now-dropped
-            // PrefillRouter; leaving it in the map causes the next decode
-            // rebuild's `register_prefill_router` to find a stale `DecodeWaiting`,
-            // return `None`, and produce a WorkerSet with no PrefillRouter at
-            // all. The stale-DecodeWaiting cleanup tests cover this rebuild
-            // path.
-            match card.worker_type {
-                Some(WorkerType::Prefill) => {
-                    if removed.is_some() {
-                        self.manager
-                            .remove_prefill_activator(&model_name, worker_namespace);
-                    }
-                    self.manager
-                        .deactivate_prefill_router_for_decode(&model_name, worker_namespace);
-                }
-                Some(WorkerType::Encode) if card.model_type.is_empty() => {
-                    if removed.is_some() {
-                        self.manager
-                            .remove_encoder_activator(&model_name, worker_namespace);
-                    }
-                    self.manager
-                        .deactivate_encoder_router_for_consumers(&model_name, worker_namespace);
-                }
-                Some(WorkerType::Decode) => {
-                    // A decode registration may create a `DecodeWaiting`
-                    // activator before `handle_add_helper` installs its
-                    // WorkerSet. Always remove that waiter on teardown, even
-                    // when no WorkerSet was installed.
-                    self.manager
-                        .remove_decode_prefill_waiter(&model_name, worker_namespace);
-                    self.manager
-                        .remove_consumer_encoder_waiter(&model_name, worker_namespace);
-                }
-                Some(WorkerType::Aggregated) | Some(WorkerType::Encode) | None => {
-                    self.manager
-                        .remove_consumer_encoder_waiter(&model_name, worker_namespace);
-                }
-            }
-        }
-
-        // Check if the Model still has instances in any namespace
-        if !active_instances.is_empty() {
-            tracing::debug!(
-                model_name,
-                active_instance_count = active_instances.len(),
-                "Model has other active instances in other namespaces"
-            );
-            return Ok(None);
-        }
-
-        // No instances remain anywhere — remove the entire Model
-        let _ = self.manager.remove_model(&model_name);
-        // Same ownership rule: only remove alias models this deployment owns.
-        for alias in &card.aliases {
-            if alias != &model_name && self.manager.alias_belongs_to(alias, &model_name) {
-                let _ = self.manager.remove_model(alias);
-                self.manager.unregister_alias_if_empty(alias, &model_name);
-            }
-        }
-
-        if let Some(tx) = &self.model_update_tx {
-            for removed_card in removed_model_cards(&self.manager, &card) {
-                tx.send(ModelUpdate::Removed(removed_card)).await.ok();
-            }
-        }
-
-        Ok(Some(model_name))
-    }
-
-    // Handles a PUT event from store, this usually means adding a new model to the list of served
-    // models.
-    async fn handle_put(
-        &self,
-        mcid: &ModelCardInstanceId,
-        card: &mut ModelDeploymentCard,
-    ) -> anyhow::Result<()> {
-        // Check if this specific (model, namespace, type) WorkerSet already exists.
-        // If so, this is just another worker joining an existing set — no pipeline build needed.
-        let model_name = card.name().to_string();
-        let namespace = mcid.namespace.clone();
-        let ws_key = worker_set_key(
-            &model_card_endpoint_id(mcid),
-            card.model_type,
-            card.worker_type,
-        );
-
-        if let Some(model) = self.manager.get_model(&model_name)
-            && model.has_worker_set(&ws_key)
-        {
-            if !model.is_checksum_compatible(&ws_key, card.mdcsum()) {
-                tracing::error!(
-                    model_name = card.name(),
-                    namespace = namespace,
-                    new_checksum = card.mdcsum(),
-                    "Checksum for new worker does not match existing WorkerSet's checksum. \
-                     Drain all old workers in this namespace before deploying a new version."
-                );
-                return Err(anyhow::anyhow!(
-                    "Checksum mismatch for worker in namespace {namespace}"
-                ));
-            }
-            self.manager
-                .save_model_card(&mcid.to_path(), card.clone())?;
-            tracing::debug!(
-                model_name = card.name(),
-                namespace = namespace,
-                "Worker joined existing WorkerSet, skipping pipeline build"
-            );
-            return Ok(());
-        }
-
-        // Guard against concurrent pipeline construction for the same (model, namespace, type)
-        let registration_key = ModelManager::model_namespace_key(&model_name, &ws_key);
-        if !self
-            .registering_worker_sets
-            .insert(registration_key.clone())
-            && !self
-                .recover_concurrent_registration(
-                    mcid,
-                    card,
-                    &model_name,
-                    &namespace,
-                    &ws_key,
-                    &registration_key,
-                )
-                .await?
-        {
-            return Ok(());
-        }
-
-        // RAII guard ensures the registration key is removed even if
-        // do_worker_set_registration panics, preventing permanent poisoning.
-        // It also wakes any waiters in recover_concurrent_registration.
-        let _guard = RegistrationGuard {
-            set: &self.registering_worker_sets,
-            key: registration_key,
-            notify: &self.registration_notify,
-        };
-
-        self.do_worker_set_registration(mcid, card).await
-    }
-
-    /// Handle the case where another task is already building the pipeline for this
-    /// (model, namespace, type). This is a recovery path — it waits for the in-flight
-    /// registration to finish, then either joins the resulting WorkerSet or retries.
-    ///
-    /// Returns `true` if the caller should proceed with its own registration
-    /// (i.e. the other task failed), `false` if the worker was handled (joined or rejected).
-    async fn recover_concurrent_registration(
-        &self,
-        mcid: &ModelCardInstanceId,
-        card: &mut ModelDeploymentCard,
-        model_name: &str,
-        namespace: &str,
-        ws_key: &str,
-        registration_key: &str,
-    ) -> anyhow::Result<bool> {
-        // Wait for the in-flight registration to complete so we can validate
-        // the new worker's checksum. Without this, a concurrent worker with a
-        // mismatched checksum could sneak past the early check in `watch`.
-        //
-        // Uses a Notify + enable() loop instead of polling to wake up
-        // immediately when the RegistrationGuard drops, avoiding up to 100ms
-        // of unnecessary latency and wasted CPU cycles.
-        // An absolute deadline ensures spurious wakeups (from unrelated
-        // registrations sharing the same Notify) cannot extend the wait
-        // beyond 30 seconds.
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
-        loop {
-            let notified = self.registration_notify.notified();
-            tokio::pin!(notified);
-            // Register interest in the notification BEFORE checking the
-            // condition to avoid a race where the guard drops between
-            // our check and the .await.
-            notified.as_mut().enable();
-            if !self.registering_worker_sets.contains(registration_key) {
-                break;
-            }
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                break;
-            }
-            if tokio::time::timeout(remaining, notified).await.is_err() {
-                break;
-            }
-        }
-
-        // If we timed out and the other task is still running, bail out rather
-        // than proceeding with concurrent pipeline construction.
-        if self.registering_worker_sets.contains(registration_key) {
-            // Save the model card so handle_delete can find it for cleanup.
-            self.manager
-                .save_model_card(&mcid.to_path(), card.clone())?;
-            tracing::warn!(
-                model_name = card.name(),
-                namespace = namespace,
-                "Timed out waiting for concurrent registration to complete, skipping"
-            );
-            return Ok(false);
-        }
-
-        // Validate checksum against the registered model
-        if let Some(model) = self.manager.get_model(model_name)
-            && !model.is_checksum_compatible(ws_key, card.mdcsum())
-        {
-            tracing::error!(
-                model_name = card.name(),
-                namespace = namespace,
-                new_checksum = card.mdcsum(),
-                "Checksum for new worker does not match existing WorkerSet's checksum. \
-                 Drain all old workers in this namespace before deploying a new version."
-            );
-            return Ok(false);
-        }
-
-        // If the first registration failed or timed out, no WorkerSet exists.
-        // Fall through to do_worker_set_registration instead of becoming a ghost
-        // worker (registered in cards but with no serving pipeline).
-        if self
-            .manager
-            .get_model(model_name)
-            .is_none_or(|m| !m.has_worker_set(ws_key))
-        {
-            // Only the first waiter to re-insert the key should proceed with
-            // registration. Other waiters return false to avoid concurrent builds.
-            if !self
-                .registering_worker_sets
-                .insert(registration_key.to_string())
-            {
-                // Save the model card so handle_delete can find it for cleanup.
-                self.manager
-                    .save_model_card(&mcid.to_path(), card.clone())?;
-                tracing::debug!(
-                    model_name = card.name(),
-                    namespace = namespace,
-                    "Another waiter won the re-registration race, skipping"
-                );
-                return Ok(false);
-            }
-            tracing::warn!(
-                model_name = card.name(),
-                namespace = namespace,
-                "Concurrent registration produced no WorkerSet, retrying"
-            );
-            return Ok(true);
-        }
-
-        self.manager
-            .save_model_card(&mcid.to_path(), card.clone())?;
-        tracing::debug!(
-            model_name = card.name(),
-            namespace = namespace,
-            "Worker joined existing WorkerSet, skipping pipeline build"
-        );
-        Ok(false)
-    }
-
-    /// Build a complete WorkerSet with all engines for this (model, namespace)
-    /// and add it to the Model.
-    async fn do_worker_set_registration(
-        &self,
-        mcid: &ModelCardInstanceId,
-        card: &mut ModelDeploymentCard,
-    ) -> anyhow::Result<()> {
-        // Fast-fail before any expensive setup when the name is already reserved
-        // as another deployment's alias (`resolve_canonical_name` returns a
-        // different, canonical name only for a reserved alias). `add_worker_set`
-        // re-checks this atomically under `reservation_lock` and is the
-        // authoritative gate; rejecting here just avoids the config download,
-        // card save, and pipeline build for a name that cannot be claimed.
-        if self.manager.resolve_canonical_name(card.name()) != card.name() {
-            tracing::error!(
-                model_name = card.name(),
-                "Refusing to register: name is reserved as an alias of another deployment"
-            );
-            return Ok(());
-        }
+        spec: &GroupSpec,
+        admitted_ids: tokio::sync::watch::Receiver<Vec<u64>>,
+        cancellation: CancellationToken,
+    ) -> anyhow::Result<PreparedWorkerSet> {
+        let mcid = &spec.representative.mcid;
+        let mut prepared_card = spec.representative.card.clone();
+        let card = &mut prepared_card;
 
         card.download_config(self.local_model_path.as_deref())
             .await?;
@@ -1511,24 +503,23 @@ where
             .namespace(&mcid.namespace)?
             .component(&mcid.component)?;
         let endpoint = component.endpoint(&mcid.endpoint);
-        let client = endpoint.client().await?;
+        let client = endpoint
+            .client()
+            .await?
+            .with_admitted_instances_and_cancellation(admitted_ids, cancellation);
         let instance_watcher = client.instance_avail_watcher();
         tracing::debug!(
             model_name = card.name(),
             namespace = mcid.namespace,
             "building worker set pipeline"
         );
-        self.manager
-            .save_model_card(&mcid.to_path(), card.clone())?;
-
         let checksum = card.mdcsum();
         let namespace = mcid.namespace.clone();
-        let ws_key = worker_set_key(
-            &model_card_endpoint_id(mcid),
-            card.model_type,
-            card.worker_type,
+        let mut lease = PreparationLease::new(
+            self.manager.clone(),
+            card.name().to_string(),
+            namespace.clone(),
         );
-
         // Build the WorkerSet with all applicable engines
         let mut worker_set = WorkerSet::new(namespace.clone(), checksum.to_string(), card.clone());
         worker_set.set_endpoint_id(endpoint.id());
@@ -1546,23 +537,14 @@ where
                     card.model_input.as_str()
                 );
             }
-            self.manager
-                .add_worker_set(card.name(), &ws_key, worker_set);
-
-            if let Some(tx) = &self.model_update_tx {
-                tx.send(ModelUpdate::Added(card.clone())).await.ok();
-            }
-            self.manager.activate_encoder_router(
-                card.name(),
-                &namespace,
-                component.endpoint(&mcid.endpoint),
-            );
-            tracing::info!(
-                model_name = card.name(),
-                namespace = %namespace,
-                "Encode worker registered and router activated"
-            );
-            return Ok(());
+            return Ok(PreparedWorkerSet {
+                worker_set: Some(worker_set),
+                card: card.clone(),
+                activation: PreparedActivation::Encoder {
+                    endpoint: component.endpoint(&mcid.endpoint),
+                },
+                lease,
+            });
         }
 
         // worker_type-driven short circuit for Prefill.
@@ -1596,55 +578,15 @@ where
                 "Prefill worker detected, registering and activating prefill router"
             );
 
-            // No engine on the worker set — just lifecycle tracking so the
-            // prefill router can be activated/deactivated as workers come
-            // and go.
-            if !self
-                .manager
-                .add_worker_set(card.name(), &ws_key, worker_set)
-            {
-                tracing::error!(
-                    model_name = card.name(),
-                    "Refusing to register prefill worker: its name is reserved as an alias of \
-                     another deployment"
-                );
-                return Ok(());
-            }
-            // Mirror the prefill WorkerSet under any aliases so a disaggregated
-            // alias reports readiness like its primary (decode attaches its own).
-            self.attach_aliases(card, &ws_key);
-
-            if supports_encoder_result_handoff(card) {
-                self.manager.enable_encoder_routing(card.name(), &namespace);
-            }
-
-            if let Some(tx) = &self.model_update_tx {
-                tx.send(ModelUpdate::Added(card.clone())).await.ok();
-            }
-
-            // activate_prefill_router is keyed by deployment namespace (not
-            // ws_key) because it coordinates between decode and prefill
-            // worker sets that share the same deployment namespace but have
-            // different ws_keys (decode `{ns}:chat|completions:decode` vs
-            // prefill `{ns}::prefill`).
-            let endpoint = component.endpoint(&mcid.endpoint);
-            let Ok(()) = self
-                .manager
-                .activate_prefill_router(card.name(), &namespace, endpoint)
-            else {
-                tracing::warn!(
-                    model_name = card.name(),
-                    "Failed to activate prefill router - prefill worker may already be activated"
-                );
-                return Ok(());
-            };
-
-            tracing::info!(
-                model_name = card.name(),
-                "Prefill worker registered and router activated successfully"
-            );
-
-            return Ok(());
+            return Ok(PreparedWorkerSet {
+                worker_set: Some(worker_set),
+                card: card.clone(),
+                activation: PreparedActivation::Prefill {
+                    endpoint: component.endpoint(&mcid.endpoint),
+                    enable_encoder_routing: supports_encoder_result_handoff(card),
+                },
+                lease,
+            });
         }
 
         if card.model_input == ModelInput::Tokens
@@ -1693,8 +635,9 @@ where
                     );
                     Some(
                         self.manager
-                            .kv_chooser_for_with_selector(
+                            .kv_chooser_for_with_selector_and_client(
                                 &endpoint,
+                                client.clone(),
                                 card.kv_cache_block_size,
                                 selector,
                                 Some(router_config.kv_router_config.clone()),
@@ -1743,6 +686,7 @@ where
             let prefill_receiver = if needs_preprocessed_routing
                 && effective_worker_type(card.worker_type, card.model_type) == WorkerType::Decode
             {
+                lease.remove_prefill_waiter = true;
                 match self
                     .manager
                     .register_prefill_router(&model_name, &namespace, &endpoint.id())
@@ -1793,6 +737,7 @@ where
                 if supports_encoder_result_handoff(card) {
                     self.manager.enable_encoder_routing(&model_name, &namespace);
                 }
+                lease.remove_encoder_waiter = true;
                 self.manager
                     .register_encoder_router(&model_name, &namespace)
                     .map(|rx| EncoderRouter::new(rx, model_name.clone(), namespace.clone()))
@@ -2127,163 +1072,282 @@ where
             );
         }
 
-        // Add the completed WorkerSet to the Model, then mirror it under any
-        // configured aliases so alias names resolve, list, and report readiness
-        // exactly like the primary.
-        if !self
-            .manager
-            .add_worker_set(card.name(), &ws_key, worker_set)
+        Ok(PreparedWorkerSet {
+            worker_set: Some(worker_set),
+            card: card.clone(),
+            activation: PreparedActivation::None,
+            lease,
+        })
+    }
+
+    fn emit_update(&self, update: ModelUpdate) {
+        if let Some(dispatch) = self.model_update_dispatch.lock().as_ref() {
+            let _ = dispatch.send(update);
+        }
+    }
+}
+
+#[async_trait]
+impl<Sel> ControllerHost for ModelWatcher<Sel>
+where
+    Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
+{
+    type Prepared = PreparedWorkerSet;
+
+    fn normalize(
+        &self,
+        instance: DiscoveryInstance,
+        namespace_filter: &NamespaceFilter,
+    ) -> anyhow::Result<Option<DesiredInstance>> {
+        let mcid = model_card_instance_id(&instance)?;
+        if !namespace_filter.matches(&mcid.namespace) {
+            return Ok(None);
+        }
+
+        let mut card = instance.deserialize_model::<ModelDeploymentCard>()?;
+        self.apply_tokenizer_backend_override(&mut card);
+        validate_card_shape(&card)?;
+        let endpoint_id = model_card_endpoint_id(&mcid);
+        let group_key = GroupKey {
+            model_name: card.name().to_string(),
+            worker_set_key: worker_set_key(&endpoint_id, card.model_type, card.worker_type),
+        };
+        let fingerprint = materialization_fingerprint(&card, &self.router_config)?;
+        Ok(Some(DesiredInstance {
+            key: mcid.to_path(),
+            mcid,
+            endpoint_id,
+            card,
+            group_key,
+            fingerprint,
+        }))
+    }
+
+    async fn prepare(
+        &self,
+        spec: GroupSpec,
+        admitted_ids: tokio::sync::watch::Receiver<Vec<u64>>,
+        cancellation: CancellationToken,
+    ) -> anyhow::Result<Self::Prepared> {
+        self.prepare_worker_set(&spec, admitted_ids, cancellation)
+            .await
+    }
+
+    fn commit_group(
+        &self,
+        spec: &GroupSpec,
+        mut prepared: Self::Prepared,
+        members: &[DesiredInstance],
+    ) -> anyhow::Result<()> {
+        let worker_set = prepared
+            .worker_set
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("prepared WorkerSet was already consumed"))?;
+        let mut committed_members = members
+            .iter()
+            .map(|member| (member.key.clone(), member.card.clone()))
+            .collect::<Vec<_>>();
+        if let Some((_, card)) = committed_members
+            .iter_mut()
+            .find(|(key, _)| key == &spec.representative.key)
         {
-            tracing::error!(
-                model_name = card.name(),
-                "Refusing to register model: its name is reserved as an alias of another deployment"
-            );
-            return Ok(());
+            *card = prepared.card.clone();
         }
-        self.attach_aliases(card, &ws_key);
-
-        if let Some(tx) = &self.model_update_tx {
-            tx.send(ModelUpdate::Added(card.clone())).await.ok();
+        self.manager.commit_discovery_group(
+            &spec.key.id(),
+            &spec.key.worker_set_key,
+            worker_set,
+            committed_members,
+            || {
+                let namespace = &spec.representative.mcid.namespace;
+                match &prepared.activation {
+                    PreparedActivation::None => {}
+                    PreparedActivation::Prefill {
+                        endpoint,
+                        enable_encoder_routing,
+                    } => {
+                        if *enable_encoder_routing {
+                            self.manager
+                                .enable_encoder_routing(prepared.card.name(), namespace);
+                        }
+                        if let Err(error) = self.manager.activate_prefill_router(
+                            prepared.card.name(),
+                            namespace,
+                            endpoint.clone(),
+                        ) {
+                            tracing::warn!(
+                                model_name = prepared.card.name(),
+                                %error,
+                                "Prefill group committed but router activation was already satisfied"
+                            );
+                        }
+                    }
+                    PreparedActivation::Encoder { endpoint } => {
+                        self.manager.activate_encoder_router(
+                            prepared.card.name(),
+                            namespace,
+                            endpoint.clone(),
+                        );
+                    }
+                }
+            },
+        )?;
+        prepared.lease.disarm();
+        self.emit_update(ModelUpdate::Added(prepared.card.clone()));
+        if prepared.card.model_type.supports_chat() {
+            self.notify_on_model.notify_waiters();
         }
-
+        tracing::info!(
+            model_name = prepared.card.name(),
+            group = %spec.key.id(),
+            members = members.len(),
+            "Committed discovered model group"
+        );
         Ok(())
     }
 
-    /// Register `card`'s aliases against its primary name and mirror the just-
-    /// added WorkerSet under each, so an alias resolves to the primary and lists
-    /// / reports readiness identically. Shared by the aggregated/decode and the
-    /// disaggregated prefill registration paths so a disaggregated alias gets
-    /// both the decode and prefill WorkerSets (the prefill worker registers on
-    /// its own early-return path and would otherwise skip alias attachment).
-    ///
-    /// `register_alias` atomically reserves the name (rejecting a collision with a
-    /// live primary or a different primary's alias); only a successful reservation
-    /// is followed by the WorkerSet attach. The reservation holds the name against
-    /// any concurrent primary claim, so the subsequent attach cannot be refused —
-    /// a refusal would indicate a broken invariant and is only logged.
-    fn attach_aliases(&self, card: &ModelDeploymentCard, ws_key: &str) {
-        if card.aliases.is_empty() {
-            return;
-        }
-        let Some(model) = self.manager.get_model(card.name()) else {
-            tracing::warn!(
-                model_name = card.name(),
-                "Model missing right after registration; aliases not attached"
-            );
-            return;
-        };
-        let Some(ws_arc) = model.get_worker_set(ws_key) else {
-            tracing::warn!(
-                model_name = card.name(),
-                ws_key,
-                "WorkerSet missing right after registration; aliases not attached"
-            );
-            return;
-        };
-        for alias in &card.aliases {
-            if alias == card.name() {
-                continue;
-            }
-            if !self.manager.register_alias(alias, card.name()) {
-                continue;
-            }
-            tracing::info!(model_name = card.name(), alias, "Registering model alias");
-            if !self
-                .manager
-                .add_worker_set_arc(alias, ws_key, ws_arc.clone())
-            {
-                // Unreachable: register_alias reserved this name, so no concurrent
-                // primary can occupy it and the attach cannot be refused.
-                tracing::error!(
-                    model_name = card.name(),
-                    alias,
-                    "Alias reserved but WorkerSet attach was refused — invariant violated"
-                );
-            }
-        }
+    fn add_group_member(&self, key: &GroupKey, member: &DesiredInstance) -> anyhow::Result<()> {
+        self.manager
+            .add_discovery_group_member(&key.id(), member.key.clone(), member.card.clone())
     }
 
-    /// All the registered ModelDeploymentCard with the EndpointId they are attached to, one per instance
-    async fn all_cards(&self) -> anyhow::Result<Vec<(EndpointId, ModelDeploymentCard)>> {
-        let discovery = self.drt.discovery();
-        let instances = discovery.list(DiscoveryQuery::AllModels).await?;
+    fn remove_group_member(&self, key: &GroupKey, instance_key: &str) -> anyhow::Result<()> {
+        self.manager
+            .remove_discovery_group_member(&key.id(), instance_key)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "instance {instance_key:?} missing from committed group {:?}",
+                    key.id()
+                )
+            })?;
+        Ok(())
+    }
 
-        let mut results = Vec::with_capacity(instances.len());
-        for instance in instances {
-            match instance.deserialize_model::<ModelDeploymentCard>() {
-                Ok(mut card) => {
-                    self.apply_tokenizer_backend_override(&mut card);
-                    let endpoint_id = match &instance {
-                        dynamo_runtime::discovery::DiscoveryInstance::Model {
-                            namespace,
-                            component,
-                            endpoint,
-                            ..
-                        } => EndpointId {
-                            namespace: namespace.clone(),
-                            component: component.clone(),
-                            name: endpoint.clone(),
-                        },
-                        _ => {
-                            tracing::error!(
-                                "Unexpected discovery instance type (expected ModelCard)"
-                            );
-                            continue;
-                        }
-                    };
-                    results.push((endpoint_id, card));
+    fn remove_group(&self, key: &GroupKey) {
+        let Some(removed) = self.manager.remove_discovery_group(&key.id(), |removed| {
+            let card = &removed.representative;
+            let namespace = &removed.namespace;
+            match effective_worker_type(card.worker_type, card.model_type) {
+                WorkerType::Prefill => {
+                    self.manager
+                        .remove_prefill_activator(card.name(), namespace);
+                    self.manager
+                        .deactivate_prefill_router_for_decode(card.name(), namespace);
                 }
-                Err(err) => {
-                    tracing::error!(%err, "Failed to deserialize model card");
-                    continue;
+                WorkerType::Encode if card.model_type.is_empty() => {
+                    self.manager
+                        .remove_encoder_activator(card.name(), namespace);
+                    self.manager
+                        .deactivate_encoder_router_for_consumers(card.name(), namespace);
+                }
+                WorkerType::Decode => {
+                    self.manager
+                        .remove_decode_prefill_waiter(card.name(), namespace);
+                    self.manager
+                        .remove_consumer_encoder_waiter(card.name(), namespace);
+                }
+                WorkerType::Aggregated | WorkerType::Encode => {
+                    self.manager
+                        .remove_consumer_encoder_waiter(card.name(), namespace);
                 }
             }
+        }) else {
+            return;
+        };
+        let removed_members = removed.cards.len();
+        let card = removed.representative;
+        for removed_card in removed_model_cards(&self.manager, &card) {
+            self.emit_update(ModelUpdate::Removed(removed_card));
         }
-        Ok(results)
+        tracing::info!(
+            model_name = card.name(),
+            group = %key.id(),
+            members = removed_members,
+            "Removed discovered model group"
+        );
     }
 
-    pub async fn cards_for_model(
-        &self,
-        model_name: &str,
-        namespace_filter: &NamespaceFilter,
-    ) -> anyhow::Result<Vec<ModelDeploymentCard>> {
-        Ok(self
-            .cards_for_model_with_endpoints(model_name, namespace_filter)
-            .await?
-            .into_iter()
-            .map(|(_, card)| card)
-            .collect())
+    fn discard_prepared(&self, prepared: Self::Prepared) {
+        drop(prepared);
     }
 
-    /// Like `cards_for_model` but also returns the EndpointId for each card,
-    /// allowing callers to filter by namespace.
-    async fn cards_for_model_with_endpoints(
+    fn project_lora(
         &self,
-        model_name: &str,
-        namespace_filter: &NamespaceFilter,
-    ) -> anyhow::Result<Vec<(EndpointId, ModelDeploymentCard)>> {
-        let mut all = self.all_cards().await?;
-        all.retain(|(endpoint_id, card)| {
-            let matches_name = card.name() == model_name;
-            let matches_namespace = namespace_filter.matches(&endpoint_id.namespace);
-            matches_name && matches_namespace
-        });
-        Ok(all)
+        endpoint_id: &EndpointId,
+        reset_worker_ids: &HashSet<u64>,
+        desired: &[(ModelCardInstanceId, ModelDeploymentCard)],
+    ) {
+        use crate::kv_router::protocols::WorkerWithDpRank;
+
+        let tracker = self.manager.lora_state_tracker_for(endpoint_id);
+        for worker_id in reset_worker_ids {
+            tracker.handle_worker_removal(WorkerWithDpRank::new(*worker_id, 0));
+        }
+        let mut desired = desired.to_vec();
+        desired.sort_by_key(|(mcid, _)| (mcid.model_suffix.is_some(), mcid.to_path()));
+        for (mcid, card) in desired {
+            seed_lora_state_from_card(&tracker, WorkerWithDpRank::new(mcid.instance_id, 0), &card);
+        }
     }
+}
+
+fn validate_card_shape(card: &ModelDeploymentCard) -> anyhow::Result<()> {
+    anyhow::ensure!(!card.name().is_empty(), "model name cannot be empty");
+    let worker_type = effective_worker_type(card.worker_type, card.model_type);
+    if worker_type == WorkerType::Prefill {
+        anyhow::ensure!(
+            card.model_input == ModelInput::Tokens,
+            "prefill workers must use token input"
+        );
+        return Ok(());
+    }
+    if worker_type == WorkerType::Encode && card.model_type.is_empty() {
+        anyhow::ensure!(
+            card.model_input == ModelInput::Tokens,
+            "surface-less encode workers must use token input"
+        );
+        return Ok(());
+    }
+
+    let supported = card.model_type.is_empty()
+        || card.model_input == ModelInput::Text
+        || (card.model_input == ModelInput::Tokens
+            && (card.model_type.supports_chat()
+                || card.model_type.supports_completions()
+                || card.model_type.supports_embedding()))
+        || (card.model_input == ModelInput::Tensor && card.model_type.supports_tensor());
+    anyhow::ensure!(
+        supported,
+        "unsupported model configuration: {} with {} input",
+        card.model_type,
+        card.model_input.as_str()
+    );
+    Ok(())
+}
+
+fn materialization_fingerprint(
+    card: &ModelDeploymentCard,
+    default_router_config: &RouterConfig,
+) -> anyhow::Result<String> {
+    let mut normalized = card.clone();
+    normalized.worker_type = Some(effective_worker_type(card.worker_type, card.model_type));
+    if normalized.router_config.is_none() {
+        normalized.router_config = Some(default_router_config.clone());
+    }
+    let bytes = serde_json::to_vec(&normalized)?;
+    Ok(blake3::hash(&bytes).to_string())
 }
 
 /// Seed the LoRA state tracker from a worker's MDC.
 ///
-/// - Adapter card (`card.lora` is `Some`): register the loaded adapter (which also records the
-///   worker's capacity) and return the adapter name so the caller can track it for failed-save
-///   removal reconciliation.
+/// - Adapter card (`card.lora` is `Some`): register the loaded adapter and worker capacity.
 /// - Base worker card advertising `runtime_config.max_gpu_lora_count`: seed capacity-only (no
 ///   phantom adapter) so the controller sees idle-but-LoRA-capable workers before the first
 ///   adapter load. Returns `None`.
 /// - Otherwise (non-LoRA worker): no-op, returns `None`.
 ///
-/// Split out of the discovery loop so the base-card capacity data flow is unit-testable without
-/// constructing a full `ModelWatcher`.
+/// The controller clears and rebuilds an endpoint's desired projection on every source-card
+/// change, so removals do not depend on separately remembered pending additions.
 fn seed_lora_state_from_card(
     state_tracker: &crate::lora::LoraStateTracker,
     worker: crate::kv_router::protocols::WorkerWithDpRank,
@@ -2314,18 +1378,6 @@ mod tests {
             component: "workers".to_string(),
             name: name.to_string(),
         }
-    }
-
-    #[test]
-    fn endpoint_liveness_considers_all_models() {
-        // This is the discovery snapshot after the last adapter card was removed: its base
-        // model remains on the same worker endpoint, so the endpoint is still live.
-        let cards = vec![(
-            test_endpoint_id("generate"),
-            ModelDeploymentCard::with_name_only("base-model"),
-        )];
-
-        assert!(has_live_endpoint_card(&cards, "ns1", "workers"));
     }
 
     #[test]
@@ -2374,7 +1426,7 @@ mod tests {
             .await
             .unwrap();
         let manager = Arc::new(ModelManager::new());
-        let watcher = ModelWatcher::new(
+        let watcher = Arc::new(ModelWatcher::new(
             drt,
             manager.clone(),
             RouterConfig::default(),
@@ -2385,7 +1437,7 @@ mod tests {
             Arc::new(Metrics::new_with_prefix(Some(
                 "watcher_mixed_text_test".to_string(),
             ))),
-        );
+        ));
         let mcid = ModelCardInstanceId {
             namespace: "mixed-text-ns".to_string(),
             component: "workers".to_string(),
@@ -2398,12 +1450,33 @@ mod tests {
         card.model_type = ModelType::Chat | ModelType::Classify | ModelType::Pooling;
         card.worker_type = Some(WorkerType::Aggregated);
 
-        watcher
-            .do_worker_set_registration(&mcid, &mut card)
+        let endpoint_id = model_card_endpoint_id(&mcid);
+        let key = GroupKey {
+            model_name: card.name().to_string(),
+            worker_set_key: worker_set_key(&endpoint_id, card.model_type, card.worker_type),
+        };
+        let desired = DesiredInstance {
+            key: mcid.to_path(),
+            mcid,
+            endpoint_id,
+            fingerprint: materialization_fingerprint(&card, &RouterConfig::default()).unwrap(),
+            card,
+            group_key: key.clone(),
+        };
+        let spec = GroupSpec {
+            key,
+            fingerprint: desired.fingerprint.clone(),
+            generation: 1,
+            representative: desired.clone(),
+        };
+        let (_admission_tx, admission_rx) = tokio::sync::watch::channel(vec![1]);
+        let prepared = watcher
+            .prepare_worker_set(&spec, admission_rx, CancellationToken::new())
             .await
             .unwrap();
+        watcher.commit_group(&spec, prepared, &[desired]).unwrap();
 
-        let model = manager.get_model(card.name()).unwrap();
+        let model = manager.get_model("mixed-text-model").unwrap();
         assert!(model.has_chat_engine());
         assert!(model.has_classify_engine());
         assert!(model.has_pooling_engine());
@@ -2452,8 +1525,7 @@ mod tests {
 
     #[test]
     fn adapter_card_registers_adapter_and_returns_name() {
-        // An adapter card registers the loaded adapter (+capacity) and returns its name so the
-        // caller can track it in pending_lora_adds.
+        // An adapter card registers the loaded adapter and its capacity in the desired ledger.
         let st = crate::lora::LoraStateTracker::new();
         let worker = crate::kv_router::protocols::WorkerWithDpRank::new(3, 0);
         let mut card = ModelDeploymentCard::with_name_only("base-model");
@@ -2466,101 +1538,6 @@ mod tests {
         assert_eq!(adapter.as_deref(), Some("adapter-x"));
         assert!(st.is_loaded("adapter-x", &worker));
         assert_eq!(st.total_lora_slots(), 2);
-    }
-
-    #[test]
-    fn registration_is_complete_only_after_card_and_worker_set_exist() {
-        let manager = ModelManager::new();
-        let mcid = ModelCardInstanceId {
-            namespace: "deployment-a".to_string(),
-            component: "backend".to_string(),
-            endpoint: "generate".to_string(),
-            instance_id: 7,
-            model_suffix: None,
-        };
-        let mut card = ModelDeploymentCard::with_name_only("llama");
-        card.model_type = ModelType::Chat;
-        card.worker_type = Some(WorkerType::Aggregated);
-
-        assert!(!is_registration_complete(&manager, &mcid, &card));
-
-        // `do_worker_set_registration` saves the card before all pipeline
-        // construction has completed. A failure after this point must remain a
-        // reconciliation candidate.
-        manager
-            .save_model_card(&mcid.to_path(), card.clone())
-            .unwrap();
-        assert!(!is_registration_complete(&manager, &mcid, &card));
-
-        let ws_key = worker_set_key(
-            &model_card_endpoint_id(&mcid),
-            card.model_type,
-            card.worker_type,
-        );
-        manager.add_worker_set(
-            card.name(),
-            &ws_key,
-            WorkerSet::new(
-                mcid.namespace.clone(),
-                "stale-checksum".to_string(),
-                card.clone(),
-            ),
-        );
-        assert!(
-            !is_registration_complete(&manager, &mcid, &card),
-            "a WorkerSet from a different model-card checksum must be retried"
-        );
-
-        manager.add_worker_set(
-            card.name(),
-            &ws_key,
-            WorkerSet::new(
-                mcid.namespace.clone(),
-                card.mdcsum().to_string(),
-                card.clone(),
-            ),
-        );
-        assert!(is_registration_complete(&manager, &mcid, &card));
-
-        manager.remove_model_card(&mcid.to_path());
-        assert!(!is_registration_complete(&manager, &mcid, &card));
-    }
-
-    #[test]
-    fn stale_cleanup_cannot_reserve_after_a_new_registration() {
-        let operation = InstanceOperation::default();
-        let snapshot_generation = operation.current_generation();
-
-        let registration_generation = operation.begin();
-
-        assert!(operation.is_current(registration_generation));
-        assert_eq!(operation.reserve_after(snapshot_generation), None);
-    }
-
-    #[tokio::test]
-    async fn newer_registration_waits_for_cleanup_and_remains_current() {
-        let operation = Arc::new(InstanceOperation::default());
-        let cleanup_generation = operation
-            .reserve_after(operation.current_generation())
-            .expect("cleanup should reserve the unchanged snapshot generation");
-        let cleanup_guard = operation.lock.lock().await;
-
-        let registration_generation = operation.begin();
-        assert!(!operation.is_current(cleanup_generation));
-
-        let registration_operation = Arc::clone(&operation);
-        let registration = tokio::spawn(async move {
-            let _guard = registration_operation.lock.lock().await;
-            registration_operation.is_current(registration_generation)
-        });
-        tokio::task::yield_now().await;
-        assert!(
-            !registration.is_finished(),
-            "the newer registration must wait until cleanup releases the instance lock"
-        );
-
-        drop(cleanup_guard);
-        assert!(registration.await.unwrap());
     }
 
     #[test]
@@ -2797,6 +1774,25 @@ mod tests {
         assert_eq!(
             effective_worker_type(None, ModelType::empty()),
             WorkerType::Aggregated
+        );
+    }
+
+    #[test]
+    fn materialization_fingerprint_normalizes_legacy_worker_role() {
+        let mut legacy = ModelDeploymentCard::with_name_only("model");
+        legacy.model_type = ModelType::Prefill;
+        let mut current = legacy.clone();
+        current.worker_type = Some(WorkerType::Prefill);
+
+        assert_eq!(
+            materialization_fingerprint(&legacy, &RouterConfig::default()).unwrap(),
+            materialization_fingerprint(&current, &RouterConfig::default()).unwrap()
+        );
+
+        current.runtime_config.max_gpu_lora_count = Some(4);
+        assert_ne!(
+            materialization_fingerprint(&legacy, &RouterConfig::default()).unwrap(),
+            materialization_fingerprint(&current, &RouterConfig::default()).unwrap()
         );
     }
 

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use dynamo_runtime::{component::Endpoint, protocols::EndpointId};
 use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     discovery::KvWorkerMonitor,
@@ -73,6 +74,9 @@ pub struct WorkerSet {
     /// Watcher for available instance IDs (from the Client's discovery watch).
     /// None for in-process models (http/grpc) which don't have a discovery client.
     instance_count_rx: Option<watch::Receiver<Vec<u64>>>,
+
+    /// Cancels background work created while materializing this WorkerSet.
+    lifecycle_cancellation: Option<CancellationToken>,
 }
 
 impl WorkerSet {
@@ -98,6 +102,7 @@ impl WorkerSet {
             prefill_router: None,
             encoder_router: None,
             instance_count_rx: None,
+            lifecycle_cancellation: None,
         }
     }
 
@@ -250,6 +255,18 @@ impl WorkerSet {
     /// Must be called before the WorkerSet is wrapped in Arc.
     pub fn set_instance_watcher(&mut self, rx: watch::Receiver<Vec<u64>>) {
         self.instance_count_rx = Some(rx);
+    }
+
+    pub(crate) fn set_lifecycle_cancellation(&mut self, cancellation: CancellationToken) {
+        self.lifecycle_cancellation = Some(cancellation);
+    }
+}
+
+impl Drop for WorkerSet {
+    fn drop(&mut self) {
+        if let Some(cancellation) = self.lifecycle_cancellation.take() {
+            cancellation.cancel();
+        }
     }
 }
 

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use dynamo_runtime::protocols::EndpointId;
+use dynamo_runtime::{component::Endpoint, protocols::EndpointId};
 use tokio::sync::watch;
 
 use crate::{
@@ -36,6 +36,9 @@ pub struct WorkerSet {
     /// Exact serving pool identity. Discovery-backed WorkerSets always set
     /// this; in-process models have no distributed endpoint.
     endpoint_id: Option<EndpointId>,
+
+    /// Endpoint handle used only by committed topology reconciliation.
+    topology_endpoint: Option<Endpoint>,
 
     /// MDC checksum for this set's configuration
     mdcsum: String,
@@ -77,6 +80,7 @@ impl WorkerSet {
         Self {
             namespace,
             endpoint_id: None,
+            topology_endpoint: None,
             mdcsum,
             card,
             chat_engine: None,
@@ -105,8 +109,13 @@ impl WorkerSet {
         self.endpoint_id.as_ref()
     }
 
-    pub(crate) fn set_endpoint_id(&mut self, endpoint_id: EndpointId) {
-        self.endpoint_id = Some(endpoint_id);
+    pub(crate) fn set_topology_endpoint(&mut self, endpoint: Endpoint) {
+        self.endpoint_id = Some(endpoint.id());
+        self.topology_endpoint = Some(endpoint);
+    }
+
+    pub(crate) fn topology_endpoint(&self) -> Option<&Endpoint> {
+        self.topology_endpoint.as_ref()
     }
 
     pub fn mdcsum(&self) -> &str {

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -349,7 +349,9 @@ impl WorkerSet {
             videos_engine: lora_context_engine(&self.videos_engine, &lora_name),
             audios_engine: lora_context_engine(&self.audios_engine, &lora_name),
             tensor_engine: lora_context_engine(&self.tensor_engine, &lora_name),
-            realtime_engine: self.realtime_engine.clone(),
+            // Realtime is bidirectional, so the server-streaming LoRA context wrapper cannot
+            // inject the adapter identity. Fail closed instead of serving the base weights.
+            realtime_engine: None,
             generate_engine,
             worker_monitor: self.worker_monitor.clone(),
             prefill_router: self.prefill_router.clone(),
@@ -486,6 +488,22 @@ mod tests {
             observed_lora.lock().unwrap().as_deref(),
             Some("adapter-model")
         );
+    }
+
+    #[test]
+    fn adapter_view_does_not_advertise_unwrapped_realtime_engine() {
+        let mut base = make_worker_set("ns1", "abc123");
+        base.realtime_engine = Some(Arc::new(crate::engines::EchoBidirectionalEngine));
+        let mut adapter_card = ModelDeploymentCard::with_name_only("adapter-model");
+        adapter_card.lora = Some(crate::model_card::LoraInfo {
+            name: "adapter-model".to_string(),
+            max_gpu_lora_count: Some(4),
+        });
+
+        let adapter = base.adapter_view(adapter_card);
+
+        assert!(base.has_realtime_engine());
+        assert!(!adapter.has_realtime_engine());
     }
 
     #[test]

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -7,6 +7,9 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use dynamo_runtime::engine::{AsyncEngine, Data};
+use dynamo_runtime::pipeline::{Error, ManyOut, SingleIn};
 use dynamo_runtime::{component::Endpoint, protocols::EndpointId};
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
@@ -28,6 +31,63 @@ use crate::{
         },
     },
 };
+
+type StreamingEngine<Req, Resp> = Arc<dyn AsyncEngine<SingleIn<Req>, ManyOut<Resp>, Error>>;
+
+struct LoraContextEngine<Req: Data, Resp: Data> {
+    inner: StreamingEngine<Req, Resp>,
+    lora_name: String,
+}
+
+#[async_trait]
+impl<Req: Data, Resp: Data> AsyncEngine<SingleIn<Req>, ManyOut<Resp>, Error>
+    for LoraContextEngine<Req, Resp>
+{
+    async fn generate(&self, mut request: SingleIn<Req>) -> Result<ManyOut<Resp>, Error> {
+        request.insert(
+            crate::preprocessor::LORA_NAME_CONTEXT_KEY,
+            self.lora_name.clone(),
+        );
+        self.inner.generate(request).await
+    }
+}
+
+struct LoraGenerateEngine {
+    inner: GenerateStreamingEngine,
+    lora_name: String,
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<crate::protocols::common::preprocessor::PreprocessedRequest>,
+        ManyOut<crate::types::Annotated<crate::protocols::common::llm_backend::LLMEngineOutput>>,
+        Error,
+    > for LoraGenerateEngine
+{
+    async fn generate(
+        &self,
+        mut request: SingleIn<crate::protocols::common::preprocessor::PreprocessedRequest>,
+    ) -> Result<
+        ManyOut<crate::types::Annotated<crate::protocols::common::llm_backend::LLMEngineOutput>>,
+        Error,
+    > {
+        request.routing.get_or_insert_default().lora_name = Some(self.lora_name.clone());
+        self.inner.generate(request).await
+    }
+}
+
+fn lora_context_engine<Req: Data, Resp: Data>(
+    engine: &Option<StreamingEngine<Req, Resp>>,
+    lora_name: &str,
+) -> Option<StreamingEngine<Req, Resp>> {
+    engine.as_ref().map(|inner| {
+        Arc::new(LoraContextEngine {
+            inner: inner.clone(),
+            lora_name: lora_name.to_string(),
+        }) as Arc<dyn AsyncEngine<SingleIn<Req>, ManyOut<Resp>, Error>>
+    })
+}
 
 /// A set of workers from the same namespace/configuration with their own pipeline.
 pub struct WorkerSet {
@@ -260,6 +320,44 @@ impl WorkerSet {
     pub(crate) fn set_lifecycle_cancellation(&mut self, cancellation: CancellationToken) {
         self.lifecycle_cancellation = Some(cancellation);
     }
+
+    pub(crate) fn adapter_view(&self, card: ModelDeploymentCard) -> Self {
+        let lora_name = card
+            .lora
+            .as_ref()
+            .expect("adapter views require LoRA metadata")
+            .name
+            .clone();
+        let generate_engine = self.generate_engine.as_ref().map(|inner| {
+            Arc::new(LoraGenerateEngine {
+                inner: inner.clone(),
+                lora_name: lora_name.clone(),
+            }) as GenerateStreamingEngine
+        });
+        Self {
+            namespace: self.namespace.clone(),
+            endpoint_id: self.endpoint_id.clone(),
+            topology_endpoint: self.topology_endpoint.clone(),
+            mdcsum: self.mdcsum.clone(),
+            card,
+            chat_engine: lora_context_engine(&self.chat_engine, &lora_name),
+            completions_engine: lora_context_engine(&self.completions_engine, &lora_name),
+            embeddings_engine: lora_context_engine(&self.embeddings_engine, &lora_name),
+            classify_engine: lora_context_engine(&self.classify_engine, &lora_name),
+            pooling_engine: lora_context_engine(&self.pooling_engine, &lora_name),
+            images_engine: lora_context_engine(&self.images_engine, &lora_name),
+            videos_engine: lora_context_engine(&self.videos_engine, &lora_name),
+            audios_engine: lora_context_engine(&self.audios_engine, &lora_name),
+            tensor_engine: lora_context_engine(&self.tensor_engine, &lora_name),
+            realtime_engine: self.realtime_engine.clone(),
+            generate_engine,
+            worker_monitor: self.worker_monitor.clone(),
+            prefill_router: self.prefill_router.clone(),
+            encoder_router: self.encoder_router.clone(),
+            instance_count_rx: self.instance_count_rx.clone(),
+            lifecycle_cancellation: None,
+        }
+    }
 }
 
 impl Drop for WorkerSet {
@@ -293,7 +391,7 @@ mod tests {
     use async_trait::async_trait;
     use dynamo_runtime::engine::AsyncEngine;
     use dynamo_runtime::pipeline::{Error, ManyOut, SingleIn};
-    use std::marker::PhantomData;
+    use std::{marker::PhantomData, sync::Mutex};
 
     fn make_worker_set(namespace: &str, mdcsum: &str) -> WorkerSet {
         WorkerSet::new(
@@ -327,11 +425,67 @@ mod tests {
         }
     }
 
+    struct CaptureGenerateEngine {
+        observed_lora: Arc<Mutex<Option<String>>>,
+    }
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for CaptureGenerateEngine
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            *self.observed_lora.lock().unwrap() = request
+                .routing
+                .as_ref()
+                .and_then(|routing| routing.lora_name.clone());
+            Err(anyhow::anyhow!("captured request"))
+        }
+    }
+
     #[test]
     fn test_worker_set_basics() {
         let ws = make_worker_set("ns1", "abc123");
         assert_eq!(ws.namespace(), "ns1");
         assert_eq!(ws.mdcsum(), "abc123");
+    }
+
+    #[tokio::test]
+    async fn adapter_view_routes_generate_requests_with_adapter_identity() {
+        let observed_lora = Arc::new(Mutex::new(None));
+        let mut base = make_worker_set("ns1", "abc123");
+        base.generate_engine = Some(Arc::new(CaptureGenerateEngine {
+            observed_lora: observed_lora.clone(),
+        }));
+        let mut adapter_card = ModelDeploymentCard::with_name_only("adapter-model");
+        adapter_card.lora = Some(crate::model_card::LoraInfo {
+            name: "adapter-model".to_string(),
+            max_gpu_lora_count: Some(4),
+        });
+        let adapter = base.adapter_view(adapter_card);
+        let request = PreprocessedRequest::builder()
+            .model("adapter-model".to_string())
+            .token_ids(vec![1])
+            .stop_conditions(Default::default())
+            .sampling_options(Default::default())
+            .output_options(Default::default())
+            .build()
+            .unwrap();
+
+        let result = adapter
+            .generate_engine
+            .as_ref()
+            .unwrap()
+            .generate(SingleIn::new(request))
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            observed_lora.lock().unwrap().as_deref(),
+            Some("adapter-model")
+        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3382,7 +3382,7 @@ pub(crate) fn check_model_serving_ready(
     state: &Arc<service_v2::State>,
     model_name: &str,
 ) -> Result<(), ErrorResponse> {
-    let Some(model) = state.manager().get_model(model_name) else {
+    let Some(model) = state.manager().get_committed_model(model_name) else {
         // Unknown model — let the per-endpoint engine accessor produce the
         // canonical 404. The readiness gate has nothing to say.
         return Ok(());
@@ -3685,7 +3685,7 @@ async fn get_model_openai(
     // just the displayable ones, so a registered-but-not-yet-ready `foo/ready`
     // still wins over the readiness sub-resource of a sibling `foo`.
     // `get_model_retrieve` applies the readiness gate itself (503 if not ready).
-    if state.manager().get_model(model_id).is_some() {
+    if state.manager().get_committed_model(model_id).is_some() {
         return get_model_retrieve(&state, model_id);
     }
 
@@ -3694,7 +3694,7 @@ async fn get_model_openai(
     // the whole point of this endpoint is to diagnose models that are
     // registered but not yet ready, so it must find them too.
     if let Some(base) = model_id.strip_suffix("/ready")
-        && state.manager().get_model(base).is_some()
+        && state.manager().get_committed_model(base).is_some()
     {
         return get_model_readiness(&state, base);
     }
@@ -3753,7 +3753,7 @@ fn get_model_readiness(
 ) -> Result<Response, ErrorResponse> {
     let model = state
         .manager()
-        .get_model(model_id)
+        .get_committed_model(model_id)
         .ok_or_else(ErrorMessage::model_not_found)?;
     Ok(Json(model.namespace_readiness()).into_response())
 }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3375,15 +3375,15 @@ pub(crate) fn model_not_ready_message(model_name: &str) -> String {
 /// namespace.
 ///
 /// Returns `503 Service Unavailable` with a structured body when the model
-/// isn't ready to serve. Models the frontend has never heard of fall through
-/// here; the per-handler engine lookup later in the request path returns a
-/// 404 instead, which is the right shape for "unknown model".
+/// isn't ready to serve. Models absent from the committed catalog, including
+/// discovered models still being built, fall through here; the per-handler
+/// engine lookup later in the request path returns a 404 instead.
 pub(crate) fn check_model_serving_ready(
     state: &Arc<service_v2::State>,
     model_name: &str,
 ) -> Result<(), ErrorResponse> {
     let Some(model) = state.manager().get_committed_model(model_name) else {
-        // Unknown model — let the per-endpoint engine accessor produce the
+        // Not committed — let the per-endpoint engine accessor produce the
         // canonical 404. The readiness gate has nothing to say.
         return Ok(());
     };
@@ -3681,18 +3681,18 @@ async fn get_model_openai(
     // per-model readiness sub-resource (Mechanism 4). This means a model
     // literally named `foo/ready` is still retrievable and never shadowed.
     //
-    // Exact match is resolved against ALL registered models (`get_model`), not
-    // just the displayable ones, so a registered-but-not-yet-ready `foo/ready`
-    // still wins over the readiness sub-resource of a sibling `foo`.
+    // Exact match is resolved against every committed model, not just the
+    // displayable ones, so a committed-but-not-yet-ready `foo/ready` still
+    // wins over the readiness sub-resource of a sibling `foo`.
     // `get_model_retrieve` applies the readiness gate itself (503 if not ready).
     if state.manager().get_committed_model(model_id).is_some() {
         return get_model_retrieve(&state, model_id);
     }
 
-    // Readiness sub-resource. Resolves against all registered models (above
-    // exact check failed, so `model_id` is not itself a registered model);
-    // the whole point of this endpoint is to diagnose models that are
-    // registered but not yet ready, so it must find them too.
+    // Readiness sub-resource. Resolves against all committed models (above
+    // exact check failed, so `model_id` is not itself a committed model);
+    // the whole point of this endpoint is to diagnose committed models that
+    // are not yet ready, so it must find them too.
     if let Some(base) = model_id.strip_suffix("/ready")
         && state.manager().get_committed_model(base).is_some()
     {

--- a/lib/llm/src/kv_router/encoder_router.rs
+++ b/lib/llm/src/kv_router/encoder_router.rs
@@ -3,12 +3,14 @@
 
 //! Optional multimodal encoder hop for token-serving pipelines.
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::{Arc, OnceLock};
 
 use anyhow::{Context as _, Result};
+use arc_swap::ArcSwapOption;
 use futures::StreamExt;
-use tokio::sync::oneshot;
+use parking_lot::Mutex;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 use dynamo_runtime::{
@@ -18,7 +20,7 @@ use dynamo_runtime::{
         Context, ManyOut, Operator, PushRouter, RouterMode, ServerStreamingEngine, SingleIn,
         async_trait,
     },
-    protocols::{annotated::Annotated, maybe_error::MaybeError},
+    protocols::{EndpointId, annotated::Annotated, maybe_error::MaybeError},
 };
 
 use crate::protocols::common::{
@@ -27,6 +29,11 @@ use crate::protocols::common::{
 };
 
 type EncodePushRouter = PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>;
+
+struct EncoderBinding {
+    endpoint_id: EndpointId,
+    router: Arc<EncodePushRouter>,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -54,7 +61,9 @@ impl EncoderLifecycleState {
 /// Encode workers are selected round-robin independently of the downstream
 /// token router mode; they do not participate in KV-aware routing.
 pub struct EncoderRouter {
-    router: OnceLock<Arc<EncodePushRouter>>,
+    binding: ArcSwapOption<EncoderBinding>,
+    target: Mutex<Option<EndpointId>>,
+    target_tx: Option<watch::Sender<Option<Endpoint>>>,
     cancel_token: CancellationToken,
     lifecycle: AtomicU8,
     model_name: String,
@@ -71,7 +80,9 @@ impl EncoderRouter {
     /// Create a permanently-disabled passthrough router.
     pub fn disabled() -> Arc<Self> {
         Arc::new(Self {
-            router: OnceLock::new(),
+            binding: ArcSwapOption::empty(),
+            target: Mutex::new(None),
+            target_tx: None,
             cancel_token: CancellationToken::new(),
             lifecycle: AtomicU8::new(EncoderLifecycleState::Pending as u8),
             model_name: String::new(),
@@ -79,100 +90,178 @@ impl EncoderRouter {
         })
     }
 
-    /// Create a router that activates when discovery observes an Encode peer.
-    pub fn new(
-        activation_rx: oneshot::Receiver<Endpoint>,
-        model_name: String,
-        namespace: String,
-    ) -> Arc<Self> {
+    /// Create a router whose endpoint is driven by committed discovery topology.
+    pub fn new(model_name: String, namespace: String) -> Arc<Self> {
         let cancel_token = CancellationToken::new();
+        let (target_tx, target_rx) = watch::channel(None);
         let router = Arc::new(Self {
-            router: OnceLock::new(),
+            binding: ArcSwapOption::empty(),
+            target: Mutex::new(None),
+            target_tx: Some(target_tx),
             cancel_token: cancel_token.clone(),
             lifecycle: AtomicU8::new(EncoderLifecycleState::Pending as u8),
             model_name,
             namespace,
         });
 
-        let router_weak = Arc::downgrade(&router);
-        tokio::spawn(async move {
-            tokio::select! {
-                result = activation_rx => {
-                    let Ok(endpoint) = result else {
-                        tracing::debug!("Encoder router activation channel closed");
-                        return;
-                    };
-                    let Some(router) = router_weak.upgrade() else {
-                        tracing::debug!("Encoder router dropped before activation");
-                        return;
-                    };
-                    if let Err(error) = router.activate(endpoint).await {
-                        tracing::error!(%error, "Failed to activate encoder router");
-                    }
-                }
-                _ = cancel_token.cancelled() => {
-                    tracing::debug!("Encoder router activation cancelled");
-                }
-            }
-        });
+        tokio::spawn(Self::drive_target(
+            Arc::downgrade(&router),
+            target_rx,
+            cancel_token,
+        ));
 
         router
     }
 
-    async fn activate(&self, endpoint: Endpoint) -> Result<()> {
+    async fn build(endpoint: Endpoint) -> Result<EncoderBinding> {
+        let endpoint_id = endpoint.id();
         let client = endpoint.client().await?;
         let router =
             EncodePushRouter::from_client_with_monitor(client, RouterMode::RoundRobin, None)
                 .await?;
-        let _ = self.router.set(Arc::new(router));
-        if self.mark_active_if_pending() {
-            tracing::info!(
-                model = %self.model_name,
-                namespace = %self.namespace,
-                "Encoder router activated"
-            );
-        } else {
-            tracing::debug!(
-                model = %self.model_name,
-                namespace = %self.namespace,
-                state = ?self.lifecycle_state(),
-                "Encoder router initialized after its activation was superseded"
-            );
-        }
-        Ok(())
+        Ok(EncoderBinding {
+            endpoint_id,
+            router: Arc::new(router),
+        })
     }
 
-    fn mark_active_if_pending(&self) -> bool {
-        self.lifecycle
-            .compare_exchange(
-                EncoderLifecycleState::Pending as u8,
-                EncoderLifecycleState::Active as u8,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            )
-            .is_ok()
+    async fn drive_target(
+        router: std::sync::Weak<Self>,
+        mut target_rx: watch::Receiver<Option<Endpoint>>,
+        cancel_token: CancellationToken,
+    ) {
+        loop {
+            let target = target_rx.borrow_and_update().clone();
+            let Some(endpoint) = target else {
+                tokio::select! {
+                    biased;
+                    _ = cancel_token.cancelled() => return,
+                    changed = target_rx.changed() => {
+                        if changed.is_err() {
+                            return;
+                        }
+                    }
+                }
+                continue;
+            };
+            let endpoint_id = endpoint.id();
+            let reuses_binding = router.upgrade().is_some_and(|router| {
+                router
+                    .binding
+                    .load_full()
+                    .is_some_and(|binding| binding.endpoint_id == endpoint_id)
+                    && router.lifecycle_state() == EncoderLifecycleState::Active
+            });
+            if reuses_binding {
+                tokio::select! {
+                    biased;
+                    _ = cancel_token.cancelled() => return,
+                    changed = target_rx.changed() => {
+                        if changed.is_err() {
+                            return;
+                        }
+                    }
+                }
+                continue;
+            }
+            let build = Self::build(endpoint);
+            tokio::pin!(build);
+            let result = tokio::select! {
+                biased;
+                _ = cancel_token.cancelled() => return,
+                changed = target_rx.changed() => {
+                    if changed.is_err() {
+                        return;
+                    }
+                    continue;
+                }
+                result = &mut build => result,
+            };
+
+            let Some(router) = router.upgrade() else {
+                return;
+            };
+            match result {
+                Ok(binding) => {
+                    let current_target = router.target.lock();
+                    if current_target.as_ref() != Some(&endpoint_id) {
+                        continue;
+                    }
+                    router.binding.store(Some(Arc::new(binding)));
+                    router
+                        .lifecycle
+                        .store(EncoderLifecycleState::Active as u8, Ordering::Release);
+                    drop(current_target);
+                    tracing::info!(
+                        model = %router.model_name,
+                        namespace = %router.namespace,
+                        %endpoint_id,
+                        "Encoder router target activated"
+                    );
+                }
+                Err(error) => {
+                    if router.target.lock().as_ref() != Some(&endpoint_id) {
+                        continue;
+                    }
+                    tracing::error!(
+                        %error,
+                        model = %router.model_name,
+                        namespace = %router.namespace,
+                        %endpoint_id,
+                        "Failed to activate encoder router target"
+                    );
+                    drop(router);
+                    tokio::select! {
+                        biased;
+                        _ = cancel_token.cancelled() => return,
+                        changed = target_rx.changed() => {
+                            if changed.is_err() {
+                                return;
+                            }
+                        }
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+                    }
+                }
+            }
+        }
     }
 
     fn lifecycle_state(&self) -> EncoderLifecycleState {
         EncoderLifecycleState::load(self.lifecycle.load(Ordering::Acquire))
     }
 
-    pub fn deactivate(&self) {
-        self.lifecycle
-            .store(EncoderLifecycleState::Unavailable as u8, Ordering::Release);
+    /// Update the desired Encode endpoint. Clearing is synchronous so requests
+    /// holding an older catalog snapshot stop using a removed endpoint before
+    /// the new catalog is published.
+    pub(crate) fn set_target(&self, target: Option<Endpoint>) {
+        let target_id = target.as_ref().map(Endpoint::id);
+        let mut current = self.target.lock();
+        if *current == target_id {
+            return;
+        }
+        *current = target_id.clone();
+        let reuses_binding = target_id.is_some()
+            && self
+                .binding
+                .load_full()
+                .is_some_and(|binding| Some(&binding.endpoint_id) == target_id.as_ref());
+        let lifecycle = if target.is_none() {
+            EncoderLifecycleState::Unavailable
+        } else if reuses_binding {
+            EncoderLifecycleState::Active
+        } else {
+            self.binding.store(None);
+            EncoderLifecycleState::Pending
+        };
+        self.lifecycle.store(lifecycle as u8, Ordering::Release);
+        if let Some(target_tx) = &self.target_tx {
+            target_tx.send_replace(target);
+        }
     }
 
-    pub fn reactivate(&self) {
-        let _ = self.lifecycle.compare_exchange(
-            EncoderLifecycleState::Unavailable as u8,
-            EncoderLifecycleState::Active as u8,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        );
-    }
-
-    pub fn is_deactivated(&self) -> bool {
-        self.lifecycle_state() == EncoderLifecycleState::Unavailable
+    #[cfg(test)]
+    pub(crate) fn target_endpoint_id(&self) -> Option<EndpointId> {
+        self.target.lock().clone()
     }
 
     fn should_encode(request: &PreprocessedRequest) -> bool {
@@ -235,11 +324,11 @@ impl
             context.metadata().clone(),
         );
         let encode_result = async {
-            let router = self
-                .router
-                .get()
+            let binding = self
+                .binding
+                .load_full()
                 .context("Encoder router is active but not initialized")?;
-            let response = router.generate(encode_context).await?;
+            let response = binding.router.generate(encode_context).await?;
             Self::consume_encode_stream(response).await
         }
         .await;
@@ -332,23 +421,12 @@ mod tests {
 
     #[tokio::test]
     async fn pending_activation_does_not_keep_router_alive() {
-        let (_activation_tx, activation_rx) = oneshot::channel();
-        let router = EncoderRouter::new(activation_rx, "model".into(), "namespace".into());
+        let router = EncoderRouter::new("model".into(), "namespace".into());
         let weak = Arc::downgrade(&router);
 
         drop(router);
 
         assert!(weak.upgrade().is_none());
-    }
-
-    #[test]
-    fn deactivation_wins_an_in_flight_activation() {
-        let router = EncoderRouter::disabled();
-
-        router.deactivate();
-
-        assert!(!router.mark_active_if_pending());
-        assert_eq!(router.lifecycle_state(), EncoderLifecycleState::Unavailable);
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use anyhow::Result;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 
 use dynamo_kv_router::{
     DEFAULT_ROUTING_GROUP, PrefillLoadEstimator, RoutingPartitionRef,
@@ -21,7 +21,9 @@ use dynamo_runtime::{
     protocols::annotated::Annotated,
 };
 
-use super::{InnerPrefillRouter, PrefillLifecycleState, PrefillRouter};
+use super::{
+    InnerPrefillRouter, PrefillBinding, PrefillBuildContext, PrefillLifecycleState, PrefillRouter,
+};
 use crate::{
     discovery::ModelManager,
     kv_router::{KvPushRouter, KvRouter, WorkerSelectorFactory},
@@ -60,7 +62,7 @@ impl PrefillRouter<DefaultWorkerSelector> {
         worker_monitor: Option<crate::discovery::KvWorkerMonitor>,
     ) -> Arc<Self> {
         Self::new_with_selector_factory(
-            activation_rx,
+            Some(activation_rx),
             model_manager,
             router_mode,
             kv_cache_block_size,
@@ -89,12 +91,13 @@ where
         session_affinity_ttl_secs: Option<u64>,
     ) -> Arc<Self> {
         Arc::new(Self {
-            prefill_router: std::sync::OnceLock::new(),
+            binding: arc_swap::ArcSwapOption::empty(),
+            target: parking_lot::Mutex::new(None),
+            target_tx: None,
             decode_router: None,
             worker_selector_factory: None,
             decode_session_affinity: std::sync::OnceLock::new(),
             model_manager,
-            endpoint_id: std::sync::OnceLock::new(),
             cancel_token: tokio_util::sync::CancellationToken::new(),
             router_mode,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
@@ -111,7 +114,7 @@ where
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new_with_selector_factory(
-        activation_rx: oneshot::Receiver<Endpoint>,
+        activation_rx: Option<oneshot::Receiver<Endpoint>>,
         model_manager: Arc<ModelManager>,
         router_mode: RouterMode,
         kv_cache_block_size: u32,
@@ -125,8 +128,8 @@ where
         is_eagle: bool,
         worker_monitor: Option<crate::discovery::KvWorkerMonitor>,
     ) -> Arc<Self> {
-        let prefill_router = std::sync::OnceLock::new();
         let cancel_token = tokio_util::sync::CancellationToken::new();
+        let (target_tx, target_rx) = watch::channel(None);
         let conditional_disagg_policy = make_conditional_disagg_policy(kv_router_config.as_ref());
         let conditional_disagg_prefill_busy_threshold = kv_router_config.as_ref().and_then(|c| {
             c.conditional_disagg_prefill_busy_threshold
@@ -137,12 +140,13 @@ where
             .and_then(|c| c.conditional_disagg_decode_busy_threshold);
 
         let router = Arc::new(Self {
-            prefill_router,
+            binding: arc_swap::ArcSwapOption::empty(),
+            target: parking_lot::Mutex::new(None),
+            target_tx: Some(target_tx),
             decode_router,
             worker_selector_factory: Some(worker_selector_factory),
             decode_session_affinity: std::sync::OnceLock::new(),
             model_manager: model_manager.clone(),
-            endpoint_id: std::sync::OnceLock::new(),
             cancel_token: cancel_token.clone(),
             router_mode,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
@@ -156,103 +160,92 @@ where
             lifecycle: std::sync::atomic::AtomicU8::new(PrefillLifecycleState::Pending as u8),
         });
 
-        // Spawn background task to wait for activation
-        let router_clone = router.clone();
-        tokio::spawn(async move {
-            tokio::select! {
-                result = activation_rx => {
-                    let Ok(endpoint) = result else {
-                        tracing::debug!("Prefill router activation channel closed without receiving endpoint");
-                        return;
-                    };
-
-                    if let Err(e) = router_clone.activate(
-                        endpoint,
-                        model_manager,
-                        kv_cache_block_size,
-                        kv_router_config,
-                        router_clone.prefill_load_estimator.clone(),
-                        worker_monitor.as_ref(),
-                    ).await {
-                        tracing::error!(error = %e, "Failed to activate prefill router");
+        tokio::spawn(Self::drive_target(
+            Arc::downgrade(&router),
+            target_rx,
+            cancel_token.clone(),
+            kv_cache_block_size,
+            kv_router_config,
+            worker_monitor,
+        ));
+        if let Some(activation_rx) = activation_rx {
+            let router = Arc::downgrade(&router);
+            tokio::spawn(async move {
+                tokio::select! {
+                    result = activation_rx => {
+                        if let (Ok(endpoint), Some(router)) = (result, router.upgrade()) {
+                            router.set_target(Some(endpoint));
+                        }
                     }
+                    _ = cancel_token.cancelled() => {}
                 }
-                _ = cancel_token.cancelled() => {
-                    tracing::debug!("Prefill router activation cancelled");
-                }
-            }
-        });
+            });
+        }
 
         router
     }
 
-    /// Activate the prefill router with the provided endpoint
-    async fn activate(
-        &self,
+    async fn build_binding(
+        context: &PrefillBuildContext<Sel>,
         endpoint: Endpoint,
-        model_manager: Arc<ModelManager>,
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
         worker_monitor: Option<&crate::discovery::KvWorkerMonitor>,
-    ) -> Result<()> {
+    ) -> Result<PrefillBinding<Sel>> {
         tracing::info!(
-            router_mode = ?self.router_mode,
+            router_mode = ?context.router_mode,
             "Activating prefill router"
         );
 
-        // Store endpoint metadata for bootstrap and topology preparation.
-        let _ = self.endpoint_id.set(endpoint.id());
+        let endpoint_id = endpoint.id();
 
         // Start runtime config watcher for this endpoint (needed for get_disaggregated_endpoint)
         // This must be done before creating the router so bootstrap info is available
-        model_manager
+        context
+            .model_manager
             .get_or_create_runtime_config_watcher(&endpoint)
             .await?;
 
-        let inner_router = if self.router_mode.is_kv_routing() {
-            let endpoint_id = endpoint.id();
+        let inner_router = if context.router_mode.is_kv_routing() {
             let discovered_cards = endpoint
                 .component()
                 .drt()
                 .discovery()
                 .list(DiscoveryQuery::EndpointModels {
-                    namespace: endpoint_id.namespace,
-                    component: endpoint_id.component,
-                    endpoint: endpoint_id.name,
+                    namespace: endpoint_id.namespace.clone(),
+                    component: endpoint_id.component.clone(),
+                    endpoint: endpoint_id.name.clone(),
                 })
                 .await;
             let is_eagle = match discovered_cards {
                 Ok(instances) => instances
                     .into_iter()
                     .find_map(|instance| instance.deserialize_model::<ModelDeploymentCard>().ok())
-                    .map_or(self.is_eagle, |card| card.runtime_config.enable_eagle),
+                    .map_or(context.is_eagle, |card| card.runtime_config.enable_eagle),
                 Err(error) => {
                     tracing::warn!(%error, "Failed to read prefill model card; using configured EAGLE mode");
-                    self.is_eagle
+                    context.is_eagle
                 }
             };
 
             // Create KV chooser using the endpoint (this is a prefill router)
             let effective_kv_router_config = kv_router_config.clone().unwrap_or_default();
-            let selector = (self
-                .worker_selector_factory
-                .as_ref()
-                .expect("enabled prefill router has a worker selector factory"))(
+            let selector = (context.worker_selector_factory)(
                 &effective_kv_router_config,
                 WORKER_TYPE_PREFILL,
-                RoutingPartitionRef::new(&self.model_name, DEFAULT_ROUTING_GROUP),
+                RoutingPartitionRef::new(&context.model_name, DEFAULT_ROUTING_GROUP),
             );
-            let kv_chooser = model_manager
+            let kv_chooser = context
+                .model_manager
                 .kv_chooser_for_with_selector(
                     &endpoint,
                     kv_cache_block_size,
                     selector,
                     kv_router_config,
-                    prefill_load_estimator,
+                    context.prefill_load_estimator.clone(),
                     Some(crate::worker_type::WorkerType::Prefill),
                     WORKER_TYPE_PREFILL,
-                    Some(self.model_name.clone()),
+                    Some(context.model_name.clone()),
                     is_eagle,
                 )
                 .await?;
@@ -261,7 +254,7 @@ where
             let client = kv_chooser.client().clone();
             Self::attach_prefill_client(worker_monitor, &client);
             let affinity =
-                create_affinity_coordinator(self.session_affinity_ttl, client.clone()).await?;
+                create_affinity_coordinator(context.session_affinity_ttl, client.clone()).await?;
 
             // Build the PushRouter for prefill with KV mode using the shared client
             let push_router = PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client_with_monitor(
@@ -282,14 +275,14 @@ where
             let client = endpoint.client().await?;
             Self::attach_prefill_client(worker_monitor, &client);
             let affinity =
-                create_affinity_coordinator(self.session_affinity_ttl, client.clone()).await?;
+                create_affinity_coordinator(context.session_affinity_ttl, client.clone()).await?;
 
             // Create simple push router with the frontend's router mode
             // Note: Per-worker metrics (active_prefill_tokens, active_decode_blocks) are only
             // available in KV routing mode where the router has actual bookkeeping.
             let push_router = PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client_with_monitor(
                 client,
-                self.router_mode,
+                context.router_mode,
                 None, // worker_monitor
             )
             .await?;
@@ -298,42 +291,15 @@ where
                 crate::session_affinity::SessionAffinityPushRouter::new_with_coordinator(
                     push_router,
                     affinity,
-                    self.router_mode.is_direct_routing(),
+                    context.router_mode.is_direct_routing(),
                 ),
             ))
         };
 
-        // Set the router (ignore error if already set).
-        let _ = self.prefill_router.set(inner_router);
-        match self.complete_activation() {
-            PrefillLifecycleState::Active => {
-                tracing::info!(
-                    router_mode = ?self.router_mode,
-                    "Prefill router activated successfully"
-                );
-            }
-            PrefillLifecycleState::Unavailable => {
-                tracing::info!(
-                    router_mode = ?self.router_mode,
-                    "Prefill router initialized after its workers became unavailable"
-                );
-            }
-            PrefillLifecycleState::Pending => unreachable!("activation must leave pending state"),
-        }
-
-        Ok(())
-    }
-
-    pub(super) fn complete_activation(&self) -> PrefillLifecycleState {
-        match self.lifecycle.compare_exchange(
-            PrefillLifecycleState::Pending as u8,
-            PrefillLifecycleState::Active as u8,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
-            Ok(_) => PrefillLifecycleState::Active,
-            Err(current) => PrefillLifecycleState::from_atomic(current),
-        }
+        Ok(PrefillBinding {
+            endpoint_id,
+            router: inner_router,
+        })
     }
 
     /// Attach the freshly-created prefill `Client` to this WorkerSet's monitor (handed in
@@ -348,105 +314,170 @@ where
         }
     }
 
-    // -- Prefill death handling --
-
-    /// Deactivate the prefill router. Called when all prefill workers are removed.
-    /// After deactivation, requests fall back to aggregated mode.
-    /// The inner router is preserved so that when workers rejoin (same endpoint/discovery),
-    /// the Client's discovery subscription picks them up automatically.
-    pub fn deactivate(&self) {
-        let transition =
-            self.lifecycle
-                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-                    match PrefillLifecycleState::from_atomic(current) {
-                        PrefillLifecycleState::Pending | PrefillLifecycleState::Active => {
-                            Some(PrefillLifecycleState::Unavailable as u8)
+    async fn drive_target(
+        router: std::sync::Weak<Self>,
+        mut target_rx: watch::Receiver<Option<Endpoint>>,
+        cancel_token: tokio_util::sync::CancellationToken,
+        kv_cache_block_size: u32,
+        kv_router_config: Option<KvRouterConfig>,
+        worker_monitor: Option<crate::discovery::KvWorkerMonitor>,
+    ) {
+        loop {
+            let target = target_rx.borrow_and_update().clone();
+            let Some(endpoint) = target else {
+                tokio::select! {
+                    biased;
+                    _ = cancel_token.cancelled() => return,
+                    changed = target_rx.changed() => {
+                        if changed.is_err() {
+                            return;
                         }
-                        PrefillLifecycleState::Unavailable => None,
                     }
-                });
-        if transition.is_err() {
-            return;
+                }
+                continue;
+            };
+            let endpoint_id = endpoint.id();
+            let Some(router_ref) = router.upgrade() else {
+                return;
+            };
+            let reuses_binding = router_ref
+                .binding
+                .load_full()
+                .is_some_and(|binding| binding.endpoint_id == endpoint_id)
+                && router_ref.lifecycle_state() == PrefillLifecycleState::Active;
+            if reuses_binding {
+                drop(router_ref);
+                tokio::select! {
+                    biased;
+                    _ = cancel_token.cancelled() => return,
+                    changed = target_rx.changed() => {
+                        if changed.is_err() {
+                            return;
+                        }
+                    }
+                }
+                continue;
+            }
+            let build_context = PrefillBuildContext {
+                model_manager: router_ref.model_manager.clone(),
+                router_mode: router_ref.router_mode,
+                worker_selector_factory: router_ref
+                    .worker_selector_factory
+                    .clone()
+                    .expect("enabled prefill router has a worker selector factory"),
+                prefill_load_estimator: router_ref.prefill_load_estimator.clone(),
+                session_affinity_ttl: router_ref.session_affinity_ttl,
+                model_name: router_ref.model_name.clone(),
+                is_eagle: router_ref.is_eagle,
+            };
+            drop(router_ref);
+            let build = Self::build_binding(
+                &build_context,
+                endpoint,
+                kv_cache_block_size,
+                kv_router_config.clone(),
+                worker_monitor.as_ref(),
+            );
+            tokio::pin!(build);
+            let result = tokio::select! {
+                biased;
+                _ = cancel_token.cancelled() => return,
+                changed = target_rx.changed() => {
+                    if changed.is_err() {
+                        return;
+                    }
+                    continue;
+                }
+                result = &mut build => result,
+            };
+            let Some(router_ref) = router.upgrade() else {
+                return;
+            };
+            match result {
+                Ok(binding) => {
+                    let current_target = router_ref.target.lock();
+                    if current_target.as_ref() != Some(&endpoint_id) {
+                        continue;
+                    }
+                    router_ref.binding.store(Some(Arc::new(binding)));
+                    router_ref
+                        .lifecycle
+                        .store(PrefillLifecycleState::Active as u8, Ordering::Release);
+                    drop(current_target);
+                    tracing::info!(
+                        model_name = %router_ref.model_name,
+                        namespace = %router_ref.namespace,
+                        %endpoint_id,
+                        "Prefill router target activated"
+                    );
+                }
+                Err(error) => {
+                    if router_ref.target.lock().as_ref() != Some(&endpoint_id) {
+                        continue;
+                    }
+                    tracing::error!(
+                        %error,
+                        model_name = %router_ref.model_name,
+                        namespace = %router_ref.namespace,
+                        %endpoint_id,
+                        "Failed to activate prefill router target"
+                    );
+                    drop(router_ref);
+                    tokio::select! {
+                        biased;
+                        _ = cancel_token.cancelled() => return,
+                        changed = target_rx.changed() => {
+                            if changed.is_err() {
+                                return;
+                            }
+                        }
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+                    }
+                }
+            }
         }
-        tracing::info!(
-            model_name = %self.model_name,
-            namespace = %self.namespace,
-            "Prefill router deactivated (all prefill workers removed)"
-        );
     }
 
-    /// Reactivate a deactivated router. Called when prefill workers rejoin.
-    /// The inner router's Client re-discovers workers via its discovery subscription.
-    ///
-    /// Note: there is a brief race between entering `Active` and the Client
-    /// actually rediscovering workers. Requests arriving in this window may fail at prefill resolution.
-    /// This is bounded by discovery propagation time (typically sub-second).
-    ///
-    /// Also note: reactivation reuses the existing inner router built from the
-    /// original endpoint. If prefill rejoins under a different endpoint identity
-    /// (e.g., reconfigured deployment), the stale Client would not discover the
-    /// new workers. This is acceptable for normal restart scenarios where the
-    /// endpoint identity is stable.
-    pub fn reactivate(&self) {
-        let initialized = self.prefill_router.get().is_some();
-        let target = if initialized {
+    /// Update the desired Prefill endpoint. Clearing is synchronous so requests
+    /// holding an older catalog snapshot bypass a removed endpoint before the
+    /// replacement catalog is published.
+    pub(crate) fn set_target(&self, target: Option<Endpoint>) {
+        let target_id = target.as_ref().map(Endpoint::id);
+        let mut current = self.target.lock();
+        if *current == target_id {
+            return;
+        }
+        *current = target_id.clone();
+        let reuses_binding = target_id.is_some()
+            && self
+                .binding
+                .load_full()
+                .is_some_and(|binding| Some(&binding.endpoint_id) == target_id.as_ref());
+        let lifecycle = if target.is_none() {
+            PrefillLifecycleState::Unavailable
+        } else if reuses_binding {
             PrefillLifecycleState::Active
         } else {
+            self.binding.store(None);
             PrefillLifecycleState::Pending
         };
-        let transition = self.lifecycle.compare_exchange(
-            PrefillLifecycleState::Unavailable as u8,
-            target as u8,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        );
-        if let Err(current) = transition {
-            PrefillLifecycleState::from_atomic(current);
-            return;
-        }
-        let state =
-            if target == PrefillLifecycleState::Pending && self.prefill_router.get().is_some() {
-                self.complete_activation()
-            } else {
-                target
-            };
-        match state {
-            PrefillLifecycleState::Active => {
-                tracing::info!(
-                    model_name = %self.model_name,
-                    namespace = %self.namespace,
-                    "Prefill router reactivated (prefill workers rejoined)"
-                );
-            }
-            PrefillLifecycleState::Pending => {
-                tracing::info!(
-                    model_name = %self.model_name,
-                    namespace = %self.namespace,
-                    "Prefill workers rejoined before router initialization completed"
-                );
-            }
-            PrefillLifecycleState::Unavailable => {}
+        self.lifecycle.store(lifecycle as u8, Ordering::Release);
+        if let Some(target_tx) = &self.target_tx {
+            target_tx.send_replace(target);
         }
     }
 
-    /// Whether this router is currently deactivated (prefill workers died).
-    pub fn is_deactivated(&self) -> bool {
-        self.lifecycle_state() == PrefillLifecycleState::Unavailable
-    }
-
-    /// Whether the inner router has initialized, even if workers are unavailable.
+    /// Whether the inner router has initialized.
     pub fn is_activated(&self) -> bool {
-        self.prefill_router.get().is_some()
+        self.binding.load().is_some()
     }
 
     pub(super) fn lifecycle_state(&self) -> PrefillLifecycleState {
         PrefillLifecycleState::from_atomic(self.lifecycle.load(Ordering::Acquire))
     }
 
-    /// Mark this router as active for testing purposes.
     #[cfg(test)]
-    pub(crate) fn mark_active_for_test(&self) {
-        self.lifecycle
-            .store(PrefillLifecycleState::Active as u8, Ordering::Release);
+    pub(crate) fn target_endpoint_id(&self) -> Option<dynamo_runtime::protocols::EndpointId> {
+        self.target.lock().clone()
     }
 }

--- a/lib/llm/src/kv_router/prefill_router/conditional_bypass.rs
+++ b/lib/llm/src/kv_router/prefill_router/conditional_bypass.rs
@@ -303,8 +303,8 @@ where
         session_affinity: Option<&SessionAffinityId>,
     ) -> Option<bool> {
         let threshold = self.conditional_disagg_prefill_busy_threshold?;
-        let prefill_router = self.prefill_router.get()?;
-        let router = match prefill_router {
+        let binding = self.binding.load_full()?;
+        let router = match &binding.router {
             InnerPrefillRouter::KvRouter(router) => router,
             InnerPrefillRouter::SimpleRouter(_) => return None,
         };

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -5,6 +5,9 @@ use std::sync::atomic::AtomicU8;
 use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
+use arc_swap::ArcSwapOption;
+use parking_lot::Mutex;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -167,14 +170,15 @@ pub struct PrefillRouter<Sel = DefaultWorkerSelector>
 where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
-    prefill_router: OnceLock<InnerPrefillRouter<Sel>>,
+    binding: ArcSwapOption<PrefillBinding<Sel>>,
+    target: Mutex<Option<EndpointId>>,
+    target_tx: Option<watch::Sender<Option<dynamo_runtime::component::Endpoint>>>,
     /// Reference to the decode-side `KvRouter` so conditional disagg can peek
     /// the cache-hot decode worker. `None` for non-KV routing and disabled routers.
     decode_router: Option<Arc<super::KvRouter<Sel>>>,
     worker_selector_factory: Option<WorkerSelectorFactory<Sel>>,
     decode_session_affinity: OnceLock<AffinityCoordinator>,
     model_manager: Arc<ModelManager>,
-    endpoint_id: OnceLock<EndpointId>,
     cancel_token: CancellationToken,
     router_mode: RouterMode,
     session_affinity_ttl: Option<std::time::Duration>,
@@ -194,26 +198,37 @@ where
     lifecycle: AtomicU8,
 }
 
+struct PrefillBinding<Sel>
+where
+    Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
+{
+    endpoint_id: EndpointId,
+    router: InnerPrefillRouter<Sel>,
+}
+
+struct PrefillBuildContext<Sel>
+where
+    Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
+{
+    model_manager: Arc<ModelManager>,
+    router_mode: RouterMode,
+    worker_selector_factory: WorkerSelectorFactory<Sel>,
+    prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
+    session_affinity_ttl: Option<std::time::Duration>,
+    model_name: String,
+    is_eagle: bool,
+}
+
 pub(crate) trait PrefillRouterLifecycle: Send + Sync {
-    fn deactivate(&self);
-    fn reactivate(&self);
-    fn is_deactivated(&self) -> bool;
+    fn set_target(&self, target: Option<dynamo_runtime::component::Endpoint>);
 }
 
 impl<Sel> PrefillRouterLifecycle for PrefillRouter<Sel>
 where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
-    fn deactivate(&self) {
-        self.deactivate();
-    }
-
-    fn reactivate(&self) {
-        self.reactivate();
-    }
-
-    fn is_deactivated(&self) -> bool {
-        self.is_deactivated()
+    fn set_target(&self, target: Option<dynamo_runtime::component::Endpoint>) {
+        self.set_target(target);
     }
 }
 
@@ -366,10 +381,11 @@ where
                 session_affinity.as_ref().clone(),
             );
         }
-        let router = self
-            .prefill_router
-            .get()
+        let binding = self
+            .binding
+            .load_full()
             .ok_or_else(|| anyhow::anyhow!(PrefillError::NotActivated))?;
+        let router = &binding.router;
         let prefill_result: Result<(PrefillOutcome, Option<RoutingConstraints>)> = async {
             let (prepared, prefill_stream) = router
                 .select_and_dispatch_prefill(prefill_context, |request, target| {
@@ -548,7 +564,8 @@ where
         target: AffinityTarget,
     ) -> anyhow::Result<PreparedPrefill> {
         let AffinityTarget { worker_id, dp_rank } = target;
-        let endpoint_id = self.endpoint_id.get();
+        let binding = self.binding.load_full();
+        let endpoint_id = binding.as_ref().map(|binding| &binding.endpoint_id);
         let topology_constraints =
             self.preflight_kv_transfer_constraints(endpoint_id, worker_id)?;
 
@@ -820,91 +837,6 @@ mod tests {
                 assert_eq!(constraints.preferred_taints["user.preferred"], 0.25);
             }
         }
-    }
-
-    fn make_test_router() -> Arc<PrefillRouter> {
-        PrefillRouter::disabled(
-            Arc::new(crate::discovery::ModelManager::new()),
-            RouterMode::RoundRobin,
-            None,
-        )
-    }
-
-    #[test]
-    fn pending_state_is_tracked() {
-        let router = make_test_router();
-        assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Pending);
-        assert!(!router.is_activated());
-        assert!(!router.is_deactivated());
-    }
-
-    #[test]
-    fn active_state_is_tracked() {
-        let router = make_test_router();
-        router.mark_active_for_test();
-
-        assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Active);
-        assert!(!router.is_deactivated());
-    }
-
-    #[test]
-    fn unavailable_state_is_tracked() {
-        let router = make_test_router();
-        router.mark_active_for_test();
-        router.deactivate();
-
-        assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Unavailable);
-        assert!(router.is_deactivated());
-    }
-
-    #[test]
-    fn deactivation_is_idempotent() {
-        let router = make_test_router();
-        router.mark_active_for_test();
-        router.deactivate();
-        router.deactivate();
-        assert!(router.is_deactivated());
-    }
-
-    #[test]
-    fn pending_router_latches_worker_availability_transitions() {
-        let router = make_test_router();
-        router.deactivate();
-        assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Unavailable);
-
-        router.reactivate();
-        router.reactivate();
-
-        assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Pending);
-    }
-
-    #[test]
-    fn activation_does_not_overwrite_latched_deactivation() {
-        let router = make_test_router();
-        router.deactivate();
-
-        assert_eq!(
-            router.complete_activation(),
-            PrefillLifecycleState::Unavailable
-        );
-        assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Unavailable);
-    }
-
-    #[test]
-    fn lifecycle_state_conversion_rejects_invalid_values() {
-        assert_eq!(
-            PrefillLifecycleState::try_from(0),
-            Ok(PrefillLifecycleState::Pending)
-        );
-        assert_eq!(
-            PrefillLifecycleState::try_from(1),
-            Ok(PrefillLifecycleState::Active)
-        );
-        assert_eq!(
-            PrefillLifecycleState::try_from(2),
-            Ok(PrefillLifecycleState::Unavailable)
-        );
-        assert_eq!(PrefillLifecycleState::try_from(3), Err(3));
     }
 
     #[test]

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -381,15 +381,15 @@ where
                 session_affinity.as_ref().clone(),
             );
         }
-        let binding = self
-            .binding
-            .load_full()
-            .ok_or_else(|| anyhow::anyhow!(PrefillError::NotActivated))?;
+        let Some(binding) = self.binding.load_full() else {
+            return next.generate(context.map(|_| req)).await;
+        };
         let router = &binding.router;
+        let endpoint_id = &binding.endpoint_id;
         let prefill_result: Result<(PrefillOutcome, Option<RoutingConstraints>)> = async {
             let (prepared, prefill_stream) = router
                 .select_and_dispatch_prefill(prefill_context, |request, target| {
-                    self.prepare_prefill_dispatch(request, target)
+                    self.prepare_prefill_dispatch(request, target, endpoint_id)
                 })
                 .await?;
             let topology_constraints = prepared.topology_constraints;
@@ -562,19 +562,16 @@ where
         &self,
         request: &mut PreprocessedRequest,
         target: AffinityTarget,
+        endpoint_id: &EndpointId,
     ) -> anyhow::Result<PreparedPrefill> {
         let AffinityTarget { worker_id, dp_rank } = target;
-        let binding = self.binding.load_full();
-        let endpoint_id = binding.as_ref().map(|binding| &binding.endpoint_id);
         let topology_constraints =
-            self.preflight_kv_transfer_constraints(endpoint_id, worker_id)?;
+            self.preflight_kv_transfer_constraints(Some(endpoint_id), worker_id)?;
 
-        let bootstrap_info = endpoint_id
-            .and_then(|endpoint_id| {
-                self.model_manager
-                    .get_disaggregated_endpoint(endpoint_id, worker_id)
-                    .map(|endpoint| (endpoint_id, endpoint))
-            })
+        let bootstrap_info = self
+            .model_manager
+            .get_disaggregated_endpoint(endpoint_id, worker_id)
+            .map(|endpoint| (endpoint_id, endpoint))
             .and_then(|(endpoint_id, endpoint)| {
                 let host = endpoint.bootstrap_host?;
                 let port = endpoint.bootstrap_port?;

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -35,12 +35,12 @@ where
         if self.lifecycle_state() != PrefillLifecycleState::Active {
             return Err(anyhow::anyhow!(PrefillError::NotActivated));
         }
-        let prefill_router = self
-            .prefill_router
-            .get()
+        let binding = self
+            .binding
+            .load_full()
             .ok_or_else(|| anyhow::anyhow!(PrefillError::NotActivated))?;
 
-        match prefill_router {
+        match &binding.router {
             InnerPrefillRouter::KvRouter(router) => {
                 let outcome = router
                     .chooser
@@ -86,7 +86,9 @@ where
     }
 
     pub fn register_workers(&self, worker_ids: &HashSet<WorkerId>) {
-        if let Some(InnerPrefillRouter::KvRouter(router)) = self.prefill_router.get() {
+        if let Some(binding) = self.binding.load_full()
+            && let InnerPrefillRouter::KvRouter(router) = &binding.router
+        {
             router.chooser.register_workers(worker_ids);
         }
     }

--- a/lib/llm/src/lora/controller.rs
+++ b/lib/llm/src/lora/controller.rs
@@ -19,7 +19,7 @@ use crate::lora::routing::mcf_allocator::{
 };
 use crate::lora::routing::table::{LoraReplicaConfig, LoraRoutingTable};
 use crate::lora::routing::{AllocationAlgorithmType, LoraAllocator, create_lora_allocator};
-use crate::lora::state_tracker::LoraStateTracker;
+use crate::lora::state_tracker::{LoraObservedSnapshot, LoraStateTracker};
 use dynamo_runtime::protocols::EndpointId;
 
 #[derive(Debug, Clone)]
@@ -58,6 +58,8 @@ pub struct LoraController {
     allocator: Box<dyn LoraAllocator>,
     routing_table: LoraRoutingTable,
     state_tracker: LoraStateTracker,
+    observed: Arc<LoraObservedSnapshot>,
+    observed_incarnation: u64,
     load_estimator: Arc<LoadEstimator>,
     metrics_endpoint: String,
     published_allocation_metric_loras: HashSet<String>,
@@ -80,6 +82,8 @@ impl LoraController {
         load_estimator: Arc<LoadEstimator>,
     ) -> Self {
         let allocator = create_lora_allocator(config.algorithm);
+        let observed = state_tracker.snapshot();
+        let observed_incarnation = observed.incarnation();
         let mcf_solver = if config.algorithm == AllocationAlgorithmType::MinCostFlow {
             let params = McfSolveParams {
                 candidate_m: config.mcf.candidate_m,
@@ -98,6 +102,8 @@ impl LoraController {
             allocator,
             routing_table,
             state_tracker,
+            observed,
+            observed_incarnation,
             load_estimator,
             metrics_endpoint: "unscoped".to_string(),
             published_allocation_metric_loras: HashSet::new(),
@@ -239,11 +245,26 @@ impl LoraController {
 
     fn recompute_allocations(&mut self) {
         self.tick += 1;
+        let observed = self.state_tracker.snapshot();
+        let incarnation = observed.incarnation();
+        if incarnation != self.observed_incarnation {
+            if self.observed_incarnation != 0 {
+                self.routing_table.clear();
+                self.hysteresis.clear();
+                self.prev_assignment.clear();
+                self.prev_workers.clear();
+                self.prev_worker_capacities.clear();
+                self.prev_replica_counts.clear();
+                self.load_estimator.reset();
+            }
+            self.observed_incarnation = incarnation;
+        }
+        self.observed = observed;
 
-        // State-tracker iteration order is intentionally unspecified (DashMap). Keep worker input
+        // Observation iteration order is intentionally unspecified. Keep worker input
         // order stable so equal-cost MCF paths and capacity-aware per-LoRA allocation converge to
         // the same routing table across controllers and repeated runs.
-        let mut workers = self.state_tracker.list_workers();
+        let mut workers = self.observed.list_workers();
         workers.sort();
         if workers.is_empty() {
             // Cluster drained: every routing entry now points at gone workers. Leaving it would
@@ -254,7 +275,7 @@ impl LoraController {
             return;
         }
 
-        let total_slots = self.state_tracker.total_lora_slots() as usize;
+        let total_slots = self.observed.total_lora_slots() as usize;
         if total_slots == 0 {
             // Workers exist but advertise zero LoRA capacity. Backends only report LoRA slots when
             // LoRA serving is enabled/capable, so zero total slots means no live worker can accept
@@ -269,7 +290,7 @@ impl LoraController {
             let live: std::collections::HashSet<WorkerWithDpRank> =
                 workers.iter().copied().collect();
             for (name, cfg) in self.routing_table.snapshot_configs() {
-                let loaded = self.state_tracker.get_loaded_workers(&name);
+                let loaded = self.observed.get_loaded_workers(&name);
                 let warm: Vec<WorkerWithDpRank> = cfg
                     .replica_set
                     .iter()
@@ -298,7 +319,7 @@ impl LoraController {
             return;
         }
 
-        let worker_slot_usage = self.state_tracker.get_worker_slot_usage();
+        let worker_slot_usage = self.observed.get_worker_slot_usage();
         let loads = self.load_estimator.get_current_load();
         let total_load: usize = loads.values().sum();
 
@@ -313,7 +334,7 @@ impl LoraController {
 
         // Collect all known LoRAs (from state tracker + from load estimator)
         let mut seen: std::collections::HashSet<String> =
-            self.state_tracker.list_loras().into_iter().collect();
+            self.observed.list_loras().into_iter().collect();
         for lora_name in loads.keys() {
             seen.insert(lora_name.clone());
         }
@@ -398,7 +419,7 @@ impl LoraController {
         if !dropped_active.is_empty() {
             let dropped_set: std::collections::HashSet<&str> =
                 dropped_active.iter().copied().collect();
-            let caps = self.state_tracker.get_worker_capacities();
+            let caps = self.observed.get_worker_capacities();
             // Committed placements this tick, excluding the dropped LoRAs themselves (their entries
             // are stale and re-decided below).
             let mut projected: HashMap<WorkerWithDpRank, usize> = HashMap::new();
@@ -417,7 +438,7 @@ impl LoraController {
                     .get_config(name)
                     .map(|c| c.replica_set)
                     .unwrap_or_default();
-                let loaded = self.state_tracker.get_loaded_workers(name);
+                let loaded = self.observed.get_loaded_workers(name);
                 let warm: Vec<WorkerWithDpRank> = prior
                     .iter()
                     .copied()
@@ -541,7 +562,7 @@ impl LoraController {
             // that is full largely because of itself (e.g. cap=1) would be evicted and moved every
             // tick — defeating the sticky placement. Charging (below) still uses the undiscounted
             // shared residual so sibling LoRAs see true remaining capacity.
-            let own_loaded = self.state_tracker.get_loaded_workers(lora_name);
+            let own_loaded = self.observed.get_loaded_workers(lora_name);
             let mut eff_usage = residual_usage.clone();
             for w in &own_loaded {
                 if let Some(usage) = eff_usage.get_mut(w) {
@@ -644,7 +665,7 @@ impl LoraController {
         active_replica_counts: &HashMap<String, usize>,
     ) {
         let churn_weight = self.config.mcf.churn_weight_default;
-        let capacities = self.state_tracker.get_worker_capacities();
+        let capacities = self.observed.get_worker_capacities();
 
         // R3-7: reset churn/overflow gauges at tick start so a failed MCF solve does not leave
         // stale values from a prior successful tick; the success branch sets the actual diff.
@@ -824,7 +845,7 @@ impl LoraController {
                 // prefers a worker that still has a free slot and never overfills the same slot
                 // across multiple unplaced LoRAs within the tick. Mirrors the HRW `dropped_active`
                 // path so both algorithms place capacity-pressured LoRAs identically.
-                let caps = self.state_tracker.get_worker_capacities();
+                let caps = self.observed.get_worker_capacities();
                 let unplaced_set: HashSet<&str> = unplaced.iter().map(String::as_str).collect();
                 let mut projected: HashMap<WorkerWithDpRank, usize> = HashMap::new();
                 for (name, cfg) in self.routing_table.snapshot_configs() {
@@ -838,7 +859,7 @@ impl LoraController {
 
                 for lora_name in unplaced {
                     let is_active = active_set.contains(lora_name.as_str());
-                    let loaded = self.state_tracker.get_loaded_workers(&lora_name);
+                    let loaded = self.observed.get_loaded_workers(&lora_name);
                     let warm: Vec<WorkerWithDpRank> = self
                         .routing_table
                         .get_config(&lora_name)
@@ -1655,6 +1676,24 @@ mod tests {
             rt.get_config("lora-a").is_none(),
             "stale routing entry must be cleared after a full worker drain"
         );
+    }
+
+    #[test]
+    fn drain_and_repopulate_between_ticks_resets_stale_allocation_state() {
+        let (mut controller, st, le, rt) = setup_controller();
+        let worker = make_worker(1);
+        st.handle_mdc_addition(worker, &make_lora_info("old", 4));
+        le.increment_load("old");
+        controller.recompute_now();
+        assert!(rt.get_config("old").is_some());
+
+        st.handle_worker_removal(worker);
+        st.handle_mdc_addition(worker, &make_lora_info("new", 4));
+        controller.recompute_now();
+
+        assert!(rt.get_config("old").is_none());
+        assert!(rt.get_config("new").is_some());
+        assert!(le.get_current_load().is_empty());
     }
 
     #[test]

--- a/lib/llm/src/lora/filter.rs
+++ b/lib/llm/src/lora/filter.rs
@@ -12,7 +12,7 @@ use crate::kv_router::protocols::WorkerWithDpRank;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 use crate::lora::routing::RendezvousHasher;
 use crate::lora::routing::table::LoraRoutingTable;
-use crate::lora::state_tracker::LoraStateTracker;
+use crate::lora::state_tracker::{LoraObservedSnapshot, LoraStateTracker};
 
 type WorkerId = u64;
 
@@ -43,8 +43,13 @@ impl LoraFilter {
     /// The HRW pin ranks by worker id (dp_rank collapsed to 0, since the filter operates on worker
     /// ids): it need not match the controller's exact pin — that worker is unavailable here — only
     /// be deterministic given the same available set.
-    fn bounded_fallback(&self, lora_name: &str, available: &[u64]) -> Vec<u64> {
-        let loaded = self.state_tracker.get_loaded_workers(lora_name);
+    fn bounded_fallback(
+        &self,
+        observed: &LoraObservedSnapshot,
+        lora_name: &str,
+        available: &[u64],
+    ) -> Vec<u64> {
+        let loaded = observed.get_loaded_workers(lora_name);
         if !loaded.is_empty() {
             let loaded_ids: HashSet<u64> = loaded.iter().map(|w| w.worker_id).collect();
             let live_loaded: Vec<u64> = available
@@ -92,6 +97,7 @@ impl LoraFilter {
         let Some(lora_name) = lora_name else {
             return available.to_vec();
         };
+        let observed = self.state_tracker.snapshot();
 
         let Some(config) = self.routing_table.get_config(lora_name) else {
             // No routing-table entry yet (controller disabled, or before the first tick).
@@ -99,7 +105,7 @@ impl LoraFilter {
             // so we don't scatter to every worker; fall back to all available only when none
             // are known-loaded. This makes the "loaded-worker fallback" real even when dynamic
             // allocation (the controller) is disabled.
-            let loaded = self.state_tracker.get_loaded_workers(lora_name);
+            let loaded = observed.get_loaded_workers(lora_name);
             if !loaded.is_empty() {
                 // O(1) membership instead of scanning `loaded` per available worker
                 // (this fallback runs on every LoRA request when allocation is disabled).
@@ -128,7 +134,7 @@ impl LoraFilter {
         let replica_id_set: HashSet<u64> = config.replica_set.iter().map(|w| w.worker_id).collect();
 
         if config.is_active {
-            let loaded = self.state_tracker.get_loaded_workers(lora_name);
+            let loaded = observed.get_loaded_workers(lora_name);
             let loaded_ids: HashSet<u64> = loaded.iter().map(|w| w.worker_id).collect();
 
             // Prefer: replica set ∩ loaded ∩ available
@@ -165,7 +171,7 @@ impl LoraFilter {
                 lora = lora_name,
                 "Replica set workers all unavailable; using bounded fallback (no scatter)"
             );
-            self.bounded_fallback(lora_name, available)
+            self.bounded_fallback(&observed, lora_name, available)
         } else {
             // Inactive: cold-start pin
             if let Some(pin_id) = config.replica_set.first().map(|w| w.worker_id)
@@ -182,7 +188,7 @@ impl LoraFilter {
                 lora = lora_name,
                 "Cold-start pin worker unavailable; using bounded fallback (no scatter)"
             );
-            self.bounded_fallback(lora_name, available)
+            self.bounded_fallback(&observed, lora_name, available)
         }
     }
 

--- a/lib/llm/src/lora/load_estimator.rs
+++ b/lib/llm/src/lora/load_estimator.rs
@@ -438,6 +438,14 @@ impl LoadEstimator {
             .remove(lora_name);
     }
 
+    pub(crate) fn reset(&self) {
+        self.data.clear();
+        self.predictors
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clear();
+    }
+
     pub fn start_polling(
         self: Arc<Self>,
         scheduler: Arc<KvScheduler>,

--- a/lib/llm/src/lora/state_tracker.rs
+++ b/lib/llm/src/lora/state_tracker.rs
@@ -51,7 +51,7 @@ const DEFAULT_MAX_GPU_LORA_COUNT: u32 = 4;
 /// (e.g. `loaded_locations` and `worker_to_loras` are inverse indexes of the
 /// same fact). Per-map atomicity is not enough: a concurrent addition and
 /// removal touching the same `(worker, lora)` could interleave their
-/// individual map writes and leave the indexes disagreeing. All three mutating
+/// individual map writes and leave the indexes disagreeing. All mutating
 /// handlers therefore serialize on `write_lock` for the duration of their
 /// multi-map update, so writers observe a consistent snapshot relative to one
 /// another. Readers stay lock-free on the individual `DashMap`s.
@@ -151,6 +151,75 @@ impl LoraStateTracker {
     pub fn set_worker_capacity(&self, worker: WorkerWithDpRank, capacity: u32) {
         let _guard = self.lock_writes();
         self.record_worker_capacity(worker, capacity);
+    }
+
+    /// Replace one retained worker's complete committed LoRA projection.
+    ///
+    /// Desired entries are installed before obsolete entries are withdrawn, so lock-free
+    /// routing readers never observe an unchanged adapter as temporarily unloaded.
+    pub(crate) fn replace_worker_projection(
+        &self,
+        worker: WorkerWithDpRank,
+        base_capacity: Option<u32>,
+        loras: &[LoraInfo],
+    ) {
+        let _guard = self.lock_writes();
+        let previous = self
+            .worker_to_loras
+            .get(&worker)
+            .map(|entry| entry.clone())
+            .unwrap_or_default();
+        let mut desired = HashMap::new();
+        let mut capacity = base_capacity;
+        for lora in loras {
+            let lora_capacity = lora.max_gpu_lora_count.unwrap_or_else(|| {
+                tracing::warn!(
+                    worker_id = worker.worker_id,
+                    dp_rank = worker.dp_rank,
+                    lora_name = lora.name,
+                    default = DEFAULT_MAX_GPU_LORA_COUNT,
+                    "LoRA MDC carries no max_gpu_lora_count; using default for placement capacity"
+                );
+                DEFAULT_MAX_GPU_LORA_COUNT
+            });
+            capacity = Some(lora_capacity);
+            desired.insert(lora.name.clone(), lora.clone());
+        }
+
+        if let Some(capacity) = capacity {
+            self.record_worker_capacity(worker, capacity);
+        } else {
+            self.worker_capacity.remove(&worker);
+        }
+
+        for (name, lora) in &desired {
+            self.loaded_locations
+                .entry(name.clone())
+                .or_default()
+                .insert(worker);
+            self.lora_info.insert((name.clone(), worker), lora.clone());
+        }
+
+        let desired_names = desired.into_keys().collect::<HashSet<_>>();
+        if desired_names.is_empty() {
+            self.worker_to_loras.remove(&worker);
+        } else {
+            self.worker_to_loras.insert(worker, desired_names.clone());
+        }
+
+        for name in previous.difference(&desired_names) {
+            let became_empty = if let Some(mut workers) = self.loaded_locations.get_mut(name) {
+                workers.remove(&worker);
+                workers.is_empty()
+            } else {
+                false
+            };
+            if became_empty {
+                self.loaded_locations
+                    .remove_if(name, |_, workers| workers.is_empty());
+            }
+            self.lora_info.remove(&(name.clone(), worker));
+        }
     }
 
     /// Record a worker's LoRA slot capacity, warning if it changes a previously-recorded value.
@@ -400,6 +469,26 @@ mod tests {
         assert!(tracker.is_loaded("lora-math", &w1));
         assert_eq!(tracker.total_lora_slots(), 8);
         assert_eq!(tracker.free_slots(&w1), 7);
+    }
+
+    #[test]
+    fn replace_worker_projection_reconciles_adapters_and_capacity() {
+        let tracker = LoraStateTracker::new();
+        let worker = make_worker(1);
+        let retained = make_lora_info("retained", Some(4));
+        let obsolete = make_lora_info("obsolete", Some(4));
+        tracker.handle_mdc_addition(worker, &retained);
+        tracker.handle_mdc_addition(worker, &obsolete);
+
+        let retained = make_lora_info("retained", Some(6));
+        let added = make_lora_info("added", Some(6));
+        tracker.replace_worker_projection(worker, Some(6), &[retained, added]);
+
+        assert!(tracker.is_loaded("retained", &worker));
+        assert!(tracker.is_loaded("added", &worker));
+        assert!(!tracker.is_loaded("obsolete", &worker));
+        assert_eq!(tracker.loaded_count(&worker), 2);
+        assert_eq!(tracker.free_slots(&worker), 4);
     }
 
     #[test]

--- a/lib/llm/src/lora/state_tracker.rs
+++ b/lib/llm/src/lora/state_tracker.rs
@@ -3,81 +3,130 @@
 
 //! LoRA State Tracker
 //!
-//! Tracks the runtime state of LoRA adapters across workers by watching MDC discovery
-//! events. Maintains which LoRAs are loaded on which workers and per-worker LoRA capacity.
-//!
-//! ## MDC Event Model
-//!
-//! Each MDC entry corresponds to a single `(worker, lora_name)` pair carrying one
-//! `LoraInfo`. The tracker handles three discrete event types:
-//!
-//! - `handle_mdc_addition`: a worker registered (or re-published) a LoRA adapter.
-//! - `handle_mdc_removal`: a worker unregistered one specific LoRA adapter.
-//! - `handle_worker_removal`: a worker left the cluster (drops all of its LoRAs).
-//!
-//! `handle_mdc_addition` is purely additive and idempotent — re-publishing the same
-//! `(worker, lora_name)` updates the stored `LoraInfo` in place. State reconciliation
-//! when a worker drops an adapter is the responsibility of the corresponding removal
-//! event, not the addition handler.
-//!
-//! ## Worker Capacity Invariant
-//!
-//! `LoraInfo::max_gpu_lora_count` is a *worker-level* property (the engine's
-//! `--max-loras` setting; see `docs/dev/dep/000N-lora-placement/lora-allocation-v2.md`),
-//! but is duplicated into every `LoraInfo` a
-//! worker publishes for convenience. All `LoraInfo` values coming from the same
-//! worker MUST carry the same `max_gpu_lora_count`. If a mismatch is observed
-//! across updates, we log a warning and adopt the latest value — but this should
-//! never happen with a correctly-configured worker.
+//! Publishes a coherent, immutable view of loaded LoRA adapters and worker capacity.
+//! Discovery replaces the complete committed projection for an endpoint; legacy
+//! event-style mutation methods remain for in-process callers. Readers pin one
+//! [`LoraObservedSnapshot`] so a routing decision cannot mix indexes from different
+//! discovery generations.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
-use dashmap::DashMap;
+use arc_swap::ArcSwap;
 
 use crate::kv_router::protocols::WorkerWithDpRank;
 use crate::model_card::LoraInfo;
 
 const DEFAULT_MAX_GPU_LORA_COUNT: u32 = 4;
 
-/// Tracks the loaded state of LoRAs across workers and per-worker capacity.
+#[derive(Clone, Debug, Default)]
+pub struct LoraObservedSnapshot {
+    incarnation: u64,
+    loaded_locations: HashMap<String, HashSet<WorkerWithDpRank>>,
+    lora_info: HashMap<(String, WorkerWithDpRank), LoraInfo>,
+    worker_to_loras: HashMap<WorkerWithDpRank, HashSet<String>>,
+    worker_capacity: HashMap<WorkerWithDpRank, u32>,
+}
+
+impl LoraObservedSnapshot {
+    pub fn incarnation(&self) -> u64 {
+        self.incarnation
+    }
+
+    pub fn get_loaded_workers(&self, lora_name: &str) -> HashSet<WorkerWithDpRank> {
+        self.loaded_locations
+            .get(lora_name)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn is_loaded(&self, lora_name: &str, worker: &WorkerWithDpRank) -> bool {
+        self.loaded_locations
+            .get(lora_name)
+            .is_some_and(|workers| workers.contains(worker))
+    }
+
+    pub fn list_loras(&self) -> Vec<String> {
+        self.loaded_locations.keys().cloned().collect()
+    }
+
+    pub fn list_workers(&self) -> Vec<WorkerWithDpRank> {
+        self.worker_capacity.keys().copied().collect()
+    }
+
+    fn slot_info(&self, worker: &WorkerWithDpRank) -> (u32, u32) {
+        let capacity = self.worker_capacity.get(worker).copied().unwrap_or(0);
+        let loaded = self
+            .worker_to_loras
+            .get(worker)
+            .map(|loras| loras.len() as u32)
+            .unwrap_or(0);
+        (loaded, capacity)
+    }
+
+    pub fn free_slots(&self, worker: &WorkerWithDpRank) -> u32 {
+        let (loaded, capacity) = self.slot_info(worker);
+        capacity.saturating_sub(loaded)
+    }
+
+    pub fn total_lora_slots(&self) -> u32 {
+        self.worker_capacity.values().sum()
+    }
+
+    pub fn get_worker_capacities(&self) -> HashMap<WorkerWithDpRank, u32> {
+        self.worker_capacity.clone()
+    }
+
+    pub fn get_worker_slot_usage(&self) -> HashMap<WorkerWithDpRank, (usize, usize)> {
+        self.worker_capacity
+            .iter()
+            .map(|(worker, capacity)| (*worker, (self.loaded_count(worker), *capacity as usize)))
+            .collect()
+    }
+
+    pub fn workers_with_free_slots(&self) -> Vec<WorkerWithDpRank> {
+        self.worker_capacity
+            .iter()
+            .filter_map(|(worker, capacity)| {
+                ((self.loaded_count(worker) as u32) < *capacity).then_some(*worker)
+            })
+            .collect()
+    }
+
+    pub fn loaded_count(&self, worker: &WorkerWithDpRank) -> usize {
+        self.worker_to_loras
+            .get(worker)
+            .map(HashSet::len)
+            .unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.worker_capacity.is_empty()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LoraWorkerProjection {
+    pub(crate) capacity: u32,
+    pub(crate) loras: Vec<LoraInfo>,
+}
+
+/// Tracks one endpoint's complete observed LoRA state.
 ///
-/// Concurrent data structure updated from MDC discovery events and read from
-/// the allocation controller and filter.
-///
-/// ## Cross-map consistency
-///
-/// State is spread across four `DashMap`s that must stay mutually consistent
-/// (e.g. `loaded_locations` and `worker_to_loras` are inverse indexes of the
-/// same fact). Per-map atomicity is not enough: a concurrent addition and
-/// removal touching the same `(worker, lora)` could interleave their
-/// individual map writes and leave the indexes disagreeing. All mutating
-/// handlers therefore serialize on `write_lock` for the duration of their
-/// multi-map update, so writers observe a consistent snapshot relative to one
-/// another. Readers stay lock-free on the individual `DashMap`s.
+/// Writers build a new immutable generation under `write_lock` and publish it
+/// with one pointer swap. A request or allocation tick can therefore pin one
+/// [`LoraObservedSnapshot`] and never combine indexes from different discovery
+/// generations.
 #[derive(Clone)]
 pub struct LoraStateTracker {
-    /// LoRA name -> set of workers where it is loaded
-    loaded_locations: Arc<DashMap<String, HashSet<WorkerWithDpRank>>>,
-    /// LoRA name, worker -> LoraInfo from MDC
-    lora_info: Arc<DashMap<(String, WorkerWithDpRank), LoraInfo>>,
-    /// Worker -> set of LoRA names loaded on that worker
-    worker_to_loras: Arc<DashMap<WorkerWithDpRank, HashSet<String>>>,
-    /// Worker -> max_gpu_lora_count capacity
-    worker_capacity: Arc<DashMap<WorkerWithDpRank, u32>>,
-    /// Serializes the multi-map mutations in the `handle_*` methods so the four
-    /// indexes above can never be left mutually inconsistent by interleaved
-    /// writers. Reads do not take this lock.
+    observed: Arc<ArcSwap<LoraObservedSnapshot>>,
     write_lock: Arc<Mutex<()>>,
 }
 
 impl LoraStateTracker {
     pub fn new() -> Self {
         Self {
-            loaded_locations: Arc::new(DashMap::new()),
-            lora_info: Arc::new(DashMap::new()),
-            worker_to_loras: Arc::new(DashMap::new()),
-            worker_capacity: Arc::new(DashMap::new()),
+            observed: Arc::new(ArcSwap::from_pointee(LoraObservedSnapshot::default())),
             write_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -86,6 +135,22 @@ impl LoraStateTracker {
     /// writer panic must not wedge all future updates).
     fn lock_writes(&self) -> std::sync::MutexGuard<'_, ()> {
         self.write_lock.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    pub fn snapshot(&self) -> Arc<LoraObservedSnapshot> {
+        self.observed.load_full()
+    }
+
+    fn mutate(&self, update: impl FnOnce(&mut LoraObservedSnapshot)) {
+        let _guard = self.lock_writes();
+        let current = self.observed.load_full();
+        let was_empty = current.is_empty();
+        let mut next = (*current).clone();
+        update(&mut next);
+        if was_empty && !next.is_empty() {
+            next.incarnation = next.incarnation.wrapping_add(1).max(1);
+        }
+        self.observed.store(Arc::new(next));
     }
 
     /// Handle an MDC addition event: a worker registered (or re-published) a LoRA adapter.
@@ -101,22 +166,6 @@ impl LoraStateTracker {
     /// previously-recorded capacity for the same worker is logged at warn level
     /// and the latest value is adopted.
     pub fn handle_mdc_addition(&self, worker: WorkerWithDpRank, lora: &LoraInfo) {
-        let _guard = self.lock_writes();
-        let lora_name = lora.name.clone();
-
-        self.loaded_locations
-            .entry(lora_name.clone())
-            .or_default()
-            .insert(worker);
-
-        self.lora_info
-            .insert((lora_name.clone(), worker), lora.clone());
-
-        self.worker_to_loras
-            .entry(worker)
-            .or_default()
-            .insert(lora_name);
-
         let capacity = lora.max_gpu_lora_count.unwrap_or_else(|| {
             tracing::warn!(
                 worker_id = worker.worker_id,
@@ -129,9 +178,20 @@ impl LoraStateTracker {
             );
             DEFAULT_MAX_GPU_LORA_COUNT
         });
-        // record_worker_capacity warns on a same-worker capacity change (shared with the
-        // base-card path in set_worker_capacity so both registration paths honor the invariant).
-        self.record_worker_capacity(worker, capacity);
+        self.mutate(|next| {
+            let lora_name = lora.name.clone();
+            next.loaded_locations
+                .entry(lora_name.clone())
+                .or_default()
+                .insert(worker);
+            next.lora_info
+                .insert((lora_name.clone(), worker), lora.clone());
+            next.worker_to_loras
+                .entry(worker)
+                .or_default()
+                .insert(lora_name);
+            record_worker_capacity(next, worker, capacity);
+        });
 
         tracing::debug!(
             worker_id = worker.worker_id,
@@ -149,130 +209,50 @@ impl LoraStateTracker {
     /// loaded LoRAs, so callers can establish cluster topology / per-worker `max_gpu_lora_count`
     /// without consuming a slot with a phantom adapter.
     pub fn set_worker_capacity(&self, worker: WorkerWithDpRank, capacity: u32) {
-        let _guard = self.lock_writes();
-        self.record_worker_capacity(worker, capacity);
+        self.mutate(|next| record_worker_capacity(next, worker, capacity));
     }
 
     /// Replace one retained worker's complete committed LoRA projection.
     ///
     /// Desired entries are installed before obsolete entries are withdrawn, so lock-free
     /// routing readers never observe an unchanged adapter as temporarily unloaded.
+    #[cfg(test)]
     pub(crate) fn replace_worker_projection(
         &self,
         worker: WorkerWithDpRank,
         base_capacity: Option<u32>,
         loras: &[LoraInfo],
     ) {
-        let _guard = self.lock_writes();
-        let previous = self
-            .worker_to_loras
-            .get(&worker)
-            .map(|entry| entry.clone())
-            .unwrap_or_default();
-        let mut desired = HashMap::new();
-        let mut capacity = base_capacity;
-        for lora in loras {
-            let lora_capacity = lora.max_gpu_lora_count.unwrap_or_else(|| {
-                tracing::warn!(
-                    worker_id = worker.worker_id,
-                    dp_rank = worker.dp_rank,
-                    lora_name = lora.name,
-                    default = DEFAULT_MAX_GPU_LORA_COUNT,
-                    "LoRA MDC carries no max_gpu_lora_count; using default for placement capacity"
-                );
-                DEFAULT_MAX_GPU_LORA_COUNT
-            });
-            capacity = Some(lora_capacity);
-            desired.insert(lora.name.clone(), lora.clone());
-        }
-
-        if let Some(capacity) = capacity {
-            self.record_worker_capacity(worker, capacity);
-        } else {
-            self.worker_capacity.remove(&worker);
-        }
-
-        for (name, lora) in &desired {
-            self.loaded_locations
-                .entry(name.clone())
-                .or_default()
-                .insert(worker);
-            self.lora_info.insert((name.clone(), worker), lora.clone());
-        }
-
-        let desired_names = desired.into_keys().collect::<HashSet<_>>();
-        if desired_names.is_empty() {
-            self.worker_to_loras.remove(&worker);
-        } else {
-            self.worker_to_loras.insert(worker, desired_names.clone());
-        }
-
-        for name in previous.difference(&desired_names) {
-            let became_empty = if let Some(mut workers) = self.loaded_locations.get_mut(name) {
-                workers.remove(&worker);
-                workers.is_empty()
-            } else {
-                false
-            };
-            if became_empty {
-                self.loaded_locations
-                    .remove_if(name, |_, workers| workers.is_empty());
-            }
-            self.lora_info.remove(&(name.clone(), worker));
-        }
+        let capacity = effective_capacity(worker, base_capacity, loras);
+        let projection = capacity.map(|capacity| LoraWorkerProjection {
+            capacity,
+            loras: loras.to_vec(),
+        });
+        self.mutate(|next| replace_worker(next, worker, projection));
     }
 
-    /// Record a worker's LoRA slot capacity, warning if it changes a previously-recorded value.
-    /// The caller must hold the write lock. Shared by
-    /// [`handle_mdc_addition`](Self::handle_mdc_addition) (adapter cards) and
-    /// [`set_worker_capacity`](Self::set_worker_capacity) (base-card capacity seeding) so a
-    /// same-worker capacity change is logged regardless of which path set it.
-    fn record_worker_capacity(&self, worker: WorkerWithDpRank, capacity: u32) {
-        if let Some(prev) = self.worker_capacity.get(&worker)
-            && *prev != capacity
-        {
-            tracing::warn!(
-                worker_id = worker.worker_id,
-                dp_rank = worker.dp_rank,
-                previous_capacity = *prev,
-                new_capacity = capacity,
-                "Worker LoRA capacity changed across registrations"
-            );
+    pub(crate) fn replace_endpoint_projection(
+        &self,
+        projections: HashMap<WorkerWithDpRank, LoraWorkerProjection>,
+    ) {
+        let _guard = self.lock_writes();
+        let current = self.observed.load_full();
+        let mut next = LoraObservedSnapshot {
+            incarnation: current.incarnation,
+            ..Default::default()
+        };
+        for (worker, projection) in projections {
+            replace_worker(&mut next, worker, Some(projection));
         }
-        self.worker_capacity.insert(worker, capacity);
+        if current.is_empty() && !next.is_empty() {
+            next.incarnation = next.incarnation.wrapping_add(1).max(1);
+        }
+        self.observed.store(Arc::new(next));
     }
 
     /// Handle an MDC removal event: a worker unregistered a LoRA adapter.
     pub fn handle_mdc_removal(&self, worker: WorkerWithDpRank, lora_name: &str) {
-        let _guard = self.lock_writes();
-        let became_empty = if let Some(mut workers) = self.loaded_locations.get_mut(lora_name) {
-            workers.remove(&worker);
-            workers.is_empty()
-        } else {
-            false
-        };
-        if became_empty {
-            // remove_if re-checks the predicate under the shard lock, so a
-            // concurrent handle_mdc_addition that races between the is_empty
-            // check above and this call cannot have its entry silently deleted.
-            self.loaded_locations
-                .remove_if(lora_name, |_, v| v.is_empty());
-        }
-
-        self.lora_info.remove(&(lora_name.to_string(), worker));
-
-        let became_empty = if let Some(mut loras) = self.worker_to_loras.get_mut(&worker) {
-            loras.remove(lora_name);
-            loras.is_empty()
-        } else {
-            false
-        };
-        if became_empty {
-            // remove_if re-checks the predicate under the shard lock, so a
-            // concurrent handle_mdc_addition that races between the drop above
-            // and this call cannot have its newly inserted entry deleted.
-            self.worker_to_loras.remove_if(&worker, |_, v| v.is_empty());
-        }
+        self.mutate(|next| remove_lora(next, worker, lora_name));
 
         tracing::debug!(
             worker_id = worker.worker_id,
@@ -284,33 +264,7 @@ impl LoraStateTracker {
 
     /// Handle a worker being completely removed.
     pub fn handle_worker_removal(&self, worker: WorkerWithDpRank) {
-        let _guard = self.lock_writes();
-
-        // Remove the capacity entry FIRST. `worker_capacity` is the enumeration
-        // spine for every slot/capacity reader (`workers_with_free_slots`,
-        // `list_workers`, `get_worker_slot_usage`, `slot_info`), so dropping it
-        // first makes the worker vanish from those snapshots atomically. If we
-        // cleared `worker_to_loras` first instead, a concurrent reader could
-        // momentarily see the worker as capacity-present with zero loaded LoRAs
-        // and wrongly report it as having free slots.
-        self.worker_capacity.remove(&worker);
-
-        if let Some((_, loras)) = self.worker_to_loras.remove(&worker) {
-            for lora_name in &loras {
-                let became_empty =
-                    if let Some(mut workers) = self.loaded_locations.get_mut(lora_name) {
-                        workers.remove(&worker);
-                        workers.is_empty()
-                    } else {
-                        false
-                    };
-                if became_empty {
-                    self.loaded_locations
-                        .remove_if(lora_name, |_, v| v.is_empty());
-                }
-                self.lora_info.remove(&(lora_name.clone(), worker));
-            }
-        }
+        self.mutate(|next| replace_worker(next, worker, None));
 
         tracing::debug!(
             worker_id = worker.worker_id,
@@ -320,116 +274,163 @@ impl LoraStateTracker {
     }
 
     pub fn get_loaded_workers(&self, lora_name: &str) -> HashSet<WorkerWithDpRank> {
-        self.loaded_locations
-            .get(lora_name)
-            .map(|entry| entry.value().clone())
-            .unwrap_or_default()
+        self.snapshot().get_loaded_workers(lora_name)
     }
 
     pub fn is_loaded(&self, lora_name: &str, worker: &WorkerWithDpRank) -> bool {
-        self.loaded_locations
-            .get(lora_name)
-            .map(|entry| entry.contains(worker))
-            .unwrap_or(false)
+        self.snapshot().is_loaded(lora_name, worker)
     }
 
     pub fn list_loras(&self) -> Vec<String> {
-        self.loaded_locations
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect()
+        self.snapshot().list_loras()
     }
 
     pub fn list_workers(&self) -> Vec<WorkerWithDpRank> {
-        self.worker_capacity
-            .iter()
-            .map(|entry| *entry.key())
-            .collect()
-    }
-
-    fn slot_info(&self, worker: &WorkerWithDpRank) -> (u32, u32) {
-        let capacity = self.worker_capacity.get(worker).map(|v| *v).unwrap_or(0);
-        let loaded = self
-            .worker_to_loras
-            .get(worker)
-            .map(|v| v.len() as u32)
-            .unwrap_or(0);
-        (loaded, capacity)
+        self.snapshot().list_workers()
     }
 
     pub fn free_slots(&self, worker: &WorkerWithDpRank) -> u32 {
-        let (loaded, capacity) = self.slot_info(worker);
-        capacity.saturating_sub(loaded)
+        self.snapshot().free_slots(worker)
     }
 
     pub fn total_lora_slots(&self) -> u32 {
-        self.worker_capacity
-            .iter()
-            .map(|entry| *entry.value())
-            .sum()
+        self.snapshot().total_lora_slots()
     }
 
     pub fn get_worker_capacities(&self) -> HashMap<WorkerWithDpRank, u32> {
-        self.worker_capacity
-            .iter()
-            .map(|entry| (*entry.key(), *entry.value()))
-            .collect()
+        self.snapshot().get_worker_capacities()
     }
 
     pub fn get_worker_slot_usage(&self) -> HashMap<WorkerWithDpRank, (usize, usize)> {
-        // Snapshot capacities first, releasing all worker_capacity shard guards
-        // before touching worker_to_loras. Reading a second DashMap while
-        // holding an iterator guard risks a lock-order deadlock against a
-        // writer that locks the two maps in the opposite order.
-        let caps: Vec<(WorkerWithDpRank, u32)> = self
-            .worker_capacity
-            .iter()
-            .map(|entry| (*entry.key(), *entry.value()))
-            .collect();
-        caps.into_iter()
-            .filter_map(|(worker, cap)| {
-                let loaded = self.loaded_count(&worker);
-                // Drop workers removed since the snapshot. handle_worker_removal
-                // clears worker_capacity before worker_to_loras, so if loaded
-                // dropped to 0 due to a concurrent removal, the capacity entry
-                // is already gone and this recheck filters out the stale row.
-                self.worker_capacity
-                    .contains_key(&worker)
-                    .then_some((worker, (loaded, cap as usize)))
-            })
-            .collect()
+        self.snapshot().get_worker_slot_usage()
     }
 
     pub fn workers_with_free_slots(&self) -> Vec<WorkerWithDpRank> {
-        // Snapshot first (see get_worker_slot_usage) to avoid holding a
-        // worker_capacity iterator guard while reading worker_to_loras.
-        let caps: Vec<(WorkerWithDpRank, u32)> = self
-            .worker_capacity
-            .iter()
-            .map(|entry| (*entry.key(), *entry.value()))
-            .collect();
-        caps.into_iter()
-            .filter(|(worker, capacity)| {
-                // loaded_count first, then re-confirm the worker still exists:
-                // a worker removed since the snapshot has its capacity cleared
-                // before worker_to_loras, so a transient loaded==0 cannot make
-                // a removed worker look free.
-                (self.loaded_count(worker) as u32) < *capacity
-                    && self.worker_capacity.contains_key(worker)
-            })
-            .map(|(worker, _)| worker)
-            .collect()
+        self.snapshot().workers_with_free_slots()
     }
 
     pub fn loaded_count(&self, worker: &WorkerWithDpRank) -> usize {
-        self.worker_to_loras
-            .get(worker)
-            .map(|v| v.len())
-            .unwrap_or(0)
+        self.snapshot().loaded_count(worker)
     }
 
     pub fn is_empty(&self) -> bool {
-        self.worker_capacity.is_empty()
+        self.snapshot().is_empty()
+    }
+}
+
+#[cfg(test)]
+fn effective_capacity(
+    worker: WorkerWithDpRank,
+    base_capacity: Option<u32>,
+    loras: &[LoraInfo],
+) -> Option<u32> {
+    if let Some(capacity) = base_capacity {
+        return Some(capacity);
+    }
+    let mut assertions = loras
+        .iter()
+        .filter_map(|lora| lora.max_gpu_lora_count)
+        .collect::<Vec<_>>();
+    assertions.sort_unstable();
+    assertions.dedup();
+    if assertions.len() > 1 {
+        tracing::warn!(
+            worker_id = worker.worker_id,
+            dp_rank = worker.dp_rank,
+            capacities = ?assertions,
+            "LoRA adapter cards disagree on worker capacity; using the conservative minimum"
+        );
+    }
+    assertions.first().copied().or_else(|| {
+        (!loras.is_empty()).then(|| {
+            tracing::warn!(
+                worker_id = worker.worker_id,
+                dp_rank = worker.dp_rank,
+                default = DEFAULT_MAX_GPU_LORA_COUNT,
+                "LoRA MDC carries no max_gpu_lora_count; using compatibility default"
+            );
+            DEFAULT_MAX_GPU_LORA_COUNT
+        })
+    })
+}
+
+fn record_worker_capacity(
+    snapshot: &mut LoraObservedSnapshot,
+    worker: WorkerWithDpRank,
+    capacity: u32,
+) {
+    if let Some(previous) = snapshot.worker_capacity.get(&worker)
+        && *previous != capacity
+    {
+        tracing::warn!(
+            worker_id = worker.worker_id,
+            dp_rank = worker.dp_rank,
+            previous_capacity = *previous,
+            new_capacity = capacity,
+            "Worker LoRA capacity changed across registrations"
+        );
+    }
+    snapshot.worker_capacity.insert(worker, capacity);
+}
+
+fn remove_lora(snapshot: &mut LoraObservedSnapshot, worker: WorkerWithDpRank, lora_name: &str) {
+    if let Some(workers) = snapshot.loaded_locations.get_mut(lora_name) {
+        workers.remove(&worker);
+        if workers.is_empty() {
+            snapshot.loaded_locations.remove(lora_name);
+        }
+    }
+    snapshot.lora_info.remove(&(lora_name.to_string(), worker));
+    if let Some(loras) = snapshot.worker_to_loras.get_mut(&worker) {
+        loras.remove(lora_name);
+        if loras.is_empty() {
+            snapshot.worker_to_loras.remove(&worker);
+        }
+    }
+}
+
+fn replace_worker(
+    snapshot: &mut LoraObservedSnapshot,
+    worker: WorkerWithDpRank,
+    projection: Option<LoraWorkerProjection>,
+) {
+    let previous = snapshot
+        .worker_to_loras
+        .get(&worker)
+        .cloned()
+        .unwrap_or_default();
+    let Some(projection) = projection else {
+        snapshot.worker_capacity.remove(&worker);
+        for name in previous {
+            remove_lora(snapshot, worker, &name);
+        }
+        return;
+    };
+
+    snapshot.worker_capacity.insert(worker, projection.capacity);
+    let desired = projection
+        .loras
+        .into_iter()
+        .map(|lora| (lora.name.clone(), lora))
+        .collect::<HashMap<_, _>>();
+    let desired_names = desired.keys().cloned().collect::<HashSet<_>>();
+    for (name, lora) in desired {
+        snapshot
+            .loaded_locations
+            .entry(name.clone())
+            .or_default()
+            .insert(worker);
+        snapshot.lora_info.insert((name, worker), lora);
+    }
+    if desired_names.is_empty() {
+        snapshot.worker_to_loras.remove(&worker);
+    } else {
+        snapshot
+            .worker_to_loras
+            .insert(worker, desired_names.clone());
+    }
+    for name in previous.difference(&desired_names) {
+        remove_lora(snapshot, worker, name);
     }
 }
 
@@ -489,6 +490,24 @@ mod tests {
         assert!(!tracker.is_loaded("obsolete", &worker));
         assert_eq!(tracker.loaded_count(&worker), 2);
         assert_eq!(tracker.free_slots(&worker), 4);
+    }
+
+    #[test]
+    fn pinned_snapshot_survives_atomic_projection_replacement() {
+        let tracker = LoraStateTracker::new();
+        let worker = make_worker(1);
+        tracker.replace_worker_projection(worker, Some(4), &[make_lora_info("old", Some(4))]);
+        let pinned = tracker.snapshot();
+
+        tracker.replace_worker_projection(worker, Some(8), &[make_lora_info("new", Some(8))]);
+
+        assert!(pinned.is_loaded("old", &worker));
+        assert!(!pinned.is_loaded("new", &worker));
+        assert_eq!(pinned.total_lora_slots(), 4);
+        let current = tracker.snapshot();
+        assert!(!current.is_loaded("old", &worker));
+        assert!(current.is_loaded("new", &worker));
+        assert_eq!(current.total_lora_slots(), 8);
     }
 
     #[test]
@@ -609,11 +628,12 @@ mod tests {
             h.join().expect("worker thread panicked");
         }
 
+        let snapshot = tracker.snapshot();
         // Invariant: every (lora -> worker) entry in loaded_locations has a
         // matching (worker -> lora) entry in worker_to_loras, and vice versa.
-        for lora in tracker.list_loras() {
-            for w in tracker.get_loaded_workers(&lora) {
-                let loras_on_w = tracker
+        for lora in snapshot.list_loras() {
+            for w in snapshot.get_loaded_workers(&lora) {
+                let loras_on_w = snapshot
                     .worker_to_loras
                     .get(&w)
                     .map(|s| s.contains(&lora))
@@ -624,11 +644,10 @@ mod tests {
                 );
             }
         }
-        for entry in tracker.worker_to_loras.iter() {
-            let w = *entry.key();
-            for lora in entry.value() {
+        for (w, loras) in &snapshot.worker_to_loras {
+            for lora in loras {
                 assert!(
-                    tracker.is_loaded(lora, &w),
+                    snapshot.is_loaded(lora, w),
                     "worker_to_loras says {lora} on {w:?} but loaded_locations disagrees"
                 );
             }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -475,6 +475,8 @@ pub struct OpenAIPreprocessor {
     routing_prepend_bos: Option<crate::protocols::TokenIdType>,
 }
 
+pub(crate) const LORA_NAME_CONTEXT_KEY: &str = "discovery.lora_name";
+
 impl OpenAIPreprocessor {
     fn omitted_max_tokens_default(
         prompt_len: usize,
@@ -1217,7 +1219,12 @@ impl OpenAIPreprocessor {
         tracker: Option<&RequestTracker>,
     ) -> Result<(PreprocessedRequest, HashMap<String, String>, bool)> {
         let (request, annotations, prompt_injected_reasoning, _image_tokens) = self
-            .preprocess_request_with_options(request, tracker, PreprocessRequestOptions::default())
+            .preprocess_request_with_options(
+                request,
+                tracker,
+                PreprocessRequestOptions::default(),
+                None,
+            )
             .await?;
         Ok((request, annotations, prompt_injected_reasoning))
     }
@@ -1235,6 +1242,7 @@ impl OpenAIPreprocessor {
         request: &R,
         tracker: Option<&RequestTracker>,
         options: PreprocessRequestOptions,
+        lora_name: Option<String>,
     ) -> Result<(
         PreprocessedRequest,
         HashMap<String, String>,
@@ -1243,7 +1251,7 @@ impl OpenAIPreprocessor {
     )> {
         let _stage_guard = StageGuard::new(STAGE_PREPROCESS, "");
         let preprocess_start = Instant::now();
-        let mut builder = self.builder(request)?;
+        let mut builder = self.builder_with_lora(request, lora_name)?;
 
         let template_start = Instant::now();
         let formatted_prompt = {
@@ -1366,6 +1374,21 @@ impl OpenAIPreprocessor {
         &self,
         request: &R,
     ) -> Result<PreprocessedRequestBuilder> {
+        self.builder_with_lora(request, None)
+    }
+
+    fn builder_with_lora<
+        R: OAIChatLikeRequest
+            + AnnotationsProvider
+            + SamplingOptionsProvider
+            + StopConditionsProvider
+            + OutputOptionsProvider
+            + NvExtProvider,
+    >(
+        &self,
+        request: &R,
+        lora_name_override: Option<String>,
+    ) -> Result<PreprocessedRequestBuilder> {
         let mut builder = PreprocessedRequest::builder();
         builder.model(request.model());
 
@@ -1450,7 +1473,7 @@ impl OpenAIPreprocessor {
         builder.output_options(output_options);
         builder.annotations(request.annotations().unwrap_or_default());
         builder.mdc_sum(Some(self.mdcsum.clone()));
-        let lora_name = self.lora_name.clone();
+        let lora_name = self.lora_name.clone().or(lora_name_override);
         let cache_namespace = request_cache_salt(request).map(str::to_owned);
 
         // Extract routing hints from nvext if present
@@ -3992,7 +4015,16 @@ impl
 
         // convert the chat completion request to a common completion request
         let (mut common_request, annotations, prompt_injected_reasoning, image_tokens) = self
-            .preprocess_request_with_options(&request, tracker.as_deref(), preprocess_options)
+            .preprocess_request_with_options(
+                &request,
+                tracker.as_deref(),
+                preprocess_options,
+                context
+                    .get_optional::<String>(LORA_NAME_CONTEXT_KEY)
+                    .ok()
+                    .flatten()
+                    .map(|name| name.as_ref().clone()),
+            )
             .await?;
         attach_agent_context_from_context(&mut common_request, &context);
 
@@ -4157,7 +4189,14 @@ impl
         let mut response_generator = Box::new(response_generator);
         let tracker = Some(response_generator.tracker());
         // convert the chat completion request to a common completion request
-        let mut builder = self.builder(&request)?;
+        let mut builder = self.builder_with_lora(
+            &request,
+            context
+                .get_optional::<String>(LORA_NAME_CONTEXT_KEY)
+                .ok()
+                .flatten()
+                .map(|name| name.as_ref().clone()),
+        )?;
 
         // Check if embeddings are provided - skip tokenization path
         let annotations = if let Some(ref prompt_embeds) = request.inner.prompt_embeds {

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -607,6 +607,90 @@ impl Client {
         self.routing_instances.instance_avail_watcher()
     }
 
+    /// Create a client view whose routable instances are restricted by a caller-owned
+    /// admission set.
+    ///
+    /// Endpoint discovery remains the source of connection metadata and hard availability. The
+    /// returned client publishes only the intersection of that endpoint membership and
+    /// `admitted_ids`, allowing a higher-level controller to keep discovered-but-unvalidated
+    /// instances out of a routing group. The view has independent overload and fault-inhibition
+    /// state, just like a freshly constructed client.
+    pub fn with_admitted_instances(
+        &self,
+        admitted_ids: tokio::sync::watch::Receiver<Vec<u64>>,
+    ) -> Self {
+        self.with_admitted_instances_and_cancellation(
+            admitted_ids,
+            self.endpoint.drt().primary_token(),
+        )
+    }
+
+    /// Like [`Self::with_admitted_instances`], with a lifecycle token for construction-time
+    /// cancellation by an owning controller.
+    pub fn with_admitted_instances_and_cancellation(
+        &self,
+        mut admitted_ids: tokio::sync::watch::Receiver<Vec<u64>>,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) -> Self {
+        let mut endpoint_instances = self.instance_source.as_ref().clone();
+        let initial = Self::filter_admitted_instances(
+            endpoint_instances.borrow().as_slice(),
+            admitted_ids.borrow().as_slice(),
+        );
+        let initial_ids = initial.iter().map(Instance::id).collect::<Vec<_>>();
+        let (instance_tx, instance_rx) = tokio::sync::watch::channel(initial);
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => break,
+                    _ = instance_tx.closed() => break,
+                    result = endpoint_instances.changed() => {
+                        if result.is_err() {
+                            break;
+                        }
+                    }
+                    result = admitted_ids.changed() => {
+                        if result.is_err() {
+                            break;
+                        }
+                    }
+                }
+
+                let next = Self::filter_admitted_instances(
+                    endpoint_instances.borrow_and_update().as_slice(),
+                    admitted_ids.borrow_and_update().as_slice(),
+                );
+                if *instance_tx.borrow() != next && instance_tx.send(next).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let client = Self {
+            endpoint: self.endpoint.clone(),
+            endpoint_discovery_source: self.endpoint_discovery_source.clone(),
+            instance_source: Arc::new(instance_rx),
+            routing_instances: Arc::new(RoutingInstancesState::new(initial_ids)),
+            reconcile_interval: self.reconcile_interval,
+        };
+        client.monitor_instance_source();
+        client
+    }
+
+    fn filter_admitted_instances(instances: &[Instance], admitted_ids: &[u64]) -> Vec<Instance> {
+        if admitted_ids.is_empty() {
+            return Vec::new();
+        }
+
+        let admitted = admitted_ids.iter().copied().collect::<HashSet<_>>();
+        instances
+            .iter()
+            .filter(|instance| admitted.contains(&instance.id()))
+            .cloned()
+            .collect()
+    }
+
     /// Subscribe to raw discovery events for this endpoint.
     ///
     /// Unlike `instance_source`, this feed does not coalesce remove→add pairs,
@@ -1262,6 +1346,41 @@ mod tests {
         // Note: We need to check if changed() was signaled
         let current = watcher.borrow().clone();
         assert_eq!(current, vec![1, 3]);
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn admitted_client_never_routes_unadmitted_endpoint_instances() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_admitted_client".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+        let endpoint_client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let worker_id = endpoint_client.wait_for_instances().await.unwrap()[0].id();
+
+        let (admission_tx, admission_rx) = tokio::sync::watch::channel(Vec::new());
+        let admitted_client = endpoint_client.with_admitted_instances(admission_rx);
+        let mut admitted = admitted_client.instance_avail_watcher();
+        assert!(admitted.borrow().is_empty());
+
+        admission_tx.send_replace(vec![worker_id]);
+        tokio::time::timeout(Duration::from_secs(1), admitted.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(admitted.borrow_and_update().clone(), vec![worker_id]);
+
+        admission_tx.send_replace(Vec::new());
+        tokio::time::timeout(Duration::from_secs(1), admitted.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admitted.borrow_and_update().is_empty());
 
         rt.shutdown();
     }

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -639,11 +639,12 @@ impl Client {
         );
         let initial_ids = initial.iter().map(Instance::id).collect::<Vec<_>>();
         let (instance_tx, instance_rx) = tokio::sync::watch::channel(initial);
+        let updater_cancel = cancel_token.clone();
 
         tokio::spawn(async move {
             loop {
                 tokio::select! {
-                    _ = cancel_token.cancelled() => break,
+                    _ = updater_cancel.cancelled() => break,
                     _ = instance_tx.closed() => break,
                     result = endpoint_instances.changed() => {
                         if result.is_err() {
@@ -661,7 +662,8 @@ impl Client {
                     endpoint_instances.borrow_and_update().as_slice(),
                     admitted_ids.borrow_and_update().as_slice(),
                 );
-                if *instance_tx.borrow() != next && instance_tx.send(next).is_err() {
+                let changed = *instance_tx.borrow() != next;
+                if changed && instance_tx.send(next).is_err() {
                     break;
                 }
             }
@@ -674,7 +676,7 @@ impl Client {
             routing_instances: Arc::new(RoutingInstancesState::new(initial_ids)),
             reconcile_interval: self.reconcile_interval,
         };
-        client.monitor_instance_source();
+        client.monitor_instance_source_with_cancellation(cancel_token);
         client
     }
 
@@ -793,8 +795,15 @@ impl Client {
     /// `instance_source`. This ensures instances removed via `report_instance_down`
     /// are eventually restored even if the discovery source doesn't emit updates.
     fn monitor_instance_source(&self) {
-        let reconcile_interval = self.reconcile_interval;
         let cancel_token = self.endpoint.drt().primary_token();
+        self.monitor_instance_source_with_cancellation(cancel_token);
+    }
+
+    fn monitor_instance_source_with_cancellation(
+        &self,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) {
+        let reconcile_interval = self.reconcile_interval;
         let client = self.clone();
         let endpoint_id = self.endpoint.id();
         tokio::task::spawn(async move {

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -676,7 +676,7 @@ impl Client {
             routing_instances: Arc::new(RoutingInstancesState::new(initial_ids)),
             reconcile_interval: self.reconcile_interval,
         };
-        client.monitor_instance_source_with_cancellation(cancel_token);
+        client.monitor_instance_source_with_cancellation(cancel_token, false);
         client
     }
 
@@ -796,12 +796,13 @@ impl Client {
     /// are eventually restored even if the discovery source doesn't emit updates.
     fn monitor_instance_source(&self) {
         let cancel_token = self.endpoint.drt().primary_token();
-        self.monitor_instance_source_with_cancellation(cancel_token);
+        self.monitor_instance_source_with_cancellation(cancel_token, true);
     }
 
     fn monitor_instance_source_with_cancellation(
         &self,
         cancel_token: tokio_util::sync::CancellationToken,
+        prune_shared_occupancy: bool,
     ) {
         let reconcile_interval = self.reconcile_interval;
         let client = self.clone();
@@ -818,12 +819,14 @@ impl Client {
                 let routing_instances = client.reconcile_discovered_instances(instance_ids);
 
                 // Clean up stale occupancy counters for instances that no longer exist.
-                let registry = client.endpoint.drt().routing_occupancy_states();
-                if let Ok(registry) = registry.try_lock()
-                    && let Some(weak) = registry.get(&client.endpoint)
-                    && let Some(state) = weak.upgrade()
-                {
-                    state.retain(routing_instances.discovered_ids());
+                if prune_shared_occupancy {
+                    let registry = client.endpoint.drt().routing_occupancy_states();
+                    if let Ok(registry) = registry.try_lock()
+                        && let Some(weak) = registry.get(&client.endpoint)
+                        && let Some(state) = weak.upgrade()
+                    {
+                        state.retain(routing_instances.discovered_ids());
+                    }
                 }
 
                 tokio::select! {

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -14,7 +14,6 @@ import logging
 import os
 import sys
 import tempfile
-import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -956,24 +955,43 @@ def test_router_decisions_router_aic(
     )
 
 
-def _wait_for_frontend_to_observe_single_pd_role(
-    frontend: KVRouterProcess,
+async def _wait_for_frontend_to_commit_single_pd_role(
+    frontend_port: int,
+    namespace: str,
     worker_type: str,
     timeout: float = 30,
 ) -> None:
-    patterns = {
-        "decode": "No prefill endpoint for namespace yet, storing sender for future activation",
-        "prefill": "Stored prefill endpoint for future decode WorkerSet registration",
-    }
-    pattern = patterns[worker_type]
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if pattern in frontend.read_logs():
-            return
-        time.sleep(0.1)
+    readiness_url = f"http://localhost:{frontend_port}/v1/models/{MODEL_NAME}/ready"
+    deadline = asyncio.get_running_loop().time() + timeout
+    last_response: object = None
+    client_timeout = aiohttp.ClientTimeout(total=10)
+    async with aiohttp.ClientSession(timeout=client_timeout) as session:
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                async with session.get(readiness_url) as response:
+                    if response.status == 200:
+                        body = await response.json()
+                        last_response = body
+                        role = (
+                            body.get("namespaces", {})
+                            .get(namespace, {})
+                            .get("worker_types", {})
+                            .get(worker_type, {})
+                        )
+                        if role.get("workers", 0) == 1:
+                            return
+                    else:
+                        last_response = {
+                            "status": response.status,
+                            "body": await response.text(),
+                        }
+            except (aiohttp.ClientError, asyncio.TimeoutError) as error:
+                last_response = repr(error)
+            await asyncio.sleep(0.1)
 
     raise AssertionError(
-        f"Frontend did not observe the standalone {worker_type} WorkerSet within {timeout}s"
+        f"Frontend did not commit the standalone {worker_type} WorkerSet within {timeout}s; "
+        f"last response: {last_response}"
     )
 
 
@@ -1093,8 +1111,10 @@ def test_mocker_disagg_startup_lifecycle(
                 )[0]
 
             if frontend is not None and len(workers) == 1:
-                _wait_for_frontend_to_observe_single_pd_role(
-                    frontend, next(iter(workers))
+                asyncio.run(
+                    _wait_for_frontend_to_commit_single_pd_role(
+                        frontend_port, namespace, next(iter(workers))
+                    )
                 )
 
         assert frontend is not None


### PR DESCRIPTION
## Summary

Replace the model watcher's distributed registration bookkeeping with a single ordered desired-state controller. The controller reduces discovery events synchronously, launches bounded cancellable WorkerSet builds, fences late results by generation and normalized materialization fingerprint, retries failures with capped backoff, and fails groups closed on simultaneous checksum conflicts.

Publish discovered serving state through one committed-group boundary. Model cards, primary and alias ownership, WorkerSets, routing activation, and LoRA projections become request-visible together through an atomic catalog snapshot. Endpoint clients are restricted to controller-admitted worker IDs so discovery cannot route through an uncommitted instance.

Adapter-suffix cards remain desired LoRA overlays rather than WorkerSet members, and watcher termination retains committed last-known-good serving state. Runtime-config, load-monitor, KV-event recovery, discovery wire formats, and public frontend APIs are unchanged.

Reviewer guide:

- `discovery/controller.rs` contains the state machine, cancellation/generation fencing, retries, conflict handling, and deterministic controller tests.
- `discovery/model_manager.rs` and `discovery/model.rs` contain the atomic committed catalog and group lifecycle boundary.
- `discovery/watcher.rs` is the materializer/host integration and LoRA projection layer.
- `runtime/component/client.rs` provides the admitted endpoint view used during materialization.

## Validation

- Adversarial discovery-churn A/B: three interleaved pairs on a 32-core Linux node, 32 stable workers plus a repeatedly added/removed 32-worker cohort, 8,192 requests per trial, and 1,920 logical discovery mutations per arm. Candidate median throughput was 295.9 vs 293.7 req/s (`+0.77%`), median mean latency was 221.09 vs 221.38 ms, frontend CPU was 2.849 vs 2.818 cores, and peak RSS was 2,172,444 vs 2,167,448 KiB. There were zero model-visibility gaps, cancellations, or churn timeouts. Median tail latency was higher in the candidate, but the three-run ranges overlapped and did not establish a regression.
- Forced termination of active workers produced 15/24,576 candidate request errors vs 26/24,576 baseline errors; both arms exhibited the existing closed-stream behavior while the model remained continuously available.
- A candidate-only checksum-conflict probe removed the model from `/v1/models` while an incompatible worker was present and restored it after the conflicting worker left.
- `cargo test -p dynamo-llm --no-default-features discovery` (204 discovery tests plus the namespace integration case)
- `cargo test -p dynamo-runtime admitted_client_never_routes_unadmitted_endpoint_instances --lib`
- Linux controller regression suite: 9/9 passed
- `(cd lib/llm && cargo clippy --no-default-features -- -D warnings)`, `(cd lib/llm && cargo fmt)`, commit hooks, and `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added more reliable automatic model discovery, worker grouping, and membership reconciliation.
  - Added dynamic admission controls so routing uses only currently approved instances.
  - Improved support for model aliases, LoRA configurations, and changing worker membership.
  - Added dynamic endpoint updates for prefill and encoder routing.

- **Bug Fixes**
  - Prevented stale discovery updates from replacing healthy committed model state.
  - Improved recovery from temporary preparation failures and cancellations.
  - Ensured readiness checks reflect only committed models and updates apply atomically.
  - Improved consistency by clearing stale LoRA routing state after worker changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->