### PR TITLE
feat(snapshot): checkpoint CUDA FABRIC mappings

### DIFF
--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -77,8 +77,14 @@ func buildCheckpointJob(
 	if storage, ok, err := checkpoint.StorageFromConfig(config.Checkpoint.Storage); err != nil {
 		return nil, err
 	} else if ok {
-		snapshotprotocol.InjectCheckpointVolume(&podTemplate.Spec, storage.PVCName)
-		snapshotprotocol.InjectCheckpointVolumeMount(targetContainer, storage.BasePath)
+		// Reuse an existing mount of the configured PVC when present.
+		volumeName, err := snapshotprotocol.InjectCheckpointVolume(&podTemplate.Spec, storage.PVCName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inject checkpoint storage volume: %w", err)
+		}
+		if err := snapshotprotocol.InjectCheckpointVolumeMount(targetContainer, volumeName, storage.BasePath); err != nil {
+			return nil, fmt.Errorf("failed to inject checkpoint storage mount: %w", err)
+		}
 		if podTemplate.Annotations == nil {
 			podTemplate.Annotations = map[string]string{}
 		}

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -262,6 +262,59 @@ func TestBuildCheckpointJob(t *testing.T) {
 	assert.Equal(t, []string{"--launch-job", "python3", "-m", "dynamo.vllm"}, job.Spec.Template.Spec.Containers[0].Args)
 }
 
+func TestBuildCheckpointJobReusesCheckpointStorageMount(t *testing.T) {
+	const volumeName = "checkpoints"
+
+	t.Log("Configure a checkpoint template that already mounts the storage PVC")
+	ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhasePending)
+	ckpt.Spec.Job.PodTemplateSpec.Spec.Volumes = []corev1.Volume{{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "snapshot-pvc"},
+		},
+	}}
+	ckpt.Spec.Job.PodTemplateSpec.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+		Name:      volumeName,
+		MountPath: "/checkpoints",
+	}}
+	r := makeCheckpointReconciler(checkpointTestScheme(), &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "snapshot-pvc", Namespace: testNamespace},
+	})
+	r.Config.Checkpoint.Storage = configv1alpha1.CheckpointStorageConfiguration{
+		Type: snapshotprotocol.StorageTypePVC,
+		PVC: configv1alpha1.CheckpointPVCConfig{
+			PVCName:  "snapshot-pvc",
+			BasePath: "/checkpoints",
+		},
+	}
+
+	t.Log("Build the checkpoint job")
+	job, err := buildCheckpointJob(context.Background(), r.Client, r.Config, ckpt, defaultCheckpointJobName)
+	require.NoError(t, err)
+
+	t.Log("Verify the existing storage volume and mount are reused exactly once")
+	var checkpointVolumes []corev1.Volume
+	for _, volume := range job.Spec.Template.Spec.Volumes {
+		assert.NotEqual(t, snapshotprotocol.CheckpointVolumeName, volume.Name)
+		if volume.PersistentVolumeClaim != nil &&
+			volume.PersistentVolumeClaim.ClaimName == "snapshot-pvc" {
+			checkpointVolumes = append(checkpointVolumes, volume)
+		}
+	}
+	require.Len(t, checkpointVolumes, 1)
+	assert.Equal(t, volumeName, checkpointVolumes[0].Name)
+
+	var baseMounts []corev1.VolumeMount
+	for _, mount := range job.Spec.Template.Spec.Containers[0].VolumeMounts {
+		assert.NotEqual(t, snapshotprotocol.CheckpointVolumeName, mount.Name)
+		if mount.MountPath == "/checkpoints" {
+			baseMounts = append(baseMounts, mount)
+		}
+	}
+	require.Len(t, baseMounts, 1)
+	assert.Equal(t, volumeName, baseMounts[0].Name)
+}
+
 func TestBuildCheckpointJobWrapsWithCudaCheckpointForMultiGPU(t *testing.T) {
 	s := checkpointTestScheme()
 	ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhasePending)

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
@@ -50,20 +50,21 @@ PID. While the CUDA process lock is held, the coordinator poisons the dedicated
 Redis database, loads the RDB, verifies the expected generation and
 manifest-bound state digest, and validates all graph metadata and allocation
 bytes. The non-restored coordinator also verifies its `NODE_NAME` against the
-source node, and each restored shim scans the real driver for every saved source
-GPU UUID. The shim accepts a process-local ordinal change only when the source
-UUID has exactly one current match, then reconciles the allocation property and
-access descriptor ordinals before replay. It rejects node changes, GPU identity
-changes, absent or ambiguous source UUIDs, and access descriptors that are not
-exactly one read/write DEVICE descriptor on the allocation GPU.
+source node. It builds a complete identity-first source-to-target placement from
+the manifest source UUIDs and target UUIDs in current runtime ordinal order,
+then sends each restored shim only its expected source entries. Each shim
+validates all detached allocation metadata before atomically updating the
+target ordinal in allocation properties and access descriptors. The saved
+source UUID remains the allocation identity; restored shims do not enumerate
+CUDA devices during placement setup.
 
 Processes launched through the shim but without capture-visible shared VMM
 mappings, such as a launcher, are not durable VMM graph participants. After
 native CUDA restore, the coordinator accepts such an endpoint only when
-`QUERY_PLACEMENT` proves that it has zero detached managed placements. An
+an empty `SET_PLACEMENT` proves that it has zero detached managed placements. An
 unexpected endpoint with any managed placement fails closed. This does not
 support partial process restore: every durable ledger participant must still
-restore on the source node with its exact captured GPU placement.
+restore on the source node under the authoritative placement plan.
 
 After all preflight checks pass, the coordinator unlocks the CUDA processes
 immediately before the first owner replay request. This is required because
@@ -151,12 +152,12 @@ or opaque transport handles. Device ordinals can occur inside opaque
 allocation-property and access-descriptor replay records, but they are not
 durable identity. The shim admits only an access descriptor whose ordinal matches
 the allocation's transient validated device ordinal; restore uses an ordinal
-only after current UUID validation. A
+only after validating the controller-supplied source/target UUID plan. A
 deterministic SHA-256 digest over that graph
 metadata and every allocation byte is stored in Redis and the checkpoint manifest. Redis
 stores the allocation graph and contents, never POSIX FDs, logical FABRIC
 tokens, raw FABRIC handles, PIDs, or socket paths. Ledger version 2 and private
-control protocol version 3 are required; cross-version artifact restore is
+control protocol version 4 are required; cross-version artifact restore is
 unsupported. The artifact requires the same architecture, CUDA ABI, and shim
 build.
 
@@ -165,7 +166,7 @@ build.
 - CUDA Driver API VMM with `requestedHandleTypes` exactly POSIX FD (`1`) or
   exactly FABRIC (`8`). Zero, combined bitmasks such as `9`, and every other
   type are rejected.
-- FABRIC is single-node IMEX unicast only. Exporter and importer must use
+- FABRIC is single-node M2 IMEX unicast only. Exporter and importer must use
   fabric-ready hardware and have access to the same IMEX channel.
 - One owner physical allocation, one complete offset-zero mapping per
   participant, all participants launched through the shim, and one
@@ -228,10 +229,8 @@ The implementation detects and rejects:
   state, or accessible IMEX channel is absent or mismatched, or when exporter
   and importer do not share the same channel;
 - fork after CUDA initialization as observed by `pthread_atfork`;
-- missing current `NODE_NAME` and target-node changes; the same physical GPU UUID
-  at a changed process-local CUDA ordinal is accepted, but an absent source UUID,
-  a source UUID visible ambiguously at multiple ordinals, or a different physical
-  GPU identity is rejected;
+- missing current `NODE_NAME`, target-node changes, or an invalid, incomplete,
+  duplicate, or participant-inconsistent authoritative GPU placement plan;
 - inconsistent manifest VMM fields, a missing/empty/non-regular
   `cuda-vmm.rdb`, or an RDB artifact without manifest opt-in;
 - a checkpoint-side RDB source that is not a regular non-empty file after
@@ -290,11 +289,8 @@ must enforce these assumptions:
 | Every participating process uses the launcher and resolves managed APIs through the preload/resolver path. | Static binaries, alternate loader namespaces, preload suppression, explicit-handle `dlvsym`, or direct explicit-handle lookup of a managed API can bypass tracking and produce an incomplete graph. cuda-python's explicit `dlsym` lookup of the CUDA resolver is supported. |
 | A process does not fork before CUDA use and then continue without `exec`. | The child inherits the parent's participant ID, listener FD, and socket path but not the control thread. It cannot create an independent endpoint, and checkpoint eventually fails through participant/process-set drift. Fork followed by `exec` reinitializes the launcher-scoped shim. |
 | Checkpoint and restore run on one logical node, with the same accessible IMEX channel and ready fabric state for FABRIC resources. | Cross-node routing is unsupported. A node, GPU, IMEX channel, or fabric-state change invalidates local brokerage and can cause `CUDA_ERROR_NOT_PERMITTED` or restore failure. |
-| The restore uses the same architecture, CUDA ABI, shim build, and source GPU UUID placement. | Same-UUID process-local ordinal reindexing is reconciled while locked. Different GPU identity or other opaque CUDA property/access changes fail preflight; replay-time CUDA failures fail the restore and trigger target teardown. |
+| The restore uses the same architecture, CUDA ABI, and shim build. | Identity and same-node remapped GPU placements are reconciled while locked from the controller plan. Other opaque CUDA property/access changes fail preflight; replay-time CUDA failures fail the restore and trigger target teardown. |
 | Redis is dedicated to this job and the restore command atomically loads the supplied RDB. | Another writer or non-atomic load can replace/mix state; digest, generation, or poison checks reject detectable drift. |
-
-Queued `SCM_RIGHTS` FDs, received-but-not-imported FDs, and stale/unconsumed
-FABRIC tokens are unsupported and unobservable.
 
 The non-restored Snapshot coordinator reads its existing `NODE_NAME` for both
 source metadata and current restore placement; restore fails closed when that
@@ -302,10 +298,11 @@ identity is unavailable. The implementation remains single-node.
 
 ## Non-goals
 
-The interposer does not support cross-node routing, relocation, multicast
-objects or APIs/state, CUDA mempools, queued/retained transport objects,
-repeated checkpoint/restore cycles, cross-version artifacts, or native
-FlashInfer checkpoint hooks. It does not remove CUDA's native checkpoint
+The interposer does not support cross-node routing, multinode IMEX, multicast
+objects or APIs/state, CUDA mempools, unobservable retained, dangling, queued,
+or received-but-not-imported transport capabilities, repeated checkpoint/restore
+cycles, cross-version artifacts, or native application checkpoint hooks,
+including native FlashInfer hooks. It does not remove CUDA's native checkpoint
 responsibility for unrelated CUDA state or legacy CUDA IPC.
 
 Deployment admission and workload discipline must enforce these assumptions.

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
@@ -50,10 +50,12 @@ PID. While the CUDA process lock is held, the coordinator poisons the dedicated
 Redis database, loads the RDB, verifies the expected generation and
 manifest-bound state digest, and validates all graph metadata and allocation
 bytes. The non-restored coordinator also verifies its `NODE_NAME` against the
-source node, and each restored shim queries the real driver for the UUID
-currently mapped to every source ordinal. The shim rejects node changes, GPU changes,
-ordinal reordering, and access descriptors that are not exactly one read/write
-DEVICE descriptor on the allocation GPU.
+source node, and each restored shim scans the real driver for every saved source
+GPU UUID. The shim accepts a process-local ordinal change only when the source
+UUID has exactly one current match, then reconciles the allocation property and
+access descriptor ordinals before replay. It rejects node changes, GPU identity
+changes, absent or ambiguous source UUIDs, and access descriptors that are not
+exactly one read/write DEVICE descriptor on the allocation GPU.
 
 Processes launched through the shim but without capture-visible shared VMM
 mappings, such as a launcher, are not durable VMM graph participants. After
@@ -286,7 +288,7 @@ must enforce these assumptions:
 | Every participating process uses the launcher and resolves managed APIs through the preload/resolver path. | Static binaries, alternate loader namespaces, preload suppression, explicit-handle `dlvsym`, or direct explicit-handle lookup of a managed API can bypass tracking and produce an incomplete graph. cuda-python's explicit `dlsym` lookup of the CUDA resolver is supported. |
 | A process does not fork before CUDA use and then continue without `exec`. | The child inherits the parent's participant ID, listener FD, and socket path but not the control thread. It cannot create an independent endpoint, and checkpoint eventually fails through participant/process-set drift. Fork followed by `exec` reinitializes the launcher-scoped shim. |
 | Checkpoint and restore run on one logical node, with the same accessible IMEX channel and ready fabric state for FABRIC resources. | Cross-node routing is unsupported. A node, GPU, IMEX channel, or fabric-state change invalidates local brokerage and can cause `CUDA_ERROR_NOT_PERMITTED` or restore failure. |
-| The restore uses the same architecture, CUDA ABI, shim build, and compatible GPU placement. | Opaque CUDA property/access bytes or device ordinals can have different meaning. Detectable preflight mismatches fail while locked; replay-time CUDA failures fail the restore and trigger target teardown. |
+| The restore uses the same architecture, CUDA ABI, shim build, and source GPU UUID placement. | Same-UUID process-local ordinal reindexing is reconciled while locked. Different GPU identity or other opaque CUDA property/access changes fail preflight; replay-time CUDA failures fail the restore and trigger target teardown. |
 | Redis is dedicated to this job and the restore command atomically loads the supplied RDB. | Another writer or non-atomic load can replace/mix state; digest, generation, or poison checks reject detectable drift. |
 
 Queued `SCM_RIGHTS` FDs, received-but-not-imported FDs, and stale/unconsumed

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
@@ -4,14 +4,15 @@ All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Snapshot CUDA POSIX-FD VMM interposer
+# Snapshot CUDA shared VMM interposer
 
 This launcher-scoped `LD_PRELOAD` interposer checkpoints complete CUDA Driver
-API VMM allocations shared through POSIX file descriptors. It is transparent
-to inference frameworks: applications do not call checkpoint hooks. The
+API VMM allocations shared through either POSIX file descriptors or single-node
+`CU_MEM_HANDLE_TYPE_FABRIC`/IMEX unicast handles. It is transparent to
+inference frameworks: applications do not call checkpoint hooks. The
 interposer composes with `cuda-checkpoint --launch-job`; Redis replaces the
-CUDA job-file role only for shim-managed POSIX-FD VMM state. CUDA checkpoint
-continues to own unrelated CUDA state, including legacy CUDA IPC.
+CUDA job-file role only for shim-managed VMM state. CUDA checkpoint continues
+to own unrelated CUDA state, including legacy CUDA IPC.
 
 ## Enablement and flow
 
@@ -50,7 +51,7 @@ Redis database, loads the RDB, verifies the expected generation and
 manifest-bound state digest, and validates all graph metadata and allocation
 bytes. The non-restored coordinator also verifies its `NODE_NAME` against the
 source node, and each restored shim queries the real driver for the UUID
-currently mapped to every source ordinal. M1 rejects node changes, GPU changes,
+currently mapped to every source ordinal. The shim rejects node changes, GPU changes,
 ordinal reordering, and access descriptors that are not exactly one read/write
 DEVICE descriptor on the allocation GPU.
 
@@ -82,28 +83,43 @@ tagged process-local logical token from supported `cuMemCreate` and
 release, and allocation-property queries. Unknown tagged tokens fail closed;
 logical tokens are never passed to the UMD.
 
-The application also never observes a raw CUDA POSIX export FD. On the first
-successful owner export, the shim assigns that allocation a random nonzero
-128-bit UUID. Every export of the same allocation returns a fresh fixed-size
-sealed memfd containing the UUID, exact owner control-socket path, and owner
-participant ID. The application can transport this opaque capability with
-`SCM_RIGHTS`; it remains caller-owned and open after import.
-Capabilities are bearer tokens: sealing protects their contents, while control
-socket directory permissions remain the authorization boundary. An importer
-accepts only the exact canonical
-`CONTROL-DIRECTORY/cuda-vmm-PID.sock` shape in its own configured control
-directory (`DYN_SNAPSHOT_CONTROL_DIR`, or `/snapshot-control` by default),
-with a positive canonical decimal namespace PID.
+The application never observes a raw CUDA POSIX export FD or raw CUDA FABRIC
+handle. On the first successful owner export, the shim assigns that allocation
+a random nonzero 128-bit UUID.
 
-An importer validates only this sealed capability. For another process's
-owner, it releases its process-global shim mutex, requests a fresh raw CUDA FD
-from the named owner over the bounded-time control socket, reacquires the
-mutex, revalidates active state, and imports that FD. A same-process import
-exports locally without calling its own control socket. The owner binds the
-broker response to the operation, allocation UUID, and participant ID. The
-owner and importer close their raw FD copies on every path and never persist
-them. Malformed tokens, unavailable owners, broker mismatches, and raw CUDA
-FDs passed directly to the import wrapper fail closed without fallback.
+- A POSIX export returns the existing fresh 256-byte sealed memfd capability
+  containing the UUID, exact owner control-socket path, and owner participant
+  ID. The application can transport this opaque capability with `SCM_RIGHTS`;
+  it remains caller-owned and open after import.
+- A FABRIC export calls the real driver on every attempt, then returns an exact
+  64-byte logical token containing a magic/version/type discriminator, UUID,
+  32 lowercase hexadecimal participant bytes, positive namespace PID, and
+  zero reserved word. The driver-produced 64 bytes are immediately discarded.
+  Repeated exports reuse the logical UUID and route identity.
+
+The POSIX capability and FABRIC token are bearer values. Control-socket
+directory permissions remain the authorization boundary. The FABRIC PID is
+only a transient local routing hint; durable allocation identity is the
+participant ID plus allocation UUID. The importer derives the canonical
+`CONTROL-DIRECTORY/cuda-vmm-PID.sock` path from its own configured control
+directory (`DYN_SNAPSHOT_CONTROL_DIR`, or `/snapshot-control` by default).
+
+For another process's owner, the importer releases its process-global shim
+mutex during bounded control-socket I/O, reacquires the mutex, revalidates
+active state and identity, then passes the freshly brokered raw handle directly
+to the real driver. A same-process import exports locally without calling its
+own socket. The private protocol is typed:
+
+| Handle type | Broker result |
+|---|---|
+| POSIX FD (`1`) | Exactly one `SCM_RIGHTS` FD and no payload |
+| FABRIC (`8`) | No FD and exactly 64 payload bytes |
+
+The owner binds responses to operation, exact handle type, allocation UUID, and
+participant ID. Raw FD copies are closed and raw FABRIC bytes are wiped and
+discarded on every path. Malformed logical tokens, raw CUDA handles passed to
+the application import wrapper, unavailable owners, and response-shape or
+identity mismatches fail closed without fallback or live Redis lookup.
 
 ## Redis and RDB contract
 
@@ -131,17 +147,24 @@ application-handle liveness, and access descriptors. It does not persist
 PIDs, FD numbers, capture allocation UUIDs, real CUDA handles, CUDA contexts,
 or opaque transport handles. Device ordinals can occur inside opaque
 allocation-property and access-descriptor replay records, but they are not
-durable identity. M1 admits only an access descriptor whose ordinal matches
+durable identity. The shim admits only an access descriptor whose ordinal matches
 the allocation's transient validated device ordinal; restore uses an ordinal
 only after current UUID validation. A
 deterministic SHA-256 digest over that graph
-metadata and every allocation byte is stored in Redis and the checkpoint
-manifest. The artifact requires the same architecture, CUDA ABI, and shim
+metadata and every allocation byte is stored in Redis and the checkpoint manifest. Redis
+stores the allocation graph and contents, never POSIX FDs, logical FABRIC
+tokens, raw FABRIC handles, PIDs, or socket paths. Ledger version 2 and private
+control protocol version 3 are required; cross-version artifact restore is
+unsupported. The artifact requires the same architecture, CUDA ABI, and shim
 build.
 
-## Supported M1 contract
+## Supported contract
 
-- CUDA Driver API POSIX-FD VMM only.
+- CUDA Driver API VMM with `requestedHandleTypes` exactly POSIX FD (`1`) or
+  exactly FABRIC (`8`). Zero, combined bitmasks such as `9`, and every other
+  type are rejected.
+- FABRIC is single-node IMEX unicast only. Exporter and importer must use
+  fabric-ready hardware and have access to the same IMEX channel.
 - One owner physical allocation, one complete offset-zero mapping per
   participant, all participants launched through the shim, and one
   checkpoint/restore cycle.
@@ -152,21 +175,34 @@ build.
 - Managed generic handles are stable shim tokens. They may remain live across
   checkpoint, or may follow the mapping-only lifecycle after application
   release.
-- POSIX sharing handles are sealed shim capabilities. Repeated owner exports
-  reuse one allocation UUID but return independent capability FDs.
+- Every owner and importer for one logical resource uses the same exact handle
+  type. POSIX sharing handles are sealed shim capabilities; FABRIC sharing
+  handles are exact 64-byte shim tokens. Repeated owner exports reuse one
+  allocation UUID.
+- Individual allocation contents are limited to Redis's 512 MiB bulk limit;
+  restore frames add only one exact record, property, and access descriptor.
 - Legacy CUDA IPC passes through unchanged to CUDA checkpoint's native
   job-file support.
 - `cuMulticastBindMem` and its available `_v2` resolver entry are poison-only:
-  binding a managed allocation is rejected before the UMD because M1 does not
+  binding a managed allocation is rejected before the UMD because the shim does not
   capture or replay multicast state. Calls with unrelated real handles pass
   through unchanged.
+
+On restore, owner reconstruction remains one path: create, exact-VA map,
+temporary write access, content copy, final access, and logical-handle rebind.
+The owner then returns either one transient POSIX FD or one transient 64-byte
+FABRIC value. A FABRIC importer receives those bytes only after its durable
+record/access metadata, calls the real import API, wipes the bytes, maps,
+applies access, and rebinds. No raw transport value enters allocation state,
+Redis, JSON, the digest, or a file.
 
 ## Detected and fail-closed
 
 The implementation detects and rejects:
 
 - missing or mixed launcher opt-in and process-set drift;
-- non-POSIX shared-handle types, unknown typed resource kinds, unknown tagged
+- zero, mixed, combined, or unsupported shared-handle types, unknown typed
+  resource kinds, unknown tagged
   logical handles, raw/unsealed/malformed sharing FDs, and untracked real
   handles used for managed map/export;
 - any successful `cuMemRetainAllocationHandle` call, even though the real
@@ -175,14 +211,20 @@ The implementation detects and rejects:
   incomplete access metadata;
 - partial, gapped, mixed managed/unmanaged, or repeated access-update ranges;
 - host, other-device, multi-device, non-read/write, or otherwise non-FlashInfer
-  access descriptors; M1 requires exactly one read/write DEVICE descriptor on
+  access descriptors; the shim requires exactly one read/write DEVICE descriptor on
   the allocation GPU;
 - missing owners/importers or local detached records that do not match the
   allocation UUID, logical object, role, exact VA, and size;
-- zero allocation UUIDs, multiple owners for one UUID, owner endpoint or
-  participant mismatches, unavailable owners, broker timeouts, responses
-  without exactly one raw FD, and any attempt to fall back to importing the
-  application capability directly;
+- zero allocation UUIDs, invalid FABRIC token magic/version/type/participant/PID
+  or reserved word, multiple owners for one UUID, owner endpoint or participant
+  mismatches, unavailable owners, broker timeouts, FABRIC responses carrying an
+  FD or not exactly 64 bytes, POSIX responses carrying a payload or not exactly
+  one FD, and any attempt to fall back to importing an application token
+  directly;
+- real CUDA FABRIC export/import failure, including
+  `CUDA_ERROR_NOT_PERMITTED` when the CUDA FABRIC-support attribute, fabric
+  state, or accessible IMEX channel is absent or mismatched, or when exporter
+  and importer do not share the same channel;
 - fork after CUDA initialization as observed by `pthread_atfork`;
 - missing current `NODE_NAME`, target-node changes, GPU UUID changes at a
   source ordinal, and ordinal reordering;
@@ -193,7 +235,8 @@ The implementation detects and rejects:
 - a restore command that leaves the pre-restore Redis poison in place, or
   loaded state whose generation, ledger digest, graph metadata, or allocation
   bytes do not match the manifest;
-- CUDA detach/replay, Redis, configuration, socket, and broker-FD cleanup
+- CUDA detach/replay, Redis, configuration, socket, broker-FD cleanup, and
+  FABRIC-byte cleanup
   failures;
 - failure to unlock the CUDA processes at the validated preflight-to-replay
   boundary;
@@ -233,23 +276,32 @@ must enforce these assumptions:
 | Assumption | Possible failure when violated |
 |---|---|
 | The process tree is quiesced before the first VMM `INSPECT` or any other checkpoint-prepare operation and remains quiesced through graph capture and all importer/owner detach operations. At its restored control point, the application remains quiescent through the unlocked owner/importer replay and final-health window. | This is an unsupported contract violation and can silently omit a live mapping from the captured graph, producing an incomplete or corrupt checkpoint. In particular, a remote import that finishes after its participant was inspected can commit a mapping absent from the captured graph. Other concurrent managed calls can cause rejection or CUDA errors; bypassed or otherwise unmanaged CUDA calls can race replay and cause silent mapping or data corruption. |
-| Every application POSIX capability FD and alias is closed before prepare. FlashInfer's self-allgather result slot can be application-owned even when it is not imported, so the workload must close it too. | M1 cannot reliably verify this. A violation can preserve a stale bearer capability outside the captured graph and may be caught later by CRIU or yield undefined behavior. |
+| Every application POSIX capability FD and alias is closed before prepare. FlashInfer's self-allgather result slot can be application-owned even when it is not imported, so the workload must close it too. | The shim cannot reliably verify this. A violation can preserve a stale bearer capability outside the captured graph and may be caught later by CRIU or yield undefined behavior. |
+| No FABRIC logical token remains queued, retained, or unconsumed at the checkpoint boundary. | The 64-byte value has no observable lifecycle. A stale token can survive outside the captured graph and route to detached or replaced owner state. |
 | No FD is queued in `SCM_RIGHTS`. | CRIU can restore a stale capability that does not refer to the newly brokered allocation. |
 | No FD has been received but not imported. | The untracked capability can survive outside the logical graph and later import stale backing. |
 | Applications treat sharing FDs as opaque transport capabilities and do not require raw CUDA-FD `fstat`, `ioctl`, or `poll` behavior. | The returned FD is a sealed memfd, not the NVIDIA character-device export. Unsupported inspection or raw-FD bypass cannot be associated safely and must not be used. |
 | Every managed allocation has one complete offset-zero mapping and one full-range access update, either individually or through an exact contiguous union. | Partial, gapped, mixed, repeated, or unobserved shape cannot be reconstructed exactly. Observed wrapped violations fail admission; bypassed calls can replay incorrectly without detection. |
-| Shared resources use only the M1 POSIX-FD allocation APIs. | IMEX/fabric handles, multicast, mempools, external memory, arrays, or unwrapped allocation-derived handles bypass the graph and can restore incomplete or stale sharing state. |
+| Shared resources use only exact POSIX-FD or FABRIC allocation types through the wrapped Driver APIs. | Multicast APIs/state, mempools, external memory, arrays, native FlashInfer checkpoint hooks, retained/queued transport objects, or unwrapped allocation-derived handles bypass the graph and can restore incomplete or stale sharing state. |
 | Every participating process uses the launcher and resolves managed APIs through the preload/resolver path. | Static binaries, alternate loader namespaces, preload suppression, explicit-handle `dlvsym`, or direct explicit-handle lookup of a managed API can bypass tracking and produce an incomplete graph. cuda-python's explicit `dlsym` lookup of the CUDA resolver is supported. |
 | A process does not fork before CUDA use and then continue without `exec`. | The child inherits the parent's participant ID, listener FD, and socket path but not the control thread. It cannot create an independent endpoint, and checkpoint eventually fails through participant/process-set drift. Fork followed by `exec` reinitializes the launcher-scoped shim. |
-| Checkpoint and restore run on one logical node. | M1 has no cross-node barrier, capability transport, or placement; changing nodes makes local POSIX-FD brokerage and device ordinals invalid. |
+| Checkpoint and restore run on one logical node, with the same accessible IMEX channel and ready fabric state for FABRIC resources. | Cross-node routing is unsupported. A node, GPU, IMEX channel, or fabric-state change invalidates local brokerage and can cause `CUDA_ERROR_NOT_PERMITTED` or restore failure. |
 | The restore uses the same architecture, CUDA ABI, shim build, and compatible GPU placement. | Opaque CUDA property/access bytes or device ordinals can have different meaning. Detectable preflight mismatches fail while locked; replay-time CUDA failures fail the restore and trigger target teardown. |
 | Redis is dedicated to this job and the restore command atomically loads the supplied RDB. | Another writer or non-atomic load can replace/mix state; digest, generation, or poison checks reject detectable drift. |
 
-Queued `SCM_RIGHTS` FDs and received-but-not-imported FDs are unsupported and
-unobservable to M1.
+Queued `SCM_RIGHTS` FDs, received-but-not-imported FDs, and stale/unconsumed
+FABRIC tokens are unsupported and unobservable.
 
 The non-restored Snapshot coordinator reads its existing `NODE_NAME` for both
 source metadata and current restore placement; restore fails closed when that
-identity is unavailable. M1 remains single-node.
+identity is unavailable. The implementation remains single-node.
+
+## Non-goals
+
+The interposer does not support cross-node routing, relocation, multicast
+objects or APIs/state, CUDA mempools, queued/retained transport objects,
+repeated checkpoint/restore cycles, cross-version artifacts, or native
+FlashInfer checkpoint hooks. It does not remove CUDA's native checkpoint
+responsibility for unrelated CUDA state or legacy CUDA IPC.
 
 Deployment admission and workload discipline must enforce these assumptions.

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
@@ -228,8 +228,10 @@ The implementation detects and rejects:
   state, or accessible IMEX channel is absent or mismatched, or when exporter
   and importer do not share the same channel;
 - fork after CUDA initialization as observed by `pthread_atfork`;
-- missing current `NODE_NAME`, target-node changes, GPU UUID changes at a
-  source ordinal, and ordinal reordering;
+- missing current `NODE_NAME` and target-node changes; the same physical GPU UUID
+  at a changed process-local CUDA ordinal is accepted, but an absent source UUID,
+  a source UUID visible ambiguously at multiple ordinals, or a different physical
+  GPU identity is rejected;
 - inconsistent manifest VMM fields, a missing/empty/non-regular
   `cuda-vmm.rdb`, or an RDB artifact without manifest opt-in;
 - a checkpoint-side RDB source that is not a regular non-empty file after

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
@@ -2441,20 +2441,13 @@ cuMemImportFromShareableHandle(
       fail("cannot record VMM capability import");
       result = CUDA_ERROR_INVALID_VALUE;
     } else {
-      if (allocation->properties.requestedHandleTypes != type) {
-        if (release == NULL || release(real_handle) != CUDA_SUCCESS)
-          fail_cleanup("cannot release cross-type imported CUDA handle");
-        free(allocation);
-        fail("real CUDA import returned cross-type allocation properties");
-        result = CUDA_ERROR_INVALID_VALUE;
-        goto done;
-      }
       memcpy(allocation->allocation_uuid, allocation_uuid, sizeof(allocation->allocation_uuid));
       allocation->exported = true;
       allocation->real_handle = real_handle;
       allocation->application_handle_live = true;
       allocation->role = DYN_VMM_IMPORTER;
       allocation->object_kind = DYN_VMM_ALLOCATION;
+      /* CUDA reports re-exportable types, not the transport used to import. */
       allocation->requested_handle_type = type;
       allocation->next = allocations;
       allocations = allocation;

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
@@ -84,6 +84,7 @@ struct allocation {
   uint32_t role;
   uint32_t object_kind;
   CUmemAllocationHandleType requested_handle_type;
+  int source_device_ordinal;
   int device_ordinal;
   CUuuid gpu_uuid;
   bool exported;
@@ -534,7 +535,6 @@ placement_seen(const struct allocation* allocation)
 
   for (previous = allocations; previous != allocation; previous = previous->next) {
     if (previous->detached &&
-        previous->device_ordinal == allocation->device_ordinal &&
         memcmp(
             previous->gpu_uuid.bytes, allocation->gpu_uuid.bytes,
             sizeof(allocation->gpu_uuid.bytes)) == 0)
@@ -543,14 +543,30 @@ placement_seen(const struct allocation* allocation)
   return false;
 }
 
+static struct dyn_vmm_placement*
+find_placement(struct dyn_vmm_placement* placements, size_t count, const CUuuid* gpu_uuid)
+{
+  size_t index;
+
+  for (index = 0; index < count; index++) {
+    if (memcmp(placements[index].source_gpu_uuid, gpu_uuid->bytes, sizeof(gpu_uuid->bytes)) == 0)
+      return &placements[index];
+  }
+  return NULL;
+}
+
 static int
 query_placement(int client, struct dyn_vmm_header* response)
 {
+  typedef CUresult(CUDAAPI * count_fn)(int*);
   typedef CUresult(CUDAAPI * uuid_fn)(CUuuid*, CUdevice);
+  count_fn get_count = (count_fn)real_symbol("cuDeviceGetCount");
   uuid_fn get_uuid = (uuid_fn)real_symbol("cuDeviceGetUuid_v2");
   struct allocation* allocation;
   struct dyn_vmm_placement* placements;
+  int device_count;
   size_t count = 0;
+  size_t index;
 
   if (get_uuid == NULL)
     get_uuid = (uuid_fn)real_symbol("cuDeviceGetUuid");
@@ -561,37 +577,120 @@ query_placement(int client, struct dyn_vmm_header* response)
       count++;
   }
   placements = calloc(count == 0 ? 1 : count, sizeof(*placements));
-  if (get_uuid == NULL || placements == NULL) {
+  if (placements == NULL) {
     free(placements);
     set_error(response, "cannot query current CUDA GPU placement");
     return send_header(client, response, -1);
   }
-  count = 0;
+  if (count == 0) {
+    if (send_header(client, response, -1) != 0) {
+      free(placements);
+      return -1;
+    }
+    free(placements);
+    return 0;
+  }
+  if (get_count == NULL || get_uuid == NULL) {
+    free(placements);
+    set_error(response, "cannot query current CUDA GPU placement");
+    return send_header(client, response, -1);
+  }
+  index = 0;
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
-    CUuuid current;
-
     if (!allocation->detached)
       continue;
     if (placement_seen(allocation))
       continue;
-    if (get_uuid(&current, allocation->device_ordinal) != CUDA_SUCCESS) {
+    placements[index].device_ordinal = -1;
+    memcpy(placements[index].source_gpu_uuid, allocation->gpu_uuid.bytes, sizeof(placements[index].source_gpu_uuid));
+    index++;
+  }
+  if (get_count(&device_count) != CUDA_SUCCESS || device_count < 0) {
+    free(placements);
+    set_error(response, "cannot query current CUDA device count");
+    return send_header(client, response, -1);
+  }
+  if ((uintmax_t)device_count > (uintmax_t)INT32_MAX + 1) {
+    free(placements);
+    set_error(response, "CUDA device ordinal cannot be represented");
+    return send_header(client, response, -1);
+  }
+  for (int device = 0; device < device_count; device++) {
+    CUuuid current;
+
+    if (get_uuid(&current, device) != CUDA_SUCCESS) {
       free(placements);
-      set_error(response, "cannot query current UUID for CUDA device ordinal");
+      set_error(response, "cannot query UUID for visible CUDA device");
       return send_header(client, response, -1);
     }
-    placements[count].device_ordinal = allocation->device_ordinal;
-    memcpy(
-        placements[count].source_gpu_uuid, allocation->gpu_uuid.bytes,
-        sizeof(placements[count].source_gpu_uuid));
-    memcpy(
-        placements[count].current_gpu_uuid, current.bytes,
-        sizeof(placements[count].current_gpu_uuid));
-    count++;
+    for (index = 0; index < count; index++) {
+      if (memcmp(placements[index].source_gpu_uuid, current.bytes, sizeof(current.bytes)) != 0)
+        continue;
+      if (placements[index].device_ordinal >= 0) {
+        free(placements);
+        set_error(response, "source CUDA GPU UUID is visible at multiple ordinals");
+        return send_header(client, response, -1);
+      }
+      placements[index].device_ordinal = (int32_t)device;
+      memcpy(placements[index].current_gpu_uuid, current.bytes, sizeof(placements[index].current_gpu_uuid));
+    }
+  }
+  for (index = 0; index < count; index++) {
+    if (placements[index].device_ordinal < 0) {
+      free(placements);
+      set_error(response, "source CUDA GPU UUID is not currently visible");
+      return send_header(client, response, -1);
+    }
+  }
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    const struct allocation* previous;
+    size_t access_index;
+
+    if (!allocation->detached)
+      continue;
+    if (find_placement(placements, count, &allocation->gpu_uuid) == NULL ||
+        allocation->properties.location.type != CU_MEM_LOCATION_TYPE_DEVICE ||
+        allocation->properties.location.id != allocation->device_ordinal ||
+        (allocation->access_count != 0 && allocation->access == NULL)) {
+      free(placements);
+      set_error(response, "detached CUDA placement metadata is inconsistent");
+      return send_header(client, response, -1);
+    }
+    for (previous = allocations; previous != allocation; previous = previous->next) {
+      if (previous->detached &&
+          memcmp(previous->gpu_uuid.bytes, allocation->gpu_uuid.bytes, sizeof(allocation->gpu_uuid.bytes)) == 0 &&
+          previous->source_device_ordinal != allocation->source_device_ordinal) {
+        free(placements);
+        set_error(response, "source CUDA GPU UUID has inconsistent saved ordinals");
+        return send_header(client, response, -1);
+      }
+    }
+    for (access_index = 0; access_index < allocation->access_count; access_index++) {
+      if (allocation->access[access_index].location.type != CU_MEM_LOCATION_TYPE_DEVICE ||
+          allocation->access[access_index].location.id != allocation->device_ordinal) {
+        free(placements);
+        set_error(response, "detached CUDA access placement is inconsistent");
+        return send_header(client, response, -1);
+      }
+    }
+  }
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    struct dyn_vmm_placement* placement;
+    size_t access_index;
+
+    if (!allocation->detached)
+      continue;
+    placement = find_placement(placements, count, &allocation->gpu_uuid);
+    allocation->device_ordinal = placement->device_ordinal;
+    allocation->properties.location.id = placement->device_ordinal;
+    for (access_index = 0; access_index < allocation->access_count; access_index++) {
+      if (allocation->access[access_index].location.type == CU_MEM_LOCATION_TYPE_DEVICE)
+        allocation->access[access_index].location.id = placement->device_ordinal;
+    }
   }
   response->count = (uint32_t)count;
   response->payload_size = count * sizeof(*placements);
-  if (send_header(client, response, -1) != 0 ||
-      write_all(client, placements, (size_t)response->payload_size) != 0) {
+  if (send_header(client, response, -1) != 0 || write_all(client, placements, (size_t)response->payload_size) != 0) {
     free(placements);
     return -1;
   }
@@ -746,6 +845,7 @@ record_gpu_identity(struct allocation* allocation)
   if (get_uuid == NULL)
     get_uuid = (uuid_fn)real_symbol("cuDeviceGetUuid");
   allocation->device_ordinal = allocation->properties.location.id;
+  allocation->source_device_ordinal = allocation->device_ordinal;
   return get_uuid != NULL &&
           get_uuid(&allocation->gpu_uuid, allocation->device_ordinal) ==
               CUDA_SUCCESS
@@ -1360,8 +1460,8 @@ detach(
 
 static int
 decode_record(
-    const struct dyn_vmm_header* request, const char* payload, struct dyn_vmm_record* record,
-    const CUmemAllocationProp** properties, const CUmemAccessDesc** access,
+    const struct dyn_vmm_header* request, char* payload, struct dyn_vmm_record* record,
+    CUmemAllocationProp** properties, CUmemAccessDesc** access,
     size_t* metadata_size)
 {
   uint64_t decoded_size;
@@ -1377,8 +1477,8 @@ decode_record(
     return -1;
   *properties = record->properties_size == 0
       ? NULL
-      : (const CUmemAllocationProp*)(payload + sizeof(*record));
-  *access = (const CUmemAccessDesc*)(
+      : (CUmemAllocationProp*)(payload + sizeof(*record));
+  *access = (CUmemAccessDesc*)(
       payload + sizeof(*record) + record->properties_size);
   *metadata_size = (size_t)decoded_size;
   if (record->object_kind != DYN_VMM_ALLOCATION ||
@@ -1386,6 +1486,33 @@ decode_record(
       (record->flags & ~DYN_VMM_APPLICATION_HANDLE_LIVE) != 0)
     return -1;
   return 0;
+}
+
+static int
+reconcile_restore_metadata(
+    struct allocation* allocation, const struct dyn_vmm_record* record, CUmemAllocationProp* properties,
+    CUmemAccessDesc* access)
+{
+  size_t index;
+
+  if (record->access_count != allocation->access_count)
+    return -1;
+  if (properties != NULL) {
+    if (properties->location.type != CU_MEM_LOCATION_TYPE_DEVICE ||
+        properties->location.id != allocation->source_device_ordinal)
+      return -1;
+    properties->location.id = allocation->device_ordinal;
+    if (memcmp(properties, &allocation->properties, sizeof(*properties)) != 0)
+      return -1;
+  }
+  for (index = 0; index < record->access_count; index++) {
+    if (access[index].location.type == CU_MEM_LOCATION_TYPE_DEVICE) {
+      if (access[index].location.id != allocation->source_device_ordinal)
+        return -1;
+      access[index].location.id = allocation->device_ordinal;
+    }
+  }
+  return memcmp(access, allocation->access, record->access_count * sizeof(*access)) == 0 ? 0 : -1;
 }
 
 #ifdef DYN_VMM_TESTING
@@ -1407,7 +1534,7 @@ test_failure(const char* stage)
 
 static int
 restore_owner(
-    int client, const struct dyn_vmm_header* request, struct dyn_vmm_header* response, const char* payload,
+    int client, const struct dyn_vmm_header* request, struct dyn_vmm_header* response, char* payload,
     int passed_fd)
 {
   typedef CUresult(CUDAAPI * copy_type)(CUdeviceptr, const void*, size_t);
@@ -1419,8 +1546,8 @@ restore_owner(
   export_fn export_handle = (export_fn)real_symbol("cuMemExportToShareableHandle");
   release_fn release = (release_fn)real_symbol("cuMemRelease");
   struct dyn_vmm_record record;
-  const CUmemAllocationProp* properties;
-  const CUmemAccessDesc* access;
+  CUmemAllocationProp* properties;
+  CUmemAccessDesc* access;
   const char* contents;
   size_t metadata_size;
   struct allocation* allocation;
@@ -1462,7 +1589,8 @@ restore_owner(
       allocation->device_ordinal != record.device_ordinal ||
       memcmp(
           allocation->gpu_uuid.bytes, record.gpu_uuid,
-          sizeof(record.gpu_uuid)) != 0) {
+          sizeof(record.gpu_uuid)) != 0 ||
+      reconcile_restore_metadata(allocation, &record, properties, access) != 0) {
     set_error(response, "owner restore metadata does not match detached process state");
     return send_header(client, response, -1);
   }
@@ -1603,8 +1731,8 @@ restore_importer(
   access_fn set_access = (access_fn)real_symbol("cuMemSetAccess");
   release_fn release = (release_fn)real_symbol("cuMemRelease");
   struct dyn_vmm_record record;
-  const CUmemAllocationProp* properties;
-  const CUmemAccessDesc* access;
+  CUmemAllocationProp* properties;
+  CUmemAccessDesc* access;
   char* contents;
   size_t metadata_size;
   struct allocation* allocation;
@@ -1652,7 +1780,8 @@ restore_importer(
       allocation->device_ordinal != record.device_ordinal ||
       memcmp(
           allocation->gpu_uuid.bytes, record.gpu_uuid,
-          sizeof(record.gpu_uuid)) != 0)
+          sizeof(record.gpu_uuid)) != 0 ||
+      reconcile_restore_metadata(allocation, &record, properties, access) != 0)
     goto failed;
   if (import_handle == NULL || map == NULL || unmap == NULL ||
       set_access == NULL || release == NULL ||

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
@@ -42,6 +42,9 @@
 #define LOGICAL_HANDLE_TAG_MASK UINT64_C(0xffff000000000000)
 #define LOGICAL_HANDLE_VALUE_MASK UINT64_C(0x0000ffffffffffff)
 
+_Static_assert(CU_IPC_HANDLE_SIZE == DYN_VMM_FABRIC_HANDLE_SIZE, "CUDA IPC handle ABI changed");
+_Static_assert(sizeof(CUmemFabricHandle) == DYN_VMM_FABRIC_HANDLE_SIZE, "CUDA FABRIC handle ABI changed");
+
 CUresult CUDAAPI cuGetProcAddress(const char*, void**, int, cuuint64_t);
 CUresult CUDAAPI cuGetProcAddress_v2(
     const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
@@ -95,9 +98,11 @@ struct access_update {
   CUmemAccessDesc* access;
 };
 
-struct passthrough_handle {
-  CUmemGenericAllocationHandle handle;
-  struct passthrough_handle* next;
+struct broker_result {
+  CUmemAllocationHandleType handle_type;
+  int fd;
+  uint8_t bytes[DYN_VMM_FABRIC_HANDLE_SIZE];
+  size_t bytes_size;
 };
 
 typedef CUresult(CUDAAPI* create_fn)(
@@ -117,7 +122,6 @@ typedef CUresult(CUDAAPI* properties_fn)(
 
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static struct allocation* allocations;
-static struct passthrough_handle* passthrough_handles;
 static bool enabled;
 static bool cuda_seen;
 static bool forked_after_cuda;
@@ -138,6 +142,7 @@ static _Atomic(uintptr_t) explicit_cu_get_proc_address_v2;
 static int write_all(int, const void*, size_t);
 static int pread_all(int, void*, size_t);
 static int send_header(int, const struct dyn_vmm_header*, int);
+static int close_owned_fd(int*, const char*);
 static void set_error(struct dyn_vmm_header*, const char*);
 static bool all_zero(const void*, size_t);
 
@@ -261,31 +266,6 @@ dlsym(void* handle, const char* name)
 }
 
 static bool
-is_passthrough_handle(CUmemGenericAllocationHandle handle)
-{
-  struct passthrough_handle* current;
-
-  for (current = passthrough_handles; current != NULL; current = current->next) {
-    if (current->handle == handle)
-      return true;
-  }
-  return false;
-}
-
-static int
-record_passthrough_handle(CUmemGenericAllocationHandle handle)
-{
-  struct passthrough_handle* current = malloc(sizeof(*current));
-
-  if (current == NULL)
-    return -1;
-  current->handle = handle;
-  current->next = passthrough_handles;
-  passthrough_handles = current;
-  return 0;
-}
-
-static bool
 valid_participant_id(const char value[DYN_VMM_PARTICIPANT_ID_SIZE])
 {
   size_t index;
@@ -295,6 +275,51 @@ valid_participant_id(const char value[DYN_VMM_PARTICIPANT_ID_SIZE])
       return false;
   }
   return value[DYN_VMM_PARTICIPANT_ID_SIZE - 1] == '\0';
+}
+
+static bool
+valid_fabric_participant_id(const char value[DYN_VMM_FABRIC_PARTICIPANT_ID_SIZE])
+{
+  size_t index;
+
+  for (index = 0; index < DYN_VMM_FABRIC_PARTICIPANT_ID_SIZE; index++) {
+    if (!((value[index] >= '0' && value[index] <= '9') || (value[index] >= 'a' && value[index] <= 'f')))
+      return false;
+  }
+  return true;
+}
+
+static bool
+supported_handle_type(CUmemAllocationHandleType type)
+{
+  return type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR || type == CU_MEM_HANDLE_TYPE_FABRIC;
+}
+
+static bool
+valid_broker_shape(CUmemAllocationHandleType type, int fd, uint64_t bytes_size)
+{
+  return (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR && fd >= 0 && bytes_size == 0) ||
+         (type == CU_MEM_HANDLE_TYPE_FABRIC && fd < 0 && bytes_size == DYN_VMM_FABRIC_HANDLE_SIZE);
+}
+
+static void
+initialize_broker_result(struct broker_result* result, CUmemAllocationHandleType type)
+{
+  memset(result, 0, sizeof(*result));
+  result->handle_type = type;
+  result->fd = -1;
+}
+
+static int
+clear_broker_result(struct broker_result* result, const char* close_error)
+{
+  int status = 0;
+
+  if (result->fd >= 0 && close_owned_fd(&result->fd, close_error) != 0)
+    status = -1;
+  explicit_bzero(result->bytes, sizeof(result->bytes));
+  result->bytes_size = 0;
+  return status;
 }
 
 static bool
@@ -439,6 +464,43 @@ read_capability(int fd, struct dyn_vmm_capability* capability)
   return 0;
 }
 
+static int
+create_fabric_token(const uint8_t uuid[DYN_VMM_ALLOCATION_UUID_SIZE], struct dyn_vmm_fabric_token* token)
+{
+  pid_t pid = getpid();
+
+  if (pid <= 0 || (uint64_t)pid > UINT32_MAX)
+    return -1;
+  memset(token, 0, sizeof(*token));
+  token->magic = DYN_VMM_FABRIC_TOKEN_MAGIC;
+  token->version = DYN_VMM_FABRIC_TOKEN_VERSION;
+  token->handle_type = CU_MEM_HANDLE_TYPE_FABRIC;
+  memcpy(token->allocation_uuid, uuid, sizeof(token->allocation_uuid));
+  memcpy(token->owner_participant_id, participant_id, sizeof(token->owner_participant_id));
+  token->owner_namespace_pid = (uint32_t)pid;
+  return 0;
+}
+
+static int
+read_fabric_token(
+    const void* encoded, struct dyn_vmm_fabric_token* token, char owner_participant[DYN_VMM_PARTICIPANT_ID_SIZE],
+    char owner_socket[sizeof(((struct sockaddr_un*)0)->sun_path)])
+{
+  if (encoded == NULL)
+    return -1;
+  memcpy(token, encoded, sizeof(*token));
+  if (token->magic != DYN_VMM_FABRIC_TOKEN_MAGIC || token->version != DYN_VMM_FABRIC_TOKEN_VERSION ||
+      token->handle_type != CU_MEM_HANDLE_TYPE_FABRIC ||
+      all_zero(token->allocation_uuid, sizeof(token->allocation_uuid)) ||
+      !valid_fabric_participant_id(token->owner_participant_id) || token->owner_namespace_pid == 0 ||
+      token->owner_namespace_pid > INT_MAX || token->reserved != 0 ||
+      format_socket_path(owner_socket, sizeof(((struct sockaddr_un*)0)->sun_path), token->owner_namespace_pid) != 0)
+    return -1;
+  memcpy(owner_participant, token->owner_participant_id, sizeof(token->owner_participant_id));
+  owner_participant[DYN_VMM_PARTICIPANT_ID_SIZE - 1] = '\0';
+  return 0;
+}
+
 #ifdef DYN_VMM_TESTING
 int
 dyn_vmm_test_capability_valid(int fd)
@@ -446,6 +508,22 @@ dyn_vmm_test_capability_valid(int fd)
   struct dyn_vmm_capability capability;
 
   return read_capability(fd, &capability) == 0;
+}
+
+int
+dyn_vmm_test_fabric_token_valid(const void* encoded)
+{
+  struct dyn_vmm_fabric_token token;
+  char owner_participant[DYN_VMM_PARTICIPANT_ID_SIZE];
+  char owner_socket[sizeof(((struct sockaddr_un*)0)->sun_path)];
+
+  return read_fabric_token(encoded, &token, owner_participant, owner_socket) == 0;
+}
+
+int
+dyn_vmm_test_broker_shape(CUmemAllocationHandleType type, int fd, uint64_t bytes_size)
+{
+  return valid_broker_shape(type, fd, bytes_size);
 }
 #endif
 
@@ -519,22 +597,6 @@ query_placement(int client, struct dyn_vmm_header* response)
   }
   free(placements);
   return 0;
-}
-
-static void
-remove_passthrough_handle(CUmemGenericAllocationHandle handle)
-{
-  struct passthrough_handle** cursor = &passthrough_handles;
-
-  while (*cursor != NULL) {
-    if ((*cursor)->handle == handle) {
-      struct passthrough_handle* removed = *cursor;
-      *cursor = removed->next;
-      free(removed);
-      return;
-    }
-    cursor = &(*cursor)->next;
-  }
 }
 
 static struct allocation*
@@ -980,41 +1042,59 @@ initialize_identity(void)
 }
 
 static CUresult
-export_raw_owner(struct allocation* allocation, int* output)
+export_raw_owner(struct allocation* allocation, struct broker_result* output)
 {
   export_fn export_handle = (export_fn)real_symbol("cuMemExportToShareableHandle");
   struct context_scope scope;
   CUresult result;
 
-  *output = -1;
+  initialize_broker_result(output, allocation == NULL ? CU_MEM_HANDLE_TYPE_NONE : allocation->requested_handle_type);
   if (allocation == NULL || allocation->role != DYN_VMM_OWNER || !allocation->exported ||
       all_zero(allocation->allocation_uuid, sizeof(allocation->allocation_uuid)) ||
       !allocation->application_handle_live || allocation->real_handle == 0 || allocation->detached ||
-      phase != DYN_VMM_ACTIVE || failed || forked_after_cuda || export_handle == NULL ||
-      enter_context(allocation->context, &scope) != 0)
+      !supported_handle_type(allocation->requested_handle_type) || phase != DYN_VMM_ACTIVE || failed ||
+      forked_after_cuda || export_handle == NULL || enter_context(allocation->context, &scope) != 0)
     return CUDA_ERROR_INVALID_HANDLE;
-  result = export_handle(output, allocation->real_handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+  if (output->handle_type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    result = export_handle(&output->fd, allocation->real_handle, output->handle_type, 0);
+  } else {
+    result = export_handle(output->bytes, allocation->real_handle, output->handle_type, 0);
+    if (result == CUDA_SUCCESS)
+      output->bytes_size = sizeof(output->bytes);
+  }
   if (leave_context(&scope) != 0) {
-    (void)close_owned_fd(output, "cannot close owner raw export after context failure");
+    (void)clear_broker_result(output, "cannot close owner raw export after context failure");
     fail("cannot restore context after owner raw export");
     return CUDA_ERROR_UNKNOWN;
   }
-  if (result == CUDA_SUCCESS && *output < 0)
+  if (result == CUDA_SUCCESS && !valid_broker_shape(output->handle_type, output->fd, output->bytes_size))
     return CUDA_ERROR_INVALID_VALUE;
   return result;
+}
+
+static int
+send_broker_result(int client, struct dyn_vmm_header* response, const struct broker_result* result)
+{
+  response->handle_type = (uint32_t)result->handle_type;
+  response->payload_size = result->bytes_size;
+  if (send_header(client, response, result->fd) != 0)
+    return -1;
+  return result->bytes_size == 0 || write_all(client, result->bytes, result->bytes_size) == 0 ? 0 : -1;
 }
 
 static int
 export_owner(int client, const struct dyn_vmm_header* request, struct dyn_vmm_header* response, int passed_fd)
 {
   struct allocation* allocation;
-  int exported_fd = -1;
+  struct broker_result exported;
   int result;
+
+  initialize_broker_result(&exported, (CUmemAllocationHandleType)request->handle_type);
 
   memcpy(response->allocation_uuid, request->allocation_uuid, sizeof(response->allocation_uuid));
   if (passed_fd >= 0 || request->payload_size != 0 || request->count != 0 || request->status != 0 ||
-      request->object_id != 0 || !all_zero(request->reserved, sizeof(request->reserved)) ||
-      !all_zero(request->message, sizeof(request->message)) ||
+      request->object_id != 0 || !supported_handle_type((CUmemAllocationHandleType)request->handle_type) ||
+      request->reserved != 0 || !all_zero(request->message, sizeof(request->message)) ||
       !all_zero(request->reserved_identity, sizeof(request->reserved_identity)) ||
       memcmp(request->participant_id, participant_id, sizeof(request->participant_id)) != 0 ||
       all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) || failed || forked_after_cuda ||
@@ -1025,19 +1105,23 @@ export_owner(int client, const struct dyn_vmm_header* request, struct dyn_vmm_he
   allocation = find_object(request->allocation_uuid, DYN_VMM_OWNER);
   if (allocation == NULL ||
       memcmp(allocation->allocation_uuid, request->allocation_uuid, sizeof(allocation->allocation_uuid)) != 0 ||
-      export_raw_owner(allocation, &exported_fd) != CUDA_SUCCESS) {
-    (void)close_owned_fd(&exported_fd, "cannot close failed owner raw export FD");
+      allocation->requested_handle_type != (CUmemAllocationHandleType)request->handle_type ||
+      export_raw_owner(allocation, &exported) != CUDA_SUCCESS) {
+    (void)clear_broker_result(&exported, "cannot close failed owner raw export FD");
     set_error(response, "owner allocation is unavailable for export");
     return send_header(client, response, -1);
   }
-  result = send_header(client, response, exported_fd);
-  if (close_owned_fd(&exported_fd, "cannot close owner raw export FD") != 0)
+  result = send_broker_result(client, response, &exported);
+  if (clear_broker_result(&exported, "cannot close owner raw export FD") != 0)
     phase = DYN_VMM_FAILED;
   return result;
 }
 
 static int
-request_owner_export(const struct dyn_vmm_capability* capability, int* exported_fd)
+request_owner_export(
+    const uint8_t allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE],
+    const char owner_participant[DYN_VMM_PARTICIPANT_ID_SIZE], const char* owner_socket,
+    CUmemAllocationHandleType handle_type, struct broker_result* exported)
 {
   struct sockaddr_un address = {.sun_family = AF_UNIX};
   struct dyn_vmm_header request;
@@ -1045,34 +1129,41 @@ request_owner_export(const struct dyn_vmm_capability* capability, int* exported_
   int client = -1;
   int result = -1;
 
-  *exported_fd = -1;
+  initialize_broker_result(exported, handle_type);
   memset(&request, 0, sizeof(request));
   request.magic = DYN_VMM_MAGIC;
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_EXPORT_OWNER;
-  memcpy(request.allocation_uuid, capability->allocation_uuid, sizeof(request.allocation_uuid));
-  snprintf(request.participant_id, sizeof(request.participant_id), "%s", capability->owner_participant_id);
-  snprintf(address.sun_path, sizeof(address.sun_path), "%s", capability->owner_socket_path);
+  request.handle_type = (uint32_t)handle_type;
+  memcpy(request.allocation_uuid, allocation_uuid, sizeof(request.allocation_uuid));
+  snprintf(request.participant_id, sizeof(request.participant_id), "%s", owner_participant);
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", owner_socket);
   client = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (client < 0 || set_socket_timeouts(client) != 0 ||
       connect(client, (const struct sockaddr*)&address, sizeof(address)) != 0 ||
-      send_header(client, &request, -1) != 0 || receive_header(client, &response, exported_fd) != 0)
+      send_header(client, &request, -1) != 0 || receive_header(client, &response, &exported->fd) != 0)
     goto done;
   if (response.magic != DYN_VMM_MAGIC || response.version != DYN_VMM_VERSION ||
       response.operation != DYN_VMM_EXPORT_OWNER || response.status != 0 || response.count != 0 ||
-      response.object_id != 0 || response.payload_size != 0 ||
-      !all_zero(response.reserved, sizeof(response.reserved)) ||
+      response.object_id != 0 || response.handle_type != (uint32_t)handle_type || response.reserved != 0 ||
       !all_zero(response.message, sizeof(response.message)) ||
       !all_zero(response.reserved_identity, sizeof(response.reserved_identity)) ||
-      memcmp(response.allocation_uuid, capability->allocation_uuid, sizeof(response.allocation_uuid)) != 0 ||
+      memcmp(response.allocation_uuid, allocation_uuid, sizeof(response.allocation_uuid)) != 0 ||
       !valid_participant_id(response.participant_id) ||
-      memcmp(response.participant_id, capability->owner_participant_id, sizeof(response.participant_id)) != 0 ||
-      *exported_fd < 0)
+      memcmp(response.participant_id, owner_participant, sizeof(response.participant_id)) != 0 ||
+      !valid_broker_shape(handle_type, exported->fd, response.payload_size))
     goto done;
+  if (handle_type == CU_MEM_HANDLE_TYPE_FABRIC) {
+    if (read_all(client, exported->bytes, sizeof(exported->bytes)) != 0)
+      goto done;
+    exported->bytes_size = sizeof(exported->bytes);
+  }
   result = 0;
 done:
   if (client >= 0 && close(client) != 0)
     result = -1;
+  if (result != 0)
+    (void)clear_broker_result(exported, "cannot close invalid owner broker response FD");
   return result;
 }
 
@@ -1112,7 +1203,7 @@ validate_admission(struct dyn_vmm_header* response)
         allocation->access[0].flags != CU_MEM_ACCESS_FLAGS_PROT_READWRITE) {
       set_error(
           response,
-          "unsupported managed access: M1 requires one read/write DEVICE "
+          "unsupported managed access: requires one read/write DEVICE "
           "descriptor on the allocation GPU");
       return -1;
     }
@@ -1271,28 +1362,27 @@ static int
 decode_record(
     const struct dyn_vmm_header* request, const char* payload, struct dyn_vmm_record* record,
     const CUmemAllocationProp** properties, const CUmemAccessDesc** access,
-    const char** contents)
+    size_t* metadata_size)
 {
-  uint64_t metadata_size;
+  uint64_t decoded_size;
 
   if (request->payload_size < sizeof(*record))
     return -1;
   memcpy(record, payload, sizeof(*record));
   if (record->access_size != sizeof(**access))
     return -1;
-  metadata_size = sizeof(*record) + record->properties_size +
+  decoded_size = sizeof(*record) + record->properties_size +
       (uint64_t)record->access_count * record->access_size;
-  if (metadata_size > request->payload_size)
+  if (decoded_size > request->payload_size || decoded_size > SIZE_MAX)
     return -1;
   *properties = record->properties_size == 0
       ? NULL
       : (const CUmemAllocationProp*)(payload + sizeof(*record));
   *access = (const CUmemAccessDesc*)(
       payload + sizeof(*record) + record->properties_size);
-  *contents = payload + metadata_size;
+  *metadata_size = (size_t)decoded_size;
   if (record->object_kind != DYN_VMM_ALLOCATION ||
-      record->requested_handle_type !=
-          CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ||
+      !supported_handle_type((CUmemAllocationHandleType)record->requested_handle_type) ||
       (record->flags & ~DYN_VMM_APPLICATION_HANDLE_LIVE) != 0)
     return -1;
   return 0;
@@ -1317,8 +1407,8 @@ test_failure(const char* stage)
 
 static int
 restore_owner(
-    int client, const struct dyn_vmm_header* request, struct dyn_vmm_header* response,
-    const char* payload)
+    int client, const struct dyn_vmm_header* request, struct dyn_vmm_header* response, const char* payload,
+    int passed_fd)
 {
   typedef CUresult(CUDAAPI * copy_type)(CUdeviceptr, const void*, size_t);
   copy_type copy = (copy_type)real_symbol("cuMemcpyHtoD_v2");
@@ -1332,6 +1422,7 @@ restore_owner(
   const CUmemAllocationProp* properties;
   const CUmemAccessDesc* access;
   const char* contents;
+  size_t metadata_size;
   struct allocation* allocation;
   struct context_scope scope;
   CUmemAccessDesc temporary_access;
@@ -1344,16 +1435,21 @@ restore_owner(
   bool handle_released = false;
   struct context_scope cleanup_scope;
   bool cleanup_context_entered = false;
-  int exported_fd = -1;
+  struct broker_result exported;
   const char* primary_error = "owner VMM restore failed; process must not resume";
 
-  if (decode_record(request, payload, &record, &properties, &access, &contents) != 0 ||
-      properties == NULL || record.properties_size != sizeof(*properties) ||
-      record.role != DYN_VMM_OWNER || record.offset != 0 ||
-      record.size != (uint64_t)(payload + request->payload_size - contents)) {
+  initialize_broker_result(&exported, (CUmemAllocationHandleType)request->handle_type);
+
+  if (passed_fd >= 0 || request->reserved != 0 ||
+      decode_record(request, payload, &record, &properties, &access, &metadata_size) != 0 || properties == NULL ||
+      record.properties_size != sizeof(*properties) || record.role != DYN_VMM_OWNER || record.offset != 0 ||
+      request->handle_type != record.requested_handle_type ||
+      properties->requestedHandleTypes != (CUmemAllocationHandleType)record.requested_handle_type ||
+      record.size != request->payload_size - metadata_size) {
     set_error(response, "invalid owner restore payload");
     return send_header(client, response, -1);
   }
+  contents = payload + metadata_size;
   allocation = find_logical_object(record.object_id, DYN_VMM_OWNER);
   if (allocation == NULL || !allocation->detached ||
       allocation->address != (CUdeviceptr)record.address ||
@@ -1412,10 +1508,15 @@ restore_owner(
           record.access_count) != CUDA_SUCCESS)
     goto failed;
   temporary_access_installed = false;
-  if (export_handle(
-          &exported_fd, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) !=
-          CUDA_SUCCESS)
-    goto failed;
+  if (record.requested_handle_type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    if (export_handle(&exported.fd, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) != CUDA_SUCCESS ||
+        exported.fd < 0)
+      goto failed;
+  } else {
+    if (export_handle(exported.bytes, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0) != CUDA_SUCCESS)
+      goto failed;
+    exported.bytes_size = sizeof(exported.bytes);
+  }
   if (test_failure("owner-export"))
     goto failed;
   if (allocation->application_handle_live) {
@@ -1431,9 +1532,9 @@ restore_owner(
   if (test_failure("owner-rebind") || leave_context(&scope) != 0)
     goto failed;
   context_entered = false;
-  if (send_header(client, response, exported_fd) != 0)
+  if (send_broker_result(client, response, &exported) != 0)
     goto failed;
-  if (close_owned_fd(&exported_fd, "cannot close owner restore export FD") != 0) {
+  if (clear_broker_result(&exported, "cannot close owner restore export FD") != 0) {
     phase = DYN_VMM_FAILED;
     return -1;
   }
@@ -1481,7 +1582,7 @@ failed:
     owns_handle = false;
     handle_released = true;
   }
-  if (close_owned_fd(&exported_fd, "owner restore cleanup could not close export FD") != 0)
+  if (clear_broker_result(&exported, "owner restore cleanup could not close export FD") != 0)
     phase = DYN_VMM_FAILED;
   if (context_entered && leave_context(&scope) != 0)
     fail_cleanup("owner restore cleanup could not restore prior CUDA context");
@@ -1494,7 +1595,7 @@ failed:
 static int
 restore_importer(
     int client, const struct dyn_vmm_header* request, struct dyn_vmm_header* response,
-    const char* payload, int* imported_fd)
+    char* payload, int* imported_fd)
 {
   import_fn import_handle = (import_fn)real_symbol("cuMemImportFromShareableHandle");
   map_fn map = (map_fn)real_symbol("cuMemMap");
@@ -1504,7 +1605,8 @@ restore_importer(
   struct dyn_vmm_record record;
   const CUmemAllocationProp* properties;
   const CUmemAccessDesc* access;
-  const char* contents;
+  char* contents;
+  size_t metadata_size;
   struct allocation* allocation;
   struct context_scope scope;
   CUmemGenericAllocationHandle handle = 0;
@@ -1515,21 +1617,29 @@ restore_importer(
   bool handle_released = false;
   struct context_scope cleanup_scope;
   bool cleanup_context_entered = false;
+  void* import_value;
+  size_t broker_size;
   const char* primary_error = "importer VMM restore failed; process must not resume";
 
-  if (decode_record(request, payload, &record, &properties, &access, &contents) != 0) {
+  if (request->reserved != 0 ||
+      decode_record(request, payload, &record, &properties, &access, &metadata_size) != 0) {
     set_error(response, "invalid importer restore payload");
     return send_header(client, response, -1);
   }
-  if (properties != NULL || contents != payload + request->payload_size ||
-      record.role != DYN_VMM_IMPORTER || record.offset != 0) {
+  contents = payload + metadata_size;
+  broker_size = (size_t)request->payload_size - metadata_size;
+  if (properties != NULL || record.role != DYN_VMM_IMPORTER || record.offset != 0 ||
+      request->handle_type != record.requested_handle_type ||
+      (record.requested_handle_type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
+       (broker_size != 0 || *imported_fd < 0)) ||
+      (record.requested_handle_type == CU_MEM_HANDLE_TYPE_FABRIC &&
+       (broker_size != DYN_VMM_FABRIC_HANDLE_SIZE || *imported_fd >= 0))) {
     set_error(response, "invalid importer restore metadata");
     return send_header(client, response, -1);
   }
-  if (*imported_fd < 0) {
-    set_error(response, "importer restore requires one broker FD");
-    return send_header(client, response, -1);
-  }
+  import_value = record.requested_handle_type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+                     ? (void*)(uintptr_t)*imported_fd
+                     : contents;
   allocation = find_logical_object(record.object_id, DYN_VMM_IMPORTER);
   if (allocation == NULL || !allocation->detached ||
       allocation->address != (CUdeviceptr)record.address ||
@@ -1549,14 +1659,15 @@ restore_importer(
       enter_context(allocation->context, &scope) != 0)
     goto failed;
   context_entered = true;
-  if (import_handle(
-          &handle, (void*)(uintptr_t)*imported_fd,
-          CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) != CUDA_SUCCESS)
+  if (import_handle(&handle, import_value, (CUmemAllocationHandleType)record.requested_handle_type) !=
+      CUDA_SUCCESS)
     goto failed;
   owns_handle = true;
-  if (close_owned_fd(
-          imported_fd, "importer restore could not close received broker FD") != 0)
+  if (record.requested_handle_type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
+      close_owned_fd(imported_fd, "importer restore could not close received broker FD") != 0)
     goto failed;
+  if (record.requested_handle_type == CU_MEM_HANDLE_TYPE_FABRIC)
+    explicit_bzero(contents, DYN_VMM_FABRIC_HANDLE_SIZE);
   if (test_failure("importer-import"))
     goto failed;
   if (map((CUdeviceptr)record.address, (size_t)record.size, 0, handle, 0) !=
@@ -1624,12 +1735,71 @@ failed:
   if (close_owned_fd(
           imported_fd, "importer restore cleanup could not close broker FD") != 0)
     phase = DYN_VMM_FAILED;
+  if (record.requested_handle_type == CU_MEM_HANDLE_TYPE_FABRIC)
+    explicit_bzero(contents, broker_size);
   if (context_entered && leave_context(&scope) != 0)
     fail_cleanup("importer restore cleanup could not restore prior CUDA context");
   if (cleanup_context_entered && leave_context(&cleanup_scope) != 0)
     fail_cleanup("importer restore cleanup could not restore prior CUDA context");
   set_error(response, primary_error);
   return send_header(client, response, -1);
+}
+
+static bool
+valid_request_shape(const struct dyn_vmm_header* request, int passed_fd)
+{
+  const uint64_t owner_metadata_size =
+      sizeof(struct dyn_vmm_record) + sizeof(CUmemAllocationProp) + sizeof(CUmemAccessDesc);
+  const uint64_t importer_metadata_size =
+      sizeof(struct dyn_vmm_record) + sizeof(CUmemAccessDesc);
+  bool bootstrap_identify =
+      request->operation == DYN_VMM_IDENTIFY &&
+      all_zero(request->participant_id, sizeof(request->participant_id));
+
+  if (request->magic != DYN_VMM_MAGIC || request->version != DYN_VMM_VERSION ||
+      request->status != 0 || request->count != 0 || request->reserved != 0 ||
+      !all_zero(request->message, sizeof(request->message)) ||
+      !all_zero(request->reserved_identity, sizeof(request->reserved_identity)) ||
+      (!bootstrap_identify &&
+       memcmp(request->participant_id, participant_id, sizeof(request->participant_id)) != 0))
+    return false;
+
+  switch (request->operation) {
+    case DYN_VMM_IDENTIFY:
+      return passed_fd < 0 && request->payload_size == 0 && request->handle_type == 0 &&
+          all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id == 0;
+    case DYN_VMM_INSPECT:
+    case DYN_VMM_QUERY_PLACEMENT:
+      return !bootstrap_identify && passed_fd < 0 && request->payload_size == 0 &&
+          request->handle_type == 0 && all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) &&
+          request->object_id == 0;
+    case DYN_VMM_READ_OWNER:
+    case DYN_VMM_DETACH_IMPORTS:
+    case DYN_VMM_DETACH_OWNERS:
+      return !bootstrap_identify && passed_fd < 0 && request->payload_size == 0 &&
+          request->handle_type == 0 && !all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) &&
+          request->object_id != 0;
+    case DYN_VMM_RESTORE_OWNER:
+      return !bootstrap_identify && passed_fd < 0 &&
+          supported_handle_type((CUmemAllocationHandleType)request->handle_type) &&
+          all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id != 0 &&
+          request->payload_size >= owner_metadata_size &&
+          request->payload_size <= owner_metadata_size + DYN_VMM_MAXIMUM_ALLOCATION_SIZE;
+    case DYN_VMM_RESTORE_IMPORT:
+      return !bootstrap_identify &&
+          ((request->handle_type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR && passed_fd >= 0) ||
+           (request->handle_type == CU_MEM_HANDLE_TYPE_FABRIC && passed_fd < 0)) &&
+          all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id != 0 &&
+          request->payload_size ==
+              importer_metadata_size +
+                  (request->handle_type == CU_MEM_HANDLE_TYPE_FABRIC ? DYN_VMM_FABRIC_HANDLE_SIZE : 0);
+    case DYN_VMM_EXPORT_OWNER:
+      return !bootstrap_identify && passed_fd < 0 && request->payload_size == 0 &&
+          supported_handle_type((CUmemAllocationHandleType)request->handle_type) &&
+          !all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id == 0;
+    default:
+      return false;
+  }
 }
 
 static void
@@ -1649,13 +1819,8 @@ serve(int client)
   snprintf(
       response.participant_id, sizeof(response.participant_id), "%s",
       participant_id);
-  if (request.magic != DYN_VMM_MAGIC || request.version != DYN_VMM_VERSION) {
+  if (!valid_request_shape(&request, passed_fd)) {
     set_error(&response, "invalid VMM control protocol");
-    (void)send_header(client, &response, -1);
-    goto done;
-  }
-  if (request.payload_size > SIZE_MAX) {
-    set_error(&response, "VMM request payload is too large");
     (void)send_header(client, &response, -1);
     goto done;
   }
@@ -1679,7 +1844,7 @@ serve(int client)
       (void)detach(client, &request, &response, DYN_VMM_OWNER);
       break;
     case DYN_VMM_RESTORE_OWNER:
-      (void)restore_owner(client, &request, &response, payload);
+      (void)restore_owner(client, &request, &response, payload, passed_fd);
       break;
     case DYN_VMM_RESTORE_IMPORT:
       (void)restore_importer(client, &request, &response, payload, &passed_fd);
@@ -1708,6 +1873,8 @@ done:
       phase = DYN_VMM_FAILED;
     pthread_mutex_unlock(&lock);
   }
+  if (payload != NULL)
+    explicit_bzero(payload, (size_t)request.payload_size);
   free(payload);
 }
 
@@ -1836,26 +2003,7 @@ cuMemCreate(
     return function != NULL
         ? function(output, size, properties, flags)
         : unavailable();
-  if (properties->requestedHandleTypes == CU_MEM_HANDLE_TYPE_NONE) {
-    pthread_mutex_lock(&lock);
-    cuda_seen = true;
-    result = function != NULL
-        ? function(output, size, properties, flags)
-        : unavailable();
-    if (result == CUDA_SUCCESS &&
-        (is_logical_handle(*output) ||
-         record_passthrough_handle(*output) != 0)) {
-      release_fn release = (release_fn)real_symbol("cuMemRelease");
-      if (release != NULL)
-        (void)release(*output);
-      fail("cannot record unshared cuMemCreate handle");
-      result = CUDA_ERROR_OUT_OF_MEMORY;
-    }
-    pthread_mutex_unlock(&lock);
-    return result;
-  }
-  if (properties->requestedHandleTypes !=
-      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+  if (!supported_handle_type(properties->requestedHandleTypes))
     return unavailable();
   pthread_mutex_lock(&lock);
   cuda_seen = true;
@@ -1913,8 +2061,6 @@ cuMemRelease(CUmemGenericAllocationHandle handle)
   cuda_seen = true;
   if (!is_logical_handle(handle)) {
     result = function != NULL ? function(handle) : unavailable();
-    if (result == CUDA_SUCCESS)
-      remove_passthrough_handle(handle);
     pthread_mutex_unlock(&lock);
     return result;
   }
@@ -1952,8 +2098,7 @@ cuMemMap(
   pthread_mutex_lock(&lock);
   cuda_seen = true;
   if (!is_logical_handle(handle)) {
-    if (!is_passthrough_handle(handle))
-      fail("cuMemMap used an untracked real generic handle");
+    fail("cuMemMap used an untracked real generic handle");
     result = function != NULL
         ? function(address, size, offset, handle, flags)
         : unavailable();
@@ -2116,6 +2261,8 @@ cuMemExportToShareableHandle(
 {
   export_fn function = (export_fn)real_symbol("cuMemExportToShareableHandle");
   struct allocation* allocation;
+  struct dyn_vmm_fabric_token fabric_token;
+  uint8_t raw_fabric[DYN_VMM_FABRIC_HANDLE_SIZE];
   uint8_t uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
   int capability_fd = -1;
   int raw_fd = -1;
@@ -2123,8 +2270,9 @@ cuMemExportToShareableHandle(
 
   if (!enabled)
     return function != NULL ? function(shareable, handle, type, flags) : unavailable();
-  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR || shareable == NULL)
+  if (!supported_handle_type(type) || shareable == NULL)
     return unavailable();
+  memset(raw_fabric, 0, sizeof(raw_fabric));
   if (!is_logical_handle(handle)) {
     pthread_mutex_lock(&lock);
     cuda_seen = true;
@@ -2136,18 +2284,25 @@ cuMemExportToShareableHandle(
   cuda_seen = true;
   allocation = find_logical_handle(handle);
   if (allocation == NULL || !allocation->application_handle_live || allocation->real_handle == 0 ||
-      allocation->role != DYN_VMM_OWNER || failed || forked_after_cuda || phase != DYN_VMM_ACTIVE) {
+      allocation->role != DYN_VMM_OWNER || allocation->requested_handle_type != type || failed || forked_after_cuda ||
+      phase != DYN_VMM_ACTIVE) {
     result = unknown_logical_handle();
   } else {
-    result = function != NULL ? function(&raw_fd, allocation->real_handle, type, flags) : unavailable();
+    result = function != NULL
+                 ? function(
+                       type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ? (void*)&raw_fd : (void*)raw_fabric,
+                       allocation->real_handle, type, flags)
+                 : unavailable();
   }
   if (result == CUDA_SUCCESS) {
-    if (raw_fd < 0) {
+    if (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR && raw_fd < 0) {
       fail("real CUDA export returned an invalid POSIX FD");
       result = CUDA_ERROR_INVALID_VALUE;
     } else {
       memcpy(uuid, allocation->allocation_uuid, sizeof(uuid));
-      if ((!allocation->exported && random_uuid(uuid) != 0) || create_capability(uuid, &capability_fd) != 0) {
+      if ((!allocation->exported && random_uuid(uuid) != 0) ||
+          (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ? create_capability(uuid, &capability_fd)
+                                                            : create_fabric_token(uuid, &fabric_token)) != 0) {
         fail("cannot create CUDA VMM allocation capability");
         result = CUDA_ERROR_OUT_OF_MEMORY;
       }
@@ -2159,8 +2314,12 @@ cuMemExportToShareableHandle(
   }
   if (result == CUDA_SUCCESS) {
     memcpy(allocation->allocation_uuid, uuid, sizeof(allocation->allocation_uuid));
-    *(int*)shareable = capability_fd;
-    capability_fd = -1;
+    if (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+      *(int*)shareable = capability_fd;
+      capability_fd = -1;
+    } else {
+      memcpy(shareable, &fabric_token, sizeof(fabric_token));
+    }
     allocation->exported = true;
   }
   if (capability_fd >= 0) {
@@ -2169,6 +2328,8 @@ cuMemExportToShareableHandle(
       phase = DYN_VMM_FAILED;
     }
   }
+  explicit_bzero(raw_fabric, sizeof(raw_fabric));
+  explicit_bzero(&fabric_token, sizeof(fabric_token));
   pthread_mutex_unlock(&lock);
   return result;
 }
@@ -2182,17 +2343,27 @@ cuMemImportFromShareableHandle(
   properties_fn get_properties = (properties_fn)real_symbol("cuMemGetAllocationPropertiesFromHandle");
   release_fn release = (release_fn)real_symbol("cuMemRelease");
   struct dyn_vmm_capability capability;
+  struct dyn_vmm_fabric_token fabric_token;
+  struct broker_result broker;
   struct allocation* allocation = NULL;
   struct allocation* owner;
   CUmemGenericAllocationHandle real_handle = 0;
-  int raw_fd = -1;
   int capability_fd = (int)(uintptr_t)os_handle;
+  uint8_t allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
+  char owner_participant[DYN_VMM_PARTICIPANT_ID_SIZE];
+  char owner_socket[sizeof(((struct sockaddr_un*)0)->sun_path)];
   bool local_owner;
   CUresult result;
 
   if (!enabled)
     return function != NULL ? function(output, os_handle, type) : unavailable();
-  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR || output == NULL) {
+  initialize_broker_result(&broker, type);
+  memset(&fabric_token, 0, sizeof(fabric_token));
+  memset(&capability, 0, sizeof(capability));
+  memset(allocation_uuid, 0, sizeof(allocation_uuid));
+  memset(owner_participant, 0, sizeof(owner_participant));
+  memset(owner_socket, 0, sizeof(owner_socket));
+  if (!supported_handle_type(type) || output == NULL) {
     pthread_mutex_lock(&lock);
     cuda_seen = true;
     fail("shareable import requires a VMM capability");
@@ -2201,20 +2372,33 @@ cuMemImportFromShareableHandle(
   }
   pthread_mutex_lock(&lock);
   cuda_seen = true;
-  if (read_capability(capability_fd, &capability) != 0) {
+  if (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    if (read_capability(capability_fd, &capability) != 0) {
+      fail("shareable import requires a valid sealed VMM capability");
+      result = CUDA_ERROR_INVALID_VALUE;
+      goto done;
+    }
+    memcpy(allocation_uuid, capability.allocation_uuid, sizeof(allocation_uuid));
+    snprintf(owner_participant, sizeof(owner_participant), "%s", capability.owner_participant_id);
+    snprintf(owner_socket, sizeof(owner_socket), "%s", capability.owner_socket_path);
+  } else if (read_fabric_token(os_handle, &fabric_token, owner_participant, owner_socket) != 0) {
     fail("shareable import requires a valid sealed VMM capability");
     result = CUDA_ERROR_INVALID_VALUE;
     goto done;
+  } else {
+    memcpy(allocation_uuid, fabric_token.allocation_uuid, sizeof(allocation_uuid));
   }
   if (failed || forked_after_cuda || phase != DYN_VMM_ACTIVE) {
     result = CUDA_ERROR_INVALID_VALUE;
     goto done;
   }
-  local_owner = strcmp(capability.owner_socket_path, socket_path) == 0 &&
-                strcmp(capability.owner_participant_id, participant_id) == 0;
+  local_owner = strcmp(owner_socket, socket_path) == 0 && strcmp(owner_participant, participant_id) == 0;
   if (local_owner) {
-    owner = find_object(capability.allocation_uuid, DYN_VMM_OWNER);
-    result = export_raw_owner(owner, &raw_fd);
+    owner = find_object(allocation_uuid, DYN_VMM_OWNER);
+    if (owner == NULL || owner->requested_handle_type != type)
+      result = CUDA_ERROR_INVALID_HANDLE;
+    else
+      result = export_raw_owner(owner, &broker);
     if (result != CUDA_SUCCESS) {
       fail("local CUDA VMM capability owner is unavailable");
       result = CUDA_ERROR_INVALID_VALUE;
@@ -2222,7 +2406,9 @@ cuMemImportFromShareableHandle(
     }
   } else {
     pthread_mutex_unlock(&lock);
-    result = request_owner_export(&capability, &raw_fd) == 0 ? CUDA_SUCCESS : CUDA_ERROR_INVALID_VALUE;
+    result = request_owner_export(allocation_uuid, owner_participant, owner_socket, type, &broker) == 0
+                 ? CUDA_SUCCESS
+                 : CUDA_ERROR_INVALID_VALUE;
     pthread_mutex_lock(&lock);
     if (result != CUDA_SUCCESS || failed || forked_after_cuda || phase != DYN_VMM_ACTIVE) {
       fail("remote CUDA VMM capability owner is unavailable");
@@ -2230,9 +2416,13 @@ cuMemImportFromShareableHandle(
       goto done;
     }
   }
-  result = function != NULL ? function(&real_handle, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+  result = function != NULL ? function(
+                                  &real_handle,
+                                  type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ? (void*)(uintptr_t)broker.fd
+                                                                                   : (void*)broker.bytes,
+                                  type)
                             : unavailable();
-  if (close_owned_fd(&raw_fd, "cannot close imported raw CUDA broker FD") != 0) {
+  if (clear_broker_result(&broker, "cannot close imported raw CUDA broker FD") != 0) {
     if (result == CUDA_SUCCESS && (release == NULL || release(real_handle) != CUDA_SUCCESS))
       fail_cleanup("cannot release failed imported CUDA handle");
     fail("cannot close imported raw CUDA broker FD");
@@ -2251,7 +2441,15 @@ cuMemImportFromShareableHandle(
       fail("cannot record VMM capability import");
       result = CUDA_ERROR_INVALID_VALUE;
     } else {
-      memcpy(allocation->allocation_uuid, capability.allocation_uuid, sizeof(allocation->allocation_uuid));
+      if (allocation->properties.requestedHandleTypes != type) {
+        if (release == NULL || release(real_handle) != CUDA_SUCCESS)
+          fail_cleanup("cannot release cross-type imported CUDA handle");
+        free(allocation);
+        fail("real CUDA import returned cross-type allocation properties");
+        result = CUDA_ERROR_INVALID_VALUE;
+        goto done;
+      }
+      memcpy(allocation->allocation_uuid, allocation_uuid, sizeof(allocation->allocation_uuid));
       allocation->exported = true;
       allocation->real_handle = real_handle;
       allocation->application_handle_live = true;
@@ -2266,10 +2464,11 @@ cuMemImportFromShareableHandle(
     fail("real CUDA capability import failed");
   }
 done:
-  if (raw_fd >= 0 && close_owned_fd(&raw_fd, "cannot close failed raw CUDA broker FD") != 0) {
+  if (clear_broker_result(&broker, "cannot close failed raw CUDA broker FD") != 0) {
     result = CUDA_ERROR_UNKNOWN;
     phase = DYN_VMM_FAILED;
   }
+  explicit_bzero(&fabric_token, sizeof(fabric_token));
   pthread_mutex_unlock(&lock);
   return result;
 }
@@ -2339,7 +2538,7 @@ cuMulticastBindMem(
   if (find_logical_handle(memory_handle) == NULL)
     result = unknown_logical_handle();
   else {
-    fail("M1 does not support multicast binding of managed allocations");
+    fail("multicast binding of managed allocations is unsupported");
     result = CUDA_ERROR_NOT_SUPPORTED;
   }
   pthread_mutex_unlock(&lock);
@@ -2370,7 +2569,7 @@ cuMulticastBindMem_v2(
   if (find_logical_handle(memory_handle) == NULL)
     result = unknown_logical_handle();
   else {
-    fail("M1 does not support multicast binding of managed allocations");
+    fail("multicast binding of managed allocations is unsupported");
     result = CUDA_ERROR_NOT_SUPPORTED;
   }
   pthread_mutex_unlock(&lock);

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
@@ -120,6 +120,13 @@ typedef CUresult(CUDAAPI* import_fn)(
 typedef CUresult(CUDAAPI* retain_fn)(CUmemGenericAllocationHandle*, void*);
 typedef CUresult(CUDAAPI* properties_fn)(
     CUmemAllocationProp*, CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* device_get_fn)(CUdevice*, int);
+typedef CUresult(CUDAAPI* device_uuid_fn)(CUuuid*, CUdevice);
+
+struct device_identity_api {
+  device_get_fn get_device;
+  device_uuid_fn get_uuid;
+};
 
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static struct allocation* allocations;
@@ -184,6 +191,25 @@ real_symbol(const char* name)
     return symbol;
   handle = (void*)atomic_load(&explicit_libcuda_handle);
   return handle == NULL ? NULL : real_dlsym(handle, name);
+}
+
+static int
+resolve_device_identity_api(struct device_identity_api* api)
+{
+  api->get_device = (device_get_fn)real_symbol("cuDeviceGet");
+  api->get_uuid = (device_uuid_fn)real_symbol("cuDeviceGetUuid_v2");
+  if (api->get_uuid == NULL)
+    api->get_uuid = (device_uuid_fn)real_symbol("cuDeviceGetUuid");
+  return api->get_device != NULL && api->get_uuid != NULL ? 0 : -1;
+}
+
+static CUresult
+device_uuid(const struct device_identity_api* api, int ordinal, CUuuid* uuid)
+{
+  CUdevice device;
+  CUresult result = api->get_device(&device, ordinal);
+
+  return result == CUDA_SUCCESS ? api->get_uuid(uuid, device) : result;
 }
 
 static bool
@@ -559,17 +585,14 @@ static int
 query_placement(int client, struct dyn_vmm_header* response)
 {
   typedef CUresult(CUDAAPI * count_fn)(int*);
-  typedef CUresult(CUDAAPI * uuid_fn)(CUuuid*, CUdevice);
   count_fn get_count = (count_fn)real_symbol("cuDeviceGetCount");
-  uuid_fn get_uuid = (uuid_fn)real_symbol("cuDeviceGetUuid_v2");
+  struct device_identity_api identity_api;
   struct allocation* allocation;
   struct dyn_vmm_placement* placements;
   int device_count;
   size_t count = 0;
   size_t index;
 
-  if (get_uuid == NULL)
-    get_uuid = (uuid_fn)real_symbol("cuDeviceGetUuid");
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
     if (!allocation->detached)
       continue;
@@ -590,7 +613,7 @@ query_placement(int client, struct dyn_vmm_header* response)
     free(placements);
     return 0;
   }
-  if (get_count == NULL || get_uuid == NULL) {
+  if (get_count == NULL || resolve_device_identity_api(&identity_api) != 0) {
     free(placements);
     set_error(response, "cannot query current CUDA GPU placement");
     return send_header(client, response, -1);
@@ -615,10 +638,10 @@ query_placement(int client, struct dyn_vmm_header* response)
     set_error(response, "CUDA device ordinal cannot be represented");
     return send_header(client, response, -1);
   }
-  for (int device = 0; device < device_count; device++) {
+  for (int ordinal = 0; ordinal < device_count; ordinal++) {
     CUuuid current;
 
-    if (get_uuid(&current, device) != CUDA_SUCCESS) {
+    if (device_uuid(&identity_api, ordinal, &current) != CUDA_SUCCESS) {
       free(placements);
       set_error(response, "cannot query UUID for visible CUDA device");
       return send_header(client, response, -1);
@@ -631,7 +654,7 @@ query_placement(int client, struct dyn_vmm_header* response)
         set_error(response, "source CUDA GPU UUID is visible at multiple ordinals");
         return send_header(client, response, -1);
       }
-      placements[index].device_ordinal = (int32_t)device;
+      placements[index].device_ordinal = (int32_t)ordinal;
       memcpy(placements[index].current_gpu_uuid, current.bytes, sizeof(placements[index].current_gpu_uuid));
     }
   }
@@ -837,20 +860,16 @@ allocate_logical_handle(CUmemGenericAllocationHandle* output)
 static int
 record_gpu_identity(struct allocation* allocation)
 {
-  typedef CUresult(CUDAAPI * uuid_fn)(CUuuid*, CUdevice);
-  uuid_fn get_uuid = (uuid_fn)real_symbol("cuDeviceGetUuid_v2");
+  struct device_identity_api identity_api;
 
   if (allocation->properties.location.type != CU_MEM_LOCATION_TYPE_DEVICE)
     return -1;
-  if (get_uuid == NULL)
-    get_uuid = (uuid_fn)real_symbol("cuDeviceGetUuid");
   allocation->device_ordinal = allocation->properties.location.id;
   allocation->source_device_ordinal = allocation->device_ordinal;
-  return get_uuid != NULL &&
-          get_uuid(&allocation->gpu_uuid, allocation->device_ordinal) ==
-              CUDA_SUCCESS
-      ? 0
-      : -1;
+  return resolve_device_identity_api(&identity_api) == 0 &&
+                 device_uuid(&identity_api, allocation->device_ordinal, &allocation->gpu_uuid) == CUDA_SUCCESS
+             ? 0
+             : -1;
 }
 
 static struct allocation*

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
@@ -552,25 +552,38 @@ dyn_vmm_test_broker_shape(CUmemAllocationHandleType type, int fd, uint64_t bytes
 {
   return valid_broker_shape(type, fd, bytes_size);
 }
+
+int
+dyn_vmm_test_corrupt_detached_placement(
+    const char* field, int value)
+{
+  struct allocation* allocation;
+  int result = -1;
+
+  pthread_mutex_lock(&lock);
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (!allocation->detached)
+      continue;
+    if (strcmp(field, "device") == 0)
+      allocation->device_ordinal = value;
+    else if (strcmp(field, "source") == 0)
+      allocation->source_device_ordinal = value;
+    else if (strcmp(field, "properties") == 0)
+      allocation->properties.location.id = value;
+    else if (strcmp(field, "access") == 0 && allocation->access_count != 0)
+      allocation->access[0].location.id = value;
+    else
+      break;
+    result = 0;
+    break;
+  }
+  pthread_mutex_unlock(&lock);
+  return result;
+}
 #endif
 
-static bool
-placement_seen(const struct allocation* allocation)
-{
-  const struct allocation* previous;
-
-  for (previous = allocations; previous != allocation; previous = previous->next) {
-    if (previous->detached &&
-        memcmp(
-            previous->gpu_uuid.bytes, allocation->gpu_uuid.bytes,
-            sizeof(allocation->gpu_uuid.bytes)) == 0)
-      return true;
-  }
-  return false;
-}
-
-static struct dyn_vmm_placement*
-find_placement(struct dyn_vmm_placement* placements, size_t count, const CUuuid* gpu_uuid)
+static const struct dyn_vmm_placement*
+find_placement(const struct dyn_vmm_placement* placements, size_t count, const CUuuid* gpu_uuid)
 {
   size_t index;
 
@@ -582,100 +595,54 @@ find_placement(struct dyn_vmm_placement* placements, size_t count, const CUuuid*
 }
 
 static int
-query_placement(int client, struct dyn_vmm_header* response)
+set_placement(
+    int client, const struct dyn_vmm_header* request, struct dyn_vmm_header* response,
+    const struct dyn_vmm_placement* placements)
 {
-  typedef CUresult(CUDAAPI * count_fn)(int*);
-  count_fn get_count = (count_fn)real_symbol("cuDeviceGetCount");
-  struct device_identity_api identity_api;
+  const struct allocation* previous;
   struct allocation* allocation;
-  struct dyn_vmm_placement* placements;
-  int device_count;
-  size_t count = 0;
   size_t index;
 
-  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
-    if (!allocation->detached)
-      continue;
-    if (!placement_seen(allocation))
-      count++;
-  }
-  placements = calloc(count == 0 ? 1 : count, sizeof(*placements));
-  if (placements == NULL) {
-    free(placements);
-    set_error(response, "cannot query current CUDA GPU placement");
-    return send_header(client, response, -1);
-  }
-  if (count == 0) {
-    if (send_header(client, response, -1) != 0) {
-      free(placements);
-      return -1;
-    }
-    free(placements);
-    return 0;
-  }
-  if (get_count == NULL || resolve_device_identity_api(&identity_api) != 0) {
-    free(placements);
-    set_error(response, "cannot query current CUDA GPU placement");
-    return send_header(client, response, -1);
-  }
-  index = 0;
-  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
-    if (!allocation->detached)
-      continue;
-    if (placement_seen(allocation))
-      continue;
-    placements[index].device_ordinal = -1;
-    memcpy(placements[index].source_gpu_uuid, allocation->gpu_uuid.bytes, sizeof(placements[index].source_gpu_uuid));
-    index++;
-  }
-  if (get_count(&device_count) != CUDA_SUCCESS || device_count < 0) {
-    free(placements);
-    set_error(response, "cannot query current CUDA device count");
-    return send_header(client, response, -1);
-  }
-  if ((uintmax_t)device_count > (uintmax_t)INT32_MAX + 1) {
-    free(placements);
-    set_error(response, "CUDA device ordinal cannot be represented");
-    return send_header(client, response, -1);
-  }
-  for (int ordinal = 0; ordinal < device_count; ordinal++) {
-    CUuuid current;
+  for (index = 0; index < request->count; index++) {
+    size_t previous_index;
 
-    if (device_uuid(&identity_api, ordinal, &current) != CUDA_SUCCESS) {
-      free(placements);
-      set_error(response, "cannot query UUID for visible CUDA device");
+    if (placements[index].device_ordinal < 0 || placements[index].reserved != 0 ||
+        all_zero(placements[index].source_gpu_uuid, sizeof(placements[index].source_gpu_uuid)) ||
+        all_zero(placements[index].target_gpu_uuid, sizeof(placements[index].target_gpu_uuid))) {
+      set_error(response, "invalid CUDA VMM placement entry");
       return send_header(client, response, -1);
     }
-    for (index = 0; index < count; index++) {
-      if (memcmp(placements[index].source_gpu_uuid, current.bytes, sizeof(current.bytes)) != 0)
-        continue;
-      if (placements[index].device_ordinal >= 0) {
-        free(placements);
-        set_error(response, "source CUDA GPU UUID is visible at multiple ordinals");
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      if (memcmp(
+              placements[previous_index].source_gpu_uuid, placements[index].source_gpu_uuid,
+              sizeof(placements[index].source_gpu_uuid)) == 0) {
+        set_error(response, "duplicate CUDA VMM source GPU UUID");
         return send_header(client, response, -1);
       }
-      placements[index].device_ordinal = (int32_t)ordinal;
-      memcpy(placements[index].current_gpu_uuid, current.bytes, sizeof(placements[index].current_gpu_uuid));
-    }
-  }
-  for (index = 0; index < count; index++) {
-    if (placements[index].device_ordinal < 0) {
-      free(placements);
-      set_error(response, "source CUDA GPU UUID is not currently visible");
-      return send_header(client, response, -1);
+      if (memcmp(
+              placements[previous_index].target_gpu_uuid, placements[index].target_gpu_uuid,
+              sizeof(placements[index].target_gpu_uuid)) == 0) {
+        set_error(response, "duplicate CUDA VMM target GPU UUID");
+        return send_header(client, response, -1);
+      }
+      if (placements[previous_index].device_ordinal == placements[index].device_ordinal) {
+        set_error(response, "duplicate CUDA VMM target ordinal");
+        return send_header(client, response, -1);
+      }
     }
   }
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
-    const struct allocation* previous;
+    const struct dyn_vmm_placement* placement;
     size_t access_index;
 
     if (!allocation->detached)
       continue;
-    if (find_placement(placements, count, &allocation->gpu_uuid) == NULL ||
+    placement = find_placement(placements, request->count, &allocation->gpu_uuid);
+    if (placement == NULL ||
+        allocation->device_ordinal != allocation->source_device_ordinal ||
         allocation->properties.location.type != CU_MEM_LOCATION_TYPE_DEVICE ||
         allocation->properties.location.id != allocation->device_ordinal ||
         (allocation->access_count != 0 && allocation->access == NULL)) {
-      free(placements);
       set_error(response, "detached CUDA placement metadata is inconsistent");
       return send_header(client, response, -1);
     }
@@ -683,7 +650,6 @@ query_placement(int client, struct dyn_vmm_header* response)
       if (previous->detached &&
           memcmp(previous->gpu_uuid.bytes, allocation->gpu_uuid.bytes, sizeof(allocation->gpu_uuid.bytes)) == 0 &&
           previous->source_device_ordinal != allocation->source_device_ordinal) {
-        free(placements);
         set_error(response, "source CUDA GPU UUID has inconsistent saved ordinals");
         return send_header(client, response, -1);
       }
@@ -691,19 +657,35 @@ query_placement(int client, struct dyn_vmm_header* response)
     for (access_index = 0; access_index < allocation->access_count; access_index++) {
       if (allocation->access[access_index].location.type != CU_MEM_LOCATION_TYPE_DEVICE ||
           allocation->access[access_index].location.id != allocation->device_ordinal) {
-        free(placements);
         set_error(response, "detached CUDA access placement is inconsistent");
         return send_header(client, response, -1);
       }
     }
   }
+  for (index = 0; index < request->count; index++) {
+    bool found = false;
+
+    for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+      if (allocation->detached &&
+          memcmp(
+              placements[index].source_gpu_uuid, allocation->gpu_uuid.bytes,
+              sizeof(placements[index].source_gpu_uuid)) == 0) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      set_error(response, "unknown CUDA VMM source GPU UUID");
+      return send_header(client, response, -1);
+    }
+  }
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
-    struct dyn_vmm_placement* placement;
+    const struct dyn_vmm_placement* placement;
     size_t access_index;
 
     if (!allocation->detached)
       continue;
-    placement = find_placement(placements, count, &allocation->gpu_uuid);
+    placement = find_placement(placements, request->count, &allocation->gpu_uuid);
     allocation->device_ordinal = placement->device_ordinal;
     allocation->properties.location.id = placement->device_ordinal;
     for (access_index = 0; access_index < allocation->access_count; access_index++) {
@@ -711,14 +693,7 @@ query_placement(int client, struct dyn_vmm_header* response)
         allocation->access[access_index].location.id = placement->device_ordinal;
     }
   }
-  response->count = (uint32_t)count;
-  response->payload_size = count * sizeof(*placements);
-  if (send_header(client, response, -1) != 0 || write_all(client, placements, (size_t)response->payload_size) != 0) {
-    free(placements);
-    return -1;
-  }
-  free(placements);
-  return 0;
+  return send_header(client, response, -1);
 }
 
 static struct allocation*
@@ -1905,7 +1880,9 @@ valid_request_shape(const struct dyn_vmm_header* request, int passed_fd)
       all_zero(request->participant_id, sizeof(request->participant_id));
 
   if (request->magic != DYN_VMM_MAGIC || request->version != DYN_VMM_VERSION ||
-      request->status != 0 || request->count != 0 || request->reserved != 0 ||
+      request->status != 0 ||
+      (request->operation != DYN_VMM_SET_PLACEMENT && request->count != 0) ||
+      request->reserved != 0 ||
       !all_zero(request->message, sizeof(request->message)) ||
       !all_zero(request->reserved_identity, sizeof(request->reserved_identity)) ||
       (!bootstrap_identify &&
@@ -1917,10 +1894,16 @@ valid_request_shape(const struct dyn_vmm_header* request, int passed_fd)
       return passed_fd < 0 && request->payload_size == 0 && request->handle_type == 0 &&
           all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id == 0;
     case DYN_VMM_INSPECT:
-    case DYN_VMM_QUERY_PLACEMENT:
       return !bootstrap_identify && passed_fd < 0 && request->payload_size == 0 &&
           request->handle_type == 0 && all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) &&
           request->object_id == 0;
+    case DYN_VMM_SET_PLACEMENT:
+      return !bootstrap_identify && passed_fd < 0 && request->handle_type == 0 &&
+          all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id == 0 &&
+          request->payload_size <= SIZE_MAX &&
+          request->payload_size <= DYN_VMM_MAXIMUM_ALLOCATION_SIZE &&
+          request->payload_size % sizeof(struct dyn_vmm_placement) == 0 &&
+          request->payload_size / sizeof(struct dyn_vmm_placement) == request->count;
     case DYN_VMM_READ_OWNER:
     case DYN_VMM_DETACH_IMPORTS:
     case DYN_VMM_DETACH_OWNERS:
@@ -2002,8 +1985,10 @@ serve(int client)
         set_error(&response, failure[0] != '\0' ? failure : "CUDA VMM shim is unhealthy");
       (void)send_header(client, &response, -1);
       break;
-    case DYN_VMM_QUERY_PLACEMENT:
-      (void)query_placement(client, &response);
+    case DYN_VMM_SET_PLACEMENT:
+      (void)set_placement(
+          client, &request, &response,
+          (const struct dyn_vmm_placement*)payload);
       break;
     case DYN_VMM_EXPORT_OWNER:
       (void)export_owner(client, &request, &response, passed_fd);

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
@@ -7,17 +7,23 @@
 #ifndef DYN_SNAPSHOT_CUDA_VMM_PROTOCOL_H
 #define DYN_SNAPSHOT_CUDA_VMM_PROTOCOL_H
 
+#include <stddef.h>
 #include <stdint.h>
 #include <sys/un.h>
 
 #define DYN_VMM_MAGIC 0x44564d4dU
-#define DYN_VMM_VERSION 2U
+#define DYN_VMM_VERSION 3U
 #define DYN_VMM_CAPABILITY_MAGIC 0x44564d43U
 #define DYN_VMM_CAPABILITY_VERSION 1U
+#define DYN_VMM_FABRIC_TOKEN_MAGIC 0x44564d46U
+#define DYN_VMM_FABRIC_TOKEN_VERSION 1U
+#define DYN_VMM_FABRIC_HANDLE_SIZE 64U
 #define DYN_VMM_SOCKET_PREFIX "cuda-vmm-"
 #define DYN_VMM_PARTICIPANT_ID_SIZE 33U
+#define DYN_VMM_FABRIC_PARTICIPANT_ID_SIZE 32U
 #define DYN_VMM_ALLOCATION_UUID_SIZE 16U
 #define DYN_VMM_GPU_UUID_SIZE 16U
+#define DYN_VMM_MAXIMUM_ALLOCATION_SIZE (UINT64_C(512) << 20)
 
 enum dyn_vmm_operation {
   DYN_VMM_INSPECT = 1,
@@ -57,13 +63,14 @@ struct dyn_vmm_header {
   uint16_t operation;
   int32_t status;
   uint32_t count;
-  uint32_t reserved[2];
+  uint32_t handle_type;
+  uint32_t reserved;
   uint8_t allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
   uint64_t object_id;
   uint64_t payload_size;
   char message[96];
   char participant_id[DYN_VMM_PARTICIPANT_ID_SIZE];
-  uint8_t reserved_identity[64];
+  uint8_t reserved_identity[71];
 };
 
 /*
@@ -97,6 +104,16 @@ struct dyn_vmm_capability {
   uint8_t reserved_identity[91];
 };
 
+struct dyn_vmm_fabric_token {
+  uint32_t magic;
+  uint16_t version;
+  uint16_t handle_type;
+  uint8_t allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
+  char owner_participant_id[DYN_VMM_FABRIC_PARTICIPANT_ID_SIZE];
+  uint32_t owner_namespace_pid;
+  uint32_t reserved;
+};
+
 struct dyn_vmm_placement {
   int32_t device_ordinal;
   uint32_t reserved;
@@ -105,8 +122,30 @@ struct dyn_vmm_placement {
 };
 
 _Static_assert(sizeof(struct dyn_vmm_header) == 256, "VMM header layout changed");
+_Static_assert(offsetof(struct dyn_vmm_header, handle_type) == 16, "VMM header handle type offset changed");
+_Static_assert(offsetof(struct dyn_vmm_header, reserved) == 20, "VMM header reserved offset changed");
+_Static_assert(offsetof(struct dyn_vmm_header, allocation_uuid) == 24, "VMM header UUID offset changed");
+_Static_assert(offsetof(struct dyn_vmm_header, object_id) == 40, "VMM header object ID offset changed");
+_Static_assert(offsetof(struct dyn_vmm_header, payload_size) == 48, "VMM header payload size offset changed");
+_Static_assert(offsetof(struct dyn_vmm_header, message) == 56, "VMM header message offset changed");
+_Static_assert(offsetof(struct dyn_vmm_header, participant_id) == 152, "VMM header participant offset changed");
+_Static_assert(offsetof(struct dyn_vmm_header, reserved_identity) == 185, "VMM header reserved identity offset changed");
+_Static_assert(
+    offsetof(struct dyn_vmm_header, reserved_identity) +
+            sizeof(((struct dyn_vmm_header*)0)->reserved_identity) ==
+        sizeof(struct dyn_vmm_header),
+    "VMM header reserved identity must end at the header boundary");
 _Static_assert(sizeof(struct dyn_vmm_record) == 96, "VMM record layout changed");
 _Static_assert(sizeof(struct dyn_vmm_capability) == 256, "VMM capability layout changed");
+_Static_assert(sizeof(struct dyn_vmm_fabric_token) == DYN_VMM_FABRIC_HANDLE_SIZE, "VMM FABRIC token layout changed");
+_Static_assert(offsetof(struct dyn_vmm_fabric_token, magic) == 0, "VMM FABRIC token magic offset changed");
+_Static_assert(offsetof(struct dyn_vmm_fabric_token, version) == 4, "VMM FABRIC token version offset changed");
+_Static_assert(offsetof(struct dyn_vmm_fabric_token, handle_type) == 6, "VMM FABRIC token handle type offset changed");
+_Static_assert(offsetof(struct dyn_vmm_fabric_token, allocation_uuid) == 8, "VMM FABRIC token UUID offset changed");
+_Static_assert(
+    offsetof(struct dyn_vmm_fabric_token, owner_participant_id) == 24, "VMM FABRIC token participant offset changed");
+_Static_assert(offsetof(struct dyn_vmm_fabric_token, owner_namespace_pid) == 56, "VMM FABRIC token PID offset changed");
+_Static_assert(offsetof(struct dyn_vmm_fabric_token, reserved) == 60, "VMM FABRIC token reserved offset changed");
 _Static_assert(sizeof(struct dyn_vmm_placement) == 40, "VMM placement layout changed");
 
 #endif

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
@@ -12,7 +12,7 @@
 #include <sys/un.h>
 
 #define DYN_VMM_MAGIC 0x44564d4dU
-#define DYN_VMM_VERSION 3U
+#define DYN_VMM_VERSION 4U
 #define DYN_VMM_CAPABILITY_MAGIC 0x44564d43U
 #define DYN_VMM_CAPABILITY_VERSION 1U
 #define DYN_VMM_FABRIC_TOKEN_MAGIC 0x44564d46U
@@ -33,7 +33,7 @@ enum dyn_vmm_operation {
   DYN_VMM_RESTORE_OWNER = 5,
   DYN_VMM_RESTORE_IMPORT = 6,
   DYN_VMM_IDENTIFY = 7,
-  DYN_VMM_QUERY_PLACEMENT = 8,
+  DYN_VMM_SET_PLACEMENT = 8,
   DYN_VMM_EXPORT_OWNER = 9,
 };
 
@@ -118,7 +118,7 @@ struct dyn_vmm_placement {
   int32_t device_ordinal;
   uint32_t reserved;
   uint8_t source_gpu_uuid[DYN_VMM_GPU_UUID_SIZE];
-  uint8_t current_gpu_uuid[DYN_VMM_GPU_UUID_SIZE];
+  uint8_t target_gpu_uuid[DYN_VMM_GPU_UUID_SIZE];
 };
 
 _Static_assert(sizeof(struct dyn_vmm_header) == 256, "VMM header layout changed");

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
@@ -43,9 +43,9 @@ static unsigned int multicast_bind_count;
 static int last_exported_fd = -1;
 static int last_internal_export_alias = -1;
 static int internal_export_aliases[32];
+static CUmemAllocationHandleType handle_types[32];
 static int last_imported_fd = -1;
 static unsigned char last_imported_fabric[CU_IPC_HANDLE_SIZE];
-static CUmemAllocationHandleType last_imported_type;
 static int colliding_export_source = -1;
 static CUdeviceptr map_addresses[16];
 static CUdeviceptr access_addresses[16];
@@ -298,12 +298,16 @@ cuMemCreate(
     CUmemGenericAllocationHandle* output, size_t size,
     const CUmemAllocationProp* properties, unsigned long long flags)
 {
+  size_t index;
+
   (void)size;
-  (void)properties;
   (void)flags;
   create_count++;
   active_handle_count++;
   *output = next_handle++;
+  index = (size_t)(*output - UINT64_C(0x1234));
+  if (index < sizeof(handle_types) / sizeof(handle_types[0]))
+    handle_types[index] = properties->requestedHandleTypes;
   return CUDA_SUCCESS;
 }
 
@@ -411,6 +415,7 @@ cuMemImportFromShareableHandle(
 {
   struct stat status;
   int fd = (int)(uintptr_t)os_handle;
+  size_t index;
 
   if (type == CU_MEM_HANDLE_TYPE_FABRIC) {
     memcpy(last_imported_fabric, os_handle, sizeof(last_imported_fabric));
@@ -419,10 +424,12 @@ cuMemImportFromShareableHandle(
   } else {
     last_imported_fd = fd;
   }
-  last_imported_type = type;
   import_count++;
   active_handle_count++;
   *output = next_handle++;
+  index = (size_t)(*output - UINT64_C(0x1234));
+  if (index < sizeof(handle_types) / sizeof(handle_types[0]))
+    handle_types[index] = CU_MEM_HANDLE_TYPE_NONE;
   return CUDA_SUCCESS;
 }
 
@@ -430,13 +437,18 @@ CUresult CUDAAPI
 cuMemGetAllocationPropertiesFromHandle(
     CUmemAllocationProp* properties, CUmemGenericAllocationHandle handle)
 {
+  size_t index = (size_t)(handle - UINT64_C(0x1234));
+
   if (!real_handle(handle))
     return CUDA_ERROR_INVALID_HANDLE;
   memset(properties, 0, sizeof(*properties));
   properties->type = CU_MEM_ALLOCATION_TYPE_PINNED;
   properties->location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   properties->location.id = 0;
-  properties->requestedHandleTypes = last_imported_type;
+  properties->requestedHandleTypes =
+      index < sizeof(handle_types) / sizeof(handle_types[0])
+          ? handle_types[index]
+          : CU_MEM_HANDLE_TYPE_NONE;
   return CUDA_SUCCESS;
 }
 

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
@@ -62,6 +62,7 @@ static pthread_t initial_thread;
 static _Thread_local CUcontext current_context;
 static CUcontext last_context;
 static int device_count = 1;
+static CUdevice device_handles[16];
 static CUdevice device_identities[16];
 
 __attribute__((constructor)) static void
@@ -70,10 +71,10 @@ initialize_fake_cuda(void)
   size_t index;
 
   initial_thread = pthread_self();
-  for (index = 0;
-       index < sizeof(device_identities) / sizeof(device_identities[0]);
-       index++)
+  for (index = 0; index < sizeof(device_identities) / sizeof(device_identities[0]); index++) {
+    device_handles[index] = (CUdevice)index;
     device_identities[index] = (CUdevice)index;
+  }
 }
 
 static int
@@ -253,12 +254,17 @@ fake_cuda_set_device_count(int count)
 }
 
 void
-fake_cuda_set_device_identity(CUdevice ordinal, CUdevice identity)
+fake_cuda_set_device_handle(int ordinal, CUdevice device)
 {
-  if (ordinal >= 0 &&
-      (size_t)ordinal <
-          sizeof(device_identities) / sizeof(device_identities[0]))
-    device_identities[ordinal] = identity;
+  if (ordinal >= 0 && (size_t)ordinal < sizeof(device_handles) / sizeof(device_handles[0]))
+    device_handles[ordinal] = device;
+}
+
+void
+fake_cuda_set_device_identity(CUdevice device, CUdevice identity)
+{
+  if (device >= 0 && (size_t)device < sizeof(device_identities) / sizeof(device_identities[0]))
+    device_identities[device] = identity;
 }
 
 unsigned int
@@ -317,18 +323,25 @@ cuCtxSetCurrent(CUcontext context)
 }
 
 CUresult CUDAAPI
+cuDeviceGet(CUdevice* device, int ordinal)
+{
+  if (device == NULL || ordinal < 0 || ordinal >= device_count ||
+      (size_t)ordinal >= sizeof(device_handles) / sizeof(device_handles[0]))
+    return CUDA_ERROR_INVALID_DEVICE;
+  *device = device_handles[ordinal];
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
 cuDeviceGetUuid_v2(CUuuid* uuid, CUdevice device)
 {
   CUdevice identity;
   size_t index;
 
-  if (device < 0 || device >= device_count ||
-      (size_t)device >=
-          sizeof(device_identities) / sizeof(device_identities[0]))
+  if (uuid == NULL || device < 0 || (size_t)device >= sizeof(device_identities) / sizeof(device_identities[0]))
     return CUDA_ERROR_INVALID_DEVICE;
   identity = device_identities[device];
-  for (index = 0; index < sizeof(uuid->bytes); index++)
-    uuid->bytes[index] = (char)(index + identity + 1);
+  for (index = 0; index < sizeof(uuid->bytes); index++) uuid->bytes[index] = (char)(index + identity + 1);
   return CUDA_SUCCESS;
 }
 
@@ -629,6 +642,8 @@ cuGetProcAddress_v2(
     *output = (void*)&cuCtxGetCurrent;
   else if (strcmp(symbol, "cuCtxSetCurrent") == 0)
     *output = (void*)&cuCtxSetCurrent;
+  else if (strcmp(symbol, "cuDeviceGet") == 0)
+    *output = (void*)&cuDeviceGet;
   else if (strcmp(symbol, "cuDeviceGetUuid_v2") == 0)
     *output = (void*)&cuDeviceGetUuid_v2;
   else if (strcmp(symbol, "cuDeviceGetCount") == 0)

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
@@ -64,6 +64,9 @@ static CUcontext last_context;
 static int device_count = 1;
 static CUdevice device_handles[16];
 static CUdevice device_identities[16];
+static unsigned int device_get_calls;
+static unsigned int device_uuid_calls;
+static unsigned int device_count_calls;
 
 __attribute__((constructor)) static void
 initialize_fake_cuda(void)
@@ -268,6 +271,24 @@ fake_cuda_set_device_identity(CUdevice device, CUdevice identity)
 }
 
 unsigned int
+fake_cuda_device_get_calls(void)
+{
+  return device_get_calls;
+}
+
+unsigned int
+fake_cuda_device_uuid_calls(void)
+{
+  return device_uuid_calls;
+}
+
+unsigned int
+fake_cuda_device_count_calls(void)
+{
+  return device_count_calls;
+}
+
+unsigned int
 fake_cuda_import_count(void)
 {
   return import_count;
@@ -325,6 +346,7 @@ cuCtxSetCurrent(CUcontext context)
 CUresult CUDAAPI
 cuDeviceGet(CUdevice* device, int ordinal)
 {
+  device_get_calls++;
   if (device == NULL || ordinal < 0 || ordinal >= device_count ||
       (size_t)ordinal >= sizeof(device_handles) / sizeof(device_handles[0]))
     return CUDA_ERROR_INVALID_DEVICE;
@@ -338,6 +360,7 @@ cuDeviceGetUuid_v2(CUuuid* uuid, CUdevice device)
   CUdevice identity;
   size_t index;
 
+  device_uuid_calls++;
   if (uuid == NULL || device < 0 || (size_t)device >= sizeof(device_identities) / sizeof(device_identities[0]))
     return CUDA_ERROR_INVALID_DEVICE;
   identity = device_identities[device];
@@ -348,6 +371,7 @@ cuDeviceGetUuid_v2(CUuuid* uuid, CUdevice device)
 CUresult CUDAAPI
 cuDeviceGetCount(int* count)
 {
+  device_count_calls++;
   if (count == NULL)
     return CUDA_ERROR_INVALID_VALUE;
   *count = device_count;

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
@@ -44,6 +44,8 @@ static int last_exported_fd = -1;
 static int last_internal_export_alias = -1;
 static int internal_export_aliases[32];
 static int last_imported_fd = -1;
+static unsigned char last_imported_fabric[CU_IPC_HANDLE_SIZE];
+static CUmemAllocationHandleType last_imported_type;
 static int colliding_export_source = -1;
 static CUdeviceptr map_addresses[16];
 static CUdeviceptr access_addresses[16];
@@ -126,6 +128,12 @@ int
 fake_cuda_last_imported_fd(void)
 {
   return last_imported_fd;
+}
+
+unsigned char
+fake_cuda_last_imported_fabric_byte(unsigned int index)
+{
+  return index < sizeof(last_imported_fabric) ? last_imported_fabric[index] : 0;
 }
 
 CUdeviceptr
@@ -361,10 +369,18 @@ cuMemExportToShareableHandle(
     CUmemAllocationHandleType type, unsigned long long flags)
 {
   int fd;
+  size_t index;
 
   (void)flags;
-  if (!real_handle(handle) ||
-      type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+  if (!real_handle(handle))
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (type == CU_MEM_HANDLE_TYPE_FABRIC) {
+    for (index = 0; index < CU_IPC_HANDLE_SIZE; index++)
+      ((unsigned char*)shareable)[index] = (unsigned char)(0xa0U + index);
+    export_count++;
+    return CUDA_SUCCESS;
+  }
+  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
     return CUDA_ERROR_INVALID_HANDLE;
   if (getenv("FAKE_CUDA_COLLIDE_EXPORT_IDENTITY") != NULL) {
     if (colliding_export_source < 0)
@@ -396,10 +412,14 @@ cuMemImportFromShareableHandle(
   struct stat status;
   int fd = (int)(uintptr_t)os_handle;
 
-  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ||
-      fstat(fd, &status) != 0)
+  if (type == CU_MEM_HANDLE_TYPE_FABRIC) {
+    memcpy(last_imported_fabric, os_handle, sizeof(last_imported_fabric));
+  } else if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR || fstat(fd, &status) != 0) {
     return CUDA_ERROR_INVALID_HANDLE;
-  last_imported_fd = fd;
+  } else {
+    last_imported_fd = fd;
+  }
+  last_imported_type = type;
   import_count++;
   active_handle_count++;
   *output = next_handle++;
@@ -416,8 +436,7 @@ cuMemGetAllocationPropertiesFromHandle(
   properties->type = CU_MEM_ALLOCATION_TYPE_PINNED;
   properties->location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   properties->location.id = 0;
-  properties->requestedHandleTypes =
-      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  properties->requestedHandleTypes = last_imported_type;
   return CUDA_SUCCESS;
 }
 

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
@@ -44,6 +44,7 @@ static int last_exported_fd = -1;
 static int last_internal_export_alias = -1;
 static int internal_export_aliases[32];
 static CUmemAllocationHandleType handle_types[32];
+static CUdevice create_devices[32];
 static int last_imported_fd = -1;
 static unsigned char last_imported_fabric[CU_IPC_HANDLE_SIZE];
 static int colliding_export_source = -1;
@@ -60,11 +61,19 @@ static CUmemGenericAllocationHandle released_handles[16];
 static pthread_t initial_thread;
 static _Thread_local CUcontext current_context;
 static CUcontext last_context;
+static int device_count = 1;
+static CUdevice device_identities[16];
 
 __attribute__((constructor)) static void
 initialize_fake_cuda(void)
 {
+  size_t index;
+
   initial_thread = pthread_self();
+  for (index = 0;
+       index < sizeof(device_identities) / sizeof(device_identities[0]);
+       index++)
+    device_identities[index] = (CUdevice)index;
 }
 
 static int
@@ -228,6 +237,30 @@ fake_cuda_create_count(void)
   return create_count;
 }
 
+CUdevice
+fake_cuda_create_device(unsigned int index)
+{
+  return index < create_count &&
+          index < sizeof(create_devices) / sizeof(create_devices[0])
+      ? create_devices[index]
+      : -1;
+}
+
+void
+fake_cuda_set_device_count(int count)
+{
+  device_count = count;
+}
+
+void
+fake_cuda_set_device_identity(CUdevice ordinal, CUdevice identity)
+{
+  if (ordinal >= 0 &&
+      (size_t)ordinal <
+          sizeof(device_identities) / sizeof(device_identities[0]))
+    device_identities[ordinal] = identity;
+}
+
 unsigned int
 fake_cuda_import_count(void)
 {
@@ -286,10 +319,25 @@ cuCtxSetCurrent(CUcontext context)
 CUresult CUDAAPI
 cuDeviceGetUuid_v2(CUuuid* uuid, CUdevice device)
 {
+  CUdevice identity;
   size_t index;
 
+  if (device < 0 || device >= device_count ||
+      (size_t)device >=
+          sizeof(device_identities) / sizeof(device_identities[0]))
+    return CUDA_ERROR_INVALID_DEVICE;
+  identity = device_identities[device];
   for (index = 0; index < sizeof(uuid->bytes); index++)
-    uuid->bytes[index] = (char)(index + device + 1);
+    uuid->bytes[index] = (char)(index + identity + 1);
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuDeviceGetCount(int* count)
+{
+  if (count == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  *count = device_count;
   return CUDA_SUCCESS;
 }
 
@@ -302,6 +350,8 @@ cuMemCreate(
 
   (void)size;
   (void)flags;
+  if (create_count < sizeof(create_devices) / sizeof(create_devices[0]))
+    create_devices[create_count] = properties->location.id;
   create_count++;
   active_handle_count++;
   *output = next_handle++;
@@ -581,6 +631,8 @@ cuGetProcAddress_v2(
     *output = (void*)&cuCtxSetCurrent;
   else if (strcmp(symbol, "cuDeviceGetUuid_v2") == 0)
     *output = (void*)&cuDeviceGetUuid_v2;
+  else if (strcmp(symbol, "cuDeviceGetCount") == 0)
+    *output = (void*)&cuDeviceGetCount;
   else if (strcmp(symbol, "cuMemcpyDtoH_v2") == 0)
     *output = (void*)&cuMemcpyDtoH_v2;
   else if (strcmp(symbol, "cuMemcpyHtoD_v2") == 0)

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
@@ -26,6 +26,9 @@
 #include "../protocol.h"
 
 unsigned int fake_cuda_create_count(void);
+CUdevice fake_cuda_create_device(unsigned int);
+void fake_cuda_set_device_count(int);
+void fake_cuda_set_device_identity(CUdevice, CUdevice);
 unsigned int fake_cuda_import_count(void);
 unsigned int fake_cuda_release_count(void);
 unsigned int fake_cuda_map_count(void);
@@ -1268,7 +1271,7 @@ test_owner_importer_success(void)
 }
 
 static void
-test_fabric_owner_importer_restore(bool fail_import)
+test_fabric_owner_importer_restore(bool fail_import, bool reindex)
 {
   CUmemGenericAllocationHandle owner;
   CUmemGenericAllocationHandle importer;
@@ -1327,7 +1330,47 @@ test_fabric_owner_importer_restore(bool fail_import)
   detach_record(importer_record, DYN_VMM_DETACH_IMPORTS, 1);
   detach_record(owner_record, DYN_VMM_DETACH_OWNERS, 1);
 
+  if (reindex) {
+    struct dyn_vmm_placement* placement;
+
+    memset(&request, 0, sizeof(request));
+    request.magic = DYN_VMM_MAGIC;
+    request.version = DYN_VMM_VERSION;
+    request.operation = DYN_VMM_QUERY_PLACEMENT;
+    fake_cuda_set_device_count(4);
+    fake_cuda_set_device_identity(0, 3);
+    fake_cuda_set_device_identity(1, 1);
+    fake_cuda_set_device_identity(2, 2);
+    fake_cuda_set_device_identity(3, 3);
+    response = exchange_fd(&request, NULL, &ignored, -1, &received_fd, 0);
+    require(
+        response.status != 0 && received_fd < 0 && strstr(response.message, "not currently visible") != NULL,
+        "placement query accepted an absent source GPU UUID");
+    free(ignored);
+
+    fake_cuda_set_device_identity(1, 0);
+    fake_cuda_set_device_identity(3, 0);
+    response = exchange_fd(&request, NULL, &ignored, -1, &received_fd, 0);
+    require(
+        response.status != 0 && received_fd < 0 && strstr(response.message, "multiple ordinals") != NULL,
+        "placement query accepted an ambiguous source GPU UUID");
+    free(ignored);
+
+    fake_cuda_set_device_identity(1, 1);
+    response = exchange(&request, NULL, &ignored, &received_fd);
+    placement = ignored;
+    require(
+        response.count == 1 && response.payload_size == sizeof(*placement) && received_fd < 0 &&
+            placement->device_ordinal == 3 && placement->reserved == 0 &&
+            memcmp(placement->source_gpu_uuid, owner_record->gpu_uuid, sizeof(placement->source_gpu_uuid)) == 0 &&
+            memcmp(placement->current_gpu_uuid, owner_record->gpu_uuid, sizeof(placement->current_gpu_uuid)) == 0,
+        "placement query did not resolve the source GPU UUID at ordinal 3");
+    free(ignored);
+  }
+
   owner_payload = restore_payload(owner_record, owner_record, &owner_payload_size, 1, 1);
+  if (reindex)
+    ((struct dyn_vmm_record*)owner_payload)->device_ordinal = 3;
   memset(&request, 0, sizeof(request));
   request.magic = DYN_VMM_MAGIC;
   request.version = DYN_VMM_VERSION;
@@ -1342,6 +1385,8 @@ test_fabric_owner_importer_restore(bool fail_import)
       "FABRIC owner restore returned the wrong broker shape");
 
   importer_metadata = restore_payload(importer_record, importer_record, &importer_metadata_size, 1, 0);
+  if (reindex)
+    ((struct dyn_vmm_record*)importer_metadata)->device_ordinal = 3;
   importer_payload_size = importer_metadata_size + DYN_VMM_FABRIC_HANDLE_SIZE;
   importer_payload = malloc(importer_payload_size);
   require(importer_payload != NULL, "cannot allocate FABRIC importer payload");
@@ -1366,6 +1411,16 @@ test_fabric_owner_importer_restore(bool fail_import)
           fake_cuda_active_handle_count() == 2 && fake_cuda_active_mapping_count() == 2 &&
           fake_cuda_multicast_bind_count() == 0,
       "FABRIC importer restore violated transport or lifecycle invariants");
+  if (reindex) {
+    CUmemAccessDesc owner_access = fake_cuda_access_descriptor(4);
+    CUmemAccessDesc importer_access = fake_cuda_access_descriptor(5);
+
+    require(
+        fake_cuda_create_device(1) == 3 && owner_access.location.type == CU_MEM_LOCATION_TYPE_DEVICE &&
+            owner_access.location.id == 3 && importer_access.location.type == CU_MEM_LOCATION_TYPE_DEVICE &&
+            importer_access.location.id == 3,
+        "FABRIC owner/importer replay did not use resolved ordinal 3");
+  }
 
 done:
   free(importer_payload);
@@ -1858,11 +1913,15 @@ main(int argc, char** argv)
     return 0;
   }
   if (argc == 2 && strcmp(argv[1], "fabric-owner-importer-success") == 0) {
-    test_fabric_owner_importer_restore(false);
+    test_fabric_owner_importer_restore(false, false);
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "fabric-ordinal-reindex") == 0) {
+    test_fabric_owner_importer_restore(false, true);
     return 0;
   }
   if (argc == 2 && strcmp(argv[1], "fabric-importer-failure") == 0) {
-    test_fabric_owner_importer_restore(true);
+    test_fabric_owner_importer_restore(true, false);
     return 0;
   }
   const int application_live = argc == 2 && strcmp(argv[1], "live") == 0;

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
@@ -1424,9 +1424,11 @@ test_fabric_repeated_export_and_self_import(void)
   CUmemGenericAllocationHandle owner;
   CUmemGenericAllocationHandle importer;
   CUmemGenericAllocationHandle repeated_importer;
+  CUmemAllocationProp imported_properties;
   struct dyn_vmm_fabric_token first;
   struct dyn_vmm_fabric_token second;
 
+  memset(&imported_properties, 0, sizeof(imported_properties));
   establish_fabric_mapping(&owner, &first, 0x100000);
   require(
       cuMemExportToShareableHandle(&second, owner, CU_MEM_HANDLE_TYPE_FABRIC, 0) == CUDA_SUCCESS,
@@ -1441,6 +1443,10 @@ test_fabric_repeated_export_and_self_import(void)
       cuMemImportFromShareableHandle(&importer, &first, CU_MEM_HANDLE_TYPE_FABRIC) == CUDA_SUCCESS &&
           fake_cuda_export_count() == 3 && fake_cuda_import_count() == 1,
       "same-process FABRIC token import failed");
+  require(
+      cuMemGetAllocationPropertiesFromHandle(&imported_properties, importer) == CUDA_SUCCESS &&
+          imported_properties.requestedHandleTypes == CU_MEM_HANDLE_TYPE_NONE,
+      "FABRIC import incorrectly required re-exportable allocation properties");
   require(
       cuMemImportFromShareableHandle(&repeated_importer, &first, CU_MEM_HANDLE_TYPE_FABRIC) == CUDA_SUCCESS &&
           repeated_importer != importer && fake_cuda_export_count() == 4 && fake_cuda_import_count() == 2,

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
@@ -10,6 +10,7 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -32,12 +33,14 @@ unsigned int fake_cuda_export_count(void);
 unsigned int fake_cuda_logical_forward_count(void);
 unsigned int fake_cuda_active_handle_count(void);
 unsigned int fake_cuda_active_mapping_count(void);
+unsigned int fake_cuda_multicast_bind_count(void);
 CUmemGenericAllocationHandle fake_cuda_last_consumed_handle(void);
 CUcontext fake_cuda_last_context(void);
 int fake_cuda_last_exported_fd(void);
 int fake_cuda_last_internal_export_alias(void);
 int fake_cuda_internal_export_alias(unsigned int);
 int fake_cuda_last_imported_fd(void);
+unsigned char fake_cuda_last_imported_fabric_byte(unsigned int);
 CUdeviceptr fake_cuda_map_address(unsigned int);
 CUdeviceptr fake_cuda_access_address(unsigned int);
 CUmemAccessDesc fake_cuda_access_descriptor(unsigned int);
@@ -49,6 +52,12 @@ unsigned char fake_cuda_copy_byte(void);
 int fake_cuda_copy_uniform(void);
 CUmemGenericAllocationHandle fake_cuda_released_handle(unsigned int);
 
+static char coordinator_participant[DYN_VMM_PARTICIPANT_ID_SIZE];
+
+static void establish_mapping(CUmemGenericAllocationHandle*, int*, CUdeviceptr);
+static void establish_fabric_mapping(CUmemGenericAllocationHandle*, struct dyn_vmm_fabric_token*, CUdeviceptr);
+static int fabric_token_is_valid(const struct dyn_vmm_fabric_token*);
+
 static void
 require(int condition, const char* message)
 {
@@ -56,6 +65,43 @@ require(int condition, const char* message)
     fprintf(stderr, "%s\n", message);
     exit(1);
   }
+}
+
+static void
+test_fabric_low_address_token(void)
+{
+  CUmemGenericAllocationHandle owner;
+  CUmemGenericAllocationHandle importer;
+  struct dyn_vmm_fabric_token token;
+  void* low = MAP_FAILED;
+
+  establish_fabric_mapping(&owner, &token, 0x100000);
+#ifdef MAP_FIXED_NOREPLACE
+  for (uintptr_t address = UINT32_C(0x10000000);
+       low == MAP_FAILED && address <= UINT32_C(0x70000000);
+       address += UINT32_C(0x10000000)) {
+    low = mmap(
+        (void*)address, 4096, PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+  }
+#endif
+#ifdef MAP_32BIT
+  if (low == MAP_FAILED)
+    low = mmap(
+        NULL, 4096, PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
+#endif
+  require(
+      low != MAP_FAILED && (uintptr_t)low <= INT_MAX,
+      "cannot allocate a valid low-address FABRIC token");
+  memcpy(low, &token, sizeof(token));
+  require(
+      fabric_token_is_valid(low) &&
+          cuMemImportFromShareableHandle(
+              &importer, low, CU_MEM_HANDLE_TYPE_FABRIC) == CUDA_SUCCESS &&
+          fake_cuda_import_count() == 1,
+      "valid low-address FABRIC token was rejected");
+  require(munmap(low, 4096) == 0, "cannot unmap low-address FABRIC token");
 }
 
 static struct dyn_vmm_capability
@@ -97,6 +143,31 @@ capability_is_valid(int fd)
 
   require(function != NULL, "cannot resolve capability validation test seam");
   return function(fd);
+}
+
+static int
+fabric_token_is_valid(const struct dyn_vmm_fabric_token* token)
+{
+  typedef int (*function_type)(const void*);
+  function_type function = (function_type)dlsym(RTLD_DEFAULT, "dyn_vmm_test_fabric_token_valid");
+
+  require(function != NULL, "cannot resolve FABRIC token validation test seam");
+  return function(token);
+}
+
+static void
+test_broker_shapes(void)
+{
+  typedef int (*function_type)(CUmemAllocationHandleType, int, uint64_t);
+  function_type valid = (function_type)dlsym(RTLD_DEFAULT, "dyn_vmm_test_broker_shape");
+
+  require(valid != NULL, "cannot resolve broker-shape validation test seam");
+  require(
+      valid(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 3, 0) &&
+          valid(CU_MEM_HANDLE_TYPE_FABRIC, -1, DYN_VMM_FABRIC_HANDLE_SIZE) &&
+          !valid(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 3, DYN_VMM_FABRIC_HANDLE_SIZE) &&
+          !valid(CU_MEM_HANDLE_TYPE_FABRIC, 3, 0) && !valid(CU_MEM_HANDLE_TYPE_FABRIC, -1, 0),
+      "cross-shaped broker responses were accepted");
 }
 
 static void
@@ -225,11 +296,12 @@ exchange_fd(
     void** response_payload, int passed_fd, int* received_fd,
     int require_success)
 {
+  struct dyn_vmm_header bound_request = *request;
   char request_control[CMSG_SPACE(sizeof(int))] = {0};
   char response_control[CMSG_SPACE(sizeof(int))] = {0};
   struct iovec request_vector = {
-      .iov_base = (void*)request,
-      .iov_len = sizeof(*request),
+      .iov_base = &bound_request,
+      .iov_len = sizeof(bound_request),
   };
   struct msghdr request_message = {
       .msg_iov = &request_vector,
@@ -246,6 +318,11 @@ exchange_fd(
   struct cmsghdr* item;
   int client = connect_control();
 
+  if (coordinator_participant[0] != '\0' &&
+      bound_request.participant_id[0] == '\0')
+    memcpy(
+        bound_request.participant_id, coordinator_participant,
+        sizeof(bound_request.participant_id));
   if (passed_fd >= 0) {
     struct cmsghdr* passed;
     request_message.msg_control = request_control;
@@ -283,6 +360,21 @@ exchange_fd(
         "cannot read VMM response payload");
   }
   close(client);
+  if (coordinator_participant[0] == '\0') {
+    require(
+        bound_request.operation == DYN_VMM_IDENTIFY &&
+            response.status == 0 && strlen(response.participant_id) == 32,
+        "initial VMM identify did not return a participant");
+    snprintf(
+        coordinator_participant, sizeof(coordinator_participant), "%s",
+        response.participant_id);
+  } else {
+    require(
+        memcmp(
+            response.participant_id, coordinator_participant,
+            sizeof(response.participant_id)) == 0,
+        "VMM response participant did not match the established endpoint");
+  }
   if (require_success)
     require(response.status == 0, response.message);
   return response;
@@ -295,6 +387,169 @@ exchange(
 {
   return exchange_fd(
       request, payload, response_payload, -1, received_fd, 1);
+}
+
+static void
+bootstrap_coordinator(void)
+{
+  struct dyn_vmm_header request = {
+      .magic = DYN_VMM_MAGIC,
+      .version = DYN_VMM_VERSION,
+      .operation = DYN_VMM_IDENTIFY,
+  };
+  void* payload;
+  int received_fd;
+
+  (void)exchange(&request, NULL, &payload, &received_fd);
+  require(payload == NULL && received_fd < 0, "initial VMM identify returned transport data");
+}
+
+static struct dyn_vmm_header
+exchange_header_only(struct dyn_vmm_header request, int passed_fd)
+{
+  char request_control[CMSG_SPACE(sizeof(int))] = {0};
+  char response_control[CMSG_SPACE(sizeof(int))] = {0};
+  struct iovec request_vector = {
+      .iov_base = &request,
+      .iov_len = sizeof(request),
+  };
+  struct msghdr request_message = {
+      .msg_iov = &request_vector,
+      .msg_iovlen = 1,
+  };
+  struct dyn_vmm_header response;
+  struct iovec response_vector = {
+      .iov_base = &response,
+      .iov_len = sizeof(response),
+  };
+  struct msghdr response_message = {
+      .msg_iov = &response_vector,
+      .msg_iovlen = 1,
+      .msg_control = response_control,
+      .msg_controllen = sizeof(response_control),
+  };
+  struct timeval timeout = {.tv_sec = 1};
+  int client = connect_control();
+
+  if (request.participant_id[0] == '\0')
+    memcpy(
+        request.participant_id, coordinator_participant,
+        sizeof(request.participant_id));
+  if (passed_fd >= 0) {
+    struct cmsghdr* item;
+
+    request_message.msg_control = request_control;
+    request_message.msg_controllen = sizeof(request_control);
+    item = CMSG_FIRSTHDR(&request_message);
+    item->cmsg_level = SOL_SOCKET;
+    item->cmsg_type = SCM_RIGHTS;
+    item->cmsg_len = CMSG_LEN(sizeof(passed_fd));
+    memcpy(CMSG_DATA(item), &passed_fd, sizeof(passed_fd));
+  }
+  require(
+      setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) == 0 &&
+          sendmsg(client, &request_message, 0) == (ssize_t)sizeof(request) &&
+          recvmsg(client, &response_message, MSG_WAITALL) == (ssize_t)sizeof(response),
+      "malformed VMM frame was not rejected before reading its payload");
+  close(client);
+  require(
+      response.status != 0 &&
+          memcmp(
+              response.participant_id, coordinator_participant,
+              sizeof(response.participant_id)) == 0,
+      "malformed VMM frame returned an invalid response");
+  return response;
+}
+
+static void
+test_control_request_validation(void)
+{
+  CUmemGenericAllocationHandle owner;
+  struct dyn_vmm_capability capability;
+  struct dyn_vmm_header request = {
+      .magic = DYN_VMM_MAGIC,
+      .version = DYN_VMM_VERSION,
+      .operation = DYN_VMM_INSPECT,
+  };
+  struct dyn_vmm_header response;
+  void* inspect_payload;
+  int received_fd;
+  int token;
+
+  establish_mapping(&owner, &token, 0x100000);
+  capability = read_capability(token);
+
+  request.payload_size = 1;
+  (void)exchange_header_only(request, -1);
+
+  request.payload_size = 0;
+  request.reserved = 1;
+  (void)exchange_header_only(request, -1);
+
+  request.reserved = 0;
+  request.reserved_identity[0] = 1;
+  (void)exchange_header_only(request, -1);
+
+  memset(&request, 0, sizeof(request));
+  request.magic = DYN_VMM_MAGIC;
+  request.version = DYN_VMM_VERSION;
+  request.operation = DYN_VMM_RESTORE_OWNER;
+  request.handle_type = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  request.object_id = 1;
+  request.payload_size = sizeof(struct dyn_vmm_record) +
+      sizeof(CUmemAllocationProp) + sizeof(CUmemAccessDesc);
+  ((uint8_t*)&request)[255] = 1;
+  (void)exchange_header_only(request, -1);
+  require(
+      fake_cuda_create_count() == 1 &&
+          fake_cuda_active_handle_count() == 1 &&
+          fake_cuda_active_mapping_count() == 1,
+      "reserved header tail reached owner restore mutation");
+
+  memset(&request, 0, sizeof(request));
+  request.magic = DYN_VMM_MAGIC;
+  request.version = DYN_VMM_VERSION;
+  request.operation = DYN_VMM_INSPECT;
+  (void)exchange_header_only(request, token);
+
+  request.operation = DYN_VMM_RESTORE_OWNER;
+  request.handle_type = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  request.object_id = 1;
+  request.payload_size = DYN_VMM_MAXIMUM_ALLOCATION_SIZE +
+      sizeof(struct dyn_vmm_record) + sizeof(CUmemAllocationProp) +
+      sizeof(CUmemAccessDesc) + 1;
+  (void)exchange_header_only(request, -1);
+
+  request.operation = DYN_VMM_RESTORE_IMPORT;
+  request.payload_size = sizeof(struct dyn_vmm_record);
+  (void)exchange_header_only(request, -1);
+
+  request.handle_type = CU_MEM_HANDLE_TYPE_FABRIC;
+  (void)exchange_header_only(request, token);
+
+  memset(&request, 0, sizeof(request));
+  request.magic = DYN_VMM_MAGIC;
+  request.version = DYN_VMM_VERSION;
+  request.operation = DYN_VMM_DETACH_OWNERS;
+  request.object_id = 1;
+  memcpy(
+      request.allocation_uuid, capability.allocation_uuid,
+      sizeof(request.allocation_uuid));
+  memcpy(
+      request.participant_id, coordinator_participant,
+      sizeof(request.participant_id));
+  request.participant_id[0] =
+      request.participant_id[0] == '0' ? '1' : '0';
+  response = exchange_fd(
+      &request, NULL, &inspect_payload, -1, &received_fd, 0);
+  require(
+      response.status != 0 && received_fd < 0 &&
+          fake_cuda_release_count() == 0 &&
+          fake_cuda_active_handle_count() == 1 &&
+          fake_cuda_active_mapping_count() == 1,
+      "wrong-participant detach mutated CUDA VMM state");
+  free(inspect_payload);
+  close(token);
 }
 
 static void
@@ -322,6 +577,28 @@ establish_mapping(
               export_fd, *logical,
               CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) == CUDA_SUCCESS,
       "cannot establish managed mapping");
+}
+
+static void
+establish_fabric_mapping(CUmemGenericAllocationHandle* logical, struct dyn_vmm_fabric_token* token, CUdeviceptr address)
+{
+  CUmemAllocationProp properties;
+  CUmemAccessDesc access;
+
+  memset(&properties, 0, sizeof(properties));
+  properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  properties.location.id = 0;
+  properties.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  memset(&access, 0, sizeof(access));
+  access.location = properties.location;
+  access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  require(
+      cuMemCreate(logical, 4096, &properties, 0) == CUDA_SUCCESS &&
+          cuMemMap(address, 4096, 0, *logical, 0) == CUDA_SUCCESS &&
+          cuMemSetAccess(address, 4096, &access, 1) == CUDA_SUCCESS &&
+          cuMemExportToShareableHandle(token, *logical, CU_MEM_HANDLE_TYPE_FABRIC, 0) == CUDA_SUCCESS,
+      "cannot establish managed FABRIC mapping");
 }
 
 static void
@@ -660,6 +937,7 @@ test_owner_restore_failure(const char* stage)
   request.magic = DYN_VMM_MAGIC;
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
+  request.handle_type = record->requested_handle_type;
   request.object_id = 1;
   request.payload_size = payload_size;
   response = exchange_fd(
@@ -753,6 +1031,7 @@ test_importer_restore_failure(const char* stage)
   request.magic = DYN_VMM_MAGIC;
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
+  request.handle_type = owner_record->requested_handle_type;
   request.object_id = 1;
   request.payload_size = owner_payload_size;
   (void)exchange(
@@ -768,6 +1047,8 @@ test_importer_restore_failure(const char* stage)
   require(setenv("DYN_SNAPSHOT_CUDA_VMM_FAIL_STAGE", stage, 1) == 0,
           "cannot configure importer restore failure");
   request.operation = DYN_VMM_RESTORE_IMPORT;
+  request.handle_type = importer_record->requested_handle_type;
+  request.handle_type = importer_record->requested_handle_type;
   request.payload_size = importer_payload_size;
   response = exchange_fd(
       &request, importer_payload, &ignored, owner_restore_fd, &received_fd, 0);
@@ -878,6 +1159,7 @@ test_owner_importer_success(void)
           importer_record->flags == DYN_VMM_APPLICATION_HANDLE_LIVE,
       "successful lifecycle inspect metadata is incomplete");
   request.operation = DYN_VMM_READ_OWNER;
+  request.object_id = 1;
   memcpy(request.allocation_uuid, owner_record->allocation_uuid, sizeof(request.allocation_uuid));
   response = exchange(&request, NULL, (void**)&owner_bytes, &received_fd);
   require(
@@ -906,6 +1188,7 @@ test_owner_importer_success(void)
   request.magic = DYN_VMM_MAGIC;
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
+  request.handle_type = owner_record->requested_handle_type;
   request.object_id = 1;
   request.payload_size = owner_payload_size;
   (void)exchange(
@@ -985,6 +1268,114 @@ test_owner_importer_success(void)
 }
 
 static void
+test_fabric_owner_importer_restore(bool fail_import)
+{
+  CUmemGenericAllocationHandle owner;
+  CUmemGenericAllocationHandle importer;
+  struct dyn_vmm_fabric_token token;
+  struct dyn_vmm_header request = {
+      .magic = DYN_VMM_MAGIC,
+      .version = DYN_VMM_VERSION,
+      .operation = DYN_VMM_INSPECT,
+  };
+  struct dyn_vmm_header response;
+  struct dyn_vmm_record* owner_record = NULL;
+  struct dyn_vmm_record* importer_record = NULL;
+  CUmemAccessDesc access;
+  char* cursor;
+  void* inspect_payload;
+  void* owner_payload;
+  void* importer_metadata;
+  void* importer_payload;
+  void* broker_bytes;
+  void* ignored;
+  size_t owner_payload_size;
+  size_t importer_metadata_size;
+  size_t importer_payload_size;
+  size_t record_size;
+  int received_fd;
+
+  establish_fabric_mapping(&owner, &token, 0x100000);
+  require(
+      cuMemImportFromShareableHandle(&importer, &token, CU_MEM_HANDLE_TYPE_FABRIC) == CUDA_SUCCESS,
+      "cannot establish FABRIC importer");
+  memset(&access, 0, sizeof(access));
+  access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access.location.id = 0;
+  access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  require(
+      cuMemMap(0x200000, 4096, 0, importer, 0) == CUDA_SUCCESS &&
+          cuMemSetAccess(0x200000, 4096, &access, 1) == CUDA_SUCCESS,
+      "cannot map FABRIC importer");
+
+  response = exchange(&request, NULL, &inspect_payload, &received_fd);
+  require(response.count == 2 && received_fd < 0, "FABRIC restore inspect omitted owner or importer");
+  cursor = inspect_payload;
+  for (uint32_t index = 0; index < response.count; index++) {
+    struct dyn_vmm_record* record = (struct dyn_vmm_record*)cursor;
+
+    record_size = sizeof(*record) + record->properties_size + (size_t)record->access_count * record->access_size;
+    require(
+        record->requested_handle_type == CU_MEM_HANDLE_TYPE_FABRIC, "FABRIC inspect recorded the wrong handle type");
+    if (record->role == DYN_VMM_OWNER)
+      owner_record = record;
+    else if (record->role == DYN_VMM_IMPORTER)
+      importer_record = record;
+    cursor += record_size;
+  }
+  require(owner_record != NULL && importer_record != NULL, "FABRIC inspect omitted a role");
+  detach_record(importer_record, DYN_VMM_DETACH_IMPORTS, 1);
+  detach_record(owner_record, DYN_VMM_DETACH_OWNERS, 1);
+
+  owner_payload = restore_payload(owner_record, owner_record, &owner_payload_size, 1, 1);
+  memset(&request, 0, sizeof(request));
+  request.magic = DYN_VMM_MAGIC;
+  request.version = DYN_VMM_VERSION;
+  request.operation = DYN_VMM_RESTORE_OWNER;
+  request.handle_type = CU_MEM_HANDLE_TYPE_FABRIC;
+  request.object_id = 1;
+  request.payload_size = owner_payload_size;
+  response = exchange(&request, owner_payload, &broker_bytes, &received_fd);
+  require(
+      response.handle_type == CU_MEM_HANDLE_TYPE_FABRIC && response.payload_size == DYN_VMM_FABRIC_HANDLE_SIZE &&
+          received_fd < 0 && broker_bytes != NULL,
+      "FABRIC owner restore returned the wrong broker shape");
+
+  importer_metadata = restore_payload(importer_record, importer_record, &importer_metadata_size, 1, 0);
+  importer_payload_size = importer_metadata_size + DYN_VMM_FABRIC_HANDLE_SIZE;
+  importer_payload = malloc(importer_payload_size);
+  require(importer_payload != NULL, "cannot allocate FABRIC importer payload");
+  memcpy(importer_payload, importer_metadata, importer_metadata_size);
+  memcpy((char*)importer_payload + importer_metadata_size, broker_bytes, DYN_VMM_FABRIC_HANDLE_SIZE);
+  request.operation = DYN_VMM_RESTORE_IMPORT;
+  request.payload_size = importer_payload_size;
+  if (fail_import)
+    require(
+        setenv("DYN_SNAPSHOT_CUDA_VMM_FAIL_STAGE", "importer-import", 1) == 0,
+        "cannot configure FABRIC importer restore failure");
+  response = exchange_fd(&request, importer_payload, &ignored, -1, &received_fd, !fail_import);
+  if (fail_import) {
+    require(
+        response.status != 0 && received_fd < 0 && fake_cuda_active_handle_count() == 1 &&
+            fake_cuda_active_mapping_count() == 1,
+        "FABRIC importer restore failure leaked resources");
+    goto done;
+  }
+  require(
+      response.handle_type == 0 && response.payload_size == 0 && received_fd < 0 && fake_cuda_import_count() == 2 &&
+          fake_cuda_active_handle_count() == 2 && fake_cuda_active_mapping_count() == 2 &&
+          fake_cuda_multicast_bind_count() == 0,
+      "FABRIC importer restore violated transport or lifecycle invariants");
+
+done:
+  free(importer_payload);
+  free(importer_metadata);
+  free(broker_bytes);
+  free(owner_payload);
+  free(inspect_payload);
+}
+
+static void
 test_repeated_export_and_self_import(void)
 {
   CUmemGenericAllocationHandle owner;
@@ -1025,6 +1416,90 @@ test_repeated_export_and_self_import(void)
       "self-import changed token ownership or retained its raw broker FD");
   close(first_fd);
   close(second_fd);
+}
+
+static void
+test_fabric_repeated_export_and_self_import(void)
+{
+  CUmemGenericAllocationHandle owner;
+  CUmemGenericAllocationHandle importer;
+  CUmemGenericAllocationHandle repeated_importer;
+  struct dyn_vmm_fabric_token first;
+  struct dyn_vmm_fabric_token second;
+
+  establish_fabric_mapping(&owner, &first, 0x100000);
+  require(
+      cuMemExportToShareableHandle(&second, owner, CU_MEM_HANDLE_TYPE_FABRIC, 0) == CUDA_SUCCESS,
+      "repeated FABRIC owner export failed");
+  require(
+      fabric_token_is_valid(&first) && fabric_token_is_valid(&second) &&
+          memcmp(first.allocation_uuid, second.allocation_uuid, sizeof(first.allocation_uuid)) == 0 &&
+          memcmp(first.owner_participant_id, second.owner_participant_id, sizeof(first.owner_participant_id)) == 0 &&
+          first.owner_namespace_pid == second.owner_namespace_pid && fake_cuda_export_count() == 2,
+      "repeated FABRIC export did not reuse logical identity");
+  require(
+      cuMemImportFromShareableHandle(&importer, &first, CU_MEM_HANDLE_TYPE_FABRIC) == CUDA_SUCCESS &&
+          fake_cuda_export_count() == 3 && fake_cuda_import_count() == 1,
+      "same-process FABRIC token import failed");
+  require(
+      cuMemImportFromShareableHandle(&repeated_importer, &first, CU_MEM_HANDLE_TYPE_FABRIC) == CUDA_SUCCESS &&
+          repeated_importer != importer && fake_cuda_export_count() == 4 && fake_cuda_import_count() == 2,
+      "repeated same-process FABRIC token import failed");
+  for (unsigned int index = 0; index < DYN_VMM_FABRIC_HANDLE_SIZE; index++) {
+    require(
+        fake_cuda_last_imported_fabric_byte(index) == (unsigned char)(0xa0U + index),
+        "FABRIC self-import did not receive fresh raw driver bytes");
+  }
+}
+
+static void
+test_invalid_fabric_token(const char* shape)
+{
+  CUmemGenericAllocationHandle owner;
+  CUmemGenericAllocationHandle importer;
+  struct dyn_vmm_fabric_token token;
+  unsigned char raw[DYN_VMM_FABRIC_HANDLE_SIZE];
+
+  establish_fabric_mapping(&owner, &token, 0x100000);
+  if (strcmp(shape, "magic") == 0) {
+    token.magic ^= 1;
+  } else if (strcmp(shape, "version") == 0) {
+    token.version++;
+  } else if (strcmp(shape, "type") == 0) {
+    token.handle_type = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  } else if (strcmp(shape, "zero-uuid") == 0) {
+    memset(token.allocation_uuid, 0, sizeof(token.allocation_uuid));
+  } else if (strcmp(shape, "participant") == 0) {
+    token.owner_participant_id[0] = 'A';
+  } else if (strcmp(shape, "zero-pid") == 0) {
+    token.owner_namespace_pid = 0;
+  } else if (strcmp(shape, "reserved") == 0) {
+    token.reserved = 1;
+  } else if (strcmp(shape, "unavailable-owner") == 0) {
+    token.owner_namespace_pid = INT_MAX;
+  } else if (strcmp(shape, "raw") == 0) {
+    for (unsigned int index = 0; index < sizeof(raw); index++) raw[index] = (unsigned char)(0xa0U + index);
+    require(
+        cuMemImportFromShareableHandle(&importer, raw, CU_MEM_HANDLE_TYPE_FABRIC) != CUDA_SUCCESS &&
+            fake_cuda_import_count() == 0,
+        "raw FABRIC handle bypass reached the driver");
+    return;
+  } else if (strcmp(shape, "cross-type") == 0) {
+    require(
+        cuMemImportFromShareableHandle(&importer, &token, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) != CUDA_SUCCESS &&
+            fake_cuda_import_count() == 0,
+        "FABRIC token was accepted through the POSIX import path");
+    return;
+  } else {
+    require(0, "unknown invalid FABRIC token shape");
+  }
+  require(
+      !fabric_token_is_valid(&token) || strcmp(shape, "unavailable-owner") == 0,
+      "malformed FABRIC token passed production validation");
+  require(
+      cuMemImportFromShareableHandle(&importer, &token, CU_MEM_HANDLE_TYPE_FABRIC) != CUDA_SUCCESS &&
+          fake_cuda_import_count() == 0,
+      "invalid FABRIC token did not fail closed");
 }
 
 static void
@@ -1206,6 +1681,26 @@ test_cross_process_child(int transport)
 }
 
 static void
+test_fabric_cross_process_child(int transport)
+{
+  CUmemGenericAllocationHandle importer;
+  struct dyn_vmm_fabric_token token;
+  char status = 1;
+
+  require(read(transport, &token, sizeof(token)) == (ssize_t)sizeof(token), "cannot receive application FABRIC token");
+  require(
+      cuMemImportFromShareableHandle(&importer, &token, CU_MEM_HANDLE_TYPE_FABRIC) == CUDA_SUCCESS &&
+          fake_cuda_import_count() == 1,
+      "cross-process FABRIC token import failed");
+  for (unsigned int index = 0; index < DYN_VMM_FABRIC_HANDLE_SIZE; index++) {
+    require(
+        fake_cuda_last_imported_fabric_byte(index) == (unsigned char)(0xa0U + index),
+        "cross-process FABRIC import received the wrong raw bytes");
+  }
+  require(write(transport, &status, 1) == 1, "cannot acknowledge FABRIC token import");
+}
+
+static void
 test_cross_process(const char* executable)
 {
   CUmemGenericAllocationHandle owner;
@@ -1247,9 +1742,47 @@ test_cross_process(const char* executable)
       "cross-process importer failed");
 }
 
+static void
+test_fabric_cross_process(const char* executable)
+{
+  CUmemGenericAllocationHandle owner;
+  struct dyn_vmm_fabric_token token;
+  char descriptor[32];
+  char child_status = 0;
+  int transport[2];
+  int child_wait_status;
+  pid_t child;
+
+  require(socketpair(AF_UNIX, SOCK_STREAM, 0, transport) == 0, "cannot create FABRIC token transport");
+  child = fork();
+  require(child >= 0, "cannot fork FABRIC importer");
+  if (child == 0) {
+    close(transport[0]);
+    snprintf(descriptor, sizeof(descriptor), "%d", transport[1]);
+    execl(executable, executable, "fabric-cross-process-child", descriptor, NULL);
+    _exit(127);
+  }
+  close(transport[1]);
+  establish_fabric_mapping(&owner, &token, 0x100000);
+  require(write(transport[0], &token, sizeof(token)) == (ssize_t)sizeof(token), "cannot send application FABRIC token");
+  require(
+      read(transport[0], &child_status, 1) == 1 && child_status == 1 && fake_cuda_export_count() == 2,
+      "cross-process FABRIC importer did not acknowledge brokerage");
+  close(transport[0]);
+  require(
+      waitpid(child, &child_wait_status, 0) == child && WIFEXITED(child_wait_status) &&
+          WEXITSTATUS(child_wait_status) == 0,
+      "cross-process FABRIC importer failed");
+}
+
 int
 main(int argc, char** argv)
 {
+  bootstrap_coordinator();
+  if (argc == 3 && strcmp(argv[1], "fabric-cross-process-child") == 0) {
+    test_fabric_cross_process_child(atoi(argv[2]));
+    return 0;
+  }
   if (argc == 3 && strcmp(argv[1], "cross-process-child") == 0) {
     test_cross_process_child(atoi(argv[2]));
     return 0;
@@ -1258,8 +1791,28 @@ main(int argc, char** argv)
     test_cross_process(argv[0]);
     return 0;
   }
+  if (argc == 2 && strcmp(argv[1], "fabric-cross-process") == 0) {
+    test_fabric_cross_process(argv[0]);
+    return 0;
+  }
   if (argc == 2 && strcmp(argv[1], "capability-self") == 0) {
     test_repeated_export_and_self_import();
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "fabric-self") == 0) {
+    test_fabric_repeated_export_and_self_import();
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "fabric-low-address") == 0) {
+    test_fabric_low_address_token();
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "control-request-validation") == 0) {
+    test_control_request_validation();
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "broker-shapes") == 0) {
+    test_broker_shapes();
     return 0;
   }
   if (argc == 2 && strcmp(argv[1], "colliding-raw-identity") == 0) {
@@ -1272,6 +1825,10 @@ main(int argc, char** argv)
   }
   if (argc == 3 && strcmp(argv[1], "invalid-capability") == 0) {
     test_invalid_capability(argv[2]);
+    return 0;
+  }
+  if (argc == 3 && strcmp(argv[1], "invalid-fabric-token") == 0) {
+    test_invalid_fabric_token(argv[2]);
     return 0;
   }
   if (argc == 3 && strcmp(argv[1], "owner-failure") == 0) {
@@ -1292,6 +1849,14 @@ main(int argc, char** argv)
   }
   if (argc == 2 && strcmp(argv[1], "owner-importer-success") == 0) {
     test_owner_importer_success();
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "fabric-owner-importer-success") == 0) {
+    test_fabric_owner_importer_restore(false);
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "fabric-importer-failure") == 0) {
+    test_fabric_owner_importer_restore(true);
     return 0;
   }
   const int application_live = argc == 2 && strcmp(argv[1], "live") == 0;
@@ -1383,6 +1948,7 @@ main(int argc, char** argv)
   request.magic = DYN_VMM_MAGIC;
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
+  request.handle_type = record->requested_handle_type;
   request.object_id = 1;
   request.payload_size = metadata_size + record->size;
   (void)exchange(&request, restore_payload, &ignored, &received_fd);

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
@@ -30,6 +30,9 @@ CUdevice fake_cuda_create_device(unsigned int);
 void fake_cuda_set_device_count(int);
 void fake_cuda_set_device_handle(int, CUdevice);
 void fake_cuda_set_device_identity(CUdevice, CUdevice);
+unsigned int fake_cuda_device_get_calls(void);
+unsigned int fake_cuda_device_uuid_calls(void);
+unsigned int fake_cuda_device_count_calls(void);
 unsigned int fake_cuda_import_count(void);
 unsigned int fake_cuda_release_count(void);
 unsigned int fake_cuda_map_count(void);
@@ -61,6 +64,8 @@ static char coordinator_participant[DYN_VMM_PARTICIPANT_ID_SIZE];
 static void establish_mapping(CUmemGenericAllocationHandle*, int*, CUdeviceptr);
 static void establish_fabric_mapping(CUmemGenericAllocationHandle*, struct dyn_vmm_fabric_token*, CUdeviceptr);
 static int fabric_token_is_valid(const struct dyn_vmm_fabric_token*);
+static struct dyn_vmm_header exchange_fd(
+    const struct dyn_vmm_header*, const void*, void**, int, int*, int);
 
 static void
 require(int condition, const char* message)
@@ -69,6 +74,65 @@ require(int condition, const char* message)
     fprintf(stderr, "%s\n", message);
     exit(1);
   }
+}
+
+static int
+corrupt_detached_placement(const char* field, int value)
+{
+  typedef int (*function_type)(const char*, int);
+  function_type function =
+      (function_type)dlsym(
+          RTLD_DEFAULT, "dyn_vmm_test_corrupt_detached_placement");
+
+  require(function != NULL, "cannot resolve placement corruption test seam");
+  return function(field, value);
+}
+
+static struct dyn_vmm_placement
+placement_from_record(
+    const struct dyn_vmm_record* record, int ordinal, bool identity)
+{
+  struct dyn_vmm_placement placement;
+
+  memset(&placement, 0, sizeof(placement));
+  placement.device_ordinal = ordinal;
+  memcpy(
+      placement.source_gpu_uuid, record->gpu_uuid,
+      sizeof(placement.source_gpu_uuid));
+  memcpy(
+      placement.target_gpu_uuid, record->gpu_uuid,
+      sizeof(placement.target_gpu_uuid));
+  if (!identity)
+    placement.target_gpu_uuid[0] ^= 0x80U;
+  return placement;
+}
+
+static struct dyn_vmm_header
+set_placement_request(
+    const struct dyn_vmm_placement* placements, uint32_t count,
+    int require_success)
+{
+  struct dyn_vmm_header request = {
+      .magic = DYN_VMM_MAGIC,
+      .version = DYN_VMM_VERSION,
+      .operation = DYN_VMM_SET_PLACEMENT,
+      .count = count,
+      .payload_size = (uint64_t)count * sizeof(*placements),
+  };
+  struct dyn_vmm_header response;
+  void* payload;
+  int received_fd;
+
+  response = exchange_fd(
+      &request, placements, &payload, -1, &received_fd, require_success);
+  require(
+      received_fd < 0 && payload == NULL,
+      "SET_PLACEMENT returned transport data");
+  if (require_success)
+    require(
+        response.count == 0 && response.payload_size == 0,
+        "SET_PLACEMENT returned a nonempty success response");
+  return response;
 }
 
 static void
@@ -491,8 +555,29 @@ test_control_request_validation(void)
   (void)exchange_header_only(request, -1);
 
   request.reserved = 0;
+  request.version = DYN_VMM_VERSION - 1;
+  (void)exchange_header_only(request, -1);
+
+  request.version = DYN_VMM_VERSION;
+  request.reserved = 0;
   request.reserved_identity[0] = 1;
   (void)exchange_header_only(request, -1);
+
+  memset(&request, 0, sizeof(request));
+  request.magic = DYN_VMM_MAGIC;
+  request.version = DYN_VMM_VERSION;
+  request.operation = DYN_VMM_SET_PLACEMENT;
+  request.count = 1;
+  (void)exchange_header_only(request, -1);
+
+  request.count = UINT32_MAX;
+  request.payload_size =
+      (uint64_t)UINT32_MAX * sizeof(struct dyn_vmm_placement);
+  (void)exchange_header_only(request, -1);
+
+  request.count = 0;
+  request.payload_size = 0;
+  (void)exchange_header_only(request, token);
 
   memset(&request, 0, sizeof(request));
   request.magic = DYN_VMM_MAGIC;
@@ -1220,6 +1305,11 @@ test_owner_importer_success(void)
           fake_cuda_active_handle_count() == 0 &&
           fake_cuda_active_mapping_count() == 0,
       "prepare did not detach importer then owner exactly once");
+  {
+    struct dyn_vmm_placement placement =
+        placement_from_record(owner_record, 0, true);
+    (void)set_placement_request(&placement, 1, 1);
+  }
 
   owner_payload = restore_payload(
       owner_record, owner_record, &owner_payload_size, 1, 1);
@@ -1371,45 +1461,19 @@ test_fabric_owner_importer_restore(bool fail_import, bool reindex)
   detach_record(owner_record, DYN_VMM_DETACH_OWNERS, 1);
 
   if (reindex) {
-    struct dyn_vmm_placement* placement;
+    struct dyn_vmm_placement placement =
+        placement_from_record(owner_record, 3, false);
+    unsigned int get_calls = fake_cuda_device_get_calls();
+    unsigned int uuid_calls = fake_cuda_device_uuid_calls();
+    unsigned int count_calls = fake_cuda_device_count_calls();
 
-    memset(&request, 0, sizeof(request));
-    request.magic = DYN_VMM_MAGIC;
-    request.version = DYN_VMM_VERSION;
-    request.operation = DYN_VMM_QUERY_PLACEMENT;
-    fake_cuda_set_device_count(4);
-    fake_cuda_set_device_handle(0, 7);
-    fake_cuda_set_device_handle(1, 8);
-    fake_cuda_set_device_handle(2, 9);
-    fake_cuda_set_device_handle(3, 10);
-    fake_cuda_set_device_identity(7, 3);
-    fake_cuda_set_device_identity(8, 1);
-    fake_cuda_set_device_identity(9, 2);
-    fake_cuda_set_device_identity(10, 3);
-    response = exchange_fd(&request, NULL, &ignored, -1, &received_fd, 0);
+    response = set_placement_request(&placement, 1, 1);
     require(
-        response.status != 0 && received_fd < 0 && strstr(response.message, "not currently visible") != NULL,
-        "placement query accepted an absent source GPU UUID");
-    free(ignored);
-
-    fake_cuda_set_device_identity(8, 0);
-    fake_cuda_set_device_identity(10, 0);
-    response = exchange_fd(&request, NULL, &ignored, -1, &received_fd, 0);
-    require(
-        response.status != 0 && received_fd < 0 && strstr(response.message, "multiple ordinals") != NULL,
-        "placement query accepted an ambiguous source GPU UUID");
-    free(ignored);
-
-    fake_cuda_set_device_identity(8, 1);
-    response = exchange(&request, NULL, &ignored, &received_fd);
-    placement = ignored;
-    require(
-        response.count == 1 && response.payload_size == sizeof(*placement) && received_fd < 0 &&
-            placement->device_ordinal == 3 && placement->reserved == 0 &&
-            memcmp(placement->source_gpu_uuid, owner_record->gpu_uuid, sizeof(placement->source_gpu_uuid)) == 0 &&
-            memcmp(placement->current_gpu_uuid, owner_record->gpu_uuid, sizeof(placement->current_gpu_uuid)) == 0,
-        "placement query did not resolve the source GPU UUID at ordinal 3");
-    free(ignored);
+        response.status == 0 &&
+            fake_cuda_device_get_calls() == get_calls &&
+            fake_cuda_device_uuid_calls() == uuid_calls &&
+            fake_cuda_device_count_calls() == count_calls,
+        "SET_PLACEMENT called CUDA enumeration or UUID APIs");
   }
 
   owner_payload = restore_payload(owner_record, owner_record, &owner_payload_size, 1, 1);
@@ -1472,6 +1536,134 @@ done:
   free(broker_bytes);
   free(owner_payload);
   free(inspect_payload);
+}
+
+static void
+test_set_placement_validation(const char* shape)
+{
+  CUmemGenericAllocationHandle first;
+  CUmemGenericAllocationHandle second;
+  struct dyn_vmm_header request = {
+      .magic = DYN_VMM_MAGIC,
+      .version = DYN_VMM_VERSION,
+      .operation = DYN_VMM_INSPECT,
+  };
+  struct dyn_vmm_header response;
+  struct dyn_vmm_record* first_record;
+  struct dyn_vmm_record* second_record;
+  struct dyn_vmm_placement placement[2];
+  void* payload;
+  int first_fd;
+  int second_fd;
+  int received_fd;
+  bool corrupted = false;
+  size_t first_size;
+
+  establish_mapping(&first, &first_fd, 0x100000);
+  if (strcmp(shape, "missing-source") == 0 ||
+      strcmp(shape, "unknown-source") == 0)
+    fake_cuda_set_device_identity(0, 1);
+  establish_mapping(&second, &second_fd, 0x200000);
+  close(first_fd);
+  close(second_fd);
+  response = exchange(&request, NULL, &payload, &received_fd);
+  require(
+      response.count == 2 && received_fd < 0,
+      "placement validation inspect omitted detached allocations");
+  first_record = payload;
+  first_size = sizeof(*first_record) + first_record->properties_size +
+      (size_t)first_record->access_count * first_record->access_size;
+  second_record = (struct dyn_vmm_record*)((char*)payload + first_size);
+  detach_record(first_record, DYN_VMM_DETACH_OWNERS, 1);
+  detach_record(second_record, DYN_VMM_DETACH_OWNERS, 2);
+  placement[0] = placement_from_record(first_record, 0, true);
+
+  if (strcmp(shape, "empty") == 0) {
+    response = set_placement_request(NULL, 0, 0);
+  } else if (strcmp(shape, "negative") == 0) {
+    placement[0].device_ordinal = -1;
+    response = set_placement_request(placement, 1, 0);
+  } else if (strcmp(shape, "reserved") == 0) {
+    placement[0].reserved = 1;
+    response = set_placement_request(placement, 1, 0);
+  } else if (strcmp(shape, "zero-source") == 0) {
+    memset(placement[0].source_gpu_uuid, 0, sizeof(placement[0].source_gpu_uuid));
+    response = set_placement_request(placement, 1, 0);
+  } else if (strcmp(shape, "zero-target") == 0) {
+    memset(placement[0].target_gpu_uuid, 0, sizeof(placement[0].target_gpu_uuid));
+    response = set_placement_request(placement, 1, 0);
+  } else if (strcmp(shape, "unknown-source") == 0) {
+    placement[0] = placement_from_record(first_record, 3, false);
+    placement[1] = placement_from_record(second_record, 1, true);
+    placement[1].source_gpu_uuid[0] ^= 0x40U;
+    response = set_placement_request(placement, 2, 0);
+  } else if (strcmp(shape, "missing-source") == 0) {
+    response = set_placement_request(placement, 1, 0);
+  } else if (
+      strcmp(shape, "duplicate-source") == 0 ||
+      strcmp(shape, "duplicate-target") == 0 ||
+      strcmp(shape, "duplicate-ordinal") == 0) {
+    placement[1] = placement[0];
+    if (strcmp(shape, "duplicate-source") != 0)
+      placement[1].source_gpu_uuid[0] ^= 0x40U;
+    if (strcmp(shape, "duplicate-target") != 0)
+      placement[1].target_gpu_uuid[0] ^= 0x40U;
+    if (strcmp(shape, "duplicate-ordinal") != 0)
+      placement[1].device_ordinal = 1;
+    response = set_placement_request(placement, 2, 0);
+  } else if (
+      strcmp(shape, "inconsistent-device") == 0 ||
+      strcmp(shape, "inconsistent-source") == 0 ||
+      strcmp(shape, "inconsistent-properties") == 0 ||
+      strcmp(shape, "inconsistent-access") == 0) {
+    const char* field = shape + strlen("inconsistent-");
+
+    if (strcmp(shape, "inconsistent-source") == 0) {
+      require(
+          corrupt_detached_placement("source", 1) == 0 &&
+              corrupt_detached_placement("device", 1) == 0 &&
+              corrupt_detached_placement("properties", 1) == 0 &&
+              corrupt_detached_placement("access", 1) == 0,
+          "cannot corrupt detached saved ordinal metadata");
+    } else {
+      require(
+          corrupt_detached_placement(field, 1) == 0,
+          "cannot corrupt detached placement metadata");
+    }
+    corrupted = true;
+    response = set_placement_request(placement, 1, 0);
+  } else {
+    require(0, "unknown SET_PLACEMENT validation shape");
+  }
+  require(
+      response.status != 0,
+      "invalid SET_PLACEMENT request was accepted");
+  if (!corrupted) {
+    placement[0] = placement_from_record(first_record, 0, true);
+    if (strcmp(shape, "missing-source") == 0 ||
+        strcmp(shape, "unknown-source") == 0) {
+      placement[1] = placement_from_record(second_record, 1, true);
+      response = set_placement_request(placement, 2, 1);
+    } else {
+      response = set_placement_request(placement, 1, 1);
+    }
+    require(
+        response.status == 0,
+        "failed SET_PLACEMENT request mutated detached metadata");
+  }
+  free(payload);
+}
+
+static void
+test_set_placement_empty_endpoint(void)
+{
+  struct dyn_vmm_header response;
+
+  bootstrap_coordinator();
+  response = set_placement_request(NULL, 0, 1);
+  require(
+      response.status == 0,
+      "zero-managed endpoint rejected empty SET_PLACEMENT");
 }
 
 static void
@@ -1970,6 +2162,14 @@ main(int argc, char** argv)
   }
   if (argc == 2 && strcmp(argv[1], "fabric-importer-failure") == 0) {
     test_fabric_owner_importer_restore(true, false);
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "set-placement-empty") == 0) {
+    test_set_placement_empty_endpoint();
+    return 0;
+  }
+  if (argc == 3 && strcmp(argv[1], "set-placement-validation") == 0) {
+    test_set_placement_validation(argv[2]);
     return 0;
   }
   const int application_live = argc == 2 && strcmp(argv[1], "live") == 0;

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
@@ -28,6 +28,7 @@
 unsigned int fake_cuda_create_count(void);
 CUdevice fake_cuda_create_device(unsigned int);
 void fake_cuda_set_device_count(int);
+void fake_cuda_set_device_handle(int, CUdevice);
 void fake_cuda_set_device_identity(CUdevice, CUdevice);
 unsigned int fake_cuda_import_count(void);
 unsigned int fake_cuda_release_count(void);
@@ -602,6 +603,45 @@ establish_fabric_mapping(CUmemGenericAllocationHandle* logical, struct dyn_vmm_f
           cuMemSetAccess(address, 4096, &access, 1) == CUDA_SUCCESS &&
           cuMemExportToShareableHandle(token, *logical, CU_MEM_HANDLE_TYPE_FABRIC, 0) == CUDA_SUCCESS,
       "cannot establish managed FABRIC mapping");
+}
+
+static void
+test_gpu_identity_capture(void)
+{
+  CUmemGenericAllocationHandle logical;
+  struct dyn_vmm_fabric_token token;
+  struct dyn_vmm_header request = {
+      .magic = DYN_VMM_MAGIC,
+      .version = DYN_VMM_VERSION,
+      .operation = DYN_VMM_INSPECT,
+  };
+  struct dyn_vmm_header response;
+  struct dyn_vmm_record* record;
+  const CUmemAllocationProp* properties;
+  CUdevice device;
+  CUuuid expected;
+  void* payload;
+  int received_fd;
+
+  fake_cuda_set_device_handle(0, 7);
+  fake_cuda_set_device_identity(7, 12);
+  require(
+      cuDeviceGet(&device, 0) == CUDA_SUCCESS && device == 7 && cuDeviceGetUuid_v2(&expected, device) == CUDA_SUCCESS,
+      "fake CUDA did not resolve ordinal 0 through device handle 7");
+  establish_fabric_mapping(&logical, &token, 0x100000);
+  response = exchange(&request, NULL, &payload, &received_fd);
+  require(
+      response.status == 0 && response.count == 1 &&
+          response.payload_size == sizeof(*record) + sizeof(*properties) + sizeof(CUmemAccessDesc) && received_fd < 0 &&
+          payload != NULL,
+      "capture inspect returned invalid metadata");
+  record = payload;
+  properties = (const CUmemAllocationProp*)((const char*)payload + sizeof(*record));
+  require(
+      record->device_ordinal == 0 && properties->location.type == CU_MEM_LOCATION_TYPE_DEVICE &&
+          properties->location.id == 0 && memcmp(record->gpu_uuid, expected.bytes, sizeof(record->gpu_uuid)) == 0,
+      "capture did not resolve the allocation ordinal before saving its GPU UUID");
+  free(payload);
 }
 
 static void
@@ -1338,25 +1378,29 @@ test_fabric_owner_importer_restore(bool fail_import, bool reindex)
     request.version = DYN_VMM_VERSION;
     request.operation = DYN_VMM_QUERY_PLACEMENT;
     fake_cuda_set_device_count(4);
-    fake_cuda_set_device_identity(0, 3);
-    fake_cuda_set_device_identity(1, 1);
-    fake_cuda_set_device_identity(2, 2);
-    fake_cuda_set_device_identity(3, 3);
+    fake_cuda_set_device_handle(0, 7);
+    fake_cuda_set_device_handle(1, 8);
+    fake_cuda_set_device_handle(2, 9);
+    fake_cuda_set_device_handle(3, 10);
+    fake_cuda_set_device_identity(7, 3);
+    fake_cuda_set_device_identity(8, 1);
+    fake_cuda_set_device_identity(9, 2);
+    fake_cuda_set_device_identity(10, 3);
     response = exchange_fd(&request, NULL, &ignored, -1, &received_fd, 0);
     require(
         response.status != 0 && received_fd < 0 && strstr(response.message, "not currently visible") != NULL,
         "placement query accepted an absent source GPU UUID");
     free(ignored);
 
-    fake_cuda_set_device_identity(1, 0);
-    fake_cuda_set_device_identity(3, 0);
+    fake_cuda_set_device_identity(8, 0);
+    fake_cuda_set_device_identity(10, 0);
     response = exchange_fd(&request, NULL, &ignored, -1, &received_fd, 0);
     require(
         response.status != 0 && received_fd < 0 && strstr(response.message, "multiple ordinals") != NULL,
         "placement query accepted an ambiguous source GPU UUID");
     free(ignored);
 
-    fake_cuda_set_device_identity(1, 1);
+    fake_cuda_set_device_identity(8, 1);
     response = exchange(&request, NULL, &ignored, &received_fd);
     placement = ignored;
     require(
@@ -1910,6 +1954,10 @@ main(int argc, char** argv)
   }
   if (argc == 2 && strcmp(argv[1], "owner-importer-success") == 0) {
     test_owner_importer_success();
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "gpu-identity-capture") == 0) {
+    test_gpu_identity_capture();
     return 0;
   }
   if (argc == 2 && strcmp(argv[1], "fabric-owner-importer-success") == 0) {

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/resolver_test.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/resolver_test.c
@@ -251,7 +251,7 @@ test_logical_handles(void)
 }
 
 static void
-test_unshared_create_passthrough(void)
+test_unshared_create_rejected(void)
 {
   CUmemAllocationProp properties;
   CUmemGenericAllocationHandle handle = 0;
@@ -260,16 +260,44 @@ test_unshared_create_passthrough(void)
   properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
   properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   require(
-      cuMemCreate(&handle, 4096, &properties, 0) == CUDA_SUCCESS &&
-          ((uint64_t)handle & UINT64_C(0xffff000000000000)) !=
-              UINT64_C(0xd94d000000000000) &&
-          cuMemMap(0x8000, 4096, 0, handle, 0) == CUDA_SUCCESS &&
-          cuMemSetAccess(0x8000, 4096, NULL, 0) == CUDA_SUCCESS &&
-          cuMemRelease(handle) == CUDA_SUCCESS,
-      "unshared real allocation did not pass through");
+      cuMemCreate(&handle, 4096, &properties, 0) != CUDA_SUCCESS && handle == 0 && fake_cuda_create_count() == 0,
+      "unshared allocation type was not rejected");
+  properties.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR | CU_MEM_HANDLE_TYPE_FABRIC;
   require(
-      fake_cuda_logical_forward_count() == 0,
-      "unshared create passthrough forwarded a logical token");
+      cuMemCreate(&handle, 4096, &properties, 0) != CUDA_SUCCESS && handle == 0 && fake_cuda_create_count() == 0,
+      "combined POSIX|FABRIC allocation type was not rejected");
+  require(fake_cuda_logical_forward_count() == 0, "unshared create rejection forwarded a logical token");
+}
+
+static void
+identify_participant(
+    const struct sockaddr_un* address,
+    char participant[DYN_VMM_PARTICIPANT_ID_SIZE])
+{
+  struct dyn_vmm_header request = {
+      .magic = DYN_VMM_MAGIC,
+      .version = DYN_VMM_VERSION,
+      .operation = DYN_VMM_IDENTIFY,
+  };
+  struct dyn_vmm_header response;
+  int client = socket(AF_UNIX, SOCK_STREAM, 0);
+
+  require(
+      client >= 0 &&
+          connect(
+              client, (const struct sockaddr*)address,
+              sizeof(*address)) == 0 &&
+          write(client, &request, sizeof(request)) ==
+              (ssize_t)sizeof(request) &&
+          read(client, &response, sizeof(response)) ==
+              (ssize_t)sizeof(response) &&
+          response.status == 0 &&
+          strlen(response.participant_id) == 32,
+      "VMM identify exchange failed");
+  close(client);
+  memcpy(
+      participant, response.participant_id,
+      DYN_VMM_PARTICIPANT_ID_SIZE);
 }
 
 static void
@@ -290,6 +318,7 @@ test_admission_succeeds_without_managed_resources(void)
           address.sun_path, sizeof(address.sun_path), "%s/%s%d.sock", control,
           DYN_VMM_SOCKET_PREFIX, getpid()) < (int)sizeof(address.sun_path),
       "socket path is too long");
+  identify_participant(&address, request.participant_id);
   client = socket(AF_UNIX, SOCK_STREAM, 0);
   require(
       client >= 0 &&
@@ -299,8 +328,7 @@ test_admission_succeeds_without_managed_resources(void)
       "VMM no-resource control exchange failed");
   close(client);
   require(
-      response.status == 0 && response.count == 0,
-      "unshared allocation poisoned VMM checkpoint admission");
+      response.status == 0 && response.count == 0, "rejected unshared allocation poisoned VMM checkpoint admission");
 }
 
 static void
@@ -318,15 +346,16 @@ test_retained_handle_admission(void)
   int client;
 
   require(
-      cuMemRetainAllocationHandle(&handle, (void*)(uintptr_t)0x1000) ==
-              CUDA_SUCCESS &&
-          handle == 0x5678,
-      "real cuMemRetainAllocationHandle result was not forwarded");
-  require(
       snprintf(
           address.sun_path, sizeof(address.sun_path), "%s/%s%d.sock", control,
           DYN_VMM_SOCKET_PREFIX, getpid()) < (int)sizeof(address.sun_path),
       "socket path is too long");
+  identify_participant(&address, request.participant_id);
+  require(
+      cuMemRetainAllocationHandle(&handle, (void*)(uintptr_t)0x1000) ==
+              CUDA_SUCCESS &&
+          handle == 0x5678,
+      "real cuMemRetainAllocationHandle result was not forwarded");
   client = socket(AF_UNIX, SOCK_STREAM, 0);
   require(
       client >= 0 &&
@@ -345,7 +374,7 @@ int
 main(int argc, char** argv)
 {
   if (argc == 2 && strcmp(argv[1], "unshared") == 0) {
-    test_unshared_create_passthrough();
+    test_unshared_create_rejected();
     test_admission_succeeds_without_managed_resources();
     return 0;
   }

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
@@ -124,6 +124,11 @@ LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
 DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
 DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
 LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
+  "$build/lifecycle_test" fabric-ordinal-reindex
+
+DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
+DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
+LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
   "$build/lifecycle_test" fabric-importer-failure
 
 for scenario in capability-self canonical-capability-path colliding-raw-identity cross-process; do

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
@@ -136,6 +136,22 @@ DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
 LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
   "$build/lifecycle_test" fabric-importer-failure
 
+DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
+DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
+LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
+  "$build/lifecycle_test" set-placement-empty
+
+for shape in \
+  empty missing-source unknown-source duplicate-source duplicate-target \
+  duplicate-ordinal negative reserved zero-source zero-target \
+  inconsistent-device inconsistent-source inconsistent-properties \
+  inconsistent-access; do
+  DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
+  DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
+  LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
+    "$build/lifecycle_test" set-placement-validation "$shape"
+done
+
 for scenario in capability-self canonical-capability-path colliding-raw-identity cross-process; do
   DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
   DYN_SNAPSHOT_CONTROL_DIR="$build/control" \

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
@@ -116,11 +116,39 @@ DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
 LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
   "$build/lifecycle_test" owner-importer-success
 
+DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
+DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
+LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
+  "$build/lifecycle_test" fabric-owner-importer-success
+
+DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
+DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
+LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
+  "$build/lifecycle_test" fabric-importer-failure
+
 for scenario in capability-self canonical-capability-path colliding-raw-identity cross-process; do
   DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
   DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
   LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
     "$build/lifecycle_test" "$scenario"
+done
+
+for scenario in \
+  fabric-self fabric-low-address fabric-cross-process broker-shapes \
+  control-request-validation; do
+  DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
+  DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
+  LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
+    "$build/lifecycle_test" "$scenario"
+done
+
+for shape in \
+  magic version type zero-uuid participant zero-pid reserved unavailable-owner \
+  raw cross-type; do
+  DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
+  DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
+  LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
+    "$build/lifecycle_test" invalid-fabric-token "$shape"
 done
 
 for shape in \

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
@@ -119,6 +119,11 @@ LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
 DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
 DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
 LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
+  "$build/lifecycle_test" gpu-identity-capture
+
+DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
+DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
+LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
   "$build/lifecycle_test" fabric-owner-importer-success
 
 DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \

--- a/deploy/snapshot/cmd/nsrestore/main.go
+++ b/deploy/snapshot/cmd/nsrestore/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/executor"
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/logging"
+	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 )
 
 func main() {
@@ -18,6 +19,7 @@ func main() {
 
 	checkpointPath := flag.String("checkpoint-path", "", "Path to checkpoint directory")
 	cudaDeviceMap := flag.String("cuda-device-map", "", "CUDA device map for cuda-checkpoint-helper restore")
+	cudaVMMPlacement := flag.String("cuda-vmm-placement", "", "Transient CUDA VMM placement plan")
 	cgroupRoot := flag.String("cgroup-root", "", "CRIU cgroup root remap path")
 	targetPodIP := flag.String("target-pod-ip", "", "Restore pod IP for CRIU TCP socket remapping")
 	flag.Parse()
@@ -26,11 +28,18 @@ func main() {
 		fatal(log, nil, "--checkpoint-path is required")
 	}
 
+	var placement []types.VMMPlacement
+	if *cudaVMMPlacement != "" {
+		if err := json.Unmarshal([]byte(*cudaVMMPlacement), &placement); err != nil {
+			fatal(log, err, "invalid --cuda-vmm-placement")
+		}
+	}
 	opts := executor.RestoreOptions{
-		CheckpointPath: *checkpointPath,
-		CUDADeviceMap:  *cudaDeviceMap,
-		CgroupRoot:     *cgroupRoot,
-		TargetPodIP:    *targetPodIP,
+		CheckpointPath:   *checkpointPath,
+		CUDADeviceMap:    *cudaDeviceMap,
+		CUDAVMMPlacement: placement,
+		CgroupRoot:       *cgroupRoot,
+		TargetPodIP:      *targetPodIP,
 	}
 
 	result, err := executor.RestoreInNamespace(context.Background(), opts, log)

--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -16,6 +17,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/client-go/kubernetes"
 	podresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 )
 
 const (
@@ -26,6 +29,7 @@ const (
 var podResourcesSocketPath = "/var/lib/kubelet/pod-resources/kubelet.sock"
 
 var gpuUUIDPattern = regexp.MustCompile(`^GPU-[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
+var normalizedGPUUUIDPattern = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
 
 type CheckpointPhaseTimings struct {
 	TotalDuration time.Duration
@@ -252,54 +256,106 @@ func FilterProcesses(ctx context.Context, allPIDs []int, log logr.Logger) []int 
 	return cudaPIDs
 }
 
-// BuildDeviceMap creates a cuda-checkpoint-helper --device-map value from source and target GPU UUID lists.
-// When a source UUID exists in the target set, it maps to itself (identity mapping) to avoid
-// unnecessary cross-GPU restore on same-node restores where kubelet returns GPUs in different order.
-// Remaining unmatched source UUIDs are paired with remaining unmatched target UUIDs positionally.
-// If all mappings are identity mappings, it returns an empty string so same-GPU restores use the
-// default CUDA restore path instead of forcing the GPU migration path.
-func BuildDeviceMap(sourceUUIDs, targetUUIDs []string, log logr.Logger) (string, error) {
+type gpuPlacement struct {
+	source        string
+	target        string
+	targetOrdinal int32
+}
+
+func normalizeGPUUUID(value string) (string, error) {
+	value = strings.TrimPrefix(value, "GPU-")
+	if !normalizedGPUUUIDPattern.MatchString(value) {
+		return "", fmt.Errorf("invalid GPU UUID %q", value)
+	}
+	return strings.ToLower(value), nil
+}
+
+func buildGPUPlacements(sourceUUIDs, targetUUIDs []string) ([]gpuPlacement, error) {
 	if len(sourceUUIDs) != len(targetUUIDs) {
-		return "", fmt.Errorf("GPU count mismatch: source has %d, target has %d", len(sourceUUIDs), len(targetUUIDs))
+		return nil, fmt.Errorf("GPU count mismatch: source has %d, target has %d", len(sourceUUIDs), len(targetUUIDs))
 	}
 	if len(sourceUUIDs) == 0 {
-		return "", fmt.Errorf("GPU UUID list is empty")
+		return nil, fmt.Errorf("GPU UUID list is empty")
 	}
+
+	sources := make([]string, len(sourceUUIDs))
+	sourceSet := make(map[string]struct{}, len(sourceUUIDs))
+	for index, value := range sourceUUIDs {
+		uuid, err := normalizeGPUUUID(value)
+		if err != nil {
+			return nil, fmt.Errorf("source GPU UUID at index %d: %w", index, err)
+		}
+		if _, duplicate := sourceSet[uuid]; duplicate {
+			return nil, fmt.Errorf("duplicate source GPU UUID %q", value)
+		}
+		sourceSet[uuid] = struct{}{}
+		sources[index] = uuid
+	}
+
+	targets := make([]string, len(targetUUIDs))
+	targetOrdinals := make(map[string]int32, len(targetUUIDs))
+	for index, value := range targetUUIDs {
+		uuid, err := normalizeGPUUUID(value)
+		if err != nil {
+			return nil, fmt.Errorf("target GPU UUID at index %d: %w", index, err)
+		}
+		if _, duplicate := targetOrdinals[uuid]; duplicate {
+			return nil, fmt.Errorf("duplicate target GPU UUID %q", value)
+		}
+		if index > math.MaxInt32 {
+			return nil, errors.New("target GPU ordinal cannot be represented")
+		}
+		targetOrdinals[uuid] = int32(index)
+		targets[index] = uuid
+	}
+
+	mapping := make(map[string]string, len(sources))
+	usedTargets := make(map[string]struct{}, len(targets))
+	for _, source := range sources {
+		if _, present := targetOrdinals[source]; present {
+			mapping[source] = source
+			usedTargets[source] = struct{}{}
+		}
+	}
+
+	remainingTargets := make([]string, 0, len(targets)-len(usedTargets))
+	for _, target := range targets {
+		if _, used := usedTargets[target]; !used {
+			remainingTargets = append(remainingTargets, target)
+		}
+	}
+	remainingIndex := 0
+	for _, source := range sources {
+		if _, identity := mapping[source]; !identity {
+			mapping[source] = remainingTargets[remainingIndex]
+			remainingIndex++
+		}
+	}
+
+	placements := make([]gpuPlacement, len(sources))
+	for index, source := range sources {
+		target := mapping[source]
+		placements[index] = gpuPlacement{
+			source:        source,
+			target:        target,
+			targetOrdinal: targetOrdinals[target],
+		}
+	}
+	return placements, nil
+}
+
+// BuildDeviceMap creates a cuda-checkpoint-helper --device-map value from source and target GPU UUID lists.
+// Identity matches are selected first, then unmatched sources are paired with
+// unmatched targets in target order. An all-identity mapping remains omitted.
+func BuildDeviceMap(sourceUUIDs, targetUUIDs []string, log logr.Logger) (string, error) {
 	log.V(1).Info("BuildDeviceMap inputs", "source_uuids", sourceUUIDs, "target_uuids", targetUUIDs)
-
-	targetSet := make(map[string]bool, len(targetUUIDs))
-	for _, t := range targetUUIDs {
-		targetSet[t] = true
+	placements, err := buildGPUPlacements(sourceUUIDs, targetUUIDs)
+	if err != nil {
+		return "", err
 	}
-
-	// First pass: identity-map any source UUID that exists in the target set
-	mapping := make(map[string]string, len(sourceUUIDs))
-	usedTargets := make(map[string]bool, len(targetUUIDs))
-	for _, src := range sourceUUIDs {
-		if targetSet[src] {
-			mapping[src] = src
-			usedTargets[src] = true
-		}
-	}
-
-	// Second pass: pair remaining source UUIDs with remaining target UUIDs positionally
-	var remainingTargets []string
-	for _, t := range targetUUIDs {
-		if !usedTargets[t] {
-			remainingTargets = append(remainingTargets, t)
-		}
-	}
-	idx := 0
-	for _, src := range sourceUUIDs {
-		if _, ok := mapping[src]; !ok {
-			mapping[src] = remainingTargets[idx]
-			idx++
-		}
-	}
-
 	allIdentity := true
-	for _, src := range sourceUUIDs {
-		if mapping[src] != src {
+	for _, placement := range placements {
+		if placement.source != placement.target {
 			allIdentity = false
 			break
 		}
@@ -308,11 +364,89 @@ func BuildDeviceMap(sourceUUIDs, targetUUIDs []string, log logr.Logger) (string,
 		return "", nil
 	}
 
-	pairs := make([]string, len(sourceUUIDs))
-	for i, src := range sourceUUIDs {
-		pairs[i] = src + "=" + mapping[src]
+	pairs := make([]string, len(placements))
+	for index, placement := range placements {
+		pairs[index] = "GPU-" + placement.source + "=GPU-" + placement.target
 	}
 	return strings.Join(pairs, ","), nil
+}
+
+// BuildVMMPlacement creates the complete authoritative VMM placement plan.
+func BuildVMMPlacement(sourceUUIDs, targetUUIDs []string) ([]types.VMMPlacement, error) {
+	placements, err := buildGPUPlacements(sourceUUIDs, targetUUIDs)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]types.VMMPlacement, len(placements))
+	for index, placement := range placements {
+		result[index] = types.VMMPlacement{
+			SourceGPUUUID: placement.source,
+			TargetGPUUUID: placement.target,
+			TargetOrdinal: placement.targetOrdinal,
+		}
+	}
+	return result, nil
+}
+
+// ValidateVMMPlacement verifies a transient plan against manifest source UUIDs.
+func ValidateVMMPlacement(
+	sourceUUIDs []string,
+	placements []types.VMMPlacement,
+) error {
+	if len(sourceUUIDs) != len(placements) {
+		return fmt.Errorf(
+			"CUDA VMM placement count is %d, want %d",
+			len(placements),
+			len(sourceUUIDs),
+		)
+	}
+	targetUUIDs := make([]string, len(placements))
+	for _, placement := range placements {
+		if placement.TargetOrdinal < 0 ||
+			int64(placement.TargetOrdinal) >= int64(len(placements)) {
+			return fmt.Errorf(
+				"CUDA VMM placement has invalid target ordinal %d",
+				placement.TargetOrdinal,
+			)
+		}
+		if targetUUIDs[placement.TargetOrdinal] != "" {
+			return fmt.Errorf(
+				"CUDA VMM placement has duplicate target ordinal %d",
+				placement.TargetOrdinal,
+			)
+		}
+		if normalized, err := normalizeGPUUUID(placement.SourceGPUUUID); err != nil ||
+			normalized != placement.SourceGPUUUID {
+			return fmt.Errorf(
+				"CUDA VMM placement has non-canonical source GPU UUID %q",
+				placement.SourceGPUUUID,
+			)
+		}
+		if normalized, err := normalizeGPUUUID(placement.TargetGPUUUID); err != nil ||
+			normalized != placement.TargetGPUUUID {
+			return fmt.Errorf(
+				"CUDA VMM placement has non-canonical target GPU UUID %q",
+				placement.TargetGPUUUID,
+			)
+		}
+		targetUUIDs[placement.TargetOrdinal] = placement.TargetGPUUUID
+	}
+	expected, err := BuildVMMPlacement(sourceUUIDs, targetUUIDs)
+	if err != nil {
+		return err
+	}
+	if len(expected) != len(placements) {
+		return errors.New("CUDA VMM placement is incomplete")
+	}
+	for index := range expected {
+		if expected[index] != placements[index] {
+			return fmt.Errorf(
+				"CUDA VMM placement entry %d does not match the device mapping policy",
+				index,
+			)
+		}
+	}
+	return nil
 }
 
 // LockAndCheckpointProcessTree locks and checkpoints CUDA state for all given PIDs.

--- a/deploy/snapshot/internal/cuda/cuda_test.go
+++ b/deploy/snapshot/internal/cuda/cuda_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -18,44 +19,89 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	podresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
+)
+
+const (
+	testGPUUUIDA = "GPU-aaaaaaaa-1111-2222-3333-444444444444"
+	testGPUUUIDB = "GPU-bbbbbbbb-5555-6666-7777-888888888888"
+	testGPUUUIDC = "GPU-cccccccc-9999-aaaa-bbbb-cccccccccccc"
+	testGPUUUIDD = "GPU-dddddddd-eeee-ffff-0000-111111111111"
 )
 
 func TestBuildDeviceMap(t *testing.T) {
 	tests := []struct {
-		name    string
-		source  []string
-		target  []string
-		want    string
-		wantErr bool
+		name          string
+		source        []string
+		target        []string
+		want          string
+		wantPlacement []types.VMMPlacement
+		wantErr       bool
 	}{
 		{
 			name:   "single GPU",
-			source: []string{"GPU-aaa"},
-			target: []string{"GPU-bbb"},
-			want:   "GPU-aaa=GPU-bbb",
+			source: []string{testGPUUUIDA},
+			target: []string{testGPUUUIDB},
+			want:   testGPUUUIDA + "=" + testGPUUUIDB,
+			wantPlacement: []types.VMMPlacement{{
+				SourceGPUUUID: strings.TrimPrefix(testGPUUUIDA, "GPU-"),
+				TargetGPUUUID: strings.TrimPrefix(testGPUUUIDB, "GPU-"),
+				TargetOrdinal: 0,
+			}},
 		},
 		{
 			name:   "single GPU identity returns no map",
-			source: []string{"GPU-aaa"},
-			target: []string{"GPU-aaa"},
+			source: []string{testGPUUUIDA},
+			target: []string{testGPUUUIDA},
 			want:   "",
+			wantPlacement: []types.VMMPlacement{{
+				SourceGPUUUID: strings.TrimPrefix(testGPUUUIDA, "GPU-"),
+				TargetGPUUUID: strings.TrimPrefix(testGPUUUIDA, "GPU-"),
+				TargetOrdinal: 0,
+			}},
 		},
 		{
 			name:   "multiple GPUs",
-			source: []string{"GPU-aaa", "GPU-bbb"},
-			target: []string{"GPU-ccc", "GPU-ddd"},
-			want:   "GPU-aaa=GPU-ccc,GPU-bbb=GPU-ddd",
+			source: []string{testGPUUUIDA, testGPUUUIDB},
+			target: []string{testGPUUUIDC, testGPUUUIDD},
+			want: testGPUUUIDA + "=" + testGPUUUIDC + "," +
+				testGPUUUIDB + "=" + testGPUUUIDD,
+			wantPlacement: []types.VMMPlacement{
+				{
+					SourceGPUUUID: strings.TrimPrefix(testGPUUUIDA, "GPU-"),
+					TargetGPUUUID: strings.TrimPrefix(testGPUUUIDC, "GPU-"),
+					TargetOrdinal: 0,
+				},
+				{
+					SourceGPUUUID: strings.TrimPrefix(testGPUUUIDB, "GPU-"),
+					TargetGPUUUID: strings.TrimPrefix(testGPUUUIDD, "GPU-"),
+					TargetOrdinal: 1,
+				},
+			},
 		},
 		{
 			name:   "multiple GPU identity returns no map",
-			source: []string{"GPU-aaa", "GPU-bbb"},
-			target: []string{"GPU-bbb", "GPU-aaa"},
+			source: []string{testGPUUUIDA, testGPUUUIDB},
+			target: []string{testGPUUUIDB, testGPUUUIDA},
 			want:   "",
+			wantPlacement: []types.VMMPlacement{
+				{
+					SourceGPUUUID: strings.TrimPrefix(testGPUUUIDA, "GPU-"),
+					TargetGPUUUID: strings.TrimPrefix(testGPUUUIDA, "GPU-"),
+					TargetOrdinal: 1,
+				},
+				{
+					SourceGPUUUID: strings.TrimPrefix(testGPUUUIDB, "GPU-"),
+					TargetGPUUUID: strings.TrimPrefix(testGPUUUIDB, "GPU-"),
+					TargetOrdinal: 0,
+				},
+			},
 		},
 		{
 			name:    "mismatched lengths",
-			source:  []string{"GPU-aaa", "GPU-bbb"},
-			target:  []string{"GPU-ccc"},
+			source:  []string{testGPUUUIDA, testGPUUUIDB},
+			target:  []string{testGPUUUIDC},
 			wantErr: true,
 		},
 		{
@@ -67,7 +113,25 @@ func TestBuildDeviceMap(t *testing.T) {
 		{
 			name:    "source empty target non-empty",
 			source:  []string{},
-			target:  []string{"GPU-aaa"},
+			target:  []string{testGPUUUIDA},
+			wantErr: true,
+		},
+		{
+			name:    "malformed source",
+			source:  []string{"GPU-not-a-uuid"},
+			target:  []string{testGPUUUIDA},
+			wantErr: true,
+		},
+		{
+			name:    "duplicate source",
+			source:  []string{testGPUUUIDA, testGPUUUIDA},
+			target:  []string{testGPUUUIDB, testGPUUUIDC},
+			wantErr: true,
+		},
+		{
+			name:    "duplicate target",
+			source:  []string{testGPUUUIDA, testGPUUUIDB},
+			target:  []string{testGPUUUIDC, testGPUUUIDC},
 			wantErr: true,
 		},
 	}
@@ -75,17 +139,91 @@ func TestBuildDeviceMap(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := BuildDeviceMap(tc.source, tc.target, logr.Discard())
+			placement, placementErr := BuildVMMPlacement(tc.source, tc.target)
 			if tc.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got %q", got)
+				}
+				if placementErr == nil {
+					t.Errorf("expected placement error, got %#v", placement)
 				}
 				return
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+			if placementErr != nil {
+				t.Fatalf("unexpected placement error: %v", placementErr)
+			}
 			if got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
+			}
+			if !slices.Equal(placement, tc.wantPlacement) {
+				t.Errorf("placement = %#v, want %#v", placement, tc.wantPlacement)
+			}
+		})
+	}
+}
+
+func TestValidateVMMPlacementRejectsInvalidPlans(t *testing.T) {
+	valid := []types.VMMPlacement{
+		{
+			SourceGPUUUID: strings.TrimPrefix(testGPUUUIDA, "GPU-"),
+			TargetGPUUUID: strings.TrimPrefix(testGPUUUIDC, "GPU-"),
+			TargetOrdinal: 0,
+		},
+		{
+			SourceGPUUUID: strings.TrimPrefix(testGPUUUIDB, "GPU-"),
+			TargetGPUUUID: strings.TrimPrefix(testGPUUUIDD, "GPU-"),
+			TargetOrdinal: 1,
+		},
+	}
+	if err := ValidateVMMPlacement(
+		[]string{testGPUUUIDA, testGPUUUIDB},
+		valid,
+	); err != nil {
+		t.Fatalf("valid placement rejected: %v", err)
+	}
+	tests := []struct {
+		name   string
+		mutate func([]types.VMMPlacement) []types.VMMPlacement
+	}{
+		{
+			name: "count mismatch",
+			mutate: func(plan []types.VMMPlacement) []types.VMMPlacement {
+				return plan[:1]
+			},
+		},
+		{
+			name: "noncanonical source UUID",
+			mutate: func(plan []types.VMMPlacement) []types.VMMPlacement {
+				plan[0].SourceGPUUUID = strings.ToUpper(plan[0].SourceGPUUUID)
+				return plan
+			},
+		},
+		{
+			name: "duplicate target ordinal",
+			mutate: func(plan []types.VMMPlacement) []types.VMMPlacement {
+				plan[1].TargetOrdinal = 0
+				return plan
+			},
+		},
+		{
+			name: "source order mismatch",
+			mutate: func(plan []types.VMMPlacement) []types.VMMPlacement {
+				plan[0], plan[1] = plan[1], plan[0]
+				return plan
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plan := slices.Clone(valid)
+			if err := ValidateVMMPlacement(
+				[]string{testGPUUUIDA, testGPUUUIDB},
+				test.mutate(plan),
+			); err == nil {
+				t.Fatal("invalid placement accepted")
 			}
 		})
 	}

--- a/deploy/snapshot/internal/cuda/vmm_interpose.go
+++ b/deploy/snapshot/internal/cuda/vmm_interpose.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sys/unix"
+
+	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 )
 
 const (
@@ -37,7 +39,7 @@ const (
 	vmmArtifactName     = "cuda-vmm.rdb"
 	vmmRestorePoison    = "dynamo:cuda-vmm:restore-poison"
 	vmmProtocolMagic    = 0x44564d4d
-	vmmProtocolVersion  = 3
+	vmmProtocolVersion  = 4
 	vmmLedgerVersion    = 2
 	vmmHeaderSize       = 256
 	vmmRecordSize       = 96
@@ -59,7 +61,7 @@ const (
 	vmmRestoreOwner    = 5
 	vmmRestoreImporter = 6
 	vmmIdentify        = 7
-	vmmQueryPlacement  = 8
+	vmmSetPlacement    = 8
 
 	vmmOwner    = 1
 	vmmImporter = 2
@@ -170,11 +172,17 @@ func verifyVMMHealth(ctx context.Context, processes []VMMProcess) error {
 
 type vmmExecutionPlacement map[string]map[string]int32
 
+type vmmPlacementSetup struct {
+	process VMMProcess
+	payload []byte
+	count   uint32
+}
+
 func currentVMMNode() (string, error) {
 	node := strings.TrimSpace(os.Getenv("NODE_NAME"))
 	if node == "" {
 		return "", errors.New(
-			"NODE_NAME is required for CUDA VMM identity placement validation",
+			"NODE_NAME is required for authoritative CUDA VMM placement validation",
 		)
 	}
 	return node, nil
@@ -647,6 +655,7 @@ func RestoreVMM(
 	generation string,
 	expectedDigest string,
 	checkpointDir string,
+	authoritativePlacement []types.VMMPlacement,
 	unlock func() error,
 	log logr.Logger,
 ) (retErr error) {
@@ -724,7 +733,12 @@ func RestoreVMM(
 	if err != nil {
 		return err
 	}
-	placement, err := validateRestoredVMMProcesses(ctx, processes, ledger, currentNode)
+	placementSetups, placement, err := validateRestoredVMMProcesses(
+		processes,
+		ledger,
+		currentNode,
+		authoritativePlacement,
+	)
 	if err != nil {
 		return err
 	}
@@ -764,6 +778,9 @@ func RestoreVMM(
 			"CUDA VMM Redis generation %s content digest is %q, want %q",
 			generation, actualDigest, expectedDigest,
 		)
+	}
+	if err := setRestoredVMMPlacement(ctx, placementSetups); err != nil {
+		return err
 	}
 	brokers := make([]vmmBrokerResult, len(ledger.Resources))
 	for index := range brokers {
@@ -910,6 +927,7 @@ func RestoreVMM(
 func validateVMMLedger(ledger vmmLedger) error {
 	participants := make(map[string]struct{}, len(ledger.Participants))
 	participantGPUs := make(map[string]map[string]struct{}, len(ledger.Participants))
+	usedParticipantGPUs := make(map[string]map[string]struct{}, len(ledger.Participants))
 	for _, participant := range ledger.Participants {
 		if participant.ID == "" || participant.Placement.Node == "" ||
 			len(participant.Placement.GPUUUIDs) == 0 {
@@ -933,6 +951,7 @@ func validateVMMLedger(ledger vmmLedger) error {
 			gpus[gpuUUID] = struct{}{}
 		}
 		participantGPUs[participant.ID] = gpus
+		usedParticipantGPUs[participant.ID] = make(map[string]struct{}, len(gpus))
 	}
 	for index, resource := range ledger.Resources {
 		if resource.ID != uint64(index+1) || resource.Kind != "allocation" ||
@@ -960,6 +979,7 @@ func validateVMMLedger(ledger vmmLedger) error {
 					resource.ID, mapping.GPUUUID, mapping.Participant,
 				)
 			}
+			usedParticipantGPUs[mapping.Participant][mapping.GPUUUID] = struct{}{}
 			if _, duplicate := seen[mapping.Participant]; duplicate {
 				return fmt.Errorf(
 					"ledger resource %d repeats participant %q",
@@ -989,6 +1009,14 @@ func validateVMMLedger(ledger vmmLedger) error {
 	}
 	if len(ledger.Resources) == 0 {
 		return errors.New("ledger contains no allocation resources")
+	}
+	for participant, gpus := range participantGPUs {
+		if len(gpus) != len(usedParticipantGPUs[participant]) {
+			return fmt.Errorf(
+				"ledger participant %q placement contains an unreferenced GPU",
+				participant,
+			)
+		}
 	}
 	return nil
 }
@@ -1210,28 +1238,85 @@ func readVMMRESPLine(reader *bufio.Reader) (string, error) {
 }
 
 func validateRestoredVMMProcesses(
-	ctx context.Context,
 	processes []VMMProcess,
 	ledger vmmLedger,
 	currentNode string,
-) (vmmExecutionPlacement, error) {
+	authoritative []types.VMMPlacement,
+) ([]vmmPlacementSetup, vmmExecutionPlacement, error) {
 	expected := make(map[string]vmmParticipant, len(ledger.Participants))
 	for _, participant := range ledger.Participants {
 		if participant.ID == "" || participant.Placement.Node == "" {
-			return nil, errors.New("CUDA VMM ledger has incomplete participant placement")
+			return nil, nil, errors.New("CUDA VMM ledger has incomplete participant placement")
 		}
 		if _, duplicate := expected[participant.ID]; duplicate {
-			return nil, fmt.Errorf("CUDA VMM ledger has duplicate participant %q", participant.ID)
+			return nil, nil, fmt.Errorf("CUDA VMM ledger has duplicate participant %q", participant.ID)
 		}
 		expected[participant.ID] = participant
 	}
 	if strings.TrimSpace(currentNode) == "" {
-		return nil, errors.New("current CUDA VMM node identity is required")
+		return nil, nil, errors.New("current CUDA VMM node identity is required")
+	}
+	plan := make(map[string]types.VMMPlacement, len(authoritative))
+	targetUUIDs := make(map[string]struct{}, len(authoritative))
+	targetOrdinals := make(map[int32]struct{}, len(authoritative))
+	for index, placement := range authoritative {
+		source := parseGPUUUID(placement.SourceGPUUUID)
+		target := parseGPUUUID(placement.TargetGPUUUID)
+		if source == nil || formatGPUUUID(source) != placement.SourceGPUUUID {
+			return nil, nil, fmt.Errorf(
+				"CUDA VMM placement entry %d has invalid source GPU UUID %q",
+				index,
+				placement.SourceGPUUUID,
+			)
+		}
+		if target == nil || formatGPUUUID(target) != placement.TargetGPUUUID {
+			return nil, nil, fmt.Errorf(
+				"CUDA VMM placement entry %d has invalid target GPU UUID %q",
+				index,
+				placement.TargetGPUUUID,
+			)
+		}
+		if placement.TargetOrdinal < 0 {
+			return nil, nil, fmt.Errorf(
+				"CUDA VMM placement entry %d has negative target ordinal %d",
+				index,
+				placement.TargetOrdinal,
+			)
+		}
+		if _, duplicate := plan[placement.SourceGPUUUID]; duplicate {
+			return nil, nil, fmt.Errorf(
+				"CUDA VMM placement has duplicate source GPU UUID %q",
+				placement.SourceGPUUUID,
+			)
+		}
+		if _, duplicate := targetUUIDs[placement.TargetGPUUUID]; duplicate {
+			return nil, nil, fmt.Errorf(
+				"CUDA VMM placement has duplicate target GPU UUID %q",
+				placement.TargetGPUUUID,
+			)
+		}
+		if _, duplicate := targetOrdinals[placement.TargetOrdinal]; duplicate {
+			return nil, nil, fmt.Errorf(
+				"CUDA VMM placement has duplicate target ordinal %d",
+				placement.TargetOrdinal,
+			)
+		}
+		plan[placement.SourceGPUUUID] = placement
+		targetUUIDs[placement.TargetGPUUUID] = struct{}{}
+		targetOrdinals[placement.TargetOrdinal] = struct{}{}
+	}
+	for ordinal := range len(authoritative) {
+		if _, present := targetOrdinals[int32(ordinal)]; !present {
+			return nil, nil, fmt.Errorf(
+				"CUDA VMM placement is missing target ordinal %d",
+				ordinal,
+			)
+		}
 	}
 	actual := make(map[string]VMMProcess, len(processes))
 	for _, process := range processes {
 		if _, duplicate := actual[process.Participant]; duplicate {
-			return nil, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"multiple restored shims claim participant %q",
 				process.Participant,
 			)
@@ -1241,123 +1326,119 @@ func validateRestoredVMMProcesses(
 	for id, participant := range expected {
 		_, ok := actual[id]
 		if !ok {
-			return nil, fmt.Errorf("CUDA VMM participant %q has no restored shim endpoint", id)
+			return nil, nil, fmt.Errorf("CUDA VMM participant %q has no restored shim endpoint", id)
 		}
 		if currentNode != participant.Placement.Node {
-			return nil, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"CUDA VMM participant %q target node is %q, source was %q",
 				id, currentNode, participant.Placement.Node,
 			)
 		}
 	}
 	placement := make(vmmExecutionPlacement, len(expected))
+	setups := make([]vmmPlacementSetup, 0, len(processes))
 	for _, process := range processes {
-		response, err := exchangeVMM(
-			ctx,
-			process,
-			vmmHeader{Operation: vmmQueryPlacement},
-			nil,
-			-1,
-			vmmResponseUntyped,
-		)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"query CUDA VMM participant %q current GPU placement: %w",
-				process.Participant,
-				err,
-			)
-		}
-		ordinals, err := decodeVMMPlacement(
-			response.header.Count,
-			response.payload,
-		)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"decode CUDA VMM participant %q current GPU placement: %w",
-				process.Participant,
-				err,
-			)
-		}
 		participant, managed := expected[process.Participant]
 		if !managed {
-			if len(ordinals) != 0 {
-				return nil, fmt.Errorf(
-					"unexpected restored CUDA VMM participant %q has %d detached managed placements",
-					process.Participant,
-					len(ordinals),
-				)
-			}
+			setups = append(setups, vmmPlacementSetup{process: process})
 			continue
 		}
-		want := make(map[string]struct{}, len(participant.Placement.GPUUUIDs))
+		local := make([]types.VMMPlacement, 0, len(participant.Placement.GPUUUIDs))
+		seen := make(map[string]struct{}, len(participant.Placement.GPUUUIDs))
 		for _, gpuUUID := range participant.Placement.GPUUUIDs {
-			want[gpuUUID] = struct{}{}
+			if _, duplicate := seen[gpuUUID]; duplicate {
+				return nil, nil, fmt.Errorf(
+					"CUDA VMM participant %q repeats source GPU %q",
+					process.Participant,
+					gpuUUID,
+				)
+			}
+			current, ok := plan[gpuUUID]
+			if !ok {
+				return nil, nil, fmt.Errorf(
+					"CUDA VMM participant %q source GPU %q is absent from the authoritative placement",
+					process.Participant,
+					gpuUUID,
+				)
+			}
+			seen[gpuUUID] = struct{}{}
+			local = append(local, current)
 		}
-		if len(ordinals) != len(want) {
-			return nil, fmt.Errorf(
-				"CUDA VMM participant %q current GPU placement count is %d, want %d",
+		payload, err := encodeVMMPlacement(local)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"encode CUDA VMM participant %q placement: %w",
 				process.Participant,
-				len(ordinals),
-				len(want),
+				err,
 			)
 		}
-		placement[process.Participant] = make(map[string]int32, len(ordinals))
-		for sourceUUID, current := range ordinals {
-			if _, ok := want[sourceUUID]; !ok {
-				return nil, fmt.Errorf(
-					"CUDA VMM participant %q reported unexpected source GPU %q",
-					process.Participant,
-					sourceUUID,
-				)
-			}
-			if sourceUUID != current.uuid {
-				return nil, fmt.Errorf(
-					"CUDA VMM participant %q ordinal %d currently maps GPU %q, source was %q",
-					process.Participant,
-					current.ordinal,
-					current.uuid,
-					sourceUUID,
-				)
-			}
-			placement[process.Participant][sourceUUID] = current.ordinal
+		setups = append(setups, vmmPlacementSetup{
+			process: process,
+			payload: payload,
+			count:   uint32(len(local)),
+		})
+		placement[process.Participant] = make(map[string]int32, len(local))
+		for _, current := range local {
+			placement[process.Participant][current.SourceGPUUUID] =
+				current.TargetOrdinal
 		}
 	}
-	return placement, nil
+	return setups, placement, nil
 }
 
-func decodeVMMPlacement(
-	count uint32,
-	payload []byte,
-) (map[string]struct {
-	uuid    string
-	ordinal int32
-}, error) {
-	if uint64(count)*vmmPlacementSize != uint64(len(payload)) {
-		return nil, errors.New("invalid VMM placement payload length")
+func encodeVMMPlacement(placements []types.VMMPlacement) ([]byte, error) {
+	size, err := vmmPlacementPayloadSize(len(placements))
+	if err != nil {
+		return nil, errors.New("CUDA VMM placement payload is too large")
 	}
-	result := make(map[string]struct {
-		uuid    string
-		ordinal int32
-	}, count)
-	for range count {
-		source := formatGPUUUID(payload[8:24])
-		current := formatGPUUUID(payload[24:40])
-		if source == "" || current == "" {
-			return nil, errors.New("invalid VMM placement GPU UUID")
+	payload := make([]byte, size)
+	for index, placement := range placements {
+		offset := index * vmmPlacementSize
+		source := parseGPUUUID(placement.SourceGPUUUID)
+		target := parseGPUUUID(placement.TargetGPUUUID)
+		if placement.TargetOrdinal < 0 || source == nil || target == nil {
+			return nil, fmt.Errorf("invalid CUDA VMM placement entry %d", index)
 		}
-		if _, duplicate := result[source]; duplicate {
-			return nil, fmt.Errorf("duplicate VMM source GPU UUID %q", source)
-		}
-		result[source] = struct {
-			uuid    string
-			ordinal int32
-		}{
-			uuid:    current,
-			ordinal: int32(binary.LittleEndian.Uint32(payload[0:4])),
-		}
-		payload = payload[vmmPlacementSize:]
+		binary.LittleEndian.PutUint32(
+			payload[offset:offset+4],
+			uint32(placement.TargetOrdinal),
+		)
+		copy(payload[offset+8:offset+24], source)
+		copy(payload[offset+24:offset+40], target)
 	}
-	return result, nil
+	return payload, nil
+}
+
+func vmmPlacementPayloadSize(count int) (int, error) {
+	if uint64(count) > uint64(^uint32(0)) ||
+		uint64(count) > uint64(vmmMaximumRedisBulk/vmmPlacementSize) {
+		return 0, errors.New("CUDA VMM placement payload is too large")
+	}
+	return count * vmmPlacementSize, nil
+}
+
+func setRestoredVMMPlacement(
+	ctx context.Context,
+	setups []vmmPlacementSetup,
+) error {
+	for _, setup := range setups {
+		_, err := exchangeVMM(
+			ctx,
+			setup.process,
+			vmmHeader{Operation: vmmSetPlacement, Count: setup.count},
+			setup.payload,
+			-1,
+			vmmResponseEmpty,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"set CUDA VMM participant %q placement: %w",
+				setup.process.Participant,
+				err,
+			)
+		}
+	}
+	return nil
 }
 
 func findVMMProcess(processes []VMMProcess, participant string) (VMMProcess, error) {
@@ -1477,6 +1558,7 @@ type vmmResponseExpectation uint8
 
 const (
 	vmmResponseUntyped vmmResponseExpectation = iota
+	vmmResponseEmpty
 	vmmResponsePOSIXBroker
 	vmmResponseFabricBroker
 )
@@ -1502,9 +1584,12 @@ func validateVMMResponseShape(
 	expectedPayloadSize := uint64(0)
 	expectedFDs := 0
 	typedBroker := true
+	exactEmpty := false
 	switch expectation {
 	case vmmResponseUntyped:
 		typedBroker = false
+	case vmmResponseEmpty:
+		exactEmpty = true
 	case vmmResponsePOSIXBroker:
 		expectedHandleType = vmmHandlePOSIX
 		expectedFDs = 1
@@ -1518,6 +1603,17 @@ func validateVMMResponseShape(
 		return 0, fmt.Errorf(
 			"VMM operation %d returned handle type %d, want %d",
 			operation, response.HandleType, expectedHandleType,
+		)
+	}
+	if exactEmpty &&
+		(response.Count != 0 ||
+			response.PayloadSize != 0 ||
+			response.ObjectID != 0 ||
+			response.AllocationUUID != ([16]byte{}) ||
+			response.Message != "") {
+		return 0, fmt.Errorf(
+			"VMM operation %d returned a nonempty success response",
+			operation,
 		)
 	}
 	if typedBroker && response.PayloadSize != expectedPayloadSize {

--- a/deploy/snapshot/internal/cuda/vmm_interpose.go
+++ b/deploy/snapshot/internal/cuda/vmm_interpose.go
@@ -37,16 +37,18 @@ const (
 	vmmArtifactName     = "cuda-vmm.rdb"
 	vmmRestorePoison    = "dynamo:cuda-vmm:restore-poison"
 	vmmProtocolMagic    = 0x44564d4d
-	vmmProtocolVersion  = 2
+	vmmProtocolVersion  = 3
+	vmmLedgerVersion    = 2
 	vmmHeaderSize       = 256
 	vmmRecordSize       = 96
 	vmmPlacementSize    = 40
+	vmmFabricHandleSize = 64
 	vmmMessageSize      = 96
 	vmmParticipantSize  = 33
 	vmmGPUUUIDSize      = 16
 	vmmTimeout          = 30 * time.Second
-	vmmMaximumPayload   = 1 << 40
 	vmmMaximumRedisBulk = 512 << 20
+	vmmMaximumPayload   = vmmMaximumRedisBulk + 1<<20
 	vmmMaximumRESPLine  = 4 << 10
 	vmmMaximumRightsFDs = 253
 
@@ -65,6 +67,9 @@ const (
 	vmmAllocation = 1
 
 	vmmApplicationHandleLive = 1
+
+	vmmHandlePOSIX  = 1
+	vmmHandleFabric = 8
 )
 
 type VMMProcess struct {
@@ -72,6 +77,82 @@ type VMMProcess struct {
 	NamespacePID int
 	SocketPath   string
 	Participant  string
+}
+
+type vmmBrokerResult struct {
+	handleType uint32
+	fd         int
+	bytes      []byte
+}
+
+func supportedVMMHandleType(handleType uint32) bool {
+	return handleType == vmmHandlePOSIX || handleType == vmmHandleFabric
+}
+
+func takeVMMBrokerResult(
+	response *vmmResponse,
+	handleType uint32,
+) (vmmBrokerResult, error) {
+	result := vmmBrokerResult{handleType: handleType, fd: -1}
+	valid := response.header.HandleType == handleType
+	switch handleType {
+	case vmmHandlePOSIX:
+		valid = valid && response.fd >= 0 && len(response.payload) == 0
+	case vmmHandleFabric:
+		valid = valid && response.fd < 0 &&
+			len(response.payload) == vmmFabricHandleSize
+	default:
+		valid = false
+	}
+	if !valid {
+		clearVMMBytes(response.payload)
+		response.payload = nil
+		return result, errors.Join(
+			fmt.Errorf(
+				"invalid CUDA VMM broker response shape for handle type %d",
+				handleType,
+			),
+			closeVMMFD(&response.fd),
+		)
+	}
+	result.fd, response.fd = response.fd, -1
+	result.bytes, response.payload = response.payload, nil
+	return result, nil
+}
+
+func closeVMMBrokerResult(result *vmmBrokerResult) error {
+	clearVMMBytes(result.bytes)
+	result.bytes = nil
+	return closeVMMFD(&result.fd)
+}
+
+func vmmImporterTransport(
+	payload []byte,
+	broker vmmBrokerResult,
+) ([]byte, int, error) {
+	switch broker.handleType {
+	case vmmHandlePOSIX:
+		if broker.fd < 0 || len(broker.bytes) != 0 {
+			return nil, -1, errors.New("invalid POSIX CUDA VMM broker result")
+		}
+		return payload, broker.fd, nil
+	case vmmHandleFabric:
+		if broker.fd >= 0 || len(broker.bytes) != vmmFabricHandleSize {
+			return nil, -1, errors.New("invalid FABRIC CUDA VMM broker result")
+		}
+		return append(append([]byte(nil), payload...), broker.bytes...), -1, nil
+	default:
+		return nil, -1, fmt.Errorf(
+			"unsupported CUDA VMM broker handle type %d",
+			broker.handleType,
+		)
+	}
+}
+
+func clearVMMBytes(content []byte) {
+	for index := range content {
+		content[index] = 0
+	}
 }
 
 func verifyVMMHealth(ctx context.Context, processes []VMMProcess) error {
@@ -136,6 +217,7 @@ type vmmRestorePlan struct {
 	resourceIndex int
 	process       VMMProcess
 	payload       []byte
+	handleType    uint32
 }
 
 func ValidateVMMProcessSet(expected, current []int) error {
@@ -170,6 +252,7 @@ type vmmHeader struct {
 	Operation      uint16
 	Status         int32
 	Count          uint32
+	HandleType     uint32
 	AllocationUUID [16]byte
 	ObjectID       uint64
 	PayloadSize    uint64
@@ -364,16 +447,29 @@ func identifyVMMProcess(process VMMProcess) (VMMProcess, error) {
 		vmmHeader{Operation: vmmIdentify},
 		nil,
 		-1,
-		vmmResponseFDNone,
+		vmmResponseUntyped,
 	)
 	if err != nil {
 		return VMMProcess{}, err
 	}
-	if len(response.payload) != 0 || response.header.Participant == "" {
+	if len(response.payload) != 0 ||
+		!validVMMParticipant(response.header.Participant) {
 		return VMMProcess{}, errors.New("VMM identify returned incomplete logical identity")
 	}
 	process.Participant = response.header.Participant
 	return process, nil
+}
+
+func validVMMParticipant(participant string) bool {
+	if len(participant) != vmmParticipantSize-1 {
+		return false
+	}
+	for _, value := range participant {
+		if (value < '0' || value > '9') && (value < 'a' || value > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func requireVMMSocket(path string) error {
@@ -409,7 +505,7 @@ func ValidateVMMArtifact(checkpointDir string, enabled bool) error {
 	return nil
 }
 
-// PrepareVMM captures the complete POSIX-FD VMM ledger, detaches every managed
+// PrepareVMM captures the complete shared VMM ledger, detaches every managed
 // mapping, and exports the dedicated Redis RDB into the checkpoint artifact.
 func PrepareVMM(
 	ctx context.Context,
@@ -469,7 +565,7 @@ func PrepareVMM(
 			},
 			nil,
 			-1,
-			vmmResponseFDNone,
+			vmmResponseUntyped,
 		)
 		if err != nil {
 			return "", fmt.Errorf("capture CUDA VMM resource %d bytes: %w", resource.ID, err)
@@ -515,7 +611,7 @@ func PrepareVMM(
 			},
 			nil,
 			-1,
-			vmmResponseFDNone,
+			vmmResponseUntyped,
 		); err != nil {
 			return "", fmt.Errorf(
 				"detach CUDA VMM resource %d %s participant %s: %w",
@@ -536,7 +632,7 @@ func PrepareVMM(
 		return "", err
 	}
 	log.Info(
-		"Captured launcher-scoped CUDA POSIX-FD VMM state",
+		"Captured launcher-scoped CUDA VMM state",
 		"generation", generation,
 		"resources", len(ledger.Resources),
 	)
@@ -615,10 +711,10 @@ func RestoreVMM(
 	if err := json.Unmarshal(encoded, &ledger); err != nil {
 		return fmt.Errorf("decode CUDA VMM Redis ledger: %w", err)
 	}
-	if ledger.Version != 1 || ledger.Generation != generation {
+	if ledger.Version != vmmLedgerVersion || ledger.Generation != generation {
 		return fmt.Errorf(
-			"CUDA VMM Redis ledger is version/generation %d/%q, want 1/%q",
-			ledger.Version, ledger.Generation, generation,
+			"CUDA VMM Redis ledger is version/generation %d/%q, want %d/%q",
+			ledger.Version, ledger.Generation, vmmLedgerVersion, generation,
 		)
 	}
 	if err := validateVMMLedger(ledger); err != nil {
@@ -669,17 +765,17 @@ func RestoreVMM(
 			generation, actualDigest, expectedDigest,
 		)
 	}
-	brokerFDs := make([]int, len(ledger.Resources))
-	for index := range brokerFDs {
-		brokerFDs[index] = -1
+	brokers := make([]vmmBrokerResult, len(ledger.Resources))
+	for index := range brokers {
+		brokers[index].fd = -1
 	}
 	defer func() {
-		for index := range brokerFDs {
-			if err := closeVMMFD(&brokerFDs[index]); err != nil {
+		for index := range brokers {
+			if err := closeVMMBrokerResult(&brokers[index]); err != nil {
 				retErr = errors.Join(
 					retErr,
 					fmt.Errorf(
-						"close CUDA VMM resource %d broker FD: %w",
+						"close CUDA VMM resource %d broker result: %w",
 						ledger.Resources[index].ID,
 						err,
 					),
@@ -707,6 +803,7 @@ func RestoreVMM(
 			resourceIndex: index,
 			process:       owner,
 			payload:       payload,
+			handleType:    resource.Owner.RequestedHandleType,
 		})
 		for _, mapping := range resource.Importers {
 			importer, err := findVMMProcess(processes, mapping.Participant)
@@ -717,6 +814,7 @@ func RestoreVMM(
 				resourceID:    resource.ID,
 				resourceIndex: index,
 				process:       importer,
+				handleType:    mapping.RequestedHandleType,
 				payload: encodeVMMRestoreRecord(
 					resource.ID,
 					vmmImporter,
@@ -734,34 +832,65 @@ func RestoreVMM(
 		response, err := exchangeVMM(
 			ctx,
 			plan.process,
-			vmmHeader{Operation: vmmRestoreOwner, ObjectID: plan.resourceID},
+			vmmHeader{
+				Operation:  vmmRestoreOwner,
+				ObjectID:   plan.resourceID,
+				HandleType: plan.handleType,
+			},
 			plan.payload,
 			-1,
-			vmmResponseFDRequired,
+			vmmBrokerResponseExpectation(plan.handleType),
 		)
 		if err != nil {
 			return fmt.Errorf("restore CUDA VMM resource %d owner: %w", plan.resourceID, err)
 		}
-		brokerFDs[plan.resourceIndex] = response.fd
+		broker, err := takeVMMBrokerResult(&response, plan.handleType)
+		if err != nil {
+			return fmt.Errorf(
+				"restore CUDA VMM resource %d owner broker: %w",
+				plan.resourceID, err,
+			)
+		}
+		brokers[plan.resourceIndex] = broker
 	}
 	for _, plan := range importerPlans {
-		if _, err := exchangeVMM(
+		payload, fd, err := vmmImporterTransport(
+			plan.payload, brokers[plan.resourceIndex],
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"prepare CUDA VMM resource %d importer transport: %w",
+				plan.resourceID, err,
+			)
+		}
+		_, err = exchangeVMM(
 			ctx,
 			plan.process,
-			vmmHeader{Operation: vmmRestoreImporter, ObjectID: plan.resourceID},
-			plan.payload,
-			brokerFDs[plan.resourceIndex],
-			vmmResponseFDNone,
-		); err != nil {
+			vmmHeader{
+				Operation:  vmmRestoreImporter,
+				ObjectID:   plan.resourceID,
+				HandleType: plan.handleType,
+			},
+			payload,
+			fd,
+			vmmResponseUntyped,
+		)
+		if plan.handleType == vmmHandleFabric {
+			clearVMMBytes(payload)
+		}
+		if err != nil {
 			return fmt.Errorf(
 				"restore CUDA VMM resource %d importer participant %s: %w",
 				plan.resourceID, plan.process.Participant, err,
 			)
 		}
 	}
-	for index := range brokerFDs {
-		if err := closeVMMFD(&brokerFDs[index]); err != nil {
-			return fmt.Errorf("close CUDA VMM resource %d broker FD: %w", ledger.Resources[index].ID, err)
+	for index := range brokers {
+		if err := closeVMMBrokerResult(&brokers[index]); err != nil {
+			return fmt.Errorf(
+				"close CUDA VMM resource %d broker result: %w",
+				ledger.Resources[index].ID, err,
+			)
 		}
 	}
 	if err := verifyVMMHealth(ctx, processes); err != nil {
@@ -771,7 +900,7 @@ func RestoreVMM(
 		return err
 	}
 	log.Info(
-		"Restored launcher-scoped CUDA POSIX-FD VMM state",
+		"Restored launcher-scoped CUDA VMM state",
 		"generation", generation,
 		"resources", len(ledger.Resources),
 	)
@@ -810,6 +939,12 @@ func validateVMMLedger(ledger vmmLedger) error {
 			resource.Owner.Participant == "" || len(resource.Importers) == 0 {
 			return fmt.Errorf("ledger resource %d is incomplete or unsupported", resource.ID)
 		}
+		if !supportedVMMHandleType(resource.Owner.RequestedHandleType) {
+			return fmt.Errorf(
+				"ledger resource %d has unsupported owner handle type %d",
+				resource.ID, resource.Owner.RequestedHandleType,
+			)
+		}
 		mappings := append([]vmmMapping{resource.Owner}, resource.Importers...)
 		seen := make(map[string]struct{}, len(mappings))
 		for _, mapping := range mappings {
@@ -832,8 +967,16 @@ func validateVMMLedger(ledger vmmLedger) error {
 				)
 			}
 			seen[mapping.Participant] = struct{}{}
+			if mapping.Size > vmmMaximumRedisBulk {
+				return fmt.Errorf(
+					"ledger resource %d mapping for participant %q exceeds the %d-byte allocation limit",
+					resource.ID, mapping.Participant, vmmMaximumRedisBulk,
+				)
+			}
 			if mapping.Address == 0 || mapping.Size == 0 ||
-				mapping.GPUUUID == "" || mapping.RequestedHandleType != 1 ||
+				mapping.GPUUUID == "" ||
+				mapping.RequestedHandleType !=
+					resource.Owner.RequestedHandleType ||
 				mapping.AccessCount == 0 || mapping.AccessSize == 0 ||
 				len(mapping.Access) !=
 					int(mapping.AccessCount)*int(mapping.AccessSize) {
@@ -868,7 +1011,7 @@ func inspectVMM(
 			vmmHeader{Operation: vmmInspect},
 			nil,
 			-1,
-			vmmResponseFDNone,
+			vmmResponseUntyped,
 		)
 		if err != nil {
 			return vmmLedger{}, fmt.Errorf("inspect CUDA process %d VMM state: %w", process.ObservedPID, err)
@@ -913,7 +1056,7 @@ func inspectVMM(
 		participantNodes[process.Participant] = sourceNode
 	}
 	participants := make(map[string]vmmParticipant, len(captures))
-	ledger := vmmLedger{Version: 1, Generation: generation}
+	ledger := vmmLedger{Version: vmmLedgerVersion, Generation: generation}
 	for index, id := range ids {
 		resource := vmmResource{
 			ID:          uint64(index + 1),
@@ -925,6 +1068,12 @@ func inspectVMM(
 				return vmmLedger{}, fmt.Errorf(
 					"CUDA VMM capture has unsupported object kind %d",
 					capture.record.kind,
+				)
+			}
+			if !supportedVMMHandleType(capture.record.handleType) {
+				return vmmLedger{}, fmt.Errorf(
+					"CUDA VMM capture has unsupported handle type %d",
+					capture.record.handleType,
 				)
 			}
 			mapping := mappingFromCapture(capture.process.Participant, capture.record)
@@ -975,6 +1124,14 @@ func inspectVMM(
 					resource.ID, importer.Participant, importer.Size, resource.Owner.Size,
 				)
 			}
+			if importer.RequestedHandleType !=
+				resource.Owner.RequestedHandleType {
+				return vmmLedger{}, fmt.Errorf(
+					"CUDA VMM resource %d mixes owner handle type %d with importer type %d",
+					resource.ID, resource.Owner.RequestedHandleType,
+					importer.RequestedHandleType,
+				)
+			}
 			if _, duplicate := resourceParticipants[importer.Participant]; duplicate {
 				return vmmLedger{}, fmt.Errorf(
 					"CUDA VMM resource %d has multiple mappings in participant %s",
@@ -986,7 +1143,7 @@ func inspectVMM(
 		ledger.Resources = append(ledger.Resources, resource)
 	}
 	if len(ledger.Resources) == 0 {
-		return vmmLedger{}, errors.New("no CUDA POSIX-FD VMM sharing graph discovered")
+		return vmmLedger{}, errors.New("no CUDA VMM sharing graph discovered")
 	}
 	participantIDs := make([]string, 0, len(participants))
 	for id := range participants {
@@ -1101,7 +1258,7 @@ func validateRestoredVMMProcesses(
 			vmmHeader{Operation: vmmQueryPlacement},
 			nil,
 			-1,
-			vmmResponseFDNone,
+			vmmResponseUntyped,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -1316,12 +1473,67 @@ func parseGPUUUID(value string) []byte {
 	return decoded
 }
 
-type vmmResponseFDExpectation uint8
+type vmmResponseExpectation uint8
 
 const (
-	vmmResponseFDNone vmmResponseFDExpectation = iota
-	vmmResponseFDRequired
+	vmmResponseUntyped vmmResponseExpectation = iota
+	vmmResponsePOSIXBroker
+	vmmResponseFabricBroker
 )
+
+func vmmBrokerResponseExpectation(handleType uint32) vmmResponseExpectation {
+	switch handleType {
+	case vmmHandlePOSIX:
+		return vmmResponsePOSIXBroker
+	case vmmHandleFabric:
+		return vmmResponseFabricBroker
+	default:
+		return vmmResponseExpectation(255)
+	}
+}
+
+func validateVMMResponseShape(
+	operation uint16,
+	response vmmHeader,
+	expectation vmmResponseExpectation,
+	fdCount int,
+) (int, error) {
+	expectedHandleType := uint32(0)
+	expectedPayloadSize := uint64(0)
+	expectedFDs := 0
+	typedBroker := true
+	switch expectation {
+	case vmmResponseUntyped:
+		typedBroker = false
+	case vmmResponsePOSIXBroker:
+		expectedHandleType = vmmHandlePOSIX
+		expectedFDs = 1
+	case vmmResponseFabricBroker:
+		expectedHandleType = vmmHandleFabric
+		expectedPayloadSize = vmmFabricHandleSize
+	default:
+		return 0, fmt.Errorf("invalid VMM response expectation %d", expectation)
+	}
+	if response.HandleType != expectedHandleType {
+		return 0, fmt.Errorf(
+			"VMM operation %d returned handle type %d, want %d",
+			operation, response.HandleType, expectedHandleType,
+		)
+	}
+	if typedBroker && response.PayloadSize != expectedPayloadSize {
+		return 0, fmt.Errorf(
+			"VMM handle type %d response payload is %d bytes, want %d",
+			expectedHandleType, response.PayloadSize, expectedPayloadSize,
+		)
+	}
+	if fdCount != expectedFDs {
+		return 0, fmt.Errorf(
+			"VMM operation %d returned %d response FDs, want %d",
+			operation, fdCount, expectedFDs,
+		)
+	}
+	return expectedFDs, nil
+}
 
 type vmmResponse struct {
 	header  vmmHeader
@@ -1354,9 +1566,19 @@ func exchangeVMM(
 	request vmmHeader,
 	payload []byte,
 	passedFD int,
-	responseFD vmmResponseFDExpectation,
+	expectation vmmResponseExpectation,
 ) (result vmmResponse, retErr error) {
 	result.fd = -1
+	if process.Participant == "" {
+		if request.Operation != vmmIdentify {
+			return result, errors.New("VMM participant identity is required")
+		}
+	} else {
+		if !validVMMParticipant(process.Participant) {
+			return result, errors.New("invalid VMM participant identity")
+		}
+		request.Participant = process.Participant
+	}
 	dialer := net.Dialer{Timeout: vmmTimeout}
 	connection, err := dialer.DialContext(ctx, "unix", process.SocketPath)
 	if err != nil {
@@ -1393,6 +1615,7 @@ func exchangeVMM(
 	responseBuffer := make([]byte, vmmHeaderSize+64*1024)
 	ancillary = make([]byte, unix.CmsgSpace(4*vmmMaximumRightsFDs))
 	size, ancillarySize, flags, _, err := unixConnection.ReadMsgUnix(responseBuffer, ancillary)
+	defer clearVMMBytes(responseBuffer[:size])
 	if err != nil {
 		return result, err
 	}
@@ -1428,33 +1651,35 @@ func exchangeVMM(
 			response.Operation, request.Operation,
 		)
 	}
+	if process.Participant != "" &&
+		response.Participant != process.Participant {
+		return result, fmt.Errorf(
+			"VMM response participant %q does not match request participant %q",
+			response.Participant, process.Participant,
+		)
+	}
 	if response.Status != 0 {
 		return result, errors.New(response.Message)
 	}
-	switch responseFD {
-	case vmmResponseFDNone:
-		if len(receivedFDs) != 0 {
-			return result, fmt.Errorf(
-				"VMM operation %d returned %d forbidden response FDs",
-				request.Operation,
-				len(receivedFDs),
-			)
-		}
-	case vmmResponseFDRequired:
-		if len(receivedFDs) != 1 {
-			return result, fmt.Errorf(
-				"VMM operation %d returned %d response FDs, want exactly one",
-				request.Operation,
-				len(receivedFDs),
-			)
-		}
-	default:
-		return result, fmt.Errorf("invalid VMM response FD expectation %d", responseFD)
+	expectedFDs, err := validateVMMResponseShape(
+		request.Operation,
+		response,
+		expectation,
+		len(receivedFDs),
+	)
+	if err != nil {
+		return result, err
 	}
 	if response.PayloadSize > vmmMaximumPayload {
 		return result, fmt.Errorf("VMM response payload %d exceeds limit", response.PayloadSize)
 	}
 	responsePayload := make([]byte, int(response.PayloadSize))
+	payloadOwned := false
+	defer func() {
+		if !payloadOwned {
+			clearVMMBytes(responsePayload)
+		}
+	}()
 	payloadPrefix := responseBuffer[vmmHeaderSize:size]
 	if uint64(len(payloadPrefix)) > response.PayloadSize {
 		return result, errors.New("VMM response exceeds declared payload size")
@@ -1464,7 +1689,8 @@ func exchangeVMM(
 		return result, err
 	}
 	result.payload = responsePayload
-	if responseFD == vmmResponseFDRequired {
+	payloadOwned = true
+	if expectedFDs == 1 {
 		result.fd = receivedFDs[0]
 		receivedFDs[0] = -1
 	}
@@ -1519,6 +1745,7 @@ func encodeVMMHeader(header vmmHeader) []byte {
 	binary.LittleEndian.PutUint16(buffer[6:8], header.Operation)
 	binary.LittleEndian.PutUint32(buffer[8:12], uint32(header.Status))
 	binary.LittleEndian.PutUint32(buffer[12:16], header.Count)
+	binary.LittleEndian.PutUint32(buffer[16:20], header.HandleType)
 	copy(buffer[24:40], header.AllocationUUID[:])
 	binary.LittleEndian.PutUint64(buffer[40:48], header.ObjectID)
 	binary.LittleEndian.PutUint64(buffer[48:56], header.PayloadSize)
@@ -1530,13 +1757,16 @@ func encodeVMMHeader(header vmmHeader) []byte {
 func decodeVMMHeader(buffer []byte) (vmmHeader, error) {
 	if len(buffer) != vmmHeaderSize ||
 		binary.LittleEndian.Uint32(buffer[0:4]) != vmmProtocolMagic ||
-		binary.LittleEndian.Uint16(buffer[4:6]) != vmmProtocolVersion {
+		binary.LittleEndian.Uint16(buffer[4:6]) != vmmProtocolVersion ||
+		binary.LittleEndian.Uint32(buffer[20:24]) != 0 ||
+		!bytes.Equal(buffer[185:256], make([]byte, 71)) {
 		return vmmHeader{}, errors.New("invalid VMM response protocol")
 	}
 	header := vmmHeader{
 		Operation:   binary.LittleEndian.Uint16(buffer[6:8]),
 		Status:      int32(binary.LittleEndian.Uint32(buffer[8:12])),
 		Count:       binary.LittleEndian.Uint32(buffer[12:16]),
+		HandleType:  binary.LittleEndian.Uint32(buffer[16:20]),
 		ObjectID:    binary.LittleEndian.Uint64(buffer[40:48]),
 		PayloadSize: binary.LittleEndian.Uint64(buffer[48:56]),
 		Message:     strings.TrimRight(string(buffer[56:56+vmmMessageSize]), "\x00"),

--- a/deploy/snapshot/internal/cuda/vmm_interpose_test.go
+++ b/deploy/snapshot/internal/cuda/vmm_interpose_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -31,7 +32,6 @@ func TestDetectVMMInterposeRequiresUniformLauncherScope(t *testing.T) {
 		if err := os.MkdirAll(path, 0700); err != nil {
 			t.Fatal(err)
 		}
-
 		if err := os.WriteFile(filepath.Join(path, "environ"), []byte(content), 0600); err != nil {
 			t.Fatal(err)
 		}
@@ -46,6 +46,419 @@ func TestDetectVMMInterposeRequiresUniformLauncherScope(t *testing.T) {
 	enabled, err := DetectVMMInterpose(procRoot, []int{10, 11})
 	if err != nil || !enabled {
 		t.Fatalf("uniform launcher scope = %t, %v", enabled, err)
+	}
+}
+
+func TestValidateVMMResponseShapeRejectsTypedPayloadBeforeAllocation(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectation vmmResponseExpectation
+		handleType  uint32
+		payloadSize uint64
+		fdCount     int
+	}{
+		{
+			name:        "oversized fabric payload",
+			expectation: vmmResponseFabricBroker,
+			handleType:  vmmHandleFabric,
+			payloadSize: vmmFabricHandleSize + 1,
+		},
+		{
+			name:        "POSIX payload",
+			expectation: vmmResponsePOSIXBroker,
+			handleType:  vmmHandlePOSIX,
+			payloadSize: 1,
+			fdCount:     1,
+		},
+		{
+			name:        "wrong handle type",
+			expectation: vmmResponseFabricBroker,
+			handleType:  vmmHandlePOSIX,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := validateVMMResponseShape(
+				vmmRestoreOwner,
+				vmmHeader{
+					HandleType:  test.handleType,
+					PayloadSize: test.payloadSize,
+				},
+				test.expectation,
+				test.fdCount,
+			)
+			if err == nil {
+				t.Fatal("invalid typed response declaration was accepted")
+			}
+		})
+	}
+}
+
+func TestRestoreVMMFabricTransport(t *testing.T) {
+	const (
+		generation   = "00112233445566778899aabbccddeeff"
+		sourceUUID   = "00112233-4455-6677-8899-aabbccddeeff"
+		participantA = "11111111111111111111111111111111"
+		participantB = "22222222222222222222222222222222"
+	)
+	contents := []byte{1, 2, 3, 4}
+	raw := bytes.Repeat([]byte{0xa5}, vmmFabricHandleSize)
+	mapping := func(participant string, address uint64) vmmMapping {
+		return vmmMapping{
+			Participant:         participant,
+			Address:             address,
+			Size:                uint64(len(contents)),
+			GPUUUID:             sourceUUID,
+			RequestedHandleType: vmmHandleFabric,
+			Access:              []byte{1, 2, 3, 4},
+			AccessCount:         1,
+			AccessSize:          4,
+		}
+	}
+	ledger := vmmLedger{
+		Version:    vmmLedgerVersion,
+		Generation: generation,
+		Participants: []vmmParticipant{
+			{
+				ID: participantA,
+				Placement: vmmPlacement{
+					Node: "node-a", GPUUUIDs: []string{sourceUUID},
+				},
+			},
+			{
+				ID: participantB,
+				Placement: vmmPlacement{
+					Node: "node-a", GPUUUIDs: []string{sourceUUID},
+				},
+			},
+		},
+		Resources: []vmmResource{{
+			ID:        1,
+			Kind:      "allocation",
+			Owner:     mapping(participantA, 0x1000),
+			Importers: []vmmMapping{mapping(participantB, 0x2000)},
+		}},
+	}
+	encoded, err := json.Marshal(ledger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(base64.StdEncoding.EncodeToString(raw))) {
+		t.Fatal("FABRIC raw broker bytes appeared in durable ledger JSON")
+	}
+	digest := sha256.New()
+	writeVMMDigestPart(digest, encoded)
+	writeVMMDigestObject(digest, 1, contents)
+	expectedDigest := hex.EncodeToString(digest.Sum(nil))
+	events := make(chan string, 8)
+	placementResponse := func(operation uint16) vmmResponse {
+		payload := make([]byte, vmmPlacementSize)
+		copy(payload[8:24], parseGPUUUID(sourceUUID))
+		copy(payload[24:40], parseGPUUUID(sourceUUID))
+		return vmmResponse{
+			header:  vmmHeader{Operation: operation, Count: 1},
+			payload: payload,
+			fd:      -1,
+		}
+	}
+	owner := serveVMMProcess(
+		t, "", participantA,
+		func(request vmmResponse) (vmmResponse, error) {
+			switch request.header.Operation {
+			case vmmQueryPlacement:
+				return placementResponse(vmmQueryPlacement), nil
+			case vmmRestoreOwner:
+				if request.header.HandleType != vmmHandleFabric ||
+					request.fd >= 0 {
+					return vmmResponse{}, errors.New("invalid FABRIC owner request shape")
+				}
+				if err := validateVMMRestoreRequest(
+					request, 1, vmmOwner, contents,
+				); err != nil {
+					return vmmResponse{}, err
+				}
+				events <- "owner"
+				return vmmResponse{
+					header: vmmHeader{
+						Operation:  vmmRestoreOwner,
+						HandleType: vmmHandleFabric,
+					},
+					payload: append([]byte(nil), raw...),
+					fd:      -1,
+				}, nil
+			case vmmIdentify:
+				return vmmResponse{
+					header: vmmHeader{
+						Operation:   vmmIdentify,
+						Participant: participantA,
+					},
+					fd: -1,
+				}, nil
+			default:
+				return vmmResponse{}, fmt.Errorf(
+					"unexpected owner operation %d", request.header.Operation,
+				)
+			}
+		},
+	)
+	importer := serveVMMProcess(
+		t, "", participantB,
+		func(request vmmResponse) (vmmResponse, error) {
+			switch request.header.Operation {
+			case vmmQueryPlacement:
+				return placementResponse(vmmQueryPlacement), nil
+			case vmmRestoreImporter:
+				if request.header.HandleType != vmmHandleFabric ||
+					request.fd >= 0 ||
+					len(request.payload) < vmmRecordSize+vmmFabricHandleSize ||
+					!bytes.Equal(
+						request.payload[len(request.payload)-vmmFabricHandleSize:],
+						raw,
+					) {
+					return vmmResponse{}, errors.New(
+						"invalid FABRIC importer request shape",
+					)
+				}
+				metadata := request.payload[:len(request.payload)-vmmFabricHandleSize]
+				request.payload = metadata
+				if err := validateVMMRestoreRequest(
+					request, 1, vmmImporter, nil,
+				); err != nil {
+					return vmmResponse{}, err
+				}
+				events <- "importer"
+				return vmmResponse{
+					header: vmmHeader{Operation: vmmRestoreImporter},
+					fd:     -1,
+				}, nil
+			case vmmIdentify:
+				return vmmResponse{
+					header: vmmHeader{
+						Operation:   vmmIdentify,
+						Participant: participantB,
+					},
+					fd: -1,
+				}, nil
+			default:
+				return vmmResponse{}, fmt.Errorf(
+					"unexpected importer operation %d",
+					request.header.Operation,
+				)
+			}
+		},
+	)
+	loaded := map[string][]byte{
+		vmmRedisKey(generation, "state"):      []byte("detached"),
+		vmmRedisKey(generation, "ledger"):     encoded,
+		vmmRedisKey(generation, "digest"):     []byte(expectedDigest),
+		vmmRedisKey(generation, "resource:1"): contents,
+	}
+	t.Setenv(VMMRedisAddressEnv, serveVMMRestoreRedis(t, loaded, nil))
+	t.Setenv(VMMRedisRDBPathEnv, "")
+	t.Setenv(VMMRedisRestoreCmdEnv, "/bin/true")
+	t.Setenv("NODE_NAME", "node-a")
+	if err := RestoreVMM(
+		context.Background(),
+		[]VMMProcess{owner, importer},
+		generation,
+		expectedDigest,
+		t.TempDir(),
+		func() error {
+			events <- "unlock"
+			return nil
+		},
+		logr.Discard(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	got := []string{<-events, <-events, <-events}
+	want := []string{"unlock", "owner", "importer"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("FABRIC restore events = %v, want %v", got, want)
+	}
+}
+
+func TestVMMProtocolV3HandleTypeLayout(t *testing.T) {
+	encoded := encodeVMMHeader(vmmHeader{
+		Operation:  vmmRestoreOwner,
+		HandleType: vmmHandleFabric,
+	})
+	if got := binary.LittleEndian.Uint16(encoded[4:6]); got != 3 {
+		t.Fatalf("protocol version = %d, want 3", got)
+	}
+	if got := binary.LittleEndian.Uint32(encoded[16:20]); got != vmmHandleFabric {
+		t.Fatalf("header handle type = %d, want %d", got, vmmHandleFabric)
+	}
+	if got := binary.LittleEndian.Uint32(encoded[20:24]); got != 0 {
+		t.Fatalf("header reserved word = %d, want 0", got)
+	}
+	if len(encoded) != vmmHeaderSize {
+		t.Fatalf("header size = %d, want %d", len(encoded), vmmHeaderSize)
+	}
+	decoded, err := decodeVMMHeader(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.HandleType != vmmHandleFabric {
+		t.Fatalf(
+			"decoded handle type = %d, want %d",
+			decoded.HandleType, vmmHandleFabric,
+		)
+	}
+	encoded[255] = 1
+	if _, err := decodeVMMHeader(encoded); err == nil {
+		t.Fatal("nonzero final reserved header byte was accepted")
+	}
+}
+
+func TestValidateVMMLedgerExactHandleTypes(t *testing.T) {
+	const (
+		owner        = "11111111111111111111111111111111"
+		importer     = "22222222222222222222222222222222"
+		sourceUUID   = "00112233-4455-6677-8899-aabbccddeeff"
+		resourceID   = uint64(1)
+		resourceSize = uint64(4096)
+	)
+	mapping := func(participant string, handleType uint32) vmmMapping {
+		return vmmMapping{
+			Participant:         participant,
+			Address:             0x1000,
+			Size:                resourceSize,
+			GPUUUID:             sourceUUID,
+			RequestedHandleType: handleType,
+			Access:              []byte{1},
+			AccessCount:         1,
+			AccessSize:          1,
+		}
+	}
+	ledger := func(ownerType, importerType uint32) vmmLedger {
+		return vmmLedger{
+			Version: vmmLedgerVersion,
+			Participants: []vmmParticipant{
+				{
+					ID: owner,
+					Placement: vmmPlacement{
+						Node: "node-a", GPUUUIDs: []string{sourceUUID},
+					},
+				},
+				{
+					ID: importer,
+					Placement: vmmPlacement{
+						Node: "node-a", GPUUUIDs: []string{sourceUUID},
+					},
+				},
+			},
+			Resources: []vmmResource{{
+				ID:        resourceID,
+				Kind:      "allocation",
+				Owner:     mapping(owner, ownerType),
+				Importers: []vmmMapping{mapping(importer, importerType)},
+			}},
+		}
+	}
+	for _, handleType := range []uint32{vmmHandlePOSIX, vmmHandleFabric} {
+		if err := validateVMMLedger(ledger(handleType, handleType)); err != nil {
+			t.Fatalf("exact handle type %d rejected: %v", handleType, err)
+		}
+	}
+	if err := validateVMMLedger(ledger(9, 9)); err == nil {
+		t.Fatal("combined POSIX|FABRIC handle type was accepted")
+	}
+	if err := validateVMMLedger(
+		ledger(vmmHandlePOSIX, vmmHandleFabric),
+	); err == nil {
+		t.Fatal("mixed owner/importer handle types were accepted")
+	}
+	atLimit := ledger(vmmHandlePOSIX, vmmHandlePOSIX)
+	atLimit.Resources[0].Owner.Size = vmmMaximumRedisBulk
+	atLimit.Resources[0].Importers[0].Size = vmmMaximumRedisBulk
+	if err := validateVMMLedger(atLimit); err != nil {
+		t.Fatalf("allocation at the Redis bulk limit was rejected: %v", err)
+	}
+	for _, role := range []string{"owner", "importer"} {
+		t.Run(role+" above allocation limit", func(t *testing.T) {
+			aboveLimit := ledger(vmmHandlePOSIX, vmmHandlePOSIX)
+			if role == "owner" {
+				aboveLimit.Resources[0].Owner.Size =
+					vmmMaximumRedisBulk + 1
+			} else {
+				aboveLimit.Resources[0].Importers[0].Size =
+					vmmMaximumRedisBulk + 1
+			}
+			if err := validateVMMLedger(aboveLimit); err == nil {
+				t.Fatal("mapping above the Redis bulk limit was accepted")
+			}
+		})
+	}
+}
+
+func TestVMMBrokerResultShapesAndCleanup(t *testing.T) {
+	t.Run("fabric", func(t *testing.T) {
+		raw := bytes.Repeat([]byte{0xa5}, vmmFabricHandleSize)
+		response := vmmResponse{
+			header:  vmmHeader{HandleType: vmmHandleFabric},
+			payload: raw,
+			fd:      -1,
+		}
+		result, err := takeVMMBrokerResult(&response, vmmHandleFabric)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.fd >= 0 || len(result.bytes) != vmmFabricHandleSize {
+			t.Fatalf("FABRIC broker result = %#v", result)
+		}
+		if err := closeVMMBrokerResult(&result); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(raw, make([]byte, vmmFabricHandleSize)) {
+			t.Fatal("FABRIC broker cleanup did not wipe raw bytes")
+		}
+	})
+	t.Run("posix rejects payload and closes fd", func(t *testing.T) {
+		fd, err := unix.MemfdCreate("vmm-broker-shape", unix.MFD_CLOEXEC)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := []byte{1}
+		response := vmmResponse{
+			header:  vmmHeader{HandleType: vmmHandlePOSIX},
+			payload: payload,
+			fd:      fd,
+		}
+		if _, err := takeVMMBrokerResult(
+			&response, vmmHandlePOSIX,
+		); err == nil {
+			t.Fatal("POSIX broker response with payload was accepted")
+		}
+		if payload[0] != 0 || response.fd != -1 {
+			t.Fatal("invalid POSIX broker result was not cleaned")
+		}
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0); err == nil {
+			t.Fatal("invalid POSIX broker FD remained open")
+		}
+	})
+}
+
+func TestVMMFabricImporterTransportIsTransient(t *testing.T) {
+	metadata := []byte{1, 2, 3}
+	raw := bytes.Repeat([]byte{0x7b}, vmmFabricHandleSize)
+	payload, fd, err := vmmImporterTransport(metadata, vmmBrokerResult{
+		handleType: vmmHandleFabric,
+		fd:         -1,
+		bytes:      raw,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd >= 0 || len(payload) != len(metadata)+vmmFabricHandleSize ||
+		!bytes.Equal(payload[:len(metadata)], metadata) ||
+		!bytes.Equal(payload[len(metadata):], raw) {
+		t.Fatalf("FABRIC importer transport has invalid shape: fd=%d len=%d", fd, len(payload))
+	}
+	payload[0] = 0xff
+	payload[len(metadata)] = 0
+	if metadata[0] != 1 || raw[0] != 0x7b {
+		t.Fatal("FABRIC importer transport aliases durable metadata or broker bytes")
 	}
 }
 
@@ -85,6 +498,27 @@ func TestRestoreVMMProcessesUsesNamespacePIDSocket(t *testing.T) {
 	}
 	if process.Participant != participant {
 		t.Fatalf("participant = %q, want %q", process.Participant, participant)
+	}
+}
+
+func TestIdentifyVMMProcessRequiresLowercaseHexParticipant(t *testing.T) {
+	tests := []string{
+		"",
+		"1111111111111111111111111111111",
+		"111111111111111111111111111111111",
+		"1111111111111111111111111111111A",
+		"1111111111111111111111111111111g",
+	}
+	for _, participant := range tests {
+		t.Run(fmt.Sprintf("%q", participant), func(t *testing.T) {
+			endpoint := serveVMMProcess(t, "", participant, nil)
+			_, err := identifyVMMProcess(VMMProcess{
+				SocketPath: endpoint.SocketPath,
+			})
+			if err == nil {
+				t.Fatalf("identify participant %q was accepted", participant)
+			}
+		})
 	}
 }
 
@@ -235,7 +669,7 @@ func TestRestoreVMMUnlockBoundary(t *testing.T) {
 		}
 	}
 	ledger := vmmLedger{
-		Version:    1,
+		Version:    vmmLedgerVersion,
 		Generation: generation,
 		Participants: []vmmParticipant{
 			{ID: participantA, Placement: vmmPlacement{Node: "node-a", GPUUUIDs: []string{sourceUUID}}},
@@ -412,6 +846,89 @@ func TestInspectVMMRejectsUnsupportedGraph(t *testing.T) {
 	}
 }
 
+func TestPrepareVMMRejectsOversizedAllocationBeforeOwnerRead(t *testing.T) {
+	const (
+		owner      = "11111111111111111111111111111111"
+		importer   = "22222222222222222222222222222222"
+		sourceUUID = "00112233-4455-6677-8899-aabbccddeeff"
+	)
+	allocationUUID := [16]byte{1}
+	operations := make(chan uint16, 3)
+	process := func(participant string, record vmmCaptureRecord) VMMProcess {
+		return serveVMMProcess(
+			t, "", participant,
+			func(request vmmResponse) (vmmResponse, error) {
+				operations <- request.header.Operation
+				if request.header.Operation != vmmInspect {
+					return vmmResponse{}, fmt.Errorf(
+						"unexpected VMM operation %d",
+						request.header.Operation,
+					)
+				}
+				payload := encodeVMMRecordsForTest(
+					[]vmmCaptureRecord{record},
+				)
+				return vmmResponse{
+					header: vmmHeader{
+						Operation: vmmInspect,
+						Count:     1,
+					},
+					payload: payload,
+					fd:      -1,
+				}, nil
+			},
+		)
+	}
+	mapping := func(role uint32, address uint64) vmmCaptureRecord {
+		record := vmmCaptureRecord{
+			allocationUUID: allocationUUID,
+			address:        address,
+			size:           vmmMaximumRedisBulk + 1,
+			role:           role,
+			gpuUUID:        sourceUUID,
+			access:         []byte{1},
+			accessCount:    1,
+			accessSize:     1,
+		}
+		if role == vmmOwner {
+			record.properties = []byte{1}
+		}
+		return record
+	}
+	t.Setenv(VMMRedisAddressEnv, "127.0.0.1:1")
+	t.Setenv(VMMRedisRDBPathEnv, filepath.Join(t.TempDir(), "dump.rdb"))
+	t.Setenv("NODE_NAME", "node-a")
+	_, err := PrepareVMM(
+		context.Background(),
+		[]VMMProcess{
+			process(owner, mapping(vmmOwner, 0x1000)),
+			process(importer, mapping(vmmImporter, 0x2000)),
+		},
+		"generation",
+		t.TempDir(),
+		logr.Discard(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "allocation limit") {
+		t.Fatalf("oversized checkpoint error = %v, want allocation limit", err)
+	}
+	for index := 0; index < 2; index++ {
+		if operation := <-operations; operation != vmmInspect {
+			t.Fatalf(
+				"checkpoint operation %d = %d, want INSPECT",
+				index, operation,
+			)
+		}
+	}
+	select {
+	case operation := <-operations:
+		t.Fatalf(
+			"oversized checkpoint reached operation %d after inspection",
+			operation,
+		)
+	default:
+	}
+}
+
 func TestDecodeVMMRecordsRejectsZeroAllocationUUID(t *testing.T) {
 	payload := encodeVMMRecordsForTest([]vmmCaptureRecord{{
 		address:     0x1000,
@@ -430,7 +947,7 @@ func TestDecodeVMMRecordsRejectsZeroAllocationUUID(t *testing.T) {
 func TestInspectVMMBuildsDeterministicGraph(t *testing.T) {
 	const ownerID = "11111111111111111111111111111111"
 	const importerID = "22222222222222222222222222222222"
-	owner := serveVMMInspect(t, []vmmCaptureRecord{{
+	owner := serveVMMInspectAs(t, ownerID, []vmmCaptureRecord{{
 		allocationUUID: [16]byte{9, 8},
 		address:        0x2000,
 		size:           4096,
@@ -440,8 +957,7 @@ func TestInspectVMMBuildsDeterministicGraph(t *testing.T) {
 		accessCount:    1,
 		accessSize:     2,
 	}})
-	owner.Participant = ownerID
-	importer := serveVMMInspect(t, []vmmCaptureRecord{{
+	importer := serveVMMInspectAs(t, importerID, []vmmCaptureRecord{{
 		allocationUUID: [16]byte{9, 8},
 		address:        0x4000,
 		size:           4096,
@@ -450,8 +966,6 @@ func TestInspectVMMBuildsDeterministicGraph(t *testing.T) {
 		accessCount:    1,
 		accessSize:     2,
 	}})
-	importer.Participant = importerID
-
 	ledger, err := inspectVMM(
 		context.Background(),
 		[]VMMProcess{importer, owner},
@@ -537,11 +1051,11 @@ func TestInspectVMMGraphEncodingIsIndependentOfDiscoveryOrder(t *testing.T) {
 		}
 		var processes []VMMProcess
 		for _, specification := range specifications {
-			process := serveVMMInspect(
+			process := serveVMMInspectAs(
 				t,
+				specification.participant,
 				[]vmmCaptureRecord{specification.record},
 			)
-			process.Participant = specification.participant
 			processes = append(processes, process)
 		}
 		if reverse {
@@ -593,9 +1107,7 @@ func TestInspectVMMKeepsIndependentOwnerUUIDsSeparate(t *testing.T) {
 		return record
 	}
 	process := func(participant string, record vmmCaptureRecord) VMMProcess {
-		result := serveVMMInspect(t, []vmmCaptureRecord{record})
-		result.Participant = participant
-		return result
+		return serveVMMInspectAs(t, participant, []vmmCaptureRecord{record})
 	}
 	uuidA := [16]byte{1}
 	uuidB := [16]byte{2}
@@ -961,13 +1473,155 @@ func TestExchangeVMMPreservesPayloadCoalescedWithHeader(t *testing.T) {
 		vmmHeader{Operation: vmmIdentify},
 		nil,
 		-1,
-		vmmResponseFDNone,
+		vmmResponseUntyped,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(response.payload, want) {
 		t.Fatalf("payload = %q, want %q", response.payload, want)
+	}
+}
+
+func TestExchangeVMMBindsEstablishedParticipant(t *testing.T) {
+	const participant = "11111111111111111111111111111111"
+	process := serveVMMProcess(
+		t,
+		"",
+		participant,
+		func(request vmmResponse) (vmmResponse, error) {
+			if request.header.Participant != participant {
+				return vmmResponse{}, fmt.Errorf(
+					"request participant = %q, want %q",
+					request.header.Participant,
+					participant,
+				)
+			}
+			return vmmResponse{
+				header: vmmHeader{Operation: request.header.Operation},
+				fd:     -1,
+			}, nil
+		},
+	)
+	if _, err := exchangeVMM(
+		context.Background(),
+		process,
+		vmmHeader{Operation: vmmInspect},
+		nil,
+		-1,
+		vmmResponseUntyped,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExchangeVMMRejectsWrongResponseParticipant(t *testing.T) {
+	const (
+		participant = "11111111111111111111111111111111"
+		wrong       = "22222222222222222222222222222222"
+	)
+	process := serveVMMProcess(
+		t,
+		"",
+		participant,
+		func(request vmmResponse) (vmmResponse, error) {
+			return vmmResponse{
+				header: vmmHeader{
+					Operation:   request.header.Operation,
+					Participant: wrong,
+				},
+				fd: -1,
+			}, nil
+		},
+	)
+	if _, err := exchangeVMM(
+		context.Background(),
+		process,
+		vmmHeader{Operation: vmmInspect},
+		nil,
+		-1,
+		vmmResponseUntyped,
+	); err == nil || !strings.Contains(err.Error(), "response participant") {
+		t.Fatalf("wrong response participant error = %v", err)
+	}
+}
+
+func TestExchangeVMMRejectsTypedBrokerShapeBeforeReadingPayload(t *testing.T) {
+	const participant = "11111111111111111111111111111111"
+	tests := []struct {
+		name        string
+		expectation vmmResponseExpectation
+		handleType  uint32
+		payloadSize uint64
+	}{
+		{
+			name:        "oversized fabric declaration",
+			expectation: vmmResponseFabricBroker,
+			handleType:  vmmHandleFabric,
+			payloadSize: vmmFabricHandleSize + 1,
+		},
+		{
+			name:        "short fabric declaration",
+			expectation: vmmResponseFabricBroker,
+			handleType:  vmmHandleFabric,
+			payloadSize: vmmFabricHandleSize - 1,
+		},
+		{
+			name:        "POSIX declaration with payload",
+			expectation: vmmResponsePOSIXBroker,
+			handleType:  vmmHandlePOSIX,
+			payloadSize: 1,
+		},
+		{
+			name:        "wrong typed handle",
+			expectation: vmmResponseFabricBroker,
+			handleType:  vmmHandlePOSIX,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "vmm.sock")
+			listener, err := net.Listen("unix", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				connection, err := listener.Accept()
+				if err != nil {
+					return
+				}
+				defer connection.Close()
+				request := make([]byte, vmmHeaderSize)
+				if _, err := io.ReadFull(connection, request); err != nil {
+					return
+				}
+				_ = writeVMMBytes(connection, encodeVMMHeader(vmmHeader{
+					Operation:   vmmRestoreOwner,
+					HandleType:  test.handleType,
+					PayloadSize: test.payloadSize,
+					Participant: participant,
+				}))
+			}()
+
+			_, err = exchangeVMM(
+				context.Background(),
+				VMMProcess{
+					SocketPath:  path,
+					Participant: participant,
+				},
+				vmmHeader{Operation: vmmRestoreOwner},
+				nil,
+				-1,
+				test.expectation,
+			)
+			<-done
+			if err == nil {
+				t.Fatal("invalid typed broker response was accepted")
+			}
+		})
 	}
 }
 
@@ -1029,7 +1683,7 @@ func testExchangeVMMClosesReceivedFD(t *testing.T, response []byte) {
 		vmmHeader{Operation: vmmIdentify},
 		nil,
 		-1,
-		vmmResponseFDNone,
+		vmmResponseUntyped,
 	)
 	<-done
 	if err == nil {
@@ -1041,6 +1695,7 @@ func testExchangeVMMClosesReceivedFD(t *testing.T, response []byte) {
 }
 
 func TestExchangeVMMRejectsMissingRequiredFD(t *testing.T) {
+	const participant = "11111111111111111111111111111111"
 	path := filepath.Join(t.TempDir(), "vmm.sock")
 	listener, err := net.Listen("unix", path)
 	if err != nil {
@@ -1058,17 +1713,19 @@ func TestExchangeVMMRejectsMissingRequiredFD(t *testing.T) {
 			return
 		}
 		_ = writeVMMBytes(connection, encodeVMMHeader(vmmHeader{
-			Operation: vmmRestoreOwner,
+			Operation:   vmmRestoreOwner,
+			HandleType:  vmmHandlePOSIX,
+			Participant: participant,
 		}))
 	}()
 
 	if _, err := exchangeVMM(
 		context.Background(),
-		VMMProcess{SocketPath: path},
+		VMMProcess{SocketPath: path, Participant: participant},
 		vmmHeader{Operation: vmmRestoreOwner},
 		nil,
 		-1,
-		vmmResponseFDRequired,
+		vmmResponsePOSIXBroker,
 	); err == nil {
 		t.Fatal("missing required response FD was accepted")
 	}
@@ -1168,10 +1825,23 @@ func serveVMMInspect(
 	records []vmmCaptureRecord,
 ) VMMProcess {
 	t.Helper()
+	return serveVMMInspectAs(
+		t,
+		"11111111111111111111111111111111",
+		records,
+	)
+}
+
+func serveVMMInspectAs(
+	t *testing.T,
+	participant string,
+	records []vmmCaptureRecord,
+) VMMProcess {
+	t.Helper()
 	return serveVMMProcess(
 		t,
 		"",
-		"11111111111111111111111111111111",
+		participant,
 		func(request vmmResponse) (vmmResponse, error) {
 			if request.header.Operation != vmmInspect {
 				return vmmResponse{}, fmt.Errorf(
@@ -1375,6 +2045,7 @@ func serveVMMRestoreProcess(
 				return response, nil
 			}
 			var err error
+			response.header.HandleType = request.header.HandleType
 			response.fd, err = unix.MemfdCreate("vmm-restore-owner", unix.MFD_CLOEXEC)
 			return response, err
 		case vmmRestoreImporter:
@@ -1416,7 +2087,9 @@ func validateVMMRestoreRequest(
 		!bytes.Equal(request.payload[metadataSize:], wantContents) {
 		return fmt.Errorf("invalid resource %d replay contents", resourceID)
 	}
-	if (request.fd >= 0) != (wantRole == vmmImporter) {
+	wantFD := wantRole == vmmImporter &&
+		request.header.HandleType == vmmHandlePOSIX
+	if (request.fd >= 0) != wantFD {
 		return fmt.Errorf("invalid resource %d replay FD", resourceID)
 	}
 	return nil
@@ -1446,14 +2119,28 @@ func serveVMMProcess(
 			}
 			request, err := readVMMTestRequest(connection)
 			if err == nil {
+				if request.header.Participant != "" &&
+					request.header.Participant != participant {
+					err = fmt.Errorf(
+						"request participant %q does not match endpoint %q",
+						request.header.Participant,
+						participant,
+					)
+				} else if request.header.Operation != vmmIdentify &&
+					request.header.Participant == "" {
+					err = errors.New("established request omitted participant")
+				}
 				response := vmmResponse{
 					header: vmmHeader{Operation: vmmIdentify, Participant: participant},
 					fd:     -1,
 				}
-				if handler != nil {
+				if err == nil && handler != nil {
 					response, err = handler(request)
 				}
 				if err == nil {
+					if response.header.Participant == "" {
+						response.header.Participant = participant
+					}
 					err = writeVMMTestResponse(connection, response)
 				}
 				err = errors.Join(err, closeVMMFD(&response.fd))

--- a/deploy/snapshot/internal/cuda/vmm_interpose_test.go
+++ b/deploy/snapshot/internal/cuda/vmm_interpose_test.go
@@ -19,9 +19,12 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sys/unix"
+
+	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 )
 
 func TestDetectVMMInterposeRequiresUniformLauncherScope(t *testing.T) {
@@ -49,41 +52,191 @@ func TestDetectVMMInterposeRequiresUniformLauncherScope(t *testing.T) {
 	}
 }
 
-func TestValidateVMMResponseShapeRejectsTypedPayloadBeforeAllocation(t *testing.T) {
+func TestExchangeVMMRejectsNonemptySuccessBeforeReadingPayload(t *testing.T) {
+	const participant = "11111111111111111111111111111111"
+	path := filepath.Join(t.TempDir(), "vmm.sock")
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	releasePeer := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		connection, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer connection.Close()
+		request := make([]byte, vmmHeaderSize)
+		if _, err := io.ReadFull(connection, request); err != nil {
+			return
+		}
+		_ = writeVMMBytes(connection, encodeVMMHeader(vmmHeader{
+			Operation:      vmmSetPlacement,
+			Count:          1,
+			AllocationUUID: [16]byte{1},
+			ObjectID:       1,
+			PayloadSize:    1,
+			Message:        "unexpected",
+			Participant:    participant,
+		}))
+		<-releasePeer
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err = exchangeVMM(
+		ctx,
+		VMMProcess{SocketPath: path, Participant: participant},
+		vmmHeader{Operation: vmmSetPlacement},
+		nil,
+		-1,
+		vmmResponseEmpty,
+	)
+	close(releasePeer)
+	<-done
+	if err == nil || !strings.Contains(err.Error(), "nonempty success response") {
+		t.Fatalf("nonempty SET_PLACEMENT response error = %v", err)
+	}
+}
+
+func TestVMMPlacementPayloadSizeLimit(t *testing.T) {
+	maximumCount := vmmMaximumRedisBulk / vmmPlacementSize
+	size, err := vmmPlacementPayloadSize(maximumCount)
+	if err != nil || size != maximumCount*vmmPlacementSize {
+		t.Fatalf("maximum placement payload size = %d, %v", size, err)
+	}
+	if _, err := vmmPlacementPayloadSize(maximumCount + 1); err == nil {
+		t.Fatal("placement payload above the C limit was accepted")
+	}
+}
+
+func TestSetRestoredVMMPlacementEmptyExtraEndpoint(t *testing.T) {
+	const (
+		participant = "11111111111111111111111111111111"
+		extra       = "22222222222222222222222222222222"
+		sourceUUID  = "00112233-4455-6677-8899-aabbccddeeff"
+	)
+	managed := serveVMMProcess(t, "", participant, func(
+		request vmmResponse,
+	) (vmmResponse, error) {
+		if err := validateVMMPlacementRequest(
+			request, sourceUUID, sourceUUID, 0,
+		); err != nil {
+			return vmmResponse{}, err
+		}
+		return vmmResponse{
+			header: vmmHeader{Operation: vmmSetPlacement},
+			fd:     -1,
+		}, nil
+	})
+	extraEndpoint := func(t *testing.T, reject bool) VMMProcess {
+		return serveVMMProcess(t, "", extra, func(
+			request vmmResponse,
+		) (vmmResponse, error) {
+			if request.header.Operation != vmmSetPlacement ||
+				request.header.Count != 0 ||
+				len(request.payload) != 0 {
+				return vmmResponse{}, errors.New("extra endpoint received nonempty setup")
+			}
+			response := vmmResponse{
+				header: vmmHeader{Operation: vmmSetPlacement},
+				fd:     -1,
+			}
+			if reject {
+				response.header.Status = -1
+				response.header.Message = "detached CUDA placement metadata is inconsistent"
+			}
+			return response, nil
+		})
+	}
+	payload, err := encodeVMMPlacement([]types.VMMPlacement{{
+		SourceGPUUUID: sourceUUID,
+		TargetGPUUUID: sourceUUID,
+		TargetOrdinal: 0,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name      string
+		reject    bool
+		wantError bool
+	}{
+		{name: "zero-managed endpoint accepts empty setup"},
+		{name: "managed endpoint rejects empty setup", reject: true, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := setRestoredVMMPlacement(
+				context.Background(),
+				[]vmmPlacementSetup{
+					{process: managed, count: 1, payload: payload},
+					{process: extraEndpoint(t, test.reject)},
+				},
+			)
+			if (err != nil) != test.wantError {
+				t.Fatalf("set placement error = %v, wantError=%t", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateVMMResponseShapeRejectsInvalidShapeBeforeAllocation(t *testing.T) {
 	tests := []struct {
 		name        string
 		expectation vmmResponseExpectation
-		handleType  uint32
-		payloadSize uint64
+		response    vmmHeader
 		fdCount     int
 	}{
 		{
 			name:        "oversized fabric payload",
 			expectation: vmmResponseFabricBroker,
-			handleType:  vmmHandleFabric,
-			payloadSize: vmmFabricHandleSize + 1,
+			response: vmmHeader{
+				HandleType:  vmmHandleFabric,
+				PayloadSize: vmmFabricHandleSize + 1,
+			},
 		},
 		{
 			name:        "POSIX payload",
 			expectation: vmmResponsePOSIXBroker,
-			handleType:  vmmHandlePOSIX,
-			payloadSize: 1,
-			fdCount:     1,
+			response: vmmHeader{
+				HandleType:  vmmHandlePOSIX,
+				PayloadSize: 1,
+			},
+			fdCount: 1,
 		},
 		{
 			name:        "wrong handle type",
 			expectation: vmmResponseFabricBroker,
-			handleType:  vmmHandlePOSIX,
+			response:    vmmHeader{HandleType: vmmHandlePOSIX},
+		},
+		{
+			name:        "empty response count",
+			expectation: vmmResponseEmpty,
+			response:    vmmHeader{Count: 1},
+		},
+		{
+			name:        "empty response object metadata",
+			expectation: vmmResponseEmpty,
+			response: vmmHeader{
+				ObjectID:       1,
+				AllocationUUID: [16]byte{1},
+				Message:        "unexpected",
+			},
+		},
+		{
+			name:        "empty response FD",
+			expectation: vmmResponseEmpty,
+			fdCount:     1,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := validateVMMResponseShape(
 				vmmRestoreOwner,
-				vmmHeader{
-					HandleType:  test.handleType,
-					PayloadSize: test.payloadSize,
-				},
+				test.response,
 				test.expectation,
 				test.fdCount,
 			)
@@ -151,29 +304,27 @@ func TestRestoreVMMFabricTransport(t *testing.T) {
 	writeVMMDigestObject(digest, 1, contents)
 	expectedDigest := hex.EncodeToString(digest.Sum(nil))
 	events := make(chan string, 8)
-	placementResponse := func(operation uint16) vmmResponse {
-		payload := make([]byte, vmmPlacementSize)
-		copy(payload[8:24], parseGPUUUID(sourceUUID))
-		copy(payload[24:40], parseGPUUUID(sourceUUID))
-		return vmmResponse{
-			header:  vmmHeader{Operation: operation, Count: 1},
-			payload: payload,
-			fd:      -1,
-		}
-	}
 	owner := serveVMMProcess(
 		t, "", participantA,
 		func(request vmmResponse) (vmmResponse, error) {
 			switch request.header.Operation {
-			case vmmQueryPlacement:
-				return placementResponse(vmmQueryPlacement), nil
+			case vmmSetPlacement:
+				if err := validateVMMPlacementRequest(
+					request, sourceUUID, sourceUUID, 0,
+				); err != nil {
+					return vmmResponse{}, err
+				}
+				return vmmResponse{
+					header: vmmHeader{Operation: vmmSetPlacement},
+					fd:     -1,
+				}, nil
 			case vmmRestoreOwner:
 				if request.header.HandleType != vmmHandleFabric ||
 					request.fd >= 0 {
 					return vmmResponse{}, errors.New("invalid FABRIC owner request shape")
 				}
 				if err := validateVMMRestoreRequest(
-					request, 1, vmmOwner, contents,
+					request, 1, vmmOwner, 0, contents,
 				); err != nil {
 					return vmmResponse{}, err
 				}
@@ -205,8 +356,16 @@ func TestRestoreVMMFabricTransport(t *testing.T) {
 		t, "", participantB,
 		func(request vmmResponse) (vmmResponse, error) {
 			switch request.header.Operation {
-			case vmmQueryPlacement:
-				return placementResponse(vmmQueryPlacement), nil
+			case vmmSetPlacement:
+				if err := validateVMMPlacementRequest(
+					request, sourceUUID, sourceUUID, 0,
+				); err != nil {
+					return vmmResponse{}, err
+				}
+				return vmmResponse{
+					header: vmmHeader{Operation: vmmSetPlacement},
+					fd:     -1,
+				}, nil
 			case vmmRestoreImporter:
 				if request.header.HandleType != vmmHandleFabric ||
 					request.fd >= 0 ||
@@ -222,7 +381,7 @@ func TestRestoreVMMFabricTransport(t *testing.T) {
 				metadata := request.payload[:len(request.payload)-vmmFabricHandleSize]
 				request.payload = metadata
 				if err := validateVMMRestoreRequest(
-					request, 1, vmmImporter, nil,
+					request, 1, vmmImporter, 0, nil,
 				); err != nil {
 					return vmmResponse{}, err
 				}
@@ -263,6 +422,11 @@ func TestRestoreVMMFabricTransport(t *testing.T) {
 		generation,
 		expectedDigest,
 		t.TempDir(),
+		[]types.VMMPlacement{{
+			SourceGPUUUID: sourceUUID,
+			TargetGPUUUID: sourceUUID,
+			TargetOrdinal: 0,
+		}},
 		func() error {
 			events <- "unlock"
 			return nil
@@ -278,13 +442,13 @@ func TestRestoreVMMFabricTransport(t *testing.T) {
 	}
 }
 
-func TestVMMProtocolV3HandleTypeLayout(t *testing.T) {
+func TestVMMProtocolV4HandleTypeLayout(t *testing.T) {
 	encoded := encodeVMMHeader(vmmHeader{
 		Operation:  vmmRestoreOwner,
 		HandleType: vmmHandleFabric,
 	})
-	if got := binary.LittleEndian.Uint16(encoded[4:6]); got != 3 {
-		t.Fatalf("protocol version = %d, want 3", got)
+	if got := binary.LittleEndian.Uint16(encoded[4:6]); got != 4 {
+		t.Fatalf("protocol version = %d, want 4", got)
 	}
 	if got := binary.LittleEndian.Uint32(encoded[16:20]); got != vmmHandleFabric {
 		t.Fatalf("header handle type = %d, want %d", got, vmmHandleFabric)
@@ -637,6 +801,7 @@ func TestRestoreVMMRejectsNoOpRestoreCommand(t *testing.T) {
 		generation,
 		"00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 		t.TempDir(),
+		nil,
 		func() error {
 			t.Fatal("preflight failure invoked unlock callback")
 			return nil
@@ -652,6 +817,7 @@ func TestRestoreVMMUnlockBoundary(t *testing.T) {
 	const (
 		generation   = "00112233445566778899aabbccddeeff"
 		sourceUUID   = "00112233-4455-6677-8899-aabbccddeeff"
+		otherUUID    = "ffeeddcc-bbaa-9988-7766-554433221100"
 		participantA = "11111111111111111111111111111111"
 		participantB = "22222222222222222222222222222222"
 	)
@@ -700,19 +866,20 @@ func TestRestoreVMMUnlockBoundary(t *testing.T) {
 	t.Setenv(VMMRedisRestoreCmdEnv, "/bin/true")
 	t.Setenv("NODE_NAME", "node-a")
 	preflight := []string{
+		"content:1", "content:2",
 		"placement:1:owner,2:importer",
 		"placement:2:owner,1:importer",
-		"content:1", "content:2",
 	}
 
 	tests := []struct {
-		name          string
-		corruptSecond bool
-		unlockError   error
-		failOwner     uint64
-		wantError     string
-		replayEvents  []string
-		noUnlock      bool
+		name                  string
+		corruptSecond         bool
+		rejectSecondPlacement bool
+		unlockError           error
+		failOwner             uint64
+		wantError             string
+		replayEvents          []string
+		noUnlock              bool
 	}{
 		{
 			name: "success unlocks once after all preflight",
@@ -728,6 +895,12 @@ func TestRestoreVMMUnlockBoundary(t *testing.T) {
 			corruptSecond: true,
 			wantError:     "content digest",
 			noUnlock:      true,
+		},
+		{
+			name:                  "second placement rejection does not unlock",
+			rejectSecondPlacement: true,
+			wantError:             "placement rejected",
+			noUnlock:              true,
 		},
 		{
 			name:        "unlock failure sends no owner replay",
@@ -760,10 +933,12 @@ func TestRestoreVMMUnlockBoundary(t *testing.T) {
 
 			processes := []VMMProcess{
 				serveVMMRestoreProcess(
-					t, participantA, sourceUUID, contents, 1, test.failOwner, events,
+					t, participantA, sourceUUID, contents, 1, test.failOwner,
+					false, events,
 				),
 				serveVMMRestoreProcess(
-					t, participantB, sourceUUID, contents, 2, test.failOwner, events,
+					t, participantB, sourceUUID, contents, 2, test.failOwner,
+					test.rejectSecondPlacement, events,
 				),
 			}
 			err := RestoreVMM(
@@ -772,6 +947,18 @@ func TestRestoreVMMUnlockBoundary(t *testing.T) {
 				generation,
 				expectedDigest,
 				t.TempDir(),
+				[]types.VMMPlacement{
+					{
+						SourceGPUUUID: sourceUUID,
+						TargetGPUUUID: sourceUUID,
+						TargetOrdinal: 1,
+					},
+					{
+						SourceGPUUUID: otherUUID,
+						TargetGPUUUID: otherUUID,
+						TargetOrdinal: 0,
+					},
+				},
 				func() error {
 					events <- "unlock"
 					return test.unlockError
@@ -789,6 +976,9 @@ func TestRestoreVMMUnlockBoundary(t *testing.T) {
 				gotEvents = append(gotEvents, <-events)
 			}
 			wantEvents := slices.Clone(preflight)
+			if test.corruptSecond {
+				wantEvents = wantEvents[:2]
+			}
 			if !test.noUnlock {
 				wantEvents = append(wantEvents, "unlock")
 			}
@@ -1147,9 +1337,10 @@ func TestInspectVMMKeepsIndependentOwnerUUIDsSeparate(t *testing.T) {
 	}
 }
 
-func TestValidateRestoredVMMProcessesRequiresIdentityPlacement(t *testing.T) {
+func TestValidateRestoredVMMProcessesUsesAuthoritativePlacement(t *testing.T) {
 	const participant = "11111111111111111111111111111111"
 	const sourceUUID = "00112233-4455-6677-8899-aabbccddeeff"
+	const targetUUID = "ffeeddcc-bbaa-9988-7766-554433221100"
 	ledger := vmmLedger{Participants: []vmmParticipant{{
 		ID: participant,
 		Placement: vmmPlacement{
@@ -1160,42 +1351,46 @@ func TestValidateRestoredVMMProcessesRequiresIdentityPlacement(t *testing.T) {
 	tests := []struct {
 		name        string
 		currentNode string
-		currentUUID string
+		placement   []types.VMMPlacement
 		wantError   string
 	}{
 		{
-			name:        "exact identity",
+			name:        "authoritative remap",
 			currentNode: "node-a",
-			currentUUID: sourceUUID,
+			placement: []types.VMMPlacement{{
+				SourceGPUUUID: sourceUUID,
+				TargetGPUUUID: targetUUID,
+				TargetOrdinal: 0,
+			}},
 		},
 		{
-			name:        "same ordinal different UUID",
+			name:        "missing source UUID",
 			currentNode: "node-a",
-			currentUUID: "ffeeddcc-bbaa-9988-7766-554433221100",
-			wantError:   "currently maps GPU",
+			placement: []types.VMMPlacement{{
+				SourceGPUUUID: targetUUID,
+				TargetGPUUUID: sourceUUID,
+				TargetOrdinal: 0,
+			}},
+			wantError: "absent from the authoritative placement",
 		},
 		{
 			name:        "different current node",
 			currentNode: "node-b",
-			currentUUID: sourceUUID,
-			wantError:   "target node",
+			placement: []types.VMMPlacement{{
+				SourceGPUUUID: sourceUUID,
+				TargetGPUUUID: targetUUID,
+				TargetOrdinal: 0,
+			}},
+			wantError: "target node",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			process := serveVMMPlacement(
-				t,
-				participant,
-				7,
-				sourceUUID,
-				test.currentUUID,
-			)
-
-			placement, err := validateRestoredVMMProcesses(
-				context.Background(),
-				[]VMMProcess{process},
+			setups, placement, err := validateRestoredVMMProcesses(
+				[]VMMProcess{{Participant: participant}},
 				ledger,
 				test.currentNode,
+				test.placement,
 			)
 			if test.wantError != "" {
 				if err == nil || !strings.Contains(err.Error(), test.wantError) {
@@ -1206,8 +1401,20 @@ func TestValidateRestoredVMMProcessesRequiresIdentityPlacement(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := placement[participant][sourceUUID]; got != 7 {
-				t.Fatalf("validated ordinal = %d, want 7", got)
+			if len(setups) != 1 {
+				t.Fatalf("placement setup count = %d, want 1", len(setups))
+			}
+			if err := validateVMMPlacementPayload(
+				setups[0].count,
+				setups[0].payload,
+				sourceUUID,
+				targetUUID,
+				0,
+			); err != nil {
+				t.Fatal(err)
+			}
+			if got := placement[participant][sourceUUID]; got != 0 {
+				t.Fatalf("validated ordinal = %d, want 0", got)
 			}
 		})
 	}
@@ -1226,90 +1433,45 @@ func TestValidateRestoredVMMProcessesParticipantSet(t *testing.T) {
 			GPUUUIDs: []string{sourceUUID},
 		},
 	}}}
-	valid := func(t *testing.T) VMMProcess {
-		return serveVMMPlacement(t, participant, 7, sourceUUID, sourceUUID)
-	}
-	empty := func(t *testing.T, id string) VMMProcess {
-		return serveVMMPlacementResponse(t, id, 0, nil)
-	}
+	valid := VMMProcess{Participant: participant}
+	empty := VMMProcess{Participant: extra}
+	placementPlan := []types.VMMPlacement{{
+		SourceGPUUUID: sourceUUID,
+		TargetGPUUUID: sourceUUID,
+		TargetOrdinal: 0,
+	}}
 	tests := []struct {
 		name          string
-		processes     func(*testing.T) []VMMProcess
+		processes     []VMMProcess
 		wantError     string
 		wantPlacement bool
 	}{
 		{
-			name: "extra empty placement is ignored",
-			processes: func(t *testing.T) []VMMProcess {
-				return []VMMProcess{valid(t), empty(t, extra)}
-			},
+			name:          "extra empty placement is ignored",
+			processes:     []VMMProcess{valid, empty},
 			wantPlacement: true,
 		},
 		{
-			name: "extra managed placement is rejected",
-			processes: func(t *testing.T) []VMMProcess {
-				return []VMMProcess{
-					valid(t),
-					serveVMMPlacement(t, extra, 7, sourceUUID, sourceUUID),
-				}
-			},
-			wantError: "unexpected restored CUDA VMM participant",
-		},
-		{
-			name: "missing expected endpoint is rejected",
-			processes: func(t *testing.T) []VMMProcess {
-				return []VMMProcess{empty(t, extra)}
-			},
+			name:      "missing expected endpoint is rejected",
+			processes: []VMMProcess{empty},
 			wantError: "has no restored shim endpoint",
 		},
 		{
-			name: "expected empty placement is rejected",
-			processes: func(t *testing.T) []VMMProcess {
-				return []VMMProcess{empty(t, participant)}
-			},
-			wantError: "current GPU placement count is 0, want 1",
-		},
-		{
 			name: "duplicate participant is rejected",
-			processes: func(*testing.T) []VMMProcess {
-				return []VMMProcess{
-					{Participant: participant},
-					{Participant: participant},
-				}
+			processes: []VMMProcess{
+				{Participant: participant},
+				{Participant: participant},
 			},
 			wantError: "multiple restored shims claim participant",
-		},
-		{
-			name: "extra placement query error is rejected",
-			processes: func(t *testing.T) []VMMProcess {
-				return []VMMProcess{
-					valid(t),
-					{
-						Participant: extra,
-						SocketPath:  filepath.Join(t.TempDir(), "missing.sock"),
-					},
-				}
-			},
-			wantError: "query CUDA VMM participant",
-		},
-		{
-			name: "extra placement decode error is rejected",
-			processes: func(t *testing.T) []VMMProcess {
-				return []VMMProcess{
-					valid(t),
-					serveVMMPlacementResponse(t, extra, 1, nil),
-				}
-			},
-			wantError: "decode CUDA VMM participant",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			placement, err := validateRestoredVMMProcesses(
-				context.Background(),
-				test.processes(t),
+			setups, placement, err := validateRestoredVMMProcesses(
+				test.processes,
 				ledger,
 				"node-a",
+				placementPlan,
 			)
 			if test.wantError != "" {
 				if err == nil || !strings.Contains(err.Error(), test.wantError) {
@@ -1326,11 +1488,15 @@ func TestValidateRestoredVMMProcessesParticipantSet(t *testing.T) {
 			if len(placement) != 1 {
 				t.Fatalf("execution placement has %d participants, want 1", len(placement))
 			}
+			if len(setups) != 2 || setups[1].count != 0 ||
+				len(setups[1].payload) != 0 {
+				t.Fatalf("extra endpoint setup = %#v, want empty payload", setups)
+			}
 			if _, ok := placement[extra]; ok {
 				t.Fatal("extra empty participant was included in execution placement")
 			}
-			if got := placement[participant][sourceUUID]; got != 7 {
-				t.Fatalf("validated ordinal = %d, want 7", got)
+			if got := placement[participant][sourceUUID]; got != 0 {
+				t.Fatalf("validated ordinal = %d, want 0", got)
 			}
 		})
 	}
@@ -1762,42 +1928,49 @@ func TestReceiveVMMFDsPreservesOwnershipOnPartialParseFailure(t *testing.T) {
 	}
 }
 
-func serveVMMPlacement(
-	t *testing.T,
-	participant string,
-	ordinal int32,
-	sourceUUID string,
-	currentUUID string,
-) VMMProcess {
-	t.Helper()
-	payload := make([]byte, vmmPlacementSize)
-	binary.LittleEndian.PutUint32(payload[0:4], uint32(ordinal))
-	copy(payload[8:24], parseGPUUUID(sourceUUID))
-	copy(payload[24:40], parseGPUUUID(currentUUID))
-	return serveVMMPlacementResponse(t, participant, 1, payload)
-}
-
-func serveVMMPlacementResponse(
-	t *testing.T,
-	participant string,
+func validateVMMPlacementPayload(
 	count uint32,
 	payload []byte,
-) VMMProcess {
-	t.Helper()
-	return serveVMMProcess(t, "", participant, func(
-		request vmmResponse,
-	) (vmmResponse, error) {
-		if request.header.Operation != vmmQueryPlacement {
-			return vmmResponse{}, fmt.Errorf(
-				"unexpected VMM operation %d", request.header.Operation,
-			)
-		}
-		return vmmResponse{
-			header:  vmmHeader{Operation: vmmQueryPlacement, Count: count},
-			payload: payload,
-			fd:      -1,
-		}, nil
-	})
+	sourceUUID string,
+	targetUUID string,
+	ordinal int32,
+) error {
+	if count != 1 || len(payload) != vmmPlacementSize {
+		return fmt.Errorf(
+			"placement shape = count %d, payload %d bytes",
+			count,
+			len(payload),
+		)
+	}
+	if binary.LittleEndian.Uint32(payload[0:4]) != uint32(ordinal) ||
+		binary.LittleEndian.Uint32(payload[4:8]) != 0 ||
+		!bytes.Equal(payload[8:24], parseGPUUUID(sourceUUID)) ||
+		!bytes.Equal(payload[24:40], parseGPUUUID(targetUUID)) {
+		return errors.New("placement payload does not match authoritative plan")
+	}
+	return nil
+}
+
+func validateVMMPlacementRequest(
+	request vmmResponse,
+	sourceUUID string,
+	targetUUID string,
+	ordinal int32,
+) error {
+	if request.header.Operation != vmmSetPlacement || request.fd >= 0 {
+		return fmt.Errorf(
+			"unexpected placement operation %d or FD %d",
+			request.header.Operation,
+			request.fd,
+		)
+	}
+	return validateVMMPlacementPayload(
+		request.header.Count,
+		request.payload,
+		sourceUUID,
+		targetUUID,
+		ordinal,
+	)
 }
 
 func countMatchingFDs(t *testing.T, dev uint64, ino uint64) int {
@@ -2010,6 +2183,7 @@ func serveVMMRestoreProcess(
 	contents [][]byte,
 	ownerResource uint64,
 	failOwner uint64,
+	rejectPlacement bool,
 	events chan<- string,
 ) VMMProcess {
 	t.Helper()
@@ -2023,17 +2197,21 @@ func serveVMMRestoreProcess(
 			fd: -1,
 		}
 		switch request.header.Operation {
-		case vmmQueryPlacement:
-			placement := make([]byte, vmmPlacementSize)
-			copy(placement[8:24], parseGPUUUID(sourceUUID))
-			copy(placement[24:40], parseGPUUUID(sourceUUID))
-			response.header.Count = 1
-			response.payload = placement
+		case vmmSetPlacement:
+			if err := validateVMMPlacementRequest(
+				request, sourceUUID, sourceUUID, 1,
+			); err != nil {
+				return response, err
+			}
 			events <- "placement:" + roleSummary
+			if rejectPlacement {
+				response.header.Status = 1
+				response.header.Message = "placement rejected"
+			}
 			return response, nil
 		case vmmRestoreOwner:
 			if err := validateVMMRestoreRequest(
-				request, ownerResource, vmmOwner,
+				request, ownerResource, vmmOwner, 1,
 				contents[ownerResource-1],
 			); err != nil {
 				return response, err
@@ -2051,7 +2229,7 @@ func serveVMMRestoreProcess(
 		case vmmRestoreImporter:
 			importerResource := uint64(3) - ownerResource
 			if err := validateVMMRestoreRequest(
-				request, importerResource, vmmImporter, nil,
+				request, importerResource, vmmImporter, 1, nil,
 			); err != nil {
 				return response, err
 			}
@@ -2070,13 +2248,16 @@ func validateVMMRestoreRequest(
 	request vmmResponse,
 	resourceID uint64,
 	wantRole uint32,
+	wantOrdinal int32,
 	wantContents []byte,
 ) error {
 	if request.header.ObjectID != resourceID || len(request.payload) < vmmRecordSize {
 		return fmt.Errorf("invalid resource %d replay header", resourceID)
 	}
 	if binary.LittleEndian.Uint64(request.payload[16:24]) != resourceID ||
-		binary.LittleEndian.Uint32(request.payload[48:52]) != wantRole {
+		binary.LittleEndian.Uint32(request.payload[48:52]) != wantRole ||
+		int32(binary.LittleEndian.Uint32(request.payload[64:68])) !=
+			wantOrdinal {
 		return fmt.Errorf("invalid resource %d replay payload", resourceID)
 	}
 	metadataSize := vmmRecordSize +

--- a/deploy/snapshot/internal/executor/nsrestore.go
+++ b/deploy/snapshot/internal/executor/nsrestore.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"syscall"
 	"time"
@@ -17,10 +18,11 @@ import (
 
 // RestoreOptions holds configuration for an in-namespace restore.
 type RestoreOptions struct {
-	CheckpointPath string
-	CUDADeviceMap  string
-	CgroupRoot     string
-	TargetPodIP    string
+	CheckpointPath   string
+	CUDADeviceMap    string
+	CUDAVMMPlacement []types.VMMPlacement
+	CgroupRoot       string
+	TargetPodIP      string
 }
 
 type RestoreInNamespaceResult struct {
@@ -47,6 +49,18 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 	}
 	if err := cuda.ValidateVMMArtifact(opts.CheckpointPath, m.CUDA.VMMInterpose); err != nil {
 		return nil, fmt.Errorf("invalid CUDA VMM checkpoint artifact: %w", err)
+	}
+	if m.CUDA.VMMInterpose {
+		if err := cuda.ValidateVMMPlacement(
+			m.CUDA.SourceGPUUUIDs,
+			opts.CUDAVMMPlacement,
+		); err != nil {
+			return nil, fmt.Errorf("invalid CUDA VMM placement: %w", err)
+		}
+	} else if opts.CUDAVMMPlacement != nil {
+		return nil, errors.New(
+			"CUDA VMM placement provided without manifest opt-in",
+		)
 	}
 	manifestReadDuration := time.Since(manifestReadStart)
 	log.V(1).Info("Loaded checkpoint manifest",
@@ -182,6 +196,7 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 				m.CUDA.VMMGeneration,
 				m.CUDA.VMMStateDigest,
 				opts.CheckpointPath,
+				opts.CUDAVMMPlacement,
 				func() error {
 					return cuda.UnlockProcessTree(ctx, restorePIDs, log)
 				},

--- a/deploy/snapshot/internal/executor/restore.go
+++ b/deploy/snapshot/internal/executor/restore.go
@@ -150,6 +150,7 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 	}
 
 	cudaDeviceMap := ""
+	var cudaVMMPlacement []types.VMMPlacement
 	if !m.CUDA.IsEmpty() {
 		if len(m.CUDA.SourceGPUUUIDs) == 0 {
 			return nil, fmt.Errorf("missing source GPU UUIDs in checkpoint manifest")
@@ -174,6 +175,15 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 		if err != nil {
 			return nil, fmt.Errorf("failed to build CUDA device map: %w", err)
 		}
+		if m.CUDA.VMMInterpose {
+			cudaVMMPlacement, err = cuda.BuildVMMPlacement(
+				m.CUDA.SourceGPUUUIDs,
+				targetGPUUUIDs,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build CUDA VMM placement: %w", err)
+			}
+		}
 		log.V(1).Info("GPU UUIDs for device map",
 			"source_uuids", m.CUDA.SourceGPUUUIDs,
 			"target_uuids", targetGPUUUIDs,
@@ -182,11 +192,12 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 	}
 
 	return &types.RestoreContainerSnapshot{
-		CheckpointPath: checkpointPath,
-		PlaceholderPID: placeholderPID,
-		TargetRoot:     fmt.Sprintf("%s/%d/root", snapshotruntime.HostProcPath, placeholderPID),
-		CgroupRoot:     cgroupRoot,
-		CUDADeviceMap:  cudaDeviceMap,
+		CheckpointPath:   checkpointPath,
+		PlaceholderPID:   placeholderPID,
+		TargetRoot:       fmt.Sprintf("%s/%d/root", snapshotruntime.HostProcPath, placeholderPID),
+		CgroupRoot:       cgroupRoot,
+		CUDADeviceMap:    cudaDeviceMap,
+		CUDAVMMPlacement: cudaVMMPlacement,
 	}, nil
 }
 
@@ -210,6 +221,13 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 	}
 	if snap.CUDADeviceMap != "" {
 		args = append(args, "--cuda-device-map", snap.CUDADeviceMap)
+	}
+	if snap.CUDAVMMPlacement != nil {
+		encoded, err := json.Marshal(snap.CUDAVMMPlacement)
+		if err != nil {
+			return nil, fmt.Errorf("encode CUDA VMM placement: %w", err)
+		}
+		args = append(args, "--cuda-vmm-placement", string(encoded))
 	}
 	if snap.CgroupRoot != "" {
 		args = append(args, "--cgroup-root", snap.CgroupRoot)

--- a/deploy/snapshot/internal/runtime/mounts.go
+++ b/deploy/snapshot/internal/runtime/mounts.go
@@ -113,16 +113,39 @@ func BuildMountPolicy(mounts []types.MountInfo, rootFS string, maskedPaths []str
 
 // RemountProcSys remounts /proc/sys read-write or read-only.
 func RemountProcSys(rw bool) error {
-	flags := uintptr(syscall.MS_BIND | syscall.MS_REMOUNT)
+	const target = "/proc/sys"
+	mounted, err := mountinfo.Mounted(target)
+	if err != nil {
+		return fmt.Errorf("failed to inspect %s mount: %w", target, err)
+	}
+	var statfs syscall.Statfs_t
+	if err := syscall.Statfs(target, &statfs); err != nil {
+		return fmt.Errorf("failed to statfs %s: %w", target, err)
+	}
+
+	return remountProcSys(rw, mounted, uintptr(statfs.Flags), syscall.Mount)
+}
+
+func remountProcSys(rw bool, mounted bool, currentFlags uintptr, mount func(string, string, string, uintptr, string) error) error {
+	const target = "/proc/sys"
+	// A bind remount requires a mount root, which privileged OCI containers
+	// do not create for readonlyPaths.
+	if rw && !mounted {
+		if err := mount(target, target, "", syscall.MS_BIND, ""); err != nil {
+			return fmt.Errorf("failed to bind mount %s for rw remount: %w", target, err)
+		}
+	}
+
+	// A bind remount replaces per-mount flags, so retain the security flags.
+	flags := currentFlags & (syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC)
+	flags |= syscall.MS_BIND | syscall.MS_REMOUNT
+	mode := "rw"
 	if !rw {
 		flags |= syscall.MS_RDONLY
+		mode = "ro"
 	}
-	if err := syscall.Mount("proc", "/proc/sys", "", flags, ""); err != nil {
-		mode := "rw"
-		if !rw {
-			mode = "ro"
-		}
-		return fmt.Errorf("failed to remount /proc/sys %s: %w", mode, err)
+	if err := mount("", target, "", flags, ""); err != nil {
+		return fmt.Errorf("failed to remount %s %s: %w", target, mode, err)
 	}
 	return nil
 }

--- a/deploy/snapshot/internal/runtime/mounts.go
+++ b/deploy/snapshot/internal/runtime/mounts.go
@@ -129,9 +129,9 @@ func RemountProcSys(rw bool) error {
 func remountProcSys(rw bool, mounted bool, currentFlags uintptr, mount func(string, string, string, uintptr, string) error) error {
 	const target = "/proc/sys"
 	// A bind remount requires a mount root, which privileged OCI containers
-	// do not create for readonlyPaths.
+	// do not create for readonlyPaths. Make it recursive to preserve descendants.
 	if rw && !mounted {
-		if err := mount(target, target, "", syscall.MS_BIND, ""); err != nil {
+		if err := mount(target, target, "", syscall.MS_BIND|syscall.MS_REC, ""); err != nil {
 			return fmt.Errorf("failed to bind mount %s for rw remount: %w", target, err)
 		}
 	}

--- a/deploy/snapshot/internal/runtime/mounts_test.go
+++ b/deploy/snapshot/internal/runtime/mounts_test.go
@@ -1,14 +1,102 @@
 package runtime
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 )
+
+func TestRemountProcSys(t *testing.T) {
+	type mountCall struct {
+		source string
+		target string
+		fstype string
+		flags  uintptr
+		data   string
+	}
+
+	currentFlags := uintptr(syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC)
+	tests := []struct {
+		name      string
+		rw        bool
+		mounted   bool
+		failCall  int
+		wantCalls []mountCall
+		wantError string
+	}{
+		{
+			name: "read-write creates bind mount",
+			rw:   true,
+			wantCalls: []mountCall{
+				{source: "/proc/sys", target: "/proc/sys", flags: syscall.MS_BIND},
+				{target: "/proc/sys", flags: currentFlags | syscall.MS_BIND | syscall.MS_REMOUNT},
+			},
+		},
+		{
+			name:    "read-only",
+			mounted: true,
+			wantCalls: []mountCall{
+				{target: "/proc/sys", flags: currentFlags | syscall.MS_BIND | syscall.MS_REMOUNT | syscall.MS_RDONLY},
+			},
+		},
+		{
+			name:      "read-write remount error",
+			rw:        true,
+			mounted:   true,
+			failCall:  1,
+			wantCalls: []mountCall{{target: "/proc/sys", flags: currentFlags | syscall.MS_BIND | syscall.MS_REMOUNT}},
+			wantError: "failed to remount /proc/sys rw: invalid argument",
+		},
+		{
+			name:      "read-only remount error",
+			mounted:   true,
+			failCall:  1,
+			wantCalls: []mountCall{{target: "/proc/sys", flags: currentFlags | syscall.MS_BIND | syscall.MS_REMOUNT | syscall.MS_RDONLY}},
+			wantError: "failed to remount /proc/sys ro: invalid argument",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls []mountCall
+			mount := func(source, target, fstype string, flags uintptr, data string) error {
+				calls = append(calls, mountCall{source, target, fstype, flags, data})
+				if len(calls) == tc.failCall {
+					return syscall.EINVAL
+				}
+				return nil
+			}
+
+			err := remountProcSys(tc.rw, tc.mounted, currentFlags, mount)
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("remountProcSys() error = %v", err)
+				}
+			} else {
+				if err == nil || err.Error() != tc.wantError {
+					t.Fatalf("remountProcSys() error = %v, want %q", err, tc.wantError)
+				}
+				if !errors.Is(err, syscall.EINVAL) {
+					t.Fatalf("remountProcSys() error does not wrap EINVAL: %v", err)
+				}
+			}
+			if len(calls) != len(tc.wantCalls) {
+				t.Fatalf("mount calls = %#v, want %#v", calls, tc.wantCalls)
+			}
+			for i := range calls {
+				if calls[i] != tc.wantCalls[i] {
+					t.Errorf("mount call %d = %#v, want %#v", i, calls[i], tc.wantCalls[i])
+				}
+			}
+		})
+	}
+}
 
 func TestClassifyMounts(t *testing.T) {
 	tests := []struct {

--- a/deploy/snapshot/internal/runtime/mounts_test.go
+++ b/deploy/snapshot/internal/runtime/mounts_test.go
@@ -34,9 +34,26 @@ func TestRemountProcSys(t *testing.T) {
 			name: "read-write creates bind mount",
 			rw:   true,
 			wantCalls: []mountCall{
-				{source: "/proc/sys", target: "/proc/sys", flags: syscall.MS_BIND},
+				{source: "/proc/sys", target: "/proc/sys", flags: syscall.MS_BIND | syscall.MS_REC},
 				{target: "/proc/sys", flags: currentFlags | syscall.MS_BIND | syscall.MS_REMOUNT},
 			},
+		},
+		{
+			name:      "read-write bind mount error",
+			rw:        true,
+			failCall:  1,
+			wantCalls: []mountCall{{source: "/proc/sys", target: "/proc/sys", flags: syscall.MS_BIND | syscall.MS_REC}},
+			wantError: "failed to bind mount /proc/sys for rw remount: invalid argument",
+		},
+		{
+			name:     "read-write remount error after creating bind mount",
+			rw:       true,
+			failCall: 2,
+			wantCalls: []mountCall{
+				{source: "/proc/sys", target: "/proc/sys", flags: syscall.MS_BIND | syscall.MS_REC},
+				{target: "/proc/sys", flags: currentFlags | syscall.MS_BIND | syscall.MS_REMOUNT},
+			},
+			wantError: "failed to remount /proc/sys rw: invalid argument",
 		},
 		{
 			name:    "read-only",

--- a/deploy/snapshot/internal/types/inspect.go
+++ b/deploy/snapshot/internal/types/inspect.go
@@ -34,9 +34,17 @@ type CheckpointContainerSnapshot struct {
 
 // RestoreContainerSnapshot holds inspected state for the restore target.
 type RestoreContainerSnapshot struct {
-	CheckpointPath string
-	PlaceholderPID int
-	TargetRoot     string
-	CgroupRoot     string
-	CUDADeviceMap  string
+	CheckpointPath   string
+	PlaceholderPID   int
+	TargetRoot       string
+	CgroupRoot       string
+	CUDADeviceMap    string
+	CUDAVMMPlacement []VMMPlacement
+}
+
+// VMMPlacement describes one transient source-to-target GPU placement.
+type VMMPlacement struct {
+	SourceGPUUUID string `json:"sourceGPUUUID"`
+	TargetGPUUUID string `json:"targetGPUUUID"`
+	TargetOrdinal int32  `json:"targetOrdinal"`
 }

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -77,8 +77,12 @@ func PrepareRestorePodSpec(
 		return fmt.Errorf("restore pod spec: %w", err)
 	}
 	EnsureLocalhostSeccompProfile(podSpec, seccompProfile)
+	checkpointVolumeName := CheckpointVolumeName
 	if storage.PVCName != "" {
-		InjectCheckpointVolume(podSpec, storage.PVCName)
+		checkpointVolumeName, err = InjectCheckpointVolume(podSpec, storage.PVCName)
+		if err != nil {
+			return fmt.Errorf("restore pod spec: %w", err)
+		}
 	}
 	for _, name := range targets {
 		var container *corev1.Container
@@ -92,7 +96,9 @@ func PrepareRestorePodSpec(
 			return fmt.Errorf("restore target container %q not found in pod spec (from %s annotation)", name, TargetContainersAnnotation)
 		}
 		if storage.BasePath != "" {
-			InjectCheckpointVolumeMount(container, storage.BasePath)
+			if err := InjectCheckpointVolumeMount(container, checkpointVolumeName, storage.BasePath); err != nil {
+				return fmt.Errorf("restore pod spec: %w", err)
+			}
 		}
 		EnsureControlVolume(podSpec, container)
 		if isCheckpointReady {
@@ -169,18 +175,14 @@ func ValidateRestorePodSpec(
 	if err != nil {
 		return err
 	}
+	checkpointVolumeName := CheckpointVolumeName
 	if storage.PVCName != "" {
-		hasVolume := false
-		for _, volume := range podSpec.Volumes {
-			if volume.Name == CheckpointVolumeName &&
-				volume.PersistentVolumeClaim != nil &&
-				volume.PersistentVolumeClaim.ClaimName == storage.PVCName {
-				hasVolume = true
-				break
-			}
+		checkpointVolumeName, err = resolveCheckpointVolumeName(podSpec, storage.PVCName)
+		if err != nil {
+			return err
 		}
-		if !hasVolume {
-			return fmt.Errorf("missing %s volume for PVC %s", CheckpointVolumeName, storage.PVCName)
+		if checkpointVolumeName == "" {
+			return fmt.Errorf("missing volume for checkpoint PVC %q", storage.PVCName)
 		}
 	}
 	hasControlVolume := false
@@ -205,15 +207,17 @@ func ValidateRestorePodSpec(
 			return fmt.Errorf("restore target container %q not found in pod spec (from %s annotation)", name, TargetContainersAnnotation)
 		}
 		if storage.BasePath != "" {
-			hasMount := false
-			for _, mount := range container.VolumeMounts {
-				if mount.Name == CheckpointVolumeName && mount.MountPath == storage.BasePath {
-					hasMount = true
-					break
-				}
+			hasMount, err := hasCompatibleCheckpointVolumeMount(container, checkpointVolumeName, storage.BasePath)
+			if err != nil {
+				return err
 			}
 			if !hasMount {
-				return fmt.Errorf("missing %s mount at %s on container %q", CheckpointVolumeName, storage.BasePath, name)
+				return fmt.Errorf(
+					"missing mount of checkpoint volume %q at %q on container %q",
+					checkpointVolumeName,
+					storage.BasePath,
+					name,
+				)
 			}
 		}
 		hasControlMount := false
@@ -363,14 +367,15 @@ func PrepareRestorePodSpecForCheckpoint(
 	return PrepareRestorePodSpec(podSpec, annotations, storage, seccompProfile, isCheckpointReady)
 }
 
-// InjectCheckpointVolume adds the checkpoint PVC volume to the pod spec if
-// not already present. Used by both the snapshot protocol and the operator's
-// GMS checkpoint wiring.
-func InjectCheckpointVolume(podSpec *corev1.PodSpec, pvcName string) {
-	for _, volume := range podSpec.Volumes {
-		if volume.Name == CheckpointVolumeName {
-			return
-		}
+// InjectCheckpointVolume resolves the unique volume backed by the checkpoint
+// PVC, adding the default volume when none exists.
+func InjectCheckpointVolume(podSpec *corev1.PodSpec, pvcName string) (string, error) {
+	volumeName, err := resolveCheckpointVolumeName(podSpec, pvcName)
+	if err != nil {
+		return "", err
+	}
+	if volumeName != "" {
+		return volumeName, nil
 	}
 
 	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
@@ -381,17 +386,81 @@ func InjectCheckpointVolume(podSpec *corev1.PodSpec, pvcName string) {
 			},
 		},
 	})
+	return CheckpointVolumeName, nil
 }
 
-func InjectCheckpointVolumeMount(container *corev1.Container, basePath string) {
-	for _, mount := range container.VolumeMounts {
-		if mount.Name == CheckpointVolumeName {
-			return
+func resolveCheckpointVolumeName(podSpec *corev1.PodSpec, pvcName string) (string, error) {
+	var match string
+	var matchReadOnly bool
+	var reserved bool
+	for _, volume := range podSpec.Volumes {
+		if volume.Name == CheckpointVolumeName {
+			reserved = true
 		}
+		if volume.PersistentVolumeClaim != nil &&
+			volume.PersistentVolumeClaim.ClaimName == pvcName {
+			if match != "" {
+				return "", fmt.Errorf("multiple volumes reference checkpoint PVC %q", pvcName)
+			}
+			match = volume.Name
+			matchReadOnly = volume.PersistentVolumeClaim.ReadOnly
+		}
+	}
+	if matchReadOnly {
+		return "", fmt.Errorf("checkpoint volume %q for PVC %q must be writable", match, pvcName)
+	}
+	if match == "" && reserved {
+		return "", fmt.Errorf(
+			"volume %q is already in use and cannot reference checkpoint PVC %q",
+			CheckpointVolumeName,
+			pvcName,
+		)
+	}
+	return match, nil
+}
+
+// InjectCheckpointVolumeMount ensures a root mount at the checkpoint base path.
+func InjectCheckpointVolumeMount(
+	container *corev1.Container,
+	volumeName string,
+	basePath string,
+) error {
+	found, err := hasCompatibleCheckpointVolumeMount(container, volumeName, basePath)
+	if err != nil || found {
+		return err
 	}
 
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      CheckpointVolumeName,
+		Name:      volumeName,
 		MountPath: basePath,
 	})
+	return nil
+}
+
+func hasCompatibleCheckpointVolumeMount(
+	container *corev1.Container,
+	volumeName string,
+	basePath string,
+) (bool, error) {
+	var found bool
+	for _, mount := range container.VolumeMounts {
+		if mount.MountPath != basePath {
+			continue
+		}
+		if found {
+			return false, fmt.Errorf("container %q has multiple volume mounts at checkpoint base path %q", container.Name, basePath)
+		}
+		found = true
+		if mount.Name != volumeName {
+			return false, fmt.Errorf("container %q mounts volume %q at checkpoint base path %q, expected volume %q", container.Name, mount.Name, basePath, volumeName)
+		}
+		if mount.SubPath != "" || mount.SubPathExpr != "" {
+			return false, fmt.Errorf("checkpoint volume %q mount at %q on container %q must not use subPath or subPathExpr", volumeName, basePath, container.Name)
+		}
+		if mount.ReadOnly {
+			return false, fmt.Errorf("checkpoint volume %q mount at %q on container %q must be writable", volumeName, basePath, container.Name)
+		}
+	}
+
+	return found, nil
 }

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -13,6 +13,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func pvcVolume(name, claimName string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claimName},
+		},
+	}
+}
+
 func TestNewRestorePod(t *testing.T) {
 	readinessProbe := &corev1.Probe{PeriodSeconds: 7, TimeoutSeconds: 3}
 	livenessProbe := &corev1.Probe{InitialDelaySeconds: 11}
@@ -134,6 +143,63 @@ func TestNewRestorePod(t *testing.T) {
 	}
 	if !foundStandbyEnv {
 		t.Fatalf("expected %s env, got %#v", RestoreStandbyModeEnv, main.Env)
+	}
+}
+
+func TestNewRestorePodReusesExistingCheckpointPVCVolumeAndMount(t *testing.T) {
+	const existingVolumeName = "checkpoints"
+	storage := Storage{
+		Type:     StorageTypePVC,
+		PVCName:  "snapshot-pvc",
+		BasePath: "/checkpoints",
+	}
+	restorePod, err := NewRestorePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{TargetContainersAnnotation: "main"},
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				pvcVolume(existingVolumeName, storage.PVCName),
+				pvcVolume(CheckpointVolumeName, "other-pvc"),
+			},
+			Containers: []corev1.Container{{
+				Name: "main",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      existingVolumeName,
+					MountPath: storage.BasePath,
+				}},
+			}},
+		},
+	}, PodOptions{
+		Storage: storage,
+	})
+	if err != nil {
+		t.Fatalf("NewRestorePod returned error: %v", err)
+	}
+
+	if len(restorePod.Spec.Volumes) != 3 {
+		t.Fatalf("expected existing, reserved, and control volumes, got %#v", restorePod.Spec.Volumes)
+	}
+	existing := restorePod.Spec.Volumes[0]
+	if existing.Name != existingVolumeName ||
+		existing.PersistentVolumeClaim == nil ||
+		existing.PersistentVolumeClaim.ClaimName != storage.PVCName {
+		t.Fatalf("expected existing checkpoint PVC volume to be reused, got %#v", existing)
+	}
+	if reserved := restorePod.Spec.Volumes[1]; reserved.Name != CheckpointVolumeName ||
+		reserved.PersistentVolumeClaim == nil ||
+		reserved.PersistentVolumeClaim.ClaimName != "other-pvc" {
+		t.Fatalf("expected unrelated reserved volume to be preserved, got %#v", reserved)
+	}
+
+	main := restorePod.Spec.Containers[0]
+	if len(main.VolumeMounts) != 2 ||
+		main.VolumeMounts[0].Name != existingVolumeName ||
+		main.VolumeMounts[0].MountPath != storage.BasePath {
+		t.Fatalf("expected one reused checkpoint root mount, got %#v", main.VolumeMounts)
+	}
+	if err := ValidateRestorePodSpec(&restorePod.Spec, restorePod.Annotations, storage, ""); err != nil {
+		t.Fatalf("expected prepared restore pod to validate, got %v", err)
 	}
 }
 
@@ -353,6 +419,105 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 	assertRestoreStartupGate(t, container.StartupProbe)
 }
 
+func TestPrepareRestorePodSpecRejectsCheckpointVolumeConflicts(t *testing.T) {
+	storage := Storage{Type: StorageTypePVC, PVCName: "snapshot-pvc", BasePath: "/checkpoints"}
+	annotations := map[string]string{TargetContainersAnnotation: "main"}
+
+	tests := []struct {
+		name    string
+		volumes []corev1.Volume
+		mounts  []corev1.VolumeMount
+		errText string
+	}{
+		{
+			name: "reserved name references another PVC",
+			volumes: []corev1.Volume{
+				pvcVolume(CheckpointVolumeName, "other-pvc"),
+			},
+			errText: `volume "checkpoint-storage" is already in use`,
+		},
+		{
+			name: "base path is occupied by another volume",
+			volumes: []corev1.Volume{
+				pvcVolume("checkpoint-data", storage.PVCName),
+				{
+					Name:         "other-data",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				},
+			},
+			mounts:  []corev1.VolumeMount{{Name: "other-data", MountPath: "/checkpoints"}},
+			errText: `container "main" mounts volume "other-data" at checkpoint base path "/checkpoints", expected volume "checkpoint-data"`,
+		},
+		{
+			name: "multiple volumes reference checkpoint PVC",
+			volumes: []corev1.Volume{
+				pvcVolume("checkpoint-data-a", storage.PVCName),
+				pvcVolume("checkpoint-data-b", storage.PVCName),
+			},
+			errText: `multiple volumes reference checkpoint PVC "snapshot-pvc"`,
+		},
+		{
+			name: "PVC volume source is read-only",
+			volumes: []corev1.Volume{{
+				Name: "checkpoint-data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: storage.PVCName,
+						ReadOnly:  true,
+					},
+				},
+			}},
+			mounts: []corev1.VolumeMount{{
+				Name:      "checkpoint-data",
+				MountPath: storage.BasePath,
+				ReadOnly:  false,
+			}},
+			errText: `checkpoint volume "checkpoint-data" for PVC "snapshot-pvc" must be writable`,
+		},
+		{
+			name: "base path mount uses subPath",
+			volumes: []corev1.Volume{
+				pvcVolume("checkpoint-data", storage.PVCName),
+			},
+			mounts: []corev1.VolumeMount{{
+				Name:      "checkpoint-data",
+				MountPath: "/checkpoints",
+				SubPath:   "snapshot",
+			}},
+			errText: `checkpoint volume "checkpoint-data" mount at "/checkpoints" on container "main" must not use subPath or subPathExpr`,
+		},
+		{
+			name: "base path mount is read-only",
+			volumes: []corev1.Volume{
+				pvcVolume("checkpoint-data", storage.PVCName),
+			},
+			mounts: []corev1.VolumeMount{{
+				Name:      "checkpoint-data",
+				MountPath: storage.BasePath,
+				ReadOnly:  true,
+			}},
+			errText: `checkpoint volume "checkpoint-data" mount at "/checkpoints" on container "main" must be writable`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			podSpec := corev1.PodSpec{
+				Volumes: test.volumes,
+				Containers: []corev1.Container{{
+					Name:         "main",
+					VolumeMounts: test.mounts,
+				}},
+			}
+
+			err := PrepareRestorePodSpec(&podSpec, annotations, storage, "", true)
+			if err == nil || !strings.Contains(err.Error(), test.errText) {
+				t.Fatalf("expected error containing %q, got %v", test.errText, err)
+			}
+		})
+	}
+}
+
 func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) {
 	livenessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
@@ -534,14 +699,27 @@ func TestValidateRestorePodSpec(t *testing.T) {
 
 	badSpec := podSpec.DeepCopy()
 	badSpec.Volumes = []corev1.Volume{badSpec.Volumes[1]}
-	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing checkpoint-storage volume for PVC snapshot-pvc" {
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != `missing volume for checkpoint PVC "snapshot-pvc"` {
 		t.Fatalf("expected missing volume error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()
 	badSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{badSpec.Containers[0].VolumeMounts[1]}
-	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != `missing checkpoint-storage mount at /checkpoints on container "main"` {
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != `missing mount of checkpoint volume "checkpoint-storage" at "/checkpoints" on container "main"` {
 		t.Fatalf("expected missing mount error, got %v", err)
+	}
+
+	badSpec = podSpec.DeepCopy()
+	badSpec.Containers[0].VolumeMounts[0].ReadOnly = true
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || !strings.Contains(err.Error(), "must be writable") {
+		t.Fatalf("expected read-only checkpoint mount error, got %v", err)
+	}
+
+	badSpec = podSpec.DeepCopy()
+	badSpec.Volumes[0].PersistentVolumeClaim.ReadOnly = true
+	badSpec.Containers[0].VolumeMounts[0].ReadOnly = false
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != `checkpoint volume "checkpoint-storage" for PVC "snapshot-pvc" must be writable` {
+		t.Fatalf("expected read-only checkpoint PVC source error, got %v", err)
 	}
 
 	badSpec = podSpec.DeepCopy()


### PR DESCRIPTION
## Summary

- extend the launcher-scoped CUDA VMM interposer to track and replay `CU_MEM_HANDLE_TYPE_FABRIC` mappings
- exchange transient FABRIC handles through the live owner broker while keeping only logical allocation identity in the Redis ledger
- preserve the POSIX FD path and fail closed on malformed or mixed transport metadata

This stacked milestone supports single-node unicast FABRIC/IMEX mappings. Multinode routing, multicast objects, queued handles, and repeated checkpoint/restore cycles remain unsupported.

Depends on #12485.

## Validation

- CUDA VMM fake-driver lifecycle and resolver harness
- `go test -count=1 ./...`
- `go test -count=1 -race ./...`
- `go vet ./...`
