### PR TITLE
docs(llm): extend worker compatibility to N-2 [DYN-3846]

### DIFF
--- a/lib/kv-router/CLAUDE.md
+++ b/lib/kv-router/CLAUDE.md
@@ -5,7 +5,7 @@ state. Keep edits scoped and read the more specific `CLAUDE.md` in subdirectorie
 when one exists.
 
 When router configuration is serialized inside a model deployment card, it is
-part of the N-1 worker/frontend wire contract described in
+part of the N-2 worker/frontend wire contract described in
 [`lib/llm/CLAUDE.md`](../llm/CLAUDE.md). Keep compatibility handling narrow and
 give deprecated wire fields a versioned removal TODO.
 

--- a/lib/llm/CLAUDE.md
+++ b/lib/llm/CLAUDE.md
@@ -1,17 +1,23 @@
-# N-1 Worker / Frontend Compatibility
+# N-2 Worker / Frontend Compatibility
 
-Assume N-1 mixed-version operation between workers and frontends during rolling
-updates: current-version components must interoperate with components from the
-immediately previous release. N-2 and older combinations are unsupported unless
-a narrower temporary exception is explicitly documented. Treat model deployment
-cards, discovery metadata, and worker/frontend wire formats owned by this crate
-as cross-process compatibility surfaces. Consider both directions: a
-previous-version worker with a current frontend and a current worker with a
-previous-version frontend.
+Assume N-2 mixed-version operation between workers and frontends during rolling
+updates. Frontends and workers from the current release and the two immediately
+previous releases may coexist in any combination and must interoperate across
+the worker/frontend boundary. This includes a single frontend concurrently
+discovering worker cards from multiple supported releases for the same logical
+deployment or worker set. Differences caused only by supported wire evolution
+must not split otherwise compatible workers, fail discovery closed, or remove
+healthy serving state. N-3 and older combinations are unsupported unless a
+narrower temporary exception is explicitly documented.
 
-- Normal, default deployment paths should remain operable across the N-1
-  boundary. Unconditional parsing or discovery failures on those paths are
-  generally compatibility bugs.
+Treat model deployment cards, discovery metadata, and worker/frontend wire
+formats owned by this crate as cross-process compatibility surfaces. Consider
+both age directions: an older worker with a newer frontend and a newer worker
+with an older frontend, anywhere within the supported window.
+
+- Normal, default deployment paths should remain operable across the N-2
+  compatibility window. Unconditional parsing or discovery failures on those
+  paths are generally compatibility bugs.
 - Prefer tolerant readers and conservative writers. Accept known legacy fields
   when they are safe to interpret, and continue emitting required legacy fields
   for the supported compatibility window.
@@ -22,9 +28,11 @@ previous-version frontend.
   semantics cannot be represented safely by the other version. Prefer a
   targeted unsupported-feature error over a generic deserialization failure.
 
-This expectation applies to cross-process worker/frontend wiring. It is not a
-general stability promise for in-process Rust APIs, which are internal unless
-explicitly documented otherwise.
+This expectation applies to cross-process worker/frontend wiring, including the
+frontend's aggregation of mixed-version worker metadata. It does not establish
+a compatibility window for direct worker-to-worker protocols or a general
+stability promise for in-process Rust APIs; those are internal unless explicitly
+documented otherwise.
 
 ## Compatibility Shims
 
@@ -40,8 +48,8 @@ Every shim must name its compatibility window and removal condition, for
 example:
 
 ```rust
-// Compatibility with v1.3 workers during v1.4 rolling upgrades.
-// TODO(v1.5): Remove when v1.3 falls outside the N-1 compatibility window.
+// Compatibility with v1.2 workers and frontends during v1.4 rolling upgrades.
+// TODO(v1.5): Remove when v1.2 falls outside the N-2 compatibility window.
 ```
 
 Remove the shim when the corresponding version leaves the supported window;


### PR DESCRIPTION
## Summary

Raise the worker/frontend compatibility contract from N-1 to N-2 for model deployment cards, discovery metadata, and worker/frontend wire formats.

Explicitly require frontends and workers from N, N-1, and N-2 to coexist in any combination during rolling updates. This includes one frontend concurrently discovering different supported card versions for the same logical deployment or WorkerSet; wire-version differences alone must not create a false conflict or remove healthy serving state.

Keep the boundary scoped to worker/frontend wiring and the frontend's aggregation of worker metadata. Direct worker-to-worker protocols and in-process Rust APIs remain outside this promise unless separately documented. This policy PR does not add future version-specific compatibility shims.

Update the KV-router guidance to reference the same N-2 contract when router configuration is carried inside an MDC.

## Validation

- Commit-time hooks passed, including codespell, conflict checks, line-ending checks, and whitespace checks.
- `git diff --check` passed.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compatibility guidance to support worker and frontend interoperability across the current and two previous releases.
  * Clarified metadata aggregation across supported versions and documented that older combinations remain unsupported.
  * Updated compatibility-shim examples and scope guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->