### PR TITLE
test(fault-tolerance): fix vLLM cancellation request budget

### DIFF
--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -39,6 +39,7 @@ from tests.utils.port_utils import allocate_port, deallocate_port
 logger = logging.getLogger(__name__)
 
 CANCELLATION_MAX_TOKENS = 2048
+PREFILL_CANCELLATION_MAX_TOKENS = 128
 XPU_CANCELLATION_MAX_TOKENS = 2096
 
 
@@ -427,7 +428,9 @@ def test_request_cancellation_vllm_decode_cancel(
 
                 # Send streaming request (non-blocking)
                 cancellable_req = send_cancellable_request(
-                    frontend.frontend_port, "chat_completion_stream"
+                    frontend.frontend_port,
+                    "chat_completion_stream",
+                    max_tokens=CANCELLATION_MAX_TOKENS,
                 )
 
                 # Poll for "Decode Request ID" pattern in decode worker (vLLM v2 pattern)
@@ -437,6 +440,7 @@ def test_request_cancellation_vllm_decode_cancel(
                     match_type="contains",
                     max_wait_ms=10000,
                     poll_interval_ms=50,
+                    cancellable_request=cancellable_req,
                 )
 
                 # Verify same request ID reached prefill worker (as "Prefill Request ID")
@@ -534,13 +538,17 @@ def test_request_cancellation_vllm_prefill_cancel(
 
                 # Send request with long prompt (non-blocking)
                 cancellable_req = send_cancellable_request(
-                    frontend.frontend_port, "completion", use_long_prompt=True
+                    frontend.frontend_port,
+                    "completion",
+                    use_long_prompt=True,
+                    max_tokens=PREFILL_CANCELLATION_MAX_TOKENS,
                 )
 
                 request_id, prefill_log_offset = poll_for_pattern(
                     process=prefill_worker,
                     pattern="Prefill Request ID: ",
                     match_type="contains",
+                    cancellable_request=cancellable_req,
                 )
 
                 # Cancel during prefill phase

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -38,7 +38,7 @@ from tests.utils.port_utils import allocate_port, deallocate_port
 
 logger = logging.getLogger(__name__)
 
-CANCELLATION_MAX_TOKENS = 16384
+CANCELLATION_MAX_TOKENS = 2048
 XPU_CANCELLATION_MAX_TOKENS = 2096
 
 
@@ -248,7 +248,7 @@ class DynamoWorkerProcess(ManagedProcess):
 @pytest.mark.timeout(
     660
 )  # worker startup can take up to 600s; allow headroom for test body
-@pytest.mark.post_merge
+@pytest.mark.pre_merge
 @pytest.mark.gpu_1
 @pytest.mark.xpu_1
 def test_request_cancellation_vllm_aggregated(
@@ -344,6 +344,9 @@ def test_request_cancellation_vllm_aggregated(
                     pattern="Decode Request ID: ",
                     log_offset=worker_log_offset,
                     match_type="contains",
+                    max_wait_ms=10000,
+                    poll_interval_ms=50,
+                    cancellable_request=cancellable_req,
                 )
 
                 # For streaming, read 5 responses before cancelling

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -248,7 +248,7 @@ class DynamoWorkerProcess(ManagedProcess):
 @pytest.mark.timeout(
     660
 )  # worker startup can take up to 600s; allow headroom for test body
-@pytest.mark.pre_merge
+@pytest.mark.post_merge
 @pytest.mark.gpu_1
 @pytest.mark.xpu_1
 def test_request_cancellation_vllm_aggregated(

--- a/tests/fault_tolerance/cancellation/utils.py
+++ b/tests/fault_tolerance/cancellation/utils.py
@@ -143,11 +143,36 @@ class CancellableRequest:
         self._active_sockets.clear()
 
         # Also close at the requests level for cleanup
-        if self.response:
+        if self.response is not None:
             self.response.close()
         for adapter in self.session.adapters.values():
             adapter.close()
         self.session.close()
+
+    def raise_for_early_failure(self) -> None:
+        """Raise when a request finishes with an error before reaching a worker."""
+        request_thread = self._request_thread
+        if request_thread is None or request_thread.is_alive():
+            return
+
+        if self.exception is not None:
+            raise AssertionError(
+                f"Request failed before reaching the worker: {self.exception}"
+            ) from self.exception
+
+        if self.response is None:
+            raise AssertionError(
+                "Request finished before reaching the worker without a response"
+            )
+
+        if not 200 <= self.response.status_code < 300:
+            response_body = self.response.text.strip()
+            if len(response_body) > 1000:
+                response_body = f"{response_body[:1000]}..."
+            raise AssertionError(
+                "Request failed before reaching the worker: "
+                f"HTTP {self.response.status_code}: {response_body}"
+            )
 
     def get_response(self):
         """Get the response or raise exception if there was one"""
@@ -561,6 +586,7 @@ def poll_for_pattern(
     max_wait_ms: int = 500,
     poll_interval_ms: int = 5,
     match_type: str = "endswith",  # "contains" or "endswith"
+    cancellable_request: CancellableRequest | None = None,
 ) -> tuple[str, int]:
     """
     Poll process log for a specific pattern.
@@ -572,6 +598,7 @@ def poll_for_pattern(
         max_wait_ms: Maximum time to wait for the pattern in milliseconds
         poll_interval_ms: Interval between polls in milliseconds
         match_type: How to match the pattern - "contains" or "endswith"
+        cancellable_request: Request to check for an early HTTP or transport failure
 
     Returns:
         Tuple of (matched_content, new_log_offset) where matched_content is:
@@ -620,9 +647,15 @@ def poll_for_pattern(
         # Update offset for next poll
         current_offset = len(log_content)
 
+        if cancellable_request is not None:
+            cancellable_request.raise_for_early_failure()
+
         # Wait before next poll
         time.sleep(poll_interval_ms / 1000.0)
         iteration += 1
+
+    if cancellable_request is not None:
+        cancellable_request.raise_for_early_failure()
 
     raise AssertionError(
         f"Failed to find '{pattern}' pattern after {max_iterations} iterations ({max_wait_ms}ms)"

--- a/tests/fault_tolerance/cancellation/utils.py
+++ b/tests/fault_tolerance/cancellation/utils.py
@@ -156,22 +156,27 @@ class CancellableRequest:
             return
 
         if self.exception is not None:
+            exception = self.exception
+            self.cancel()
             raise AssertionError(
-                f"Request failed before reaching the worker: {self.exception}"
-            ) from self.exception
+                f"Request failed before reaching the worker: {exception}"
+            ) from exception
 
         if self.response is None:
+            self.cancel()
             raise AssertionError(
                 "Request finished before reaching the worker without a response"
             )
 
         if not 200 <= self.response.status_code < 300:
+            status_code = self.response.status_code
             response_body = self.response.text.strip()
             if len(response_body) > 1000:
                 response_body = f"{response_body[:1000]}..."
+            self.cancel()
             raise AssertionError(
                 "Request failed before reaching the worker: "
-                f"HTTP {self.response.status_code}: {response_body}"
+                f"HTTP {status_code}: {response_body}"
             )
 
     def get_response(self):


### PR DESCRIPTION
## Summary

- cap aggregated vLLM cancellation requests at 2,048 output tokens so prompt plus output stays within the worker's 4,096-token context limit
- surface early frontend HTTP and transport failures instead of timing out while polling for a worker log marker
- allow 10 seconds for the initial decode marker on slower CI runners
- retain the test in `post_merge` after validating the fix through temporary `pre_merge` coverage

## Root cause

The test requested 16,384 output tokens from an aggregated worker advertising a 4,096-token context window. Strict frontend admission rejected the request with HTTP 400 before it reached the vLLM worker, while the test continued polling for `Decode Request ID` and reported a misleading log timeout.

## Validation

- [Pre-merge vLLM GPU CI](https://github.com/ai-dynamo/dynamo/actions/runs/31276004287/job/93150497350):
  - `test_request_cancellation_vllm_aggregated[nats]` passed in 52.60s
  - `test_request_cancellation_vllm_aggregated[tcp]` passed in 52.59s
- `python3 -m py_compile tests/fault_tolerance/cancellation/test_vllm.py tests/fault_tolerance/cancellation/utils.py`
- `ruff check tests/fault_tolerance/cancellation/test_vllm.py tests/fault_tolerance/cancellation/utils.py`
- `ruff format --check tests/fault_tolerance/cancellation/test_vllm.py tests/fault_tolerance/cancellation/utils.py`
- `git diff --check`

## Tracking

- [OPS-8068: CI failure in post-merge vLLM runtime test](https://linear.app/nvidia/issue/OPS-8068/ci-failure-post-merge-ci-pipeline-vllm-runtime-test-cuda130-amd64)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling to close active request resources more reliably.
  * Added clearer detection and reporting of failed or incomplete cancellation requests.
  * Improved timeout behavior by identifying request failures during cancellation checks.

* **Tests**
  * Strengthened cancellation coverage and reduced test wait times for faster, more dependable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->