### PR TITLE
feat(router): add pluggable worker filters

### DIFF
--- a/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
+++ b/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
@@ -32,7 +32,7 @@ For each request, Dynamo first applies its built-in worker eligibility rules. Cu
 
 The example catalog registers two policy types:
 
-- A basic policy that scores active requests for every worker type.
+- A basic policy that can require a minimum effective cache overlap, then scores active requests for every worker type.
 - A disaggregated policy with separate prefill and decode scorers and pickers.
 
 In the Python frontend, the disaggregated factory selects its components from `worker_type`:
@@ -42,7 +42,9 @@ In the Python frontend, the disaggregated factory selects its components from `w
 | Prefill | Active prefill tokens | Select the lowest total cost |
 | Decode | Projected decode blocks | Select the lowest total cost |
 
-Both policies request only the `LOAD` signal group. A policy can also request cache or routing signals when its filter, scorer, or picker uses them.
+The `least-busy` policy requests `LOAD` by default. Set a positive `min_effective_overlap_blocks` value to also request `CACHE` and reject workers below that threshold. The `disaggregated-load` policy requests only `LOAD`.
+
+The cache-overlap filter is a hard requirement. If no eligible worker meets the threshold, Dynamo returns HTTP 503.
 
 ## Register and Configure a Policy
 
@@ -108,7 +110,7 @@ Implement `WorkerPicker` to choose one row after scoring. `WorkerInputView::cand
 
 Candidate order is unspecified. Inspect the worker, cost, or another signal instead of relying on the first row.
 
-The [basic policy](https://github.com/ai-dynamo/dynamo/blob/main/examples/router/custom-policy-example/basic/src/lib.rs) shows one scorer and picker. The `disaggregated` crate in the [custom policy example](https://github.com/ai-dynamo/dynamo/tree/main/examples/router/custom-policy-example) shows separate implementations for prefill and decode workers.
+The [basic policy](https://github.com/ai-dynamo/dynamo/blob/main/examples/router/custom-policy-example/basic/src/lib.rs) shows an optional cache-overlap filter, scorer, and picker. The `disaggregated` crate in the [custom policy example](https://github.com/ai-dynamo/dynamo/tree/main/examples/router/custom-policy-example) shows separate implementations for prefill and decode workers.
 
 ### Available Signals
 

--- a/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
+++ b/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
@@ -100,15 +100,17 @@ These paths are build inputs. The policy can remain in its own repository, but i
 </Step>
 <Step title="Write filters, scorers, and a picker" id="write-filters-scorers-and-picker">
 
-Implement `WorkerFilter` to exclude an eligible worker. `keep` receives the request context and one candidate. Return `true` to keep it. Filters run before scorers and pickers.
+Implement `WorkerFilter` to exclude an eligible worker. `keep` receives the request context and one candidate. Return `true` to keep it. For each candidate, Dynamo runs filters in declaration order before any scorer. Every filter receives the union of signal groups requested by the policy's filters.
 
-Implement `WorkerScorer` for each cost that the policy measures. `score` receives the request-wide context and one eligible worker. Return a finite cost where lower values are better.
+Implement `WorkerScorer` for each cost that the policy measures. `score` receives the request-wide context and one kept worker. Return a finite cost where lower values are better.
 
-A policy can combine multiple scorers. Dynamo calls each scorer for every eligible worker and adds their costs.
+A policy can combine multiple scorers. Dynamo calls each scorer in declaration order for every kept worker and adds their costs.
 
 Implement `WorkerPicker` to choose one row after scoring. `WorkerInputView::candidates()` contains each worker identity and its total cost. Return the index of the selected row.
 
-Candidate order is unspecified. Inspect the worker, cost, or another signal instead of relying on the first row.
+Candidate row order and callback order across different candidates are unspecified. Inspect the worker, cost, or another signal instead of relying on the first row or on filters and scorers being interleaved.
+
+Dynamo normally sends a kept candidate directly to the scorers. If the built-in scorer needs the minimum active prefill load across a filtered set, Dynamo buffers the kept candidates, computes that baseline during filtering, and then scores them in a second pass. Policies that do not need this filtered aggregate do not buffer candidates.
 
 The [basic policy](https://github.com/ai-dynamo/dynamo/blob/main/examples/router/custom-policy-example/basic/src/lib.rs) shows an optional cache-overlap filter, scorer, and picker. The `disaggregated` crate in the [custom policy example](https://github.com/ai-dynamo/dynamo/tree/main/examples/router/custom-policy-example) shows separate implementations for prefill and decode workers.
 

--- a/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
+++ b/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
@@ -2,11 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Write Custom Routing Strategies
-subtitle: Link Rust scorers and pickers into the Dynamo frontend or EPP
+subtitle: Link Rust filters, scorers, and pickers into the Dynamo frontend or EPP
 ---
 
 <Warning>
-**Experimental.** A custom worker-selection policy controls how Dynamo scores eligible workers and selects one. Dynamo still owns discovery, eligibility, queueing, reservations, accounting, and metrics.
+**Experimental.** A custom worker-selection policy controls how Dynamo filters and scores eligible workers, then selects one. Dynamo still owns discovery, eligibility, queueing, reservations, accounting, and metrics.
 </Warning>
 
 The [custom policy example](https://github.com/ai-dynamo/dynamo/tree/main/examples/router/custom-policy-example) contains the complete source and commands for both integration paths.
@@ -15,7 +15,7 @@ The [custom policy example](https://github.com/ai-dynamo/dynamo/tree/main/exampl
 
 A custom routing strategy has four parts:
 
-1. A policy crate defines one or more scorers and one picker.
+1. A policy crate defines filters, scorers, and one picker.
 2. A catalog crate registers each policy type under a unique name.
 3. The router policy configuration selects a named policy instance and supplies its parameters.
 4. The Python frontend or Endpoint Picker Provider (EPP) links the catalog into its binary.
@@ -24,9 +24,9 @@ The catalog is a compile-time extension point. Dynamo does not load policy libra
 
 At startup, Dynamo reads the selected policy instance and asks its provider to parse the parameter map. The provider returns a factory after validation succeeds. Invalid parameters, unknown types, and duplicate registrations stop startup.
 
-Dynamo calls the factory once for each routing partition. The factory receives the router configuration, worker type, and partition identity. It can build different scorer and picker combinations for prefill and decode workers.
+Dynamo calls the factory once for each routing partition. The factory receives the router configuration, worker type, and partition identity. It can build different filter, scorer, and picker combinations for prefill and decode workers.
 
-For each request, Dynamo first applies its built-in worker eligibility rules. The custom scorers assign finite costs to the remaining workers. The picker returns one row from that scored candidate set, then Dynamo reserves and routes to that worker.
+For each request, Dynamo first applies its built-in worker eligibility rules. Custom filters can exclude the remaining workers. The custom scorers assign finite costs to workers that remain. The picker returns one row from that scored candidate set, then Dynamo reserves and routes to that worker.
 
 ## Example Policies
 
@@ -42,7 +42,7 @@ In the Python frontend, the disaggregated factory selects its components from `w
 | Prefill | Active prefill tokens | Select the lowest total cost |
 | Decode | Projected decode blocks | Select the lowest total cost |
 
-Both policies request only the `LOAD` signal group. A policy can also request cache or routing signals when its scorer or picker uses them.
+Both policies request only the `LOAD` signal group. A policy can also request cache or routing signals when its filter, scorer, or picker uses them.
 
 ## Register and Configure a Policy
 
@@ -62,7 +62,7 @@ cargo init --lib --name acme-routing-policy "$POLICY_DIR/policy"
 cargo init --lib --name acme-routing-catalog "$POLICY_DIR/catalog"
 ```
 
-The policy crate contains the scorer, picker, provider, and factory. The catalog registers one or more policy crates.
+The policy crate contains filters, scorers, a picker, provider, and factory. The catalog registers one or more policy crates.
 
 </Step>
 <Step title="Add the dependencies" id="add-the-dependencies">
@@ -96,7 +96,9 @@ cargo add \
 These paths are build inputs. The policy can remain in its own repository, but it must compile against the Dynamo revision used by the host binary.
 
 </Step>
-<Step title="Write the scorer and picker" id="write-the-scorer-and-picker">
+<Step title="Write filters, scorers, and a picker" id="write-filters-scorers-and-picker">
+
+Implement `WorkerFilter` to exclude an eligible worker. `keep` receives the request context and one candidate. Return `true` to keep it. Filters run before scorers and pickers.
 
 Implement `WorkerScorer` for each cost that the policy measures. `score` receives the request-wide context and one eligible worker. Return a finite cost where lower values are better.
 
@@ -110,7 +112,7 @@ The [basic policy](https://github.com/ai-dynamo/dynamo/blob/main/examples/router
 
 ### Available Signals
 
-Request context and worker identity are always available. Optional per-worker signals are calculated only when a scorer or picker requests their group.
+Request context and worker identity are always available. Optional per-worker signals are calculated only when a filter, scorer, or picker requests their group.
 
 | Source | Available values | Meaning |
 |---|---|---|
@@ -133,7 +135,7 @@ Declare optional inputs with `required_worker_inputs`. Use `WorkerInputs::NONE` 
 | `LOAD` | `active_requests()` | Requests currently active on the worker |
 | `ROUTING` | `preferred_taint_multiplier()` | Cost multiplier from the request's preferred routing constraints, when applicable |
 
-Read scorer inputs through `WorkerCandidate::cache()`, `load()`, or `routing()`. A picker receives aligned arrays through `WorkerInputView`. Each component must declare every group that it reads.
+Read filter and scorer inputs through `WorkerCandidate::cache()`, `load()`, or `routing()`. A picker receives aligned arrays through `WorkerInputView`. Each component must declare every group that it reads.
 
 </Step>
 <Step title="Add the provider and factory" id="add-the-provider-and-factory">
@@ -142,7 +144,7 @@ Define the policy parameter type and reject unknown fields. The provider parses 
 
 Dynamo calls the factory once for each routing partition. The factory receives the router configuration, partition identity, and `worker_type`.
 
-Build a `WorkerSelectionPolicy` from the scorers and picker. Branch on `worker_type` when prefill and decode workers need different behavior.
+Build a `WorkerSelectionPolicy` from the filters, scorers, and picker. Branch on `worker_type` when prefill and decode workers need different behavior.
 
 </Step>
 <Step title="Register the policy" id="register-the-policy">
@@ -254,8 +256,8 @@ cargo run --release
 
 - Return finite scorer costs. Dynamo rejects non-finite contributions and totals.
 - Return a row from `WorkerInputView::candidates()`. Dynamo validates the index before reservation and accounting.
-- Declare every signal a scorer or picker reads with `required_worker_inputs`. Request only the signals you use.
+- Declare every signal a filter, scorer, or picker reads with `required_worker_inputs`. Request only the signals you use.
 - Treat candidate row order as unspecified. Use worker identity or another explicit signal if tie behavior matters.
-- Keep blocking I/O and panics out of `score` and `pick`. Both run in Dynamo's scheduler queue actor.
+- Keep blocking I/O and panics out of `keep`, `score`, and `pick`. All run in Dynamo's scheduler queue actor.
 
 For the built-in cost model, see [Routing Concepts](../knowledge-base/modular-components/router/routing-concepts.md). For the full standalone EPP deployment, see [Using GAIE with vanilla vLLM](../../kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx).

--- a/examples/router/custom-policy-example/CLAUDE.md
+++ b/examples/router/custom-policy-example/CLAUDE.md
@@ -6,9 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 # Custom Worker Selection Example
 
 - Keep each policy in its own crate and register it through `catalog`.
-- Keep scorer and picker algorithms small enough to explain in `README.md`.
-- Declare every signal read by a scorer or picker with `required_worker_inputs`.
+- Keep filter, scorer, and picker algorithms small enough to explain in `README.md`.
+- Declare every signal read by a filter, scorer, or picker with `required_worker_inputs`.
 - Parse and validate YAML parameters in the provider before creating the factory.
-- Keep blocking I/O, panics, and shared mutable state out of `score` and `pick`.
+- Keep blocking I/O, panics, and shared mutable state out of `keep`, `score`, and `pick`.
 - Add new crates to the root Cargo workspace and add focused registration tests.
 - Update `README.md` and the custom worker-selection docs page when the example workflow changes.

--- a/examples/router/custom-policy-example/README.md
+++ b/examples/router/custom-policy-example/README.md
@@ -11,10 +11,12 @@ This example shows how to link custom Rust worker-selection policies into the Dy
 
 | Crate | Purpose |
 |---|---|
-| `basic` | Uses one scorer and picker for every worker type. It scores active requests and picks the lowest cost. |
+| `basic` | Optionally requires cache overlap, then scores active requests and picks the lowest cost. |
 | `disaggregated` | Uses separate scorer and picker types for prefill and decode workers. |
 | `catalog` | Registers both policy types with Dynamo. Add new policy crates here. |
 | `epp` | Runs the catalog in a standalone EPP binary. |
+
+Each policy crate keeps configuration, factory creation, and registration in `lib.rs`. The filter, scorer, and picker algorithms live in focused source files.
 
 The disaggregated policy keeps the algorithm deliberately small:
 
@@ -47,12 +49,18 @@ worker_selection:
     - name: least-busy
       type: least-busy
       parameters: {}
+    - name: cache-affinity
+      type: least-busy
+      parameters:
+        min_effective_overlap_blocks: 8
     - name: disaggregated-load
       type: disaggregated-load
       parameters: {}
 ```
 
-Change `default` to `least-busy` to use the basic policy. Set `DYN_ROUTER_WORKER_SELECTION_POLICY` to either instance name to override the YAML default. Use `default` to select Dynamo's built-in policy.
+Change `default` to `least-busy` to use the basic policy without a filter. Change it to `cache-affinity` to require at least eight effective cache-overlap blocks. Set a positive `min_effective_overlap_blocks` value. Set `DYN_ROUTER_WORKER_SELECTION_POLICY` to an instance name to override the YAML default. Use `default` to select Dynamo's built-in policy.
+
+The cache-affinity filter is a hard requirement. If no eligible worker meets the threshold, Dynamo returns HTTP 503.
 
 ## Run With the Python Frontend
 
@@ -101,7 +109,7 @@ Follow the [standalone EPP guide](../../../docs/fern/pages/kubernetes/kv-aware-r
 
 Start with a new Rust library crate. The `basic` and `disaggregated` crates are runnable references, not templates.
 
-1. Implement the scorer and picker. Declare each signal with `required_worker_inputs`.
+1. Implement filters, scorers, and a picker. Declare each signal with `required_worker_inputs`.
 2. Parse and validate policy parameters in the provider.
 3. Return a factory that builds the policy for each worker type.
 4. Register a unique policy type name.
@@ -109,4 +117,4 @@ Start with a new Rust library crate. The `basic` and `disaggregated` crates are 
 
 The [custom routing guide](../../../docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx) explains the traits, available signals, factory lifecycle, and registration flow.
 
-`score` and `pick` run in the scheduler queue actor. Keep them free of blocking I/O and return finite costs and a valid candidate row.
+`keep`, `score`, and `pick` run in the scheduler queue actor. Keep them free of blocking I/O. Return finite costs and a valid candidate row.

--- a/examples/router/custom-policy-example/README.md
+++ b/examples/router/custom-policy-example/README.md
@@ -118,3 +118,5 @@ Start with a new Rust library crate. The `basic` and `disaggregated` crates are 
 The [custom routing guide](../../../docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx) explains the traits, available signals, factory lifecycle, and registration flow.
 
 `keep`, `score`, and `pick` run in the scheduler queue actor. Keep them free of blocking I/O. Return finite costs and a valid candidate row.
+
+For each candidate, filters run in declaration order before scorers. Candidate order and callback order across different candidates are unspecified. Dynamo normally scores kept candidates directly. It buffers them only when the built-in scorer needs a minimum active prefill load across the filtered set.

--- a/examples/router/custom-policy-example/basic/src/filter.rs
+++ b/examples/router/custom-policy-example/basic/src/filter.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cache-affinity filter for the `least-busy` policy.
+
+use dynamo_kv_router::{
+    WorkerCandidate, WorkerFilter, WorkerInputs, WorkerSelectionContext, WorkerSelectionPolicyError,
+};
+
+/// Keeps workers whose effective cache overlap meets the configured minimum.
+pub(crate) struct MinimumEffectiveOverlapFilter {
+    pub(crate) min_effective_overlap_blocks: f64,
+}
+
+impl WorkerFilter for MinimumEffectiveOverlapFilter {
+    /// Requests cache inputs before the scorer runs.
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        WorkerInputs::CACHE
+    }
+
+    /// Keeps a candidate when its effective cache overlap meets the minimum.
+    fn keep(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        candidate: &WorkerCandidate,
+    ) -> Result<bool, WorkerSelectionPolicyError> {
+        let cache = candidate
+            .cache()
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("cache input unavailable"))?;
+        Ok(cache.effective_overlap_blocks() >= self.min_effective_overlap_blocks)
+    }
+}

--- a/examples/router/custom-policy-example/basic/src/lib.rs
+++ b/examples/router/custom-policy-example/basic/src/lib.rs
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Basic custom worker-selection policy example.
+//! Factory and registration for the `least-busy` policy.
+//!
+//! The policy optionally filters workers by effective cache overlap, then ranks
+//! the remaining workers by active requests.
+
+mod filter;
+mod selection;
 
 use std::sync::Arc;
 
@@ -10,62 +16,51 @@ use dynamo_kv_router::services::selection::{
     WorkerSelectionPolicyProviderError, WorkerSelectionPolicyRegistry,
     WorkerSelectionPolicyRegistryError,
 };
-use dynamo_kv_router::{
-    KvRouterConfig, WorkerCandidate, WorkerInputView, WorkerInputs, WorkerPicker, WorkerScorer,
-    WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelectionPolicyError,
-};
-
-struct LeastBusyScorer;
-
-impl WorkerScorer for LeastBusyScorer {
-    fn required_worker_inputs(&self) -> WorkerInputs {
-        WorkerInputs::LOAD
-    }
-
-    fn score(
-        &mut self,
-        _context: &WorkerSelectionContext<'_>,
-        candidate: &WorkerCandidate,
-    ) -> Result<f64, WorkerSelectionPolicyError> {
-        let load = candidate
-            .load()
-            .ok_or_else(|| WorkerSelectionPolicyError::failed("load input unavailable"))?;
-        Ok(load.active_requests() as f64)
-    }
-}
-
-struct LowestCostPicker;
-
-impl WorkerPicker for LowestCostPicker {
-    fn pick(
-        &mut self,
-        _context: &WorkerSelectionContext<'_>,
-        input: WorkerInputView<'_>,
-    ) -> Result<usize, WorkerSelectionPolicyError> {
-        input
-            .candidates()
-            .iter()
-            .enumerate()
-            .min_by(|(_, left), (_, right)| left.cost().total_cmp(&right.cost()))
-            .map(|(row, _)| row)
-            .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible worker"))
-    }
-}
+use dynamo_kv_router::{KvRouterConfig, WorkerFilter, WorkerSelectionPolicy};
+use filter::MinimumEffectiveOverlapFilter;
+use selection::{LeastBusyScorer, LowestCostPicker};
 
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
-struct Parameters {}
+struct Parameters {
+    #[serde(default)]
+    min_effective_overlap_blocks: Option<f64>,
+}
+
+fn validate_min_effective_overlap_blocks(
+    min_effective_overlap_blocks: Option<f64>,
+) -> Result<(), WorkerSelectionPolicyProviderError> {
+    if let Some(value) = min_effective_overlap_blocks
+        && (!value.is_finite() || value <= 0.0)
+    {
+        return Err(WorkerSelectionPolicyProviderError::new(
+            "min_effective_overlap_blocks must be a finite positive number",
+        ));
+    }
+    Ok(())
+}
 
 fn provider(
     parameters: &WorkerSelectionPolicyParameters,
 ) -> Result<WorkerSelectionPolicyFactory, WorkerSelectionPolicyProviderError> {
-    let _: Parameters = parameters.deserialize()?;
+    let parameters: Parameters = parameters.deserialize()?;
+    validate_min_effective_overlap_blocks(parameters.min_effective_overlap_blocks)?;
+    let min_effective_overlap_blocks = parameters.min_effective_overlap_blocks;
 
     Ok(Arc::new(
-        |config: &KvRouterConfig, worker_type, _partition| {
-            WorkerSelectionPolicy::new(
+        move |config: &KvRouterConfig, worker_type, _partition| {
+            let filters: Vec<Box<dyn WorkerFilter>> = min_effective_overlap_blocks.map_or_else(
+                Vec::new,
+                |min_effective_overlap_blocks| {
+                    vec![Box::new(MinimumEffectiveOverlapFilter {
+                        min_effective_overlap_blocks,
+                    }) as Box<dyn WorkerFilter>]
+                },
+            );
+            WorkerSelectionPolicy::new_with_filters(
                 config.clone(),
                 worker_type,
+                filters,
                 vec![Box::new(LeastBusyScorer)],
                 Box::new(LowestCostPicker),
             )
@@ -77,4 +72,18 @@ pub fn register(
     registry: &mut WorkerSelectionPolicyRegistry,
 ) -> Result<(), WorkerSelectionPolicyRegistryError> {
     registry.register("least-busy", Arc::new(provider))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_min_effective_overlap_blocks() {
+        assert!(validate_min_effective_overlap_blocks(None).is_ok());
+        assert!(validate_min_effective_overlap_blocks(Some(8.0)).is_ok());
+        assert!(validate_min_effective_overlap_blocks(Some(0.0)).is_err());
+        assert!(validate_min_effective_overlap_blocks(Some(-1.0)).is_err());
+        assert!(validate_min_effective_overlap_blocks(Some(f64::NAN)).is_err());
+    }
 }

--- a/examples/router/custom-policy-example/basic/src/selection.rs
+++ b/examples/router/custom-policy-example/basic/src/selection.rs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Load scorer and lowest-cost picker for the `least-busy` policy.
+
+use dynamo_kv_router::{
+    WorkerCandidate, WorkerInputView, WorkerInputs, WorkerPicker, WorkerScorer,
+    WorkerSelectionContext, WorkerSelectionPolicyError,
+};
+
+/// Scores each candidate by its current number of active requests.
+pub(crate) struct LeastBusyScorer;
+
+impl WorkerScorer for LeastBusyScorer {
+    /// Requests load inputs for the active-request count.
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        WorkerInputs::LOAD
+    }
+
+    /// Returns the active-request count as a lower-is-better cost.
+    fn score(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        candidate: &WorkerCandidate,
+    ) -> Result<f64, WorkerSelectionPolicyError> {
+        let load = candidate
+            .load()
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("load input unavailable"))?;
+        Ok(load.active_requests() as f64)
+    }
+}
+
+/// Picks the candidate with the lowest accumulated scorer cost.
+pub(crate) struct LowestCostPicker;
+
+impl WorkerPicker for LowestCostPicker {
+    /// Returns the row with the lowest cost.
+    fn pick(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        input: WorkerInputView<'_>,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        input
+            .candidates()
+            .iter()
+            .enumerate()
+            .min_by(|(_, left), (_, right)| left.cost().total_cmp(&right.cost()))
+            .map(|(row, _)| row)
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible worker"))
+    }
+}

--- a/examples/router/custom-policy-example/disaggregated/src/lib.rs
+++ b/examples/router/custom-policy-example/disaggregated/src/lib.rs
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Custom worker-selection policy with separate prefill and decode behavior.
+//! Factory and registration for the `disaggregated-load` policy.
+//!
+//! The factory selects prefill or decode components for each routing partition.
+
+mod picker;
+mod scorer;
 
 use std::sync::Arc;
 
@@ -10,84 +15,11 @@ use dynamo_kv_router::services::selection::{
     WorkerSelectionPolicyProviderError, WorkerSelectionPolicyRegistry,
     WorkerSelectionPolicyRegistryError,
 };
-use dynamo_kv_router::{
-    KvRouterConfig, WorkerCandidate, WorkerInputView, WorkerInputs, WorkerPicker, WorkerScorer,
-    WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelectionPolicyError,
-};
+use dynamo_kv_router::{KvRouterConfig, WorkerPicker, WorkerScorer, WorkerSelectionPolicy};
+use picker::{DecodePicker, PrefillPicker};
+use scorer::{DecodeLoadScorer, PrefillLoadScorer};
 
 const DECODE_WORKER_TYPE: &str = "decode";
-
-struct PrefillLoadScorer;
-
-impl WorkerScorer for PrefillLoadScorer {
-    fn required_worker_inputs(&self) -> WorkerInputs {
-        WorkerInputs::LOAD
-    }
-
-    fn score(
-        &mut self,
-        _context: &WorkerSelectionContext<'_>,
-        candidate: &WorkerCandidate,
-    ) -> Result<f64, WorkerSelectionPolicyError> {
-        let load = candidate
-            .load()
-            .ok_or_else(|| WorkerSelectionPolicyError::failed("load input unavailable"))?;
-        Ok(load.active_prefill_tokens() as f64)
-    }
-}
-
-struct DecodeLoadScorer;
-
-impl WorkerScorer for DecodeLoadScorer {
-    fn required_worker_inputs(&self) -> WorkerInputs {
-        WorkerInputs::LOAD
-    }
-
-    fn score(
-        &mut self,
-        _context: &WorkerSelectionContext<'_>,
-        candidate: &WorkerCandidate,
-    ) -> Result<f64, WorkerSelectionPolicyError> {
-        let load = candidate
-            .load()
-            .ok_or_else(|| WorkerSelectionPolicyError::failed("load input unavailable"))?;
-        Ok(load.decode_cost_blocks())
-    }
-}
-
-fn lowest_cost_row(input: WorkerInputView<'_>) -> Result<usize, WorkerSelectionPolicyError> {
-    input
-        .candidates()
-        .iter()
-        .enumerate()
-        .min_by(|(_, left), (_, right)| left.cost().total_cmp(&right.cost()))
-        .map(|(row, _)| row)
-        .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible worker"))
-}
-
-struct PrefillPicker;
-
-impl WorkerPicker for PrefillPicker {
-    fn pick(
-        &mut self,
-        _context: &WorkerSelectionContext<'_>,
-        input: WorkerInputView<'_>,
-    ) -> Result<usize, WorkerSelectionPolicyError> {
-        lowest_cost_row(input)
-    }
-}
-
-struct DecodePicker;
-
-impl WorkerPicker for DecodePicker {
-    fn pick(
-        &mut self,
-        _context: &WorkerSelectionContext<'_>,
-        input: WorkerInputView<'_>,
-    ) -> Result<usize, WorkerSelectionPolicyError> {
-        lowest_cost_row(input)
-    }
-}
 
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/examples/router/custom-policy-example/disaggregated/src/picker.rs
+++ b/examples/router/custom-policy-example/disaggregated/src/picker.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pickers for prefill and decode routing partitions.
+
+use dynamo_kv_router::{
+    WorkerInputView, WorkerPicker, WorkerSelectionContext, WorkerSelectionPolicyError,
+};
+
+/// Finds the candidate row with the lowest accumulated scorer cost.
+fn lowest_cost_row(input: WorkerInputView<'_>) -> Result<usize, WorkerSelectionPolicyError> {
+    input
+        .candidates()
+        .iter()
+        .enumerate()
+        .min_by(|(_, left), (_, right)| left.cost().total_cmp(&right.cost()))
+        .map(|(row, _)| row)
+        .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible worker"))
+}
+
+/// Picks the prefill candidate with the lowest total cost.
+pub(crate) struct PrefillPicker;
+
+impl WorkerPicker for PrefillPicker {
+    /// Returns the prefill candidate row with the lowest cost.
+    fn pick(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        input: WorkerInputView<'_>,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        lowest_cost_row(input)
+    }
+}
+
+/// Picks the decode candidate with the lowest total cost.
+pub(crate) struct DecodePicker;
+
+impl WorkerPicker for DecodePicker {
+    /// Returns the decode candidate row with the lowest cost.
+    fn pick(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        input: WorkerInputView<'_>,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        lowest_cost_row(input)
+    }
+}

--- a/examples/router/custom-policy-example/disaggregated/src/scorer.rs
+++ b/examples/router/custom-policy-example/disaggregated/src/scorer.rs
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Load scorers for prefill and decode routing partitions.
+
+use dynamo_kv_router::{
+    WorkerCandidate, WorkerInputs, WorkerScorer, WorkerSelectionContext, WorkerSelectionPolicyError,
+};
+
+/// Scores prefill workers by active prefill tokens.
+pub(crate) struct PrefillLoadScorer;
+
+impl WorkerScorer for PrefillLoadScorer {
+    /// Requests load inputs for active prefill tokens.
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        WorkerInputs::LOAD
+    }
+
+    /// Returns the active prefill-token count as a lower-is-better cost.
+    fn score(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        candidate: &WorkerCandidate,
+    ) -> Result<f64, WorkerSelectionPolicyError> {
+        let load = candidate
+            .load()
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("load input unavailable"))?;
+        Ok(load.active_prefill_tokens() as f64)
+    }
+}
+
+/// Scores decode workers by their projected decode cost in blocks.
+pub(crate) struct DecodeLoadScorer;
+
+impl WorkerScorer for DecodeLoadScorer {
+    /// Requests load inputs for projected decode cost.
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        WorkerInputs::LOAD
+    }
+
+    /// Returns the projected decode cost as a lower-is-better cost.
+    fn score(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        candidate: &WorkerCandidate,
+    ) -> Result<f64, WorkerSelectionPolicyError> {
+        let load = candidate
+            .load()
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("load input unavailable"))?;
+        Ok(load.decode_cost_blocks())
+    }
+}

--- a/lib/kv-router/benches/worker_selection.rs
+++ b/lib/kv-router/benches/worker_selection.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Default worker-selection scaling benchmark.
+//! Worker-selection scaling benchmark for built-in and custom policies.
 //!
 //! Run with: `cargo bench -p dynamo-kv-router --bench worker_selection`
 
@@ -14,7 +14,9 @@ use dynamo_kv_router::protocols::{
 };
 use dynamo_kv_router::scheduling::{OverlapSignals, ScheduleMode};
 use dynamo_kv_router::{
-    DefaultWorkerSelector, KvRouterConfig, SchedulingRequest, WorkerLoadProjection, WorkerSelector,
+    DefaultWorkerPicker, DefaultWorkerScorer, DefaultWorkerSelector, KvRouterConfig,
+    SchedulingRequest, WorkerCandidate, WorkerFilter, WorkerLoadProjection, WorkerSelectionContext,
+    WorkerSelectionPolicy, WorkerSelectionPolicyError, WorkerSelector,
 };
 use rustc_hash::FxHashMap;
 
@@ -42,6 +44,18 @@ impl WorkerConfigLike for BenchWorkerConfig {
 
     fn taints(&self) -> &HashSet<String> {
         &self.taints
+    }
+}
+
+struct KeepAllFilter;
+
+impl WorkerFilter for KeepAllFilter {
+    fn keep(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        _candidate: &WorkerCandidate,
+    ) -> Result<bool, WorkerSelectionPolicyError> {
+        Ok(true)
     }
 }
 
@@ -140,5 +154,90 @@ fn worker_selection(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, worker_selection);
+fn custom_worker_selection(c: &mut Criterion) {
+    const WORKER_COUNT: usize = 10_000;
+
+    for (scenario, overlap_score_credit_decay) in
+        [("direct", 0.0), ("filtered_prefill_baseline", 1.0)]
+    {
+        for temperature in [0.0, 0.7] {
+            let (workers, request) = fixture(WORKER_COUNT);
+            let config = KvRouterConfig {
+                router_temperature: temperature,
+                overlap_score_credit_decay,
+                ..Default::default()
+            };
+            let default = DefaultWorkerSelector::new(Some(config.clone()), "prefill");
+            let custom_no_filter = WorkerSelectionPolicy::new(
+                config.clone(),
+                "prefill",
+                vec![Box::new(DefaultWorkerScorer::new(
+                    config.clone(),
+                    "prefill",
+                ))],
+                Box::new(DefaultWorkerPicker::new(temperature)),
+            );
+            let custom_keep_all_filter = WorkerSelectionPolicy::new_with_filters(
+                config.clone(),
+                "prefill",
+                vec![Box::new(KeepAllFilter)],
+                vec![Box::new(DefaultWorkerScorer::new(config, "prefill"))],
+                Box::new(DefaultWorkerPicker::new(temperature)),
+            );
+            let mut group = c.benchmark_group(format!(
+                "custom_worker_selection/{scenario}/temperature_{temperature}/10_000"
+            ));
+            group.warm_up_time(Duration::from_secs(2));
+            group.measurement_time(Duration::from_secs(5));
+            group.sample_size(50);
+            group.throughput(Throughput::Elements(WORKER_COUNT as u64));
+
+            group.bench_function("default", |b| {
+                b.iter(|| {
+                    black_box(
+                        default
+                            .select_worker(
+                                black_box(&workers),
+                                black_box(&request),
+                                request.eligibility(),
+                                black_box(16),
+                            )
+                            .unwrap(),
+                    )
+                })
+            });
+            group.bench_function("custom_no_filter", |b| {
+                b.iter(|| {
+                    black_box(
+                        custom_no_filter
+                            .select_worker(
+                                black_box(&workers),
+                                black_box(&request),
+                                request.eligibility(),
+                                black_box(16),
+                            )
+                            .unwrap(),
+                    )
+                })
+            });
+            group.bench_function("custom_keep_all_filter", |b| {
+                b.iter(|| {
+                    black_box(
+                        custom_keep_all_filter
+                            .select_worker(
+                                black_box(&workers),
+                                black_box(&request),
+                                request.eligibility(),
+                                black_box(16),
+                            )
+                            .unwrap(),
+                    )
+                })
+            });
+            group.finish();
+        }
+    }
+}
+
+criterion_group!(benches, worker_selection, custom_worker_selection);
 criterion_main!(benches);

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -76,9 +76,9 @@ pub use scheduling::{
 };
 pub use selector::{
     DefaultWorkerPicker, DefaultWorkerScorer, DefaultWorkerSelector, ScoredWorkerCandidate,
-    WorkerCacheInput, WorkerCandidate, WorkerInputView, WorkerInputs, WorkerLoadInput,
-    WorkerPicker, WorkerRoutingInput, WorkerScorer, WorkerSelectionContext, WorkerSelectionPolicy,
-    WorkerSelector,
+    WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView, WorkerInputs,
+    WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer, WorkerSelectionContext,
+    WorkerSelectionPolicy, WorkerSelector,
 };
 pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
 

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -323,7 +323,7 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
             state.filter_inputs | state.scorer_picker_inputs
         }
     };
-    let input =
+    let mut input =
         WorkerSelectionInput::new(workers, request, eligibility, block_size, weights, inputs);
     let selected = match state {
         WorkerSelectionPolicyStateRef::Default(picker) => {
@@ -336,7 +336,7 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
         WorkerSelectionPolicyStateRef::Custom(state) => {
             let mut state = state.borrow_mut();
             let has_eligible_worker =
-                collect_custom_candidates(&mut state, &input, workers, request, eligibility)?;
+                collect_custom_candidates(&mut state, &mut input, workers, request, eligibility)?;
             let CustomWorkerSelectionState {
                 picker,
                 picker_inputs,

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -314,13 +314,26 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
     }
 
     let weights = selection_weights(kv_router_config, request);
-    let inputs = match &state {
-        WorkerSelectionPolicyStateRef::Default(_) => {
-            WorkerInputs::ALL | WorkerInputs::MIN_ACTIVE_PREFILL_TOKENS
-        }
+    let (inputs, needs_filtered_baseline) = match &state {
+        WorkerSelectionPolicyStateRef::Default(_) => (
+            WorkerInputs::ALL | WorkerInputs::MIN_ACTIVE_PREFILL_TOKENS,
+            false,
+        ),
         WorkerSelectionPolicyStateRef::Custom(state) => {
             let state = RefCell::borrow(state);
-            state.filter_inputs | state.scorer_picker_inputs
+            let needs_filtered_baseline = !state.filters.is_empty()
+                && state
+                    .scorer_picker_inputs
+                    .contains(WorkerInputs::MIN_ACTIVE_PREFILL_TOKENS)
+                && request.track_prefill_tokens
+                && weights.overlap_score_credit_decay > 0.0;
+            let inputs = state.filter_inputs | state.scorer_picker_inputs;
+            let inputs = if needs_filtered_baseline {
+                inputs.without(WorkerInputs::MIN_ACTIVE_PREFILL_TOKENS)
+            } else {
+                inputs
+            };
+            (inputs, needs_filtered_baseline)
         }
     };
     let mut input =
@@ -335,8 +348,14 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
         }
         WorkerSelectionPolicyStateRef::Custom(state) => {
             let mut state = state.borrow_mut();
-            let has_eligible_worker =
-                collect_custom_candidates(&mut state, &mut input, workers, request, eligibility)?;
+            let has_eligible_worker = collect_custom_candidates(
+                &mut state,
+                &mut input,
+                workers,
+                request,
+                eligibility,
+                needs_filtered_baseline,
+            )?;
             let CustomWorkerSelectionState {
                 picker,
                 picker_inputs,

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -9,9 +9,9 @@ mod policy;
 
 pub use default::{DefaultWorkerPicker, DefaultWorkerScorer, DefaultWorkerSelector};
 pub use policy::{
-    ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerInputView, WorkerInputs,
-    WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer, WorkerSelectionContext,
-    WorkerSelectionPolicy,
+    ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView,
+    WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
+    WorkerSelectionContext, WorkerSelectionPolicy,
 };
 
 use default::{pick_default_worker, selection_weights};
@@ -318,7 +318,10 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
         WorkerSelectionPolicyStateRef::Default(_) => {
             WorkerInputs::ALL | WorkerInputs::MIN_ACTIVE_PREFILL_TOKENS
         }
-        WorkerSelectionPolicyStateRef::Custom(state) => RefCell::borrow(state).worker_inputs,
+        WorkerSelectionPolicyStateRef::Custom(state) => {
+            let state = RefCell::borrow(state);
+            state.filter_inputs | state.scorer_picker_inputs
+        }
     };
     let input =
         WorkerSelectionInput::new(workers, request, eligibility, block_size, weights, inputs);
@@ -332,7 +335,8 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
         }
         WorkerSelectionPolicyStateRef::Custom(state) => {
             let mut state = state.borrow_mut();
-            collect_custom_candidates(&mut state, &input, workers, request, eligibility)?;
+            let has_eligible_worker =
+                collect_custom_candidates(&mut state, &input, workers, request, eligibility)?;
             let CustomWorkerSelectionState {
                 picker,
                 picker_inputs,
@@ -343,6 +347,9 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
                 ..
             } = &mut *state;
             if candidates.is_empty() {
+                if has_eligible_worker {
+                    return Err(KvSchedulerError::AllEligibleWorkersFiltered);
+                }
                 None
             } else {
                 debug_assert!(

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -55,7 +55,7 @@ impl WorkerInputs {
         self.0 & other.0 == other.0
     }
 
-    fn without(self, other: Self) -> Self {
+    pub(super) fn without(self, other: Self) -> Self {
         Self(self.0 & !other.0)
     }
 }
@@ -113,6 +113,9 @@ pub trait WorkerScorer: Send {
     ) -> Result<f64, WorkerSelectionPolicyError>;
 }
 
+/// Filters run in declaration order for each candidate. Callback order across different
+/// candidates and scorers is unspecified; implementations must not depend on filters and scorers
+/// being interleaved.
 pub trait WorkerFilter: Send {
     /// Declare the worker-signal groups needed by this filter.
     fn required_worker_inputs(&self) -> WorkerInputs {
@@ -403,12 +406,53 @@ impl WorkerSelectionPolicy {
     }
 }
 
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn push_scored_candidate(
+    context: &WorkerSelectionContext<'_>,
+    candidate: &WorkerCandidate,
+    scorers: &mut [Box<dyn WorkerScorer>],
+    picker_inputs: WorkerInputs,
+    candidates: &mut Vec<ScoredWorkerCandidate>,
+    cache_inputs: &mut Vec<WorkerCacheInput>,
+    load_inputs: &mut Vec<WorkerLoadInput>,
+    routing_inputs: &mut Vec<WorkerRoutingInput>,
+) -> Result<(), KvSchedulerError> {
+    let mut cost = 0.0;
+    for (scorer_index, scorer) in scorers.iter_mut().enumerate() {
+        let contribution = scorer.score(context, candidate)?;
+        cost += contribution;
+        if !contribution.is_finite() || !cost.is_finite() {
+            return Err(WorkerSelectionPolicyError::NonFiniteCost {
+                scorer_index,
+                row: candidates.len(),
+            }
+            .into());
+        }
+    }
+    candidates.push(ScoredWorkerCandidate {
+        worker: candidate.worker,
+        cost,
+    });
+    if picker_inputs.contains(WorkerInputs::CACHE) {
+        cache_inputs.push(candidate.cache);
+    }
+    if picker_inputs.contains(WorkerInputs::LOAD) {
+        load_inputs.push(candidate.load);
+    }
+    if picker_inputs.contains(WorkerInputs::ROUTING) {
+        routing_inputs.push(candidate.routing);
+    }
+    Ok(())
+}
+
 pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
     state: &mut CustomWorkerSelectionState,
     input: &mut WorkerSelectionInput<'_>,
     workers: &HashMap<WorkerId, C>,
     request: &SchedulingRequest,
     eligibility: RoutingEligibility<'_>,
+    needs_filtered_baseline: bool,
 ) -> Result<bool, KvSchedulerError> {
     let CustomWorkerSelectionState {
         filters,
@@ -428,9 +472,45 @@ pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
     cache_inputs.clear();
     load_inputs.clear();
     routing_inputs.clear();
+    if filters.is_empty() {
+        let pinned = eligibility.pinned_worker().is_some();
+        let mut error = None;
+        eligibility.any_eligible_worker_rank(workers, |worker, config| {
+            let preferred_taint_multiplier =
+                if pinned || !scorer_picker_inputs.contains(WorkerInputs::ROUTING) {
+                    None
+                } else {
+                    request
+                        .routing_constraints
+                        .preferred_taint_multiplier(config.taints())
+                };
+            let candidate = input.row(worker, preferred_taint_multiplier, *scorer_picker_inputs);
+            if let Err(policy_error) = push_scored_candidate(
+                &input.context,
+                &candidate,
+                scorers,
+                *picker_inputs,
+                candidates,
+                cache_inputs,
+                load_inputs,
+                routing_inputs,
+            ) {
+                error = Some(policy_error);
+                return true;
+            }
+            false
+        });
+        if let Some(error) = error {
+            return Err(error);
+        }
+        return Ok(!candidates.is_empty());
+    }
+
     let pinned = eligibility.pinned_worker().is_some();
     let mut has_eligible_worker = false;
     let mut error = None;
+    debug_assert!(!needs_filtered_baseline || scorer_picker_inputs.contains(WorkerInputs::LOAD));
+    let mut min_active_prefill_tokens = usize::MAX;
     eligibility.any_eligible_worker_rank(workers, |worker, config| {
         has_eligible_worker = true;
         let routing_multiplier = |inputs: WorkerInputs| {
@@ -442,80 +522,66 @@ pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
                     .preferred_taint_multiplier(config.taints())
             }
         };
-        let filter_candidate = (!filters.is_empty())
-            .then(|| input.row(worker, routing_multiplier(*filter_inputs), *filter_inputs));
-        if let Some(filter_candidate) = filter_candidate.as_ref() {
-            for filter in filters.iter_mut() {
-                match filter.keep(&input.context, filter_candidate) {
-                    Ok(true) => {}
-                    Ok(false) => return false,
-                    Err(policy_error) => {
-                        error = Some(policy_error.into());
-                        return true;
-                    }
+        let filter_candidate =
+            input.row(worker, routing_multiplier(*filter_inputs), *filter_inputs);
+        for filter in filters.iter_mut() {
+            match filter.keep(&input.context, &filter_candidate) {
+                Ok(true) => {}
+                Ok(false) => return false,
+                Err(policy_error) => {
+                    error = Some(policy_error.into());
+                    return true;
                 }
             }
         }
 
-        let candidate = match filter_candidate {
-            Some(filter_candidate) => {
-                let additional_inputs = scorer_picker_inputs.without(*filter_inputs);
-                let additional = input.row(
-                    worker,
-                    routing_multiplier(additional_inputs),
-                    additional_inputs,
-                );
-                filter_candidate.with_inputs_from(&additional, *scorer_picker_inputs)
-            }
-            None => input.row(
-                worker,
-                routing_multiplier(*scorer_picker_inputs),
-                *scorer_picker_inputs,
-            ),
-        };
-        unscored_candidates.push(candidate);
+        let additional_inputs = scorer_picker_inputs.without(*filter_inputs);
+        let additional = input.row(
+            worker,
+            routing_multiplier(additional_inputs),
+            additional_inputs,
+        );
+        let candidate = filter_candidate.with_inputs_from(&additional, *scorer_picker_inputs);
+        if needs_filtered_baseline {
+            min_active_prefill_tokens =
+                min_active_prefill_tokens.min(candidate.load.active_prefill_tokens);
+            unscored_candidates.push(candidate);
+        } else if let Err(policy_error) = push_scored_candidate(
+            &input.context,
+            &candidate,
+            scorers,
+            *picker_inputs,
+            candidates,
+            cache_inputs,
+            load_inputs,
+            routing_inputs,
+        ) {
+            error = Some(policy_error);
+            return true;
+        }
         false
     });
     if let Some(error) = error {
         return Err(error);
     }
 
-    if scorer_picker_inputs.contains(WorkerInputs::MIN_ACTIVE_PREFILL_TOKENS)
-        && input.context.track_prefill_tokens
-        && input.context.weights.overlap_score_credit_decay > 0.0
-    {
-        input.context.min_active_prefill_tokens = unscored_candidates
-            .iter()
-            .map(|candidate| candidate.load.active_prefill_tokens)
-            .min()
-            .unwrap_or(0);
-    }
-
-    for candidate in unscored_candidates.iter() {
-        let mut cost = 0.0;
-        for (scorer_index, scorer) in scorers.iter_mut().enumerate() {
-            let contribution = scorer.score(&input.context, candidate)?;
-            cost += contribution;
-            if !contribution.is_finite() || !cost.is_finite() {
-                return Err(WorkerSelectionPolicyError::NonFiniteCost {
-                    scorer_index,
-                    row: candidates.len(),
-                }
-                .into());
-            }
-        }
-        candidates.push(ScoredWorkerCandidate {
-            worker: candidate.worker,
-            cost,
-        });
-        if picker_inputs.contains(WorkerInputs::CACHE) {
-            cache_inputs.push(candidate.cache);
-        }
-        if picker_inputs.contains(WorkerInputs::LOAD) {
-            load_inputs.push(candidate.load);
-        }
-        if picker_inputs.contains(WorkerInputs::ROUTING) {
-            routing_inputs.push(candidate.routing);
+    if needs_filtered_baseline {
+        input.context.min_active_prefill_tokens = if min_active_prefill_tokens == usize::MAX {
+            0
+        } else {
+            min_active_prefill_tokens
+        };
+        for candidate in unscored_candidates.iter() {
+            push_scored_candidate(
+                &input.context,
+                candidate,
+                scorers,
+                *picker_inputs,
+                candidates,
+                cache_inputs,
+                load_inputs,
+                routing_inputs,
+            )?;
         }
     }
     Ok(has_eligible_worker)
@@ -805,5 +871,61 @@ mod tests {
             .select_worker(&workers, &request, request.eligibility(), 16)
             .unwrap();
         assert_eq!(selected.worker, worker1);
+    }
+
+    #[test]
+    fn policies_without_filtered_baseline_score_without_buffering() {
+        struct KeepAll;
+
+        impl WorkerFilter for KeepAll {
+            fn keep(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                _candidate: &WorkerCandidate,
+            ) -> Result<bool, WorkerSelectionPolicyError> {
+                Ok(true)
+            }
+        }
+
+        let workers = HashMap::from([(0, TaintedWorkerConfig::default())]);
+        let mut request = base_request(16);
+        request.track_prefill_tokens = true;
+
+        let no_filter_config = KvRouterConfig {
+            overlap_score_credit_decay: 1.0,
+            ..Default::default()
+        };
+        let no_filter_policy = WorkerSelectionPolicy::new(
+            no_filter_config.clone(),
+            "test",
+            vec![Box::new(DefaultWorkerScorer::new(no_filter_config, "test"))],
+            Box::new(DefaultWorkerPicker::new(0.0)),
+        );
+        no_filter_policy
+            .select_worker(&workers, &request, request.eligibility(), 16)
+            .unwrap();
+        let WorkerSelectionPolicyState::Custom(state) = &no_filter_policy.state else {
+            panic!("expected custom policy state");
+        };
+        assert!(state.borrow().unscored_candidates.is_empty());
+
+        let filtered_config = KvRouterConfig {
+            overlap_score_credit_decay: 0.0,
+            ..Default::default()
+        };
+        let filtered_policy = WorkerSelectionPolicy::new_with_filters(
+            filtered_config.clone(),
+            "test",
+            vec![Box::new(KeepAll)],
+            vec![Box::new(DefaultWorkerScorer::new(filtered_config, "test"))],
+            Box::new(DefaultWorkerPicker::new(0.0)),
+        );
+        filtered_policy
+            .select_worker(&workers, &request, request.eligibility(), 16)
+            .unwrap();
+        let WorkerSelectionPolicyState::Custom(state) = &filtered_policy.state else {
+            panic!("expected custom policy state");
+        };
+        assert!(state.borrow().unscored_candidates.is_empty());
     }
 }

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -54,6 +54,10 @@ impl WorkerInputs {
     pub const fn contains(self, other: Self) -> bool {
         self.0 & other.0 == other.0
     }
+
+    fn without(self, other: Self) -> Self {
+        Self(self.0 & !other.0)
+    }
 }
 
 impl BitOr for WorkerInputs {
@@ -107,6 +111,20 @@ pub trait WorkerScorer: Send {
         context: &WorkerSelectionContext<'_>,
         candidate: &WorkerCandidate,
     ) -> Result<f64, WorkerSelectionPolicyError>;
+}
+
+pub trait WorkerFilter: Send {
+    /// Declare the worker-signal groups needed by this filter.
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        WorkerInputs::NONE
+    }
+
+    /// Return `true` to keep an eligible worker in the policy candidate set.
+    fn keep(
+        &mut self,
+        context: &WorkerSelectionContext<'_>,
+        candidate: &WorkerCandidate,
+    ) -> Result<bool, WorkerSelectionPolicyError>;
 }
 
 pub trait WorkerPicker: Send {
@@ -183,6 +201,41 @@ impl WorkerCandidate {
         self.inputs
             .contains(WorkerInputs::ROUTING)
             .then_some(&self.routing)
+    }
+
+    fn with_inputs_from(&self, additional: &Self, inputs: WorkerInputs) -> Self {
+        debug_assert_eq!(self.worker, additional.worker);
+        Self {
+            worker: self.worker,
+            inputs,
+            cache: if inputs.contains(WorkerInputs::CACHE) {
+                if self.inputs.contains(WorkerInputs::CACHE) {
+                    self.cache
+                } else {
+                    additional.cache
+                }
+            } else {
+                WorkerCacheInput::default()
+            },
+            load: if inputs.contains(WorkerInputs::LOAD) {
+                if self.inputs.contains(WorkerInputs::LOAD) {
+                    self.load
+                } else {
+                    additional.load
+                }
+            } else {
+                WorkerLoadInput::default()
+            },
+            routing: if inputs.contains(WorkerInputs::ROUTING) {
+                if self.inputs.contains(WorkerInputs::ROUTING) {
+                    self.routing
+                } else {
+                    additional.routing
+                }
+            } else {
+                WorkerRoutingInput::default()
+            },
+        }
     }
 }
 
@@ -273,9 +326,11 @@ pub(super) enum WorkerSelectionPolicyStateRef<'a> {
 }
 
 pub(super) struct CustomWorkerSelectionState {
+    pub(super) filters: Vec<Box<dyn WorkerFilter>>,
     pub(super) scorers: Vec<Box<dyn WorkerScorer>>,
     pub(super) picker: Box<dyn WorkerPicker>,
-    pub(super) worker_inputs: WorkerInputs,
+    pub(super) filter_inputs: WorkerInputs,
+    pub(super) scorer_picker_inputs: WorkerInputs,
     pub(super) picker_inputs: WorkerInputs,
     pub(super) candidates: Vec<ScoredWorkerCandidate>,
     pub(super) cache_inputs: Vec<WorkerCacheInput>,
@@ -300,17 +355,32 @@ impl WorkerSelectionPolicy {
         scorers: Vec<Box<dyn WorkerScorer>>,
         picker: Box<dyn WorkerPicker>,
     ) -> Self {
+        Self::new_with_filters(kv_router_config, worker_type, Vec::new(), scorers, picker)
+    }
+
+    pub fn new_with_filters(
+        kv_router_config: KvRouterConfig,
+        worker_type: &'static str,
+        filters: Vec<Box<dyn WorkerFilter>>,
+        scorers: Vec<Box<dyn WorkerScorer>>,
+        picker: Box<dyn WorkerPicker>,
+    ) -> Self {
         let picker_inputs = picker.required_worker_inputs();
-        let worker_inputs = scorers.iter().fold(picker_inputs, |inputs, scorer| {
+        let filter_inputs = filters.iter().fold(WorkerInputs::NONE, |inputs, filter| {
+            inputs | filter.required_worker_inputs()
+        });
+        let scorer_picker_inputs = scorers.iter().fold(picker_inputs, |inputs, scorer| {
             inputs | scorer.required_worker_inputs()
         });
         Self {
             kv_router_config,
             worker_type,
             state: WorkerSelectionPolicyState::Custom(RefCell::new(CustomWorkerSelectionState {
+                filters,
                 scorers,
                 picker,
-                worker_inputs,
+                filter_inputs,
+                scorer_picker_inputs,
                 picker_inputs,
                 candidates: Vec::new(),
                 cache_inputs: Vec::new(),
@@ -337,10 +407,12 @@ pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
     workers: &HashMap<WorkerId, C>,
     request: &SchedulingRequest,
     eligibility: RoutingEligibility<'_>,
-) -> Result<(), KvSchedulerError> {
+) -> Result<bool, KvSchedulerError> {
     let CustomWorkerSelectionState {
+        filters,
         scorers,
-        worker_inputs,
+        filter_inputs,
+        scorer_picker_inputs,
         picker_inputs,
         candidates,
         cache_inputs,
@@ -353,17 +425,50 @@ pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
     load_inputs.clear();
     routing_inputs.clear();
     let pinned = eligibility.pinned_worker().is_some();
+    let mut has_eligible_worker = false;
     let mut error = None;
     eligibility.any_eligible_worker_rank(workers, |worker, config| {
-        let preferred_taint_multiplier =
-            if pinned || !(*worker_inputs).contains(WorkerInputs::ROUTING) {
+        has_eligible_worker = true;
+        let routing_multiplier = |inputs: WorkerInputs| {
+            if pinned || !inputs.contains(WorkerInputs::ROUTING) {
                 None
             } else {
                 request
                     .routing_constraints
                     .preferred_taint_multiplier(config.taints())
-            };
-        let candidate = input.row(worker, preferred_taint_multiplier, *worker_inputs);
+            }
+        };
+        let filter_candidate = (!filters.is_empty())
+            .then(|| input.row(worker, routing_multiplier(*filter_inputs), *filter_inputs));
+        if let Some(filter_candidate) = filter_candidate.as_ref() {
+            for filter in filters.iter_mut() {
+                match filter.keep(&input.context, filter_candidate) {
+                    Ok(true) => {}
+                    Ok(false) => return false,
+                    Err(policy_error) => {
+                        error = Some(policy_error.into());
+                        return true;
+                    }
+                }
+            }
+        }
+
+        let candidate = match filter_candidate {
+            Some(filter_candidate) => {
+                let additional_inputs = scorer_picker_inputs.without(*filter_inputs);
+                let additional = input.row(
+                    worker,
+                    routing_multiplier(additional_inputs),
+                    additional_inputs,
+                );
+                filter_candidate.with_inputs_from(&additional, *scorer_picker_inputs)
+            }
+            None => input.row(
+                worker,
+                routing_multiplier(*scorer_picker_inputs),
+                *scorer_picker_inputs,
+            ),
+        };
         let mut cost = 0.0;
         for (scorer_index, scorer) in scorers.iter_mut().enumerate() {
             let contribution = match scorer.score(&input.context, &candidate) {
@@ -399,7 +504,7 @@ pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
     });
     match error {
         Some(error) => Err(error),
-        None => Ok(()),
+        None => Ok(has_eligible_worker),
     }
 }
 
@@ -568,5 +673,54 @@ mod tests {
         policy
             .select_worker(&workers, &request, request.eligibility(), 16)
             .unwrap();
+    }
+
+    #[test]
+    fn rejected_filters_do_not_materialize_scorer_inputs() {
+        struct RejectWithoutSignals;
+
+        impl WorkerFilter for RejectWithoutSignals {
+            fn keep(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                candidate: &WorkerCandidate,
+            ) -> Result<bool, WorkerSelectionPolicyError> {
+                assert!(candidate.cache().is_none());
+                assert!(candidate.load().is_none());
+                assert!(candidate.routing().is_none());
+                Ok(false)
+            }
+        }
+
+        struct CacheScorer;
+
+        impl WorkerScorer for CacheScorer {
+            fn required_worker_inputs(&self) -> WorkerInputs {
+                WorkerInputs::CACHE
+            }
+
+            fn score(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                _candidate: &WorkerCandidate,
+            ) -> Result<f64, WorkerSelectionPolicyError> {
+                unreachable!("rejected worker must not reach scorers")
+            }
+        }
+
+        let workers = HashMap::from([(0, TaintedWorkerConfig::default())]);
+        let request = base_request(16);
+        let policy = WorkerSelectionPolicy::new_with_filters(
+            KvRouterConfig::default(),
+            "test",
+            vec![Box::new(RejectWithoutSignals)],
+            vec![Box::new(CacheScorer)],
+            Box::new(DefaultWorkerPicker::new(0.0)),
+        );
+
+        assert!(matches!(
+            policy.select_worker(&workers, &request, request.eligibility(), 16),
+            Err(KvSchedulerError::AllEligibleWorkersFiltered)
+        ));
     }
 }

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -332,6 +332,7 @@ pub(super) struct CustomWorkerSelectionState {
     pub(super) filter_inputs: WorkerInputs,
     pub(super) scorer_picker_inputs: WorkerInputs,
     pub(super) picker_inputs: WorkerInputs,
+    pub(super) unscored_candidates: Vec<WorkerCandidate>,
     pub(super) candidates: Vec<ScoredWorkerCandidate>,
     pub(super) cache_inputs: Vec<WorkerCacheInput>,
     pub(super) load_inputs: Vec<WorkerLoadInput>,
@@ -382,6 +383,7 @@ impl WorkerSelectionPolicy {
                 filter_inputs,
                 scorer_picker_inputs,
                 picker_inputs,
+                unscored_candidates: Vec::new(),
                 candidates: Vec::new(),
                 cache_inputs: Vec::new(),
                 load_inputs: Vec::new(),
@@ -403,7 +405,7 @@ impl WorkerSelectionPolicy {
 
 pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
     state: &mut CustomWorkerSelectionState,
-    input: &WorkerSelectionInput<'_>,
+    input: &mut WorkerSelectionInput<'_>,
     workers: &HashMap<WorkerId, C>,
     request: &SchedulingRequest,
     eligibility: RoutingEligibility<'_>,
@@ -414,12 +416,14 @@ pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
         filter_inputs,
         scorer_picker_inputs,
         picker_inputs,
+        unscored_candidates,
         candidates,
         cache_inputs,
         load_inputs,
         routing_inputs,
         ..
     } = state;
+    unscored_candidates.clear();
     candidates.clear();
     cache_inputs.clear();
     load_inputs.clear();
@@ -469,28 +473,41 @@ pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
                 *scorer_picker_inputs,
             ),
         };
+        unscored_candidates.push(candidate);
+        false
+    });
+    if let Some(error) = error {
+        return Err(error);
+    }
+
+    if scorer_picker_inputs.contains(WorkerInputs::MIN_ACTIVE_PREFILL_TOKENS)
+        && input.context.track_prefill_tokens
+        && input.context.weights.overlap_score_credit_decay > 0.0
+    {
+        input.context.min_active_prefill_tokens = unscored_candidates
+            .iter()
+            .map(|candidate| candidate.load.active_prefill_tokens)
+            .min()
+            .unwrap_or(0);
+    }
+
+    for candidate in unscored_candidates.iter() {
         let mut cost = 0.0;
         for (scorer_index, scorer) in scorers.iter_mut().enumerate() {
-            let contribution = match scorer.score(&input.context, &candidate) {
-                Ok(contribution) => contribution,
-                Err(policy_error) => {
-                    error = Some(policy_error.into());
-                    return true;
-                }
-            };
+            let contribution = scorer.score(&input.context, candidate)?;
             cost += contribution;
             if !contribution.is_finite() || !cost.is_finite() {
-                error = Some(
-                    WorkerSelectionPolicyError::NonFiniteCost {
-                        scorer_index,
-                        row: candidates.len(),
-                    }
-                    .into(),
-                );
-                return true;
+                return Err(WorkerSelectionPolicyError::NonFiniteCost {
+                    scorer_index,
+                    row: candidates.len(),
+                }
+                .into());
             }
         }
-        candidates.push(ScoredWorkerCandidate { worker, cost });
+        candidates.push(ScoredWorkerCandidate {
+            worker: candidate.worker,
+            cost,
+        });
         if picker_inputs.contains(WorkerInputs::CACHE) {
             cache_inputs.push(candidate.cache);
         }
@@ -500,12 +517,8 @@ pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
         if picker_inputs.contains(WorkerInputs::ROUTING) {
             routing_inputs.push(candidate.routing);
         }
-        false
-    });
-    match error {
-        Some(error) => Err(error),
-        None => Ok(has_eligible_worker),
     }
+    Ok(has_eligible_worker)
 }
 
 impl<C: WorkerConfigLike> WorkerSelector<C> for WorkerSelectionPolicy {
@@ -722,5 +735,75 @@ mod tests {
             policy.select_worker(&workers, &request, request.eligibility(), 16),
             Err(KvSchedulerError::AllEligibleWorkersFiltered)
         ));
+    }
+
+    #[test]
+    fn filters_recompute_min_active_prefill_tokens() {
+        struct RejectWorkerZero;
+
+        impl WorkerFilter for RejectWorkerZero {
+            fn keep(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                candidate: &WorkerCandidate,
+            ) -> Result<bool, WorkerSelectionPolicyError> {
+                Ok(candidate.worker().worker_id != 0)
+            }
+        }
+
+        struct AssertFilteredBaseline;
+
+        impl WorkerScorer for AssertFilteredBaseline {
+            fn required_worker_inputs(&self) -> WorkerInputs {
+                WorkerInputs::LOAD | WorkerInputs::MIN_ACTIVE_PREFILL_TOKENS
+            }
+
+            fn score(
+                &mut self,
+                context: &WorkerSelectionContext<'_>,
+                _candidate: &WorkerCandidate,
+            ) -> Result<f64, WorkerSelectionPolicyError> {
+                assert_eq!(context.min_active_prefill_tokens, 9);
+                Ok(0.0)
+            }
+        }
+
+        let worker0 = WorkerWithDpRank::from_worker_id(0);
+        let worker1 = WorkerWithDpRank::from_worker_id(1);
+        let workers = HashMap::from([
+            (0, TaintedWorkerConfig::default()),
+            (1, TaintedWorkerConfig::default()),
+        ]);
+        let mut request = base_request(16);
+        request.track_prefill_tokens = true;
+        request.worker_loads.insert(
+            worker0,
+            crate::sequences::WorkerLoadProjection {
+                active_prefill_tokens: 1,
+                ..Default::default()
+            },
+        );
+        request.worker_loads.insert(
+            worker1,
+            crate::sequences::WorkerLoadProjection {
+                active_prefill_tokens: 9,
+                ..Default::default()
+            },
+        );
+        let policy = WorkerSelectionPolicy::new_with_filters(
+            KvRouterConfig {
+                overlap_score_credit_decay: 1.0,
+                ..Default::default()
+            },
+            "test",
+            vec![Box::new(RejectWorkerZero)],
+            vec![Box::new(AssertFilteredBaseline)],
+            Box::new(DefaultWorkerPicker::new(0.0)),
+        );
+
+        let selected = policy
+            .select_worker(&workers, &request, request.eligibility(), 16)
+            .unwrap();
+        assert_eq!(selected.worker, worker1);
     }
 }

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -62,6 +62,8 @@ pub struct TierOverlapBlocks {
     pub disk: FxHashMap<WorkerWithDpRank, usize>,
 }
 
+/// Downstream matches must include a wildcard arm because this enum is non-exhaustive.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum KvSchedulerError {
     #[error("no endpoints available to route work")]

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -73,6 +73,9 @@ pub enum KvSchedulerError {
     #[error("all eligible workers are overloaded")]
     AllEligibleWorkersOverloaded,
 
+    #[error("all eligible workers were rejected by policy filters")]
+    AllEligibleWorkersFiltered,
+
     #[error("pinned worker {worker_id} is overloaded")]
     PinnedWorkerOverloaded { worker_id: WorkerId },
 

--- a/lib/kv-router/src/services/selection/error.rs
+++ b/lib/kv-router/src/services/selection/error.rs
@@ -62,6 +62,7 @@ impl SelectionError {
 fn scheduler_error_status(error: &KvSchedulerError) -> StatusCode {
     match error {
         KvSchedulerError::NoEndpoints
+        | KvSchedulerError::AllEligibleWorkersFiltered
         | KvSchedulerError::SubscriberShutdown
         | KvSchedulerError::InitFailed(_) => StatusCode::SERVICE_UNAVAILABLE,
         KvSchedulerError::WorkerSelectionPolicy(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -101,5 +102,22 @@ impl IntoResponse for SelectionError {
             Json(serde_json::json!({"error": self.to_string()})),
         )
             .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filtered_workers_are_unavailable_not_overloaded() {
+        assert_eq!(
+            SelectionError::Scheduler(KvSchedulerError::AllEligibleWorkersFiltered).status_code(),
+            StatusCode::SERVICE_UNAVAILABLE.as_u16()
+        );
+        assert_eq!(
+            SelectionError::Scheduler(KvSchedulerError::AllEligibleWorkersOverloaded).status_code(),
+            StatusCode::TOO_MANY_REQUESTS.as_u16()
+        );
     }
 }

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -5,7 +5,6 @@ use axum::Router;
 use axum::body::{Body, to_bytes};
 use axum::http::{Request, StatusCode, header};
 use axum::response::Response;
-use std::cell::Cell;
 use std::io::Write;
 use std::net::TcpListener as StdTcpListener;
 use std::sync::Arc;
@@ -27,8 +26,8 @@ use crate::scheduling::WorkerSelectionPolicyError;
 use crate::scheduling::config::RouterConfigOverride;
 use crate::scheduling::overlap::build_overlap_scores_response;
 use crate::scheduling::selector::{
-    WorkerCandidate, WorkerInputView, WorkerPicker, WorkerScorer, WorkerSelectionContext,
-    WorkerSelectionPolicy,
+    WorkerCandidate, WorkerFilter, WorkerInputView, WorkerPicker, WorkerScorer,
+    WorkerSelectionContext, WorkerSelectionPolicy,
 };
 use crate::{TrackingHashContext, TrackingHashScope};
 use tempfile::NamedTempFile;
@@ -44,20 +43,6 @@ fn test_config() -> crate::config::KvRouterConfig {
 fn app() -> Router {
     let service = Arc::new(SelectionService::new_local_for_test(test_config(), 1));
     create_router(Arc::new(AppState { service }))
-}
-
-struct HighestWorkerScorer {
-    calls: Cell<usize>,
-}
-impl WorkerScorer for HighestWorkerScorer {
-    fn score(
-        &mut self,
-        _context: &WorkerSelectionContext<'_>,
-        candidate: &WorkerCandidate,
-    ) -> Result<f64, WorkerSelectionPolicyError> {
-        self.calls.set(self.calls.get() + 1);
-        Ok(-2.0 * candidate.worker().worker_id as f64)
-    }
 }
 
 struct WorkerIdScorer;
@@ -111,6 +96,30 @@ impl WorkerPicker for InvalidRowPicker {
         input: WorkerInputView<'_>,
     ) -> Result<usize, WorkerSelectionPolicyError> {
         Ok(input.candidates().len())
+    }
+}
+
+struct RejectAllFilter;
+
+impl WorkerFilter for RejectAllFilter {
+    fn keep(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        _candidate: &WorkerCandidate,
+    ) -> Result<bool, WorkerSelectionPolicyError> {
+        Ok(false)
+    }
+}
+
+struct RejectWorker(WorkerId);
+
+impl WorkerFilter for RejectWorker {
+    fn keep(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        candidate: &WorkerCandidate,
+    ) -> Result<bool, WorkerSelectionPolicyError> {
+        Ok(candidate.worker().worker_id != self.0)
     }
 }
 
@@ -272,7 +281,8 @@ async fn active_requests(app: Router, worker_id: WorkerId) -> u64 {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn worker_selection_policy_factory_is_per_partition_composes_and_books() {
+async fn worker_selection_policy_factory_is_per_partition_composes_filter_scorer_picker_and_books()
+{
     let factory_calls = Arc::new(AtomicUsize::new(0));
     let factory_partitions = Arc::new(Mutex::new(Vec::new()));
     let factory_rendezvous = Arc::new(FactoryRendezvous::default());
@@ -285,15 +295,11 @@ async fn worker_selection_policy_factory_is_per_partition_composes_and_books() {
             calls.fetch_add(1, Ordering::Relaxed);
             partitions.lock().unwrap().push(partition.into_owned());
             rendezvous.wait_for_peer();
-            WorkerSelectionPolicy::new(
+            WorkerSelectionPolicy::new_with_filters(
                 config.clone(),
                 worker_type,
-                vec![
-                    Box::new(WorkerIdScorer),
-                    Box::new(HighestWorkerScorer {
-                        calls: Cell::new(0),
-                    }),
-                ],
+                vec![Box::new(RejectWorker(1))],
+                vec![Box::new(WorkerIdScorer)],
                 Box::new(LowestCostPicker),
             )
         })
@@ -308,9 +314,9 @@ async fn worker_selection_policy_factory_is_per_partition_composes_and_books() {
     let other_app = app.clone();
     let other_registration = tokio::spawn(async move {
         let body = serde_json::json!({
-            "worker_id": 3,
+            "worker_id": 4,
             "model_name": "other-model",
-            "endpoint": "http://worker-3:8000",
+            "endpoint": "http://worker-4:8000",
             "block_size": 4
         });
         post(other_app, "/workers", &body.to_string()).await
@@ -325,6 +331,10 @@ async fn worker_selection_policy_factory_is_per_partition_composes_and_books() {
     );
     assert_eq!(
         register_worker_id(app.clone(), 2, None).await.status(),
+        StatusCode::CREATED
+    );
+    assert_eq!(
+        register_worker_id(app.clone(), 3, None).await.status(),
         StatusCode::CREATED
     );
     assert_eq!(factory_calls.load(Ordering::Relaxed), 2);
@@ -415,6 +425,33 @@ async fn native_worker_selection_policy_rejects_invalid_rows_before_booking() {
             .unwrap()
             .contains("candidate row")
     );
+    assert_eq!(active_requests(app, 1).await, 0);
+}
+
+#[tokio::test]
+async fn worker_selection_filter_returns_unavailable_without_booking() {
+    let app = native_policy_app(|config, worker_type, _partition| {
+        WorkerSelectionPolicy::new_with_filters(
+            config.clone(),
+            worker_type,
+            vec![Box::new(RejectAllFilter)],
+            Vec::new(),
+            Box::new(LowestCostPicker),
+        )
+    })
+    .await;
+    assert_eq!(
+        register_worker_id(app.clone(), 1, None).await.status(),
+        StatusCode::CREATED
+    );
+
+    let rejected = post(
+        app.clone(),
+        "/select_and_reserve",
+        r#"{"model_name":"model","token_ids":[1,2,3,4],"selection_id":"filtered"}"#,
+    )
+    .await;
+    assert_eq!(rejected.status(), StatusCode::SERVICE_UNAVAILABLE);
     assert_eq!(active_requests(app, 1).await, 0);
 }
 

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -229,21 +229,31 @@ pub const WORKER_KV_INDEXER_BUFFER_SIZE: usize = 1024; // store 1024 most recent
 fn map_scheduler_error(error: scheduling::KvSchedulerError) -> anyhow::Error {
     // Keep the two overload cases apart. A single overloaded worker can be
     // retried elsewhere; a pool with no free worker cannot, and migrating it
-    // would just bounce the request around. Both remain HTTP 529 to the client.
-    let error_type = match error {
-        scheduling::KvSchedulerError::PinnedWorkerOverloaded { .. } => ErrorType::WorkerOverloaded,
-        scheduling::KvSchedulerError::AllEligibleWorkersOverloaded => ErrorType::ResourceExhausted,
+    // would just bounce the request around. A filter rejection is unavailable,
+    // not overload, and becomes HTTP 503.
+    let (error_type, overloaded) = match error {
+        scheduling::KvSchedulerError::PinnedWorkerOverloaded { .. } => {
+            (ErrorType::WorkerOverloaded, true)
+        }
+        scheduling::KvSchedulerError::AllEligibleWorkersOverloaded => {
+            (ErrorType::ResourceExhausted, true)
+        }
+        scheduling::KvSchedulerError::AllEligibleWorkersFiltered => (ErrorType::Unavailable, false),
         _ => return error.into(),
     };
 
     let message = error.to_string();
-    let cause = PipelineError::ServiceOverloaded(message.clone());
-    DynamoError::builder()
+    let error = DynamoError::builder()
         .error_type(error_type)
-        .message(message)
-        .cause(cause)
-        .build()
-        .into()
+        .message(message.clone());
+    if overloaded {
+        error
+            .cause(PipelineError::ServiceOverloaded(message))
+            .build()
+            .into()
+    } else {
+        error.build().into()
+    }
 }
 
 fn cancelled_error(context_id: &str) -> anyhow::Error {
@@ -1655,6 +1665,16 @@ mod tests {
 
     use crate::kv_router::scheduler::KvSchedulerError;
     use crate::local_model::runtime_config::ModelRuntimeConfig;
+
+    #[test]
+    fn all_filtered_workers_map_to_unavailable() {
+        let error = map_scheduler_error(KvSchedulerError::AllEligibleWorkersFiltered);
+        let dynamo_error = error
+            .downcast_ref::<DynamoError>()
+            .expect("filtered workers should produce a DynamoError");
+
+        assert_eq!(dynamo_error.error_type(), ErrorType::Unavailable);
+    }
 
     #[test]
     fn keyed_tracking_requires_nonempty_model_name() {


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Adds composable `WorkerFilter` policies to custom worker selection, stacked on #12992's policy catalog and examples. Filters reduce the candidate set before scoring, so teams can enforce policy-specific worker admission without changing Dynamo's built-in eligibility rules.

CLOSES: DYN-3713

### How This Was Implemented
- Adds `WorkerFilter` and `WorkerSelectionPolicy::new_with_filters`; `new` remains the no-filter compatibility constructor.
- Runs built-in eligibility first, then filters, scorers, and the picker; rejected workers never materialize scorer or picker inputs.
- Returns unavailable (HTTP 503) when filters reject every built-in eligible worker.
- Adds the optional `min_effective_overlap_blocks` cache-affinity example while retaining the existing no-filter `least-busy` behavior.
- Splits the example algorithms into focused Rust modules and updates the guide and README.

<details>
<summary>Walkthrough</summary>

#### Mental model

A `WorkerFilter` decides whether a worker that passed Dynamo's built-in eligibility rules participates in a custom policy. Filter state, scorers, and picker state are owned by the per-partition policy instance.

```mermaid
flowchart LR
    R[Request] --> E[Dynamo eligibility]
    E --> F[WorkerFilter(s)]
    F --> I[Materialize scorer and picker inputs]
    I --> S[WorkerScorer(s)]
    S --> P[WorkerPicker]
    P --> B[Reserve and route]
```

#### Request lifecycle

Filters receive only the signals they declare. Dynamo materializes remaining scorer and picker signals only for kept candidates, then runs scorers and picker on that set. If filters reject all built-in eligible workers, selection returns unavailable and the HTTP frontend responds with 503.

#### State and ordering

Dynamo computes the `DefaultWorkerScorer` minimum prefill-load baseline after filtering, so filtered workers do not affect scores for kept workers. A queued request evaluates custom filters when it is selected; queue placement does not evaluate policy callbacks.

#### Boundaries and limitations

The default selector remains unchanged. This PR does not add session affinity or pin-specific callback semantics. `min_effective_overlap_blocks` is a hard cache-affinity requirement; if no candidate meets it, the request returns 503.

</details>

### Validation
- `cargo fmt --all -- --check`
- `cargo test -p dynamo-kv-router scheduling::selector::` (26 passed)
- `cargo test -p dynamo-custom-policy-example-basic -p dynamo-custom-policy-example-disaggregated -p dynamo-custom-policy-example-catalog`
- `cargo build -p dynamo-custom-policy-example-epp`
- `fern check && fern docs broken-links` from `docs/` (0 errors; 11 existing warnings)
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for filtering eligible workers before scoring and selection.
  - Custom routing policies can now use worker signals to apply filtering rules.
  - Exposed worker-filter configuration for broader policy customization.

- **Bug Fixes**
  - Requests now return **503 Service Unavailable** when all eligible workers are filtered out, without booking load.
  - Preserved distinct overload responses and improved pinned-worker selection behavior.

- **Documentation**
  - Expanded the developer guide with worker-filter policies, configuration, eligibility behavior, signal requirements, and HTTP frontend restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
