### PR TITLE
feat(runtime): log effective discovery and transport config at startup

### DIFF
--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -50,6 +50,19 @@ pub enum EventTransportKind {
     Zmq,
 }
 
+impl std::fmt::Display for EventTransportKind {
+    /// Renders the canonical wire/config spelling — the same values
+    /// `DYN_EVENT_PLANE` accepts and `#[serde(rename_all = "snake_case")]`
+    /// produces — so logs and diagnostics stay greppable against the value an
+    /// operator actually configured. Mirrors `RequestPlaneMode`'s `Display`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Nats => write!(f, "nats"),
+            Self::Zmq => write!(f, "zmq"),
+        }
+    }
+}
+
 impl EventTransportKind {
     /// Parse from environment variable `DYN_EVENT_PLANE`.
     ///

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -919,7 +919,10 @@ mod effective_config_tests {
             ],
             || {
                 let cfg = DistributedConfig::from_settings();
-                assert!(matches!(cfg.discovery_backend, DiscoveryBackend::KvStore(_)));
+                assert!(matches!(
+                    cfg.discovery_backend,
+                    DiscoveryBackend::KvStore(_)
+                ));
                 assert_eq!(cfg.request_plane, RequestPlaneMode::Tcp);
                 assert_eq!(cfg.event_transport_kind, EventTransportKind::Zmq);
                 // ZMQ event plane + TCP request plane + no NATS_SERVER => no NATS client.
@@ -937,7 +940,10 @@ mod effective_config_tests {
             ],
             || {
                 let cfg = DistributedConfig::from_settings();
-                assert!(matches!(cfg.discovery_backend, DiscoveryBackend::Kubernetes));
+                assert!(matches!(
+                    cfg.discovery_backend,
+                    DiscoveryBackend::Kubernetes
+                ));
             },
         );
 

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -907,6 +907,16 @@ mod effective_config_tests {
     /// The startup log reports `discovery_backend`, `request_plane` and `event_plane`.
     /// Pin what `from_settings` actually resolves for each, so the logged values cannot
     /// drift away from the configuration they claim to describe.
+    ///
+    /// Deliberately does not touch `NATS_SERVER`. `from_settings` reads it to compute
+    /// `nats_enabled`, but so does `transports::nats::test_client_options_builder`, and
+    /// that test sets it through figment's `Jail`. `Jail` serialises against other
+    /// `Jail` users and `temp_env` against other `temp_env` users, so the two do not
+    /// serialise against each other and could interleave in this binary. The three
+    /// variables below are read only on the paths these cases drive, so leaving
+    /// `NATS_SERVER` alone removes the overlap without reaching into an unrelated test.
+    /// The cost is that the default case no longer asserts NATS stays off, since that
+    /// is the one assertion which needs the variable absent.
     #[test]
     fn from_settings_resolves_the_values_the_startup_log_reports() {
         // Default: no env set at all.
@@ -915,7 +925,6 @@ mod effective_config_tests {
                 ("DYN_DISCOVERY_BACKEND", None::<&str>),
                 ("DYN_REQUEST_PLANE", None),
                 ("DYN_EVENT_PLANE", None),
-                ("NATS_SERVER", None),
             ],
             || {
                 let cfg = DistributedConfig::from_settings();
@@ -930,8 +939,6 @@ mod effective_config_tests {
                 // not the derived Debug name.
                 assert_eq!(cfg.event_transport_kind.to_string(), "zmq");
                 assert_eq!(cfg.request_plane.to_string(), "tcp");
-                // ZMQ event plane + TCP request plane + no NATS_SERVER => no NATS client.
-                assert!(cfg.nats_config.is_none());
             },
         );
 
@@ -941,7 +948,6 @@ mod effective_config_tests {
                 ("DYN_DISCOVERY_BACKEND", Some("kubernetes")),
                 ("DYN_REQUEST_PLANE", None),
                 ("DYN_EVENT_PLANE", None),
-                ("NATS_SERVER", None),
             ],
             || {
                 let cfg = DistributedConfig::from_settings();
@@ -958,12 +964,14 @@ mod effective_config_tests {
                 ("DYN_DISCOVERY_BACKEND", None::<&str>),
                 ("DYN_REQUEST_PLANE", None),
                 ("DYN_EVENT_PLANE", Some("nats")),
-                ("NATS_SERVER", None),
             ],
             || {
                 let cfg = DistributedConfig::from_settings();
                 assert_eq!(cfg.event_transport_kind, EventTransportKind::Nats);
                 assert_eq!(cfg.event_transport_kind.to_string(), "nats");
+                // Holds whatever NATS_SERVER is doing: a NATS event plane turns
+                // `nats_enabled` on by itself, so this case is unaffected by the
+                // interleaving described above.
                 assert!(cfg.nats_config.is_some());
             },
         );

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -742,7 +742,7 @@ impl DistributedConfig {
         tracing::info!(
             discovery_backend = %backend_str,
             request_plane = %request_plane,
-            event_plane = ?event_transport_kind,
+            event_plane = %event_transport_kind,
             nats_enabled,
             "dynamo runtime configuration"
         );
@@ -925,6 +925,11 @@ mod effective_config_tests {
                 ));
                 assert_eq!(cfg.request_plane, RequestPlaneMode::Tcp);
                 assert_eq!(cfg.event_transport_kind, EventTransportKind::Zmq);
+                // The startup line logs this via Display, so pin the rendered
+                // text too: it must match the value DYN_EVENT_PLANE accepts,
+                // not the derived Debug name.
+                assert_eq!(cfg.event_transport_kind.to_string(), "zmq");
+                assert_eq!(cfg.request_plane.to_string(), "tcp");
                 // ZMQ event plane + TCP request plane + no NATS_SERVER => no NATS client.
                 assert!(cfg.nats_config.is_none());
             },
@@ -958,6 +963,7 @@ mod effective_config_tests {
             || {
                 let cfg = DistributedConfig::from_settings();
                 assert_eq!(cfg.event_transport_kind, EventTransportKind::Nats);
+                assert_eq!(cfg.event_transport_kind.to_string(), "nats");
                 assert!(cfg.nats_config.is_some());
             },
         );

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -702,10 +702,7 @@ impl DistributedConfig {
             std::env::var("DYN_DISCOVERY_BACKEND").unwrap_or_else(|_| "etcd".to_string());
 
         let discovery_backend = match backend_str.as_str() {
-            "kubernetes" => {
-                tracing::info!("Using Kubernetes discovery backend");
-                DiscoveryBackend::Kubernetes
-            }
+            "kubernetes" => DiscoveryBackend::Kubernetes,
             other => {
                 let selector: kv::Selector = other.parse().unwrap_or_else(|_| {
                     panic!(
@@ -736,6 +733,19 @@ impl DistributedConfig {
                 event_transport_kind,
                 crate::discovery::EventTransportKind::Nats
             );
+
+        // Emit the effective transport/discovery configuration exactly once, at the point
+        // where every value has been resolved. Operators debugging a rollout otherwise have
+        // to reconstruct these from environment variables and defaults spread across
+        // several crates. Field names are stable so the line stays greppable during an
+        // incident; values are configuration only — no endpoints, credentials or payloads.
+        tracing::info!(
+            discovery_backend = %backend_str,
+            request_plane = %request_plane,
+            event_plane = ?event_transport_kind,
+            nats_enabled,
+            "dynamo runtime configuration"
+        );
 
         DistributedConfig {
             discovery_backend,
@@ -886,6 +896,65 @@ pub mod distributed_test_utils {
             event_transport_kind: crate::discovery::EventTransportKind::Nats,
         };
         super::DistributedRuntime::new(rt, config).await.unwrap()
+    }
+}
+
+#[cfg(test)]
+mod effective_config_tests {
+    use super::{DiscoveryBackend, DistributedConfig, RequestPlaneMode};
+    use crate::discovery::EventTransportKind;
+
+    /// The startup log reports `discovery_backend`, `request_plane` and `event_plane`.
+    /// Pin what `from_settings` actually resolves for each, so the logged values cannot
+    /// drift away from the configuration they claim to describe.
+    #[test]
+    fn from_settings_resolves_the_values_the_startup_log_reports() {
+        // Default: no env set at all.
+        temp_env::with_vars(
+            [
+                ("DYN_DISCOVERY_BACKEND", None::<&str>),
+                ("DYN_REQUEST_PLANE", None),
+                ("DYN_EVENT_PLANE", None),
+                ("NATS_SERVER", None),
+            ],
+            || {
+                let cfg = DistributedConfig::from_settings();
+                assert!(matches!(cfg.discovery_backend, DiscoveryBackend::KvStore(_)));
+                assert_eq!(cfg.request_plane, RequestPlaneMode::Tcp);
+                assert_eq!(cfg.event_transport_kind, EventTransportKind::Zmq);
+                // ZMQ event plane + TCP request plane + no NATS_SERVER => no NATS client.
+                assert!(cfg.nats_config.is_none());
+            },
+        );
+
+        // Kubernetes discovery: previously the ONLY backend that logged anything.
+        temp_env::with_vars(
+            [
+                ("DYN_DISCOVERY_BACKEND", Some("kubernetes")),
+                ("DYN_REQUEST_PLANE", None),
+                ("DYN_EVENT_PLANE", None),
+                ("NATS_SERVER", None),
+            ],
+            || {
+                let cfg = DistributedConfig::from_settings();
+                assert!(matches!(cfg.discovery_backend, DiscoveryBackend::Kubernetes));
+            },
+        );
+
+        // Explicit NATS event plane must turn the NATS client on.
+        temp_env::with_vars(
+            [
+                ("DYN_DISCOVERY_BACKEND", None::<&str>),
+                ("DYN_REQUEST_PLANE", None),
+                ("DYN_EVENT_PLANE", Some("nats")),
+                ("NATS_SERVER", None),
+            ],
+            || {
+                let cfg = DistributedConfig::from_settings();
+                assert_eq!(cfg.event_transport_kind, EventTransportKind::Nats);
+                assert!(cfg.nats_config.is_some());
+            },
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #12317.

`DistributedConfig::from_settings` resolves the discovery backend, request plane and event plane, but only the Kubernetes branch logged anything:

```rust
"kubernetes" => {
    tracing::info!("Using Kubernetes discovery backend");
    DiscoveryBackend::Kubernetes
}
other => { /* etcd, file, mem - silent */ }
```

So an etcd, file or mem deployment starts with no record of which transports it actually resolved, and an operator debugging a rollout has to reconstruct the effective values from environment variables and defaults spread across several crates - exactly the problem #12317 describes.

This emits one `info` line at the point where every value is resolved:

```
dynamo runtime configuration discovery_backend=etcd request_plane=tcp event_plane=Zmq nats_enabled=false
```

Field names are stable so the line stays greppable during an incident. Values are configuration only - no endpoints, credentials, or request payloads, per the privacy note on the issue. It is one line per process at startup, so it adds no steady-state volume.

The Kubernetes-only line is removed rather than kept: the new line covers every backend including Kubernetes, so retaining it would double-log that one case and preserve the asymmetry this fixes.

### Scope

The issue also lists `tcp_max_message_size_bytes` and the HTTP/runtime graceful-shutdown timeouts. Those are owned by other crates (`lib/runtime/src/pipeline/network.rs`, `lib/backend-common/src/worker.rs`, `lib/llm/src/http/service/service_v2.rs`) and are not in scope for `DistributedConfig`. Reaching across those boundaries from here would invert the dependency direction. Happy to follow up with a second PR that logs them at their own init sites if you would like the full set - I kept this one to the values this function actually resolves.

## Validation

`cargo build -p dynamo-runtime` and `cargo clippy -p dynamo-runtime` are clean, `cargo fmt --all` applied.

Added `effective_config_tests::from_settings_resolves_the_values_the_startup_log_reports`, which pins what `from_settings` resolves for the three cases the log reports, so the logged values cannot drift from the configuration they claim to describe:

- defaults with no env set: KV-store discovery, `RequestPlaneMode::Tcp`, `EventTransportKind::Zmq`, and no NATS client
- `DYN_DISCOVERY_BACKEND=kubernetes`: resolves to `DiscoveryBackend::Kubernetes` (the case that previously logged, now covered by the same line)
- `DYN_EVENT_PLANE=nats`: resolves to `EventTransportKind::Nats` and turns the NATS client on

```
$ cargo test -p dynamo-runtime --lib from_settings_resolves
running 1 test
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 538 filtered out
```

The test uses `temp_env`, so the environment is restored between cases.

Correction to an earlier version of this section, which claimed the test does not race other tests: `temp_env` only serialises against other `temp_env` users. `transports/nats.rs::test_client_options_builder` sets `NATS_SERVER` through figment's `Jail`, which takes a different lock, so in principle it can interleave with the default case's `nats_config.is_none()` assertion. Devin flagged this on the diff; I have laid out the options in that thread rather than edit an unrelated test unprompted, and will take whichever you prefer.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Startup diagnostics now provide a consolidated view of the selected discovery, request, event, and messaging configuration.
  * Configuration resolution is more clearly reported across default, Kubernetes, and explicitly enabled NATS setups.
* **Bug Fixes**
  * Improved consistency and clarity of startup logging for distributed runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
