### PR TITLE
fix(operator): preserve automatic checkpoint identity

### DIFF
--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -307,15 +307,13 @@ func (r *dgdCheckpointsReconciler) createCheckpointCR(
 		r.Client,
 		dynamoDeployment.Namespace,
 		checkpointID,
-		nvidiacomv1alpha1.DynamoCheckpointIdentity{
-			Model:            fmt.Sprintf("%s/%s", dynamoDeployment.Namespace, dynamoDeployment.Name),
-			BackendFramework: string(backendFramework),
-			ExtraParameters: map[string]string{
-				"dgdUID":       string(dynamoDeployment.UID),
-				"component":    componentName,
-				"checkpointID": checkpointID,
-			},
-		},
+		expectedAutomaticCheckpointIdentity(
+			dynamoDeployment,
+			componentName,
+			checkpointID,
+			checkpointConfig.Identity,
+			backendFramework,
+		),
 		podTemplate,
 		targetContainerName,
 		deletionPolicy,
@@ -331,6 +329,36 @@ func (r *dgdCheckpointsReconciler) createCheckpointCR(
 		}
 	}
 	return ckpt, nil
+}
+
+func expectedAutomaticCheckpointIdentity(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	componentName string,
+	checkpointID string,
+	configured *nvidiacomv1beta1.DynamoCheckpointIdentity,
+	backendFramework dynamo.BackendFramework,
+) nvidiacomv1alpha1.DynamoCheckpointIdentity {
+	identity := nvidiacomv1alpha1.DynamoCheckpointIdentity{}
+	if configured != nil {
+		identity = *dynamo.ToAlphaCheckpointIdentity(configured).DeepCopy()
+	}
+	if identity.Model == "" {
+		identity.Model = fmt.Sprintf("%s/%s", dgd.Namespace, dgd.Name)
+	}
+	identity.BackendFramework = string(backendFramework)
+	if identity.TensorParallelSize == 0 {
+		identity.TensorParallelSize = 1
+	}
+	if identity.PipelineParallelSize == 0 {
+		identity.PipelineParallelSize = 1
+	}
+	if identity.ExtraParameters == nil {
+		identity.ExtraParameters = map[string]string{}
+	}
+	identity.ExtraParameters["dgdUID"] = string(dgd.UID)
+	identity.ExtraParameters["component"] = componentName
+	identity.ExtraParameters["checkpointID"] = checkpointID
+	return identity
 }
 
 func checkpointGMSResourceClaimTemplateName(checkpointID string) string {

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -183,6 +183,86 @@ func TestDGDCheckpointsReconciler_CreateDoesNotReuseExistingCapture(t *testing.T
 	}
 }
 
+func TestDGDCheckpointsReconciler_CreatePreservesConfiguredIdentity(t *testing.T) {
+	ctx := context.Background()
+	testScheme := newDynamoGraphDeploymentControllerTestScheme(t)
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(testScheme).Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{},
+	}
+	configuredIdentity := &v1beta1.DynamoCheckpointIdentity{
+		Model:                "Qwen/Qwen3-0.6B",
+		BackendFramework:     string(dynamo.BackendFrameworkSGLang),
+		DynamoVersion:        "1.2.3",
+		TensorParallelSize:   2,
+		PipelineParallelSize: 1,
+		Dtype:                "bf16",
+		MaxModelLen:          32768,
+		ExtraParameters: map[string]string{
+			"custom":       "preserved",
+			"dgdUID":       "user-value",
+			"component":    "user-value",
+			"checkpointID": "user-value",
+		},
+	}
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+			UID:       types.UID("dgd-uid"),
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{{
+				ComponentName: "worker",
+				ComponentType: v1beta1.ComponentTypeWorker,
+				PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  commonconsts.MainContainerName,
+						Image: "checkpoint-writer:latest",
+					}},
+				}},
+				Experimental: &v1beta1.ExperimentalSpec{
+					Checkpoint: &v1beta1.ComponentCheckpointConfig{
+						Enabled:  true,
+						Mode:     v1beta1.CheckpointModeAuto,
+						Identity: configuredIdentity,
+					},
+				},
+			}},
+		},
+	}
+
+	t.Log("Create an automatic checkpoint from the configured identity")
+	ckpt, err := newTestDGDCheckpointsReconciler(reconciler).createCheckpointCR(
+		ctx,
+		dgd,
+		"worker",
+		&dgd.Spec.Components[0],
+	)
+	require.NoError(t, err)
+
+	checkpointID := ckpt.Labels[snapshotprotocol.CheckpointIDLabel]
+	assert.Equal(t, v1alpha1.DynamoCheckpointIdentity{
+		Model:                "Qwen/Qwen3-0.6B",
+		BackendFramework:     string(dynamo.BackendFrameworkVLLM),
+		DynamoVersion:        "1.2.3",
+		TensorParallelSize:   2,
+		PipelineParallelSize: 1,
+		Dtype:                "bf16",
+		MaxModelLen:          32768,
+		ExtraParameters: map[string]string{
+			"custom":       "preserved",
+			"dgdUID":       "dgd-uid",
+			"component":    "worker",
+			"checkpointID": checkpointID,
+		},
+	}, ckpt.Spec.Identity)
+	assert.Equal(t, "user-value", configuredIdentity.ExtraParameters["dgdUID"])
+	assert.Equal(t, string(dynamo.BackendFrameworkSGLang), configuredIdentity.BackendFramework)
+}
+
 func TestDGDCheckpointsReconciler_CreateDoesNotAdoptLegacyIdentityTemplate(t *testing.T) {
 	t.Log("Build a legacy checkpoint and ResourceClaimTemplate with existing ownership")
 	ctx := context.Background()
@@ -639,7 +719,10 @@ func TestDGDCheckpointsReconciler_AutoUsesTargetContainerWithoutIdentity(t *test
 	ckpt := &v1alpha1.DynamoCheckpoint{}
 	require.NoError(t, reconciler.Get(ctx, types.NamespacedName{Name: checkpointStatuses["worker"].CheckpointName, Namespace: "default"}, ckpt))
 	assert.Equal(t, "snapshot-me", ckpt.Spec.Job.TargetContainerName)
+	assert.Equal(t, "default/test-dgd", ckpt.Spec.Identity.Model)
 	assert.Equal(t, string(dynamo.BackendFrameworkVLLM), ckpt.Spec.Identity.BackendFramework)
+	assert.Equal(t, int32(1), ckpt.Spec.Identity.TensorParallelSize)
+	assert.Equal(t, int32(1), ckpt.Spec.Identity.PipelineParallelSize)
 	assert.Equal(t, checkpointStatuses["worker"].CheckpointID, ckpt.Spec.Identity.ExtraParameters["checkpointID"])
 }
 


### PR DESCRIPTION
## Summary

Automatic `DynamoCheckpoint` creation accepts an identity that describes the captured model and deployment shape. Previously, the operator built a fresh identity from only the model and resolved backend. That discarded explicitly supplied tensor parallelism (TP), pipeline parallelism (PP), Dynamo version, data type, maximum model length, and extension metadata, then silently normalized omitted TP/PP fields to 1. As a result, a real ordinary TP2 checkpoint could be recorded with false TP1 provenance.

This change:

- deep-copies the supplied identity so normalization never mutates the caller;
- preserves explicit model, TP, PP, and other supplied identity fields;
- keeps the resolved backend and operator-owned provenance keys authoritative;
- normalizes only omitted TP and PP values to 1; and
- tests both preservation/immutability and the defaulted no-identity case.

This is a metadata-correctness fix. It does **not** enable TP2 automatic failover; Snapshot-backed automatic failover remains limited to TP=PP=DP=1 in this stack.

A final live AKS ordinary TP2 Snapshot rerun at the exact eight-branch composite verified the corrected identity and downstream immutable binding end to end; exact evidence is recorded under Live AKS TP2 identity validation. This remains ordinary TP2 capture/restore evidence, not TP2 automatic failover.

## Related Issues

Relates to [DEP #12671](https://github.com/ai-dynamo/dynamo/issues/12671).

## Validation

- Focused operator checkpoint/controller/webhook Go tests passed.
- Operator lint passed with `golangci-lint v1.64.8`.

### Final eight-branch chain validation

- Operator checkpoint/controller/webhook validation passed with `go test ./internal/checkpoint ./internal/controller ./internal/webhook/validation -count=1`.
- Operator lint passed with `make lint`, invoking `golangci-lint v1.64.8`.
- Snapshot validation passed with `make lint`, `go test ./internal/criu -count=1`, `go test -race ./internal/criu -count=1`, `go test ./... -count=1`, and `go vet ./...` from `deploy/snapshot`.
- Python formatting/lint hooks passed with repository-pinned isort 5.12.0, Black 23.1.0, flake8 7.3.0, and Ruff 0.5.2.
- Independent reviews approved the final local chain.
- Full live AKS Snapshot-backed failover E2E for the supported TP=PP=DP=1 profile: **PASS**.

### Live AKS TP2 identity validation

At exact eight-branch composite `d209f77f91911a4267dea203490a0e410b9e1b1e`:

- A namespace-scoped AKS operator upgrade used the corrected exact composite image index `sha256:fba2f709673f7949b3da463a577e18522a11bd35ca08634c1ff06329529077aa` (amd64 manifest `sha256:dc2d076270079a7e4f65e04eacda6c7227a4870e1c1e75fc4c8d38de6b552b5b`); CRDs were untouched.
- A fresh ordinary TP2 source became Ready with ranks 0/1, two DRA GPUs, and inference HTTP 200.
- Checkpoint `checkpoint-5d2f7c0d202210efee4455fa50f3727d` (UID `89acc792-c13d-4302-9dab-bb4e8e143eac`) became Ready. Its live identity was exactly model `Qwen/Qwen3-0.6B`, backend `vllm`, TP=2, and PP=1; custom `extra` metadata was preserved, while spoofed reserved `dgdUID`, `component`, and `checkpointID` values were overwritten correctly.
- GMS V1 artifacts `device-0` and `device-1` each contained 24 allocations totaling 610,271,232 bytes.
- Two fresh restores from immutable binding `v1/89acc792-c13d-4302-9dab-bb4e8e143eac/1/942c43260c8204ad6867ebea038ea31cc37b390d406fbf1ee1f6d9cd700b1c73` both reached `RestoreSucceeded`, ranks 0/1, two GPUs/loaders, and inference HTTP 200; restore totals were approximately 21.53s and 20.95s.
- No CRIU, socket, pagemap, or TCP regressions were observed. The existing full-failover TP1 DGD remained Ready and continued serving inference with HTTP 200.

**Scope:** This proves ordinary TP2 Snapshot capture/restore plus corrected identity, provenance, and immutable binding. TP2 automatic failover remains unsupported and is not claimed; Snapshot-backed automatic failover remains limited to TP=PP=DP=1.

Full CI is not claimed.

## Stack

GitHub Stack: [#12903](https://github.com/ai-dynamo/dynamo/stacks/12903)

| Order | PR | Change |
| ---: | --- | --- |
| 1 | [#12887](https://github.com/ai-dynamo/dynamo/pull/12887) | Remap clone-unsafe sockets during restore |
| 2 | **[#12902](https://github.com/ai-dynamo/dynamo/pull/12902)** | **Preserve automatic checkpoint identity** |
| 3 | [#12869](https://github.com/ai-dynamo/dynamo/pull/12869) | Elect the failover owner before worker publication |
| 4 | [#12870](https://github.com/ai-dynamo/dynamo/pull/12870) | Support a second IntraPod shadow |
| 5 | [#12871](https://github.com/ai-dynamo/dynamo/pull/12871) | Retain restored engines paused |
| 6 | [#12872](https://github.com/ai-dynamo/dynamo/pull/12872) | Verify automatic checkpoint provenance |
| 7 | [#12873](https://github.com/ai-dynamo/dynamo/pull/12873) | Bind workloads to verified checkpoints |
| 8 | [#12874](https://github.com/ai-dynamo/dynamo/pull/12874) | Enable Snapshot-backed IntraPod failover |
