### PR TITLE
fix(frontend): backport protocol request validation to 1.4

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -32,16 +32,17 @@ use super::{
     RouteDoc,
     disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
     metrics::{
-        CancellationLabels, Endpoint,
+        CancellationLabels, Endpoint, ErrorType, InflightGuard,
         process_chat_response_and_observe_metrics as process_response_and_observe_metrics,
     },
     service_v2,
 };
+use crate::engines::ValidateRequest;
 use crate::protocols::anthropic::stream_converter::AnthropicStreamConverter;
 use crate::protocols::anthropic::types::{
-    AnthropicCountTokensRequest, AnthropicCountTokensResponse, AnthropicCreateMessageRequest,
-    AnthropicErrorBody, AnthropicErrorResponse, SystemContent,
-    chat_completion_to_anthropic_response,
+    AnthropicContentBlock, AnthropicCountTokensRequest, AnthropicCountTokensResponse,
+    AnthropicCreateMessageRequest, AnthropicErrorBody, AnthropicErrorResponse, AnthropicMessage,
+    AnthropicMessageContent, AnthropicTool, SystemContent, chat_completion_to_anthropic_response,
 };
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
@@ -56,7 +57,7 @@ use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 
 // Re-use helpers from the openai module (sibling under service/)
-use super::error::SanitizedError;
+use super::error::{SanitizedError, invalid_argument};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
 use super::openai::{get_body_limit, get_or_create_request_id};
 
@@ -132,21 +133,150 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 // Handlers
 // ---------------------------------------------------------------------------
 
+#[derive(Debug)]
+enum AnthropicRequestValidationError {
+    InvalidArgument(String),
+    NotImplemented(String),
+}
+
+impl AnthropicRequestValidationError {
+    fn status(&self) -> StatusCode {
+        match self {
+            Self::InvalidArgument(_) => StatusCode::BAD_REQUEST,
+            Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
+        }
+    }
+
+    fn metric_error_type(&self) -> ErrorType {
+        match self {
+            Self::InvalidArgument(_) => ErrorType::Validation,
+            Self::NotImplemented(_) => ErrorType::NotImplemented,
+        }
+    }
+
+    fn anthropic_error_type(&self) -> &'static str {
+        match self {
+            Self::InvalidArgument(_) => "invalid_request_error",
+            Self::NotImplemented(_) => "api_error",
+        }
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            Self::InvalidArgument(message) | Self::NotImplemented(message) => message,
+        }
+    }
+}
+
+fn validate_anthropic_messages(
+    messages: &[AnthropicMessage],
+) -> Result<(), AnthropicRequestValidationError> {
+    if messages.is_empty() {
+        return Err(AnthropicRequestValidationError::InvalidArgument(
+            "messages: field required".to_string(),
+        ));
+    }
+
+    for (message_index, message) in messages.iter().enumerate() {
+        let AnthropicMessageContent::Blocks { content } = &message.content else {
+            continue;
+        };
+        if content.is_empty() {
+            return Err(AnthropicRequestValidationError::InvalidArgument(format!(
+                "messages[{message_index}].content: must contain at least one content block"
+            )));
+        }
+        for (block_index, block) in content.iter().enumerate() {
+            if let AnthropicContentBlock::Other(value) = block {
+                if !value.is_object() {
+                    return Err(AnthropicRequestValidationError::InvalidArgument(format!(
+                        "messages[{message_index}].content[{block_index}]: content blocks must be objects"
+                    )));
+                }
+                let Some(block_type) = value
+                    .get("type")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|block_type| !block_type.is_empty())
+                else {
+                    return Err(AnthropicRequestValidationError::InvalidArgument(format!(
+                        "messages[{message_index}].content[{block_index}].type: must be a non-empty string"
+                    )));
+                };
+                return Err(AnthropicRequestValidationError::NotImplemented(format!(
+                    "messages[{message_index}].content[{block_index}]: content block type \"{block_type}\" is not supported"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_anthropic_tools(
+    tools: Option<&[AnthropicTool]>,
+) -> Result<(), AnthropicRequestValidationError> {
+    for (tool_index, tool) in tools.unwrap_or_default().iter().enumerate() {
+        match tool.tool_type.as_deref() {
+            Some("") => {
+                return Err(AnthropicRequestValidationError::InvalidArgument(format!(
+                    "tools[{tool_index}].type: must be a non-empty string"
+                )));
+            }
+            Some("custom") | None => {
+                if tool.input_schema.is_none() {
+                    return Err(AnthropicRequestValidationError::InvalidArgument(format!(
+                        "tools[{tool_index}].input_schema: field required for client tools"
+                    )));
+                }
+            }
+            Some(tool_type) => {
+                return Err(AnthropicRequestValidationError::NotImplemented(format!(
+                    "tools[{tool_index}]: server tool type \"{tool_type}\" is not supported"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Top-level HTTP handler for POST /v1/messages.
 async fn handler_anthropic_messages(
     State((state, template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
     headers: HeaderMap,
     Json(mut request): Json<AnthropicCreateMessageRequest>,
 ) -> Result<Response, Response> {
-    // Validate required fields
-    if request.messages.is_empty() {
+    let request_id = get_or_create_request_id(&headers);
+    let streaming = request.stream;
+    let resolved_model = resolve_request_model(&request.model, template.as_ref());
+    let canonical_model = state.manager().resolve_canonical_name(resolved_model);
+    let metric_model = state
+        .manager()
+        .metric_model_for(&canonical_model)
+        .to_string();
+    let mut inflight_guard = state.metrics_clone().create_inflight_guard(
+        &metric_model,
+        Endpoint::AnthropicMessages,
+        streaming,
+        &request_id,
+    );
+
+    if let Err(error) = validate_anthropic_messages(&request.messages) {
+        inflight_guard.mark_error(error.metric_error_type());
         return Err(anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            "messages: field required",
+            error.status(),
+            error.anthropic_error_type(),
+            error.message(),
+        ));
+    }
+    if let Err(error) = validate_anthropic_tools(request.tools.as_deref()) {
+        inflight_guard.mark_error(error.metric_error_type());
+        return Err(anthropic_error(
+            error.status(),
+            error.anthropic_error_type(),
+            error.message(),
         ));
     }
     if request.max_tokens == 0 {
+        inflight_guard.mark_error(ErrorType::Validation);
         return Err(anthropic_error(
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
@@ -156,20 +286,13 @@ async fn handler_anthropic_messages(
     gate_anthropic_nvext(&mut request, state.nvext_enabled());
 
     // Create request context
-    let request_id = get_or_create_request_id(&headers);
-    let streaming = request.stream;
-    let resolved_model = resolve_request_model(&request.model, template.as_ref());
-    // Canonicalize alias → primary for the metric label (see anthropic_messages).
-    let canonical_model = state.manager().resolve_canonical_name(resolved_model);
     let cancellation_labels = CancellationLabels {
-        model: state
-            .manager()
-            .metric_model_for(&canonical_model)
-            .to_string(),
+        model: metric_model,
         endpoint: Endpoint::AnthropicMessages.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
     let metadata = extract_metadata_from_http(&headers).map_err(|err| {
+        inflight_guard.mark_error(ErrorType::Validation);
         anthropic_error(
             StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
             "invalid_request_error",
@@ -195,7 +318,15 @@ async fn handler_anthropic_messages(
     .await;
 
     let response = tokio::spawn(
-        anthropic_messages(state, template, request, headers, stream_handle).in_current_span(),
+        anthropic_messages(
+            state,
+            template,
+            request,
+            headers,
+            stream_handle,
+            inflight_guard,
+        )
+        .in_current_span(),
     )
     .await
     .map_err(|e| {
@@ -217,6 +348,7 @@ async fn anthropic_messages(
     mut request: Context<AnthropicCreateMessageRequest>,
     headers: HeaderMap,
     mut stream_handle: ConnectionHandle,
+    mut inflight_guard: InflightGuard,
 ) -> Result<Response, Response> {
     let streaming = request.stream;
     let request_id = request.id().to_string();
@@ -264,16 +396,22 @@ async fn anthropic_messages(
             // "overloaded_error" by `anthropic_error`). Reuses the OpenAI path's
             // canonical, customer-facing message so both APIs report the same
             // text. Anything else is a genuine missing model → 404.
-            crate::discovery::ModelManagerError::ModelUnavailable(_) => anthropic_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "overloaded_error",
-                &super::openai::model_not_ready_message(&model),
-            ),
-            _ => anthropic_error(
-                StatusCode::NOT_FOUND,
-                "not_found_error",
-                &format!("Model '{}' not found", model),
-            ),
+            crate::discovery::ModelManagerError::ModelUnavailable(_) => {
+                inflight_guard.mark_error(ErrorType::Unavailable);
+                anthropic_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "overloaded_error",
+                    &super::openai::model_not_ready_message(&model),
+                )
+            }
+            _ => {
+                inflight_guard.mark_error(ErrorType::NotFound);
+                anthropic_error(
+                    StatusCode::NOT_FOUND,
+                    "not_found_error",
+                    &format!("Model '{}' not found", model),
+                )
+            }
         })?;
 
     let (orig_request, context) = request.into_parts();
@@ -297,6 +435,7 @@ async fn anthropic_messages(
 
     // Convert Anthropic request -> UnifiedRequest -> Chat Completion request
     let unified_request: UnifiedRequest = orig_request.try_into().map_err(|e: anyhow::Error| {
+        inflight_guard.mark_error(ErrorType::Validation);
         tracing::error!(
             request_id,
             error = %e,
@@ -315,6 +454,15 @@ async fn anthropic_messages(
     let anthropic_ctx = unified_request.anthropic_context().cloned();
     let mut chat_request = unified_request.into_inner();
     apply_anthropic_header_routing_overrides(&mut chat_request, &headers, state.nvext_enabled());
+    if let Err(error) = chat_request.validate() {
+        inflight_guard.mark_error(ErrorType::Validation);
+        let error = invalid_argument(error.to_string());
+        return Err(anthropic_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            error.message(),
+        ));
+    }
     // When a reasoning parser is configured and the client hasn't explicitly
     // disabled thinking, assume the model's chat template will inject `<think>`.
     //
@@ -361,14 +509,6 @@ async fn anthropic_messages(
     );
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
-
-    // Create inflight_guard early to ensure all errors are counted
-    let mut inflight_guard = state.metrics_clone().create_inflight_guard(
-        &model,
-        Endpoint::AnthropicMessages,
-        streaming,
-        request.id(),
-    );
 
     tracing::trace!("Issuing generate call for Anthropic messages");
 
@@ -560,6 +700,15 @@ async fn handler_count_tokens(
     State((state, _template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
     Json(mut request): Json<AnthropicCountTokensRequest>,
 ) -> Result<Response, Response> {
+    if let Err(error) = validate_anthropic_messages(&request.messages) {
+        return Err(anthropic_error(
+            error.status(),
+            error.anthropic_error_type(),
+            error.message(),
+        ));
+    }
+    // Count Tokens does not convert or execute tools, so keep tool definitions
+    // permissive here. TODO: Add validation when Anthropic server tools are supported.
     if state.strip_anthropic_preamble_enabled() {
         strip_billing_preamble(&mut request.system);
     }

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -5,6 +5,7 @@ use std::sync::LazyLock;
 
 use axum::http::StatusCode;
 use dynamo_runtime::config::environment_names::llm as env_llm;
+use dynamo_runtime::error::{DynamoError, ErrorType as DynamoErrorType};
 use thiserror::Error;
 
 fn parse_overload_status_code(value: Option<&str>) -> StatusCode {
@@ -35,6 +36,15 @@ pub(crate) fn overload_status_code() -> StatusCode {
 pub struct HttpError {
     pub code: u16,
     pub message: String,
+}
+
+/// Construct a typed invalid-argument error for validation performed at an
+/// HTTP protocol adapter boundary.
+pub(crate) fn invalid_argument(message: impl Into<String>) -> DynamoError {
+    DynamoError::builder()
+        .error_type(DynamoErrorType::InvalidArgument)
+        .message(message)
+        .build()
 }
 
 /// Canonical sanitized error responses returned at the HTTP boundary.

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use super::{
     RouteDoc,
     disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
-    error::HttpError,
+    error::{HttpError, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
     metrics::{
         CancellationLabels, Endpoint, ErrorType, EventConverter,
@@ -62,7 +62,10 @@ use crate::protocols::openai::{
     delta_common,
     embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
     images::{NvCreateImageRequest, NvImagesResponse},
-    responses::{NvCreateResponse, NvResponse, ResponseParams, chat_completion_to_response},
+    responses::{
+        NvCreateResponse, NvResponse, ResponseParams, ResponsesConversionError,
+        chat_completion_to_response,
+    },
     videos::{NvCreateVideoRequest, NvVideosResponse},
 };
 use crate::protocols::unified::UnifiedRequest;
@@ -160,6 +163,29 @@ fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
 /// Extract ErrorType from ErrorResponse for metrics
 fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
     classify_error_for_metrics(response.0, &response.1.message)
+}
+
+fn responses_conversion_error_type(error: &anyhow::Error) -> ErrorType {
+    match error.downcast_ref::<ResponsesConversionError>() {
+        Some(ResponsesConversionError::InvalidArgument(_)) => ErrorType::Validation,
+        Some(ResponsesConversionError::NotImplemented(_)) => ErrorType::NotImplemented,
+        None => ErrorType::Internal,
+    }
+}
+
+fn responses_conversion_error_response(error: anyhow::Error) -> ErrorResponse {
+    const CONTEXT: &str = "Failed to convert responses request";
+
+    match error.downcast_ref::<ResponsesConversionError>() {
+        Some(ResponsesConversionError::InvalidArgument(message)) => ErrorMessage::from_anyhow(
+            invalid_argument(format!("{CONTEXT}: {message}")).into(),
+            CONTEXT,
+        ),
+        Some(ResponsesConversionError::NotImplemented(message)) => {
+            ErrorMessage::not_implemented_error(format!("{VALIDATION_PREFIX}{CONTEXT}: {message}"))
+        }
+        None => ErrorMessage::from_anyhow(error, CONTEXT),
+    }
 }
 
 /// Match `InvalidArgument` at top-level OR under `Backend()`.
@@ -2484,12 +2510,9 @@ async fn responses(
             error = %e,
             "Failed to convert NvCreateResponse to UnifiedRequest",
         );
-        let err_response = ErrorMessage::not_implemented_error(
-            VALIDATION_PREFIX.to_string()
-                + "Failed to convert responses request: "
-                + &e.to_string(),
-        );
-        inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+        let error_type = responses_conversion_error_type(&e);
+        let err_response = responses_conversion_error_response(e);
+        inflight_guard.mark_error(error_type);
         err_response
     })?;
     // Extract the API context before consuming the UnifiedRequest — this
@@ -2499,6 +2522,14 @@ async fn responses(
     let mut chat_request = unified_request.into_inner();
     if let Err(err_response) = normalize_chat_reasoning_template_args(&mut chat_request) {
         inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+        return Err(err_response);
+    }
+    if let Err(error) = chat_request.validate() {
+        let err_response = ErrorMessage::from_anyhow(
+            invalid_argument(error.to_string()).into(),
+            "Invalid responses request",
+        );
+        inflight_guard.mark_error(ErrorType::Validation);
         return Err(err_response);
     }
 
@@ -5390,6 +5421,20 @@ mod tests {
         assert_eq!(
             extract_error_type_from_response(&response),
             ErrorType::NotImplemented
+        );
+    }
+
+    #[test]
+    fn untyped_responses_conversion_errors_remain_internal() {
+        let response = responses_conversion_error_response(anyhow::anyhow!(
+            "internal response conversion details"
+        ));
+
+        assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.1.message, "Failed to convert responses request");
+        assert_eq!(
+            extract_error_type_from_response(&response),
+            ErrorType::Internal
         );
     }
 

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -111,7 +111,11 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
         }
 
         // Convert tools
-        let tools = req.tools.as_ref().map(|t| convert_anthropic_tools(t));
+        let tools = req
+            .tools
+            .as_deref()
+            .map(convert_anthropic_tools)
+            .transpose()?;
 
         // Convert tool_choice
         let tool_choice = req.tool_choice.as_ref().map(convert_anthropic_tool_choice);
@@ -119,6 +123,7 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
         // Convert stop_sequences -> stop
         let stop = req
             .stop_sequences
+            .filter(|sequences| !sequences.is_empty())
             .map(dynamo_protocols::types::Stop::StringArray);
 
         Ok(NvCreateChatCompletionRequest {
@@ -459,22 +464,17 @@ fn convert_assistant_blocks(
 }
 
 /// Convert Anthropic tools to ChatCompletionTools.
-fn convert_anthropic_tools(tools: &[AnthropicTool]) -> Vec<ChatCompletionTool> {
+fn convert_anthropic_tools(
+    tools: &[AnthropicTool],
+) -> Result<Vec<ChatCompletionTool>, anyhow::Error> {
     tools
         .iter()
-        .filter_map(|tool| {
-            // Server tools (web_search, bash, etc.) don't have input_schema
-            // and can't be meaningfully converted to OpenAI function tools.
-            // They are backend-specific and handled separately.
-            let schema = tool.input_schema.clone().or_else(|| {
-                tracing::debug!(
-                    tool_name = %tool.name,
-                    tool_type = ?tool.tool_type,
-                    "Skipping server tool in OpenAI conversion (no input_schema)"
-                );
-                None
+        .enumerate()
+        .map(|(tool_index, tool)| {
+            let schema = tool.input_schema.clone().ok_or_else(|| {
+                anyhow::anyhow!("tools[{tool_index}].input_schema: field required for client tools")
             })?;
-            Some(ChatCompletionTool {
+            Ok(ChatCompletionTool {
                 r#type: ChatCompletionToolType::Function,
                 function: FunctionObject {
                     name: tool.name.clone(),
@@ -929,6 +929,12 @@ mod tests {
             container: None,
             output_config: None,
         };
+
+        let mut empty_req = req.clone();
+        empty_req.stop_sequences = Some(vec![]);
+        let empty_chat_req: NvCreateChatCompletionRequest = empty_req.try_into().unwrap();
+        assert!(empty_chat_req.inner.stop.is_none());
+        crate::engines::ValidateRequest::validate(&empty_chat_req).unwrap();
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         assert!(chat_req.inner.stop.is_some());

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -877,16 +877,31 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_accepts_positive_max_tokens() {
+    fn test_validate_accepts_max_tokens_at_upper_bound() {
         let request_json = json!({
             "model": "test-model",
             "messages": [{"role": "user", "content": "Hello"}],
-            "max_tokens": 1
+            "max_tokens": 1_048_576
         });
         let request: NvCreateChatCompletionRequest =
             serde_json::from_value(request_json).expect("Failed to deserialize request");
 
         assert!(ValidateRequest::validate(&request).is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_max_tokens_above_upper_bound() {
+        let request_json = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 1_048_577
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(request_json).expect("Failed to deserialize request");
+
+        let err = ValidateRequest::validate(&request)
+            .expect_err("max_tokens above the upper bound must be rejected");
+        assert!(err.to_string().contains("must not exceed 1048576"));
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -236,6 +236,14 @@ impl OpenAIStopConditionsProvider for NvCreateResponse {
 // Responses API -> Chat Completions conversion
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ResponsesConversionError {
+    #[error("{0}")]
+    InvalidArgument(String),
+    #[error("{0}")]
+    NotImplemented(String),
+}
+
 /// Convert a Responses API ImageDetail to the Chat Completions ImageDetail.
 /// The responses module re-exports an `ImageDetail` from the upstream async-openai
 /// crate which is distinct from `dynamo_protocols::types::ImageDetail` (chat).
@@ -276,17 +284,32 @@ fn convert_input_content_to_user_content(
                 ));
             }
             InputContent::InputImage(img) => {
-                if img.file_id.is_some() && img.image_url.is_none() {
-                    return Err(anyhow::anyhow!(
-                        "Image input by file_id is not yet supported"
-                    ));
-                }
-                let url_str = img
-                    .image_url
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("input_image requires image_url"))?;
-                let url = url::Url::parse(url_str)
-                    .map_err(|e| anyhow::anyhow!("Invalid image URL '{}': {}", url_str, e))?;
+                let url_str = match (img.file_id.as_deref(), img.image_url.as_deref()) {
+                    (None, None) => {
+                        return Err(ResponsesConversionError::InvalidArgument(
+                            "input_image requires file_id or image_url".to_string(),
+                        )
+                        .into());
+                    }
+                    (Some(file_id), None) if file_id.trim().is_empty() => {
+                        return Err(ResponsesConversionError::InvalidArgument(
+                            "input_image file_id must be non-empty".to_string(),
+                        )
+                        .into());
+                    }
+                    (Some(_), None) => {
+                        return Err(ResponsesConversionError::NotImplemented(
+                            "Image input by file_id is not yet supported".to_string(),
+                        )
+                        .into());
+                    }
+                    (_, Some(url_str)) => url_str,
+                };
+                let url = url::Url::parse(url_str).map_err(|error| {
+                    ResponsesConversionError::InvalidArgument(format!(
+                        "Invalid image URL '{url_str}': {error}"
+                    ))
+                })?;
                 let mut image_url = ImageUrl::from(url.to_string());
                 image_url.detail = Some(convert_image_detail_str(&img.detail));
                 let image_part = ChatCompletionRequestMessageContentPartImageArgs::default()
@@ -295,8 +318,41 @@ fn convert_input_content_to_user_content(
                 chat_parts.push(image_part.into());
             }
             // TODO: handle InputVideo / InputAudio when upstream adds them
-            InputContent::InputFile(_) => {
-                return Err(anyhow::anyhow!("File input content is not yet supported"));
+            InputContent::InputFile(file) => {
+                let (source_field, source_value) = match (
+                    file.file_data.as_deref(),
+                    file.file_id.as_deref(),
+                    file.file_url.as_deref(),
+                ) {
+                    (Some(file_data), None, None) => ("file_data", file_data),
+                    (None, Some(file_id), None) => ("file_id", file_id),
+                    (None, None, Some(file_url)) => ("file_url", file_url),
+                    _ => {
+                        return Err(ResponsesConversionError::InvalidArgument(
+                            "input_file requires exactly one of file_data, file_id, or file_url"
+                                .to_string(),
+                        )
+                        .into());
+                    }
+                };
+                if source_value.trim().is_empty() {
+                    return Err(ResponsesConversionError::InvalidArgument(format!(
+                        "input_file {source_field} must be non-empty"
+                    ))
+                    .into());
+                }
+                if source_field == "file_url" {
+                    url::Url::parse(source_value).map_err(|error| {
+                        ResponsesConversionError::InvalidArgument(format!(
+                            "Invalid file URL '{source_value}': {error}"
+                        ))
+                    })?;
+                }
+
+                return Err(ResponsesConversionError::NotImplemented(
+                    "File input content is not yet supported".to_string(),
+                )
+                .into());
             }
         }
     }
@@ -1452,7 +1508,7 @@ mod tests {
     }
 
     #[test]
-    fn test_input_items_with_image() {
+    fn test_input_items_with_file_id_and_image_url_prefers_url() {
         let req = NvCreateResponse {
             inner: CreateResponse {
                 input: InputParam::Items(vec![InputItem::Item(Item::Message(MessageItem::Input(
@@ -1463,7 +1519,7 @@ mod tests {
                             }),
                             InputContent::InputImage(InputImageContent {
                                 detail: Default::default(), // ImageDetail::Auto
-                                file_id: None,
+                                file_id: Some("file_123".into()),
                                 image_url: Some("https://example.com/cat.jpg".into()),
                             }),
                         ],

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -90,8 +90,8 @@ pub const MAX_STOP_SEQUENCES: usize = 32;
 /// Maximum allowed number of tools.
 pub const MAX_TOOLS: usize = 1536;
 // Metadata validation constants removed - we are no longer restricting the metadata field char limits
-/// Maximum allowed length for function names
-pub const MAX_FUNCTION_NAME_LENGTH: usize = 96;
+/// Both `/v1/messages` and `/v1/responses` define a 128-character tool-name limit.
+pub const MAX_FUNCTION_NAME_LENGTH: usize = 128;
 /// Minimum allowed value for `repetition_penalty`
 pub const MIN_REPETITION_PENALTY: f32 = 0.0;
 /// Maximum allowed value for `repetition_penalty`
@@ -763,12 +763,23 @@ pub fn validate_suffix(suffix: Option<&str>) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+const MAX_OUTPUT_TOKENS: u32 = 1_048_576;
+
 /// Validates max_tokens parameter
 pub fn validate_max_tokens(max_tokens: Option<u32>) -> Result<(), anyhow::Error> {
     if let Some(tokens) = max_tokens
         && tokens == 0
     {
         anyhow::bail!("Max tokens must be greater than 0, got {}", tokens);
+    }
+    if let Some(tokens) = max_tokens
+        && tokens > MAX_OUTPUT_TOKENS
+    {
+        anyhow::bail!(
+            "Max tokens must not exceed {}, got {}",
+            MAX_OUTPUT_TOKENS,
+            tokens
+        );
     }
     Ok(())
 }
@@ -782,6 +793,15 @@ pub fn validate_max_completion_tokens(
     {
         anyhow::bail!(
             "Max completion tokens must be greater than 0, got {}",
+            tokens
+        );
+    }
+    if let Some(tokens) = max_completion_tokens
+        && tokens > MAX_OUTPUT_TOKENS
+    {
+        anyhow::bail!(
+            "Max completion tokens must not exceed {}, got {}",
+            MAX_OUTPUT_TOKENS,
             tokens
         );
     }

--- a/lib/llm/tests/common/http_harness.rs
+++ b/lib/llm/tests/common/http_harness.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
-use dynamo_llm::http::service::service_v2::HttpService;
+use dynamo_llm::http::service::{Metrics, service_v2::HttpService};
 use dynamo_llm::model_card::ModelDeploymentCard;
 use dynamo_llm::protocols::codec::create_message_stream;
 use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
@@ -36,6 +36,8 @@ pub struct HarnessService {
     pub base_url: String,
     pub client: reqwest::Client,
     pub engine: Arc<ScriptedChatEngine>,
+    #[allow(dead_code)]
+    pub metrics: Arc<Metrics>,
     cancel: CancellationToken,
     join: Option<tokio::task::JoinHandle<Result<()>>>,
 }
@@ -68,6 +70,7 @@ impl HarnessService {
             .expect("failed to build harness HTTP service");
 
         let card = ModelDeploymentCard::with_name_only(MODEL);
+        let metrics = service.state_clone().metrics_clone();
         service
             .model_manager()
             .add_chat_completions_model(MODEL, card.mdcsum(), engine.clone())
@@ -82,6 +85,7 @@ impl HarnessService {
             base_url,
             client,
             engine,
+            metrics,
             cancel,
             join: Some(join),
         }

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -1,0 +1,506 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP regressions for validation performed by protocol adapters.
+
+use dynamo_llm::http::service::metrics::{Endpoint, ErrorType, RequestType, Status};
+use dynamo_runtime::config::environment_names::llm::{
+    DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
+};
+use serde_json::{Value, json};
+use serial_test::serial;
+
+#[allow(dead_code)]
+#[path = "common/http_harness.rs"]
+mod http_harness;
+#[path = "common/ports.rs"]
+mod ports;
+#[allow(dead_code)]
+#[path = "common/scripted_chat_engine.rs"]
+mod scripted_chat_engine;
+
+use http_harness::{HarnessService, MODEL, load_agent_fixture};
+
+const BASE_ENV: [(&str, Option<&str>); 2] = [
+    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+];
+
+async fn post_json(svc: &HarnessService, path: &str, body: Value) -> reqwest::Response {
+    svc.client
+        .post(format!("{}{path}", svc.base_url))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+#[derive(Clone, Copy)]
+enum ExpectedError {
+    Validation,
+    NotImplemented,
+}
+
+impl ExpectedError {
+    fn status(self) -> reqwest::StatusCode {
+        match self {
+            Self::Validation => reqwest::StatusCode::BAD_REQUEST,
+            Self::NotImplemented => reqwest::StatusCode::NOT_IMPLEMENTED,
+        }
+    }
+
+    fn anthropic_type(self) -> &'static str {
+        match self {
+            Self::Validation => "invalid_request_error",
+            Self::NotImplemented => "api_error",
+        }
+    }
+}
+
+async fn assert_openai_error(response: reqwest::Response, expected: ExpectedError, message: &str) {
+    let status = expected.status();
+    assert_eq!(response.status(), status);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["code"].as_u64(), Some(u64::from(status.as_u16())));
+    assert!(
+        body["message"].as_str().is_some_and(|actual| actual
+            .to_ascii_lowercase()
+            .contains(&message.to_ascii_lowercase())),
+        "unexpected OpenAI error body: {body}"
+    );
+}
+
+async fn assert_anthropic_error(
+    response: reqwest::Response,
+    expected: ExpectedError,
+    message: &str,
+) {
+    assert_eq!(response.status(), expected.status());
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["type"], "error");
+    assert_eq!(body["error"]["type"], expected.anthropic_type());
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|actual| actual.contains(message)),
+        "unexpected Anthropic error body: {body}"
+    );
+}
+
+fn assert_error_metrics(
+    svc: &HarnessService,
+    endpoint: &Endpoint,
+    request_type: &RequestType,
+    expected: &[(ErrorType, u64)],
+) {
+    for (error_type, expected) in expected {
+        assert_eq!(
+            svc.metrics.get_request_counter(
+                MODEL,
+                endpoint,
+                request_type,
+                &Status::Error,
+                error_type,
+            ),
+            *expected,
+            "unexpected {error_type:?} count for {endpoint}/{request_type}"
+        );
+    }
+}
+
+fn tool_name_requests(name: &str) -> [(&'static str, Value, bool); 3] {
+    [
+        (
+            "/v1/messages",
+            json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "name": name,
+                    "input_schema": {"type": "object", "properties": {}}
+                }]
+            }),
+            true,
+        ),
+        (
+            "/v1/responses",
+            json!({
+                "model": MODEL,
+                "input": "ping",
+                "tools": [{
+                    "type": "function",
+                    "name": name,
+                    "parameters": {"type": "object", "properties": {}}
+                }]
+            }),
+            false,
+        ),
+        (
+            "/v1/chat/completions",
+            json!({
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "parameters": {"type": "object", "properties": {}}
+                    }
+                }]
+            }),
+            false,
+        ),
+    ]
+}
+
+#[tokio::test]
+#[serial]
+async fn responses_conversion_distinguishes_invalid_from_unsupported() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+
+        for (stream, content, expected, message) in [
+            (
+                true,
+                json!({"type": "input_image", "file_id": "file_123"}),
+                ExpectedError::NotImplemented,
+                "image input by file_id",
+            ),
+            (
+                false,
+                json!({
+                    "type": "input_file",
+                    "file_url": "https://example.com/report.pdf"
+                }),
+                ExpectedError::NotImplemented,
+                "file input content",
+            ),
+            (
+                false,
+                json!({"type": "input_image"}),
+                ExpectedError::Validation,
+                "requires file_id or image_url",
+            ),
+            (
+                true,
+                json!({"type": "input_file"}),
+                ExpectedError::Validation,
+                "requires exactly one of file_data, file_id, or file_url",
+            ),
+        ] {
+            let response = post_json(
+                &svc,
+                "/v1/responses",
+                json!({
+                    "model": MODEL,
+                    "stream": stream,
+                    "input": [{"role": "user", "content": [content]}]
+                }),
+            )
+            .await;
+            assert_openai_error(response, expected, message).await;
+        }
+
+        for request_type in [RequestType::Unary, RequestType::Stream] {
+            assert_error_metrics(
+                &svc,
+                &Endpoint::Responses,
+                &request_type,
+                &[
+                    (ErrorType::NotImplemented, 1),
+                    (ErrorType::Validation, 1),
+                    (ErrorType::Internal, 0),
+                ],
+            );
+        }
+
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn anthropic_tools_reject_unsupported_and_malformed_definitions() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+
+        for (stream, tool_choice) in [
+            (false, None),
+            (true, Some(json!({"type": "tool", "name": "web_search"}))),
+        ] {
+            let mut body = json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "stream": stream,
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{
+                    "type": "web_search_20260209",
+                    "name": "web_search"
+                }]
+            });
+            if let Some(tool_choice) = tool_choice {
+                body["tool_choice"] = tool_choice;
+            }
+            let response = post_json(&svc, "/v1/messages", body).await;
+            assert_anthropic_error(
+                response,
+                ExpectedError::NotImplemented,
+                "server tool type \"web_search_20260209\" is not supported",
+            )
+            .await;
+        }
+
+        let response = post_json(
+            &svc,
+            "/v1/messages",
+            json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "stream": false,
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "tools": [{"name": "get_weather"}]
+            }),
+        )
+        .await;
+        assert_anthropic_error(
+            response,
+            ExpectedError::Validation,
+            "tools[0].input_schema: field required",
+        )
+        .await;
+
+        for request_type in [RequestType::Unary, RequestType::Stream] {
+            let validation = match &request_type {
+                RequestType::Unary => 1,
+                RequestType::Stream => 0,
+            };
+            assert_error_metrics(
+                &svc,
+                &Endpoint::AnthropicMessages,
+                &request_type,
+                &[
+                    (ErrorType::NotImplemented, 1),
+                    (ErrorType::Validation, validation),
+                    (ErrorType::Internal, 0),
+                ],
+            );
+        }
+
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+// `reqwest::send` completes when response headers arrive. A 400 for `stream: true`
+// proves converted-request validation ran before the HTTP 200 SSE response was committed.
+#[tokio::test]
+#[serial]
+async fn converted_validation_errors_are_returned_before_streaming_headers() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+
+        for (stream, field) in [
+            (false, json!({"top_p": 2.0})),
+            (true, json!({"temperature": 3.0})),
+        ] {
+            let mut body = json!({"model": MODEL, "input": "ping", "stream": stream});
+            body.as_object_mut()
+                .unwrap()
+                .extend(field.as_object().unwrap().clone());
+            let response = post_json(&svc, "/v1/responses", body).await;
+            assert_openai_error(response, ExpectedError::Validation, "must be").await;
+        }
+
+        for (stream, field) in [
+            (false, json!({"temperature": 3.0})),
+            (true, json!({"top_p": 2.0})),
+        ] {
+            let mut body = json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "stream": stream,
+                "messages": [{"role": "user", "content": "ping"}]
+            });
+            body.as_object_mut()
+                .unwrap()
+                .extend(field.as_object().unwrap().clone());
+            let response = post_json(&svc, "/v1/messages", body).await;
+            assert_anthropic_error(response, ExpectedError::Validation, "must be").await;
+        }
+
+        for endpoint in [Endpoint::Responses, Endpoint::AnthropicMessages] {
+            for request_type in [RequestType::Unary, RequestType::Stream] {
+                assert_error_metrics(
+                    &svc,
+                    &endpoint,
+                    &request_type,
+                    &[(ErrorType::Validation, 1), (ErrorType::Internal, 0)],
+                );
+            }
+        }
+
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn responses_reject_empty_input_and_required_tool_choice_without_tools() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+
+        for (body, message) in [
+            (
+                json!({"model": MODEL, "input": [], "max_tokens": 10}),
+                "messages",
+            ),
+            (
+                json!({
+                    "model": MODEL,
+                    "input": "ping",
+                    "tools": [],
+                    "tool_choice": "required"
+                }),
+                "tool_choice is \"required\"",
+            ),
+        ] {
+            let response = post_json(&svc, "/v1/responses", body).await;
+            assert_openai_error(response, ExpectedError::Validation, message).await;
+        }
+
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn anthropic_content_validation_applies_to_messages_and_count_tokens() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+
+        for (path, body, expected, message) in [
+            (
+                "/v1/messages",
+                json!({
+                    "model": MODEL,
+                    "max_tokens": 10,
+                    "stream": true,
+                    "messages": [{"role": "user", "content": ["hello"]}]
+                }),
+                ExpectedError::Validation,
+                "content blocks must be objects",
+            ),
+            (
+                "/v1/messages",
+                json!({
+                    "model": MODEL,
+                    "max_tokens": 10,
+                    "messages": [{"role": "user", "content": []}]
+                }),
+                ExpectedError::Validation,
+                "must contain at least one content block",
+            ),
+            (
+                "/v1/messages/count_tokens",
+                json!({
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": ["hello"]}]
+                }),
+                ExpectedError::Validation,
+                "content blocks must be objects",
+            ),
+            (
+                "/v1/messages",
+                json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "messages": [{
+                        "role": "user",
+                        "content": [
+                            {"type": "future_block_type", "value": 1},
+                            {"type": "text", "text": "ping"}
+                        ]
+                    }]
+                }),
+                ExpectedError::NotImplemented,
+                "content block type \"future_block_type\"",
+            ),
+            (
+                "/v1/messages/count_tokens",
+                json!({
+                    "model": MODEL,
+                    "messages": [{
+                        "role": "user",
+                        "content": [{"type": "future_block_type", "value": 1}]
+                    }]
+                }),
+                ExpectedError::NotImplemented,
+                "content block type \"future_block_type\"",
+            ),
+        ] {
+            let response = post_json(&svc, path, body).await;
+            assert_anthropic_error(response, expected, message).await;
+        }
+
+        for request_type in [RequestType::Unary, RequestType::Stream] {
+            let not_implemented = match &request_type {
+                RequestType::Unary => 1,
+                RequestType::Stream => 0,
+            };
+            assert_error_metrics(
+                &svc,
+                &Endpoint::AnthropicMessages,
+                &request_type,
+                &[
+                    (ErrorType::Validation, 1),
+                    (ErrorType::NotImplemented, not_implemented),
+                    (ErrorType::Internal, 0),
+                ],
+            );
+        }
+
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn tool_name_limit_is_shared_across_protocols() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let valid_script = load_agent_fixture("text.sse").await.unwrap();
+        let svc =
+            HarnessService::start([valid_script.clone(), valid_script.clone(), valid_script]).await;
+
+        let max_length_tool_name = "a".repeat(128);
+        for (path, body, _) in tool_name_requests(&max_length_tool_name) {
+            let response = post_json(&svc, path, body).await;
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+        }
+
+        let too_long_tool_name = "a".repeat(129);
+        for (path, body, anthropic) in tool_name_requests(&too_long_tool_name) {
+            let response = post_json(&svc, path, body).await;
+            if anthropic {
+                assert_anthropic_error(response, ExpectedError::Validation, "128 character limit")
+                    .await;
+            } else {
+                assert_openai_error(response, ExpectedError::Validation, "128 character limit")
+                    .await;
+            }
+        }
+
+        assert_eq!(svc.engine.take_requests().await.len(), 3);
+        svc.shutdown().await;
+    })
+    .await;
+}


### PR DESCRIPTION
## Summary

- Cherry-pick [#12809](https://github.com/ai-dynamo/dynamo/pull/12809) onto `release/1.4.0`.
- Validate converted OpenAI Responses and Anthropic requests before backend dispatch for unary and streaming requests.
- Return 400 for invalid/malformed inputs and 501 for recognized but unsupported features.
- Enforce the 1,048,576 output-token ceiling and shared 128-character tool-name limit.
- Adapt the regression suite to release/1.4.0, where the newer pre-commit error-peek setting and response-carried metric classification are not present.

## Tracking

Fixes DYN-3787

Fixes DYN-3788

Fixes DYN-3789

## Original change

- PR: [#12809](https://github.com/ai-dynamo/dynamo/pull/12809)
- Merge commit: [`5b33610194`](https://github.com/ai-dynamo/dynamo/commit/5b336101944a1b7d9f1fab9afd03aee5dab37fc6)
- Backport commit: [`0ddd24fd51`](https://github.com/ai-dynamo/dynamo/commit/0ddd24fd514abc495e136769ddd1255caa6a1bd8)

## Validation

- `cargo test -p dynamo-llm --test frontend_protocol_validation_http` — 6 passed
- `cargo test -p dynamo-llm --lib max_tokens` — 5 passed
- `cargo fmt --all -- --check` — passed
- `git diff --check origin/release/1.4.0...HEAD` — passed