### PR TITLE
fix(frontend): decode vLLM JSON tool-call fallback

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Awaitable, Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -51,10 +52,15 @@ class PreprocessResult:
     engine_prompt: dict[str, Any]
     prompt_token_ids: list[int]
     guided_decoding: dict[str, Any] | None = None
+    uses_dynamo_json_tool_call_fallback: bool = False
 
 
 _ASYNC_TOKENIZER_POOL: dict[int, Callable[..., Awaitable[Any]]] = {}
 SKIP_REQUEST_VALIDATION = os.getenv("DYN_VLLM_SKIP_REQUEST_VALIDATION", "1") == "1"
+
+
+def _reject_non_finite_json(value: str) -> Any:
+    raise ValueError(f"non-finite JSON number: {value}")
 
 
 def _is_named_tool_choice(tool_choice: Any) -> bool:
@@ -170,12 +176,8 @@ def _should_build_tool_call_guidance(
         return False
     if structural_tag_scope == "always":
         return True
-    # TODO: parallel_tool_calls only decides whether a structural tag is attempted;
-    # it does not bound call count in the forced-choice JSON fallback below.
-    # get_json_schema_from_tools emits {"type": "array", "minItems": 1} with no
-    # maxItems, matching build_required_schema in protocols/openai/tools.rs, so
-    # parallel_tool_calls=false can still produce several calls. sglang_prepost.py
-    # is the only path that forwards the flag into its schema builder.
+    # An explicit single-call request is enough to attempt structural-tag
+    # guidance. Forced-choice JSON guidance also bounds its array schema below.
     explicit_single_call = (
         "parallel_tool_calls" in request.model_fields_set
         and request.parallel_tool_calls is False
@@ -253,6 +255,11 @@ def build_tool_call_guided_decoding(
         # _validate_chat_completion_request.
         json_schema = get_json_schema_from_tools(tool_choice, request.tools)
         if json_schema is not None:
+            if (
+                request.parallel_tool_calls is False
+                and json_schema.get("type") == "array"
+            ):
+                json_schema["maxItems"] = 1
             return {"json": json_schema}
     return None
 
@@ -602,6 +609,19 @@ async def preprocess_chat_request(
         if assistant_guided_decoding is not None and not is_forced_tool_choice
         else tool_guided_decoding
     )
+    # build_tool_call_guided_decoding falls back to Dynamo's generic JSON schema
+    # when a forced tool choice has no parser-provided grammar.  That can happen
+    # both without a parser and with parsers (for example Hermes) whose
+    # adjust_request() leaves structured_outputs unchanged.  In either case the
+    # model emits Dynamo's bare JSON wire format, which must bypass the parser's
+    # native-syntax decoder during postprocessing.
+    uses_dynamo_json_tool_call_fallback = (
+        is_forced_tool_choice
+        and parser_guided_decoding is None
+        and guided_decoding is tool_guided_decoding
+        and isinstance(tool_guided_decoding, dict)
+        and "json" in tool_guided_decoding
+    )
 
     _, engine_prompt = await renderer.render_messages_async(messages, chat_params)
 
@@ -622,6 +642,7 @@ async def preprocess_chat_request(
         engine_prompt=engine_prompt,
         prompt_token_ids=tokens,
         guided_decoding=guided_decoding,
+        uses_dynamo_json_tool_call_fallback=uses_dynamo_json_tool_call_fallback,
     )
 
 
@@ -637,12 +658,14 @@ class StreamingPostProcessor:
         reasoning_parser_class: type[ReasoningParser] | None,
         chat_template_kwargs: dict[str, Any],
         stream_response: bool = True,
+        uses_dynamo_json_tool_call_fallback: bool = False,
     ) -> None:
         self.tokenizer = tokenizer
         self.request_for_sampling = request_for_sampling
         self.sampling_params = sampling_params
         self.tool_parser = tool_parser
         self.stream_response = stream_response
+        self._uses_dynamo_json_tool_call_fallback = uses_dynamo_json_tool_call_fallback
         # See https://github.com/ai-dynamo/dynamo/issues/8636 —
         # when the chat template runs with enable_thinking=False,
         # the reasoning open/close tags live in the prompt and the generated
@@ -662,7 +685,9 @@ class StreamingPostProcessor:
             else None
         )
         self._fast_plain_text = (
-            self.tool_parser is None and self.reasoning_parser is None
+            self.tool_parser is None
+            and self.reasoning_parser is None
+            and not self._uses_dynamo_json_tool_call_fallback
         )
 
         self._control_markers = tuple(
@@ -683,6 +708,104 @@ class StreamingPostProcessor:
         # this correctly, so we accumulate text here and fall back to the
         # non-streaming extract_tool_calls() once the buffer is complete.
         self._tool_text_buffer: str | None = None
+        self._dynamo_json_fallback_chunks: dict[int, list[str]] = {}
+
+    def _decode_dynamo_json_fallback_tool_calls(
+        self, text: str
+    ) -> list[dict[str, Any]]:
+        """Convert Dynamo's JSON fallback wire format into OpenAI tool calls."""
+        try:
+            tool_calls = json.loads(text, parse_constant=_reject_non_finite_json)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError(
+                "Dynamo JSON tool-call fallback was not valid JSON"
+            ) from exc
+
+        available_tool_names = {
+            tool.function.name for tool in self.request_for_sampling.tools or []
+        }
+        tool_choice = self.request_for_sampling.tool_choice
+        required_tool_name = None
+        if _is_named_tool_choice(tool_choice):
+            if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam):
+                required_tool_name = tool_choice.function.name
+            else:
+                required_tool_name = tool_choice["function"]["name"]
+            tool_calls = [
+                {
+                    "name": required_tool_name,
+                    "parameters": tool_calls,
+                }
+            ]
+        elif not isinstance(tool_calls, list) or not tool_calls:
+            raise ValueError(
+                "Dynamo JSON tool-call fallback must contain a tool-call array"
+            )
+
+        if (
+            self.request_for_sampling.parallel_tool_calls is False
+            and len(tool_calls) > 1
+        ):
+            raise ValueError(
+                "Dynamo JSON tool-call fallback returned multiple tool calls "
+                "when parallel_tool_calls is false"
+            )
+
+        parsed_tool_calls: list[dict[str, Any]] = []
+        for index, tool_call in enumerate(tool_calls):
+            if not isinstance(tool_call, dict):
+                raise TypeError(
+                    "Dynamo JSON tool-call fallback entries must be objects"
+                )
+            name = tool_call.get("name")
+            if "parameters" not in tool_call:
+                raise TypeError(
+                    "Dynamo JSON tool-call fallback entries must include parameters"
+                )
+            parameters = tool_call["parameters"]
+            if not isinstance(name, str) or name not in available_tool_names:
+                raise ValueError(
+                    "Dynamo JSON tool-call fallback named an unavailable tool"
+                )
+            if required_tool_name is not None and name != required_tool_name:
+                raise ValueError(
+                    "Dynamo JSON tool-call fallback did not use the required tool"
+                )
+            parsed_tool_calls.append(
+                DeltaToolCall(
+                    index=index,
+                    type="function",
+                    id=make_tool_call_id(),
+                    function=DeltaFunctionCall(
+                        name=name,
+                        arguments=json.dumps(parameters, separators=(",", ":")),
+                    ),
+                ).model_dump(exclude_none=True)
+            )
+        return parsed_tool_calls
+
+    def _process_dynamo_json_fallback_tool_calls(
+        self, output: Any
+    ) -> dict[str, Any] | None:
+        chunks = self._dynamo_json_fallback_chunks.setdefault(output.index, [])
+        if output.text:
+            chunks.append(output.text)
+        if not output.finish_reason:
+            return None
+
+        text = "".join(self._dynamo_json_fallback_chunks.pop(output.index))
+        delta: dict[str, Any]
+        try:
+            tool_calls = self._decode_dynamo_json_fallback_tool_calls(text)
+        except (TypeError, ValueError):
+            delta = {"role": "assistant", "content": text} if text else {}
+            return self._build_choice(output, delta)
+
+        delta = {
+            "role": "assistant",
+            "tool_calls": tool_calls,
+        }
+        return self._build_choice(output, delta)
 
     def _should_buffer_for_non_streaming_tool_parse(self) -> bool:
         return (
@@ -923,6 +1046,8 @@ class StreamingPostProcessor:
         return self._build_choice(output, delta)
 
     def process_output(self, output: Any) -> dict[str, Any] | None:
+        if self._uses_dynamo_json_tool_call_fallback:
+            return self._process_dynamo_json_fallback_tool_calls(output)
         if self._should_buffer_for_non_streaming_tool_parse():
             return self._process_non_streaming_tool_output(output)
 

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -22,10 +22,14 @@ from _tool_guidance_parity import (
     tool_choice_value,
 )
 from transformers import AutoTokenizer
-from vllm.sampling_params import StructuredOutputsParams
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 
 from dynamo.frontend import prepost as prepost_module
-from dynamo.frontend.prepost import _prepare_request, build_tool_call_guided_decoding
+from dynamo.frontend.prepost import (
+    StreamingPostProcessor,
+    _prepare_request,
+    build_tool_call_guided_decoding,
+)
 from dynamo.llm.exceptions import InvalidArgument
 
 # NOTE: dynamo.frontend.vllm_processor is imported lazily inside the tests that
@@ -92,6 +96,301 @@ TOOL_REQUEST = {
         }
     ],
 }
+
+
+class TestDynamoJsonToolCallFallback:
+    """Dynamo's forced-choice JSON fallback must emit OpenAI tool calls."""
+
+    def _post_processor(
+        self,
+        tokenizer,
+        *,
+        tool_choice,
+        stream_response,
+        parallel_tool_calls=None,
+        tool_parameters=None,
+    ):
+        request = json.loads(json.dumps(TOOL_REQUEST))
+        request["tool_choice"] = tool_choice
+        if parallel_tool_calls is not None:
+            request["parallel_tool_calls"] = parallel_tool_calls
+        if tool_parameters is not None:
+            request["tools"][0]["function"]["parameters"] = tool_parameters
+        request, _, _, _, _ = _prepare_request(
+            request,
+            tokenizer=tokenizer,
+            tool_parser_class=None,
+        )
+        return StreamingPostProcessor(
+            tokenizer=tokenizer,
+            request_for_sampling=request,
+            sampling_params=SamplingParams(),
+            prompt_token_ids=[],
+            tool_parser=None,
+            reasoning_parser_class=None,
+            chat_template_kwargs={},
+            stream_response=stream_response,
+            uses_dynamo_json_tool_call_fallback=True,
+        )
+
+    def test_streaming_required_choice_converts_json_to_tool_calls(self, tokenizer):
+        post = self._post_processor(
+            tokenizer, tool_choice="required", stream_response=True
+        )
+
+        assert (
+            post.process_output(
+                SimpleNamespace(
+                    index=0,
+                    text='[{"name":"get_weather","parameters":',
+                    token_ids=[],
+                    finish_reason=None,
+                    logprobs=None,
+                )
+            )
+            is None
+        )
+
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text='{"city":"Paris"}}]',
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice["finish_reason"] == "tool_calls"
+        assert "content" not in choice["delta"]
+        tool_call = choice["delta"]["tool_calls"][0]
+        assert tool_call["function"] == {
+            "name": "get_weather",
+            "arguments": '{"city":"Paris"}',
+        }
+
+    def test_non_streaming_named_choice_converts_json_to_tool_calls(self, tokenizer):
+        post = self._post_processor(
+            tokenizer,
+            tool_choice={
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+            stream_response=False,
+        )
+
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text='{"city":"Paris"}',
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice["finish_reason"] == "tool_calls"
+        assert "content" not in choice["delta"]
+        assert choice["delta"]["tool_calls"][0]["function"] == {
+            "name": "get_weather",
+            "arguments": '{"city":"Paris"}',
+        }
+
+    def test_invalid_fallback_output_is_returned_as_content(self, tokenizer):
+        post = self._post_processor(
+            tokenizer, tool_choice="required", stream_response=True
+        )
+
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text='[{"name":"get_weather","parameters":',
+                token_ids=[],
+                finish_reason="length",
+                logprobs=None,
+            )
+        )
+
+        assert choice["finish_reason"] == "length"
+        assert choice["delta"] == {
+            "role": "assistant",
+            "content": '[{"name":"get_weather","parameters":',
+        }
+
+    def test_multiple_fallback_tool_calls_respect_parallel_setting(self, tokenizer):
+        post = self._post_processor(
+            tokenizer,
+            tool_choice="required",
+            stream_response=False,
+            parallel_tool_calls=False,
+        )
+        text = (
+            '[{"name":"get_weather","parameters":{"city":"Paris"}},'
+            '{"name":"get_weather","parameters":{"city":"London"}}]'
+        )
+
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text=text,
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice["finish_reason"] == "stop"
+        assert choice["delta"] == {"role": "assistant", "content": text}
+
+    def test_non_finite_fallback_arguments_are_returned_as_content(self, tokenizer):
+        post = self._post_processor(
+            tokenizer, tool_choice="required", stream_response=False
+        )
+        text = '[{"name":"get_weather","parameters":{"temperature":NaN}}]'
+
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text=text,
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice is not None
+        assert choice["finish_reason"] == "stop"
+        assert choice["delta"] == {"role": "assistant", "content": text}
+
+    def test_invalid_fallback_does_not_leave_partial_tool_state(self, tokenizer):
+        post = self._post_processor(
+            tokenizer, tool_choice="required", stream_response=False
+        )
+        text = (
+            '[{"name":"get_weather","parameters":{"city":"Paris"}},'
+            '{"name":"unknown","parameters":{}}]'
+        )
+
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text=text,
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice is not None
+        assert choice["finish_reason"] == "stop"
+        assert choice["delta"] == {"role": "assistant", "content": text}
+        assert post.in_progress_tool_calls == {}
+
+    def test_named_choice_accepts_array_arguments(self, tokenizer):
+        post = self._post_processor(
+            tokenizer,
+            tool_choice={
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+            stream_response=False,
+            tool_parameters={"type": "array", "items": {"type": "string"}},
+        )
+
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text='["Paris","Seoul"]',
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice is not None
+        assert choice["delta"]["tool_calls"][0]["function"]["arguments"] == (
+            '["Paris","Seoul"]'
+        )
+
+    def test_required_choice_accepts_null_arguments(self, tokenizer):
+        post = self._post_processor(
+            tokenizer,
+            tool_choice="required",
+            stream_response=False,
+            tool_parameters={"type": "null"},
+        )
+
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text='[{"name":"get_weather","parameters":null}]',
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice is not None
+        assert choice["delta"]["tool_calls"][0]["function"]["arguments"] == "null"
+
+    def test_missing_parameters_are_returned_as_content(self, tokenizer):
+        post = self._post_processor(
+            tokenizer, tool_choice="required", stream_response=False
+        )
+        text = '[{"name":"get_weather"}]'
+
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text=text,
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice is not None
+        assert choice["delta"] == {"role": "assistant", "content": text}
+
+    def test_streaming_choices_keep_independent_json_buffers(self, tokenizer):
+        post = self._post_processor(
+            tokenizer, tool_choice="required", stream_response=True
+        )
+
+        for index in (0, 1):
+            assert (
+                post.process_output(
+                    SimpleNamespace(
+                        index=index,
+                        text='[{"name":"get_weather","parameters":{"city":"',
+                        token_ids=[],
+                        finish_reason=None,
+                        logprobs=None,
+                    )
+                )
+                is None
+            )
+
+        choices = [
+            post.process_output(
+                SimpleNamespace(
+                    index=index,
+                    text=f'{city}"}}}}]',
+                    token_ids=[],
+                    finish_reason="stop",
+                    logprobs=None,
+                )
+            )
+            for index, city in ((1, "Seoul"), (0, "Paris"))
+        ]
+
+        for choice, (index, city) in zip(choices, ((1, "Seoul"), (0, "Paris"))):
+            assert choice is not None
+            assert choice["index"] == index
+            assert choice["finish_reason"] == "tool_calls"
+            assert choice["delta"]["tool_calls"][0]["function"]["arguments"] == (
+                f'{{"city":"{city}"}}'
+            )
 
 
 @pytest.fixture(scope="module")
@@ -1180,6 +1479,20 @@ class TestToolCallGuidedDecoding:
         assert set(guided) == {"json"}
         assert parser.requests == []
 
+    def test_required_choice_disables_parallel_calls_in_json_guidance(self, tokenizer):
+        guided = build_tool_call_guided_decoding(
+            self._request(
+                tokenizer,
+                tool_choice="required",
+                parallel_tool_calls=False,
+            ),
+            tool_parser=None,
+        )
+
+        assert guided is not None
+        assert guided["json"]["type"] == "array"
+        assert guided["json"]["maxItems"] == 1
+
     # Parsers that require native tool syntax must not get a forced JSON schema.
     @pytest.mark.parametrize(
         "tool_choice",
@@ -1247,6 +1560,62 @@ class TestToolCallGuidedDecoding:
         )
 
         assert result.guided_decoding == {"grammar": 'root ::= "<tool_call>"'}
+        assert result.uses_dynamo_json_tool_call_fallback is False
+
+    @pytest.mark.parametrize(
+        "tool_parser_class",
+        [None, _FakePassthroughToolParser],
+        ids=["no-parser", "parser-without-guidance"],
+    )
+    @pytest.mark.asyncio
+    async def test_generic_json_guidance_enables_matching_postprocessor(
+        self, tokenizer, tool_parser_class
+    ):
+        result = await prepost_module.preprocess_chat_request(
+            {**TOOL_REQUEST, "tool_choice": "required"},
+            tokenizer=tokenizer,
+            renderer=SimpleNamespace(
+                render_messages_async=AsyncMock(
+                    return_value=(None, {"prompt_token_ids": [1]})
+                )
+            ),
+            tool_parser_class=tool_parser_class,
+            structural_tag_mode="off",
+        )
+
+        assert result.guided_decoding is not None
+        assert set(result.guided_decoding) == {"json"}
+        assert result.uses_dynamo_json_tool_call_fallback is True
+
+        post = StreamingPostProcessor(
+            tokenizer=tokenizer,
+            request_for_sampling=result.request_for_sampling,
+            sampling_params=SamplingParams(),
+            prompt_token_ids=result.prompt_token_ids,
+            tool_parser=result.tool_parser,
+            reasoning_parser_class=None,
+            chat_template_kwargs=result.chat_template_kwargs,
+            stream_response=False,
+            uses_dynamo_json_tool_call_fallback=(
+                result.uses_dynamo_json_tool_call_fallback
+            ),
+        )
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text='[{"name":"get_weather","parameters":{"city":"Paris"}}]',
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice is not None
+        assert choice["finish_reason"] == "tool_calls"
+        assert choice["delta"]["tool_calls"][0]["function"] == {
+            "name": "get_weather",
+            "arguments": '{"city":"Paris"}',
+        }
 
     # Explicit assistant constraints must override automatic tool-call guidance.
     @pytest.mark.parametrize(

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -687,6 +687,9 @@ class VllmProcessor:
                     reasoning_parser_class=self.reasoning_parser_class,
                     chat_template_kwargs=chat_template_kwargs,
                     stream_response=bool(request.get("stream", False)),
+                    uses_dynamo_json_tool_call_fallback=(
+                        pre.uses_dynamo_json_tool_call_fallback
+                    ),
                 )
 
             # StreamingPostProcessor keeps delta/tool/reasoning parser state, so

--- a/docs/fern/pages/reference/api/python/frontend.mdx
+++ b/docs/fern/pages/reference/api/python/frontend.mdx
@@ -20,7 +20,7 @@ from dynamo.frontend.vllm_processor import EngineFactory
 EngineFactory(config: FrontendConfig, flags: Namespace)
 ```
 
-[`components/src/dynamo/frontend/vllm_processor.py#L931`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L931)
+[`components/src/dynamo/frontend/vllm_processor.py#L934`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L934)
 
 **Public methods**
 
@@ -32,7 +32,7 @@ __init__(config: FrontendConfig, flags: Namespace)
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L932)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L935)
 
 <h4 id="api-dynamo-frontend-vllm-processor-enginefactory-chat-engine-factory">chat_engine_factory</h4>
 
@@ -42,7 +42,7 @@ chat_engine_factory(instance_id: ModelCardInstanceId, mdc: ModelDeploymentCard, 
 
 Called by Rust when a model is discovered.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L951)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L954)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-frontend-args-frontendarggroup" title="FrontendArgGroup (class)">
@@ -127,17 +127,17 @@ from dynamo.frontend.prepost import PreprocessResult
 ```
 
 ```python
-PreprocessResult(request_for_sampling: ChatCompletionRequest, tool_parser: ToolParser | None, chat_template_kwargs: dict[str, Any], engine_prompt: dict[str, Any], prompt_token_ids: list[int], guided_decoding: dict[str, Any] | None = None) -> None
+PreprocessResult(request_for_sampling: ChatCompletionRequest, tool_parser: ToolParser | None, chat_template_kwargs: dict[str, Any], engine_prompt: dict[str, Any], prompt_token_ids: list[int], guided_decoding: dict[str, Any] | None = None, uses_dynamo_json_tool_call_fallback: bool = False) -> None
 ```
 
-[`components/src/dynamo/frontend/prepost.py#L46`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L46)
+[`components/src/dynamo/frontend/prepost.py#L47`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L47)
 
 **Public methods**
 
 <h4 id="api-dynamo-frontend-prepost-preprocessresult-init">__init__</h4>
 
 ```python
-__init__(request_for_sampling: ChatCompletionRequest, tool_parser: ToolParser | None, chat_template_kwargs: dict[str, Any], engine_prompt: dict[str, Any], prompt_token_ids: list[int], guided_decoding: dict[str, Any] | None = None) -> None
+__init__(request_for_sampling: ChatCompletionRequest, tool_parser: ToolParser | None, chat_template_kwargs: dict[str, Any], engine_prompt: dict[str, Any], prompt_token_ids: list[int], guided_decoding: dict[str, Any] | None = None, uses_dynamo_json_tool_call_fallback: bool = False) -> None
 ```
 
 No summary available.
@@ -328,22 +328,22 @@ from dynamo.frontend.prepost import StreamingPostProcessor
 ```
 
 ```python
-StreamingPostProcessor(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionRequest, sampling_params: SamplingParams, prompt_token_ids: Sequence[int], tool_parser: ToolParser | None, reasoning_parser_class: type[ReasoningParser] | None, chat_template_kwargs: dict[str, Any], stream_response: bool = True) -> None
+StreamingPostProcessor(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionRequest, sampling_params: SamplingParams, prompt_token_ids: Sequence[int], tool_parser: ToolParser | None, reasoning_parser_class: type[ReasoningParser] | None, chat_template_kwargs: dict[str, Any], stream_response: bool = True, uses_dynamo_json_tool_call_fallback: bool = False) -> None
 ```
 
-[`components/src/dynamo/frontend/prepost.py#L628`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L628)
+[`components/src/dynamo/frontend/prepost.py#L649`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L649)
 
 **Public methods**
 
 <h4 id="api-dynamo-frontend-prepost-streamingpostprocessor-init">__init__</h4>
 
 ```python
-__init__(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionRequest, sampling_params: SamplingParams, prompt_token_ids: Sequence[int], tool_parser: ToolParser | None, reasoning_parser_class: type[ReasoningParser] | None, chat_template_kwargs: dict[str, Any], stream_response: bool = True) -> None
+__init__(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionRequest, sampling_params: SamplingParams, prompt_token_ids: Sequence[int], tool_parser: ToolParser | None, reasoning_parser_class: type[ReasoningParser] | None, chat_template_kwargs: dict[str, Any], stream_response: bool = True, uses_dynamo_json_tool_call_fallback: bool = False) -> None
 ```
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L629)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L650)
 
 <h4 id="api-dynamo-frontend-prepost-streamingpostprocessor-process-output">process_output</h4>
 
@@ -353,7 +353,7 @@ process_output(output: Any) -> dict[str, Any] | None
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L925)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L1048)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-vllm-processor-vllmprocessor" title="VllmProcessor (class)">
@@ -448,7 +448,7 @@ from dynamo.frontend.prepost import build_tool_call_guided_decoding
 build_tool_call_guided_decoding(request: ChatCompletionRequest, tool_parser: ToolParser | None, *, parser_guided_decoding: dict[str, Any] | None = None, structural_tag_mode: str = 'off', structural_tag_scope: str = 'auto', structural_tag_schema: str = 'auto') -> dict[str, Any] | None
 ```
 
-[`components/src/dynamo/frontend/prepost.py#L207`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L207)
+[`components/src/dynamo/frontend/prepost.py#L209`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L209)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-sglang-prepost-build-tool-call-guided-decoding" title="build_tool_call_guided_decoding (function)">
@@ -700,7 +700,7 @@ from dynamo.frontend.prepost import preprocess_chat_request
 preprocess_chat_request(request: dict[str, Any] | ChatCompletionRequest, *, tokenizer: TokenizerLike, renderer: _Renderer, tool_parser_class: type[ToolParser] | None, exclude_tools_when_tool_choice_none: bool = True, enable_auto_tool_choice: bool = False, default_chat_template_kwargs: dict[str, Any] | None = None, default_thinking_mode: str | None = None, structural_tag_mode: str = 'off', structural_tag_scope: str = 'auto', structural_tag_schema: str = 'auto') -> PreprocessResult
 ```
 
-[`components/src/dynamo/frontend/prepost.py#L522`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L522)
+[`components/src/dynamo/frontend/prepost.py#L529`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L529)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-sglang-prepost-preprocess-chat-request" title="preprocess_chat_request (function)">


### PR DESCRIPTION
## Summary

Fixes #12876.

Forced vLLM tool choices use the generic JSON-schema fallback introduced in #12684 when no parser-specific grammar or structural-tag constraint is available. The generated JSON was previously returned as assistant content instead of OpenAI-compatible `tool_calls`.

This change records when the generic JSON fallback is selected and routes the completed output through matching post-processing. It supports required and named tool choices, configured parsers that do not provide structured guidance, streaming and non-streaming responses, JSON argument values, and parallel tool-call validation. Malformed or truncated output is preserved as assistant content with its original finish reason.

The generated Python API reference is updated for the new preprocessing and post-processing fields.

## Validation

- `.venv/bin/python -m pytest -W ignore components/src/dynamo/frontend/tests/test_vllm_processor_unit.py -q` — 112 passed
- `uv run --no-project --python 3.13 --with griffe==2.1.0 python3 docs/fern/scripts/gen_python_api.py --check --since upstream/main`
- `git diff --check`