### PR TITLE
fix(epp): reserve prefill load across disaggregated routing

### DIFF
--- a/deploy/inference-gateway/epp/go.mod
+++ b/deploy/inference-gateway/epp/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3
+	github.com/google/uuid v1.6.0
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260603065144-7c1f1994dbff
 )
@@ -45,7 +46,6 @@ require (
 	github.com/google/cel-go v0.28.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/decode_scorer.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/decode_scorer.go
@@ -54,11 +54,12 @@ var _ rc.ResponseBodyProcessor = &DynDecodeScorer{}
 
 // DecodeRoutingState holds routing information passed from Score() to PreRequest().
 type DecodeRoutingState struct {
-	WorkerID        string
-	DpRank          uint32
-	PrefillWorkerID string
-	TokenData       []int64
-	CacheNamespace  string
+	WorkerID           string
+	DpRank             uint32
+	PrefillWorkerID    string
+	TokenData          []int64
+	CacheNamespace     string
+	PrefillReservation *PrefillReservationState
 }
 
 // Clone implements plugins.StateData.
@@ -71,6 +72,9 @@ func (s *DecodeRoutingState) Clone() plugins.StateData {
 		DpRank:          s.DpRank,
 		PrefillWorkerID: s.PrefillWorkerID,
 		CacheNamespace:  s.CacheNamespace,
+	}
+	if s.PrefillReservation != nil {
+		clone.PrefillReservation = s.PrefillReservation.Clone().(*PrefillReservationState)
 	}
 	if s.TokenData != nil {
 		clone.TokenData = make([]int64, len(s.TokenData))
@@ -102,16 +106,24 @@ func DynDecodeScorerFactory(name string, rawParameters json.RawMessage, handle p
 // NewDynDecodeScorer initializes a new DynDecodeScorer.
 func NewDynDecodeScorer(ctx context.Context) *DynDecodeScorer {
 	return &DynDecodeScorer{
-		typedName:   plugins.TypedName{Type: DynDecodeScorerType, Name: DynDecodeScorerType},
-		pluginState: plugins.NewPluginState(ctx),
+		typedName:              plugins.TypedName{Type: DynDecodeScorerType, Name: DynDecodeScorerType},
+		pluginState:            plugins.NewPluginState(ctx),
+		routeDecode:            dynscorer.CallRouteDecodeRequest,
+		addDecodeRequest:       dynscorer.CallAddRequest,
+		freeDecodeRequest:      dynscorer.CallFreeRequest,
+		freePrefillReservation: dynscorer.CallFreePrefillRequest,
 	}
 }
 
 // DynDecodeScorer is a scorer plugin for the decode scheduling profile.
 type DynDecodeScorer struct {
-	typedName      plugins.TypedName
-	pluginState    *plugins.PluginState
-	firstTokenSeen sync.Map
+	typedName              plugins.TypedName
+	pluginState            *plugins.PluginState
+	firstTokenSeen         sync.Map
+	routeDecode            func(string, string, bool) (*dynscorer.RoutingResult, error)
+	addDecodeRequest       func(string, []int64, uint64, uint32, string) error
+	freeDecodeRequest      func(string) error
+	freePrefillReservation func(string, uint64, uint32) error
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
@@ -130,6 +142,31 @@ func (s *DynDecodeScorer) Category() schedtypes.ScorerCategory {
 	return schedtypes.Affinity
 }
 
+func (s *DynDecodeScorer) releasePrefillReservation(ctx context.Context, reservation *PrefillReservationState, reason string) bool {
+	if reservation == nil || reservation.ReservationID == "" {
+		return true
+	}
+	if err := s.freePrefillReservation(reservation.ReservationID, reservation.WorkerID, reservation.DpRank); err != nil {
+		log.FromContext(ctx).V(logutil.DEFAULT).Error(err,
+			"DynDecodeScorer: failed to roll back prefill reservation",
+			"reservationID", reservation.ReservationID,
+			"reason", reason)
+		return false
+	}
+	return true
+}
+
+func (s *DynDecodeScorer) rollbackCyclePrefillReservation(ctx context.Context, cycleState *schedtypes.CycleState, request *schedtypes.InferenceRequest, reason string) {
+	cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: false})
+	if request != nil && request.Headers != nil {
+		delete(request.Headers, PrefillWorkerIDHeader)
+		delete(request.Headers, PrefillDpRankHeader)
+	}
+	if s.releasePrefillReservation(ctx, readCyclePrefillReservation(cycleState), reason) {
+		clearCyclePrefillReservation(cycleState)
+	}
+}
+
 // Score scores endpoints for decode suitability.
 func (s *DynDecodeScorer) Score(ctx context.Context, cycleState *schedtypes.CycleState, req *schedtypes.InferenceRequest, endpoints []schedtypes.Endpoint) map[schedtypes.Endpoint]float64 {
 	logger := log.FromContext(ctx)
@@ -139,6 +176,7 @@ func (s *DynDecodeScorer) Score(ctx context.Context, cycleState *schedtypes.Cycl
 	requestJSON, err := buildRequestJSON(req)
 	if err != nil {
 		logger.V(logutil.DEFAULT).Error(err, "DynDecodeScorer: failed to build request")
+		s.rollbackCyclePrefillReservation(ctx, cycleState, req, "decode request serialization failed")
 		return uniformScores(endpoints, 1.0)
 	}
 
@@ -147,9 +185,16 @@ func (s *DynDecodeScorer) Score(ctx context.Context, cycleState *schedtypes.Cycl
 		"endpointCount", len(endpoints),
 		"endpointsJSON", string(endpointsJSON))
 
-	result, err := dynscorer.CallRouteDecodeRequest(requestJSON, endpointsJSON, isDisaggregated)
+	result, err := s.routeDecode(requestJSON, endpointsJSON, isDisaggregated)
 	if err != nil {
 		logger.V(logutil.DEFAULT).Error(err, "DynDecodeScorer: FFI decode routing failed")
+		s.rollbackCyclePrefillReservation(ctx, cycleState, req, "decode routing failed")
+		return uniformScores(endpoints, 1.0)
+	}
+	if err := ctx.Err(); err != nil {
+		logger.V(logutil.VERBOSE).Info("DynDecodeScorer: request cancelled after decode routing",
+			"error", err.Error())
+		s.rollbackCyclePrefillReservation(ctx, cycleState, req, "request cancelled after decode routing")
 		return uniformScores(endpoints, 1.0)
 	}
 
@@ -183,10 +228,11 @@ func (s *DynDecodeScorer) Score(ctx context.Context, cycleState *schedtypes.Cycl
 	// Store routing state for PreRequest bookkeeping
 	if req.RequestId != "" {
 		routingState := &DecodeRoutingState{
-			WorkerID:       workerIDStr,
-			DpRank:         result.DpRank,
-			TokenData:      result.TokenData,
-			CacheNamespace: result.CacheNamespace,
+			WorkerID:           workerIDStr,
+			DpRank:             result.DpRank,
+			TokenData:          result.TokenData,
+			CacheNamespace:     result.CacheNamespace,
+			PrefillReservation: readCyclePrefillReservation(cycleState),
 		}
 		s.pluginState.Write(req.RequestId, plugins.StateKey(decodeStateKey), routingState)
 	}
@@ -222,10 +268,17 @@ func (s *DynDecodeScorer) PreRequest(ctx context.Context, request *schedtypes.In
 	if _, parseErr := fmt.Sscanf(state.WorkerID, "%d", &workerIDUint); parseErr != nil {
 		logger.V(logutil.DEFAULT).Error(parseErr, "DynDecodeScorer PreRequest: invalid worker ID",
 			"requestID", request.RequestId, "workerID", state.WorkerID)
+		s.releasePrefillReservation(ctx, state.PrefillReservation, "decode worker ID invalid")
+		return
+	}
+	if err := ctx.Err(); err != nil {
+		logger.V(logutil.VERBOSE).Info("DynDecodeScorer PreRequest: request cancelled before decode booking",
+			"requestID", request.RequestId)
+		s.releasePrefillReservation(ctx, state.PrefillReservation, "request cancelled before decode booking")
 		return
 	}
 
-	if addErr := dynscorer.CallAddRequest(
+	if addErr := s.addDecodeRequest(
 		request.RequestId,
 		state.TokenData,
 		workerIDUint,
@@ -234,6 +287,17 @@ func (s *DynDecodeScorer) PreRequest(ctx context.Context, request *schedtypes.In
 	); addErr != nil {
 		logger.V(logutil.DEFAULT).Error(addErr, "DynDecodeScorer PreRequest: failed to add request",
 			"requestID", request.RequestId)
+		s.releasePrefillReservation(ctx, state.PrefillReservation, "decode booking failed")
+		return
+	}
+	if err := ctx.Err(); err != nil {
+		logger.V(logutil.VERBOSE).Info("DynDecodeScorer PreRequest: request cancelled after decode booking",
+			"requestID", request.RequestId)
+		if freeErr := s.freeDecodeRequest(request.RequestId); freeErr != nil {
+			logger.V(logutil.DEFAULT).Error(freeErr, "DynDecodeScorer PreRequest: failed to roll back decode booking",
+				"requestID", request.RequestId)
+		}
+		s.releasePrefillReservation(ctx, state.PrefillReservation, "request cancelled after decode booking")
 		return
 	}
 

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/prefill_scorer.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/prefill_scorer.go
@@ -21,10 +21,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 
+	"github.com/google/uuid"
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	plugins "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	rc "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
 	schedtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 
 	dynscorer "github.com/nvidia/dynamo/deploy/inference-gateway/pkg/plugins/dynamo_kv_scorer"
@@ -33,16 +37,43 @@ import (
 const (
 	// DynPrefillScorerType is the plugin type registered in the plugin registry.
 	DynPrefillScorerType = "dyn-prefill-scorer"
+
+	prefillReservationStateKey      = plugins.StateKey("dynamo-prefill-reservation-state")
+	prefillReservationCycleStateKey = plugins.StateKey("dynamo-prefill-reservation-cycle-state")
 )
 
-// compile-time type assertion
+// compile-time type assertions
 var _ schedtypes.Scorer = &DynPrefillScorer{}
+var _ plugins.Plugin = &DynPrefillScorer{}
+var _ rc.ResponseBodyProcessor = &DynPrefillScorer{}
+
+// PrefillReservationState tracks the Rust scheduler booking acquired by Score.
+type PrefillReservationState struct {
+	ReservationID string
+	WorkerID      uint64
+	DpRank        uint32
+	releaseTried  atomic.Bool
+}
+
+// Clone implements plugins.StateData.
+func (s *PrefillReservationState) Clone() plugins.StateData {
+	if s == nil {
+		return nil
+	}
+	clone := &PrefillReservationState{
+		ReservationID: s.ReservationID,
+		WorkerID:      s.WorkerID,
+		DpRank:        s.DpRank,
+	}
+	clone.releaseTried.Store(s.releaseTried.Load())
+	return clone
+}
 
 // DynPrefillScorerConfig holds the configuration for the DynPrefillScorer plugin.
 type DynPrefillScorerConfig struct{}
 
 // DynPrefillScorerFactory defines the factory function for DynPrefillScorer.
-func DynPrefillScorerFactory(name string, rawParameters json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
+func DynPrefillScorerFactory(name string, rawParameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
 	cfg := DynPrefillScorerConfig{}
 	if rawParameters != nil {
 		if err := json.Unmarshal(rawParameters, &cfg); err != nil {
@@ -54,19 +85,33 @@ func DynPrefillScorerFactory(name string, rawParameters json.RawMessage, _ plugi
 		return nil, fmt.Errorf("Dynamo FFI init for prefill scorer failed: %w", err)
 	}
 
-	return NewDynPrefillScorer().WithName(name), nil
+	return newDynPrefillScorer(handle.Context()).WithName(name), nil
 }
 
 // NewDynPrefillScorer initializes a new DynPrefillScorer.
 func NewDynPrefillScorer() *DynPrefillScorer {
+	return newDynPrefillScorer(context.Background())
+}
+
+func newDynPrefillScorer(ctx context.Context) *DynPrefillScorer {
 	return &DynPrefillScorer{
-		typedName: plugins.TypedName{Type: DynPrefillScorerType, Name: DynPrefillScorerType},
+		typedName:               plugins.TypedName{Type: DynPrefillScorerType, Name: DynPrefillScorerType},
+		pluginState:             plugins.NewPluginState(ctx),
+		routeAndReservePrefill:  dynscorer.CallRouteAndReservePrefillRequest,
+		routePrefillAdvisory:    dynscorer.CallRoutePrefillRequest,
+		freePrefillReservation:  dynscorer.CallFreePrefillRequest,
+		newPrefillReservationID: func() string { return "epp-prefill-" + uuid.NewString() },
 	}
 }
 
 // DynPrefillScorer is a scorer plugin for the prefill scheduling profile.
 type DynPrefillScorer struct {
-	typedName plugins.TypedName
+	typedName               plugins.TypedName
+	pluginState             *plugins.PluginState
+	routeAndReservePrefill  func(string, string, string) (*dynscorer.RoutingResult, error)
+	routePrefillAdvisory    func(string, string) (*dynscorer.RoutingResult, error)
+	freePrefillReservation  func(string, uint64, uint32) error
+	newPrefillReservationID func() string
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
@@ -105,7 +150,30 @@ func (s *DynPrefillScorer) Score(ctx context.Context, cycleState *schedtypes.Cyc
 		"endpointCount", len(endpoints),
 		"endpointsJSON", string(endpointsJSON))
 
-	result, err := dynscorer.CallRoutePrefillRequest(requestJSON, endpointsJSON)
+	var result *dynscorer.RoutingResult
+	if req.RequestId == "" {
+		logger.V(logutil.DEFAULT).Info("DynPrefillScorer: request has no ID; using advisory routing without a reservation")
+		result, err = s.routePrefillAdvisory(requestJSON, endpointsJSON)
+	} else {
+		if releaseErr := s.releaseReservation(ctx, req.RequestId, true); releaseErr != nil {
+			logger.V(logutil.DEFAULT).Error(releaseErr, "DynPrefillScorer: failed to release previous reservation",
+				"requestID", req.RequestId)
+			cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: false})
+			return uniformScores(endpoints, 0)
+		}
+
+		reservationID := s.newPrefillReservationID()
+		result, err = s.routeAndReservePrefill(reservationID, requestJSON, endpointsJSON)
+		if err == nil {
+			reservation := &PrefillReservationState{
+				ReservationID: reservationID,
+				WorkerID:      result.WorkerID,
+				DpRank:        result.DpRank,
+			}
+			s.pluginState.Write(req.RequestId, prefillReservationStateKey, reservation)
+			cycleState.Write(prefillReservationCycleStateKey, reservation)
+		}
+	}
 	if err != nil {
 		logger.V(logutil.DEFAULT).Error(err, "DynPrefillScorer: FFI prefill routing failed")
 		cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: false})
@@ -129,4 +197,38 @@ func (s *DynPrefillScorer) Score(ctx context.Context, cycleState *schedtypes.Cyc
 	}
 
 	return uniformScores(endpoints, 1.0)
+}
+
+// ResponseBody releases prefill load as soon as a decode response is observed.
+// At that point the remote prefill stage has completed. The framework also
+// invokes this hook with EndOfStream for cancellations after target selection.
+func (s *DynPrefillScorer) ResponseBody(ctx context.Context, request *schedtypes.InferenceRequest, response *rc.Response, _ *fwkdl.EndpointMetadata) {
+	if request == nil || request.RequestId == "" {
+		return
+	}
+	// Intermediate chunks skip a failed first attempt; the terminal callback
+	// gets one bounded retry without stalling every chunk on synchronous FFI.
+	retry := response != nil && response.EndOfStream
+	if err := s.releaseReservation(ctx, request.RequestId, retry); err != nil {
+		log.FromContext(ctx).V(logutil.DEFAULT).Error(err,
+			"DynPrefillScorer ResponseBody: failed to free prefill reservation",
+			"requestID", request.RequestId)
+	}
+}
+
+func (s *DynPrefillScorer) releaseReservation(_ context.Context, requestID string, retry bool) error {
+	state, err := plugins.ReadPluginStateKey[*PrefillReservationState](
+		s.pluginState, requestID, prefillReservationStateKey,
+	)
+	if err != nil {
+		return nil
+	}
+	if !retry && state.releaseTried.Swap(true) {
+		return nil
+	}
+	if err := s.freePrefillReservation(state.ReservationID, state.WorkerID, state.DpRank); err != nil {
+		return err
+	}
+	s.pluginState.Delete(requestID)
+	return nil
 }

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/prefill_scorer_test.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/prefill_scorer_test.go
@@ -1,0 +1,351 @@
+/*
+Copyright 2026 NVIDIA Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disagg
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	plugins "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	rc "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
+	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
+	schedtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+
+	dynscorer "github.com/nvidia/dynamo/deploy/inference-gateway/pkg/plugins/dynamo_kv_scorer"
+)
+
+func TestDynPrefillScorerReservesAndReleasesOnce(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scorer := newDynPrefillScorer(ctx)
+	scorer.newPrefillReservationID = func() string { return "prefill-reservation-1" }
+	reserveCalls := 0
+	scorer.routeAndReservePrefill = func(reservationID, _, _ string) (*dynscorer.RoutingResult, error) {
+		reserveCalls++
+		if reservationID != "prefill-reservation-1" {
+			t.Fatalf("unexpected reservation ID: %q", reservationID)
+		}
+		return &dynscorer.RoutingResult{WorkerID: 42, DpRank: 3}, nil
+	}
+	freeCalls := 0
+	scorer.freePrefillReservation = func(reservationID string, workerID uint64, dpRank uint32) error {
+		freeCalls++
+		if reservationID != "prefill-reservation-1" || workerID != 42 || dpRank != 3 {
+			t.Fatalf("unexpected cleanup: reservation=%q worker=%d rank=%d", reservationID, workerID, dpRank)
+		}
+		return nil
+	}
+
+	cycleState := schedtypes.NewCycleState()
+	cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: true})
+	request := testPrefillRequest("request-1")
+	scorer.Score(ctx, cycleState, request, nil)
+
+	if reserveCalls != 1 {
+		t.Fatalf("reserve calls = %d, want 1", reserveCalls)
+	}
+	if got := request.Headers[PrefillWorkerIDHeader]; got != "42" {
+		t.Fatalf("prefill worker header = %q, want 42", got)
+	}
+	if got := request.Headers[PrefillDpRankHeader]; got != "3" {
+		t.Fatalf("prefill DP rank header = %q, want 3", got)
+	}
+
+	state, err := plugins.ReadPluginStateKey[*PrefillReservationState](
+		scorer.pluginState, request.RequestId, plugins.StateKey(prefillReservationStateKey),
+	)
+	if err != nil || state.ReservationID != "prefill-reservation-1" {
+		t.Fatalf("reservation state = %#v, err = %v", state, err)
+	}
+
+	scorer.ResponseBody(ctx, request, &rc.Response{StartOfStream: true}, nil)
+	scorer.ResponseBody(ctx, request, &rc.Response{EndOfStream: true}, nil)
+	if freeCalls != 1 {
+		t.Fatalf("free calls = %d, want 1", freeCalls)
+	}
+}
+
+func TestDynPrefillScorerUsesAdvisoryRoutingWithoutRequestID(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scorer := newDynPrefillScorer(ctx)
+	reserveCalls := 0
+	scorer.routeAndReservePrefill = func(_, _, _ string) (*dynscorer.RoutingResult, error) {
+		reserveCalls++
+		return nil, nil
+	}
+	advisoryCalls := 0
+	scorer.routePrefillAdvisory = func(_, _ string) (*dynscorer.RoutingResult, error) {
+		advisoryCalls++
+		return &dynscorer.RoutingResult{WorkerID: 7, DpRank: dynscorer.UnsetDpRank}, nil
+	}
+
+	cycleState := schedtypes.NewCycleState()
+	cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: true})
+	request := testPrefillRequest("")
+	scorer.Score(ctx, cycleState, request, nil)
+
+	if reserveCalls != 0 || advisoryCalls != 1 {
+		t.Fatalf("reserve calls = %d, advisory calls = %d; want 0 and 1", reserveCalls, advisoryCalls)
+	}
+	if got := request.Headers[PrefillWorkerIDHeader]; got != "7" {
+		t.Fatalf("prefill worker header = %q, want 7", got)
+	}
+}
+
+func TestDynPrefillScorerRetriesFailedCleanup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scorer := newDynPrefillScorer(ctx)
+	scorer.pluginState.Write("request-1", plugins.StateKey(prefillReservationStateKey), &PrefillReservationState{
+		ReservationID: "prefill-reservation-1",
+		WorkerID:      42,
+		DpRank:        3,
+	})
+
+	freeCalls := 0
+	scorer.freePrefillReservation = func(_ string, _ uint64, _ uint32) error {
+		freeCalls++
+		if freeCalls == 1 {
+			return errors.New("temporary cleanup failure")
+		}
+		return nil
+	}
+
+	request := testPrefillRequest("request-1")
+	scorer.ResponseBody(ctx, request, &rc.Response{StartOfStream: true}, nil)
+	scorer.ResponseBody(ctx, request, &rc.Response{}, nil)
+	if freeCalls != 1 {
+		t.Fatalf("free calls before terminal retry = %d, want 1", freeCalls)
+	}
+	if _, err := plugins.ReadPluginStateKey[*PrefillReservationState](
+		scorer.pluginState, request.RequestId, plugins.StateKey(prefillReservationStateKey),
+	); err != nil {
+		t.Fatalf("reservation state removed after failed cleanup: %v", err)
+	}
+
+	scorer.ResponseBody(ctx, request, &rc.Response{EndOfStream: true}, nil)
+	if freeCalls != 2 {
+		t.Fatalf("free calls = %d, want 2", freeCalls)
+	}
+	if _, err := plugins.ReadPluginStateKey[*PrefillReservationState](
+		scorer.pluginState, request.RequestId, plugins.StateKey(prefillReservationStateKey),
+	); err == nil {
+		t.Fatal("reservation state retained after successful cleanup retry")
+	}
+}
+
+func TestDynPrefillScorerReleasesPriorReservationBeforeRescoring(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scorer := newDynPrefillScorer(ctx)
+	reservationIDs := []string{"prefill-reservation-1", "prefill-reservation-2"}
+	scorer.newPrefillReservationID = func() string {
+		id := reservationIDs[0]
+		reservationIDs = reservationIDs[1:]
+		return id
+	}
+	events := make([]string, 0, 3)
+	scorer.routeAndReservePrefill = func(reservationID, _, _ string) (*dynscorer.RoutingResult, error) {
+		events = append(events, "reserve:"+reservationID)
+		return &dynscorer.RoutingResult{WorkerID: 42, DpRank: 3}, nil
+	}
+	scorer.freePrefillReservation = func(reservationID string, _ uint64, _ uint32) error {
+		events = append(events, "free:"+reservationID)
+		return nil
+	}
+
+	cycleState := schedtypes.NewCycleState()
+	cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: true})
+	request := testPrefillRequest("request-1")
+	scorer.Score(ctx, cycleState, request, nil)
+	scorer.Score(ctx, cycleState, request, nil)
+
+	want := []string{
+		"reserve:prefill-reservation-1",
+		"free:prefill-reservation-1",
+		"reserve:prefill-reservation-2",
+	}
+	if len(events) != len(want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+	for i := range want {
+		if events[i] != want[i] {
+			t.Fatalf("events = %v, want %v", events, want)
+		}
+	}
+
+	state, err := plugins.ReadPluginStateKey[*PrefillReservationState](
+		scorer.pluginState, request.RequestId, plugins.StateKey(prefillReservationStateKey),
+	)
+	if err != nil || state.ReservationID != "prefill-reservation-2" {
+		t.Fatalf("reservation state = %#v, err = %v", state, err)
+	}
+}
+
+func TestDynDecodeScorerRollsBackPrefillWhenDecodeRoutingFails(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scorer := NewDynDecodeScorer(ctx)
+	scorer.routeDecode = func(_, _ string, _ bool) (*dynscorer.RoutingResult, error) {
+		return nil, errors.New("decode routing failed")
+	}
+	freeCalls := 0
+	scorer.freePrefillReservation = func(reservationID string, workerID uint64, dpRank uint32) error {
+		freeCalls++
+		if reservationID != "prefill-reservation-1" || workerID != 42 || dpRank != 3 {
+			t.Fatalf("unexpected cleanup: reservation=%q worker=%d rank=%d", reservationID, workerID, dpRank)
+		}
+		return nil
+	}
+
+	cycleState := schedtypes.NewCycleState()
+	cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: true})
+	cycleState.Write(prefillReservationCycleStateKey, &PrefillReservationState{
+		ReservationID: "prefill-reservation-1",
+		WorkerID:      42,
+		DpRank:        3,
+	})
+
+	scorer.Score(ctx, cycleState, testPrefillRequest("request-1"), nil)
+
+	if freeCalls != 1 {
+		t.Fatalf("free calls = %d, want 1", freeCalls)
+	}
+	if readPrefillEnabled(cycleState) {
+		t.Fatal("prefill remained enabled after decode routing rollback")
+	}
+	if reservation := readCyclePrefillReservation(cycleState); reservation != nil {
+		t.Fatalf("cycle reservation not cleared: %#v", reservation)
+	}
+}
+
+func TestDynDecodeScorerRollsBackPrefillWhenCancelledAfterRouting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scorer := NewDynDecodeScorer(ctx)
+	scorer.routeDecode = func(_, _ string, _ bool) (*dynscorer.RoutingResult, error) {
+		cancel()
+		return &dynscorer.RoutingResult{WorkerID: 7}, nil
+	}
+	freeCalls := 0
+	scorer.freePrefillReservation = func(reservationID string, workerID uint64, dpRank uint32) error {
+		freeCalls++
+		if reservationID != "prefill-reservation-1" || workerID != 42 || dpRank != 3 {
+			t.Fatalf("unexpected cleanup: reservation=%q worker=%d rank=%d", reservationID, workerID, dpRank)
+		}
+		return nil
+	}
+
+	cycleState := schedtypes.NewCycleState()
+	cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: true})
+	cycleState.Write(prefillReservationCycleStateKey, &PrefillReservationState{
+		ReservationID: "prefill-reservation-1",
+		WorkerID:      42,
+		DpRank:        3,
+	})
+
+	scorer.Score(ctx, cycleState, testPrefillRequest("request-1"), nil)
+
+	if freeCalls != 1 {
+		t.Fatalf("free calls = %d, want 1", freeCalls)
+	}
+	if readPrefillEnabled(cycleState) {
+		t.Fatal("prefill remained enabled after cancellation rollback")
+	}
+}
+
+func TestDynDecodeScorerRollsBackPrefillWhenDecodeBookingFails(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scorer := NewDynDecodeScorer(ctx)
+	scorer.addDecodeRequest = func(string, []int64, uint64, uint32, string) error {
+		return errors.New("decode booking failed")
+	}
+	freeCalls := 0
+	scorer.freePrefillReservation = func(reservationID string, workerID uint64, dpRank uint32) error {
+		freeCalls++
+		if reservationID != "prefill-reservation-1" || workerID != 42 || dpRank != 3 {
+			t.Fatalf("unexpected cleanup: reservation=%q worker=%d rank=%d", reservationID, workerID, dpRank)
+		}
+		return nil
+	}
+	scorer.pluginState.Write("request-1", plugins.StateKey(decodeStateKey), &DecodeRoutingState{
+		WorkerID: "7",
+		PrefillReservation: &PrefillReservationState{
+			ReservationID: "prefill-reservation-1",
+			WorkerID:      42,
+			DpRank:        3,
+		},
+	})
+
+	scorer.PreRequest(ctx, testPrefillRequest("request-1"), nil)
+
+	if freeCalls != 1 {
+		t.Fatalf("free calls = %d, want 1", freeCalls)
+	}
+}
+
+func TestDisaggProfileHandlerRollsBackPrefillOnTerminalFailure(t *testing.T) {
+	ctx := context.Background()
+	handler := NewDisaggProfileHandler()
+	freeCalls := 0
+	handler.freePrefillReservation = func(reservationID string, workerID uint64, dpRank uint32) error {
+		freeCalls++
+		if reservationID != "prefill-reservation-1" || workerID != 42 || dpRank != 3 {
+			t.Fatalf("unexpected cleanup: reservation=%q worker=%d rank=%d", reservationID, workerID, dpRank)
+		}
+		return nil
+	}
+	cycleState := schedtypes.NewCycleState()
+	cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: true})
+	cycleState.Write(prefillReservationCycleStateKey, &PrefillReservationState{
+		ReservationID: "prefill-reservation-1",
+		WorkerID:      42,
+		DpRank:        3,
+	})
+
+	if _, err := handler.ProcessResults(ctx, cycleState, nil, map[string]*schedtypes.ProfileRunResult{}); err == nil {
+		t.Fatal("expected empty profile results to fail")
+	}
+	if freeCalls != 1 {
+		t.Fatalf("free calls = %d, want 1", freeCalls)
+	}
+	if readPrefillEnabled(cycleState) {
+		t.Fatal("prefill remained enabled after terminal profile failure")
+	}
+}
+
+func testPrefillRequest(requestID string) *schedtypes.InferenceRequest {
+	return &schedtypes.InferenceRequest{
+		RequestId: requestID,
+		Body: &fwkrh.InferenceRequestBody{
+			Payload: fwkrh.PayloadMap{
+				"model":  "test-model",
+				"prompt": "hello",
+			},
+		},
+	}
+}

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/profile_handler.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/profile_handler.go
@@ -26,6 +26,8 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	plugins "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	schedtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+
+	dynscorer "github.com/nvidia/dynamo/deploy/inference-gateway/pkg/plugins/dynamo_kv_scorer"
 )
 
 const (
@@ -53,13 +55,31 @@ func DisaggProfileHandlerFactory(name string, rawParameters json.RawMessage, _ p
 // NewDisaggProfileHandler initializes a new DisaggProfileHandler.
 func NewDisaggProfileHandler() *DisaggProfileHandler {
 	return &DisaggProfileHandler{
-		typedName: plugins.TypedName{Type: DisaggProfileHandlerType, Name: DisaggProfileHandlerType},
+		typedName:              plugins.TypedName{Type: DisaggProfileHandlerType, Name: DisaggProfileHandlerType},
+		freePrefillReservation: dynscorer.CallFreePrefillRequest,
 	}
 }
 
 // DisaggProfileHandler is a ProfileHandler that orchestrates prefill/decode disaggregated serving.
 type DisaggProfileHandler struct {
-	typedName plugins.TypedName
+	typedName              plugins.TypedName
+	freePrefillReservation func(string, uint64, uint32) error
+}
+
+func (h *DisaggProfileHandler) rollbackPrefillReservation(ctx context.Context, cycleState *schedtypes.CycleState, reason string) {
+	cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: false})
+	reservation := readCyclePrefillReservation(cycleState)
+	if reservation == nil || reservation.ReservationID == "" {
+		return
+	}
+	if err := h.freePrefillReservation(reservation.ReservationID, reservation.WorkerID, reservation.DpRank); err != nil {
+		log.FromContext(ctx).V(logutil.DEFAULT).Error(err,
+			"DisaggProfileHandler: failed to roll back prefill reservation",
+			"reservationID", reservation.ReservationID,
+			"reason", reason)
+		return
+	}
+	clearCyclePrefillReservation(cycleState)
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
@@ -102,7 +122,7 @@ func (h *DisaggProfileHandler) Pick(ctx context.Context, cycleState *schedtypes.
 		if _, decodeDone := profileResults[DecodeProfileName]; !decodeDone {
 			if prefillResult == nil {
 				logger.Info("DisaggProfileHandler: prefill profile failed (no workers?), falling back to aggregated decode")
-				cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: false})
+				h.rollbackPrefillReservation(ctx, cycleState, "prefill profile produced no result")
 			}
 
 			if decodeProfile, ok := profiles[DecodeProfileName]; ok {
@@ -117,10 +137,11 @@ func (h *DisaggProfileHandler) Pick(ctx context.Context, cycleState *schedtypes.
 }
 
 // ProcessResults aggregates the profile run results and designates the primary profile.
-func (h *DisaggProfileHandler) ProcessResults(_ context.Context, _ *schedtypes.CycleState, _ *schedtypes.InferenceRequest,
+func (h *DisaggProfileHandler) ProcessResults(ctx context.Context, cycleState *schedtypes.CycleState, _ *schedtypes.InferenceRequest,
 	profileResults map[string]*schedtypes.ProfileRunResult) (*schedtypes.SchedulingResult, error) {
 
 	if len(profileResults) == 0 {
+		h.rollbackPrefillReservation(ctx, cycleState, "no scheduling profile results")
 		return nil, errors.New("disagg profile handler received no profile results")
 	}
 
@@ -133,6 +154,7 @@ func (h *DisaggProfileHandler) ProcessResults(_ context.Context, _ *schedtypes.C
 	}
 
 	if profileResults[primaryProfile] == nil {
+		h.rollbackPrefillReservation(ctx, cycleState, "primary scheduling profile failed")
 		return nil, fmt.Errorf("primary profile '%s' failed to produce a result", primaryProfile)
 	}
 

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
@@ -67,6 +67,19 @@ func readPrefillEnabled(cycleState *schedtypes.CycleState) bool {
 	return false
 }
 
+func readCyclePrefillReservation(cycleState *schedtypes.CycleState) *PrefillReservationState {
+	state, err := schedtypes.ReadCycleStateKey[*PrefillReservationState](cycleState, prefillReservationCycleStateKey)
+	if err == nil {
+		return state
+	}
+	return nil
+}
+
+func clearCyclePrefillReservation(cycleState *schedtypes.CycleState) {
+	cycleState.Delete(prefillReservationCycleStateKey)
+	cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: false})
+}
+
 // buildRequestJSON builds an OpenAI-compatible JSON string from a GAIE LLMRequest.
 func buildRequestJSON(req *schedtypes.InferenceRequest) (string, error) {
 	return dynscorer.BuildOpenAIRequestJSON(req)

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
@@ -71,6 +71,12 @@ query_router_result_t route_prefill_request(RouterHandles *handle,
                                             const char *pods_json,
                                             CRoutingResult *out_result);
 
+query_router_result_t route_and_reserve_prefill_request(RouterHandles *handle,
+                                                        const char *reservation_id,
+                                                        const char *request_json,
+                                                        const char *pods_json,
+                                                        CRoutingResult *out_result);
+
 query_router_result_t route_decode_request(RouterHandles *handle,
                                            const char *request_json,
                                            const char *pods_json,
@@ -91,6 +97,11 @@ query_router_result_t mark_prefill_complete(RouterHandles *handle,
 
 query_router_result_t free_request(RouterHandles *handle,
                                    const char *request_id);
+
+query_router_result_t free_prefill_request(RouterHandles *handle,
+                                           const char *reservation_id,
+                                           uint64_t worker_id,
+                                           uint32_t dp_rank);
 
 void free_routing_result(CRoutingResult *result);
 
@@ -408,6 +419,34 @@ func CallFreeRequest(requestID string) error {
 	return nil
 }
 
+// CallFreePrefillRequest releases an atomically reserved prefill booking.
+// The worker identity makes delayed or duplicate cleanup ownership-safe.
+func CallFreePrefillRequest(reservationID string, workerID uint64, dpRank uint32) error {
+	if !routerInitialized {
+		return fmt.Errorf("dynamo router not initialized")
+	}
+
+	routerHandlesMutex.RLock()
+	router := routerHandles
+	routerHandlesMutex.RUnlock()
+	if router == nil {
+		return fmt.Errorf("dynamo router handles not created")
+	}
+
+	cReservationID := C.CString(reservationID)
+	defer C.free(unsafe.Pointer(cReservationID))
+	rc := C.free_prefill_request(
+		router,
+		cReservationID,
+		C.uint64_t(workerID),
+		C.uint32_t(dpRank),
+	)
+	if rc != C.QUERY_ROUTER_OK {
+		return fmt.Errorf("free_prefill_request failed with code %d", rc)
+	}
+	return nil
+}
+
 // RoutingResult holds the result of a prefill or decode routing call.
 type RoutingResult struct {
 	WorkerID       uint64
@@ -466,6 +505,51 @@ func CallRoutePrefillRequest(requestJSON string, podsJSON string) (*RoutingResul
 	rc := C.route_prefill_request(router, cRequestJSON, cPodsJSON, &result)
 	if rc != C.QUERY_ROUTER_OK {
 		return nil, fmt.Errorf("route_prefill_request failed with code %d", rc)
+	}
+
+	tokens := extractTokenData(&result)
+	cacheNamespace := extractCacheNamespace(&result)
+	workerID := uint64(result.prefill_worker_id)
+	dpRank := uint32(result.prefill_dp_rank)
+	C.free_routing_result(&result)
+
+	return &RoutingResult{
+		WorkerID:       workerID,
+		DpRank:         dpRank,
+		TokenData:      tokens,
+		CacheNamespace: cacheNamespace,
+	}, nil
+}
+
+// CallRouteAndReservePrefillRequest atomically selects a prefill worker and
+// books its scheduler load under reservationID before returning.
+func CallRouteAndReservePrefillRequest(reservationID string, requestJSON string, podsJSON string) (*RoutingResult, error) {
+	if !routerInitialized {
+		return nil, fmt.Errorf("dynamo router not initialized")
+	}
+
+	routerHandlesMutex.RLock()
+	router := routerHandles
+	routerHandlesMutex.RUnlock()
+	if router == nil {
+		return nil, fmt.Errorf("dynamo router handles not created")
+	}
+
+	cReservationID := C.CString(reservationID)
+	defer C.free(unsafe.Pointer(cReservationID))
+	cRequestJSON := C.CString(requestJSON)
+	defer C.free(unsafe.Pointer(cRequestJSON))
+
+	var cPodsJSON *C.char
+	if podsJSON != "" {
+		cPodsJSON = C.CString(podsJSON)
+		defer C.free(unsafe.Pointer(cPodsJSON))
+	}
+
+	var result C.CRoutingResult
+	rc := C.route_and_reserve_prefill_request(router, cReservationID, cRequestJSON, cPodsJSON, &result)
+	if rc != C.QUERY_ROUTER_OK {
+		return nil, fmt.Errorf("route_and_reserve_prefill_request failed with code %d", rc)
 	}
 
 	tokens := extractTokenData(&result)

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -321,6 +321,7 @@ impl Router {
     /// adjusts the policy score, while `strict_priority` selects the primary tier.
     pub async fn route_prefill(
         &self,
+        reservation_id: &str,
         tokens: &[u32],
         cache_namespace: Option<String>,
         priority_jump: f64,
@@ -331,11 +332,10 @@ impl Router {
             self.prefill_router.register_workers(ids);
         }
 
-        // TODO(epp-prefill-booking): Atomically reserve the selected prefill worker
-        // and release it on first output, cancellation, or routing failure.
         let outcome = self
             .prefill_router
-            .query_prefill_worker(
+            .reserve_prefill_worker(
+                reservation_id,
                 tokens,
                 None,
                 None,
@@ -446,14 +446,19 @@ impl Router {
 
     /// Mark prefill as completed for a request.
     pub async fn mark_prefill_complete(&self, request_id: &str) -> Result<()> {
+        let prefill_router = self.prefill_router.clone();
         let decode_router = self.decode_router.clone();
         let request_id = request_id.to_owned();
 
         tokio::time::timeout(BOOKKEEPING_TIMEOUT, async {
-            decode_router
-                .mark_prefill_completed(&request_id)
-                .await
-                .map_err(|e| anyhow::anyhow!("mark_prefill_completed failed: {e}"))
+            let (prefill_result, decode_result) = tokio::join!(
+                prefill_router.free_prefill_reservation(&request_id),
+                decode_router.mark_prefill_completed(&request_id),
+            );
+            prefill_result.map_err(|e| anyhow::anyhow!("free prefill reservation failed: {e}"))?;
+            decode_result
+                .map_err(|e| anyhow::anyhow!("mark decode prefill completed failed: {e}"))?;
+            Ok(())
         })
         .await
         .map_err(|_| anyhow::anyhow!("mark_prefill_complete timed out"))?
@@ -461,14 +466,18 @@ impl Router {
 
     /// Free a request from the router's bookkeeping.
     pub async fn free_request(&self, request_id: &str) -> Result<()> {
+        let prefill_router = self.prefill_router.clone();
         let decode_router = self.decode_router.clone();
         let request_id = request_id.to_owned();
 
         tokio::time::timeout(BOOKKEEPING_TIMEOUT, async {
-            decode_router
-                .free(&request_id)
-                .await
-                .map_err(|e| anyhow::anyhow!("free failed: {e}"))
+            let (prefill_result, decode_result) = tokio::join!(
+                prefill_router.free_prefill_reservation(&request_id),
+                decode_router.free(&request_id),
+            );
+            prefill_result.map_err(|e| anyhow::anyhow!("free prefill reservation failed: {e}"))?;
+            decode_result.map_err(|e| anyhow::anyhow!("free decode reservation failed: {e}"))?;
+            Ok(())
         })
         .await
         .map_err(|_| anyhow::anyhow!("free_request timed out"))?
@@ -862,6 +871,74 @@ fn apply_subset_filter<'a>(
         .collect()
 }
 
+/// Rolls back a native EPP booking if `pick` is cancelled or returns before
+/// the ext-proc server adopts its reservation ID.
+struct RoutingReservationGuard {
+    prefill_router: Arc<PrefillRouter>,
+    decode_router: Arc<KvRouter>,
+    reservation_id: String,
+    armed: bool,
+}
+
+impl RoutingReservationGuard {
+    fn new(
+        prefill_router: Arc<PrefillRouter>,
+        decode_router: Arc<KvRouter>,
+        reservation_id: String,
+    ) -> Self {
+        Self {
+            prefill_router,
+            decode_router,
+            reservation_id,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for RoutingReservationGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            tracing::warn!(
+                reservation_id = %self.reservation_id,
+                "Cannot roll back routing reservation because the Tokio runtime is unavailable"
+            );
+            return;
+        };
+
+        let prefill_router = self.prefill_router.clone();
+        let decode_router = self.decode_router.clone();
+        let reservation_id = std::mem::take(&mut self.reservation_id);
+        runtime.spawn(async move {
+            let cleanup = async {
+                let (prefill_result, decode_result) = tokio::join!(
+                    prefill_router.free_prefill_reservation(&reservation_id),
+                    decode_router.free(&reservation_id),
+                );
+                if let Err(error) = prefill_result {
+                    tracing::warn!(%reservation_id, %error, "Failed to roll back prefill reservation");
+                }
+                if let Err(error) = decode_result {
+                    tracing::warn!(%reservation_id, %error, "Failed to roll back decode reservation");
+                }
+            };
+            if tokio::time::timeout(BOOKKEEPING_TIMEOUT, cleanup)
+                .await
+                .is_err()
+            {
+                tracing::warn!(%reservation_id, "Routing reservation rollback timed out");
+            }
+        });
+    }
+}
+
 #[tonic::async_trait]
 impl EndpointPicker for Router {
     async fn pick(
@@ -948,12 +1025,23 @@ impl EndpointPicker for Router {
         let cache_namespace =
             cache_namespace_with_header_override(&req.headers, body_cache_namespace);
 
+        // Use a gateway-owned ID so concurrent streams that reuse x-request-id
+        // never overwrite each other's scheduler state. The guard owns cleanup
+        // until the server adopts this ID from the successful PickResult.
+        let reservation_id = format!("epp-prefill-{}", uuid::Uuid::new_v4());
+        let mut reservation_guard = RoutingReservationGuard::new(
+            self.prefill_router.clone(),
+            self.decode_router.clone(),
+            reservation_id.clone(),
+        );
+
         // Try prefill routing first (disaggregated mode).
         //
         // If the prefill router is not activated (no prefill workers discovered yet, or the inner
         // router has been deactivated), fall back to aggregated routing.
         let prefill_result = self
             .route_prefill(
+                &reservation_id,
                 &tokens,
                 cache_namespace.clone(),
                 priority_jump,
@@ -965,6 +1053,9 @@ impl EndpointPicker for Router {
         let is_disaggregated = match &prefill_result {
             Ok(_) => true,
             Err(e) => {
+                // Admission did not return a booking; retain the existing
+                // aggregated fallback policy without scheduling cleanup work.
+                reservation_guard.disarm();
                 tracing::debug!(
                     error = %e,
                     "Prefill routing failed; falling back to aggregated mode"
@@ -973,10 +1064,6 @@ impl EndpointPicker for Router {
             }
         };
 
-        // TODO(epp-atomic-admission): Replace query-only selection plus add_request
-        // with one tracked operation. Propagate booking failures, use an internal
-        // booking ID independent of x-request-id, handle cancellation races, roll
-        // back endpoint-resolution failures, and never forward to an unbooked fallback.
         let (decode_worker, _overlap) = self
             .route_decode(
                 &tokens,
@@ -1016,10 +1103,15 @@ impl EndpointPicker for Router {
 
         // Register the request with the router for bookkeeping (load tracking).
         // Mirrors Go EPP's PreRequest() → CallAddRequest(requestID, tokenData, workerID, dpRank).
-        if !req.request_id.is_empty()
-            && let Err(e) = self
+        let booking_id = if is_disaggregated {
+            reservation_id.as_str()
+        } else {
+            req.request_id.as_str()
+        };
+        if !booking_id.is_empty()
+            && let Err(error) = self
                 .add_request(
-                    &req.request_id,
+                    booking_id,
                     &tokens,
                     decode_worker.worker_id,
                     decode_worker.dp_rank,
@@ -1028,11 +1120,9 @@ impl EndpointPicker for Router {
                 )
                 .await
         {
-            tracing::warn!(
-                request_id = %req.request_id,
-                error = %e,
-                "Failed to register request with router bookkeeping"
-            );
+            return Err(PickError::RoutingFailed(format!(
+                "Failed to register decode reservation: {error}"
+            )));
         }
 
         // Build routing headers matching the Go EPP's disagg plugin:
@@ -1084,12 +1174,16 @@ impl EndpointPicker for Router {
             tracing::debug!(key = %k, value = %v, "Routing header set in PickResult");
         }
 
+        if is_disaggregated {
+            reservation_guard.disarm();
+        }
+
         Ok(PickResult {
             endpoint,
             fallbacks: vec![],
             headers,
             token_ids: Some(tokens),
-            reservation_id: None,
+            reservation_id: is_disaggregated.then_some(reservation_id),
         })
     }
 

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -528,6 +528,57 @@ impl RouterHandles {
         }
     }
 
+    /// Atomically select and reserve a prefill worker for an external dispatcher.
+    #[expect(clippy::too_many_arguments)]
+    async fn reserve_prefill_worker(
+        &self,
+        reservation_id: &str,
+        tokens: &[u32],
+        block_mm_infos: Option<&[Option<dynamo_kv_router::protocols::BlockExtraInfo>]>,
+        lora_name: Option<String>,
+        cache_namespace: Option<String>,
+        priority_jump: f64,
+        strict_priority: u32,
+        allowed_worker_ids: Option<HashSet<WorkerId>>,
+        routing_constraints: RoutingConstraints,
+    ) -> Result<(u64, Option<u32>), QueryRouterResult> {
+        if let Some(ref ids) = allowed_worker_ids {
+            self.prefill_router.register_workers(ids);
+        }
+
+        let outcome = self
+            .prefill_router
+            .reserve_prefill_worker(
+                reservation_id,
+                tokens,
+                block_mm_infos,
+                lora_name,
+                cache_namespace,
+                priority_jump,
+                strict_priority,
+                allowed_worker_ids,
+                routing_constraints,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!(error = ?e, reservation_id, "Prefill reservation failed");
+                QueryRouterResult::ErrQueryFailed
+            })?;
+        match outcome {
+            PrefillQueryOutcome::Routed { worker_id, dp_rank } => Ok((worker_id, dp_rank)),
+            PrefillQueryOutcome::QueueRejected { rejection } => {
+                tracing::warn!(
+                    policy_class = %rejection.policy_class,
+                    limit_kind = %rejection.limit_kind,
+                    current = rejection.current,
+                    limit = rejection.limit,
+                    "Prefill reservation rejected by policy-class queue limit"
+                );
+                Err(QueryRouterResult::ErrBackpressure)
+            }
+        }
+    }
+
     /// Query optimal decode worker for a request.
     /// For disaggregated mode, set `is_disaggregated` to true to use overlap_score_credit=0
     /// (since KV cache is being transferred from prefill, not reused).
@@ -1164,6 +1215,66 @@ pub unsafe extern "C" fn free_request(
     }
 }
 
+/// Release an externally dispatched prefill reservation.
+///
+/// The worker identity makes delayed or duplicate cleanup safe if a reservation
+/// ID is ever reused. Missing reservations and ownership mismatches are no-ops.
+///
+/// # Safety
+/// - `handle` must be a valid `RouterHandles` handle
+/// - `reservation_id` must be a valid null-terminated C string
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn free_prefill_request(
+    handle: RouterHandlesPtr,
+    reservation_id: *const c_char,
+    worker_id: u64,
+    dp_rank: u32,
+) -> QueryRouterResult {
+    if handle.is_null() || reservation_id.is_null() {
+        return QueryRouterResult::ErrInvalidParam;
+    }
+
+    let handles = unsafe { &*handle };
+    let reservation_id = match unsafe { CStr::from_ptr(reservation_id) }.to_str() {
+        Ok(id) if !id.is_empty() => id.to_owned(),
+        _ => return QueryRouterResult::ErrInvalidParam,
+    };
+    let prefill_router = handles.prefill_router.clone();
+    let worker = WorkerWithDpRank::new(worker_id, dp_rank);
+
+    let result = handles.runtime.secondary().block_on(async {
+        tokio::time::timeout(
+            Duration::from_secs(BOOKKEEPING_TIMEOUT_SEC),
+            prefill_router.free_prefill_request(&reservation_id, worker),
+        )
+        .await
+    });
+
+    match result {
+        Ok(Ok(())) => QueryRouterResult::Ok,
+        Ok(Err(error)) => {
+            tracing::warn!(
+                reservation_id,
+                worker_id,
+                dp_rank,
+                error = %error,
+                "Failed to free prefill reservation"
+            );
+            QueryRouterResult::ErrQueryFailed
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                reservation_id,
+                worker_id,
+                dp_rank,
+                timeout_secs = BOOKKEEPING_TIMEOUT_SEC,
+                "Freeing prefill reservation timed out"
+            );
+            QueryRouterResult::ErrTimeout
+        }
+    }
+}
+
 /// Destroy router handles
 ///
 /// # Safety
@@ -1469,6 +1580,87 @@ pub unsafe extern "C" fn route_prefill_request(
 
     match result {
         Ok((prefill_worker_id, prefill_dp_rank)) => {
+            let out = unsafe { &mut *out_result };
+            *out = CRoutingResult::default();
+            out.is_disaggregated = true;
+            out.prefill_worker_id = prefill_worker_id;
+            out.prefill_dp_rank = prefill_dp_rank;
+            write_tokens_to_result(&tokens, out);
+            write_cache_namespace_to_result(cache_namespace.as_deref(), out);
+            QueryRouterResult::Ok
+        }
+        Err(code) => code,
+    }
+}
+
+/// Atomically select and reserve the best **prefill** worker.
+///
+/// Unlike [`route_prefill_request`], this function books the selected worker's
+/// scheduler load before returning. The caller must eventually invoke
+/// [`free_prefill_request`] with the same reservation and selected worker.
+///
+/// # Safety
+/// - `handle` must be a valid `RouterHandles` handle
+/// - `reservation_id` and `request_json` must be valid null-terminated C strings
+/// - `pods_json` must be a valid null-terminated C string containing JSON, or null
+/// - `out_result` must be a valid pointer
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn route_and_reserve_prefill_request(
+    handle: RouterHandlesPtr,
+    reservation_id: *const c_char,
+    request_json: *const c_char,
+    pods_json: *const c_char,
+    out_result: *mut CRoutingResult,
+) -> QueryRouterResult {
+    if handle.is_null()
+        || reservation_id.is_null()
+        || request_json.is_null()
+        || out_result.is_null()
+    {
+        return QueryRouterResult::ErrInvalidParam;
+    }
+
+    let reservation_id = match unsafe { CStr::from_ptr(reservation_id) }.to_str() {
+        Ok(id) if !id.is_empty() => id.to_owned(),
+        _ => return QueryRouterResult::ErrInvalidParam,
+    };
+    let handles = unsafe { &*handle };
+    let (tokens, cache_namespace, priority_jump, strict_priority, routing_constraints) =
+        match unsafe { preprocess_request(handles, request_json) } {
+            Ok(t) => t,
+            Err(code) => return code,
+        };
+    let allowed_worker_ids = unsafe { parse_pods_filter(pods_json) };
+
+    let result = handles.runtime.secondary().block_on(async {
+        let (prefill_worker_id, prefill_dp_rank) = handles
+            .reserve_prefill_worker(
+                &reservation_id,
+                &tokens,
+                None,
+                None,
+                cache_namespace.clone(),
+                priority_jump,
+                strict_priority,
+                allowed_worker_ids,
+                routing_constraints,
+            )
+            .await?;
+        Ok((prefill_worker_id, prefill_dp_rank.unwrap_or(u32::MAX)))
+    });
+
+    match result {
+        Ok((prefill_worker_id, prefill_dp_rank)) => {
+            tracing::info!(
+                reservation_id,
+                prefill_worker_id,
+                prefill_dp_rank,
+                token_count = tokens.len(),
+                priority_jump,
+                strict_priority,
+                "Reserved prefill worker"
+            );
+
             let out = unsafe { &mut *out_result };
             *out = CRoutingResult::default();
             out.is_disaggregated = true;

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -4,7 +4,7 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
-use dynamo_kv_router::protocols::{BlockExtraInfo, RoutingConstraints, WorkerId};
+use dynamo_kv_router::protocols::{BlockExtraInfo, RoutingConstraints, WorkerId, WorkerWithDpRank};
 use dynamo_kv_router::selector::WorkerSelector;
 
 use super::{
@@ -32,6 +32,68 @@ where
         allowed_worker_ids: Option<HashSet<WorkerId>>,
         routing_constraints: RoutingConstraints,
     ) -> Result<PrefillQueryOutcome> {
+        self.select_prefill_worker_inner(
+            None,
+            token_ids,
+            block_mm_infos,
+            lora_name,
+            cache_namespace,
+            priority_jump,
+            strict_priority,
+            allowed_worker_ids,
+            routing_constraints,
+        )
+        .await
+    }
+
+    /// Atomically select and reserve the best prefill worker.
+    ///
+    /// The reservation contributes to scheduler load before this method returns,
+    /// so concurrent callers cannot all select from the same stale load snapshot.
+    /// The caller must eventually release it with [`Self::free_prefill_request`].
+    #[expect(clippy::too_many_arguments)]
+    pub async fn reserve_prefill_worker(
+        &self,
+        reservation_id: &str,
+        token_ids: &[u32],
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        lora_name: Option<String>,
+        cache_namespace: Option<String>,
+        priority_jump: f64,
+        strict_priority: u32,
+        allowed_worker_ids: Option<HashSet<WorkerId>>,
+        routing_constraints: RoutingConstraints,
+    ) -> Result<PrefillQueryOutcome> {
+        if reservation_id.is_empty() {
+            anyhow::bail!("prefill reservation ID must not be empty");
+        }
+        self.select_prefill_worker_inner(
+            Some(reservation_id),
+            token_ids,
+            block_mm_infos,
+            lora_name,
+            cache_namespace,
+            priority_jump,
+            strict_priority,
+            allowed_worker_ids,
+            routing_constraints,
+        )
+        .await
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    async fn select_prefill_worker_inner(
+        &self,
+        reservation_id: Option<&str>,
+        token_ids: &[u32],
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        lora_name: Option<String>,
+        cache_namespace: Option<String>,
+        priority_jump: f64,
+        strict_priority: u32,
+        allowed_worker_ids: Option<HashSet<WorkerId>>,
+        routing_constraints: RoutingConstraints,
+    ) -> Result<PrefillQueryOutcome> {
         if self.lifecycle_state() != PrefillLifecycleState::Active {
             return Err(anyhow::anyhow!(PrefillError::NotActivated));
         }
@@ -45,11 +107,11 @@ where
                 let outcome = router
                     .chooser
                     .find_best_match_details(
-                        None,
+                        reservation_id,
                         token_ids,
                         block_mm_infos,
                         None,
-                        false,
+                        reservation_id.is_some(),
                         false,
                         lora_name,
                         cache_namespace,
@@ -85,11 +147,217 @@ where
         }
     }
 
+    /// Release a prefill reservation if it is still owned by `worker`.
+    ///
+    /// Missing reservations and ownership mismatches are idempotent no-ops.
+    pub async fn free_prefill_request(
+        &self,
+        reservation_id: &str,
+        worker: WorkerWithDpRank,
+    ) -> Result<()> {
+        let Some(binding) = self.binding.load_full() else {
+            return Ok(());
+        };
+        if let InnerPrefillRouter::KvRouter(router) = &binding.router {
+            router
+                .chooser
+                .free_if_worker(reservation_id, worker)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Release a gateway-owned prefill reservation by its unforgeable ID.
+    ///
+    /// This variant is used by the native ext-proc cancellation guard, which
+    /// may be dropped after admission but before the selected worker is
+    /// returned to the caller. Gateway-generated UUIDs make an unqualified
+    /// release ownership-safe; external C callers should use
+    /// [`Self::free_prefill_request`] instead.
+    pub async fn free_prefill_reservation(&self, reservation_id: &str) -> Result<()> {
+        let Some(binding) = self.binding.load_full() else {
+            return Ok(());
+        };
+        if let InnerPrefillRouter::KvRouter(router) = &binding.router {
+            router.chooser.free(reservation_id).await?;
+        }
+        Ok(())
+    }
+
     pub fn register_workers(&self, worker_ids: &HashSet<WorkerId>) {
         if let Some(binding) = self.binding.load_full()
             && let InnerPrefillRouter::KvRouter(router) = &binding.router
         {
             router.chooser.register_workers(worker_ids);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, atomic::Ordering},
+    };
+
+    use dynamo_kv_router::{config::KvRouterConfig, selector::DefaultWorkerSelector};
+    use dynamo_runtime::{
+        DistributedRuntime, Runtime,
+        distributed::DistributedConfig,
+        pipeline::{PushRouter, RouterMode},
+        protocols::annotated::Annotated,
+    };
+    use tokio::sync::watch;
+
+    use super::super::PrefillBinding;
+    use super::*;
+    use crate::{
+        discovery::ModelManager,
+        kv_router::{KvPushRouter, KvRouter},
+        protocols::common::llm_backend::{LLMEngineOutput, PreprocessedRequest},
+        worker_type::WorkerType,
+    };
+
+    async fn tracked_prefill_router() -> (Arc<PrefillRouter>, Arc<KvRouter>) {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed = DistributedRuntime::new(runtime, DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let component = distributed
+            .namespace(format!("tracked-prefill-test-{}", uuid::Uuid::new_v4()))
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap();
+        let endpoint = component.endpoint("generate");
+        let endpoint_id = endpoint.id();
+        let client = endpoint.client().await.unwrap();
+        let (_workers_tx, workers_rx) = watch::channel(HashMap::from([
+            (7, ModelRuntimeConfig::default()),
+            (8, ModelRuntimeConfig::default()),
+        ]));
+        let config = KvRouterConfig {
+            overlap_score_credit: 0.0,
+            router_temperature: 0.0,
+            use_kv_events: false,
+            router_track_active_blocks: false,
+            router_track_prefill_tokens: true,
+            skip_initial_worker_wait: true,
+            ..Default::default()
+        };
+        let chooser = Arc::new(
+            KvRouter::new_with_worker_role(
+                endpoint,
+                client.clone(),
+                workers_rx,
+                None,
+                16,
+                DefaultWorkerSelector::new(Some(config.clone()), "prefill"),
+                Some(config),
+                None,
+                Some(WorkerType::Prefill),
+                "prefill",
+                Some("tracked-prefill-test".to_string()),
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let push_router =
+            PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client(
+                client,
+                RouterMode::KV,
+            )
+            .await
+            .unwrap();
+        let router = PrefillRouter::disabled(Arc::new(ModelManager::new()), RouterMode::KV, None);
+        router.binding.store(Some(Arc::new(PrefillBinding {
+            endpoint_id,
+            router: InnerPrefillRouter::KvRouter(Arc::new(KvPushRouter::new_with_coordinator(
+                push_router,
+                chooser.clone(),
+                None,
+            ))),
+        })));
+        router
+            .lifecycle
+            .store(PrefillLifecycleState::Active as u8, Ordering::Release);
+
+        (router, chooser)
+    }
+
+    fn routed_worker(outcome: PrefillQueryOutcome) -> WorkerWithDpRank {
+        match outcome {
+            PrefillQueryOutcome::Routed {
+                worker_id,
+                dp_rank: Some(dp_rank),
+            } => WorkerWithDpRank::new(worker_id, dp_rank),
+            _ => panic!("expected routed prefill worker with a DP rank"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tracked_admissions_observe_prior_prefill_booking() {
+        let (router, chooser) = tracked_prefill_router().await;
+        let tokens = vec![1; 64];
+
+        let first = routed_worker(
+            router
+                .reserve_prefill_worker(
+                    "reservation-1",
+                    &tokens,
+                    None,
+                    None,
+                    None,
+                    0.0,
+                    0,
+                    None,
+                    RoutingConstraints::default(),
+                )
+                .await
+                .unwrap(),
+        );
+        let second = routed_worker(
+            router
+                .reserve_prefill_worker(
+                    "reservation-2",
+                    &tokens,
+                    None,
+                    None,
+                    None,
+                    0.0,
+                    0,
+                    None,
+                    RoutingConstraints::default(),
+                )
+                .await
+                .unwrap(),
+        );
+
+        assert_ne!(
+            first, second,
+            "the second request should select the idle worker"
+        );
+        let loads = chooser
+            .get_potential_loads(&[], None, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(loads.len(), 2);
+        assert!(loads.iter().all(|load| load.potential_prefill_tokens == 64));
+
+        router
+            .free_prefill_request("reservation-1", first)
+            .await
+            .unwrap();
+        router
+            .free_prefill_request("reservation-2", second)
+            .await
+            .unwrap();
+        let loads = chooser
+            .get_potential_loads(&[], None, None, None, None)
+            .await
+            .unwrap();
+        assert!(loads.iter().all(|load| load.potential_prefill_tokens == 0));
     }
 }


### PR DESCRIPTION
## Overview

This PR fixes load-blind prefill routing for disaggregated deployments using the inference-gateway EPP.

In the affected path, selecting a prefill worker was advisory: the router calculated a preferred worker but did not immediately record the incoming request as projected load on that worker. Subsequent routing decisions could therefore observe the same stale load snapshot. When workers had similar or no KV-cache overlap, requests could continue selecting already-busy workers while other prefill replicas remained idle.

This PR introduces atomic prefill selection and reservation for both inference-gateway implementations:

- The Go plugin-based EPP.
- The native Rust ext-proc EPP.

The selected worker's projected prefill load is now recorded before routing returns. The reservation is retained only while prefill is active and is fully released when the first decode response is observed. The implementation also handles routing failures, cancellation, duplicate lifecycle calls, bounded cleanup retries, SimpleRouter compatibility, and aggregated-serving fallback.

This work overlaps with #12907 and is submitted as an alternative implementation. The main lifecycle and compatibility differences are described below.

## Summary

The change introduces a tracked prefill reservation lifecycle:

1. The gateway generates a unique internal reservation ID.
2. Prefill worker selection and projected-load booking occur atomically.
3. Later admissions observe the load booked by earlier admissions.
4. Decode-routing and scheduling failures roll the prefill reservation back.
5. The first response fully removes the prefill reservation.
6. End-of-stream cleanup remains responsible for decode bookkeeping.
7. Duplicate and delayed cleanup calls remain safe and idempotent.

This restores the missing load signal without removing KV-overlap scoring or changing the router into strict round-robin scheduling.

## Root cause

The EPP prefill path called the prefill router in query-only mode. `PrefillRouter::query_prefill_worker` ultimately invoked the worker selector with scheduler state updates disabled. Unlike the native frontend/push-router path, selecting a prefill worker did not create a tracked request in scheduler state.

The Go EPP separately called `CallAddRequest` for the selected decode worker, but it had no corresponding booking operation for the selected prefill worker. Native ext-proc had the same advisory prefill behavior.

As a result:

- `active_prefill_tokens` did not include newly routed EPP requests.
- An idle prefill worker and a worker that had just received several requests could appear equally loaded.
- For prompts with equal or negligible KV overlap, selection had no useful signal representing projected prefill work.
- Requests could queue behind busy prefill workers while equivalent replicas remained idle.

Disabling active-block tracking was not itself the primary issue. Prefill balancing can use projected prefill-token load, but only when the gateway records that load at admission time.

## Details

### Atomic prefill selection and reservation

`PrefillRouter` now exposes a tracked reservation operation in addition to its existing advisory query operation.

The new operation supplies a reservation ID to `find_best_match_details` and enables scheduler state updates during selection. Selection and booking therefore occur in one scheduler operation. A second request sees the load created by the first request rather than selecting from the same stale state.

The existing advisory API remains available for callers that only need a recommendation.

### Additive C ABI

Two additive C ABI operations are introduced:

- `route_and_reserve_prefill_request`
- `free_prefill_request`

The reserve operation:

- Reuses the existing request preprocessing and tokenization path.
- Applies the caller-provided allowed-worker filter.
- Selects the best prefill worker.
- Books projected prefill load before returning.
- Returns the worker, DP rank, token IDs, and cache namespace.

The external free operation requires the internal reservation ID, selected worker ID, and selected DP rank. Worker-qualified cleanup prevents a delayed cleanup for a reused or incorrect reservation ID from deleting state owned by another worker.

Existing C ABI routing operations remain unchanged.

### Go EPP reservation ownership

The Go prefill scorer creates a gateway-owned UUID for each tracked admission. The scheduler booking ID is deliberately separate from the externally visible request ID.

After successful admission, the scorer stores:

- Reservation ID.
- Selected prefill worker ID.
- Selected DP rank.

This state is shared across the prefill and decode scheduling phases so failure paths can release the exact reservation they own.

If a request has no usable request ID, the scorer preserves advisory routing instead of creating a reservation that cannot be tracked through the response lifecycle.

### Prefill reservation lifetime

The reservation represents work performed by the prefill stage. It is fully removed on the first decode response instead of remaining active for the entire decode stream.

Keeping it until decode end-of-stream would allow long-running decode requests to continue contributing active-request load to the prefill worker after prefill had finished.

The normal lifecycle is:

```text
request admitted
    |
    v
prefill worker selected and load reserved
    |
    v
decode worker selected and decode request booked
    |
    v
first response observed
    |
    +--> prefill reservation fully released
    +--> decode router marks prefill complete
    |
    v
end of stream
    |
    +--> decode request released
```

Cleanup operations are idempotent.

### Early-failure rollback in Go EPP

A projected-load reservation must not survive when routing or dispatch fails before a response is produced. The Go path releases its prefill reservation when:

- Request serialization fails before decode routing.
- Decode routing fails.
- Cancellation is observed immediately after decode routing.
- The selected decode worker ID is invalid.
- Cancellation is observed before decode booking.
- Decode booking fails.
- Cancellation is observed immediately after decode booking.
- The prefill profile produces no result.
- No scheduling profile produces a result.
- The selected primary scheduling profile fails.

When cancellation occurs after the decode request has been booked, both projected loads are removed: the decode booking is freed and the prefill reservation is freed.

After a target has been selected, the gateway framework's forced terminal response hook supplies cleanup for stream termination and client-disconnect paths.

### Bounded response-path cleanup retry

Prefill cleanup crosses the synchronous FFI boundary and is subject to the bookkeeping timeout. Repeating a failed cleanup call on every response chunk could repeatedly delay a streaming response.

The response hook therefore uses a bounded policy:

- Attempt cleanup on the first response.
- Skip subsequent intermediate chunks if the first attempt fails.
- Retry once on the terminal response callback.

Successful cleanup immediately deletes reservation state, making later callbacks no-ops.

### Native ext-proc reservation ownership

Native Rust ext-proc now uses tracked prefill admission as well. For a disaggregated request it:

- Generates an internal `epp-prefill-<uuid>` reservation ID.
- Atomically selects and books a prefill worker.
- Uses the internal ID for related decode bookkeeping.
- Returns that ID through `PickResult` for lifecycle callbacks.
- Fully releases prefill state on the first response.
- Releases any remaining prefill and decode state on completion.

The internal ID keeps scheduler ownership separate from an externally supplied request identifier.

### Cancellation-safe native guard

A routing reservation guard owns the admission while `pick()` is executing. If the future is cancelled or returns an error after admission but before the caller adopts the result, dropping the guard schedules bounded cleanup for the prefill and decode routers.

The guard:

- Uses `tokio::runtime::Handle::try_current()` before spawning cleanup.
- Avoids panicking during runtime shutdown.
- Applies the bookkeeping timeout.
- Logs prefill and decode cleanup failures independently.
- Is disarmed only after a successful disaggregated `PickResult` is constructed.

This covers failures during decode selection, decode booking, endpoint resolution, and cancellation of the routing future after prefill admission.

### Preserve fallback and SimpleRouter behavior

The existing aggregated-serving fallback remains intact. If tracked prefill admission is unavailable, native ext-proc retains its previous fallback behavior.

`InnerPrefillRouter::SimpleRouter` also retains its existing worker selection. SimpleRouter has no KV scheduler state to book, so callers receive the selected worker without creating scheduler load state.

### Cleanup trust boundaries

Two cleanup variants serve different trust boundaries:

- External C/Go callers use worker-qualified cleanup.
- Native ext-proc uses unqualified cleanup only for gateway-generated UUIDs.

Missing reservations, repeated cleanup, and worker-ownership mismatches are idempotent no-ops.

## Failure-handling matrix

| Failure point | Prefill cleanup | Decode cleanup | Result |
|---|---:|---:|---|
| Prefill selection fails | No booking exists | Not applicable | Preserve fallback |
| Decode routing fails | Released | No booking exists | No leaked prefill load |
| Cancellation after decode selection | Released | No booking exists | Request terminates cleanly |
| Invalid decode worker | Released | No booking exists | Request is not booked |
| Decode booking fails | Released | No valid booking | Request is not forwarded as booked |
| Cancellation after decode booking | Released | Released | Both projected loads removed |
| Scheduling profile fails | Released | No booking exists | Fallback or terminal error |
| Native `pick()` is dropped | Released by guard | Released by guard | No unadopted booking |
| First response arrives | Fully released | Prefill marked complete | Decode continues |
| End of stream | Idempotent no-op | Fully released | Lifecycle complete |

## Behavioral impact

Before this change, several similar requests could select the same worker because the gateway did not update scheduler load during admission.

After this change, every tracked admission immediately changes projected prefill load. A subsequent equal-overlap request can prefer an idle worker.

KV-cache overlap remains part of the decision. A sufficiently valuable cache match may still outweigh a load difference according to configured scheduler weights. This change restores the missing load component; it does not impose round-robin behavior.

## Comparison with #12907

This PR overlaps with #12907 but uses a different lifecycle design. Notable differences include:

- Prefill state is fully released on the first response rather than retaining an active request for the complete decode duration.
- SimpleRouter behavior is preserved.
- Aggregated fallback behavior is preserved.
- Native cancellation cleanup verifies that a Tokio runtime is available before spawning.
- Response cleanup retries are bounded rather than repeated on every streamed chunk.
- External cleanup is worker-qualified.
- Decode-routing, booking, cancellation, and terminal profile failures roll reservations back.
- A real scheduler regression verifies that reservations affect subsequent worker selection.

I am happy to adapt or split the implementation if maintainers prefer incorporating parts of this work into #12907.

## Tests added

### Go lifecycle regressions

`prefill_scorer_test.go` covers:

1. Reserving and releasing a prefill worker exactly once.
2. Advisory routing when a request has no ID.
3. Bounded terminal retry after a failed cleanup.
4. Releasing an earlier reservation before rescoring.
5. Rollback when decode routing fails.
6. Rollback when cancellation occurs after decode routing.
7. Rollback when decode booking fails.
8. Rollback when profile processing terminates without a usable result.

The Go tests inject behavior at the FFI boundary so lifecycle transitions and error paths can be asserted deterministically.

### Rust scheduler-load regression

`tracked_admissions_observe_prior_prefill_booking` uses the real `KvRouter`, `DefaultWorkerSelector`, and `PrefillRouter`.

The test creates two workers with equal KV overlap, prefill-token tracking enabled, active-block tracking disabled, and deterministic temperature. It then:

1. Reserves a 64-token request.
2. Reserves another equal 64-token request.
3. Verifies that the second admission selects the previously idle worker.
4. Verifies that each worker reports 64 projected prefill tokens.
5. Releases both reservations.
6. Verifies that both workers return to zero projected prefill tokens.

This exercises real scheduler state rather than mocking the selection algorithm.

## Validation

Validation used the repository-pinned Rust 1.96.1 toolchain and Go 1.26.3.

Focused Rust scheduler regression:

```text
cargo test -p dynamo-llm --lib \
  tracked_admissions_observe_prior_prefill_booking -- --nocapture
```

Result: `1 passed; 0 failed; 1983 filtered out`.

Native ext-proc compile check:

```text
cargo check -p dynamo-ext-proc --lib
```

Result: passed.

Rust C ABI build:

```text
cargo build -p libdynamo_llm
```

Result: passed and produced both static and shared libraries.

Go package tests:

```text
go test ./pkg/plugins/disagg
```

Result: passed. The package was tested while linked against the real Rust static library. After the final Go-only bounded-retry adjustment, it was run again with a link-only FFI test stub; the Rust ABI was unchanged by that adjustment.

Package-scoped Clippy:

```text
cargo clippy \
  -p dynamo-llm \
  -p libdynamo_llm \
  -p dynamo-ext-proc \
  --lib -- -D warnings
```

Result: passed.

Formatting and diff checks:

```text
cargo fmt --all -- --check
git diff --check
```

Result: passed.

## Kubernetes validation still required

A Kubernetes multi-prefill load test was not run locally because a suitable GPU cluster was not available.

Recommended deployment validation:

1. Deploy a disaggregated model with at least three prefill replicas.
2. Route sustained mixed-prompt traffic through inference-gateway EPP.
3. Use low/equal-overlap prompts for the load-balancing portion.
4. Scrape `vllm:num_requests_running` and `vllm:num_requests_waiting` per prefill pod.
5. Confirm that idle workers receive new requests before equivalent busy workers continue accumulating queues.
6. Repeat with strong-overlap prompts to verify that cache-aware routing remains effective.
7. Include cancellations and failed requests and verify that projected scheduler load returns to baseline.

Expected results:

- Projected prefill load changes immediately after admission.
- Idle replicas do not remain unused while equivalent busy replicas accumulate queues.
- Reservations disappear after prefill completion or failure.
- Aggregated fallback continues when prefill routing is unavailable.
- Strong cache overlap can still outweigh smaller load differences according to configured weights.

## Where should the reviewer start?

1. `lib/llm/src/kv_router/prefill_router/query.rs`
   - Atomic select-and-reserve behavior.
   - Reservation cleanup APIs.
   - Real scheduler regression.

2. `deploy/inference-gateway/epp/pkg/plugins/disagg/prefill_scorer.go`
   - Go reservation ownership and response lifecycle.
   - Bounded cleanup retry.

3. `deploy/inference-gateway/epp/pkg/plugins/disagg/decode_scorer.go`
   - Decode failure and cancellation rollback.

4. `deploy/inference-gateway/ext-proc/src/epp.rs`
   - Native reservation guard and lifecycle propagation.

5. `lib/bindings/c/src/lib.rs`
   - Additive reserve/free C ABI.

6. `deploy/inference-gateway/epp/pkg/plugins/disagg/prefill_scorer_test.go`
   - Go lifecycle regression coverage.

## Related Issues

- Closes #12864
- Alternative implementation to #12907
