### PR TITLE
ci: skip the post-merge pipeline on docs-only pushes

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -8,6 +8,19 @@ on:
     branches:
       - main
       - 'release/*.*.*'
+    # Docs-only pushes cannot change what this pipeline builds or tests, and
+    # they are already covered by the pre-merge Fern checks and fern-docs.yml.
+    # Same exclusion trigger_ci.yml carries, for the same reason.
+    #
+    # Today a docs merge still runs the full ~110-minute image build: 4 of the
+    # last 30 runs on main were docs-only. It also matters for any scheduled job
+    # that commits generated docs to main -- the community events refresh being
+    # the first -- which would otherwise wake this pipeline once a day.
+    paths-ignore:
+      - 'docs/**'
+      - 'fern/**'
+      - '**.md'
+      - '**.rst'
   workflow_dispatch:
     inputs:
       framework:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,45 @@ jobs:
           echo "Source commit SHA: ${COMMIT_SHA}"
           echo "Nightly: ${NIGHTLY}"
 
+      # Every image this pipeline republishes is tagged ${COMMIT_SHA}-*, and
+      # post-merge CI is what builds them. post-merge CI skips docs-only pushes,
+      # so a commit that touched only docs has no images -- and the failure would
+      # otherwise surface much later, mid-release, as an opaque "manifest
+      # unknown" from the first image copy. Fail here instead, while nothing has
+      # been tagged or published, and say what to do about it.
+      - name: Verify post-merge CI built images for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ steps.extract.outputs.commit_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Existence, not success. post-merge CI is a ~50-job pipeline whose
+          # image builds routinely succeed while a downstream test fails, so
+          # gating on overall success would block releases that do have images.
+          # Zero runs is the unambiguous signal: the workflow never fired for
+          # this SHA, so nothing was ever built for it.
+          COUNT=$(gh api \
+            "repos/${REPO}/actions/workflows/post-merge-ci.yml/runs?head_sha=${COMMIT_SHA}" \
+            --jq '.total_count' 2>/dev/null || echo "unknown")
+
+          # Never block a release on a flaky API call: warn and let the image
+          # copy be the judge, which is the behaviour before this check existed.
+          if [ "${COUNT}" = "unknown" ]; then
+            echo "::warning::Could not query post-merge CI runs for ${COMMIT_SHA}; continuing."
+            exit 0
+          fi
+
+          if [ "${COUNT}" -eq 0 ]; then
+            echo "::error::No post-merge CI run exists for ${COMMIT_SHA}, so its ${COMMIT_SHA}-* images were never built."
+            echo "post-merge CI skips docs-only pushes, so a documentation-only commit has no images."
+            echo "Re-run this release against the most recent commit with a successful post-merge CI run."
+            exit 1
+          fi
+
+          echo "Found ${COUNT} post-merge CI run(s) for ${COMMIT_SHA}."
+
       # Checkout at the source commit with full tags so the RC-number step can
       # enumerate existing v<VERSION>-rc<N> tags and auto-increment. Also lets
       # downstream jobs (release-publish, stage-wheels-artifactory) consume the


### PR DESCRIPTION
Split out of #12861 — it was the one change in that PR outside `docs/`, and it needs an answer from CI owners that the docs work should not wait on. Full history is in [this thread](https://github.com/ai-dynamo/dynamo/pull/12861#discussion_r_PRRT_kwDOOCjvss6Xm5a8) (thanks @dmitry-tokarev-nv for raising it).

## What this does

Adds `paths-ignore: ['docs/**', 'fern/**', '**.md', '**.rst']` to `post-merge-ci.yml`'s `push:` trigger — the exact set `trigger_ci.yml` already carries.

## Why

post-merge-ci builds and pushes the SHA-tagged image set (`<sha>-operator`, `<sha>-snapshot-agent`, `<sha>-power-agent`, and the `main-<framework>-runtime-<sha>` family) and takes **90–110 minutes**. A docs-only merge cannot change any of it, and docs are already covered by the pre-merge Fern checks and `fern-docs.yml`.

This is not hypothetical — **4 of the last 30** post-merge-ci runs on `main` were docs-only commits, each a full ~110-minute image build. For example *"docs: point the Fern CLI link at the CLI reference"* ran 110 minutes.

It also matters for scheduled jobs that commit generated docs to `main` — the community events refresh in #12861 being the first — which would otherwise wake this pipeline once a day.

## The open question for CI owners

**After this change, a docs-only merge produces a `main` HEAD SHA for which none of those image tags exist.** Today every `main` SHA has images; afterwards that stops being true.

What has been checked so far:

- **In-repo: no consumer.** Searching `.github/`, `deploy/`, `recipes/`, `docs/`, and `container/` for the SHA-tag families, every hit is in `pr.yaml` and `build-on-demand.yml` — and those build images for their *own* `github.sha` rather than resolving a `main` SHA someone else built. (@dmitry-tokarev-nv reached the same conclusion independently.)
- **Pattern correctness.** `**` matches `/` in Actions path filters, so `'**.md'` covers nested markdown, and the set is byte-identical to `trigger_ci.yml`'s.

**What is still unknown, and what this PR needs:** whether anything *outside* this repo resolves "the image built from current main" by SHA — the dynamo-ci GitLab pipelines, or any deploy tooling. If something does, it would break only on docs-only merges: intermittent, starting after this lands, and looking unrelated to a docs change. That is expensive to trace back, hence asking first.

If such a consumer exists, the alternative is to keep the pipeline skipped but preserve the invariant — on a docs-only push, re-tag the previous SHA's images onto the new SHA. A registry tag copy, no rebuild.

## Note

Unrelated, but visible while gathering the above: **all 30 of the most recent post-merge-ci runs on `main` failed.** That predates this PR and is not addressed here, but it likely wants its own look.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation-only changes no longer trigger the post-merge CI pipeline, reducing unnecessary automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->