### PR TITLE
fix(sglang): clean up temporary disagg configs

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -351,7 +351,7 @@ async def parse_args(args: list[str]) -> Config:
     dynamo_config.validate()
 
     # Dealing with SGLang native configs
-    temp_config_file = None  # Track temp file for cleanup
+    temp_config_file = None
     if dynamo_config.disagg_config and dynamo_config.disagg_config_key:
         section_data = _load_disagg_config_section(
             dynamo_config.disagg_config, dynamo_config.disagg_config_key
@@ -364,21 +364,25 @@ async def parse_args(args: list[str]) -> Config:
         unknown.append("--config")
         unknown.append(temp_config_file)
 
-    if "--config" in unknown:
-        config_merger = ConfigArgumentMerger(parser=sglang_only_parser)
-        unknown = config_merger.merge_config_with_args(unknown)
+    try:
+        if "--config" in unknown:
+            config_merger = ConfigArgumentMerger(parser=sglang_only_parser)
+            unknown = config_merger.merge_config_with_args(unknown)
 
-    unknown = _normalize_multimodal_disaggregation_args(unknown, dynamo_config)
-    dynamo_config.validate_multimodal_topology()
+        unknown = _normalize_multimodal_disaggregation_args(unknown, dynamo_config)
+        dynamo_config.validate_multimodal_topology()
 
-    parsed_args = sglang_only_parser.parse_args(unknown)
-
-    # Clean up temp file if created
-    if temp_config_file and os.path.exists(temp_config_file):
-        try:
-            os.unlink(temp_config_file)
-        except Exception:
-            logging.warning(f"Failed to clean up temp config file: {temp_config_file}")
+        parsed_args = sglang_only_parser.parse_args(unknown)
+    finally:
+        if temp_config_file and os.path.exists(temp_config_file):
+            try:
+                os.unlink(temp_config_file)
+            except OSError as e:
+                logging.warning(
+                    "Failed to clean up temp config file %s: %s",
+                    temp_config_file,
+                    e,
+                )
 
     bootstrap_port = _reserve_disaggregation_bootstrap_port()
 

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -17,6 +17,7 @@ from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 from sglang.srt.managers.io_struct import ProfileReq
 
 import dynamo.sglang._compat as sglang_compat
+import dynamo.sglang.args as sglang_args
 from dynamo.common.constants import DisaggregationMode, EmbeddingTransferMode
 from dynamo.common.snapshot.constants import SNAPSHOT_CONTROL_DIR_ENV
 from dynamo.sglang._compat import (
@@ -1038,12 +1039,15 @@ async def test_disagg_config_preserves_bootstrap_port(tmp_path, mock_sglang_cli)
 
 
 @pytest.mark.asyncio
-async def test_disagg_config_rejects_dynamo_keys(tmp_path, mock_sglang_cli, capfd):
+async def test_disagg_config_rejects_dynamo_keys(
+    tmp_path, mock_sglang_cli, capfd, monkeypatch
+):
     """Disagg config should only accept SGLang-native keys."""
     config_path = tmp_path / "disagg.yaml"
     config_path.write_text(
         yaml.safe_dump({"prefill": {"store-kv": "mem"}}), encoding="utf-8"
     )
+    monkeypatch.setattr(sglang_args.tempfile, "tempdir", str(tmp_path))
 
     mock_sglang_cli(
         "--model",
@@ -1059,6 +1063,7 @@ async def test_disagg_config_rejects_dynamo_keys(tmp_path, mock_sglang_cli, capf
 
     out, err = capfd.readouterr()
     assert "unrecognized arguments: --store-kv mem" in err
+    assert not list(tmp_path.glob("dynamo_config_*.yaml"))
 
 
 def test_disagg_health_check_payload_includes_bootstrap_info():


### PR DESCRIPTION
## Summary

- remove the temporary SGLang YAML generated for a selected disaggregated configuration section even when configuration merging, topology validation, or argument parsing fails
- preserve the original parsing failure while logging an `OSError` if cleanup itself cannot complete
- extend the invalid disaggregated configuration test to verify that no generated YAML remains after `argparse` exits

## Background

When `--disagg-config` and `--disagg-config-key` are used together, Dynamo extracts the selected section into a temporary YAML file and passes that file through SGLang's native `--config` flow. The cleanup previously ran only after `sglang_only_parser.parse_args()` returned successfully.

Invalid SGLang options in the selected section cause `argparse` to raise `SystemExit` before reaching that cleanup block. Configuration merging or multimodal topology validation can fail at the same point as well. Repeated failed worker launches can therefore leave `dynamo_config_*.yaml` files behind in the system temporary directory.

This change places the portion of parsing that consumes the generated YAML inside `try/finally`, keeping the successful path unchanged while making cleanup independent of the parse result.

## Validation

- `uvx --from ruff==0.5.2 ruff check components/src/dynamo/sglang/args.py components/src/dynamo/sglang/tests/test_sglang_unit.py`
- `uvx --from black==23.1.0 black --check components/src/dynamo/sglang/args.py components/src/dynamo/sglang/tests/test_sglang_unit.py`
- `uvx --from isort==5.12.0 isort --check-only components/src/dynamo/sglang/args.py components/src/dynamo/sglang/tests/test_sglang_unit.py`
- `.venv/bin/python -m py_compile components/src/dynamo/sglang/args.py components/src/dynamo/sglang/tests/test_sglang_unit.py`
- `git diff --check`

The focused pytest was not run locally because the existing `.venv` does not contain pytest or the optional SGLang dependency.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary configuration files during SGLang setup, including when configuration processing or validation fails.
  * Cleanup errors are handled safely without interrupting the setup process.

* **Tests**
  * Added coverage confirming temporary Dynamo configuration files are not generated for unsupported disaggregation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->