### PR TITLE
fix(sglang): validate token IDs on all client-supplied input paths

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -1007,10 +1007,11 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
                     400,
                     f"token input[{index}] must be an integer token ID",
                 )
-            # Dynamo's Rust frontend uses u32 token IDs, so negatives are not expected.
-            if (
-                max_input_token_id is not None and token_id > max_input_token_id
-            ) and token_id not in allowed_oov_ids:
+            if token_id < 0 or (
+                max_input_token_id is not None
+                and token_id > max_input_token_id
+                and token_id not in allowed_oov_ids
+            ):
                 raise HttpError(400, f"Token id {token_id} is out of vocabulary")
 
     def _validate_input_token_ids(
@@ -1018,15 +1019,12 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         request: Dict[str, Any],
         request_input: Any,
     ) -> None:
-        """Reject out-of-vocabulary IDs on any client-supplied token input.
+        """Reject out-of-vocabulary IDs in resolved token lists.
 
-        Token IDs reach the engine unchanged both through ``nvext.token_data``
-        and through the OpenAI ``prompt`` token-array forms of
-        ``/v1/completions``, which the frontend forwards without tokenizing.
-        Neither carries a marker distinguishing it from frontend-tokenized
-        input, so every resolved token list is validated. Text handed to
-        SGLang's own tokenizer cannot carry an out-of-vocabulary ID and is
-        skipped.
+        Client-supplied token arrays and locally encoded ``prompt``/``text``
+        inputs resolve to lists and are validated. Rendered chat prompts remain
+        strings for SGLang to tokenize and cannot contain client-supplied token
+        IDs, so they are skipped.
         """
         if self.use_sglang_tokenizer and isinstance(request_input, str):
             return

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -927,7 +927,7 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         request_input = self.input_param_manager.get_input_param(
             request, use_tokenizer=self.use_sglang_tokenizer
         )
-        self._validate_nvext_token_data(request, request_input)
+        self._validate_input_token_ids(request, request_input)
 
         return {
             "prompt" if isinstance(request_input, str) else "input_ids": request_input
@@ -998,14 +998,14 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         allowed_oov_ids: frozenset[int] = frozenset(),
     ) -> None:
         if not isinstance(token_ids, list):
-            raise HttpError(400, "nvext.token_data must resolve to a token ID list")
+            raise HttpError(400, "token input must resolve to a token ID list")
 
         max_input_token_id = self._max_input_token_id
         for index, token_id in enumerate(token_ids):
             if isinstance(token_id, bool) or not isinstance(token_id, int):
                 raise HttpError(
                     400,
-                    f"nvext.token_data[{index}] must be an integer token ID",
+                    f"token input[{index}] must be an integer token ID",
                 )
             # Dynamo's Rust frontend uses u32 token IDs, so negatives are not expected.
             if (
@@ -1013,21 +1013,26 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
             ) and token_id not in allowed_oov_ids:
                 raise HttpError(400, f"Token id {token_id} is out of vocabulary")
 
-    def _validate_nvext_token_data(
+    def _validate_input_token_ids(
         self,
         request: Dict[str, Any],
-        token_ids: Any,
+        request_input: Any,
     ) -> None:
-        """Reject out-of-vocabulary IDs supplied through ``nvext.token_data``."""
-        extra_args = request.get("extra_args")
-        if not isinstance(extra_args, dict):
-            return
-        nvext = extra_args.get("nvext")
-        if not isinstance(nvext, dict) or nvext.get("token_in") is not True:
+        """Reject out-of-vocabulary IDs on any client-supplied token input.
+
+        Token IDs reach the engine unchanged both through ``nvext.token_data``
+        and through the OpenAI ``prompt`` token-array forms of
+        ``/v1/completions``, which the frontend forwards without tokenizing.
+        Neither carries a marker distinguishing it from frontend-tokenized
+        input, so every resolved token list is validated. Text handed to
+        SGLang's own tokenizer cannot carry an out-of-vocabulary ID and is
+        skipped.
+        """
+        if self.use_sglang_tokenizer and isinstance(request_input, str):
             return
 
         self._validate_token_ids(
-            token_ids,
+            request_input,
             self._resolve_request_multimodal_token_ids(request),
         )
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -403,11 +403,14 @@ def test_nvext_token_data_skips_validation_when_model_bound_is_unavailable():
     assert handler._get_input_param(request) == {"input_ids": [2**32 - 1]}
 
 
-def test_nvext_token_data_without_model_bound_rejects_locally_invalid_token_id():
+@pytest.mark.parametrize("invalid_token_id", [True, -1])
+def test_nvext_token_data_without_model_bound_rejects_locally_invalid_token_id(
+    invalid_token_id,
+):
     handler = _new_token_input_handler()
     handler._max_input_token_id = None
     request = {
-        "token_ids": [True],
+        "token_ids": [invalid_token_id],
         "extra_args": {"nvext": {"token_in": True}},
     }
 
@@ -431,7 +434,7 @@ def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
     assert error.value.code == 400
 
 
-@pytest.mark.parametrize("invalid_token_id", [151936, 2**32 - 1])
+@pytest.mark.parametrize("invalid_token_id", [-1, 151936, 2**32 - 1])
 def test_openai_prompt_token_array_rejects_out_of_vocabulary_token_id(
     invalid_token_id,
 ):
@@ -475,7 +478,7 @@ def test_unmarked_multimodal_placeholder_token_is_accepted():
     assert handler._get_input_param(request) == {"input_ids": [1, 32000]}
 
 
-def test_sglang_tokenizer_text_input_skips_token_validation():
+def test_sglang_tokenizer_rendered_chat_prompt_skips_token_validation():
     handler = _new_decode_handler(use_sglang_tokenizer=True)
     handler._max_input_token_id = 151935
     handler.input_param_manager = SimpleNamespace(

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -385,7 +385,7 @@ def test_nvext_token_data_rejects_marked_string_payload():
 
     with pytest.raises(
         HttpError,
-        match=r"nvext\.token_data must resolve to a token ID list",
+        match=r"token input must resolve to a token ID list",
     ) as error:
         handler._get_input_param(request)
 
@@ -431,11 +431,58 @@ def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
     assert error.value.code == 400
 
 
-def test_nvext_token_data_validation_skips_ordinary_token_input():
-    handler = _new_token_input_handler()
-    request = {"token_ids": [2**32 - 1]}
+@pytest.mark.parametrize("invalid_token_id", [151936, 2**32 - 1])
+def test_openai_prompt_token_array_rejects_out_of_vocabulary_token_id(
+    invalid_token_id,
+):
+    """``/v1/completions`` token arrays are client-supplied and untokenized.
 
-    assert handler._get_input_param(request) == {"input_ids": [2**32 - 1]}
+    The frontend forwards ``prompt: [...]`` verbatim without setting the
+    ``nvext.token_in`` marker, so validation must not be gated on that marker.
+    """
+    handler = _new_token_input_handler()
+    request = {"token_ids": [1, invalid_token_id]}
+
+    with pytest.raises(
+        HttpError,
+        match=rf"Token id {invalid_token_id} is out of vocabulary",
+    ) as error:
+        handler._get_input_param(request)
+
+    assert error.value.code == 400
+
+
+def test_openai_prompt_token_array_accepts_in_vocabulary_token_id():
+    handler = _new_token_input_handler()
+    request = {"token_ids": [1, 151935]}
+
+    assert handler._get_input_param(request) == {"input_ids": [1, 151935]}
+
+
+def test_unmarked_multimodal_placeholder_token_is_accepted():
+    handler = _new_token_input_handler(maximum_input_token_id=31999)
+    handler.engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            mm_processor=SimpleNamespace(),
+            model_config=SimpleNamespace(image_token_id=32000),
+        )
+    )
+    request = {
+        "token_ids": [1, 32000],
+        "multi_modal_data": {"image_url": [{"Url": "https://example.com/image.png"}]},
+    }
+
+    assert handler._get_input_param(request) == {"input_ids": [1, 32000]}
+
+
+def test_sglang_tokenizer_text_input_skips_token_validation():
+    handler = _new_decode_handler(use_sglang_tokenizer=True)
+    handler._max_input_token_id = 151935
+    handler.input_param_manager = SimpleNamespace(
+        get_input_param=lambda request, use_tokenizer: "rendered prompt"
+    )
+
+    assert handler._get_input_param({"messages": []}) == {"prompt": "rendered prompt"}
 
 
 async def _stream(items):


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

fix: validate client-supplied token IDs on all SGLang token input paths

## Details:

<!-- Describe the changes made in this PR. -->

Currently, it implents token validation for the `nvext.token_data` path. This PR extends that validation to the remaining client-supplied token path.

The OpenAI `/v1/completions` spec allows four forms of `prompt`, two of which are token ID arrays:

```
curl -s http://frontend:8000/v1/completions -H 'Content-Type: application/json' -d '{
  "model": "Qwen/Qwen3-0.6B",
  "prompt": [151643, 9707, 4294967295],
  "max_tokens": 8
}'
```

151643 and 9707 are valid, 4294967295 indexes out of bounds on the GPU embedding weight matrix.

This is usually not malicious. It comes from a client that tokenizes locally and then assembles the array, accidentally inserting a length, an offset, or a hash value as a token ID, or from a client tokenizer that does not match the server-side model vocabulary.

An integer-array prompt on `/v1/completions` carries no `token_in` marker and never passes through frontend tokenization. It is raw user input. An out-of-range ID here can cause SGLang to fail downstream.

This PR applies the same out-of-vocabulary validation when tokens arrive through prompt

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for client-provided token inputs across supported request formats.
  - Added consistent handling for invalid or out-of-vocabulary tokens.
  - Preserved support for SGLang-tokenized text and multimodal placeholder tokens.
  - Updated validation error messages to use clearer, generic wording.

- **Tests**
  - Expanded coverage for prompt token arrays, accepted inputs, rejected inputs, and tokenizer-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->