### PR TITLE
fix(container): bump nats-server to v2.12.12

### DIFF
--- a/container/compliance/native_packages.yaml
+++ b/container/compliance/native_packages.yaml
@@ -133,7 +133,7 @@ packages:
   # nats-server — messaging server, downloaded as a .deb in dynamo_base (dpkg -i
   # may not survive into the final runtime layer attribution reliably).
   - name: nats-server
-    version: v2.10.28
+    version: v2.12.12
     license: Apache-2.0
     source: https://github.com/nats-io/nats-server
     images:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -38,7 +38,7 @@ dynamo:
   # and uv rejects cache entries written by a newer version.
   uv_version: "0.12.0"
 
-  nats_version: v2.10.28
+  nats_version: v2.12.12
   etcd_version: v3.5.30
 
   nixl_ref: v1.0.1


### PR DESCRIPTION
## Overview

Bumps the `nats-server` pin from `v2.10.28` to `v2.12.12`.

Fixes #12356

## Details

`v2.12.12` is built with Go 1.25.11.

The binary is bumped rather than removed: `tests/conftest.py`'s `NatsServer` fixture executes `/usr/bin/nats-server`, and the local dev workflow depends on it.

## Changes

| File | Change |
| --- | --- |
| `container/context.yaml` | `nats_version: v2.10.28` -> `v2.12.12` |
| `container/compliance/native_packages.yaml` | `nats-server` version pin updated to match |

`container/context.yaml` is the single source of truth consumed by `templates/args.Dockerfile`, so no per-framework Dockerfile edits are needed. The compliance manifest carries a parallel pin for attribution and is kept in sync.

## Validation

Reported in #12356 with the following verified prior to this PR:

- `nats-server v2.12.12` embeds Go 1.25.11
- CLI flags used by Dynamo are unchanged
- Pinned clients continue to work: `nats-py==2.12.0`, `async-nats==0.49.1`
- Full source rebuild completes

Release `.deb` assets confirmed present for both `amd64` and `arm64`.

## Notes for reviewers

- This crosses two minor versions (2.10 -> 2.12), so CI image builds are the gate rather than the local rebuild above.
- `release/1.4.0` is already cut carrying `v2.10.28`, so this needs a cherry-pick once merged.

## Reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled NATS Server to version v2.12.12.
  * Updated the default NATS version used in Dynamo configuration to v2.12.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->