### PR TITLE
feat(skills): operator-granted stopping, topology as a hypothesis tier, empirical measurement validity

### DIFF
--- a/.agents/skills/analyze-aiperf-results/SKILL.md
+++ b/.agents/skills/analyze-aiperf-results/SKILL.md
@@ -105,7 +105,8 @@ Cross-series results may provide context but never a gain, loss, or Pareto calcu
    history table.
 6. Calculate signed percent change as `(current - prior) / prior * 100`. Also state whether the value is higher or
    lower and whether that direction is an improvement or regression.
-7. Classify an absolute performance change of `0.5%` or less as noise and report it without recommending a repeat
+7. Classify an absolute performance change at or below the measured noise floor of the active benchmark series (see
+   `comparison-uncertainty.md`) as noise and report it without recommending a repeat
    solely because the delta is small.
 8. Analyze one valid run by default. A clear, substantial, plausible gain or loss may support a conclusion without a
    repeat; state that it is single-run evidence.

--- a/.agents/skills/consult-perf-knowledge/SKILL.md
+++ b/.agents/skills/consult-perf-knowledge/SKILL.md
@@ -96,8 +96,9 @@ Record:
 - absolute current metrics and client-visible symptoms;
 - comparisons with the series baseline, previous valid iteration, best prior result per objective, and relevant
   same-series history when available;
-- run count, repeat rationale when applicable, the `0.5%` noise floor, and AIPerf confidence intervals or coefficient
-  of variation only when deliberate repetitions made them useful;
+- run count, repeat rationale when applicable, the measured noise floor of the active benchmark series (per
+  `comparison-uncertainty.md`), and AIPerf confidence intervals or coefficient of variation only when deliberate
+  repetitions made them useful;
 - proxy limitations, missing metrics, resource or placement differences, or other uncertainty; and
 - whether any surprising prior result needs engagement or plausibility rechecking.
 
@@ -126,10 +127,12 @@ Before generating a hypothesis, determine whether a broad or narrow knob adjustm
   remains untested or has not been ruled out by current evidence.
 - Prefer a narrow move only after the broad landscape has been screened and valid measurements
   show a demonstrated, meaningful signal in the selected family.
-- Return to exploration when a narrow change is invalid, inconclusive, within the `0.5%` noise floor, reverses the
-  expected direction, or reveals a different limiting regime.
+- Return to exploration when a narrow change is invalid, inconclusive, within the measured noise floor of the
+  active benchmark series, reverses the expected direction, or reveals a different limiting regime.
 
-Perform a fresh broad-lever scan before every hypothesis. Explicitly screen:
+Maintain one persistent search-calibration ledger for the engagement instead of regenerating a scan for every
+hypothesis. Before each hypothesis, update the ledger by delta, re-reviewing every row whose evidence regime changed
+(a topology adoption, new variance data, an answered ask). The ledger explicitly covers:
 
 1. deployment topology and fit, including model fit, parallelism, replication, aggregated versus disaggregated
    serving, disaggregated rate matching, GPU allocation, and placement or fabric constraints;
@@ -138,8 +141,11 @@ Perform a fresh broad-lever scan before every hypothesis. Explicitly screen:
    routing and prefix reuse; KVBM or engine KV offload; and frontend, transport, and pod resources; and
 3. Local Planner only when its conditional lane applies.
 
-For each family, record its coverage as `tested`, `ruled-out`, `not-applicable`, `untested-promising`, or
-`reopened-by-new-evidence`, plus its expected upside and the evidence for that disposition. Compare all applicable families for potential benefit and information value before choosing one.
+For each family, record its coverage as `tested`, `ruled-out`, `not-applicable`, `untested-promising`, `deferred`,
+or `reopened-by-new-evidence`, plus its expected upside and the evidence for that disposition. A `ruled-out` row must
+cite a measurement, a sourced hard constraint, a confirmed incompatibility, or an explicit operator decision;
+expected upside below the minimum detectable effect is `deferred` (still visible, and stackable under a documented
+one-variable exception), never `ruled-out`. Compare all applicable families for potential benefit and information value before choosing one.
 
 During exploration, prefer an independently testable change that crosses into a different high-impact family or tests
 a coarse, documented operating regime. Do not keep adjusting the same knob in single-digit or otherwise near-neighbor
@@ -152,7 +158,8 @@ Follow `agent-docs/guides/knob-tuning/tuning-hierarchy.md`:
 
 1. Classify the exact model and compute memory fit, minimum parallelism, and headroom.
 2. Complete the exploration-versus-exploitation calibration and full broad-lever scan above.
-3. Screen topology first. Keep it unchanged unless current evidence supports a structural mismatch.
+3. Consider topology first as a hypothesis category per the tuning hierarchy; an inherited layout is a candidate,
+   not a settled decision.
 4. When topology is viable, consider Tier 2 families in default priority order, then finish screening the remaining
    families before selecting a candidate.
 5. Record why each major family was retained, skipped, rejected, or superseded by stronger current-run evidence.

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -104,6 +104,12 @@ Review the assigned DGD and any support manifests explicitly included in the han
 Stop before mutation if required namespace, CRDs, PVC prerequisites, secret names, storage class, images, or GPU
 capacity are missing.
 
+When checking GPU capacity, count every pod that is bound to a node (`spec.nodeName` set) and not in a terminal phase
+(`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in
+`ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes carrying taints beyond the
+standard GPU taint (tenant reservations) from schedulable capacity, and never add tolerations for them. Report free
+capacity as the largest schedulable per-node block, not a cluster-wide sum: a 4-GPU pod needs 4 free GPUs on one node.
+
 If a manifest must change only to work with the target cluster, such as resolving a storage class placeholder or adding
 a required node-taint toleration, update only the copy under `applied_manifests/`. Preserve the handed-off source
 and record the exact change and reason in `deployment_ledger.json`. Do not change performance knobs.

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -106,9 +106,11 @@ capacity are missing.
 
 When checking GPU capacity, count every pod that is bound to a node (`spec.nodeName` set) and not in a terminal phase
 (`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in
-`ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes carrying taints beyond the
-standard GPU taint (tenant reservations) from schedulable capacity, and never add tolerations for them. Report free
-capacity as the largest schedulable per-node block, not a cluster-wide sum: a 4-GPU pod needs 4 free GPUs on one node.
+`ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes whose taints the
+assigned manifest does not already tolerate, and never add new tolerations for other tenants' reservation taints.
+Evaluate fit per component pod — each pod's GPU request, node selectors, affinity, and tolerations against per-node
+free blocks — rather than a cluster-wide sum: a multi-component DGD schedules only if every one of its pods fits on
+some node.
 
 If a manifest must change only to work with the target cluster, such as resolving a storage class placeholder or adding
 a required node-taint toleration, update only the copy under `applied_manifests/`. Preserve the handed-off source

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -108,9 +108,11 @@ When checking GPU capacity, count every pod that is bound to a node (`spec.nodeN
 (`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in
 `ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes whose taints the
 assigned manifest does not already tolerate, and never add new tolerations for other tenants' reservation taints.
-Evaluate fit per component pod — each pod's GPU request, node selectors, affinity, and tolerations against per-node
-free blocks — rather than a cluster-wide sum: a multi-component DGD schedules only if every one of its pods fits on
-some node.
+Evaluate fit by expanding the DGD into its full multiset of pod demands (every component, every replica) and placing
+them against per-node free blocks while decrementing remaining capacity — two pods cannot count the same free GPUs.
+Honor each pod's node selectors, required affinity/anti-affinity, and tolerations during placement. If the DGD cannot
+be faithfully expanded into pod demands, report capacity as unknown, not sufficient. When `resources.gpu_ceiling` is
+set in the workload contract, also verify the run's total concurrent GPU holdings stay within it.
 
 If a manifest must change only to work with the target cluster, such as resolving a storage class placeholder or adding
 a required node-taint toleration, update only the copy under `applied_manifests/`. Preserve the handed-off source

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -61,6 +61,14 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - Accept natural-language answers; do not make the user author YAML.
 - Do not ask for secret values, kubeconfig contents, registry credentials, or Kubernetes Secret data.
 - Do not add a ceremonial confirmation round when the user's message already provides an unambiguous value.
+- Ask once for the resource envelope: the GPU floor and ceiling in play for this work, whether parallel experiments
+  are authorized within the ceiling, any knobs the user forbids changing, and any teardown deadline. Record the
+  answers in the contract's `resources` block. When capacity within the ceiling allows, downstream roles prefer
+  running approved candidates in parallel (one variable per slot, slot attribution in every ledger record) over
+  queueing them serially.
+- When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
+  numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
+  before recording it.
 
 If blocking facts remain, return the questions to the parent and stop without handing work to a downstream role.
 
@@ -118,6 +126,22 @@ Before finalizing:
 
 Do not overwrite the contract after handoff to `recipe-deployer`. A different performance question may use a new
 benchmark series within this contract; a material change to the user workload requires a new experiment root.
+
+## Contract Corrections
+
+A correction of fact is different from a material change: the user is not changing the workload, they are fixing a
+misreported description of the same workload (a wrong traffic number, a fleet-level figure that should have been
+per-replica, a mistaken SLO value). When the user corrects the contract:
+
+1. Append a correction annotation to the experiment ledger recording what changed, why, and when. Never rewrite or
+   delete prior records.
+2. Mark every run measured under the pre-correction contract as superseded, not invalid: those runs remain evidence
+   about the conditions they actually measured.
+3. Update the contract file in place with the correction noted inline, and recompute its SHA256.
+4. Re-establish the baseline under the corrected contract before proposing any new candidate.
+
+If the user is genuinely changing the workload rather than correcting its description, the existing rule applies:
+new experiment root.
 
 ## Return
 

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -61,11 +61,11 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - Accept natural-language answers; do not make the user author YAML.
 - Do not ask for secret values, kubeconfig contents, registry credentials, or Kubernetes Secret data.
 - Do not add a ceremonial confirmation round when the user's message already provides an unambiguous value.
-- Ask once for the resource envelope: the GPU floor and ceiling in play for this work, whether parallel experiments
-  are authorized within the ceiling, any knobs the user forbids changing, and any teardown deadline. Record the
-  answers in the contract's `resources` block. The envelope informs capacity planning; candidates still run serially
-  under the current iteration model (each iteration retires the previous deployment). Do not run candidates in
-  parallel unless artifact roots, DGD names, and teardown ownership are slot-isolated.
+- When the user supplies resource limits — a ceiling on total concurrent GPU use, or knobs they forbid changing —
+  record them in the contract's `resources` block. Ask about limits only when the run's scope makes them blocking
+  (for example, when architectural changes such as replica scaling or disaggregation are in scope and the ceiling
+  determines what may be proposed). Candidates run serially under the current iteration model; parallel candidate
+  execution is not supported.
 - When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
   numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
   before recording it.
@@ -129,22 +129,25 @@ benchmark series within this contract; a material change to the user workload re
 
 ## Contract Corrections
 
-A correction of fact is different from a material change: the user is not changing the workload, they are fixing a
-misreported description of the same workload (a wrong traffic number, a fleet-level figure that should have been
-per-replica, a mistaken SLO value). When the user corrects the contract:
+A correction of fact is the user fixing a misreported description of the same workload (a wrong traffic number, a
+fleet-level figure that should have been per-replica, a mistaken SLO value).
 
-1. Append a correction record to `<EXP_ROOT>/analysis/workload-corrections.jsonl` (append-only) stating what
-   changed, why, when, and which prior runs or iterations it supersedes. Never rewrite or delete prior records.
-2. Mark every run measured under the pre-correction contract as superseded, not invalid: those runs remain evidence
-   about the conditions they actually measured.
-3. Update the contract file in place with the correction noted inline, and recompute its SHA256.
-4. Return the corrected path and SHA256 to the parent for re-handoff: every downstream role holding the
-   pre-correction hash must receive the corrected pair before doing further work. This procedure is the only
-   sanctioned exception to the freeze rule above.
-5. Re-establish the baseline under the corrected contract before proposing any new candidate.
+**Before handoff to `recipe-deployer`**: the contract is still this skill's working file; amend it, note the
+correction inline, and recompute its SHA256.
 
-If the user is genuinely changing the workload rather than correcting its description, the existing rule applies:
-new experiment root.
+**After handoff**: the contract and its hash are frozen and historical artifacts reference them; do not mutate either.
+Instead:
+
+1. Start a new experiment root via this skill, carrying the corrected values forward and re-capturing the canonical
+   DGD copy there.
+2. Write one append-only supersedence marker in the old root, `<OLD_EXP_ROOT>/SUPERSEDED`, recording the corrected
+   field(s), the reason, the timestamp, and the new `EXP_ROOT`. Do not edit or delete any other artifact in the old
+   root: its runs remain valid evidence about the conditions they actually measured.
+3. Re-establish the baseline in the new root before proposing any candidate. Prior conclusions do not carry over;
+   they may be cited as evidence about the superseded conditions.
+
+This makes a post-handoff correction operationally identical to a material workload change (both open a new root);
+the distinction is recorded by the SUPERSEDED marker, not by editing frozen files.
 
 ## Return
 

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -63,9 +63,9 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - Do not add a ceremonial confirmation round when the user's message already provides an unambiguous value.
 - Ask once for the resource envelope: the GPU floor and ceiling in play for this work, whether parallel experiments
   are authorized within the ceiling, any knobs the user forbids changing, and any teardown deadline. Record the
-  answers in the contract's `resources` block. When capacity within the ceiling allows, downstream roles prefer
-  running approved candidates in parallel (one variable per slot, slot attribution in every ledger record) over
-  queueing them serially.
+  answers in the contract's `resources` block. The envelope informs capacity planning; candidates still run serially
+  under the current iteration model (each iteration retires the previous deployment). Do not run candidates in
+  parallel unless artifact roots, DGD names, and teardown ownership are slot-isolated.
 - When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
   numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
   before recording it.
@@ -133,12 +133,15 @@ A correction of fact is different from a material change: the user is not changi
 misreported description of the same workload (a wrong traffic number, a fleet-level figure that should have been
 per-replica, a mistaken SLO value). When the user corrects the contract:
 
-1. Append a correction annotation to the experiment ledger recording what changed, why, and when. Never rewrite or
-   delete prior records.
+1. Append a correction record to `<EXP_ROOT>/analysis/workload-corrections.jsonl` (append-only) stating what
+   changed, why, when, and which prior runs or iterations it supersedes. Never rewrite or delete prior records.
 2. Mark every run measured under the pre-correction contract as superseded, not invalid: those runs remain evidence
    about the conditions they actually measured.
 3. Update the contract file in place with the correction noted inline, and recompute its SHA256.
-4. Re-establish the baseline under the corrected contract before proposing any new candidate.
+4. Return the corrected path and SHA256 to the parent for re-handoff: every downstream role holding the
+   pre-correction hash must receive the corrected pair before doing further work. This procedure is the only
+   sanctioned exception to the freeze rule above.
+5. Re-establish the baseline under the corrected contract before proposing any new candidate.
 
 If the user is genuinely changing the workload rather than correcting its description, the existing rule applies:
 new experiment root.

--- a/.github/ISSUE_TEMPLATE/agent-reported.yml
+++ b/.github/ISSUE_TEMPLATE/agent-reported.yml
@@ -1,0 +1,29 @@
+name: Agent-reported instruction gap
+description: For AI agents using the optimization skills — report instructions that misled, blocked, or contradicted live verification.
+labels: ["agent-reported"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For AI agents. Search existing agent-reported issues before filing; one issue per
+        optimization session; sanitize all user/engagement specifics.
+  - type: input
+    id: agent-identity
+    attributes:
+      label: Agent identity
+      description: Driver model and the skills commit you were running.
+      placeholder: "claude-opus-4-8, skills @ abc1234"
+    validations:
+      required: true
+  - type: textarea
+    id: gap
+    attributes:
+      label: What the instructions said vs what you verified
+      description: Describe the instruction gap only. No user workload details, traffic numbers, cluster/namespace names, company names, or credentials.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested correction
+      description: Optional. The wording you would have needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,12 @@ notices. Two rules:
 1. **Operators: launch unattended runs inside your harness's goal mode.** Goal mode is an operator action at launch,
    not something these instructions can enable mid-run. On Codex CLI, wrap the run in `/goal` with a token budget. On
    Claude Code (v2.1.139+), wrap it in `/goal`; its completion condition is model-evaluated and may include a bound
-   such as "or stop after N turns" as part of the condition text (a soft limit, not a hard budget). If an unattended
+   such as "or stop after N turns" as part of the condition text (a soft limit, not a hard budget). A validated
+   condition template: "Test every lever family that is testable within the authorized budget. Never stop because a
+   report exists. Parked on pending asks with nothing else testable is a valid pause, not completion. Valid stops: an
+   operator-granted stop-request, the authorized budget exhausted, access lost, or operator interrupt." Always name
+   the budget (GPU-hours, wall-clock, failed-deployment limit) in the condition; a bare "never stop" silently relies
+   on credential expiry as its budget. If an unattended
    run is requested and no goal mode or external loop is in place, say so at the start rather than discovering it at
    the first stall.
 2. **Never end a turn on narrated intent during a loop.** Either perform the next step in the same turn, launch it as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,25 @@ user supplied. Do not dispatch `recipe_deployer`, `perf_analyzer`, `hypothesis_g
 `recipe_deployer`; pass the same immutable workload path and hash to every later role. Do not insert a recipe
 exploration or selection step before the baseline deployment.
 
+## Long-Running Runs And Harness Compatibility
+
+An optimization loop is long-running, unattended work. An interactive harness ends its turn whenever the agent stops
+calling tools — a turn that ends on narrated intent ("now I'll test disagg") silently stalls the loop until a human
+notices. Two rules:
+
+1. **Wrap the loop in your harness's goal mode.** On Codex CLI, use `/goal` with a token budget. On Claude Code
+   (v2.1.139+), use `/goal` with an `or stop after N turns` clause. Both keep the loop running until the objective is
+   judged complete or the budget is reached.
+2. **Never end a turn on narrated intent during a loop.** Either perform the next step in the same turn, launch it as
+   background work that will re-invoke you, or return the specific blocking question you need answered.
+
+**Harness tiers.** These roles and skills are developed and tested on Claude Code and Codex CLI (role configurations
+ship for both). The skills follow the Agent Skills open standard and load on other compliant harnesses (for example,
+OpenCode reads `.claude/skills/` and `.agents/skills/` directly), with three known degradations there: no native goal
+mode (run lights-out sessions under an external loop), role isolation may collapse into a single context (weakening
+the independence of adversarial review), and every rule in this pack is prompt-enforced, so discipline depends on the
+driver model. If you hit an instruction gap on any harness, file an issue on this repository describing the gap.
+
 ## Ecosystem
 
 Sibling repositories this repo integrates with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,7 @@ notices. Two rules:
    background work that will re-invoke you, or return the specific blocking question you need answered.
 
 **Harness tiers.** These roles and skills are developed and tested on Claude Code and Codex CLI (role configurations
-ship for both). The skills follow the Agent Skills open standard and load on other compliant harnesses (for example,
-OpenCode reads `.claude/skills/` and `.agents/skills/` directly), with three known degradations there: no native goal
+ship for both). The skills follow the Agent Skills open standard and load on other compliant harnesses (for example, OpenCode includes `.agents/skills/` among its standard skill search paths), with three known degradations there: no native goal
 mode (run lights-out sessions under an external loop), role isolation may collapse into a single context (weakening
 the independence of adversarial review), and every rule in this pack is prompt-enforced, so discipline depends on the
 driver model. If you hit an instruction gap on any harness, file an issue on this repository describing the gap.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,17 @@ exactly. All of this is enforced by `scripts/validate_skills.py` (pre-commit hoo
 `validate-skills`). Changes under `.agents/skills/` are also validated by NVSkills CI —
 a maintainer comments `/nvskills-ci` on the PR.
 
+## Improving These Instructions
+
+If these skills or instructions misled you, blocked you, or contradicted what you verified live, file an issue on
+this repository with the `agent-reported` label. Rules:
+
+1. Search existing `agent-reported` issues first; comment on a duplicate instead of filing a new one.
+2. File at most one issue per optimization session; batch findings into it.
+3. Identify yourself as an AI agent, including your driver model and the skills commit you were running.
+4. Sanitize completely: no user workload details, traffic numbers, cluster or namespace names, company names, or
+   credentials. Describe the instruction gap, not the engagement.
+
 ## Optimization Role Dispatch
 
 When the first user message starts a new Dynamo recipe optimization run, dispatch `user_interviewer` before any other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,17 +82,23 @@ An optimization loop is long-running, unattended work. An interactive harness en
 calling tools — a turn that ends on narrated intent ("now I'll test disagg") silently stalls the loop until a human
 notices. Two rules:
 
-1. **Wrap the loop in your harness's goal mode.** On Codex CLI, use `/goal` with a token budget. On Claude Code
-   (v2.1.139+), use `/goal` with an `or stop after N turns` clause. Both keep the loop running until the objective is
-   judged complete or the budget is reached.
+1. **Operators: launch unattended runs inside your harness's goal mode.** Goal mode is an operator action at launch,
+   not something these instructions can enable mid-run. On Codex CLI, wrap the run in `/goal` with a token budget. On
+   Claude Code (v2.1.139+), wrap it in `/goal`; its completion condition is model-evaluated and may include a bound
+   such as "or stop after N turns" as part of the condition text (a soft limit, not a hard budget). If an unattended
+   run is requested and no goal mode or external loop is in place, say so at the start rather than discovering it at
+   the first stall.
 2. **Never end a turn on narrated intent during a loop.** Either perform the next step in the same turn, launch it as
    background work that will re-invoke you, or return the specific blocking question you need answered.
 
-**Harness tiers.** These roles and skills are developed and tested on Claude Code and Codex CLI (role configurations
-ship for both). The skills follow the Agent Skills open standard and load on other compliant harnesses (for example, OpenCode includes `.agents/skills/` among its standard skill search paths), with three known degradations there: no native goal
-mode (run lights-out sessions under an external loop), role isolation may collapse into a single context (weakening
-the independence of adversarial review), and every rule in this pack is prompt-enforced, so discipline depends on the
-driver model. If you hit an instruction gap on any harness, file an issue on this repository describing the gap.
+**Harness tiers.** These roles and skills are developed and tested on Claude Code and Codex CLI. Isolated role
+configurations currently ship for Codex only (`.codex/agents/*.toml`); on Claude Code the roles run in-context within
+one session (no `.claude/agents/` configurations yet), so adversarial review there is same-context review, not an
+independent reviewer. The skills follow the Agent Skills open standard and load on other compliant harnesses (for
+example, OpenCode includes `.agents/skills/` among its standard skill search paths), with the same in-context role
+caveat plus two more degradations: no native goal mode (run lights-out sessions under an external loop), and every
+rule in this pack is prompt-enforced, so discipline depends on the driver model. If you hit an instruction gap on any
+harness, prepare a sanitized issue describing the gap and ask your operator to approve filing it on this repository.
 
 ## Ecosystem
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,14 +68,15 @@ a maintainer comments `/nvskills-ci` on the PR.
 
 ## Improving These Instructions
 
-If these skills or instructions misled you, blocked you, or contradicted what you verified live, file an issue on
-this repository with the `agent-reported` label. Rules:
+If these skills or instructions misled you, blocked you, or contradicted what you verified live, prepare an issue for
+this repository with the `agent-reported` label and ask your operator to approve filing it — filing is an external
+write and requires operator consent. Rules:
 
-1. Search existing `agent-reported` issues first; comment on a duplicate instead of filing a new one.
-2. File at most one issue per optimization session; batch findings into it.
+1. Search existing `agent-reported` issues first; propose commenting on a duplicate instead of filing a new one.
+2. Prepare at most one issue per optimization session; batch findings into it.
 3. Identify yourself as an AI agent, including your driver model and the skills commit you were running.
 4. Sanitize completely: no user workload details, traffic numbers, cluster or namespace names, company names, or
-   credentials. Describe the instruction gap, not the engagement.
+   credentials. Describe the instruction gap, not the engagement. Show the operator the full draft before filing.
 
 ## Optimization Role Dispatch
 

--- a/agent-docs/guides/knob-tuning/tuning-hierarchy.md
+++ b/agent-docs/guides/knob-tuning/tuning-hierarchy.md
@@ -26,17 +26,24 @@ If the current configuration did not engage or the run is invalid, repair or rem
 optimization.
 
 
-## Category 1 — Deployment Topology and Fit
+## Category 1 — Deployment Topology and Operating Regime
 
-First ask whether the deployment shape can efficiently serve the user workload. Topology is a hypothesis category,
-not only a deploy-time fit check: a configuration that fits can still be the wrong shape for the operating point.
-Evaluate topology in this order:
+First ask whether the deployment shape can efficiently serve the user workload. Topology sets four things at once,
+and only one of them is memory: per-rank effective batch and arithmetic intensity (the throughput axis); weight and
+KV memory footprint (the fit axis); the collective-communication pattern and volume (TP all-reduce, EP all-to-all,
+none for DP); and whether attention and weights are replicated or sharded. Do not evaluate a topology change on
+memory alone: when memory is not binding, the topology question is not closed; it moves to compute and
+communication. A configuration that fits can still be the wrong shape for the operating point. Evaluate topology in
+this order:
 
 1. Compute the model, activation, and KV-memory fit and establish the minimum viable TP, PP, and EP.
-2. Compute the effective per-rank batch at the target concurrency: a data-parallel layout that leaves each rank a
-   trivial batch under-utilizes compute even though it fits.
-3. Prefer the smallest parallelism that fits with operating headroom and a useful per-rank batch at the target
-   concurrency, then use remaining fixed-budget GPUs for replicas when the workload can benefit from them.
+2. Compute the effective per-rank batch at the target concurrency: data parallelism serves batch/N per replica,
+   shrinking per-rank batch and starving compute even though everything fits, while tensor parallelism runs the
+   whole batch through one sharded forward pass, raising per-rank batch and freeing memory at the cost of
+   collective communication.
+3. Among layouts that fit with operating headroom, prefer the one that maximizes useful per-rank batch and compute
+   efficiency at the target concurrency, then weigh its communication cost; fit is a constraint, not the objective.
+   Use remaining fixed-budget GPUs for replicas when the workload can benefit from them.
 4. Consider aggregated versus disaggregated serving only when workload shape, scale, or independent prefill/decode
    objectives justify the transfer and coordination cost.
 5. For an existing disaggregated deployment, check prefill/decode allocation and rate matching before adding workers.

--- a/agent-docs/guides/knob-tuning/tuning-hierarchy.md
+++ b/agent-docs/guides/knob-tuning/tuning-hierarchy.md
@@ -28,19 +28,27 @@ optimization.
 
 ## Category 1 — Deployment Topology and Fit
 
-First ask whether the deployment shape can efficiently serve the user workload. This is a screening decision, not an
-automatic topology experiment. Evaluate topology in this order:
+First ask whether the deployment shape can efficiently serve the user workload. Topology is a hypothesis category,
+not only a deploy-time fit check: a configuration that fits can still be the wrong shape for the operating point.
+Evaluate topology in this order:
 
 1. Compute the model, activation, and KV-memory fit and establish the minimum viable TP, PP, and EP.
-2. Prefer the smallest parallelism that fits with operating headroom, then use remaining fixed-budget GPUs for
-   replicas when the workload can benefit from them.
-3. Consider aggregated versus disaggregated serving only when workload shape, scale, or independent prefill/decode
+2. Compute the effective per-rank batch at the target concurrency: a data-parallel layout that leaves each rank a
+   trivial batch under-utilizes compute even though it fits.
+3. Prefer the smallest parallelism that fits with operating headroom and a useful per-rank batch at the target
+   concurrency, then use remaining fixed-budget GPUs for replicas when the workload can benefit from them.
+4. Consider aggregated versus disaggregated serving only when workload shape, scale, or independent prefill/decode
    objectives justify the transfer and coordination cost.
-4. For an existing disaggregated deployment, check prefill/decode allocation and rate matching before adding workers.
-5. Verify node placement and the required fast fabric when the selected topology crosses GPUs or nodes.
+5. For an existing disaggregated deployment, check prefill/decode allocation and rate matching before adding workers.
+6. Verify node placement and the required fast fabric when the selected topology crosses GPUs or nodes.
 
-Choose a topology hypothesis only when model sizing, Kubernetes or engine evidence, rate imbalance, transfer behavior,
-or same-regime history supports a structural mismatch. Consult the
+Choose a topology hypothesis when model-sizing arithmetic, per-rank batch at the target concurrency, Kubernetes or
+engine evidence, rate imbalance, transfer behavior, same-regime history, or a sibling recipe for the same model on
+other hardware supports a structural mismatch. Sibling recipes are hypothesis priors, not adoption evidence: even
+when their checkpoint or hardware is incompatible, their parallelism and serving-mode choices transfer as candidates.
+Rank candidate layouts cheaply (sizing arithmetic, projections, published same-model recipes) before spending a
+deployment on one, and revisit topology after baseline characterization and whenever the measured regime changes; an
+inherited layout is a candidate like any other, not a settled decision. Consult the
 [model-sizing guides](../model-sizing/classification.md) and, for disaggregated serving,
 [rate matching](../rate-matching/matching.md).
 

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -136,8 +136,24 @@ Keep every previous manifest, consultation, review, and benchmark artifact uncha
 After deployment, choose the benchmark based on the approved performance question. It may reuse an applicable series
 or create a new one. Never claim a direct gain across series.
 
-Stop when the user constraints are met, no useful optimization ideas remain, the user-specified budget is exhausted,
-or the generator returns `no-proposal`.
+The loop is always in exactly one state: `ACTIVE`, `PARKED_ON_ASKS`, `STOP_REQUESTED`, `STOP_GRANTED`, or
+`BUDGET_STOP`. A `no-proposal` consultation never ends the engagement; it obligates the generator to produce exactly
+one of:
+
+- the next candidate;
+- an **ask**: a recorded question whose answer would unblock the highest-value deferred lever family. Asks are
+  non-blocking: record the ask, surface it in one line of passing output, and keep working any still-testable
+  family. Deduplicate pending asks, surface only the highest-value few, and lead the next operator-facing response
+  with them. Enter `PARKED_ON_ASKS` (a pause, not a stop) only when pending asks are the only remaining work, and
+  record how deployed resources are held and when they scale down;
+- a **stop-request**: the search-calibration record in a terminal state, meaning every lever family is `tested`,
+  `asked` and answered, `ruled-out`, or `deferred`. A `ruled-out` row must cite a measurement, a sourced hard
+  constraint, a confirmed incompatibility, or an explicit operator decision; the generator's own unsourced reasoning
+  does not qualify, and expected upside below the minimum detectable effect is `deferred`, not `ruled-out`. Hand the
+  stop-request to `hypothesis-challenger` for evidence-class validation.
+
+Stop only when the operator grants a validated stop-request (`STOP_GRANTED`), the authorized budget is exhausted
+(`BUDGET_STOP`), or access is lost and cannot be restored. Never stop because a report exists.
 
 ## 7. Finalize
 

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -157,6 +157,14 @@ Stop only when the operator grants a validated stop-request (`STOP_GRANTED`), th
 
 ## 7. Finalize
 
+Before recommending, run a correctness regression check whenever the recommended configuration differs from the
+user-provided baseline in an output-affecting dimension (parallelism or reduction order, speculative decoding,
+quantization, attention or MoE backend, KV dtype or reuse): replay 8-16 fixed representative prompts with frozen
+continuations through both configurations and compare teacher-forced per-token log-probabilities, calibrating the
+tolerance with a baseline-versus-baseline repeat; require zero request failures, malformed responses, non-finite
+scores, and no unexpected truncation. If no such check is possible, record an ask; report a waived check as
+`correctness: unverified`, never as a pass. Record the correctness status in `recommended_config.md`.
+
 Recommend the best valid candidate for the target objective, not automatically the most recent iteration. Write the
 final configuration to `EXP_ROOT/final/recommended_config.md`, reproduction commands to
 `EXP_ROOT/final/reproduced_commands.sh`, and limitations to `EXP_ROOT/final/known_limitations.md`. Include paths to the

--- a/agent-docs/rules/benchmarking/comparison-uncertainty.md
+++ b/agent-docs/rules/benchmarking/comparison-uncertainty.md
@@ -5,16 +5,32 @@ SPDX-License-Identifier: Apache-2.0
 
 # Comparison Uncertainty
 
-Default to one measured AIPerf run per candidate. Configure each measured run to finish in 30 minutes or less. GPU
-benchmarking is expensive, so do not collect repetitions only to produce confidence intervals.
+Default to one measured AIPerf run per candidate. Configure each measured run to finish in 30 minutes or less
+unless the operator authorizes longer windows; record any such authorization in the benchmark plan. GPU benchmarking
+is expensive, so do not collect repetitions only to produce confidence intervals.
 
 ## Default Decision Policy
 
 - **Current result**: the configuration being evaluated.
 - **Reference result**: the valid baseline or prior configuration used for comparison.
 - Compare the same metric, statistic, unit, workload phase, and benchmark-series identity.
-- Classify an absolute performance change of `0.5%` or less as noise. Report it without automatically repeating the
-  benchmark.
+- Establish the noise floor of each benchmark series empirically before adopting or retiring any candidate on a
+  small delta: run a pilot repetition (n=3) of one configuration at the decision point, compute the run-to-run
+  spread, and derive the minimum detectable effect. Treat any default percentage as a placeholder, never as a
+  measured floor; uncontrolled state such as prefix-cache carryover can put the real floor an order of magnitude
+  higher.
+- Screening and categorical outcomes (OOM, error storms, wide-margin SLO results) remain valid at n=1.
+- For adopt-or-retire decisions inside the noise band, use paired repetitions with controlled or deliberately
+  randomized warmup and cache state (for example concurrent arms on separate nodes, or AB/BA ordering), analyze the
+  paired differences rather than comparing two means, and add repetitions sequentially up to a declared maximum while
+  the interval overlaps the decision boundary.
+- Give the selected finalist a fresh confirmatory repetition after selection: adaptive search across many candidates
+  inflates the best observed result.
+- Keep practical significance separate from detectability: state the smallest delta that matters for the engagement
+  and do not claim gains below it regardless of statistical separation.
+- Record neighbour occupancy (what else runs on the node) with every measurement and compare only like with like. A
+  fleet or full-node projection from idle-neighbour measurements is invalid until confirmed by one co-located
+  measurement with load generation verified unsaturated.
 - A clear, substantial improvement or regression may support a conclusion from one valid, isolated, plausible run.
   State that the comparison is single-run evidence.
 - Repeat a valid benchmark only when the existing evidence cannot support a consequential decision, another run is

--- a/agent-docs/rules/execution/run-artifacts.md
+++ b/agent-docs/rules/execution/run-artifacts.md
@@ -92,6 +92,10 @@ runs/<EXP_ID>/
 - `knowledge-consult.md`: required consultation result for `proposed`, `no-proposal`, and `blocked` outcomes.
 - `deploy-draft.yaml`: candidate DGD created only for a materialized proposal; it remains here until challenger
   approval assigns it to the next deployment iteration.
+- `asks.jsonl` (under `EXP_ROOT/analysis/`): append-only operator-ask record with the question, blocked lever
+  family, expected upside, status (`pending` or `answered`), and the answer once received. Deduplicate before
+  appending. A stop-request is not a separate file: it is the terminal search-calibration record in
+  `knowledge-consult.md` plus its challenger validation.
 
 ## Deployment Directories
 

--- a/agent-docs/rules/execution/user-workload.md
+++ b/agent-docs/rules/execution/user-workload.md
@@ -66,11 +66,8 @@ preferences:
   mode: ""                         # agg, disagg
 
 resources:
-  gpu_floor: null                  # GPUs guaranteed available to this work
-  gpu_ceiling: null                # maximum GPUs the user authorizes, across all concurrent experiments
-  parallel_experiments: null      # user authorization for concurrent candidates (advisory until the loop supports slot isolation)
+  gpu_ceiling: null                # maximum total GPUs the user authorizes this run to hold at once
   pinned: []                       # configuration knobs the user forbids changing (e.g. ["mode", "precision"])
-  teardown_deadline: ""            # optional wall-clock bound by which all run resources must be gone
 
 objectives:
   ttft_ms_p95_max: null            # optional time to first token
@@ -100,8 +97,10 @@ created_at: ""
   `deployment.dgd_sha256` to match that file.
 - `kube_context` and `namespace` are required. The namespace must already exist.
 - Treat `resources.gpu_ceiling` as authorization, not entitlement: every GPU-consuming experiment still requires its
-  own evidence and adversarial review. Treat `resources.pinned` entries as hard constraints enforced at hypothesis
-  review and deploy preflight, not as style preferences.
+  own evidence and adversarial review. `hardware[]` describes what the workload serves on; `gpu_ceiling` bounds the
+  run's total concurrent GPU holdings and must be at least the assigned DGD's total request. When unset, the assigned
+  DGD's own footprint is the bound. `hypothesis-challenger` must reject candidates that change a `pinned` knob or
+  exceed `gpu_ceiling`; `deploy-dynamo-recipe` preflight must verify both before mutation.
 - `storage_class` is optional when the required PVC already exists or a suitable cluster default is known. If the run
   must create a PVC and no suitable class can be determined safely, return a focused question to the user.
 - Token lengths are optional customer-provided traffic hints, not required benchmark keys. Prefer real traces or

--- a/agent-docs/rules/execution/user-workload.md
+++ b/agent-docs/rules/execution/user-workload.md
@@ -65,6 +65,13 @@ preferences:
   framework: ""                    # vLLM, SGLang, or TRT-LLM
   mode: ""                         # agg, disagg
 
+resources:
+  gpu_floor: null                  # GPUs guaranteed available to this work
+  gpu_ceiling: null                # maximum GPUs the user authorizes, across all concurrent experiments
+  parallel_experiments: null      # whether the user authorizes concurrent candidate experiments within the ceiling
+  pinned: []                       # configuration knobs the user forbids changing (e.g. ["mode", "precision"])
+  teardown_deadline: ""            # optional wall-clock bound by which all run resources must be gone
+
 objectives:
   ttft_ms_p95_max: null            # optional time to first token
   itl_ms_p95_max: null             # optional inter-token-latency
@@ -92,6 +99,9 @@ created_at: ""
 - Require `deployment.dgd_path` to resolve to `<EXP_ROOT>/inputs/user_provided_dgd.yaml`, and require
   `deployment.dgd_sha256` to match that file.
 - `kube_context` and `namespace` are required. The namespace must already exist.
+- Treat `resources.gpu_ceiling` as authorization, not entitlement: every GPU-consuming experiment still requires its
+  own evidence and adversarial review. Treat `resources.pinned` entries as hard constraints enforced at hypothesis
+  review and deploy preflight, not as style preferences.
 - `storage_class` is optional when the required PVC already exists or a suitable cluster default is known. If the run
   must create a PVC and no suitable class can be determined safely, return a focused question to the user.
 - Token lengths are optional customer-provided traffic hints, not required benchmark keys. Prefer real traces or

--- a/agent-docs/rules/execution/user-workload.md
+++ b/agent-docs/rules/execution/user-workload.md
@@ -68,7 +68,7 @@ preferences:
 resources:
   gpu_floor: null                  # GPUs guaranteed available to this work
   gpu_ceiling: null                # maximum GPUs the user authorizes, across all concurrent experiments
-  parallel_experiments: null      # whether the user authorizes concurrent candidate experiments within the ceiling
+  parallel_experiments: null      # user authorization for concurrent candidates (advisory until the loop supports slot isolation)
   pinned: []                       # configuration knobs the user forbids changing (e.g. ["mode", "precision"])
   teardown_deadline: ""            # optional wall-clock bound by which all run resources must be gone
 

--- a/agent-docs/rules/verification/overlap.md
+++ b/agent-docs/rules/verification/overlap.md
@@ -5,7 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # Overlap
 
-Classify an absolute performance change of `0.5%` or less as noise and report it without automatically repeating the
+Classify an absolute performance change at or below the measured noise floor of the active benchmark series (see
+`comparison-uncertainty.md`) as noise and report it without automatically repeating the
 benchmark. A clear, substantial gain or loss may support a conclusion from one valid, isolated, plausible run; identify
 it as single-run evidence.
 

--- a/agents/hypothesis-challenger/AGENTS.md
+++ b/agents/hypothesis-challenger/AGENTS.md
@@ -64,8 +64,12 @@ Do not:
 - exact `<DEPLOY_ROOT>/next-candidate/deploy-draft.yaml` path
 - prior deployment, benchmark, hypothesis, and challenger-review history
 
-Review only a materialized proposal. For a `no-proposal` or `blocked` consultation, return without creating a candidate
-review.
+Review a materialized proposal or a stop-request. For a `no-proposal` or `blocked` consultation that carries no
+stop-request, return without creating a candidate review. For a stop-request, validate completeness and evidence
+class: every lever family carries a terminal disposition, and every `ruled-out` row cites a measurement, a sourced
+hard constraint, a confirmed incompatibility, or an explicit operator decision. Append the verdict to
+`challenger-reviews.jsonl` as for any review, and state in it that this is procedural validation, not independent
+adversarial assurance.
 
 Before reviewing, require every input path to exist under the assigned `EXP_ROOT`, recompute the user-workload,
 source, consultation, and draft hashes, and verify that the source benchmark artifacts identify the same active

--- a/agents/hypothesis-generator/AGENTS.md
+++ b/agents/hypothesis-generator/AGENTS.md
@@ -113,7 +113,9 @@ For a proposed candidate, write these files under `DEPLOY_ROOT/next-candidate/` 
 - `deploy-draft.yaml`: the complete candidate DGD containing only the resolved selected change.
 
 For `no-proposal` or `blocked`, write `knowledge-consult.md` with the decision and supporting evidence, but do not
-create a misleading `deploy-draft.yaml`.
+create a misleading `deploy-draft.yaml`. Neither outcome ends the engagement: follow the ask and stop-request
+obligations in the optimization loop's Iterate Or Stop step, including its evidence classes for terminal
+dispositions.
 
 Return exact paths and SHA256 hashes, not only filenames or iteration numbers. Never overwrite an existing
 `next-candidate/` record whose source hash or semantic diff identifies a different proposal.

--- a/agents/perf-analyzer/AGENTS.md
+++ b/agents/perf-analyzer/AGENTS.md
@@ -44,6 +44,8 @@ benchmarking begins. Define the performance question before selecting the benchm
 - Verify config engagement and benchmark isolation, and record the runtime, resources, and execution details.
 - Default to one measured run of 30 minutes or less. Preserve its configuration and raw artifacts unchanged.
 - Evaluate target SLOs and compare only valid same-series results, reporting absolute metrics, deltas, and uncertainty.
+- When the measured SLO boundary falls within one concurrency step of the operating point, report throughput at the
+  floor and one step past it, so the operator can judge whether the floor's exact value is load-bearing.
 - Write the required machine-readable and Markdown outputs, or return a structured blocker.
 
 ## Do Not


### PR DESCRIPTION
Third PR from extended clean-room UAT of the optimization skill pack. **Stacked on #12825 and #12858** — only the last six commits are new here; this merges cleanly once both land.

## Findings driving this PR

Two full clean-room engagements (DeepSeek-V4-Flash, adapting the H200 agentic recipe to an H100 cluster) exercised the pack end to end:

1. **Both engagements self-declared completion prematurely** through the loop's self-judged exits ("no useful optimization ideas remain" / generator `no-proposal`). The second did so with **zero measured improvement**, recommending the unmodified port. When the operator forced continuation, the same agent then tested 20 candidates across 9 lever families and found **+99% output tok/s/GPU (t = 10.22, reproduced 6/6)** — a win every existing gate had approved stopping without. The stopping decision was also the only verdict the challenger never reviewed.
2. **The winner was a Category 1 topology change** (inherited DP4+EP replaced by TP4), screened as "model fits" at iteration 000 and unrevisited for twelve knob iterations — while a sibling recipe for the same model carried the answer the whole time. Fitting is not the same as fitting well: at the operating point, DP4 gave each rank a batch of two sequences.
3. **The documented 0.5% noise floor was wrong ~20x** on the target setup (~13% run-to-run, driven by prefix-cache state). A +5.6% single-run "best of run" was retracted at paired n=3 (−4.6%). Every knob-level delta of the engagement was inside the noise band.
4. **Idle-neighbour measurements over-projected fleet capacity ~1.8x** until a co-located test was run.
5. **Recommendations were promoted with no output-quality verification** — the loop has no correctness path at all.

## Changes

- **Stop-request protocol** (`optimize-loop.md` §6, both hypothesis roles, `run-artifacts.md`): `no-proposal` never ends the engagement; the generator produces a candidate, a non-blocking **ask**, or a **stop-request** (the search-calibration record in a terminal state, with evidence classes required for `ruled-out`). The challenger validates stop-requests procedurally. Stops are operator-granted; budget exhaustion and access loss remain unconditional.
- **Topology restored as a hypothesis category** (`tuning-hierarchy.md`): per-rank batch joins the fit evaluation; sibling recipes and cheap layout ranking join the admissible evidence (as priors, not adoption evidence); topology is revisited after baseline characterization. Anti-churn guardrails retained unchanged.
- **Measurement validity** (`comparison-uncertainty.md` + references): empirical per-series noise floors, paired-difference analysis with sequential replication, a fresh confirmatory run for the finalist, practical significance separated from detectability, neighbour-occupancy recording with a co-location requirement before fleet projections. Screening and categorical outcomes stay valid at n=1.
- **Correctness regression gate** (`optimize-loop.md` §7): teacher-forced per-token logprob comparison on frozen continuations before recommending any output-affecting change; waivers reported as `correctness: unverified`, never as a pass.
- **Persistent calibration ledger** (`consult-perf-knowledge`): replaces the per-hypothesis full rescan; adds the `deferred` disposition so below-MDE candidates stay visible instead of being ruled out.
- **Docs**: validated unattended-run goal-condition template with an explicit campaign envelope; SLO-knee sensitivity reporting in the analyzer.

## Design notes

- Challenger review of stop-requests is labeled what it is: completeness/evidence-class validation, not independent adversarial assurance (per the in-context role caveat documented in #12858). It still earned its keep in UAT, killing one candidate revision pre-GPU on a mechanistic objection.
- Asks are non-blocking by design so unattended runs never hang on a question; `PARKED_ON_ASKS` records resource disposition so a parked engagement doesn't squat GPUs.
- The statistical protocol was revised after cross-model adversarial review (paired differences rather than two-sample comparisons, sequential replication, winner's-curse control).

## Future work

- [ ] Content-valid speculative-decoding measurement loop — #12918
- [ ] Port a full accuracy-gate skill (the teacher-forced check is a regression smoke test, not an eval)
- [ ] Validate a standing settings-level goal hook for dedicated unattended rigs (vs per-session goal mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->