### PR TITLE
refactor(vllm): add reusable decoder runtime

### DIFF
--- a/components/src/dynamo/vllm/decoder_runtime.py
+++ b/components/src/dynamo/vllm/decoder_runtime.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared Dynamo-to-vLLM decoder implementation."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Mapping
+from enum import Enum
+from typing import Any, cast
+
+from vllm.config import ModelConfig, VllmConfig
+from vllm.outputs import RequestOutput
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+from vllm.v1.engine.async_llm import AsyncLLM
+
+from dynamo.common.backend import GenerateChunk, GenerateRequest
+from dynamo.common.backend import logprobs as _shared_logprobs
+from dynamo.llm.exceptions import InvalidArgument
+
+from .decoder_output import ExtractLogprobs, _VllmDecodeOutputAdapter
+from .decoder_sampling import build_sampling_params
+
+GenerateFactory = Callable[[Any], AsyncIterator[RequestOutput]]
+GenerationAdmission = Callable[[Any, GenerateFactory], AsyncIterator[RequestOutput]]
+_LORA_UNSET = object()
+
+
+class DecodeOutputMode(Enum):
+    """Native output shape requested by a Dynamo decoder adapter."""
+
+    STREAM_DELTA = RequestOutputKind.DELTA
+    FINAL_ONLY = RequestOutputKind.FINAL_ONLY
+
+
+class VllmDecoderRuntime:
+    """Own and drive one native vLLM decoder for Dynamo adapters."""
+
+    def __init__(
+        self,
+        *,
+        engine: AsyncLLM,
+        vllm_config: VllmConfig,
+        default_sampling_params: Mapping[str, Any] | None,
+    ) -> None:
+        self._engine: AsyncLLM | None = engine
+        self._vllm_config = vllm_config
+        self._default_sampling_params = dict(default_sampling_params or {})
+
+    @property
+    def engine(self) -> AsyncLLM:
+        """Return the native engine while this runtime is active."""
+
+        if self._engine is None:
+            raise RuntimeError("VllmDecoderRuntime is shut down")
+        return self._engine
+
+    @property
+    def vllm_config(self) -> VllmConfig:
+        return self._vllm_config
+
+    @property
+    def model_config(self) -> ModelConfig:
+        return self._vllm_config.model_config
+
+    @property
+    def default_sampling_params(self) -> Mapping[str, Any]:
+        return self._default_sampling_params
+
+    def prepare_sampling_params(
+        self,
+        request: GenerateRequest | Mapping[str, Any],
+        *,
+        enable_rl: bool = False,
+        prompt: Any | None = None,
+        output_mode: DecodeOutputMode = DecodeOutputMode.STREAM_DELTA,
+    ) -> SamplingParams:
+        """Translate a Dynamo request and enforce the resolved prompt budget."""
+
+        request_dict = cast(dict[str, Any], request)
+        prepared_token_ids = (
+            prompt.get("prompt_token_ids") if isinstance(prompt, Mapping) else None
+        )
+        prompt_token_count = len(
+            prepared_token_ids
+            if prepared_token_ids is not None
+            else request_dict.get("token_ids") or []
+        )
+
+        available_tokens = self.model_config.max_model_len - prompt_token_count
+        if available_tokens < 1:
+            raise InvalidArgument(
+                "prepared decoder prompt leaves no room for generation: "
+                f"prompt_tokens={prompt_token_count}, "
+                f"max_model_len={self.model_config.max_model_len}"
+            )
+        requested_max_tokens = (request_dict.get("stop_conditions") or {}).get(
+            "max_tokens"
+        )
+        if requested_max_tokens is not None and requested_max_tokens > available_tokens:
+            raise InvalidArgument(
+                "requested max_tokens exceeds the prepared prompt budget: "
+                f"max_tokens={requested_max_tokens}, available={available_tokens}"
+            )
+
+        sampling_params = build_sampling_params(
+            request_dict,
+            dict(self._default_sampling_params),
+            model_max_len=self.model_config.max_model_len,
+            enable_rl=enable_rl,
+            prompt_token_count_override=prompt_token_count,
+        )
+        sampling_params.detokenize = False
+        sampling_params.output_kind = output_mode.value
+        return sampling_params
+
+    async def decode(
+        self,
+        prompt: Any,
+        sampling_params: SamplingParams,
+        request_id: str,
+        *,
+        engine_options: Mapping[str, Any] | None = None,
+        lora_request: Any = _LORA_UNSET,
+        admission: GenerationAdmission | None = None,
+        extract_logprobs: ExtractLogprobs | None = None,
+    ) -> AsyncIterator[GenerateChunk]:
+        """Run native generation and emit canonical Dynamo token chunks."""
+
+        options = dict(engine_options or {})
+
+        def create_generator(
+            admitted_lora_request: Any,
+        ) -> AsyncIterator[RequestOutput]:
+            admitted_options = dict(options)
+            if admitted_lora_request is not _LORA_UNSET:
+                admitted_options["lora_request"] = admitted_lora_request
+            return self.engine.generate(
+                prompt,
+                sampling_params,
+                request_id,
+                **admitted_options,
+            )
+
+        if admission is None:
+            native_stream = create_generator(lora_request)
+        else:
+            native_stream = admission(lora_request, create_generator)
+
+        output_adapter = _VllmDecodeOutputAdapter(
+            sampling_params,
+            tokenizer=getattr(self.engine, "tokenizer", None),
+            extract_logprobs=extract_logprobs or self._extract_logprobs,
+        )
+        async for response in native_stream:
+            for chunk in output_adapter.convert(response):
+                yield cast(GenerateChunk, chunk)
+            # Preserve the production handler's terminal handling for a native
+            # response with no choices. The adapter emits one error chunk; no
+            # later engine responses should leak through for the same request.
+            if not response.outputs:
+                break
+
+    @staticmethod
+    def _extract_logprobs(
+        output: Any,
+        num_output_tokens_so_far: int,
+        tokenizer: Any = None,
+    ) -> tuple[list[float] | None, list[list[dict]] | None]:
+        return _shared_logprobs.extract_from_completion_output(
+            output,
+            num_output_tokens_so_far,
+            tokenizer=tokenizer,
+            fallback_to_first_on_missing=True,
+            include_bytes=True,
+        )
+
+    async def abort(self, request_id: str) -> None:
+        """Abort an active request if the runtime has not been shut down."""
+
+        engine = self._engine
+        if engine is not None:
+            await engine.abort(request_id)
+
+    def shutdown(self) -> None:
+        """Shut down the native engine at most once."""
+
+        engine = self._engine
+        self._engine = None
+        if engine is not None:
+            engine.shutdown(timeout=self._vllm_config.shutdown_timeout)

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -86,6 +86,7 @@ from .args import Config
 from .cache_info import get_configured_kv_event_block_size
 from .capacity import publish_vllm_token_budget
 from .constants import DisaggregationMode, EmbeddingTransferMode
+from .decoder_runtime import VllmDecoderRuntime
 from .engine_monitor import VllmEngineMonitor
 from .lora_state import LoRAState
 from .multimodal_utils.custom_encoder import (
@@ -2637,6 +2638,36 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         else:
             logger.debug(formatted_message)
 
+
+class DecodeWorkerHandler(BaseWorkerHandler):
+    def __init__(
+        self,
+        runtime,
+        config: Config,
+        decoder_runtime: VllmDecoderRuntime,
+        enable_multimodal: bool = False,
+        generate_endpoint=None,
+        use_vllm_tokenizer: bool = False,
+        shutdown_event: asyncio.Event | None = None,
+        enable_frontend_decoding: bool = False,
+        encode_worker_client: Client | None = None,
+    ):
+        self.decoder_runtime = decoder_runtime
+        super().__init__(
+            runtime,
+            config,
+            decoder_runtime.engine,
+            decoder_runtime.default_sampling_params,
+            model_max_len=decoder_runtime.model_config.max_model_len,
+            model_config=decoder_runtime.model_config,
+            enable_multimodal=enable_multimodal,
+            generate_endpoint=generate_endpoint,
+            use_vllm_tokenizer=use_vllm_tokenizer,
+            shutdown_event=shutdown_event,
+            enable_frontend_decoding=enable_frontend_decoding,
+            encode_worker_client=encode_worker_client,
+        )
+
     async def generate_tokens(
         self,
         prompt,
@@ -2649,99 +2680,57 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         reasoning_ended=None,
         reasoning_parser_kwargs=None,
     ):
+        """Generate canonical token chunks through the shared decoder runtime."""
+
         try:
-            # Log LoRA usage for this generation (debug level to avoid log spam)
             self._log_with_lora_context(
                 "Starting token generation for request {request_id}{lora_info}",
                 request_id,
                 lora_request,
             )
-            gen = self._generate_with_lora_admission_lock(
-                lora_request,
-                lambda admitted_lora_request: self.engine_client.generate(
-                    prompt,
-                    sampling_params,
-                    request_id,
-                    lora_request=admitted_lora_request,
-                    data_parallel_rank=data_parallel_rank,
-                    trace_headers=trace_headers,
-                    priority=priority,
-                    **_engine_generate_reasoning_kwargs(
-                        self.engine_client,
-                        reasoning_ended,
-                        reasoning_parser_kwargs,
-                    ),
+            engine_options = {
+                "data_parallel_rank": data_parallel_rank,
+                "trace_headers": trace_headers,
+                "priority": priority,
+                **_engine_generate_reasoning_kwargs(
+                    self.engine_client,
+                    reasoning_ended,
+                    reasoning_parser_kwargs,
                 ),
-            )
-
-            output_adapter = _VllmDecodeOutputAdapter(
+            }
+            async for chunk in self.decoder_runtime.decode(
+                prompt,
                 sampling_params,
-                tokenizer=getattr(self.engine_client, "tokenizer", None),
+                request_id,
+                engine_options=engine_options,
+                lora_request=lora_request,
+                admission=self._generate_with_lora_admission_lock,
                 extract_logprobs=self._extract_logprobs,
-            )
-            async for res in gen:
-                if not res.outputs:
-                    self._log_with_lora_context(
-                        "Request {request_id}{lora_info} returned no outputs",
-                        request_id,
-                        lora_request,
-                    )
-                    for chunk in output_adapter.convert(res):
-                        yield chunk
-                    break
-                for chunk in output_adapter.convert(res):
-                    finish_reason = chunk.get("finish_reason")
-                    if finish_reason:
-                        output_index = int(chunk.get("index") or 0)
+            ):
+                finish_reason = chunk.get("finish_reason")
+                if finish_reason:
+                    if str(finish_reason).startswith("error"):
+                        self._log_with_lora_context(
+                            "Request {request_id}{lora_info} returned no outputs",
+                            request_id,
+                            lora_request,
+                        )
+                    else:
+                        usage = chunk.get("completion_usage") or {}
                         self._log_with_lora_context(
                             "Completed token generation for request {request_id}{lora_info}: "
                             "{output_tokens} output tokens, finish_reason={finish_reason}",
                             request_id,
                             lora_request,
-                            output_tokens=output_adapter.completion_tokens(
-                                output_index
-                            ),
+                            output_tokens=usage.get("completion_tokens", 0),
                             finish_reason=finish_reason,
                         )
-                    yield chunk
-
+                yield chunk
         except EngineDeadError as e:
             logger.error(f"vLLM EngineDeadError: {e}")
             logger.warning("Initiating Dynamo Runtime shutdown.")
             self.runtime.shutdown()
             os._exit(1)
-
-
-class DecodeWorkerHandler(BaseWorkerHandler):
-    def __init__(
-        self,
-        runtime,
-        config: Config,
-        engine,
-        default_sampling_params,
-        model_max_len: int | None = None,
-        model_config: ModelConfig | None = None,
-        enable_multimodal: bool = False,
-        generate_endpoint=None,
-        use_vllm_tokenizer: bool = False,
-        shutdown_event: asyncio.Event | None = None,
-        enable_frontend_decoding: bool = False,
-        encode_worker_client: Client | None = None,
-    ):
-        super().__init__(
-            runtime,
-            config,
-            engine,
-            default_sampling_params,
-            model_max_len=model_max_len,
-            model_config=model_config,
-            enable_multimodal=enable_multimodal,
-            generate_endpoint=generate_endpoint,
-            use_vllm_tokenizer=use_vllm_tokenizer,
-            shutdown_event=shutdown_event,
-            enable_frontend_decoding=enable_frontend_decoding,
-            encode_worker_client=encode_worker_client,
-        )
 
     async def generate(self, request, context):
         # Use context ID for request tracking and correlation
@@ -2949,12 +2938,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         _apply_nvext_cache_salt(request, prompt)
 
-        # Build sampling params from request
-        sampling_params = build_sampling_params(
+        # Build sampling params through the shared decoder implementation.
+        sampling_params = self.decoder_runtime.prepare_sampling_params(
             request,
-            self.default_sampling_params,
-            self.model_max_len,
             enable_rl=self.config.enable_rl,
+            prompt=prompt,
         )
 
         if kv_params is not None:

--- a/components/src/dynamo/vllm/tests/test_vllm_decoder_runtime.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_decoder_runtime.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from vllm.sampling_params import SamplingParams
+
+pytest.importorskip(
+    "vllm.v1.engine.async_llm",
+    reason="a full vLLM installation is required by the decoder runtime",
+)
+
+from dynamo.vllm.decoder_runtime import VllmDecoderRuntime  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+]
+
+
+def _runtime(engine: MagicMock) -> VllmDecoderRuntime:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=128),
+        shutdown_timeout=7.0,
+    )
+    return VllmDecoderRuntime(
+        engine=cast(Any, engine),
+        vllm_config=cast(Any, config),
+        default_sampling_params={"temperature": 0.4},
+    )
+
+
+def test_prepare_sampling_params_uses_prepared_prompt_length() -> None:
+    runtime = _runtime(MagicMock())
+
+    sampling_params = runtime.prepare_sampling_params(
+        {
+            "token_ids": [1],
+            "sampling_options": {},
+            "stop_conditions": {},
+            "output_options": {},
+        },
+        prompt={"prompt_token_ids": list(range(100))},
+    )
+
+    assert sampling_params.max_tokens == 28
+
+
+@pytest.mark.asyncio
+async def test_decode_delegates_and_adapts_native_output() -> None:
+    engine = MagicMock()
+    sampling_params = SamplingParams(max_tokens=1)
+
+    async def native_stream():
+        yield SimpleNamespace(
+            outputs=[
+                SimpleNamespace(
+                    index=0,
+                    token_ids=[7],
+                    finish_reason="length",
+                    stop_reason=None,
+                    logprobs=None,
+                    routed_experts=None,
+                )
+            ],
+            prompt_token_ids=[1, 2],
+            prompt_logprobs=None,
+            num_cached_tokens=0,
+        )
+
+    engine.generate.return_value = native_stream()
+    runtime = _runtime(engine)
+
+    chunks = [
+        chunk
+        async for chunk in runtime.decode(
+            {"prompt_token_ids": [1, 2]},
+            sampling_params,
+            "request-1",
+            engine_options={"priority": 3},
+        )
+    ]
+
+    assert chunks == [
+        {
+            "index": 0,
+            "token_ids": [7],
+            "finish_reason": "length",
+            "completion_usage": {
+                "prompt_tokens": 2,
+                "completion_tokens": 1,
+                "total_tokens": 3,
+                "prompt_tokens_details": {"cached_tokens": 0},
+            },
+        }
+    ]
+    engine.generate.assert_called_once_with(
+        {"prompt_token_ids": [1, 2]},
+        sampling_params,
+        "request-1",
+        priority=3,
+    )
+
+
+@pytest.mark.asyncio
+async def test_decode_stops_after_native_response_without_outputs() -> None:
+    engine = MagicMock()
+
+    async def native_stream():
+        yield SimpleNamespace(outputs=[])
+        yield SimpleNamespace(
+            outputs=[
+                SimpleNamespace(
+                    index=0,
+                    token_ids=[7],
+                    finish_reason="length",
+                    stop_reason=None,
+                    logprobs=None,
+                    routed_experts=None,
+                )
+            ],
+            prompt_token_ids=[1],
+            prompt_logprobs=None,
+            num_cached_tokens=0,
+        )
+
+    engine.generate.return_value = native_stream()
+    runtime = _runtime(engine)
+
+    chunks = [
+        chunk
+        async for chunk in runtime.decode(
+            {"prompt_token_ids": [1]},
+            SamplingParams(max_tokens=1),
+            "request-1",
+        )
+    ]
+
+    assert chunks == [
+        {
+            "finish_reason": "error: No outputs from vLLM engine",
+            "index": 0,
+            "token_ids": [],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_abort_and_shutdown_are_lifecycle_safe() -> None:
+    engine = MagicMock()
+    engine.abort = AsyncMock()
+    runtime = _runtime(engine)
+
+    await runtime.abort("request-1")
+    runtime.shutdown()
+    runtime.shutdown()
+    await runtime.abort("request-2")
+
+    engine.abort.assert_awaited_once_with("request-1")
+    engine.shutdown.assert_called_once_with(timeout=7.0)
+    with pytest.raises(RuntimeError, match="shut down"):
+        _ = runtime.engine

--- a/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
@@ -6,7 +6,8 @@ from types import SimpleNamespace
 import pytest
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
-from dynamo.vllm.handlers import BaseWorkerHandler, build_sampling_params
+from dynamo.vllm.decoder_runtime import VllmDecoderRuntime
+from dynamo.vllm.handlers import DecodeWorkerHandler, build_sampling_params
 
 pytestmark = [
     pytest.mark.unit,
@@ -73,8 +74,16 @@ def _handler_with_responses(responses):
 
     handler = SimpleNamespace()
     handler.engine_client = _FakeEngineClient(responses)
+    handler.decoder_runtime = VllmDecoderRuntime(
+        engine=handler.engine_client,
+        vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(max_model_len=128),
+            shutdown_timeout=1.0,
+        ),
+        default_sampling_params={},
+    )
     handler.runtime = SimpleNamespace(shutdown=lambda: None)
-    handler._extract_logprobs = BaseWorkerHandler._extract_logprobs
+    handler._extract_logprobs = DecodeWorkerHandler._extract_logprobs
     handler._log_with_lora_context = _ignore_log
     # These delta-streaming tests exercise base-model requests only. Model the
     # no-LoRA branch without constructing the full legacy worker handler.
@@ -87,7 +96,7 @@ def _handler_with_responses(responses):
 async def _collect_handler_chunks(responses):
     handler = _handler_with_responses(responses)
     chunks = []
-    async for chunk in BaseWorkerHandler.generate_tokens(
+    async for chunk in DecodeWorkerHandler.generate_tokens(
         handler,
         prompt=None,
         sampling_params=SamplingParams(),

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -68,11 +68,10 @@ def test_decode_worker_lifecycle_cleanup_in_reverse_construction_order():
     shutdown_event = asyncio.Event()
     handler = Mock()
     handler.cleanup.side_effect = lambda: calls.append("handler")
-    engine_client = Mock()
-    engine_client.shutdown.side_effect = lambda **_kwargs: calls.append("engine")
+    decoder_runtime = Mock()
+    decoder_runtime.shutdown.side_effect = lambda: calls.append("engine")
     resources = _DecodeWorkerLifecycle(
-        engine_client=engine_client,
-        vllm_config=SimpleNamespace(shutdown_timeout=7.0),
+        decoder_runtime=decoder_runtime,
         handler=handler,
         shutdown_event=shutdown_event,
     )
@@ -81,23 +80,22 @@ def test_decode_worker_lifecycle_cleanup_in_reverse_construction_order():
 
     assert calls == ["handler", "engine"]
     assert shutdown_event.is_set()
-    engine_client.shutdown.assert_called_once_with(timeout=7.0)
+    decoder_runtime.shutdown.assert_called_once_with()
 
 
 def test_decode_worker_lifecycle_shutdown_engine_when_handler_cleanup_fails():
     handler = Mock()
     handler.cleanup.side_effect = RuntimeError("handler cleanup failed")
-    engine_client = Mock()
+    decoder_runtime = Mock()
     resources = _DecodeWorkerLifecycle(
-        engine_client=engine_client,
-        vllm_config=SimpleNamespace(shutdown_timeout=5.0),
+        decoder_runtime=decoder_runtime,
         handler=handler,
     )
 
     with pytest.raises(RuntimeError, match="handler cleanup failed"):
         resources.cleanup()
 
-    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+    decoder_runtime.shutdown.assert_called_once_with()
 
 
 def test_decode_worker_lifecycle_chains_handler_and_engine_cleanup_failures():
@@ -105,11 +103,10 @@ def test_decode_worker_lifecycle_chains_handler_and_engine_cleanup_failures():
     engine_error = RuntimeError("engine shutdown failed")
     handler = Mock()
     handler.cleanup.side_effect = handler_error
-    engine_client = Mock()
-    engine_client.shutdown.side_effect = engine_error
+    decoder_runtime = Mock()
+    decoder_runtime.shutdown.side_effect = engine_error
     lifecycle = _DecodeWorkerLifecycle(
-        engine_client=engine_client,
-        vllm_config=SimpleNamespace(shutdown_timeout=5.0),
+        decoder_runtime=decoder_runtime,
         handler=handler,
     )
 
@@ -118,20 +115,19 @@ def test_decode_worker_lifecycle_chains_handler_and_engine_cleanup_failures():
 
     assert exc_info.value is engine_error
     assert exc_info.value.__context__ is handler_error
-    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+    decoder_runtime.shutdown.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_custom_encoder_preserves_primary_error_when_cleanup_fails(caplog):
     factory = _make_factory()
-    engine_client = Mock()
+    decoder_runtime = Mock()
     handler = Mock()
     handler.cleanup.side_effect = RuntimeError("handler cleanup failed")
     startup_error = ValueError("decode worker startup failed")
 
     async def fail_after_resource_creation(*_args, lifecycle, **_kwargs):
-        lifecycle.engine_client = engine_client
-        lifecycle.vllm_config = SimpleNamespace(shutdown_timeout=5.0)
+        lifecycle.decoder_runtime = decoder_runtime
         lifecycle.handler = handler
         raise startup_error
 
@@ -143,19 +139,18 @@ async def test_custom_encoder_preserves_primary_error_when_cleanup_fails(caplog)
         await factory._create_decode_worker(Mock(), config, asyncio.Event(), [])
 
     assert exc_info.value is startup_error
-    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+    decoder_runtime.shutdown.assert_called_once_with()
     assert "Failed to clean up decode worker after an earlier failure" in caplog.text
 
 
 @pytest.mark.asyncio
 async def test_decode_worker_without_custom_encoder_uses_lifecycle():
     factory = _make_factory()
-    engine_client = Mock()
+    decoder_runtime = Mock()
     startup_error = ValueError("decode worker startup failed")
 
     async def fail_after_engine_creation(*_args, lifecycle, **_kwargs):
-        lifecycle.engine_client = engine_client
-        lifecycle.vllm_config = SimpleNamespace(shutdown_timeout=5.0)
+        lifecycle.decoder_runtime = decoder_runtime
         raise startup_error
 
     factory._run_decode_worker = fail_after_engine_creation  # type: ignore[method-assign]
@@ -165,7 +160,7 @@ async def test_decode_worker_without_custom_encoder_uses_lifecycle():
         await factory._create_decode_worker(Mock(), config, asyncio.Event(), [])
 
     assert exc_info.value is startup_error
-    engine_client.shutdown.assert_called_once_with(timeout=5.0)
+    decoder_runtime.shutdown.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -183,7 +178,7 @@ async def test_custom_encoder_shutdown_engine_on_startup_failure(
     engine_setup: EngineSetupResult = (
         engine_client,
         vllm_config,
-        Mock(),
+        {},
         str(tmp_path / "prometheus"),
         Mock(),
     )

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -80,16 +80,28 @@ def _make_handler(
     if config is None:
         config = _make_config()
     model_config = MagicMock(enable_prompt_embeds=True)
+    model_config.max_model_len = 2048
+    engine_client = MagicMock()
+    decoder_runtime = mod.VllmDecoderRuntime(
+        engine=engine_client,
+        vllm_config=SimpleNamespace(
+            model_config=model_config,
+            shutdown_timeout=1.0,
+        ),
+        default_sampling_params={},
+    )
     with patch.object(mod.BaseWorkerHandler, "__init__", return_value=None):
         handler = mod.DecodeWorkerHandler(
             runtime=MagicMock(),
             config=config,
-            engine=MagicMock(),
-            default_sampling_params={},
-            model_config=model_config,
+            decoder_runtime=decoder_runtime,
             encode_worker_client=encode_worker_client,
         )
     handler.model_config = model_config
+    handler.engine_client = decoder_runtime.engine
+    handler.default_sampling_params = {}
+    handler.model_max_len = model_config.max_model_len
+    handler.config = config
     handler._multimodal_request_processor = VllmMultimodalRequestProcessor(
         model=config.model,
         enable_multimodal=config.enable_multimodal,
@@ -115,6 +127,37 @@ def _make_raw_frontend_request(image_urls: list[str] | None = None) -> dict:
         "stop_conditions": {},
         "output_options": {},
     }
+
+
+@pytest.mark.asyncio
+async def test_decode_handler_delegates_generation_to_runtime() -> None:
+    handler = _make_handler()
+    calls = []
+
+    async def decode(*args, **kwargs):
+        calls.append((args, kwargs))
+        yield {"index": 0, "token_ids": [7], "finish_reason": "length"}
+
+    handler.decoder_runtime.decode = decode  # type: ignore[method-assign]
+    sampling_params = MagicMock()
+
+    chunks = [
+        chunk
+        async for chunk in handler.generate_tokens(
+            {"prompt_token_ids": [1, 2]},
+            sampling_params,
+            "request-1",
+            priority=2,
+        )
+    ]
+
+    assert chunks == [{"index": 0, "token_ids": [7], "finish_reason": "length"}]
+    assert calls[0][0] == (
+        {"prompt_token_ids": [1, 2]},
+        sampling_params,
+        "request-1",
+    )
+    assert calls[0][1]["engine_options"]["priority"] == 2
 
 
 def _make_vllm_request(request_id: str = "req-1") -> vLLMMultimodalRequest:
@@ -259,7 +302,6 @@ class TestReasoningParserForwarding:
             if False:
                 yield None
 
-        handler.engine_client = MagicMock()
         handler.engine_client.generate = fake_generate
 
         chunks = []
@@ -303,7 +345,6 @@ class TestReasoningParserForwarding:
             if False:
                 yield None
 
-        handler.engine_client = MagicMock()
         handler.engine_client.generate = fake_generate
 
         chunks = []
@@ -361,7 +402,6 @@ class TestReasoningParserForwarding:
                 prompt_logprobs=None,
             )
 
-        handler.engine_client = MagicMock()
         handler.engine_client.generate = fake_generate
 
         chunks = []
@@ -426,7 +466,6 @@ class TestReasoningParserForwarding:
                 prompt_logprobs=None,
             )
 
-        handler.engine_client = MagicMock()
         handler.engine_client.generate = fake_generate
 
         chunks = []
@@ -470,7 +509,6 @@ class TestReasoningParserForwarding:
                 prompt_logprobs=None,
             )
 
-        handler.engine_client = MagicMock()
         handler.engine_client.generate = fake_generate
 
         chunks = []
@@ -626,18 +664,27 @@ def _make_decode_handler(
     """Construct a DecodeWorkerHandler with mocked internals."""
     config = _make_config(model=model, disaggregation_mode=disaggregation_mode)
     model_config = MagicMock(enable_prompt_embeds=True)
+    model_config.max_model_len = 4096
+    engine_client = MagicMock()
+    decoder_runtime = mod.VllmDecoderRuntime(
+        engine=engine_client,
+        vllm_config=SimpleNamespace(
+            model_config=model_config,
+            shutdown_timeout=1.0,
+        ),
+        default_sampling_params={},
+    )
     with patch.object(mod.BaseWorkerHandler, "__init__", return_value=None):
         handler = mod.DecodeWorkerHandler(
             runtime=MagicMock(),
             config=config,
-            engine=MagicMock(),
-            default_sampling_params={},
-            model_config=model_config,
+            decoder_runtime=decoder_runtime,
         )
     handler.config = config
     handler.model_config = model_config
     handler.model_max_len = 4096
     handler.default_sampling_params = {}
+    handler.engine_client = engine_client
     handler.kv_event_publisher = None
     handler.otel_tracing_enabled = False
     handler.input_param_manager = MagicMock()

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -34,6 +34,7 @@ from .args import Config
 from .cache_info import configure_kv_event_block_size
 from .capacity import per_rank_kv_blocks
 from .constants import DisaggregationMode
+from .decoder_runtime import VllmDecoderRuntime
 from .handlers import (
     BaseWorkerHandler,
     DecodeWorkerHandler,
@@ -543,8 +544,7 @@ SetupMetricsCollectionFn = Callable[..., None]
 
 @dataclass
 class _DecodeWorkerLifecycle:
-    engine_client: Optional[AsyncLLM] = None
-    vllm_config: Optional[VllmConfig] = None
+    decoder_runtime: VllmDecoderRuntime | None = None
     handler: Optional[BaseWorkerHandler] = None
     shutdown_event: asyncio.Event | None = None
 
@@ -575,8 +575,8 @@ class _DecodeWorkerLifecycle:
             if self.handler is not None:
                 self.handler.cleanup()
         finally:
-            if self.engine_client is not None and self.vllm_config is not None:
-                self.engine_client.shutdown(timeout=self.vllm_config.shutdown_timeout)
+            if self.decoder_runtime is not None:
+                self.decoder_runtime.shutdown()
 
 
 class WorkerFactory:
@@ -1155,8 +1155,12 @@ class WorkerFactory:
                 prometheus_temp_dir,
                 component_gauges,
             ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
-        lifecycle.engine_client = engine_client
-        lifecycle.vllm_config = vllm_config
+        decoder_runtime = VllmDecoderRuntime(
+            engine=engine_client,
+            vllm_config=vllm_config,
+            default_sampling_params=default_sampling_params,
+        )
+        lifecycle.decoder_runtime = decoder_runtime
         await configure_kv_event_block_size(engine_client, vllm_config)
 
         # TODO Hack to get data, move this to registering in TBD
@@ -1178,10 +1182,7 @@ class WorkerFactory:
         handler = DecodeWorkerHandler(
             runtime,
             config,
-            engine_client,
-            default_sampling_params,
-            getattr(getattr(vllm_config, "model_config", None), "max_model_len", None),
-            model_config=getattr(vllm_config, "model_config", None),
+            decoder_runtime,
             enable_multimodal=config.enable_multimodal,
             generate_endpoint=generate_endpoint,
             use_vllm_tokenizer=config.use_vllm_tokenizer,


### PR DESCRIPTION
_Based on #13073._

## Why

Standalone `dynamo.vllm` serving and workflow stages need one Dynamo-to-vLLM decode implementation. Sharing only the raw engine would still duplicate prompt budgeting, sampling preparation, output adaptation, abort, and shutdown behavior.

## What Change

- Add `VllmDecoderRuntime` around an already configured `AsyncLLM`.
- Centralize request preparation, prompt-budget validation, generation, chunk adaptation, abort, and shutdown.
- Delegate handler decoding to the runtime while the handler retains admission, registration, and transport policy.

```mermaid
classDiagram
    DecodeWorkerHandler o-- VllmDecoderRuntime : delegates decode
    VllmDecoderRuntime --> AsyncLLM : drives
    VllmDecoderRuntime ..> SamplingParams : prepares
    VllmDecoderRuntime ..> VllmDecodeOutputAdapter : adapts
```

## Test Plan

- Focused runtime and handler qualification: 226 passed and 5 intentionally skipped.
- Built stack-tip H100 qualification: 107 tests passed, including the shared runtime suite.
