### PR TITLE
feat(examples): compare workflow and bespoke vision ensemble

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -234,6 +234,7 @@ areas:
   - examples/backends/tritonserver/
   - examples/common/
   - examples/custom_backend/
+  - examples/experimental/
   - lib/backend-common/
   - lib/backend-common/examples/
   - lib/sidecar/README.md

--- a/examples/experimental/__init__.py
+++ b/examples/experimental/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental Dynamo examples."""

--- a/examples/experimental/workflow/__init__.py
+++ b/examples/experimental/workflow/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental workflow examples."""

--- a/examples/experimental/workflow/user_ensemble/README.md
+++ b/examples/experimental/workflow/user_ensemble/README.md
@@ -13,7 +13,7 @@ request ──> inline encoder ────────> │ GenerateRequest   �
                          └──────────────────────────────────> merge ──> chunk
 ```
 
-The declarative version uses `Workflow` and `WorkflowOrchestrator.bind(...)` to own graph scheduling, endpoint discovery, Generate-stream folding, validation, cancellation, and result propagation. Inline runners and the remote Generate endpoint are bound together in the orchestrator worker. The bespoke version contains the equivalent endpoint client, fan-out, stream collection, sibling cancellation, and merge control flow explicitly. This is a runnable code comparison, not a performance claim.
+Both versions reuse `GenerateEndpointInvoker` for request validation, token-stream folding, and remote-call cancellation. The declarative version uses `Workflow` and `WorkflowOrchestrator.bind(...)` to own graph scheduling, endpoint discovery, inline-versus-remote dispatch, sibling cancellation, and result propagation. The bespoke version contains the equivalent endpoint client, fan-out, task joins, sibling cancellation, and merge control flow explicitly. This is a runnable comparison of orchestration ownership, not a performance claim.
 
 ## Run
 

--- a/examples/experimental/workflow/user_ensemble/README.md
+++ b/examples/experimental/workflow/user_ensemble/README.md
@@ -1,0 +1,34 @@
+# User ensemble
+
+Experimental: This workflow API is under active development and may evolve based on feedback. You can alternatively compose the same discoverable Dynamo endpoints directly, as `bespoke/` demonstrates.
+
+This example serves the same application in two ways. Both keep the custom encoder, dummy classifier, request adaptation, and response merge inside one orchestrator process. Only a stock aggregated `dynamo.vllm` worker is remote.
+
+```text
+                                      stock dynamo.vllm
+                                    ┌───────────────────┐
+request ──> inline encoder ────────> │ GenerateRequest   │ ──┐
+                 │                  │ + encoder_result  │   │
+                 └─> classifier     └───────────────────┘   │
+                         └──────────────────────────────────> merge ──> chunk
+```
+
+The declarative version uses `Workflow`, `compile_workflow`, and `WorkflowOrchestrator` to own graph scheduling, endpoint discovery, Generate-stream folding, validation, cancellation, and result propagation. The bespoke version contains the equivalent endpoint client, fan-out, stream collection, sibling cancellation, and merge control flow explicitly. This is a runnable code comparison, not a performance claim.
+
+## Run
+
+From the repository root, launch one implementation:
+
+```bash
+examples/experimental/workflow/user_ensemble/workflow/launch.sh
+# or
+examples/experimental/workflow/user_ensemble/bespoke/launch.sh
+```
+
+Then send the shared request:
+
+```bash
+python -m examples.experimental.workflow.user_ensemble.common.client
+```
+
+Both launchers use the TCP request plane with MsgPack because `encoder_result` contains binary tensor data. The bundled Hitchhiker encoder makes the image represent a known phrase so a successful response contains `42`; replace `DYN_ENCODER_CLASS` with an application encoder implementing `VisionEncoderBackend`.

--- a/examples/experimental/workflow/user_ensemble/README.md
+++ b/examples/experimental/workflow/user_ensemble/README.md
@@ -13,7 +13,7 @@ request ──> inline encoder ────────> │ GenerateRequest   �
                          └──────────────────────────────────> merge ──> chunk
 ```
 
-The declarative version uses `Workflow`, `compile_workflow`, and `WorkflowOrchestrator` to own graph scheduling, endpoint discovery, Generate-stream folding, validation, cancellation, and result propagation. The bespoke version contains the equivalent endpoint client, fan-out, stream collection, sibling cancellation, and merge control flow explicitly. This is a runnable code comparison, not a performance claim.
+The declarative version uses `Workflow` and `WorkflowOrchestrator.bind(...)` to own graph scheduling, endpoint discovery, Generate-stream folding, validation, cancellation, and result propagation. Inline runners and the remote Generate endpoint are bound together in the orchestrator worker. The bespoke version contains the equivalent endpoint client, fan-out, stream collection, sibling cancellation, and merge control flow explicitly. This is a runnable code comparison, not a performance claim.
 
 ## Run
 

--- a/examples/experimental/workflow/user_ensemble/__init__.py
+++ b/examples/experimental/workflow/user_ensemble/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Vision encoder, classifier, and stock-vLLM ensemble example."""

--- a/examples/experimental/workflow/user_ensemble/bespoke/__init__.py
+++ b/examples/experimental/workflow/user_ensemble/bespoke/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct Dynamo-endpoint orchestration for comparison."""

--- a/examples/experimental/workflow/user_ensemble/bespoke/launch.sh
+++ b/examples/experimental/workflow/user_ensemble/bespoke/launch.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(readlink -f "$SCRIPT_DIR/../../../../..")"
+source "$REPO_ROOT/examples/common/gpu_utils.sh"
+source "$REPO_ROOT/examples/common/launch_utils.sh"
+trap dynamo_exit_trap EXIT
+
+MODEL="${DYN_MODEL:-Qwen/Qwen2.5-1.5B-Instruct}"
+PUBLIC_MODEL_NAME="${DYN_SERVED_MODEL_NAME:-user-ensemble}"
+DECODER_MODEL_NAME="${DYN_DECODER_MODEL_NAME:-user-ensemble-decoder}"
+NAMESPACE="${DYN_NAMESPACE:-workflow-user-ensemble}"
+GENERATOR_ENDPOINT="$NAMESPACE.generator.generate"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+WORKER_GPU="${DYN_WORKER_GPU:-${CUDA_VISIBLE_DEVICES:-0}}"
+MAX_MODEL_LEN="${DYN_MAX_MODEL_LEN:-4096}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+[[ -z "$GPU_MEM_ARGS" ]] && GPU_MEM_ARGS="--gpu-memory-utilization 0.8"
+
+export DYN_NAMESPACE="$NAMESPACE"
+export DYN_REQUEST_PLANE=tcp
+export DYN_REQUEST_PLANE_CODEC=msgpack
+export DYN_TCP_MAX_MESSAGE_SIZE=209715200
+export DYN_HTTP_BODY_LIMIT_MB=200
+
+print_launch_banner --no-curl "Bespoke User Ensemble" "$MODEL" "$HTTP_PORT" \
+    "Public model: $PUBLIC_MODEL_NAME" \
+    "Manual fan-out, stream collection, cancellation, and response merge" \
+    "Remote: dyn://$GENERATOR_ENDPOINT"
+
+python -m dynamo.frontend --http-port "$HTTP_PORT" --enable-nvext &
+
+CUDA_VISIBLE_DEVICES="$WORKER_GPU" \
+DYN_SYSTEM_PORT="${DYN_GENERATOR_SYSTEM_PORT:-8081}" \
+python -m dynamo.vllm \
+    --model "$MODEL" \
+    --served-model-name "$DECODER_MODEL_NAME" \
+    --endpoint "dyn://$GENERATOR_ENDPOINT" \
+    --enable-prompt-embeds \
+    --max-model-len "$MAX_MODEL_LEN" \
+    $GPU_MEM_ARGS \
+    "$@" &
+
+DYN_MODEL="$MODEL" \
+DYN_SERVED_MODEL_NAME="$PUBLIC_MODEL_NAME" \
+DYN_SYSTEM_PORT="${DYN_ORCHESTRATOR_SYSTEM_PORT:-8082}" \
+python -m \
+    examples.experimental.workflow.user_ensemble.bespoke.orchestrator_worker &
+
+wait_any_exit

--- a/examples/experimental/workflow/user_ensemble/bespoke/orchestrator_worker.py
+++ b/examples/experimental/workflow/user_ensemble/bespoke/orchestrator_worker.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serve the user ensemble by manually coordinating Dynamo endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+from typing import Any
+
+from dynamo.experimental.workflow import StageContext
+from dynamo.experimental.workflow.vllm import ExternalEncoderRequestStage
+from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+from examples.experimental.workflow.user_ensemble.common.config import (
+    CHAT_TEMPLATE,
+    GENERATOR_ENDPOINT,
+    MODEL,
+    ORCHESTRATOR_ENDPOINT,
+    PUBLIC_MODEL_NAME,
+    build_encoder_stage,
+)
+from examples.experimental.workflow.user_ensemble.common.stages import (
+    DummyClassifier,
+    EnsembleResponseStage,
+)
+
+
+class BespokeEnsembleHandler:
+    """Manually implement the same fan-out, remote call, and merge lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        encoder: Any,
+        classifier: Any,
+        request_adapter: Any,
+        response: Any,
+        generator_client: Any,
+    ) -> None:
+        self._encoder = encoder
+        self._classifier = classifier
+        self._request_adapter = request_adapter
+        self._response = response
+        self._generator_client = generator_client
+
+    async def generate(
+        self,
+        request: Mapping[str, Any],
+        context: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        execution = asyncio.create_task(
+            self._run(request, context),
+            name=f"bespoke-ensemble:{context.id()}",
+        )
+        cancellation = asyncio.ensure_future(context.async_killed_or_stopped())
+        try:
+            done, _ = await asyncio.wait(
+                {execution, cancellation}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if execution not in done:
+                execution.cancel()
+                await asyncio.gather(execution, return_exceptions=True)
+                return
+            yield await execution
+        except BaseException:
+            if not execution.done():
+                execution.cancel()
+                await asyncio.gather(execution, return_exceptions=True)
+            raise
+        finally:
+            if not cancellation.done():
+                cancellation.cancel()
+            await asyncio.gather(cancellation, return_exceptions=True)
+
+    async def _run(
+        self,
+        request: Mapping[str, Any],
+        context: Any,
+    ) -> dict[str, Any]:
+        _validate_generate_request(request)
+        attempt_id = context.id()
+        encoder_context = StageContext(
+            workflow_name=None,
+            stage_id="encoder",
+            attempt_id=attempt_id,
+        )
+        encoded = await self._encoder.run({"request": request}, encoder_context)
+
+        classifier_task = asyncio.create_task(
+            self._classifier.run(
+                {"encoder_features": encoded["encoder_features"]},
+                StageContext(None, "classifier", attempt_id),
+            ),
+            name=f"bespoke-classifier:{attempt_id}",
+        )
+        generator_context = None
+        generator_task = None
+        try:
+            prepared = await self._request_adapter.run(
+                {
+                    "request": request,
+                    "encoder_features": encoded["encoder_features"],
+                    "encoder_metadata": encoded["encoder_metadata"],
+                },
+                StageContext(None, "request_adapter", attempt_id),
+            )
+            generator_context = context.detached(f"{attempt_id}:generator")
+            stream = await self._generator_client.round_robin(
+                prepared["request"],
+                annotated=False,
+                context=generator_context,
+            )
+            generator_task = asyncio.create_task(
+                _collect_generation(stream),
+                name=f"bespoke-generator:{attempt_id}",
+            )
+            classified, completion = await asyncio.gather(
+                classifier_task,
+                generator_task,
+            )
+        except BaseException:
+            classifier_task.cancel()
+            if generator_task is not None:
+                generator_task.cancel()
+            if generator_context is not None:
+                generator_context.stop_generating()
+            await asyncio.gather(
+                classifier_task,
+                *([generator_task] if generator_task is not None else []),
+                return_exceptions=True,
+            )
+            raise
+
+        result = await self._response.run(
+            {
+                "completion": completion,
+                "scores": classified["scores"],
+            },
+            StageContext(None, "response", attempt_id),
+        )
+        return dict(result["chunk"])
+
+
+def _validate_generate_request(request: Mapping[str, Any]) -> None:
+    """Match the unary restrictions enforced by GenerateEndpointBinding."""
+
+    sampling_options = request.get("sampling_options", {})
+    if not isinstance(sampling_options, Mapping):
+        raise TypeError("sampling_options must be an object")
+    if sampling_options.get("n") not in (None, 1):
+        raise ValueError("user ensemble requires n=1")
+    output_options = request.get("output_options", {})
+    if not isinstance(output_options, Mapping):
+        raise TypeError("output_options must be an object")
+    if (
+        output_options.get("logprobs") is not None
+        or output_options.get("prompt_logprobs") is not None
+    ):
+        raise ValueError("user ensemble does not support logprobs")
+
+
+async def _collect_generation(stream: AsyncIterator[Any]) -> dict[str, Any]:
+    """Fold stock Generate deltas without using workflow runtime adapters."""
+
+    token_ids: list[int] = []
+    terminal: dict[str, Any] | None = None
+    async for value in stream:
+        if terminal is not None:
+            raise RuntimeError("generator returned data after its terminal chunk")
+        if not isinstance(value, Mapping):
+            raise TypeError("generator returned a non-object chunk")
+        chunk = dict(value)
+        if chunk.get("index") != 0:
+            raise RuntimeError("user ensemble requires generator choice index 0")
+        delta = chunk.get("token_ids")
+        if not isinstance(delta, list) or any(
+            isinstance(token_id, bool) or not isinstance(token_id, int)
+            for token_id in delta
+        ):
+            raise TypeError("generator returned invalid token_ids")
+        if "log_probs" in chunk or "top_logprobs" in chunk:
+            raise RuntimeError("user ensemble does not support generator logprobs")
+        token_ids.extend(delta)
+        finish_reason = chunk.get("finish_reason")
+        if finish_reason is not None:
+            if not isinstance(finish_reason, str) or not finish_reason:
+                raise TypeError("generator returned invalid finish_reason")
+            terminal = chunk
+    if terminal is None:
+        raise RuntimeError("generator returned no terminal chunk")
+    terminal["token_ids"] = token_ids
+    return terminal
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime) -> None:
+    encoder = build_encoder_stage()
+    try:
+        generator_client = await runtime.endpoint(GENERATOR_ENDPOINT).client()
+        await generator_client.wait_for_instances()
+        handler = BespokeEnsembleHandler(
+            encoder=encoder,
+            classifier=DummyClassifier(),
+            request_adapter=ExternalEncoderRequestStage(),
+            response=EnsembleResponseStage(),
+            generator_client=generator_client,
+        )
+        endpoint = runtime.endpoint(ORCHESTRATOR_ENDPOINT)
+        await register_model(
+            ModelInput.Tokens,
+            ModelType.Chat,
+            endpoint,
+            MODEL,
+            model_name=PUBLIC_MODEL_NAME,
+            worker_type=WorkerType.Aggregated,
+            custom_template_path=str(CHAT_TEMPLATE),
+            ignore_weights=True,
+        )
+        await endpoint.serve_endpoint(handler.generate)
+    finally:
+        encoder.close()
+
+
+def main() -> None:
+    asyncio.run(worker())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/workflow/user_ensemble/bespoke/orchestrator_worker.py
+++ b/examples/experimental/workflow/user_ensemble/bespoke/orchestrator_worker.py
@@ -10,7 +10,11 @@ from collections.abc import AsyncIterator, Mapping
 from typing import Any
 
 from dynamo.experimental.workflow import StageContext
-from dynamo.experimental.workflow.vllm import ExternalEncoderRequestStage
+from dynamo.experimental.workflow.generate import GenerateEndpointInvoker
+from dynamo.experimental.workflow.vllm import (
+    DynamoVllmStage,
+    ExternalEncoderRequestStage,
+)
 from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from examples.experimental.workflow.user_ensemble.common.config import (
@@ -37,13 +41,13 @@ class BespokeEnsembleHandler:
         classifier: Any,
         request_adapter: Any,
         response: Any,
-        generator_client: Any,
+        generator: GenerateEndpointInvoker,
     ) -> None:
         self._encoder = encoder
         self._classifier = classifier
         self._request_adapter = request_adapter
         self._response = response
-        self._generator_client = generator_client
+        self._generator = generator
 
     async def generate(
         self,
@@ -79,7 +83,6 @@ class BespokeEnsembleHandler:
         request: Mapping[str, Any],
         context: Any,
     ) -> dict[str, Any]:
-        _validate_generate_request(request)
         attempt_id = context.id()
         encoder_context = StageContext(
             workflow_name=None,
@@ -95,7 +98,6 @@ class BespokeEnsembleHandler:
             ),
             name=f"bespoke-classifier:{attempt_id}",
         )
-        generator_context = None
         generator_task = None
         try:
             prepared = await self._request_adapter.run(
@@ -106,17 +108,17 @@ class BespokeEnsembleHandler:
                 },
                 StageContext(None, "request_adapter", attempt_id),
             )
-            generator_context = context.detached(f"{attempt_id}:generator")
-            stream = await self._generator_client.round_robin(
-                prepared["request"],
-                annotated=False,
-                context=generator_context,
-            )
             generator_task = asyncio.create_task(
-                _collect_generation(stream),
+                self._generator.run(
+                    "generator",
+                    DynamoVllmStage.request_complete_contract,
+                    {"request": prepared["request"]},
+                    StageContext(None, "generator", attempt_id),
+                    request_context=context,
+                ),
                 name=f"bespoke-generator:{attempt_id}",
             )
-            classified, completion = await asyncio.gather(
+            classified, generated = await asyncio.gather(
                 classifier_task,
                 generator_task,
             )
@@ -124,8 +126,6 @@ class BespokeEnsembleHandler:
             classifier_task.cancel()
             if generator_task is not None:
                 generator_task.cancel()
-            if generator_context is not None:
-                generator_context.stop_generating()
             await asyncio.gather(
                 classifier_task,
                 *([generator_task] if generator_task is not None else []),
@@ -135,63 +135,12 @@ class BespokeEnsembleHandler:
 
         result = await self._response.run(
             {
-                "completion": completion,
+                "completion": generated["completion"],
                 "scores": classified["scores"],
             },
             StageContext(None, "response", attempt_id),
         )
         return dict(result["chunk"])
-
-
-def _validate_generate_request(request: Mapping[str, Any]) -> None:
-    """Match the unary restrictions enforced by GenerateEndpointBinding."""
-
-    sampling_options = request.get("sampling_options", {})
-    if not isinstance(sampling_options, Mapping):
-        raise TypeError("sampling_options must be an object")
-    if sampling_options.get("n") not in (None, 1):
-        raise ValueError("user ensemble requires n=1")
-    output_options = request.get("output_options", {})
-    if not isinstance(output_options, Mapping):
-        raise TypeError("output_options must be an object")
-    if (
-        output_options.get("logprobs") is not None
-        or output_options.get("prompt_logprobs") is not None
-    ):
-        raise ValueError("user ensemble does not support logprobs")
-
-
-async def _collect_generation(stream: AsyncIterator[Any]) -> dict[str, Any]:
-    """Fold stock Generate deltas without using workflow runtime adapters."""
-
-    token_ids: list[int] = []
-    terminal: dict[str, Any] | None = None
-    async for value in stream:
-        if terminal is not None:
-            raise RuntimeError("generator returned data after its terminal chunk")
-        if not isinstance(value, Mapping):
-            raise TypeError("generator returned a non-object chunk")
-        chunk = dict(value)
-        if chunk.get("index") != 0:
-            raise RuntimeError("user ensemble requires generator choice index 0")
-        delta = chunk.get("token_ids")
-        if not isinstance(delta, list) or any(
-            isinstance(token_id, bool) or not isinstance(token_id, int)
-            for token_id in delta
-        ):
-            raise TypeError("generator returned invalid token_ids")
-        if "log_probs" in chunk or "top_logprobs" in chunk:
-            raise RuntimeError("user ensemble does not support generator logprobs")
-        token_ids.extend(delta)
-        finish_reason = chunk.get("finish_reason")
-        if finish_reason is not None:
-            if not isinstance(finish_reason, str) or not finish_reason:
-                raise TypeError("generator returned invalid finish_reason")
-            terminal = chunk
-    if terminal is None:
-        raise RuntimeError("generator returned no terminal chunk")
-    terminal["token_ids"] = token_ids
-    return terminal
 
 
 @dynamo_worker()
@@ -205,7 +154,7 @@ async def worker(runtime: DistributedRuntime) -> None:
             classifier=DummyClassifier(),
             request_adapter=ExternalEncoderRequestStage(),
             response=EnsembleResponseStage(),
-            generator_client=generator_client,
+            generator=GenerateEndpointInvoker(generator_client),
         )
         endpoint = runtime.endpoint(ORCHESTRATOR_ENDPOINT)
         await register_model(

--- a/examples/experimental/workflow/user_ensemble/common/__init__.py
+++ b/examples/experimental/workflow/user_ensemble/common/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Business stages and settings shared by both ensemble implementations."""

--- a/examples/experimental/workflow/user_ensemble/common/client.py
+++ b/examples/experimental/workflow/user_ensemble/common/client.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise either user-ensemble implementation through the stock frontend."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Any
+
+import aiohttp
+
+from examples.experimental.workflow.user_ensemble.common.config import PUBLIC_MODEL_NAME
+
+_ONE_PIXEL_PNG = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/"
+    "x8AAusB9Wl2nL8AAAAASUVORK5CYII="
+)
+
+
+async def request_completion(base_url: str) -> dict[str, Any]:
+    payload = {
+        "model": PUBLIC_MODEL_NAME,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Based on The Hitchhiker's Guide to the Galaxy, "
+                            "The Answer to"
+                        ),
+                    },
+                    {"type": "image_url", "image_url": {"url": _ONE_PIXEL_PNG}},
+                    {"type": "text", "text": " is? Answer with one number."},
+                ],
+            }
+        ],
+        "max_tokens": 8,
+        "temperature": 0,
+        "stream": False,
+        "nvext": {"extra_fields": ["engine_data"]},
+    }
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{base_url.rstrip('/')}/v1/chat/completions",
+            json=payload,
+        ) as response:
+            response.raise_for_status()
+            result = await response.json()
+
+    text = result["choices"][0]["message"]["content"]
+    if "42" not in text:
+        raise RuntimeError(f"unexpected completion: {text!r}")
+    scores = result["nvext"]["engine_data"]["user_ensemble"]["classifier_scores"]
+    if scores.get("dummy-positive") != 1.0:
+        raise RuntimeError(f"unexpected classifier scores: {scores!r}")
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    args = parser.parse_args()
+    print(asyncio.run(request_completion(args.base_url)))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/workflow/user_ensemble/common/config.py
+++ b/examples/experimental/workflow/user_ensemble/common/config.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared model, endpoint, and encoder configuration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dynamo.experimental.workflow.vllm import EncoderStage
+from dynamo.vllm.multimodal_utils.custom_encoder import (
+    resolve_vision_encoder_backend_class,
+)
+
+DEFAULT_MODEL = "Qwen/Qwen2.5-1.5B-Instruct"
+DEFAULT_ENCODER_CLASS = (
+    "examples.custom_encoder.hitchhikers_vision_encoder." "HitchhikersVisionEncoder"
+)
+
+MODEL = os.environ.get("DYN_MODEL", DEFAULT_MODEL)
+ENCODER_CLASS = os.environ.get("DYN_ENCODER_CLASS", DEFAULT_ENCODER_CLASS)
+PUBLIC_MODEL_NAME = os.environ.get("DYN_SERVED_MODEL_NAME", "user-ensemble")
+DECODER_MODEL_NAME = os.environ.get("DYN_DECODER_MODEL_NAME", "user-ensemble-decoder")
+
+NAMESPACE = os.environ.get("DYN_NAMESPACE", "workflow-user-ensemble")
+GENERATOR_ENDPOINT = f"{NAMESPACE}.generator.generate"
+ORCHESTRATOR_ENDPOINT = f"{NAMESPACE}.orchestrator.generate"
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+CHAT_TEMPLATE = Path(
+    os.environ.get(
+        "DYN_CUSTOM_JINJA_TEMPLATE",
+        REPO_ROOT / "examples/custom_encoder/templates/qwen_vl.jinja",
+    )
+)
+
+
+def build_encoder_stage() -> EncoderStage:
+    """Load the configured author backend through Dynamo's reusable stage."""
+
+    backend_type = resolve_vision_encoder_backend_class(ENCODER_CLASS)
+    return EncoderStage.from_backend(backend_type(), model=MODEL)

--- a/examples/experimental/workflow/user_ensemble/common/stages.py
+++ b/examples/experimental/workflow/user_ensemble/common/stages.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Application-specific stages shared by both ensemble implementations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+
+from dynamo.experimental.workflow import StageContext, StageContract
+from dynamo.llm.exceptions import InvalidArgument
+
+
+class DummyClassifier:
+    """Read encoder features and return deterministic demonstration scores."""
+
+    contract = StageContract(
+        id="dummy-encoder-classifier",
+        inputs={"encoder_features"},
+        outputs={"scores"},
+    )
+
+    async def run(
+        self,
+        inputs: Mapping[str, Any],
+        context: StageContext,
+    ) -> Mapping[str, Any]:
+        del context
+        features = inputs["encoder_features"]
+        if not isinstance(features, torch.Tensor) or features.dim() != 2:
+            raise InvalidArgument("classifier requires a 2D encoder tensor")
+        return {
+            "scores": {
+                "dummy-positive": 1.0,
+                "feature-rows": float(features.shape[0]),
+            }
+        }
+
+
+class EnsembleResponseStage:
+    """Attach classifier scores to the completed token response."""
+
+    contract = StageContract(
+        id="ensemble-response",
+        inputs={"completion", "scores"},
+        outputs={"chunk"},
+    )
+
+    async def run(
+        self,
+        inputs: Mapping[str, Any],
+        context: StageContext,
+    ) -> Mapping[str, Any]:
+        del context
+        completion = inputs["completion"]
+        scores = inputs["scores"]
+        if not isinstance(completion, Mapping):
+            raise TypeError("generator completion must be an object")
+        if not isinstance(scores, Mapping):
+            raise TypeError("classifier scores must be an object")
+
+        chunk = dict(completion)
+        engine_data_value = chunk.get("engine_data") or {}
+        if not isinstance(engine_data_value, Mapping):
+            raise TypeError("generator engine_data must be an object")
+        engine_data = dict(engine_data_value)
+        engine_data["user_ensemble"] = {"classifier_scores": dict(scores)}
+        chunk["engine_data"] = engine_data
+        return {"chunk": chunk}

--- a/examples/experimental/workflow/user_ensemble/tests/__init__.py
+++ b/examples/experimental/workflow/user_ensemble/tests/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the user-ensemble comparison."""

--- a/examples/experimental/workflow/user_ensemble/tests/test_bespoke.py
+++ b/examples/experimental/workflow/user_ensemble/tests/test_bespoke.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+from typing import Any
+
+import pytest
+
+from examples.experimental.workflow.user_ensemble.bespoke.orchestrator_worker import (
+    BespokeEnsembleHandler,
+    _collect_generation,
+)
+from examples.experimental.workflow.user_ensemble.common.stages import (
+    EnsembleResponseStage,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+
+
+class _Runner:
+    def __init__(self, output: Mapping[str, Any]) -> None:
+        self.output = output
+
+    async def run(self, inputs: Mapping[str, Any], context: Any) -> Mapping[str, Any]:
+        del inputs, context
+        return self.output
+
+
+class _RequestAdapter:
+    async def run(self, inputs: Mapping[str, Any], context: Any) -> Mapping[str, Any]:
+        del context
+        request = dict(inputs["request"])
+        request["encoder_result"] = {"test": "encoded"}
+        return {"request": request}
+
+
+async def _stream() -> AsyncIterator[dict[str, Any]]:
+    yield {"token_ids": [4], "index": 0}
+    yield {"token_ids": [2], "index": 0, "finish_reason": "stop"}
+
+
+class _Client:
+    request: dict[str, Any] | None = None
+
+    async def round_robin(
+        self,
+        request: Mapping[str, Any],
+        *,
+        annotated: bool,
+        context: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        assert annotated is False
+        self.request = dict(request)
+        return _stream()
+
+
+class _DetachedContext:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop_generating(self) -> None:
+        self.stopped = True
+
+
+class _Context:
+    def __init__(self) -> None:
+        self.detached_context = _DetachedContext()
+        self.cancelled = asyncio.Event()
+
+    def id(self) -> str:
+        return "request-1"
+
+    def detached(self, request_id: str) -> _DetachedContext:
+        assert request_id == "request-1:generator"
+        return self.detached_context
+
+    async def async_killed_or_stopped(self) -> None:
+        await self.cancelled.wait()
+
+
+def _handler(
+    client: Any,
+    *,
+    classifier: Any | None = None,
+) -> BespokeEnsembleHandler:
+    return BespokeEnsembleHandler(
+        encoder=_Runner(
+            {
+                "encoder_features": "features",
+                "encoder_metadata": {"rows": [0, 1]},
+            }
+        ),
+        classifier=classifier or _Runner({"scores": {"dummy-positive": 1.0}}),
+        request_adapter=_RequestAdapter(),
+        response=EnsembleResponseStage(),
+        generator_client=client,
+    )
+
+
+async def test_bespoke_handler_manually_coordinates_same_result() -> None:
+    client = _Client()
+    context = _Context()
+
+    chunks = [
+        chunk async for chunk in _handler(client).generate({"token_ids": [1]}, context)
+    ]
+
+    assert client.request == {
+        "token_ids": [1],
+        "encoder_result": {"test": "encoded"},
+    }
+    assert chunks[0]["token_ids"] == [4, 2]
+    assert chunks[0]["engine_data"]["user_ensemble"] == {
+        "classifier_scores": {"dummy-positive": 1.0}
+    }
+    assert context.detached_context.stopped is False
+
+
+class _StalledRunner:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = False
+
+    async def run(self, inputs: Mapping[str, Any], context: Any) -> Mapping[str, Any]:
+        del inputs, context
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
+class _StalledClient(_Client):
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    async def round_robin(
+        self,
+        request: Mapping[str, Any],
+        *,
+        annotated: bool,
+        context: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        del request, annotated, context
+
+        async def stalled() -> AsyncIterator[dict[str, Any]]:
+            self.started.set()
+            await asyncio.Event().wait()
+            yield {}
+
+        return stalled()
+
+
+async def test_bespoke_handler_propagates_caller_cancellation() -> None:
+    client = _StalledClient()
+    classifier = _StalledRunner()
+    context = _Context()
+    stream = _handler(client, classifier=classifier).generate(
+        {"token_ids": [1]}, context
+    )
+    response = asyncio.create_task(anext(stream))
+    await client.started.wait()
+
+    context.cancelled.set()
+
+    with pytest.raises(StopAsyncIteration):
+        await response
+    assert context.detached_context.stopped is True
+    assert classifier.cancelled is True
+
+
+@pytest.mark.parametrize(
+    "request,match",
+    [
+        ({"sampling_options": {"n": 2}}, "requires n=1"),
+        ({"output_options": {"logprobs": 1}}, "does not support logprobs"),
+        (
+            {"output_options": {"prompt_logprobs": 1}},
+            "does not support logprobs",
+        ),
+    ],
+)
+async def test_bespoke_handler_matches_generate_option_restrictions(
+    request: dict[str, Any],
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        await anext(_handler(_Client()).generate(request, _Context()))
+
+
+@pytest.mark.parametrize(
+    "chunks,match",
+    [
+        ([{"token_ids": [1], "index": 0}], "no terminal"),
+        (
+            [
+                {"token_ids": [1], "index": 0, "finish_reason": "stop"},
+                {"token_ids": [2], "index": 0},
+            ],
+            "after its terminal",
+        ),
+        (
+            [
+                {
+                    "token_ids": [1],
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "log_probs": [-0.1],
+                }
+            ],
+            "generator logprobs",
+        ),
+        (
+            [{"token_ids": [1], "index": 0, "finish_reason": ""}],
+            "invalid finish_reason",
+        ),
+    ],
+)
+async def test_bespoke_stream_validation_parity(
+    chunks: list[dict[str, Any]],
+    match: str,
+) -> None:
+    async def values() -> AsyncIterator[dict[str, Any]]:
+        for chunk in chunks:
+            yield chunk
+
+    with pytest.raises((RuntimeError, TypeError), match=match):
+        await _collect_generation(values())

--- a/examples/experimental/workflow/user_ensemble/tests/test_bespoke.py
+++ b/examples/experimental/workflow/user_ensemble/tests/test_bespoke.py
@@ -7,9 +7,10 @@ from typing import Any
 
 import pytest
 
+from dynamo.experimental.workflow import WorkflowExecutionError
+from dynamo.experimental.workflow.generate import GenerateEndpointInvoker
 from examples.experimental.workflow.user_ensemble.bespoke.orchestrator_worker import (
     BespokeEnsembleHandler,
-    _collect_generation,
 )
 from examples.experimental.workflow.user_ensemble.common.stages import (
     EnsembleResponseStage,
@@ -94,7 +95,7 @@ def _handler(
         classifier=classifier or _Runner({"scores": {"dummy-positive": 1.0}}),
         request_adapter=_RequestAdapter(),
         response=EnsembleResponseStage(),
-        generator_client=client,
+        generator=GenerateEndpointInvoker(client),
     )
 
 
@@ -172,7 +173,7 @@ async def test_bespoke_handler_propagates_caller_cancellation() -> None:
 
 
 @pytest.mark.parametrize(
-    "request,match",
+    "request_value,match",
     [
         ({"sampling_options": {"n": 2}}, "requires n=1"),
         ({"output_options": {"logprobs": 1}}, "does not support logprobs"),
@@ -182,49 +183,9 @@ async def test_bespoke_handler_propagates_caller_cancellation() -> None:
         ),
     ],
 )
-async def test_bespoke_handler_matches_generate_option_restrictions(
-    request: dict[str, Any],
+async def test_bespoke_handler_reuses_generate_option_validation(
+    request_value: dict[str, Any],
     match: str,
 ) -> None:
-    with pytest.raises(ValueError, match=match):
-        await anext(_handler(_Client()).generate(request, _Context()))
-
-
-@pytest.mark.parametrize(
-    "chunks,match",
-    [
-        ([{"token_ids": [1], "index": 0}], "no terminal"),
-        (
-            [
-                {"token_ids": [1], "index": 0, "finish_reason": "stop"},
-                {"token_ids": [2], "index": 0},
-            ],
-            "after its terminal",
-        ),
-        (
-            [
-                {
-                    "token_ids": [1],
-                    "index": 0,
-                    "finish_reason": "stop",
-                    "log_probs": [-0.1],
-                }
-            ],
-            "generator logprobs",
-        ),
-        (
-            [{"token_ids": [1], "index": 0, "finish_reason": ""}],
-            "invalid finish_reason",
-        ),
-    ],
-)
-async def test_bespoke_stream_validation_parity(
-    chunks: list[dict[str, Any]],
-    match: str,
-) -> None:
-    async def values() -> AsyncIterator[dict[str, Any]]:
-        for chunk in chunks:
-            yield chunk
-
-    with pytest.raises((RuntimeError, TypeError), match=match):
-        await _collect_generation(values())
+    with pytest.raises(WorkflowExecutionError, match=match):
+        await anext(_handler(_Client()).generate(request_value, _Context()))

--- a/examples/experimental/workflow/user_ensemble/tests/test_workflow.py
+++ b/examples/experimental/workflow/user_ensemble/tests/test_workflow.py
@@ -5,34 +5,29 @@ from types import SimpleNamespace
 
 import pytest
 
-from dynamo.experimental.workflow import GenerateEndpointBinding, InlineBinding
 from examples.experimental.workflow.user_ensemble.common.stages import (
     EnsembleResponseStage,
 )
 from examples.experimental.workflow.user_ensemble.workflow.workflow import (
-    compile_user_ensemble,
+    define_workflow,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
 
 
-def test_user_ensemble_compiles_mixed_placement() -> None:
-    plan = compile_user_ensemble()
+def test_user_ensemble_authors_request_only_generator() -> None:
+    workflow_ir = define_workflow().build()
+    stages = {stage.id: stage for stage in workflow_ir.stages}
 
-    assert set(plan.bindings) == {
+    assert set(stages) == {
         "encoder",
         "classifier",
         "request_adapter",
         "generator",
         "response",
     }
-    assert isinstance(plan.bindings["generator"], GenerateEndpointBinding)
-    assert all(
-        isinstance(plan.bindings[stage_id], InlineBinding)
-        for stage_id in ("encoder", "classifier", "request_adapter", "response")
-    )
-    assert plan.stage_contracts["generator"].inputs == {"request"}
-    assert plan.stage_contracts["generator"].outputs == {"completion"}
+    assert stages["generator"].contract.inputs == {"request"}
+    assert stages["generator"].contract.outputs == {"completion"}
 
 
 async def test_response_stage_preserves_completion_and_adds_scores() -> None:

--- a/examples/experimental/workflow/user_ensemble/tests/test_workflow.py
+++ b/examples/experimental/workflow/user_ensemble/tests/test_workflow.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.experimental.workflow import GenerateEndpointBinding, InlineBinding
+from examples.experimental.workflow.user_ensemble.common.stages import (
+    EnsembleResponseStage,
+)
+from examples.experimental.workflow.user_ensemble.workflow.workflow import (
+    compile_user_ensemble,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+
+
+def test_user_ensemble_compiles_mixed_placement() -> None:
+    plan = compile_user_ensemble()
+
+    assert set(plan.bindings) == {
+        "encoder",
+        "classifier",
+        "request_adapter",
+        "generator",
+        "response",
+    }
+    assert isinstance(plan.bindings["generator"], GenerateEndpointBinding)
+    assert all(
+        isinstance(plan.bindings[stage_id], InlineBinding)
+        for stage_id in ("encoder", "classifier", "request_adapter", "response")
+    )
+    assert plan.stage_contracts["generator"].inputs == {"request"}
+    assert plan.stage_contracts["generator"].outputs == {"completion"}
+
+
+async def test_response_stage_preserves_completion_and_adds_scores() -> None:
+    result = await EnsembleResponseStage().run(
+        {
+            "completion": {
+                "token_ids": [4, 2],
+                "index": 0,
+                "finish_reason": "stop",
+                "engine_data": {"decoder": "vllm"},
+            },
+            "scores": {"dummy-positive": 1.0},
+        },
+        SimpleNamespace(),
+    )
+
+    assert result["chunk"]["token_ids"] == [4, 2]
+    assert result["chunk"]["engine_data"] == {
+        "decoder": "vllm",
+        "user_ensemble": {"classifier_scores": {"dummy-positive": 1.0}},
+    }

--- a/examples/experimental/workflow/user_ensemble/workflow/__init__.py
+++ b/examples/experimental/workflow/user_ensemble/workflow/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declarative user-ensemble implementation."""

--- a/examples/experimental/workflow/user_ensemble/workflow/launch.sh
+++ b/examples/experimental/workflow/user_ensemble/workflow/launch.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(readlink -f "$SCRIPT_DIR/../../../../..")"
+source "$REPO_ROOT/examples/common/gpu_utils.sh"
+source "$REPO_ROOT/examples/common/launch_utils.sh"
+trap dynamo_exit_trap EXIT
+
+MODEL="${DYN_MODEL:-Qwen/Qwen2.5-1.5B-Instruct}"
+PUBLIC_MODEL_NAME="${DYN_SERVED_MODEL_NAME:-user-ensemble}"
+DECODER_MODEL_NAME="${DYN_DECODER_MODEL_NAME:-user-ensemble-decoder}"
+NAMESPACE="${DYN_NAMESPACE:-workflow-user-ensemble}"
+GENERATOR_ENDPOINT="$NAMESPACE.generator.generate"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+WORKER_GPU="${DYN_WORKER_GPU:-${CUDA_VISIBLE_DEVICES:-0}}"
+MAX_MODEL_LEN="${DYN_MAX_MODEL_LEN:-4096}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+[[ -z "$GPU_MEM_ARGS" ]] && GPU_MEM_ARGS="--gpu-memory-utilization 0.8"
+
+export DYN_NAMESPACE="$NAMESPACE"
+export DYN_REQUEST_PLANE=tcp
+export DYN_REQUEST_PLANE_CODEC=msgpack
+export DYN_TCP_MAX_MESSAGE_SIZE=209715200
+export DYN_HTTP_BODY_LIMIT_MB=200
+
+print_launch_banner --no-curl "Workflow User Ensemble" "$MODEL" "$HTTP_PORT" \
+    "Public model: $PUBLIC_MODEL_NAME" \
+    "Inline: encoder, classifier, request adapter, response" \
+    "Remote: dyn://$GENERATOR_ENDPOINT"
+
+python -m dynamo.frontend --http-port "$HTTP_PORT" --enable-nvext &
+
+CUDA_VISIBLE_DEVICES="$WORKER_GPU" \
+DYN_SYSTEM_PORT="${DYN_GENERATOR_SYSTEM_PORT:-8081}" \
+python -m dynamo.vllm \
+    --model "$MODEL" \
+    --served-model-name "$DECODER_MODEL_NAME" \
+    --endpoint "dyn://$GENERATOR_ENDPOINT" \
+    --enable-prompt-embeds \
+    --max-model-len "$MAX_MODEL_LEN" \
+    $GPU_MEM_ARGS \
+    "$@" &
+
+DYN_MODEL="$MODEL" \
+DYN_SERVED_MODEL_NAME="$PUBLIC_MODEL_NAME" \
+DYN_SYSTEM_PORT="${DYN_ORCHESTRATOR_SYSTEM_PORT:-8082}" \
+python -m \
+    examples.experimental.workflow.user_ensemble.workflow.orchestrator_worker &
+
+wait_any_exit

--- a/examples/experimental/workflow/user_ensemble/workflow/orchestrator_worker.py
+++ b/examples/experimental/workflow/user_ensemble/workflow/orchestrator_worker.py
@@ -5,12 +5,18 @@
 
 import asyncio
 
-from dynamo.experimental.workflow import WorkflowEndpointHandler, WorkflowOrchestrator
+from dynamo.experimental.workflow import (
+    GenerateEndpointBinding,
+    InlineBinding,
+    WorkflowEndpointHandler,
+    WorkflowOrchestrator,
+)
 from dynamo.experimental.workflow.vllm import ExternalEncoderRequestStage
 from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from examples.experimental.workflow.user_ensemble.common.config import (
     CHAT_TEMPLATE,
+    GENERATOR_ENDPOINT,
     MODEL,
     ORCHESTRATOR_ENDPOINT,
     PUBLIC_MODEL_NAME,
@@ -21,7 +27,7 @@ from examples.experimental.workflow.user_ensemble.common.stages import (
     EnsembleResponseStage,
 )
 from examples.experimental.workflow.user_ensemble.workflow.workflow import (
-    compile_user_ensemble,
+    define_workflow,
 )
 
 
@@ -30,14 +36,15 @@ async def worker(runtime: DistributedRuntime) -> None:
     encoder = build_encoder_stage()
     try:
         orchestrator = await WorkflowOrchestrator.bind(
-            compile_user_ensemble(),
-            runtime=runtime,
-            inline_runners={
-                "encoder": encoder,
-                "classifier": DummyClassifier(),
-                "request_adapter": ExternalEncoderRequestStage(),
-                "response": EnsembleResponseStage(),
+            define_workflow(),
+            bindings={
+                "encoder": InlineBinding(encoder),
+                "classifier": InlineBinding(DummyClassifier()),
+                "request_adapter": InlineBinding(ExternalEncoderRequestStage()),
+                "generator": GenerateEndpointBinding(GENERATOR_ENDPOINT),
+                "response": InlineBinding(EnsembleResponseStage()),
             },
+            runtime=runtime,
         )
         endpoint = runtime.endpoint(ORCHESTRATOR_ENDPOINT)
         await register_model(

--- a/examples/experimental/workflow/user_ensemble/workflow/orchestrator_worker.py
+++ b/examples/experimental/workflow/user_ensemble/workflow/orchestrator_worker.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serve the declarative user ensemble as one discovered model worker."""
+
+import asyncio
+
+from dynamo.experimental.workflow import WorkflowEndpointHandler, WorkflowOrchestrator
+from dynamo.experimental.workflow.vllm import ExternalEncoderRequestStage
+from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+from examples.experimental.workflow.user_ensemble.common.config import (
+    CHAT_TEMPLATE,
+    MODEL,
+    ORCHESTRATOR_ENDPOINT,
+    PUBLIC_MODEL_NAME,
+    build_encoder_stage,
+)
+from examples.experimental.workflow.user_ensemble.common.stages import (
+    DummyClassifier,
+    EnsembleResponseStage,
+)
+from examples.experimental.workflow.user_ensemble.workflow.workflow import (
+    compile_user_ensemble,
+)
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime) -> None:
+    encoder = build_encoder_stage()
+    try:
+        orchestrator = await WorkflowOrchestrator.bind(
+            compile_user_ensemble(),
+            runtime=runtime,
+            inline_runners={
+                "encoder": encoder,
+                "classifier": DummyClassifier(),
+                "request_adapter": ExternalEncoderRequestStage(),
+                "response": EnsembleResponseStage(),
+            },
+        )
+        endpoint = runtime.endpoint(ORCHESTRATOR_ENDPOINT)
+        await register_model(
+            ModelInput.Tokens,
+            ModelType.Chat,
+            endpoint,
+            MODEL,
+            model_name=PUBLIC_MODEL_NAME,
+            worker_type=WorkerType.Aggregated,
+            custom_template_path=str(CHAT_TEMPLATE),
+            ignore_weights=True,
+        )
+        await endpoint.serve_endpoint(WorkflowEndpointHandler(orchestrator).generate)
+    finally:
+        encoder.close()
+
+
+def main() -> None:
+    asyncio.run(worker())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/workflow/user_ensemble/workflow/workflow.py
+++ b/examples/experimental/workflow/user_ensemble/workflow/workflow.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Author and compile the mixed-placement user ensemble."""
+
+from dynamo.experimental.workflow import (
+    DeploymentSpec,
+    ExecutionPlan,
+    GenerateEndpointBinding,
+    InlineBinding,
+    Workflow,
+    compile_workflow,
+)
+from dynamo.experimental.workflow.vllm import (
+    DynamoVllmStage,
+    EncoderStage,
+    ExternalEncoderRequestStage,
+)
+from examples.experimental.workflow.user_ensemble.common.config import (
+    GENERATOR_ENDPOINT,
+)
+from examples.experimental.workflow.user_ensemble.common.stages import (
+    DummyClassifier,
+    EnsembleResponseStage,
+)
+
+
+def define_workflow() -> Workflow:
+    """Declare application dataflow independently from stage placement."""
+
+    workflow = Workflow("user-ensemble")
+    request = workflow.input("request")
+    encoder = workflow.stage("encoder", EncoderStage.contract, request=request)
+    classifier = workflow.stage(
+        "classifier",
+        DummyClassifier.contract,
+        encoder_features=encoder.encoder_features,
+    )
+    prepared = workflow.stage(
+        "request_adapter",
+        ExternalEncoderRequestStage.contract,
+        request=request,
+        encoder_features=encoder.encoder_features,
+        encoder_metadata=encoder.encoder_metadata,
+    )
+    generator = workflow.stage(
+        "generator",
+        DynamoVllmStage.request_complete_contract,
+        request=prepared.request,
+    )
+    response = workflow.stage(
+        "response",
+        EnsembleResponseStage.contract,
+        completion=generator.completion,
+        scores=classifier.scores,
+    )
+    workflow.output("chunk", response.chunk)
+    return workflow
+
+
+def compile_user_ensemble() -> ExecutionPlan:
+    """Bind four inline stages and one discovered stock Generate endpoint."""
+
+    return compile_workflow(
+        define_workflow(),
+        DeploymentSpec(
+            bindings={
+                "encoder": InlineBinding("encoder"),
+                "classifier": InlineBinding("classifier"),
+                "request_adapter": InlineBinding("request_adapter"),
+                "generator": GenerateEndpointBinding(GENERATOR_ENDPOINT),
+                "response": InlineBinding("response"),
+            }
+        ),
+    )

--- a/examples/experimental/workflow/user_ensemble/workflow/workflow.py
+++ b/examples/experimental/workflow/user_ensemble/workflow/workflow.py
@@ -1,23 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Author and compile the mixed-placement user ensemble."""
+"""Author the placement-neutral user ensemble."""
 
-from dynamo.experimental.workflow import (
-    DeploymentSpec,
-    ExecutionPlan,
-    GenerateEndpointBinding,
-    InlineBinding,
-    Workflow,
-    compile_workflow,
-)
+from dynamo.experimental.workflow import Workflow
 from dynamo.experimental.workflow.vllm import (
     DynamoVllmStage,
     EncoderStage,
     ExternalEncoderRequestStage,
-)
-from examples.experimental.workflow.user_ensemble.common.config import (
-    GENERATOR_ENDPOINT,
 )
 from examples.experimental.workflow.user_ensemble.common.stages import (
     DummyClassifier,
@@ -56,20 +46,3 @@ def define_workflow() -> Workflow:
     )
     workflow.output("chunk", response.chunk)
     return workflow
-
-
-def compile_user_ensemble() -> ExecutionPlan:
-    """Bind four inline stages and one discovered stock Generate endpoint."""
-
-    return compile_workflow(
-        define_workflow(),
-        DeploymentSpec(
-            bindings={
-                "encoder": InlineBinding("encoder"),
-                "classifier": InlineBinding("classifier"),
-                "request_adapter": InlineBinding("request_adapter"),
-                "generator": GenerateEndpointBinding(GENERATOR_ENDPOINT),
-                "response": InlineBinding("response"),
-            }
-        ),
-    )


### PR DESCRIPTION
_Based on #13293._

## Why

Dynamo endpoints already let applications build this ensemble manually, so the workflow API should demonstrate its value against an equivalent baseline. Both variants share the inline components, stock vLLM worker, and the same `GenerateEndpointInvoker` for request validation, stream folding, and remote-call cancellation. This isolates the comparison to orchestration ownership: the workflow runtime owns graph scheduling and binding, while the bespoke handler owns coroutine and sibling-task lifecycle.

## Effect

```text
                  ┌─> inline classifier ────────────┐
request → encoder ┤                                 ├→ inline merge → chunk
                  └─> request adapter → stock vLLM ─┘
```

## What Change

- Add declarative and bespoke mixed-placement vision ensembles.
- Share stages, launch topology, and Generate endpoint invocation.
- Keep scheduling and sibling lifecycle as the comparison.

```mermaid
classDiagram
    WorkflowOrchestrator *-- StageDispatcher : schedules graph
    StageDispatcher ..> GenerateEndpointInvoker : invokes remote Generate
    BespokeEnsembleHandler ..> GenerateEndpointInvoker : invokes same adapter
    GenerateEndpointInvoker ..> DynamoClient : calls discovered endpoint
    BespokeEnsembleHandler --> EncoderStage : schedules inline

    note for WorkflowOrchestrator "Owns authored graph execution"
    note for BespokeEnsembleHandler "Owns equivalent task orchestration"
    note for GenerateEndpointInvoker "Shares validation, folding, and call cancellation"
```

## Test Plan

- Generate adapter and bespoke orchestration CPU behavior pass.
- Targeted pre-commit hooks pass.
