### PR TITLE
fix(trtllm): reject guided JSON ref cycles missed by backend-only validation

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -37,6 +37,7 @@ from dynamo.common.backend import logprobs as _shared_logprobs
 from dynamo.common.backend.engine import is_generation_stage
 from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
 from dynamo.common.multimodal.cache_uuid import reject_unsupported_multimodal_uuids
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.llm.exceptions import EngineShutdown
@@ -1526,8 +1527,12 @@ class HandlerBase(BaseGenerativeHandler):
                 if valid_choices:
                     regex = "(" + "|".join(re.escape(c) for c in valid_choices) + ")"
 
+            json_schema = guided_decoding.get("json")
+            if json_schema is not None:
+                reject_nonprogressing_guided_json_ref_cycles(json_schema)
+
             overrides["guided_decoding"] = GuidedDecodingParams(
-                json=guided_decoding.get("json"),
+                json=json_schema,
                 regex=regex,
                 grammar=guided_decoding.get("grammar"),
                 json_object=guided_decoding.get("json_object", False),

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import json
 import re as re_mod
 from copy import deepcopy
 from dataclasses import dataclass
@@ -22,7 +23,7 @@ from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
 from tensorrt_llm.llmapi import DisaggregatedParams
 from tensorrt_llm.llmapi.llm import SamplingParams
 
-from dynamo.llm.exceptions import EngineShutdown
+from dynamo.llm.exceptions import EngineShutdown, HttpError
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
 from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor
@@ -371,6 +372,54 @@ class TestGuidedDecodingFromToolChoice:
         result = HandlerBase._override_sampling_params(sampling_params, request)
 
         assert result.guided_decoding.regex is None
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            {"$ref": "#"},
+            json.dumps({"$ref": "#"}),
+            {
+                "$defs": {
+                    "A": {"$ref": "#/$defs/B"},
+                    "B": {"$ref": "#/$defs/A"},
+                },
+                "$ref": "#/$defs/A",
+            },
+        ],
+    )
+    def test_rejects_guided_json_reference_cycles(self, schema):
+        """Non-progressing local $ref cycles must be rejected before reaching
+        the grammar compiler, matching the vLLM and SGLang backends."""
+        sampling_params = MockSamplingParams()
+        request = {"sampling_options": {"guided_decoding": {"json": schema}}}
+
+        with pytest.raises(HttpError) as error:
+            HandlerBase._override_sampling_params(sampling_params, request)
+
+        assert error.value.code == 400
+
+    def test_accepts_productive_recursive_guided_json(self):
+        """Recursive schemas that consume input stay supported."""
+        schema = {
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "children": {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/Node"},
+                        }
+                    },
+                }
+            },
+            "$ref": "#/$defs/Node",
+        }
+        sampling_params = MockSamplingParams()
+        request = {"sampling_options": {"guided_decoding": {"json": schema}}}
+
+        result = HandlerBase._override_sampling_params(sampling_params, request)
+
+        assert result.guided_decoding.json == schema
 
 
 class _ConcreteHandler(HandlerBase):


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

 reject guided JSON $ref cycles missed by backend-only validation for trtllm

## Details:

<!-- Describe the changes made in this PR. -->

Currently, the a backend-neutral guided JSON schema validator `reject_nonprogressing_guided_json_ref_cycles` is wired it into the vLLM and SGLang request handlers. The TRT-LLM handler is not updated, so the same client input still reaches the grammar compiler there.

TRT-LLM's `docs/fern/pages/reference/backends/tensorrt-llm-configuration.md` promises: 

"Both xgrammar and llguidance provide grammar-constrained generation for JSON schema, regex, and similar output formats."

This PR applies that same validation to TRT-LLM.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for guided JSON schemas by rejecting invalid non-progressing reference cycles.
  * Productive recursive schemas continue to be accepted.
  * Invalid schemas now return a clear HTTP 400 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->