### PR TITLE
fix(runtime): trigger migration on TCP connection failure

### DIFF
--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -1159,14 +1159,11 @@ impl HostPool {
             }
         }
 
-        Err(cannot_connect_error(
+        anyhow::bail!(
+            "No healthy TCP connection to {} after {} connect retries",
             self.addr,
-            anyhow::anyhow!(
-                "No healthy TCP connection to {} after {} connect retries",
-                self.addr,
-                MAX_CONNECT_RETRIES
-            ),
-        ))
+            MAX_CONNECT_RETRIES
+        )
     }
 }
 

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -1500,8 +1500,24 @@ impl RequestPlaneClient for TcpRequestClient {
             headers.insert("x-endpoint-path".to_string(), endpoint_name.clone());
         }
 
-        // Get shared connection from pool (Arc, not exclusive borrow)
-        let conn = self.pool.get_connection(addr).await?;
+        // Get shared connection from pool (Arc, not exclusive borrow).
+        // A cold connection failure must use the same error type as a send failure so the
+        // request migration layer can retry it on another worker.
+        let conn = self.pool.get_connection(addr).await.map_err(|e| {
+            self.stats.errors.fetch_add(1, Ordering::Relaxed);
+            TCP_ERRORS_TOTAL.inc();
+            tracing::warn!(%addr, error = %e, "TCP connection failed");
+            let cause = crate::error::DynamoError::from(
+                e.into_boxed_dyn_error() as Box<dyn std::error::Error + 'static>
+            );
+            anyhow::anyhow!(
+                crate::error::DynamoError::builder()
+                    .error_type(crate::error::ErrorType::CannotConnect)
+                    .message(format!("TCP connection to {addr} failed"))
+                    .cause(cause)
+                    .build()
+            )
+        })?;
 
         let result = tokio::time::timeout(
             self.config.request_timeout,
@@ -1643,6 +1659,37 @@ mod tests {
         let client = client.unwrap();
         assert_eq!(client.transport_name(), "tcp");
         assert!(client.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn test_cold_connection_failure_is_cannot_connect() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let client = TcpRequestClient::with_config(TcpRequestConfig {
+            request_timeout: Duration::from_secs(1),
+            connect_timeout: Duration::from_secs(1),
+            pool_size: 1,
+            channel_buffer: 1,
+        })
+        .unwrap();
+
+        let err = client
+            .send_request(
+                format!("{addr}/generate"),
+                Bytes::from_static(b"ping"),
+                Headers::new(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(crate::error::match_error_chain(
+            err.as_ref(),
+            &[crate::error::ErrorType::CannotConnect],
+            &[],
+        ));
+        assert_eq!(client.stats.errors.load(Ordering::Relaxed), 1);
     }
 
     /// Helper: spawn a mock TCP server that echoes requests.

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -871,6 +871,19 @@ impl TcpConnection {
     }
 }
 
+fn cannot_connect_error(addr: SocketAddr, error: anyhow::Error) -> anyhow::Error {
+    let cause = crate::error::DynamoError::from(
+        error.into_boxed_dyn_error() as Box<dyn std::error::Error + 'static>
+    );
+    anyhow::anyhow!(
+        crate::error::DynamoError::builder()
+            .error_type(crate::error::ErrorType::CannotConnect)
+            .message(format!("TCP connection to {addr} failed"))
+            .cause(cause)
+            .build()
+    )
+}
+
 /// Per-host connection pool with LRU lifecycle and ArcSwap-based snapshot.
 ///
 /// Hot path: `ArcSwap::load()` + atomic round-robin (~40ns total, fully lock-free).
@@ -1087,7 +1100,7 @@ impl HostPool {
                     }
                     Err(e) => {
                         self.connect_notify.notify_waiters();
-                        return Err(e);
+                        return Err(cannot_connect_error(self.addr, e));
                     }
                 }
             }
@@ -1146,11 +1159,14 @@ impl HostPool {
             }
         }
 
-        anyhow::bail!(
-            "No healthy TCP connection to {} after {} connect retries",
+        Err(cannot_connect_error(
             self.addr,
-            MAX_CONNECT_RETRIES
-        )
+            anyhow::anyhow!(
+                "No healthy TCP connection to {} after {} connect retries",
+                self.addr,
+                MAX_CONNECT_RETRIES
+            ),
+        ))
     }
 }
 
@@ -1500,23 +1516,13 @@ impl RequestPlaneClient for TcpRequestClient {
             headers.insert("x-endpoint-path".to_string(), endpoint_name.clone());
         }
 
-        // Get shared connection from pool (Arc, not exclusive borrow).
-        // A cold connection failure must use the same error type as a send failure so the
-        // request migration layer can retry it on another worker.
+        // Get shared connection from pool (Arc, not exclusive borrow). Actual connection
+        // failures are classified at the dial site; local pool errors retain their type.
         let conn = self.pool.get_connection(addr).await.map_err(|e| {
             self.stats.errors.fetch_add(1, Ordering::Relaxed);
             TCP_ERRORS_TOTAL.inc();
-            tracing::warn!(%addr, error = %e, "TCP connection failed");
-            let cause = crate::error::DynamoError::from(
-                e.into_boxed_dyn_error() as Box<dyn std::error::Error + 'static>
-            );
-            anyhow::anyhow!(
-                crate::error::DynamoError::builder()
-                    .error_type(crate::error::ErrorType::CannotConnect)
-                    .message(format!("TCP connection to {addr} failed"))
-                    .cause(cause)
-                    .build()
-            )
+            tracing::warn!(%addr, error = %e, "TCP connection unavailable");
+            e
         })?;
 
         let result = tokio::time::timeout(
@@ -1689,6 +1695,39 @@ mod tests {
             &[crate::error::ErrorType::CannotConnect],
             &[],
         ));
+        assert!(
+            err.chain().count() > 1,
+            "cold connection failure must retain its cause"
+        );
+        assert_eq!(client.stats.errors.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn test_closed_connect_limiter_is_not_cannot_connect() {
+        let client = TcpRequestClient::with_config(TcpRequestConfig {
+            request_timeout: Duration::from_secs(1),
+            connect_timeout: Duration::from_secs(1),
+            pool_size: 1,
+            channel_buffer: 1,
+        })
+        .unwrap();
+        client.pool.connect_limiter.close();
+
+        let err = client
+            .send_request(
+                "127.0.0.1:1/generate".to_string(),
+                Bytes::from_static(b"ping"),
+                Headers::new(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(!crate::error::match_error_chain(
+            err.as_ref(),
+            &[crate::error::ErrorType::CannotConnect],
+            &[],
+        ));
+        assert!(err.to_string().contains("Global connect limiter closed"));
         assert_eq!(client.stats.errors.load(Ordering::Relaxed), 1);
     }
 


### PR DESCRIPTION
## Overview:

- Classify actual TCP connection-establishment failures as `ErrorType::CannotConnect`.
- Allow the request migration layer to retry another worker when the initial TCP connection cannot be established.
- Record failed connection attempts using the existing TCP error counters and structured logging.
- Add a regression test covering cold TCP connection failures.

## Details:

When the TCP request plane attempted to send a request without an existing pooled connection, `TcpConnectionPool::get_connection()` errors were propagated directly with `?`.

These errors did not contain `ErrorType::CannotConnect`. The request migration layer determines whether an error is migratable by inspecting its typed error chain, so an initial TCP connection failure was treated as non-migratable and returned to the client instead of retrying another worker.

TCP failures occurring after a connection was established were already classified as `CannotConnect`, resulting in inconsistent behavior between connection establishment and request transmission failures.

## Where should the reviewer start?

Wrap terminal connection-pool failures in a `DynamoError` with:

```rust
ErrorType::CannotConnect
```
The original connection error is preserved as the cause.
The failure path also:
- Increments the existing per-client TCP error count;
- Increments the existing TCP_ERRORS_TOTAL metric;
- Emits a structured warning with the target address and original error.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TCP connection failures now return a consistent connection error.
  * Added error statistics, metrics, and warning logs for failed connection attempts.
  * Improved reliability of cold-connection failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->