### PR TITLE
fix(planner): auto-resolve the AIC database version and fall back to FPM regression

### DIFF
--- a/components/src/dynamo/planner/core/perf_model/aic_adapter.py
+++ b/components/src/dynamo/planner/core/perf_model/aic_adapter.py
@@ -16,6 +16,8 @@ import math
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from aiconfigurator_core.sdk.perf_database import get_latest_database_version
+
 from dynamo.common.forward_pass_metrics import (
     FPM_VERSION,
     ForwardPassMetrics,
@@ -41,6 +43,18 @@ _ENGINE_MODEL_INIT_EXCEPTIONS = (ImportError, *_ENGINE_MODEL_EXCEPTIONS)
 DEFAULT_MAX_NUM_BATCHED_TOKENS = 8192
 DEFAULT_MAX_NUM_SEQS = 512
 DEFAULT_MAX_KV_TOKENS = 2_000_000
+
+
+def _resolve_backend_version(spec: AICPerfModelSpec) -> Optional[str]:
+    """Resolve the packaged AIC perf-database version for a spec.
+
+    ``backend_version`` identifies an aiconfigurator-core data asset, not the
+    engine version a user runs, so a config that omits it is resolved here
+    rather than pushed onto the user.
+    """
+    if spec.backend_version is not None:
+        return spec.backend_version
+    return get_latest_database_version(spec.system, spec.backend)
 
 
 @dataclass(frozen=True)
@@ -242,13 +256,26 @@ class PlannerEnginePerfModel:
         pick = self._pick_for_worker(spec)
         if pick is None:
             return None
+        # aiconfigurator-core treats backend_version as required and raises a
+        # non-fallback-safe error when it is missing, so resolve the packaged
+        # database version here and drop to FPM regression when there is none.
+        backend_version = _resolve_backend_version(spec)
+        if backend_version is None:
+            logger.warning(
+                "No AIC performance database is available for system=%s, "
+                "backend=%s; using FPM regression instead of native AIC "
+                "estimates.",
+                spec.system,
+                spec.backend,
+            )
+            return None
         nextn = self._effective_speculative_nextn()
         return {
             "schema_version": 1,
             "model_name": spec.hf_id,
             "system_name": spec.system,
             "backend": spec.backend,
-            "backend_version": spec.backend_version,
+            "backend_version": backend_version,
             "kv_block_size": (
                 self._capabilities.kv_cache_block_size
                 if self._capabilities is not None

--- a/components/src/dynamo/planner/tests/unit/test_aic_perf_adapter.py
+++ b/components/src/dynamo/planner/tests/unit/test_aic_perf_adapter.py
@@ -101,11 +101,18 @@ def _install_fake_engine(fake_engine_factory, fake_model: _FakeEngineModel) -> N
     fake_engine_factory.last_kwargs = None
 
 
+# These tests replace the engine factory, so the value is never used against a
+# real database -- it only has to be non-None so that version resolution
+# short-circuits and the tests stay independent of the installed wheel.
+_STUB_BACKEND_VERSION = "test-backend-version"
+
+
 def _config(
     *,
     dp: int = 1,
     min_observations: int = 5,
     speculative_nextn: int = 0,
+    backend_version: str | None = _STUB_BACKEND_VERSION,
 ) -> PlannerConfig:
     pick = PickedParallelConfig(dp=dp)
     return PlannerConfig.model_construct(
@@ -113,6 +120,7 @@ def _config(
             hf_id="Qwen/Qwen3-0.6B",
             system="h200_sxm",
             backend="vllm",
+            backend_version=backend_version,
             prefill_pick=pick,
             decode_pick=pick,
         ),
@@ -541,3 +549,204 @@ def test_adapter_does_not_expose_legacy_prediction_passthroughs():
         "find_best_engine_agg_rps",
     ):
         assert not hasattr(PlannerEnginePerfModel, name)
+
+
+def _ready_engine() -> _FakeEngineModel:
+    return _FakeEngineModel(
+        diagnostics={
+            "source": "aic",
+            "readiness": "ready",
+            "retained_observations": 0,
+            "correction_ready_buckets": 0,
+            "last_warning": None,
+        }
+    )
+
+
+@pytest.fixture
+def stub_latest_database_version(monkeypatch):
+    """Stub the packaged AIC perf-database version lookup."""
+
+    def install(version):
+        lookups = []
+
+        def fake(system, backend):
+            lookups.append((system, backend))
+            return version
+
+        monkeypatch.setattr(
+            aic_adapter,
+            "get_latest_database_version",
+            fake,
+        )
+        return lookups
+
+    return install
+
+
+def test_missing_backend_version_resolves_packaged_database_version(
+    fake_engine_factory, stub_latest_database_version
+):
+    """A hand-written config without backend_version must still query natively."""
+    lookups = stub_latest_database_version("0.24.0")
+    _install_fake_engine(fake_engine_factory, _ready_engine())
+
+    PlannerEnginePerfModel(
+        worker_type="decode",
+        config=_config(backend_version=None),
+        capabilities=_caps(),
+    )
+
+    assert fake_engine_factory.last_kwargs is not None
+    aic_config = fake_engine_factory.last_kwargs["aic_config"]
+    assert aic_config is not None
+    assert aic_config["backend_version"] == "0.24.0"
+    assert lookups == [("h200_sxm", "vllm")]
+
+
+def test_unresolvable_backend_version_falls_back_to_regression(
+    fake_engine_factory, stub_latest_database_version
+):
+    """No packaged database means FPM regression, not a hard native failure."""
+    stub_latest_database_version(None)
+    _install_fake_engine(fake_engine_factory, _ready_engine())
+
+    PlannerEnginePerfModel(
+        worker_type="decode",
+        config=_config(backend_version=None),
+        capabilities=_caps(),
+    )
+
+    assert fake_engine_factory.last_kwargs is not None
+    assert fake_engine_factory.last_kwargs["aic_config"] is None
+
+
+def test_explicit_backend_version_takes_precedence_over_lookup(
+    fake_engine_factory, stub_latest_database_version
+):
+    stub_latest_database_version("9.9.9")
+    _install_fake_engine(fake_engine_factory, _ready_engine())
+
+    PlannerEnginePerfModel(
+        worker_type="decode",
+        config=_config(backend_version="0.19.0"),
+        capabilities=_caps(),
+    )
+
+    assert fake_engine_factory.last_kwargs is not None
+    aic_config = fake_engine_factory.last_kwargs["aic_config"]
+    assert aic_config is not None
+    assert aic_config["backend_version"] == "0.19.0"
+
+
+def _real_engine_config(backend_version):
+    """Engine config in the shape `_build_aic_config` emits."""
+    return {
+        "schema_version": 1,
+        "model_name": "nvidia/Llama-3.1-8B-Instruct-FP8",
+        "system_name": "h200_sxm",
+        "backend": "vllm",
+        "backend_version": backend_version,
+        "kv_block_size": 16,
+        "tp_size": 1,
+        "pp_size": 1,
+        "moe_tp_size": 1,
+        "moe_ep_size": 1,
+        "attention_dp_size": 1,
+        "cp_size": None,
+        "weight_dtype": None,
+        "moe_dtype": None,
+        "activation_dtype": None,
+        "kv_cache_dtype": None,
+        "nextn": None,
+        "extra": {},
+    }
+
+
+_REAL_ENGINE_OPTIONS = {
+    "max_observations": 16,
+    "min_observations": 5,
+    "bucket_count": 16,
+    "max_num_tokens": 8192,
+    "max_batch_size": 512,
+    "max_kv_tokens": 2_000_000,
+}
+
+
+def test_aic_core_rejects_missing_backend_version():
+    """Pin the upstream contract the adapter's version resolution works around.
+
+    aiconfigurator-core raises ``InvalidEngineConfig`` for a missing
+    ``backend_version``, and that variant is not fallback-safe, so the wheel
+    does not degrade to regression on its own.
+    """
+    aic_sdk = pytest.importorskip("aiconfigurator_core.sdk")
+
+    with pytest.raises(ValueError, match="backend_version is required"):
+        aic_sdk.RustForwardPassPerfModel.best_available(
+            _real_engine_config(None), _REAL_ENGINE_OPTIONS
+        )
+
+
+def test_aic_core_accepts_resolved_backend_version():
+    """The same config succeeds once the packaged version is supplied."""
+    aic_sdk = pytest.importorskip("aiconfigurator_core.sdk")
+    perf_database = pytest.importorskip("aiconfigurator_core.sdk.perf_database")
+
+    version = perf_database.get_latest_database_version("h200_sxm", "vllm")
+    if version is None:
+        pytest.skip("wheel ships no h200_sxm/vllm performance database")
+
+    model = aic_sdk.RustForwardPassPerfModel.best_available(
+        _real_engine_config(version), _REAL_ENGINE_OPTIONS
+    )
+
+    assert model.diagnostics()["source"] == "aic"
+
+
+def test_config_without_backend_version_initializes_native_model():
+    """End-to-end guard against silent SLA-autoscaling failure.
+
+    Uses the real wheel: a hand-written config that omits ``backend_version``
+    must still produce a usable native model instead of leaving the planner
+    permanently unable to estimate.
+    """
+    perf_database = pytest.importorskip("aiconfigurator_core.sdk.perf_database")
+    if perf_database.get_latest_database_version("h200_sxm", "vllm") is None:
+        pytest.skip("wheel ships no h200_sxm/vllm performance database")
+
+    pick = PickedParallelConfig(dp=1)
+    config = PlannerConfig.model_construct(
+        aic_perf_model=AICPerfModelSpec.model_construct(
+            hf_id="nvidia/Llama-3.1-8B-Instruct-FP8",
+            system="h200_sxm",
+            backend="vllm",
+            backend_version=None,
+            prefill_pick=pick,
+            decode_pick=pick,
+        ),
+        max_num_fpm_samples=16,
+        load_min_observations=5,
+        fpm_sample_bucket_size=16,
+        ttft_ms=500.0,
+        itl_ms=50.0,
+        speculative_nextn=0,
+    )
+
+    model = PlannerEnginePerfModel(
+        worker_type="decode",
+        config=config,
+        capabilities=EngineCapabilities(
+            max_num_batched_tokens=8192,
+            max_num_seqs=512,
+            max_kv_tokens=2_000_000,
+            kv_cache_block_size=16,
+        ),
+    )
+
+    capacity = model.find_engine_capacity_rps(
+        isl=1000, osl=200, ttft_sla_ms=500.0, itl_sla_ms=50.0
+    )
+
+    assert capacity is not None
+    assert capacity.rps > 0


### PR DESCRIPTION

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

fix(planner): auto-resolve the AIC database version and fall back to FPM regression

## Details:

<!-- Describe the changes made in this PR. -->

The `DynamoGraphDeploymentRequest` CRD exposes `spec.features.planner.aic_perf_model.backend_version`, documented as an "Optional backend version string". The same field also reaches the planner when a `DynamoGraphDeployment` mounts a `planner_config.json` directly.

Dynamo marks `backend_version` as optional, but the underlying `aiconfigurator-core` dependency treats it as required, and that error is not on the FPM fallback whitelist, so the perf model neither works nor degrades.

As a result the planner starts normally and never exits with an error. It only logs a single warning:

```
Failed to initialize AIC engine perf model for decode ... invalid engine config: backend_version is required to load the perf database
```

SLA autoscaling is then silently dead for the lifetime of the process.

The fix resolves backend_version automatically, so users no longer have to supply it. When no version can be resolved, the adapter now falls back to FPM regression instead of leaving the perf model permanently unavailable.


## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically selects the latest available performance-database version when no AIC backend version is specified.
  * Preserves explicitly configured backend versions.
  * Falls back to FPM regression with a warning when no compatible database version is available.
  * Improves capacity estimation using resolved performance-model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->