### PR TITLE
docs: add the Qwen3.5-122B-A10B recipe page to the Fern docs site

### DIFF
--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -492,6 +492,9 @@ navigation:
           - page: Qwen3-32B
             path: pages/recipes/model-recipes/qwen3-32b.mdx
             slug: qwen3-32b
+          - page: Qwen3.5-122B-A10B
+            path: pages/recipes/model-recipes/qwen3-5-122b.mdx
+            slug: qwen3-5-122b
           - page: Qwen3-235B-A22B FP8
             path: pages/recipes/model-recipes/qwen3-235b-a22b-fp8.mdx
             slug: qwen3-235b-a22b-fp8

--- a/docs/fern/pages/recipes/_catalog/index.yaml
+++ b/docs/fern/pages/recipes/_catalog/index.yaml
@@ -24,6 +24,7 @@ recipes:
 - deepseek-v3-2-nvfp4
 - gpt-oss-120b
 - qwen3-32b
+- qwen3-5-122b
 - qwen3-235b-a22b-fp8
 - qwen3-32b-fp8
 - llama-3-3-70b

--- a/docs/fern/pages/recipes/_catalog/recipes/qwen3-5-122b.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/qwen3-5-122b.yaml
@@ -111,9 +111,9 @@ related_benchmarks: []
 maintainer: null
 gaps:
 - aggregated is the recommended path on both SKUs. The disaggregated targets are a
-  functional reference rather than a throughput recommendation: at 90% KV-cache hit the
-  dedicated prefill worker emits no output tokens, and on H200 disaggregation also gives
-  up MTP
+  functional reference rather than a throughput recommendation, because at 90% KV-cache
+  hit the dedicated prefill worker emits no output tokens, and on H200 disaggregation
+  also gives up MTP
 - both disaggregated targets carry --no-async-scheduling on vLLM < 0.26.0, costing ~7% throughput
 - TP2 sharding is an H200 FP8 win only. On B200 NVFP4 it loses in both topologies, and on
   H200 disaggregated it reaches 294.8 tok/s/GPU but regresses IFEval 84.66 to 80.22, so

--- a/docs/fern/pages/recipes/_catalog/recipes/qwen3-5-122b.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/qwen3-5-122b.yaml
@@ -110,8 +110,10 @@ targets:
 related_benchmarks: []
 maintainer: null
 gaps:
-- aggregated is the recommended path on both SKUs; disaggregated is retained for deployments
-  that scale prefill and decode independently
+- aggregated is the recommended path on both SKUs. The disaggregated targets are a
+  functional reference rather than a throughput recommendation: at 90% KV-cache hit the
+  dedicated prefill worker emits no output tokens, and on H200 disaggregation also gives
+  up MTP
 - both disaggregated targets carry --no-async-scheduling on vLLM < 0.26.0, costing ~7% throughput
 - TP2 sharding is an H200 FP8 win only. On B200 NVFP4 it loses in both topologies, and on
   H200 disaggregated it reaches 294.8 tok/s/GPU but regresses IFEval 84.66 to 80.22, so

--- a/docs/fern/pages/recipes/_catalog/recipes/qwen3-5-122b.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/qwen3-5-122b.yaml
@@ -110,10 +110,10 @@ targets:
 related_benchmarks: []
 maintainer: null
 gaps:
-- aggregated is the recommended path on both SKUs. The disaggregated targets are a
-  functional reference rather than a throughput recommendation, because at 90% KV-cache
-  hit the dedicated prefill worker emits no output tokens, and on H200 disaggregation
-  also gives up MTP
+- aggregated is the recommended path on both SKUs; the disaggregated targets are a
+  functional reference, not a throughput recommendation. At 90% KV-cache hit the prefill
+  worker has little to do yet emits no output tokens. MTP runs on H200 aggregated only —
+  H200 disaggregated gives it up, and neither B200 profile runs it
 - both disaggregated targets carry --no-async-scheduling on vLLM < 0.26.0, costing ~7% throughput
 - TP2 sharding is an H200 FP8 win only. On B200 NVFP4 it loses in both topologies, and on
   H200 disaggregated it reaches 294.8 tok/s/GPU but regresses IFEval 84.66 to 80.22, so

--- a/docs/fern/pages/recipes/_catalog/recipes/qwen3-5-122b.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/qwen3-5-122b.yaml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+id: qwen3-5-122b
+title: Qwen3.5-122B-A10B
+page: pages/recipes/model-recipes/qwen3-5-122b.mdx
+provider: alibaba
+model:
+  name: Qwen3.5-122B-A10B
+  hf_id: nvidia/Qwen3.5-122B-A10B-NVFP4 (B200) / Qwen/Qwen3.5-122B-A10B-FP8 (H200)
+  precision: NVFP4 + FP8 KV (B200) / FP8 (H200; FP8 KV on disaggregated only)
+status: validated
+targets:
+- id: agg-b200-agentic
+  recommended: true
+  hardware:
+    gpu: B200
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: aggregated
+  techniques:
+  - tp1
+  - fp8-kv-cache
+  - kv-aware-routing
+  workload:
+    type: agentic-trace-replay
+    traffic: Mooncake agentic trace, 64K median ISL / 400 median OSL, 90% KV cache hit, concurrency 50
+  deploy:
+    asset: recipes/qwen3.5-122b/nvfp4/vllm/agg-b200-agentic/deploy.yaml
+  benchmark:
+    tool: aiperf
+    asset: recipes/qwen3.5-122b/nvfp4/perf/perf.yaml
+  expected_performance:
+    available: true
+    summary: 1173.2 output tok/s/GPU, 52.4 user tok/s P50, TTFT P50 246 ms at concurrency 50 over 2 TP1 replicas (3,541-request agentic trace)
+- id: agg-h200-agentic
+  recommended: true
+  hardware:
+    gpu: H200
+    count: 4
+  runtime:
+    framework: vLLM
+  topology: aggregated
+  techniques:
+  - tp2
+  - mtp-spec-dec
+  - kv-aware-routing
+  workload:
+    type: agentic-trace-replay
+    traffic: Mooncake agentic trace, 64K median ISL / 400 median OSL, 90% KV cache hit, concurrency 64
+  deploy:
+    asset: recipes/qwen3.5-122b/fp8/vllm/agg-h200-agentic/deploy.yaml
+  benchmark:
+    tool: aiperf
+    asset: recipes/qwen3.5-122b/fp8/perf/perf.yaml
+  expected_performance:
+    available: true
+    summary: 720.3 output tok/s/GPU, 52.9 user tok/s P50, TTFT P50 313 ms at concurrency 64 over 2 TP2 replicas (3,541-request agentic trace)
+- id: disagg-b200-agentic
+  recommended: false
+  hardware:
+    gpu: B200
+    count: 3
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - 1p2d
+  - tp1-per-role
+  - fp8-kv-cache
+  - kv-aware-routing
+  - pd-kv-transfer
+  workload:
+    type: agentic-trace-replay
+    traffic: Mooncake agentic trace, 64K median ISL / 400 median OSL, 90% KV cache hit, concurrency 60
+  deploy:
+    asset: recipes/qwen3.5-122b/nvfp4/vllm/disagg-b200-agentic/deploy.yaml
+  benchmark:
+    tool: aiperf
+    asset: recipes/qwen3.5-122b/nvfp4/perf/perf.yaml
+  expected_performance:
+    available: true
+    summary: 916.6 output tok/s/GPU, 51.4 user tok/s P50, TTFT P50 1353 ms at concurrency 60 (3,541-request agentic trace)
+- id: disagg-h200-agentic
+  recommended: false
+  hardware:
+    gpu: H200
+    count: 3
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - 1p2d
+  - tp1-per-role
+  - fp8-kv-cache
+  - kv-aware-routing
+  - pd-kv-transfer
+  workload:
+    type: agentic-trace-replay
+    traffic: Mooncake agentic trace, 64K median ISL / 400 median OSL, 90% KV cache hit, concurrency 18
+  deploy:
+    asset: recipes/qwen3.5-122b/fp8/vllm/disagg-h200-agentic/deploy.yaml
+  benchmark:
+    tool: aiperf
+    asset: recipes/qwen3.5-122b/fp8/perf/perf.yaml
+  expected_performance:
+    available: true
+    summary: 256.5 output tok/s/GPU, 52.5 user tok/s P50, TTFT P50 3087 ms at concurrency 18 (3,541-request agentic trace)
+related_benchmarks: []
+maintainer: null
+gaps:
+- aggregated is the recommended path on both SKUs; disaggregated is retained for deployments
+  that scale prefill and decode independently
+- both disaggregated targets carry --no-async-scheduling on vLLM < 0.26.0, costing ~7% throughput
+- TP2 sharding is an H200 FP8 win only. On B200 NVFP4 it loses in both topologies, and on
+  H200 disaggregated it reaches 294.8 tok/s/GPU but regresses IFEval 84.66 to 80.22, so
+  only the H200 aggregated profile ships sharded

--- a/docs/fern/pages/recipes/model-recipes/overview.mdx
+++ b/docs/fern/pages/recipes/model-recipes/overview.mdx
@@ -37,11 +37,11 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
   <div className="dynamo-recipe-browser-header">
     <div>
       <p className="dynamo-recipe-eyebrow">Recipe catalog</p>
-      <h3>16 model families</h3>
+      <h3>17 model families</h3>
       <p>Filter by provider, runtime, and hardware. Each card notes its serving technique and workload shape.</p>
     </div>
     <div className="dynamo-catalog-facts">
-      <strong>80</strong>
+      <strong>84</strong>
       <span>Deployable configurations</span>
       <button className="dynamo-filter-reset" type="reset">Reset filters</button>
     </div>
@@ -185,6 +185,15 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
     <p className="dynamo-model-summary">Disaggregated vLLM serving with KV-aware routing on 16x H200, for multi-turn conversational traffic with prefix reuse.</p>
     <div className="dynamo-model-tags"><span>vLLM</span><span>16x H200</span><span>Multi-turn conversation</span><span>Related benchmark</span></div>
   <a className="dynamo-card-link" href="qwen3-32b.mdx" aria-label="Open the Qwen3-32B recipe">Open recipe</a>
+  </div>
+  <div className="dynamo-model-card" data-recipe-card data-provider="qwen" data-runtime="vllm" data-hardware="b200 h200" data-technique="aggregated disaggregated kv-routing spec-decoding" data-workload="agentic">
+    <div className="dynamo-model-card-top">
+      <img className="dynamo-model-logo" src="../../../assets/img/recipes/providers/qwen.webp" alt="" />
+      <div><h3>Qwen3.5-122B-A10B</h3><p>Qwen</p></div>
+    </div>
+    <p className="dynamo-model-summary">vLLM recipes for long-context agentic traffic on B200 NVFP4 and H200 FP8, aggregated or disaggregated 1P2D, with KV-aware routing and MTP speculation on H200 aggregated.</p>
+    <div className="dynamo-model-tags"><span>vLLM</span><span>2-4x B200/H200</span><span>Agentic trace replay</span></div>
+  <a className="dynamo-card-link" href="qwen3-5-122b.mdx" aria-label="Open the Qwen3.5-122B-A10B recipe">Open recipe</a>
   </div>
   <div className="dynamo-model-card" data-recipe-card data-provider="qwen" data-runtime="trtllm" data-hardware="b200 h100 h200" data-technique="aggregated disaggregated expert-parallel" data-workload="static-generation">
     <div className="dynamo-model-card-top">

--- a/docs/fern/pages/recipes/model-recipes/qwen3-5-122b.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen3-5-122b.mdx
@@ -64,13 +64,12 @@ All four targets below are Dynamo + vLLM deployments of Alibaba's Qwen3.5-122B-A
 ## Prerequisites
 
 1. Dynamo Platform installed on the target cluster with DGD CRDs served.
-2. nvcr pull access for `nvcr.io/nvidia/ai-dynamo`. The manifests set no `imagePullSecrets` — create `nvcr-secret` and attach it to the namespace's default service account.
-3. A Hugging Face token stored as `hf-token-secret`. The checkpoint is public and Apache-2.0.
-4. A `model-cache` PVC (ReadWriteMany), populated with the manifests in `model-cache/`.
+2. A Hugging Face token stored as `hf-token-secret`. The checkpoint is public and Apache-2.0.
+3. A `model-cache` PVC (ReadWriteMany), populated with the manifests in `model-cache/`.
 
 <div data-variant="disagg">
 
-5. GPU-local RDMA NICs exposed to pods (an `rdma/ib` device plugin) for NIXL KV transfer.
+4. GPU-local RDMA NICs exposed to pods (an `rdma/ib` device plugin) for NIXL KV transfer.
 
 </div>
 
@@ -231,7 +230,7 @@ Measured on the 3,541-request agentic Mooncake trace, block size 512, closed-loo
 | `agg-h200-agentic` | H200 | Aggregated | 4 | MTP, 3 tokens | c64, at the 50 tok/s/user floor |
 | `disagg-h200-agentic` | H200 | Disaggregated 1P2D | 3 | None | c18, at the 50 tok/s/user floor |
 
-Aggregated leads on both SKUs at the same SLA — 1173.2 against 916.6 output tok/s per GPU on B200, and 720.3 against 256.5 on H200. Disaggregated remains supported for deployments that scale prefill and decode independently.
+Aggregated leads on both SKUs at the same SLA — 1173.2 against 916.6 output tok/s per GPU on B200, and 720.3 against 256.5 on H200. **Aggregated is the recommended profile; the disaggregated targets are a functional reference rather than a throughput recommendation.** This workload runs at a 90% KV-cache hit rate, so the dedicated prefill worker has little to do while still emitting no output tokens, and on H200 disaggregation additionally gives up MTP. Choose it when prefill and decode must scale independently, or for a workload with a lower cache-hit rate.
 
 ## Notes
 

--- a/docs/fern/pages/recipes/model-recipes/qwen3-5-122b.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen3-5-122b.mdx
@@ -1,0 +1,264 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Qwen3.5-122B-A10B"
+subtitle: "Serve Qwen3.5-122B-A10B with Dynamo and vLLM on B200 or H200 for long-context agentic workloads."
+---
+
+import { RecipeStyles } from "@/components/RecipeStyles";
+
+<RecipeStyles />
+
+All four targets below are Dynamo + vLLM deployments of Alibaba's Qwen3.5-122B-A10B — a 122B total / 10B active hybrid MoE combining Gated DeltaNet linear attention with full attention every fourth layer — tuned for an agentic workload (64K median ISL / 400 median OSL, 90% KV cache hit) with KV-aware routing. B200 runs the NVFP4 checkpoint at TP1; H200 runs FP8, where the weights leave less room for paged KV, so the aggregated profile shards to TP2 and adds MTP speculative decoding. Aggregated is the recommended path on both SKUs. Pick your target; every command on this page updates to match.
+
+<div className="dynamo-target-picker">
+<p className="dynamo-target-picker-title">Choose your deployment target</p>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">GPU</span>
+<input type="radio" id="recipe-sku-h200" name="recipe-sku" value="h200" defaultChecked />
+<label htmlFor="recipe-sku-h200">H200 · FP8</label>
+<input type="radio" id="recipe-sku-b200" name="recipe-sku" value="b200" />
+<label htmlFor="recipe-sku-b200">B200 · NVFP4</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
+<label htmlFor="recipe-variant-agg">Aggregated <span className="dynamo-target-picker-hint">Recommended</span></label>
+<input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
+<label htmlFor="recipe-variant-disagg">Disaggregated</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="agg">
+<span><b>Checkpoint</b> Qwen/Qwen3.5-122B-A10B-FP8</span>
+<span><b>Precision</b> FP8 weights, BF16 KV</span>
+<span><b>GPUs</b> 2x H200 per replica, `replicas: 2` (4x)</span>
+<span><b>Parallelism</b> TP2</span>
+<span><b>Spec decode</b> MTP, 3 tokens</span>
+<span><b>Routing</b> KV-aware</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="disagg">
+<span><b>Checkpoint</b> Qwen/Qwen3.5-122B-A10B-FP8</span>
+<span><b>Precision</b> FP8 + FP8 KV</span>
+<span><b>GPUs</b> 1x H200 prefill + 2x H200 decode</span>
+<span><b>Parallelism</b> TP1 per worker</span>
+<span><b>Spec decode</b> None — see Limitations</span>
+<span><b>Routing</b> KV-aware, NIXL/UCX over IB</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="agg">
+<span><b>Checkpoint</b> nvidia/Qwen3.5-122B-A10B-NVFP4</span>
+<span><b>Precision</b> NVFP4 + FP8 KV</span>
+<span><b>GPUs</b> 1x B200 per replica, `replicas: 2` (2x)</span>
+<span><b>Parallelism</b> TP1</span>
+<span><b>Spec decode</b> None</span>
+<span><b>Routing</b> KV-aware</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="disagg">
+<span><b>Checkpoint</b> nvidia/Qwen3.5-122B-A10B-NVFP4</span>
+<span><b>Precision</b> NVFP4 + FP8 KV</span>
+<span><b>GPUs</b> 1x B200 prefill + 2x B200 decode</span>
+<span><b>Parallelism</b> TP1 per worker</span>
+<span><b>Spec decode</b> None</span>
+<span><b>Routing</b> KV-aware, NIXL/UCX over IB</span>
+</div>
+</div>
+
+## Prerequisites
+
+1. Dynamo Platform installed on the target cluster with DGD CRDs served.
+2. nvcr pull access for `nvcr.io/nvidia/ai-dynamo`. The manifests set no `imagePullSecrets` — create `nvcr-secret` and attach it to the namespace's default service account.
+3. A Hugging Face token stored as `hf-token-secret`. The checkpoint is public and Apache-2.0.
+4. A `model-cache` PVC (ReadWriteMany), populated with the manifests in `model-cache/`.
+
+<div data-variant="disagg">
+
+5. GPU-local RDMA NICs exposed to pods (an `rdma/ib` device plugin) for NIXL KV transfer.
+
+</div>
+
+```bash
+export NAMESPACE=your-namespace
+kubectl create namespace ${NAMESPACE}
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
+```
+
+## Deploy
+
+Create the cache and download the checkpoint. Set `storageClassName` in `model-cache.yaml` to a ReadWriteMany class first.
+
+<div data-sku="h200">
+
+```bash
+kubectl apply -f recipes/qwen3.5-122b/fp8/model-cache/model-cache.yaml -n ${NAMESPACE}
+kubectl apply -f recipes/qwen3.5-122b/fp8/model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=7200s
+```
+
+</div>
+
+<div data-sku="b200">
+
+```bash
+kubectl apply -f recipes/qwen3.5-122b/nvfp4/model-cache/model-cache.yaml -n ${NAMESPACE}
+kubectl apply -f recipes/qwen3.5-122b/nvfp4/model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=7200s
+```
+
+</div>
+
+<div data-sku="h200" data-variant="agg">
+
+```bash
+kubectl apply -f recipes/qwen3.5-122b/fp8/vllm/agg-h200-agentic/deploy.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen35-122b-agg-h200-agentic \
+  -n ${NAMESPACE} --timeout=7200s
+```
+
+Deploy `replicas: 2` or more so the KV-aware router has replicas to route shared prefixes across. Each replica is TP2, so a full 8x H200 node runs `replicas: 4`.
+
+</div>
+
+<div data-sku="h200" data-variant="disagg">
+
+```bash
+kubectl apply -f recipes/qwen3.5-122b/fp8/vllm/disagg-h200-agentic/deploy.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen35-122b-disagg-h200-agentic \
+  -n ${NAMESPACE} --timeout=7200s
+```
+
+</div>
+
+<div data-sku="b200" data-variant="agg">
+
+```bash
+kubectl apply -f recipes/qwen3.5-122b/nvfp4/vllm/agg-b200-agentic/deploy.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen35-122b-agg-b200-agentic \
+  -n ${NAMESPACE} --timeout=7200s
+```
+
+Deploy `replicas: 2` or more so the KV-aware router has replicas to route shared prefixes across. Each replica is TP1, so a full 8x B200 node runs `replicas: 8`.
+
+</div>
+
+<div data-sku="b200" data-variant="disagg">
+
+```bash
+kubectl apply -f recipes/qwen3.5-122b/nvfp4/vllm/disagg-b200-agentic/deploy.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen35-122b-disagg-b200-agentic \
+  -n ${NAMESPACE} --timeout=7200s
+```
+
+</div>
+
+First cold starts take 30-45 minutes while the runtime loads the weights and captures CUDA graphs; a measured cold load spent 28.5 minutes on weights alone before graph capture began.
+
+## Smoke Test
+
+```bash
+kubectl port-forward -n ${NAMESPACE} \
+  svc/$(kubectl get svc -o name -n ${NAMESPACE} | grep frontend | head -1 | cut -d/ -f2) 8000:8000 &
+
+curl http://localhost:8000/v1/models
+
+curl http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "Qwen/Qwen3.5-122B-A10B",
+  "messages": [{"role": "user", "content": "Hello"}],
+  "max_tokens": 32
+}'
+```
+
+Both SKUs serve the model as `Qwen/Qwen3.5-122B-A10B` regardless of the underlying checkpoint.
+
+## Benchmark
+
+The benchmark replays a Mooncake-format agentic trace through AIPerf.
+
+<div data-sku="b200">
+
+```bash
+kubectl apply -f recipes/qwen3.5-122b/nvfp4/perf/perf.yaml -n ${NAMESPACE}
+```
+
+See [nvfp4/perf/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/nvfp4/perf/README.md) for the full workflow.
+
+</div>
+
+<div data-sku="h200">
+
+```bash
+kubectl apply -f recipes/qwen3.5-122b/fp8/perf/perf.yaml -n ${NAMESPACE}
+```
+
+Edit `ENDPOINT` and `CONCURRENCY` in the Job to select a target — aggregated at c64, disaggregated at c18. See [fp8/perf/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/fp8/perf/README.md) for the full workflow.
+
+AIPerf builds its replay schedule from a `timestamp` field. The shipped trace rows have none, and without one AIPerf replays a small default instead of the whole file, so add one before staging the trace on the PVC:
+
+```bash
+git lfs install
+git lfs pull --include "recipes/kimi-k2.6/perf/traces/*"
+python3 -c "
+import json
+src='recipes/qwen3.5-122b/fp8/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl'
+for line in open(src):
+    print(json.dumps({'timestamp': 0, **json.loads(line)}))
+" > mooncake_agentic.jsonl
+```
+
+Confirm a run replayed the whole file: `Request Count` in `profile_export_aiperf.csv` should be about 3,411, plus roughly 130 rows that exceed the 262,144-token context and return errors.
+
+</div>
+
+## Expected Performance
+
+Measured on the 3,541-request agentic Mooncake trace, block size 512, closed-loop. SLA: P50 TTFT under 5 s and P50 output at or above 50 tok/s/user. Each target is reported at its highest SLA-passing concurrency.
+
+| Target | GPUs | Concurrency | User output tok/s | TTFT (P50) | System output tok/s/GPU |
+|--------|------|-------------|-------------------|------------|-------------------------|
+| B200 aggregated, 2x TP1 | 2 | 50 | 52.4 | 246 ms | 1173.2 |
+| B200 disaggregated 1P2D | 3 | 60 | 51.4 | 1353 ms | 916.6 |
+| H200 aggregated, 2x TP2 + MTP | 4 | 64 | 52.9 | 313 ms | 720.3 |
+| H200 disaggregated 1P2D | 3 | 18 | 52.5 | 3087 ms | 256.5 |
+
+## Compare All Targets
+
+| Target | GPU | Topology | GPUs | Spec decode | Reported point |
+|--------|-----|----------|------|-------------|----------------|
+| `agg-b200-agentic` | B200 | Aggregated | 2 | None | c50, at the 50 tok/s/user floor |
+| `disagg-b200-agentic` | B200 | Disaggregated 1P2D | 3 | None | c60, at the 50 tok/s/user floor |
+| `agg-h200-agentic` | H200 | Aggregated | 4 | MTP, 3 tokens | c64, at the 50 tok/s/user floor |
+| `disagg-h200-agentic` | H200 | Disaggregated 1P2D | 3 | None | c18, at the 50 tok/s/user floor |
+
+Aggregated leads on both SKUs at the same SLA — 1173.2 against 916.6 output tok/s per GPU on B200, and 720.3 against 256.5 on H200. Disaggregated remains supported for deployments that scale prefill and decode independently.
+
+## Notes
+
+- Worker `--block-size` must match the frontend `--kv-cache-block-size`. If they diverge, prefix hashing does not line up and KV-aware routing silently degrades toward round-robin.
+- The H200 aggregated target runs `--kv-cache-dtype auto`; the disaggregated targets and both B200 targets use `fp8`. FP8 KV costs compute and only pays back when the cache is the binding constraint, which it is not at TP2.
+
+<div data-sku="h200" data-variant="agg">
+
+- Ship the `speculative-config` ConfigMap key; benchmark with `speculative-config-synthetic`, which forces the acceptance length of 2.937 measured against real text. Real MTP reports about 3.2 on this trace because the Mooncake rows synthesise prompts from `hash_ids`, which the draft predicts more easily than real text.
+
+</div>
+
+## Limitations
+
+- Prefill and decode must use the same tensor-parallel size when disaggregated — asymmetric sharding fails the NIXL transfer with a block-size mismatch.
+- MTP is not supported with disaggregation on this architecture. NIXL's Mamba conv-state transfer needs `VLLM_SSM_CONV_STATE_LAYOUT=DS`, which conflicts with the `mamba_cache_mode='align'` that MTP plus prefix caching forces ([vllm#38898](https://github.com/vllm-project/vllm/issues/38898)).
+
+<div data-variant="disagg">
+
+- Disaggregated decode requires `--no-async-scheduling` on vLLM earlier than 0.26.0. Without it the KV-block zeroing kernel races the NIXL RDMA write and silently erases transferred KV. The flag costs about 7% throughput and can be dropped on a runtime shipping vLLM 0.26.0 or later.
+
+</div>
+
+## Source
+
+- [recipes/qwen3.5-122b](https://github.com/ai-dynamo/dynamo/tree/main/recipes/qwen3.5-122b)
+- [H200 aggregated deploy manifest](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/fp8/vllm/agg-h200-agentic/deploy.yaml)
+- [H200 disaggregated deploy manifest](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/fp8/vllm/disagg-h200-agentic/deploy.yaml)
+- [B200 aggregated deploy manifest](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/nvfp4/vllm/agg-b200-agentic/deploy.yaml)
+- [B200 disaggregated deploy manifest](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/nvfp4/vllm/disagg-b200-agentic/deploy.yaml)

--- a/docs/fern/pages/recipes/model-recipes/qwen3-5-122b.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen3-5-122b.mdx
@@ -230,7 +230,7 @@ Measured on the 3,541-request agentic Mooncake trace, block size 512, closed-loo
 | `agg-h200-agentic` | H200 | Aggregated | 4 | MTP, 3 tokens | c64, at the 50 tok/s/user floor |
 | `disagg-h200-agentic` | H200 | Disaggregated 1P2D | 3 | None | c18, at the 50 tok/s/user floor |
 
-Aggregated leads on both SKUs at the same SLA — 1173.2 against 916.6 output tok/s per GPU on B200, and 720.3 against 256.5 on H200. **Aggregated is the recommended profile; the disaggregated targets are a functional reference rather than a throughput recommendation.** This workload runs at a 90% KV-cache hit rate, so the dedicated prefill worker has little to do while still emitting no output tokens, and on H200 disaggregation additionally gives up MTP. Choose it when prefill and decode must scale independently, or for a workload with a lower cache-hit rate.
+Aggregated leads on both SKUs at the same SLA: 1173.2 against 916.6 output tok/s per GPU on B200, 720.3 against 256.5 on H200. **Aggregated is the recommended profile; the disaggregated targets are a functional reference rather than a throughput recommendation.** At 90% KV-cache hit the dedicated prefill worker has little to do yet emits no output tokens, and both disaggregated targets pay ~7% for `--no-async-scheduling` on vLLM < 0.26.0. MTP runs on H200 aggregated only — H200 disaggregated gives it up, and neither B200 profile runs it. Choose disaggregation to scale prefill and decode independently, or for a workload with a lower cache-hit rate.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Adds the customer-facing Fern docs for **Qwen/Qwen3.5-122B-A10B**: a catalog entry, nav
entry, landing card, and a GPU x topology recipe page covering all four shipped targets.

Split out of #12088 so the H200 recipe can merge independently of #11665.

### Targets documented — iso-SLA

All four on the same 3,541-request agentic Mooncake trace, block size 512, closed-loop,
one selection rule: **the highest concurrency that holds P50 TTFT < 5 s and P50 output
>= 50 tok/s/user.**

| Target | GPU | Topology | GPUs | MTP | Conc | User tok/s | TTFT (P50) | tok/s/GPU |
|--------|-----|----------|-----:|:---:|-----:|-----------:|-----------:|----------:|
| `nvfp4/vllm/agg-b200-agentic` | B200 | AGG, 2x TP1 | 2 | no | 50 | 52.4 | 246 ms | **1173.2** |
| `nvfp4/vllm/disagg-b200-agentic` | B200 | 1P2D | 3 | no | 60 | 51.4 | 1353 ms | 916.6 |
| `fp8/vllm/agg-h200-agentic` | H200 | AGG, 2x TP2 | 4 | yes | 64 | 52.9 | 313 ms | **720.3** |
| `fp8/vllm/disagg-h200-agentic` | H200 | 1P2D | 3 | no | 18 | 52.5 | 3087 ms | 256.5 |

Every row sits within 51.4-52.9 tok/s/user, so the four are reported at the same point on
the SLA curve rather than at arbitrary concurrencies. Aggregated is the recommended path
on both SKUs.

## Dependencies

**Both recipe PRs must merge first.**

| PR | provides |
| --- | --- |
| #11665 | `recipes/qwen3.5-122b/nvfp4/**` — the two B200 targets |
| #12088 | `recipes/qwen3.5-122b/fp8/**` — the two H200 targets |

Until both land, `docs/fern/pages/recipes/_catalog/validate.py` reports missing deploy and
perf assets. `lychee` also 404s on the page's `blob/main` source links until this merges.
Neither is a content defect.

This PR touches `docs/fern/**` only. The recipe index rows live with the recipes they
point at: the FP8 rows in #12088, the NVFP4 rows offered to #11665.

## Contents

- `docs/fern/pages/recipes/model-recipes/qwen3-5-122b.mdx` — GPU x topology picker
  (H200/B200 x agg/disagg), Prerequisites, Deploy, Smoke Test, Benchmark, Expected
  Performance, Compare All Targets, Notes, Limitations, Source
- `docs/fern/pages/recipes/_catalog/recipes/qwen3-5-122b.yaml` + registration in
  `_catalog/index.yaml`
- `docs/fern/index.yml` nav entry
- Landing card in `model-recipes/overview.mdx`, with the family count 15 -> 16 and the
  deployable-configuration count 42 -> 46

## Validation

- `python3 docs/fern/pages/recipes/_catalog/validate.py` passes except for the four
  expected missing `nvfp4/**` assets described above.
- Every number on the page and in the catalog checked against the manifests in both
  recipe PRs: TP size, GPU counts, `kv-cache-dtype`, whether `--speculative-config` is
  set, and the four benchmark rows.
- MTP is claimed only for the H200 aggregated target, matching the manifests; the catalog
  carries `mtp-spec-dec` on that target alone.
- Picker axis values (`h200`/`b200`, `agg`/`disagg`) already have CSS rules in
  `RecipeStyles.tsx`; no component change needed. Technique tokens use the repo's
  `kv-routing` / `spec-decoding` vocabulary so the landing filters match the card.
- MDX `<div>` blocks balanced; landing card count matches the heading.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete Qwen3.5-122B-A10B deployment recipe for Dynamo and vLLM.
  * Added support for FP8 deployments on H200 GPUs and NVFP4 deployments on B200 GPUs.
  * Documented aggregated and disaggregated serving configurations, agentic workloads, KV-aware routing, and speculative decoding.
  * Added deployment manifests, model caching and download workflows, smoke tests, and performance benchmarking guidance.

* **Documentation**
  * Updated the recipe catalog and overview with the new model family and deployable configurations.
  * Added setup requirements, expected performance, limitations, and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
