### PR TITLE
fix: resolve uv backend dependency conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,41 @@ mocker = [
     "aiconfigurator-core==0.11.0.dev20260728",
 ]
 
+[tool.uv]
+# Some backend extras have incompatible transitive dependency requirements.
+# Each conflict below identifies the dependency that prevents co-installation.
+conflicts = [
+    # vLLM and SGLang have incompatible NIXL requirements.
+    [
+        { extra = "vllm" },
+        { extra = "sglang" },
+    ],
+    # TensorRT-LLM and the mocker have incompatible NumPy requirements.
+    [
+        { extra = "trtllm" },
+        { extra = "mocker" },
+    ],
+    # TensorRT-LLM and vLLM have incompatible flashinfer-python requirements.
+    [
+        { extra = "trtllm" },
+        { extra = "vllm" },
+    ],
+    # The mocker and vLLM have incompatible NumPy requirements on macOS with Python 3.14.
+    [
+        { extra = "mocker" },
+        { extra = "vllm" },
+    ],
+    # SGLang and TensorRT-LLM have incompatible XGrammar requirements.
+    [
+        { extra = "sglang" },
+        { extra = "trtllm" },
+    ],
+]
+
+
+[tool.uv.dependency-groups]
+docs = { requires-python = ">=3.11" }
+
 [project.entry-points.pytest11]
 vllm_tests = "dynamo.vllm.tests.conftest"
 trtllm_tests = "dynamo.trtllm.tests.conftest"


### PR DESCRIPTION
## Summary

- declare mutually exclusive backend extras through `tool.uv.conflicts`
- set the docs dependency group to Python 3.11+, matching the requirement of `sphinx-reredirects>=1.0.0`

## Root Cause

`uv lock` resolves optional extras universally. Several backend extras require incompatible versions of transitive dependencies and cannot be installed in the same environment:

- `vllm` and `sglang`: incompatible `nixl` versions
- `trtllm` and `mocker`: incompatible NumPy requirements
- `trtllm` and `vllm`: incompatible `flashinfer-python` versions
- `trtllm` and `sglang`: incompatible `xgrammar` versions
- `mocker` and `vllm`: incompatible NumPy requirements on Python 3.14 for macOS

`sglang` and `mocker` resolve successfully together, so they are intentionally not declared as conflicting.

Fixes #12932