### PR TITLE
fix(trtllm): prompt_logprobs off-by-one silently corrupts every prompt score

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1294,9 +1294,18 @@ class HandlerBase(BaseGenerativeHandler):
                             out["top_logprobs"] = top_logprobs
 
                         if prompt_logprobs_payload is None:
-                            prompt_logprobs_payload = _shared_logprobs.extract_prompt_logprobs_from_completion_output(
+                            payload = _shared_logprobs.extract_prompt_logprobs_from_completion_output(
                                 output
                             )
+                            if payload:
+                                # TRT-LLM aligns prompt logprobs to
+                                # `prompt_token_ids[1:] + first_generation_token`,
+                                # so index i describes prompt token i+1 and the
+                                # last entry describes the first *generated*
+                                # token. Drop that entry and prepend `None` to
+                                # restore Dynamo's `PromptLogprobs` contract
+                                # (index i -> prompt token i, BOS = None).
+                                prompt_logprobs_payload = [None, *payload[:-1]]
 
                         if output.finish_reason:
                             out["finish_reason"] = output.finish_reason

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -783,6 +783,29 @@ class TestGenerateLocally:
             prompt_logprobs = []
         return self._make_mock_generation_result_sequence([prompt_logprobs])
 
+    @staticmethod
+    def _trtllm_prompt_logprobs():
+        """Engine-shaped prompt logprobs for the `[1, 2, 3]` prompt.
+
+        TRT-LLM computes these against `prompt_token_ids[1:] +
+        first_generation_token`, so the array covers prompt tokens 2 and 3
+        followed by the first generated token (42).
+        """
+        return [
+            {2: MagicMock(logprob=-0.25, rank=1, decoded_token="two")},
+            {3: MagicMock(logprob=-0.5, rank=1, decoded_token="three")},
+            {42: MagicMock(logprob=-0.75, rank=1, decoded_token="gen")},
+        ]
+
+    @staticmethod
+    def _expected_prompt_logprobs():
+        """Dynamo-shaped payload: index i describes prompt token i, BOS=None."""
+        return [
+            None,
+            {"2": {"logprob": -0.25, "rank": 1, "decoded_token": "two"}},
+            {"3": {"logprob": -0.5, "rank": 1, "decoded_token": "three"}},
+        ]
+
     def _make_mock_generation_result_sequence(self, prompt_logprobs_per_chunk):
         """Mock GenerationResult with cumulative output across streaming chunks."""
         results = []
@@ -862,13 +885,11 @@ class TestGenerateLocally:
     @pytest.mark.asyncio
     async def test_zero_prompt_logprobs_is_forwarded_and_returned(self):
         handler = self._make_handler()
-        prompt_logprob = MagicMock(
-            logprob=-0.25,
-            rank=1,
-            decoded_token="two",
-        )
+        # TRT-LLM aligns prompt logprobs to
+        # `prompt_token_ids[1:] + first_generation_token`, so a 3-token prompt
+        # yields 3 entries: tokens 2 and 3, then the first generated token.
         generation_result = self._make_mock_generation_result(
-            prompt_logprobs=[None, {2: prompt_logprob}]
+            prompt_logprobs=self._trtllm_prompt_logprobs()
         )
         handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
 
@@ -887,16 +908,38 @@ class TestGenerateLocally:
 
         _, kwargs = handler.engine.llm.generate_async.call_args
         assert kwargs["sampling_params"].prompt_logprobs == 0
-        assert chunks[-1]["engine_data"]["prompt_logprobs"] == [
-            None,
-            {
-                "2": {
-                    "logprob": -0.25,
-                    "rank": 1,
-                    "decoded_token": "two",
-                }
-            },
+        # Index 0 is `None` (no logprob for the first prompt token) and the
+        # generated-token entry is dropped, matching the vLLM/SGLang shape.
+        assert (
+            chunks[-1]["engine_data"]["prompt_logprobs"]
+            == self._expected_prompt_logprobs()
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_token_prompt_logprobs_collapses_to_bos_only(self):
+        handler = self._make_handler()
+        # A 1-token prompt leaves TRT-LLM with a single entry, and it belongs
+        # to the first generated token, so nothing survives but the BOS `None`.
+        generation_result = self._make_mock_generation_result(
+            prompt_logprobs=[
+                {42: MagicMock(logprob=-0.75, rank=1, decoded_token="gen")}
+            ]
+        )
+        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
+
+        request = {
+            "token_ids": [1],
+            "stop_conditions": {"max_tokens": 10},
+            "sampling_options": {},
+            "output_options": {"prompt_logprobs": 0},
+        }
+
+        chunks = [
+            chunk
+            async for chunk in handler.generate_locally(request, self._make_context())
         ]
+
+        assert chunks[-1]["engine_data"]["prompt_logprobs"] == [None]
 
     @pytest.mark.asyncio
     async def test_empty_prompt_logprobs_is_not_returned(self):
@@ -920,13 +963,8 @@ class TestGenerateLocally:
     @pytest.mark.asyncio
     async def test_prompt_logprobs_can_arrive_after_empty_streaming_chunk(self):
         handler = self._make_handler()
-        prompt_logprob = MagicMock(
-            logprob=-0.25,
-            rank=1,
-            decoded_token="two",
-        )
         generation_result = self._make_mock_generation_result_sequence(
-            [[], [None, {2: prompt_logprob}]]
+            [[], self._trtllm_prompt_logprobs()]
         )
         handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
 
@@ -942,16 +980,10 @@ class TestGenerateLocally:
             async for chunk in handler.generate_locally(request, self._make_context())
         ]
 
-        assert chunks[-1]["engine_data"]["prompt_logprobs"] == [
-            None,
-            {
-                "2": {
-                    "logprob": -0.25,
-                    "rank": 1,
-                    "decoded_token": "two",
-                }
-            },
-        ]
+        assert (
+            chunks[-1]["engine_data"]["prompt_logprobs"]
+            == self._expected_prompt_logprobs()
+        )
 
     def test_trtllm_sampling_params_accepts_zero_prompt_logprobs(self):
         sampling_params = SamplingParams(prompt_logprobs=0)


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

TRT-LLM backend returns misaligned `prompt_logprobs`

## Details:

Dynamo's Rust frontend defines the wire format every backend must produce:

```
// https://github.com/ai-dynamo/dynamo/blob/main/lib/llm/src/protocols/common/llm_backend.rs#L27

/// Per-token map of `token_id -> PromptLogprobEntry`. The first position
/// is `None` (no logprob exists for BOS / the very first prompt token).
pub type PromptLogprobs = Vec<Option<std::collections::HashMap<TokenIdType, PromptLogprobEntry>>>;
```

For instance, a user deploys the TensorRT-LLM backend and requests prompt scores:

```
POST /v1/completions
{
  "model": "...",
  "prompt": "The capital of France",
  "max_tokens": 4,
  "prompt_logprobs": 0,
  "nvext": {"extra_fields": ["prompt_logprobs"]}
}
```

"The capital of France" is the prompt. The model continues from it, and the first generated token is " is" (full output might be " is Paris.").

So, as the vLLM backend already does. The correct response has `null` at index 0:

```
Array length = number of prompt tokens; index i is the score of prompt token i.

index 0: null            <- <BOS>, no score
index 1: score of "The"
index 2: score of "capital"
index 3: score of "of"
index 4: score of "France"
```

The TRT-LLM backend passes the engine's five scores through verbatim, with no conversion:

```
index 0: score of "The"      <- client reads it as <BOS>
index 1: score of "capital"  <- client reads it as "The"
index 2: score of "of"
index 3: score of "France"
index 4: score of " is"      <- client reads it as "France", but it is the generated token
```

Every position is shifted by one, and the trailing entry belongs to a generated token, not to the prompt.

The fix is to drop the trailing generated-token entry and prepend `null`

### Comparison with vLLM

vLLM initializes `prompt_logprobs` with a leading `None`:

```python
// https://github.com/vllm-project/vllm/blob/main/vllm/logprobs.py#L162

def create_prompt_logprobs(flat_logprobs: bool) -> PromptLogprobs:
    """Creates a container to store prompt logprobs for a request"""
    logprobs: PromptLogprobs = FlatLogprobs() if flat_logprobs else []
    # NOTE: logprob of first prompt token is None.
    logprobs.append(None)
    return logprobs
```

Therefore, vLLM's output already matches Dynamo's positional contract. 

The Dynamo vLLM worker only needs to serialize the entries into Dynamo's wire format; it does not need to shift, prepend, or remove any positions.

### Verification against the pinned TensorRT-LLM version

Dynamo pins TensorRT-LLM to `1.3.0rc23`, and its text worker explicitly selects `Backend.PYTORCH`. In this version, TensorRT-LLM aligns `prompt_logprobs` with  `prompt_token_ids[1:] + first_generation_token`

The upstream GPU test confirms the same shape:

```
// https://github.com/NVIDIA/TensorRT-LLM/blob/v1.3.0rc23/tests/unittest/_torch/sampler/test_logits_logprobs.py#L310-L322

logprobs = output.outputs[0].prompt_logprobs
token_ids = output.prompt_token_ids[1:] + output.outputs[0].token_ids[:1]
```

Therefore, the first prompt_logprobs entry describes prompt_token_ids[1], it is not a leading `None`. The final entry describes the first generated token.

This differs from Dynamo's PromptLogprobs contract, which requires a leading None and one position per prompt token.


<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected prompt logprob alignment for TRT-LLM responses.
  * Ensured results include the expected beginning-of-sequence entry and properly correspond to prompt tokens.
  * Fixed streaming behavior and single-token prompt handling.

* **Tests**
  * Expanded coverage for prompt logprob alignment, streaming responses, and single-token prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->