### PR TITLE
fix(container): bump nats-server to v2.12.12 (cherry-pick #12917)

### DIFF
--- a/container/compliance/native_packages.yaml
+++ b/container/compliance/native_packages.yaml
@@ -133,7 +133,7 @@ packages:
   # nats-server — messaging server, downloaded as a .deb in dynamo_base (dpkg -i
   # may not survive into the final runtime layer attribution reliably).
   - name: nats-server
-    version: v2.10.28
+    version: v2.12.12
     license: Apache-2.0
     source: https://github.com/nats-io/nats-server
     images:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -38,7 +38,7 @@ dynamo:
   # and uv rejects cache entries written by a newer version.
   uv_version: "0.12.0"
 
-  nats_version: v2.10.28
+  nats_version: v2.12.12
   etcd_version: v3.5.30
 
   nixl_ref: v1.0.1


### PR DESCRIPTION
Cherry-pick of #12917 onto `release/1.4.0`.

## Summary

`release/1.4.0` pinned `nats_version: v2.10.28`, so the CVE bump that landed
on `main` was not on the release line. This picks it across.

- `container/context.yaml` — `nats_version` v2.10.28 → v2.12.12
- `container/compliance/native_packages.yaml` — matching `nats-server` entry

Clean cherry-pick of `84512e7c3`; no conflict, both pins applied unchanged.

## Validation

- `git cherry-pick -x 84512e7c3` applied with no conflict.
- Both files read `v2.12.12` on this branch after the pick, confirmed by
  grepping each pin rather than trusting the pick's exit code.
- Original PR #12917 merged green (62 checks) and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->