### PR TITLE
fix(codeowners): carry planner ownership through the team, not per-person rows

### DIFF
--- a/.github/codeowners/external_contributors.yaml
+++ b/.github/codeowners/external_contributors.yaml
@@ -42,15 +42,3 @@
 #       - router
 
 contributors:
-  - name: Jason Zhou
-    github: jasonqinzhou
-    level: maintainer
-    affiliation: NVIDIA
-    areas:
-      - planner
-  - name: Yongming Ding
-    github: dreamtalen
-    level: maintainer
-    affiliation: NVIDIA
-    areas:
-      - planner

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -160,22 +160,22 @@
 # === diffusion  (@ai-dynamo/dynamo-diffusion-codeowners) ===
 /examples/diffusers/                                                         @ai-dynamo/dynamo-diffusion-codeowners
 
-# === planner  (@ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen) ===
-/aisimulate/                                                                 @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/examples/global_planner/                                                    @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/examples/power-aware-budget/                                                @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/planner/                                              @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/profiler/                                             @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/planner/core/                                         @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/planner/tests/                                        @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/global_planner/                                       @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/planner/config/                                       @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/profiler/tests/                                       @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/profiler/utils/                                       @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/planner/offline/                                      @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/planner/connectors/                                   @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/planner/monitoring/                                   @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/global_planner/tests/                                 @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
+# === planner  (@ai-dynamo/dynamo-planner-codeowners) ===
+/aisimulate/                                                                 @ai-dynamo/dynamo-planner-codeowners
+/examples/global_planner/                                                    @ai-dynamo/dynamo-planner-codeowners
+/examples/power-aware-budget/                                                @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/planner/                                              @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/profiler/                                             @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/planner/core/                                         @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/planner/tests/                                        @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/global_planner/                                       @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/planner/config/                                       @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/profiler/tests/                                       @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/profiler/utils/                                       @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/planner/offline/                                      @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/planner/connectors/                                   @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/planner/monitoring/                                   @ai-dynamo/dynamo-planner-codeowners
+/components/src/dynamo/global_planner/tests/                                 @ai-dynamo/dynamo-planner-codeowners
 
 # === runtime  (@ai-dynamo/dynamo-runtime-codeowners) ===
 /tests/                                                                      @ai-dynamo/dynamo-runtime-codeowners
@@ -600,7 +600,7 @@
 /tests/deploy/                                                               @ai-dynamo/dynamo-ops-codeowners @ai-dynamo/dynamo-operator-codeowners
 /docs/fern/agents/                                                           @ai-dynamo/dynamo-docs-codeowners @ai-dynamo/dynamo-agents-codeowners
 /benchmarks/router/                                                          @ai-dynamo/dynamo-performance-codeowners @ai-dynamo/dynamo-router-codeowners
-/deploy/power-agent/                                                         @ai-dynamo/dynamo-operator-codeowners @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
+/deploy/power-agent/                                                         @ai-dynamo/dynamo-operator-codeowners @ai-dynamo/dynamo-planner-codeowners
 /lib/llm/src/mocker/                                                         @ai-dynamo/dynamo-runtime-codeowners @ai-dynamo/dynamo-performance-codeowners
 /dev/nats-server.conf                                                        @ai-dynamo/dynamo-ops-codeowners @ai-dynamo/dynamo-runtime-codeowners
 /lib/bench/kv_router/                                                        @ai-dynamo/dynamo-performance-codeowners @ai-dynamo/dynamo-router-codeowners
@@ -646,7 +646,7 @@
 /components/src/dynamo/common/protocols/                                     @ai-dynamo/dynamo-frontend-codeowners @ai-dynamo/dynamo-multimodal-codeowners
 /components/src/dynamo/trtllm/metrics.py                                     @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-observability-codeowners
 /components/src/dynamo/vllm/publisher.py                                     @ai-dynamo/dynamo-backend-vllm-codeowners @ai-dynamo/dynamo-observability-codeowners
-/lib/mocker/src/replay/planner_handle.rs                                     @ai-dynamo/dynamo-performance-codeowners @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
+/lib/mocker/src/replay/planner_handle.rs                                     @ai-dynamo/dynamo-performance-codeowners @ai-dynamo/dynamo-planner-codeowners
 /lib/runtime/src/system_status_server.rs                                     @ai-dynamo/dynamo-runtime-codeowners @ai-dynamo/dynamo-observability-codeowners
 /components/src/dynamo/sglang/protocol.py                                    @ai-dynamo/dynamo-backend-sglang-codeowners @ai-dynamo/dynamo-diffusion-codeowners
 /components/src/dynamo/sglang/snapshot.py                                    @ai-dynamo/dynamo-backend-sglang-codeowners @ai-dynamo/dynamo-gms-codeowners
@@ -693,21 +693,21 @@
 /components/src/dynamo/trtllm/multimodal_processor.py                        @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-multimodal-codeowners
 /components/src/dynamo/vllm/instrumented_scheduler.py                        @ai-dynamo/dynamo-backend-vllm-codeowners @ai-dynamo/dynamo-observability-codeowners
 /components/src/dynamo/vllm/kv_connector_protocols.py                        @ai-dynamo/dynamo-backend-vllm-codeowners @ai-dynamo/dynamo-kv-memory-codeowners
-/components/src/dynamo/profiler/utils/dgdr_validate.py                       @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/planner/connectors/kubernetes.py                      @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/profiler/utils/dgd_generation.py                      @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners @jasonqinzhou @dreamtalen
+/components/src/dynamo/profiler/utils/dgdr_validate.py                       @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners
+/components/src/dynamo/planner/connectors/kubernetes.py                      @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners
+/components/src/dynamo/profiler/utils/dgd_generation.py                      @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners
 /components/src/dynamo/common/multimodal/routing_utils.py                    @ai-dynamo/dynamo-multimodal-codeowners @ai-dynamo/dynamo-router-codeowners
 /components/src/dynamo/trtllm/configs/diffusion_config.py                    @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-diffusion-codeowners
 /components/src/dynamo/trtllm/engines/diffusion_engine.py                    @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-diffusion-codeowners
 /components/src/dynamo/trtllm/request_handlers/diffusion/                    @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-diffusion-codeowners
 /components/src/dynamo/common/recv_forward_pass_metrics.py                   @ai-dynamo/dynamo-runtime-codeowners @ai-dynamo/dynamo-observability-codeowners
 /components/src/dynamo/sglang/request_handlers/multimodal/                   @ai-dynamo/dynamo-backend-sglang-codeowners @ai-dynamo/dynamo-multimodal-codeowners
-/components/src/dynamo/planner/connectors/kubernetes_api.py                  @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py                  @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners @jasonqinzhou @dreamtalen
+/components/src/dynamo/planner/connectors/kubernetes_api.py                  @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners
+/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py                  @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-operator-codeowners
 /deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/                  @ai-dynamo/dynamo-epp-codeowners @ai-dynamo/dynamo-router-codeowners
-/components/src/dynamo/planner/monitoring/planner_metrics.py                 @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-observability-codeowners @jasonqinzhou @dreamtalen
-/components/src/dynamo/planner/monitoring/traffic_metrics.py                 @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-observability-codeowners @jasonqinzhou @dreamtalen
-/deploy/observability/grafana-planner-dashboard-configmap.yaml               @ai-dynamo/dynamo-observability-codeowners @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
+/components/src/dynamo/planner/monitoring/planner_metrics.py                 @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-observability-codeowners
+/components/src/dynamo/planner/monitoring/traffic_metrics.py                 @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-observability-codeowners
+/deploy/observability/grafana-planner-dashboard-configmap.yaml               @ai-dynamo/dynamo-observability-codeowners @ai-dynamo/dynamo-planner-codeowners
 /components/src/dynamo/sglang/request_handlers/image_diffusion/              @ai-dynamo/dynamo-backend-sglang-codeowners @ai-dynamo/dynamo-diffusion-codeowners
 /components/src/dynamo/trtllm/workers/image_diffusion_worker.py              @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-diffusion-codeowners
 /components/src/dynamo/trtllm/workers/video_diffusion_worker.py              @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-diffusion-codeowners
@@ -722,5 +722,5 @@
 /components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py       @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-gms-codeowners
 /components/src/dynamo/sglang/request_handlers/llm/diffusion_handler.py      @ai-dynamo/dynamo-backend-sglang-codeowners @ai-dynamo/dynamo-diffusion-codeowners
 /components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py   @ai-dynamo/dynamo-runtime-codeowners @ai-dynamo/dynamo-multimodal-codeowners
-/components/src/dynamo/mocker/utils/planner_profiler_perf_data_converter.py  @ai-dynamo/dynamo-performance-codeowners @ai-dynamo/dynamo-planner-codeowners @jasonqinzhou @dreamtalen
+/components/src/dynamo/mocker/utils/planner_profiler_perf_data_converter.py  @ai-dynamo/dynamo-performance-codeowners @ai-dynamo/dynamo-planner-codeowners
 /tests/fault_tolerance/hardware/fault_injection_service/api_service/main.py  @ai-dynamo/dynamo-fault-tolerance-codeowners @ai-dynamo/dynamo-observability-codeowners

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,7 +9,4 @@ Generated from `.github/codeowners/external_contributors.yaml`. Do not
 hand-edit — update that file and regenerate (see
 `.github/codeowners/README.md`).
 
-| Contributor | Level | GitHub | Affiliation | Areas |
-| --- | --- | --- | --- | --- |
-| Jason Zhou | Maintainer | [@jasonqinzhou](https://github.com/jasonqinzhou) | NVIDIA | `planner` |
-| Yongming Ding | Maintainer | [@dreamtalen](https://github.com/dreamtalen) | NVIDIA | `planner` |
+_No external contributors yet._


### PR DESCRIPTION
## Summary

`@jasonqinzhou` and `@dreamtalen` were added to `external_contributors.yaml` in
`038c642b56` (#12446), which appends them as co-owners on every line the planner
team owns. Both are NVIDIA staff, and that registry is for individuals granted
area-scoped ownership who are **not** covered by an org team — so the per-person
rows were the wrong mechanism.

**They are now members of `@ai-dynamo/dynamo-planner-codeowners`**, so this
removes no ownership. They keep the same paths through the team and pick up the
rest of the team's coverage.

It also clears a review gate nobody could satisfy. The registry's own header
states ownership is co-ownership under *"any one approves"*, but GitHub enforced
the two handles as an independent requirement: #12110 sat green with **every**
owning team approved — docs, ops, runtime, planner, operator, 94 checks passing —
and stayed `BLOCKED` on two individually requested reviewers. Any PR touching a
planner path would hit the same wall.

## Changes

- `external_contributors.yaml` — both entries removed (registry now empty; the
  mechanism and its example remain for future use)
- `CODEOWNERS` — regenerated; the four planner lines drop the two handles
- `CONTRIBUTORS.md` — regenerated

> [!NOTE]
> `CONTRIBUTORS.md` loses its two Maintainer rows, because it is generated from
> this same registry. That is a visible change — flagging it explicitly in case
> the recognition should be preserved some other way. Ownership does not depend
> on it.

## Validation

- Team membership confirmed `active` for both **before** the rows were removed,
  so there is no window where they hold neither.
- Every changed `CODEOWNERS` line involves only those two handles — verified by
  diffing with them filtered out and confirming nothing remains.
- Regenerated with the full documented invocation, including `--advisory-out`.
  That flag writes nothing here: `areas.yaml` declares no advisory rules (its one
  `advisory:` key is `advisory: false`), so `_render_advisory` returns `None` and
  no `advisory-reviewers.yaml` is emitted or tracked. An earlier version of this
  description claimed the file came out byte-identical, which was wrong -- there
  is no file to compare.
- Generator reports 618 rules across 23 teams, unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->