### PR TITLE
feat(operator): persist immutable DGD workload provider selection

### DIFF
--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -42,6 +42,11 @@ const (
 
 	KubeAnnotationEnableGrove = "nvidia.com/enable-grove"
 
+	// KubeAnnotationWorkloadProvider records the controller-owned immutable graph-level workload provider.
+	KubeAnnotationWorkloadProvider = "nvidia.com/workload-provider"
+	WorkloadProviderComponent      = "component"
+	WorkloadProviderGrove          = "grove"
+
 	// KubeAnnotationGroveUpdateStrategy temporarily exposes the Grove
 	// PodCliqueSet update strategy while the long-term DGD API is settled.
 	// Supported values match Grove exactly: "RollingRecreate" and "OnDelete".

--- a/deploy/operator/internal/controller/dgd_grove_program.go
+++ b/deploy/operator/internal/controller/dgd_grove_program.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type groveProgram struct {
@@ -33,6 +35,7 @@ type groveProgram struct {
 	workloads       *groveWorkloadsReconciler
 	scalingAdapters *dgdScalingAdaptersReconciler
 	topology        *dgdGroveTopologyConditionReconciler
+	gate            features.Gate
 }
 
 // newGroveProgram wires the Grove pathway at the DGD composition root.
@@ -62,6 +65,7 @@ func (r *DynamoGraphDeploymentReconciler) newGroveProgram() *groveProgram {
 		),
 		scalingAdapters: newDGDScalingAdaptersReconciler(r.Client, r.Recorder),
 		topology:        newDGDGroveTopologyConditionReconciler(r.Client),
+		gate:            r.RuntimeConfig.Gate,
 	}
 }
 
@@ -73,6 +77,17 @@ func (p *groveProgram) Reconcile(
 	req workloadProgramRequest,
 ) (programResult workloadProgramResult, retErr error) {
 	programResult = newWorkloadProgramResult(req.DGD)
+
+	// Fail a durable Grove selection when Grove is unavailable rather than falling back.
+	if !p.gate.Enabled(features.Grove) {
+		err := failWorkloadProgram(
+			reasonSelectedWorkloadProviderUnavailable,
+			fmt.Errorf("selected workload provider %q is unavailable because Grove is disabled", workloadProviderGrove),
+		)
+		programResult.Fail(req.DGD.Generation, reasonSelectedWorkloadProviderUnavailable, err)
+		return programResult, reconcile.TerminalError(err)
+	}
+
 	defer func() {
 		if retErr != nil {
 			reason := reasonFailedToReconcileResources

--- a/deploy/operator/internal/controller/dgd_workload_program.go
+++ b/deploy/operator/internal/controller/dgd_workload_program.go
@@ -73,12 +73,17 @@ type workloadProgram interface {
 }
 
 func (r *DynamoGraphDeploymentReconciler) selectWorkloadProgram(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-) workloadProgram {
-	if r.isGrovePathway(dgd) {
-		return r.newGroveProgram()
+	provider workloadProvider,
+) (workloadProgram, error) {
+	// Dispatch each durable provider value to its complete workload program.
+	switch provider {
+	case workloadProviderGrove:
+		return r.newGroveProgram(), nil
+	case workloadProviderComponent:
+		return r.newComponentProgram(), nil
+	default:
+		return nil, fmt.Errorf("unsupported workload provider %q", provider)
 	}
-	return r.newComponentProgram()
 }
 
 func newWorkloadProgramResult(

--- a/deploy/operator/internal/controller/dgd_workload_program_test.go
+++ b/deploy/operator/internal/controller/dgd_workload_program_test.go
@@ -41,55 +41,37 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestDGDWorkloadProgramSelection(t *testing.T) {
 	tests := []struct {
-		name               string
-		groveEnabled       bool
-		annotations        map[string]string
-		topologyConstraint *nvidiacomv1beta1.SpecTopologyConstraint
-		wantProgram        workloadProgram
+		name        string
+		provider    workloadProvider
+		wantProgram workloadProgram
 	}{
 		{
-			name: "Grove feature disabled selects component program despite topology intent",
-			topologyConstraint: &nvidiacomv1beta1.SpecTopologyConstraint{
-				ClusterTopologyName: "test-topology",
-			},
+			name:        "component provider selects component program",
+			provider:    workloadProviderComponent,
 			wantProgram: &componentProgram{},
 		},
 		{
-			name:         "Grove feature enabled selects Grove program",
-			groveEnabled: true,
-			wantProgram:  &groveProgram{},
-		},
-		{
-			name:         "explicit Grove disable selects component program",
-			groveEnabled: true,
-			annotations: map[string]string{
-				commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueFalse,
-			},
-			wantProgram: &componentProgram{},
+			name:        "Grove provider selects Grove program",
+			provider:    workloadProviderGrove,
+			wantProgram: &groveProgram{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Log("Build the reconciler selection inputs")
-			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
-				ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations},
-				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
-					TopologyConstraint: tt.topologyConstraint,
-				},
-			}
+			t.Log("Build the program composition root")
 			reconciler := &DynamoGraphDeploymentReconciler{
-				RuntimeConfig: &commonController.RuntimeConfig{
-					Gate: features.Gates{Grove: tt.groveEnabled},
-				},
+				RuntimeConfig: &commonController.RuntimeConfig{},
 			}
 
-			t.Log("Select one complete workload program")
-			got := reconciler.selectWorkloadProgram(dgd)
+			t.Log("Select one complete workload program from the durable provider")
+			got, err := reconciler.selectWorkloadProgram(tt.provider)
+			require.NoError(t, err)
 
 			assert.IsType(t, tt.wantProgram, got)
 			if component, ok := got.(*componentProgram); ok {
@@ -111,6 +93,26 @@ func TestDGDWorkloadProgramSelection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSelectedGroveProgramDoesNotFallbackWhenUnavailable(t *testing.T) {
+	t.Log("Create a DGD request and an unavailable Grove program")
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Generation: 3},
+	}
+	program := &groveProgram{gate: features.Gates{}}
+
+	t.Log("Reconcile the durably selected Grove program while Grove is unavailable")
+	result, err := program.Reconcile(t.Context(), workloadProgramRequest{DGD: dgd})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, reconcile.TerminalError(nil))
+
+	t.Log("Verify Grove reports provider unavailability without invoking component reconciliation")
+	ready := meta.FindStatusCondition(result.Status.Conditions, "Ready")
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, string(reasonSelectedWorkloadProviderUnavailable), ready.Reason)
+	assert.Contains(t, ready.Message, "Grove is disabled")
 }
 
 func TestNewWorkloadProgramResultCopiesStatus(t *testing.T) {
@@ -377,7 +379,7 @@ func TestGroveProgram_ReconcilePreservesResultOnError(t *testing.T) {
 		Client:        kubeClient,
 		Recorder:      events.NewFakeRecorder(10),
 		Config:        &configv1alpha1.OperatorConfiguration{},
-		RuntimeConfig: &commonController.RuntimeConfig{},
+		RuntimeConfig: &commonController.RuntimeConfig{Gate: features.Gates{Grove: true}},
 	}
 	program := reconciler.newGroveProgram()
 	dgd.Status = nvidiacomv1beta1.DynamoGraphDeploymentStatus{

--- a/deploy/operator/internal/controller/dgd_workload_provider.go
+++ b/deploy/operator/internal/controller/dgd_workload_provider.go
@@ -1,0 +1,181 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type workloadProvider string
+
+const (
+	workloadProviderComponent workloadProvider = consts.WorkloadProviderComponent
+	workloadProviderGrove     workloadProvider = consts.WorkloadProviderGrove
+)
+
+var (
+	errConflictingWorkloadProviders = errors.New("conflicting workload providers")
+	errUnsupportedWorkloadProvider  = errors.New("unsupported workload provider")
+)
+
+// ensureWorkloadProvider persists a missing provider before workload reconciliation.
+func (r *DynamoGraphDeploymentReconciler) ensureWorkloadProvider(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) (workloadProvider, error) {
+	// Reuse a materialized provider without consulting mutable routing inputs.
+	if value, exists := dgd.Annotations[consts.KubeAnnotationWorkloadProvider]; exists {
+		return parseWorkloadProvider(value)
+	}
+
+	// Adopt the workload family already owned by a legacy unannotated DGD.
+	provider, found, err := providerFromOwnedWorkloads(ctx, r.Client, dgd)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		provider = providerFromCurrentIntent(r.RuntimeConfig.Gate, dgd)
+	}
+
+	// Persist the adopted or creation-time selection with optimistic concurrency control.
+	base := dgd.DeepCopy()
+
+	// Materialize the selected provider on the object passed to the API client.
+	if dgd.Annotations == nil {
+		dgd.Annotations = make(map[string]string)
+	}
+	dgd.Annotations[consts.KubeAnnotationWorkloadProvider] = string(provider)
+
+	// Persist the selection and retain the API server's returned object state.
+	patch := client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
+	if err := r.Patch(ctx, dgd, patch); err != nil {
+		dgd.Annotations = base.Annotations
+		return "", fmt.Errorf("persist workload provider %q: %w", provider, err)
+	}
+
+	return provider, nil
+}
+
+func providerFromOwnedWorkloads(
+	ctx context.Context,
+	reader client.Reader,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) (workloadProvider, bool, error) {
+	// Observe both workload families before deciding whether either is authoritative.
+	hasComponents, err := hasOwnedComponentWorkloads(ctx, reader, dgd)
+	if err != nil {
+		return "", false, err
+	}
+	hasGrove, err := hasOwnedGroveWorkloads(ctx, reader, dgd)
+	if err != nil {
+		return "", false, err
+	}
+
+	// Adopt one unambiguous family and fail closed when both families exist.
+	switch {
+	case hasComponents && hasGrove:
+		return "", false, fmt.Errorf(
+			"%w: DynamoGraphDeployment %s/%s owns DynamoComponentDeployments and PodCliqueSets",
+			errConflictingWorkloadProviders,
+			dgd.Namespace,
+			dgd.Name,
+		)
+	case hasGrove:
+		return workloadProviderGrove, true, nil
+	case hasComponents:
+		return workloadProviderComponent, true, nil
+	default:
+		return "", false, nil
+	}
+}
+
+func hasOwnedComponentWorkloads(
+	ctx context.Context,
+	reader client.Reader,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) (bool, error) {
+	// Scan the namespace cache because mutable labels cannot prove legacy ownership.
+	list := &nvidiacomv1beta1.DynamoComponentDeploymentList{}
+	if err := reader.List(ctx, list, client.InNamespace(dgd.Namespace)); err != nil {
+		return false, fmt.Errorf("list owned DynamoComponentDeployments: %w", err)
+	}
+
+	// Accept only the controller reference as authoritative ownership evidence.
+	for i := range list.Items {
+		if metav1.IsControlledBy(&list.Items[i], dgd) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func hasOwnedGroveWorkloads(
+	ctx context.Context,
+	reader client.Reader,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) (bool, error) {
+	// Treat an unavailable optional Grove API as an empty observable workload family.
+	list := &grovev1alpha1.PodCliqueSetList{}
+	if err := reader.List(ctx, list, client.InNamespace(dgd.Namespace)); err != nil {
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("list owned PodCliqueSets: %w", err)
+	}
+
+	// Accept only the controller reference as authoritative ownership evidence.
+	for i := range list.Items {
+		if metav1.IsControlledBy(&list.Items[i], dgd) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func providerFromCurrentIntent(
+	gate features.Gate,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) workloadProvider {
+	// Grove is the default when its gate is enabled unless the DGD opts out.
+	if gate.Enabled(features.Grove) &&
+		strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableGrove]) != consts.KubeLabelValueFalse {
+		return workloadProviderGrove
+	}
+	return workloadProviderComponent
+}
+
+func parseWorkloadProvider(value string) (workloadProvider, error) {
+	// Accept only the workload programs implemented by this controller.
+	switch workloadProvider(value) {
+	case workloadProviderComponent, workloadProviderGrove:
+		return workloadProvider(value), nil
+	default:
+		return "", fmt.Errorf("%w: %q", errUnsupportedWorkloadProvider, value)
+	}
+}

--- a/deploy/operator/internal/controller/dgd_workload_provider_test.go
+++ b/deploy/operator/internal/controller/dgd_workload_provider_test.go
@@ -1,0 +1,342 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"testing"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestEnsureWorkloadProvider(t *testing.T) {
+	listErr := errors.New("list failed")
+	tests := []struct {
+		name         string
+		gate         features.Gates
+		annotations  map[string]string
+		workloads    []providerTestWorkload
+		groveListErr error
+		wantProvider workloadProvider
+		wantErr      string
+		wantErrIs    error
+	}{
+		{
+			name: "materialized component remains authoritative when Grove is enabled",
+			gate: features.Gates{Grove: true},
+			annotations: map[string]string{
+				consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderComponent,
+			},
+			workloads:    []providerTestWorkload{{provider: workloadProviderGrove, owned: true}},
+			wantProvider: workloadProviderComponent,
+		},
+		{
+			name:         "no owned workloads select Grove from current intent",
+			gate:         features.Gates{Grove: true},
+			wantProvider: workloadProviderGrove,
+		},
+		{
+			name: "explicit Grove opt-out locks in component",
+			gate: features.Gates{Grove: true},
+			annotations: map[string]string{
+				consts.KubeAnnotationEnableGrove: "FALSE",
+			},
+			wantProvider: workloadProviderComponent,
+		},
+		{
+			name:         "owned DCD adopts component despite current Grove intent",
+			gate:         features.Gates{Grove: true},
+			workloads:    []providerTestWorkload{{provider: workloadProviderComponent, owned: true}},
+			wantProvider: workloadProviderComponent,
+		},
+		{
+			name: "owned PodCliqueSet adopts Grove despite current component intent",
+			annotations: map[string]string{
+				consts.KubeAnnotationEnableGrove: consts.KubeLabelValueFalse,
+			},
+			workloads:    []providerTestWorkload{{provider: workloadProviderGrove, owned: true}},
+			wantProvider: workloadProviderGrove,
+		},
+		{
+			name: "mixed owned workload families fail closed",
+			workloads: []providerTestWorkload{
+				{provider: workloadProviderComponent, owned: true},
+				{provider: workloadProviderGrove, owned: true},
+			},
+			wantErr:   "owns DynamoComponentDeployments and PodCliqueSets",
+			wantErrIs: errConflictingWorkloadProviders,
+		},
+		{
+			name: "foreign workloads are ignored",
+			gate: features.Gates{Grove: true},
+			workloads: []providerTestWorkload{
+				{provider: workloadProviderComponent},
+				{provider: workloadProviderGrove},
+			},
+			wantProvider: workloadProviderGrove,
+		},
+		{
+			name: "cluster without Grove API selects component from current intent",
+			groveListErr: fmt.Errorf("discover Grove API: %w", &meta.NoKindMatchError{
+				GroupKind:        grovev1alpha1.SchemeGroupVersion.WithKind("PodCliqueSet").GroupKind(),
+				SearchedVersions: []string{grovev1alpha1.SchemeGroupVersion.Version},
+			}),
+			wantProvider: workloadProviderComponent,
+		},
+		{
+			name:         "workload discovery failure does not freeze a provider",
+			groveListErr: listErr,
+			wantErr:      "list owned PodCliqueSets",
+			wantErrIs:    listErr,
+		},
+		{
+			name: "unsupported materialized provider fails",
+			annotations: map[string]string{
+				consts.KubeAnnotationWorkloadProvider: "unknown",
+			},
+			wantErr:   "unsupported workload provider",
+			wantErrIs: errUnsupportedWorkloadProvider,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Store one DGD and the workload families visible during adoption")
+			seed := &nvidiacomv1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "graph",
+					Namespace:   "default",
+					UID:         types.UID("graph-uid"),
+					Annotations: maps.Clone(tt.annotations),
+				},
+			}
+			objects := []client.Object{seed}
+			for i, workload := range tt.workloads {
+				objects = append(objects, newProviderTestWorkload(t, seed, i, workload))
+			}
+			clientBuilder := fake.NewClientBuilder().
+				WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+				WithObjects(objects...)
+			if tt.groveListErr != nil {
+				clientBuilder = clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+					List: func(
+						ctx context.Context,
+						kubeClient client.WithWatch,
+						list client.ObjectList,
+						opts ...client.ListOption,
+					) error {
+						if _, ok := list.(*grovev1alpha1.PodCliqueSetList); ok {
+							return tt.groveListErr
+						}
+						return kubeClient.List(ctx, list, opts...)
+					},
+				})
+			}
+			kubeClient := clientBuilder.Build()
+			live := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(seed), live))
+			reconciler := &DynamoGraphDeploymentReconciler{
+				Client:        kubeClient,
+				RuntimeConfig: &commoncontroller.RuntimeConfig{Gate: tt.gate},
+			}
+
+			t.Log("Resolve and, when missing, persist the provider")
+			provider, err := reconciler.ensureWorkloadProvider(t.Context(), live)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.ErrorIs(t, err, tt.wantErrIs)
+
+				t.Log("Verify a failed adoption did not freeze an arbitrary provider")
+				stored := &nvidiacomv1beta1.DynamoGraphDeployment{}
+				require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(seed), stored))
+				if _, originallySelected := tt.annotations[consts.KubeAnnotationWorkloadProvider]; !originallySelected {
+					assert.NotContains(t, stored.Annotations, consts.KubeAnnotationWorkloadProvider)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantProvider, provider)
+			assert.Equal(t, string(tt.wantProvider), live.Annotations[consts.KubeAnnotationWorkloadProvider])
+
+			t.Log("Verify the stored annotation matches the selected provider")
+			stored := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(seed), stored))
+			assert.Equal(t, string(tt.wantProvider), stored.Annotations[consts.KubeAnnotationWorkloadProvider])
+		})
+	}
+}
+
+type providerTestWorkload struct {
+	provider workloadProvider
+	owned    bool
+}
+
+func newProviderTestWorkload(
+	t testing.TB,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	index int,
+	workload providerTestWorkload,
+) client.Object {
+	t.Helper()
+
+	var ownerReferences []metav1.OwnerReference
+	if workload.owned {
+		ownerReferences = []metav1.OwnerReference{
+			*metav1.NewControllerRef(dgd, nvidiacomv1beta1.GroupVersion.WithKind("DynamoGraphDeployment")),
+		}
+	}
+	objectMeta := metav1.ObjectMeta{
+		Name:            fmt.Sprintf("%s-%d", workload.provider, index),
+		Namespace:       dgd.Namespace,
+		OwnerReferences: ownerReferences,
+	}
+
+	switch workload.provider {
+	case workloadProviderComponent:
+		return &nvidiacomv1beta1.DynamoComponentDeployment{ObjectMeta: objectMeta}
+	case workloadProviderGrove:
+		return &grovev1alpha1.PodCliqueSet{ObjectMeta: objectMeta}
+	default:
+		t.Fatalf("unsupported test workload provider %q", workload.provider)
+		return nil
+	}
+}
+
+func TestEnsureWorkloadProviderRestoresObjectAfterPatchFailure(t *testing.T) {
+	t.Log("Inject a provider patch failure for an unannotated DGD")
+	patchErr := errors.New("patch failed")
+	seed := &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "graph", Namespace: "default"},
+	}
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+		WithObjects(seed).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(context.Context, client.WithWatch, client.Object, client.Patch, ...client.PatchOption) error {
+				return patchErr
+			},
+		}).
+		Build()
+	live := &nvidiacomv1beta1.DynamoGraphDeployment{}
+	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(seed), live))
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client:        kubeClient,
+		RuntimeConfig: &commoncontroller.RuntimeConfig{},
+	}
+
+	t.Log("Attempt to lock in the provider")
+	_, err := reconciler.ensureWorkloadProvider(t.Context(), live)
+	require.ErrorIs(t, err, patchErr)
+	assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
+
+	t.Log("Verify the request object does not retain an unpersisted annotation")
+	assert.Nil(t, live.Annotations)
+}
+
+func TestDynamoGraphDeploymentReconcileReportsUnsupportedWorkloadProvider(t *testing.T) {
+	statusUpdateErr := errors.New("status update failed")
+	tests := []struct {
+		name            string
+		statusUpdateErr error
+	}{
+		{
+			name: "persists the failure before returning a terminal error",
+		},
+		{
+			name:            "keeps a failed status update retryable",
+			statusUpdateErr: statusUpdateErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Store a DGD with an unsupported immutable workload provider")
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "graph",
+					Namespace:  "default",
+					Generation: 4,
+					Annotations: map[string]string{
+						consts.KubeAnnotationWorkloadProvider: "unknown",
+					},
+				},
+			}
+			builder := fake.NewClientBuilder().
+				WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+				WithObjects(dgd).
+				WithStatusSubresource(&nvidiacomv1beta1.DynamoGraphDeployment{})
+			if tt.statusUpdateErr != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					SubResourceUpdate: func(
+						context.Context,
+						client.Client,
+						string,
+						client.Object,
+						...client.SubResourceUpdateOption,
+					) error {
+						return tt.statusUpdateErr
+					},
+				})
+			}
+			kubeClient := builder.Build()
+			reconciler := &DynamoGraphDeploymentReconciler{
+				Client:        kubeClient,
+				RuntimeConfig: &commoncontroller.RuntimeConfig{},
+			}
+
+			t.Log("Reconcile the invalid durable provider")
+			_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(dgd),
+			})
+			if tt.statusUpdateErr != nil {
+				t.Log("Verify a failed diagnosis write remains retryable")
+				require.ErrorIs(t, err, tt.statusUpdateErr)
+				assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
+				return
+			}
+			require.ErrorIs(t, err, errUnsupportedWorkloadProvider)
+			assert.ErrorIs(t, err, reconcile.TerminalError(nil))
+
+			t.Log("Verify the immutable provider failure is visible in DGD status")
+			stored := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(dgd), stored))
+			ready := meta.FindStatusCondition(stored.Status.Conditions, "Ready")
+			require.NotNil(t, ready)
+			assert.Equal(t, metav1.ConditionFalse, ready.Status)
+			assert.Equal(t, string(reasonUnsupportedWorkloadProvider), ready.Reason)
+			assert.Contains(t, ready.Message, "unsupported workload provider")
+		})
+	}
+}

--- a/deploy/operator/internal/controller/dra_claim_dependencies.go
+++ b/deploy/operator/internal/controller/dra_claim_dependencies.go
@@ -10,8 +10,10 @@ import (
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -147,6 +149,17 @@ func (r *DynamoGraphDeploymentReconciler) mapResourceClaimTemplateToDGDRequests(
 	return r.mapDRAClaimToDGDRequests(ctx, obj, true)
 }
 
+func (r *DynamoGraphDeploymentReconciler) shouldMapDRAEventToDGD(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) bool {
+	// DGD-level DRA events serve Grove; unselected legacy DGDs remain eligible until adoption.
+	if !r.RuntimeConfig.Gate.Enabled(features.Grove) {
+		return false
+	}
+	provider, selected := dgd.Annotations[consts.KubeAnnotationWorkloadProvider]
+	return !selected || provider == consts.WorkloadProviderGrove
+}
+
 func (r *DynamoGraphDeploymentReconciler) mapDRAClaimToDGDRequests(
 	ctx context.Context,
 	obj client.Object,
@@ -161,7 +174,7 @@ func (r *DynamoGraphDeploymentReconciler) mapDRAClaimToDGDRequests(
 	requests := make([]ctrl.Request, 0)
 	for i := range deployments.Items {
 		deployment := &deployments.Items[i]
-		if !r.isGrovePathway(deployment) {
+		if !r.shouldMapDRAEventToDGD(deployment) {
 			continue
 		}
 		for componentIndex := range deployment.Spec.Components {
@@ -191,7 +204,7 @@ func (r *DynamoGraphDeploymentReconciler) mapDeviceClassToDGDRequests(
 	for i := range deployments.Items {
 		deployment := &deployments.Items[i]
 		if !commonController.NamespaceAllowed(r.Config, r.RuntimeConfig, deployment, deployment.Namespace) ||
-			!r.isGrovePathway(deployment) {
+			!r.shouldMapDRAEventToDGD(deployment) {
 			continue
 		}
 		for componentIndex := range deployment.Spec.Components {

--- a/deploy/operator/internal/controller/dra_claim_dependencies_test.go
+++ b/deploy/operator/internal/controller/dra_claim_dependencies_test.go
@@ -101,13 +101,15 @@ func TestMapResourceClaimTemplateToDGDRequests(t *testing.T) {
 		},
 	}
 	unrelated.Spec.Components[0].Multinode = nil
-	lws := matching.DeepCopy()
-	lws.Name = "lws"
-	lws.Annotations = map[string]string{commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueFalse}
+	component := matching.DeepCopy()
+	component.Name = "component"
+	component.Annotations = map[string]string{
+		commonconsts.KubeAnnotationWorkloadProvider: commonconsts.WorkloadProviderComponent,
+	}
 	scheme := runtime.NewScheme()
 	require.NoError(t, nvidiacomv1beta1.AddToScheme(scheme))
 	reconciler := &DynamoGraphDeploymentReconciler{
-		Client:        fake.NewClientBuilder().WithScheme(scheme).WithObjects(matching, unrelated, lws).Build(),
+		Client:        fake.NewClientBuilder().WithScheme(scheme).WithObjects(matching, unrelated, component).Build(),
 		RuntimeConfig: &commonController.RuntimeConfig{Gate: features.Gates{Grove: true}},
 	}
 
@@ -117,6 +119,64 @@ func TestMapResourceClaimTemplateToDGDRequests(t *testing.T) {
 	})
 
 	assert.Equal(t, []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: "default", Name: "matching"}}}, requests)
+}
+
+func TestShouldMapDRAEventToDGD(t *testing.T) {
+	tests := []struct {
+		name         string
+		groveEnabled bool
+		annotations  map[string]string
+		want         bool
+	}{
+		{
+			name:         "selected Grove provider receives DGD-level DRA events",
+			groveEnabled: true,
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationWorkloadProvider: commonconsts.WorkloadProviderGrove,
+			},
+			want: true,
+		},
+		{
+			name:         "selected component provider relies on DCD-level DRA events",
+			groveEnabled: true,
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationWorkloadProvider: commonconsts.WorkloadProviderComponent,
+			},
+		},
+		{
+			name:         "unselected legacy DGD remains eligible until adoption",
+			groveEnabled: true,
+			want:         true,
+		},
+		{
+			name: "disabled Grove provider receives no DGD-level DRA events",
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationWorkloadProvider: commonconsts.WorkloadProviderGrove,
+			},
+		},
+		{
+			name:         "unsupported provider receives no DGD-level DRA events",
+			groveEnabled: true,
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationWorkloadProvider: "unknown",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build the provider state visible to the DRA event mapper")
+			reconciler := &DynamoGraphDeploymentReconciler{
+				RuntimeConfig: &commonController.RuntimeConfig{Gate: features.Gates{Grove: tt.groveEnabled}},
+			}
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations},
+			}
+
+			t.Log("Decide whether the DGD-level Grove program consumes the DRA event")
+			assert.Equal(t, tt.want, reconciler.shouldMapDRAEventToDGD(dgd))
+		})
+	}
 }
 
 func TestMapDeviceClassToDCDRequests(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
 
@@ -39,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -52,12 +52,14 @@ import (
 )
 
 const (
-	reasonFailedToInitializeWorkerHash Reason = "failed_to_initialize_worker_hash"
-	reasonFailedToMigrateWorkerHash    Reason = "failed_to_migrate_worker_hash"
-	reasonNoMultinodeOrchestrator      Reason = "no_multinode_orchestrator_available"
-	reasonFailedToReconcileResources   Reason = "failed_to_reconcile_the_resources"
-	reasonRollingUpdateFailed          Reason = "rolling_update_failed"
-	reasonWaitingForCheckpoint         Reason = "waiting_for_checkpoint"
+	reasonFailedToInitializeWorkerHash        Reason = "failed_to_initialize_worker_hash"
+	reasonFailedToMigrateWorkerHash           Reason = "failed_to_migrate_worker_hash"
+	reasonNoMultinodeOrchestrator             Reason = "no_multinode_orchestrator_available"
+	reasonFailedToReconcileResources          Reason = "failed_to_reconcile_the_resources"
+	reasonRollingUpdateFailed                 Reason = "rolling_update_failed"
+	reasonWaitingForCheckpoint                Reason = "waiting_for_checkpoint"
+	reasonSelectedWorkloadProviderUnavailable Reason = "selected_workload_provider_unavailable"
+	reasonUnsupportedWorkloadProvider         Reason = "unsupported_workload_provider"
 
 	dgdComponentPodIndex = ".metadata.dgdComponent"
 )
@@ -129,6 +131,24 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	// Lock in the provider before allowing any other reconciliation effects.
+	provider, err := r.ensureWorkloadProvider(ctx, dynamoDeployment)
+
+	// Keep adoption and patch failures retryable while making an invalid stored selection terminal.
+	if err != nil {
+		if !errors.Is(err, errUnsupportedWorkloadProvider) {
+			return ctrl.Result{}, err
+		}
+
+		// Persist the invalid selection diagnosis before suppressing automatic retries.
+		programResult := newWorkloadProgramResult(dynamoDeployment)
+		programResult.Fail(dynamoDeployment.Generation, reasonUnsupportedWorkloadProvider, err)
+		if statusErr := r.persistWorkloadProgramResult(ctx, dynamoDeployment, programResult); statusErr != nil {
+			return programResult.Result, statusErr
+		}
+		return programResult.Result, reconcile.TerminalError(err)
+	}
+
 	// Reject unsupported stored configurations before any primary-resource mutation.
 	var compatibilityErrs []error
 	for i := range dynamoDeployment.Spec.Components {
@@ -161,7 +181,11 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
-	program := r.selectWorkloadProgram(dynamoDeployment)
+	// Dispatch exclusively through the persisted provider.
+	program, err := r.selectWorkloadProgram(provider)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	programResult, programErr := program.Reconcile(ctx, workloadProgramRequest{
 		DGD: dynamoDeployment,
 	})
@@ -194,11 +218,6 @@ func (r *DynamoGraphDeploymentReconciler) persistWorkloadProgramResult(
 		}
 	}
 	return nil
-}
-
-func (r *DynamoGraphDeploymentReconciler) isGrovePathway(dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
-	return r.RuntimeConfig.Gate.Enabled(features.Grove) && (dgd.Annotations == nil ||
-		strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableGrove]) != consts.KubeLabelValueFalse)
 }
 
 func (r *DynamoGraphDeploymentReconciler) FinalizeResource(ctx context.Context, dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment) error {
@@ -287,9 +306,12 @@ func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) err
 			GenericFunc: func(ge event.GenericEvent) bool { return false },
 		}))
 	}
+
+	// Register Grove-owned workload watches only when the Grove feature is enabled.
 	if r.RuntimeConfig.Gate.Enabled(features.Grove) {
 		ctrlBuilder = newGroveWatchSetup(r.Client).addTo(ctrlBuilder)
 	}
+
 	// Wrap with metrics collection
 	observedReconciler := observability.NewObservedReconciler(r, consts.ResourceTypeDynamoGraphDeployment)
 	return ctrlBuilder.Complete(observedReconciler)

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -79,7 +79,8 @@ func newTestDGDResourceSyncer(reconciler *DynamoGraphDeploymentReconciler) dgdRe
 	return newDGDResourceSyncer(reconciler.Client, reconciler.Recorder)
 }
 
-func TestDynamoGraphDeploymentReconcileRejectsStoredCheckpointIncompatibilityBeforeSideEffects(t *testing.T) {
+func TestDynamoGraphDeploymentReconcileLocksProviderBeforeRejectingStoredCheckpointIncompatibility(t *testing.T) {
+	t.Log("Store a DGD with an incompatible checkpoint configuration")
 	dgd := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test-dgd",
@@ -118,6 +119,7 @@ func TestDynamoGraphDeploymentReconcileRejectsStoredCheckpointIncompatibilityBef
 		RuntimeConfig: &controller_common.RuntimeConfig{},
 	}
 
+	t.Log("Reconcile once to persist the provider before reporting incompatibility")
 	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: client.ObjectKeyFromObject(dgd),
 	})
@@ -127,7 +129,7 @@ func TestDynamoGraphDeploymentReconcileRejectsStoredCheckpointIncompatibilityBef
 	var stored v1beta1.DynamoGraphDeployment
 	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), &stored))
 	require.False(t, controller_common.ContainsFinalizer(&stored))
-	require.Empty(t, stored.Annotations)
+	require.Equal(t, commonconsts.WorkloadProviderComponent, stored.Annotations[commonconsts.KubeAnnotationWorkloadProvider])
 	require.Equal(t, v1beta1.DGDStateFailed, stored.Status.State)
 	ready := meta.FindStatusCondition(stored.Status.Conditions, "Ready")
 	require.NotNil(t, ready)
@@ -680,91 +682,6 @@ func (m *mockScaleInterface) Update(ctx context.Context, resource schema.GroupRe
 func (m *mockScaleInterface) Patch(ctx context.Context, gvr schema.GroupVersionResource, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*autoscalingv1.Scale, error) {
 	// Return a dummy scale object
 	return &autoscalingv1.Scale{}, nil
-}
-
-func TestDynamoGraphDeploymentReconciler_isGrovePathway(t *testing.T) {
-	tests := []struct {
-		name         string
-		groveEnabled bool
-		annotations  map[string]string
-		want         bool
-	}{
-		{
-			name:         "feature disabled without annotation selects component pathway",
-			groveEnabled: false,
-			want:         false,
-		},
-		{
-			name:         "feature disabled ignores explicit enable annotation",
-			groveEnabled: false,
-			annotations: map[string]string{
-				commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueTrue,
-			},
-			want: false,
-		},
-		{
-			name:         "feature enabled without annotations selects Grove",
-			groveEnabled: true,
-			want:         true,
-		},
-		{
-			name:         "feature enabled with unrelated annotation selects Grove",
-			groveEnabled: true,
-			annotations: map[string]string{
-				"example.com/unrelated": "value",
-			},
-			want: true,
-		},
-		{
-			name:         "feature enabled with explicit enable annotation selects Grove",
-			groveEnabled: true,
-			annotations: map[string]string{
-				commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueTrue,
-			},
-			want: true,
-		},
-		{
-			name:         "feature enabled with explicit disable annotation selects component pathway",
-			groveEnabled: true,
-			annotations: map[string]string{
-				commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueFalse,
-			},
-			want: false,
-		},
-		{
-			name:         "explicit disable annotation is case insensitive",
-			groveEnabled: true,
-			annotations: map[string]string{
-				commonconsts.KubeAnnotationEnableGrove: "FaLsE",
-			},
-			want: false,
-		},
-		{
-			name:         "unknown annotation value does not disable Grove",
-			groveEnabled: true,
-			annotations: map[string]string{
-				commonconsts.KubeAnnotationEnableGrove: "invalid",
-			},
-			want: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Log("Build a reconciler and DGD with the pathway-selection inputs")
-			reconciler := &DynamoGraphDeploymentReconciler{
-				RuntimeConfig: &controller_common.RuntimeConfig{
-					Gate: features.Gates{Grove: tt.groveEnabled},
-				},
-			}
-			dgd := &v1beta1.DynamoGraphDeployment{
-				ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations},
-			}
-
-			t.Log("Evaluate the current Grove pathway-selection contract")
-			assert.Equal(t, tt.want, reconciler.isGrovePathway(dgd))
-		})
-	}
 }
 
 func TestGroveWorkloadsReconciler_Reconcile(t *testing.T) {

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
@@ -55,9 +55,10 @@ func NewDGDDefaulter(operatorVersion string) *DGDDefaulter {
 
 // Default implements admission.CustomDefaulter.
 // On every operation: defaults nil Replicas to 1 for all components.
-// On every Grove-pathway operation: defaults nil MinAvailable to 1. Scaling to
-// replicas=0 does not rewrite MinAvailable; it remains the component's
-// configured minimum viable unit.
+// On CREATE: sets the controller-owned workload provider from routing intent before provider-specific defaults.
+// Existing unannotated DGDs remain unselected for controller-side workload adoption.
+// On the Grove pathway: defaults nil MinAvailable to 1. Scaling to replicas=0
+// does not rewrite MinAvailable; it remains the component's configured minimum viable unit.
 // On CREATE: stamps nvidia.com/dynamo-operator-origin-version with the operator version.
 // On UPDATE/DELETE: the origin version annotation is immutable once set.
 func (d *DGDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
@@ -78,26 +79,26 @@ func (d *DGDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 		return nil
 	}
 
-	// Default nil replicas to 1 for all components. The Replicas field is
-	// *int32 with omitempty, so users can legally omit it. Without this
-	// default the controller panics on a nil pointer dereference in
-	// expandRolesForComponent(). Apply on every operation so that components
-	// added via UPDATE also get the default.
-	grovePathway := d.isGrovePathway(ctx, dgd)
+	// Resolve the authoritative or creation-time provider before applying component defaults.
+	provider, providerSelected := defaultWorkloadProvider(ctx, dgd, req.Operation)
+
+	// Default nil replicas on every operation so newly added components remain safe to expand.
 	for i := range dgd.Spec.Components {
 		component := &dgd.Spec.Components[i]
+
+		// Default omitted replica counts before the controller expands component roles.
 		if component.Replicas == nil {
 			component.Replicas = ptr.To(int32(1))
 		}
-		if grovePathway && component.MinAvailable == nil {
+
+		// Default Grove's minimum available replicas only for Grove-selected DGDs.
+		if providerSelected && provider == consts.WorkloadProviderGrove && component.MinAvailable == nil {
 			component.MinAvailable = ptr.To(int32(1))
 		}
 	}
 
+	// Stamp creation provenance independently from level-based provider defaulting.
 	if req.Operation == admissionv1.Create {
-		if dgd.Annotations == nil {
-			dgd.Annotations = make(map[string]string)
-		}
 		// Stamp operator version on creation (don't overwrite if already set)
 		if _, exists := dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion]; !exists {
 			dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion] = d.OperatorVersion
@@ -111,9 +112,34 @@ func (d *DGDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	return nil
 }
 
-func (d *DGDDefaulter) isGrovePathway(ctx context.Context, dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
-	return features.MustGateFrom(ctx).Enabled(features.Grove) && (dgd.Annotations == nil ||
-		strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableGrove]) != consts.KubeLabelValueFalse)
+func defaultWorkloadProvider(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	operation admissionv1.Operation,
+) (string, bool) {
+	// Keep existing selections authoritative and leave legacy updates for controller adoption.
+	if operation != admissionv1.Create {
+		if provider, exists := dgd.Annotations[consts.KubeAnnotationWorkloadProvider]; exists {
+			return provider, true
+		}
+		return "", false
+	}
+
+	// Derive every new DGD from user-facing routing intent, ignoring the controller-owned annotation.
+	provider := consts.WorkloadProviderComponent
+
+	// Select Grove when it is enabled and the DGD has not opted out.
+	if features.MustGateFrom(ctx).Enabled(features.Grove) &&
+		strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableGrove]) != consts.KubeLabelValueFalse {
+		provider = consts.WorkloadProviderGrove
+	}
+
+	// Allocate annotation storage before materializing the selected provider.
+	if dgd.Annotations == nil {
+		dgd.Annotations = make(map[string]string)
+	}
+	dgd.Annotations[consts.KubeAnnotationWorkloadProvider] = provider
+	return provider, true
 }
 
 // RegisterWithManager registers the defaulting webhook with the manager.

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler_test.go
@@ -268,6 +268,8 @@ func TestDGDDefaulter_DefaultsGroveMinAvailable(t *testing.T) {
 		annotations      map[string]string
 		components       []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec
 		wantMinAvailable map[string]*int32
+		wantProvider     string
+		wantUnselected   bool
 	}{
 		{
 			name:         "CREATE defaults nil replicas to minAvailable 1 on Grove pathway",
@@ -281,15 +283,32 @@ func TestDGDDefaulter_DefaultsGroveMinAvailable(t *testing.T) {
 			},
 		},
 		{
-			name:         "UPDATE defaults positive replicas to minAvailable 1 on Grove pathway",
+			name:         "CREATE ignores a user-supplied provider and follows routing intent",
+			op:           admissionv1.Create,
+			groveEnabled: true,
+			annotations: map[string]string{
+				consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderGrove,
+				consts.KubeAnnotationEnableGrove:      consts.KubeLabelValueFalse,
+			},
+			components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+				{ComponentName: "Worker", Replicas: ptr.To(int32(3))},
+			},
+			wantMinAvailable: map[string]*int32{
+				"Worker": nil,
+			},
+			wantProvider: consts.WorkloadProviderComponent,
+		},
+		{
+			name:         "legacy UPDATE remains unselected for controller adoption",
 			op:           admissionv1.Update,
 			groveEnabled: true,
 			components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
 				{ComponentName: "Worker", Replicas: ptr.To(int32(3))},
 			},
 			wantMinAvailable: map[string]*int32{
-				"Worker": ptr.To(int32(1)),
+				"Worker": nil,
 			},
+			wantUnselected: true,
 		},
 		{
 			name:         "defaults zero replicas to minAvailable 1 on Grove pathway",
@@ -393,10 +412,40 @@ func TestDGDDefaulter_DefaultsGroveMinAvailable(t *testing.T) {
 				"Worker": nil,
 			},
 		},
+		{
+			name:         "selected Grove provider remains authoritative when the feature gate is disabled",
+			op:           admissionv1.Update,
+			groveEnabled: false,
+			annotations: map[string]string{
+				consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderGrove,
+				consts.KubeAnnotationEnableGrove:      consts.KubeLabelValueFalse,
+			},
+			components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+				{ComponentName: "Worker", Replicas: ptr.To(int32(3))},
+			},
+			wantMinAvailable: map[string]*int32{
+				"Worker": ptr.To(int32(1)),
+			},
+		},
+		{
+			name:         "selected component provider remains authoritative when Grove is enabled",
+			op:           admissionv1.Update,
+			groveEnabled: true,
+			annotations: map[string]string{
+				consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderComponent,
+			},
+			components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+				{ComponentName: "Worker", Replicas: ptr.To(int32(3))},
+			},
+			wantMinAvailable: map[string]*int32{
+				"Worker": nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build a DGD and defaulter for the provider-defaulting scenario")
 			defaulter := NewDGDDefaulter("0.9.0")
 			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -411,10 +460,22 @@ func TestDGDDefaulter_DefaultsGroveMinAvailable(t *testing.T) {
 			ctx := admissionCtx(tt.op, nvidiacomv1beta1.DynamoGraphDeploymentGVK)
 			ctx = features.WithGate(ctx, features.Gates{Grove: tt.groveEnabled})
 
+			t.Log("Apply level-based component defaults")
 			if err := defaulter.Default(ctx, dgd); err != nil {
 				t.Fatalf("Default() unexpected error: %v", err)
 			}
 
+			t.Log("Verify provider selection and component minimum availability")
+			if tt.wantProvider != "" {
+				if got := dgd.Annotations[consts.KubeAnnotationWorkloadProvider]; got != tt.wantProvider {
+					t.Errorf("workload provider = %q, want %q", got, tt.wantProvider)
+				}
+			}
+			if tt.wantUnselected {
+				if _, exists := dgd.Annotations[consts.KubeAnnotationWorkloadProvider]; exists {
+					t.Errorf("provider annotation was materialized before controller adoption")
+				}
+			}
 			for name, want := range tt.wantMinAvailable {
 				component := dgd.GetComponentByName(name)
 				if component == nil {

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -196,6 +196,16 @@ func (v *dynamoGraphDeploymentValidation) validateObjectMeta(
 		))
 	}
 
+	// Restrict the durable workload provider to programs implemented by the controller.
+	if value, exists := objectMeta.Annotations[consts.KubeAnnotationWorkloadProvider]; exists &&
+		value != consts.WorkloadProviderComponent && value != consts.WorkloadProviderGrove {
+		allErrs = append(allErrs, field.NotSupported(
+			annotationsPath.Key(consts.KubeAnnotationWorkloadProvider),
+			value,
+			[]string{consts.WorkloadProviderComponent, consts.WorkloadProviderGrove},
+		))
+	}
+
 	if hasIntraPodFailover && objectMeta.Annotations[consts.KubeAnnotationDynamoKubeDiscoveryMode] != "container" {
 		allErrs = append(allErrs, field.Invalid(
 			annotationsPath.Key(consts.KubeAnnotationDynamoKubeDiscoveryMode),
@@ -499,6 +509,11 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentUpdate(
 	oldDGD *nvidiacomv1beta1.DynamoGraphDeployment,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, v.validateObjectMetaUpdate(
+		&newDGD.ObjectMeta,
+		&oldDGD.ObjectMeta,
+		field.NewPath("metadata"),
+	)...)
 	allErrs = append(allErrs, v.validateDynamoGraphDeploymentSpecUpdate(
 		&newDGD.Spec,
 		&oldDGD.Spec,
@@ -519,6 +534,43 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentUpdate(
 			}
 		}
 	}
+	return allErrs
+}
+
+// validateObjectMetaUpdate validates a DGD metadata update.
+// newObjectMeta, oldObjectMeta, and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateObjectMetaUpdate(
+	newObjectMeta *metav1.ObjectMeta,
+	oldObjectMeta *metav1.ObjectMeta,
+	fldPath *field.Path,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	annotationsPath := fldPath.Child("annotations")
+	newProvider, newProviderExists := newObjectMeta.Annotations[consts.KubeAnnotationWorkloadProvider]
+	oldProvider, oldProviderExists := oldObjectMeta.Annotations[consts.KubeAnnotationWorkloadProvider]
+
+	// Reserve the initial legacy-provider materialization for the configured operator identity.
+	if !oldProviderExists && newProviderExists && v.operatorPrincipal != "" &&
+		(v.userInfo == nil || v.userInfo.Username != v.operatorPrincipal) {
+		allErrs = append(allErrs, field.Forbidden(
+			annotationsPath.Key(consts.KubeAnnotationWorkloadProvider),
+			"may only be materialized by the Dynamo operator",
+		))
+	}
+
+	// Once materialized, the workload provider cannot be replaced or removed.
+	if oldProviderExists && (!newProviderExists || newProvider != oldProvider) {
+		var invalidValue any
+		if newProviderExists {
+			invalidValue = newProvider
+		}
+		allErrs = append(allErrs, field.Invalid(
+			annotationsPath.Key(consts.KubeAnnotationWorkloadProvider),
+			invalidValue,
+			apivalidation.FieldImmutableErrorMsg,
+		))
+	}
+
 	return allErrs
 }
 

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
@@ -46,7 +46,7 @@ type DynamoGraphDeploymentHandler struct {
 // NewDynamoGraphDeploymentHandler creates a new handler for DynamoGraphDeployment Webhook.
 // mgr must not be nil.
 // operatorPrincipal is the full Kubernetes SA username of the operator, used to authorize
-// replica changes on scaling-adapter-enabled components (#7656).
+// legacy workload-provider materialization and replica changes on scaling-adapter-enabled components (#7656).
 func NewDynamoGraphDeploymentHandler(mgr manager.Manager, operatorPrincipal string) *DynamoGraphDeploymentHandler {
 	return &DynamoGraphDeploymentHandler{
 		mgr:               mgr,

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -101,6 +102,18 @@ func TestDynamoGraphDeploymentHandlerValidateUpdate(t *testing.T) {
 		newDGD.Spec.BackendFramework = sglangBackendFramework
 		_, err := handler.ValidateUpdate(ctx, oldDGD, newDGD)
 		assertBetaValidationErrors(t, err, []string{`spec.backendFramework: Invalid value: "sglang": is immutable and cannot be changed after creation`})
+	})
+
+	t.Run("missing operator identity does not block legacy provider materialization", func(t *testing.T) {
+		oldDGD := newBetaDGDForValidation()
+		newDGD := oldDGD.DeepCopy()
+		newDGD.Annotations = map[string]string{
+			consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderComponent,
+		}
+		unconfiguredHandler := NewDynamoGraphDeploymentHandler(newGroveTopologyTestManager(t), "")
+		if _, err := unconfiguredHandler.ValidateUpdate(ctx, oldDGD, newDGD); err != nil {
+			t.Fatalf("ValidateUpdate() error = %v, want optional operator identity to remain permissive", err)
+		}
 	})
 }
 

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_helpers.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_helpers.go
@@ -137,6 +137,27 @@ func grovePathwayForDynamoGraphDeployment(
 	groveEnabled bool,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) (bool, string) {
+	// A durable selection takes precedence over current capabilities and the
+	// original routing annotation. Availability is reported by the selected
+	// workload program, while admission retains that program's API semantics.
+	if provider, exists := dgd.Annotations[consts.KubeAnnotationWorkloadProvider]; exists {
+		switch provider {
+		case consts.WorkloadProviderGrove:
+			return true, ""
+		case consts.WorkloadProviderComponent:
+			return false, fmt.Sprintf(
+				"requires the Grove pathway, but workload provider %q is selected",
+				provider,
+			)
+		default:
+			return false, fmt.Sprintf(
+				"requires the Grove pathway, but annotation %q has unsupported value %q",
+				consts.KubeAnnotationWorkloadProvider,
+				provider,
+			)
+		}
+	}
+
 	if !groveEnabled {
 		return false, "requires the Grove pathway, but Grove is disabled in the operator configuration"
 	}

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -39,6 +39,7 @@ import (
 const (
 	dgdAdmissionWorkerName      = "worker"
 	dgdAdmissionUpperWorkerName = "WORKER"
+	dgdAdmissionPriorityClass   = "high-priority"
 )
 
 const sglangBackendFramework = "sglang"
@@ -52,6 +53,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 		name               string
 		deployment         runtime.Object
 		oldDeployment      runtime.Object
+		oldBeforeUpdate    runtime.Object
 		mutateRequest      func(*testing.T, map[string]any) // mutates the source-version request map
 		withoutTopology    bool                             // omits the default cluster topology fixture
 		groveDisabled      bool                             // disables the configured Grove pathway
@@ -66,6 +68,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 		wantWarnings       []string
 		notWantErr         string
 		wantPodAnnotations map[string]string
+		wantProvider       string
 	}{
 		// Baseline create-path rules.
 		{
@@ -215,7 +218,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				enableBetaInterPodGMS(betaWorkerComponent(dgd))
 			}),
-			wantWebhookErrs: []string{"spec.components[1].experimental.gpuMemoryService.mode: Forbidden: requires the Grove pathway, but Grove is disabled in the operator configuration"},
+			wantWebhookErrs: []string{`spec.components[1].experimental.gpuMemoryService.mode: Forbidden: requires the Grove pathway, but workload provider "component" is selected`},
 		},
 		{
 			name: "inter-pod GMS requires vLLM backend",
@@ -952,7 +955,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "grove-topology", Domain: "zone"},
 				}
 			}),
-			wantWebhookErrs: []string{`spec.experimental.kvTransferPolicy.clusterTopologyName: Forbidden: requires the Grove pathway; remove or unset annotation "nvidia.com/enable-grove" (currently "false")`},
+			wantWebhookErrs: []string{`spec.experimental.kvTransferPolicy.clusterTopologyName: Forbidden: requires the Grove pathway, but workload provider "component" is selected`},
 		},
 		{
 			name: "KV-transfer domain is required by the schema",
@@ -1436,14 +1439,14 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			name:          "priority class requires Grove",
 			groveDisabled: true,
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Spec.PriorityClassName = "high-priority"
+				dgd.Spec.PriorityClassName = dgdAdmissionPriorityClass
 			}),
-			wantWebhookErrs: []string{"spec.priorityClassName: Forbidden: requires the Grove pathway, but Grove is disabled in the operator configuration"},
+			wantWebhookErrs: []string{`spec.priorityClassName: Forbidden: requires the Grove pathway, but workload provider "component" is selected`},
 		},
 		{
 			name: "priority class is allowed with Grove",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Spec.PriorityClassName = "high-priority"
+				dgd.Spec.PriorityClassName = dgdAdmissionPriorityClass
 			}),
 		},
 		{
@@ -1600,6 +1603,100 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 		},
 
 		// Metadata annotation rules.
+		{
+			name: "workload provider input is normalized from routing intent on create",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderComponent,
+				}
+			}),
+			wantProvider: consts.WorkloadProviderGrove,
+		},
+		{
+			name:               "unsupported stored workload provider is rejected",
+			seedWithoutWebhook: true,
+			oldBeforeUpdate:    betaComponentDGDForAdmission(nil),
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationWorkloadProvider: "unknown",
+				}
+			}),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationWorkloadProvider: "unknown",
+				}
+				dgd.Labels = map[string]string{"updated": "true"}
+			}),
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/workload-provider]: Unsupported value: "unknown": supported values: "component", "grove"`},
+		},
+		{
+			name:               "user cannot materialize a legacy workload provider",
+			seedWithoutWebhook: true,
+			oldBeforeUpdate:    betaComponentDGDForAdmission(nil),
+			oldDeployment:      betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderComponent,
+				}
+			}),
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/workload-provider]: Forbidden: may only be materialized by the Dynamo operator`},
+		},
+		{
+			name:               "operator can materialize a legacy workload provider",
+			seedWithoutWebhook: true,
+			username:           admissionOperatorPrincipal,
+			oldBeforeUpdate:    betaComponentDGDForAdmission(nil),
+			oldDeployment:      betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderComponent,
+				}
+			}),
+		},
+		{
+			name:               "workload provider cannot change",
+			seedWithoutWebhook: true,
+			oldDeployment:      betaComponentDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderGrove,
+				}
+			}),
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/workload-provider]: Invalid value: "grove": ` + apivalidation.FieldImmutableErrorMsg},
+		},
+		{
+			name:               "Grove provider retains Grove admission semantics when the gate is disabled",
+			seedWithoutWebhook: true,
+			groveDisabled:      true,
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderGrove,
+				}
+				dgd.Spec.PriorityClassName = dgdAdmissionPriorityClass
+			}),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderGrove,
+				}
+				dgd.Spec.PriorityClassName = dgdAdmissionPriorityClass
+				dgd.Labels = map[string]string{"updated": "true"}
+			}),
+		},
+		{
+			name:               "component provider retains component admission semantics when Grove is enabled",
+			seedWithoutWebhook: true,
+			oldDeployment: betaComponentDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.PriorityClassName = dgdAdmissionPriorityClass
+			}),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderComponent,
+				}
+				dgd.Spec.PriorityClassName = dgdAdmissionPriorityClass
+				dgd.Labels = map[string]string{"updated": "true"}
+			}),
+			wantWebhookErrs: []string{`spec.priorityClassName: Forbidden: requires the Grove pathway, but workload provider "component" is selected`},
+		},
 		{
 			name: "origin version accepts semver",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
@@ -2184,10 +2281,12 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Assemble the admission scenario from the table entry")
 			gates := features.Gates{Checkpoint: !tt.checkpointOff, Grove: !tt.groveDisabled}
 			test := admissionTestCase{
 				object:             tt.deployment,
 				oldObject:          tt.oldDeployment,
+				oldBeforeUpdate:    tt.oldBeforeUpdate,
 				mutateObject:       tt.mutateRequest,
 				gates:              gates,
 				withoutTopology:    tt.withoutTopology,
@@ -2201,7 +2300,9 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				notWantError:       tt.notWantErr,
 			}
 			if tt.oldDeployment != nil {
-				test.oldBeforeUpdate = dgdBeforeRestart(t, tt.oldDeployment)
+				if test.oldBeforeUpdate == nil {
+					test.oldBeforeUpdate = dgdBeforeRestart(t, tt.oldDeployment)
+				}
 				if tt.checkpointOff || tt.groveDisabled {
 					seedGates := gates
 					seedGates.Checkpoint = true
@@ -2210,12 +2311,23 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				}
 			}
 			actual := runAdmissionTest(t, test)
-			if tt.wantPodAnnotations != nil {
-				t.Log("Verify the API server preserved embedded component pod-template annotations")
+			if tt.wantPodAnnotations != nil || tt.wantProvider != "" {
+				t.Log("Convert the admitted DGD for result assertions")
 				var actualDGD nvidiacomv1beta1.DynamoGraphDeployment
 				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(actual.Object, &actualDGD); err != nil {
 					t.Fatalf("convert admitted DGD: %v", err)
 				}
+				if tt.wantProvider != "" {
+					t.Log("Verify creation-time routing intent determined the admitted workload provider")
+					if got := actualDGD.Annotations[consts.KubeAnnotationWorkloadProvider]; got != tt.wantProvider {
+						t.Fatalf("workload provider = %q, want %q", got, tt.wantProvider)
+					}
+				}
+				if tt.wantPodAnnotations == nil {
+					return
+				}
+
+				t.Log("Verify the API server preserved embedded component pod-template annotations")
 				component := actualDGD.GetComponentByName(dgdAdmissionWorkerName)
 				if component == nil || component.PodTemplate == nil {
 					t.Fatalf("admitted DGD has no pod template for component %q", dgdAdmissionWorkerName)
@@ -2270,6 +2382,20 @@ func betaDGDForAdmission(
 		mutate(dgd)
 	}
 	return dgd
+}
+
+func betaComponentDGDForAdmission(
+	mutate func(*nvidiacomv1beta1.DynamoGraphDeployment),
+) *nvidiacomv1beta1.DynamoGraphDeployment {
+	return betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+		dgd.Annotations = map[string]string{
+			consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderComponent,
+			consts.KubeAnnotationEnableGrove:      consts.KubeLabelValueFalse,
+		}
+		if mutate != nil {
+			mutate(dgd)
+		}
+	})
 }
 
 func alphaDGDForAdmission(

--- a/deploy/operator/internal/webhook/validation/suite_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/suite_envtest_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -139,6 +140,8 @@ func runAdmissionTest(t *testing.T, test admissionTestCase) *unstructured.Unstru
 		t.Log("Submit the update request through the Kubernetes API server")
 		admissionGate.set(test.gates)
 		warnings.clear()
+		oldFixture, _ := admissionObject(t, test.oldObject, env.Namespace(), nil)
+		current = applyAdmissionFixtureChanges(old, oldFixture, current)
 		current.SetResourceVersion(old.GetResourceVersion())
 		result, err = resourceClient.Update(t.Context(), current, metav1.UpdateOptions{})
 	}
@@ -269,7 +272,9 @@ func seedAdmissionObject(
 		t.Fatalf("create old resource state: %v", err)
 	}
 	if test.oldBeforeUpdate != nil {
-		old, _ := admissionObject(t, test.oldObject, namespace, nil)
+		before, _ := admissionObject(t, test.oldBeforeUpdate, namespace, nil)
+		oldFixture, _ := admissionObject(t, test.oldObject, namespace, nil)
+		old := applyAdmissionFixtureChanges(created, before, oldFixture)
 		old.SetResourceVersion(created.GetResourceVersion())
 		created, err = resourceClient.Update(t.Context(), old, metav1.UpdateOptions{})
 		if err != nil {
@@ -291,6 +296,64 @@ func seedAdmissionObject(
 		}
 	}
 	return created
+}
+
+func applyAdmissionFixtureChanges(
+	live *unstructured.Unstructured,
+	oldFixture *unstructured.Unstructured,
+	newFixture *unstructured.Unstructured,
+) *unstructured.Unstructured {
+	updated := live.DeepCopy()
+	updated.Object = applyAdmissionFixtureValueChanges(
+		updated.Object,
+		oldFixture.Object,
+		newFixture.Object,
+	).(map[string]any)
+	return updated
+}
+
+func applyAdmissionFixtureValueChanges(live, oldFixture, newFixture any) any {
+	if reflect.DeepEqual(oldFixture, newFixture) {
+		return runtime.DeepCopyJSONValue(live)
+	}
+
+	oldMap, oldIsMap := oldFixture.(map[string]any)
+	newMap, newIsMap := newFixture.(map[string]any)
+	liveMap, liveIsMap := live.(map[string]any)
+	if oldIsMap && newIsMap && liveIsMap {
+		updated := runtime.DeepCopyJSONValue(liveMap).(map[string]any)
+		for key := range oldMap {
+			if _, exists := newMap[key]; !exists {
+				delete(updated, key)
+			}
+		}
+		for key, newValue := range newMap {
+			oldValue, existed := oldMap[key]
+			if !existed {
+				updated[key] = runtime.DeepCopyJSONValue(newValue)
+				continue
+			}
+			updated[key] = applyAdmissionFixtureValueChanges(updated[key], oldValue, newValue)
+		}
+		return updated
+	}
+
+	oldList, oldIsList := oldFixture.([]any)
+	newList, newIsList := newFixture.([]any)
+	liveList, liveIsList := live.([]any)
+	if oldIsList && newIsList && liveIsList {
+		updated := make([]any, len(newList))
+		for i, newValue := range newList {
+			if i < len(oldList) && i < len(liveList) {
+				updated[i] = applyAdmissionFixtureValueChanges(liveList[i], oldList[i], newValue)
+				continue
+			}
+			updated[i] = runtime.DeepCopyJSONValue(newValue)
+		}
+		return updated
+	}
+
+	return runtime.DeepCopyJSONValue(newFixture)
 }
 
 func pruneZeroValues(value any) (any, bool) {


### PR DESCRIPTION
## Summary

DynamoGraphDeployment workload-provider selection currently depends on live routing intent and operator feature gates. That means the effective provider can change during the lifetime of a DGD.

This change makes the graph-level provider durable by materializing `nvidia.com/workload-provider` with either `component` or `grove` before workload reconciliation begins. Once recorded, that value is authoritative and immutable.

Related to #12938.

## What changed

- Materialize a missing workload provider from the current Grove gate and `nvidia.com/enable-grove` intent.
- Apply provider selection level-wise in the defaulting webhook before provider-specific defaults.
- Add a controller-side safety net for legacy objects or requests that bypass admission:
  - persist a missing provider with optimistic concurrency;
  - return and requeue after persistence;
  - perform no finalizer, status, or workload effects before the provider is durable.
- Dispatch the DGD exclusively through the program named by the persisted annotation.
- Keep the persisted provider authoritative when feature gates or routing annotations later change.
- Reject unsupported provider values and changes or removal after the provider has been materialized.
- If a DGD is durably selected to Grove while Grove is unavailable:
  - do not fall back to the Component program;
  - publish `Ready=False` with `selected_workload_provider_unavailable`;
  - return a terminal reconciliation error after status persistence.

## Upgrade behavior

An existing DGD without `nvidia.com/workload-provider` is assigned from current routing intent on its next admission or controller reconciliation. Selection is persisted before further reconciliation effects.

This change intentionally does not inspect or adopt from existing DCD or PodCliqueSet resources. It establishes a small immutable-selection boundary instead of a compatibility or recovery framework.

After selection, changing `nvidia.com/enable-grove`, feature gates, or API availability does not silently switch the workload program. Changing providers requires deleting and recreating the DGD.

## Provider boundaries

The values in this change identify graph-level workload programs:

- `component` selects the DCD-based Component program.
- `grove` selects the Grove program.

Deployment versus LeaderWorkerSet remains an internal choice of the DCD controller within the Component program. LWS therefore does not require another graph-level provider value or a separate DGD provider-selection mechanism.

Future graph-level programs can extend this contract with an additional provider value while retaining the same materialize-once and dispatch-from-persisted-state rules.

## Validation

- `docker buildx build --platform linux/arm64 --target linter --progress=plain --build-context snapshot=../snapshot .`
- `docker buildx build --platform linux/arm64 --target tester --progress=plain --build-context snapshot=../snapshot --build-context operator=../operator --build-context operator-chart=../helm/charts/platform/components/operator .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable workload-provider selection for deployments, supporting Grove and component providers.
  * Provider choices are persisted and reused during reconciliation.
  * Added validation to allow supported providers and prevent changing or removing an established provider.
  * Provider-specific defaults and admission behavior now respect the selected provider.
  * Disabled or unavailable Grove selections now report a terminal error without fallback.

* **Bug Fixes**
  * Improved handling of provider conflicts, unsupported values, and persistence failures.
  * Prevented side effects before provider selection is finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->