### PR TITLE
feat(operator): start a Ray head on a single-pod elastic EP component

### DIFF
--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -185,6 +185,9 @@ const (
 	// VLLMNixlSideChannelHostEnvVar is the env var that tells vLLM which host IP to use for the NIXL side channel.
 	VLLMNixlSideChannelHostEnvVar = "VLLM_NIXL_SIDE_CHANNEL_HOST"
 
+	// VLLMDPMasterIPEnvVar is the env var that tells vLLM which IP hosts the data-parallel master.
+	VLLMDPMasterIPEnvVar = "VLLM_DP_MASTER_IP"
+
 	// Metrics related constants
 	KubeAnnotationEnableMetrics  = "nvidia.com/enable-metrics"  // User-provided annotation to control metrics
 	KubeLabelMetricsEnabled      = "nvidia.com/metrics-enabled" // Controller-managed label for pod selection

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -188,6 +188,10 @@ const (
 	// VLLMDPMasterIPEnvVar is the env var that tells vLLM which IP hosts the data-parallel master.
 	VLLMDPMasterIPEnvVar = "VLLM_DP_MASTER_IP"
 
+	// PodIPEnvVar carries the pod's own IP from the downward API, for launch
+	// commands that must name an address rather than let a library guess one.
+	PodIPEnvVar = "POD_IP"
+
 	// Metrics related constants
 	KubeAnnotationEnableMetrics  = "nvidia.com/enable-metrics"  // User-provided annotation to control metrics
 	KubeLabelMetricsEnabled      = "nvidia.com/metrics-enabled" // Controller-managed label for pod selection

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -24,7 +24,10 @@ const (
 	distributedExecutorFlag   = "--distributed-executor-backend"
 	enableElasticEPFlag       = "--enable-elastic-ep"
 	dataParallelBackendFlag   = "--data-parallel-backend"
-	dataParallelBackendRay    = "ray"
+	// dataParallelBackendShortFlag is vLLM's documented short alias for
+	// --data-parallel-backend (see the v0.26.0 `vllm serve` CLI reference).
+	dataParallelBackendShortFlag = "-dpb"
+	dataParallelBackendRay       = "ray"
 )
 
 type VLLMBackend struct {
@@ -73,7 +76,7 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 			container.ReadinessProbe = nil
 			container.StartupProbe = nil
 		}
-	} else if role == RoleMain && isElasticEPRayLaunch(getExpandedArgs(container)) {
+	} else if role == RoleMain && isElasticEPRayLaunch(container) {
 		// A single-pod elastic-EP component still needs a Ray head, so that
 		// follower pods created later have a cluster to join. Only the leader
 		// arm applies here: a lone pod is expanded as RoleMain, never RoleWorker.
@@ -448,17 +451,27 @@ func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, servi
 		for i, arg := range container.Args {
 			quotedArgs[i] = shellQuoteForBashC(arg)
 		}
+		vllmCommand := strings.TrimSpace(strings.Join(quotedCmd, " ") + " " + strings.Join(quotedArgs, " "))
+		// A single-pod RoleMain leader is an ordinary serving pod that Kubernetes
+		// rolls, evicts, and deletes, so exec the engine: it then runs as the
+		// container's main process (PID 1) and receives SIGTERM directly for a
+		// graceful shutdown, instead of being killed after the grace period with
+		// in-flight requests dropped. The backgrounded Ray head continues as its
+		// child. The multinode RoleLeader keeps its historical no-exec form so
+		// this stays scoped to the new single-pod path.
+		if role == RoleMain {
+			vllmCommand = "exec " + vllmCommand
+		}
 		// Poll Ray head readiness with a bounded retry loop (150 × 2 s = 5 min max).
 		// An unbounded `until` loop would spin forever if `ray start --head` crashes
 		// silently or the port never opens.
 		container.Args = []string{fmt.Sprintf(
 			`ray start --head --port=%s --block & `+
 				`i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; `+
-				`do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && %s %s`,
+				`do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && %s`,
 			VLLMPort,
 			VLLMPort,
-			strings.Join(quotedCmd, " "),
-			strings.Join(quotedArgs, " "),
+			vllmCommand,
 		)}
 	case RoleWorker:
 		leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
@@ -489,21 +502,39 @@ func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, servi
 	container.Command = []string{"/bin/sh", "-c"}
 }
 
-// isElasticEPRayLaunch reports whether args ask for the elastic-EP Ray topology.
+// isElasticEPRayLaunch reports whether the container asks for the elastic-EP Ray
+// topology.
 //
 // Elastic EP only works on the Ray data-parallel backend: vLLM's Ray executor is
 // what grows and shrinks workers at runtime, and the engine refuses a scale
 // request on any other backend. Requiring both flags keeps a Ray head off pods
 // that pass --enable-elastic-ep while running the default backend, where it
 // would launch a process nothing ever talks to.
-func isElasticEPRayLaunch(expandedArgs []string) bool {
-	// hasArg matches both the "--data-parallel-backend ray" and
-	// "--data-parallel-backend=ray" spellings. vLLM (argparse) treats them as
-	// equivalent, so the equals form must trigger Ray-head injection too;
-	// otherwise a single-pod deployment written that way silently starts
-	// without a Ray head and followers can never join.
-	return hasFlag(expandedArgs, enableElasticEPFlag) &&
-		hasArg(expandedArgs, dataParallelBackendFlag, dataParallelBackendRay)
+//
+// Detection scans the full command line (Command + Args) so the flags are found
+// whether the manifest carries them in Command or Args, and it accepts vLLM's
+// long --data-parallel-backend flag and its documented -dpb alias in both the
+// "flag value" and "flag=value" spellings — vLLM's argparse treats all of these
+// as equivalent, so any of them must trigger Ray-head injection.
+func isElasticEPRayLaunch(container *corev1.Container) bool {
+	expanded := getExpandedCommandLine(container)
+	return hasFlag(expanded, enableElasticEPFlag) &&
+		(hasArg(expanded, dataParallelBackendFlag, dataParallelBackendRay) ||
+			hasArg(expanded, dataParallelBackendShortFlag, dataParallelBackendRay))
+}
+
+// getExpandedCommandLine flattens Command and Args and splits any space-joined
+// tokens, so flag detection works whether the manifest puts flags in Command or
+// Args and whether they are separate list items or a single combined string.
+func getExpandedCommandLine(container *corev1.Container) []string {
+	commandLine := make([]string, 0, len(container.Command)+len(container.Args))
+	commandLine = append(commandLine, container.Command...)
+	commandLine = append(commandLine, container.Args...)
+	expanded := make([]string, 0, len(commandLine))
+	for _, arg := range commandLine {
+		expanded = append(expanded, strings.Fields(arg)...)
+	}
+	return expanded
 }
 
 // hasFlag returns true if flag exists in expandedArgs.

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -76,7 +76,7 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 			container.ReadinessProbe = nil
 			container.StartupProbe = nil
 		}
-	} else if role == RoleMain && isElasticEPRayLaunch(container) {
+	} else if role == RoleMain && IsElasticEPRayLaunch(container) {
 		// A single-pod elastic-EP component still needs a Ray head, so that
 		// follower pods created later have a cluster to join. Only the leader
 		// arm applies here: a lone pod is expanded as RoleMain, never RoleWorker.
@@ -546,7 +546,7 @@ func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, servi
 	return true
 }
 
-// isElasticEPRayLaunch reports whether the container asks for the elastic-EP Ray
+// IsElasticEPRayLaunch reports whether the container asks for the elastic-EP Ray
 // topology.
 //
 // Elastic EP only works on the Ray data-parallel backend: vLLM's Ray executor is
@@ -560,7 +560,7 @@ func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, servi
 // long --data-parallel-backend flag and its documented -dpb alias in both the
 // "flag value" and "flag=value" spellings — vLLM's argparse treats all of these
 // as equivalent, so any of them must trigger Ray-head injection.
-func isElasticEPRayLaunch(container *corev1.Container) bool {
+func IsElasticEPRayLaunch(container *corev1.Container) bool {
 	expanded := getExpandedCommandLine(container)
 	return hasFlag(expanded, enableElasticEPFlag) &&
 		(hasArg(expanded, dataParallelBackendFlag, dataParallelBackendRay) ||

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -481,18 +481,13 @@ func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, servi
 // that pass --enable-elastic-ep while running the default backend, where it
 // would launch a process nothing ever talks to.
 func isElasticEPRayLaunch(expandedArgs []string) bool {
+	// hasArg matches both the "--data-parallel-backend ray" and
+	// "--data-parallel-backend=ray" spellings. vLLM (argparse) treats them as
+	// equivalent, so the equals form must trigger Ray-head injection too;
+	// otherwise a single-pod deployment written that way silently starts
+	// without a Ray head and followers can never join.
 	return hasFlag(expandedArgs, enableElasticEPFlag) &&
-		hasFlagValue(expandedArgs, dataParallelBackendFlag, dataParallelBackendRay)
-}
-
-// hasFlagValue returns true if flag appears in expandedArgs followed by value.
-func hasFlagValue(expandedArgs []string, flag, value string) bool {
-	for i, arg := range expandedArgs {
-		if arg == flag && i+1 < len(expandedArgs) && expandedArgs[i+1] == value {
-			return true
-		}
-	}
-	return false
+		hasArg(expandedArgs, dataParallelBackendFlag, dataParallelBackendRay)
 }
 
 // hasFlag returns true if flag exists in expandedArgs.

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -80,23 +80,25 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 		// A single-pod elastic-EP component still needs a Ray head, so that
 		// follower pods created later have a cluster to join. Only the leader
 		// arm applies here: a lone pod is expanded as RoleMain, never RoleWorker.
-		injectElasticEPRayLaunchFlags(container, role, serviceName, multinodeDeployer)
-
-		// At --data-parallel-size 1, vLLM discards the DP master IP it derives
-		// from the Ray node and reads VLLM_DP_MASTER_IP instead, which defaults
-		// to 127.0.0.1. Ray registers the head under the pod IP, so the engine
-		// then looks for a node that does not exist and aborts with "The DP
-		// master node (ip: 127.0.0.1) is missing or dead". Neither VLLM_HOST_IP
-		// nor --data-parallel-address survives that overwrite; this env var is
-		// the only value the fallback reads.
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name: commonconsts.VLLMDPMasterIPEnvVar,
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "status.podIP",
+		if injectElasticEPRayLaunchFlags(container, role, serviceName, multinodeDeployer) {
+			// Bind VLLM_DP_MASTER_IP only when a Ray head was actually injected.
+			//
+			// At --data-parallel-size 1, vLLM discards the DP master IP it derives
+			// from the Ray node and reads VLLM_DP_MASTER_IP instead, which defaults
+			// to 127.0.0.1. Ray registers the head under the pod IP, so the engine
+			// then looks for a node that does not exist and aborts with "The DP
+			// master node (ip: 127.0.0.1) is missing or dead". Neither VLLM_HOST_IP
+			// nor --data-parallel-address survives that overwrite; this env var is
+			// the only value the fallback reads.
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name: commonconsts.VLLMDPMasterIPEnvVar,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "status.podIP",
+					},
 				},
-			},
-		})
+			})
+		}
 	}
 
 	// Set compilation cache environment variables for VLLM
@@ -438,18 +440,37 @@ func injectRayDistributedLaunchFlags(container *corev1.Container, role Role, ser
 //
 // Leader (or a single-pod RoleMain): ray start --head --port=6379 --block & <tcp-poll-ray-ready 150×2s> && <vllm cmd>
 // Worker: <poll /live HTTP until 200> && ray start --address=<leader>:6379 --block
-func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer) {
+// injectElasticEPRayLaunchFlags returns true when it rewrote the container to
+// front the engine with a Ray head, and false when it deliberately left the
+// container untouched (see the empty-Command case below), so callers can gate
+// side effects such as the VLLM_DP_MASTER_IP injection on whether a Ray head was
+// actually set up.
+func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer) bool {
 	switch role {
 	// RoleMain is a component deployed as a single pod; it heads the Ray
 	// cluster exactly as a multi-node leader does.
 	case RoleLeader, RoleMain:
+		// The Ray-head wrapper has to run a concrete executable once the head is
+		// up, but an empty Command means the real entrypoint is the image
+		// ENTRYPOINT, which the operator cannot see or reconstruct. Rewriting here
+		// would emit a shell command with no executable (e.g. `exec --model ...`)
+		// and break a pod that Kubernetes would otherwise start from its
+		// ENTRYPOINT. Leave that invocation intact and skip the Ray head; a
+		// single-pod Ray head needs an explicit Command.
+		if len(container.Command) == 0 {
+			log.Log.WithName("vllm-backend").Info(
+				"elastic-EP Ray head not injected: container has no explicit Command; "+
+					"set an explicit command to start the single-pod Ray head",
+				"service", serviceName, "role", role)
+			return false
+		}
 		quotedCmd := make([]string, len(container.Command))
 		for i, tok := range container.Command {
-			quotedCmd[i] = shellQuoteForBashC(tok)
+			quotedCmd[i] = shellQuotePOSIX(tok)
 		}
 		quotedArgs := make([]string, len(container.Args))
 		for i, arg := range container.Args {
-			quotedArgs[i] = shellQuoteForBashC(arg)
+			quotedArgs[i] = shellQuotePOSIX(arg)
 		}
 		vllmCommand := strings.TrimSpace(strings.Join(quotedCmd, " ") + " " + strings.Join(quotedArgs, " "))
 		// A single-pod RoleMain leader is an ordinary serving pod that Kubernetes
@@ -500,6 +521,7 @@ func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, servi
 		)}
 	}
 	container.Command = []string{"/bin/sh", "-c"}
+	return true
 }
 
 // isElasticEPRayLaunch reports whether the container asks for the elastic-EP Ray

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -81,23 +81,32 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 		// follower pods created later have a cluster to join. Only the leader
 		// arm applies here: a lone pod is expanded as RoleMain, never RoleWorker.
 		if injectElasticEPRayLaunchFlags(container, role, serviceName, multinodeDeployer) {
-			// Bind VLLM_DP_MASTER_IP only when a Ray head was actually injected.
+			// Bind both addresses only when a Ray head was actually injected.
 			//
-			// At --data-parallel-size 1, vLLM discards the DP master IP it derives
-			// from the Ray node and reads VLLM_DP_MASTER_IP instead, which defaults
-			// to 127.0.0.1. Ray registers the head under the pod IP, so the engine
-			// then looks for a node that does not exist and aborts with "The DP
-			// master node (ip: 127.0.0.1) is missing or dead". Neither VLLM_HOST_IP
-			// nor --data-parallel-address survives that overwrite; this env var is
-			// the only value the fallback reads.
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name: commonconsts.VLLMDPMasterIPEnvVar,
-				ValueFrom: &corev1.EnvVarSource{
+			// Both resolve from status.podIP, which is the point: the Ray head
+			// registers under that address and vLLM searches for that address, so
+			// the two cannot disagree. POD_IP is what the launch command
+			// interpolates into --node-ip-address; VLLM_DP_MASTER_IP is what the
+			// engine reads.
+			//
+			// The engine needs telling because at --data-parallel-size 1 vLLM
+			// discards the DP master IP it derives from the Ray node and falls back
+			// to VLLM_DP_MASTER_IP, which defaults to 127.0.0.1 — so it looks for a
+			// node that does not exist and aborts with "The DP master node (ip:
+			// 127.0.0.1) is missing or dead". Neither VLLM_HOST_IP nor
+			// --data-parallel-address survives that overwrite; this env var is the
+			// only value the fallback reads.
+			podIPRef := func() *corev1.EnvVarSource {
+				return &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{
 						FieldPath: "status.podIP",
 					},
-				},
-			})
+				}
+			}
+			container.Env = append(container.Env,
+				corev1.EnvVar{Name: commonconsts.PodIPEnvVar, ValueFrom: podIPRef()},
+				corev1.EnvVar{Name: commonconsts.VLLMDPMasterIPEnvVar, ValueFrom: podIPRef()},
+			)
 		}
 	}
 
@@ -483,14 +492,27 @@ func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, servi
 		if role == RoleMain {
 			vllmCommand = "exec " + vllmCommand
 		}
+		// Name the head's address on the single-pod path instead of letting Ray
+		// pick one. vLLM is told the DP master is at status.podIP (see the caller)
+		// and then looks for the Ray node registered under that exact address.
+		// Ray left to itself chooses an interface by its own heuristic, so on a
+		// pod with more than one network the two disagree and the engine aborts
+		// with the same "DP master node is missing or dead" the env var exists to
+		// prevent. The multinode leader keeps auto-detection: neither side of that
+		// pair is pinned, so both run the same heuristic and agree with each other.
+		nodeIPFlag := ""
+		if role == RoleMain {
+			nodeIPFlag = fmt.Sprintf(` --node-ip-address="$%s"`, commonconsts.PodIPEnvVar)
+		}
 		// Poll Ray head readiness with a bounded retry loop (150 × 2 s = 5 min max).
 		// An unbounded `until` loop would spin forever if `ray start --head` crashes
 		// silently or the port never opens.
 		container.Args = []string{fmt.Sprintf(
-			`ray start --head --port=%s --block & `+
+			`ray start --head --port=%s%s --block & `+
 				`i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; `+
 				`do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && %s`,
 			VLLMPort,
+			nodeIPFlag,
 			VLLMPort,
 			vllmCommand,
 		)}

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -78,6 +78,22 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 		// follower pods created later have a cluster to join. Only the leader
 		// arm applies here: a lone pod is expanded as RoleMain, never RoleWorker.
 		injectElasticEPRayLaunchFlags(container, role, serviceName, multinodeDeployer)
+
+		// At --data-parallel-size 1, vLLM discards the DP master IP it derives
+		// from the Ray node and reads VLLM_DP_MASTER_IP instead, which defaults
+		// to 127.0.0.1. Ray registers the head under the pod IP, so the engine
+		// then looks for a node that does not exist and aborts with "The DP
+		// master node (ip: 127.0.0.1) is missing or dead". Neither VLLM_HOST_IP
+		// nor --data-parallel-address survives that overwrite; this env var is
+		// the only value the fallback reads.
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name: commonconsts.VLLMDPMasterIPEnvVar,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.podIP",
+				},
+			},
+		})
 	}
 
 	// Set compilation cache environment variables for VLLM

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -23,6 +23,8 @@ const (
 	dataParallelSizeLocalFlag = "--data-parallel-size-local"
 	distributedExecutorFlag   = "--distributed-executor-backend"
 	enableElasticEPFlag       = "--enable-elastic-ep"
+	dataParallelBackendFlag   = "--data-parallel-backend"
+	dataParallelBackendRay    = "ray"
 )
 
 type VLLMBackend struct {
@@ -71,6 +73,11 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 			container.ReadinessProbe = nil
 			container.StartupProbe = nil
 		}
+	} else if role == RoleMain && isElasticEPRayLaunch(getExpandedArgs(container)) {
+		// A single-pod elastic-EP component still needs a Ray head, so that
+		// follower pods created later have a cluster to join. Only the leader
+		// arm applies here: a lone pod is expanded as RoleMain, never RoleWorker.
+		injectElasticEPRayLaunchFlags(container, role, serviceName, multinodeDeployer)
 	}
 
 	// Set compilation cache environment variables for VLLM
@@ -410,11 +417,13 @@ func injectRayDistributedLaunchFlags(container *corev1.Container, role Role, ser
 // health-gate ensuring only the leader is in Ray at vLLM startup, vLLM
 // naturally places all --data-parallel-size workers on the leader node.
 //
-// Leader: ray start --head --port=6379 --block & <tcp-poll-ray-ready 150×2s> && <vllm cmd>
+// Leader (or a single-pod RoleMain): ray start --head --port=6379 --block & <tcp-poll-ray-ready 150×2s> && <vllm cmd>
 // Worker: <poll /live HTTP until 200> && ray start --address=<leader>:6379 --block
 func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer) {
 	switch role {
-	case RoleLeader:
+	// RoleMain is a component deployed as a single pod; it heads the Ray
+	// cluster exactly as a multi-node leader does.
+	case RoleLeader, RoleMain:
 		quotedCmd := make([]string, len(container.Command))
 		for i, tok := range container.Command {
 			quotedCmd[i] = shellQuoteForBashC(tok)
@@ -462,6 +471,28 @@ func injectElasticEPRayLaunchFlags(container *corev1.Container, role Role, servi
 		)}
 	}
 	container.Command = []string{"/bin/sh", "-c"}
+}
+
+// isElasticEPRayLaunch reports whether args ask for the elastic-EP Ray topology.
+//
+// Elastic EP only works on the Ray data-parallel backend: vLLM's Ray executor is
+// what grows and shrinks workers at runtime, and the engine refuses a scale
+// request on any other backend. Requiring both flags keeps a Ray head off pods
+// that pass --enable-elastic-ep while running the default backend, where it
+// would launch a process nothing ever talks to.
+func isElasticEPRayLaunch(expandedArgs []string) bool {
+	return hasFlag(expandedArgs, enableElasticEPFlag) &&
+		hasFlagValue(expandedArgs, dataParallelBackendFlag, dataParallelBackendRay)
+}
+
+// hasFlagValue returns true if flag appears in expandedArgs followed by value.
+func hasFlagValue(expandedArgs []string, flag, value string) bool {
+	for i, arg := range expandedArgs {
+		if arg == flag && i+1 < len(expandedArgs) && expandedArgs[i+1] == value {
+			return true
+		}
+	}
+	return false
 }
 
 // hasFlag returns true if flag exists in expandedArgs.

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -254,7 +254,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			gpuCount: 4,
 			expectedArgs: []string{fmt.Sprintf(
-				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
+				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
 			expectProbesKept:    true,
@@ -278,7 +278,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			gpuCount: 4,
 			expectedArgs: []string{fmt.Sprintf(
-				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend=ray %s`,
+				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend=ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
 			expectProbesKept:    true,
@@ -302,7 +302,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			gpuCount: 4,
 			expectedArgs: []string{fmt.Sprintf(
-				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test -dpb ray %s`,
+				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test -dpb ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
 			expectProbesKept:    true,
@@ -323,7 +323,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			gpuCount: 4,
 			expectedArgs: []string{fmt.Sprintf(
-				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test -dpb=ray %s`,
+				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test -dpb=ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
 			expectProbesKept:    true,
@@ -345,7 +345,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			gpuCount: 4,
 			expectedArgs: []string{fmt.Sprintf(
-				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --data-parallel-backend ray %s`,
+				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --data-parallel-backend ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
 			expectProbesKept:    true,
@@ -450,15 +450,23 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				g.Expect(tt.initialContainer.StartupProbe).ToNot(gomega.BeNil())
 			}
 
-			// Asserted on every case, so that the env var cannot leak into a
+			// Asserted on every case, so that neither env var can leak into a
 			// container that did not ask for a Ray head.
 			dpMasterIP := findEnvVar(tt.initialContainer.Env, commonconsts.VLLMDPMasterIPEnvVar)
+			podIP := findEnvVar(tt.initialContainer.Env, commonconsts.PodIPEnvVar)
 			if tt.expectDPMasterIPEnv {
 				t.Log("without this, vLLM looks for the DP master at 127.0.0.1 and aborts")
 				g.Expect(dpMasterIP).ToNot(gomega.BeNil())
 				g.Expect(dpMasterIP.ValueFrom.FieldRef.FieldPath).To(gomega.Equal("status.podIP"))
+
+				// The launch command interpolates POD_IP into --node-ip-address, so
+				// an unset value would start the Ray head with an empty address.
+				t.Log("the Ray head registers under this address; vLLM searches for it")
+				g.Expect(podIP).ToNot(gomega.BeNil())
+				g.Expect(podIP.ValueFrom.FieldRef.FieldPath).To(gomega.Equal("status.podIP"))
 			} else {
 				g.Expect(dpMasterIP).To(gomega.BeNil())
+				g.Expect(podIP).To(gomega.BeNil())
 			}
 		})
 	}
@@ -899,7 +907,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			gpuCount:    2,
 			annotations: nil,
 			expectedArgs: []string{fmt.Sprintf(
-				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
+				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
 			description: "A component deployed as one pod is expanded as RoleMain rather than RoleLeader, so the leader arm must match it (with exec, so vLLM receives SIGTERM) or the Ray head is never started",

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -2,8 +2,10 @@ package dynamo
 
 import (
 	"fmt"
+	"os/exec"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -12,6 +14,43 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
+
+// TestShellQuotePOSIX_ArgvRoundTrip re-parses the quoted tokens through a real
+// /bin/sh and verifies every original argv element comes back byte-for-byte —
+// including embedded single quotes, whitespace, newlines, shell control
+// operators, and the empty string. Asserting only the generated string cannot
+// prove argv is preserved, so this exercises the shell itself.
+func TestShellQuotePOSIX_ArgvRoundTrip(t *testing.T) {
+	tokens := []string{
+		"python3", "-m", "dynamo.vllm",
+		"--model", "test",
+		"--data-parallel-backend=ray", "-dpb=ray", enableElasticEPFlag,
+		`--chat-template={{ 'it''s' }}`, // single quotes and spaces
+		"",                              // empty token must survive as its own arg
+		"a b\tc",                        // whitespace
+		"line1\nline2",                  // newline
+		"semi;pipe|amp&",                // shell control operators
+		`d$ollar$(whoami)`,              // no command/parameter expansion
+		`back\slash`,
+		`glob*?[x]`,
+	}
+	quoted := make([]string, len(tokens))
+	for i, tok := range tokens {
+		quoted[i] = shellQuotePOSIX(tok)
+	}
+	// set -- re-splits the quoted line into positional params; printing each
+	// NUL-delimited lets empties and whitespace compare exactly.
+	script := "set -- " + strings.Join(quoted, " ") + `; for a in "$@"; do printf '%s\000' "$a"; done`
+	out, err := exec.Command("/bin/sh", "-c", script).Output()
+	if err != nil {
+		t.Fatalf("/bin/sh -c failed: %v", err)
+	}
+	got := strings.Split(string(out), "\x00")
+	got = got[:len(got)-1] // trailing NUL yields a final empty element
+	if !reflect.DeepEqual(got, tokens) {
+		t.Fatalf("argv not preserved through sh -c:\n got  %#v\n want %#v", got, tokens)
+	}
+}
 
 func findEnvVar(env []corev1.EnvVar, name string) *corev1.EnvVar {
 	for i := range env {
@@ -311,6 +350,22 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			)},
 			expectProbesKept:    true,
 			expectDPMasterIPEnv: true,
+		},
+		// A single-pod spec may omit Command and run only the image ENTRYPOINT
+		// with Args. The operator cannot see the ENTRYPOINT, so it must leave that
+		// invocation intact instead of emitting a command with no executable, and
+		// it must not bind VLLM_DP_MASTER_IP for a Ray head it never started.
+		{
+			name:              "single node elastic EP with no Command preserves the ENTRYPOINT invocation",
+			numberOfNodes:     1,
+			role:              RoleMain,
+			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Args: []string{"--model", "test", "--data-parallel-backend", "ray", enableElasticEPFlag},
+			},
+			gpuCount:          4,
+			expectNotModified: true,
 		},
 		{
 			name:              "single node without elastic EP keeps its plain command",

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -39,6 +39,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 		expectedArgs        []string
 		expectNotModified   bool // If true, container args should not change
 		expectProbesRemoved bool // If true, probes should be nil
+		expectProbesKept    bool // If true, probes should survive untouched
 	}{
 		{
 			name:              "single node does not modify args",
@@ -187,6 +188,69 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			expectedArgs:        []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "16", "--distributed-executor-backend", "mp", "--nnodes", "2", "--master-addr", "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE)", "--master-port", commonconsts.VLLMMpMasterPort, "--node-rank", "0"},
 			expectProbesRemoved: true,
 		},
+		// A single-pod elastic-EP component heads a Ray cluster that follower
+		// pods join later, so it needs the leader wiring despite nodeCount 1.
+		{
+			name:              "single node elastic EP gets a ray head",
+			numberOfNodes:     1,
+			role:              RoleMain,
+			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command:       []string{"python3", "-m", "dynamo.vllm"},
+				Args:          []string{"--model", "test", "--data-parallel-backend", "ray", enableElasticEPFlag},
+				LivenessProbe: &corev1.Probe{},
+				StartupProbe:  &corev1.Probe{},
+			},
+			gpuCount: 4,
+			expectedArgs: []string{fmt.Sprintf(
+				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
+				VLLMPort, VLLMPort, enableElasticEPFlag,
+			)},
+			expectProbesKept: true,
+		},
+		{
+			name:              "single node without elastic EP keeps its plain command",
+			numberOfNodes:     1,
+			role:              RoleMain,
+			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command: []string{"python3", "-m", "dynamo.vllm"},
+				Args:    []string{"--model", "test", "--data-parallel-backend", "ray"},
+			},
+			gpuCount:          4,
+			expectNotModified: true,
+		},
+		// moe_agg.yaml and moe_disagg.yaml pass --enable-elastic-ep on the default
+		// data-parallel backend. A Ray head there would serve nobody and would put
+		// a 300s startup gate in front of an engine that works today.
+		{
+			name:              "single node elastic EP without the ray backend is left alone",
+			numberOfNodes:     1,
+			role:              RoleMain,
+			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command: []string{"python3", "-m", "dynamo.vllm"},
+				Args:    []string{"--model", "test", enableElasticEPFlag},
+			},
+			gpuCount:          2,
+			expectNotModified: true,
+		},
+		{
+			name:              "single node elastic EP on a non-ray backend is left alone",
+			numberOfNodes:     1,
+			role:              RoleMain,
+			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command: []string{"python3", "-m", "dynamo.vllm"},
+				Args:    []string{"--model", "test", "--data-parallel-backend", "mp", enableElasticEPFlag},
+			},
+			gpuCount:          2,
+			expectNotModified: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -219,6 +283,12 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				g.Expect(tt.initialContainer.LivenessProbe).To(gomega.BeNil())
 				g.Expect(tt.initialContainer.ReadinessProbe).To(gomega.BeNil())
 				g.Expect(tt.initialContainer.StartupProbe).To(gomega.BeNil())
+			}
+
+			if tt.expectProbesKept {
+				t.Log("a leader serves traffic, so its probes must survive the rewrite")
+				g.Expect(tt.initialContainer.LivenessProbe).ToNot(gomega.BeNil())
+				g.Expect(tt.initialContainer.StartupProbe).ToNot(gomega.BeNil())
 			}
 		})
 	}
@@ -647,6 +717,22 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 				VLLMPort,
 			)},
 			description: "Same as Grove worker but uses $(LWS_LEADER_ADDRESS) (kubelet-expanded) instead of the Grove-specific DNS address",
+		},
+		{
+			name:              "elastic EP main: takes the leader arm",
+			role:              RoleMain,
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command: []string{"python3", "-m", "dynamo.vllm"},
+				Args:    []string{"--model", "test", "--data-parallel-backend", "ray", enableElasticEPFlag},
+			},
+			gpuCount:    2,
+			annotations: nil,
+			expectedArgs: []string{fmt.Sprintf(
+				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
+				VLLMPort, VLLMPort, enableElasticEPFlag,
+			)},
+			description: "A component deployed as one pod is expanded as RoleMain rather than RoleLeader, so the leader arm must match it or the Ray head is never started",
 		},
 	}
 

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -197,14 +197,38 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer: &corev1.Container{
-				Command:       []string{"python3", "-m", "dynamo.vllm"},
-				Args:          []string{"--model", "test", "--data-parallel-backend", "ray", enableElasticEPFlag},
-				LivenessProbe: &corev1.Probe{},
-				StartupProbe:  &corev1.Probe{},
+				Command:        []string{"python3", "-m", "dynamo.vllm"},
+				Args:           []string{"--model", "test", "--data-parallel-backend", "ray", enableElasticEPFlag},
+				LivenessProbe:  &corev1.Probe{},
+				ReadinessProbe: &corev1.Probe{},
+				StartupProbe:   &corev1.Probe{},
 			},
 			gpuCount: 4,
 			expectedArgs: []string{fmt.Sprintf(
 				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
+				VLLMPort, VLLMPort, enableElasticEPFlag,
+			)},
+			expectProbesKept: true,
+		},
+		// vLLM's argparse accepts --data-parallel-backend=ray as an equivalent of
+		// the space-separated form, so the equals spelling must also start a Ray
+		// head (regression guard for isElasticEPRayLaunch/hasArg).
+		{
+			name:              "single node elastic EP gets a ray head with the inline backend flag",
+			numberOfNodes:     1,
+			role:              RoleMain,
+			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command:        []string{"python3", "-m", "dynamo.vllm"},
+				Args:           []string{"--model", "test", "--data-parallel-backend=ray", enableElasticEPFlag},
+				LivenessProbe:  &corev1.Probe{},
+				ReadinessProbe: &corev1.Probe{},
+				StartupProbe:   &corev1.Probe{},
+			},
+			gpuCount: 4,
+			expectedArgs: []string{fmt.Sprintf(
+				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && python3 -m dynamo.vllm --model test --data-parallel-backend=ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
 			expectProbesKept: true,
@@ -288,6 +312,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			if tt.expectProbesKept {
 				t.Log("a leader serves traffic, so its probes must survive the rewrite")
 				g.Expect(tt.initialContainer.LivenessProbe).ToNot(gomega.BeNil())
+				g.Expect(tt.initialContainer.ReadinessProbe).ToNot(gomega.BeNil())
 				g.Expect(tt.initialContainer.StartupProbe).ToNot(gomega.BeNil())
 			}
 		})

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -13,6 +13,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+func findEnvVar(env []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range env {
+		if env[i].Name == name {
+			return &env[i]
+		}
+	}
+	return nil
+}
+
 func TestGetContainerGPUsRecognizesMIGResources(t *testing.T) {
 	resources := &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -40,6 +49,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 		expectNotModified   bool // If true, container args should not change
 		expectProbesRemoved bool // If true, probes should be nil
 		expectProbesKept    bool // If true, probes should survive untouched
+		expectDPMasterIPEnv bool // If true, VLLM_DP_MASTER_IP should be bound to the pod IP
 	}{
 		{
 			name:              "single node does not modify args",
@@ -208,7 +218,8 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
-			expectProbesKept: true,
+			expectProbesKept:    true,
+			expectDPMasterIPEnv: true,
 		},
 		// vLLM's argparse accepts --data-parallel-backend=ray as an equivalent of
 		// the space-separated form, so the equals spelling must also start a Ray
@@ -231,7 +242,8 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && python3 -m dynamo.vllm --model test --data-parallel-backend=ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
-			expectProbesKept: true,
+			expectProbesKept:    true,
+			expectDPMasterIPEnv: true,
 		},
 		{
 			name:              "single node without elastic EP keeps its plain command",
@@ -314,6 +326,17 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				g.Expect(tt.initialContainer.LivenessProbe).ToNot(gomega.BeNil())
 				g.Expect(tt.initialContainer.ReadinessProbe).ToNot(gomega.BeNil())
 				g.Expect(tt.initialContainer.StartupProbe).ToNot(gomega.BeNil())
+			}
+
+			// Asserted on every case, so that the env var cannot leak into a
+			// container that did not ask for a Ray head.
+			dpMasterIP := findEnvVar(tt.initialContainer.Env, commonconsts.VLLMDPMasterIPEnvVar)
+			if tt.expectDPMasterIPEnv {
+				t.Log("without this, vLLM looks for the DP master at 127.0.0.1 and aborts")
+				g.Expect(dpMasterIP).ToNot(gomega.BeNil())
+				g.Expect(dpMasterIP.ValueFrom.FieldRef.FieldPath).To(gomega.Equal("status.podIP"))
+			} else {
+				g.Expect(dpMasterIP).To(gomega.BeNil())
 			}
 		})
 	}

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -215,7 +215,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			gpuCount: 4,
 			expectedArgs: []string{fmt.Sprintf(
-				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
+				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
 			expectProbesKept:    true,
@@ -239,7 +239,74 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			gpuCount: 4,
 			expectedArgs: []string{fmt.Sprintf(
-				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && python3 -m dynamo.vllm --model test --data-parallel-backend=ray %s`,
+				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend=ray %s`,
+				VLLMPort, VLLMPort, enableElasticEPFlag,
+			)},
+			expectProbesKept:    true,
+			expectDPMasterIPEnv: true,
+		},
+		// vLLM v0.26.0 documents -dpb as the short alias for
+		// --data-parallel-backend, so both its split and equals spellings must
+		// also start a Ray head (regression guard for the -dpb alias).
+		{
+			name:              "single node elastic EP gets a ray head with the -dpb short alias",
+			numberOfNodes:     1,
+			role:              RoleMain,
+			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command:        []string{"python3", "-m", "dynamo.vllm"},
+				Args:           []string{"--model", "test", "-dpb", "ray", enableElasticEPFlag},
+				LivenessProbe:  &corev1.Probe{},
+				ReadinessProbe: &corev1.Probe{},
+				StartupProbe:   &corev1.Probe{},
+			},
+			gpuCount: 4,
+			expectedArgs: []string{fmt.Sprintf(
+				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test -dpb ray %s`,
+				VLLMPort, VLLMPort, enableElasticEPFlag,
+			)},
+			expectProbesKept:    true,
+			expectDPMasterIPEnv: true,
+		},
+		{
+			name:              "single node elastic EP gets a ray head with the inline -dpb alias",
+			numberOfNodes:     1,
+			role:              RoleMain,
+			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command:        []string{"python3", "-m", "dynamo.vllm"},
+				Args:           []string{"--model", "test", "-dpb=ray", enableElasticEPFlag},
+				LivenessProbe:  &corev1.Probe{},
+				ReadinessProbe: &corev1.Probe{},
+				StartupProbe:   &corev1.Probe{},
+			},
+			gpuCount: 4,
+			expectedArgs: []string{fmt.Sprintf(
+				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test -dpb=ray %s`,
+				VLLMPort, VLLMPort, enableElasticEPFlag,
+			)},
+			expectProbesKept:    true,
+			expectDPMasterIPEnv: true,
+		},
+		// The elastic-EP flags may be carried in Command instead of Args; detection
+		// scans the full command line, so this must also start a Ray head.
+		{
+			name:              "single node elastic EP detects flags placed in Command",
+			numberOfNodes:     1,
+			role:              RoleMain,
+			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command:        []string{"python3", "-m", "dynamo.vllm", "--data-parallel-backend", "ray", enableElasticEPFlag},
+				LivenessProbe:  &corev1.Probe{},
+				ReadinessProbe: &corev1.Probe{},
+				StartupProbe:   &corev1.Probe{},
+			},
+			gpuCount: 4,
+			expectedArgs: []string{fmt.Sprintf(
+				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --data-parallel-backend ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
 			expectProbesKept:    true,
@@ -777,10 +844,10 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			gpuCount:    2,
 			annotations: nil,
 			expectedArgs: []string{fmt.Sprintf(
-				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
+				`ray start --head --port=%s --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
 			)},
-			description: "A component deployed as one pod is expanded as RoleMain rather than RoleLeader, so the leader arm must match it or the Ray head is never started",
+			description: "A component deployed as one pod is expanded as RoleMain rather than RoleLeader, so the leader arm must match it (with exec, so vLLM receives SIGTERM) or the Ray head is never started",
 		},
 	}
 

--- a/deploy/operator/internal/dynamo/utils.go
+++ b/deploy/operator/internal/dynamo/utils.go
@@ -54,6 +54,25 @@ func shellQuoteForBashC(s string) string {
 	return s
 }
 
+// shellSafeToken matches tokens that are literal to the shell in every context
+// and therefore need no quoting inside sh -c.
+var shellSafeToken = regexp.MustCompile(`^[A-Za-z0-9_@%+=:,./-]+$`)
+
+// shellQuotePOSIX renders s as exactly one argv token that survives `sh -c`
+// unchanged. Tokens built only from shell-neutral characters pass through
+// unquoted for readability; everything else — whitespace, quotes, $, ;, |, &,
+// globs, and the empty string — is wrapped in single quotes, inside which every
+// byte is literal except the single quote itself, which is closed and re-opened
+// via the '\” idiom. Unlike shellQuoteForBashC this is argv-preserving: it
+// round-trips arbitrary tokens (including empty ones and embedded quotes)
+// through the shell without splitting, dropping, or reinterpreting them.
+func shellQuotePOSIX(s string) string {
+	if shellSafeToken.MatchString(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 // containerHasArg reports whether the container already carries the given
 // flag/value pair in its Args (either as adjacent tokens "flag", "value" or
 // as a single token "flag=value" or "flag value" embedded inside a shell

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -131,12 +131,14 @@ func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeploymentS
 		grovePathway                      = false
 		validateInferencePoolAvailability = false
 	)
-	return v.validateDynamoComponentDeploymentSharedSpec(
+	allErrs := validateElasticEPRequiresCommand(spec.BackendFramework, &spec.DynamoComponentDeploymentSharedSpec, fldPath)
+	allErrs = append(allErrs, v.validateDynamoComponentDeploymentSharedSpec(
 		&spec.DynamoComponentDeploymentSharedSpec,
 		fldPath,
 		grovePathway,
 		validateInferencePoolAvailability,
-	)
+	)...)
+	return allErrs
 }
 
 // validateDynamoComponentDeploymentUpdate validates an update. newDCD and oldDCD must not be nil.

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -270,6 +270,8 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpec(
 		// Phase-1 power accounting reads scalar GPU resources and cannot account for DRA devices.
 		allErrs = append(allErrs, v.validateDGDComponentPowerAnnotation(component, componentPath)...)
 
+		allErrs = append(allErrs, validateElasticEPRequiresCommand(spec.BackendFramework, component, componentPath)...)
+
 		allErrs = append(allErrs, v.validateDynamoComponentDeploymentSharedSpec(
 			component,
 			componentPath,

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_unit_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_unit_test.go
@@ -150,3 +150,103 @@ func assertBetaValidationErrors(t *testing.T, err error, wantErrs []string) {
 		t.Fatalf("webhook errors = %v, want %v", gotErrs, wantErrs)
 	}
 }
+
+func elasticEPSharedSpec(command, args []string) *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec {
+	return &nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+		PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    consts.MainContainerName,
+				Command: command,
+				Args:    args,
+			}},
+		}},
+	}
+}
+
+func TestValidateElasticEPRequiresCommand(t *testing.T) {
+	const vllm = "vllm"
+	rayArgs := []string{"--model", "test", "--data-parallel-backend", "ray", "--enable-elastic-ep"}
+	fldPath := field.NewPath("spec")
+	const commandPath = "spec.podTemplate.spec.containers[0].command"
+
+	tests := []struct {
+		name    string
+		backend string
+		spec    *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec
+		want    []string
+	}{
+		{
+			name:    "vllm elastic-EP ray with empty command is rejected",
+			backend: vllm,
+			spec:    elasticEPSharedSpec(nil, rayArgs),
+			want:    []string{commandPath},
+		},
+		{
+			name:    "vllm elastic-EP with -dpb=ray alias and empty command is rejected",
+			backend: vllm,
+			spec:    elasticEPSharedSpec(nil, []string{"--model", "test", "-dpb=ray", "--enable-elastic-ep"}),
+			want:    []string{commandPath},
+		},
+		{
+			name:    "explicit command is accepted",
+			backend: vllm,
+			spec:    elasticEPSharedSpec([]string{"python3", "-m", "dynamo.vllm"}, rayArgs),
+			want:    nil,
+		},
+		{
+			name:    "elastic-EP flags carried in Command are accepted",
+			backend: vllm,
+			spec:    elasticEPSharedSpec([]string{"python3", "-m", "dynamo.vllm", "--data-parallel-backend", "ray", "--enable-elastic-ep"}, nil),
+			want:    nil,
+		},
+		{
+			name:    "non-vllm backend is not validated",
+			backend: sglangBackendFramework,
+			spec:    elasticEPSharedSpec(nil, rayArgs),
+			want:    nil,
+		},
+		{
+			name:    "vllm without elastic-EP is accepted",
+			backend: vllm,
+			spec:    elasticEPSharedSpec(nil, []string{"--model", "test"}),
+			want:    nil,
+		},
+		{
+			name:    "vllm elastic-EP on a non-ray backend is accepted",
+			backend: vllm,
+			spec:    elasticEPSharedSpec(nil, []string{"--model", "test", "--data-parallel-backend", "mp", "--enable-elastic-ep"}),
+			want:    nil,
+		},
+		{
+			name:    "nil pod template is ignored",
+			backend: vllm,
+			spec:    &nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{},
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertFieldPaths(t, validateElasticEPRequiresCommand(tt.backend, tt.spec, fldPath), tt.want)
+		})
+	}
+}
+
+// TestDynamoGraphDeploymentRejectsElasticEPWithoutCommand proves the rule is
+// wired into the DGD admission path end to end, not just callable in isolation.
+func TestDynamoGraphDeploymentRejectsElasticEPWithoutCommand(t *testing.T) {
+	dgd := newBetaDGDForValidation()
+	// components[1] is the worker; make it request elastic-EP Ray with no command.
+	dgd.Spec.Components[1].PodTemplate.Spec.Containers[0].Args = []string{
+		"--model", "test", "--data-parallel-backend", "ray", "--enable-elastic-ep",
+	}
+
+	validator := newDynamoGraphDeploymentTestValidator(t)
+	ctx := features.WithGate(context.Background(), features.Gates{Grove: true})
+	_, err := validator.Validate(ctx, dgd, runtimeVersionSourceV1Beta1)
+	if err == nil || !k8serrors.IsInvalid(err) {
+		t.Fatalf("Validate() error = %v, want invalid field error", err)
+	}
+	if !strings.Contains(err.Error(), "requires an explicit container command") {
+		t.Fatalf("Validate() error = %v, want elastic-EP command requirement", err)
+	}
+}

--- a/deploy/operator/internal/webhook/validation/shared_helpers.go
+++ b/deploy/operator/internal/webhook/validation/shared_helpers.go
@@ -25,6 +25,7 @@ import (
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/runtimeversion"
@@ -161,6 +162,42 @@ func inferencePoolAvailabilityError(ctx context.Context, mgr ctrl.Manager) error
 		"InferencePool API group (%s) is not available in the cluster; install the Gateway API Inference Extension before deploying EPP components",
 		epp.InferencePoolGroup,
 	)
+}
+
+// validateElasticEPRequiresCommand rejects a vLLM component that requests the
+// elastic-EP Ray topology (--enable-elastic-ep with --data-parallel-backend ray,
+// including the -dpb alias and flag=value spellings) but omits the main
+// container command. The operator starts the single-pod Ray head by rewriting
+// the container to run "ray start ... && <command>", which needs an explicit
+// executable; with only the image ENTRYPOINT (empty command) it cannot build
+// that command, so elastic EP would silently never start. Fail closed here with
+// an actionable error rather than admit a request the operator cannot fulfill.
+func validateElasticEPRequiresCommand(
+	backendFramework string,
+	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	if backendFramework != string(dynamo.BackendFrameworkVLLM) || spec.PodTemplate == nil {
+		return allErrs
+	}
+	containers := spec.PodTemplate.Spec.Containers
+	index := containerIndexByName(containers, consts.MainContainerName)
+	if index < 0 {
+		return allErrs
+	}
+	mainContainer := &containers[index]
+	if len(mainContainer.Command) > 0 || !dynamo.IsElasticEPRayLaunch(mainContainer) {
+		return allErrs
+	}
+	commandPath := fldPath.Child("podTemplate", "spec", "containers").Index(index).Child("command")
+	allErrs = append(allErrs, field.Required(
+		commandPath,
+		"elastic expert parallelism (--enable-elastic-ep with --data-parallel-backend ray) requires an explicit "+
+			"container command; the operator starts the single-pod Ray head by wrapping that command and cannot "+
+			"start it from the image ENTRYPOINT",
+	))
+	return allErrs
 }
 
 func gpuMemoryServiceFor(

--- a/docs/fern/pages/kubernetes/model-deployment/multinode-deployments.md
+++ b/docs/fern/pages/kubernetes/model-deployment/multinode-deployments.md
@@ -264,7 +264,31 @@ For multi-node tensor/pipeline parallelism, **the `mp` (multiprocessing) backend
 **For Elastic EP (Data Parallel with Ray):**
 1. Ensure Ray is installed in your container: `pip install "ray>=2.55.0"`
 2. Add `--data-parallel-backend ray` to your vLLM launch command.
+3. Define an explicit `command` on the main container. The operator starts the single-pod Ray head by wrapping your command, so it cannot fall back to the image `ENTRYPOINT`. The bundled single-pod and multinode Elastic EP templates already set `command: [python3, -m, dynamo.vllm]`.
 
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: my-elastic-ep-deployment
+spec:
+  services:
+    VllmDecodeWorker:
+      # ... your component spec
+      extraPodSpec:
+        mainContainer:
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --data-parallel-backend
+            - ray
+            - --enable-elastic-ep
+```
+
+> [!IMPORTANT]
+> A component that requests Elastic EP (`--enable-elastic-ep` with `--data-parallel-backend ray`, or the `-dpb ray` alias) but leaves `command` empty is rejected at admission — the operator cannot wrap the image `ENTRYPOINT` to launch the Ray head. Add an explicit `command` (for example `command: [python3, -m, dynamo.vllm]`) to make the manifest valid.
 
 The `mp` backend is the official recommendation and should be used for all new deployments.
 


### PR DESCRIPTION
## Overview:

**What we want.** A Dynamo deployment where one pod runs the vLLM leader and serves on its own, and where extra pods can join later to widen the expert-parallel group. Elastic EP is the vLLM feature that makes that group resizable while the engine is running. It works by putting every participating pod into one Ray cluster, with the leader running the Ray head.

**What is broken today.** Deploy a component as a single pod, pass `--enable-elastic-ep`, and nothing happens. No Ray head starts, so there is no cluster for anything to join, and the flag is silently ignored. Elastic EP works only if the component is declared multinode.

**Why.** Two independent reasons, either of which alone is enough:

1. The elastic-EP dispatch sits inside the `numberOfNodes > 1` branch of `UpdateContainer`, so a one-pod component never reaches it.
2. Even if it did, the leader wiring in `injectElasticEPRayLaunchFlags` matches only `RoleLeader` — and a one-pod component is expanded as `RoleMain`, so it would fall straight through.

**What this changes.** Add a single-pod branch beside the multinode one, and let the leader arm match `RoleMain` as well as `RoleLeader`. A solo leader then starts `ray start --head` exactly as a multinode leader does, and is told where to find it via `VLLM_DP_MASTER_IP`.

This is worth having on its own, since single-pod elastic EP is simply broken today. It is also the first step toward a leader that serves alone with followers attaching at an arbitrary later time.

## Details:

### The wiring

`UpdateContainer` in `deploy/operator/internal/dynamo/backend_vllm.go` gains an `else if` branch for single-pod components, and `injectElasticEPRayLaunchFlags` now treats `RoleMain` identically to `RoleLeader`.

Probes are deliberately left in place. The multinode path strips them from workers, but this pod is a leader that serves traffic, so it keeps them.

### Why the branch also requires the Ray backend

The new branch fires only when the args carry **both** `--enable-elastic-ep` and `--data-parallel-backend ray`, expressed as a named predicate `isElasticEPRayLaunch`.

The second condition is load-bearing, not defensive. Elastic EP only functions on the Ray data-parallel backend — vLLM asserts it outright in `scale_elastic_ep` with *"Only ray DP backend supports scaling elastic EP"*. On any other backend, a Ray head is a process nothing ever connects to, sitting behind a 300-second startup gate.

That is not hypothetical. Three single-pod templates in this repo pass `--enable-elastic-ep`:

| Template | Ray DP backend | Without the extra condition |
|---|---|---|
| `moe_elastic_ep_demo.yaml` | yes | Correct — gains the Ray head it needs |
| `moe_agg.yaml` | no | Would gain a Ray head nothing uses |
| `moe_disagg.yaml` | no | Same, on both of its components |

The latter two are not misconfigured. `--enable-elastic-ep` still does real work for them: it requires EPLB, rejects pipeline parallelism, and selects the `pynccl` EPLB communicator. They simply cannot scale at runtime. Without the backend condition, this PR would have added a Ray head and a startup gate to two configurations that work today.

### Telling vLLM where the DP master is

Starting the Ray head is necessary but not sufficient, and the second half is not obvious.

Ray registers the head under the pod IP, since the whole point is that another pod reaches it later. vLLM derives the same address for its data-parallel master — `arg_utils.py` calls `get_ip()` for the Ray backend and logs *"Using host IP %s as ray-based data parallel address"*. So far so good.

Then `ParallelConfig.__post_init__` throws it away. Its condition is `data_parallel_size > 1 or data_parallel_size_local == 0`, and at **`--data-parallel-size 1`** neither holds, so it takes the offline-SPMD branch and overwrites the derived address with `envs.VLLM_DP_MASTER_IP` — default `127.0.0.1`. Engine startup then asserts on a Ray node that does not exist:

```
The DP master node (ip: 127.0.0.1) is missing or dead
```

The root cause upstream is a conflated signal: `data_parallel_size` defaults to 1, so vLLM cannot distinguish "DP not configured" from "DP configured with one rank". A solo elastic-EP leader is exactly the second, read as the first. Reported as [vllm-project/vllm#51712](https://github.com/vllm-project/vllm/issues/51712); if it is fixed upstream this injection stops being load-bearing, but it is correct to carry it either way.

Two things that look like they should fix it, and do not. `VLLM_HOST_IP` only steers `get_ip()`, whose result is then discarded. `--data-parallel-address` is discarded by the same branch. `VLLM_DP_MASTER_IP` is the one value the fallback actually reads, so the operator binds it to `status.podIP` behind the same predicate that starts the Ray head. This mirrors the existing `VLLM_NIXL_SIDE_CHANNEL_HOST` injection a few lines above.

Note this only bites at dp=1. `moe_elastic_ep_demo.yaml` runs dp=2 in one pod and takes the other branch, which is why single-pod elastic EP appeared to work in that shape.

### Naming the head's address, not guessing it

Telling vLLM the master is at `status.podIP` is only half of a pair. vLLM then looks up the Ray node registered under that exact address, and Ray, left alone, picks an interface by its own heuristic. The two agree only as long as that heuristic lands on the pod IP — true on a single-interface pod, not guaranteed on one with a second network, and a mismatch there produces the identical "missing or dead" abort.

Before this change nothing was pinned at either end, so vLLM's `get_ip()` and Ray's detection ran the same heuristic and agreed with each other whatever they chose. Pinning one end alone would trade a self-consistent pair for a mismatched one.

So the head is given its address explicitly: `POD_IP` is bound from the downward API and interpolated into `--node-ip-address`. Both values resolve from `status.podIP`, which is the point — they cannot drift. This also makes the generated command match the hand-written leader command already validated on a GB200 cluster.

The flag is scoped to `RoleMain`. A multinode leader gets no `VLLM_DP_MASTER_IP`, so adding `--node-ip-address` there would interpolate an unset variable and start the head with an empty address.

### What is deliberately left alone

The multinode branch keys on the elastic-EP flag alone and has the same looseness. It stays as it is: every multinode elastic-EP template in the tree already sets the Ray backend, so tightening it would change nothing here while altering behaviour for anyone outside the tree. Worth doing, but as its own change.

### Tests

Six cases in `backend_vllm_test.go`, all confirmed to fail without the corresponding production change:

- a single-pod elastic-EP component gets the Ray head pinned to `$POD_IP`, and keeps its probes;
- `RoleMain` takes the leader arm;
- four regression guards — no elastic-EP flag, the flag with no backend specified, and the flag on an explicitly non-Ray backend — each asserting the container is left untouched.

Both env bindings are asserted on **every** case in the table rather than only the positive ones: present and bound to `status.podIP` where a Ray head is started, absent everywhere else, including the whole multinode set. That makes it impossible for either to leak into a container that did not ask for a head, and the multinode expectations double as the guard that their rendered command is unchanged.

## Where should the reviewer start?

`backend_vllm.go`: the new `else if` in `UpdateContainer`, and the `isElasticEPRayLaunch` predicate. The judgement call worth pressing on is whether requiring the Ray backend is right, or whether this should mirror the looser multinode branch instead.

Then `TestVLLMBackend_UpdateContainer/single_node_elastic_EP_without_the_ray_backend_is_left_alone`, which is the test that keeps `moe_agg.yaml` and `moe_disagg.yaml` rendering exactly as they do today.

The `VLLM_DP_MASTER_IP` binding is the other place to look, and the question there is scope: it is gated on the same predicate as the Ray head, which deliberately leaves the multinode path alone even though the same vLLM behaviour would apply to a multinode leader at dp=1.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


