### PR TITLE
fix(frontend): return 4xx for backend request rejections on /v1/audio/speech (cherry-pick #12832, #12807)

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3618,10 +3618,16 @@ async fn audio_speech(
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
-    let stream = engine
-        .generate(request)
-        .await
-        .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate audio"))?;
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model, super::metrics::Endpoint::Audios);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to generate audio");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
 
     let mut http_queue_guard = Some(http_queue_guard);
     let stream = stream.inspect(move |response| {
@@ -3635,12 +3641,17 @@ async fn audio_speech(
     let response = NvAudioSpeechResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to fold audio stream for {}: {:?}", request_id, e);
-            ErrorMessage::internal_server_error("Failed to fold audio stream")
+            let err_response =
+                ErrorMessage::from_anyhow(anyhow::Error::new(e), "Failed to fold audio stream");
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
         })?;
 
     // Check for failure before marking success
     if response.status == "failed" {
+        // Without this the guard drops on its default and books this 400 as an
+        // internal error.
+        inflight.mark_error(ErrorType::Validation);
         return Ok((axum::http::StatusCode::BAD_REQUEST, Json(response)).into_response());
     }
 

--- a/lib/llm/src/protocols/openai/audios/aggregator.rs
+++ b/lib/llm/src/protocols/openai/audios/aggregator.rs
@@ -5,6 +5,7 @@ use futures::Stream;
 
 use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvAudioSpeechResponse;
 
@@ -22,7 +23,7 @@ impl NvAudioSpeechResponse {
     /// Aggregates an annotated stream of audio responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvAudioSpeechResponse>>,
-    ) -> Result<NvAudioSpeechResponse, String> {
+    ) -> Result<NvAudioSpeechResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, TryStreamExt};
 use std::collections::{BTreeMap, HashMap};
 
 use dynamo_parsers::tool_calling::try_tool_call_parse_aggregate_finalize;
@@ -17,6 +17,7 @@ use crate::protocols::{
 
 use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_runtime::engine::DataStream;
+use dynamo_runtime::error::DynamoError;
 
 fn is_harmony_parser(parser: &str) -> bool {
     parser == "harmony"
@@ -42,8 +43,6 @@ pub struct DeltaAggregator {
     system_fingerprint: Option<String>,
     /// Map of incremental response choices, keyed by index.
     choices: HashMap<u32, DeltaChoice>,
-    /// Optional error message if an error occurs during aggregation.
-    error: Option<String>,
     /// Optional service tier information for the response.
     service_tier: Option<dynamo_protocols::types::ServiceTierResponse>,
     /// Aggregated nvext field from stream responses
@@ -199,7 +198,6 @@ impl DeltaAggregator {
             usage: None,
             system_fingerprint: None,
             choices: HashMap::new(),
-            error: None,
             service_tier: None,
             nvext: None,
         }
@@ -213,25 +211,15 @@ impl DeltaAggregator {
     ///
     /// # Returns
     /// * `Ok(NvCreateChatCompletionResponse)` if aggregation is successful.
-    /// * `Err(String)` if an error occurs during processing.
+    /// * `Err(DynamoError)` if an error occurs during processing.
     pub async fn apply(
         stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String> {
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         let mut aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                // Attempt to unwrap the delta, capturing any errors.
-                let delta = match delta.ok() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(delta) = delta.data
-                {
+            .map(Annotated::into_data)
+            .try_fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
+                if let Some(delta) = delta {
                     aggregator.id = delta.inner.id;
                     aggregator.model = delta.inner.model;
                     aggregator.created = delta.inner.created;
@@ -339,14 +327,9 @@ impl DeltaAggregator {
                         }
                     }
                 }
-                aggregator
+                Ok(aggregator)
             })
-            .await;
-
-        // Return early if an error was encountered.
-        if let Some(error) = aggregator.error {
-            return Err(error);
-        }
+            .await?;
 
         // #8640: finalize the per-index tool-call chunk accumulator into the
         // choice's `tool_calls` vector. Chunks missing id or name across the
@@ -523,11 +506,11 @@ pub trait ChatCompletionAggregator {
     ///
     /// # Returns
     /// * `Ok(NvCreateChatCompletionResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
+    /// * `Err(DynamoError)` if an error occurs.
     async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String>;
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError>;
 
     /// Converts an SSE stream into a [`NvCreateChatCompletionResponse`].
     ///
@@ -536,25 +519,25 @@ pub trait ChatCompletionAggregator {
     ///
     /// # Returns
     /// * `Ok(NvCreateChatCompletionResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
+    /// * `Err(DynamoError)` if an error occurs.
     async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String>;
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError>;
 }
 
 impl ChatCompletionAggregator for NvCreateChatCompletionResponse {
     async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String> {
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         DeltaAggregator::apply(stream, parsing_options).await
     }
 
     async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String> {
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateChatCompletionStreamResponse>(stream);
         NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options).await
     }
@@ -1825,5 +1808,42 @@ mod tests {
             "content key must be serialized as null when absent"
         );
         assert!(json.get("reasoning_content").is_some());
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_error_after_partial_output() {
+        use dynamo_runtime::error::{BackendError, ErrorType};
+
+        let partial = create_test_delta(
+            0,
+            "partial",
+            Some(dynamo_protocols::types::Role::Assistant),
+            None,
+            None,
+            None,
+        );
+        let error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid sampling parameter")
+            .build();
+        let stream = stream::iter(vec![
+            partial,
+            Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(error),
+            },
+        ]);
+
+        let error = DeltaAggregator::apply(stream, ParsingOptions::default())
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid sampling parameter");
     }
 }

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -3,8 +3,8 @@
 
 use std::collections::HashMap;
 
-use anyhow::Result;
-use futures::{Stream, StreamExt};
+use dynamo_runtime::error::DynamoError;
+use futures::{Stream, StreamExt, TryStreamExt};
 
 use super::NvCreateCompletionResponse;
 use crate::protocols::{
@@ -23,7 +23,6 @@ pub struct DeltaAggregator {
     usage: Option<dynamo_protocols::types::CompletionUsage>,
     system_fingerprint: Option<String>,
     choices: HashMap<u32, DeltaChoice>,
-    error: Option<String>,
     nvext: Option<serde_json::Value>,
 }
 
@@ -49,7 +48,6 @@ impl DeltaAggregator {
             usage: None,
             system_fingerprint: None,
             choices: HashMap::new(),
-            error: None,
             nvext: None,
         }
     }
@@ -58,21 +56,12 @@ impl DeltaAggregator {
     pub async fn apply(
         stream: impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateCompletionResponse> {
+    ) -> Result<NvCreateCompletionResponse, DynamoError> {
         tracing::debug!("Tool Call Parser: {:?}", parsing_options.tool_call_parser); // TODO: remove this once completion has tool call support
         let aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                let delta = match delta.ok() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(delta) = delta.data
-                {
+            .map(Annotated::into_data)
+            .try_fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
+                if let Some(delta) = delta {
                     // TODO(#14) - Aggregate Annotation
 
                     // these are cheap to move so we do it every time since we are consuming the delta
@@ -137,16 +126,9 @@ impl DeltaAggregator {
                         }
                     }
                 }
-                aggregator
+                Ok(aggregator)
             })
-            .await;
-
-        // If we have an error, return it
-        let aggregator = if let Some(error) = aggregator.error {
-            return Err(anyhow::anyhow!(error));
-        } else {
-            aggregator
-        };
+            .await?;
 
         // extra the aggregated deltas and sort by index
         let mut choices: Vec<_> = aggregator
@@ -193,7 +175,7 @@ impl NvCreateCompletionResponse {
     pub async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateCompletionResponse> {
+    ) -> Result<NvCreateCompletionResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateCompletionResponse>(stream);
         NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options).await
     }
@@ -201,7 +183,7 @@ impl NvCreateCompletionResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateCompletionResponse> {
+    ) -> Result<NvCreateCompletionResponse, DynamoError> {
         DeltaAggregator::apply(stream, parsing_options).await
     }
 }
@@ -462,5 +444,34 @@ mod tests {
             choice1.finish_reason,
             Some(dynamo_protocols::types::CompletionFinishReason::Stop)
         );
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_error_after_partial_output() {
+        use dynamo_runtime::error::{BackendError, ErrorType};
+
+        let error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("unsupported logprobs")
+            .build();
+        let stream = stream::iter(vec![
+            create_test_delta(0, "partial", None, None),
+            Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(error),
+            },
+        ]);
+
+        let error = DeltaAggregator::apply(stream, ParsingOptions::default())
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "unsupported logprobs");
     }
 }

--- a/lib/llm/src/protocols/openai/embeddings/aggregator.rs
+++ b/lib/llm/src/protocols/openai/embeddings/aggregator.rs
@@ -9,7 +9,7 @@ use crate::protocols::{
     openai::stream_aggregator::{StreamAggregable, aggregate_stream},
 };
 
-use dynamo_runtime::engine::DataStream;
+use dynamo_runtime::{engine::DataStream, error::DynamoError};
 use futures::Stream;
 
 impl StreamAggregable for NvCreateEmbeddingResponse {
@@ -28,7 +28,7 @@ impl NvCreateEmbeddingResponse {
     /// Converts an SSE stream into a [`NvCreateEmbeddingResponse`].
     pub async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
-    ) -> Result<NvCreateEmbeddingResponse, String> {
+    ) -> Result<NvCreateEmbeddingResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateEmbeddingResponse>(stream);
         NvCreateEmbeddingResponse::from_annotated_stream(stream).await
     }
@@ -36,7 +36,7 @@ impl NvCreateEmbeddingResponse {
     /// Aggregates an annotated stream of embedding responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateEmbeddingResponse>>,
-    ) -> Result<NvCreateEmbeddingResponse, String> {
+    ) -> Result<NvCreateEmbeddingResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }
@@ -44,6 +44,7 @@ impl NvCreateEmbeddingResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_runtime::error::{BackendError, ErrorType};
     use futures::stream;
 
     fn create_test_embedding_response(
@@ -141,7 +142,40 @@ mod tests {
         let result = NvCreateEmbeddingResponse::from_annotated_stream(Box::pin(stream)).await;
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Test error"));
+        assert!(result.unwrap_err().to_string().contains("Test error"));
+    }
+
+    #[tokio::test]
+    async fn test_typed_error_after_data_is_preserved() {
+        let embedding = dynamo_protocols::types::Embedding {
+            index: 0,
+            object: "embedding".to_string(),
+            embedding: dynamo_protocols::types::EmbeddingVector::Float(vec![0.1]),
+        };
+        let response = create_test_embedding_response(vec![embedding], 1, 1);
+        let error = Annotated::<NvCreateEmbeddingResponse> {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: None,
+            error: Some(
+                DynamoError::builder()
+                    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                    .message("invalid embedding request")
+                    .build(),
+            ),
+        };
+
+        let result =
+            NvCreateEmbeddingResponse::from_annotated_stream(stream::iter(vec![response, error]))
+                .await;
+
+        let error = result.expect_err("typed error must win over partial data");
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid embedding request");
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -569,8 +569,7 @@ impl GenerateAggregator {
         let mut aggregator = GenerateAggregator::new(request_id);
         pin_mut!(stream);
         while let Some(delta) = stream.next().await {
-            let delta = delta.ok().map_err(anyhow::Error::msg)?;
-            if let Some(output) = delta.data {
+            if let Some(output) = delta.into_data().map_err(anyhow::Error::new)? {
                 aggregator.apply_output(output, options)?;
             }
         }

--- a/lib/llm/src/protocols/openai/images/aggregator.rs
+++ b/lib/llm/src/protocols/openai/images/aggregator.rs
@@ -5,6 +5,7 @@ use futures::Stream;
 
 use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvImagesResponse;
 
@@ -22,7 +23,7 @@ impl NvImagesResponse {
     /// Aggregates an annotated stream of image responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvImagesResponse>>,
-    ) -> Result<NvImagesResponse, String> {
+    ) -> Result<NvImagesResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -38,3 +38,60 @@ where
 
     Ok(response.unwrap_or_else(T::empty))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_runtime::{
+        error::{BackendError, ErrorType},
+        protocols::maybe_error::MaybeError,
+    };
+    use futures::stream;
+    use serde::Deserialize;
+
+    #[derive(Debug, Default, PartialEq, Deserialize)]
+    struct Chunks(Vec<u32>);
+
+    impl StreamAggregable for Chunks {
+        fn empty() -> Self {
+            Self::default()
+        }
+
+        fn merge(&mut self, next: Self) {
+            self.0.extend(next.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn merges_data_and_falls_back_to_empty() {
+        let empty = aggregate_stream::<Chunks, _>(stream::empty())
+            .await
+            .unwrap();
+        assert_eq!(empty, Chunks(vec![]));
+
+        let stream = stream::iter(vec![
+            Annotated::from_data(Chunks(vec![1])),
+            Annotated::from_data(Chunks(vec![2])),
+        ]);
+        assert_eq!(aggregate_stream(stream).await.unwrap(), Chunks(vec![1, 2]));
+    }
+
+    /// The property every OpenAI endpoint depends on: a backend rejection keeps
+    /// its type, so the HTTP layer can answer 4xx rather than a blanket 500.
+    #[tokio::test]
+    async fn preserves_backend_error_type() {
+        let stream = stream::iter(vec![Annotated::<Chunks>::from_err(
+            DynamoError::builder()
+                .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                .message("invalid argument")
+                .build(),
+        )]);
+
+        let error = aggregate_stream(stream).await.unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid argument");
+    }
+}

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -4,6 +4,7 @@
 use futures::{Stream, StreamExt};
 
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 /// Response types whose `Annotated<T>` streams can be folded into a single `T`
 /// using shared aggregation infrastructure.
@@ -18,7 +19,7 @@ pub trait StreamAggregable: Sized {
 /// Aggregate a stream of [`Annotated<T>`] into a single `T`. The first error
 /// encountered short-circuits further merging and is returned; the remainder
 /// of the stream is dropped.
-pub async fn aggregate_stream<T, S>(stream: S) -> Result<T, String>
+pub async fn aggregate_stream<T, S>(stream: S) -> Result<T, DynamoError>
 where
     T: StreamAggregable,
     S: Stream<Item = Annotated<T>>,
@@ -27,8 +28,7 @@ where
     let mut response: Option<T> = None;
 
     while let Some(delta) = stream.next().await {
-        let delta = delta.ok()?;
-        if let Some(data) = delta.data {
+        if let Some(data) = delta.into_data()? {
             match response.as_mut() {
                 Some(existing) => existing.merge(data),
                 None => response = Some(data),

--- a/lib/llm/src/protocols/openai/videos/aggregator.rs
+++ b/lib/llm/src/protocols/openai/videos/aggregator.rs
@@ -5,6 +5,7 @@ use futures::Stream;
 
 use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvVideosResponse;
 
@@ -22,7 +23,7 @@ impl NvVideosResponse {
     /// Aggregates an annotated stream of video responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvVideosResponse>>,
-    ) -> Result<NvVideosResponse, String> {
+    ) -> Result<NvVideosResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/tensor.rs
+++ b/lib/llm/src/protocols/tensor.rs
@@ -4,7 +4,7 @@
 use crate::protocols::Annotated;
 use anyhow::Result;
 use dynamo_runtime::protocols::annotated::AnnotationsProvider;
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, pin_mut};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use validator::Validate;
@@ -264,55 +264,21 @@ impl AnnotationsProvider for NvCreateTensorRequest {
     }
 }
 
-pub struct DeltaAggregator {
-    response: Option<NvCreateTensorResponse>,
-    error: Option<String>,
-}
-
 impl NvCreateTensorResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateTensorResponse>>,
     ) -> Result<NvCreateTensorResponse> {
-        let aggregator = stream
-            .fold(
-                DeltaAggregator {
-                    response: None,
-                    error: None,
-                },
-                |mut aggregator, delta| async move {
-                    let delta = match delta.ok() {
-                        Ok(delta) => delta,
-                        Err(error) => {
-                            if aggregator.error.is_none() {
-                                aggregator.error = Some(error);
-                            }
-                            return aggregator;
-                        }
-                    };
-                    match delta.data {
-                        Some(resp) => {
-                            if aggregator.response.is_none() {
-                                aggregator.response = Some(resp);
-                            } else if aggregator.error.is_none() {
-                                aggregator.error =
-                                    Some("Multiple responses in non-streaming mode".to_string());
-                            }
-                        }
-                        None => {
-                            // Ignore metadata-only deltas in non-streaming mode.
-                        }
-                    }
-                    aggregator
-                },
-            )
-            .await;
-        if let Some(error) = aggregator.error {
-            Err(anyhow::anyhow!(error))
-        } else if let Some(response) = aggregator.response {
-            Ok(response)
-        } else {
-            Err(anyhow::anyhow!("No response received"))
+        pin_mut!(stream);
+        let mut response = None;
+        while let Some(delta) = stream.next().await {
+            let Some(next) = delta.into_data().map_err(anyhow::Error::new)? else {
+                continue;
+            };
+            if response.replace(next).is_some() {
+                anyhow::bail!("Multiple responses in non-streaming mode");
+            }
         }
+        response.ok_or_else(|| anyhow::anyhow!("No response received"))
     }
 }
 

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -24,6 +24,7 @@ use dynamo_llm::{
 use dynamo_runtime::metrics::prometheus_names::{frontend_service, name_prefix};
 use dynamo_runtime::{
     CancellationToken,
+    error::DynamoError,
     pipeline::{
         AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn, async_trait,
     },
@@ -1208,6 +1209,224 @@ async fn test_nvext_disabled_strips_request_and_response() {
     assert!(
         !body.contains("\"nvext\""),
         "nvext gate off: response must not contain an `nvext` field, got: {body}"
+    );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}
+
+/// Audio engine whose only response frame is a `Backend(InvalidArgument)`
+/// error — models a worker rejecting the request during deserialization
+/// (e.g. a `task_type` value outside the backend's accepted set).
+struct InvalidArgumentAudiosEngine {}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > for InvalidArgumentAudiosEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+    ) -> Result<
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > {
+        use dynamo_runtime::error::{BackendError, ErrorType as DynErrorType};
+        let (_request, context) = request.transfer(());
+        let ctx = context.context();
+        let stream = stream! {
+            yield Annotated::<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse> {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(
+                    DynamoError::builder()
+                        .error_type(DynErrorType::Backend(BackendError::InvalidArgument))
+                        .message(
+                            "ValidationError: 1 validation error for NvCreateAudioSpeechRequest \
+                             task_type Input should be 'CustomVoice', 'VoiceDesign', 'Base'",
+                        )
+                        .build(),
+                ),
+            };
+        };
+        Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
+
+/// The `/v1/audio/speech` request schema is looser in the frontend than in the
+/// worker (the worker constrains e.g. `task_type` to a model-specific set), so
+/// out-of-range values can only be rejected worker-side. That rejection must
+/// reach the caller as a 4xx carrying the backend's message, not as a 500
+/// about folding the audio stream.
+#[tokio::test]
+async fn test_audio_speech_backend_invalid_argument_returns_4xx() {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder().port(port).build().unwrap();
+    service.enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Audios, true);
+
+    let state = service.state_clone();
+    let manager = state.manager();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task =
+        tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+    wait_for_service_ready(port).await;
+
+    let registry = Registry::new();
+    let card = ModelDeploymentCard::with_name_only("tts-model");
+    manager
+        .add_audios_model(
+            "tts-model",
+            card.mdcsum(),
+            Arc::new(InvalidArgumentAudiosEngine {}),
+        )
+        .unwrap();
+
+    let metrics = state.metrics_clone();
+    metrics.register(&registry).unwrap();
+
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/v1/audio/speech"))
+        .json(&serde_json::json!({
+            "model": "tts-model",
+            "input": "The quick brown fox jumps over the lazy dog.",
+            "voice": "vivian",
+            "language": "English",
+            "task_type": "NotARealTaskType",
+        }))
+        .send()
+        .await
+        .expect("POST /v1/audio/speech");
+
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Backend(InvalidArgument) on /v1/audio/speech must land as HTTP 400; got {status}, body: {text}"
+    );
+    assert!(
+        text.contains("task_type"),
+        "expected the backend validation message to name the offending field; got: {text}"
+    );
+
+    // Backport divergence from main, which asserts `Validation` here.
+    // `ErrorMessage::metric_error_type` arrived with #12092 and is not on this
+    // release branch, so the label falls back to `classify_error_for_metrics`,
+    // which maps 400 to `Internal` unless the message begins with
+    // "Validation:" — the backend's text begins with "ValidationError:".
+    // The status code and message the caller sees are unaffected.
+    // If #12092 is ever backported, restore the `Validation` assertion.
+    compare_counter(
+        &metrics,
+        "tts-model",
+        &Endpoint::Audios,
+        &RequestType::Unary,
+        &Status::Error,
+        &ErrorType::Internal,
+        1,
+    );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}
+
+/// Audio engine that completes normally but reports `status: "failed"`, the
+/// shape a worker uses to signal it could not produce audio.
+struct FailedStatusAudiosEngine {}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > for FailedStatusAudiosEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<dynamo_llm::protocols::openai::audios::NvCreateAudioSpeechRequest>,
+    ) -> Result<
+        ManyOut<Annotated<dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse>>,
+        Error,
+    > {
+        use dynamo_llm::protocols::openai::audios::NvAudioSpeechResponse;
+        let (_request, context) = request.transfer(());
+        let ctx = context.context();
+        let stream = stream! {
+            yield Annotated::from_data(NvAudioSpeechResponse {
+                status: "failed".to_string(),
+                error: Some("voice cloning failed".to_string()),
+                ..NvAudioSpeechResponse::empty()
+            });
+        };
+        Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
+
+/// A worker-reported `status: "failed"` returns 400, so it must meter as a
+/// client error too. The inflight guard defaults to `internal` when unmarked,
+/// which would book this 400 as a server fault.
+#[tokio::test]
+async fn test_audio_speech_failed_status_meters_as_client_error() {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder().port(port).build().unwrap();
+    service.enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Audios, true);
+
+    let state = service.state_clone();
+    let manager = state.manager();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task =
+        tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+    wait_for_service_ready(port).await;
+
+    let registry = Registry::new();
+    let card = ModelDeploymentCard::with_name_only("tts-model");
+    manager
+        .add_audios_model(
+            "tts-model",
+            card.mdcsum(),
+            Arc::new(FailedStatusAudiosEngine {}),
+        )
+        .unwrap();
+
+    let metrics = state.metrics_clone();
+    metrics.register(&registry).unwrap();
+
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/v1/audio/speech"))
+        .json(&serde_json::json!({"model": "tts-model", "input": "hello"}))
+        .send()
+        .await
+        .expect("POST /v1/audio/speech");
+
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {text}");
+    assert!(
+        text.contains("voice cloning failed"),
+        "the worker's failure reason must reach the caller; got: {text}"
+    );
+
+    compare_counter(
+        &metrics,
+        "tts-model",
+        &Endpoint::Audios,
+        &RequestType::Unary,
+        &Status::Error,
+        &ErrorType::Validation,
+        1,
     );
 
     cancel_token.cancel();

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -3,7 +3,7 @@
 
 use super::maybe_error::MaybeError;
 use crate::error::DynamoError;
-use anyhow::{Result, anyhow as error};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 pub trait AnnotationsProvider {
@@ -33,6 +33,20 @@ pub struct Annotated<R> {
 }
 
 impl<R> Annotated<R> {
+    fn cloned_error(&self) -> Option<DynamoError> {
+        self.is_error().then(|| {
+            self.error.clone().unwrap_or_else(|| {
+                DynamoError::msg(
+                    self.comment
+                        .as_ref()
+                        .filter(|comments| !comments.is_empty())
+                        .map(|comments| comments.join(", "))
+                        .unwrap_or_else(|| "unknown error".to_string()),
+                )
+            })
+        })
+    }
+
     /// Create a new annotated stream from the given error string
     pub fn from_error(error: impl Into<String>) -> Self {
         Self {
@@ -74,19 +88,19 @@ impl<R> Annotated<R> {
     /// Convert to a [`Result<Self, String>`]
     /// If [`Self::event`] is "error", return an error message
     pub fn ok(self) -> Result<Self, String> {
-        if let Some(event) = &self.event
-            && event == "error"
-        {
-            // First check DynamoError, then fallback to comment
-            if let Some(ref err) = self.error {
-                return Err(err.to_string());
-            }
-            return Err(self
-                .comment
-                .unwrap_or(vec!["unknown error".to_string()])
-                .join(", "));
+        if let Some(error) = self.cloned_error() {
+            return Err(error.to_string());
         }
         Ok(self)
+    }
+
+    /// Consume the annotation and return its optional payload while preserving
+    /// structured errors.
+    pub fn into_data(self) -> Result<Option<R>, DynamoError> {
+        if let Some(error) = self.cloned_error() {
+            return Err(error);
+        }
+        Ok(self.data)
     }
 
     pub fn is_ok(&self) -> bool {
@@ -130,24 +144,7 @@ impl<R> Annotated<R> {
     }
 
     pub fn into_result(self) -> Result<Option<R>> {
-        match self.data {
-            Some(data) => Ok(Some(data)),
-            None => match self.event {
-                Some(event) if event == "error" => {
-                    // First check DynamoError, then fallback to comment
-                    if let Some(ref err) = self.error {
-                        Err(error!("{}", err))?
-                    } else {
-                        Err(error!(
-                            self.comment
-                                .unwrap_or(vec!["unknown error".to_string()])
-                                .join(", ")
-                        ))?
-                    }
-                }
-                _ => Ok(None),
-            },
-        }
+        self.into_data().map_err(anyhow::Error::new)
     }
 }
 
@@ -168,22 +165,7 @@ where
     }
 
     fn err(&self) -> Option<DynamoError> {
-        if self.is_error() {
-            // First check DynamoError field
-            if let Some(ref error) = self.error {
-                return Some(error.clone());
-            }
-
-            // Fallback to comment-based error
-            if let Some(comment) = &self.comment
-                && !comment.is_empty()
-            {
-                return Some(DynamoError::msg(comment.join("; ")));
-            }
-            Some(DynamoError::msg("unknown error"))
-        } else {
-            None
-        }
+        self.cloned_error()
     }
 }
 
@@ -214,6 +196,27 @@ mod tests {
         assert!(annotated.is_err());
         let err = annotated.err().unwrap();
         assert!(err.to_string().contains("connection lost"));
+    }
+
+    #[test]
+    fn test_comment_only_error_fallback() {
+        for (comments, expected) in [
+            (vec![], "unknown error"),
+            (
+                vec!["first".to_string(), "second".to_string()],
+                "first, second",
+            ),
+        ] {
+            let annotated = Annotated::<String> {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: Some(comments),
+                error: None,
+            };
+
+            assert_eq!(annotated.err().unwrap().message(), expected);
+        }
     }
 
     #[test]
@@ -252,6 +255,24 @@ mod tests {
         let result = annotated.ok();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("connection lost"));
+    }
+
+    #[test]
+    fn test_into_data_preserves_error_type() {
+        use crate::error::{BackendError, ErrorType};
+
+        let error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid request")
+            .build();
+        let annotated = Annotated::<String>::from_err(error);
+
+        let error = annotated.into_data().unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid request");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Cherry-pick #12807 and #12832 to `release/1.4.0`, as a single PR because #12832 does not build without #12807.
- An invalid `task_type` on `/v1/audio/speech` returned HTTP 500 `"Failed to fold audio stream"` instead of a 4xx naming the field. The worker's message reached the frontend intact; only its *classification* was lost during stream folding, leaving the handler nothing to choose a status from.
- #12807 makes stream aggregation preserve the typed `DynamoError`; #12832 routes the audio handler's fold error through `ErrorMessage::from_anyhow` so `Backend(InvalidArgument)` becomes 400 with the backend's message, and fixes three metrics paths in the same handler.

Fixes DYN-3779

## Original PRs

- Main PR: #12807 — `refactor(llm): preserve typed aggregation errors`
  - Merge commit: `eb2198a82f434fc9f37ca87c66d2e460ecf7860c`
  - Backport commit: `11cd184576`
- Main PR: #12832 — `fix(frontend): return 4xx for backend request rejections on /v1/audio/speech`
  - Merge commit: `9eafac64592dbeebe94387d158b791c6557dc544`
  - Backport commit: `0dd8fb1e86`

## Conflict resolution

Three conflicts, all from `release/1.4.0` predating structure on `main`:

1. **`classify/aggregator.rs`, `pooling/aggregator.rs`** (modify/delete) — those endpoints do not exist on this branch (absent from `protocols/openai.rs`). Both files dropped from the backport rather than introduced.
2. **`stream_aggregator.rs`** (content) — `release/1.4.0` had `delta.ok()?` where #12807 introduces `delta.into_data()?`. Took #12807's version; the `Annotated::into_data` it needs is included in this cherry-pick via `lib/runtime/src/protocols/annotated.rs`.
3. **`tests/http-service.rs`** (content) — #12832 anchors its 213 added lines after `test_streaming_responses_returns_4xx_on_backend_invalid_argument`, which does not exist here. Block appended instead; `use dynamo_runtime::error::DynamoError` added, as this branch's import list lacks it.

## Behaviour divergence from main — please read

One assertion in `test_audio_speech_backend_invalid_argument_returns_4xx` had to be adapted, and it reflects a real difference on this branch.

`ErrorMessage::metric_error_type` arrived with #12092 (`fix(frontend): reject over-context requests before streaming`), which is not on `release/1.4.0` and is far too large to drag in — 1598 lines across the preprocessor, token-budget parity, and Python tests. Without that field, `extract_error_type_from_response` falls back to `classify_error_for_metrics`, which maps 400 to `Internal` unless the message begins with `"Validation:"`; the backend's text begins with `"ValidationError:"`.

So on this branch the fold-path 400 meters as `error_type=internal` rather than `validation`. The assertion was changed to match, with a comment naming the cause and the condition for restoring it.

**The caller-visible fix is unaffected** — status code and message are identical to `main`. Only the metric label is coarser. The `failed`-branch test still asserts `Validation`, because that path calls `inflight.mark_error(ErrorType::Validation)` explicitly rather than deriving the label from the response.

## Validation

```
cargo test -p dynamo-llm --lib                                1871 passed, 0 failed
cargo test -p dynamo-llm --test http-service                    10 passed, 0 failed
cargo test -p dynamo-llm --test aggregators                      8 passed, 0 failed
cargo clippy -p dynamo-llm --no-deps --all-targets -- -D warnings    clean
cargo fmt --all -- --check                                           clean
git diff --check origin/release/1.4.0..HEAD                          clean
pre-commit (via commit hooks)                                        passed
```

Both audio tests were confirmed to exercise the fix rather than pass incidentally: on `main` I verified each fails without its corresponding change.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->