### PR TITLE
fix(router): accept relay endpoint futures [DYN-3795]

### DIFF
--- a/components/src/dynamo/kv_dc_relay/__main__.py
+++ b/components/src/dynamo/kv_dc_relay/__main__.py
@@ -76,7 +76,7 @@ async def worker(runtime: DistributedRuntime) -> None:
     try:
         if hasattr(relay, "stats") and hasattr(relay, "snapshot"):
             endpoint_tasks.append(
-                asyncio.create_task(
+                asyncio.ensure_future(
                     runtime.endpoint(
                         f"{namespace}.{diagnostics_component}.stats"
                     ).serve_endpoint(
@@ -87,7 +87,7 @@ async def worker(runtime: DistributedRuntime) -> None:
                 )
             )
             endpoint_tasks.append(
-                asyncio.create_task(
+                asyncio.ensure_future(
                     runtime.endpoint(
                         f"{namespace}.{diagnostics_component}.snapshot"
                     ).serve_endpoint(
@@ -103,7 +103,7 @@ async def worker(runtime: DistributedRuntime) -> None:
                 "enable the ckf-diagnostics Cargo feature to expose them"
             )
         endpoint_tasks.append(
-            asyncio.create_task(
+            asyncio.ensure_future(
                 runtime.endpoint(
                     f"{namespace}.{diagnostics_component}.health"
                 ).serve_endpoint(


### PR DESCRIPTION
## Summary

Replace `asyncio.create_task` with `asyncio.ensure_future` for the KV DC Relay endpoint servers.

`Endpoint.serve_endpoint` returns an asyncio Future through the Python binding, while `create_task` only accepts coroutines. The mismatch raises `TypeError` during relay startup before its health endpoint can serve. `ensure_future` accepts the returned Future and preserves the existing cancellation and shutdown flow.

## Validation

- `git diff --check`
- Commit hooks: isort, Black, Flake8, codespell, and Ruff
- Not run: builds or test suites

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting diagnostic endpoint servers for statistics, snapshots, and health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->