### PR TITLE
feat(mocker): support priority-aware controlled offline replay

### DIFF
--- a/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
+++ b/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
@@ -103,9 +103,10 @@ Example:
 {"timestamp": 0, "input_length": 6755, "output_length": 500, "hash_ids": [0, 1, 2, 3]}
 ```
 
-Rows without `session_id` are independent requests. Priority fields affect only pending requests
-when `--router-mode kv_router` is active; they do not change round-robin routing or execution order
-inside a selected engine.
+Rows without `session_id` are independent requests. `priority` affects pending requests when
+`--router-mode kv_router` is active and execution order inside a selected vLLM mocker engine; higher
+values run first. `strict_priority` affects the KV router pending queue only. Neither field changes
+round-robin routing.
 
 ### Multi-turn sessions
 

--- a/lib/data-gen/src/lib.rs
+++ b/lib/data-gen/src/lib.rs
@@ -15,7 +15,7 @@ pub mod request_trace;
 pub mod satf;
 
 pub use mooncake::{
-    AgenticMooncakeRow, AgenticToolEvent, MooncakeJsonlWriter, MooncakeRow, RollingHashIdMapper,
-    WriterStats, hash_token_blocks, ids_for_sequence_hashes, require_positive,
-    sequence_hashes_for_tokens, try_hash_token_blocks, write_empty_files,
+    AgenticMooncakeRow, AgenticToolEvent, MooncakeJsonlWriter, MooncakeRoutingConstraints,
+    MooncakeRow, RollingHashIdMapper, WriterStats, hash_token_blocks, ids_for_sequence_hashes,
+    require_positive, sequence_hashes_for_tokens, try_hash_token_blocks, write_empty_files,
 };

--- a/lib/data-gen/src/mooncake.rs
+++ b/lib/data-gen/src/mooncake.rs
@@ -18,6 +18,7 @@ use anyhow::{Context, Result, bail};
 use dynamo_kv_hashing::{Request, compute_hash_v2, compute_next_sequence_hash};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
@@ -61,6 +62,17 @@ pub struct MooncakeRow {
     pub strict_priority: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_class: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing_constraints: Option<MooncakeRoutingConstraints>,
+}
+
+/// Request-level worker-taint constraints used by KV-router replay.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct MooncakeRoutingConstraints {
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub required_taints: HashSet<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub preferred_taints: HashMap<String, f32>,
 }
 
 /// One row of an agentic Mooncake replay trace.
@@ -98,6 +110,8 @@ pub struct AgenticMooncakeRow {
     pub strict_priority: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_class: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing_constraints: Option<MooncakeRoutingConstraints>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_kind: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -283,8 +283,8 @@ pub struct DirectRequest {
     pub uuid: Option<Uuid>,
     pub dp_rank: u32,
     pub arrival_timestamp_ms: Option<f64>,
-    /// TODO: Replay maps this to router queue priority only; mock-engine
-    /// scheduling does not consume it yet.
+    /// Unified Dynamo scheduling priority. The vLLM mocker schedules higher
+    /// values first; replay also maps this into router queue priority.
     #[serde(default, skip_serializing_if = "is_zero_i32")]
     pub priority: i32,
     /// NOTE: Strict priority orders the router's pending queue only. It does

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -4,6 +4,7 @@
 use derive_builder::Builder;
 use dynamo_kv_router::config::RouterQueuePolicy;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -641,6 +642,8 @@ struct MockEngineArgsSerde {
     zmq_replay_port: OptionalConfigValue<u16>,
     preemption_mode: OptionalConfigValue<String>,
     router_queue_policy: OptionalConfigValue<String>,
+    worker_taints: OptionalConfigValue<Vec<HashSet<String>>>,
+    worker_max_num_seqs: OptionalConfigValue<Vec<usize>>,
     sglang: OptionalConfigValue<SglangArgs>,
     trtllm: OptionalConfigValue<TrtllmArgs>,
     #[serde(rename = "has_perf_model")]
@@ -983,6 +986,16 @@ pub struct MockEngineArgs {
     /// Optional replay-only override for the router queue policy.
     #[builder(default = "None")]
     pub router_queue_policy: Option<RouterQueuePolicy>,
+
+    /// Replay-only taints published by each logical worker, indexed by worker ID.
+    /// An empty vector leaves every replay worker untainted.
+    #[builder(default)]
+    pub worker_taints: Vec<HashSet<String>>,
+
+    /// Replay-only active-sequence limits indexed by logical worker ID.
+    /// An empty vector uses `max_num_seqs` for every replay worker.
+    #[builder(default)]
+    pub worker_max_num_seqs: Vec<usize>,
 
     /// SGLang-specific configuration. Only used when `engine_type == Sglang`.
     #[builder(default = "None")]
@@ -1343,6 +1356,25 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
                 .transpose()?;
             builder = builder.router_queue_policy(router_queue_policy);
         }
+        if let Some(worker_taints) = compat.worker_taints.into_non_null("worker_taints")? {
+            if worker_taints
+                .iter()
+                .flatten()
+                .any(|taint| taint.trim().is_empty())
+            {
+                return Err("worker_taints must not contain empty strings".to_string());
+            }
+            builder = builder.worker_taints(worker_taints);
+        }
+        if let Some(worker_max_num_seqs) = compat
+            .worker_max_num_seqs
+            .into_non_null("worker_max_num_seqs")?
+        {
+            if worker_max_num_seqs.contains(&0) {
+                return Err("worker_max_num_seqs values must be positive".to_string());
+            }
+            builder = builder.worker_max_num_seqs(worker_max_num_seqs);
+        }
         if let Some(sglang) = compat.sglang.into_nullable() {
             builder = builder.sglang(sglang);
         }
@@ -1693,6 +1725,20 @@ mod tests {
         let serialized = serde_json::to_value(args).unwrap();
 
         assert!(serialized.get("g1_backend").is_none());
+    }
+
+    #[test]
+    fn test_mock_engine_args_accepts_per_worker_sequence_limits() {
+        let args = MockEngineArgs::from_json_str(
+            &json!({"worker_max_num_seqs": [24, 24, 64, 64]}).to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(args.worker_max_num_seqs, vec![24, 24, 64, 64]);
+        let error =
+            MockEngineArgs::from_json_str(&json!({"worker_max_num_seqs": [24, 0]}).to_string())
+                .unwrap_err();
+        assert!(error.to_string().contains("must be positive"));
     }
 
     #[test]

--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
 use anyhow::{Context, Result, anyhow, bail};
+use dynamo_kv_router::protocols::RoutingConstraints;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rustc_hash::FxHashMap;
@@ -12,7 +13,7 @@ use uuid::Uuid;
 
 use super::trace::validate_synthesizable_prompt;
 use super::types::{
-    AgenticTrace, CompactReadyTurn, ReadyTurn, ReplayRequestHashes, ReplayRequestPayload, Trace,
+    AgenticTrace, ReadyReplayTurn, ReadyTurn, ReplayRequestHashes, ReplayRequestPayload, Trace,
 };
 use super::{SYNTHETIC_OUTPUT_SEED, planned_output_token_ids};
 use crate::common::protocols::DirectRequest;
@@ -128,6 +129,7 @@ struct TurnRuntime {
     priority: i32,
     strict_priority: u32,
     policy_class: Option<String>,
+    routing_constraints: RoutingConstraints,
     #[cfg(any(test, feature = "replay-bench"))]
     deterministic_request_id: Option<Uuid>,
 }
@@ -467,6 +469,7 @@ impl WorkloadDriver {
                     priority: turn.priority,
                     strict_priority: turn.strict_priority,
                     policy_class: turn.policy_class,
+                    routing_constraints: turn.routing_constraints,
                     #[cfg(feature = "replay-bench")]
                     deterministic_request_id: crate::replay::canonical_replay_active()
                         .then(|| Uuid::from_u128(session_index as u128 + 1)),
@@ -577,6 +580,7 @@ impl WorkloadDriver {
                             priority: turn.priority,
                             strict_priority: turn.strict_priority,
                             policy_class: turn.policy_class,
+                            routing_constraints: turn.routing_constraints,
                             #[cfg(feature = "replay-bench")]
                             deterministic_request_id,
                             #[cfg(all(test, not(feature = "replay-bench")))]
@@ -687,13 +691,14 @@ impl WorkloadDriver {
     }
 
     pub fn pop_ready(&mut self, now_ms: f64, limit: usize) -> Vec<ReadyTurn> {
-        self.pop_ready_compact(now_ms, limit)
+        self.pop_ready_replay(now_ms, limit)
             .into_iter()
-            .map(CompactReadyTurn::into_ready_turn)
+            .map(ReadyReplayTurn::into_ready_turn)
             .collect()
     }
 
-    pub(crate) fn pop_ready_compact(&mut self, now_ms: f64, limit: usize) -> Vec<CompactReadyTurn> {
+    /// Pop ready turns without materializing compact Mooncake prompts.
+    pub fn pop_ready_replay(&mut self, now_ms: f64, limit: usize) -> Vec<ReadyReplayTurn> {
         let effective_limit = self.policy.dispatch_limit(limit, self.in_flight.len());
         if effective_limit == 0 {
             return Vec::new();
@@ -752,6 +757,7 @@ impl WorkloadDriver {
                         input_length,
                         hash_ids,
                         self.trace_block_size,
+                        turn.routing_constraints.clone(),
                     );
                     // The router needs engine-block hashes at arrival, but it
                     // does not need to retain the expanded prompt. Materialize
@@ -776,17 +782,20 @@ impl WorkloadDriver {
                     let replay_hashes = self.include_replay_hashes.then(|| {
                         ReplayRequestHashes::from_tokens(&request_tokens, self.engine_block_size)
                     });
-                    let request = ReplayRequestPayload::materialized(DirectRequest {
-                        tokens: request_tokens,
-                        max_output_tokens: turn.max_output_tokens,
-                        output_token_ids: turn.output_token_ids.clone(),
-                        uuid: Some(request_uuid),
-                        dp_rank: 0,
-                        arrival_timestamp_ms,
-                        priority: turn.priority,
-                        strict_priority: turn.strict_priority,
-                        policy_class: turn.policy_class.clone(),
-                    });
+                    let request = ReplayRequestPayload::materialized_with_constraints(
+                        DirectRequest {
+                            tokens: request_tokens,
+                            max_output_tokens: turn.max_output_tokens,
+                            output_token_ids: turn.output_token_ids.clone(),
+                            uuid: Some(request_uuid),
+                            dp_rank: 0,
+                            arrival_timestamp_ms,
+                            priority: turn.priority,
+                            strict_priority: turn.strict_priority,
+                            policy_class: turn.policy_class.clone(),
+                        },
+                        turn.routing_constraints.clone(),
+                    );
                     (request, replay_hashes)
                 }
             };
@@ -800,7 +809,7 @@ impl WorkloadDriver {
                     emitted_output_tokens: 0,
                 },
             );
-            emitted.push(CompactReadyTurn {
+            emitted.push(ReadyReplayTurn {
                 request_uuid,
                 session_id: session.session_id.clone(),
                 turn_index,
@@ -812,6 +821,10 @@ impl WorkloadDriver {
             });
         }
         emitted
+    }
+
+    pub(crate) fn pop_ready_compact(&mut self, now_ms: f64, limit: usize) -> Vec<ReadyReplayTurn> {
+        self.pop_ready_replay(now_ms, limit)
     }
 
     pub fn on_output_token(&mut self, request_uuid: Uuid, token_id: u32) -> Result<()> {
@@ -1566,6 +1579,7 @@ mod tests {
                         priority: 3,
                         strict_priority: 4,
                         policy_class: None,
+                        routing_constraints: Default::default(),
                     },
                     TurnTrace {
                         input_length: 3,
@@ -1577,6 +1591,7 @@ mod tests {
                         priority: -2,
                         strict_priority: 7,
                         policy_class: None,
+                        routing_constraints: Default::default(),
                     },
                 ],
             }],

--- a/lib/mocker/src/loadgen/mod.rs
+++ b/lib/mocker/src/loadgen/mod.rs
@@ -11,13 +11,12 @@ use rand::rngs::StdRng;
 
 pub use driver::WorkloadDriver;
 pub use trace::validate_trace_files;
-pub(crate) use types::ReplayRequestPayload;
 pub use types::{
     AgenticTrace, AgenticTurnTrace, ArrivalSpec, DelaySpec, DynamoRequestTrace, LengthSpec,
-    OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY, OUTPUT_REPLAY_ID_ANNOTATION_KEY, ReadyTurn,
-    ReplayRequestHashes, RouterSequence, SequenceHashMode, SessionPartitionSpec, SessionTrace,
-    SyntheticTraceSpec, Trace, TraceFileFormat, TurnTrace, effective_replay_key,
-    output_replay_id_annotation,
+    OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY, OUTPUT_REPLAY_ID_ANNOTATION_KEY, ReadyReplayTurn,
+    ReadyTurn, ReplayRequestHashes, ReplayRequestPayload, RouterSequence, SequenceHashMode,
+    SessionPartitionSpec, SessionTrace, SyntheticTraceSpec, Trace, TraceFileFormat, TurnTrace,
+    effective_replay_key, output_replay_id_annotation,
 };
 
 pub(super) const SYNTHETIC_OUTPUT_SEED: u64 = 0xD37A_0A7E_5EED;

--- a/lib/mocker/src/loadgen/tests.rs
+++ b/lib/mocker/src/loadgen/tests.rs
@@ -522,6 +522,7 @@ fn test_turn_to_direct_request_repeats_hash_ids_by_block_size() {
         priority: -2,
         strict_priority: 8,
         policy_class: None,
+        routing_constraints: Default::default(),
     };
 
     let request = turn

--- a/lib/mocker/src/loadgen/trace.rs
+++ b/lib/mocker/src/loadgen/trace.rs
@@ -12,10 +12,10 @@ use dynamo_data_gen::request_trace::{
     load::{RequestTraceMode, load_request_trace_records},
     mooncake::lower_mooncake_rows,
 };
-use dynamo_data_gen::{AgenticMooncakeRow, MooncakeRow};
+use dynamo_data_gen::{AgenticMooncakeRow, MooncakeRoutingConstraints, MooncakeRow};
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::protocols::{
-    ExternalSequenceBlockHash, WorkerId, XXH3_SEED, compute_seq_hash_for_block,
+    ExternalSequenceBlockHash, RoutingConstraints, WorkerId, XXH3_SEED, compute_seq_hash_for_block,
 };
 use dynamo_tokens::compute_hash_v2;
 use rand::rngs::StdRng;
@@ -32,6 +32,17 @@ use super::types::{
 };
 use super::{SYNTHETIC_OUTPUT_SEED, planned_output_token_ids};
 use crate::common::protocols::DirectRequest;
+
+fn replay_routing_constraints(
+    constraints: Option<MooncakeRoutingConstraints>,
+) -> RoutingConstraints {
+    constraints.map_or_else(RoutingConstraints::default, |constraints| {
+        RoutingConstraints {
+            required_taints: constraints.required_taints,
+            preferred_taints: constraints.preferred_taints,
+        }
+    })
+}
 
 #[derive(Debug, Deserialize)]
 struct RawAppliedComputeAgenticRecord {
@@ -340,6 +351,7 @@ impl MooncakeTraceBuilder {
         let priority = raw.priority.unwrap_or(0);
         let strict_priority = raw.strict_priority.unwrap_or(0);
         let policy_class = raw.policy_class.clone();
+        let routing_constraints = replay_routing_constraints(raw.routing_constraints);
 
         let session_index = *self
             .session_indices
@@ -422,6 +434,7 @@ impl MooncakeTraceBuilder {
             priority,
             strict_priority,
             policy_class,
+            routing_constraints,
         });
         if let Some(timestamp_ms) = timestamp_ms {
             self.last_timestamps[session_index] = Some(timestamp_ms);
@@ -1245,6 +1258,7 @@ impl AgenticTraceBuilder {
                 line_idx,
             )
         });
+        let routing_constraints = replay_routing_constraints(raw.routing_constraints);
         self.turns.push(AgenticTurnTrace {
             replay_key,
             request_id: raw.request_id,
@@ -1260,6 +1274,7 @@ impl AgenticTraceBuilder {
             priority: raw.priority.unwrap_or(0),
             strict_priority: raw.strict_priority.unwrap_or(0),
             policy_class: raw.policy_class,
+            routing_constraints,
             wait_for: raw.wait_for,
             prefix_reset: raw.prefix_reset.unwrap_or(false),
         });

--- a/lib/mocker/src/loadgen/types.rs
+++ b/lib/mocker/src/loadgen/types.rs
@@ -3,8 +3,8 @@
 
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::protocols::{
-    BlockHashOptions, ExternalSequenceBlockHash, WorkerId, compute_block_hash_for_seq,
-    compute_seq_hash_for_block,
+    BlockHashOptions, ExternalSequenceBlockHash, RoutingConstraints, WorkerId,
+    compute_block_hash_for_seq, compute_seq_hash_for_block,
 };
 use dynamo_tokens::SequenceHash;
 use uuid::Uuid;
@@ -99,6 +99,7 @@ pub struct TurnTrace {
     pub priority: i32,
     pub strict_priority: u32,
     pub policy_class: Option<String>,
+    pub routing_constraints: RoutingConstraints,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -115,6 +116,7 @@ pub struct AgenticTurnTrace {
     pub priority: i32,
     pub strict_priority: u32,
     pub policy_class: Option<String>,
+    pub routing_constraints: RoutingConstraints,
     pub wait_for: Vec<String>,
     pub prefix_reset: bool,
 }
@@ -203,6 +205,7 @@ pub struct ReadyTurn {
     pub scheduled_ready_at_ms: f64,
     pub replay_hashes: Option<ReplayRequestHashes>,
     pub request: DirectRequest,
+    pub routing_constraints: RoutingConstraints,
 }
 
 /// A request whose prompt may still be represented by one hash id per trace
@@ -210,19 +213,33 @@ pub struct ReadyTurn {
 /// prefill router queues the request and materializes tokens only when a
 /// worker admits it.
 #[derive(Debug)]
-pub(crate) enum ReplayRequestPayload {
-    Materialized(DirectRequest),
+pub enum ReplayRequestPayload {
+    Materialized {
+        request: DirectRequest,
+        routing_constraints: RoutingConstraints,
+    },
     Deferred {
         request_metadata: DirectRequest,
         input_length: usize,
         hash_ids: Vec<u32>,
         trace_block_size: usize,
+        routing_constraints: RoutingConstraints,
     },
 }
 
 impl ReplayRequestPayload {
     pub(crate) fn materialized(request: DirectRequest) -> Self {
-        Self::Materialized(request)
+        Self::materialized_with_constraints(request, RoutingConstraints::default())
+    }
+
+    pub(crate) fn materialized_with_constraints(
+        request: DirectRequest,
+        routing_constraints: RoutingConstraints,
+    ) -> Self {
+        Self::Materialized {
+            request,
+            routing_constraints,
+        }
     }
 
     pub(super) fn deferred(
@@ -230,6 +247,7 @@ impl ReplayRequestPayload {
         input_length: usize,
         hash_ids: Vec<u32>,
         trace_block_size: usize,
+        routing_constraints: RoutingConstraints,
     ) -> Self {
         debug_assert!(request_metadata.tokens.is_empty());
         Self::Deferred {
@@ -237,19 +255,33 @@ impl ReplayRequestPayload {
             input_length,
             hash_ids,
             trace_block_size,
+            routing_constraints,
+        }
+    }
+
+    pub(crate) fn routing_constraints(&self) -> &RoutingConstraints {
+        match self {
+            Self::Materialized {
+                routing_constraints,
+                ..
+            }
+            | Self::Deferred {
+                routing_constraints,
+                ..
+            } => routing_constraints,
         }
     }
 
     pub(crate) fn input_length(&self) -> usize {
         match self {
-            Self::Materialized(request) => request.tokens.len(),
+            Self::Materialized { request, .. } => request.tokens.len(),
             Self::Deferred { input_length, .. } => *input_length,
         }
     }
 
     pub(crate) fn metadata(&self) -> &DirectRequest {
         match self {
-            Self::Materialized(request) => request,
+            Self::Materialized { request, .. } => request,
             Self::Deferred {
                 request_metadata, ..
             } => request_metadata,
@@ -258,7 +290,7 @@ impl ReplayRequestPayload {
 
     pub(crate) fn metadata_mut(&mut self) -> &mut DirectRequest {
         match self {
-            Self::Materialized(request) => request,
+            Self::Materialized { request, .. } => request,
             Self::Deferred {
                 request_metadata, ..
             } => request_metadata,
@@ -267,21 +299,21 @@ impl ReplayRequestPayload {
 
     pub(crate) fn materialized_tokens(&self) -> Option<&[u32]> {
         match self {
-            Self::Materialized(request) => Some(&request.tokens),
+            Self::Materialized { request, .. } => Some(&request.tokens),
             Self::Deferred { .. } => None,
         }
     }
 
     pub(crate) fn materialized_request(&self) -> Option<&DirectRequest> {
         match self {
-            Self::Materialized(request) => Some(request),
+            Self::Materialized { request, .. } => Some(request),
             Self::Deferred { .. } => None,
         }
     }
 
     pub(crate) fn prompt_tokens(&self) -> Vec<u32> {
         match self {
-            Self::Materialized(request) => request.tokens.clone(),
+            Self::Materialized { request, .. } => request.tokens.clone(),
             Self::Deferred {
                 input_length,
                 hash_ids,
@@ -293,12 +325,13 @@ impl ReplayRequestPayload {
 
     pub(crate) fn into_direct_request(self) -> DirectRequest {
         match self {
-            Self::Materialized(request) => request,
+            Self::Materialized { request, .. } => request,
             Self::Deferred {
                 mut request_metadata,
                 input_length,
                 hash_ids,
                 trace_block_size,
+                ..
             } => {
                 request_metadata.tokens =
                     synthesize_validated_trace_tokens(input_length, &hash_ids, trace_block_size);
@@ -309,27 +342,32 @@ impl ReplayRequestPayload {
 
     pub(crate) fn materialize(&mut self) -> Option<&DirectRequest> {
         if matches!(self, Self::Deferred { .. }) {
-            let payload = std::mem::replace(self, Self::Materialized(DirectRequest::default()));
-            *self = Self::Materialized(payload.into_direct_request());
+            let constraints = self.routing_constraints().clone();
+            let payload = std::mem::replace(
+                self,
+                Self::materialized_with_constraints(DirectRequest::default(), constraints.clone()),
+            );
+            *self = Self::materialized_with_constraints(payload.into_direct_request(), constraints);
         }
         self.materialized_request()
     }
 }
 
 #[derive(Debug)]
-pub(crate) struct CompactReadyTurn {
-    pub(crate) request_uuid: Uuid,
-    pub(crate) session_id: String,
-    pub(crate) turn_index: usize,
-    pub(crate) replay_key: Option<String>,
-    pub(crate) scheduled_ready_at_ms: f64,
-    pub(crate) replay_hashes: Option<ReplayRequestHashes>,
-    pub(crate) emit_session_metadata: bool,
-    pub(crate) request: ReplayRequestPayload,
+pub struct ReadyReplayTurn {
+    pub request_uuid: Uuid,
+    pub session_id: String,
+    pub turn_index: usize,
+    pub replay_key: Option<String>,
+    pub scheduled_ready_at_ms: f64,
+    pub replay_hashes: Option<ReplayRequestHashes>,
+    pub emit_session_metadata: bool,
+    pub request: ReplayRequestPayload,
 }
 
-impl CompactReadyTurn {
+impl ReadyReplayTurn {
     pub(crate) fn into_ready_turn(self) -> ReadyTurn {
+        let routing_constraints = self.request.routing_constraints().clone();
         ReadyTurn {
             request_uuid: self.request_uuid,
             session_id: self.session_id,
@@ -339,6 +377,7 @@ impl CompactReadyTurn {
             scheduled_ready_at_ms: self.scheduled_ready_at_ms,
             replay_hashes: self.replay_hashes,
             request: self.request.into_direct_request(),
+            routing_constraints,
         }
     }
 }

--- a/lib/mocker/src/loadgen/types.rs
+++ b/lib/mocker/src/loadgen/types.rs
@@ -259,7 +259,22 @@ impl ReplayRequestPayload {
         }
     }
 
-    pub(crate) fn routing_constraints(&self) -> &RoutingConstraints {
+    /// Routing constraints attached to this replay request.
+    pub fn routing_constraints(&self) -> &RoutingConstraints {
+        match self {
+            Self::Materialized {
+                routing_constraints,
+                ..
+            }
+            | Self::Deferred {
+                routing_constraints,
+                ..
+            } => routing_constraints,
+        }
+    }
+
+    /// Mutable routing constraints for an external controlled-replay source.
+    pub fn routing_constraints_mut(&mut self) -> &mut RoutingConstraints {
         match self {
             Self::Materialized {
                 routing_constraints,

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -173,11 +173,14 @@ pub use offline::{
     CanonicalExecutionMetadata, CanonicalReplayCoverage, CanonicalReplayMetadata,
     CanonicalReplayRecord, CanonicalReplayRouterMode, CanonicalReplayTopology,
     CanonicalRouterMetadata, CanonicalSemanticFeatures, CanonicalSlaMetadata,
-    CanonicalSyntheticSpec, CanonicalWorkloadMetadata, EnginePressureState, KvIngestBoundary,
-    KvIngestBoundaryStats, KvIngestEvidence, LifecycleOperation, OfflineRuntimeEvidence,
-    PressureEvidence, PressureKind, PressureRecord, WorkerLifecycleTransition,
+    CanonicalSyntheticSpec, CanonicalWorkloadMetadata, ControlledReplayOptions,
+    EnginePressureState, KvIngestBoundary, KvIngestBoundaryStats, KvIngestEvidence,
+    LifecycleOperation, OfflineRuntimeEvidence, PressureEvidence, PressureKind, PressureRecord,
+    ReplayWorkSource, ReplayWorkSourceContext, ReplayWorkSubmission, WorkerLifecycleTransition,
     WorkerLifecycleTransitionKind, WorkerPool, WorkerPoolState, canonical_engine_pool_metadata,
-    canonical_router_metadata, canonical_topology, with_runtime_evidence,
+    canonical_router_metadata, canonical_topology, simulate_controlled_aggregated,
+    simulate_controlled_aggregated_kv_router_with_options,
+    simulate_controlled_aggregated_with_options, with_runtime_evidence,
 };
 pub use validate::validate_replay_args_mode;
 

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -180,7 +180,8 @@ pub use offline::{
     WorkerLifecycleTransitionKind, WorkerPool, WorkerPoolState, canonical_engine_pool_metadata,
     canonical_router_metadata, canonical_topology, simulate_controlled_aggregated,
     simulate_controlled_aggregated_kv_router_with_options,
-    simulate_controlled_aggregated_with_options, with_runtime_evidence,
+    simulate_controlled_aggregated_with_options,
+    simulate_controlled_heterogeneous_aggregated_kv_router_with_options, with_runtime_evidence,
 };
 pub use validate::validate_replay_args_mode;
 

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -112,20 +112,29 @@ impl<Events: EngineEventBatch> AggregatedPlacement<Events, ()>
     }
 }
 
-pub(in crate::replay) type RoundRobinAggRuntime =
-    AggRuntimeImpl<AggregatedRoundRobinPlacement<()>, NoEngineEvents, NoReplayMetadata>;
+pub(in crate::replay) type RoundRobinAggRuntime = AggRuntimeImpl<
+    AggregatedRoundRobinPlacement<()>,
+    NoEngineEvents,
+    NoReplayMetadata,
+    AdmissionQueue<NoReplayMetadata>,
+>;
 
-pub(in crate::replay) struct AggRuntimeImpl<PlacementPolicyImpl, Observation, Metadata>
-where
+pub(in crate::replay) struct AggRuntimeImpl<
+    PlacementPolicyImpl,
+    Observation,
+    Metadata,
+    Admission = AdmissionQueue<Metadata>,
+> where
     Observation: ReplayEngineObservation,
     Metadata: ReplayAdmissionMetadata,
     PlacementPolicyImpl: AggregatedPlacement<Observation::Batch, Metadata>,
+    Admission: CoreAdmissionSource<Request = ReplayRequestPayload, Metadata = Metadata>,
 {
     now_ms: f64,
     dp_size: u32,
     next_event_seq: u64,
     next_scaling_tick_ordinal: u64,
-    admission: AdmissionQueue<Metadata>,
+    admission: Admission,
     requests: FxHashMap<Uuid, AggRequestState>,
     engine: EngineComponent<Observation>,
     collector: TraceCollector,
@@ -152,7 +161,14 @@ where
     stepped: bool,
 }
 
-impl AggRuntimeImpl<AggregatedRoundRobinPlacement<()>, NoEngineEvents, NoReplayMetadata> {
+impl
+    AggRuntimeImpl<
+        AggregatedRoundRobinPlacement<()>,
+        NoEngineEvents,
+        NoReplayMetadata,
+        AdmissionQueue<NoReplayMetadata>,
+    >
+{
     pub(in crate::replay) fn new_round_robin(
         args: &MockEngineArgs,
         pending: VecDeque<DirectRequest>,
@@ -182,16 +198,17 @@ impl AggRuntimeImpl<AggregatedRoundRobinPlacement<()>, NoEngineEvents, NoReplayM
     }
 }
 
-impl<PlacementPolicyImpl, Observation, Metadata>
-    AggRuntimeImpl<PlacementPolicyImpl, Observation, Metadata>
+impl<PlacementPolicyImpl, Observation, Metadata, Admission>
+    AggRuntimeImpl<PlacementPolicyImpl, Observation, Metadata, Admission>
 where
     Observation: ReplayEngineObservation,
     Metadata: ReplayAdmissionMetadata,
     PlacementPolicyImpl: AggregatedPlacement<Observation::Batch, Metadata>,
+    Admission: CoreAdmissionSource<Request = ReplayRequestPayload, Metadata = Metadata>,
 {
     pub(in crate::replay::offline) fn new_composed(
         args: &MockEngineArgs,
-        admission: AdmissionQueue<Metadata>,
+        admission: Admission,
         num_workers: usize,
         create_placement: impl FnOnce(
             &MockEngineArgs,
@@ -199,6 +216,12 @@ where
         ) -> anyhow::Result<PlacementPolicyImpl>,
     ) -> anyhow::Result<Self> {
         let args = args.clone().normalized()?;
+        anyhow::ensure!(
+            args.worker_max_num_seqs.is_empty() || args.worker_max_num_seqs.len() == num_workers,
+            "worker_max_num_seqs must be empty or contain exactly one entry per replay worker: got {} for {} workers",
+            args.worker_max_num_seqs.len(),
+            num_workers,
+        );
         let progress = ReplayProgress::new(
             CoreAdmissionSource::total_requests(&admission),
             "offline replay",
@@ -424,9 +447,9 @@ where
         let input_length = request.input_length();
         let output_length = request.metadata().max_output_tokens;
         request.metadata_mut().uuid = Some(uuid);
-        if matches!(self.admission.mode(), ReplayMode::Concurrency { .. }) {
-            request.metadata_mut().arrival_timestamp_ms = Some(arrival_time_ms);
-        }
+        // The source is authoritative for logical arrival time. This also removes
+        // the runtime's dependency on the concrete AdmissionQueue replay mode.
+        request.metadata_mut().arrival_timestamp_ms = Some(arrival_time_ms);
 
         self.collector
             .on_arrival(uuid, arrival_time_ms, input_length, output_length);
@@ -521,7 +544,7 @@ where
     fn next_timestamp(&mut self) -> Option<f64> {
         let next_event_ms = self.events.peek().map(|event| event.at_ms);
         let next = choose_next_timestamp(
-            CoreAdmissionSource::next_ready_time_ms(&mut self.admission),
+            CoreAdmissionSource::next_internal_event_ms(&mut self.admission),
             next_event_ms,
         );
         #[cfg(feature = "kvbm-offload")]
@@ -728,9 +751,8 @@ where
     fn release_ready_arrivals(&mut self) -> anyhow::Result<bool> {
         let mut released_any = false;
         let cluster_in_flight = self.cluster_in_flight();
-        for ready in self
-            .admission
-            .drain_ready_compact(self.now_ms, cluster_in_flight)?
+        for ready in
+            CoreAdmissionSource::drain_ready(&mut self.admission, self.now_ms, cluster_in_flight)?
         {
             let ReadyArrival {
                 request,
@@ -1361,7 +1383,205 @@ mod tests {
     use crate::replay::{TraceRequestStatsSnapshot, normalize_trace_requests};
     use rstest::rstest;
     use std::cell::RefCell;
+    use std::collections::HashMap;
     use std::rc::Rc;
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum TwoTurnSourceEvent {
+        Submitted { turn_index: usize, at_ms: f64 },
+        WaitingForCompletion { turn_index: usize, at_ms: f64 },
+        Terminal { turn_index: usize, at_ms: f64 },
+        TimerArmed { turn_index: usize, at_ms: f64 },
+    }
+
+    struct TwoTurnWorkSource {
+        driver: WorkloadDriver,
+        events: Rc<RefCell<Vec<TwoTurnSourceEvent>>>,
+        in_flight_turns: HashMap<Uuid, usize>,
+    }
+
+    impl TwoTurnWorkSource {
+        fn new(events: Rc<RefCell<Vec<TwoTurnSourceEvent>>>) -> Self {
+            let trace = Trace {
+                block_size: 64,
+                sessions: vec![SessionTrace {
+                    session_id: "two-turn-session".to_string(),
+                    first_arrival_timestamp_ms: Some(0.0),
+                    turns: vec![
+                        TurnTrace {
+                            input_length: 64,
+                            max_output_tokens: 2,
+                            hash_ids: vec![11],
+                            delay_after_previous_ms: 0.0,
+                            ..Default::default()
+                        },
+                        TurnTrace {
+                            input_length: 64,
+                            max_output_tokens: 2,
+                            hash_ids: vec![12],
+                            delay_after_previous_ms: 10.0,
+                            ..Default::default()
+                        },
+                    ],
+                }],
+            };
+            let driver = WorkloadDriver::new_concurrency(trace, 64, 1)
+                .unwrap()
+                .with_deterministic_request_ids(1);
+            Self {
+                driver,
+                events,
+                in_flight_turns: HashMap::new(),
+            }
+        }
+    }
+
+    impl CoreAdmissionSource for TwoTurnWorkSource {
+        type Request = ReplayRequestPayload;
+        type Metadata = ();
+
+        fn next_internal_event_ms(&mut self) -> Option<f64> {
+            self.driver.next_ready_time_ms()
+        }
+
+        fn drain_ready(
+            &mut self,
+            now_ms: f64,
+            _cluster_in_flight: usize,
+        ) -> anyhow::Result<Vec<ReadyArrival<Self::Request, Self::Metadata>>> {
+            Ok(self
+                .driver
+                .pop_ready_compact(now_ms, usize::MAX)
+                .into_iter()
+                .map(|ready| {
+                    self.in_flight_turns
+                        .insert(ready.request_uuid, ready.turn_index);
+                    self.events
+                        .borrow_mut()
+                        .push(TwoTurnSourceEvent::Submitted {
+                            turn_index: ready.turn_index,
+                            at_ms: now_ms,
+                        });
+                    if self.driver.next_ready_time_ms().is_none() {
+                        self.events
+                            .borrow_mut()
+                            .push(TwoTurnSourceEvent::WaitingForCompletion {
+                                turn_index: ready.turn_index,
+                                at_ms: now_ms,
+                            });
+                    }
+                    ReadyArrival {
+                        request: ready.request,
+                        arrival_time_ms: now_ms,
+                        metadata: (),
+                        session_id: Some(ready.session_id),
+                        turn_index: Some(ready.turn_index),
+                    }
+                })
+                .collect())
+        }
+
+        fn on_output_token(&mut self, request_id: Uuid, token_id: u32) -> anyhow::Result<()> {
+            self.driver.on_output_token(request_id, token_id)
+        }
+
+        fn on_terminal(
+            &mut self,
+            request_id: Uuid,
+            now_ms: f64,
+            rejected: bool,
+        ) -> anyhow::Result<()> {
+            let turn_index = self
+                .in_flight_turns
+                .remove(&request_id)
+                .expect("terminal request must belong to a submitted turn");
+            self.events.borrow_mut().push(TwoTurnSourceEvent::Terminal {
+                turn_index,
+                at_ms: now_ms,
+            });
+            self.driver.on_terminal(request_id, now_ms, rejected)?;
+            if let Some(at_ms) = self.driver.next_ready_time_ms() {
+                self.events
+                    .borrow_mut()
+                    .push(TwoTurnSourceEvent::TimerArmed {
+                        turn_index: turn_index + 1,
+                        at_ms,
+                    });
+            }
+            Ok(())
+        }
+
+        fn is_drained(&self) -> bool {
+            self.driver.is_drained()
+        }
+
+        fn total_requests(&self) -> usize {
+            self.driver.total_turns()
+        }
+    }
+
+    #[test]
+    fn generic_work_source_waits_for_terminal_before_arming_second_turn() {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let source = TwoTurnWorkSource::new(Rc::clone(&events));
+        let args = fast_router_args();
+        let runtime = AggRuntimeImpl::<
+            AggregatedRoundRobinPlacement<()>,
+            NoEngineEvents,
+            (),
+            TwoTurnWorkSource,
+        >::new_composed(&args, source, 1, |args, topology| {
+            Ok(AggregatedRoundRobinPlacement::new(args.dp_size, topology))
+        })
+        .unwrap();
+
+        let (collector, _) = runtime.run().unwrap();
+        let report = collector.finish();
+        assert_eq!(report.request_counts.completed_requests, 2);
+
+        let events = events.borrow();
+        println!("two-turn generic work-source event log:");
+        for event in events.iter() {
+            match event {
+                TwoTurnSourceEvent::Submitted { turn_index, at_ms } => {
+                    println!("  {at_ms:>9.3} ms  submit turn {turn_index}");
+                }
+                TwoTurnSourceEvent::WaitingForCompletion { turn_index, at_ms } => {
+                    println!(
+                        "  {at_ms:>9.3} ms  no source timer; wait for turn {turn_index} completion"
+                    );
+                }
+                TwoTurnSourceEvent::Terminal { turn_index, at_ms } => {
+                    println!("  {at_ms:>9.3} ms  terminal turn {turn_index}");
+                }
+                TwoTurnSourceEvent::TimerArmed { turn_index, at_ms } => {
+                    println!("  {at_ms:>9.3} ms  arm turn {turn_index} delay timer");
+                }
+            }
+        }
+
+        let first_terminal_ms = events
+            .iter()
+            .find_map(|event| match event {
+                TwoTurnSourceEvent::Terminal {
+                    turn_index: 0,
+                    at_ms,
+                } => Some(*at_ms),
+                _ => None,
+            })
+            .unwrap();
+        let second_submit_ms = events
+            .iter()
+            .find_map(|event| match event {
+                TwoTurnSourceEvent::Submitted {
+                    turn_index: 1,
+                    at_ms,
+                } => Some(*at_ms),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(second_submit_ms, first_terminal_ms + 10.0);
+    }
 
     struct CaptureOncePolicy {
         at_ms: f64,

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -48,7 +48,7 @@ use anyhow::bail;
 use rustc_hash::FxHashMap;
 #[cfg(test)]
 use std::collections::HashMap;
-use std::collections::{BinaryHeap, VecDeque};
+use std::collections::{BinaryHeap, HashSet, VecDeque};
 use uuid::Uuid;
 
 fn common_origin(mut origins: impl Iterator<Item = u64>) -> Option<u64> {
@@ -266,6 +266,106 @@ where
                 Vec::new();
                 num_workers.saturating_mul(args.dp_size.max(1) as usize)
             ],
+            #[cfg(test)]
+            stepped: false,
+        })
+    }
+
+    pub(in crate::replay::offline) fn new_composed_heterogeneous(
+        worker_args: &[MockEngineArgs],
+        worker_taints: &[HashSet<String>],
+        admission: Admission,
+        create_placement: impl FnOnce(
+            &[MockEngineArgs],
+            &[HashSet<String>],
+            Vec<WorkerTopology>,
+        ) -> anyhow::Result<PlacementPolicyImpl>,
+    ) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            !worker_args.is_empty(),
+            "heterogeneous replay requires at least one worker"
+        );
+        anyhow::ensure!(
+            worker_taints.is_empty() || worker_taints.len() == worker_args.len(),
+            "worker_taints must be empty or contain exactly one entry per replay worker: got {} for {} workers",
+            worker_taints.len(),
+            worker_args.len(),
+        );
+        let worker_args = worker_args
+            .iter()
+            .cloned()
+            .map(MockEngineArgs::normalized)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let block_size = worker_args[0].block_size;
+        let gpus_per_worker = worker_args[0].aic_gpus_per_worker();
+        for (worker_id, args) in worker_args.iter().enumerate() {
+            anyhow::ensure!(
+                args.block_size == block_size,
+                "heterogeneous worker {worker_id} uses block_size {}, expected {block_size}",
+                args.block_size,
+            );
+            anyhow::ensure!(
+                args.aic_gpus_per_worker() == gpus_per_worker,
+                "heterogeneous worker {worker_id} uses {} GPUs, expected {gpus_per_worker}",
+                args.aic_gpus_per_worker(),
+            );
+            anyhow::ensure!(
+                args.worker_max_num_seqs.is_empty(),
+                "heterogeneous worker {worker_id} must set max_num_seqs directly"
+            );
+            anyhow::ensure!(
+                args.worker_taints.is_empty(),
+                "heterogeneous worker {worker_id} must provide taints to the replay entrypoint"
+            );
+        }
+        let progress = ReplayProgress::new(
+            CoreAdmissionSource::total_requests(&admission),
+            "offline replay",
+        );
+        #[cfg(test)]
+        let scheduler_count: usize = worker_args
+            .iter()
+            .map(|args| args.dp_size.max(1) as usize)
+            .sum();
+        let dp_size = worker_args
+            .iter()
+            .map(|args| args.dp_size.max(1))
+            .max()
+            .unwrap_or(1);
+        let mut engine = EngineComponent::<Observation>::new_heterogeneous_ranked(
+            SimulationWorkerStage::Aggregated,
+            EnginePassMode::Visible,
+            worker_args.clone(),
+        );
+        engine.set_scaling_args(worker_args[0].clone(), Observation::CAPTURE_RAW);
+        let placement = create_placement(&worker_args, worker_taints, engine.active_topology())?;
+
+        let mut collector = TraceCollector::default();
+        collector.set_gpus_per_worker(0, gpus_per_worker);
+
+        Ok(Self {
+            now_ms: 0.0,
+            dp_size,
+            next_event_seq: 0,
+            next_scaling_tick_ordinal: 0,
+            admission,
+            requests: FxHashMap::default(),
+            engine,
+            collector,
+            events: BinaryHeap::new(),
+            placement,
+            progress,
+            #[cfg(test)]
+            stats: AggRuntimeStats::default(),
+            #[cfg(not(test))]
+            stats: AggRuntimeStats,
+            fpm_buffer: LatestFpmBuffer::default(),
+            traffic: TrafficAccumulator::new(),
+            max_sim_time_ms: None,
+            scaling_policy: None,
+            collect_fpm: false,
+            #[cfg(test)]
+            worker_active_requests: vec![Vec::new(); scheduler_count],
             #[cfg(test)]
             stepped: false,
         })

--- a/lib/mocker/src/replay/offline/components/admission.rs
+++ b/lib/mocker/src/replay/offline/components/admission.rs
@@ -76,7 +76,7 @@ enum AdmissionSource {
     Workload(WorkloadDriver),
 }
 
-pub(in crate::replay::offline) struct AdmissionQueue<Metadata = KvReplayMetadata> {
+pub(in crate::replay) struct AdmissionQueue<Metadata = KvReplayMetadata> {
     source: AdmissionSource,
     mode: ReplayMode,
     metadata: PhantomData<Metadata>,
@@ -103,10 +103,6 @@ impl<Metadata: ReplayAdmissionMetadata> AdmissionQueue<Metadata> {
             mode,
             metadata: PhantomData,
         }
-    }
-
-    pub(in crate::replay::offline) fn mode(&self) -> ReplayMode {
-        self.mode
     }
 
     pub(in crate::replay::offline) fn next_ready_time_ms(&mut self) -> Option<f64> {
@@ -260,7 +256,7 @@ impl<Metadata: ReplayAdmissionMetadata> CoreAdmissionSource for AdmissionQueue<M
     type Request = ReplayRequestPayload;
     type Metadata = Metadata;
 
-    fn next_ready_time_ms(&mut self) -> Option<f64> {
+    fn next_internal_event_ms(&mut self) -> Option<f64> {
         AdmissionQueue::next_ready_time_ms(self)
     }
 

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -140,6 +140,10 @@ where
         let mut workers = Vec::with_capacity(num_workers.saturating_mul(dp_size));
         let mut worker_groups = Vec::with_capacity(num_workers);
         for worker_id in 0..num_workers {
+            let mut worker_args = args.clone();
+            if let Some(&max_num_seqs) = args.worker_max_num_seqs.get(worker_id) {
+                worker_args.max_num_seqs = Some(max_num_seqs);
+            }
             let mut rank_ids = Vec::with_capacity(dp_size);
             for dp_rank in 0..dp_size {
                 let rank_id = worker_id * dp_size + dp_rank;
@@ -148,7 +152,7 @@ where
                     rank_id,
                     worker_id as u64,
                     dp_rank as u32,
-                    args.clone(),
+                    worker_args.clone(),
                     Observation::CAPTURE_RAW,
                 )));
                 rank_ids.push(rank_id);
@@ -309,6 +313,10 @@ where
     /// the stable mocker worker ID.
     pub(in crate::replay::offline) fn add_worker(&mut self) -> usize {
         let worker_id = self.worker_groups.len();
+        let mut worker_args = self.args.clone();
+        if let Some(&max_num_seqs) = self.args.worker_max_num_seqs.get(worker_id) {
+            worker_args.max_num_seqs = Some(max_num_seqs);
+        }
         let mut rank_ids = Vec::with_capacity(self.args.dp_size.max(1) as usize);
         for dp_rank in 0..self.args.dp_size.max(1) {
             let rank_id = self.workers.len();
@@ -316,7 +324,7 @@ where
                 rank_id,
                 worker_id as u64,
                 dp_rank,
-                self.args.clone(),
+                worker_args.clone(),
                 self.capture_raw,
             );
             debug_assert_eq!(rank_id, self.workers.len());

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -179,6 +179,60 @@ where
         component
     }
 
+    /// Build one logical worker from each supplied engine configuration.
+    ///
+    /// Unlike [`Self::new_ranked`], each worker may use a different DP width,
+    /// scheduler limit, KV capacity, and performance model. Stable scheduler
+    /// IDs are assigned densely across the resulting heterogeneous groups.
+    pub(in crate::replay::offline) fn new_heterogeneous_ranked(
+        stage: SimulationWorkerStage,
+        pass_mode: EnginePassMode,
+        worker_args: Vec<MockEngineArgs>,
+    ) -> Self {
+        debug_assert!(!worker_args.is_empty());
+        let default_args = worker_args[0].clone();
+        let total_ranks = worker_args
+            .iter()
+            .map(|args| args.dp_size.max(1) as usize)
+            .sum();
+        let mut workers = Vec::with_capacity(total_ranks);
+        let mut worker_groups = Vec::with_capacity(worker_args.len());
+        for (worker_id, args) in worker_args.into_iter().enumerate() {
+            let dp_size = args.dp_size.max(1) as usize;
+            let mut rank_ids = Vec::with_capacity(dp_size);
+            for dp_rank in 0..dp_size {
+                let rank_id = workers.len();
+                workers.push(Some(OfflineWorkerState::new_with_rank(
+                    rank_id,
+                    worker_id as u64,
+                    dp_rank as u32,
+                    args.clone(),
+                    Observation::CAPTURE_RAW,
+                )));
+                rank_ids.push(rank_id);
+            }
+            worker_groups.push(Some(rank_ids));
+        }
+        let live_group_count = worker_groups.len();
+        let mut component = Self {
+            stage,
+            pass_mode,
+            workers,
+            worker_groups,
+            live_group_count,
+            total_in_flight: 0,
+            ready_groups: BTreeSet::new(),
+            deferred_ready_groups: BTreeSet::new(),
+            pending_removal: BTreeSet::new(),
+            pending_startup: BTreeSet::new(),
+            args: default_args,
+            capture_raw: Observation::CAPTURE_RAW,
+            observation: PhantomData,
+        };
+        component.refresh_all_groups();
+        component
+    }
+
     /// Set the engine args used when adding workers dynamically.
     pub(in crate::replay::offline) fn set_scaling_args(
         &mut self,

--- a/lib/mocker/src/replay/offline/controlled.rs
+++ b/lib/mocker/src/replay/offline/controlled.rs
@@ -1,0 +1,488 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Public controller boundary for offline replay.
+//!
+//! A controller owns request release and its own logical timers. Dynamo owns
+//! placement, continuous batching, engine timing, and request lifecycle events.
+
+use std::marker::PhantomData;
+
+use anyhow::{Result, ensure};
+use uuid::Uuid;
+
+use super::agg::AggRuntimeImpl;
+use super::components::{KvReplayMetadata, ReplayAdmissionMetadata};
+use super::core::round_robin::AggregatedRoundRobinPlacement;
+use super::core::{AdmissionSource, NoEngineEvents, ReadyArrival};
+use super::extensions::kv_events::RouterEventObservation;
+use super::extensions::kv_router::KvRouterPlacement;
+use crate::common::protocols::MockEngineArgs;
+use crate::loadgen::{ReplayRequestHashes, ReplayRequestPayload};
+use crate::replay::{ReplayTerminalStatus, TraceSimulationReport};
+
+/// Runtime state visible to a work source when Dynamo asks for ready requests.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReplayWorkSourceContext {
+    pub now_ms: f64,
+    pub cluster_in_flight: usize,
+}
+
+/// One inference request released by an external replay controller.
+#[derive(Debug)]
+pub struct ReplayWorkSubmission {
+    /// Source-owned identity used to correlate output and terminal callbacks.
+    pub request_id: Uuid,
+    pub arrival_time_ms: f64,
+    pub request: ReplayRequestPayload,
+    pub replay_hashes: Option<ReplayRequestHashes>,
+    pub session_id: Option<String>,
+    pub turn_index: Option<usize>,
+}
+
+/// Event-driven request source for Dynamo offline replay.
+///
+/// `next_internal_event_ms` reports only timers already known by the source.
+/// It must return `None` while progress depends solely on an in-flight request;
+/// Dynamo will call `on_terminal` when that request finishes.
+pub trait ReplayWorkSource {
+    fn next_internal_event_ms(&mut self) -> Option<f64>;
+
+    fn drain_ready(
+        &mut self,
+        context: ReplayWorkSourceContext,
+    ) -> Result<Vec<ReplayWorkSubmission>>;
+
+    fn on_output_token(&mut self, request_id: Uuid, token_id: u32) -> Result<()>;
+
+    fn on_terminal(
+        &mut self,
+        request_id: Uuid,
+        now_ms: f64,
+        status: ReplayTerminalStatus,
+    ) -> Result<()>;
+
+    fn is_drained(&self) -> bool;
+
+    fn total_requests(&self) -> usize;
+}
+
+/// Optional detail capture for an externally controlled replay.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ControlledReplayOptions {
+    /// Retain one [`crate::replay::PerRequestRecord`] for every terminal request.
+    pub capture_per_request: bool,
+}
+
+struct ControlledAdmission<'source, Source, Metadata> {
+    source: &'source mut Source,
+    metadata: PhantomData<Metadata>,
+}
+
+impl<'source, Source, Metadata> ControlledAdmission<'source, Source, Metadata> {
+    fn new(source: &'source mut Source) -> Self {
+        Self {
+            source,
+            metadata: PhantomData,
+        }
+    }
+}
+
+impl<Source, Metadata> AdmissionSource for ControlledAdmission<'_, Source, Metadata>
+where
+    Source: ReplayWorkSource,
+    Metadata: ReplayAdmissionMetadata,
+{
+    type Request = ReplayRequestPayload;
+    type Metadata = Metadata;
+
+    fn next_internal_event_ms(&mut self) -> Option<f64> {
+        self.source.next_internal_event_ms()
+    }
+
+    fn drain_ready(
+        &mut self,
+        now_ms: f64,
+        cluster_in_flight: usize,
+    ) -> Result<Vec<ReadyArrival<Self::Request, Self::Metadata>>> {
+        self.source
+            .drain_ready(ReplayWorkSourceContext {
+                now_ms,
+                cluster_in_flight,
+            })?
+            .into_iter()
+            .map(|mut submission| {
+                ensure!(
+                    submission.arrival_time_ms.is_finite()
+                        && submission.arrival_time_ms >= 0.0
+                        && submission.arrival_time_ms <= now_ms,
+                    "controlled replay source emitted request {} with invalid arrival time {} at now={now_ms}",
+                    submission.request_id,
+                    submission.arrival_time_ms,
+                );
+                if let Some(payload_id) = submission.request.metadata().uuid {
+                    ensure!(
+                        payload_id == submission.request_id,
+                        "controlled replay submission ID {} does not match payload ID {payload_id}",
+                        submission.request_id,
+                    );
+                }
+                submission.request.metadata_mut().uuid = Some(submission.request_id);
+                Ok(ReadyArrival {
+                    request: submission.request,
+                    arrival_time_ms: submission.arrival_time_ms,
+                    metadata: Metadata::from_hashes(submission.replay_hashes),
+                    session_id: submission.session_id,
+                    turn_index: submission.turn_index,
+                })
+            })
+            .collect()
+    }
+
+    fn on_output_token(&mut self, request_id: Uuid, token_id: u32) -> Result<()> {
+        self.source.on_output_token(request_id, token_id)
+    }
+
+    fn on_terminal(&mut self, request_id: Uuid, now_ms: f64, rejected: bool) -> Result<()> {
+        let status = if rejected {
+            ReplayTerminalStatus::Rejected
+        } else {
+            ReplayTerminalStatus::Completed
+        };
+        self.source.on_terminal(request_id, now_ms, status)
+    }
+
+    fn is_drained(&self) -> bool {
+        self.source.is_drained()
+    }
+
+    fn total_requests(&self) -> usize {
+        self.source.total_requests()
+    }
+}
+
+/// Run an externally controlled workload through Dynamo's aggregated,
+/// round-robin offline replay engine.
+pub fn simulate_controlled_aggregated<Source>(
+    args: &MockEngineArgs,
+    num_workers: usize,
+    source: &mut Source,
+) -> Result<TraceSimulationReport>
+where
+    Source: ReplayWorkSource,
+{
+    simulate_controlled_aggregated_with_options(
+        args,
+        num_workers,
+        source,
+        ControlledReplayOptions::default(),
+    )
+}
+
+/// Run an externally controlled workload and optionally retain request detail.
+pub fn simulate_controlled_aggregated_with_options<Source>(
+    args: &MockEngineArgs,
+    num_workers: usize,
+    source: &mut Source,
+    options: ControlledReplayOptions,
+) -> Result<TraceSimulationReport>
+where
+    Source: ReplayWorkSource,
+{
+    ensure!(
+        num_workers > 0,
+        "controlled replay requires at least one worker"
+    );
+    let admission = ControlledAdmission::<Source, ()>::new(source);
+    let runtime = AggRuntimeImpl::<
+        AggregatedRoundRobinPlacement<()>,
+        NoEngineEvents,
+        (),
+        ControlledAdmission<'_, Source, ()>,
+    >::new_composed(args, admission, num_workers, |args, topology| {
+        Ok(AggregatedRoundRobinPlacement::new(args.dp_size, topology))
+    })?
+    .with_per_request_records(options.capture_per_request);
+    let (collector, _) = runtime.run()?;
+    Ok(collector.finish())
+}
+
+/// Run an externally controlled workload through Dynamo's aggregated KV
+/// router. Request constraints and `MockEngineArgs::worker_taints` determine
+/// the eligible workers.
+pub fn simulate_controlled_aggregated_kv_router_with_options<Source>(
+    args: &MockEngineArgs,
+    num_workers: usize,
+    source: &mut Source,
+    options: ControlledReplayOptions,
+) -> Result<TraceSimulationReport>
+where
+    Source: ReplayWorkSource,
+{
+    ensure!(
+        num_workers > 0,
+        "controlled replay requires at least one worker"
+    );
+    let admission = ControlledAdmission::<Source, KvReplayMetadata>::new(source);
+    let runtime = AggRuntimeImpl::<
+        KvRouterPlacement,
+        RouterEventObservation,
+        KvReplayMetadata,
+        ControlledAdmission<'_, Source, KvReplayMetadata>,
+    >::new_composed(args, admission, num_workers, |args, _topology| {
+        KvRouterPlacement::new(args, None, None, num_workers)
+    })?
+    .with_per_request_records(options.capture_per_request);
+    let (collector, _) = runtime.run()?;
+    Ok(collector.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use super::*;
+    use crate::loadgen::{SessionTrace, Trace, TurnTrace, WorkloadDriver};
+
+    struct DriverSource {
+        driver: WorkloadDriver,
+        turns: HashMap<Uuid, (String, usize)>,
+        submissions: Vec<(String, usize, f64)>,
+        terminals: Vec<(String, usize, f64)>,
+    }
+
+    impl DriverSource {
+        fn new(trace: Trace) -> Self {
+            let engine_block_size = trace.block_size;
+            Self {
+                driver: WorkloadDriver::new_concurrency(trace, engine_block_size, usize::MAX)
+                    .unwrap()
+                    .with_deterministic_request_ids(7),
+                turns: HashMap::new(),
+                submissions: Vec::new(),
+                terminals: Vec::new(),
+            }
+        }
+    }
+
+    impl ReplayWorkSource for DriverSource {
+        fn next_internal_event_ms(&mut self) -> Option<f64> {
+            self.driver.next_ready_time_ms()
+        }
+
+        fn drain_ready(
+            &mut self,
+            context: ReplayWorkSourceContext,
+        ) -> Result<Vec<ReplayWorkSubmission>> {
+            Ok(self
+                .driver
+                .pop_ready_replay(context.now_ms, usize::MAX)
+                .into_iter()
+                .map(|ready| {
+                    self.turns.insert(
+                        ready.request_uuid,
+                        (ready.session_id.clone(), ready.turn_index),
+                    );
+                    self.submissions.push((
+                        ready.session_id.clone(),
+                        ready.turn_index,
+                        context.now_ms,
+                    ));
+                    ReplayWorkSubmission {
+                        request_id: ready.request_uuid,
+                        arrival_time_ms: context.now_ms,
+                        request: ready.request,
+                        replay_hashes: ready.replay_hashes,
+                        session_id: Some(ready.session_id),
+                        turn_index: Some(ready.turn_index),
+                    }
+                })
+                .collect())
+        }
+
+        fn on_output_token(&mut self, request_id: Uuid, token_id: u32) -> Result<()> {
+            self.driver.on_output_token(request_id, token_id)
+        }
+
+        fn on_terminal(
+            &mut self,
+            request_id: Uuid,
+            now_ms: f64,
+            status: ReplayTerminalStatus,
+        ) -> Result<()> {
+            let (session_id, turn_index) = self.turns.remove(&request_id).unwrap();
+            self.terminals.push((session_id, turn_index, now_ms));
+            self.driver
+                .on_terminal(request_id, now_ms, status == ReplayTerminalStatus::Rejected)
+        }
+
+        fn is_drained(&self) -> bool {
+            self.driver.is_drained()
+        }
+
+        fn total_requests(&self) -> usize {
+            self.driver.total_turns()
+        }
+    }
+
+    fn args() -> MockEngineArgs {
+        MockEngineArgs::builder()
+            .block_size(64)
+            .num_gpu_blocks(256)
+            .max_num_batched_tokens(Some(8192))
+            .max_num_seqs(Some(8))
+            .enable_prefix_caching(true)
+            .enable_chunked_prefill(true)
+            .speedup_ratio(1000.0)
+            .build()
+            .unwrap()
+    }
+
+    fn turn(hash_id: u32, required_taint: Option<&str>) -> TurnTrace {
+        let mut turn = TurnTrace {
+            input_length: 64,
+            max_output_tokens: 8,
+            hash_ids: vec![hash_id],
+            ..Default::default()
+        };
+        if let Some(taint) = required_taint {
+            turn.routing_constraints
+                .required_taints
+                .insert(taint.to_string());
+        }
+        turn
+    }
+
+    #[test]
+    fn public_controlled_replay_arms_delay_after_terminal() {
+        let trace = Trace {
+            block_size: 64,
+            sessions: vec![SessionTrace {
+                session_id: "two-turn".to_string(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![
+                    turn(1, None),
+                    TurnTrace {
+                        delay_after_previous_ms: 10.0,
+                        ..turn(2, None)
+                    },
+                ],
+            }],
+        };
+        let mut source = DriverSource::new(trace);
+
+        let report = simulate_controlled_aggregated(&args(), 1, &mut source).unwrap();
+
+        assert_eq!(report.request_counts.completed_requests, 2);
+        let first_terminal = source
+            .terminals
+            .iter()
+            .find(|(_, turn, _)| *turn == 0)
+            .unwrap()
+            .2;
+        let second_submission = source
+            .submissions
+            .iter()
+            .find(|(_, turn, _)| *turn == 1)
+            .unwrap()
+            .2;
+        assert_eq!(second_submission, first_terminal + 10.0);
+    }
+
+    #[test]
+    fn controlled_kv_router_honors_required_worker_taints() {
+        let trace = Trace {
+            block_size: 64,
+            sessions: vec![
+                SessionTrace {
+                    session_id: "high".to_string(),
+                    first_arrival_timestamp_ms: Some(0.0),
+                    turns: vec![turn(1, Some("tier=high"))],
+                },
+                SessionTrace {
+                    session_id: "low".to_string(),
+                    first_arrival_timestamp_ms: Some(0.0),
+                    turns: vec![turn(2, Some("tier=low"))],
+                },
+            ],
+        };
+        let mut source = DriverSource::new(trace);
+        let mut args = args();
+        args.worker_taints = vec![
+            HashSet::from(["tier=high".to_string()]),
+            HashSet::from(["tier=low".to_string()]),
+        ];
+
+        let report = simulate_controlled_aggregated_kv_router_with_options(
+            &args,
+            2,
+            &mut source,
+            ControlledReplayOptions {
+                capture_per_request: true,
+            },
+        )
+        .unwrap();
+
+        let workers = report
+            .per_request
+            .iter()
+            .map(|request| {
+                (
+                    request.session_id.as_deref().unwrap(),
+                    request.decode_worker_idx.unwrap(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        assert_eq!(workers["high"], 0);
+        assert_eq!(workers["low"], 1);
+    }
+
+    #[test]
+    fn controlled_replay_applies_per_worker_sequence_limits() {
+        let trace = Trace {
+            block_size: 64,
+            sessions: (0..4)
+                .map(|index| SessionTrace {
+                    session_id: format!("session-{index}"),
+                    first_arrival_timestamp_ms: Some(0.0),
+                    turns: vec![turn(index + 1, None)],
+                })
+                .collect(),
+        };
+        let mut source = DriverSource::new(trace);
+        let mut args = args();
+        args.worker_max_num_seqs = vec![1, 2];
+
+        let report = simulate_controlled_aggregated_with_options(
+            &args,
+            2,
+            &mut source,
+            ControlledReplayOptions {
+                capture_per_request: true,
+            },
+        )
+        .unwrap();
+
+        let mut by_worker: HashMap<usize, Vec<_>> = HashMap::new();
+        for request in &report.per_request {
+            by_worker
+                .entry(request.decode_worker_idx.unwrap())
+                .or_default()
+                .push(request);
+        }
+        for requests in by_worker.values_mut() {
+            requests.sort_by(|left, right| {
+                left.first_admit_ms
+                    .unwrap()
+                    .total_cmp(&right.first_admit_ms.unwrap())
+            });
+        }
+        assert_eq!(by_worker[&0].len(), 2);
+        assert_eq!(by_worker[&1].len(), 2);
+        assert!(by_worker[&0][1].first_admit_ms.unwrap() >= by_worker[&0][0].terminal_time_ms);
+        assert_eq!(
+            by_worker[&1][0].first_admit_ms,
+            by_worker[&1][1].first_admit_ms
+        );
+    }
+}

--- a/lib/mocker/src/replay/offline/controlled.rs
+++ b/lib/mocker/src/replay/offline/controlled.rs
@@ -6,9 +6,12 @@
 //! A controller owns request release and its own logical timers. Dynamo owns
 //! placement, continuous batching, engine timing, and request lifecycle events.
 
+use std::collections::HashSet;
 use std::marker::PhantomData;
+use std::time::Duration;
 
 use anyhow::{Result, ensure};
+use dynamo_kv_router::config::KvRouterConfig;
 use uuid::Uuid;
 
 use super::agg::AggRuntimeImpl;
@@ -68,10 +71,41 @@ pub trait ReplayWorkSource {
 }
 
 /// Optional detail capture for an externally controlled replay.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct ControlledReplayOptions {
     /// Retain one [`crate::replay::PerRequestRecord`] for every terminal request.
     pub capture_per_request: bool,
+    /// Keep later requests from the same session on the initially selected
+    /// worker/rank until this logical-time idle TTL expires.
+    pub session_affinity_ttl: Option<Duration>,
+    /// Predict route-time KV placement for this logical-time TTL while the
+    /// engine's authoritative KV event is still in flight.
+    pub router_predicted_ttl: Option<Duration>,
+    /// Block-equivalent decode cost charged for every active request on a
+    /// candidate worker.
+    pub decode_active_request_weight: Option<f64>,
+}
+
+fn controlled_router_config(
+    predicted_ttl: Option<Duration>,
+    decode_active_request_weight: Option<f64>,
+) -> Result<Option<KvRouterConfig>> {
+    if predicted_ttl.is_none() && decode_active_request_weight.is_none() {
+        return Ok(None);
+    }
+    let mut config = KvRouterConfig::default();
+    if let Some(ttl) = predicted_ttl {
+        config.use_kv_events = true;
+        config.router_predicted_ttl_secs = Some(ttl.as_secs_f64());
+    }
+    if let Some(weight) = decode_active_request_weight {
+        ensure!(
+            weight.is_finite() && weight >= 0.0,
+            "decode active-request weight must be finite and nonnegative"
+        );
+        config.decode_active_request_weight = weight;
+    }
+    Ok(Some(config))
 }
 
 struct ControlledAdmission<'source, Source, Metadata> {
@@ -190,6 +224,12 @@ where
     Source: ReplayWorkSource,
 {
     ensure!(
+        options.session_affinity_ttl.is_none()
+            && options.router_predicted_ttl.is_none()
+            && options.decode_active_request_weight.is_none(),
+        "controlled round-robin replay does not support KV-router TTL options"
+    );
+    ensure!(
         num_workers > 0,
         "controlled replay requires at least one worker"
     );
@@ -230,8 +270,61 @@ where
         KvReplayMetadata,
         ControlledAdmission<'_, Source, KvReplayMetadata>,
     >::new_composed(args, admission, num_workers, |args, _topology| {
-        KvRouterPlacement::new(args, None, None, num_workers)
+        KvRouterPlacement::new_with_session_affinity(
+            args,
+            controlled_router_config(
+                options.router_predicted_ttl,
+                options.decode_active_request_weight,
+            )?,
+            None,
+            num_workers,
+            options.session_affinity_ttl,
+        )
     })?
+    .with_per_request_records(options.capture_per_request);
+    let (collector, _) = runtime.run()?;
+    Ok(collector.finish())
+}
+
+/// Run an externally controlled workload across heterogeneous aggregated
+/// workers. Each worker owns its own normalized engine topology and
+/// performance model; required taints select between those worker pools.
+pub fn simulate_controlled_heterogeneous_aggregated_kv_router_with_options<Source>(
+    worker_args: &[MockEngineArgs],
+    worker_taints: &[HashSet<String>],
+    source: &mut Source,
+    options: ControlledReplayOptions,
+) -> Result<TraceSimulationReport>
+where
+    Source: ReplayWorkSource,
+{
+    ensure!(
+        !worker_args.is_empty(),
+        "controlled heterogeneous replay requires at least one worker"
+    );
+    let admission = ControlledAdmission::<Source, KvReplayMetadata>::new(source);
+    let runtime = AggRuntimeImpl::<
+        KvRouterPlacement,
+        RouterEventObservation,
+        KvReplayMetadata,
+        ControlledAdmission<'_, Source, KvReplayMetadata>,
+    >::new_composed_heterogeneous(
+        worker_args,
+        worker_taints,
+        admission,
+        |worker_args, worker_taints, _topology| {
+            KvRouterPlacement::new_heterogeneous_with_session_affinity(
+                worker_args,
+                worker_taints,
+                controlled_router_config(
+                    options.router_predicted_ttl,
+                    options.decode_active_request_weight,
+                )?,
+                None,
+                options.session_affinity_ttl,
+            )
+        },
+    )?
     .with_per_request_records(options.capture_per_request);
     let (collector, _) = runtime.run()?;
     Ok(collector.finish())
@@ -354,6 +447,15 @@ mod tests {
     }
 
     #[test]
+    fn controlled_router_config_applies_decode_active_request_weight() {
+        let config = controlled_router_config(None, Some(128.0))
+            .unwrap()
+            .unwrap();
+        assert_eq!(config.decode_active_request_weight, 128.0);
+        assert!(controlled_router_config(None, Some(f64::NAN)).is_err());
+    }
+
+    #[test]
     fn public_controlled_replay_arms_delay_after_terminal() {
         let trace = Trace {
             block_size: 64,
@@ -419,6 +521,7 @@ mod tests {
             &mut source,
             ControlledReplayOptions {
                 capture_per_request: true,
+                ..ControlledReplayOptions::default()
             },
         )
         .unwrap();
@@ -435,6 +538,61 @@ mod tests {
             .collect::<HashMap<_, _>>();
         assert_eq!(workers["high"], 0);
         assert_eq!(workers["low"], 1);
+    }
+
+    #[test]
+    fn controlled_kv_router_supports_heterogeneous_worker_topologies() {
+        let trace = Trace {
+            block_size: 64,
+            sessions: vec![
+                SessionTrace {
+                    session_id: "throughput".to_string(),
+                    first_arrival_timestamp_ms: Some(0.0),
+                    turns: vec![turn(1, Some("tier=throughput"))],
+                },
+                SessionTrace {
+                    session_id: "tail".to_string(),
+                    first_arrival_timestamp_ms: Some(0.0),
+                    turns: vec![turn(2, Some("tier=tail"))],
+                },
+            ],
+        };
+        let mut source = DriverSource::new(trace);
+        let mut throughput_args = args();
+        throughput_args.dp_size = 2;
+        let mut tail_args = args();
+        tail_args.aic_tp_size = Some(2);
+        tail_args.max_num_seqs = Some(1);
+        let worker_args = vec![throughput_args, tail_args];
+        let worker_taints = vec![
+            HashSet::from(["tier=throughput".to_string()]),
+            HashSet::from(["tier=tail".to_string()]),
+        ];
+
+        let report = simulate_controlled_heterogeneous_aggregated_kv_router_with_options(
+            &worker_args,
+            &worker_taints,
+            &mut source,
+            ControlledReplayOptions {
+                capture_per_request: true,
+                ..ControlledReplayOptions::default()
+            },
+        )
+        .unwrap();
+
+        let workers = report
+            .per_request
+            .iter()
+            .map(|request| {
+                (
+                    request.session_id.as_deref().unwrap(),
+                    request.decode_worker_idx.unwrap(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        assert!(workers["throughput"] < 2);
+        assert_eq!(workers["tail"], 2);
+        assert_eq!(report.throughput.decode_gpus_per_worker, 2);
     }
 
     #[test]
@@ -459,6 +617,7 @@ mod tests {
             &mut source,
             ControlledReplayOptions {
                 capture_per_request: true,
+                ..ControlledReplayOptions::default()
             },
         )
         .unwrap();

--- a/lib/mocker/src/replay/offline/controlled.rs
+++ b/lib/mocker/src/replay/offline/controlled.rs
@@ -540,6 +540,49 @@ mod tests {
         assert_eq!(workers["low"], 1);
     }
 
+    #[cfg(feature = "replay-bench")]
+    #[test]
+    fn controlled_kv_router_replay_is_reproducible() {
+        fn run() -> (f64, Vec<(String, usize, f64)>) {
+            let trace = Trace {
+                block_size: 64,
+                sessions: (0..32)
+                    .map(|index| SessionTrace {
+                        session_id: format!("session-{index}"),
+                        first_arrival_timestamp_ms: Some(0.0),
+                        turns: vec![turn(index + 1, None)],
+                    })
+                    .collect(),
+            };
+            let mut source = DriverSource::new(trace);
+            let report = simulate_controlled_aggregated_kv_router_with_options(
+                &args(),
+                4,
+                &mut source,
+                ControlledReplayOptions {
+                    capture_per_request: true,
+                    ..ControlledReplayOptions::default()
+                },
+            )
+            .unwrap();
+            let mut requests = report
+                .per_request
+                .into_iter()
+                .map(|request| {
+                    (
+                        request.session_id.unwrap(),
+                        request.decode_worker_idx.unwrap(),
+                        request.terminal_time_ms,
+                    )
+                })
+                .collect::<Vec<_>>();
+            requests.sort_by(|left, right| left.0.cmp(&right.0));
+            (report.throughput.duration_ms, requests)
+        }
+
+        assert_eq!(run(), run());
+    }
+
     #[test]
     fn controlled_kv_router_supports_heterogeneous_worker_topologies() {
         let trace = Trace {

--- a/lib/mocker/src/replay/offline/core/mod.rs
+++ b/lib/mocker/src/replay/offline/core/mod.rs
@@ -28,7 +28,12 @@ pub(crate) trait AdmissionSource {
     type Request;
     type Metadata;
 
-    fn next_ready_time_ms(&mut self) -> Option<f64>;
+    /// Return the next source-owned event time.
+    ///
+    /// This does not predict engine completions. A source waiting on an in-flight
+    /// request returns `None`; `on_terminal` may then arm a new timer after the
+    /// completion arrives.
+    fn next_internal_event_ms(&mut self) -> Option<f64>;
     fn drain_ready(
         &mut self,
         now_ms: f64,

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -1776,7 +1776,7 @@ where
     fn next_timestamp(&mut self) -> Option<f64> {
         let next_event_ms = self.events.peek().map(|event| event.at_ms);
         let next = choose_next_timestamp(
-            CoreAdmissionSource::next_ready_time_ms(&mut self.admission),
+            CoreAdmissionSource::next_internal_event_ms(&mut self.admission),
             next_event_ms,
         );
         #[cfg(feature = "kvbm-offload")]

--- a/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
@@ -256,6 +256,7 @@ struct PendingRequest {
     strict_priority: u32,
     policy_class: Option<String>,
     session_id: Option<String>,
+    routing_constraints: RoutingConstraints,
 }
 
 impl PendingRequest {
@@ -304,7 +305,7 @@ impl PendingRequest {
             expected_output_tokens: self.expected_output_tokens,
             pinned_worker: None,
             allowed_worker_ids: None,
-            routing_constraints: RoutingConstraints::default(),
+            routing_constraints: self.routing_constraints.clone(),
             shared_cache_hits: None,
             resp_tx: None,
         }
@@ -378,6 +379,7 @@ trait PlacementRequestView {
     fn metadata(&self) -> &DirectRequest;
     fn input_length(&self) -> usize;
     fn prompt_tokens(&self) -> Cow<'_, [u32]>;
+    fn routing_constraints(&self) -> RoutingConstraints;
 }
 
 impl PlacementRequestView for DirectRequest {
@@ -391,6 +393,10 @@ impl PlacementRequestView for DirectRequest {
 
     fn prompt_tokens(&self) -> Cow<'_, [u32]> {
         Cow::Borrowed(&self.tokens)
+    }
+
+    fn routing_constraints(&self) -> RoutingConstraints {
+        RoutingConstraints::default()
     }
 }
 
@@ -408,6 +414,10 @@ impl PlacementRequestView for ReplayRequestPayload {
             Some(tokens) => Cow::Borrowed(tokens),
             None => Cow::Owned(ReplayRequestPayload::prompt_tokens(self)),
         }
+    }
+
+    fn routing_constraints(&self) -> RoutingConstraints {
+        self.routing_constraints().clone()
     }
 }
 
@@ -505,6 +515,12 @@ impl OfflineReplayRouter {
         prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
         num_workers: usize,
     ) -> Result<Self> {
+        anyhow::ensure!(
+            args.worker_taints.is_empty() || args.worker_taints.len() == num_workers,
+            "worker_taints must be empty or contain exactly one entry per replay worker: got {} for {} workers",
+            args.worker_taints.len(),
+            num_workers,
+        );
         let config = replay_router_config(args, router_config);
         let tracking_hash = TrackingHashContext::from_config(&config)?;
         let worker_config_template = replay_worker_config(args);
@@ -859,6 +875,7 @@ impl OfflineReplayRouter {
             strict_priority,
             policy_class: request.policy_class.clone(),
             session_id,
+            routing_constraints: request_view.routing_constraints(),
         })
     }
 

--- a/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
@@ -2,19 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
 use dynamo_kv_router::LocalBlockHash;
+use dynamo_kv_router::approx::BlockEntry;
 pub(in crate::replay) use dynamo_kv_router::config::KvRouterConfig as ReplayKvRouterConfig;
 use dynamo_kv_router::config::KvRouterConfig;
 #[cfg(test)]
 pub(in crate::replay) use dynamo_kv_router::config::RouterQueuePolicy;
+use dynamo_kv_router::indexer::RoutingDecisionHashes;
 use dynamo_kv_router::protocols::{
-    BlockHashOptions, OverlapScores, PrefillLoadHint, RouterEvent, RoutingConstraints,
-    WorkerConfigLike, WorkerId, WorkerWithDpRank, compute_block_hash_for_seq,
+    BlockHashOptions, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData,
+    KvCacheStoreData, KvCacheStoredBlockData, OverlapScores, PrefillLoadHint, RouterEvent,
+    RoutingConstraints, WorkerConfigLike, WorkerId, WorkerWithDpRank, compute_block_hash_for_seq,
 };
 use dynamo_kv_router::queue::DEFAULT_MAX_BATCHED_TOKENS;
 use dynamo_kv_router::scheduling::{
@@ -44,7 +47,8 @@ use crate::replay::offline::core::{
 use crate::replay::offline::extensions::kv_events::RouterEventBatch;
 use crate::replay::router_shared::{
     ReplayNoopPublisher, ReplayWorkerConfig, replay_router_config, replay_selector, replay_slots,
-    replay_worker_config, replay_workers_with_configs,
+    replay_slots_with_block_size, replay_worker_config, replay_workers_with_configs,
+    replay_workers_with_heterogeneous_configs,
 };
 use crate::replay::{ReplayPrefillLoadEstimator, ReplayRouterMode};
 
@@ -191,32 +195,61 @@ pub(crate) struct OfflineRouterSnapshot {
 }
 
 struct SyncReplayIndexer {
-    block_size: u32,
     tree: RadixTree,
+    predicted: Option<SyncPredictedIndexer>,
 }
 
 impl SyncReplayIndexer {
-    fn new(block_size: u32) -> Self {
-        Self {
-            block_size,
+    fn new(predicted_ttl_secs: Option<f64>) -> Result<Self> {
+        let predicted = predicted_ttl_secs
+            .map(|ttl_secs| {
+                anyhow::ensure!(
+                    ttl_secs.is_finite() && ttl_secs > 0.0,
+                    "router predicted TTL must be finite and greater than zero"
+                );
+                Ok(SyncPredictedIndexer::new(Duration::from_secs_f64(ttl_secs)))
+            })
+            .transpose()?;
+        Ok(Self {
             tree: RadixTree::new(),
+            predicted,
+        })
+    }
+
+    fn predicted_enabled(&self) -> bool {
+        self.predicted.is_some()
+    }
+
+    fn find_matches_for_hashes(
+        &mut self,
+        local_block_hashes: &[LocalBlockHash],
+        now_ms: f64,
+    ) -> OverlapScores {
+        let mut scores = self.tree.find_matches(local_block_hashes.to_vec(), false);
+        if let Some(predicted) = self.predicted.as_mut() {
+            for (worker, predicted_score) in
+                predicted.find_matches(local_block_hashes, now_ms).scores
+            {
+                scores
+                    .scores
+                    .entry(worker)
+                    .and_modify(|score| *score = (*score).max(predicted_score))
+                    .or_insert(predicted_score);
+            }
         }
+        scores
     }
 
-    fn find_matches_for_request(&self, tokens: &[u32], lora_name: Option<&str>) -> OverlapScores {
-        let sequence = compute_block_hash_for_seq(
-            tokens,
-            self.block_size,
-            BlockHashOptions {
-                lora_name,
-                ..Default::default()
-            },
-        );
-        self.tree.find_matches(sequence, false)
-    }
-
-    fn find_matches_for_hashes(&self, local_block_hashes: Vec<LocalBlockHash>) -> OverlapScores {
-        self.tree.find_matches(local_block_hashes, false)
+    fn record_routing_decision(
+        &mut self,
+        worker: WorkerWithDpRank,
+        hashes: Option<RoutingDecisionHashes>,
+        now_ms: f64,
+    ) -> Result<()> {
+        if let (Some(predicted), Some(hashes)) = (self.predicted.as_mut(), hashes) {
+            predicted.record(worker, hashes, now_ms)?;
+        }
+        Ok(())
     }
 
     fn apply_event(&mut self, event: RouterEvent) -> Result<()> {
@@ -225,6 +258,13 @@ impl SyncReplayIndexer {
             return Ok(());
         }
         self.tree.apply_event(event).map_err(Into::into)
+    }
+
+    fn remove_worker(&mut self, worker_id: WorkerId) {
+        self.tree.remove_worker(worker_id);
+        if let Some(predicted) = self.predicted.as_mut() {
+            predicted.remove_worker(worker_id);
+        }
     }
 
     #[cfg(test)]
@@ -245,9 +285,138 @@ impl SyncReplayIndexer {
     }
 }
 
+/// Logical-time equivalent of Dynamo's short-TTL predict-on-route side indexer.
+/// The primary replay tree continues to receive engine KV events; this tree only
+/// carries route-time predictions and is merged with primary overlap by max.
+struct SyncPredictedIndexer {
+    ttl_ms: f64,
+    tree: RadixTree,
+    live_expiries: HashMap<BlockEntry, u64>,
+    expiries: BTreeMap<u64, Vec<BlockEntry>>,
+    event_id: u64,
+}
+
+impl SyncPredictedIndexer {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            ttl_ms: ttl.as_secs_f64() * 1_000.0,
+            tree: RadixTree::new(),
+            live_expiries: HashMap::new(),
+            expiries: BTreeMap::new(),
+            event_id: 0,
+        }
+    }
+
+    fn time_key(now_ms: f64) -> u64 {
+        (now_ms.max(0.0) * 1_000.0).floor() as u64
+    }
+
+    fn expiry_key(&self, now_ms: f64) -> u64 {
+        ((now_ms.max(0.0) + self.ttl_ms) * 1_000.0).ceil() as u64
+    }
+
+    fn find_matches(&mut self, local_hashes: &[LocalBlockHash], now_ms: f64) -> OverlapScores {
+        self.expire(now_ms);
+        self.tree.find_matches(local_hashes.to_vec(), false)
+    }
+
+    fn record(
+        &mut self,
+        worker: WorkerWithDpRank,
+        hashes: RoutingDecisionHashes,
+        now_ms: f64,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            hashes.local_hashes.len() == hashes.sequence_hashes.len(),
+            "routing-decision local and sequence hash counts differ"
+        );
+        self.expire(now_ms);
+        self.event_id = self.event_id.saturating_add(1);
+        let blocks = hashes
+            .local_hashes
+            .iter()
+            .zip(&hashes.sequence_hashes)
+            .map(|(local_hash, sequence_hash)| KvCacheStoredBlockData {
+                tokens_hash: *local_hash,
+                block_hash: ExternalSequenceBlockHash(*sequence_hash),
+                mm_extra_info: None,
+            })
+            .collect();
+        self.tree.apply_event(RouterEvent::new(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id: self.event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    start_position: None,
+                    blocks,
+                }),
+                dp_rank: worker.dp_rank,
+            },
+        ))?;
+
+        let expiry = self.expiry_key(now_ms);
+        let entries = hashes
+            .sequence_hashes
+            .into_iter()
+            .enumerate()
+            .map(|(seq_position, hash)| BlockEntry {
+                key: ExternalSequenceBlockHash(hash),
+                worker,
+                seq_position,
+            })
+            .collect::<Vec<_>>();
+        for entry in &entries {
+            self.live_expiries.insert(*entry, expiry);
+        }
+        self.expiries.entry(expiry).or_default().extend(entries);
+        Ok(())
+    }
+
+    fn expire(&mut self, now_ms: f64) {
+        let now = Self::time_key(now_ms);
+        let mut due_by_worker = BTreeMap::<WorkerWithDpRank, Vec<BlockEntry>>::new();
+        while self
+            .expiries
+            .first_key_value()
+            .is_some_and(|(&expiry, _)| expiry <= now)
+        {
+            let (expiry, entries) = self.expiries.pop_first().expect("entry exists");
+            for entry in entries {
+                if self.live_expiries.get(&entry).copied() == Some(expiry) {
+                    self.live_expiries.remove(&entry);
+                    due_by_worker.entry(entry.worker).or_default().push(entry);
+                }
+            }
+        }
+
+        for (worker, mut entries) in due_by_worker {
+            entries.sort_unstable_by_key(|entry| entry.seq_position);
+            self.event_id = self.event_id.saturating_add(1);
+            let _ = self.tree.apply_event(RouterEvent::new(
+                worker.worker_id,
+                KvCacheEvent {
+                    event_id: self.event_id,
+                    data: KvCacheEventData::Removed(KvCacheRemoveData {
+                        block_hashes: entries.into_iter().map(|entry| entry.key).collect(),
+                    }),
+                    dp_rank: worker.dp_rank,
+                },
+            ));
+        }
+    }
+
+    fn remove_worker(&mut self, worker_id: WorkerId) {
+        self.tree.remove_worker(worker_id);
+        self.live_expiries
+            .retain(|entry, _| entry.worker.worker_id != worker_id);
+    }
+}
+
 struct PendingRequest {
     uuid: Uuid,
     token_seq: Option<Vec<SequenceHash>>,
+    routing_decision_hashes: Option<RoutingDecisionHashes>,
     isl_tokens: usize,
     overlaps: OverlapScores,
     track_prefill_tokens: bool,
@@ -256,6 +425,7 @@ struct PendingRequest {
     strict_priority: u32,
     policy_class: Option<String>,
     session_id: Option<String>,
+    pinned_worker: Option<WorkerWithDpRank>,
     routing_constraints: RoutingConstraints,
 }
 
@@ -303,13 +473,19 @@ impl PendingRequest {
             policy_class: self.policy_class.clone(),
             session_id: self.session_id.clone(),
             expected_output_tokens: self.expected_output_tokens,
-            pinned_worker: None,
+            pinned_worker: self.pinned_worker,
             allowed_worker_ids: None,
             routing_constraints: self.routing_constraints.clone(),
             shared_cache_hits: None,
             resp_tx: None,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OfflineSessionAffinity {
+    worker: WorkerWithDpRank,
+    expires_at_ms: f64,
 }
 
 pub(crate) struct OfflineReplayRouter {
@@ -319,11 +495,14 @@ pub(crate) struct OfflineReplayRouter {
     profile: PolicyProfile,
     worker_config_template: ReplayWorkerConfig,
     workers_with_configs: HashMap<WorkerId, ReplayWorkerConfig>,
+    scheduler_ids_by_worker: HashMap<WorkerId, Vec<usize>>,
     slots: Arc<ActiveSequencesMultiWorker<ReplayNoopPublisher>>,
     selector: DefaultWorkerSelector,
     pending: PolicyQueue<PendingRequest>,
     indexer: SyncReplayIndexer,
     prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+    session_affinity_ttl: Option<Duration>,
+    session_affinity: HashMap<String, OfflineSessionAffinity>,
     decay_time_epoch: Instant,
     tracking_hash: TrackingHashContext,
 }
@@ -339,12 +518,47 @@ impl KvRouterPlacement {
         prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
         num_workers: usize,
     ) -> Result<Self> {
+        Self::new_with_session_affinity(
+            args,
+            router_config,
+            prefill_load_estimator,
+            num_workers,
+            None,
+        )
+    }
+
+    pub(in crate::replay) fn new_with_session_affinity(
+        args: &MockEngineArgs,
+        router_config: Option<KvRouterConfig>,
+        prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+        num_workers: usize,
+        session_affinity_ttl: Option<Duration>,
+    ) -> Result<Self> {
         Ok(Self {
-            router: OfflineReplayRouter::new(
+            router: OfflineReplayRouter::new_with_session_affinity(
                 args,
                 router_config,
                 prefill_load_estimator,
                 num_workers,
+                session_affinity_ttl,
+            )?,
+        })
+    }
+
+    pub(in crate::replay) fn new_heterogeneous_with_session_affinity(
+        worker_args: &[MockEngineArgs],
+        worker_taints: &[HashSet<String>],
+        router_config: Option<KvRouterConfig>,
+        prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+        session_affinity_ttl: Option<Duration>,
+    ) -> Result<Self> {
+        Ok(Self {
+            router: OfflineReplayRouter::new_heterogeneous_with_session_affinity(
+                worker_args,
+                worker_taints,
+                router_config,
+                prefill_load_estimator,
+                session_affinity_ttl,
             )?,
         })
     }
@@ -509,12 +723,33 @@ impl<Request: PlacementRequestView> PlacementPolicy<Request> for KvRouterPlaceme
 }
 
 impl OfflineReplayRouter {
+    #[cfg(test)]
     pub(crate) fn new(
         args: &MockEngineArgs,
         router_config: Option<KvRouterConfig>,
         prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
         num_workers: usize,
     ) -> Result<Self> {
+        Self::new_with_session_affinity(
+            args,
+            router_config,
+            prefill_load_estimator,
+            num_workers,
+            None,
+        )
+    }
+
+    pub(crate) fn new_with_session_affinity(
+        args: &MockEngineArgs,
+        router_config: Option<KvRouterConfig>,
+        prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+        num_workers: usize,
+        session_affinity_ttl: Option<Duration>,
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            session_affinity_ttl.is_none_or(|ttl| !ttl.is_zero()),
+            "session affinity TTL must be greater than zero"
+        );
         anyhow::ensure!(
             args.worker_taints.is_empty() || args.worker_taints.len() == num_workers,
             "worker_taints must be empty or contain exactly one entry per replay worker: got {} for {} workers",
@@ -522,9 +757,21 @@ impl OfflineReplayRouter {
             num_workers,
         );
         let config = replay_router_config(args, router_config);
+        let predicted_ttl_secs = config.router_predicted_ttl_secs;
         let tracking_hash = TrackingHashContext::from_config(&config)?;
         let worker_config_template = replay_worker_config(args);
         let workers_with_configs = replay_workers_with_configs(args, num_workers);
+        let dp_size = args.dp_size.max(1);
+        let scheduler_ids_by_worker = (0..num_workers)
+            .map(|worker_id| {
+                (
+                    worker_id as WorkerId,
+                    (0..dp_size as usize)
+                        .map(|dp_rank| worker_id * dp_size as usize + dp_rank)
+                        .collect(),
+                )
+            })
+            .collect();
         let slots = replay_slots(args, &workers_with_configs);
         let selector = replay_selector(&config);
         let profile = config
@@ -534,18 +781,98 @@ impl OfflineReplayRouter {
         Ok(Self {
             config,
             block_size: args.block_size as u32,
-            dp_size: args.dp_size.max(1),
+            dp_size,
             profile: profile.clone(),
             worker_config_template,
             workers_with_configs,
+            scheduler_ids_by_worker,
             slots,
             selector,
             pending: PolicyQueue::new(profile),
-            indexer: SyncReplayIndexer::new(args.block_size as u32),
+            indexer: SyncReplayIndexer::new(predicted_ttl_secs)?,
             prefill_load_estimator,
+            session_affinity_ttl,
+            session_affinity: HashMap::new(),
             // This is only a base Instant for converting replay `now_ms` values into
             // synthetic `Instant`s. All subsequent decay/accounting uses virtual replay
             // time derived from this epoch, not wall-clock progression.
+            decay_time_epoch: Instant::now(),
+            tracking_hash,
+        })
+    }
+
+    pub(crate) fn new_heterogeneous_with_session_affinity(
+        worker_args: &[MockEngineArgs],
+        worker_taints: &[HashSet<String>],
+        router_config: Option<KvRouterConfig>,
+        prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+        session_affinity_ttl: Option<Duration>,
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            session_affinity_ttl.is_none_or(|ttl| !ttl.is_zero()),
+            "session affinity TTL must be greater than zero"
+        );
+        anyhow::ensure!(
+            !worker_args.is_empty(),
+            "heterogeneous router requires at least one worker"
+        );
+        anyhow::ensure!(
+            worker_taints.is_empty() || worker_taints.len() == worker_args.len(),
+            "worker_taints must be empty or contain exactly one entry per replay worker: got {} for {} workers",
+            worker_taints.len(),
+            worker_args.len(),
+        );
+        let args = &worker_args[0];
+        anyhow::ensure!(
+            worker_args
+                .iter()
+                .all(|worker_args| worker_args.block_size == args.block_size),
+            "heterogeneous router workers must use a common block size"
+        );
+        let config = replay_router_config(args, router_config);
+        let predicted_ttl_secs = config.router_predicted_ttl_secs;
+        let tracking_hash = TrackingHashContext::from_config(&config)?;
+        let worker_config_template = replay_worker_config(args);
+        let workers_with_configs =
+            replay_workers_with_heterogeneous_configs(worker_args, worker_taints);
+        let slots = replay_slots_with_block_size(args.block_size, &workers_with_configs);
+        let selector = replay_selector(&config);
+        let profile = config
+            .configured_policy_profile()
+            .map_err(anyhow::Error::from)?;
+        let dp_size = worker_args
+            .iter()
+            .map(|worker_args| worker_args.dp_size.max(1))
+            .max()
+            .unwrap_or(1);
+        let mut next_scheduler_id = 0;
+        let scheduler_ids_by_worker = worker_args
+            .iter()
+            .enumerate()
+            .map(|(worker_id, worker_args)| {
+                let rank_count = worker_args.dp_size.max(1) as usize;
+                let scheduler_ids =
+                    (next_scheduler_id..next_scheduler_id + rank_count).collect::<Vec<_>>();
+                next_scheduler_id += rank_count;
+                (worker_id as WorkerId, scheduler_ids)
+            })
+            .collect();
+
+        Ok(Self {
+            config,
+            block_size: args.block_size as u32,
+            dp_size,
+            profile: profile.clone(),
+            worker_config_template,
+            workers_with_configs,
+            scheduler_ids_by_worker,
+            slots,
+            selector,
+            pending: PolicyQueue::new(profile),
+            indexer: SyncReplayIndexer::new(predicted_ttl_secs)?,
+            prefill_load_estimator,
+            session_affinity_ttl,
+            session_affinity: HashMap::new(),
             decay_time_epoch: Instant::now(),
             tracking_hash,
         })
@@ -586,8 +913,13 @@ impl OfflineReplayRouter {
         session_id: Option<String>,
         now_ms: f64,
     ) -> Result<RouterEffects> {
-        let pending =
-            self.build_pending_request(request, max_output_tokens, replay_hashes, session_id)?;
+        let pending = self.build_pending_request(
+            request,
+            max_output_tokens,
+            replay_hashes,
+            session_id,
+            now_ms,
+        )?;
         let decay_now = self.decay_now(now_ms);
         let (class_index, snapshot) = match self
             .profile
@@ -701,11 +1033,23 @@ impl OfflineReplayRouter {
         {
             return Err(anyhow!("router worker {worker_id} already exists"));
         }
+        let next_scheduler_id = self
+            .scheduler_ids_by_worker
+            .values()
+            .flatten()
+            .copied()
+            .max()
+            .map_or(0, |scheduler_id| scheduler_id + 1);
+        self.scheduler_ids_by_worker.insert(
+            wid,
+            (next_scheduler_id..next_scheduler_id + self.dp_size as usize).collect(),
+        );
         if let Err(error) = self
             .slots
             .upsert_worker(WorkerDpRange::new(wid, 0, self.dp_size))
         {
             self.workers_with_configs.remove(&wid);
+            self.scheduler_ids_by_worker.remove(&wid);
             return Err(error.into());
         }
 
@@ -724,6 +1068,8 @@ impl OfflineReplayRouter {
     pub(crate) fn remove_worker(&mut self, worker_id: usize) -> Result<()> {
         let wid = worker_id as WorkerId;
         self.workers_with_configs.remove(&wid);
+        self.session_affinity
+            .retain(|_, affinity| affinity.worker.worker_id != wid);
         Ok(())
     }
 
@@ -734,7 +1080,8 @@ impl OfflineReplayRouter {
         self.slots
             .unregister_worker(wid)
             .map_err(anyhow::Error::from)?;
-        self.indexer.tree.remove_worker(wid);
+        self.indexer.remove_worker(wid);
+        self.scheduler_ids_by_worker.remove(&wid);
         Ok(())
     }
 
@@ -807,11 +1154,12 @@ impl OfflineReplayRouter {
     }
 
     fn build_pending_request<Request: PlacementRequestView>(
-        &self,
+        &mut self,
         request_view: &Request,
         max_output_tokens: usize,
         replay_hashes: Option<ReplayRequestHashes>,
         session_id: Option<String>,
+        now_ms: f64,
     ) -> Result<PendingRequest> {
         let request = request_view.metadata();
         let input_length = request_view.input_length();
@@ -819,11 +1167,18 @@ impl OfflineReplayRouter {
             .uuid
             .ok_or_else(|| anyhow!("offline replay requires requests to have stable UUIDs"))?;
         let (priority_jump, strict_priority) = request.router_priorities();
-        let (overlaps, token_seq) = match replay_hashes {
+        let (overlaps, token_seq, routing_decision_hashes) = match replay_hashes {
             Some(replay_hashes) => {
                 let overlaps = self
                     .indexer
-                    .find_matches_for_hashes(replay_hashes.local_block_hashes);
+                    .find_matches_for_hashes(&replay_hashes.local_block_hashes, now_ms);
+                let routing_decision_hashes =
+                    self.indexer
+                        .predicted_enabled()
+                        .then(|| RoutingDecisionHashes {
+                            local_hashes: replay_hashes.local_block_hashes.clone(),
+                            sequence_hashes: replay_hashes.sequence_hashes.clone(),
+                        });
                 let token_seq = if !self.config.router_track_active_blocks {
                     None
                 } else if self.config.router_assume_kv_reuse
@@ -844,11 +1199,20 @@ impl OfflineReplayRouter {
                         None,
                     )
                 };
-                (overlaps, token_seq)
+                (overlaps, token_seq, routing_decision_hashes)
             }
             None => {
                 let tokens = request_view.prompt_tokens();
-                let overlaps = self.indexer.find_matches_for_request(&tokens, None);
+                let local_hashes = compute_block_hash_for_seq(
+                    &tokens,
+                    self.block_size,
+                    BlockHashOptions::default(),
+                );
+                let overlaps = self.indexer.find_matches_for_hashes(&local_hashes, now_ms);
+                let routing_decision_hashes = self
+                    .indexer
+                    .predicted_enabled()
+                    .then(|| RoutingDecisionHashes::from_local_hashes(local_hashes));
                 let token_seq = self.config.compute_seq_hashes_for_tracking_with_context(
                     &self.tracking_hash,
                     self.tracking_hash_scope(),
@@ -857,13 +1221,18 @@ impl OfflineReplayRouter {
                     BlockHashOptions::default(),
                     None,
                 );
-                (overlaps, token_seq)
+                (overlaps, token_seq, routing_decision_hashes)
             }
         };
+
+        let routing_constraints = request_view.routing_constraints();
+        let pinned_worker =
+            self.resolve_session_affinity(session_id.as_deref(), &routing_constraints, now_ms);
 
         Ok(PendingRequest {
             uuid,
             token_seq,
+            routing_decision_hashes,
             isl_tokens: input_length,
             overlaps,
             track_prefill_tokens: self.config.router_track_prefill_tokens,
@@ -875,8 +1244,60 @@ impl OfflineReplayRouter {
             strict_priority,
             policy_class: request.policy_class.clone(),
             session_id,
-            routing_constraints: request_view.routing_constraints(),
+            pinned_worker,
+            routing_constraints,
         })
+    }
+
+    fn resolve_session_affinity(
+        &mut self,
+        session_id: Option<&str>,
+        routing_constraints: &RoutingConstraints,
+        now_ms: f64,
+    ) -> Option<WorkerWithDpRank> {
+        let ttl = self.session_affinity_ttl?;
+        let session_id = session_id?;
+        let affinity = self.session_affinity.get(session_id).copied()?;
+        let worker_valid = affinity.expires_at_ms > now_ms
+            && self
+                .workers_with_configs
+                .get(&affinity.worker.worker_id)
+                .is_some_and(|config| {
+                    let start = config.data_parallel_start_rank();
+                    let end = start.saturating_add(config.data_parallel_size());
+                    (start..end).contains(&affinity.worker.dp_rank)
+                        && routing_constraints.is_compatible_with_worker_taints(config.taints())
+                });
+        if !worker_valid {
+            self.session_affinity.remove(session_id);
+            return None;
+        }
+        self.session_affinity.insert(
+            session_id.to_string(),
+            OfflineSessionAffinity {
+                worker: affinity.worker,
+                expires_at_ms: now_ms + ttl.as_secs_f64() * 1000.0,
+            },
+        );
+        Some(affinity.worker)
+    }
+
+    fn bind_session_affinity(
+        &mut self,
+        session_id: Option<&str>,
+        worker: WorkerWithDpRank,
+        now_ms: f64,
+    ) {
+        let (Some(ttl), Some(session_id)) = (self.session_affinity_ttl, session_id) else {
+            return;
+        };
+        self.session_affinity.insert(
+            session_id.to_string(),
+            OfflineSessionAffinity {
+                worker,
+                expires_at_ms: now_ms + ttl.as_secs_f64() * 1000.0,
+            },
+        );
     }
 
     fn tracking_hash_scope(&self) -> TrackingHashScope<'_> {
@@ -891,6 +1312,11 @@ impl OfflineReplayRouter {
         request: PendingRequest,
         decay_now: Instant,
     ) -> Result<AdmitOutcome> {
+        let now_ms = decay_now
+            .checked_duration_since(self.decay_time_epoch)
+            .unwrap_or_default()
+            .as_secs_f64()
+            * 1000.0;
         let worker_loads = self
             .slots
             .project_worker_loads(request.token_seq.as_deref(), decay_now);
@@ -902,15 +1328,21 @@ impl OfflineReplayRouter {
             eligibility,
             self.block_size,
         )?;
+        let session_id = request.session_id.clone();
         let worker_id = usize::try_from(selection.worker.worker_id)
             .map_err(|_| anyhow!("selected worker id does not fit into usize"))?;
         let dp_rank = usize::try_from(selection.worker.dp_rank)
             .map_err(|_| anyhow!("selected dp rank does not fit into usize"))?;
-        let worker_idx = worker_id
-            .checked_mul(self.dp_size as usize)
-            .and_then(|base| base.checked_add(dp_rank))
-            .ok_or_else(|| anyhow!("selected worker/rank index overflow"))?;
+        let worker_idx = self
+            .scheduler_ids_by_worker
+            .get(&selection.worker.worker_id)
+            .and_then(|scheduler_ids| scheduler_ids.get(dp_rank))
+            .copied()
+            .ok_or_else(|| {
+                anyhow!("selected worker {worker_id} has no DP rank {dp_rank} scheduler")
+            })?;
         let request_id = request.request_id();
+        let routing_decision_hashes = request.routing_decision_hashes;
         let prefill_load_hint = self.prefill_load_hint_for(
             request.isl_tokens,
             selection.cached_tokens,
@@ -935,6 +1367,9 @@ impl OfflineReplayRouter {
                 decay_now,
             )
             .map_err(anyhow::Error::from)?;
+        self.indexer
+            .record_routing_decision(selection.worker, routing_decision_hashes, now_ms)?;
+        self.bind_session_affinity(session_id.as_deref(), selection.worker, now_ms);
 
         Ok(AdmitOutcome {
             worker_idx,
@@ -1052,14 +1487,17 @@ mod tests {
     use dynamo_kv_router::protocols::{
         BlockHashOptions, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData,
         KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier,
-        WorkerId,
+        WorkerId, WorkerWithDpRank,
     };
     use dynamo_kv_router::{PrefillLoadEstimator, TrackingHashAlgorithm};
     use rustc_hash::FxHashMap;
     use tempfile::NamedTempFile;
     use uuid::Uuid;
 
-    use super::{OfflineReplayRouter, ReplayRequestHashes, SyncReplayIndexer, WorkerAdmission};
+    use super::{
+        OfflineReplayRouter, ReplayRequestHashes, RoutingDecisionHashes, SyncReplayIndexer,
+        WorkerAdmission,
+    };
     use crate::common::protocols::{DirectRequest, MockEngineArgs};
     use crate::replay::ReplayPrefillLoadEstimator;
 
@@ -1179,7 +1617,7 @@ mod tests {
 
     #[test]
     fn session_identity_reaches_scheduling_request() {
-        let router = OfflineReplayRouter::new(&replay_args(), None, None, 1).unwrap();
+        let mut router = OfflineReplayRouter::new(&replay_args(), None, None, 1).unwrap();
         let request = request(1, 7);
         let pending = router
             .build_pending_request(
@@ -1187,11 +1625,58 @@ mod tests {
                 request.max_output_tokens,
                 None,
                 Some("session-a".to_string()),
+                0.0,
             )
             .unwrap();
         let scheduling_request = pending.scheduling_request(64, FxHashMap::default());
 
         assert_eq!(scheduling_request.session_id.as_deref(), Some("session-a"));
+    }
+
+    #[test]
+    fn session_affinity_pins_until_logical_idle_ttl_expires() {
+        let mut router = OfflineReplayRouter::new_with_session_affinity(
+            &replay_args(),
+            None,
+            None,
+            2,
+            Some(Duration::from_secs(10)),
+        )
+        .unwrap();
+
+        let first = router
+            .on_request_arrival_for_session(
+                &request(1, 7),
+                None,
+                Some("session-a".to_string()),
+                0.0,
+            )
+            .unwrap()
+            .admissions[0]
+            .worker_idx;
+        let before_expiry = router
+            .on_request_arrival_for_session(
+                &request(2, 8),
+                None,
+                Some("session-a".to_string()),
+                1_000.0,
+            )
+            .unwrap()
+            .admissions[0]
+            .worker_idx;
+        let after_expiry = router
+            .on_request_arrival_for_session(
+                &request(3, 9),
+                None,
+                Some("session-a".to_string()),
+                11_001.0,
+            )
+            .unwrap()
+            .admissions[0]
+            .worker_idx;
+
+        assert_eq!(before_expiry, first);
+        assert_ne!(after_expiry, first);
     }
 
     #[test]
@@ -1204,7 +1689,7 @@ mod tests {
             router_tracking_key_id: Some("2026-01".to_string()),
             ..Default::default()
         };
-        let router = OfflineReplayRouter::new(&replay_args(), Some(config), None, 1).unwrap();
+        let mut router = OfflineReplayRouter::new(&replay_args(), Some(config), None, 1).unwrap();
         let request = request(1, 7);
         let replay_hashes = ReplayRequestHashes::from_tokens(&request.tokens, router.block_size);
         let expected = router.config.compute_seq_hashes_for_tracking_with_context(
@@ -1222,6 +1707,7 @@ mod tests {
                 request.max_output_tokens,
                 Some(replay_hashes.clone()),
                 None,
+                0.0,
             )
             .unwrap();
 
@@ -1231,7 +1717,7 @@ mod tests {
 
     #[test]
     fn lower_tier_events_do_not_enter_offline_primary_index() {
-        let mut indexer = SyncReplayIndexer::new(64);
+        let mut indexer = SyncReplayIndexer::new(None).unwrap();
 
         indexer
             .apply_event(store_event(7, 1, 101, StorageTier::HostPinned))
@@ -1242,6 +1728,42 @@ mod tests {
             .apply_event(store_event(7, 2, 101, StorageTier::Device))
             .unwrap();
         assert_eq!(indexer.debug_snapshot().total_cached_blocks, 1);
+    }
+
+    #[test]
+    fn predicted_route_overlap_expires_in_logical_time() {
+        let mut indexer = SyncReplayIndexer::new(Some(5.0)).unwrap();
+        let local_hashes = vec![LocalBlockHash(101), LocalBlockHash(102)];
+        let worker = WorkerWithDpRank::new(7, 0);
+
+        assert!(
+            indexer
+                .find_matches_for_hashes(&local_hashes, 0.0)
+                .scores
+                .is_empty()
+        );
+        indexer
+            .record_routing_decision(
+                worker,
+                Some(RoutingDecisionHashes::from_local_hashes(
+                    local_hashes.clone(),
+                )),
+                0.0,
+            )
+            .unwrap();
+        assert_eq!(
+            indexer
+                .find_matches_for_hashes(&local_hashes, 4_999.0)
+                .scores
+                .get(&worker),
+            Some(&2)
+        );
+        assert!(
+            indexer
+                .find_matches_for_hashes(&local_hashes, 5_001.0)
+                .scores
+                .is_empty()
+        );
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/mod.rs
+++ b/lib/mocker/src/replay/offline/mod.rs
@@ -6,6 +6,7 @@ pub(crate) use crate::replay::normalize_trace_requests;
 pub(crate) mod agg;
 mod canonical;
 pub(crate) mod components;
+mod controlled;
 pub(crate) mod core;
 pub(crate) mod disagg;
 mod entrypoints;
@@ -26,6 +27,11 @@ pub use canonical::{
     CanonicalReplayRecord, CanonicalReplayTopology, CanonicalSemanticFeatures,
     CanonicalSlaMetadata, CanonicalSyntheticSpec, CanonicalWorkloadMetadata,
     canonical_engine_pool_metadata, canonical_topology,
+};
+pub use controlled::{
+    ControlledReplayOptions, ReplayWorkSource, ReplayWorkSourceContext, ReplayWorkSubmission,
+    simulate_controlled_aggregated, simulate_controlled_aggregated_kv_router_with_options,
+    simulate_controlled_aggregated_with_options,
 };
 pub use entrypoints::run_offline_handoff_conformance;
 pub(crate) use entrypoints::{

--- a/lib/mocker/src/replay/offline/mod.rs
+++ b/lib/mocker/src/replay/offline/mod.rs
@@ -32,6 +32,7 @@ pub use controlled::{
     ControlledReplayOptions, ReplayWorkSource, ReplayWorkSourceContext, ReplayWorkSubmission,
     simulate_controlled_aggregated, simulate_controlled_aggregated_kv_router_with_options,
     simulate_controlled_aggregated_with_options,
+    simulate_controlled_heterogeneous_aggregated_kv_router_with_options,
 };
 pub use entrypoints::run_offline_handoff_conformance;
 pub(crate) use entrypoints::{

--- a/lib/mocker/src/replay/router_shared.rs
+++ b/lib/mocker/src/replay/router_shared.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::common::protocols::MockEngineArgs;
@@ -33,6 +34,7 @@ pub(super) struct ReplayWorkerConfig {
     pub(super) total_kv_blocks: u64,
     pub(super) data_parallel_start_rank: u32,
     pub(super) data_parallel_size: u32,
+    pub(super) taints: HashSet<String>,
 }
 
 impl WorkerConfigLike for ReplayWorkerConfig {
@@ -51,6 +53,10 @@ impl WorkerConfigLike for ReplayWorkerConfig {
     fn total_kv_blocks(&self) -> Option<u64> {
         Some(self.total_kv_blocks)
     }
+
+    fn taints(&self) -> &HashSet<String> {
+        &self.taints
+    }
 }
 
 pub(super) type ReplayScheduler =
@@ -65,6 +71,7 @@ pub(in crate::replay) fn replay_worker_config(args: &MockEngineArgs) -> ReplayWo
         total_kv_blocks: args.num_gpu_blocks as u64,
         data_parallel_start_rank: 0,
         data_parallel_size: args.dp_size.max(1),
+        taints: HashSet::new(),
     }
 }
 
@@ -74,7 +81,15 @@ pub(super) fn replay_workers_with_configs(
 ) -> HashMap<WorkerId, ReplayWorkerConfig> {
     let worker_config = replay_worker_config(args);
     (0..num_workers)
-        .map(|worker_idx| (worker_idx as WorkerId, worker_config.clone()))
+        .map(|worker_idx| {
+            let mut config = worker_config.clone();
+            config.taints = args
+                .worker_taints
+                .get(worker_idx)
+                .cloned()
+                .unwrap_or_default();
+            (worker_idx as WorkerId, config)
+        })
         .collect()
 }
 

--- a/lib/mocker/src/replay/router_shared.rs
+++ b/lib/mocker/src/replay/router_shared.rs
@@ -144,11 +144,13 @@ pub(super) fn replay_slots_with_block_size(
 }
 
 pub(super) fn replay_selector(config: &KvRouterConfig) -> DefaultWorkerSelector {
+    // The opt-in replay-bench feature promises repeatable offline experiments,
+    // including externally controlled replays that do not enter the canonical
+    // report guard. Normal builds retain the production selector below.
     #[cfg(feature = "replay-bench")]
-    if super::canonical_replay_active() {
-        return DefaultWorkerSelector::new_seeded(Some(config.clone()), "replay", 0xD1A0_5EED);
-    }
+    return DefaultWorkerSelector::new_seeded(Some(config.clone()), "replay", 0xD1A0_5EED);
 
+    #[cfg(not(feature = "replay-bench"))]
     DefaultWorkerSelector::new(Some(config.clone()), "replay")
 }
 

--- a/lib/mocker/src/replay/router_shared.rs
+++ b/lib/mocker/src/replay/router_shared.rs
@@ -93,8 +93,30 @@ pub(super) fn replay_workers_with_configs(
         .collect()
 }
 
+pub(super) fn replay_workers_with_heterogeneous_configs(
+    worker_args: &[MockEngineArgs],
+    worker_taints: &[HashSet<String>],
+) -> HashMap<WorkerId, ReplayWorkerConfig> {
+    worker_args
+        .iter()
+        .enumerate()
+        .map(|(worker_idx, args)| {
+            let mut config = replay_worker_config(args);
+            config.taints = worker_taints.get(worker_idx).cloned().unwrap_or_default();
+            (worker_idx as WorkerId, config)
+        })
+        .collect()
+}
+
 pub(super) fn replay_slots(
     args: &MockEngineArgs,
+    workers_with_configs: &HashMap<WorkerId, ReplayWorkerConfig>,
+) -> Arc<ActiveSequencesMultiWorker<ReplayNoopPublisher>> {
+    replay_slots_with_block_size(args.block_size, workers_with_configs)
+}
+
+pub(super) fn replay_slots_with_block_size(
+    block_size: usize,
     workers_with_configs: &HashMap<WorkerId, ReplayWorkerConfig>,
 ) -> Arc<ActiveSequencesMultiWorker<ReplayNoopPublisher>> {
     let dp_range = workers_with_configs
@@ -113,7 +135,7 @@ pub(super) fn replay_slots(
     // not mask replay dead ends by expiring requests that are still live in virtual time.
     Arc::new(ActiveSequencesMultiWorker::new_without_expiry(
         ReplayNoopPublisher,
-        args.block_size,
+        block_size,
         dp_range,
         false,
         0,

--- a/lib/mocker/src/scheduler/vllm/CLAUDE.md
+++ b/lib/mocker/src/scheduler/vllm/CLAUDE.md
@@ -23,5 +23,6 @@ TRT-LLM. `EngineType::Trtllm` uses the same `VllmCore` with a different
   admission path.
 - Discount only active cached prefix blocks from physical capacity. Inactive
   cached blocks must consume capacity when reactivated.
-- Preserve FIFO waiting behavior. A candidate that cannot be admitted now must
-  remain queued without preempting running work.
+- Preserve stable priority waiting behavior: higher Dynamo priorities run
+  first, with FIFO arrival order within each priority. A candidate that cannot
+  be admitted now must remain queued without preempting running work.

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -300,7 +300,7 @@ impl SchedulerState {
         }
     }
 
-    fn next_waiting_uuid(&mut self) -> Option<Uuid> {
+    fn next_waiting_uuid(&mut self, prefer_materialized: bool) -> Option<Uuid> {
         loop {
             let entry = *self.waiting.entries.first()?;
             let is_live = self.waiting_members.contains(&entry.uuid)
@@ -309,7 +309,7 @@ impl SchedulerState {
                         && WaitingRequest::from_state(entry.uuid, request) == entry
                 });
             if is_live {
-                return Some(entry.uuid);
+                break;
             }
 
             // Terminal removal and lifecycle transitions eagerly delete their
@@ -319,6 +319,21 @@ impl SchedulerState {
             self.waiting.entries.remove(&entry);
             self.waiting_members.remove(&entry.uuid);
         }
+
+        if prefer_materialized
+            && let Some(entry) = self.waiting.entries.iter().find(|entry| {
+                self.waiting_members.contains(&entry.uuid)
+                    && self.requests.get(&entry.uuid).is_some_and(|request| {
+                        request.status != RequestStatus::Running
+                            && request.prompt_is_prebuilt()
+                            && WaitingRequest::from_state(entry.uuid, request) == **entry
+                    })
+            })
+        {
+            return Some(entry.uuid);
+        }
+
+        self.waiting.entries.first().map(|entry| entry.uuid)
     }
 
     #[cfg_attr(feature = "profile", inline(never))]
@@ -1626,7 +1641,11 @@ impl VllmCore {
         let admission = AdmissionInvariant::new(self.pending_destinations.has_pending());
         let mut rejected_uuids: Vec<Uuid> = Vec::new();
         while !preempted_any && self.state.running.len() < max_num_running {
-            let Some(uuid) = self.state.next_waiting_uuid() else {
+            let prefer_materialized = matches!(
+                admission.stage_for(false),
+                AdmissionStage::PendingDestinationHead
+            );
+            let Some(uuid) = self.state.next_waiting_uuid(prefer_materialized) else {
                 break;
             };
             if self.refresh_request_offload_dependency(uuid).is_some() {

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::VecDeque;
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, VecDeque};
 use std::time::Duration;
 
 use dynamo_kv_router::protocols::WorkerId;
@@ -49,6 +50,11 @@ pub(crate) enum RequestStatus {
 
 pub(crate) struct VllmRequestState {
     pub(crate) sequence: RequestKvState,
+    /// Unified Dynamo request priority. Higher values are scheduled first.
+    pub(crate) priority: i32,
+    /// Monotonic arrival order assigned when the request first enters this
+    /// scheduler. Requeues retain this value so equal priorities remain FIFO.
+    pub(crate) arrival_order: u64,
     pub(crate) status: RequestStatus,
     pub(crate) num_computed_tokens: usize,
     pub(crate) num_preemptions: usize,
@@ -94,10 +100,102 @@ impl VllmRequestState {
     }
 }
 
+/// A queue entry ordered by Dynamo priority descending, then original arrival
+/// ascending. The UUID tie-breaker makes the ordering total without affecting
+/// FIFO order because every scheduler-assigned arrival order is unique.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct WaitingRequest {
+    uuid: Uuid,
+    priority: i32,
+    arrival_order: u64,
+}
+
+impl WaitingRequest {
+    fn from_state(uuid: Uuid, request: &VllmRequestState) -> Self {
+        Self {
+            uuid,
+            priority: request.priority,
+            arrival_order: request.arrival_order,
+        }
+    }
+}
+
+impl Ord for WaitingRequest {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // `BTreeSet::first` yields the smallest entry. Invert the priority
+        // comparison so a larger Dynamo priority is scheduled first.
+        other
+            .priority
+            .cmp(&self.priority)
+            .then_with(|| self.arrival_order.cmp(&other.arrival_order))
+            .then_with(|| self.uuid.cmp(&other.uuid))
+    }
+}
+
+impl PartialOrd for WaitingRequest {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Stable priority queue used by the vLLM waiting path. It intentionally keeps
+/// the small queue-shaped inspection API used by scheduler diagnostics and
+/// tests while making dequeue order explicit.
+#[derive(Default)]
+pub(crate) struct StablePriorityQueue {
+    entries: BTreeSet<WaitingRequest>,
+}
+
+impl StablePriorityQueue {
+    fn insert(&mut self, entry: WaitingRequest) {
+        let inserted = self.entries.insert(entry);
+        debug_assert!(inserted, "waiting queue inserted a duplicate request");
+    }
+
+    fn remove(&mut self, entry: &WaitingRequest) {
+        self.entries.remove(entry);
+    }
+
+    fn remove_uuid(&mut self, uuid: Uuid) {
+        let stale = self
+            .entries
+            .iter()
+            .find(|entry| entry.uuid == uuid)
+            .copied();
+        if let Some(entry) = stale {
+            self.entries.remove(&entry);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn front(&self) -> Option<&Uuid> {
+        self.entries.first().map(|entry| &entry.uuid)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Uuid> {
+        self.entries.iter().map(|entry| &entry.uuid)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, uuid: &Uuid) -> bool {
+        self.entries.iter().any(|entry| &entry.uuid == uuid)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct SchedulerState {
-    pub(crate) waiting: VecDeque<Uuid>,
+    pub(crate) waiting: StablePriorityQueue,
     waiting_members: FxHashSet<Uuid>,
+    next_arrival_order: u64,
     pub(crate) running: VecDeque<Uuid>,
     running_members: FxHashSet<Uuid>,
     pub(crate) requests: FxHashMap<Uuid, VllmRequestState>,
@@ -152,11 +250,25 @@ impl SchedulerState {
             .unwrap_or_default()
     }
 
+    fn next_arrival_order(&mut self) -> u64 {
+        let arrival_order = self.next_arrival_order;
+        self.next_arrival_order = self
+            .next_arrival_order
+            .checked_add(1)
+            .expect("vLLM scheduler arrival order overflowed");
+        arrival_order
+    }
+
     fn push_waiting(&mut self, uuid: Uuid) {
         if !self.waiting_members.insert(uuid) {
             return;
         }
-        self.waiting.push_back(uuid);
+        let request = self
+            .requests
+            .get(&uuid)
+            .expect("waiting request missing from state map");
+        self.waiting
+            .insert(WaitingRequest::from_state(uuid, request));
     }
 
     fn insert_waiting(&mut self, uuid: Uuid, request: VllmRequestState) {
@@ -165,50 +277,48 @@ impl SchedulerState {
         self.push_waiting(uuid);
     }
 
-    fn prepend_waiting(&mut self, uuid: Uuid) {
-        if !self.waiting_members.insert(uuid) {
-            return;
-        }
-        self.waiting.push_front(uuid);
+    /// Requeue a request using its original priority and arrival order. This
+    /// applies to preemption and swap-in resumption, so neither lifecycle can
+    /// change the stable order among equal-priority requests.
+    fn requeue_waiting(&mut self, uuid: Uuid) {
+        self.push_waiting(uuid);
     }
 
     /// Remove `uuid` from the waiting queue and from the
-    /// `waiting_members` set. Shared between `transition_to_running`
-    /// (which then promotes to running) and the offload admission
-    /// hook's parking path (which keeps the request in `Waiting`
-    /// status while parked on a swap-in).
+    /// `waiting_members` set. Shared between `transition_to_running`, terminal
+    /// cleanup, and the offload admission hook's swap-in parking path.
     fn remove_from_waiting(&mut self, uuid: Uuid) {
-        if let Some(position) = self.waiting.iter().position(|waiting| *waiting == uuid) {
-            self.waiting.remove(position);
+        if self.waiting_members.remove(&uuid) {
+            if let Some(request) = self.requests.get(&uuid) {
+                self.waiting
+                    .remove(&WaitingRequest::from_state(uuid, request));
+            } else {
+                // Keep cancellation/removal robust if a previous lifecycle
+                // transition left a stale queue entry behind.
+                self.waiting.remove_uuid(uuid);
+            }
         }
-        self.waiting_members.remove(&uuid);
     }
 
-    fn next_waiting_uuid(&mut self, prefer_materialized: bool) -> Option<Uuid> {
+    fn next_waiting_uuid(&mut self) -> Option<Uuid> {
         loop {
-            let uuid = *self.waiting.front()?;
-            if self.waiting_members.contains(&uuid)
-                && self
-                    .requests
-                    .get(&uuid)
-                    .is_some_and(|request| request.status != RequestStatus::Running)
-            {
-                break;
+            let entry = *self.waiting.entries.first()?;
+            let is_live = self.waiting_members.contains(&entry.uuid)
+                && self.requests.get(&entry.uuid).is_some_and(|request| {
+                    request.status != RequestStatus::Running
+                        && WaitingRequest::from_state(entry.uuid, request) == entry
+                });
+            if is_live {
+                return Some(entry.uuid);
             }
-            self.waiting.pop_front();
-            self.waiting_members.remove(&uuid);
-        }
 
-        if prefer_materialized {
-            return self.waiting.iter().copied().find(|uuid| {
-                self.waiting_members.contains(uuid)
-                    && self
-                        .requests
-                        .get(uuid)
-                        .is_some_and(VllmRequestState::prompt_is_prebuilt)
-            });
+            // Terminal removal and lifecycle transitions eagerly delete their
+            // entry. Retain this head cleanup as a defensive path for any
+            // stale entry left by an interrupted transition without scanning
+            // the whole queue on every admission.
+            self.waiting.entries.remove(&entry);
+            self.waiting_members.remove(&entry.uuid);
         }
-        self.waiting.front().copied()
     }
 
     #[cfg_attr(feature = "profile", inline(never))]
@@ -240,7 +350,7 @@ impl SchedulerState {
     }
 
     pub(crate) fn take_completed(&mut self, uuid: &Uuid) -> Option<VllmRequestState> {
-        self.waiting_members.remove(uuid);
+        self.remove_from_waiting(*uuid);
         self.running_members.remove(uuid);
         self.requests.remove(uuid)
     }
@@ -277,7 +387,7 @@ impl SchedulerState {
         self.preemptions_total += 1;
         let signals = request.sequence.reset_legacy_with_signal();
         request.debug_assert_invariants(uuid);
-        self.prepend_waiting(uuid);
+        self.requeue_waiting(uuid);
         Some(PreemptedRequest {
             uuid,
             signals,
@@ -346,10 +456,38 @@ impl SchedulerState {
                 );
                 request.debug_assert_invariants(*uuid);
             }
-            debug_assert!(
-                self.waiting.len() >= self.waiting_members.len(),
-                "waiting queue dropped live membership entries"
+            debug_assert_eq!(
+                self.waiting.len(),
+                self.waiting_members.len(),
+                "waiting queue and membership set disagree"
             );
+            for entry in &self.waiting.entries {
+                debug_assert!(
+                    self.waiting_members.contains(&entry.uuid),
+                    "stale request {} remains in the waiting priority queue",
+                    entry.uuid,
+                );
+                if let Some(request) = self.requests.get(&entry.uuid) {
+                    debug_assert_ne!(
+                        request.status,
+                        RequestStatus::Running,
+                        "running request {} remains in the waiting priority queue",
+                        entry.uuid,
+                    );
+                    debug_assert_eq!(
+                        *entry,
+                        WaitingRequest::from_state(entry.uuid, request),
+                        "waiting request {} priority entry does not match state",
+                        entry.uuid,
+                    );
+                } else {
+                    debug_assert!(
+                        false,
+                        "waiting request {} missing from state map",
+                        entry.uuid,
+                    );
+                }
+            }
             debug_assert!(
                 self.running.len() >= self.running_members.len(),
                 "running queue dropped live membership entries"
@@ -873,11 +1011,13 @@ impl VllmCore {
     }
 
     fn make_request_state(
-        &self,
+        &mut self,
         request: DirectRequest,
         status: RequestStatus,
     ) -> VllmRequestState {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+        let priority = request.priority;
+        let arrival_order = self.state.next_arrival_order();
         let prompt_len = request.tokens.len();
         let mut max_output_tokens = request.max_output_tokens;
         let planned_output_ids = request.output_token_ids;
@@ -935,6 +1075,8 @@ impl VllmCore {
         };
         VllmRequestState {
             sequence,
+            priority,
+            arrival_order,
             status,
             num_computed_tokens: 0,
             num_preemptions: 0,
@@ -1179,11 +1321,10 @@ impl VllmCore {
         }
 
         self.requests_awaiting_swap_in = pending;
-        // Completed swap-ins are ready to run immediately: put them back at
-        // the front so unrelated cold requests cannot evict the freshly
-        // onboarded inactive blocks first. Iterate in reverse because each
-        // completion prepends to the queue; this preserves completion order.
-        for aws in completed.into_iter().rev() {
+        // Completed swap-ins re-enter with their original priority and arrival
+        // order. This preserves FIFO among equal priorities without allowing a
+        // lower-priority resumed request to bypass newer higher-priority work.
+        for aws in completed {
             self.complete_swap_in(aws);
         }
         if self.kv_manager.num_active_blocks() < active_before {
@@ -1236,8 +1377,8 @@ impl VllmCore {
     }
 
     /// Register the onboard'd PLHs into G1 inactive (so the request's
-    /// next `process_use` sees `InactiveHit`) and re-queue the request at
-    /// the front for admission. The swap-in covers
+    /// next `process_use` sees `InactiveHit`) and re-queue the request for
+    /// stable-priority admission. The swap-in covers
     /// `[skip_blocks .. skip_blocks + count]` of the request's block
     /// sequence — we skip the G1-cached prefix the request already had
     /// and register only the uncached-remainder blocks that the engine
@@ -1301,7 +1442,7 @@ impl VllmCore {
             outcome.consumed_entries, entries_len,
             "reserved destination slots should cover every swapped-in block"
         );
-        self.state.prepend_waiting(aws.uuid);
+        self.state.requeue_waiting(aws.uuid);
     }
 
     /// Admission-side hook: park a request on a G2 swap-in covering its
@@ -1485,11 +1626,7 @@ impl VllmCore {
         let admission = AdmissionInvariant::new(self.pending_destinations.has_pending());
         let mut rejected_uuids: Vec<Uuid> = Vec::new();
         while !preempted_any && self.state.running.len() < max_num_running {
-            let prefer_materialized = matches!(
-                admission.stage_for(false),
-                AdmissionStage::PendingDestinationHead
-            );
-            let Some(uuid) = self.state.next_waiting_uuid(prefer_materialized) else {
+            let Some(uuid) = self.state.next_waiting_uuid() else {
                 break;
             };
             if self.refresh_request_offload_dependency(uuid).is_some() {

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -1208,6 +1208,88 @@ mod core_behavior {
     }
 
     #[test]
+    fn higher_dynamo_priority_overtakes_lower_priority_waiting_request() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(8)
+            .max_num_batched_tokens(Some(4))
+            .max_num_seqs(Some(1))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(false)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let low = Uuid::from_u128(60_001);
+        let high = Uuid::from_u128(60_002);
+        core.receive(DirectRequest {
+            tokens: vec![1; 4],
+            max_output_tokens: 2,
+            uuid: Some(low),
+            priority: -2,
+            ..Default::default()
+        });
+        core.receive(DirectRequest {
+            tokens: vec![2; 4],
+            max_output_tokens: 2,
+            uuid: Some(high),
+            priority: 7,
+            ..Default::default()
+        });
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let pass = core.execute_pass(&mut collector, 0.0);
+
+        assert_eq!(
+            pass.admissions
+                .iter()
+                .map(|admission| admission.uuid)
+                .collect::<Vec<_>>(),
+            vec![high]
+        );
+        assert_eq!(core.state.requests[&high].priority, 7);
+        assert_eq!(core.state.waiting.front().copied(), Some(low));
+    }
+
+    #[test]
+    fn equal_dynamo_priority_preserves_waiting_arrival_order() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(8)
+            .max_num_batched_tokens(Some(4))
+            .max_num_seqs(Some(1))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(false)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let first = Uuid::from_u128(60_011);
+        let second = Uuid::from_u128(60_012);
+        for uuid in [first, second] {
+            core.receive(DirectRequest {
+                tokens: vec![1; 4],
+                max_output_tokens: 2,
+                uuid: Some(uuid),
+                priority: 3,
+                ..Default::default()
+            });
+        }
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let pass = core.execute_pass(&mut collector, 0.0);
+
+        assert_eq!(
+            pass.admissions
+                .iter()
+                .map(|admission| admission.uuid)
+                .collect::<Vec<_>>(),
+            vec![first]
+        );
+        assert_eq!(core.state.waiting.front().copied(), Some(second));
+    }
+
+    #[test]
     fn test_running_requests_consume_budget_before_waiting() {
         let args = MockEngineArgs::builder()
             .block_size(4)
@@ -1406,6 +1488,7 @@ mod core_behavior {
                 uuid: Some(uuid),
                 dp_rank: 0,
                 arrival_timestamp_ms: None,
+                priority: 5,
                 ..Default::default()
             });
         }
@@ -1425,6 +1508,7 @@ mod core_behavior {
         assert_eq!(request.status, RequestStatus::Preempted);
         assert_eq!(request.num_computed_tokens, 0);
         assert_eq!(request.num_preemptions, 1);
+        assert_eq!(request.priority, 5);
         assert_eq!(core.state.waiting.front().copied(), Some(r2));
         assert_eq!(preemptions_before, 1);
     }
@@ -1616,6 +1700,8 @@ mod core_behavior {
             uuid,
             VllmRequestState {
                 sequence: RequestKvState::kvbm(sequence),
+                priority: 0,
+                arrival_order: 0,
                 status: RequestStatus::Running,
                 num_computed_tokens: 9,
                 num_preemptions: 1,
@@ -3143,6 +3229,8 @@ mod offload {
             uuid,
             VllmRequestState {
                 sequence: RequestKvState::kvbm(sequence),
+                priority: 0,
+                arrival_order: 0,
                 status: RequestStatus::Running,
                 num_computed_tokens,
                 num_preemptions: 0,
@@ -3997,11 +4085,10 @@ mod offload {
         );
     }
 
-    /// Completed swap-ins have just paid G2→G1 bandwidth and registered their
-    /// blocks into G1 inactive. They must re-enter at the front, before cold
-    /// requests can allocate and evict those freshly onboarded blocks.
+    /// Completed swap-ins retain their original priority and arrival order.
+    /// Equal-priority cold requests that arrived later must not overtake them.
     #[tokio::test]
-    async fn completed_swap_ins_reenter_front_preserving_order() {
+    async fn completed_swap_ins_reenter_in_stable_priority_order() {
         let args = MockEngineArgs::builder()
             .g1_backend(G1Backend::Kvbm)
             .num_gpu_blocks(2)
@@ -4084,9 +4171,9 @@ mod offload {
         );
 
         // Both 1 MB transfers share a 2 GB/s link, so each receives
-        // 1 GB/s and finishes at 1 ms. On promotion they should be
-        // admitted before the cold request, preserving their original
-        // parking order.
+        // 1 GB/s and finishes at 1 ms. On promotion they should be admitted
+        // before the equal-priority cold request, preserving original arrival
+        // order across the parking lifecycle.
         let pass2 = core.execute_pass(&mut collector, 1.0);
         let admitted: Vec<_> = pass2
             .admissions
@@ -4096,7 +4183,7 @@ mod offload {
         assert_eq!(
             admitted,
             vec![first_hit, second_hit],
-            "completed swap-ins should re-enter ahead of cold requests in order"
+            "completed swap-ins should retain stable priority order after parking"
         );
     }
 


### PR DESCRIPTION
## Summary

- replace the vLLM mocker waiting deque with stable priority ordering
- add a generic event-driven `ReplayWorkSource` boundary for externally controlled offline replay
- expose request terminal/output callbacks, internal controller timers, and per-request capture
- support request routing constraints, worker taints, and per-worker sequence limits
- preserve prebuilt-request admission when pending destinations block fresh work

## Validation

- `cargo test -p dynamo-mocker --lib` (723 passed)
- `cargo fmt --check`
- `git diff --check`

Includes Dynamo-native tests for priority/FIFO ordering, delayed follow-up turns, taint-constrained routing, and per-worker sequence limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled replay simulation with configurable request capture and external work sources.
  * Added per-request routing constraints, including required and preferred worker taints.
  * Added per-worker taints and maximum active-sequence limits.
  * Added public replay controls and runtime reporting interfaces.

* **Bug Fixes**
  * Replay routing constraints are now preserved throughout request scheduling.
  * Waiting requests now follow stable priority order, with FIFO handling for equal priorities.
  * Improved validation for worker configuration and replay request consistency.

* **Documentation**
  * Clarified how priority and strict-priority settings affect replay scheduling and routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->