### PR TITLE
fix(kv-router): stamp request identity on decode-affinity scoring row

### DIFF
--- a/lib/kv-router/src/scheduling/selector/default.rs
+++ b/lib/kv-router/src/scheduling/selector/default.rs
@@ -266,7 +266,12 @@ impl<C: Borrow<KvRouterConfig>> DefaultWorkerScorer<C> {
             let overlap_adjusted_decode_blocks =
                 (decode_cost_blocks - overlap_credit_blocks).max(0.0);
             let logit = overlap_adjusted_decode_blocks + active_request_cost_blocks;
+            // Stamped for the same reason as the two rows below: this row is emitted from the
+            // `SchedulerQueueActor` task, so the logging layer cannot attach request identity to
+            // it, and this branch returns early without reaching them.
             tracing::debug!(
+                request_id = context.request_id,
+                worker_type = self.worker_type,
                 "{formula_name} for worker_id={} dp_rank={:?} with {effective_overlap_blocks:.2} effective cached blocks: {logit:.3} \
                  = max(0, decode_blocks - overlap_credit_blocks) + active_request_cost_blocks \
                  = max(0, {decode_cost_blocks:.3} - {overlap_credit_blocks:.3}) + {active_request_cost_blocks:.3}",


### PR DESCRIPTION
## Summary

`DefaultWorkerScorer::worker_logit` has three `tracing::debug!` sites that emit one candidate scoring row each. Two of them carry `request_id` and `worker_type` so the candidates of a single routing decision can be grouped by id in one hop. The third — the decode-affinity branch — carries neither, and it `return`s before reaching the other two.

The result is that any decision taking the decode-affinity branch emits candidate rows without request identity, so grouping them back into a decision requires the line-adjacency heuristic that stamping was added to replace.

This is not occasional. The branch predicate reads the **configured** `overlap_score_credit` (default `1.0`), not any measured overlap:

```rust
if self.worker_type == "decode"
    && !context.track_prefill_tokens
    && weights.overlap_score_credit > 0.0
```

so on an affected deployment every decision takes the branch and 100% of candidate rows lose their identity fields — even when the measured overlap is zero.

### Affected configurations

| Deployment | `worker_type` | `track_prefill_tokens` | `overlap_score_credit` | Affected |
|---|---|---|---|---|
| Aggregated + `--no-router-track-prefill-tokens` | `decode` | `false` (flag) | `1.0` (default) | **Yes — all decisions** |
| Aggregated, default flags | `decode` | `true` | `1.0` | No |
| Disaggregated, decode pool | `decode` | `false` (forced) | `0.0` (forced) | No |
| Disaggregated, prefill pool | `prefill` | `true` | `1.0` | No |

Aggregated deployments route through `worker_type = "decode"` unconditionally, so the aggregated case only needs the user-facing `--no-router-track-prefill-tokens` flag to be affected. The disaggregated decode pool is spared because `build_decode_router_override` forces `overlap_score_credit: Some(0.0)`, making the third condition false.

### Origin

Two PRs landed the same day touching this function. #12370 (15:24 PT) added the identity fields to the two rows that existed then. #11720 (19:39 PT) added this third row from a branch that predated the stamping. `git merge-base --is-ancestor` confirms #12370 was already in #11720's ancestry, so this is a parallel-development merge miss rather than an intentional change — the two PRs touched disjoint lines, so git saw no conflict.

### Fix

Add the two fields so all three candidate rows share one shape. `context.request_id` and `self.worker_type` are already in scope in this branch (it already reads `self.worker_type` and `context.track_prefill_tokens` in its own predicate), both are borrowed `&str` with no allocation, and both are evaluated inside the macro so they cost nothing when DEBUG is disabled.

**Severity is observability only.** Routing behaviour, metrics and API surfaces are unchanged, and these rows are DEBUG-level, so a default INFO deployment sees no change.

### Follow-ups not in this PR

- No in-repo test asserts these fields on selector rows, which is why CI did not catch the original gap. `tests/utils/router_logs.py` already parses `request_id` out of router logs, so the assertion has a natural home.
- The three emit sites duplicate the identity fields by hand, which is what let them drift apart. Factoring the emit into one helper would make the next scoring branch inherit the fields automatically.

## Validation

- `cargo check -p dynamo-kv-router` — clean
- `cargo clippy -p dynamo-kv-router` — no new warnings
- `cargo fmt --all -- --check` — clean

Behavioural verification was done on the `1.4.0` line, where the same defect is present, by running an aggregated deployment (`dynamo.frontend --router-mode kv` + `dynamo.mocker --num-workers 3`, Qwen3-0.6B) twice with only `--no-router-track-prefill-tokens` differing:

- control (flag off): 24 of 24 candidate rows carried both fields
- subject (flag on): 24 of 24 candidate rows carried neither, and `overlap_credit_blocks: 0.000` confirmed the branch fired with no measured overlap

The control arm establishes that the log directives, deployment and field parsers all work, so the subject result is attributable to the branch and not to test setup.

An internal Linear ticket also tracks this (DYN-3804).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced decode-worker scoring logs with request IDs and worker types for more complete diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->