### PR TITLE
fix(kv-router): cherry-pick stamp request identity on decode-affinity scoring row onto release/1.4.0 (#12955)

### DIFF
--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -249,7 +249,12 @@ impl DefaultWorkerSelector {
             let overlap_adjusted_decode_blocks =
                 (decode_cost_blocks - overlap_credit_blocks).max(0.0);
             let logit = overlap_adjusted_decode_blocks + active_request_cost_blocks;
+            // Stamped for the same reason as the two rows below: this row is emitted from the
+            // `SchedulerQueueActor` task, so the logging layer cannot attach request identity to
+            // it, and this branch returns early without reaching them.
             tracing::debug!(
+                request_id = request.mode.request_id().unwrap_or("-"),
+                worker_type = self.worker_type,
                 "{formula_name} for worker_id={} dp_rank={:?} with {effective_overlap_blocks:.2} effective cached blocks: {logit:.3} \
                  = max(0, decode_blocks - overlap_credit_blocks) + active_request_cost_blocks \
                  = max(0, {decode_cost_blocks:.3} - {overlap_credit_blocks:.3}) + {active_request_cost_blocks:.3}",


### PR DESCRIPTION
## Summary

Cherry-pick of #12955 onto `release/1.4.0`. **Adapted, not a clean pick** — see *Adaptation* below.

`DefaultWorkerSelector::worker_logit` has three `tracing::debug!` sites that emit one candidate scoring row each. Two carry `request_id` and `worker_type` so the candidates of a single routing decision can be grouped by id in one hop. The third — the decode-affinity branch at `lib/kv-router/src/scheduling/selector.rs:252` — carries neither, and it `return`s at `:259` before reaching the other two.

The branch predicate reads the **configured** `overlap_score_credit` (default `1.0`), not any measured overlap:

```rust
if self.worker_type == "decode"
    && !request.track_prefill_tokens
    && weights.overlap_score_credit > 0.0
```

so on an affected deployment every decision takes the branch and 100% of candidate rows lose their identity fields — even when measured overlap is zero.

### Affected configurations

| Deployment | `worker_type` | `track_prefill_tokens` | `overlap_score_credit` | Affected |
|---|---|---|---|---|
| Aggregated + `--no-router-track-prefill-tokens` | `decode` | `false` (flag) | `1.0` (default) | **Yes — all decisions** |
| Aggregated, default flags | `decode` | `true` | `1.0` | No |
| Disaggregated, decode pool | `decode` | `false` (forced) | `0.0` (forced) | No |
| Disaggregated, prefill pool | `prefill` | `true` | `1.0` | No |

Aggregated deployments route through `worker_type = "decode"` unconditionally, so the aggregated case only needs the user-facing `--no-router-track-prefill-tokens` flag to be affected. The disaggregated decode pool is spared because `build_decode_router_override` forces `overlap_score_credit: Some(0.0)`, making the third condition false.

**Severity is observability only.** Routing behaviour, metrics and API surfaces are unchanged, and these rows are DEBUG-level, so a default INFO deployment sees no change.

## Adaptation

A straight `git cherry-pick -x` of the main commit **applies cleanly** — git's rename detection matches `scheduling/selector/default.rs` back to `scheduling/selector.rs` — but the result **does not compile**:

```
error[E0425]: cannot find value `context` in this scope
```

`main` has since refactored the selector into a module and threads a `WorkerSelectionContext`, so it reads `context.request_id`. That symbol does not exist on this branch, where `worker_logit` still takes `request: &SchedulingRequest`. The accessor here is therefore the pre-refactor form:

```rust
request_id = request.mode.request_id().unwrap_or("-"),
```

which is exactly what the two sibling rows on this branch already use (`selector.rs:274`, `:289`). The emitted field name and value are identical to main's; only the in-scope accessor differs. This is the only difference from the picked commit.

## Validation

- `cargo check -p dynamo-kv-router` — clean
- `cargo clippy -p dynamo-kv-router` — no new warnings
- `cargo fmt --all -- --check` — clean
- Confirmed the unadapted pick fails to build (the `E0425` above), so the adaptation is load-bearing rather than cosmetic

Behavioural verification on this release line: an aggregated deployment (`dynamo.frontend --router-mode kv` + `dynamo.mocker --num-workers 3`, Qwen3-0.6B) run twice with only `--no-router-track-prefill-tokens` differing —

- control (flag off): 24 of 24 candidate rows carried both fields
- subject (flag on): 24 of 24 candidate rows carried neither, and `overlap_credit_blocks: 0.000` confirmed the branch fired with no measured overlap

The control arm establishes that the log directives, deployment and field parsers all work, so the subject result is attributable to the branch and not to test setup.

An internal Linear ticket also tracks this (DYN-3804).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->