### PR TITLE
test(ci): GPU-tests speedups (OPS-8033, OPS-8113, OPS-8117)

### DIFF
--- a/components/src/dynamo/frontend/tests/test_sglang_multimodal_prepost.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_multimodal_prepost.py
@@ -19,7 +19,7 @@ from dynamo.frontend.sglang_prepost import (
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
 ]

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_api.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_api.py
@@ -16,7 +16,7 @@ import pytest
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
 ]

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -62,7 +62,10 @@ from dynamo.frontend.utils import (
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
+    # Registers the tokenizer in the session predownload manifest (tests/conftest.py)
+    # so it stays fetchable after a worker's predownload test flips HF_HUB_OFFLINE.
+    pytest.mark.model("Qwen/Qwen3-0.6B"),
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
 ]

--- a/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
@@ -25,7 +25,11 @@ from dynamo.frontend.sglang_prepost import SglangStreamingPostProcessor
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
+    # This file builds a real tokenizer at module scope; declare the model so
+    # Registers the tokenizer in the session predownload manifest (tests/conftest.py)
+    # so it stays fetchable after a worker's predownload test flips HF_HUB_OFFLINE.
+    pytest.mark.model("Qwen/Qwen3-0.6B"),
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
 ]

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -42,11 +42,16 @@ def _resolve_qwen3_tool_parser_class():
         return Qwen3CoderToolParser
 
 
-# Needs vllm packages (gpu_1 container), but does not allocate GPU VRAM.
+# Needs vllm packages, but never touches a GPU.
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
+    # This file builds a real tokenizer. The marker declares it in the session
+    # predownload manifest (tests/conftest.py), which is what keeps it fetchable
+    # on a lane that predownloads and flips HF_HUB_OFFLINE; the CPU lane has no
+    # predownload consumer today, so there it is fetched live.
+    pytest.mark.model("Qwen/Qwen3-0.6B"),
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),

--- a/components/src/dynamo/sglang/tests/test_fpm_contract.py
+++ b/components/src/dynamo/sglang/tests/test_fpm_contract.py
@@ -14,7 +14,7 @@ import pytest
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
-    pytest.mark.gpu_1,  # needs sglang packages installed
+    pytest.mark.gpu_0,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
 ]

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -29,7 +29,7 @@ from dynamo.sglang.request_handlers.multimodal.encode_worker_handler import (
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
-    pytest.mark.gpu_1,  # sglang tests run on GPU-enabled workers
+    pytest.mark.gpu_0,
     # These are sub-second unit tests. A generous cap so a hang here fails
     # this test instead of stalling the whole session.
     pytest.mark.timeout(60),

--- a/components/src/dynamo/sglang/tests/test_sglang_nvdec_video_decoder.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_nvdec_video_decoder.py
@@ -28,7 +28,7 @@ from dynamo.sglang.request_handlers.multimodal.nvdec_video_decoder import (
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
-    pytest.mark.gpu_1,  # sglang tests run on GPU-enabled workers
+    pytest.mark.gpu_0,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
 ]
@@ -93,6 +93,9 @@ def test_get_frames_as_tensor_returns_nhwc_uint8_cpu(decoder) -> None:
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="pinned host memory requires CUDA"
 )
+# The one test here that touches CUDA. It stays consistent with the file's
+# gpu_0 mark because gpu_0 means "no GPU required": on the CPU-only lane it
+# skips itself, and on the GPU job's gpu_0 stage it runs and guards pinning.
 def test_frames_are_pinned_on_cuda(decoder) -> None:
     """Pinned memory is the performance contract of this return type.
 

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -58,13 +58,43 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
     pytest.mark.core,
-    pytest.mark.gpu_1,  # needs sglang & GPU packages installed but does not actually use GPU
+    pytest.mark.gpu_0,
     pytest.mark.profiled_vram_gib(0),  # These unit tests do not actually use GPU VRAM
     pytest.mark.pre_merge,
 ]
 # Create SGLang-specific CLI args fixture
 # This will use monkeypatch to write to argv
 mock_sglang_cli = make_cli_args_fixture("dynamo.sglang")
+
+
+@pytest.fixture(autouse=True)
+def _cpu_engine_when_no_accelerator(monkeypatch):
+    """Honor the file's gpu_0 contract on hosts with no accelerator.
+
+    Many tests here run parse_args, and SGLang's ServerArgs.__post_init__
+    auto-detects a device only when --device is not given; on a host with no
+    accelerator the detection walks every platform and ends in
+    NotImplementedError (get_device -> SRTPlatform(unknown), verified on the
+    amd64 image with the GPU masked). SGLANG_USE_CPU_ENGINE=1 is SGLang's
+    public knob that makes the detection return "cpu". Set it only when CUDA
+    is absent so GPU hosts keep exercising the real detection path, and clear
+    the lru_caches on both probes so a worker that cached the no-env result
+    while running another file's tests cannot poison this one (and vice
+    versa on teardown, via the second clear).
+    """
+    import torch
+
+    if torch.cuda.is_available():
+        yield
+        return
+    from sglang.srt.utils import common as _sgl_common
+
+    monkeypatch.setenv("SGLANG_USE_CPU_ENGINE", "1")
+    _sgl_common.is_cpu.cache_clear()
+    _sgl_common.get_device.cache_clear()
+    yield
+    _sgl_common.is_cpu.cache_clear()
+    _sgl_common.get_device.cache_clear()
 
 
 def _make_sglang_config(**overrides):

--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -75,6 +75,56 @@ def pytest_ignore_collect(collection_path, config):
     return None
 
 
+_PLATFORM_UNSET = object()
+
+
+@pytest.fixture
+def vllm_cpu_platform_when_no_accelerator():
+    """Pin vLLM's CpuPlatform on hosts where vLLM recognizes no accelerator.
+
+    Tests that build the vLLM engine argument parser reach
+    ``DeviceConfig.__post_init__``, which resolves ``current_platform`` when
+    ``device`` is left at ``"auto"`` and raises ``RuntimeError: Failed to infer
+    device type`` if the resolved platform has an empty ``device_type``. With no
+    accelerator every builtin platform plugin declines and the resolver falls
+    back to ``UnspecifiedPlatform``, whose ``device_type`` is exactly that. The
+    parser instantiates each config dataclass to compute its argparse default,
+    so this fires while *building* the parser -- passing ``--device cpu`` cannot
+    avoid it.
+
+    Gating on ``device_type`` rather than on ``torch.cuda`` makes this a no-op
+    wherever vLLM already recognizes the hardware, so both CUDA and XPU runners
+    keep exercising real detection (these modules are also marked ``xpu_1``).
+
+    ``vllm.platforms`` resolves ``current_platform`` lazily through a module
+    ``__getattr__``, and assigning the name writes a real module-dict entry that
+    shadows the hook. That entry, not the ``__setattr__`` the module also
+    defines, is what makes the pin visible: the interpreter never calls a
+    module-level ``__setattr__``, since PEP 562 covers only ``__getattr__`` and
+    ``__dir__``. Teardown therefore *deletes* the entry to re-arm the lazy hook
+    -- assigning the previous value back would leave the resolver shadowed for
+    every later test on this xdist worker.
+    """
+    import vllm.platforms as vllm_platforms
+    from vllm.platforms import current_platform
+
+    if current_platform.device_type:
+        yield
+        return
+
+    from vllm.platforms.cpu import CpuPlatform
+
+    previous = vllm_platforms.__dict__.get("current_platform", _PLATFORM_UNSET)
+    vllm_platforms.current_platform = CpuPlatform()
+    try:
+        yield
+    finally:
+        if previous is _PLATFORM_UNSET:
+            del vllm_platforms.current_platform
+        else:
+            vllm_platforms.current_platform = previous
+
+
 def make_cli_args_fixture(module_name: str):
     """Create a pytest fixture for mocking CLI arguments for vllm backend."""
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -20,7 +20,10 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
+    # Building the vLLM argument parser resolves a device; on an accelerator-less
+    # host that raises unless a platform is pinned first.
+    pytest.mark.usefixtures("vllm_cpu_platform_when_no_accelerator"),
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),

--- a/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
@@ -18,7 +18,7 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
@@ -19,7 +19,7 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
@@ -28,7 +28,7 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s

--- a/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
+++ b/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
@@ -20,7 +20,7 @@ except ImportError:
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -46,9 +46,10 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
     pytest.mark.core,
-    # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
-    # runners with "Failed to infer device type" even for mock tests.
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
+    # Building the vLLM argument parser resolves a device; on an accelerator-less
+    # host that raises unless a platform is pinned first.
+    pytest.mark.usefixtures("vllm_cpu_platform_when_no_accelerator"),
     pytest.mark.xpu_1,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -23,9 +23,7 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
     pytest.mark.core,
-    # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
-    # runners with "Failed to infer device type" even for mock tests.
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.xpu_1,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s

--- a/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
@@ -63,7 +63,11 @@ pytestmark = [
     pytest.mark.gpu_1,
     pytest.mark.model(VLLM_MM_MODEL),
     pytest.mark.requested_vllm_kv_cache_bytes(1_719_075_000),
-    pytest.mark.profiled_vram_gib(18.7),
+    # Measured solo peak, which is what profiled_vram_gib means. The KV cap
+    # above pins the footprint, so this matches test_vllm_mm_router_e2e.py --
+    # same model, same cap, same 7.6 GiB. The previous 18.7 exceeded the
+    # multi-process budget, which made every test in this file exclusive.
+    pytest.mark.profiled_vram_gib(7.6),
 ]
 
 

--- a/tests/mm_router/test_router_rust_mm_router_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_router_e2e.py
@@ -61,7 +61,11 @@ pytestmark = [
     pytest.mark.gpu_1,
     pytest.mark.model(VLLM_MM_MODEL),
     pytest.mark.requested_vllm_kv_cache_bytes(1_719_075_000),
-    pytest.mark.profiled_vram_gib(18.7),
+    # Measured solo peak, which is what profiled_vram_gib means. The KV cap
+    # above pins the footprint, so this matches test_vllm_mm_router_e2e.py --
+    # same model, same cap, same 7.6 GiB. The previous 18.7 exceeded the
+    # multi-process budget, which made every test in this file exclusive.
+    pytest.mark.profiled_vram_gib(7.6),
 ]
 
 


### PR DESCRIPTION
## Summary

Cherry-pick 3 merged CI test-scheduling changes from `main` onto `release/1.4.0` as one PR. All three shrink the `pre_merge` GPU stage by moving CPU-only work off the VRAM-budgeted lane or by correcting an over-stated VRAM reservation; none of them change product code.

| Cherry-pick | Origin | Effect on the GPU stage |
|---|---|---|
| `test(ci): reclassify CPU-only sglang unit tests from gpu_1 to gpu_0 (OPS-8033)` | #12718 (`8d4a014873`) | 8 CPU-only sglang unit files leave the VRAM stage (~8,400s cumulative); loadscope runs them in ~21s |
| `test(ci): reclassify CPU-only vllm unit tests from gpu_1 to gpu_0 (OPS-8113)` | #12826 (`a274300453`) | 322 vLLM tests / ~12,024s of 19,562s cumulative leave the VRAM stage |
| `test(ci): correct the mm_router VRAM profile from 18.7 to the measured 7.6 GiB (OPS-8117)` | #12842 (`3405438c75`) | 18.7 GiB exceeded the multi-process budget and made every test in those two files exclusive; 7.6 GiB is the measured solo peak |

Each commit is cherry-picked individually with `-x`, so the origin commit is recorded in each message and per-PR attribution is preserved.

Linear: OPS-8033, OPS-8113, OPS-8117

### Conflict resolution

Only #12718 conflicted, in two files, and both conflicts were `main`-vs-`release/1.4.0` drift rather than anything in the backported change. Resolved to apply the `gpu_1` → `gpu_0` intent and nothing else:

- `test_sglang_multimodal_embedding_cache.py` — took `gpu_0`, kept this branch's `timeout(60)` block, and did **not** pull in `main`'s `pytest.mark.multimodal` (not present on `release/1.4.0`).
- `test_sglang_unit.py` — took the `_cpu_engine_when_no_accelerator` autouse fixture (the actual mechanism behind the reclassification) and dropped `test_configured_engine_route_cannot_replace_built_in_route`, which is pre-existing `main` context unrelated to this change.

The other two cherry-picks applied cleanly.

## Validation

- Combined diff is 19 files (8 + 9 + 2), matching the sum of the three source PRs — no extra files rode along.
- Both conflict-resolved files parse; no conflict markers remain anywhere in the tree.
- `pre-commit run --all-files` passes on this branch with no autofixes.
- Verified the mm_router comment's cross-reference still holds here: `tests/mm_router/test_vllm_mm_router_e2e.py` is also at `profiled_vram_gib(7.6)` on `release/1.4.0`.
- The one remaining `pytest.mark.gpu_1` under the touched vLLM test dirs (`omni/test_omni_nixl_connector.py`) is intentional — #12826 left it at `gpu_1` on `main` too.
- All three commits are GPG-signed and DCO signed-off.

CI on the release branch still needs a maintainer `/ok to test b2ba74f959`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->