### PR TITLE
fix(http): report overload status for worker-side rejections

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2096,6 +2096,15 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
                 .unwrap_or_else(|| "Unknown error".to_string())
         };
 
+        // Capacity rejection is not a backend fault. Workers report it with their
+        // own status (503), which a client cannot tell from a real outage, so the
+        // error chain wins over the payload code — admission-path and worker-path
+        // rejections then surface identically. See DYN_HTTP_OVERLOAD_STATUS_CODE.
+        let overloaded = event
+            .error
+            .as_ref()
+            .is_some_and(|error| super::metrics::request_was_rejected(error));
+
         // Parse the status-bearing node's own message. The diagnostic string
         // above includes its causes and therefore is not necessarily JSON.
         let status_message = event
@@ -2106,12 +2115,16 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
         if let Ok(error_payload) = serde_json::from_str::<ErrorPayload>(status_message) {
             // Preserve explicit HTTP-like statuses (for example 415); Python
             // 4xx exceptions share the Backend(InvalidArgument) category.
-            let code = match error_payload.code {
-                Some(code) => {
-                    StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+            let code = if overloaded {
+                overload_status_code()
+            } else {
+                match error_payload.code {
+                    Some(code) => {
+                        StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+                    }
+                    None if invalid_argument.is_some() => StatusCode::BAD_REQUEST,
+                    None => StatusCode::INTERNAL_SERVER_ERROR,
                 }
-                None if invalid_argument.is_some() => StatusCode::BAD_REQUEST,
-                None => StatusCode::INTERNAL_SERVER_ERROR,
             };
             let message = error_payload
                 .message
@@ -2124,6 +2137,10 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
                 invalid_argument.message().to_string(),
                 StatusCode::BAD_REQUEST,
             ));
+        }
+
+        if overloaded {
+            return Some((error_str, overload_status_code()));
         }
 
         return Some((error_str, StatusCode::INTERNAL_SERVER_ERROR));
@@ -4907,6 +4924,93 @@ mod tests {
                 "client response must not include the underlying engine message"
             );
         }
+    }
+
+    #[test]
+    fn backend_overload_reports_overload_status_not_worker_status() {
+        use dynamo_runtime::error::{DynamoError, ErrorType};
+
+        // Production path: a vLLM worker rejects on its own slot limit and puts
+        // 503 in the payload. The chain says ResourceExhausted, so the client
+        // must see the overload status rather than a generic outage.
+        let event: Annotated<NvCreateChatCompletionStreamResponse> = Annotated {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: None,
+            error: Some(
+                DynamoError::builder()
+                    .error_type(ErrorType::ResourceExhausted)
+                    .message(
+                        r#"{"message":"Worker local total request limit reached (32/32)","code":503}"#,
+                    )
+                    .build(),
+            ),
+        };
+
+        let (message, status) =
+            extract_backend_error_if_present(&event).expect("error event should be extracted");
+        assert_eq!(status, overload_status_code());
+        assert_eq!(status.as_u16(), 529);
+        assert!(message.contains("request limit reached"));
+    }
+
+    #[test]
+    fn backend_non_overload_status_is_still_preserved() {
+        use dynamo_runtime::error::{DynamoError, ErrorType};
+
+        // The override is scoped to capacity rejections; a genuine backend
+        // failure must keep the status the worker chose.
+        let event: Annotated<NvCreateChatCompletionStreamResponse> = Annotated {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: None,
+            error: Some(
+                DynamoError::builder()
+                    .error_type(ErrorType::Unknown)
+                    .message(r#"{"message":"engine crashed","code":503}"#)
+                    .build(),
+            ),
+        };
+
+        let (_, status) =
+            extract_backend_error_if_present(&event).expect("error event should be extracted");
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn python_worker_503_reaches_the_frontend_as_backend_unknown() {
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+
+        // Exactly what map_python_exception (bindings/python/rust/engine.rs) and
+        // py_err_to_dynamo (backend.rs) build for a Python exception carrying
+        // `.code = 503`: 503 is outside 400..500, so the type is Backend(Unknown)
+        // and the message is the JSON envelope. No cause is attached.
+        let event: Annotated<NvCreateChatCompletionStreamResponse> = Annotated {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: None,
+            error: Some(
+                DynamoError::builder()
+                    .error_type(ErrorType::Backend(BackendError::Unknown))
+                    .message(
+                        r#"{"message":"Worker local total request limit reached (32/32)","code":503}"#,
+                    )
+                    .build(),
+            ),
+        };
+
+        // request_was_rejected keys on ErrorType::ResourceExhausted, which this
+        // shape never carries, so the overload override does not engage.
+        assert!(!super::super::metrics::request_was_rejected(
+            event.error.as_ref().expect("error is set")
+        ));
+
+        let (_, status) =
+            extract_backend_error_if_present(&event).expect("error event should be extracted");
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2047,11 +2047,32 @@ fn escape_json_string_control_chars(body: &[u8]) -> Option<Vec<u8>> {
     changed.then_some(out)
 }
 
+/// A backend error extracted from an event, ready for `backend_error_response`.
+struct BackendErrorInfo {
+    message: String,
+    status: StatusCode,
+    /// Classification already established from the error chain, when the
+    /// status alone is not enough to recover it. `None` means "derive it from
+    /// `status`" — the ordinary case for a status the worker supplied.
+    sanitized: Option<SanitizedError>,
+}
+
+impl BackendErrorInfo {
+    /// The common case: nothing known beyond what the worker reported.
+    fn from_status(message: String, status: StatusCode) -> Self {
+        Self {
+            message,
+            status,
+            sanitized: None,
+        }
+    }
+}
+
 /// Checks if an Annotated event represents a backend error and extracts error information.
-/// Returns Some((message, status_code)) if it's an error, None otherwise.
+/// Returns Some(info) if it's an error, None otherwise.
 fn extract_backend_error_if_present<T: serde::Serialize>(
     event: &Annotated<T>,
-) -> Option<(String, StatusCode)> {
+) -> Option<BackendErrorInfo> {
     #[derive(serde::Deserialize)]
     struct ErrorPayload {
         message: Option<String>,
@@ -2129,21 +2150,32 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
             let message = error_payload
                 .message
                 .unwrap_or_else(|| status_message.to_string());
-            return Some((message, code));
+            return Some(BackendErrorInfo {
+                message,
+                status: code,
+                sanitized: overloaded.then_some(SanitizedError::Overloaded),
+            });
         }
 
         if let Some(invalid_argument) = invalid_argument {
-            return Some((
+            return Some(BackendErrorInfo::from_status(
                 invalid_argument.message().to_string(),
                 StatusCode::BAD_REQUEST,
             ));
         }
 
         if overloaded {
-            return Some((error_str, overload_status_code()));
+            return Some(BackendErrorInfo {
+                message: error_str,
+                status: overload_status_code(),
+                sanitized: Some(SanitizedError::Overloaded),
+            });
         }
 
-        return Some((error_str, StatusCode::INTERNAL_SERVER_ERROR));
+        return Some(BackendErrorInfo::from_status(
+            error_str,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ));
     }
 
     // Check if the data payload itself contains an error structure with code >= 400
@@ -2157,7 +2189,7 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
         let message = error_payload
             .message
             .unwrap_or_else(|| json_value.to_string());
-        return Some((message, code));
+        return Some(BackendErrorInfo::from_status(message, code));
     }
 
     // Check if comment contains error information (without event: error)
@@ -2173,13 +2205,16 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
         {
             let code = StatusCode::from_u16(code_num).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
             let message = error_payload.message.unwrap_or(comment_str);
-            return Some((message, code));
+            return Some(BackendErrorInfo::from_status(message, code));
         }
 
         // Comments present with no data AND no event type indicates error
         // (events with event types like "request_id" or "event.dynamo.test.sentinel" are annotations)
         if event.data.is_none() && event.event.is_none() {
-            return Some((comment_str, StatusCode::INTERNAL_SERVER_ERROR));
+            return Some(BackendErrorInfo::from_status(
+                comment_str,
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ));
         }
     }
 
@@ -2256,8 +2291,8 @@ where
             continue;
         }
 
-        if let Some((error_msg, status_code)) = extract_backend_error_if_present(&event) {
-            return Err(backend_error_response(error_msg, status_code));
+        if let Some(backend_error) = extract_backend_error_if_present(&event) {
+            return Err(backend_error_response(backend_error));
         }
 
         // First non-annotation, non-error event — hand back for downstream
@@ -2267,20 +2302,29 @@ where
     }
 }
 
-/// Convert an `(error_msg, status_code)` pair from `extract_backend_error_if_present`
-/// into the wire `ErrorResponse`. Shared between the non-streaming preflight
+/// Convert a `BackendErrorInfo` from `extract_backend_error_if_present` into the
+/// wire `ErrorResponse`. Shared between the non-streaming preflight
 /// (`check_for_backend_error`) and the streaming preflight so both paths speak
 /// the same sanitization + status contract to the client.
-fn backend_error_response(error_msg: String, status_code: StatusCode) -> ErrorResponse {
-    match SanitizedError::for_backend_status(status_code) {
-        Some(variant) => ErrorMessage::sanitized_with_details(variant, error_msg),
+///
+/// A classification carried on the info wins over one derived from the status:
+/// the status alone cannot distinguish a capacity rejection from an outage once
+/// `DYN_HTTP_OVERLOAD_STATUS_CODE` is set outside the 5xx range.
+fn backend_error_response(backend_error: BackendErrorInfo) -> ErrorResponse {
+    let BackendErrorInfo {
+        message,
+        status,
+        sanitized,
+    } = backend_error;
+    match sanitized.or_else(|| SanitizedError::for_backend_status(status)) {
+        Some(variant) => ErrorMessage::sanitized_with_details(variant, message),
         // 4xx (non-499): protocol contract — forward backend message as-is.
         None => (
-            status_code,
+            status,
             Json(ErrorMessage {
-                message: error_msg,
-                error_type: map_error_code_to_error_type(status_code),
-                code: status_code.as_u16(),
+                message,
+                error_type: map_error_code_to_error_type(status),
+                code: status.as_u16(),
                 details: None,
                 metric_error_type: None,
             }),
@@ -4948,11 +4992,17 @@ mod tests {
             ),
         };
 
-        let (message, status) =
+        let backend_error =
             extract_backend_error_if_present(&event).expect("error event should be extracted");
-        assert_eq!(status, overload_status_code());
-        assert_eq!(status.as_u16(), 529);
-        assert!(message.contains("request limit reached"));
+        assert_eq!(backend_error.status, overload_status_code());
+        assert_eq!(backend_error.status.as_u16(), 529);
+        assert!(backend_error.message.contains("request limit reached"));
+        // Carried, not re-derived from the status — this is what keeps the
+        // rendering identical to the admission path at any configured status.
+        assert!(matches!(
+            backend_error.sanitized,
+            Some(SanitizedError::Overloaded)
+        ));
     }
 
     #[test]
@@ -4974,9 +5024,30 @@ mod tests {
             ),
         };
 
-        let (_, status) =
+        let backend_error =
             extract_backend_error_if_present(&event).expect("error event should be extracted");
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(backend_error.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(backend_error.sanitized.is_none());
+    }
+
+    #[test]
+    fn backend_overload_is_sanitized_at_a_non_5xx_overload_status() {
+        // DYN_HTTP_OVERLOAD_STATUS_CODE accepts 200-999. Deriving the category
+        // from the status alone sends a 4xx overload down the forward-verbatim
+        // path, leaking the worker's internal text; a 2xx/3xx one down the
+        // coerce-to-500 path, dropping the configured status. The carried
+        // category avoids both, so the worker path renders exactly like the
+        // admission path at every configured value.
+        let response = backend_error_response(BackendErrorInfo {
+            message: "Worker local total request limit reached (32/32)".to_string(),
+            status: StatusCode::TOO_MANY_REQUESTS,
+            sanitized: Some(SanitizedError::Overloaded),
+        });
+
+        assert_eq!(response.0, overload_status_code());
+        assert_eq!(response.1.code, overload_status_code().as_u16());
+        assert_eq!(response.1.message, SanitizedError::Overloaded.to_string());
+        assert!(!response.1.message.contains("32/32"));
     }
 
     #[test]
@@ -5008,9 +5079,9 @@ mod tests {
             event.error.as_ref().expect("error is set")
         ));
 
-        let (_, status) =
+        let backend_error =
             extract_backend_error_if_present(&event).expect("error event should be extracted");
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(backend_error.status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Overload rejections reach clients as HTTP 503 in the common case, not the configured overload status (529 by default).

There are two paths that produce an overload response, and only one is remapped today:

- **Admission path** — the frontend rejects before dispatch. `ErrorMessage::from_anyhow` checks `request_was_rejected(err)` and returns `SanitizedError::Overloaded` → `overload_status_code()`. Correct.
- **Backend-error path** — the request reaches a worker, the worker's own admission control rejects it, and that returns as an error event whose payload carries `"code": 503`. `extract_backend_error_if_present` preserves the payload status verbatim ("Preserve explicit HTTP-like statuses"), so the client sees 503.

Worker-side admission is where overload is actually enforced in most deployments, so the majority of overload rejections take the second path and report the wrong status.

## Evidence

Measured on a production deployment running 1.3.0 with the admission-path remap in place, over 24h on a single function:

| | count |
|---|---|
| client-visible 503 | 51 |
| client-visible 529 | 5 |
| frontend overload counter | 1,550 |

Roughly 90% of overload reached clients as 503. The 529s are the admission-path slice; the 503s came back from workers with a status already stamped into the payload. The same pattern held across four models in that fleet, all of which shed at a worker-side limit.

## Change

`extract_backend_error_if_present` now consults the error chain before trusting the payload:

```rust
let overloaded = event
    .error
    .as_ref()
    .is_some_and(|error| super::metrics::request_was_rejected(error));
```

When set, the function returns `overload_status_code()` instead of the worker-supplied code. Applied at both exits — the JSON-payload branch and the non-JSON fallback, which would otherwise return 500.

This reuses `request_was_rejected`, the same classifier the admission path uses, so both paths now surface identically. Behaviour is unchanged for every non-overload error: a genuine backend failure keeps whatever status it reported.

The status remains configurable via `DYN_HTTP_OVERLOAD_STATUS_CODE`.

## Tests

Two added:

- `backend_overload_reports_overload_status_not_worker_status` — reproduces the production case: a `ResourceExhausted` chain with `"code": 503` in the payload must yield 529.
- `backend_non_overload_status_is_still_preserved` — guards the inverse: an unrelated failure carrying 503 keeps 503.

`cargo test -p dynamo-llm --lib http::service::openai` → **92 passed, 0 failed**, no regressions in the module.

## Open question for reviewers

`request_was_rejected` walks the entire error cause chain via `match_error_chain`. The neighbouring `invalid_argument` classification in the same function deliberately does **not** — its comment notes that an inner invalid argument must not override an outer unavailable or internal error.

This patch is intentionally inconsistent with that neighbour. The reasoning: for overload, a false negative (a real capacity rejection reported as 503) is worse than a false positive, and using the same classifier as the admission path keeps the two consistent with each other.

The counter-argument is real though — a genuinely broken request carrying a `ResourceExhausted` somewhere in its causes would now return 529 and invite a client to retry something permanently broken. If maintainers prefer top-level-only classification here, that is a one-line change and I am happy to make it.

## Not addressed

The `event.data` and `comment` branches of the same function consult no error chain and would still preserve a worker-supplied status. They appear to carry far less traffic than the `event: "error"` path, but they are the same latent issue.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of capacity-related backend errors by returning the configured overload status.
  * Preserved genuine non-overload backend statuses.
  * Improved classification of unknown errors from Python workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->