### PR TITLE
test(agents): verify skills CODEOWNERS routing

### DIFF
--- a/.agents/skills/pr-monitor/SKILL.md
+++ b/.agents/skills/pr-monitor/SKILL.md
@@ -233,6 +233,8 @@ Synthesize into a concise report:
 
 If any checks are still pending or in-progress, offer to monitor them.
 
+<!-- Temporary CODEOWNERS routing test; remove before merging. -->
+
 **List remaining checks:**
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a comment-only marker to an existing skill under `.agents/skills/`.
- Exercise the CODEOWNERS routing for a temporary test PR.

## Validation

- `python3 scripts/validate_skills.py`
- Repository pre-commit hooks passed.

This is a temporary draft PR for verifying reviewer assignment. Close it without merging after the CODEOWNERS routing is confirmed.
