### PR TITLE
Ben's edits: clean-room UAT hardening of the optimization skills (consolidated)

### DIFF
--- a/.agents/skills/analyze-aiperf-results/SKILL.md
+++ b/.agents/skills/analyze-aiperf-results/SKILL.md
@@ -105,7 +105,8 @@ Cross-series results may provide context but never a gain, loss, or Pareto calcu
    history table.
 6. Calculate signed percent change as `(current - prior) / prior * 100`. Also state whether the value is higher or
    lower and whether that direction is an improvement or regression.
-7. Classify an absolute performance change of `0.5%` or less as noise and report it without recommending a repeat
+7. Classify an absolute performance change at or below the measured noise floor of the active benchmark series (see
+   `comparison-uncertainty.md`) as noise and report it without recommending a repeat
    solely because the delta is small.
 8. Analyze one valid run by default. A clear, substantial, plausible gain or loss may support a conclusion without a
    repeat; state that it is single-run evidence.

--- a/.agents/skills/consult-perf-knowledge/SKILL.md
+++ b/.agents/skills/consult-perf-knowledge/SKILL.md
@@ -130,8 +130,9 @@ Before generating a hypothesis, determine whether a broad or narrow knob adjustm
 - Return to exploration when a narrow change is invalid, inconclusive, within the measured noise floor of the
   active benchmark series, reverses the expected direction, or reveals a different limiting regime.
 
-Maintain one persistent search-calibration ledger for the engagement instead of regenerating a scan for every
-hypothesis. Before each hypothesis, update the ledger by delta, re-reviewing every row whose evidence regime changed
+Maintain one persistent search-calibration ledger for the engagement at
+`EXP_ROOT/analysis/search-calibration.md` instead of regenerating a scan for every
+hypothesis; each iteration's `knowledge-consult.md` records only the delta applied to it. Before each hypothesis, update the ledger by delta, re-reviewing every row whose evidence regime changed
 (a topology adoption, new variance data, an answered ask). The ledger explicitly covers:
 
 1. deployment topology and fit, including model fit, parallelism, replication, aggregated versus disaggregated
@@ -243,7 +244,8 @@ distinct categories, including AIPerf profiler data, but keep each entry concise
 official documentation that supplied a constraint or recommendation.
 
 Include relevant same-series history and tuning-hierarchy decisions without reproducing every rejected option. Treat
-cross-series results as context only. Classify an absolute change of `0.5%` or less as noise. A clear, substantial,
+cross-series results as context only. Classify an absolute change at or below the measured noise floor of the active
+benchmark series (per `comparison-uncertainty.md`) as noise. A clear, substantial,
 plausible improvement may be supported by one valid run; do not require a repeat or confidence intervals solely to
 support it. Preserve an `inconclusive` analysis when the evidence cannot support the direction or magnitude. Always
 include the search calibration, even for `no-proposal` or `blocked`, so the next iteration does not forget unexplored

--- a/.agents/skills/consult-perf-knowledge/SKILL.md
+++ b/.agents/skills/consult-perf-knowledge/SKILL.md
@@ -96,8 +96,9 @@ Record:
 - absolute current metrics and client-visible symptoms;
 - comparisons with the series baseline, previous valid iteration, best prior result per objective, and relevant
   same-series history when available;
-- run count, repeat rationale when applicable, the `0.5%` noise floor, and AIPerf confidence intervals or coefficient
-  of variation only when deliberate repetitions made them useful;
+- run count, repeat rationale when applicable, the measured noise floor of the active benchmark series (per
+  `comparison-uncertainty.md`), and AIPerf confidence intervals or coefficient of variation only when deliberate
+  repetitions made them useful;
 - proxy limitations, missing metrics, resource or placement differences, or other uncertainty; and
 - whether any surprising prior result needs engagement or plausibility rechecking.
 
@@ -126,10 +127,12 @@ Before generating a hypothesis, determine whether a broad or narrow knob adjustm
   remains untested or has not been ruled out by current evidence.
 - Prefer a narrow move only after the broad landscape has been screened and valid measurements
   show a demonstrated, meaningful signal in the selected family.
-- Return to exploration when a narrow change is invalid, inconclusive, within the `0.5%` noise floor, reverses the
-  expected direction, or reveals a different limiting regime.
+- Return to exploration when a narrow change is invalid, inconclusive, within the measured noise floor of the
+  active benchmark series, reverses the expected direction, or reveals a different limiting regime.
 
-Perform a fresh broad-lever scan before every hypothesis. Explicitly screen:
+Maintain one persistent search-calibration ledger for the engagement instead of regenerating a scan for every
+hypothesis. Before each hypothesis, update the ledger by delta, re-reviewing every row whose evidence regime changed
+(a topology adoption, new variance data, an answered ask). The ledger explicitly covers:
 
 1. deployment topology and fit, including model fit, parallelism, replication, aggregated versus disaggregated
    serving, disaggregated rate matching, GPU allocation, and placement or fabric constraints;
@@ -138,8 +141,11 @@ Perform a fresh broad-lever scan before every hypothesis. Explicitly screen:
    routing and prefix reuse; KVBM or engine KV offload; and frontend, transport, and pod resources; and
 3. Local Planner only when its conditional lane applies.
 
-For each family, record its coverage as `tested`, `ruled-out`, `not-applicable`, `untested-promising`, or
-`reopened-by-new-evidence`, plus its expected upside and the evidence for that disposition. Compare all applicable families for potential benefit and information value before choosing one.
+For each family, record its coverage as `tested`, `ruled-out`, `not-applicable`, `untested-promising`, `deferred`,
+or `reopened-by-new-evidence`, plus its expected upside and the evidence for that disposition. A `ruled-out` row must
+cite a measurement, a sourced hard constraint, a confirmed incompatibility, or an explicit operator decision;
+expected upside below the minimum detectable effect is `deferred` (still visible, and stackable under a documented
+one-variable exception), never `ruled-out`. Compare all applicable families for potential benefit and information value before choosing one.
 
 During exploration, prefer an independently testable change that crosses into a different high-impact family or tests
 a coarse, documented operating regime. Do not keep adjusting the same knob in single-digit or otherwise near-neighbor
@@ -152,7 +158,8 @@ Follow `agent-docs/guides/knob-tuning/tuning-hierarchy.md`:
 
 1. Classify the exact model and compute memory fit, minimum parallelism, and headroom.
 2. Complete the exploration-versus-exploitation calibration and full broad-lever scan above.
-3. Screen topology first. Keep it unchanged unless current evidence supports a structural mismatch.
+3. Consider topology first as a hypothesis category per the tuning hierarchy; an inherited layout is a candidate,
+   not a settled decision.
 4. When topology is viable, consider Tier 2 families in default priority order, then finish screening the remaining
    families before selecting a candidate.
 5. Record why each major family was retained, skipped, rejected, or superseded by stronger current-run evidence.

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -102,7 +102,8 @@ Review the assigned DGD and any support manifests explicitly included in the han
 - GPU requests, node selectors, tolerations, and GPU SKU expectations
 
 Stop before mutation if required namespace, CRDs, PVC prerequisites, secret names, storage class, images, or GPU
-capacity are missing.
+capacity are missing. Also verify before mutation that the assigned manifest changes no knob listed in the
+contract's `resources.pinned` and that total concurrent GPU holdings stay within `resources.gpu_ceiling`.
 
 When checking GPU capacity, count every pod that is bound to a node (`spec.nodeName` set) and not in a terminal phase
 (`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -104,6 +104,12 @@ Review the assigned DGD and any support manifests explicitly included in the han
 Stop before mutation if required namespace, CRDs, PVC prerequisites, secret names, storage class, images, or GPU
 capacity are missing.
 
+When checking GPU capacity, count every pod that is bound to a node (`spec.nodeName` set) and not in a terminal phase
+(`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in
+`ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes carrying taints beyond the
+standard GPU taint (tenant reservations) from schedulable capacity, and never add tolerations for them. Report free
+capacity as the largest schedulable per-node block, not a cluster-wide sum: a 4-GPU pod needs 4 free GPUs on one node.
+
 If a manifest must change only to work with the target cluster, such as resolving a storage class placeholder or adding
 a required node-taint toleration, update only the copy under `applied_manifests/`. Preserve the handed-off source
 and record the exact change and reason in `deployment_ledger.json`. Do not change performance knobs.

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -106,9 +106,11 @@ capacity are missing.
 
 When checking GPU capacity, count every pod that is bound to a node (`spec.nodeName` set) and not in a terminal phase
 (`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in
-`ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes carrying taints beyond the
-standard GPU taint (tenant reservations) from schedulable capacity, and never add tolerations for them. Report free
-capacity as the largest schedulable per-node block, not a cluster-wide sum: a 4-GPU pod needs 4 free GPUs on one node.
+`ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes whose taints the
+assigned manifest does not already tolerate, and never add new tolerations for other tenants' reservation taints.
+Evaluate fit per component pod — each pod's GPU request, node selectors, affinity, and tolerations against per-node
+free blocks — rather than a cluster-wide sum: a multi-component DGD schedules only if every one of its pods fits on
+some node.
 
 If a manifest must change only to work with the target cluster, such as resolving a storage class placeholder or adding
 a required node-taint toleration, update only the copy under `applied_manifests/`. Preserve the handed-off source

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -108,9 +108,11 @@ When checking GPU capacity, count every pod that is bound to a node (`spec.nodeN
 (`Succeeded`/`Failed`) as holding its full GPU request. Do not filter on `phase == Running`: pods in
 `ImagePullBackOff`, `ContainerCreating`, or init hold their reservations. Exclude nodes whose taints the
 assigned manifest does not already tolerate, and never add new tolerations for other tenants' reservation taints.
-Evaluate fit per component pod — each pod's GPU request, node selectors, affinity, and tolerations against per-node
-free blocks — rather than a cluster-wide sum: a multi-component DGD schedules only if every one of its pods fits on
-some node.
+Evaluate fit by expanding the DGD into its full multiset of pod demands (every component, every replica) and placing
+them against per-node free blocks while decrementing remaining capacity — two pods cannot count the same free GPUs.
+Honor each pod's node selectors, required affinity/anti-affinity, and tolerations during placement. If the DGD cannot
+be faithfully expanded into pod demands, report capacity as unknown, not sufficient. When `resources.gpu_ceiling` is
+set in the workload contract, also verify the run's total concurrent GPU holdings stay within it.
 
 If a manifest must change only to work with the target cluster, such as resolving a storage class placeholder or adding
 a required node-taint toleration, update only the copy under `applied_manifests/`. Preserve the handed-off source

--- a/.agents/skills/perform-adversarial-review/SKILL.md
+++ b/.agents/skills/perform-adversarial-review/SKILL.md
@@ -84,7 +84,8 @@ Attack the proposal from these directions:
 
 - **Evidence**: Does it contain at least three distinct qualifying categories, including AIPerf profiler data? Does
   each source support the stated mechanism, or has contextual evidence been promoted beyond its limits?
-- **Uncertainty**: Are changes of `0.5%` or less classified as noise? For larger changes, does the conclusion match the
+- **Uncertainty**: Are changes at or below the measured noise floor of the active benchmark series classified as
+  noise (per `comparison-uncertainty.md`)? For larger changes, does the conclusion match the
   available single-run or multi-run evidence? Were confidence intervals used only when deliberate repetitions made
   them useful, and is every requested repeat necessary enough to justify its GPU cost? Are degraded single-run
   statistics or surprising gains treated cautiously?

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -61,6 +61,14 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - Accept natural-language answers; do not make the user author YAML.
 - Do not ask for secret values, kubeconfig contents, registry credentials, or Kubernetes Secret data.
 - Do not add a ceremonial confirmation round when the user's message already provides an unambiguous value.
+- Ask once for the resource envelope: the GPU floor and ceiling in play for this work, whether parallel experiments
+  are authorized within the ceiling, any knobs the user forbids changing, and any teardown deadline. Record the
+  answers in the contract's `resources` block. When capacity within the ceiling allows, downstream roles prefer
+  running approved candidates in parallel (one variable per slot, slot attribution in every ledger record) over
+  queueing them serially.
+- When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
+  numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
+  before recording it.
 
 If blocking facts remain, return the questions to the parent and stop without handing work to a downstream role.
 
@@ -118,6 +126,22 @@ Before finalizing:
 
 Do not overwrite the contract after handoff to `recipe-deployer`. A different performance question may use a new
 benchmark series within this contract; a material change to the user workload requires a new experiment root.
+
+## Contract Corrections
+
+A correction of fact is different from a material change: the user is not changing the workload, they are fixing a
+misreported description of the same workload (a wrong traffic number, a fleet-level figure that should have been
+per-replica, a mistaken SLO value). When the user corrects the contract:
+
+1. Append a correction annotation to the experiment ledger recording what changed, why, and when. Never rewrite or
+   delete prior records.
+2. Mark every run measured under the pre-correction contract as superseded, not invalid: those runs remain evidence
+   about the conditions they actually measured.
+3. Update the contract file in place with the correction noted inline, and recompute its SHA256.
+4. Re-establish the baseline under the corrected contract before proposing any new candidate.
+
+If the user is genuinely changing the workload rather than correcting its description, the existing rule applies:
+new experiment root.
 
 ## Return
 

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -42,10 +42,19 @@ Resolve these blocking fields:
 
 - one concrete user-provided YAML document containing a `DynamoGraphDeployment`;
 - workload profile name, type, and a concrete description of the serving traffic;
-- exact model source and revision when the user fixes one;
+- exact model source and revision when the user fixes one, plus the fallback policy when the requested revision
+  may be unsupported by the available engine or weights (fall back to a named alternative and mark the target
+  blocked, or halt);
+- the user's current production deployment configuration when one exists (path or paste): it anchors every
+  later comparison and seeds topology priors; when unavailable, record that explicitly as a known comparison
+  limitation;
 - allowed hardware type and count, including heterogeneous allocations;
 - Kubernetes context and existing namespace; and
-- either an exact trace or enough traffic-shape information to configure a defensible benchmark.
+- either an exact trace or enough traffic-shape information to configure a defensible benchmark. A parametric
+  description is a first-class option between presets and traces: AIPerf synthesizes static shapes (ISL/OSL mean
+  and stddev, prefix reuse via the prefix-prompt pool and length controls) and multiturn sessions (session count,
+  turns per session mean/stddev, per-turn delay) in a single command — offer "describe your workload" whenever the
+  user has neither a matching preset nor a trace, and record the elicited parameters in the contract.
 
 Objectives, SLOs, framework, precision, topology, storage class, and exact token or load values may remain unspecified
 when the user explicitly has no constraint or preference. Represent those values with the schema's empty value; do not
@@ -69,6 +78,11 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
   numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
   before recording it.
+
+Before writing the contract, enumerate every fact the downstream roles (deployer, benchmarker, hypothesis loop,
+analyzer) will require, and ask all still-missing ones in the single upfront batch: a question that first surfaces
+after the optimization loop has started is an interview defect. Record any fact the user defers as an explicit
+assumption in the contract so the loop can proceed non-blockingly.
 
 If blocking facts remain, return the questions to the parent and stop without handing work to a downstream role.
 
@@ -161,3 +175,8 @@ Return:
 
 The user interviewer hands both path-and-hash pairs directly to `recipe-deployer`. The workload path and hash remain
 supporting context for `perf-analyzer`, `hypothesis-generator`, and `hypothesis-challenger`.
+
+End with an operator handoff line before any deployment starts: state that the interview is complete, give the
+contract path, and tell the operator that the engagement now runs a long unattended loop — without goal mode the
+session pauses for input at every turn end — and that this is the moment to arm it (AGENTS.md, Long-Running Runs,
+has the condition template; fill in the budget).

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -61,11 +61,11 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - Accept natural-language answers; do not make the user author YAML.
 - Do not ask for secret values, kubeconfig contents, registry credentials, or Kubernetes Secret data.
 - Do not add a ceremonial confirmation round when the user's message already provides an unambiguous value.
-- Ask once for the resource envelope: the GPU floor and ceiling in play for this work, whether parallel experiments
-  are authorized within the ceiling, any knobs the user forbids changing, and any teardown deadline. Record the
-  answers in the contract's `resources` block. The envelope informs capacity planning; candidates still run serially
-  under the current iteration model (each iteration retires the previous deployment). Do not run candidates in
-  parallel unless artifact roots, DGD names, and teardown ownership are slot-isolated.
+- When the user supplies resource limits — a ceiling on total concurrent GPU use, or knobs they forbid changing —
+  record them in the contract's `resources` block. Ask about limits only when the run's scope makes them blocking
+  (for example, when architectural changes such as replica scaling or disaggregation are in scope and the ceiling
+  determines what may be proposed). Candidates run serially under the current iteration model; parallel candidate
+  execution is not supported.
 - When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
   numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
   before recording it.
@@ -129,22 +129,25 @@ benchmark series within this contract; a material change to the user workload re
 
 ## Contract Corrections
 
-A correction of fact is different from a material change: the user is not changing the workload, they are fixing a
-misreported description of the same workload (a wrong traffic number, a fleet-level figure that should have been
-per-replica, a mistaken SLO value). When the user corrects the contract:
+A correction of fact is the user fixing a misreported description of the same workload (a wrong traffic number, a
+fleet-level figure that should have been per-replica, a mistaken SLO value).
 
-1. Append a correction record to `<EXP_ROOT>/analysis/workload-corrections.jsonl` (append-only) stating what
-   changed, why, when, and which prior runs or iterations it supersedes. Never rewrite or delete prior records.
-2. Mark every run measured under the pre-correction contract as superseded, not invalid: those runs remain evidence
-   about the conditions they actually measured.
-3. Update the contract file in place with the correction noted inline, and recompute its SHA256.
-4. Return the corrected path and SHA256 to the parent for re-handoff: every downstream role holding the
-   pre-correction hash must receive the corrected pair before doing further work. This procedure is the only
-   sanctioned exception to the freeze rule above.
-5. Re-establish the baseline under the corrected contract before proposing any new candidate.
+**Before handoff to `recipe-deployer`**: the contract is still this skill's working file; amend it, note the
+correction inline, and recompute its SHA256.
 
-If the user is genuinely changing the workload rather than correcting its description, the existing rule applies:
-new experiment root.
+**After handoff**: the contract and its hash are frozen and historical artifacts reference them; do not mutate either.
+Instead:
+
+1. Start a new experiment root via this skill, carrying the corrected values forward and re-capturing the canonical
+   DGD copy there.
+2. Write one append-only supersedence marker in the old root, `<OLD_EXP_ROOT>/SUPERSEDED`, recording the corrected
+   field(s), the reason, the timestamp, and the new `EXP_ROOT`. Do not edit or delete any other artifact in the old
+   root: its runs remain valid evidence about the conditions they actually measured.
+3. Re-establish the baseline in the new root before proposing any candidate. Prior conclusions do not carry over;
+   they may be cited as evidence about the superseded conditions.
+
+This makes a post-handoff correction operationally identical to a material workload change (both open a new root);
+the distinction is recorded by the SUPERSEDED marker, not by editing frozen files.
 
 ## Return
 

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -63,9 +63,9 @@ Ask only for blocking facts that remain unknown or contradictory after reading a
 - Do not add a ceremonial confirmation round when the user's message already provides an unambiguous value.
 - Ask once for the resource envelope: the GPU floor and ceiling in play for this work, whether parallel experiments
   are authorized within the ceiling, any knobs the user forbids changing, and any teardown deadline. Record the
-  answers in the contract's `resources` block. When capacity within the ceiling allows, downstream roles prefer
-  running approved candidates in parallel (one variable per slot, slot attribution in every ledger record) over
-  queueing them serially.
+  answers in the contract's `resources` block. The envelope informs capacity planning; candidates still run serially
+  under the current iteration model (each iteration retires the previous deployment). Do not run candidates in
+  parallel unless artifact roots, DGD names, and teardown ownership are slot-isolated.
 - When the user's production deployment shape differs from the unit under test (for example, fleet-level traffic
   numbers but a single-replica test deployment), derive the per-unit load explicitly and confirm it with the user
   before recording it.
@@ -133,12 +133,15 @@ A correction of fact is different from a material change: the user is not changi
 misreported description of the same workload (a wrong traffic number, a fleet-level figure that should have been
 per-replica, a mistaken SLO value). When the user corrects the contract:
 
-1. Append a correction annotation to the experiment ledger recording what changed, why, and when. Never rewrite or
-   delete prior records.
+1. Append a correction record to `<EXP_ROOT>/analysis/workload-corrections.jsonl` (append-only) stating what
+   changed, why, when, and which prior runs or iterations it supersedes. Never rewrite or delete prior records.
 2. Mark every run measured under the pre-correction contract as superseded, not invalid: those runs remain evidence
    about the conditions they actually measured.
 3. Update the contract file in place with the correction noted inline, and recompute its SHA256.
-4. Re-establish the baseline under the corrected contract before proposing any new candidate.
+4. Return the corrected path and SHA256 to the parent for re-handoff: every downstream role holding the
+   pre-correction hash must receive the corrected pair before doing further work. This procedure is the only
+   sanctioned exception to the freeze rule above.
+5. Re-establish the baseline under the corrected contract before proposing any new candidate.
 
 If the user is genuinely changing the workload rather than correcting its description, the existing rule applies:
 new experiment root.

--- a/.github/ISSUE_TEMPLATE/agent-reported.yml
+++ b/.github/ISSUE_TEMPLATE/agent-reported.yml
@@ -1,5 +1,8 @@
 name: Agent-reported instruction gap
 description: For AI agents using the optimization skills — report instructions that misled, blocked, or contradicted live verification.
+title: "[AGENT]: "
+# NOTE: the "agent-reported" label must exist in the repository before this template is used —
+# GitHub silently drops unknown labels at issue creation.
 labels: ["agent-reported"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/agent-reported.yml
+++ b/.github/ISSUE_TEMPLATE/agent-reported.yml
@@ -1,0 +1,29 @@
+name: Agent-reported instruction gap
+description: For AI agents using the optimization skills — report instructions that misled, blocked, or contradicted live verification.
+labels: ["agent-reported"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For AI agents. Search existing agent-reported issues before filing; one issue per
+        optimization session; sanitize all user/engagement specifics.
+  - type: input
+    id: agent-identity
+    attributes:
+      label: Agent identity
+      description: Driver model and the skills commit you were running.
+      placeholder: "claude-opus-4-8, skills @ abc1234"
+    validations:
+      required: true
+  - type: textarea
+    id: gap
+    attributes:
+      label: What the instructions said vs what you verified
+      description: Describe the instruction gap only. No user workload details, traffic numbers, cluster/namespace names, company names, or credentials.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested correction
+      description: Optional. The wording you would have needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,8 @@ notices. Two rules:
    the budget (GPU-hours, wall-clock, failed-deployment limit) in the condition; a bare "never stop" silently relies
    on credential expiry as its budget. Tell the operator at the START of any optimization
    engagement — not only when they say "unattended" — that this is long-running work and how to arm goal mode; the
-   user-interviewer's contract handoff is the natural moment. The template's parked-on-asks pause assumes a
+   user-interviewer's contract handoff is the natural moment. Arm goal mode only AFTER the contract questions are
+   answered: a goal hook armed while questions are outstanding forces the run past them onto its own defaults. The template's parked-on-asks pause assumes a
    reachable operator: for runs where the operator will be away, instruct the agent not to park on asks (asks are
    logged and the loop continues) and keep only the hard stops. Blocking question tools suspend the turn BEFORE the
    goal hook can evaluate, so one blocking question can hang an unattended run for hours; harnesses that support

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,12 @@ notices. Two rules:
 1. **Operators: launch unattended runs inside your harness's goal mode.** Goal mode is an operator action at launch,
    not something these instructions can enable mid-run. On Codex CLI, wrap the run in `/goal` with a token budget. On
    Claude Code (v2.1.139+), wrap it in `/goal`; its completion condition is model-evaluated and may include a bound
-   such as "or stop after N turns" as part of the condition text (a soft limit, not a hard budget). If an unattended
+   such as "or stop after N turns" as part of the condition text (a soft limit, not a hard budget). A validated
+   condition template: "Test every lever family that is testable within the authorized budget. Never stop because a
+   report exists. Parked on pending asks with nothing else testable is a valid pause, not completion. Valid stops: an
+   operator-granted stop-request, the authorized budget exhausted, access lost, or operator interrupt." Always name
+   the budget (GPU-hours, wall-clock, failed-deployment limit) in the condition; a bare "never stop" silently relies
+   on credential expiry as its budget. If an unattended
    run is requested and no goal mode or external loop is in place, say so at the start rather than discovering it at
    the first stall.
 2. **Never end a turn on narrated intent during a loop.** Either perform the next step in the same turn, launch it as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,25 @@ user supplied. Do not dispatch `recipe_deployer`, `perf_analyzer`, `hypothesis_g
 `recipe_deployer`; pass the same immutable workload path and hash to every later role. Do not insert a recipe
 exploration or selection step before the baseline deployment.
 
+## Long-Running Runs And Harness Compatibility
+
+An optimization loop is long-running, unattended work. An interactive harness ends its turn whenever the agent stops
+calling tools — a turn that ends on narrated intent ("now I'll test disagg") silently stalls the loop until a human
+notices. Two rules:
+
+1. **Wrap the loop in your harness's goal mode.** On Codex CLI, use `/goal` with a token budget. On Claude Code
+   (v2.1.139+), use `/goal` with an `or stop after N turns` clause. Both keep the loop running until the objective is
+   judged complete or the budget is reached.
+2. **Never end a turn on narrated intent during a loop.** Either perform the next step in the same turn, launch it as
+   background work that will re-invoke you, or return the specific blocking question you need answered.
+
+**Harness tiers.** These roles and skills are developed and tested on Claude Code and Codex CLI (role configurations
+ship for both). The skills follow the Agent Skills open standard and load on other compliant harnesses (for example,
+OpenCode reads `.claude/skills/` and `.agents/skills/` directly), with three known degradations there: no native goal
+mode (run lights-out sessions under an external loop), role isolation may collapse into a single context (weakening
+the independence of adversarial review), and every rule in this pack is prompt-enforced, so discipline depends on the
+driver model. If you hit an instruction gap on any harness, file an issue on this repository describing the gap.
+
 ## Ecosystem
 
 Sibling repositories this repo integrates with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,7 @@ notices. Two rules:
    background work that will re-invoke you, or return the specific blocking question you need answered.
 
 **Harness tiers.** These roles and skills are developed and tested on Claude Code and Codex CLI (role configurations
-ship for both). The skills follow the Agent Skills open standard and load on other compliant harnesses (for example,
-OpenCode reads `.claude/skills/` and `.agents/skills/` directly), with three known degradations there: no native goal
+ship for both). The skills follow the Agent Skills open standard and load on other compliant harnesses (for example, OpenCode includes `.agents/skills/` among its standard skill search paths), with three known degradations there: no native goal
 mode (run lights-out sessions under an external loop), role isolation may collapse into a single context (weakening
 the independence of adversarial review), and every rule in this pack is prompt-enforced, so discipline depends on the
 driver model. If you hit an instruction gap on any harness, file an issue on this repository describing the gap.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,17 @@ exactly. All of this is enforced by `scripts/validate_skills.py` (pre-commit hoo
 `validate-skills`). Changes under `.agents/skills/` are also validated by NVSkills CI —
 a maintainer comments `/nvskills-ci` on the PR.
 
+## Improving These Instructions
+
+If these skills or instructions misled you, blocked you, or contradicted what you verified live, file an issue on
+this repository with the `agent-reported` label. Rules:
+
+1. Search existing `agent-reported` issues first; comment on a duplicate instead of filing a new one.
+2. File at most one issue per optimization session; batch findings into it.
+3. Identify yourself as an AI agent, including your driver model and the skills commit you were running.
+4. Sanitize completely: no user workload details, traffic numbers, cluster or namespace names, company names, or
+   credentials. Describe the instruction gap, not the engagement.
+
 ## Optimization Role Dispatch
 
 When the first user message starts a new Dynamo recipe optimization run, dispatch `user_interviewer` before any other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,17 +82,23 @@ An optimization loop is long-running, unattended work. An interactive harness en
 calling tools — a turn that ends on narrated intent ("now I'll test disagg") silently stalls the loop until a human
 notices. Two rules:
 
-1. **Wrap the loop in your harness's goal mode.** On Codex CLI, use `/goal` with a token budget. On Claude Code
-   (v2.1.139+), use `/goal` with an `or stop after N turns` clause. Both keep the loop running until the objective is
-   judged complete or the budget is reached.
+1. **Operators: launch unattended runs inside your harness's goal mode.** Goal mode is an operator action at launch,
+   not something these instructions can enable mid-run. On Codex CLI, wrap the run in `/goal` with a token budget. On
+   Claude Code (v2.1.139+), wrap it in `/goal`; its completion condition is model-evaluated and may include a bound
+   such as "or stop after N turns" as part of the condition text (a soft limit, not a hard budget). If an unattended
+   run is requested and no goal mode or external loop is in place, say so at the start rather than discovering it at
+   the first stall.
 2. **Never end a turn on narrated intent during a loop.** Either perform the next step in the same turn, launch it as
    background work that will re-invoke you, or return the specific blocking question you need answered.
 
-**Harness tiers.** These roles and skills are developed and tested on Claude Code and Codex CLI (role configurations
-ship for both). The skills follow the Agent Skills open standard and load on other compliant harnesses (for example, OpenCode includes `.agents/skills/` among its standard skill search paths), with three known degradations there: no native goal
-mode (run lights-out sessions under an external loop), role isolation may collapse into a single context (weakening
-the independence of adversarial review), and every rule in this pack is prompt-enforced, so discipline depends on the
-driver model. If you hit an instruction gap on any harness, file an issue on this repository describing the gap.
+**Harness tiers.** These roles and skills are developed and tested on Claude Code and Codex CLI. Isolated role
+configurations currently ship for Codex only (`.codex/agents/*.toml`); on Claude Code the roles run in-context within
+one session (no `.claude/agents/` configurations yet), so adversarial review there is same-context review, not an
+independent reviewer. The skills follow the Agent Skills open standard and load on other compliant harnesses (for
+example, OpenCode includes `.agents/skills/` among its standard skill search paths), with the same in-context role
+caveat plus two more degradations: no native goal mode (run lights-out sessions under an external loop), and every
+rule in this pack is prompt-enforced, so discipline depends on the driver model. If you hit an instruction gap on any
+harness, prepare a sanitized issue describing the gap and ask your operator to approve filing it on this repository.
 
 ## Ecosystem
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,14 +68,15 @@ a maintainer comments `/nvskills-ci` on the PR.
 
 ## Improving These Instructions
 
-If these skills or instructions misled you, blocked you, or contradicted what you verified live, file an issue on
-this repository with the `agent-reported` label. Rules:
+If these skills or instructions misled you, blocked you, or contradicted what you verified live, prepare an issue for
+this repository with the `agent-reported` label and ask your operator to approve filing it — filing is an external
+write and requires operator consent. Rules:
 
-1. Search existing `agent-reported` issues first; comment on a duplicate instead of filing a new one.
-2. File at most one issue per optimization session; batch findings into it.
+1. Search existing `agent-reported` issues first; propose commenting on a duplicate instead of filing a new one.
+2. Prepare at most one issue per optimization session; batch findings into it.
 3. Identify yourself as an AI agent, including your driver model and the skills commit you were running.
 4. Sanitize completely: no user workload details, traffic numbers, cluster or namespace names, company names, or
-   credentials. Describe the instruction gap, not the engagement.
+   credentials. Describe the instruction gap, not the engagement. Show the operator the full draft before filing.
 
 ## Optimization Role Dispatch
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,13 @@ notices. Two rules:
    report exists. Parked on pending asks with nothing else testable is a valid pause, not completion. Valid stops: an
    operator-granted stop-request, the authorized budget exhausted, access lost, or operator interrupt." Always name
    the budget (GPU-hours, wall-clock, failed-deployment limit) in the condition; a bare "never stop" silently relies
-   on credential expiry as its budget. If an unattended
-   run is requested and no goal mode or external loop is in place, say so at the start rather than discovering it at
-   the first stall.
+   on credential expiry as its budget. Tell the operator at the START of any optimization
+   engagement — not only when they say "unattended" — that this is long-running work and how to arm goal mode; the
+   user-interviewer's contract handoff is the natural moment. The template's parked-on-asks pause assumes a
+   reachable operator: for runs where the operator will be away, instruct the agent not to park on asks (asks are
+   logged and the loop continues) and keep only the hard stops. Blocking question tools suspend the turn BEFORE the
+   goal hook can evaluate, so one blocking question can hang an unattended run for hours; harnesses that support
+   tool restrictions should disallow blocking question tools in goal mode.
 2. **Never end a turn on narrated intent during a loop.** Either perform the next step in the same turn, launch it as
    background work that will re-invoke you, or return the specific blocking question you need answered.
 

--- a/agent-docs/guides/knob-tuning/tuning-hierarchy.md
+++ b/agent-docs/guides/knob-tuning/tuning-hierarchy.md
@@ -26,17 +26,24 @@ If the current configuration did not engage or the run is invalid, repair or rem
 optimization.
 
 
-## Category 1 — Deployment Topology and Fit
+## Category 1 — Deployment Topology and Operating Regime
 
-First ask whether the deployment shape can efficiently serve the user workload. Topology is a hypothesis category,
-not only a deploy-time fit check: a configuration that fits can still be the wrong shape for the operating point.
-Evaluate topology in this order:
+First ask whether the deployment shape can efficiently serve the user workload. Topology sets four things at once,
+and only one of them is memory: per-rank effective batch and arithmetic intensity (the throughput axis); weight and
+KV memory footprint (the fit axis); the collective-communication pattern and volume (TP all-reduce, EP all-to-all,
+none for DP); and whether attention and weights are replicated or sharded. Do not evaluate a topology change on
+memory alone: when memory is not binding, the topology question is not closed; it moves to compute and
+communication. A configuration that fits can still be the wrong shape for the operating point. Evaluate topology in
+this order:
 
 1. Compute the model, activation, and KV-memory fit and establish the minimum viable TP, PP, and EP.
-2. Compute the effective per-rank batch at the target concurrency: a data-parallel layout that leaves each rank a
-   trivial batch under-utilizes compute even though it fits.
-3. Prefer the smallest parallelism that fits with operating headroom and a useful per-rank batch at the target
-   concurrency, then use remaining fixed-budget GPUs for replicas when the workload can benefit from them.
+2. Compute the effective per-rank batch at the target concurrency: data parallelism serves batch/N per replica,
+   shrinking per-rank batch and starving compute even though everything fits, while tensor parallelism runs the
+   whole batch through one sharded forward pass, raising per-rank batch and freeing memory at the cost of
+   collective communication.
+3. Among layouts that fit with operating headroom, prefer the one that maximizes useful per-rank batch and compute
+   efficiency at the target concurrency, then weigh its communication cost; fit is a constraint, not the objective.
+   Use remaining fixed-budget GPUs for replicas when the workload can benefit from them.
 4. Consider aggregated versus disaggregated serving only when workload shape, scale, or independent prefill/decode
    objectives justify the transfer and coordination cost.
 5. For an existing disaggregated deployment, check prefill/decode allocation and rate matching before adding workers.

--- a/agent-docs/guides/knob-tuning/tuning-hierarchy.md
+++ b/agent-docs/guides/knob-tuning/tuning-hierarchy.md
@@ -28,19 +28,27 @@ optimization.
 
 ## Category 1 — Deployment Topology and Fit
 
-First ask whether the deployment shape can efficiently serve the user workload. This is a screening decision, not an
-automatic topology experiment. Evaluate topology in this order:
+First ask whether the deployment shape can efficiently serve the user workload. Topology is a hypothesis category,
+not only a deploy-time fit check: a configuration that fits can still be the wrong shape for the operating point.
+Evaluate topology in this order:
 
 1. Compute the model, activation, and KV-memory fit and establish the minimum viable TP, PP, and EP.
-2. Prefer the smallest parallelism that fits with operating headroom, then use remaining fixed-budget GPUs for
-   replicas when the workload can benefit from them.
-3. Consider aggregated versus disaggregated serving only when workload shape, scale, or independent prefill/decode
+2. Compute the effective per-rank batch at the target concurrency: a data-parallel layout that leaves each rank a
+   trivial batch under-utilizes compute even though it fits.
+3. Prefer the smallest parallelism that fits with operating headroom and a useful per-rank batch at the target
+   concurrency, then use remaining fixed-budget GPUs for replicas when the workload can benefit from them.
+4. Consider aggregated versus disaggregated serving only when workload shape, scale, or independent prefill/decode
    objectives justify the transfer and coordination cost.
-4. For an existing disaggregated deployment, check prefill/decode allocation and rate matching before adding workers.
-5. Verify node placement and the required fast fabric when the selected topology crosses GPUs or nodes.
+5. For an existing disaggregated deployment, check prefill/decode allocation and rate matching before adding workers.
+6. Verify node placement and the required fast fabric when the selected topology crosses GPUs or nodes.
 
-Choose a topology hypothesis only when model sizing, Kubernetes or engine evidence, rate imbalance, transfer behavior,
-or same-regime history supports a structural mismatch. Consult the
+Choose a topology hypothesis when model-sizing arithmetic, per-rank batch at the target concurrency, Kubernetes or
+engine evidence, rate imbalance, transfer behavior, same-regime history, or a sibling recipe for the same model on
+other hardware supports a structural mismatch. Sibling recipes are hypothesis priors, not adoption evidence: even
+when their checkpoint or hardware is incompatible, their parallelism and serving-mode choices transfer as candidates.
+Rank candidate layouts cheaply (sizing arithmetic, projections, published same-model recipes) before spending a
+deployment on one, and revisit topology after baseline characterization and whenever the measured regime changes; an
+inherited layout is a candidate like any other, not a settled decision. Consult the
 [model-sizing guides](../model-sizing/classification.md) and, for disaggregated serving,
 [rate matching](../rate-matching/matching.md).
 

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -149,10 +149,16 @@ one of:
   with them. Enter `PARKED_ON_ASKS` (a pause, not a stop) only when pending asks are the only remaining work, and
   record how deployed resources are held and when they scale down;
 - a **stop-request**: the search-calibration record in a terminal state, meaning every lever family is `tested`,
-  `asked` and answered, `ruled-out`, or `deferred`. A `ruled-out` row must cite a measurement, a sourced hard
+  `asked` and answered, `ruled-out`, or `deferred`. Prepare the Finalize artifacts (section 7), including the
+  recommendation's `Correctness status:` line, BEFORE submitting the stop-request — the stop-request references the
+  draft recommendation, and operator grant closes the engagement rather than starting its write-up. A `ruled-out` row must cite a measurement, a sourced hard
   constraint, a confirmed incompatibility, or an explicit operator decision; the generator's own unsourced reasoning
   does not qualify, and expected upside below the minimum detectable effect is `deferred`, not `ruled-out`. Hand the
   stop-request to `hypothesis-challenger` for evidence-class validation.
+
+While a stop-request awaits challenger validation and operator grant (`STOP_REQUESTED`), continue confirmatory
+runs, cleanup, and any still-testable work; launch no new candidate families. If the challenger or operator returns
+objections, re-enter `ACTIVE`.
 
 Stop only when the operator grants a validated stop-request (`STOP_GRANTED`), the authorized budget is exhausted
 (`BUDGET_STOP`), or access is lost and cannot be restored. Never stop because a report exists.

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -158,8 +158,10 @@ one of:
   recommendation's `Correctness status:` line, BEFORE submitting the stop-request — the stop-request references the
   draft recommendation, and operator grant closes the engagement rather than starting its write-up. A `ruled-out` row must cite a measurement, a sourced hard
   constraint, a confirmed incompatibility, or an explicit operator decision; the generator's own unsourced reasoning
-  does not qualify, and expected upside below the minimum detectable effect is `deferred`, not `ruled-out`. Hand the
-  stop-request to `hypothesis-challenger` for evidence-class validation.
+  does not qualify, and expected upside below the minimum detectable effect is `deferred`, not `ruled-out`. While
+  more than half of any granted budget remains, `deferred` is not a terminal state for a family whose recorded
+  expected upside is medium or higher: test it, ask about it, or rule it out with qualifying evidence before
+  requesting a stop. Hand the stop-request to `hypothesis-challenger` for evidence-class validation.
 
 While a stop-request awaits challenger validation and operator grant (`STOP_REQUESTED`), continue confirmatory
 runs, cleanup, and any still-testable work; launch no new candidate families. If the challenger or operator returns

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -66,7 +66,12 @@ not contradict the user workload. Do not edit, replace, or select an alternative
 
 Give the exact assigned DGD path and SHA256, `user_workload.yaml` path and SHA256, iteration, and previous
 `DEPLOY_ROOT` when applicable to `recipe-deployer`. For iteration 0, the assigned DGD is the immutable
-`user_provided_dgd.yaml`; later iterations use the exact challenger-approved draft. The deployer creates:
+`user_provided_dgd.yaml` when it can run on the target as provided. When it cannot — an adaptation engagement, where
+the user's DGD targets different hardware, checkpoints, or fabric — the deployer instead selects the closest viable
+recipe for the target as the iteration-0 base, records the selection evidence, and diffs it against the immutable
+user DGD so every inherited constraint and deviation is explicit. Do not carry hardware-bound topology, transport, or
+checkpoint choices from an incompatible source manifest into the baseline without evidence they fit the target.
+Later iterations use the exact challenger-approved draft. The deployer creates:
 
 ```text
 <EXP_ROOT>/artifacts/deploy-iter-<NNN>/

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -136,8 +136,24 @@ Keep every previous manifest, consultation, review, and benchmark artifact uncha
 After deployment, choose the benchmark based on the approved performance question. It may reuse an applicable series
 or create a new one. Never claim a direct gain across series.
 
-Stop when the user constraints are met, no useful optimization ideas remain, the user-specified budget is exhausted,
-or the generator returns `no-proposal`.
+The loop is always in exactly one state: `ACTIVE`, `PARKED_ON_ASKS`, `STOP_REQUESTED`, `STOP_GRANTED`, or
+`BUDGET_STOP`. A `no-proposal` consultation never ends the engagement; it obligates the generator to produce exactly
+one of:
+
+- the next candidate;
+- an **ask**: a recorded question whose answer would unblock the highest-value deferred lever family. Asks are
+  non-blocking: record the ask, surface it in one line of passing output, and keep working any still-testable
+  family. Deduplicate pending asks, surface only the highest-value few, and lead the next operator-facing response
+  with them. Enter `PARKED_ON_ASKS` (a pause, not a stop) only when pending asks are the only remaining work, and
+  record how deployed resources are held and when they scale down;
+- a **stop-request**: the search-calibration record in a terminal state, meaning every lever family is `tested`,
+  `asked` and answered, `ruled-out`, or `deferred`. A `ruled-out` row must cite a measurement, a sourced hard
+  constraint, a confirmed incompatibility, or an explicit operator decision; the generator's own unsourced reasoning
+  does not qualify, and expected upside below the minimum detectable effect is `deferred`, not `ruled-out`. Hand the
+  stop-request to `hypothesis-challenger` for evidence-class validation.
+
+Stop only when the operator grants a validated stop-request (`STOP_GRANTED`), the authorized budget is exhausted
+(`BUDGET_STOP`), or access is lost and cannot be restored. Never stop because a report exists.
 
 ## 7. Finalize
 

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -157,6 +157,14 @@ Stop only when the operator grants a validated stop-request (`STOP_GRANTED`), th
 
 ## 7. Finalize
 
+Before recommending, run a correctness regression check whenever the recommended configuration differs from the
+user-provided baseline in an output-affecting dimension (parallelism or reduction order, speculative decoding,
+quantization, attention or MoE backend, KV dtype or reuse): replay 8-16 fixed representative prompts with frozen
+continuations through both configurations and compare teacher-forced per-token log-probabilities, calibrating the
+tolerance with a baseline-versus-baseline repeat; require zero request failures, malformed responses, non-finite
+scores, and no unexpected truncation. If no such check is possible, record an ask; report a waived check as
+`correctness: unverified`, never as a pass. Record the correctness status in `recommended_config.md`.
+
 Recommend the best valid candidate for the target objective, not automatically the most recent iteration. Write the
 final configuration to `EXP_ROOT/final/recommended_config.md`, reproduction commands to
 `EXP_ROOT/final/reproduced_commands.sh`, and limitations to `EXP_ROOT/final/known_limitations.md`. Include paths to the

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -143,7 +143,9 @@ one of:
 - the next candidate;
 - an **ask**: a recorded question whose answer would unblock the highest-value deferred lever family. Asks are
   non-blocking: record the ask, surface it in one line of passing output, and keep working any still-testable
-  family. Deduplicate pending asks, surface only the highest-value few, and lead the next operator-facing response
+  family. Never deliver an ask through a blocking question tool during the loop — a blocking question suspends the
+  turn before any goal hook can evaluate and can hang an unattended run; asks go to the artifact and the loop
+  continues. Deduplicate pending asks, surface only the highest-value few, and lead the next operator-facing response
   with them. Enter `PARKED_ON_ASKS` (a pause, not a stop) only when pending asks are the only remaining work, and
   record how deployed resources are held and when they scale down;
 - a **stop-request**: the search-calibration record in a terminal state, meaning every lever family is `tested`,
@@ -164,6 +166,10 @@ continuations through both configurations and compare teacher-forced per-token l
 tolerance with a baseline-versus-baseline repeat; require zero request failures, malformed responses, non-finite
 scores, and no unexpected truncation. If no such check is possible, record an ask; report a waived check as
 `correctness: unverified`, never as a pass. Record the correctness status in `recommended_config.md`.
+
+When the recommended or baseline configuration has speculative decoding enabled, state in the recommendation that
+its acceptance behavior was measured on synthetic benchmark content and the measured magnitude may not transfer to
+production traffic; acceptance length is passively observable in production telemetry and should be confirmed there.
 
 Recommend the best valid candidate for the target objective, not automatically the most recent iteration. Write the
 final configuration to `EXP_ROOT/final/recommended_config.md`, reproduction commands to

--- a/agent-docs/rules/benchmarking/comparison-uncertainty.md
+++ b/agent-docs/rules/benchmarking/comparison-uncertainty.md
@@ -28,9 +28,15 @@ is expensive, so do not collect repetitions only to produce confidence intervals
   inflates the best observed result.
 - Keep practical significance separate from detectability: state the smallest delta that matters for the engagement
   and do not claim gains below it regardless of statistical separation.
-- Record neighbour occupancy (what else runs on the node) with every measurement and compare only like with like. A
-  fleet or full-node projection from idle-neighbour measurements is invalid until confirmed by one co-located
-  measurement with load generation verified unsaturated.
+- Record neighbour occupancy (what else runs on the node) with every measurement and compare only like with like:
+  candidates measured under the same occupancy are like-for-like. A fleet or full-node projection from
+  idle-neighbour measurements is invalid until confirmed by one co-located measurement with load generation
+  verified unsaturated.
+- Neighbour occupancy is a recorded condition, not an admission gate. Do not require idle or exclusive nodes to
+  measure: on a shared cluster they may never exist, and an empirical noise floor measured under real occupancy is
+  the decision floor. Reserve isolation requests for the finalist's confirmatory absolutes, and when isolation is
+  unavailable even then, report the finalist with occupancy labeled as a limitation rather than blocking the
+  engagement.
 - Cache-state policy for reuse-heavy workloads: reset caches between points and rank candidates on cold, identical
   content (comparability), but before promising an absolute number — a floor-pick or a fleet projection — on a
   workload with substantial prefix reuse, confirm the finalist once at warm steady state. A cold, short window

--- a/agent-docs/rules/benchmarking/comparison-uncertainty.md
+++ b/agent-docs/rules/benchmarking/comparison-uncertainty.md
@@ -16,7 +16,9 @@ is expensive, so do not collect repetitions only to produce confidence intervals
 - Compare the same metric, statistic, unit, workload phase, and benchmark-series identity.
 - Establish the noise floor of each benchmark series empirically before adopting or retiring any candidate on a
   small delta: run a pilot repetition (n=3) of one configuration at the decision point, compute the run-to-run
-  spread, and derive the minimum detectable effect. Treat any default percentage as a placeholder, never as a
+  spread, and derive the minimum detectable effect. This pilot runs ONCE per benchmark series and is amortized
+  across every candidate measured in that series; candidates themselves stay single-run unless their delta falls
+  inside the measured noise band. Treat any default percentage as a placeholder, never as a
   measured floor; uncontrolled state such as prefix-cache carryover can put the real floor an order of magnitude
   higher.
 - Screening and categorical outcomes (OOM, error storms, wide-margin SLO results) remain valid at n=1.

--- a/agent-docs/rules/benchmarking/comparison-uncertainty.md
+++ b/agent-docs/rules/benchmarking/comparison-uncertainty.md
@@ -36,7 +36,9 @@ is expensive, so do not collect repetitions only to produce confidence intervals
   measure: on a shared cluster they may never exist, and an empirical noise floor measured under real occupancy is
   the decision floor. Reserve isolation requests for the finalist's confirmatory absolutes, and when isolation is
   unavailable even then, report the finalist with occupancy labeled as a limitation rather than blocking the
-  engagement.
+  engagement. A neighbour transition during a measurement invalidates that run only when the run's own time-series
+  shows a corresponding performance shift; otherwise record the transition and keep the run — on a shared cluster
+  transitions are constant, and a rule that discards every affected run converges to no eligible runs at all.
 - Cache-state policy for reuse-heavy workloads: reset caches between points and rank candidates on cold, identical
   content (comparability), but before promising an absolute number — a floor-pick or a fleet projection — on a
   workload with substantial prefix reuse, confirm the finalist once at warm steady state. A cold, short window

--- a/agent-docs/rules/benchmarking/comparison-uncertainty.md
+++ b/agent-docs/rules/benchmarking/comparison-uncertainty.md
@@ -5,16 +5,32 @@ SPDX-License-Identifier: Apache-2.0
 
 # Comparison Uncertainty
 
-Default to one measured AIPerf run per candidate. Configure each measured run to finish in 30 minutes or less. GPU
-benchmarking is expensive, so do not collect repetitions only to produce confidence intervals.
+Default to one measured AIPerf run per candidate. Configure each measured run to finish in 30 minutes or less
+unless the operator authorizes longer windows; record any such authorization in the benchmark plan. GPU benchmarking
+is expensive, so do not collect repetitions only to produce confidence intervals.
 
 ## Default Decision Policy
 
 - **Current result**: the configuration being evaluated.
 - **Reference result**: the valid baseline or prior configuration used for comparison.
 - Compare the same metric, statistic, unit, workload phase, and benchmark-series identity.
-- Classify an absolute performance change of `0.5%` or less as noise. Report it without automatically repeating the
-  benchmark.
+- Establish the noise floor of each benchmark series empirically before adopting or retiring any candidate on a
+  small delta: run a pilot repetition (n=3) of one configuration at the decision point, compute the run-to-run
+  spread, and derive the minimum detectable effect. Treat any default percentage as a placeholder, never as a
+  measured floor; uncontrolled state such as prefix-cache carryover can put the real floor an order of magnitude
+  higher.
+- Screening and categorical outcomes (OOM, error storms, wide-margin SLO results) remain valid at n=1.
+- For adopt-or-retire decisions inside the noise band, use paired repetitions with controlled or deliberately
+  randomized warmup and cache state (for example concurrent arms on separate nodes, or AB/BA ordering), analyze the
+  paired differences rather than comparing two means, and add repetitions sequentially up to a declared maximum while
+  the interval overlaps the decision boundary.
+- Give the selected finalist a fresh confirmatory repetition after selection: adaptive search across many candidates
+  inflates the best observed result.
+- Keep practical significance separate from detectability: state the smallest delta that matters for the engagement
+  and do not claim gains below it regardless of statistical separation.
+- Record neighbour occupancy (what else runs on the node) with every measurement and compare only like with like. A
+  fleet or full-node projection from idle-neighbour measurements is invalid until confirmed by one co-located
+  measurement with load generation verified unsaturated.
 - A clear, substantial improvement or regression may support a conclusion from one valid, isolated, plausible run.
   State that the comparison is single-run evidence.
 - Repeat a valid benchmark only when the existing evidence cannot support a consequential decision, another run is

--- a/agent-docs/rules/benchmarking/comparison-uncertainty.md
+++ b/agent-docs/rules/benchmarking/comparison-uncertainty.md
@@ -31,6 +31,10 @@ is expensive, so do not collect repetitions only to produce confidence intervals
 - Record neighbour occupancy (what else runs on the node) with every measurement and compare only like with like. A
   fleet or full-node projection from idle-neighbour measurements is invalid until confirmed by one co-located
   measurement with load generation verified unsaturated.
+- Cache-state policy for reuse-heavy workloads: reset caches between points and rank candidates on cold, identical
+  content (comparability), but before promising an absolute number — a floor-pick or a fleet projection — on a
+  workload with substantial prefix reuse, confirm the finalist once at warm steady state. A cold, short window
+  measures the cold-to-warm transient, not the regime production runs in.
 - A clear, substantial improvement or regression may support a conclusion from one valid, isolated, plausible run.
   State that the comparison is single-run evidence.
 - Repeat a valid benchmark only when the existing evidence cannot support a consequential decision, another run is

--- a/agent-docs/rules/execution/run-artifacts.md
+++ b/agent-docs/rules/execution/run-artifacts.md
@@ -92,6 +92,10 @@ runs/<EXP_ID>/
 - `knowledge-consult.md`: required consultation result for `proposed`, `no-proposal`, and `blocked` outcomes.
 - `deploy-draft.yaml`: candidate DGD created only for a materialized proposal; it remains here until challenger
   approval assigns it to the next deployment iteration.
+- `asks.jsonl` (under `EXP_ROOT/analysis/`): append-only operator-ask record with the question, blocked lever
+  family, expected upside, status (`pending` or `answered`), and the answer once received. Deduplicate before
+  appending. A stop-request is not a separate file: it is the terminal search-calibration record in
+  `knowledge-consult.md` plus its challenger validation.
 
 ## Deployment Directories
 

--- a/agent-docs/rules/execution/run-artifacts.md
+++ b/agent-docs/rules/execution/run-artifacts.md
@@ -138,6 +138,8 @@ runs/<EXP_ID>/
   `deploy-draft.yaml`.
 - Make direct comparisons only when `benchmark_audit.json` marks every run valid and their plan and benchmark-series
   identities match.
+- `recommended_config.md` MUST carry a `Correctness status:` line — `verified (scope stated)`,
+  `unverified (waived: reason)`, or `blocked (ask recorded)`. A recommendation without it is incomplete.
 - Do not treat a final recommendation as reproducible unless it points to the user workload, original user-provided
   DGD, applied manifests, deployment ledger, applicable benchmark plans, audits, summaries, performance analyses, and
   raw benchmark artifacts.

--- a/agent-docs/rules/execution/user-workload.md
+++ b/agent-docs/rules/execution/user-workload.md
@@ -66,11 +66,8 @@ preferences:
   mode: ""                         # agg, disagg
 
 resources:
-  gpu_floor: null                  # GPUs guaranteed available to this work
-  gpu_ceiling: null                # maximum GPUs the user authorizes, across all concurrent experiments
-  parallel_experiments: null      # user authorization for concurrent candidates (advisory until the loop supports slot isolation)
+  gpu_ceiling: null                # maximum total GPUs the user authorizes this run to hold at once
   pinned: []                       # configuration knobs the user forbids changing (e.g. ["mode", "precision"])
-  teardown_deadline: ""            # optional wall-clock bound by which all run resources must be gone
 
 objectives:
   ttft_ms_p95_max: null            # optional time to first token
@@ -100,8 +97,10 @@ created_at: ""
   `deployment.dgd_sha256` to match that file.
 - `kube_context` and `namespace` are required. The namespace must already exist.
 - Treat `resources.gpu_ceiling` as authorization, not entitlement: every GPU-consuming experiment still requires its
-  own evidence and adversarial review. Treat `resources.pinned` entries as hard constraints enforced at hypothesis
-  review and deploy preflight, not as style preferences.
+  own evidence and adversarial review. `hardware[]` describes what the workload serves on; `gpu_ceiling` bounds the
+  run's total concurrent GPU holdings and must be at least the assigned DGD's total request. When unset, the assigned
+  DGD's own footprint is the bound. `hypothesis-challenger` must reject candidates that change a `pinned` knob or
+  exceed `gpu_ceiling`; `deploy-dynamo-recipe` preflight must verify both before mutation.
 - `storage_class` is optional when the required PVC already exists or a suitable cluster default is known. If the run
   must create a PVC and no suitable class can be determined safely, return a focused question to the user.
 - Token lengths are optional customer-provided traffic hints, not required benchmark keys. Prefer real traces or

--- a/agent-docs/rules/execution/user-workload.md
+++ b/agent-docs/rules/execution/user-workload.md
@@ -65,6 +65,13 @@ preferences:
   framework: ""                    # vLLM, SGLang, or TRT-LLM
   mode: ""                         # agg, disagg
 
+resources:
+  gpu_floor: null                  # GPUs guaranteed available to this work
+  gpu_ceiling: null                # maximum GPUs the user authorizes, across all concurrent experiments
+  parallel_experiments: null      # whether the user authorizes concurrent candidate experiments within the ceiling
+  pinned: []                       # configuration knobs the user forbids changing (e.g. ["mode", "precision"])
+  teardown_deadline: ""            # optional wall-clock bound by which all run resources must be gone
+
 objectives:
   ttft_ms_p95_max: null            # optional time to first token
   itl_ms_p95_max: null             # optional inter-token-latency
@@ -92,6 +99,9 @@ created_at: ""
 - Require `deployment.dgd_path` to resolve to `<EXP_ROOT>/inputs/user_provided_dgd.yaml`, and require
   `deployment.dgd_sha256` to match that file.
 - `kube_context` and `namespace` are required. The namespace must already exist.
+- Treat `resources.gpu_ceiling` as authorization, not entitlement: every GPU-consuming experiment still requires its
+  own evidence and adversarial review. Treat `resources.pinned` entries as hard constraints enforced at hypothesis
+  review and deploy preflight, not as style preferences.
 - `storage_class` is optional when the required PVC already exists or a suitable cluster default is known. If the run
   must create a PVC and no suitable class can be determined safely, return a focused question to the user.
 - Token lengths are optional customer-provided traffic hints, not required benchmark keys. Prefer real traces or

--- a/agent-docs/rules/execution/user-workload.md
+++ b/agent-docs/rules/execution/user-workload.md
@@ -68,7 +68,7 @@ preferences:
 resources:
   gpu_floor: null                  # GPUs guaranteed available to this work
   gpu_ceiling: null                # maximum GPUs the user authorizes, across all concurrent experiments
-  parallel_experiments: null      # whether the user authorizes concurrent candidate experiments within the ceiling
+  parallel_experiments: null      # user authorization for concurrent candidates (advisory until the loop supports slot isolation)
   pinned: []                       # configuration knobs the user forbids changing (e.g. ["mode", "precision"])
   teardown_deadline: ""            # optional wall-clock bound by which all run resources must be gone
 

--- a/agent-docs/rules/verification/overlap.md
+++ b/agent-docs/rules/verification/overlap.md
@@ -5,7 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # Overlap
 
-Classify an absolute performance change of `0.5%` or less as noise and report it without automatically repeating the
+Classify an absolute performance change at or below the measured noise floor of the active benchmark series (see
+`comparison-uncertainty.md`) as noise and report it without automatically repeating the
 benchmark. A clear, substantial gain or loss may support a conclusion from one valid, isolated, plausible run; identify
 it as single-run evidence.
 

--- a/agents/hypothesis-challenger/AGENTS.md
+++ b/agents/hypothesis-challenger/AGENTS.md
@@ -44,6 +44,8 @@ Do:
 - Verify that the proposal states a concrete performance question and expected measurable effect without selecting a
   benchmark merely to favor the candidate.
 - Return one verdict—`approve`, `revise`, or `reject`—with the strongest objections first.
+- Reject any candidate that changes a knob listed in the contract's `resources.pinned` or whose deployment would
+  exceed `resources.gpu_ceiling`; these are blocking objections regardless of evidence quality.
 - Return every non-approval to `hypothesis-generator` with only the minimal revision or follow-up needed.
 
 Do not:
@@ -67,8 +69,8 @@ Do not:
 Review a materialized proposal or a stop-request. For a `no-proposal` or `blocked` consultation that carries no
 stop-request, return without creating a candidate review. For a stop-request, validate completeness and evidence
 class: every lever family carries a terminal disposition, every `ruled-out` row cites a measurement, a sourced
-hard constraint, a confirmed incompatibility, or an explicit operator decision, and the final recommendation carries
-its required `Correctness status:` line. Append the verdict to
+hard constraint, a confirmed incompatibility, or an explicit operator decision, and the draft recommendation
+accompanying the stop-request carries its required `Correctness status:` line. Append the verdict to
 `challenger-reviews.jsonl` as for any review, and state in it that this is procedural validation, not independent
 adversarial assurance.
 

--- a/agents/hypothesis-challenger/AGENTS.md
+++ b/agents/hypothesis-challenger/AGENTS.md
@@ -69,7 +69,9 @@ Do not:
 Review a materialized proposal or a stop-request. For a `no-proposal` or `blocked` consultation that carries no
 stop-request, return without creating a candidate review. For a stop-request, validate completeness and evidence
 class: every lever family carries a terminal disposition, every `ruled-out` row cites a measurement, a sourced
-hard constraint, a confirmed incompatibility, or an explicit operator decision, and the draft recommendation
+hard constraint, a confirmed incompatibility, or an explicit operator decision, no family with medium-or-higher
+recorded expected upside remains merely `deferred` while more than half of any granted budget remains (reject the
+stop-request and return that family as the required follow-up), and the draft recommendation
 accompanying the stop-request carries its required `Correctness status:` line. Append the verdict to
 `challenger-reviews.jsonl` as for any review, and state in it that this is procedural validation, not independent
 adversarial assurance.

--- a/agents/hypothesis-challenger/AGENTS.md
+++ b/agents/hypothesis-challenger/AGENTS.md
@@ -66,8 +66,9 @@ Do not:
 
 Review a materialized proposal or a stop-request. For a `no-proposal` or `blocked` consultation that carries no
 stop-request, return without creating a candidate review. For a stop-request, validate completeness and evidence
-class: every lever family carries a terminal disposition, and every `ruled-out` row cites a measurement, a sourced
-hard constraint, a confirmed incompatibility, or an explicit operator decision. Append the verdict to
+class: every lever family carries a terminal disposition, every `ruled-out` row cites a measurement, a sourced
+hard constraint, a confirmed incompatibility, or an explicit operator decision, and the final recommendation carries
+its required `Correctness status:` line. Append the verdict to
 `challenger-reviews.jsonl` as for any review, and state in it that this is procedural validation, not independent
 adversarial assurance.
 

--- a/agents/hypothesis-challenger/AGENTS.md
+++ b/agents/hypothesis-challenger/AGENTS.md
@@ -64,8 +64,12 @@ Do not:
 - exact `<DEPLOY_ROOT>/next-candidate/deploy-draft.yaml` path
 - prior deployment, benchmark, hypothesis, and challenger-review history
 
-Review only a materialized proposal. For a `no-proposal` or `blocked` consultation, return without creating a candidate
-review.
+Review a materialized proposal or a stop-request. For a `no-proposal` or `blocked` consultation that carries no
+stop-request, return without creating a candidate review. For a stop-request, validate completeness and evidence
+class: every lever family carries a terminal disposition, and every `ruled-out` row cites a measurement, a sourced
+hard constraint, a confirmed incompatibility, or an explicit operator decision. Append the verdict to
+`challenger-reviews.jsonl` as for any review, and state in it that this is procedural validation, not independent
+adversarial assurance.
 
 Before reviewing, require every input path to exist under the assigned `EXP_ROOT`, recompute the user-workload,
 source, consultation, and draft hashes, and verify that the source benchmark artifacts identify the same active

--- a/agents/hypothesis-generator/AGENTS.md
+++ b/agents/hypothesis-generator/AGENTS.md
@@ -113,7 +113,9 @@ For a proposed candidate, write these files under `DEPLOY_ROOT/next-candidate/` 
 - `deploy-draft.yaml`: the complete candidate DGD containing only the resolved selected change.
 
 For `no-proposal` or `blocked`, write `knowledge-consult.md` with the decision and supporting evidence, but do not
-create a misleading `deploy-draft.yaml`.
+create a misleading `deploy-draft.yaml`. Neither outcome ends the engagement: follow the ask and stop-request
+obligations in the optimization loop's Iterate Or Stop step, including its evidence classes for terminal
+dispositions.
 
 Return exact paths and SHA256 hashes, not only filenames or iteration numbers. Never overwrite an existing
 `next-candidate/` record whose source hash or semantic diff identifies a different proposal.

--- a/agents/perf-analyzer/AGENTS.md
+++ b/agents/perf-analyzer/AGENTS.md
@@ -44,6 +44,8 @@ benchmarking begins. Define the performance question before selecting the benchm
 - Verify config engagement and benchmark isolation, and record the runtime, resources, and execution details.
 - Default to one measured run of 30 minutes or less. Preserve its configuration and raw artifacts unchanged.
 - Evaluate target SLOs and compare only valid same-series results, reporting absolute metrics, deltas, and uncertainty.
+- When the measured SLO boundary falls within one concurrency step of the operating point, report throughput at the
+  floor and one step past it, so the operator can judge whether the floor's exact value is load-bearing.
 - Write the required machine-readable and Markdown outputs, or return a structured blocker.
 
 ## Do Not


### PR DESCRIPTION
Consolidates #12825, #12858, and #12919 plus the final round of UAT findings into one review unit, per maintainer preference (those three are now closed with pointers here; all their commits are on this branch unchanged). Commits are thematic and separable — if any theme needs debate, say so and I'll split it back out rather than hold the rest.

## Evidence base

Three full clean-room engagements drove every change here: a fresh agent, a realistic customer fiction, real clusters, no coaching. Each run tested the pack as shipped at that point; each ran the previous round's fixes.

- **Run 1** (B200-class): declared complete having considered 3 of 8 lever families.
- **Run 2** (H100 adaptation): with run-1 fixes merged, enumerated 8/8 — then declared complete with zero improvement. Forced continuation via harness goal mode then found **+99% tok/s/GPU (t=10.22)** in a topology change the loop had screened out; a documented 0.5% noise floor proved ~20x wrong; an idle-neighbour fleet projection proved 1.8x optimistic.
- **Run 3** (identical scenario, full PR stack): found the topology winner in ~2 iterations (vs 13+forcing), delivered **+49.1%** against an honestly-pinned baseline, executed the stop-request protocol end-to-end (drafted early, held while budget remained, submitted at budget exhaustion, resources released), logged 6 questions non-blockingly with assumptions, measured fleet scaling with a concurrent two-unit test instead of multiplying, and refused a nominally-better config inside its measured noise band. Two residuals became this PR's final commits: the correctness gate never fired unprompted (on challenge, the check proved cheap and decisive: 12 probes, 10/12 exact match, ~2 GPU-h), and every absolute number was cold-cache on a 90%-reuse workload.

## Change map (chronological by commit; see commit messages for per-change evidence)

| Theme | Commits |
|---|---|
| Resource envelope, capacity accounting, contract corrections, agent-reported issues | a5a13c39, df6ff5e6, 2c81b991 + review fixes |
| Search calibration / broad-lever scan with per-family dispositions | a5a13c39 (validated: run 2 went 8/8 where run 1 went 3/8) |
| Long-running runs + harness compatibility tiers | f3cb541c, 371bfa19 |
| Stop-request protocol: no self-judged exits; non-blocking asks; operator-granted stops | 588fa358 |
| Correctness regression gate at finalize | 9cf193cb; enforcement as a required field: 748bea8b |
| Topology as hypothesis category + operating-regime framing | f558e319, ba92a804 |
| Measurement validity: empirical noise floors, paired analysis, confirmatory finalist runs, occupancy | b1a388a5; cache-state policy: e71e2468 |
| Persistent calibration ledger; deferred disposition; measured floors | 0809aac7 |
| Goal-condition template with named budget; SLO-knee reporting | 9c83e514 |
| Interview completeness + parametric AIPerf workloads + goal-mode handoff | 979d2b9f |
| Asks never via blocking tools; SpecDec content-transfer flag | fbfa8da1 |

## Future work

- [x] Agent-reported bugs from run 3 filed and fixed: #12971 (fixed by #12974), #12972 (documented in #12974; root cause upstream in the vLLM fused DSV4 attention path — analysis in the issue)
- [ ] Content-valid speculative-decoding measurement loop — #12918
- [ ] Port a full accuracy-gate skill (the smoke check is a regression gate, not an eval)
- [ ] Harness-level enforcement: disallow blocking question tools in goal mode (prompt-level guidance shipped here; run 3 proved prompt-level alone is bypassable)
- [ ] Codex-driver validation run of this full stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
