### PR TITLE
fix(sglang): complete completions logprob parity

### DIFF
--- a/components/src/dynamo/common/backend/logprobs.py
+++ b/components/src/dynamo/common/backend/logprobs.py
@@ -230,6 +230,79 @@ def extract_prompt_logprobs_from_sglang_meta(
     return payload
 
 
+def _decode_sglang_token_ids(
+    token_ids: list[int],
+    tokenizer: Any,
+) -> list[Optional[str]]:
+    """Decode individual token IDs like SGLang's OpenAI adapter."""
+    if not token_ids or tokenizer is None:
+        return [None] * len(token_ids)
+    try:
+        return list(tokenizer.batch_decode([[token_id] for token_id in token_ids]))
+    except Exception:
+        logger.debug("SGLang tokenizer failed to decode logprob tokens", exc_info=True)
+        return [None] * len(token_ids)
+
+
+def extract_openai_completion_prompt_logprobs(
+    meta_info: dict[str, Any],
+    *,
+    tokenizer: Any = None,
+) -> Optional[dict[str, Any]]:
+    """Return SGLang prompt logprobs in the legacy completions wire shape."""
+    input_logprobs = meta_info.get("input_token_logprobs")
+    if not input_logprobs:
+        return None
+
+    input_top_logprobs = meta_info.get("input_top_logprobs") or []
+    decoded_input_tokens = iter(
+        _decode_sglang_token_ids(
+            [token_id for _, token_id, token in input_logprobs if token is None],
+            tokenizer,
+        )
+    )
+    tokens: list[str] = []
+    token_logprobs: list[Optional[float]] = []
+    top_logprobs: list[Optional[dict[str, float]]] = []
+
+    for index, entry in enumerate(input_logprobs):
+        logprob, _token_id, token = entry
+        token_text = token if token is not None else next(decoded_input_tokens, None)
+        tokens.append(token_text or "")
+        token_logprobs.append(None if logprob is None else float(logprob))
+        top_at_position = (
+            input_top_logprobs[index] if index < len(input_top_logprobs) else None
+        )
+        if top_at_position is None:
+            top_logprobs.append(None)
+            continue
+
+        decoded_top_tokens = iter(
+            _decode_sglang_token_ids(
+                [token_id for _, token_id, token in top_at_position if token is None],
+                tokenizer,
+            )
+        )
+        top_logprobs.append(
+            {
+                (
+                    top_token
+                    if top_token is not None
+                    else next(decoded_top_tokens, None) or "null"
+                ): float(top_logprob)
+                for top_logprob, _token_id, top_token in top_at_position
+            }
+        )
+
+    return {
+        "tokens": tokens,
+        "token_logprobs": token_logprobs,
+        "top_logprobs": top_logprobs,
+        # Dynamo generated protocol offsets are u32; SGLang emits -1.
+        "text_offset": [0] * len(tokens),
+    }
+
+
 _SGLANG_TOP_LOGPROBS_UNSUPPORTED_MSG = (
     "Dynamo's SGLang backend does not currently support logprobs >= 1 due to "
     "an O(N) per-position detokenization in the upstream sglang tokenizer "
@@ -301,20 +374,36 @@ def extract_from_sglang_meta(
     meta_info: dict[str, Any],
     num_output_logprobs_so_far: int,
     *,
+    num_output_tokens_in_chunk: Optional[int] = None,
     return_tokens_as_token_ids: bool = False,
 ) -> tuple[Optional[list[float]], Optional[list[list[dict[str, Any]]]], int]:
-    """Extract logprobs from SGLang's ``meta_info`` dict.
+    """Extract logprobs from SGLang ``meta_info`` across supported stream shapes.
 
-    SGLang's ``output_token_logprobs`` / ``output_top_logprobs`` are
-    cumulative across stream chunks even though ``output_ids`` is
-    disjoint — the caller passes the running count to slice the new
-    entries, and the returned third element is the updated count.
+    SGLang emits cumulative metadata on some releases and metadata for just
+    the disjoint ``output_ids`` chunk on others. Prefer the exact per-chunk
+    window when its length matches ``output_ids``; otherwise use the running
+    cursor for cumulative metadata.
     """
     output_token_logprobs = meta_info.get("output_token_logprobs")
     if not output_token_logprobs:
         return None, None, num_output_logprobs_so_far
 
-    new_logprobs = output_token_logprobs[num_output_logprobs_so_far:]
+    per_chunk = (
+        num_output_tokens_in_chunk is not None
+        and len(output_token_logprobs) <= num_output_tokens_in_chunk
+    )
+    if per_chunk:
+        start = 0
+        end = len(output_token_logprobs)
+        next_logprobs_total = num_output_logprobs_so_far + end
+    else:
+        start = num_output_logprobs_so_far
+        end = len(output_token_logprobs)
+        if num_output_tokens_in_chunk is not None:
+            end = min(end, start + num_output_tokens_in_chunk)
+        next_logprobs_total = len(output_token_logprobs)
+
+    new_logprobs = output_token_logprobs[start:end]
     if not new_logprobs:
         return None, None, num_output_logprobs_so_far
 
@@ -323,7 +412,7 @@ def extract_from_sglang_meta(
     top_logprobs: Optional[list[list[dict[str, Any]]]] = None
     output_top = meta_info.get("output_top_logprobs")
     if output_top:
-        new_top = output_top[num_output_logprobs_so_far:]
+        new_top = output_top[start:end]
         if new_top:
             top_logprobs = []
             for position_entries in new_top:
@@ -346,4 +435,4 @@ def extract_from_sglang_meta(
                     )
                 top_logprobs.append(position_list)
 
-    return log_probs, top_logprobs, len(output_token_logprobs)
+    return log_probs, top_logprobs, next_logprobs_total

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -14,6 +14,7 @@ from dynamo.common.backend.logprobs import (
     build_sglang_logprob_kwargs,
     extract_from_completion_output,
     extract_from_sglang_meta,
+    extract_openai_completion_prompt_logprobs,
     extract_prompt_logprobs_from_completion_output,
     extract_prompt_logprobs_from_sglang_meta,
     parse_logprob_options,
@@ -321,6 +322,33 @@ def test_prompt_logprobs_sglang_handles_missing_decoded_token():
     assert payload[1] == {"9": {"logprob": -0.7}}
 
 
+def test_openai_completion_prompt_logprobs_preserve_sglang_legacy_shape():
+    class _Tokenizer:
+        def batch_decode(self, token_ids):
+            return [f"token-{token_id[0]}" for token_id in token_ids]
+
+    payload = extract_openai_completion_prompt_logprobs(
+        {
+            "input_token_logprobs": [(None, 1, None), (-0.2, 2, " b")],
+            "input_top_logprobs": [
+                None,
+                [(-0.2, 2, " b"), (-1.2, 3, " c"), (-2.2, 4, None)],
+            ],
+        },
+        tokenizer=_Tokenizer(),
+    )
+
+    assert payload == {
+        "tokens": ["token-1", " b"],
+        "token_logprobs": [None, -0.2],
+        "top_logprobs": [
+            None,
+            {" b": -0.2, " c": -1.2, "token-4": -2.2},
+        ],
+        "text_offset": [0, 0],
+    }
+
+
 # ---------------------------------------------------------------------------
 # build_sglang_logprob_kwargs
 # ---------------------------------------------------------------------------
@@ -333,7 +361,10 @@ def test_sglang_kwargs_empty_when_no_options():
 def test_sglang_kwargs_logprobs_zero_allowed_without_gate():
     # The default gate forbids logprobs >= 1; logprobs=0 always works.
     kwargs = build_sglang_logprob_kwargs({"logprobs": 0}, allow_top_logprobs=False)
-    assert kwargs == {"return_logprob": True, "top_logprobs_num": 0}
+    assert kwargs == {
+        "return_logprob": True,
+        "top_logprobs_num": 0,
+    }
 
 
 def test_sglang_kwargs_top_logprobs_rejected_without_gate():
@@ -343,7 +374,10 @@ def test_sglang_kwargs_top_logprobs_rejected_without_gate():
 
 def test_sglang_kwargs_top_logprobs_allowed_with_gate():
     kwargs = build_sglang_logprob_kwargs({"logprobs": 2}, allow_top_logprobs=True)
-    assert kwargs == {"return_logprob": True, "top_logprobs_num": 2}
+    assert kwargs == {
+        "return_logprob": True,
+        "top_logprobs_num": 2,
+    }
 
 
 def test_sglang_kwargs_prompt_logprobs_sets_start_len_zero():

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -331,11 +331,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
     def _extract_logprobs(
         meta_info: Dict[str, Any],
         num_output_logprobs_so_far: int,
+        *,
+        num_output_tokens_in_chunk: int | None = None,
         return_tokens_as_token_ids: bool = False,
     ) -> tuple:
         return _shared_logprobs.extract_from_sglang_meta(
             meta_info,
             num_output_logprobs_so_far,
+            num_output_tokens_in_chunk=num_output_tokens_in_chunk,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
         )
 
@@ -367,6 +370,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         return_tokens_as_token_ids = bool(
             output_options.get("return_tokens_as_token_ids")
         )
+        include_prompt_logprobs = output_options.get("prompt_logprobs") is not None
         user_stop_token_ids = _user_stop_token_ids(request)
 
         lora_path = self._resolve_lora(request)
@@ -424,6 +428,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     return_tokens_as_token_ids,
                     user_stop_token_ids=user_stop_token_ids,
+                    include_prompt_logprobs=include_prompt_logprobs,
                     metadata_uploader=metadata_uploader,
                 ):
                     yield out
@@ -494,6 +499,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     return_tokens_as_token_ids,
                     user_stop_token_ids=user_stop_token_ids,
+                    include_prompt_logprobs=include_prompt_logprobs,
                     metadata_uploader=metadata_uploader,
                 ):
                     yield out
@@ -513,6 +519,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         context: Context,
         return_tokens_as_token_ids: bool = False,
         user_stop_token_ids: set[int] | None = None,
+        include_prompt_logprobs: bool = False,
         metadata_uploader: MetadataUploader | None = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process token-based stream output.
@@ -534,6 +541,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # With n>1, chunks for different choices are interleaved, so track the
         # cumulative-logprob cursor per choice index instead of globally.
         output_logprobs_per_choice: dict[int, int] = {}
+        prompt_logprobs_emitted: set[int] = set()
         async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
@@ -585,6 +593,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     ) = self._extract_logprobs(
                         meta_info,
                         output_logprobs_per_choice.get(output_idx, 0),
+                        num_output_tokens_in_chunk=len(output_ids),
                         return_tokens_as_token_ids=return_tokens_as_token_ids,
                     )
                     output_logprobs_per_choice[output_idx] = next_logprobs_total
@@ -593,12 +602,34 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     if top_logprobs is not None:
                         out["top_logprobs"] = top_logprobs
 
+                engine_data: dict[str, Any] = dict(res.get("engine_data") or {})
+                if (
+                    metadata_uploader is None
+                    and include_prompt_logprobs
+                    and output_idx not in prompt_logprobs_emitted
+                ):
+                    tokenizer = getattr(
+                        getattr(self.engine, "tokenizer_manager", None),
+                        "tokenizer",
+                        None,
+                    )
+                    prompt_logprobs = (
+                        _shared_logprobs.extract_openai_completion_prompt_logprobs(
+                            meta_info, tokenizer=tokenizer
+                        )
+                    )
+                    if prompt_logprobs is not None:
+                        engine_data[
+                            "openai_completion_prompt_logprobs"
+                        ] = prompt_logprobs
+                        prompt_logprobs_emitted.add(output_idx)
+
                 routed_experts = meta_info.get("routed_experts")
                 if routed_experts is not None and metadata_uploader is None:
                     # sglang >= 0.5.11 base64-encodes routed_experts upstream. It rides
                     # the engine's opaque engine_data passthrough (surfaced by the frontend
                     # as nvext.routed_experts); disaggregated_params stays KV-transfer only.
-                    out["engine_data"] = {"routed_experts": routed_experts}
+                    engine_data["routed_experts"] = routed_experts
                 if finish_reason:
                     input_tokens = meta_info.get("prompt_tokens")
                     completion_tokens = meta_info.get("completion_tokens")
@@ -624,6 +655,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                             meta_info.clear()
                 elif metadata_uploader is not None:
                     meta_info.clear()
+                if engine_data:
+                    out["engine_data"] = engine_data
                 if not context.is_stopped():
                     yield out
 

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -324,7 +324,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
     def _build_logprob_kwargs(request: Dict[str, Any]) -> Dict[str, Any]:
         return _shared_logprobs.build_sglang_logprob_kwargs(
             request.get("output_options", {}) or {},
-            allow_top_logprobs=_shared_logprobs.sglang_top_logprobs_allowed(),
+            allow_top_logprobs=True,
         )
 
     @staticmethod

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -660,11 +660,12 @@ def test_build_logprob_kwargs_allows_chosen_token_logprobs(monkeypatch):
     assert kwargs == {"return_logprob": True, "top_logprobs_num": 0}
 
 
-def test_build_logprob_kwargs_rejects_top_logprobs_by_default(monkeypatch):
-    monkeypatch.delenv("DYN_SGL_ALLOW_TOP_LOGPROBS", raising=False)
+def test_build_logprob_kwargs_forwards_requested_top_logprob_depth():
+    kwargs = DecodeWorkerHandler._build_logprob_kwargs(
+        {"output_options": {"logprobs": 2}}
+    )
 
-    with pytest.raises(ValueError, match="does not currently support logprobs >= 1"):
-        DecodeWorkerHandler._build_logprob_kwargs({"output_options": {"logprobs": 1}})
+    assert kwargs == {"return_logprob": True, "top_logprobs_num": 2}
 
 
 def test_build_logprob_kwargs_allows_top_logprobs_with_escape_hatch(monkeypatch):

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -657,7 +657,10 @@ def test_build_logprob_kwargs_allows_chosen_token_logprobs(monkeypatch):
         {"output_options": {"logprobs": 0}}
     )
 
-    assert kwargs == {"return_logprob": True, "top_logprobs_num": 0}
+    assert kwargs == {
+        "return_logprob": True,
+        "top_logprobs_num": 0,
+    }
 
 
 def test_build_logprob_kwargs_forwards_requested_top_logprob_depth():
@@ -665,7 +668,10 @@ def test_build_logprob_kwargs_forwards_requested_top_logprob_depth():
         {"output_options": {"logprobs": 2}}
     )
 
-    assert kwargs == {"return_logprob": True, "top_logprobs_num": 2}
+    assert kwargs == {
+        "return_logprob": True,
+        "top_logprobs_num": 2,
+    }
 
 
 def test_build_logprob_kwargs_allows_top_logprobs_with_escape_hatch(monkeypatch):
@@ -675,7 +681,10 @@ def test_build_logprob_kwargs_allows_top_logprobs_with_escape_hatch(monkeypatch)
         {"output_options": {"logprobs": 2}}
     )
 
-    assert kwargs == {"return_logprob": True, "top_logprobs_num": 2}
+    assert kwargs == {
+        "return_logprob": True,
+        "top_logprobs_num": 2,
+    }
 
 
 def test_extract_logprobs_formats_top_tokens_as_token_ids():
@@ -904,6 +913,41 @@ async def test_process_token_stream_tracks_logprobs_per_choice_index():
     assert [chunk["index"] for chunk in chunks] == [0, 1, 0]
     assert [chunk["token_ids"] for chunk in chunks] == [[101], [201], [102]]
     assert [chunk["log_probs"] for chunk in chunks] == [[-0.1], [-0.2], [-0.3]]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_handles_incremental_sglang_logprobs():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": None,
+                            "output_token_logprobs": [(-0.1, 101, "a")],
+                        },
+                    },
+                    {
+                        "index": 0,
+                        "output_ids": [102],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop"},
+                            "output_token_logprobs": [(-0.2, 102, "b")],
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+        )
+    )
+
+    assert [chunk["log_probs"] for chunk in chunks] == [[-0.1], [-0.2]]
 
 
 @pytest.mark.asyncio

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -562,6 +562,26 @@ mod tests {
     }
 
     #[test]
+    fn test_sglang_compatible_logprob_depth_validation() {
+        for depth in [6, 21, u8::MAX] {
+            let accepted: NvCreateCompletionRequest = serde_json::from_value(json!({
+                "model": "test-model",
+                "prompt": "test",
+                "logprobs": depth
+            }))
+            .expect("deserialize accepted depth");
+            ValidateRequest::validate(&accepted).expect("SGLang-compatible depth must validate");
+        }
+
+        let too_large = serde_json::from_value::<NvCreateCompletionRequest>(json!({
+            "model": "test-model",
+            "prompt": "test",
+            "logprobs": 256
+        }));
+        assert!(too_large.is_err());
+    }
+
+    #[test]
     fn test_prompt_embeds_only() {
         // Create valid embeddings: > 100 bytes (PyTorch format)
         let valid_data = vec![0u8; 256];

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -428,7 +428,9 @@ impl OpenAIOutputOptionsProvider for NvCreateCompletionRequest {
         self.common.prompt_logprobs.or_else(|| {
             self.inner
                 .echo
-                .and_then(|echo| if echo { Some(1) } else { None })
+                .filter(|echo| *echo)
+                .and(self.inner.logprobs)
+                .map(|logprobs| logprobs as u32)
         })
     }
 
@@ -543,11 +545,12 @@ mod tests {
     }
 
     #[test]
-    fn test_prompt_logprobs_propagates() {
+    fn test_echo_uses_requested_logprob_depth_for_prompt_logprobs() {
         let request_json = json!({
             "model": "test-model",
             "prompt": [1, 2, 3],
-            "prompt_logprobs": 3
+            "echo": true,
+            "logprobs": 3
         });
         let request: NvCreateCompletionRequest =
             serde_json::from_value(request_json).expect("Failed to deserialize request");

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -118,7 +118,12 @@ impl DeltaGenerator {
                 .map(|(((t, tid), lp), top_lps)| {
                     let converted =
                         convert_backend_top_logprobs(top_lps, t, *tid, *lp, return_as_ids);
-                    serde_json::to_value(converted).unwrap()
+                    serde_json::Value::Object(
+                        converted
+                            .into_iter()
+                            .map(|entry| (entry.token, serde_json::json!(entry.logprob)))
+                            .collect(),
+                    )
                 })
                 .collect()
         });
@@ -141,6 +146,31 @@ impl DeltaGenerator {
             text_offset,
             top_logprobs: top_lps,
         })
+    }
+
+    fn prompt_logprobs_from_engine_data(
+        engine_data: Option<&serde_json::Value>,
+    ) -> Option<dynamo_protocols::types::Logprobs> {
+        engine_data
+            .and_then(|data| data.get("openai_completion_prompt_logprobs"))
+            .and_then(|logprobs| serde_json::from_value(logprobs.clone()).ok())
+    }
+
+    fn merge_logprobs(
+        prompt_logprobs: Option<dynamo_protocols::types::Logprobs>,
+        completion_logprobs: Option<dynamo_protocols::types::Logprobs>,
+    ) -> Option<dynamo_protocols::types::Logprobs> {
+        match (prompt_logprobs, completion_logprobs) {
+            (Some(mut prompt), Some(completion)) => {
+                prompt.tokens.extend(completion.tokens);
+                prompt.token_logprobs.extend(completion.token_logprobs);
+                prompt.top_logprobs.extend(completion.top_logprobs);
+                prompt.text_offset.extend(completion.text_offset);
+                Some(prompt)
+            }
+            (Some(prompt), None) => Some(prompt),
+            (None, completion) => completion,
+        }
     }
 
     pub fn create_choice(
@@ -255,20 +285,26 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
         } else {
             None
         };
-        let logprobs = self.create_logprobs(
+
+        let finish_reason = delta.finish_reason.map(Into::into);
+        let stop_reason = delta.stop_reason.clone();
+
+        // Create the first choice chunk. SGLang supplies echoed-prompt
+        // logprobs in its opaque engine metadata; prepend those only here.
+        let index = delta.index.unwrap_or(0);
+        let is_first_choice_delta = self.echoed_choices.insert(index);
+        let prompt_logprobs = is_first_choice_delta
+            .then(|| Self::prompt_logprobs_from_engine_data(delta.engine_data.as_ref()))
+            .flatten();
+        let completion_logprobs = self.create_logprobs(
             delta.tokens,
             delta.token_ids,
             delta.log_probs,
             delta.top_logprobs,
         );
-
-        let finish_reason = delta.finish_reason.map(Into::into);
-        let stop_reason = delta.stop_reason.clone();
-
-        // create choice
-        let index = delta.index.unwrap_or(0);
+        let logprobs = Self::merge_logprobs(prompt_logprobs, completion_logprobs);
         let text = delta.text.clone().map(|text| {
-            if self.echoed_choices.insert(index) {
+            if is_first_choice_delta {
                 self.echo_text.clone().unwrap_or_default() + &text
             } else {
                 text
@@ -464,6 +500,44 @@ mod tests {
     }
 
     #[test]
+    fn test_echo_prepends_sglang_prompt_logprobs_to_first_chunk() {
+        let mut request = create_test_request();
+        request.inner.echo = Some(true);
+        request.inner.logprobs = Some(2);
+        let mut generator = request.response_generator("req-prompt-logprobs".to_string());
+        let mut output = final_backend_output();
+        output.log_probs = Some(vec![-0.5]);
+        output.top_logprobs = Some(vec![vec![common::llm_backend::TopLogprob {
+            rank: 1,
+            token_id: 1,
+            token: Some("hello".to_string()),
+            logprob: -0.5,
+            bytes: None,
+        }]]);
+        output.engine_data = Some(serde_json::json!({
+            "openai_completion_prompt_logprobs": {
+                "tokens": ["test"],
+                "token_logprobs": [null],
+                "top_logprobs": [null],
+                "text_offset": [0]
+            }
+        }));
+
+        let response = generator
+            .choice_from_postprocessor(output)
+            .expect("choice generation");
+        let logprobs = response.inner.choices[0]
+            .logprobs
+            .as_ref()
+            .expect("logprobs");
+
+        assert_eq!(logprobs.tokens, vec!["test", "hello"]);
+        assert_eq!(logprobs.token_logprobs, vec![None, Some(-0.5)]);
+        assert_eq!(logprobs.top_logprobs[0], serde_json::Value::Null);
+        assert_eq!(logprobs.top_logprobs[1], serde_json::json!({"hello": -0.5}));
+    }
+
+    #[test]
     fn test_plain_request_without_extra_fields_omits_nvext() {
         let request = create_test_request();
         let mut generator = request.response_generator("req-no-nvext".to_string());
@@ -559,19 +633,10 @@ mod tests {
 
         assert_eq!(logprobs.tokens, vec!["token_id:123"]);
         let top_logprobs = logprobs.top_logprobs[0]
-            .as_array()
-            .expect("top_logprobs array");
-        let other = top_logprobs
-            .iter()
-            .find(|item| item["token"] == "token_id:999")
-            .expect("top token_id formatting");
-        assert_eq!(other["bytes"], serde_json::json!(b"token_id:999"));
-        let selected = top_logprobs
-            .iter()
-            .find(|item| item["token"] == "token_id:123")
-            .expect("selected token fallback");
-        assert_eq!(selected["token"], "token_id:123");
-        assert_eq!(selected["bytes"], serde_json::json!(b"token_id:123"));
+            .as_object()
+            .expect("top_logprobs map");
+        assert_eq!(top_logprobs["token_id:999"], serde_json::json!(-1.0));
+        assert_eq!(top_logprobs["token_id:123"], serde_json::json!(-0.5));
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use super::{NvCreateCompletionRequest, NvCreateCompletionResponse};
 use crate::{
@@ -32,7 +32,15 @@ impl NvCreateCompletionRequest {
             self.inner.logprobs.is_some(),
             self.nvext(),
         );
-        DeltaGenerator::new(self.inner.model.clone(), options, request_id)
+        DeltaGenerator::new(
+            self.inner.model.clone(),
+            options,
+            request_id,
+            self.inner
+                .echo
+                .filter(|echo| *echo)
+                .map(|_| super::prompt_to_string(&self.inner.prompt)),
+        )
     }
 }
 
@@ -45,10 +53,17 @@ pub struct DeltaGenerator {
     usage: dynamo_protocols::types::CompletionUsage,
     options: DeltaGeneratorOptions,
     tracker: Arc<RequestTracker>,
+    echo_text: Option<String>,
+    echoed_choices: HashSet<u32>,
 }
 
 impl DeltaGenerator {
-    pub fn new(model: String, options: DeltaGeneratorOptions, request_id: String) -> Self {
+    pub fn new(
+        model: String,
+        options: DeltaGeneratorOptions,
+        request_id: String,
+        echo_text: Option<String>,
+    ) -> Self {
         let (now, usage, tracker) = delta_common::initial_state();
         Self {
             id: format!("cmpl-{request_id}"),
@@ -59,6 +74,8 @@ impl DeltaGenerator {
             usage,
             options,
             tracker,
+            echo_text,
+            echoed_choices: HashSet::new(),
         }
     }
 
@@ -117,10 +134,11 @@ impl DeltaGenerator {
             })
             .collect();
 
+        let text_offset = vec![0; tokens_out.len()];
         Some(dynamo_protocols::types::Logprobs {
             tokens: tokens_out,
             token_logprobs: tok_lps.into_iter().map(Some).collect(),
-            text_offset: vec![],
+            text_offset,
             top_logprobs: top_lps,
         })
     }
@@ -249,7 +267,14 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
 
         // create choice
         let index = delta.index.unwrap_or(0);
-        let mut response = self.create_choice(index, delta.text.clone(), finish_reason, logprobs);
+        let text = delta.text.clone().map(|text| {
+            if self.echoed_choices.insert(index) {
+                self.echo_text.clone().unwrap_or_default() + &text
+            } else {
+                text
+            }
+        });
+        let mut response = self.create_choice(index, text, finish_reason, logprobs);
 
         // Record finish for timing/ITL accounting even when timing is not returned to the client.
         // Kept at call site because it's a side effect on the tracker — not a gating decision.
@@ -421,6 +446,21 @@ mod tests {
             })),
             routing_data: None,
         }
+    }
+
+    #[test]
+    fn test_echo_prefixes_only_the_first_choice_chunk() {
+        let mut request = create_test_request();
+        request.inner.echo = Some(true);
+        let mut generator = request.response_generator("req-echo".to_string());
+        let first = generator
+            .choice_from_postprocessor(final_backend_output())
+            .unwrap();
+        assert_eq!(first.inner.choices[0].text, "testhello");
+        let mut second = final_backend_output();
+        second.text = Some(" world".to_string());
+        let second = generator.choice_from_postprocessor(second).unwrap();
+        assert_eq!(second.inner.choices[0].text, " world");
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -61,7 +61,7 @@ pub const MAX_TOP_LOGPROBS: u8 = 20;
 /// Minimum allowed value for `logprobs` in completion requests
 pub const MIN_LOGPROBS: u8 = 0;
 /// Maximum allowed value for `logprobs` in completion requests
-pub const MAX_LOGPROBS: u8 = 5;
+pub const MAX_LOGPROBS: u8 = u8::MAX;
 
 /// Minimum allowed value for `n` (number of choices)
 pub const MIN_N: u8 = 1;


### PR DESCRIPTION
## Summary
- Align SGLang /v1/completions echo text, prompt/completion token logprobs, legacy top-logprob maps, and streaming chunk behavior with vanilla SGLang.
- Support both cumulative and per-chunk SGLang token-logprob metadata, and decode prompt logprob tokens through the SGLang tokenizer.
- Permit SGLang-compatible requested logprob depths through the protocol practical u8 limit.

## Validation
- cargo fmt --all --check
- cargo test -p dynamo-llm protocols::openai::completions --lib (36 passed)
- uvx ruff@0.5.2 check on all changed Python files
- Focused Python tests from the hash-verified final candidate package on an isolated B200 pod: 8 shared-logprob tests and 4 SGLang decode-handler tests passed.
- Live parity against raw SGLang 0.5.16 and Dynamo using the same B200 pod and /shared/Qwen3-4B model:
  - Non-streaming echo=true, logprobs=2: text, token sequence, token logprobs, top-logprob maps, and usage matched.
  - Streaming echo=true, logprobs=2: first SSE event contained echoed prompt plus first generated token/logprobs; later events each contained their generated token/logprobs; stream ended with [DONE].
  - Raw SGLang accepted logprobs=21 with 21 candidates (HTTP 200); Dynamo now does the same (HTTP 200).
  - Known protocol limitation: raw SGLang emits text_offset=-1; Dynamo generated completions Logprobs offsets are unsigned, so the aligned Dynamo values are 0.
- Built dynamoci.azurecr.io/sglang-generate-logprobs:warnold-completions-parity-r3-20260811 locally in the authorized cluster builder, copied its Dynamo package into the isolated test pod, and verified matching _core.abi3.so and decode_handler.py SHA-256 hashes before the final probes. Registry push was unavailable because the builder credentials are pull-only.