### PR TITLE
fix(router): accept relay endpoint futures [DYN-3795] (cherry-pick #12948)

### DIFF
--- a/components/src/dynamo/kv_dc_relay/__main__.py
+++ b/components/src/dynamo/kv_dc_relay/__main__.py
@@ -76,7 +76,7 @@ async def worker(runtime: DistributedRuntime) -> None:
     try:
         if hasattr(relay, "stats") and hasattr(relay, "snapshot"):
             endpoint_tasks.append(
-                asyncio.create_task(
+                asyncio.ensure_future(
                     runtime.endpoint(
                         f"{namespace}.{diagnostics_component}.stats"
                     ).serve_endpoint(
@@ -87,7 +87,7 @@ async def worker(runtime: DistributedRuntime) -> None:
                 )
             )
             endpoint_tasks.append(
-                asyncio.create_task(
+                asyncio.ensure_future(
                     runtime.endpoint(
                         f"{namespace}.{diagnostics_component}.snapshot"
                     ).serve_endpoint(
@@ -103,7 +103,7 @@ async def worker(runtime: DistributedRuntime) -> None:
                 "enable the ckf-diagnostics Cargo feature to expose them"
             )
         endpoint_tasks.append(
-            asyncio.create_task(
+            asyncio.ensure_future(
                 runtime.endpoint(
                     f"{namespace}.{diagnostics_component}.health"
                 ).serve_endpoint(


### PR DESCRIPTION
## Summary

- Backport #12948 to release/1.4.0.
- Accept the future returned by relay endpoint serving without passing it to asyncio.create_task.
- Tracks DYN-3795.

## Validation

- Source PR #12948 passed required CI.
- Independent CPU campaign validated the real relay entrypoint, hard pinning, cadence, aggregation, and deduplication.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->