### PR TITLE
docs(vllm): document current benchmark sampling flags, demote the legacy aliases

### DIFF
--- a/docs/fern/pages/reference/backends/vllm-configuration.mdx
+++ b/docs/fern/pages/reference/backends/vllm-configuration.mdx
@@ -191,22 +191,40 @@ These flags control the self-benchmark sweep that runs on startup before the wor
   Environment variable: `DYN_BENCHMARK_MODE`
 </ParamField>
 
-<ParamField path="--benchmark-prefill-granularity" type="integer" default="16">
-  Number of ISL sample points for the prefill sweep.
+<ParamField path="--benchmark-points-file" type="string" default="null">
+  JSON file of explicit pure prefill/decode benchmark points, applied uniformly to every data-parallel rank. The file completely replaces generated grid sampling for the phases selected by `--benchmark-mode`, so the sampling limits below are ignored when it is set. It is read and normalized once before vLLM workers start, then the same contents are forwarded to every rank.
 
-  Environment variable: `DYN_BENCHMARK_PREFILL_GRANULARITY`
+  Environment variable: `DYN_BENCHMARK_POINTS_FILE`
 </ParamField>
 
-<ParamField path="--benchmark-decode-length-granularity" type="integer" default="6">
-  Number of context length sample points for the decode sweep.
+<ParamField path="--prefill-max-new-token-samples" type="integer" default="64">
+  Maximum number of iteration-total prefill new-token samples. If the CUDA-graph-aware axis has more points, points are selected uniformly across the sorted axis while always retaining its minimum and maximum. Must be at least 2.
 
-  Environment variable: `DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY`
+  Environment variable: `DYN_PREFILL_MAX_NEW_TOKEN_SAMPLES`
 </ParamField>
 
-<ParamField path="--benchmark-decode-batch-granularity" type="integer" default="6">
-  Number of batch size sample points per context length for the decode sweep.
+<ParamField path="--prefill-max-kv-read-token-samples" type="integer" default="16">
+  Maximum number of iteration-total prefill KV-read-token samples for each (new tokens, batch size) pair. If the block-aligned KV ladder has more points, points are selected uniformly while always retaining zero and the feasible maximum. Must be at least 2.
 
-  Environment variable: `DYN_BENCHMARK_DECODE_BATCH_GRANULARITY`
+  Environment variable: `DYN_PREFILL_MAX_KV_READ_TOKEN_SAMPLES`
+</ParamField>
+
+<ParamField path="--prefix-max-batch-size-samples" type="integer" default="3">
+  Maximum number of prefill request-batch-size samples for each new-token point. Keeps the first N values from the sorted power-of-two-plus-legal-maximum axis, so the default of 3 selects `[1, 2, 4]` when all three are legal. Must be positive.
+
+  Environment variable: `DYN_PREFIX_MAX_BATCH_SIZE_SAMPLES`
+</ParamField>
+
+<ParamField path="--decode-max-kv-read-token-samples" type="integer" default="128">
+  Maximum number of iteration-total decode KV-read-token samples for each batch size. If the KV ladder has more points, points are selected uniformly while always retaining its minimum and feasible maximum. Must be at least 2.
+
+  Environment variable: `DYN_DECODE_MAX_KV_READ_TOKEN_SAMPLES`
+</ParamField>
+
+<ParamField path="--decode-max-batch-size-samples" type="integer" default="128">
+  Maximum number of decode batch-size samples. If the CUDA-graph-aware axis has more points, points are selected uniformly while always retaining the minimum and feasible maximum. Must be at least 2.
+
+  Environment variable: `DYN_DECODE_MAX_BATCH_SIZE_SAMPLES`
 </ParamField>
 
 <ParamField path="--benchmark-warmup-iterations" type="integer" default="5">
@@ -235,6 +253,36 @@ These flags are retained for backward compatibility and will be removed in a fut
   **Deprecated** — accepted for compatibility with older ModelExpress manifests only. The vLLM ModelExpress plugin reads its own configuration.
 
   Environment variable: `MODEL_EXPRESS_URL`
+</ParamField>
+
+<ParamField path="--benchmark-prefill-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--prefill-max-new-token-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_PREFILL_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-prefill-kv-read-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--prefill-max-kv-read-token-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_PREFILL_KV_READ_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-prefill-batch-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--prefix-max-batch-size-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_PREFILL_BATCH_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-decode-length-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--decode-max-kv-read-token-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-decode-batch-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--decode-max-batch-size-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_DECODE_BATCH_GRANULARITY`
 </ParamField>
 
 ## Validation rules


### PR DESCRIPTION
## Summary

The vLLM Benchmarking reference listed five `--benchmark-*-granularity` flags as current parameters, with defaults that have no source in the code. Those flags are **deprecated compatibility aliases**: `components/src/dynamo/vllm/backend_args.py` registers them in `legacy_sampling_flags` with `default=None` and help text that names a replacement for each.

The six current parameters were not documented at all, so a reader configuring a self-benchmark sweep reached for the deprecated path and tuned against defaults that do not exist.

## Changes

**Documented as current**, with the real defaults and selection semantics from the source:

| Parameter | Default |
|---|---|
| `--benchmark-points-file` | null |
| `--prefill-max-new-token-samples` | 64 |
| `--prefill-max-kv-read-token-samples` | 16 |
| `--prefix-max-batch-size-samples` | 3 |
| `--decode-max-kv-read-token-samples` | 128 |
| `--decode-max-batch-size-samples` | 128 |

**Moved to the existing Deprecated section**, each naming its replacement: `--benchmark-prefill-granularity`, `--benchmark-prefill-kv-read-granularity`, `--benchmark-prefill-batch-granularity`, `--benchmark-decode-length-granularity`, `--benchmark-decode-batch-granularity`.

## Scope

The originating report covered four items against `release/1.4.0`. Three are already correct on `main` and are release-branch-only: the planner engine-capacity metric name, the Prometheus CA-bundle field description, and the planner CLI examples. This PR fixes the one item still wrong on `main`; the cherry-pick carries the full set to the release branch.

Documentation only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying benchmark points through a dedicated file.
  * Added configurable sampling limits for prefill, KV reads, batch sizes, and decode benchmarks.

* **Documentation**
  * Documented new benchmark configuration options.
  * Marked older granularity settings as deprecated and provided replacement options.
  * Added documentation for deprecated prefill KV-read and batch granularity settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->