### PR TITLE
fix(vllm): measure self-benchmark decode on the resident path

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -3700,11 +3700,24 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_decode_stage = _DecodeStage.MEASURING
         output = super().schedule(throttle_prefills=True)
         if point is None or output.total_num_scheduled_tokens != point.batch_size:
+            expected_tokens = point.batch_size if point is not None else 0
+            if output.total_num_scheduled_tokens > 0:
+                error = RuntimeError(
+                    "resident benchmark decode scheduled "
+                    f"{output.total_num_scheduled_tokens} of {expected_tokens} requests"
+                )
+                logger.error(
+                    "Aborting benchmark before dispatching a partial resident "
+                    "decode batch: %s",
+                    point,
+                )
+                self._bench_abort(error)
+                raise error
             logger.warning(
                 "Skipping benchmark decode point after the resident batch "
                 "scheduled %d of %d requests: %s",
                 output.total_num_scheduled_tokens,
-                point.batch_size if point is not None else 0,
+                expected_tokens,
                 point,
             )
             self._bench_cleanup_requests()

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -1537,9 +1537,9 @@ class InstrumentedScheduler(AsyncScheduler):
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         if self._bench_active and self._bench_phase != _BenchPhase.IDLE:
-            if self._bench_decode_stage is _DecodeStage.RESIDENT:
-                return self._bench_measure_resident_batch()
             try:
+                if self._bench_decode_stage is _DecodeStage.RESIDENT:
+                    return self._bench_measure_resident_batch()
                 output = self._bench_step()
             except Exception as error:
                 point = self._bench_current_point
@@ -3702,17 +3702,10 @@ class InstrumentedScheduler(AsyncScheduler):
         if point is None or output.total_num_scheduled_tokens != point.batch_size:
             expected_tokens = point.batch_size if point is not None else 0
             if output.total_num_scheduled_tokens > 0:
-                error = RuntimeError(
+                raise RuntimeError(
                     "resident benchmark decode scheduled "
                     f"{output.total_num_scheduled_tokens} of {expected_tokens} requests"
                 )
-                logger.error(
-                    "Aborting benchmark before dispatching a partial resident "
-                    "decode batch: %s",
-                    point,
-                )
-                self._bench_abort(error)
-                raise error
             logger.warning(
                 "Skipping benchmark decode point after the resident batch "
                 "scheduled %d of %d requests: %s",
@@ -3728,15 +3721,7 @@ class InstrumentedScheduler(AsyncScheduler):
             return output
 
         self._bench_sync_pending = True
-        try:
-            self._bench_synchronize_output(output)
-        except Exception as error:
-            logger.exception(
-                "Benchmark synchronization failed (benchmark_id=%s)",
-                point.benchmark_id,
-            )
-            self._bench_abort(error)
-            raise
+        self._bench_synchronize_output(output)
         self._schedule_times.append(time.monotonic())
         return output
 

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -3720,7 +3720,10 @@ class InstrumentedScheduler(AsyncScheduler):
         output = super().schedule(throttle_prefills=True)
         if point is None or output.total_num_scheduled_tokens != point.batch_size:
             expected_tokens = point.batch_size if point is not None else 0
-            if output.total_num_scheduled_tokens > 0:
+            if (
+                output.total_num_scheduled_tokens > 0
+                or self._bench_synchronizer is not None
+            ):
                 raise RuntimeError(
                     "resident benchmark decode scheduled "
                     f"{output.total_num_scheduled_tokens} of {expected_tokens} requests"

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -3638,21 +3638,12 @@ class InstrumentedScheduler(AsyncScheduler):
             pass  # fall through to inject next point
 
         elif self._bench_active_req_ids:
-            if not self._bench_current_fpms:
-                if not self._bench_point_result_timed_out():
-                    return None
-                point = self._bench_current_point
-                if point is not None:
-                    logger.warning(
-                        "Skipping benchmark decode point after its measurement "
-                        "timed out: %s",
-                        point,
-                    )
-                    self._bench_skip_point(point, "decode_measurement_timeout")
-                    self._bench_current_point = None
-                    self._bench_point_deadline = 0.0
-            else:
-                self._bench_save_current_point()
+            if (
+                not self._bench_current_fpms
+                and not self._bench_point_result_timed_out()
+            ):
+                return None
+            self._bench_save_current_point()
             self._bench_cleanup_requests()
             if self._bench_transition_to_timeout_done():
                 return None
@@ -3718,26 +3709,33 @@ class InstrumentedScheduler(AsyncScheduler):
         point = self._bench_current_point
         self._bench_decode_stage = _DecodeStage.MEASURING
         output = super().schedule(throttle_prefills=True)
-        if point is None or output.total_num_scheduled_tokens != point.batch_size:
-            expected_tokens = point.batch_size if point is not None else 0
-            if (
-                output.total_num_scheduled_tokens > 0
-                or self._bench_synchronizer is not None
-            ):
+        if point is None:
+            raise RuntimeError("resident benchmark decode has no current point")
+        if output.total_num_scheduled_tokens != point.batch_size:
+            if self._bench_synchronizer is not None:
                 raise RuntimeError(
                     "resident benchmark decode scheduled "
-                    f"{output.total_num_scheduled_tokens} of {expected_tokens} requests"
+                    f"{output.total_num_scheduled_tokens} of {point.batch_size} requests"
                 )
+            if output.total_num_scheduled_tokens > 0:
+                logger.warning(
+                    "Deferring benchmark decode point skip until the partial "
+                    "resident batch completes: scheduled %d of %d requests: %s",
+                    output.total_num_scheduled_tokens,
+                    point.batch_size,
+                    point,
+                )
+                self._schedule_times.append(time.monotonic())
+                return output
             logger.warning(
                 "Skipping benchmark decode point after the resident batch "
                 "scheduled %d of %d requests: %s",
                 output.total_num_scheduled_tokens,
-                expected_tokens,
+                point.batch_size,
                 point,
             )
             self._bench_cleanup_requests()
-            if point is not None:
-                self._bench_skip_point(point, "decode_measurement_failed")
+            self._bench_skip_point(point, "decode_measurement_failed")
             self._bench_current_point = None
             self._bench_drain_pending = True
             return output
@@ -3791,11 +3789,24 @@ class InstrumentedScheduler(AsyncScheduler):
             for result in rank_results:
                 dp_rank = result["dp_rank"]
                 fpms = result.get("fpms")
-                if not isinstance(fpms, list) or len(fpms) != 1:
+                if not isinstance(fpms, list):
+                    raise TypeError(
+                        "each self-benchmark point must produce exactly one FPM: "
+                        f"benchmark_id={point.benchmark_id} rank={dp_rank} "
+                        "count=invalid"
+                    )
+                if not fpms:
+                    if validation_failure is None:
+                        validation_failure = (
+                            dp_rank,
+                            f"{point.point_type}_measurement_timeout",
+                        )
+                    continue
+                if len(fpms) != 1:
                     raise RuntimeError(
                         "each self-benchmark point must produce exactly one FPM: "
                         f"benchmark_id={point.benchmark_id} rank={dp_rank} "
-                        f"count={len(fpms) if isinstance(fpms, list) else 'invalid'}"
+                        f"count={len(fpms)}"
                     )
                 fpm = fpms[0]
                 if fpm.get("counter_id") != point.benchmark_id:

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -120,6 +120,8 @@ from dynamo.vllm.benchmark_points import (
     PrefillPointCandidate,
 )
 
+Scheduler = AsyncScheduler.__bases__[0]
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -1603,7 +1605,14 @@ class InstrumentedScheduler(AsyncScheduler):
                     )
                 # This retention frame will never produce sampled output, so
                 # bypass AsyncScheduler's output-placeholder accounting.
-                super(AsyncScheduler, self)._update_after_schedule(empty)
+                # Name the base explicitly so MRO changes cannot silently
+                # route this through async placeholder accounting.
+                if Scheduler.__name__ != "Scheduler":
+                    raise RuntimeError(
+                        "AsyncScheduler must directly inherit Scheduler for "
+                        "retention-frame handling"
+                    )
+                Scheduler._update_after_schedule(self, empty)
                 return empty
 
         return self._schedule_and_record_time(throttle_prefills)
@@ -3629,12 +3638,21 @@ class InstrumentedScheduler(AsyncScheduler):
             pass  # fall through to inject next point
 
         elif self._bench_active_req_ids:
-            if (
-                not self._bench_current_fpms
-                and not self._bench_point_result_timed_out()
-            ):
-                return None
-            self._bench_save_current_point()
+            if not self._bench_current_fpms:
+                if not self._bench_point_result_timed_out():
+                    return None
+                point = self._bench_current_point
+                if point is not None:
+                    logger.warning(
+                        "Skipping benchmark decode point after its measurement "
+                        "timed out: %s",
+                        point,
+                    )
+                    self._bench_skip_point(point, "decode_measurement_timeout")
+                    self._bench_current_point = None
+                    self._bench_point_deadline = 0.0
+            else:
+                self._bench_save_current_point()
             self._bench_cleanup_requests()
             if self._bench_transition_to_timeout_done():
                 return None
@@ -3658,8 +3676,9 @@ class InstrumentedScheduler(AsyncScheduler):
         # entries are clamped; the point is then recorded at the coordinate
         # the steady step actually measures.
         injected_lengths = [max(1, ctx - 1) for ctx in context_lengths]
-        admission_kv_tokens = sum(injected_lengths)
-        steady_kv_tokens = admission_kv_tokens + point.batch_size
+        steady_kv_tokens = self._bench_decode_steady_kv_tokens(
+            point.batch_size, point.total_kv_read_tokens
+        )
         if steady_kv_tokens != point.total_kv_read_tokens:
             point = replace(
                 point,

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -165,6 +165,15 @@ class _BenchPhase(enum.Enum):
     DONE = "done"
 
 
+class _DecodeStage(enum.Enum):
+    """Current stage of a decode point's admit-then-measure cycle."""
+
+    IDLE = "idle"
+    ADMITTING = "admitting"
+    RESIDENT = "resident"
+    MEASURING = "measuring"
+
+
 @dataclass
 class BenchmarkPoint:
     point_type: str  # "prefill" or "decode"
@@ -1475,6 +1484,7 @@ class InstrumentedScheduler(AsyncScheduler):
         self._prompt_len_per_req: dict[str, int] = {}
         self._bench_active: bool = False
         self._bench_phase: _BenchPhase = _BenchPhase.IDLE
+        self._bench_decode_stage: _DecodeStage = _DecodeStage.IDLE
         self._bench_synchronizer: _BenchmarkSynchronizer | None = None
 
         base_port = int(os.environ.get(ENV_FPM_PORT, str(DEFAULT_FPM_PORT)))
@@ -1527,6 +1537,8 @@ class InstrumentedScheduler(AsyncScheduler):
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         if self._bench_active and self._bench_phase != _BenchPhase.IDLE:
+            if self._bench_decode_stage is _DecodeStage.RESIDENT:
+                return self._bench_measure_resident_batch()
             try:
                 output = self._bench_step()
             except Exception as error:
@@ -1560,7 +1572,10 @@ class InstrumentedScheduler(AsyncScheduler):
                 empty = SchedulerOutput(
                     scheduled_new_reqs=[],
                     scheduled_cached_reqs=CachedRequestData.make_empty(),
-                    num_scheduled_tokens={},
+                    # Preserve the model runner's resident rows while async
+                    # scheduling drains the admission output. Zero counts keep
+                    # this a no-model-work frame.
+                    num_scheduled_tokens=dict.fromkeys(self._bench_active_req_ids, 0),
                     total_num_scheduled_tokens=0,
                     scheduled_spec_decode_tokens={},
                     scheduled_encoder_inputs={},
@@ -1586,7 +1601,9 @@ class InstrumentedScheduler(AsyncScheduler):
                     empty.ec_connector_metadata = (
                         self.ec_connector.build_connector_meta(empty)
                     )
-                self._update_after_schedule(empty)
+                # This retention frame will never produce sampled output, so
+                # bypass AsyncScheduler's output-placeholder accounting.
+                super(AsyncScheduler, self)._update_after_schedule(empty)
                 return empty
 
         return self._schedule_and_record_time(throttle_prefills)
@@ -1649,6 +1666,13 @@ class InstrumentedScheduler(AsyncScheduler):
         model_output_arrival = (
             time.monotonic() if scheduler_output.total_num_scheduled_tokens > 0 else 0.0
         )
+        if (
+            scheduler_output.total_num_scheduled_tokens == 0
+            and scheduler_output.num_scheduled_tokens
+        ):
+            # The worker has consumed the retention map. The parent output
+            # update requires all remaining token counts to be positive.
+            scheduler_output.num_scheduled_tokens = {}
         result = super().update_from_output(scheduler_output, model_runner_output)
 
         if scheduler_output.total_num_scheduled_tokens > 0:
@@ -1657,20 +1681,11 @@ class InstrumentedScheduler(AsyncScheduler):
             is_benchmark_point = self._bench_active and (
                 self._bench_should_record_scheduled(scheduled)
             )
-            if is_benchmark_point and self._bench_steady_fpm_expected():
-                # Steady-state sample of a two-step decode point. Under async
-                # scheduling its schedule() ran while the admission step was
-                # still on the GPU, so the narrow schedule->output span would
-                # also count that wait; the inter-update period is the true
-                # iteration time (and is what the non-benchmark path reports
-                # for production steps).
-                wall_time = model_output_arrival - self._last_update_time
-            else:
-                wall_time = self._iteration_wall_time(
-                    model_output_arrival,
-                    t_sched,
-                    is_benchmark_point=is_benchmark_point,
-                )
+            wall_time = self._iteration_wall_time(
+                model_output_arrival,
+                t_sched,
+                is_benchmark_point=is_benchmark_point,
+            )
             self._last_update_time = model_output_arrival
 
             metrics = self._extract_metrics(
@@ -1680,6 +1695,8 @@ class InstrumentedScheduler(AsyncScheduler):
                 scheduled=scheduled,
             )
             self._publish_or_record_metrics(metrics)
+            if self._bench_decode_stage is _DecodeStage.ADMITTING:
+                self._bench_decode_stage = _DecodeStage.RESIDENT
         else:
             self._last_update_time = 0.0
 
@@ -1792,29 +1809,6 @@ class InstrumentedScheduler(AsyncScheduler):
         """Keep only the forward-pass type represented by the current point."""
         return self._bench_should_record_scheduled(metrics.scheduled_requests)
 
-    def _bench_steady_fpm_expected(self) -> bool:
-        """True when the FPM about to be recorded is a steady-state sample.
-
-        The admission FPM of a two-step decode point is already in
-        ``_bench_current_fpms``, so the update being processed belongs to
-        the steady step. ``_last_update_time`` is the admission step's
-        arrival: the steady step is dispatched by the first ``schedule()``
-        call after the admission step, so the two updates are adjacent in
-        the engine's FIFO and the empty-step zeroing of
-        ``_last_update_time`` (empty outputs DO flow through
-        ``update_from_output``) can only happen after the steady update.
-        Should that adjacency ever break, the ``> 0`` guard fails closed
-        to the narrow window instead of recording a garbage timestamp.
-        """
-        point = getattr(self, "_bench_current_point", None)
-        return (
-            point is not None
-            and point.point_type == "decode"
-            and getattr(self, "_bench_expected_fpms", 1) > 1
-            and len(getattr(self, "_bench_current_fpms", [])) >= 1
-            and self._last_update_time > 0
-        )
-
     def _bench_should_record_scheduled(
         self, scheduled: ScheduledRequestMetrics
     ) -> bool:
@@ -1823,7 +1817,10 @@ class InstrumentedScheduler(AsyncScheduler):
             return False
         if point.point_type == "prefill":
             return scheduled.num_prefill_requests > 0
-        return scheduled.num_decode_requests > 0
+        return (
+            self._bench_decode_stage is _DecodeStage.MEASURING
+            and scheduled.num_decode_requests > 0
+        )
 
     def _compute_queued(self) -> QueuedRequestMetrics:
         """Single-pass aggregation over ``self.waiting`` and ``self.skipped_waiting``.
@@ -2054,6 +2051,7 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_missing_phases: list[str] = []
         self._bench_current_fpms: list[dict] = []
         self._bench_active_req_ids: set[str] = set()
+        self._bench_decode_stage = _DecodeStage.IDLE
         self._bench_seq = 0
         self._bench_grid_built = False
         self._bench_expected_points = 0
@@ -2073,13 +2071,6 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_stop_requested = False
         self._bench_stop_reason: str | None = None
         self._bench_point_deadline = 0.0
-        # Steady-state decode measurement (see _bench_make_steady_step):
-        # how many extra production-shaped steps remain to dispatch for the
-        # current point, and how many FPMs the point must collect before it
-        # is saved (decode: admission + steady = 2; prefill: 1).
-        self._bench_extra_steps_left = 0
-        self._bench_expected_fpms = 1
-        self._bench_admission_kv_tokens = 0
         self._bench_point_result_timeout_seconds = (
             float(_BenchmarkSynchronizer.MAX_SYNC_TIMEOUT_SECONDS) * 0.8
         )
@@ -3262,8 +3253,8 @@ class InstrumentedScheduler(AsyncScheduler):
             r for r in running if r.request_id not in self._bench_active_req_ids
         ]
         self._bench_active_req_ids.clear()
+        self._bench_decode_stage = _DecodeStage.IDLE
         self._schedule_times.clear()
-        self._bench_extra_steps_left = 0
 
     def _bench_clear_prefix_cache(self) -> None:
         """Remove all synthetic prefix entries before normal serving starts."""
@@ -3320,16 +3311,13 @@ class InstrumentedScheduler(AsyncScheduler):
                 "sum_decode_kv_tokens": 0,
             }
         else:
-            # The synchronized output is the ADMISSION step, which runs one
-            # token short of the point's coordinate (the steady step measured
-            # afterwards reads the full context).
             expected = {
                 "total_num_scheduled_tokens": point.batch_size,
                 "num_prefill_requests": 0,
                 "sum_prefill_tokens": 0,
                 "sum_prefill_kv_tokens": 0,
                 "num_decode_requests": point.batch_size,
-                "sum_decode_kv_tokens": self._bench_admission_kv_tokens,
+                "sum_decode_kv_tokens": point.total_kv_read_tokens,
             }
         if summary == expected:
             return None
@@ -3344,9 +3332,8 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_synchronizer = None
         self._bench_active = False
         self._bench_phase = _BenchPhase.IDLE
+        self._bench_decode_stage = _DecodeStage.IDLE
         self._bench_sync_pending = False
-        self._bench_extra_steps_left = 0
-        self._bench_expected_fpms = 1
         self._schedule_times.clear()
         self._last_update_time = 0.0
         if resume_publisher:
@@ -3591,8 +3578,6 @@ class InstrumentedScheduler(AsyncScheduler):
             self.kv_cache_manager.new_step_starts()
 
             self._bench_current_point = point
-            self._bench_expected_fpms = 1
-            self._bench_extra_steps_left = 0
             injected = self._bench_inject_prefill(
                 prompt_lens=[
                     new_tokens + kv_read_tokens
@@ -3623,8 +3608,6 @@ class InstrumentedScheduler(AsyncScheduler):
             return None
 
         self._bench_current_point = point
-        self._bench_expected_fpms = 1
-        self._bench_extra_steps_left = 0
         injected = self._bench_inject_prefill(
             prompt_lens=new_token_lengths,
             max_tokens=1,
@@ -3641,109 +3624,16 @@ class InstrumentedScheduler(AsyncScheduler):
         )
         return None
 
-    def _bench_make_steady_step(self) -> SchedulerOutput | None:
-        """One production-shaped decode step for the injected requests.
-
-        A decode point's first step admits its requests as brand-new
-        (``scheduled_new_reqs``: full prompt arrays, first-touch bookkeeping)
-        -- a shape that production decode traffic never has after its prefill.
-        The step built here goes out through ``scheduled_cached_reqs`` exactly
-        like a real decode iteration: a per-request delta instead of the full
-        token arrays. Only this step's FPM is recorded.
-
-        Mirrors the parent scheduler's running-request branch
-        (vllm/v1/core/sched/scheduler.py); ``delay_cache_blocks=True`` matches
-        the admission injection and skips the allocation-time prefix-cache
-        commit (the async scheduler still caches blocks on output updates --
-        isolation is guaranteed by the per-request cache salts and the
-        post-benchmark ``reset_prefix_cache``).
-        """
-        reqs = [
-            request
-            for request in self.running
-            if request.request_id in self._bench_active_req_ids
-            and not request.is_finished()
-        ]
-        if not reqs:
-            return None
-        new_blocks = {}
-        for request in reqs:
-            blocks = self.kv_cache_manager.allocate_slots(
-                request,
-                1,
-                num_lookahead_tokens=getattr(self, "num_lookahead_tokens", 0),
-                delay_cache_blocks=True,
-            )
-            if blocks is None:
-                return None
-            new_blocks[request.request_id] = blocks
-        cached = CachedRequestData(
-            req_ids=[request.request_id for request in reqs],
-            resumed_req_ids=set(),
-            new_token_ids=[],
-            all_token_ids={},
-            new_block_ids=[
-                new_blocks[request.request_id].get_block_ids(allow_none=True)
-                for request in reqs
-            ],
-            num_computed_tokens=[request.num_computed_tokens for request in reqs],
-            num_output_tokens=[
-                max(1, request.num_output_tokens + request.num_output_placeholders)
-                for request in reqs
-            ],
-        )
-        output = SchedulerOutput(
-            scheduled_new_reqs=[],
-            scheduled_cached_reqs=cached,
-            num_scheduled_tokens={request.request_id: 1 for request in reqs},
-            total_num_scheduled_tokens=len(reqs),
-            scheduled_spec_decode_tokens={},
-            scheduled_encoder_inputs={},
-            num_common_prefix_blocks=([0] * self.kv_cache_manager.num_kv_cache_groups),
-            finished_req_ids=self.finished_req_ids,
-            free_encoder_mm_hashes=[],
-            new_block_ids_to_zero=(
-                (self.kv_cache_manager.take_new_block_ids() or None)
-                if getattr(self, "needs_kv_cache_zeroing", False)
-                else None
-            ),
-        )
-        if self.connector is not None:
-            output.kv_connector_metadata = self.connector.build_connector_meta(output)
-        if self.ec_connector is not None:
-            output.ec_connector_metadata = self.ec_connector.build_connector_meta(
-                output
-            )
-        return output
-
     def _bench_step_decode(self) -> SchedulerOutput | None:
         if self._bench_drain_if_pending():
             pass  # fall through to inject next point
 
         elif self._bench_active_req_ids:
             if (
-                getattr(self, "_bench_extra_steps_left", 0) > 0
+                not self._bench_current_fpms
                 and not self._bench_point_result_timed_out()
             ):
-                # The steady step deliberately does NOT re-arm the READY/GO
-                # barrier: production decode steps have no per-step barrier
-                # either (ranks stay aligned through the collectives), and a
-                # ZMQ round between the admission and steady updates would be
-                # counted into the steady step's inter-update wall_time under
-                # synchronous scheduling. Group agreement on the point is
-                # still enforced at collect_result.
-                steady = self._bench_make_steady_step()
-                if steady is not None:
-                    self._bench_extra_steps_left -= 1
-                    return steady
-                # Defensive: feasibility reserved ctx+1 slots per request, so
-                # this should be unreachable. Wait out the point deadline; the
-                # admission-only FPM then fails shape validation and the point
-                # is skipped through the normal group-synchronized save path.
                 return None
-            if len(self._bench_current_fpms) < getattr(self, "_bench_expected_fpms", 1):
-                if not self._bench_point_result_timed_out():
-                    return None
             self._bench_save_current_point()
             self._bench_cleanup_requests()
             if self._bench_transition_to_timeout_done():
@@ -3768,8 +3658,8 @@ class InstrumentedScheduler(AsyncScheduler):
         # entries are clamped; the point is then recorded at the coordinate
         # the steady step actually measures.
         injected_lengths = [max(1, ctx - 1) for ctx in context_lengths]
-        self._bench_admission_kv_tokens = sum(injected_lengths)
-        steady_kv_tokens = self._bench_admission_kv_tokens + point.batch_size
+        admission_kv_tokens = sum(injected_lengths)
+        steady_kv_tokens = admission_kv_tokens + point.batch_size
         if steady_kv_tokens != point.total_kv_read_tokens:
             point = replace(
                 point,
@@ -3778,8 +3668,6 @@ class InstrumentedScheduler(AsyncScheduler):
             )
         self._bench_current_point = point
         self._bench_current_fpms = []
-        self._bench_extra_steps_left = 1
-        self._bench_expected_fpms = 2
         logger.info(
             "Benchmark decode: total_kv_reads=%d batch_size=%d",
             point.total_kv_read_tokens,
@@ -3797,9 +3685,46 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_cleanup_requests()
             self._bench_skip_point(point, "decode_injection_failed")
             self._bench_current_point = None
-            self._bench_extra_steps_left = 0
             return None
+        self._bench_decode_stage = _DecodeStage.ADMITTING
+        # Admission is scaffolding, but it still needs a deadline in case its
+        # output never arrives to release the resident measurement.
+        self._bench_point_deadline = (
+            time.monotonic() + self._bench_point_result_timeout_seconds
+        )
+        return output
+
+    def _bench_measure_resident_batch(self) -> SchedulerOutput:
+        """Schedule and record the decode batch admitted by the prior pass."""
+        point = self._bench_current_point
+        self._bench_decode_stage = _DecodeStage.MEASURING
+        output = super().schedule(throttle_prefills=True)
+        if point is None or output.total_num_scheduled_tokens != point.batch_size:
+            logger.warning(
+                "Skipping benchmark decode point after the resident batch "
+                "scheduled %d of %d requests: %s",
+                output.total_num_scheduled_tokens,
+                point.batch_size if point is not None else 0,
+                point,
+            )
+            self._bench_cleanup_requests()
+            if point is not None:
+                self._bench_skip_point(point, "decode_measurement_failed")
+            self._bench_current_point = None
+            self._bench_drain_pending = True
+            return output
+
         self._bench_sync_pending = True
+        try:
+            self._bench_synchronize_output(output)
+        except Exception as error:
+            logger.exception(
+                "Benchmark synchronization failed (benchmark_id=%s)",
+                point.benchmark_id,
+            )
+            self._bench_abort(error)
+            raise
+        self._schedule_times.append(time.monotonic())
         return output
 
     def _bench_pop_next(self, point_type: str) -> BenchmarkPoint | None:
@@ -3820,15 +3745,6 @@ class InstrumentedScheduler(AsyncScheduler):
         if self._bench_current_point is not None:
             point = self._bench_current_point
             local_fpms = list(self._bench_current_fpms)
-            expected_fpms = getattr(self, "_bench_expected_fpms", 1)
-            if expected_fpms > 1 and len(local_fpms) >= expected_fpms:
-                # Keep only the steady-state sample; the admission step is
-                # scaffolding. A rank that reached the deadline with the
-                # admission FPM alone sends it through collect_result
-                # unchanged: the shape validator rejects it
-                # (sum_decode_kv_tokens mismatch) and every rank skips the
-                # point together -- no rank ever bypasses the barrier.
-                local_fpms = local_fpms[-1:]
             if self._bench_synchronizer is not None:
                 group_result = self._bench_synchronizer.collect_result(
                     point,

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3604,6 +3604,8 @@ def test_resident_measurement_partial_mismatch_aborts_before_dispatch(monkeypatc
         point_type="decode", benchmark_id=8, total_kv_read_tokens=128, batch_size=2
     )
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_active = True
+    stub._bench_phase = _BenchPhase.DECODE_SWEEP
     stub._bench_current_point = point
     stub._bench_decode_stage = _DecodeStage.RESIDENT
     stub._bench_abort = MagicMock()
@@ -3615,6 +3617,28 @@ def test_resident_measurement_partial_mismatch_aborts_before_dispatch(monkeypatc
     )
 
     with pytest.raises(RuntimeError, match="scheduled 1 of 2 requests") as exc_info:
-        InstrumentedScheduler._bench_measure_resident_batch(stub)
+        InstrumentedScheduler.schedule(stub)
 
     stub._bench_abort.assert_called_once_with(exc_info.value)
+
+
+def test_resident_parent_schedule_failure_aborts_benchmark(monkeypatch):
+    error = RuntimeError("parent scheduling failed")
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_active = True
+    stub._bench_phase = _BenchPhase.DECODE_SWEEP
+    stub._bench_current_point = BenchmarkPoint(
+        point_type="decode", benchmark_id=9, total_kv_read_tokens=128, batch_size=2
+    )
+    stub._bench_decode_stage = _DecodeStage.RESIDENT
+    stub._bench_abort = MagicMock()
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "schedule",
+        MagicMock(side_effect=error),
+    )
+
+    with pytest.raises(RuntimeError, match="parent scheduling failed"):
+        InstrumentedScheduler.schedule(stub)
+
+    stub._bench_abort.assert_called_once_with(error)

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3590,6 +3590,7 @@ def test_resident_measurement_empty_mismatch_skips_point(monkeypatch):
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_current_point = point
     stub._bench_decode_stage = _DecodeStage.RESIDENT
+    stub._bench_synchronizer = None
     stub._bench_cleanup_requests = MagicMock()
     stub._bench_skip_point = MagicMock()
     stub._bench_drain_pending = False
@@ -3605,6 +3606,29 @@ def test_resident_measurement_empty_mismatch_skips_point(monkeypatch):
     stub._bench_skip_point.assert_called_once_with(point, "decode_measurement_failed")
     assert stub._bench_current_point is None
     assert stub._bench_drain_pending is True
+
+
+def test_resident_empty_mismatch_aborts_attention_dp_peers(monkeypatch):
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=8, total_kv_read_tokens=128, batch_size=2
+    )
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_active = True
+    stub._bench_phase = _BenchPhase.DECODE_SWEEP
+    stub._bench_current_point = point
+    stub._bench_decode_stage = _DecodeStage.RESIDENT
+    stub._bench_synchronizer = object()
+    stub._bench_abort = MagicMock()
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "schedule",
+        MagicMock(return_value=SimpleNamespace(total_num_scheduled_tokens=0)),
+    )
+
+    with pytest.raises(RuntimeError, match="scheduled 0 of 2 requests") as exc_info:
+        InstrumentedScheduler.schedule(stub)
+
+    stub._bench_abort.assert_called_once_with(exc_info.value)
 
 
 def test_resident_measurement_partial_mismatch_aborts_before_dispatch(monkeypatch):

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3239,8 +3239,7 @@ def test_prefill_point_with_exact_batch_shape_is_saved():
     ]
 
 
-@pytest.mark.parametrize("fpm_count", [0, 2])
-def test_benchmark_point_rejects_non_single_fpm_count(fpm_count):
+def test_benchmark_point_rejects_multiple_fpms():
     point = BenchmarkPoint(
         point_type="decode",
         benchmark_id=4,
@@ -3253,10 +3252,51 @@ def test_benchmark_point_rejects_non_single_fpm_count(fpm_count):
             "sum_decode_kv_tokens": 48,
         }
     }
-    stub = _benchmark_save_stub(point, [fpm.copy() for _ in range(fpm_count)])
+    stub = _benchmark_save_stub(point, [fpm.copy(), fpm.copy()])
 
     with pytest.raises(RuntimeError, match="exactly one FPM"):
         InstrumentedScheduler._bench_save_current_point(stub)
+
+
+def test_decode_timeout_group_skip_collects_all_ranks():
+    point = BenchmarkPoint(
+        point_type="decode",
+        benchmark_id=4,
+        total_kv_read_tokens=48,
+        batch_size=3,
+    )
+    rank1_fpm = {
+        "counter_id": point.benchmark_id,
+        "dp_rank": 1,
+        "wall_time": 0.01,
+        "scheduled_requests": {
+            "num_decode_requests": point.batch_size,
+            "sum_decode_kv_tokens": point.total_kv_read_tokens,
+        },
+    }
+    stub = _benchmark_save_stub(point, [])
+    stub._bench_dp_size = 2
+    stub._bench_deadline_monotonic = None
+    stub._bench_synchronizer = MagicMock()
+    stub._bench_synchronizer.collect_result.return_value = (
+        instrumented_scheduler_module._BenchmarkGroupResult(
+            rank_results=[
+                {"dp_rank": 0, "fpms": []},
+                {"dp_rank": 1, "fpms": [rank1_fpm]},
+            ],
+            stop_requested=False,
+        )
+    )
+
+    InstrumentedScheduler._bench_save_current_point(stub)
+
+    stub._bench_synchronizer.collect_result.assert_called_once_with(
+        point, [], stop_deadline_monotonic=None
+    )
+    assert stub._bench_results == []
+    assert stub._bench_skipped_points == [
+        SkippedBenchmarkPoint(point=point, reason="decode_measurement_timeout")
+    ]
 
 
 def test_decode_point_with_no_fpm_stops_waiting_at_deadline(monkeypatch):
@@ -3272,7 +3312,6 @@ def test_decode_point_with_no_fpm_stops_waiting_at_deadline(monkeypatch):
     stub._bench_current_point = point
     stub._bench_current_fpms = []
     stub._bench_point_deadline = 1.0
-    stub._bench_skipped_points = []
     stub._bench_save_current_point = MagicMock()
     stub._bench_cleanup_requests = MagicMock()
     stub._bench_transition_to_timeout_done = MagicMock(return_value=False)
@@ -3280,14 +3319,9 @@ def test_decode_point_with_no_fpm_stops_waiting_at_deadline(monkeypatch):
 
     assert InstrumentedScheduler._bench_step_decode(stub) is None
 
-    stub._bench_save_current_point.assert_not_called()
+    stub._bench_save_current_point.assert_called_once_with()
     stub._bench_cleanup_requests.assert_called_once_with()
-    assert stub._bench_current_point is None
-    assert stub._bench_point_deadline == 0.0
     assert stub._bench_drain_pending is True
-    assert stub._bench_skipped_points == [
-        SkippedBenchmarkPoint(point=point, reason="decode_measurement_timeout")
-    ]
 
 
 def test_prefill_point_with_measured_batch_size_mismatch_is_skipped():
@@ -3631,7 +3665,35 @@ def test_resident_empty_mismatch_aborts_attention_dp_peers(monkeypatch):
     stub._bench_abort.assert_called_once_with(exc_info.value)
 
 
-def test_resident_measurement_partial_mismatch_aborts_before_dispatch(monkeypatch):
+def test_resident_partial_mismatch_completes_before_single_rank_skip(monkeypatch):
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=8, total_kv_read_tokens=128, batch_size=2
+    )
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_current_point = point
+    stub._bench_decode_stage = _DecodeStage.RESIDENT
+    stub._bench_synchronizer = None
+    stub._schedule_times = deque()
+    stub._bench_cleanup_requests = MagicMock()
+    output = SimpleNamespace(total_num_scheduled_tokens=1)
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "schedule",
+        MagicMock(return_value=output),
+    )
+    monkeypatch.setattr(
+        instrumented_scheduler_module.time, "monotonic", MagicMock(return_value=42.0)
+    )
+
+    assert InstrumentedScheduler._bench_measure_resident_batch(stub) is output
+
+    stub._bench_cleanup_requests.assert_not_called()
+    assert stub._bench_current_point is point
+    assert stub._bench_decode_stage is _DecodeStage.MEASURING
+    assert list(stub._schedule_times) == [42.0]
+
+
+def test_resident_partial_mismatch_aborts_attention_dp(monkeypatch):
     point = BenchmarkPoint(
         point_type="decode", benchmark_id=8, total_kv_read_tokens=128, batch_size=2
     )
@@ -3640,6 +3702,7 @@ def test_resident_measurement_partial_mismatch_aborts_before_dispatch(monkeypatc
     stub._bench_phase = _BenchPhase.DECODE_SWEEP
     stub._bench_current_point = point
     stub._bench_decode_stage = _DecodeStage.RESIDENT
+    stub._bench_synchronizer = object()
     stub._bench_abort = MagicMock()
     output = SimpleNamespace(total_num_scheduled_tokens=1)
     monkeypatch.setattr(

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3575,7 +3575,7 @@ def test_resident_measurement_uses_parent_scheduler_after_sync(monkeypatch):
     assert list(stub._schedule_times) == [42.0]
 
 
-def test_resident_measurement_mismatch_skips_point(monkeypatch):
+def test_resident_measurement_empty_mismatch_skips_point(monkeypatch):
     point = BenchmarkPoint(
         point_type="decode", benchmark_id=8, total_kv_read_tokens=128, batch_size=2
     )
@@ -3585,7 +3585,7 @@ def test_resident_measurement_mismatch_skips_point(monkeypatch):
     stub._bench_cleanup_requests = MagicMock()
     stub._bench_skip_point = MagicMock()
     stub._bench_drain_pending = False
-    output = SimpleNamespace(total_num_scheduled_tokens=1)
+    output = SimpleNamespace(total_num_scheduled_tokens=0)
     monkeypatch.setattr(
         instrumented_scheduler_module.AsyncScheduler,
         "schedule",
@@ -3597,3 +3597,24 @@ def test_resident_measurement_mismatch_skips_point(monkeypatch):
     stub._bench_skip_point.assert_called_once_with(point, "decode_measurement_failed")
     assert stub._bench_current_point is None
     assert stub._bench_drain_pending is True
+
+
+def test_resident_measurement_partial_mismatch_aborts_before_dispatch(monkeypatch):
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=8, total_kv_read_tokens=128, batch_size=2
+    )
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_current_point = point
+    stub._bench_decode_stage = _DecodeStage.RESIDENT
+    stub._bench_abort = MagicMock()
+    output = SimpleNamespace(total_num_scheduled_tokens=1)
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "schedule",
+        MagicMock(return_value=output),
+    )
+
+    with pytest.raises(RuntimeError, match="scheduled 1 of 2 requests") as exc_info:
+        InstrumentedScheduler._bench_measure_resident_batch(stub)
+
+    stub._bench_abort.assert_called_once_with(exc_info.value)

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -1288,7 +1288,7 @@ def test_decode_sweep_empty_frame_attaches_kv_connector_metadata(monkeypatch):
     connector.build_connector_meta = MagicMock(return_value=sentinel)
     base_update = MagicMock()
     monkeypatch.setattr(
-        instrumented_scheduler_module.AsyncScheduler.__mro__[1],
+        instrumented_scheduler_module.Scheduler,
         "_update_after_schedule",
         base_update,
     )
@@ -1299,7 +1299,7 @@ def test_decode_sweep_empty_frame_attaches_kv_connector_metadata(monkeypatch):
     assert out.kv_connector_metadata is sentinel
     assert out.num_scheduled_tokens == {"__bench_0": 0}
     connector.build_connector_meta.assert_called_once_with(out)
-    base_update.assert_called_once_with(out)
+    base_update.assert_called_once_with(stub, out)
     stub._update_after_schedule.assert_not_called()
     # ec_connector is None on the stub; the ec field stays untouched.
     assert out.ec_connector_metadata is None
@@ -1313,7 +1313,7 @@ def test_decode_sweep_empty_frame_attaches_ec_connector_metadata_when_set(monkey
     ec_connector = MagicMock()
     ec_connector.build_connector_meta = MagicMock(return_value=ec_meta)
     monkeypatch.setattr(
-        instrumented_scheduler_module.AsyncScheduler.__mro__[1],
+        instrumented_scheduler_module.Scheduler,
         "_update_after_schedule",
         MagicMock(),
     )
@@ -1333,7 +1333,7 @@ def test_decode_sweep_empty_frame_no_connector_leaves_metadata_none(monkeypatch)
     metadata fields still None.
     """
     monkeypatch.setattr(
-        instrumented_scheduler_module.AsyncScheduler.__mro__[1],
+        instrumented_scheduler_module.Scheduler,
         "_update_after_schedule",
         MagicMock(),
     )
@@ -3272,14 +3272,22 @@ def test_decode_point_with_no_fpm_stops_waiting_at_deadline(monkeypatch):
     stub._bench_current_point = point
     stub._bench_current_fpms = []
     stub._bench_point_deadline = 1.0
-    stub._bench_save_current_point = MagicMock(
-        side_effect=RuntimeError("exactly one FPM")
-    )
+    stub._bench_skipped_points = []
+    stub._bench_save_current_point = MagicMock()
+    stub._bench_cleanup_requests = MagicMock()
+    stub._bench_transition_to_timeout_done = MagicMock(return_value=False)
     monkeypatch.setattr(instrumented_scheduler_module.time, "monotonic", lambda: 2.0)
 
-    with pytest.raises(RuntimeError, match="exactly one FPM"):
-        InstrumentedScheduler._bench_step_decode(stub)
-    stub._bench_save_current_point.assert_called_once_with()
+    assert InstrumentedScheduler._bench_step_decode(stub) is None
+
+    stub._bench_save_current_point.assert_not_called()
+    stub._bench_cleanup_requests.assert_called_once_with()
+    assert stub._bench_current_point is None
+    assert stub._bench_point_deadline == 0.0
+    assert stub._bench_drain_pending is True
+    assert stub._bench_skipped_points == [
+        SkippedBenchmarkPoint(point=point, reason="decode_measurement_timeout")
+    ]
 
 
 def test_prefill_point_with_measured_batch_size_mismatch_is_skipped():

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -42,6 +42,7 @@ from dynamo.vllm.instrumented_scheduler import (  # noqa: E402
     InstrumentedScheduler,
     SkippedBenchmarkPoint,
     _BenchPhase,
+    _DecodeStage,
 )
 
 pytestmark = [
@@ -143,6 +144,9 @@ def _run_extract_scheduled(
     stub._bench_phase = (
         _BenchPhase.DECODE_SWEEP if bench_decode_ids is not None else _BenchPhase.IDLE
     )
+    stub._bench_decode_stage = (
+        _DecodeStage.MEASURING if bench_decode_ids is not None else _DecodeStage.IDLE
+    )
     stub._bench_active_req_ids = set(bench_decode_ids or [])
     output = SimpleNamespace(
         scheduled_new_reqs=new_reqs,
@@ -229,6 +233,9 @@ def test_benchmark_records_only_current_point_forward_pass_type(
 ):
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_current_point = BenchmarkPoint(point_type=point_type)
+    stub._bench_decode_stage = (
+        _DecodeStage.MEASURING if point_type == "decode" else _DecodeStage.IDLE
+    )
     metrics = SimpleNamespace(
         scheduled_requests=SimpleNamespace(
             num_prefill_requests=num_prefill,
@@ -269,6 +276,7 @@ def test_benchmark_timing_stops_before_vllm_state_update(monkeypatch):
     stub._last_update_time = 0.0
     stub._bench_active = True
     stub._bench_current_point = BenchmarkPoint(point_type="decode", benchmark_id=1)
+    stub._bench_decode_stage = _DecodeStage.MEASURING
     stub._extract_scheduled = MagicMock(
         return_value=instrumented_scheduler_module.ScheduledRequestMetrics(
             num_decode_requests=1
@@ -1100,6 +1108,7 @@ def test_benchmark_fpm_uses_benchmark_id_and_is_not_published():
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_active = True
     stub._bench_current_point = BenchmarkPoint(point_type="decode", benchmark_id=7)
+    stub._bench_decode_stage = _DecodeStage.MEASURING
     stub._bench_current_fpms = []
     stub._publisher = MagicMock()
     metrics = instrumented_scheduler_module.ForwardPassMetrics(
@@ -1136,16 +1145,13 @@ def test_benchmark_output_summary_must_match_point_before_go():
         batch_size=2,
     )
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
-    # The synchronized output is the admission step, which runs one token
-    # short per request (the steady step reads the full 128 afterwards).
-    stub._bench_admission_kv_tokens = 126
     matching = {
         "total_num_scheduled_tokens": 2,
         "num_prefill_requests": 0,
         "sum_prefill_tokens": 0,
         "sum_prefill_kv_tokens": 0,
         "num_decode_requests": 2,
-        "sum_decode_kv_tokens": 126,
+        "sum_decode_kv_tokens": 128,
     }
 
     assert (
@@ -1159,11 +1165,11 @@ def test_benchmark_output_summary_must_match_point_before_go():
     )
     assert "benchmark_id=3 SchedulerOutput does not match" in error
 
-    full_context = dict(matching, sum_decode_kv_tokens=128)
+    admission_context = dict(matching, sum_decode_kv_tokens=126)
     error = InstrumentedScheduler._bench_output_validation_error(
-        stub, point, full_context
+        stub, point, admission_context
     )
-    assert error is not None, "the admission step must run one token short"
+    assert error is not None, "only the resident measurement may synchronize"
 
 
 def test_dp_rank_falls_back_to_rank_when_index_absent():
@@ -1253,6 +1259,7 @@ def _make_decode_sweep_stub(connector, ec_connector=None):
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_active = True
     stub._bench_phase = _BenchPhase.DECODE_SWEEP
+    stub._bench_decode_stage = _DecodeStage.ADMITTING
     stub._bench_active_req_ids = {"__bench_0"}
     stub.kv_cache_manager = MagicMock()
     stub.kv_cache_manager.num_kv_cache_groups = 1
@@ -1272,30 +1279,44 @@ def _make_decode_sweep_stub(connector, ec_connector=None):
     return stub
 
 
-def test_decode_sweep_empty_frame_attaches_kv_connector_metadata():
+def test_decode_sweep_empty_frame_attaches_kv_connector_metadata(monkeypatch):
     """Parent's ``build_connector_meta`` must be called on the empty drain
     frame; metadata is then attached to the returned SchedulerOutput.
     """
     sentinel = object()
     connector = MagicMock()
     connector.build_connector_meta = MagicMock(return_value=sentinel)
+    base_update = MagicMock()
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler.__mro__[1],
+        "_update_after_schedule",
+        base_update,
+    )
 
     stub = _make_decode_sweep_stub(connector=connector)
     out = InstrumentedScheduler.schedule(stub)
 
     assert out.kv_connector_metadata is sentinel
+    assert out.num_scheduled_tokens == {"__bench_0": 0}
     connector.build_connector_meta.assert_called_once_with(out)
+    base_update.assert_called_once_with(out)
+    stub._update_after_schedule.assert_not_called()
     # ec_connector is None on the stub; the ec field stays untouched.
     assert out.ec_connector_metadata is None
 
 
-def test_decode_sweep_empty_frame_attaches_ec_connector_metadata_when_set():
+def test_decode_sweep_empty_frame_attaches_ec_connector_metadata_when_set(monkeypatch):
     kv_meta = object()
     ec_meta = object()
     connector = MagicMock()
     connector.build_connector_meta = MagicMock(return_value=kv_meta)
     ec_connector = MagicMock()
     ec_connector.build_connector_meta = MagicMock(return_value=ec_meta)
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler.__mro__[1],
+        "_update_after_schedule",
+        MagicMock(),
+    )
 
     stub = _make_decode_sweep_stub(connector=connector, ec_connector=ec_connector)
     out = InstrumentedScheduler.schedule(stub)
@@ -1306,17 +1327,51 @@ def test_decode_sweep_empty_frame_attaches_ec_connector_metadata_when_set():
     ec_connector.build_connector_meta.assert_called_once_with(out)
 
 
-def test_decode_sweep_empty_frame_no_connector_leaves_metadata_none():
+def test_decode_sweep_empty_frame_no_connector_leaves_metadata_none(monkeypatch):
     """No connector configured (aggregated worker without
     --kv-transfer-config): the empty frame is returned with both
-    metadata fields still None -- exercising the ``getattr(..., None)``
-    guard in the fix.
+    metadata fields still None.
     """
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler.__mro__[1],
+        "_update_after_schedule",
+        MagicMock(),
+    )
     stub = _make_decode_sweep_stub(connector=None)
     out = InstrumentedScheduler.schedule(stub)
 
     assert out.kv_connector_metadata is None
     assert out.ec_connector_metadata is None
+
+
+def test_retention_map_is_removed_before_parent_output_update(monkeypatch):
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_active = True
+    stub._bench_current_point = BenchmarkPoint(point_type="decode")
+    stub._bench_decode_stage = _DecodeStage.ADMITTING
+    stub._last_update_time = 1.0
+    stub._cleanup_finished = MagicMock()
+    output = SimpleNamespace(
+        total_num_scheduled_tokens=0,
+        num_scheduled_tokens={"__bench_0": 0},
+    )
+
+    def parent_update(_self, scheduler_output, _model_runner_output):
+        assert scheduler_output.num_scheduled_tokens == {}
+        return "parent-result"
+
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "update_from_output",
+        parent_update,
+    )
+
+    assert (
+        InstrumentedScheduler.update_from_output(stub, output, object())
+        == "parent-result"
+    )
+    assert output.num_scheduled_tokens == {}
+    assert stub._last_update_time == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -3112,7 +3167,6 @@ def _benchmark_save_stub(point: BenchmarkPoint, fpms: list[dict]):
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_current_point = point
     stub._bench_current_fpms = fpms
-    stub._bench_expected_fpms = 1
     stub._bench_results = []
     stub._bench_iteration_groups = []
     stub._bench_skipped_points = []
@@ -3347,7 +3401,7 @@ def test_zero_request_decode_injection_is_skipped_immediately():
 
 
 # ---------------------------------------------------------------------------
-# Steady-state decode measurement (two-step points)
+# Resident decode measurement
 # ---------------------------------------------------------------------------
 
 
@@ -3360,6 +3414,8 @@ def _steady_injection_stub(point: BenchmarkPoint):
     stub._bench_grid = deque([point])
     stub._bench_current_point = None
     stub._bench_current_fpms = []
+    stub._bench_sync_pending = False
+    stub._bench_point_result_timeout_seconds = 5.0
     stub._bench_stop_at_timeout_boundary = MagicMock(return_value=False)
     stub._bench_inject_fake_decode = MagicMock(
         return_value=SimpleNamespace(total_num_scheduled_tokens=point.batch_size)
@@ -3377,13 +3433,12 @@ def test_decode_injection_admits_one_token_short():
 
     assert output is not None
     stub._bench_inject_fake_decode.assert_called_once_with([63, 63])
-    assert stub._bench_admission_kv_tokens == 126
-    assert stub._bench_extra_steps_left == 1
-    assert stub._bench_expected_fpms == 2
+    assert stub._bench_decode_stage is _DecodeStage.ADMITTING
     # No clamping: the point keeps its grid coordinate.
     assert stub._bench_current_point.total_kv_read_tokens == 128
     assert "context_clamped" not in stub._bench_current_point.sample_reasons
-    assert stub._bench_sync_pending is True
+    assert stub._bench_sync_pending is False
+    assert stub._bench_point_deadline > 0
 
 
 def test_decode_ctx1_point_is_clamped_and_recorded_at_measured_coordinate():
@@ -3398,7 +3453,6 @@ def test_decode_ctx1_point_is_clamped_and_recorded_at_measured_coordinate():
 
     assert output is not None
     stub._bench_inject_fake_decode.assert_called_once_with([1, 1, 1, 1])
-    assert stub._bench_admission_kv_tokens == 4
     # The steady step reads ctx=2 per request; the point is recorded at the
     # coordinate it actually measures.
     assert stub._bench_current_point.total_kv_read_tokens == 8
@@ -3406,28 +3460,19 @@ def test_decode_ctx1_point_is_clamped_and_recorded_at_measured_coordinate():
     assert stub._bench_current_point.benchmark_id == 6
 
 
-def test_steady_step_dispatch_then_wait_then_save():
+def test_decode_waits_for_resident_measurement_then_saves():
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_drain_pending = False
     stub._bench_active_req_ids = {"__bench_0"}
     stub._bench_current_fpms = []
-    stub._bench_extra_steps_left = 1
-    stub._bench_expected_fpms = 2
     stub._bench_point_deadline = 0.0
-    steady_output = object()
-    stub._bench_make_steady_step = MagicMock(return_value=steady_output)
-
-    assert InstrumentedScheduler._bench_step_decode(stub) is steady_output
-    assert stub._bench_extra_steps_left == 0
-
-    # Only the admission FPM has arrived: keep waiting, no save.
     stub._bench_save_current_point = MagicMock()
-    stub._bench_current_fpms = [{"admission": True}]
+
+    # Admission is never recorded, so wait until the resident pass arrives.
     assert InstrumentedScheduler._bench_step_decode(stub) is None
     stub._bench_save_current_point.assert_not_called()
 
-    # Second (steady) FPM arrived: save and enter drain.
-    stub._bench_current_fpms = [{"admission": True}, {"steady": True}]
+    stub._bench_current_fpms = [{"resident": True}]
     stub._bench_cleanup_requests = MagicMock()
     stub._bench_transition_to_timeout_done = MagicMock(return_value=False)
     assert InstrumentedScheduler._bench_step_decode(stub) is None
@@ -3435,215 +3480,120 @@ def test_steady_step_dispatch_then_wait_then_save():
     assert stub._bench_drain_pending is True
 
 
-def test_steady_step_unavailable_waits_out_the_deadline():
-    import time
-
+def test_decode_admission_fpm_is_not_recorded():
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
-    stub._bench_drain_pending = False
-    stub._bench_active_req_ids = {"__bench_0"}
-    stub._bench_current_fpms = [{"admission": True}]
-    stub._bench_extra_steps_left = 1
-    stub._bench_expected_fpms = 2
-    stub._bench_point_deadline = 0.0  # no deadline yet -> not timed out
-    stub._bench_make_steady_step = MagicMock(return_value=None)
-    stub._bench_save_current_point = MagicMock()
+    stub._bench_current_point = BenchmarkPoint(point_type="decode")
+    stub._bench_decode_stage = _DecodeStage.ADMITTING
+    scheduled = instrumented_scheduler_module.ScheduledRequestMetrics(
+        num_decode_requests=2
+    )
+    assert (
+        InstrumentedScheduler._bench_should_record_scheduled(stub, scheduled) is False
+    )
 
-    # Builder failed: no dispatch, no save, state intact for a retry.
-    assert InstrumentedScheduler._bench_step_decode(stub) is None
-    stub._bench_save_current_point.assert_not_called()
-    assert stub._bench_extra_steps_left == 1
-
-    # Once the deadline passes, the point flows into the normal save path
-    # (where the admission-only FPM fails shape validation and the group
-    # skips together).
-    stub._bench_point_deadline = time.monotonic() - 1.0
-    stub._bench_cleanup_requests = MagicMock()
-    stub._bench_transition_to_timeout_done = MagicMock(return_value=False)
-    assert InstrumentedScheduler._bench_step_decode(stub) is None
-    stub._bench_save_current_point.assert_called_once_with()
+    stub._bench_decode_stage = _DecodeStage.MEASURING
+    assert InstrumentedScheduler._bench_should_record_scheduled(stub, scheduled) is True
 
 
-def test_make_steady_step_builds_production_shaped_output():
+def test_admission_update_releases_resident_measurement(monkeypatch):
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=1, total_kv_read_tokens=128, batch_size=2
+    )
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
-    requests = [
-        SimpleNamespace(
-            request_id=f"__bench_{index}",
-            num_computed_tokens=63 + index,
-            num_output_tokens=0,
-            num_output_placeholders=1,
-            is_finished=lambda: False,
+    stub._schedule_times = deque([10.0])
+    stub._last_update_time = 0.0
+    stub._bench_active = True
+    stub._bench_current_point = point
+    stub._bench_current_fpms = []
+    stub._bench_decode_stage = _DecodeStage.ADMITTING
+    scheduled = instrumented_scheduler_module.ScheduledRequestMetrics(
+        num_decode_requests=2,
+        sum_decode_kv_tokens=126,
+    )
+    stub._extract_scheduled = MagicMock(return_value=scheduled)
+    stub._compute_queued = MagicMock(return_value=None)
+    stub._extract_metrics = MagicMock(
+        return_value=instrumented_scheduler_module.ForwardPassMetrics(
+            scheduled_requests=scheduled
         )
-        for index in range(2)
-    ]
-    stub.running = requests
-    stub._bench_active_req_ids = {r.request_id for r in requests}
-    blocks = MagicMock()
-    blocks.get_block_ids.return_value = None
-    kv = MagicMock()
-    kv.allocate_slots.return_value = blocks
-    kv.num_kv_cache_groups = 1
-    stub.kv_cache_manager = kv
-    stub.num_lookahead_tokens = 0
-    stub.needs_kv_cache_zeroing = False
-    stub.finished_req_ids = set()
-    stub.connector = None
-    stub.ec_connector = None
-
-    output = InstrumentedScheduler._bench_make_steady_step(stub)
-
-    assert output.scheduled_new_reqs == []
-    cached = output.scheduled_cached_reqs
-    assert cached.req_ids == ["__bench_0", "__bench_1"]
-    assert cached.resumed_req_ids == set()
-    assert cached.new_token_ids == []
-    assert cached.num_computed_tokens == [63, 64]
-    assert cached.num_output_tokens == [1, 1]
-    assert output.total_num_scheduled_tokens == 2
-    assert output.num_scheduled_tokens == {"__bench_0": 1, "__bench_1": 1}
-    kv.allocate_slots.assert_any_call(
-        requests[0], 1, num_lookahead_tokens=0, delay_cache_blocks=True
     )
-    blocks.get_block_ids.assert_called_with(allow_none=True)
+    stub._cleanup_finished = MagicMock()
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "update_from_output",
+        MagicMock(return_value="parent-result"),
+    )
+    monkeypatch.setattr(
+        instrumented_scheduler_module.time,
+        "monotonic",
+        MagicMock(return_value=20.0),
+    )
+    output = SimpleNamespace(
+        total_num_scheduled_tokens=2,
+        num_scheduled_tokens={"__bench_0": 1, "__bench_1": 1},
+    )
+
+    assert (
+        InstrumentedScheduler.update_from_output(stub, output, object())
+        == "parent-result"
+    )
+    assert stub._bench_decode_stage is _DecodeStage.RESIDENT
+    assert stub._bench_current_fpms == []
 
 
-def test_make_steady_step_returns_none_when_kv_exhausted():
+def test_resident_measurement_uses_parent_scheduler_after_sync(monkeypatch):
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=7, total_kv_read_tokens=128, batch_size=2
+    )
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
-    request = SimpleNamespace(
-        request_id="__bench_0",
-        num_computed_tokens=63,
-        num_output_tokens=0,
-        num_output_placeholders=1,
-        is_finished=lambda: False,
+    stub._bench_current_point = point
+    stub._bench_decode_stage = _DecodeStage.RESIDENT
+    stub._bench_sync_pending = False
+    stub._schedule_times = deque()
+    output = SimpleNamespace(total_num_scheduled_tokens=2)
+    parent_schedule = MagicMock(return_value=output)
+    events = []
+    stub._bench_synchronize_output = MagicMock(
+        side_effect=lambda scheduled_output: events.append(("sync", scheduled_output))
     )
-    stub.running = [request]
-    stub._bench_active_req_ids = {"__bench_0"}
-    kv = MagicMock()
-    kv.allocate_slots.return_value = None
-    stub.kv_cache_manager = kv
-    stub.num_lookahead_tokens = 0
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "schedule",
+        parent_schedule,
+    )
+    monkeypatch.setattr(
+        instrumented_scheduler_module.time,
+        "monotonic",
+        MagicMock(side_effect=lambda: events.append(("time", None)) or 42.0),
+    )
 
-    assert InstrumentedScheduler._bench_make_steady_step(stub) is None
-
-
-def _steady_fpm(sum_kv: int, batch: int, bench_id: int = 1, rank: int = 0) -> dict:
-    return {
-        "counter_id": bench_id,
-        "dp_rank": rank,
-        "wall_time": 1.0,
-        "scheduled_requests": {
-            "num_decode_requests": batch,
-            "sum_decode_kv_tokens": sum_kv,
-        },
-    }
+    assert InstrumentedScheduler._bench_measure_resident_batch(stub) is output
+    parent_schedule.assert_called_once_with(throttle_prefills=True)
+    assert stub._bench_decode_stage is _DecodeStage.MEASURING
+    assert stub._bench_sync_pending is True
+    assert events == [("sync", output), ("time", None)]
+    assert list(stub._schedule_times) == [42.0]
 
 
-def test_save_records_only_the_steady_fpm():
+def test_resident_measurement_mismatch_skips_point(monkeypatch):
     point = BenchmarkPoint(
-        point_type="decode", benchmark_id=1, total_kv_read_tokens=128, batch_size=2
+        point_type="decode", benchmark_id=8, total_kv_read_tokens=128, batch_size=2
     )
-    admission = _steady_fpm(126, 2)
-    steady = _steady_fpm(128, 2)
-    stub = _benchmark_save_stub(point, [admission, steady])
-    stub._bench_expected_fpms = 2
-
-    InstrumentedScheduler._bench_save_current_point(stub)
-
-    assert len(stub._bench_results) == 1
-    assert stub._bench_results[0].fpms == [steady]
-    assert stub._bench_skipped_points == []
-
-
-def test_save_admission_only_fpm_becomes_validation_skip():
-    point = BenchmarkPoint(
-        point_type="decode", benchmark_id=1, total_kv_read_tokens=128, batch_size=2
-    )
-    stub = _benchmark_save_stub(point, [_steady_fpm(126, 2)])
-    stub._bench_expected_fpms = 2  # steady FPM never arrived
-
-    InstrumentedScheduler._bench_save_current_point(stub)
-
-    assert stub._bench_results == []
-    assert stub._bench_skipped_points == [
-        SkippedBenchmarkPoint(point=point, reason="measured_decode_context_mismatch")
-    ]
-
-
-@pytest.mark.timeout(60)
-def test_two_step_group_skip_traverses_barrier_without_deadlock():
-    """One rank misses its steady FPM while the other has both: the short
-    rank must still enter collect_result so the whole group leaves the
-    barrier together and skips the point consistently."""
-    import time
-
-    endpoint = f"inproc://benchmark-sync-{uuid.uuid4().hex}"
-    rank0 = instrumented_scheduler_module._BenchmarkSynchronizer(
-        dp_rank=0, dp_size=2, master_ip="unused", port=0, timeout=5, endpoint=endpoint
-    )
-    rank1 = instrumented_scheduler_module._BenchmarkSynchronizer(
-        dp_rank=1, dp_size=2, master_ip="unused", port=0, timeout=5, endpoint=endpoint
-    )
-    point = BenchmarkPoint(
-        point_type="decode", benchmark_id=1, total_kv_read_tokens=128, batch_size=2
-    )
-
-    def build(rank, synchronizer, fpms):
-        stub = _benchmark_save_stub(point, fpms)
-        stub._bench_expected_fpms = 2
-        stub._bench_synchronizer = synchronizer
-        stub._bench_dp_size = 2
-        stub._fpm_dp_rank = rank
-        stub._bench_deadline_monotonic = time.monotonic() + 30.0
-        return stub
-
-    # rank0 timed out with only the admission FPM; rank1 got both.
-    stub0 = build(0, rank0, [_steady_fpm(126, 2, rank=0)])
-    stub1 = build(1, rank1, [_steady_fpm(126, 2, rank=1), _steady_fpm(128, 2, rank=1)])
-
-    errors: dict[int, Exception] = {}
-
-    def save(rank, stub):
-        try:
-            InstrumentedScheduler._bench_save_current_point(stub)
-        except Exception as error:  # pragma: no cover - failure diagnostics
-            errors[rank] = error
-
-    follower = threading.Thread(target=save, args=(1, stub1))
-    follower.start()
-    try:
-        save(0, stub0)
-        follower.join(timeout=10)
-        assert not follower.is_alive(), "rank1 deadlocked in collect_result"
-    finally:
-        rank1.close()
-        rank0.close()
-
-    assert errors == {}
-    for stub in (stub0, stub1):
-        assert stub._bench_results == []
-        assert [s.reason for s in stub._bench_skipped_points] == [
-            "measured_decode_context_mismatch"
-        ]
-
-
-def test_steady_fpm_gate_only_fires_for_two_step_decode_points():
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
-    stub._last_update_time = 100.0
-    stub._bench_current_point = BenchmarkPoint(point_type="decode")
-    stub._bench_expected_fpms = 2
-    stub._bench_current_fpms = [{"admission": True}]
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is True
+    stub._bench_current_point = point
+    stub._bench_decode_stage = _DecodeStage.RESIDENT
+    stub._bench_cleanup_requests = MagicMock()
+    stub._bench_skip_point = MagicMock()
+    stub._bench_drain_pending = False
+    output = SimpleNamespace(total_num_scheduled_tokens=1)
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "schedule",
+        MagicMock(return_value=output),
+    )
 
-    stub._bench_current_fpms = []  # admission FPM not recorded yet
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
-
-    stub._bench_current_fpms = [{"admission": True}]
-    stub._bench_expected_fpms = 1  # single-step point
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
-
-    stub._bench_expected_fpms = 2
-    stub._bench_current_point = BenchmarkPoint(point_type="prefill")
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
-
-    stub._bench_current_point = BenchmarkPoint(point_type="decode")
-    stub._last_update_time = 0.0  # previous update was an empty step
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
+    assert InstrumentedScheduler._bench_measure_resident_batch(stub) is output
+    stub._bench_cleanup_requests.assert_called_once_with()
+    stub._bench_skip_point.assert_called_once_with(point, "decode_measurement_failed")
+    assert stub._bench_current_point is None
+    assert stub._bench_drain_pending is True


### PR DESCRIPTION
## Summary

Fix vLLM decode self-benchmarking so the measured iteration uses the same resident cached-request path as normal production decode.

The current benchmark performs an admission pass followed by a second decode pass, but async drain frames can remove the synthetic requests from the GPU model runner's persistent input batch. The measured pass then re-adds every request, recopies prompt tokens, and rebuilds block-table rows.

This adds host work proportional to KV context length and causes the benchmark to overstate the marginal cost of cached tokens.

## Details

This PR changes the decode benchmark to an explicit state machine:

1. Admit the synthetic batch one token before the requested context.
2. Wait for admission to complete.
3. Preserve the active request IDs through async empty frames.
4. Use the parent scheduler to produce the measured resident decode step.
5. Record only that resident step's `ForwardPassMetrics`.

Retention-only empty frames carry active request IDs with zero scheduled-token counts. They perform no model work and use the base `Scheduler` post-schedule handling so `AsyncScheduler` does not create output placeholders for work that will never produce output. The retention map is removed before normal scheduler output processing, where zero token counts are invalid.

The measured pass is produced through `super().schedule(throttle_prefills=True)` instead of manually constructing a cached `SchedulerOutput`. This keeps benchmark behavior aligned with the production scheduling, allocation, connector, and bookkeeping paths.

The measured schedule timestamp is recorded after attention-DP synchronization, excluding admission and barrier waits. If the resident batch is preempted or no longer matches the requested shape, the existing generated-point skip and explicit-point failure policies apply.

### Why this matters

A controlled TP1 H100 benchmark with FP8 KV cache showed:

| Measurement state | Decode slope |
| --- | ---: |
| Second decode step without resident retention | 1.62 ns/KV token |
| Resident batch retained | 1.01 ns/KV token |
| Natural persistent decode | 0.96 ns/KV token |
| Attention kernels alone | 1.02 ns/KV token |

Component timing attributed the discrepancy to model-runner state rebuilding:

- `InputBatch.add_request`: removed a 0.513 ns/token contribution
- `_update_states`: reduced from 0.524 to 0.004 ns/token
- total host scaling: reduced from 0.576 to 0.055 ns/token

After retaining the batch, the synthetic benchmark, natural decode, and attention-kernel measurements agree at approximately 1 ns/KV token.

This is therefore a measurement-correctness fix rather than merely a benchmark optimization.

### Compatibility

This PR intentionally preserves the existing:

- `ForwardPassMetrics` wire schema
- benchmark-point schema
- attention-DP capacity negotiation and grid synchronization
- pipeline-parallel benchmark guard
- EAGLE and hybrid KV-cache handling
- connector metadata handling
- aggregate Welford metrics
- benchmark result schema

## Validation

- [ ] Sync engine scheduling records exactly one resident FPM per decode point.
- [ ] Async engine scheduling records exactly one resident FPM per decode point.
- [x] Admission passes are not recorded.
- [x] Retention frames perform no model work or async placeholder accounting.
- [x] Retention maps are removed before scheduler output processing.
- [x] The measured step uses the parent scheduler.
- [x] The measured batch size and KV coordinate match the benchmark point.
- [x] Preemption and timeout paths clean up correctly.
- [x] KV and EC connector metadata remains valid.
- [x] Attention-DP synchronization tests pass.
- [x] Existing instrumented-scheduler tests pass: `143 passed`.
- [x] Repository isort, Black, Flake8, Ruff, and pytest-marker hooks pass.

## Where should the reviewer start?

Start with:

- `components/src/dynamo/vllm/instrumented_scheduler.py`
  - the decode benchmark state transitions
  - the retention-only empty-output branch
  - resident scheduling and FPM selection
- `components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py`
  - async retention regression coverage
  - admission-versus-resident recording tests

## Related Issues

🚫 This PR is NOT linked to an issue:

- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decode benchmarking accuracy by measuring steady-state resident batches separately from request admission.
  * Corrected decode KV-read synchronization and context accounting.
  * Improved handling of retained requests, empty scheduling frames, and connector metadata.
  * Added safer behavior for benchmark timeouts, failed measurements, and drain scenarios.

* **Tests**
  * Expanded coverage for decode-stage transitions, resident measurement, padded allocations, and benchmark cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->