### PR TITLE
docs: sync router and planner reference pages to the shipped 1.4.0 behavior

### DIFF
--- a/docs/fern/backends/vllm/vllm-config-reference.mdx
+++ b/docs/fern/backends/vllm/vllm-config-reference.mdx
@@ -239,8 +239,8 @@ These flags control the self-benchmark sweep that runs on startup before the wor
   Environment variable: `DYN_BENCHMARK_OUTPUT_PATH`
 </ParamField>
 
-<ParamField path="--benchmark-timeout" type="integer" default="300">
-  Maximum seconds to wait for the benchmark to complete. Worker startup fails if this limit is exceeded.
+<ParamField path="--benchmark-timeout" type="integer" default="900">
+  Soft limit, in seconds, for the self-benchmark. Reaching it does not fail worker startup: the iteration being measured finishes, the partial results collected so far are returned, and engine startup continues. A bounded cleanup grace still fails closed if no result is written at all. Must be positive.
 
   Environment variable: `DYN_BENCHMARK_TIMEOUT`
 </ParamField>
@@ -248,6 +248,12 @@ These flags control the self-benchmark sweep that runs on startup before the wor
 ## Deprecated
 
 These flags are retained for backward compatibility and will be removed in a future release. Each is mapped to its replacement at startup with a deprecation warning.
+
+The five `--benchmark-*-granularity` flags below are read only when `--benchmark-mode` is set and `--benchmark-points-file` is not; otherwise they are ignored entirely, and none of the translation, range checking, or deprecation warnings described here takes place. Under those conditions each is translated to its replacement at startup, with a deprecation warning, and is accepted in the range 1 to 1024; a value outside it raises a `ValueError`. Because the four uniform-sampling limits need both endpoints of their axis, a legacy value of `1` maps to `2` for those flags.
+
+<Warning>
+With `--benchmark-mode` set and no points file, passing a legacy flag together with its replacement raises a `ValueError` at startup, for example `cannot combine --benchmark-decode-length-granularity with --decode-max-kv-read-token-samples`, and likewise for each of the other pairs. Migrate to the replacement rather than setting both. All five are ignored when `--benchmark-points-file` is set.
+</Warning>
 
 <ParamField path="--benchmark-prefill-granularity" type="integer" default="null" deprecated={true}>
   **Deprecated** — use `--prefill-max-new-token-samples`. Legacy values are translated to the new sampling limit.

--- a/docs/fern/backends/vllm/vllm-config-reference.mdx
+++ b/docs/fern/backends/vllm/vllm-config-reference.mdx
@@ -191,22 +191,40 @@ These flags control the self-benchmark sweep that runs on startup before the wor
   Environment variable: `DYN_BENCHMARK_MODE`
 </ParamField>
 
-<ParamField path="--benchmark-prefill-granularity" type="integer" default="16">
-  Number of ISL sample points for the prefill sweep.
+<ParamField path="--benchmark-points-file" type="string" default="null">
+  JSON file of explicit pure prefill/decode benchmark points, applied uniformly to every data-parallel rank. The file completely replaces generated grid sampling for the phases selected by `--benchmark-mode`, so the sampling limits below are ignored when it is set. It is read and normalized once before vLLM workers start, then the same contents are forwarded to every rank.
 
-  Environment variable: `DYN_BENCHMARK_PREFILL_GRANULARITY`
+  Environment variable: `DYN_BENCHMARK_POINTS_FILE`
 </ParamField>
 
-<ParamField path="--benchmark-decode-length-granularity" type="integer" default="6">
-  Number of context length sample points for the decode sweep.
+<ParamField path="--prefill-max-new-token-samples" type="integer" default="64">
+  Maximum number of iteration-total prefill new-token samples. If the CUDA-graph-aware axis has more points, points are selected uniformly across the sorted axis while always retaining its minimum and maximum. Must be at least 2.
 
-  Environment variable: `DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY`
+  Environment variable: `DYN_PREFILL_MAX_NEW_TOKEN_SAMPLES`
 </ParamField>
 
-<ParamField path="--benchmark-decode-batch-granularity" type="integer" default="6">
-  Number of batch size sample points per context length for the decode sweep.
+<ParamField path="--prefill-max-kv-read-token-samples" type="integer" default="16">
+  Maximum number of iteration-total prefill KV-read-token samples for each (new tokens, batch size) pair. If the block-aligned KV ladder has more points, points are selected uniformly while always retaining zero and the feasible maximum. Must be at least 2.
 
-  Environment variable: `DYN_BENCHMARK_DECODE_BATCH_GRANULARITY`
+  Environment variable: `DYN_PREFILL_MAX_KV_READ_TOKEN_SAMPLES`
+</ParamField>
+
+<ParamField path="--prefix-max-batch-size-samples" type="integer" default="3">
+  Maximum number of prefill request-batch-size samples for each new-token point. Keeps the first N values from the sorted power-of-two-plus-legal-maximum axis, so the default of 3 selects `[1, 2, 4]` when all three are legal. Must be positive.
+
+  Environment variable: `DYN_PREFIX_MAX_BATCH_SIZE_SAMPLES`
+</ParamField>
+
+<ParamField path="--decode-max-kv-read-token-samples" type="integer" default="128">
+  Maximum number of iteration-total decode KV-read-token samples for each batch size. If the KV ladder has more points, points are selected uniformly while always retaining its minimum and feasible maximum. Must be at least 2.
+
+  Environment variable: `DYN_DECODE_MAX_KV_READ_TOKEN_SAMPLES`
+</ParamField>
+
+<ParamField path="--decode-max-batch-size-samples" type="integer" default="128">
+  Maximum number of decode batch-size samples. If the CUDA-graph-aware axis has more points, points are selected uniformly while always retaining the minimum and feasible maximum. Must be at least 2.
+
+  Environment variable: `DYN_DECODE_MAX_BATCH_SIZE_SAMPLES`
 </ParamField>
 
 <ParamField path="--benchmark-warmup-iterations" type="integer" default="5">
@@ -230,6 +248,36 @@ These flags control the self-benchmark sweep that runs on startup before the wor
 ## Deprecated
 
 These flags are retained for backward compatibility and will be removed in a future release. Each is mapped to its replacement at startup with a deprecation warning.
+
+<ParamField path="--benchmark-prefill-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--prefill-max-new-token-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_PREFILL_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-prefill-kv-read-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--prefill-max-kv-read-token-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_PREFILL_KV_READ_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-prefill-batch-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--prefix-max-batch-size-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_PREFILL_BATCH_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-decode-length-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--decode-max-kv-read-token-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-decode-batch-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--decode-max-batch-size-samples`. Legacy values are translated to the new sampling limit.
+
+  Environment variable: `DYN_BENCHMARK_DECODE_BATCH_GRANULARITY`
+</ParamField>
 
 <ParamField path="--model-express-url" type="string" default="null" deprecated={true}>
   **Deprecated** — accepted for compatibility with older ModelExpress manifests only. The vLLM ModelExpress plugin reads its own configuration.

--- a/docs/fern/components/frontend/nvext.md
+++ b/docs/fern/components/frontend/nvext.md
@@ -108,9 +108,12 @@ cache-reuse behavior.
 
 The `nvext` protocol is enabled by default. To turn it off, set `DYN_DISABLE_FRONTEND_NVEXT` to a
 truthy value (`1`, `true`, `yes`, or `on`, case-insensitive). The frontend then drops
-`request.nvext` at handler entry, ignores the routing-override headers
-(`x-dynamo-worker-instance-id`, `x-dynamo-prefill-instance-id`, `x-dynamo-dp-rank`,
-`x-dynamo-prefill-dp-rank`), and ignores the response-side `extra_fields` opt-in. The top-level
+`request.nvext` at handler entry and ignores every routing-override header, along with the
+response-side `extra_fields` opt-in. That includes `x-tenant-id`, which is what sets
+`cache_salt`, so per-tenant cache isolation stops applying: requests fall back to unsalted
+hashing and can share cache entries across tenants. It also includes the worker and rank
+overrides (`x-dynamo-worker-instance-id`, `x-dynamo-prefill-instance-id`, `x-dynamo-dp-rank`,
+`x-dynamo-prefill-dp-rank`) and their aliases. The top-level
 backend-compatibility field is not part of the NvExt protocol. Cache salt is an isolation key,
 not an authentication or authorization mechanism;
 gateways must still authenticate the tenant identity they place in `x-tenant-id`.

--- a/docs/fern/components/frontend/nvext.md
+++ b/docs/fern/components/frontend/nvext.md
@@ -106,9 +106,13 @@ Empty strings are treated as absent. In particular, an empty `nvext.cache_salt` 
 non-empty top-level compatibility value. Requests without a salt retain the unsalted hashing and
 cache-reuse behavior.
 
-`DYN_ENABLE_FRONTEND_NVEXT=false` disables both the `nvext` form and routing-header overrides,
-including `x-tenant-id`. The top-level backend-compatibility field is not part of the NvExt
-protocol. Cache salt is an isolation key, not an authentication or authorization mechanism;
+The `nvext` protocol is enabled by default. To turn it off, set `DYN_DISABLE_FRONTEND_NVEXT` to a
+truthy value (`1`, `true`, `yes`, or `on`, case-insensitive). The frontend then drops
+`request.nvext` at handler entry, ignores the routing-override headers
+(`x-dynamo-worker-instance-id`, `x-dynamo-prefill-instance-id`, `x-dynamo-dp-rank`,
+`x-dynamo-prefill-dp-rank`), and ignores the response-side `extra_fields` opt-in. The top-level
+backend-compatibility field is not part of the NvExt protocol. Cache salt is an isolation key,
+not an authentication or authorization mechanism;
 gateways must still authenticate the tenant identity they place in `x-tenant-id`.
 
 Session identity is header-only. Use the coding-agent headers or Dynamo

--- a/docs/fern/components/planner/README.md
+++ b/docs/fern/components/planner/README.md
@@ -260,7 +260,7 @@ In advisory mode, the Planner still observes traffic and FPM data, computes reco
 Additional series support dashboards and offline analysis:
 
 - **Perf-model latency estimates:** `dynamo_planner_estimated_ttft_ms` and `dynamo_planner_estimated_itl_ms` reflect the maximum estimated TTFT and ITL from the engine perf model across engines.
-- **Engine capacity:** `dynamo_planner_engine_prefill_requests_per_second` and `dynamo_planner_engine_decode_requests_per_second` report single-engine prefill and decode capacity under the configured SLA.
+- **Engine capacity:** `dynamo_planner_engine_prefill_capacity_requests_per_second` and `dynamo_planner_engine_decode_capacity_requests_per_second` report single-engine prefill and decode capacity under the configured SLA.
 - **Scaling decision reasons:** `dynamo_planner_load_scaling_decision` and `dynamo_planner_throughput_scaling_decision` are Enum gauges whose state labels encode why each mode chose to scale, hold, or skip (for example `scale_up`, `no_fpm_data`, `set_lower_bound`).
 - **Per-engine FPM queue depths:** `dynamo_planner_engine_queued_prefill_tokens`, `dynamo_planner_engine_queued_decode_kv_tokens`, and `dynamo_planner_engine_inflight_decode_kv_tokens` are labeled with `worker_id` and `dp_rank` for each engine.
 

--- a/docs/fern/components/planner/planner-config-reference.mdx
+++ b/docs/fern/components/planner/planner-config-reference.mdx
@@ -298,7 +298,7 @@ These fields default from environment variables and are excluded from serialized
 </ParamField>
 
 <ParamField path="metric_pulling_prometheus_ca_bundle" type="string" default="env PROMETHEUS_CA_BUNDLE">
-  Path to a CA bundle for verifying the upstream Prometheus TLS certificate. No-op unless SSL verification is enabled. Must point to an existing file when set.
+  Path to a CA bundle for verifying the upstream Prometheus TLS certificate. When set, the bundle is used for verification regardless of `metric_pulling_prometheus_ssl_verify`. Must point to an existing file.
 </ParamField>
 
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">

--- a/docs/fern/components/planner/planner-examples.md
+++ b/docs/fern/components/planner/planner-examples.md
@@ -36,6 +36,7 @@ and OSL samples.
 For workloads with rapid changes, tune the Kalman filter:
 
 ```yaml
+optimization_target: sla  # Required: predictor tuning is inert without it
 load_predictor: kalman
 kalman_q_level: 2.0       # Higher = more responsive to level changes
 kalman_q_trend: 0.5       # Higher = trend changes faster
@@ -49,6 +50,7 @@ load_predictor_log1p: true  # Often helps with request-rate series
 For workloads with daily/weekly patterns:
 
 ```yaml
+optimization_target: sla  # Required: predictor tuning is inert without it
 load_predictor: prophet
 prophet_window_size: 100  # Larger window for seasonal detection
 load_predictor_log1p: true

--- a/docs/fern/components/planner/planner-examples.md
+++ b/docs/fern/components/planner/planner-examples.md
@@ -12,16 +12,20 @@ reference, see the [Planner Guide](planner-guide.md).
 
 ## Custom Load Predictors
 
+Each YAML block in this section is a standalone `PlannerConfig`. Save the block
+as `planner.yaml` and pass it to
+`python -m dynamo.planner --config planner.yaml`. To use the same fields in a
+DGDR, nest them under `spec.features.planner`.
+
 ### Warm-starting with Trace Data
 
 Pre-load predictors with historical request patterns before live traffic:
 
 ```yaml
-# In planner arguments
-args:
-  - --load-predictor arima
-  - --load-predictor-warmup-trace /data/trace.jsonl
-  - --load-predictor-log1p
+optimization_target: sla
+load_predictor: arima
+load_predictor_warmup_trace: /data/trace.jsonl
+load_predictor_log1p: true
 ```
 
 The trace file should be in mooncake-style JSONL format with request-count, ISL,
@@ -32,13 +36,12 @@ and OSL samples.
 For workloads with rapid changes, tune the Kalman filter:
 
 ```yaml
-args:
-  - --load-predictor kalman
-  - --kalman-q-level 2.0      # Higher = more responsive to level changes
-  - --kalman-q-trend 0.5      # Higher = trend changes faster
-  - --kalman-r 5.0            # Lower = trusts new measurements more
-  - --kalman-min-points 3     # Fewer points before forecasting starts
-  - --load-predictor-log1p    # Often helps with request-rate series
+load_predictor: kalman
+kalman_q_level: 2.0       # Higher = more responsive to level changes
+kalman_q_trend: 0.5       # Higher = trend changes faster
+kalman_r: 5.0             # Lower = trusts new measurements more
+kalman_min_points: 3      # Fewer points before forecasting starts
+load_predictor_log1p: true  # Often helps with request-rate series
 ```
 
 ### Prophet for Seasonal Workloads
@@ -46,10 +49,9 @@ args:
 For workloads with daily/weekly patterns:
 
 ```yaml
-args:
-  - --load-predictor prophet
-  - --prophet-window-size 100   # Larger window for seasonal detection
-  - --load-predictor-log1p
+load_predictor: prophet
+prophet_window_size: 100  # Larger window for seasonal detection
+load_predictor_log1p: true
 ```
 
 ## Virtual Connector

--- a/docs/fern/components/router/router-examples.md
+++ b/docs/fern/components/router/router-examples.md
@@ -295,6 +295,25 @@ For full documentation on implementing KV event publishing for custom inference 
 - **ZMQ relay**: For engines that emit raw KV events over ZMQ (like SGLang and vLLM), the same `KvEventPublisher` subscribes to the ZMQ socket and relays events automatically
 - API reference, event structure, ZMQ wire format, and best practices
 
+### Advertising a separate KV-state endpoint
+
+By default, consumers assume a worker's KV state is described by the same endpoint it serves
+requests on. Pass `kv_state_endpoint` to `WorkerConfig` when KV-state ownership lives somewhere
+other than the serving endpoint, so the two can be discovered independently:
+
+```python
+config = WorkerConfig(
+    namespace="dynamo",
+    component="backend",
+    endpoint="generate",
+    kv_state_endpoint="dynamo.kvstate.events",
+    model_name=model_name,
+)
+```
+
+Leave it unset for the common case. Existing deployments stay wire-compatible, since an unset
+value resolves to the serving endpoint.
+
 ## Global Router (Hierarchical Routing)
 
 For deployments with multiple worker pools, the **Global Router** enables hierarchical routing by sitting between the frontend and local routers. It selects the appropriate pool for each request based on configurable policies, supporting disaggregated topologies where pools are tuned for different workload characteristics.

--- a/docs/fern/components/router/router-guide.md
+++ b/docs/fern/components/router/router-guide.md
@@ -155,6 +155,7 @@ Disaggregated mode is activated automatically when prefill workers register alon
 - **[Router Operations](router-operations.md)**: Replicas, remote indexers, persistence, and recovery
 - **[Router Examples](router-examples.md)**: Python API usage, K8s examples, and custom routing patterns
 - **[Router Testing](router-testing.md)**: Recommended test layers for non-trivial router changes
+- **[Multi-DC KV Routing](multi-dc-kv-routing.md)**: Cross-datacenter KV routing and the DC Relay
 - **[Standalone Indexer](standalone-indexer.md)**: Run the KV indexer as a separate service
 - **[Standalone Selection Service](standalone-selection.md)**: Select workers and account for reservations without forwarding requests
 - **[Standalone Slot Tracker](standalone-slot-tracker.md)**: Run active-request accounting as a separate service

--- a/docs/fern/kubernetes/dgdr-reference.mdx
+++ b/docs/fern/kubernetes/dgdr-reference.mdx
@@ -465,7 +465,7 @@ These fields default from environment variables and are excluded from serialized
 </ParamField>
 
 <ParamField path="metric_pulling_prometheus_ca_bundle" type="string" default="env PROMETHEUS_CA_BUNDLE">
-  Path to a CA bundle for verifying the upstream Prometheus TLS certificate. No-op unless SSL verification is enabled. Must point to an existing file when set.
+  Path to a CA bundle for verifying the upstream Prometheus TLS certificate. When set, the bundle is used for verification regardless of `metric_pulling_prometheus_ssl_verify`. Must point to an existing file.
 </ParamField>
 
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">

--- a/docs/fern/reference/observability/metric-labels.mdx
+++ b/docs/fern/reference/observability/metric-labels.mdx
@@ -108,7 +108,13 @@ Added by an individual metric family. Each label appears only on the metrics not
 <ParamField path="status" type="string">
   `[Shared]` On `dynamo_component_kv_cache_events_applied` — the outcome of applying a KV cache event to the router's radix-tree index.
 
-  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>ok</Badge> <Badge intent="note" minimal>parent_block_not_found</Badge> <Badge intent="note" minimal>block_not_found</Badge> <Badge intent="note" minimal>invalid_block</Badge> <Badge intent="note" minimal>capacity_exhausted</Badge> <Badge intent="note" minimal>indexer_invariant_violation</Badge></span>
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>ok</Badge> <Badge intent="note" minimal>parent_block_not_found</Badge> <Badge intent="note" minimal>block_not_found</Badge> <Badge intent="note" minimal>invalid_block</Badge> <Badge intent="note" minimal>capacity_exhausted</Badge> <Badge intent="note" minimal>allocation_failed</Badge> <Badge intent="note" minimal>ownership_degree_overflow</Badge> <Badge intent="note" minimal>indexer_invariant_violation</Badge></span>
+</ParamField>
+
+<ParamField path="outcome" type="string">
+  `[Shared]` On `dynamo_kvrouter_ckf_mutation_total` — the block-level CKF mutation outcome, finer-grained than the event `status` above.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>unknown_remove</Badge> <Badge intent="note" minimal>capacity_exhausted</Badge></span>
 </ParamField>
 
 <ParamField path="event_type" type="string">

--- a/docs/fern/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/reference/observability/metrics-catalog.mdx
@@ -332,11 +332,11 @@ The frontend registers these metrics when queueing is enabled by `--router-queue
   KV cache events applied to the router's radix-tree index. Includes events applied to the device tier and lower tiers such as host-pinned memory and disk. Appears only when `--router-kv-overlap-score-credit` is greater than 0 and workers publish KV events. Labeled by `status` and `event_type` — see [Metric-specific labels](metric-labels.mdx#metric-specific-labels).
 </ParamField>
 
-<ParamField path="dynamo_kvrouter_ckf_mutation_total" type="counter">
+<ParamField path="dynamo_component_ckf_mutation_total" type="counter">
   CKF block-level mutation outcomes recorded by the router indexer, finer-grained than the event `status` on the counter above. Labeled by `outcome` — see [Metric-specific labels](metric-labels.mdx#metric-specific-labels).
 </ParamField>
 
-The standalone indexer exposes the device-tier-only counter `dynamo_kvrouter_kv_cache_events_applied`; see [Standalone KV Indexer](../../components/router/standalone-indexer.md).
+The standalone indexer exposes the device-tier-only counter `dynamo_kvrouter_kv_cache_events_applied` and the CKF counter as `dynamo_kvrouter_ckf_mutation_total`; see [Standalone KV Indexer](../../components/router/standalone-indexer.md).
 
 ### Availability by configuration
 

--- a/docs/fern/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/reference/observability/metrics-catalog.mdx
@@ -332,6 +332,10 @@ The frontend registers these metrics when queueing is enabled by `--router-queue
   KV cache events applied to the router's radix-tree index. Includes events applied to the device tier and lower tiers such as host-pinned memory and disk. Appears only when `--router-kv-overlap-score-credit` is greater than 0 and workers publish KV events. Labeled by `status` and `event_type` — see [Metric-specific labels](metric-labels.mdx#metric-specific-labels).
 </ParamField>
 
+<ParamField path="dynamo_kvrouter_ckf_mutation_total" type="counter">
+  CKF block-level mutation outcomes recorded by the router indexer, finer-grained than the event `status` on the counter above. Labeled by `outcome` — see [Metric-specific labels](metric-labels.mdx#metric-specific-labels).
+</ParamField>
+
 The standalone indexer exposes the device-tier-only counter `dynamo_kvrouter_kv_cache_events_applied`; see [Standalone KV Indexer](../../components/router/standalone-indexer.md).
 
 ### Availability by configuration


### PR DESCRIPTION
## Summary

Adapted port of #12975 (6571617) and #12979 (6572846) onto `release/1.4.0`. Closes both docs P0s.

## Why this is not a straight cherry-pick

Two reasons, both worth review attention:

1. **The docs tree was restructured on `main` after the branch cut** (#10855), so every path differs. `components/frontend/nvext.md` here is `pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md` there.
2. **Three of the four 6572846 items are release-branch-only.** They are already correct on `main` with no commit behind them, so there is nothing to pick — they are applied by hand here: the planner engine-capacity metric names, the Prometheus CA-bundle description in two files, and the planner CLI examples.

## 6571617 — router docs

| File | Change |
|---|---|
| `nvext.md` | `DYN_ENABLE_FRONTEND_NVEXT` does not exist. The switch is `DYN_DISABLE_FRONTEND_NVEXT` (`lib/runtime/src/config/environment_names.rs`), so following the old text was a silent no-op: `nvext` and the routing-override headers stayed active |
| `router-examples.md` | Document the `kv_state_endpoint` `WorkerConfig` parameter and its serving-endpoint default |
| `metrics-catalog.mdx` | Add `dynamo_kvrouter_ckf_mutation_total` |
| `metric-labels.mdx` | Add `allocation_failed` and `ownership_degree_overflow` (the list carried 6 of 8), plus the CKF `outcome` label |
| `router-guide.md` | Cross-link Multi-DC KV Routing, whose entry point was lost in the restructure |

## 6572846 — planner and vLLM docs

| File | Change |
|---|---|
| `planner/README.md` | Metrics are `engine_prefill_capacity_requests_per_second` and `engine_decode_capacity_requests_per_second`; the documented names never existed |
| `planner-config-reference.mdx`, `dgdr-reference.mdx` | The CA bundle applies **regardless of** `ssl_verify`, the opposite of what both pages said (`planner_config.py`) |
| `planner-examples.md` | The Planner main process takes `--config planner.yaml`, not the eight CLI flags the examples used. Converted to `PlannerConfig` YAML, matching main |
| `vllm-config-reference.mdx` | Document the six current benchmark sampling parameters with real defaults; demote the five `--benchmark-*-granularity` aliases, which `backend_args.py` registers as deprecated with `default=None` |

## Verification

Every item was checked against this branch's source before editing, and re-checked after. Documentation only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->