### PR TITLE
feat: add GMS v1 checkpoint lifecycle control

### DIFF
--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -21,6 +21,7 @@ if not HAS_GMS:
 from gpu_memory_service.cli import args as cli_args
 from gpu_memory_service.cli import runner, server
 from gpu_memory_service.cli.args import parse_args
+from gpu_memory_service.v1 import device as v1_device
 
 pytestmark = [
     pytest.mark.pre_merge,
@@ -70,6 +71,14 @@ def test_v1_cli_dispatches_cuda_only_child(monkeypatch, capsys):
     with pytest.raises(SystemExit):
         server.main(["--use-v1", "--device-type", "xpu"])
     assert "--use-v1 only supports --device-type=cuda" in capsys.readouterr().err
+
+
+def test_v1_socket_path_rejects_af_unix_overflow(monkeypatch):
+    monkeypatch.setenv("GMS_SOCKET_DIR", "/" + "s" * 200)
+    monkeypatch.setattr(v1_device, "get_device_uuid", lambda _device: "GPU-0")
+
+    with pytest.raises(ValueError, match="too long for AF_UNIX"):
+        v1_device.get_socket_path(0, "weights")
 
 
 class _Process:

--- a/lib/gpu_memory_service/tests/test_v1_checkpoint.py
+++ b/lib/gpu_memory_service/tests/test_v1_checkpoint.py
@@ -1,0 +1,328 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import ExitStack
+
+import pytest
+from _fake_vmm import FakeVMM
+from gpu_memory_service.common.locks import RequestedLockType
+from gpu_memory_service.v1 import cli
+from gpu_memory_service.v1.checkpoint import GMSCheckpointClient, GMSCheckpointLifecycle
+from gpu_memory_service.v1.client.session import _GMSClientSession
+from gpu_memory_service.v1.protocol import PrepareCheckpointRequest
+from gpu_memory_service.v1.server.rpc import GMSRPCServer, GMSServerMemoryManager
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+class _V1Owner:
+    def __init__(self, tmp_path):
+        self.lifecycle = GMSCheckpointLifecycle()
+        self.vmm = FakeVMM(granularity=64)
+        self.managers = {
+            domain: GMSServerMemoryManager(
+                "GPU-0",
+                self.vmm,
+                0,
+                checkpoint_lifecycle=self.lifecycle,
+            )
+            for domain in ("weights", "kv_cache")
+        }
+        self.lifecycle.bind_domains(self.managers)
+        self.paths = {
+            domain: str(tmp_path / f"{domain}.sock") for domain in self.managers
+        }
+        self._stack = ExitStack()
+        self.servers = {
+            domain: self._stack.enter_context(
+                GMSRPCServer(
+                    self.paths[domain],
+                    manager,
+                )
+            )
+            for domain, manager in self.managers.items()
+        }
+        self.threads = [
+            threading.Thread(target=server.serve_forever, daemon=True)
+            for server in self.servers.values()
+        ]
+        for thread in self.threads:
+            thread.start()
+
+    def close(self) -> None:
+        for server in self.servers.values():
+            server.shutdown()
+        self._stack.close()
+        for thread in self.threads:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+    def publish_weights(self) -> None:
+        writer = _GMSClientSession(self.paths["weights"], RequestedLockType.RW)
+        writer.allocate("weight-0", 64)
+        writer.commit()
+        writer.close()
+        self.wait_for_quiesced("weights")
+
+    def wait_for_quiesced(self, domain: str) -> None:
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            sessions = self.managers[domain].session_snapshot()
+            if not sessions.rw_sessions and not sessions.ro_sessions:
+                return
+            time.sleep(0.001)
+        raise TimeoutError(f"{domain} sessions did not quiesce")
+
+    def control(self, domain: str = "weights") -> GMSCheckpointClient:
+        return GMSCheckpointClient(self.paths[domain], timeout=2)
+
+
+@pytest.fixture
+def v1_owner(tmp_path):
+    owner = _V1Owner(tmp_path)
+    try:
+        yield owner
+    finally:
+        owner.close()
+
+
+@pytest.mark.timeout(10)
+def test_prepare_fences_both_domains_and_abort_is_retry_safe(v1_owner) -> None:
+    v1_owner.publish_weights()
+    control = v1_owner.control()
+
+    prepared = control.prepare()
+    assert prepared.state == "checkpoint_ready"
+    assert prepared.token
+
+    assert control.prepare() == prepared
+    for domain, lock_type in (
+        ("weights", RequestedLockType.RO),
+        ("kv_cache", RequestedLockType.RW),
+    ):
+        with pytest.raises(RuntimeError, match="admission is fenced"):
+            _GMSClientSession(v1_owner.paths[domain], lock_type)
+    assert v1_owner.control("kv_cache").state() == prepared
+    with pytest.raises(RuntimeError, match="does not match"):
+        control.abort("wrong-token")
+    assert control.state() == prepared
+
+    aborted = control.abort(prepared.token)
+    assert aborted.state == "serving"
+    assert aborted.token is None
+    assert control.abort(prepared.token) == aborted
+    with pytest.raises(RuntimeError, match="stale or already resolved"):
+        control.complete(prepared.token)
+
+    second = control.prepare()
+    assert second.token and second.token != prepared.token
+    with pytest.raises(RuntimeError, match="does not match"):
+        control.abort(prepared.token)
+    control.abort(second.token)
+
+
+@pytest.mark.timeout(10)
+def test_complete_is_retry_safe(v1_owner) -> None:
+    v1_owner.publish_weights()
+    control = v1_owner.control()
+    prepared = control.prepare()
+    assert prepared.token
+
+    completed = control.complete(prepared.token)
+    assert completed.state == "serving"
+    assert control.complete(prepared.token) == completed
+    with pytest.raises(RuntimeError, match="stale or already resolved"):
+        control.abort(prepared.token)
+
+
+@pytest.mark.timeout(10)
+def test_prepare_rejects_invalid_domain_and_session_state(
+    v1_owner, monkeypatch
+) -> None:
+    control = v1_owner.control()
+    with pytest.raises(RuntimeError, match="weights must be committed"):
+        control.prepare()
+
+    v1_owner.publish_weights()
+    reader = _GMSClientSession(v1_owner.paths["weights"], RequestedLockType.RO)
+    with pytest.raises(RuntimeError, match="weights has active or waiting sessions"):
+        control.prepare()
+
+    waiting_writer: list[_GMSClientSession] = []
+    writer_thread = threading.Thread(
+        target=lambda: waiting_writer.append(
+            _GMSClientSession(v1_owner.paths["weights"], RequestedLockType.RW)
+        ),
+        daemon=True,
+    )
+    writer_thread.start()
+    deadline = time.monotonic() + 2
+    while v1_owner.managers["weights"].session_snapshot().waiting_writers != 1:
+        if time.monotonic() >= deadline:
+            raise TimeoutError("writer did not enter the admission queue")
+        time.sleep(0.001)
+    with pytest.raises(RuntimeError, match="weights has active or waiting sessions"):
+        control.prepare()
+    reader.close()
+    writer_thread.join(timeout=2)
+    assert not writer_thread.is_alive()
+    waiting_writer.pop().close()
+    v1_owner.wait_for_quiesced("weights")
+    v1_owner.publish_weights()
+
+    kv_cache = v1_owner.managers["kv_cache"]
+    monkeypatch.setattr(
+        kv_cache,
+        "allocation_snapshot",
+        lambda: (("unexpected-kv", 64),),
+    )
+    with pytest.raises(RuntimeError, match="kv_cache must be empty"):
+        control.prepare()
+
+
+@pytest.mark.timeout(10)
+def test_prepare_rejects_committed_or_active_kv(v1_owner) -> None:
+    v1_owner.publish_weights()
+    control = v1_owner.control()
+    kv_writer = _GMSClientSession(v1_owner.paths["kv_cache"], RequestedLockType.RW)
+    kv_writer.allocate("kv-0", 64)
+    with pytest.raises(RuntimeError, match="kv_cache has active or waiting sessions"):
+        control.prepare()
+    kv_writer.commit()
+    kv_writer.close()
+    v1_owner.wait_for_quiesced("kv_cache")
+
+    with pytest.raises(RuntimeError, match="kv_cache must not be committed"):
+        control.prepare()
+
+
+@pytest.mark.timeout(10)
+def test_prepare_rejects_writer_reservation(v1_owner, monkeypatch) -> None:
+    v1_owner.publish_weights()
+    weights = v1_owner.managers["weights"]
+    clear_started = threading.Event()
+    clear_allowed = threading.Event()
+    original_clear = weights._sessions._clear_epoch
+
+    def blocked_clear() -> object:
+        clear_started.set()
+        assert clear_allowed.wait(5)
+        return original_clear()
+
+    monkeypatch.setattr(weights._sessions, "_clear_epoch", blocked_clear)
+    writers: list[_GMSClientSession] = []
+    writer_thread = threading.Thread(
+        target=lambda: writers.append(
+            _GMSClientSession(v1_owner.paths["weights"], RequestedLockType.RW)
+        ),
+        daemon=True,
+    )
+    writer_thread.start()
+    try:
+        assert clear_started.wait(5)
+        assert weights.session_snapshot().writer_reserved
+        with pytest.raises(
+            RuntimeError, match="weights has active or waiting sessions"
+        ):
+            v1_owner.control().prepare()
+    finally:
+        clear_allowed.set()
+    writer_thread.join(timeout=5)
+    assert not writer_thread.is_alive()
+    writers.pop().close()
+
+
+@pytest.mark.timeout(10)
+def test_handshake_racing_prepare_cannot_cross_the_fence(v1_owner) -> None:
+    v1_owner.publish_weights()
+    outcome: list[str] = []
+
+    with v1_owner.lifecycle.condition:
+        thread = threading.Thread(
+            target=_record_handshake,
+            args=(v1_owner, outcome),
+            daemon=True,
+        )
+        thread.start()
+        prepared = v1_owner.lifecycle.handle(PrepareCheckpointRequest())
+        assert prepared.state == "checkpoint_ready"
+
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert outcome == ["rejected"]
+
+
+def _record_handshake(v1_owner: _V1Owner, outcome: list[str]) -> None:
+    try:
+        session = _GMSClientSession(v1_owner.paths["weights"], RequestedLockType.RO)
+    except RuntimeError as exc:
+        if "admission is fenced" not in str(exc):
+            raise
+        outcome.append("rejected")
+        return
+    session.close()
+    outcome.append("admitted")
+
+
+def test_cli_composes_one_lifecycle_across_both_domains(monkeypatch) -> None:
+    servers = []
+
+    class _Server:
+        def __init__(self, path, manager):
+            self.path = path
+            self.manager = manager
+            self.checkpoint_lifecycle = manager.checkpoint_lifecycle
+            servers.append(self)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    monkeypatch.setattr(cli, "get_vmm", lambda: FakeVMM(granularity=64))
+    monkeypatch.setattr(cli.device_identity, "get_device_uuid", lambda _device: "GPU-0")
+    monkeypatch.setattr(
+        cli,
+        "get_socket_path",
+        lambda device, domain: f"/{device}-{domain}.sock",
+    )
+    monkeypatch.setattr(cli, "GMSRPCServer", _Server)
+    monkeypatch.setattr(cli, "run_servers", lambda _servers, _stop: None)
+    monkeypatch.setattr(cli.signal, "signal", lambda *_args: None)
+
+    cli.main(["--device", "0"])
+
+    assert [server.path for server in servers] == [
+        "/0-weights.sock",
+        "/0-kv_cache.sock",
+    ]
+    lifecycle = servers[0].checkpoint_lifecycle
+    assert servers[1].checkpoint_lifecycle is lifecycle
+    assert all(server.manager.checkpoint_lifecycle is lifecycle for server in servers)
+
+
+def test_bind_domains_rejects_a_different_lifecycle() -> None:
+    lifecycle = GMSCheckpointLifecycle()
+    other = GMSCheckpointLifecycle()
+    managers = {
+        domain: GMSServerMemoryManager(
+            "GPU-0",
+            FakeVMM(granularity=64),
+            0,
+            checkpoint_lifecycle=other,
+        )
+        for domain in ("weights", "kv_cache")
+    }
+
+    with pytest.raises(ValueError, match="must share their checkpoint lifecycle"):
+        lifecycle.bind_domains(managers)

--- a/lib/gpu_memory_service/tests/test_v1_memory_manager.py
+++ b/lib/gpu_memory_service/tests/test_v1_memory_manager.py
@@ -16,6 +16,12 @@ from gpu_memory_service.v1.server.rpc import GMSRPCServer, GMSServerMemoryManage
 pytestmark = [pytest.mark.pre_merge, pytest.mark.integration, pytest.mark.gpu_0]
 
 
+def _stop(server: GMSRPCServer, thread: threading.Thread) -> None:
+    server.shutdown()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+
 @pytest.mark.timeout(10)
 def test_same_client_manager_preserves_weights_and_recreates_kv(
     tmp_path,
@@ -26,15 +32,12 @@ def test_same_client_manager_preserves_weights_and_recreates_kv(
     }
     vmms = {domain: FakeVMM(granularity=64) for domain in paths}
     with ExitStack() as stack:
-        servers = {}
-        threads = {}
         for domain, path in paths.items():
             manager = GMSServerMemoryManager("GPU-0", vmms[domain], 0)
-            server = GMSRPCServer(path, manager)
+            server = stack.enter_context(GMSRPCServer(path, manager))
             thread = threading.Thread(target=server.serve_forever, daemon=True)
             thread.start()
-            servers[domain] = stack.enter_context(server)
-            threads[domain] = thread
+            stack.callback(_stop, server, thread)
 
         identity_events = []
         physical_uuid = ["GPU-0"]
@@ -106,8 +109,45 @@ def test_same_client_manager_preserves_weights_and_recreates_kv(
         with pytest.raises(RuntimeError, match="sidecar is on another physical GPU"):
             weights.connect(RequestedLockType.RO)
         kv_cache.close()
-        for server in servers.values():
-            server.shutdown()
-        for thread in threads.values():
-            thread.join(timeout=10)
-            assert not thread.is_alive()
+
+
+def test_identity_mismatch_wins_when_session_close_fails(monkeypatch) -> None:
+    class _Session:
+        identity = ("nonce", "GPU-1")
+
+        def close(self) -> None:
+            raise ConnectionError("close failed")
+
+    monkeypatch.setattr(device_identity, "invalidate_device_uuid_cache", lambda: None)
+    monkeypatch.setattr(device_identity, "get_device_uuid", lambda _device: "GPU-0")
+    manager = GMSClientMemoryManager(
+        "/unused.sock",
+        FakeVMM(granularity=64),
+        0,
+        session_factory=lambda *_args: _Session(),
+    )
+
+    with pytest.raises(RuntimeError, match="sidecar is on another physical GPU"):
+        manager.connect(RequestedLockType.RO)
+
+
+def test_latched_failure_raises_fresh_exceptions(monkeypatch) -> None:
+    monkeypatch.setattr(device_identity, "invalidate_device_uuid_cache", lambda: None)
+    monkeypatch.setattr(device_identity, "get_device_uuid", lambda _device: "GPU-0")
+
+    def fail_session(*_args):
+        raise ConnectionError("boom")
+
+    manager = GMSClientMemoryManager(
+        "/unused.sock",
+        FakeVMM(granularity=64),
+        0,
+        session_factory=fail_session,
+    )
+
+    with pytest.raises(RuntimeError) as first:
+        manager.connect(RequestedLockType.RO)
+    with pytest.raises(RuntimeError) as second:
+        manager.connect(RequestedLockType.RO)
+    assert first.value is not second.value
+    assert str(first.value) == str(second.value)

--- a/lib/gpu_memory_service/tests/test_v1_parameter_storage.py
+++ b/lib/gpu_memory_service/tests/test_v1_parameter_storage.py
@@ -56,6 +56,8 @@ def test_copy_out_preserves_tensorimpls_and_nonparameter_aliases() -> None:
         (4,),
         (1,),
     )
+    outside = torch.arange(8, dtype=torch.float32)
+    outside_storage = int(outside.untyped_storage()._cdata)
     del source
 
     mapping = LocalMapping(
@@ -120,6 +122,8 @@ def test_copy_out_preserves_tensorimpls_and_nonparameter_aliases() -> None:
     )
     assert int(workspace.untyped_storage()._cdata) != original_storage
     assert workspace.untyped_storage()._cdata != model.disjoint.untyped_storage()._cdata
+    assert int(outside.untyped_storage()._cdata) == outside_storage
+    assert outside.tolist() == list(map(float, range(8)))
     assert model.weight.tolist() == list(map(float, range(32)))
     assert model.overlap.tolist() == list(map(float, range(8, 24)))
     assert model.disjoint.tolist() == [48.0, 49.0, 50.0, 51.0]

--- a/lib/gpu_memory_service/tests/test_v1_protocol.py
+++ b/lib/gpu_memory_service/tests/test_v1_protocol.py
@@ -22,6 +22,7 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.none,
     pytest.mark.gpu_0,
+    pytest.mark.timeout(10),
 ]
 
 

--- a/lib/gpu_memory_service/tests/test_v1_server.py
+++ b/lib/gpu_memory_service/tests/test_v1_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import socket
+import stat
 import threading
 from time import monotonic
 
@@ -12,25 +13,46 @@ import pytest
 from _fake_vmm import FakeVMM
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.v1.client.session import _GMSClientSession
-from gpu_memory_service.v1.protocol import HandshakeRequest, send_message
+from gpu_memory_service.v1.protocol import (
+    AllocateRequest,
+    HandshakeRequest,
+    HandshakeResponse,
+    receive_message,
+    send_message,
+)
+from gpu_memory_service.v1.server import rpc as rpc_module
 from gpu_memory_service.v1.server.rpc import GMSRPCServer, GMSServerMemoryManager
 
 pytestmark = [pytest.mark.pre_merge, pytest.mark.integration, pytest.mark.gpu_0]
 
 
-def _serve(path: str, vmm: FakeVMM):
-    manager = GMSServerMemoryManager("GPU-0", vmm, 0)
-    server = GMSRPCServer(path, manager)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    return manager, server, thread
-
-
 def _stop(server: GMSRPCServer, thread: threading.Thread) -> None:
     server.shutdown()
     server.server_close()
-    thread.join(timeout=10)
+    thread.join(timeout=5)
     assert not thread.is_alive()
+
+
+@pytest.fixture
+def serve():
+    running: list[tuple[GMSRPCServer, threading.Thread]] = []
+
+    def start(path: str, vmm: FakeVMM) -> GMSServerMemoryManager:
+        manager = GMSServerMemoryManager("GPU-0", vmm, 0)
+        server = GMSRPCServer(path, manager)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        try:
+            thread.start()
+        except BaseException:
+            server.server_close()
+            raise
+        running.append((server, thread))
+        return manager
+
+    yield start
+
+    for server, thread in reversed(running):
+        _stop(server, thread)
 
 
 def _connect_in_thread(path: str, lock_type: RequestedLockType):
@@ -46,21 +68,77 @@ def _connect_in_thread(path: str, lock_type: RequestedLockType):
     return result, connected, thread
 
 
+def test_socket_has_private_mode_at_bind(tmp_path, monkeypatch) -> None:
+    path = str(tmp_path / "gms.sock")
+    modes_at_chmod: list[int] = []
+    chmod = rpc_module.os.chmod
+
+    def observe_chmod(socket_path: str, mode: int) -> None:
+        modes_at_chmod.append(stat.S_IMODE(os.stat(socket_path).st_mode))
+        chmod(socket_path, mode)
+
+    monkeypatch.setattr(rpc_module.os, "chmod", observe_chmod)
+    with GMSRPCServer(
+        path,
+        GMSServerMemoryManager("GPU-0", FakeVMM(granularity=64), 0),
+    ):
+        assert modes_at_chmod == [0o600]
+
+
 @pytest.mark.timeout(10)
-def test_client_waits_for_server_startup_and_deadlines_absent_socket(tmp_path) -> None:
+def test_connected_session_times_out_stalled_rpc(tmp_path) -> None:
+    path = str(tmp_path / "stalled.sock")
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(path)
+    listener.listen()
+    release = threading.Event()
+
+    def stall() -> None:
+        connection, _ = listener.accept()
+        with connection:
+            request, received_fd = receive_message(connection)
+            assert isinstance(request, HandshakeRequest)
+            assert received_fd < 0
+            send_message(
+                connection,
+                HandshakeResponse(GrantedLockType.RW, "nonce", "GPU-0"),
+            )
+            request, received_fd = receive_message(connection)
+            assert isinstance(request, AllocateRequest)
+            assert received_fd < 0
+            assert release.wait(5)
+
+    thread = threading.Thread(target=stall, daemon=True)
+    thread.start()
+    try:
+        session = _GMSClientSession(
+            path,
+            RequestedLockType.RW,
+            connect_timeout=0.2,
+        )
+        with pytest.raises(ConnectionError, match="AllocateRequest failed"):
+            session.allocate("stalled", 64)
+    finally:
+        release.set()
+        listener.close()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+
+@pytest.mark.timeout(10)
+def test_client_waits_for_server_startup_and_deadlines_absent_socket(
+    tmp_path, serve
+) -> None:
     path = str(tmp_path / "gms.sock")
     result, connected, client_thread = _connect_in_thread(path, RequestedLockType.RW)
     assert not connected.wait(0.1)
     assert client_thread.is_alive()
 
-    _manager, server, server_thread = _serve(path, FakeVMM(granularity=64))
-    try:
-        assert connected.wait(5)
-        result.pop().close()
-        client_thread.join(timeout=5)
-        assert not client_thread.is_alive()
-    finally:
-        _stop(server, server_thread)
+    serve(path, FakeVMM(granularity=64))
+    assert connected.wait(5)
+    result.pop().close()
+    client_thread.join(timeout=5)
+    assert not client_thread.is_alive()
 
     started_at = monotonic()
     with pytest.raises(ConnectionError, match="GMS sidecar socket"):
@@ -74,10 +152,10 @@ def test_client_waits_for_server_startup_and_deadlines_absent_socket(tmp_path) -
 
 
 @pytest.mark.timeout(10)
-def test_rw_close_waits_for_epoch_release(tmp_path, monkeypatch) -> None:
+def test_rw_close_waits_for_epoch_release(tmp_path, monkeypatch, serve) -> None:
     path = str(tmp_path / "gms.sock")
     vmm = FakeVMM(granularity=64)
-    _manager, server, server_thread = _serve(path, vmm)
+    serve(path, vmm)
     writer = _GMSClientSession(path, RequestedLockType.RW)
     writer.allocate("ephemeral", 64)
 
@@ -106,17 +184,17 @@ def test_rw_close_waits_for_epoch_release(tmp_path, monkeypatch) -> None:
     close_thread.join(timeout=5)
     assert not close_thread.is_alive()
     assert not vmm.server_handles
-    _stop(server, server_thread)
 
 
 @pytest.mark.timeout(10)
 def test_sessions_commit_share_prioritize_writer_and_release_on_disconnect(
     tmp_path,
     monkeypatch,
+    serve,
 ) -> None:
     path = str(tmp_path / "gms.sock")
     vmm = FakeVMM(granularity=64)
-    manager, server, server_thread = _serve(path, vmm)
+    manager = serve(path, vmm)
     first_writer = _GMSClientSession(path, RequestedLockType.RW)
     first_writer.allocate("aborted", 64)
 
@@ -193,4 +271,3 @@ def test_sessions_commit_share_prioritize_writer_and_release_on_disconnect(
     ):
         thread.join(timeout=5)
         assert not thread.is_alive()
-    _stop(server, server_thread)

--- a/lib/gpu_memory_service/v1/README.md
+++ b/lib/gpu_memory_service/v1/README.md
@@ -95,6 +95,20 @@ copy. Client import consumes and closes the received copy. The wire protocol is
 a small typed `msgspec.Struct` MessagePack protocol; there is no JSON
 compatibility path.
 
+## Checkpoint control
+
+After the engine has slept and both GMS domains are quiescent, an external
+controller calls `prepare`. The sidecar atomically requires committed weights
+with retained allocations and an empty, uncommitted KV-cache domain, then
+fences new admission across both domain sockets. A handshake that races the
+fence is rejected under V1's fail-stop contract.
+
+The fence has no expiry. `abort` and `complete` require the active opaque token
+and are retry-safe for the same resolution. Because control calls are one-shot,
+a replacement controller can call `state` to recover the active token before
+explicitly aborting or completing the checkpoint. Access to the mode-`0600`
+rank-local socket is the control-plane trust boundary.
+
 ## Cold weight storage
 
 The checkpoint saver with `--use-v1` connects RO to the rank-local `weights`

--- a/lib/gpu_memory_service/v1/checkpoint.py
+++ b/lib/gpu_memory_service/v1/checkpoint.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-wide checkpoint lifecycle and control client for GMS V1."""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import threading
+from collections.abc import Mapping
+from typing import Protocol
+from uuid import uuid4
+
+from gpu_memory_service.v1.protocol import (
+    AbortCheckpointRequest,
+    CheckpointControlRequest,
+    CheckpointStateResponse,
+    CompleteRestoreRequest,
+    ErrorResponse,
+    GetCheckpointStateRequest,
+    PrepareCheckpointRequest,
+    receive_message,
+    send_message,
+)
+from gpu_memory_service.v1.server.rpc import SessionSnapshot
+
+logger = logging.getLogger(__name__)
+
+_SERVING = "serving"
+_CHECKPOINT_READY = "checkpoint_ready"
+_WEIGHTS_DOMAIN = "weights"
+_KV_CACHE_DOMAIN = "kv_cache"
+
+
+class _CheckpointDomainManager(Protocol):
+    @property
+    def checkpoint_lifecycle(self) -> GMSCheckpointLifecycle | None:
+        ...
+
+    def session_snapshot(self) -> SessionSnapshot:
+        ...
+
+    def allocation_snapshot(self) -> tuple[tuple[str, int], ...]:
+        ...
+
+
+class GMSCheckpointLifecycle:
+    """Fence both V1 domains while an external controller snapshots the owner."""
+
+    def __init__(self) -> None:
+        self.condition = threading.Condition(threading.RLock())
+        self._managers: Mapping[str, _CheckpointDomainManager] | None = None
+        self._state = _SERVING
+        self._generation = 0
+        self._token: str | None = None
+        self._last_resolution: tuple[str, str] | None = None
+
+    def bind_domains(self, managers: Mapping[str, _CheckpointDomainManager]) -> None:
+        """Bind exactly the weights and KV-cache managers sharing this lifecycle."""
+        if set(managers) != {_WEIGHTS_DOMAIN, _KV_CACHE_DOMAIN}:
+            raise ValueError("checkpoint lifecycle requires weights and kv_cache")
+        if any(
+            manager.checkpoint_lifecycle is not self for manager in managers.values()
+        ):
+            raise ValueError("checkpoint domains must share their checkpoint lifecycle")
+        with self.condition:
+            if self._managers is not None:
+                raise RuntimeError("checkpoint lifecycle domains are already bound")
+            self._managers = dict(managers)
+
+    def admission_allowed(self) -> bool:
+        """Return whether sessions may start, including re-entrant locked calls."""
+        with self.condition:
+            return self._state == _SERVING
+
+    def handle(self, request: CheckpointControlRequest) -> CheckpointStateResponse:
+        """Fence on prepare and apply tokened, retry-safe abort/complete requests."""
+        with self.condition:
+            if isinstance(request, PrepareCheckpointRequest):
+                return self._prepare()
+            if isinstance(request, AbortCheckpointRequest):
+                return self._resolve(request.token, "abort")
+            if isinstance(request, CompleteRestoreRequest):
+                return self._resolve(request.token, "complete")
+            if isinstance(request, GetCheckpointStateRequest):
+                return self._response()
+            raise RuntimeError(
+                f"unsupported checkpoint request {type(request).__name__}"
+            )
+
+    def _prepare(self) -> CheckpointStateResponse:
+        """Atomically require checkpoint-safe domains, then fence admission."""
+        if self._state == _CHECKPOINT_READY:
+            return self._response()
+
+        managers = self._require_managers()
+        weights = managers[_WEIGHTS_DOMAIN]
+        kv_cache = managers[_KV_CACHE_DOMAIN]
+        weights_sessions = weights.session_snapshot()
+        kv_sessions = kv_cache.session_snapshot()
+        self._require_quiesced(_WEIGHTS_DOMAIN, weights_sessions)
+        self._require_quiesced(_KV_CACHE_DOMAIN, kv_sessions)
+        if not weights_sessions.committed:
+            raise RuntimeError("weights must be committed before checkpoint")
+        if kv_sessions.committed:
+            raise RuntimeError("kv_cache must not be committed before checkpoint")
+
+        weight_allocations = weights.allocation_snapshot()
+        kv_allocations = kv_cache.allocation_snapshot()
+        if not weight_allocations:
+            raise RuntimeError("weights must contain committed allocations")
+        if kv_allocations:
+            raise RuntimeError("kv_cache must be empty before checkpoint")
+
+        self._generation += 1
+        self._token = str(uuid4())
+        self._state = _CHECKPOINT_READY
+        self._last_resolution = None
+        self.condition.notify_all()
+        logger.info("GMS checkpoint generation %d is ready", self._generation)
+        return self._response()
+
+    def _resolve(self, token: str, resolution: str) -> CheckpointStateResponse:
+        if not token:
+            raise RuntimeError("checkpoint token must not be empty")
+        if self._state == _SERVING:
+            if self._last_resolution == (resolution, token):
+                return self._response()
+            raise RuntimeError("checkpoint token is stale or already resolved")
+        if token != self._token:
+            raise RuntimeError(
+                "checkpoint token does not match the prepared checkpoint"
+            )
+
+        self._state = _SERVING
+        self._token = None
+        self._last_resolution = (resolution, token)
+        self.condition.notify_all()
+        logger.info(
+            "GMS checkpoint generation %d resolved by %s",
+            self._generation,
+            resolution,
+        )
+        return self._response()
+
+    @staticmethod
+    def _require_quiesced(name: str, sessions: SessionSnapshot) -> None:
+        if (
+            sessions.rw_sessions
+            or sessions.ro_sessions
+            or sessions.waiting_writers
+            or sessions.writer_reserved
+        ):
+            raise RuntimeError(f"{name} has active or waiting sessions")
+
+    def _require_managers(self) -> Mapping[str, _CheckpointDomainManager]:
+        if self._managers is None:
+            raise RuntimeError("checkpoint lifecycle domains are not bound")
+        return self._managers
+
+    def _response(self) -> CheckpointStateResponse:
+        return CheckpointStateResponse(self._state, self._token)
+
+
+class GMSCheckpointClient:
+    """Issue bounded one-shot checkpoint-control requests through a domain socket."""
+
+    def __init__(self, path: str, *, timeout: float = 10.0):
+        if timeout <= 0:
+            raise ValueError("checkpoint control timeout must be positive")
+        self._path = path
+        self._timeout = timeout
+
+    def prepare(self) -> CheckpointStateResponse:
+        return self._call(PrepareCheckpointRequest())
+
+    def abort(self, token: str) -> CheckpointStateResponse:
+        return self._call(AbortCheckpointRequest(token))
+
+    def complete(self, token: str) -> CheckpointStateResponse:
+        return self._call(CompleteRestoreRequest(token))
+
+    def state(self) -> CheckpointStateResponse:
+        return self._call(GetCheckpointStateRequest())
+
+    def _call(self, request: CheckpointControlRequest) -> CheckpointStateResponse:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as control_socket:
+            control_socket.settimeout(self._timeout)
+            control_socket.connect(self._path)
+            send_message(control_socket, request)
+            response, received_fd = receive_message(control_socket)
+        if received_fd >= 0:
+            os.close(received_fd)
+            raise RuntimeError("checkpoint control returned an unexpected FD")
+        if isinstance(response, ErrorResponse):
+            raise RuntimeError(response.message)  # noqa: TRY004
+        if not isinstance(response, CheckpointStateResponse):
+            raise TypeError(f"checkpoint control returned {type(response).__name__}")
+        return response

--- a/lib/gpu_memory_service/v1/cli.py
+++ b/lib/gpu_memory_service/v1/cli.py
@@ -12,6 +12,7 @@ from threading import Event
 
 from gpu_memory_service.common.vmm import get_vmm
 from gpu_memory_service.v1 import device as device_identity
+from gpu_memory_service.v1.checkpoint import GMSCheckpointLifecycle
 from gpu_memory_service.v1.device import get_socket_path
 from gpu_memory_service.v1.server.rpc import GMSRPCServer, GMSServerMemoryManager
 
@@ -56,11 +57,22 @@ def main(argv: list[str] | None = None) -> None:
     vmm = get_vmm()
     gpu_uuid = device_identity.get_device_uuid(args.device)
     with ExitStack() as stack:
+        checkpoint_lifecycle = GMSCheckpointLifecycle()
+        managers = {
+            domain: GMSServerMemoryManager(
+                gpu_uuid,
+                vmm,
+                args.device,
+                checkpoint_lifecycle=checkpoint_lifecycle,
+            )
+            for domain in _DOMAINS
+        }
+        checkpoint_lifecycle.bind_domains(managers)
         servers = [
             stack.enter_context(
                 GMSRPCServer(
                     get_socket_path(args.device, domain),
-                    GMSServerMemoryManager(gpu_uuid, vmm, args.device),
+                    managers[domain],
                 )
             )
             for domain in _DOMAINS

--- a/lib/gpu_memory_service/v1/client/memory_manager.py
+++ b/lib/gpu_memory_service/v1/client/memory_manager.py
@@ -55,7 +55,7 @@ class GMSClientMemoryManager:
         self._session: _GMSClientSession | None = None
         self._mappings: dict[int, _InstalledMapping] = {}
         self._lock = threading.RLock()
-        self._failure: RuntimeError | None = None
+        self._failure: str | None = None
         self._vmm.ensure_initialized()
         self._granularity = int(self._vmm.get_allocation_granularity(device))
         if self._granularity <= 0:
@@ -80,7 +80,10 @@ class GMSClientMemoryManager:
                 device_uuid = device_identity.get_device_uuid(self._device)
                 session = self._session_factory(self._socket_path, lock_type)
                 if session.identity[1] != device_uuid:
-                    session.close()
+                    try:
+                        session.close()
+                    except Exception:
+                        logger.exception("GMS close failed after identity mismatch")
                     raise RuntimeError("GMS sidecar is on another physical GPU")
                 self._session = session
             except Exception as exc:
@@ -250,11 +253,11 @@ class GMSClientMemoryManager:
 
     def _check(self) -> None:
         if self._failure is not None:
-            raise self._failure
+            raise RuntimeError(self._failure)
 
     def _latch(self, message: str, cause: Exception) -> RuntimeError:
         if self._failure is None:
-            self._failure = RuntimeError(f"{message}: {cause}")
+            self._failure = f"{message}: {cause}"
         session = self._session
         self._session = None
         if session is not None:
@@ -262,4 +265,4 @@ class GMSClientMemoryManager:
                 session.close()
             except Exception:
                 logger.exception("GMS disconnect failed after operational failure")
-        return self._failure
+        return RuntimeError(self._failure)

--- a/lib/gpu_memory_service/v1/client/parameter_storage.py
+++ b/lib/gpu_memory_service/v1/client/parameter_storage.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import gc
 import math
+from bisect import bisect_right
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
@@ -47,7 +48,7 @@ if TYPE_CHECKING:
     from gpu_memory_service.v1.client.mapping import LocalMapping
 
 
-def tensor_storage_byte_bounds(tensor: "torch.Tensor") -> tuple[int, int]:
+def tensor_storage_byte_bounds(tensor: torch.Tensor) -> tuple[int, int]:
     """Return the bounding storage-relative byte range touched by a tensor."""
     element_size = int(tensor.element_size())
     start = int(tensor.storage_offset())
@@ -60,8 +61,8 @@ def tensor_storage_byte_bounds(tensor: "torch.Tensor") -> tuple[int, int]:
 
 
 def _rebind(
-    tensors: list["torch.Tensor"],
-    storage: "torch.UntypedStorage",
+    tensors: list[torch.Tensor],
+    storage: torch.UntypedStorage,
     source_start: int,
 ) -> None:
     with torch.inference_mode():
@@ -78,7 +79,7 @@ def _rebind(
 
 
 def _clone_storage_spans_and_rebind_tensors(
-    tensors: Iterable["torch.Tensor"],
+    tensors: Iterable[torch.Tensor],
 ) -> int:
     """Copy overlapping storage spans while preserving TensorImpls and aliases."""
     by_storage: dict[int, tuple[torch.UntypedStorage, dict[int, torch.Tensor]]] = {}
@@ -140,14 +141,11 @@ def _clone_storage_spans_and_rebind_tensors(
 def _iter_live_tensors(model: object):
     yield from model.parameters()
     for value in gc.get_objects():
-        if (
-            isinstance(type(value), torch._C._TensorMeta)
-            and value.layout is torch.strided
-        ):
+        if issubclass(type(value), torch.Tensor) and value.layout is torch.strided:
             yield value
 
 
-def _discover_live_tensors(model: object) -> list[tuple["torch.Tensor", bool]]:
+def _discover_live_tensors(model: object) -> list[tuple[torch.Tensor, bool]]:
     objects: dict[int, tuple[torch.Tensor, bool]] = {}
     for tensor in _iter_live_tensors(model):
         tensor_id = int(tensor._cdata)
@@ -163,31 +161,34 @@ def _discover_live_tensors(model: object) -> list[tuple["torch.Tensor", bool]]:
 
 
 def _containing_mapping(
-    tensor: "torch.Tensor",
-    mappings: tuple["LocalMapping", ...],
-) -> "LocalMapping | None":
+    tensor: torch.Tensor,
+    mappings: tuple[LocalMapping, ...],
+    mapping_bases: tuple[int, ...],
+) -> LocalMapping | None:
     storage = tensor.untyped_storage()
     storage_start = int(storage.data_ptr())
     storage_end = storage_start + int(storage.nbytes())
-    for mapping in mappings:
-        if (
-            mapping.base <= storage_start
-            and storage_end <= mapping.base + mapping.aligned_size
-        ):
-            return mapping
+    index = bisect_right(mapping_bases, storage_start) - 1
+    if index < 0:
+        return None
+    mapping = mappings[index]
+    if storage_end <= mapping.base + mapping.aligned_size:
+        return mapping
     return None
 
 
 def copy_non_parameter_tensors_to_default_allocator(
     model: object,
-    mappings: tuple["LocalMapping", ...],
+    mappings: tuple[LocalMapping, ...],
 ) -> tuple[int, int]:
     """Copy live non-Parameters out of GMS and return span/copy byte counts."""
     gc.collect()
+    mappings = tuple(sorted(mappings, key=lambda mapping: mapping.base))
+    mapping_bases = tuple(mapping.base for mapping in mappings)
     retained_parameter_spans: list[tuple[int, int]] = []
     non_parameters: list[torch.Tensor] = []
     for tensor, is_parameter in _discover_live_tensors(model):
-        if _containing_mapping(tensor, mappings) is None:
+        if _containing_mapping(tensor, mappings, mapping_bases) is None:
             continue
         if not is_parameter:
             non_parameters.append(tensor)

--- a/lib/gpu_memory_service/v1/client/session.py
+++ b/lib/gpu_memory_service/v1/client/session.py
@@ -59,6 +59,7 @@ class _GMSClientSession:
                 self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 try:
                     self._socket.connect(path)
+                    self._socket.settimeout(connect_timeout)
                     break
                 except (FileNotFoundError, ConnectionRefusedError) as cause:
                     self._socket.close()
@@ -82,10 +83,10 @@ class _GMSClientSession:
                 response, received_fd = receive_message(self._socket)
             except TimeoutError as cause:
                 raise ConnectionError(
-                    "Timed out waiting for GMS lock admission"
+                    "Timed out waiting for GMS handshake or lock admission"
                 ) from cause
             finally:
-                self._socket.settimeout(None)
+                self._socket.settimeout(connect_timeout)
             handshake = self._decode(
                 "handshake",
                 response,

--- a/lib/gpu_memory_service/v1/device.py
+++ b/lib/gpu_memory_service/v1/device.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from functools import cache
 from uuid import UUID
@@ -14,6 +15,8 @@ try:
     from cuda.bindings import driver as cuda
 except ImportError:
     cuda = None
+
+_AF_UNIX_PATH_LIMIT = 104 if sys.platform == "darwin" else 108
 
 
 def _check_cuda(result, operation: str) -> None:
@@ -61,7 +64,14 @@ def invalidate_device_uuid_cache() -> None:
 def get_socket_path(device: int, tag: str = "weights") -> str:
     """Return the V1 socket path for a CUDA-visible device and domain."""
     socket_dir = os.environ.get("GMS_SOCKET_DIR") or tempfile.gettempdir()
-    return os.path.join(
+    path = os.path.join(
         socket_dir,
         f"gms_{get_device_uuid(device)}_{tag}.sock",
     )
+    path_bytes = len(os.fsencode(path))
+    if path_bytes >= _AF_UNIX_PATH_LIMIT:
+        raise ValueError(
+            "GMS socket path is too long for AF_UNIX "
+            f"({path_bytes} bytes, limit {_AF_UNIX_PATH_LIMIT - 1}): {path}"
+        )
+    return path

--- a/lib/gpu_memory_service/v1/integrations/vllm/backend.py
+++ b/lib/gpu_memory_service/v1/integrations/vllm/backend.py
@@ -75,20 +75,24 @@ class GMSV1SleepModeBackend(SleepModeBackend):
 
     def __init__(self) -> None:
         super().__init__()
+        weights: GMSClientMemoryManager | None = None
+        kv_cache: GMSClientMemoryManager | None = None
         _reserve_allocator(self)
         try:
             self._device = torch.cuda.current_device()
             vmm = get_vmm()
-            self._weights = GMSClientMemoryManager(
+            weights = GMSClientMemoryManager(
                 get_socket_path(self._device, _WEIGHTS),
                 vmm,
                 self._device,
             )
-            self._kv_cache = GMSClientMemoryManager(
+            kv_cache = GMSClientMemoryManager(
                 get_socket_path(self._device, _KV_CACHE),
                 vmm,
                 self._device,
             )
+            self._weights = weights
+            self._kv_cache = kv_cache
             self._active_domain: ContextVar[str | None] = ContextVar(
                 "gms_v1_active_domain",
                 default=None,
@@ -115,7 +119,7 @@ class GMSV1SleepModeBackend(SleepModeBackend):
             self._free_callback = self._free
             _claim_allocator(self, self._malloc_callback, self._free_callback)
         except BaseException:
-            self._disconnect_after_failure()
+            self._disconnect_managers_after_failure(kv_cache, weights)
             _release_allocator_reservation(self)
             raise
 
@@ -162,12 +166,12 @@ class GMSV1SleepModeBackend(SleepModeBackend):
         try:
             gc.collect()
             self._raise_if_allocator_failed()
+            torch.cuda.empty_cache()
+            self._raise_if_allocator_failed()
             self._weights.unmap_all_vas()
             self._weights.disconnect()
             self._kv_cache.unmap_all_vas()
             self._kv_cache.disconnect()
-            torch.cuda.empty_cache()
-            self._raise_if_allocator_failed()
             self._state = "SUSPENDED"
         except Exception:  # noqa: BLE001
             common_utils.fail(
@@ -276,10 +280,13 @@ class GMSV1SleepModeBackend(SleepModeBackend):
             raise RuntimeError("allocator callback failed") from failure
 
     def _disconnect_after_failure(self) -> None:
-        for manager in (
-            getattr(self, "_kv_cache", None),
-            getattr(self, "_weights", None),
-        ):
+        self._disconnect_managers_after_failure(self._kv_cache, self._weights)
+
+    @staticmethod
+    def _disconnect_managers_after_failure(
+        *managers: GMSClientMemoryManager | None,
+    ) -> None:
+        for manager in managers:
             if manager is None:
                 continue
             try:

--- a/lib/gpu_memory_service/v1/protocol.py
+++ b/lib/gpu_memory_service/v1/protocol.py
@@ -62,6 +62,30 @@ class AbortRequest(msgspec.Struct, tag="abort_request", forbid_unknown_fields=Tr
     pass
 
 
+class PrepareCheckpointRequest(
+    msgspec.Struct, tag="prepare_checkpoint_request", forbid_unknown_fields=True
+):
+    pass
+
+
+class AbortCheckpointRequest(
+    msgspec.Struct, tag="abort_checkpoint_request", forbid_unknown_fields=True
+):
+    token: str
+
+
+class CompleteRestoreRequest(
+    msgspec.Struct, tag="complete_restore_request", forbid_unknown_fields=True
+):
+    token: str
+
+
+class GetCheckpointStateRequest(
+    msgspec.Struct, tag="get_checkpoint_state_request", forbid_unknown_fields=True
+):
+    pass
+
+
 class AllocationRecord(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     allocation_id: str
     aligned_size: int
@@ -83,6 +107,13 @@ class ListAllocationsResponse(
     allocations: tuple[AllocationRecord, ...]
 
 
+class CheckpointStateResponse(
+    msgspec.Struct, tag="checkpoint_state_response", forbid_unknown_fields=True
+):
+    state: str
+    token: str | None
+
+
 class ErrorResponse(msgspec.Struct, tag="error_response", forbid_unknown_fields=True):
     message: str
     out_of_memory: bool = False
@@ -96,10 +127,22 @@ Request: TypeAlias = (
     | CommitRequest
     | AbortRequest
 )
-Response: TypeAlias = (
-    SuccessResponse | ExportResponse | ListAllocationsResponse | ErrorResponse
+CheckpointControlRequest: TypeAlias = (
+    PrepareCheckpointRequest
+    | AbortCheckpointRequest
+    | CompleteRestoreRequest
+    | GetCheckpointStateRequest
 )
-Message: TypeAlias = HandshakeRequest | HandshakeResponse | Request | Response
+Response: TypeAlias = (
+    SuccessResponse
+    | ExportResponse
+    | ListAllocationsResponse
+    | CheckpointStateResponse
+    | ErrorResponse
+)
+Message: TypeAlias = (
+    HandshakeRequest | HandshakeResponse | Request | CheckpointControlRequest | Response
+)
 REQUEST_TYPES = (
     AllocateRequest,
     ExportRequest,
@@ -107,6 +150,12 @@ REQUEST_TYPES = (
     ListAllocationsRequest,
     CommitRequest,
     AbortRequest,
+)
+CHECKPOINT_CONTROL_TYPES = (
+    PrepareCheckpointRequest,
+    AbortCheckpointRequest,
+    CompleteRestoreRequest,
+    GetCheckpointStateRequest,
 )
 
 _encoder = msgspec.msgpack.Encoder()

--- a/lib/gpu_memory_service/v1/server/rpc.py
+++ b/lib/gpu_memory_service/v1/server/rpc.py
@@ -15,11 +15,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from time import monotonic
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.vmm import VMMDevice
 from gpu_memory_service.v1.protocol import (
+    CHECKPOINT_CONTROL_TYPES,
     REQUEST_TYPES,
     AbortRequest,
     AllocateRequest,
@@ -41,6 +43,9 @@ from gpu_memory_service.v1.protocol import (
     send_message,
 )
 from gpu_memory_service.v1.server.allocations import GMSAllocationManager
+
+if TYPE_CHECKING:
+    from gpu_memory_service.v1.checkpoint import GMSCheckpointLifecycle
 
 logger = logging.getLogger(__name__)
 
@@ -71,12 +76,34 @@ class ServerSession:
     mode: GrantedLockType
 
 
+@dataclass(frozen=True)
+class SessionSnapshot:
+    committed: bool
+    rw_sessions: int
+    ro_sessions: int
+    waiting_writers: int
+    writer_reserved: bool
+
+
 class GMSSessionManager:
     """Own lock admission, writer priority, publication, and crash cleanup."""
 
-    def __init__(self, clear_epoch: Callable[[], object]):
+    def __init__(
+        self,
+        clear_epoch: Callable[[], object],
+        *,
+        condition: threading.Condition | None = None,
+        admission_allowed: Callable[[], bool] | None = None,
+    ):
         self._clear_epoch = clear_epoch
-        self._condition = threading.Condition()
+        if (condition is None) != (admission_allowed is None):
+            raise ValueError(
+                "checkpoint condition and admission callback must be configured together"
+            )
+        self._condition = condition if condition is not None else threading.Condition()
+        self._admission_allowed = (
+            admission_allowed if admission_allowed is not None else lambda: True
+        )
         self._rw_session: ServerSession | None = None
         self._ro_sessions: set[ServerSession] = set()
         self._writer_reserved = False
@@ -92,10 +119,16 @@ class GMSSessionManager:
         deadline = monotonic() + timeout if timeout is not None else None
         if requested is RequestedLockType.RW:
             with self._condition:
+                self._require_admission()
                 self._waiting_writers += 1
                 try:
-                    if not self._wait_for(self._can_grant_rw, deadline, is_cancelled):
+                    if not self._wait_for(
+                        lambda: self._admission_allowed() and self._can_grant_rw(),
+                        deadline,
+                        is_cancelled,
+                    ):
                         return None
+                    self._require_admission()
                     if is_cancelled is not None and is_cancelled():
                         return None
                     self._reserve_writer()
@@ -105,14 +138,25 @@ class GMSSessionManager:
             return self._start_writer()
 
         with self._condition:
+            self._require_admission()
             if requested is RequestedLockType.RO:
-                if not self._wait_for(self._can_grant_ro, deadline, is_cancelled):
+                if not self._wait_for(
+                    lambda: self._admission_allowed() and self._can_grant_ro(),
+                    deadline,
+                    is_cancelled,
+                ):
                     return None
+                self._require_admission()
                 return self._start_reader()
             if requested is not RequestedLockType.RW_OR_RO:
                 raise RuntimeError(f"unsupported GMS lock type {requested.value}")
-            if not self._wait_for(self._can_grant_rw_or_ro, deadline, is_cancelled):
+            if not self._wait_for(
+                lambda: self._admission_allowed() and self._can_grant_rw_or_ro(),
+                deadline,
+                is_cancelled,
+            ):
                 return None
+            self._require_admission()
             if self._can_grant_ro():
                 return self._start_reader()
             if is_cancelled is not None and is_cancelled():
@@ -157,6 +201,20 @@ class GMSSessionManager:
     def is_active(self, session: ServerSession) -> bool:
         with self._condition:
             return session is self._rw_session or session in self._ro_sessions
+
+    def snapshot(self) -> SessionSnapshot:
+        with self._condition:
+            return SessionSnapshot(
+                committed=self._committed,
+                rw_sessions=int(self._rw_session is not None),
+                ro_sessions=len(self._ro_sessions),
+                waiting_writers=self._waiting_writers,
+                writer_reserved=self._writer_reserved,
+            )
+
+    def _require_admission(self) -> None:
+        if not self._admission_allowed():
+            raise RuntimeError("GMS admission is fenced for checkpoint")
 
     def _can_grant_rw(self) -> bool:
         return (
@@ -214,6 +272,7 @@ class GMSSessionManager:
         is_cancelled: Callable[[], bool] | None,
     ) -> bool:
         while True:
+            self._require_admission()
             if is_cancelled is not None and is_cancelled():
                 return False
             if predicate():
@@ -233,17 +292,41 @@ class GMSSessionManager:
 class GMSServerMemoryManager:
     """Own identity, lock admission, and physical allocations for one socket."""
 
-    def __init__(self, gpu_uuid: str, vmm: VMMDevice, device: int):
+    def __init__(
+        self,
+        gpu_uuid: str,
+        vmm: VMMDevice,
+        device: int,
+        *,
+        checkpoint_lifecycle: GMSCheckpointLifecycle | None = None,
+    ):
         if not gpu_uuid:
             raise ValueError("GPU UUID must not be empty")
         self._identity = (str(uuid4()), gpu_uuid)
         self._allocations = GMSAllocationManager(vmm, device)
         self._allocation_sizes: dict[str, int] = {}
-        self._sessions = GMSSessionManager(self._clear_allocations)
+        self._checkpoint_lifecycle = checkpoint_lifecycle
+        self._sessions = GMSSessionManager(
+            self._clear_allocations,
+            condition=(
+                checkpoint_lifecycle.condition
+                if checkpoint_lifecycle is not None
+                else None
+            ),
+            admission_allowed=(
+                checkpoint_lifecycle.admission_allowed
+                if checkpoint_lifecycle is not None
+                else None
+            ),
+        )
 
     @property
     def identity(self) -> tuple[str, str]:
         return self._identity
+
+    @property
+    def checkpoint_lifecycle(self) -> GMSCheckpointLifecycle | None:
+        return self._checkpoint_lifecycle
 
     def acquire(
         self,
@@ -288,6 +371,12 @@ class GMSServerMemoryManager:
     def close(self, session: ServerSession) -> None:
         self._sessions.close(session)
 
+    def session_snapshot(self) -> SessionSnapshot:
+        return self._sessions.snapshot()
+
+    def allocation_snapshot(self) -> tuple[tuple[str, int], ...]:
+        return tuple(sorted(self._allocation_sizes.items()))
+
     def _clear_allocations(self) -> int:
         cleared = self._allocations.clear()
         self._allocation_sizes.clear()
@@ -309,8 +398,19 @@ class _GMSRequestHandler(socketserver.BaseRequestHandler):
         session: ServerSession | None = None
         try:
             request = self._receive()
+            if isinstance(request, CHECKPOINT_CONTROL_TYPES):
+                lifecycle = self.server.checkpoint_lifecycle
+                if lifecycle is None:
+                    response = ErrorResponse("GMS checkpoint lifecycle is unavailable")
+                else:
+                    try:
+                        response = lifecycle.handle(request)
+                    except RuntimeError as exc:
+                        response = ErrorResponse(str(exc))
+                send_message(self.request, response)
+                return
             if not isinstance(request, HandshakeRequest):
-                raise RuntimeError("expected GMS handshake")
+                raise RuntimeError("expected GMS handshake")  # noqa: TRY004
             manager = self.server.manager
             if (
                 request.expected_identity is not None
@@ -321,10 +421,14 @@ class _GMSRequestHandler(socketserver.BaseRequestHandler):
                     ErrorResponse("GMS server incarnation or physical GPU changed"),
                 )
                 return
-            session = manager.acquire(
-                request.lock_type,
-                lambda: not _socket_is_alive(self.request),
-            )
+            try:
+                session = manager.acquire(
+                    request.lock_type,
+                    lambda: not _socket_is_alive(self.request),
+                )
+            except RuntimeError as exc:
+                send_message(self.request, ErrorResponse(str(exc)))
+                return
             if session is None:
                 return
             nonce, gpu_uuid = manager.identity
@@ -342,7 +446,7 @@ class _GMSRequestHandler(socketserver.BaseRequestHandler):
                 export_fd = -1
                 try:
                     if not isinstance(request, REQUEST_TYPES):
-                        raise RuntimeError(
+                        raise RuntimeError(  # noqa: TRY004
                             "handshake is valid only as the first message"
                         )
                     response, export_fd = manager.handle_request(session, request)
@@ -394,9 +498,18 @@ class GMSRPCServer(socketserver.ThreadingUnixStreamServer):
     def __init__(self, path: str, manager: GMSServerMemoryManager):
         self.path = path
         self.manager = manager
+        self.checkpoint_lifecycle = manager.checkpoint_lifecycle
         self._prepare_socket_path()
-        super().__init__(path, _GMSRequestHandler)
-        os.chmod(path, 0o600)
+        previous_umask = os.umask(0o177)
+        try:
+            super().__init__(path, _GMSRequestHandler)
+        finally:
+            os.umask(previous_umask)
+        try:
+            os.chmod(path, 0o600)
+        except BaseException:
+            self.server_close()
+            raise
 
     def _prepare_socket_path(self) -> None:
         if not os.path.exists(self.path):


### PR DESCRIPTION
## Overview:

Add a process-wide checkpoint lifecycle shared by the V1 weights and KV-cache domains. Fence new sessions once both domains are checkpoint-safe, and expose `prepare`, `state`, `abort`, and `complete` control RPCs for resolving the checkpoint lifecycle.

## Details:

- Add a process-wide checkpoint lifecycle shared by the V1 weights and KV-cache GMS servers.
- Add typed `prepare`, `state`, `abort`, and `complete` control RPCs.
- Require committed, quiescent weights and an empty, uncommitted KV cache before preparing a checkpoint.
- Fence new client admission across both domains while checkpoint state is unresolved.
- Use an opaque token to identify and resolve the active checkpoint attempt.
- Make `prepare` idempotent and make `abort` and `complete` retries safe for the active token.

## Where should the reviewer start?

Tests:

- `lib/gpu_memory_service/tests/test_v1_checkpoint.py::test_prepare_fences_both_domains_and_abort_is_retry_safe`
- `lib/gpu_memory_service/tests/test_v1_checkpoint.py::test_complete_is_retry_safe`
- `lib/gpu_memory_service/tests/test_v1_checkpoint.py::test_handshake_racing_prepare_cannot_cross_the_fence`

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental GMS V1 support for GPU memory management.
  * Added V1 command-line launch options and CUDA device validation.
  * Added checkpoint preparation, restore, abort, and lifecycle controls.
  * Added vLLM SleepMode integration for weight and KV-cache memory.
  * Added suspend and resume support with mapping restoration.
* **Documentation**
  * Added guidance covering V1 setup, operation, checkpointing, and launch commands.
* **Bug Fixes**
  * Improved connection handling, cleanup, validation, and recovery during memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->