### PR TITLE
fix(ci): sanitize truncated operator branch label

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -128,6 +128,9 @@ runs:
           BRANCH_SANITIZED="${BRANCH_SANITIZED/pull-request/pr}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED//./-}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED:0:10}"
+          while [[ "${BRANCH_SANITIZED}" =~ [^[:alnum:]]$ ]]; do
+            BRANCH_SANITIZED="${BRANCH_SANITIZED%?}"
+          done
           echo "namespace=gh-id-${{ github.run_id }}-${BRANCH_SANITIZED}-dt" >> "$GITHUB_OUTPUT"
           echo "namespace_suffix=${BRANCH_SANITIZED}" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
## Overview:

  Fixes a deterministic post-merge deployment failure on release branches such as `release/1.4.0`.

  The branch-name sanitizer truncated `release-1-4-0` to `release-1-`, which is invalid when used as the
  `dynamo.github/cleanup-key` Kubernetes label value.

  ## Details:

  After truncating the sanitized branch name to 10 characters, remove any trailing non-alphanumeric characters.

  This changes the failing value from `release-1-` to the valid label value `release-1`.

  ## Where should the reviewer start?

  Review `.github/actions/setup-dynamo-operator/action.yml`, specifically the branch-name sanitization in the `Resolve
  names` step.

  ## Validation:

  - Ran `pre-commit run --files .github/actions/setup-dynamo-operator/action.yml`.
  - Confirmed `release/1.4.0` resolves to `release-1`.
  - Confirmed `main`, `pull-request/12999`, and `release/10.4.0` continue to produce valid label values.

  ## Related Issues

  **🚫 This PR is NOT linked to an issue**:

  - [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch-based namespace naming by removing trailing non-alphanumeric characters after truncation.
  * Prevents malformed or invalid namespace suffixes in generated names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->