### PR TITLE
feat(kv-router): add router queue cancelled and force-expired lifecycle metrics

### DIFF
--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -397,6 +397,10 @@ class router:
     OVERLAP_BLOCKS_LOST = "router_overlap_blocks_lost"
     # Whether the router currently has a worker/dp_rank registered (1 = registered)
     WORKER_REGISTERED = "router_worker_registered"
+    # Total number of requests cancelled before admission while in or waiting for the router queue
+    QUEUE_CANCELLED_REQUESTS_TOTAL = "router_queue_cancelled_requests_total"
+    # Total number of requests force-expired by router sequence bookkeeping
+    FORCE_EXPIRED_REQUESTS_TOTAL = "router_force_expired_requests_total"
 
 
 class router_request:

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -871,6 +871,7 @@ impl<
             }
             unmanaged_request_ids.insert(cleanup.request_id);
         }
+        let mut cancelled_from_pending = 0;
         if !unmanaged_request_ids.is_empty() {
             for class_index in 0..self.profile.classes().len() {
                 let (removed, class_head_removed) =
@@ -882,10 +883,16 @@ impl<
                             .is_some_and(|request_id| unmanaged_request_ids.contains(request_id))
                     });
                 removed_ready_head |= class_head_removed;
+                cancelled_from_pending += removed.len();
                 for entry in removed {
                     self.subtract_pending_counters(class_index, entry.snapshot());
                 }
             }
+        }
+        if cancelled_from_pending > 0 {
+            self.slots
+                .publisher()
+                .record_cancelled_requests(self.slots.worker_type(), cancelled_from_pending);
         }
         made_ready || (removed_ready_head && self.has_dispatchable_ready_head())
     }
@@ -1165,6 +1172,9 @@ impl<
                 request_id = %sequence_request.request_id,
                 "Skipping scheduler booking for cancelled request"
             );
+            self.slots
+                .publisher()
+                .record_cancelled_requests(self.slots.worker_type(), 1);
             return false;
         }
 
@@ -1182,7 +1192,10 @@ impl<
             return true;
         }
 
-        tracing::debug!(%request_id, "Rolling back undelivered scheduler booking");
+        tracing::debug!(%request_id, "Rolling back undelivered scheduler booking after caller dropped");
+        self.slots
+            .publisher()
+            .record_cancelled_requests(self.slots.worker_type(), 1);
         if let Err(error) = self.slots.free(&request_id, Instant::now()) {
             tracing::error!(%request_id, %error, "Failed to roll back scheduler booking");
         }

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -123,6 +123,12 @@ pub trait SequencePublisher: Send + Sync {
 
     /// Observe that a worker/dp_rank was removed from the router.
     fn observe_worker_removed(&self, _worker: &WorkerWithDpRank, _worker_type: &str) {}
+
+    /// Record requests that were abandoned before admission (response path closed or queued entry pruned).
+    fn record_cancelled_requests(&self, _worker_type: &str, _count: usize) {}
+
+    /// Record requests that were force-expired by sequence bookkeeping.
+    fn record_force_expired_requests(&self, _worker_type: &str, _count: usize) {}
 }
 
 /// Admission failures reported by bounded active-sequence publisher queues.
@@ -918,6 +924,11 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         self.worker_type
     }
 
+    /// Get the publisher used for sequence events and metric observation.
+    pub fn publisher(&self) -> &Arc<P> {
+        &self.publisher
+    }
+
     /// Query all workers for the potential blocks and tokens.
     pub fn potential_blocks_and_tokens<const INCLUDE_ACTIVE_REQUESTS: bool>(
         &self,
@@ -1078,6 +1089,10 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 self.publish_worker_load_snapshot(slot.worker, load, now);
             }
         }
+        if removed_request_count > 0 {
+            self.publisher
+                .record_force_expired_requests(self.worker_type, removed_request_count);
+        }
         drop(table);
         let duration = now.elapsed();
         tracing::debug!(
@@ -1197,6 +1212,11 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             );
             break (outcome.expired_request_ids, load);
         };
+
+        if !expired_request_ids.is_empty() {
+            self.publisher
+                .record_force_expired_requests(self.worker_type, expired_request_ids.len());
+        }
 
         self.request_index
             .remove_requests(expired_request_ids.iter());

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -44,7 +44,8 @@
 //!
 //! See also: `docs/observability/metrics.md` (Router Metrics section).
 
-use std::sync::{Arc, LazyLock, OnceLock};
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use std::time::Duration;
 
 use dynamo_runtime::component::Component;
@@ -462,6 +463,70 @@ impl RouterWorkerStatusMetrics {
                 target_endpoint,
             ])
             .set(count as i64);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Router queue lifecycle metrics (component-scoped counters)
+// ---------------------------------------------------------------------------
+
+/// Component-scoped counters for requests that are cancelled before admission or
+/// force-expired by sequence bookkeeping in the router queue.
+pub(crate) struct RouterQueueLifecycleMetrics {
+    /// Total number of requests cancelled before admission while in or waiting for the router queue.
+    pub cancelled_requests_total: IntCounterVec,
+    /// Total number of requests force-expired by router sequence bookkeeping.
+    pub force_expired_requests_total: IntCounterVec,
+}
+
+static ROUTER_QUEUE_LIFECYCLE_METRICS: LazyLock<Mutex<HashMap<Component, Arc<RouterQueueLifecycleMetrics>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+impl RouterQueueLifecycleMetrics {
+    /// Create component-scoped queue lifecycle counters for router observability.
+    ///
+    /// These metrics are labeled by `worker_type` ("prefill", "decode", "aggregated")
+    /// so operators can distinguish cancellation/force-expiry behavior across pools.
+    pub fn from_component(component: &Component) -> Arc<Self> {
+        let mut cache = ROUTER_QUEUE_LIFECYCLE_METRICS.lock().unwrap();
+        cache.get(component).cloned().unwrap_or_else(|| {
+            let metrics = component.metrics();
+            let cancelled_requests_total = metrics
+                .create_intcountervec(
+                    router::QUEUE_CANCELLED_REQUESTS_TOTAL,
+                    "Total number of requests cancelled before admission while in or waiting for the router queue",
+                    &[labels::WORKER_TYPE],
+                    &[],
+                )
+                .expect("failed to create router_queue_cancelled_requests_total");
+            let force_expired_requests_total = metrics
+                .create_intcountervec(
+                    router::FORCE_EXPIRED_REQUESTS_TOTAL,
+                    "Total number of requests force-expired by router sequence bookkeeping",
+                    &[labels::WORKER_TYPE],
+                    &[],
+                )
+                .expect("failed to create router_force_expired_requests_total");
+
+            let metrics = Arc::new(Self {
+                cancelled_requests_total,
+                force_expired_requests_total,
+            });
+            cache.insert(component.clone(), Arc::clone(&metrics));
+            metrics
+        })
+    }
+
+    pub fn record_cancelled_requests(&self, worker_type: &str, count: usize) {
+        self.cancelled_requests_total
+            .with_label_values(&[worker_type])
+            .inc_by(count as u64);
+    }
+
+    pub fn record_force_expired_requests(&self, worker_type: &str, count: usize) {
+        self.force_expired_requests_total
+            .with_label_values(&[worker_type])
+            .inc_by(count as u64);
     }
 }
 
@@ -1341,6 +1406,70 @@ dynamo_frontend_router_queue_pending_requests{model=\"model\",policy_class=\"def
             Duration::from_millis(1),
         );
         // Reaching here without panic confirms saturating_sub works
+    }
+
+    #[test]
+    fn test_router_queue_lifecycle_metrics_pef() {
+        let registry = prometheus::Registry::new();
+        let cancelled = IntCounterVec::new(
+            Opts::new(
+                format!(
+                    "{}_{}",
+                    name_prefix::COMPONENT,
+                    router::QUEUE_CANCELLED_REQUESTS_TOTAL
+                ),
+                "Total number of requests cancelled before admission while in or waiting for the router queue",
+            ),
+            &[labels::WORKER_TYPE],
+        )
+        .unwrap();
+        let force_expired = IntCounterVec::new(
+            Opts::new(
+                format!(
+                    "{}_{}",
+                    name_prefix::COMPONENT,
+                    router::FORCE_EXPIRED_REQUESTS_TOTAL
+                ),
+                "Total number of requests force-expired by router sequence bookkeeping",
+            ),
+            &[labels::WORKER_TYPE],
+        )
+        .unwrap();
+        registry.register(Box::new(cancelled.clone())).unwrap();
+        registry.register(Box::new(force_expired.clone())).unwrap();
+
+        let metrics = RouterQueueLifecycleMetrics {
+            cancelled_requests_total: cancelled,
+            force_expired_requests_total: force_expired,
+        };
+
+        metrics.record_cancelled_requests("decode", 2);
+        metrics.record_cancelled_requests("prefill", 1);
+        metrics.record_force_expired_requests("decode", 3);
+
+        let output = gather_pef(&registry);
+        assert!(
+            output.contains("# HELP dynamo_component_router_queue_cancelled_requests_total"),
+            "PEF missing HELP for cancelled requests. Got:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_queue_cancelled_requests_total{worker_type=\"decode\"} 2"
+            ),
+            "PEF missing decode cancelled count. Got:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_queue_cancelled_requests_total{worker_type=\"prefill\"} 1"
+            ),
+            "PEF missing prefill cancelled count. Got:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_force_expired_requests_total{worker_type=\"decode\"} 3"
+            ),
+            "PEF missing force-expired count. Got:\n{output}"
+        );
     }
 
     #[test]

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -33,7 +33,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
-use super::metrics::{RouterWorkerStatusMetrics, WORKER_LOAD_METRICS};
+use super::metrics::{RouterQueueLifecycleMetrics, RouterWorkerStatusMetrics, WORKER_LOAD_METRICS};
 use crate::kv_router::{ACTIVE_SEQUENCES_SUBJECT, KV_METRICS_SUBJECT};
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 #[cfg(test)]
@@ -114,6 +114,7 @@ pub struct RuntimeSequencePublisher {
     event_sender: Option<ActiveSequenceEventSender>,
     metrics_publisher: Arc<EventPublisher>,
     worker_status_metrics: Arc<RouterWorkerStatusMetrics>,
+    queue_lifecycle_metrics: Arc<RouterQueueLifecycleMetrics>,
 }
 
 impl SequencePublisher for RuntimeSequencePublisher {
@@ -176,6 +177,16 @@ impl SequencePublisher for RuntimeSequencePublisher {
     fn observe_worker_removed(&self, worker: &WorkerWithDpRank, worker_type: &str) {
         self.worker_status_metrics
             .remove_worker(worker.worker_id, worker.dp_rank, worker_type);
+    }
+
+    fn record_cancelled_requests(&self, worker_type: &str, count: usize) {
+        self.queue_lifecycle_metrics
+            .record_cancelled_requests(worker_type, count);
+    }
+
+    fn record_force_expired_requests(&self, worker_type: &str, count: usize) {
+        self.queue_lifecycle_metrics
+            .record_force_expired_requests(worker_type, count);
     }
 }
 
@@ -427,11 +438,19 @@ pub async fn create_multi_worker_sequences(
     let metrics_publisher =
         Arc::new(EventPublisher::for_endpoint(&endpoint, KV_METRICS_SUBJECT).await?);
     let worker_status_metrics = RouterWorkerStatusMetrics::from_component(endpoint.component());
+    let queue_lifecycle_metrics = RouterQueueLifecycleMetrics::from_component(endpoint.component());
+    // Eagerly create the worker_type series for this router so the families
+    // appear in /metrics scrapes even before any cancellation or force-expiry
+    // event has occurred. Without this, an IntCounterVec with no children is
+    // omitted from Prometheus output, making the metric invisible at startup.
+    queue_lifecycle_metrics.record_cancelled_requests(worker_type, 0);
+    queue_lifecycle_metrics.record_force_expired_requests(worker_type, 0);
 
     let publisher = RuntimeSequencePublisher {
         event_sender,
         metrics_publisher,
         worker_status_metrics,
+        queue_lifecycle_metrics,
     };
 
     let dp_range: HashMap<u64, (u32, u32)> = workers_with_configs

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -657,6 +657,12 @@ pub mod router {
 
     /// Whether the router currently has a worker/dp_rank registered (1 = registered)
     pub const WORKER_REGISTERED: &str = "router_worker_registered";
+
+    /// Total number of requests cancelled before admission while in or waiting for the router queue
+    pub const QUEUE_CANCELLED_REQUESTS_TOTAL: &str = "router_queue_cancelled_requests_total";
+
+    /// Total number of requests force-expired by router sequence bookkeeping
+    pub const FORCE_EXPIRED_REQUESTS_TOTAL: &str = "router_force_expired_requests_total";
 }
 
 /// Frontend pipeline stage and event-loop metrics


### PR DESCRIPTION
## Overview:

Add two component-scoped Prometheus counters to the KV router so operators can observe requests that are cancelled before admission or force-expired by router sequence bookkeeping:

- `dynamo_component_router_queue_cancelled_requests_total{worker_type}`

- `dynamo_component_router_force_expired_requests_total{worker_type}`

Both counters are labeled by `worker_type` (`prefill`, `decode`, `aggregated`).

## Details:

Rust metrics (`lib/llm/src/kv_router/metrics.rs`)

- Added `RouterQueueLifecycleMetrics` struct with `IntCounterVec` for `cancelled_requests_total` and `force_expired_requests_total`

- Added PEF (Prometheus exposition format) unit test `test_router_queue_lifecycle_metrics_pef` to verify metric names and label values.

Metric name constants

`lib/runtime/src/metrics/prometheus_names.rs`: added `router::QUEUE_CANCELLED_REQUESTS_TOTAL` and `router::FORCE_EXPIRED_REQUESTS_TOTAL`.

## Where should the reviewer start?

1. `lib/runtime/src/metrics/prometheus_names.rs` - review the new two metrics name.
2. `lib/llm/src/kv_router/metrics.rs` - review the `RouterQueueLifecycleMetrics` and `test_router_queue_lifecycle_metrics_pef`
3. `lib/kv-router/src/scheduling/queue.rs` / `lib/kv-router/src/sequences/multi_worker.rs` / `lib/llm/src/kv_router/sequence.rs` — confirm the counters are incremented at the right lifecycle points.


## Validation

Verified locally using dynamo.frontend + dynamo.mocker for both new metrics:

- dynamo_component_router_queue_cancelled_requests_total

- dynamo_component_router_force_expired_requests_total

### Setup
Start mock workers (limit concurrency and slow down processing so requests queue/expire in the router):

```sh
python3 -m dynamo.mocker \
  --discovery-backend file \
  --model-path /root/.cache/models/Qwen3-0.6B/ \
  --disaggregation-mode prefill \
  --speedup-ratio 0.1 --max-num-seqs 1

python3 -m dynamo.mocker \
  --discovery-backend file \
  --model-path /root/.cache/models/Qwen3-0.6B/ \
  --disaggregation-mode decode \
  --speedup-ratio 0.1 --max-num-seqs 1
```

1. `router_queue_cancelled_requests_total`

Start frontend normally:
```sh
python3 -m dynamo.frontend --router-mode kv --discovery-backend file --http-port 8000
```

Send concurrent requests with short timeout so clients disconnect while requests are still queued, and check metric:
```sh 
curl -s http://127.0.0.1:8000/metrics | grep router_queue_cancelled
```
result shows:
```sh
dynamo_component_router_queue_cancelled_requests_total{dynamo_component="backend",dynamo_namespace="dynamo",worker_id="3af3e033b131080f",worker_type="decode"} 45
dynamo_component_router_queue_cancelled_requests_total{dynamo_component="prefill",dynamo_namespace="dynamo",worker_id="3af3e033b131080f",worker_type="prefill"} 0
```

2. `router_force_expired_requests_total`

Start frontend with a short active-request expiry:
```sh
DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS=10 \
python3 -m dynamo.frontend --router-mode kv --discovery-backend file --http-port 8000
```

Slow mock workers to extreme so a booked request never completes:
```sh
python3 -m dynamo.mocker ... --disaggregation-mode prefill --speedup-ratio 0.000001 --max-num-seqs 1
python3 -m dynamo.mocker ... --disaggregation-mode decode --speedup-ratio 0.000001 --max-num-seqs 1
```

Send a streaming request and keep the connection open,  Wait >10 seconds, then send a second request to trigger force_expiry(), and then check metric:

```sh
curl -s http://127.0.0.1:8000/metrics | grep router_force_expired
```

result shows:
```sh
dynamo_component_router_force_expired_requests_total{dynamo_component="prefill",dynamo_namespace="dynamo",worker_id="936d2dc44cbb1fe5",worker_type="prefill"} 1
dynamo_component_router_force_expired_requests_total{dynamo_component="backend",dynamo_namespace="dynamo",worker_id="936d2dc44cbb1fe5",worker_type="decode"} 0
```



### Result
- `dynamo_component_router_queue_cancelled_requests_total`:   Counter increments when clients disconnect while requests are in the router queue.

- `dynamo_component_router_force_expired_requests_total`: Counter increments when active requests exceed `DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS` and are cleaned up.


## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #13004 
- Related to #12301

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

