### PR TITLE
Add opt-in graceful shutdown hooks for dynamo_worker decorator

### DIFF
--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import os
+import signal
 import warnings
 from functools import wraps
 from typing import Any, AsyncGenerator, Callable, Optional, Type, Union
@@ -18,7 +19,7 @@ from dynamo._core import Endpoint as Endpoint
 from dynamo._core import PyAsyncRequestStream as PyAsyncRequestStream
 
 
-def dynamo_worker(enable_nats: Optional[bool] = None):
+def dynamo_worker(enable_nats: Optional[bool] = None, register_shutdown: bool = False):
     """
     Decorator that creates a DistributedRuntime and passes it to the worker function.
 
@@ -26,6 +27,7 @@ def dynamo_worker(enable_nats: Optional[bool] = None):
         enable_nats: Deprecated. NATS enablement is now determined automatically
             from the event-plane configuration. This parameter is accepted for
             backwards compatibility but will be removed in a future release.
+        register_shutdown: Boolean flag to gracefully shutdown a dynamo worker post SIGTERM, SIGINT.
     """
     if enable_nats is not None:
         warnings.warn(
@@ -43,7 +45,9 @@ def dynamo_worker(enable_nats: Optional[bool] = None):
             request_plane = os.environ.get("DYN_REQUEST_PLANE", "tcp")
             discovery_backend = os.environ.get("DYN_DISCOVERY_BACKEND", "etcd")
             runtime = DistributedRuntime(loop, discovery_backend, request_plane)
-
+            if register_shutdown:
+                for sig in (signal.SIGINT, signal.SIGTERM):
+                    loop.add_signal_handler(sig, runtime.shutdown)
             await func(runtime, *args, **kwargs)
 
         return wrapper

--- a/lib/bindings/python/tests/test_dynamo_worker_shutdown.py
+++ b/lib/bindings/python/tests/test_dynamo_worker_shutdown.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test the opt-in `register_shutdown` kwarg on the `dynamo_worker` decorator:
+
+- Default (`register_shutdown` omitted) leaves signal handling untouched.
+- `register_shutdown=True` registers SIGINT and SIGTERM handlers that call
+  the runtime's graceful shutdown path.
+- The option composes with the existing deprecated `enable_nats` kwarg.
+
+DistributedRuntime is mocked throughout so these tests don't need a real
+etcd/discovery backend or a live Tokio runtime.
+"""
+
+import asyncio
+import inspect
+import signal
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynamo.runtime import dynamo_worker
+
+pytestmark = [
+    pytest.mark.unit,
+]
+
+
+def test_dynamo_worker_accepts_register_shutdown_kwarg():
+    """dynamo_worker() should accept register_shutdown as an optional kwarg, defaulting to False."""
+    sig = inspect.signature(dynamo_worker)
+    assert "register_shutdown" in sig.parameters
+    param = sig.parameters["register_shutdown"]
+    assert param.default is False
+
+
+@patch("dynamo.runtime.DistributedRuntime")
+def test_dynamo_worker_default_does_not_register_shutdown_handlers(mock_runtime_cls):
+    """Omitting register_shutdown should not call add_signal_handler at all."""
+    mock_runtime_cls.return_value = MagicMock()
+
+    @dynamo_worker()
+    async def _worker(runtime):
+        pass
+
+    async def _run():
+        loop = asyncio.get_running_loop()
+        with patch.object(loop, "add_signal_handler") as mock_add_handler:
+            await _worker()
+        mock_add_handler.assert_not_called()
+
+    asyncio.run(_run())
+
+
+@patch("dynamo.runtime.DistributedRuntime")
+def test_dynamo_worker_register_shutdown_true_registers_both_signals(mock_runtime_cls):
+    """register_shutdown=True should register SIGINT and SIGTERM against runtime.shutdown."""
+    mock_runtime_instance = MagicMock()
+    mock_runtime_cls.return_value = mock_runtime_instance
+
+    @dynamo_worker(register_shutdown=True)
+    async def _worker(runtime):
+        return "ok"
+
+    async def _run():
+        loop = asyncio.get_running_loop()
+        with patch.object(loop, "add_signal_handler") as mock_add_handler:
+            await _worker()
+        return mock_add_handler
+
+    mock_add_handler = asyncio.run(_run())
+
+    registered_signals = {call.args[0] for call in mock_add_handler.call_args_list}
+    assert registered_signals == {signal.SIGINT, signal.SIGTERM}
+    for call in mock_add_handler.call_args_list:
+        assert call.args[1] == mock_runtime_instance.shutdown
+
+
+@patch("dynamo.runtime.DistributedRuntime")
+def test_dynamo_worker_register_shutdown_composes_with_enable_nats(mock_runtime_cls):
+    """register_shutdown=True should still work alongside the deprecated enable_nats kwarg."""
+    mock_runtime_cls.return_value = MagicMock()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+
+        @dynamo_worker(enable_nats=True, register_shutdown=True)
+        async def _worker(runtime):
+            return "ok"
+
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert len(deprecation_warnings) == 1
+    assert "enable_nats" in str(deprecation_warnings[0].message)
+
+    async def _run():
+        loop = asyncio.get_running_loop()
+        with patch.object(loop, "add_signal_handler") as mock_add_handler:
+            await _worker()
+        return mock_add_handler
+
+    mock_add_handler = asyncio.run(_run())
+    assert mock_add_handler.call_count == 2


### PR DESCRIPTION
## Summary

Adds an opt-in `register_shutdown: bool = False` parameter to the `dynamo_worker` decorator (`lib/bindings/python/src/dynamo/runtime/__init__.py`). When set to `True`, the worker startup path registers `SIGINT`/`SIGTERM` handlers that call `DistributedRuntime.shutdown()` (the runtime's existing graceful shutdown path), so Python-owned runtime startup paths can opt into responding to process signals instead of relying on external teardown alone.

```python
@dynamo_worker(register_shutdown=True)
async def worker(request):
    return {"ok": True}
```

- Default (`register_shutdown` omitted) is unchanged — no new handlers, no new warnings.
- Composes with the existing deprecated `enable_nats` kwarg.

## Test plan

- [x] `inspect.signature(dynamo_worker)` exposes `register_shutdown` with default `False`
- [x] `@dynamo_worker(register_shutdown=True)` registers both `SIGINT` and `SIGTERM` against `runtime.shutdown`
- [x] Default `@dynamo_worker()` path does not touch `add_signal_handler`
- [x] `register_shutdown=True` composes correctly with `enable_nats=True` (both take effect independently)
- [x] Added `lib/bindings/python/tests/test_dynamo_worker_shutdown.py`, all 4 tests passing
- [x] Pre-commit hooks (isort, black, flake8, codespell, etc.) passing

Fixes #12296
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional shutdown registration setting for Dynamo workers.
  * When enabled, workers now shut down cleanly in response to interrupt and termination signals.
  * The setting is disabled by default, preserving existing behavior.

* **Bug Fixes**
  * Preserved compatibility and deprecation warnings for the existing NATS configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->