### PR TITLE
test(router): add configuration CLI coverage

### DIFF
--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -90,6 +90,11 @@ class DynamoRuntimeConfig(ConfigBase):
             raise ValueError(
                 f"--engine-request-limit must be a positive integer, got {self.engine_request_limit}"
             )
+        if self.engine_request_limit is not None:
+            # The ingress pool is implemented in Rust and reads this setting
+            # directly from the process environment. Keep CLI and environment
+            # configuration behavior identical after argument resolution.
+            os.environ["DYN_ENGINE_REQUEST_LIMIT"] = str(self.engine_request_limit)
 
     def _validate_output_modalities(self) -> None:
         """Validate --output-modalities values."""

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -30,6 +30,15 @@ def _clear_rejection_threshold_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
+def _parse_kv_router_config(
+    argv: list[str],
+) -> tuple[KvRouterConfigBase, str]:
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+    args = parser.parse_args(argv)
+    return KvRouterConfigBase.from_cli_args(args), parser.format_help()
+
+
 def test_aic_perf_moe_cli_flows_to_binding_kwargs() -> None:
     parser = argparse.ArgumentParser()
     AicPerfArgGroup().add_arguments(parser)
@@ -296,19 +305,189 @@ def test_load_aware_preserves_cache_hit_weights() -> None:
     assert kwargs["disk_cache_hit_weight"] == 0.1
 
 
-def test_policy_config_cli_overrides_environment(
+def test_kv_router_operational_defaults_match_public_contract(monkeypatch) -> None:
+    for env_var in (
+        "DYN_ROUTER_EVENT_THREADS",
+        "DYN_ROUTER_QUEUE_POLICY",
+        "DYN_ROUTER_QUEUE_THRESHOLD",
+        "DYN_ROUTER_POLICY_CONFIG",
+        "DYN_ROUTER_HOST_CACHE_HIT_WEIGHT",
+        "DYN_ROUTER_DISK_CACHE_HIT_WEIGHT",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    config, help_text = _parse_kv_router_config([])
+    kwargs = config.kv_router_kwargs()
+
+    assert kwargs["router_event_threads"] == 4
+    assert kwargs["router_queue_policy"] == "fcfs"
+    assert kwargs["router_queue_threshold"] is None
+    assert kwargs["router_policy_config"] is None
+    assert kwargs["host_cache_hit_weight"] == 0.75
+    assert kwargs["disk_cache_hit_weight"] == 0.25
+    assert "--router-event-threads" in help_text
+    assert "--router-queue-policy" in help_text
+    assert "--router-policy-config" in help_text
+
+
+@pytest.mark.parametrize(
+    (
+        "env_var",
+        "flag",
+        "env_value",
+        "cli_value",
+        "field",
+        "expected_env",
+        "expected_cli",
+    ),
+    [
+        (
+            "DYN_ROUTER_EVENT_THREADS",
+            "--router-event-threads",
+            "2",
+            "1",
+            "router_event_threads",
+            2,
+            1,
+        ),
+        (
+            "DYN_ROUTER_QUEUE_POLICY",
+            "--router-queue-policy",
+            "wspt",
+            "fcfs",
+            "router_queue_policy",
+            "wspt",
+            "fcfs",
+        ),
+        (
+            "DYN_ROUTER_QUEUE_THRESHOLD",
+            "--router-queue-threshold",
+            "0.5",
+            "0.75",
+            "router_queue_threshold",
+            0.5,
+            0.75,
+        ),
+        (
+            "DYN_ROUTER_HOST_CACHE_HIT_WEIGHT",
+            "--router-host-cache-hit-weight",
+            "0.6",
+            "0.9",
+            "host_cache_hit_weight",
+            0.6,
+            0.9,
+        ),
+        (
+            "DYN_ROUTER_DISK_CACHE_HIT_WEIGHT",
+            "--router-disk-cache-hit-weight",
+            "0.2",
+            "0.4",
+            "disk_cache_hit_weight",
+            0.2,
+            0.4,
+        ),
+    ],
+    ids=[
+        "event-threads",
+        "queue-policy",
+        "queue-threshold",
+        "host-cache-weight",
+        "disk-cache-weight",
+    ],
+)
+def test_kv_router_cli_overrides_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    env_var: str,
+    flag: str,
+    env_value: str,
+    cli_value: str,
+    field: str,
+    expected_env: object,
+    expected_cli: object,
+) -> None:
+    monkeypatch.setenv(env_var, env_value)
+
+    env_config, _ = _parse_kv_router_config([])
+    cli_config, _ = _parse_kv_router_config([flag, cli_value])
+
+    assert env_config.kv_router_kwargs()[field] == expected_env
+    assert cli_config.kv_router_kwargs()[field] == expected_cli
+
+
+def test_policy_config_supports_environment_and_cli_precedence(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     env_policy_path = str(tmp_path / "env-policy.yaml")
     explicit_policy_path = str(tmp_path / "explicit-policy.yaml")
+    monkeypatch.delenv("DYN_ROUTER_POLICY_CONFIG", raising=False)
+
+    default_config, _ = _parse_kv_router_config([])
+    assert default_config.kv_router_kwargs()["router_policy_config"] is None
+
     monkeypatch.setenv("DYN_ROUTER_POLICY_CONFIG", env_policy_path)
+    env_config, _ = _parse_kv_router_config([])
+    assert env_config.kv_router_kwargs()["router_policy_config"] == env_policy_path
+
+    cli_config, _ = _parse_kv_router_config(
+        ["--router-policy-config", explicit_policy_path]
+    )
+    assert cli_config.kv_router_kwargs()["router_policy_config"] == explicit_policy_path
+
+
+def test_router_queue_policy_rejects_unknown_value(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_ROUTER_QUEUE_POLICY", raising=False)
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)
 
-    args = parser.parse_args(["--router-policy-config", explicit_policy_path])
-    config = KvRouterConfigBase.from_cli_args(args)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--router-queue-policy", "shortest-first"])
 
-    assert config.kv_router_kwargs()["router_policy_config"] == explicit_policy_path
+
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [
+        ("--router-max-tree-size", "1024"),
+        ("--router-prune-target-ratio", "0.5"),
+    ],
+)
+def test_frontend_rejects_removed_router_pruning_options(flag: str, value: str) -> None:
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([flag, value])
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (
+            ["--router-mode", "round-robin", "--serve-indexer"],
+            "--serve-indexer requires --router-mode=kv",
+        ),
+        (
+            [
+                "--router-mode",
+                "kv",
+                "--serve-indexer",
+                "--use-remote-indexer",
+            ],
+            "--serve-indexer and --use-remote-indexer are mutually exclusive",
+        ),
+    ],
+    ids=["serve-requires-kv", "local-and-remote-mutually-exclusive"],
+)
+def test_frontend_indexer_flag_constraints(
+    monkeypatch: pytest.MonkeyPatch, argv: list[str], message: str
+) -> None:
+    monkeypatch.delenv("DYN_SERVE_INDEXER", raising=False)
+    monkeypatch.delenv("DYN_USE_REMOTE_INDEXER", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(parser.parse_args(argv))
+
+    with pytest.raises(ValueError, match=message):
+        config.validate()
 
 
 def test_load_aware_clears_predicted_ttl() -> None:

--- a/components/src/dynamo/common/tests/configuration/test_runtime_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_runtime_args.py
@@ -51,6 +51,53 @@ def test_kv_state_endpoint_supports_cli_and_env(monkeypatch):
     assert "DYN_KV_STATE_ENDPOINT" in help_text
 
 
+def test_event_plane_documents_zmq_default_and_supports_cli_and_env(monkeypatch):
+    monkeypatch.delenv("DYN_EVENT_PLANE", raising=False)
+
+    default_config, help_text = _parse_runtime_args([])
+
+    assert default_config.event_plane is None
+    assert "defaults to 'zmq'" in help_text
+    assert "DYN_EVENT_PLANE" in help_text
+
+    monkeypatch.setenv("DYN_EVENT_PLANE", "nats")
+    env_config, _ = _parse_runtime_args([])
+    cli_config, _ = _parse_runtime_args(["--event-plane", "zmq"])
+
+    assert env_config.event_plane == "nats"
+    assert cli_config.event_plane == "zmq"
+
+
+def test_event_plane_rejects_unknown_value(monkeypatch):
+    monkeypatch.delenv("DYN_EVENT_PLANE", raising=False)
+
+    with pytest.raises(SystemExit):
+        _parse_runtime_args(["--event-plane", "invalid"])
+
+
+def test_engine_request_limit_supports_environment_and_cli_precedence(monkeypatch):
+    monkeypatch.setenv("DYN_ENGINE_REQUEST_LIMIT", "8")
+
+    env_config, help_text = _parse_runtime_args([])
+    assert env_config.engine_request_limit == 8
+    assert os.environ["DYN_ENGINE_REQUEST_LIMIT"] == "8"
+
+    cli_config, _ = _parse_runtime_args(["--engine-request-limit", "16"])
+    assert cli_config.engine_request_limit == 16
+    assert os.environ["DYN_ENGINE_REQUEST_LIMIT"] == "16"
+    assert "DYN_ENGINE_REQUEST_LIMIT" in help_text
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_engine_request_limit_rejects_non_positive_values(monkeypatch, limit):
+    monkeypatch.delenv("DYN_ENGINE_REQUEST_LIMIT", raising=False)
+
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        _parse_runtime_args(["--engine-request-limit", str(limit)])
+
+    assert "DYN_ENGINE_REQUEST_LIMIT" not in os.environ
+
+
 def test_fpm_trace_env_enables_and_is_canonicalized(monkeypatch):
     monkeypatch.setenv("DYN_FPM_TRACE", "on")
 

--- a/components/src/dynamo/router/tests/test_args.py
+++ b/components/src/dynamo/router/tests/test_args.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.router.args import parse_args
+
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
+_ENDPOINT = "dynamo.backend.generate"
+
+
+def test_standalone_router_rejects_local_and_remote_indexers(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_SERVE_INDEXER", raising=False)
+    monkeypatch.delenv("DYN_USE_REMOTE_INDEXER", raising=False)
+
+    with pytest.raises(
+        ValueError,
+        match="--serve-indexer and --use-remote-indexer are mutually exclusive",
+    ):
+        parse_args(
+            [
+                "--endpoint",
+                _ENDPOINT,
+                "--serve-indexer",
+                "--use-remote-indexer",
+            ]
+        )
+
+
+def test_standalone_router_rejects_conflicting_indexer_environment(monkeypatch) -> None:
+    monkeypatch.setenv("DYN_SERVE_INDEXER", "true")
+    monkeypatch.setenv("DYN_USE_REMOTE_INDEXER", "true")
+
+    with pytest.raises(
+        ValueError,
+        match="--serve-indexer and --use-remote-indexer are mutually exclusive",
+    ):
+        parse_args(["--endpoint", _ENDPOINT])


### PR DESCRIPTION
## Summary

- Add unit coverage for router and runtime configuration/CLI defaults, environment precedence, invalid values, removed flags, and indexer argument exclusivity.
- Add router CLI parsing coverage for endpoint, model, namespace, component, and routing-mode options.
- Propagate `--engine-request-limit` to `DYN_ENGINE_REQUEST_LIMIT` so the Rust ingress path receives the configured value.

## Why

The router's configuration and CLI contracts need direct upstream regression coverage. The engine request limit was parsed into Python configuration but not exported to the environment consumed by the Rust ingress path.

## Tracking

- [DYN-3840: Add upstream router configuration and CLI contract coverage](https://linear.app/nvidia/issue/DYN-3840/add-upstream-router-configuration-and-cli-contract-coverage)

## Validation

- 74 focused router/runtime configuration tests passed.
- Relevant pre-commit hooks passed, including formatting, lint, spelling, and pytest marker validation.