### PR TITLE
perf(frontend): flush detokenization metrics once

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -243,7 +243,7 @@ const DEFAULT_THINKING_MODE_RUNTIME_KEY: &str = "default_thinking_mode";
 /// frontend's own recordings (when present) take precedence over the forwarded values.
 fn drain_router_routing_data(
     data: &mut Option<BackendOutput>,
-    tracker: Option<&std::sync::Arc<crate::protocols::common::timing::RequestTracker>>,
+    tracker: Option<&crate::protocols::common::timing::RequestTracker>,
 ) {
     let Some(routing_data) = data.as_mut().and_then(|d| d.routing_data.take()) else {
         return;
@@ -3154,6 +3154,7 @@ impl OpenAIPreprocessor {
         {
             response_stream: Pin<Box<dyn Stream<Item = Annotated<BackendOutput>> + Send>>,
             response_generator: Box<dyn DeltaGeneratorExt<Resp>>,
+            tracker: Option<Arc<RequestTracker>>,
             context: Arc<dyn AsyncEngineContext>,
             cancelled: bool,
             cumulative_output_tokens: usize,
@@ -3170,9 +3171,26 @@ impl OpenAIPreprocessor {
             image_tokens: Option<usize>,
         }
 
+        impl<Resp> Drop for State<Resp>
+        where
+            Resp: Send + Sync + Clone + 'static + std::fmt::Debug,
+        {
+            fn drop(&mut self) {
+                let Some(tracker) = self.tracker.as_deref() else {
+                    return;
+                };
+                if let Some(total) = tracker.detokenize_total_latency() {
+                    DETOKENIZE_TOTAL_US.inc_by(total.as_micros() as f64);
+                }
+                DETOKENIZE_TOKEN_COUNT.inc_by(tracker.detokenize_count() as f64);
+            }
+        }
+
+        let tracker = generator.tracker();
         let state = State {
             response_stream: Box::pin(stream),
             response_generator: generator,
+            tracker,
             context: context.clone(),
             cancelled: false,
             cumulative_output_tokens: 0,
@@ -3213,10 +3231,7 @@ impl OpenAIPreprocessor {
                     // Split topology: overlay a standalone router's forwarded routing_data
                     // (timing, query-only token_ids) onto this request's tracker so the
                     // frontend's nvext/timing surfaces populate.
-                    drain_router_routing_data(
-                        &mut response.data,
-                        inner.response_generator.tracker().as_ref(),
-                    );
+                    drain_router_routing_data(&mut response.data, inner.tracker.as_deref());
 
                     if inner.cancelled {
                         tracing::debug!(
@@ -3278,17 +3293,15 @@ impl OpenAIPreprocessor {
 
                     // Create LLM metrics annotation with prefill/decode worker info from tracker.
                     // Worker types are stored at routing time to avoid expensive MDC lookup.
-                    let tracker = inner.response_generator.tracker();
-                    let prefill_worker_id = tracker.as_ref().and_then(|t| t.prefill_worker_id());
-                    let prefill_dp_rank = tracker.as_ref().and_then(|t| t.prefill_dp_rank());
+                    let tracker = inner.tracker.as_deref();
+                    let prefill_worker_id = tracker.and_then(|t| t.prefill_worker_id());
+                    let prefill_dp_rank = tracker.and_then(|t| t.prefill_dp_rank());
                     let prefill_worker_type = tracker
-                        .as_ref()
                         .and_then(|t| t.prefill_worker_type())
                         .map(String::from);
-                    let decode_worker_id = tracker.as_ref().and_then(|t| t.decode_worker_id());
-                    let decode_dp_rank = tracker.as_ref().and_then(|t| t.decode_dp_rank());
+                    let decode_worker_id = tracker.and_then(|t| t.decode_worker_id());
+                    let decode_dp_rank = tracker.and_then(|t| t.decode_dp_rank());
                     let decode_worker_type = tracker
-                        .as_ref()
                         .and_then(|t| t.decode_worker_type())
                         .map(String::from);
                     let llm_metrics = LLMMetricAnnotation {
@@ -3306,15 +3319,14 @@ impl OpenAIPreprocessor {
                         decode_worker_id,
                         decode_dp_rank,
                         decode_worker_type,
-                        tokenize_latency: tracker.as_ref().and_then(|t| t.tokenize_latency()),
+                        tokenize_latency: tracker.and_then(|t| t.tokenize_latency()),
                         detokenize_total_latency: tracker
-                            .as_ref()
                             .and_then(|t| t.detokenize_total_latency()),
-                        detokenize_count: tracker.as_ref().map(|t| t.detokenize_count()),
+                        detokenize_count: tracker.map(|t| t.detokenize_count()),
                     };
                     if inner.trace_tokens_enabled {
                         crate::request_trace::record_llm_metric_tokens(
-                            tracker.as_deref(),
+                            tracker,
                             isl,
                             current_osl,
                             None,
@@ -3340,36 +3352,24 @@ impl OpenAIPreprocessor {
                     // again. The stream is exhausted and will panic if polled after None.
                     inner.finished = true;
 
-                    // Flush per-request detokenize accumulators to global Prometheus counters
-                    // once, after the backend response stream completes.
-                    if let Some(t) = inner.response_generator.tracker().as_ref() {
-                        if let Some(total) = t.detokenize_total_latency() {
-                            DETOKENIZE_TOTAL_US.inc_by(total.as_micros() as f64);
-                        }
-                        DETOKENIZE_TOKEN_COUNT.inc_by(t.detokenize_count() as f64);
-                    }
-
                     if inner.finish_reason_sent && !inner.usage_chunk_sent {
                         inner.usage_chunk_sent = true;
 
                         let usage_chunk = inner.response_generator.create_usage_chunk();
                         let usage = inner.response_generator.get_usage();
-                        let tracker = inner.response_generator.tracker();
+                        let tracker = inner.tracker.as_deref();
                         let cached_tokens = usage
                             .prompt_tokens_details
                             .as_ref()
                             .and_then(|d| d.cached_tokens.map(|c| c as usize));
-                        let prefill_worker_id =
-                            tracker.as_ref().and_then(|t| t.prefill_worker_id());
-                        let prefill_dp_rank = tracker.as_ref().and_then(|t| t.prefill_dp_rank());
+                        let prefill_worker_id = tracker.and_then(|t| t.prefill_worker_id());
+                        let prefill_dp_rank = tracker.and_then(|t| t.prefill_dp_rank());
                         let prefill_worker_type = tracker
-                            .as_ref()
                             .and_then(|t| t.prefill_worker_type())
                             .map(String::from);
-                        let decode_worker_id = tracker.as_ref().and_then(|t| t.decode_worker_id());
-                        let decode_dp_rank = tracker.as_ref().and_then(|t| t.decode_dp_rank());
+                        let decode_worker_id = tracker.and_then(|t| t.decode_worker_id());
+                        let decode_dp_rank = tracker.and_then(|t| t.decode_dp_rank());
                         let decode_worker_type = tracker
-                            .as_ref()
                             .and_then(|t| t.decode_worker_type())
                             .map(String::from);
                         let llm_metrics = LLMMetricAnnotation {
@@ -3387,15 +3387,14 @@ impl OpenAIPreprocessor {
                             decode_worker_id,
                             decode_dp_rank,
                             decode_worker_type,
-                            tokenize_latency: tracker.as_ref().and_then(|t| t.tokenize_latency()),
+                            tokenize_latency: tracker.and_then(|t| t.tokenize_latency()),
                             detokenize_total_latency: tracker
-                                .as_ref()
                                 .and_then(|t| t.detokenize_total_latency()),
-                            detokenize_count: tracker.as_ref().map(|t| t.detokenize_count()),
+                            detokenize_count: tracker.map(|t| t.detokenize_count()),
                         };
                         if inner.trace_tokens_enabled {
                             crate::request_trace::record_llm_metric_tokens(
-                                tracker.as_deref(),
+                                tracker,
                                 Some(usage.prompt_tokens as usize),
                                 usage.completion_tokens as usize,
                                 cached_tokens,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -290,6 +290,41 @@ where
     attach_metrics_annotation(response, &metrics);
 }
 
+#[inline]
+fn build_llm_metric_annotation(
+    tracker: Option<&RequestTracker>,
+    input_tokens: usize,
+    output_tokens: usize,
+    chunk_tokens: usize,
+    cached_tokens: Option<usize>,
+    mm_counts: MultimodalCounts,
+    image_tokens: Option<usize>,
+) -> LLMMetricAnnotation {
+    LLMMetricAnnotation {
+        input_tokens,
+        output_tokens,
+        chunk_tokens,
+        cached_tokens,
+        image_count: mm_counts.image,
+        video_count: mm_counts.video,
+        audio_count: mm_counts.audio,
+        image_tokens,
+        prefill_worker_id: tracker.and_then(|t| t.prefill_worker_id()),
+        prefill_dp_rank: tracker.and_then(|t| t.prefill_dp_rank()),
+        prefill_worker_type: tracker
+            .and_then(|t| t.prefill_worker_type())
+            .map(String::from),
+        decode_worker_id: tracker.and_then(|t| t.decode_worker_id()),
+        decode_dp_rank: tracker.and_then(|t| t.decode_dp_rank()),
+        decode_worker_type: tracker
+            .and_then(|t| t.decode_worker_type())
+            .map(String::from),
+        tokenize_latency: tracker.and_then(|t| t.tokenize_latency()),
+        detokenize_total_latency: tracker.and_then(|t| t.detokenize_total_latency()),
+        detokenize_count: tracker.map(|t| t.detokenize_count()),
+    }
+}
+
 // Reasoning State for reasoning parsing transformation step.
 //
 // The reasoning parser and the guided-JSON bypass decision are kept per
@@ -3148,13 +3183,36 @@ impl OpenAIPreprocessor {
         S: Stream<Item = Annotated<BackendOutput>> + Send + 'static,
         Resp: Send + Sync + Clone + 'static + std::fmt::Debug,
     {
+        struct DetokenizeMetricsGuard {
+            tracker: Option<Arc<RequestTracker>>,
+        }
+
+        impl DetokenizeMetricsGuard {
+            #[inline]
+            fn tracker(&self) -> Option<&RequestTracker> {
+                self.tracker.as_deref()
+            }
+        }
+
+        impl Drop for DetokenizeMetricsGuard {
+            fn drop(&mut self) {
+                let Some(tracker) = self.tracker() else {
+                    return;
+                };
+                if let Some(total) = tracker.detokenize_total_latency() {
+                    DETOKENIZE_TOTAL_US.inc_by(total.as_micros() as f64);
+                }
+                DETOKENIZE_TOKEN_COUNT.inc_by(tracker.detokenize_count() as f64);
+            }
+        }
+
         struct State<Resp>
         where
             Resp: Send + Sync + Clone + 'static + std::fmt::Debug,
         {
             response_stream: Pin<Box<dyn Stream<Item = Annotated<BackendOutput>> + Send>>,
             response_generator: Box<dyn DeltaGeneratorExt<Resp>>,
-            tracker: Option<Arc<RequestTracker>>,
+            detokenize_metrics: DetokenizeMetricsGuard,
             context: Arc<dyn AsyncEngineContext>,
             cancelled: bool,
             cumulative_output_tokens: usize,
@@ -3171,26 +3229,11 @@ impl OpenAIPreprocessor {
             image_tokens: Option<usize>,
         }
 
-        impl<Resp> Drop for State<Resp>
-        where
-            Resp: Send + Sync + Clone + 'static + std::fmt::Debug,
-        {
-            fn drop(&mut self) {
-                let Some(tracker) = self.tracker.as_deref() else {
-                    return;
-                };
-                if let Some(total) = tracker.detokenize_total_latency() {
-                    DETOKENIZE_TOTAL_US.inc_by(total.as_micros() as f64);
-                }
-                DETOKENIZE_TOKEN_COUNT.inc_by(tracker.detokenize_count() as f64);
-            }
-        }
-
         let tracker = generator.tracker();
         let state = State {
             response_stream: Box::pin(stream),
             response_generator: generator,
-            tracker,
+            detokenize_metrics: DetokenizeMetricsGuard { tracker },
             context: context.clone(),
             cancelled: false,
             cumulative_output_tokens: 0,
@@ -3231,7 +3274,10 @@ impl OpenAIPreprocessor {
                     // Split topology: overlay a standalone router's forwarded routing_data
                     // (timing, query-only token_ids) onto this request's tracker so the
                     // frontend's nvext/timing surfaces populate.
-                    drain_router_routing_data(&mut response.data, inner.tracker.as_deref());
+                    drain_router_routing_data(
+                        &mut response.data,
+                        inner.detokenize_metrics.tracker(),
+                    );
 
                     if inner.cancelled {
                         tracing::debug!(
@@ -3293,37 +3339,16 @@ impl OpenAIPreprocessor {
 
                     // Create LLM metrics annotation with prefill/decode worker info from tracker.
                     // Worker types are stored at routing time to avoid expensive MDC lookup.
-                    let tracker = inner.tracker.as_deref();
-                    let prefill_worker_id = tracker.and_then(|t| t.prefill_worker_id());
-                    let prefill_dp_rank = tracker.and_then(|t| t.prefill_dp_rank());
-                    let prefill_worker_type = tracker
-                        .and_then(|t| t.prefill_worker_type())
-                        .map(String::from);
-                    let decode_worker_id = tracker.and_then(|t| t.decode_worker_id());
-                    let decode_dp_rank = tracker.and_then(|t| t.decode_dp_rank());
-                    let decode_worker_type = tracker
-                        .and_then(|t| t.decode_worker_type())
-                        .map(String::from);
-                    let llm_metrics = LLMMetricAnnotation {
-                        input_tokens: isl.unwrap_or(0),
-                        output_tokens: current_osl,
+                    let tracker = inner.detokenize_metrics.tracker();
+                    let llm_metrics = build_llm_metric_annotation(
+                        tracker,
+                        isl.unwrap_or(0),
+                        current_osl,
                         chunk_tokens,
-                        cached_tokens: None,
-                        image_count: inner.mm_counts.image,
-                        video_count: inner.mm_counts.video,
-                        audio_count: inner.mm_counts.audio,
-                        image_tokens: inner.image_tokens,
-                        prefill_worker_id,
-                        prefill_dp_rank,
-                        prefill_worker_type,
-                        decode_worker_id,
-                        decode_dp_rank,
-                        decode_worker_type,
-                        tokenize_latency: tracker.and_then(|t| t.tokenize_latency()),
-                        detokenize_total_latency: tracker
-                            .and_then(|t| t.detokenize_total_latency()),
-                        detokenize_count: tracker.map(|t| t.detokenize_count()),
-                    };
+                        None,
+                        inner.mm_counts,
+                        inner.image_tokens,
+                    );
                     if inner.trace_tokens_enabled {
                         crate::request_trace::record_llm_metric_tokens(
                             tracker,
@@ -3357,41 +3382,20 @@ impl OpenAIPreprocessor {
 
                         let usage_chunk = inner.response_generator.create_usage_chunk();
                         let usage = inner.response_generator.get_usage();
-                        let tracker = inner.tracker.as_deref();
+                        let tracker = inner.detokenize_metrics.tracker();
                         let cached_tokens = usage
                             .prompt_tokens_details
                             .as_ref()
                             .and_then(|d| d.cached_tokens.map(|c| c as usize));
-                        let prefill_worker_id = tracker.and_then(|t| t.prefill_worker_id());
-                        let prefill_dp_rank = tracker.and_then(|t| t.prefill_dp_rank());
-                        let prefill_worker_type = tracker
-                            .and_then(|t| t.prefill_worker_type())
-                            .map(String::from);
-                        let decode_worker_id = tracker.and_then(|t| t.decode_worker_id());
-                        let decode_dp_rank = tracker.and_then(|t| t.decode_dp_rank());
-                        let decode_worker_type = tracker
-                            .and_then(|t| t.decode_worker_type())
-                            .map(String::from);
-                        let llm_metrics = LLMMetricAnnotation {
-                            input_tokens: usage.prompt_tokens as usize,
-                            output_tokens: usage.completion_tokens as usize,
-                            chunk_tokens: 0,
+                        let llm_metrics = build_llm_metric_annotation(
+                            tracker,
+                            usage.prompt_tokens as usize,
+                            usage.completion_tokens as usize,
+                            0,
                             cached_tokens,
-                            image_count: inner.mm_counts.image,
-                            video_count: inner.mm_counts.video,
-                            audio_count: inner.mm_counts.audio,
-                            image_tokens: inner.image_tokens,
-                            prefill_worker_id,
-                            prefill_dp_rank,
-                            prefill_worker_type,
-                            decode_worker_id,
-                            decode_dp_rank,
-                            decode_worker_type,
-                            tokenize_latency: tracker.and_then(|t| t.tokenize_latency()),
-                            detokenize_total_latency: tracker
-                                .and_then(|t| t.detokenize_total_latency()),
-                            detokenize_count: tracker.map(|t| t.detokenize_count()),
-                        };
+                            inner.mm_counts,
+                            inner.image_tokens,
+                        );
                         if inner.trace_tokens_enabled {
                             crate::request_trace::record_llm_metric_tokens(
                                 tracker,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -3321,15 +3321,6 @@ impl OpenAIPreprocessor {
                         );
                     }
 
-                    // Flush per-request detokenize accumulators to global Prometheus counters
-                    // (once per request instead of per-token).
-                    if let Some(t) = tracker.as_ref() {
-                        if let Some(total) = t.detokenize_total_latency() {
-                            DETOKENIZE_TOTAL_US.inc_by(total.as_micros() as f64);
-                        }
-                        DETOKENIZE_TOKEN_COUNT.inc_by(t.detokenize_count() as f64);
-                    }
-
                     attach_llm_metrics(&mut response, llm_metrics);
 
                     // Mark if we've seen a finish_reason
@@ -3348,6 +3339,15 @@ impl OpenAIPreprocessor {
                     // Stream has ended - must set finished to true to prevent unfold from polling
                     // again. The stream is exhausted and will panic if polled after None.
                     inner.finished = true;
+
+                    // Flush per-request detokenize accumulators to global Prometheus counters
+                    // once, after the backend response stream completes.
+                    if let Some(t) = inner.response_generator.tracker().as_ref() {
+                        if let Some(total) = t.detokenize_total_latency() {
+                            DETOKENIZE_TOTAL_US.inc_by(total.as_micros() as f64);
+                        }
+                        DETOKENIZE_TOKEN_COUNT.inc_by(t.detokenize_count() as f64);
+                    }
 
                     if inner.finish_reason_sent && !inner.usage_chunk_sent {
                         inner.usage_chunk_sent = true;
@@ -3400,15 +3400,6 @@ impl OpenAIPreprocessor {
                                 usage.completion_tokens as usize,
                                 cached_tokens,
                             );
-                        }
-
-                        // Flush per-request detokenize accumulators to global Prometheus counters
-                        // (once per request instead of per-token).
-                        if let Some(t) = tracker.as_ref() {
-                            if let Some(total) = t.detokenize_total_latency() {
-                                DETOKENIZE_TOTAL_US.inc_by(total.as_micros() as f64);
-                            }
-                            DETOKENIZE_TOKEN_COUNT.inc_by(t.detokenize_count() as f64);
                         }
 
                         let usage_requested = inner.response_generator.is_usage_enabled();

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -329,6 +329,7 @@ pub trait DeltaGeneratorExt<ResponseType: Send + 'static + std::fmt::Debug>:
     fn get_usage(&self) -> dynamo_protocols::types::CompletionUsage;
 
     /// Returns the request tracker if available, for accessing worker timing metrics.
+    /// Implementors that own request timing data must override this method.
     fn tracker(&self) -> Option<std::sync::Arc<common::timing::RequestTracker>> {
         None
     }

--- a/lib/llm/tests/test_streaming_usage.rs
+++ b/lib/llm/tests/test_streaming_usage.rs
@@ -275,6 +275,7 @@ async fn test_streaming_without_usage() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn test_detokenize_metrics_flush_once_at_stream_completion() {
     let request = create_chat_request(None, None);
     let response_generator = request.response_generator("test-detokenize-metrics".to_string());
@@ -309,9 +310,101 @@ async fn test_detokenize_metrics_flush_once_at_stream_completion() {
         assert_eq!(DETOKENIZE_TOTAL_US.get(), total_us_before);
     }
 
-    // Polling past the final backend chunk reaches stream completion and emits the
-    // internal usage item. The per-request totals must be flushed exactly once here.
+    // Polling past the final backend chunk emits the internal usage item. The state
+    // is still live, so the per-request totals must remain local.
     assert!(transformed_stream.next().await.is_some());
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get(), count_before);
+    assert_eq!(DETOKENIZE_TOTAL_US.get(), total_us_before);
+
+    // The next poll drops the completed state and flushes its totals once.
+    assert!(transformed_stream.next().await.is_none());
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, 3.0);
+    assert_eq!(DETOKENIZE_TOTAL_US.get() - total_us_before, 30.0);
+
+    assert!(transformed_stream.next().await.is_none());
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, 3.0);
+    assert_eq!(DETOKENIZE_TOTAL_US.get() - total_us_before, 30.0);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_detokenize_metrics_flush_when_stream_is_dropped() {
+    let request = create_chat_request(None, None);
+    let response_generator = request.response_generator("test-detokenize-drop".to_string());
+    let tracker = response_generator.tracker();
+
+    let count_before = DETOKENIZE_TOKEN_COUNT.get();
+    let total_us_before = DETOKENIZE_TOTAL_US.get();
+
+    let tracked = tracker.clone();
+    let outputs = build_backend_outputs_with_cached_tokens(None);
+    let stream = stream::iter(outputs.into_iter().map(move |output| {
+        tracked.record_detokenize_latency(Duration::from_micros(10));
+        Annotated::from_data(output)
+    }));
+    let ctx = Arc::new(MockContext::new());
+    let backend_stream = dynamo_runtime::engine::ResponseStream::new(Box::pin(stream), ctx.clone());
+
+    let mut transformed_stream = Box::pin(OpenAIPreprocessor::transform_postprocessor_stream(
+        backend_stream,
+        Box::new(response_generator),
+        ctx,
+        false,
+        false,
+        None,
+        Default::default(),
+    ));
+
+    for _ in 0..2 {
+        assert!(transformed_stream.next().await.is_some());
+        assert_eq!(DETOKENIZE_TOKEN_COUNT.get(), count_before);
+        assert_eq!(DETOKENIZE_TOTAL_US.get(), total_us_before);
+    }
+
+    drop(transformed_stream);
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, 2.0);
+    assert_eq!(DETOKENIZE_TOTAL_US.get() - total_us_before, 20.0);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_detokenize_metrics_flush_on_postprocessor_cancellation() {
+    let request = create_chat_request(None, None);
+    let response_generator = request.response_generator("test-detokenize-cancel".to_string());
+    let tracker = response_generator.tracker();
+
+    let count_before = DETOKENIZE_TOKEN_COUNT.get();
+    let total_us_before = DETOKENIZE_TOTAL_US.get();
+
+    let tracked = tracker.clone();
+    let mut outputs = build_backend_outputs_with_cached_tokens(None);
+    outputs[1].finish_reason = Some(FinishReason::Error("test error".to_string()));
+    let stream = stream::iter(outputs.into_iter().map(move |output| {
+        tracked.record_detokenize_latency(Duration::from_micros(10));
+        Annotated::from_data(output)
+    }));
+    let ctx = Arc::new(MockContext::new());
+    let backend_stream = dynamo_runtime::engine::ResponseStream::new(Box::pin(stream), ctx.clone());
+
+    let mut transformed_stream = Box::pin(OpenAIPreprocessor::transform_postprocessor_stream(
+        backend_stream,
+        Box::new(response_generator),
+        ctx.clone(),
+        false,
+        false,
+        None,
+        Default::default(),
+    ));
+
+    assert!(transformed_stream.next().await.is_some());
+    let error = transformed_stream.next().await.expect("error response");
+    assert!(error.is_error());
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get(), count_before);
+    assert_eq!(DETOKENIZE_TOTAL_US.get(), total_us_before);
+
+    // The next backend item observes the cancellation and drops the state.
+    assert!(transformed_stream.next().await.is_none());
+    assert!(ctx.is_stopped());
     assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, 3.0);
     assert_eq!(DETOKENIZE_TOTAL_US.get() - total_us_before, 30.0);
 

--- a/lib/llm/tests/test_streaming_usage.rs
+++ b/lib/llm/tests/test_streaming_usage.rs
@@ -19,12 +19,14 @@ use dynamo_protocols::types::{
     PromptTokensDetails,
 };
 use dynamo_runtime::engine::{AsyncEngineContext, AsyncEngineStream};
+use dynamo_runtime::metrics::frontend_perf::{DETOKENIZE_TOKEN_COUNT, DETOKENIZE_TOTAL_US};
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::StreamExt;
 use futures::stream;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 // Mock context for testing
 #[derive(Debug)]
@@ -270,6 +272,52 @@ async fn test_streaming_without_usage() {
             );
         }
     }
+}
+
+#[tokio::test]
+async fn test_detokenize_metrics_flush_once_at_stream_completion() {
+    let request = create_chat_request(None, None);
+    let response_generator = request.response_generator("test-detokenize-metrics".to_string());
+    let tracker = response_generator.tracker();
+
+    let count_before = DETOKENIZE_TOKEN_COUNT.get();
+    let total_us_before = DETOKENIZE_TOTAL_US.get();
+
+    let tracked = tracker.clone();
+    let outputs = build_backend_outputs_with_cached_tokens(None);
+    let stream = stream::iter(outputs.into_iter().map(move |output| {
+        tracked.record_detokenize_latency(Duration::from_micros(10));
+        Annotated::from_data(output)
+    }));
+    let ctx = Arc::new(MockContext::new());
+    let backend_stream = dynamo_runtime::engine::ResponseStream::new(Box::pin(stream), ctx.clone());
+
+    let transformed_stream = OpenAIPreprocessor::transform_postprocessor_stream(
+        backend_stream,
+        Box::new(response_generator),
+        ctx,
+        false,
+        false,
+        None,
+        Default::default(),
+    );
+    futures::pin_mut!(transformed_stream);
+
+    for _ in 0..3 {
+        assert!(transformed_stream.next().await.is_some());
+        assert_eq!(DETOKENIZE_TOKEN_COUNT.get(), count_before);
+        assert_eq!(DETOKENIZE_TOTAL_US.get(), total_us_before);
+    }
+
+    // Polling past the final backend chunk reaches stream completion and emits the
+    // internal usage item. The per-request totals must be flushed exactly once here.
+    assert!(transformed_stream.next().await.is_some());
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, 3.0);
+    assert_eq!(DETOKENIZE_TOTAL_US.get() - total_us_before, 30.0);
+
+    assert!(transformed_stream.next().await.is_none());
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, 3.0);
+    assert_eq!(DETOKENIZE_TOTAL_US.get() - total_us_before, 30.0);
 }
 
 #[tokio::test]

--- a/lib/llm/tests/test_streaming_usage.rs
+++ b/lib/llm/tests/test_streaming_usage.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use dynamo_llm::preprocessor::OpenAIPreprocessor;
+use dynamo_llm::preprocessor::{ANNOTATION_PAYLOAD_USAGE, OpenAIPreprocessor};
 use dynamo_llm::protocols::common::llm_backend::{BackendOutput, FinishReason};
 use dynamo_llm::protocols::openai::ParsingOptions;
 use dynamo_llm::protocols::openai::chat_completions::{
-    NvCreateChatCompletionRequest, aggregator::ChatCompletionAggregator,
+    DeltaGenerator, NvCreateChatCompletionRequest, aggregator::ChatCompletionAggregator,
 };
 use dynamo_llm::protocols::openai::completions::NvCreateCompletionRequest;
 use dynamo_protocols::types::{
@@ -25,7 +25,7 @@ use futures::StreamExt;
 use futures::stream;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 // Mock context for testing
@@ -211,6 +211,41 @@ fn create_chat_request(
     }
 }
 
+struct DetokenizeMetricsFixture {
+    response_generator: DeltaGenerator,
+    context: Arc<MockContext>,
+    backend_stream: Pin<Box<dyn AsyncEngineStream<Annotated<BackendOutput>>>>,
+    yielded: Arc<AtomicUsize>,
+}
+
+fn create_detokenize_metrics_fixture(
+    request_id: &str,
+    include_usage: Option<bool>,
+    outputs: Vec<BackendOutput>,
+    detokenize_latency: Duration,
+) -> DetokenizeMetricsFixture {
+    let request = create_chat_request(include_usage, None);
+    let response_generator = request.response_generator(request_id.to_string());
+    let tracker = response_generator.tracker();
+    let yielded = Arc::new(AtomicUsize::new(0));
+    let yielded_by_stream = yielded.clone();
+    let stream = stream::iter(outputs.into_iter().map(move |output| {
+        yielded_by_stream.fetch_add(1, Ordering::Relaxed);
+        tracker.record_detokenize_latency(detokenize_latency);
+        Annotated::from_data(output)
+    }));
+    let context = Arc::new(MockContext::new());
+    let backend_stream =
+        dynamo_runtime::engine::ResponseStream::new(Box::pin(stream), context.clone());
+
+    DetokenizeMetricsFixture {
+        response_generator,
+        context,
+        backend_stream,
+        yielded,
+    }
+}
+
 #[tokio::test]
 async fn test_streaming_without_usage() {
     // Create request without stream_options (usage should not be included)
@@ -277,26 +312,25 @@ async fn test_streaming_without_usage() {
 #[tokio::test]
 #[serial_test::serial]
 async fn test_detokenize_metrics_flush_once_at_stream_completion() {
-    let request = create_chat_request(None, None);
-    let response_generator = request.response_generator("test-detokenize-metrics".to_string());
-    let tracker = response_generator.tracker();
-
     let count_before = DETOKENIZE_TOKEN_COUNT.get();
     let total_us_before = DETOKENIZE_TOTAL_US.get();
 
-    let tracked = tracker.clone();
-    let outputs = build_backend_outputs_with_cached_tokens(None);
-    let stream = stream::iter(outputs.into_iter().map(move |output| {
-        tracked.record_detokenize_latency(Duration::from_micros(10));
-        Annotated::from_data(output)
-    }));
-    let ctx = Arc::new(MockContext::new());
-    let backend_stream = dynamo_runtime::engine::ResponseStream::new(Box::pin(stream), ctx.clone());
+    let DetokenizeMetricsFixture {
+        response_generator,
+        context,
+        backend_stream,
+        yielded,
+    } = create_detokenize_metrics_fixture(
+        "test-detokenize-metrics",
+        None,
+        build_backend_outputs_with_cached_tokens(None),
+        Duration::from_micros(10),
+    );
 
     let transformed_stream = OpenAIPreprocessor::transform_postprocessor_stream(
         backend_stream,
         Box::new(response_generator),
-        ctx,
+        context,
         false,
         false,
         None,
@@ -318,6 +352,7 @@ async fn test_detokenize_metrics_flush_once_at_stream_completion() {
 
     // The next poll drops the completed state and flushes its totals once.
     assert!(transformed_stream.next().await.is_none());
+    assert_eq!(yielded.load(Ordering::Relaxed), 3);
     assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, 3.0);
     assert_eq!(DETOKENIZE_TOTAL_US.get() - total_us_before, 30.0);
 
@@ -329,26 +364,25 @@ async fn test_detokenize_metrics_flush_once_at_stream_completion() {
 #[tokio::test]
 #[serial_test::serial]
 async fn test_detokenize_metrics_flush_when_stream_is_dropped() {
-    let request = create_chat_request(None, None);
-    let response_generator = request.response_generator("test-detokenize-drop".to_string());
-    let tracker = response_generator.tracker();
-
     let count_before = DETOKENIZE_TOKEN_COUNT.get();
     let total_us_before = DETOKENIZE_TOTAL_US.get();
 
-    let tracked = tracker.clone();
-    let outputs = build_backend_outputs_with_cached_tokens(None);
-    let stream = stream::iter(outputs.into_iter().map(move |output| {
-        tracked.record_detokenize_latency(Duration::from_micros(10));
-        Annotated::from_data(output)
-    }));
-    let ctx = Arc::new(MockContext::new());
-    let backend_stream = dynamo_runtime::engine::ResponseStream::new(Box::pin(stream), ctx.clone());
+    let DetokenizeMetricsFixture {
+        response_generator,
+        context,
+        backend_stream,
+        yielded,
+    } = create_detokenize_metrics_fixture(
+        "test-detokenize-drop",
+        None,
+        build_backend_outputs_with_cached_tokens(None),
+        Duration::from_micros(10),
+    );
 
     let mut transformed_stream = Box::pin(OpenAIPreprocessor::transform_postprocessor_stream(
         backend_stream,
         Box::new(response_generator),
-        ctx,
+        context,
         false,
         false,
         None,
@@ -362,6 +396,7 @@ async fn test_detokenize_metrics_flush_when_stream_is_dropped() {
     }
 
     drop(transformed_stream);
+    assert_eq!(yielded.load(Ordering::Relaxed), 2);
     assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, 2.0);
     assert_eq!(DETOKENIZE_TOTAL_US.get() - total_us_before, 20.0);
 }
@@ -369,27 +404,28 @@ async fn test_detokenize_metrics_flush_when_stream_is_dropped() {
 #[tokio::test]
 #[serial_test::serial]
 async fn test_detokenize_metrics_flush_on_postprocessor_cancellation() {
-    let request = create_chat_request(None, None);
-    let response_generator = request.response_generator("test-detokenize-cancel".to_string());
-    let tracker = response_generator.tracker();
-
     let count_before = DETOKENIZE_TOKEN_COUNT.get();
     let total_us_before = DETOKENIZE_TOTAL_US.get();
 
-    let tracked = tracker.clone();
     let mut outputs = build_backend_outputs_with_cached_tokens(None);
     outputs[1].finish_reason = Some(FinishReason::Error("test error".to_string()));
-    let stream = stream::iter(outputs.into_iter().map(move |output| {
-        tracked.record_detokenize_latency(Duration::from_micros(10));
-        Annotated::from_data(output)
-    }));
-    let ctx = Arc::new(MockContext::new());
-    let backend_stream = dynamo_runtime::engine::ResponseStream::new(Box::pin(stream), ctx.clone());
+
+    let DetokenizeMetricsFixture {
+        response_generator,
+        context,
+        backend_stream,
+        yielded,
+    } = create_detokenize_metrics_fixture(
+        "test-detokenize-cancel",
+        None,
+        outputs,
+        Duration::from_micros(10),
+    );
 
     let mut transformed_stream = Box::pin(OpenAIPreprocessor::transform_postprocessor_stream(
         backend_stream,
         Box::new(response_generator),
-        ctx.clone(),
+        context.clone(),
         false,
         false,
         None,
@@ -404,7 +440,75 @@ async fn test_detokenize_metrics_flush_on_postprocessor_cancellation() {
 
     // The next backend item observes the cancellation and drops the state.
     assert!(transformed_stream.next().await.is_none());
-    assert!(ctx.is_stopped());
+    assert!(context.is_stopped());
+    let yielded_count = yielded.load(Ordering::Relaxed) as f64;
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, yielded_count);
+    assert_eq!(
+        DETOKENIZE_TOTAL_US.get() - total_us_before,
+        yielded_count * 10.0
+    );
+
+    assert!(transformed_stream.next().await.is_none());
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, yielded_count);
+    assert_eq!(
+        DETOKENIZE_TOTAL_US.get() - total_us_before,
+        yielded_count * 10.0
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_detokenize_metrics_flush_once_with_payload_usage() {
+    let count_before = DETOKENIZE_TOKEN_COUNT.get();
+    let total_us_before = DETOKENIZE_TOTAL_US.get();
+
+    let DetokenizeMetricsFixture {
+        response_generator,
+        context,
+        backend_stream,
+        yielded,
+    } = create_detokenize_metrics_fixture(
+        "test-detokenize-payload-usage",
+        Some(true),
+        build_backend_outputs_with_cached_tokens(None),
+        Duration::from_micros(10),
+    );
+
+    let transformed_stream = OpenAIPreprocessor::transform_postprocessor_stream(
+        backend_stream,
+        Box::new(response_generator),
+        context,
+        true,
+        false,
+        None,
+        Default::default(),
+    );
+    futures::pin_mut!(transformed_stream);
+
+    for _ in 0..3 {
+        assert!(transformed_stream.next().await.is_some());
+        assert_eq!(DETOKENIZE_TOKEN_COUNT.get(), count_before);
+        assert_eq!(DETOKENIZE_TOTAL_US.get(), total_us_before);
+    }
+
+    let payload_usage = transformed_stream
+        .next()
+        .await
+        .expect("internal payload usage chunk");
+    assert_eq!(
+        payload_usage.event.as_deref(),
+        Some(ANNOTATION_PAYLOAD_USAGE)
+    );
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get(), count_before);
+    assert_eq!(DETOKENIZE_TOTAL_US.get(), total_us_before);
+
+    let client_usage = transformed_stream.next().await.expect("client usage chunk");
+    assert!(client_usage.event.is_none());
+    assert_eq!(DETOKENIZE_TOKEN_COUNT.get(), count_before);
+    assert_eq!(DETOKENIZE_TOTAL_US.get(), total_us_before);
+
+    assert!(transformed_stream.next().await.is_none());
+    assert_eq!(yielded.load(Ordering::Relaxed), 3);
     assert_eq!(DETOKENIZE_TOKEN_COUNT.get() - count_before, 3.0);
     assert_eq!(DETOKENIZE_TOTAL_US.get() - total_us_before, 30.0);
 


### PR DESCRIPTION
## Summary

Flush the existing detokenization Prometheus accumulators once when the transformed response stream is dropped. This removes cumulative per-chunk counter updates without losing partial metrics when a request is cancelled, errors, times out, or its consumer drops the stream early.

Metric names, types, units, PromQL behavior, response payloads, and usage-chunk ordering are unchanged.

## Details

The request tracker stores cumulative detokenization count and duration. The old response path added those cumulative values to the global counters for every emitted backend chunk, which caused triangular overcounting and repeated floating-point counter updates on a highly concurrent streaming path.

This change:

- caches the optional request tracker `Arc` once instead of cloning it on each chunk
- uses a small drop guard to publish the final accumulated values for normal completion, cancellation, backend errors, downstream short-circuits, and early stream drops
- performs no new per-chunk synchronization and needs no idempotency flag because each request owns one tracker and one guard
- uses one private inline helper to build normal and usage-chunk `LLMMetricAnnotation` values from the same fields
- adds serial regression tests for normal completion, payload usage, early drop, and postprocessor cancellation

## Performance evidence

The initial Tyche AgentX c=10240 profile on the earlier profiled base showed:

- detokenization metric observations per completed request fell from 5,298.7 to 3.55
- `futures_util::stream::unfold::Unfold::poll_next` exclusive CPU fell from 47.42% to 1.07%
- the exact metric block used 4 of 261,897 samples, or 0.0015% exclusive CPU
- frontend CPU time fell from 24.51 ms/request to 15.07 ms/request versus the prior full-node repeat

A later matched upstream-main versus PR diagnostic profile confirmed the mechanism:

- frontend CPU fell from 38.30 to 18.95 ms/request in the first 120-second window
- `Unfold::poll_next` fell from 39.047% to 0.437% exclusive CPU
- detokenization observations fell from 3,091.7 to 1.365 per completed request
- both perf captures had zero lost samples and fewer than 5% unresolved frames

That matched pair had native transport request errors: 0.0278% in the control and 0.2944% in the experiment. It is valid CPU-mechanism evidence, but its full-drain throughput and TTFT results are not clean acceptance claims.

## Validation

Validated after rebasing onto upstream `da31d3f00dc51ad431299ee537e5a1f4c9af6a71`:

- `cargo test -p dynamo-llm --test test_streaming_usage` (14 passed)
- `cargo fmt --all -- --check`
- `cargo check -p dynamo-llm`
- `git diff --check`
- source inspection confirms that counter updates exist only in the drop guard and that the request tracker is cloned once when stream state is created

## Where should the reviewer start?

Start with `DetokenizeMetricsGuard` and `build_llm_metric_annotation` in `lib/llm/src/preprocessor.rs`, then review the four metric lifecycle tests in `lib/llm/tests/test_streaming_usage.rs`.

## Related Issues

**This PR is not linked to an issue:**

- [x] Confirmed - no related issue
