### PR TITLE
fix(ci): gate fern-check job on docs OR fern_components

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -69,7 +69,7 @@ jobs:
   fern-check:
     name: Fern Configuration Check
     needs: changed-files
-    if: needs.changed-files.outputs.docs == 'true'
+    if: needs.changed-files.outputs.docs == 'true' || needs.changed-files.outputs.fern_components == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

fix(ci): gate fern-check job on docs OR fern_components so self-editing workflow changes self-verify

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->


.github/filters.yaml:30 lists `.github/workflows/pre-merge.yml` under `fern_components`.

In `pre-merge.yml`, the step `Parse custom MDX components` declares this dependency:

```
if: needs.changed-files.outputs.fern_components == 'true'
```

Therefore, in `pre-merge.yml`, the job `fern-check` that contains it must ensure:

```
if: needs.changed-files.outputs.docs == 'true' || needs.changed-files.outputs.fern_components == 'true
```


## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue
