### PR TITLE
fix(container): build NIXL against EFA libfabric for EFA images

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -14,7 +14,7 @@
 #   trtllm   -> trtllm build and test
 #   frontend -> frontend EPP image build, dynamo build-test
 #   benchmarks -> dynamo build-test (runs tests/benchmarks/** pytest suite)
-#   efa      -> all framework EFA runtime image builds (changes to container/templates/aws.Dockerfile)
+#   efa      -> all framework EFA runtime image builds (aws.Dockerfile, wheel_builder.Dockerfile)
 #   examples -> recipe-check (Kustomize recipe generation and unit tests)
 #   sidecar  -> classification only; source and proto files also match rust
 #   docs     -> fern docs lint, sync, and version release (docs/ directory)
@@ -350,3 +350,6 @@ benchmarks:
 
 efa:
   - 'container/templates/aws.Dockerfile'
+  # wheel_builder builds NIXL against the EFA libfabric under make_efa, so a
+  # change here can only be validated by building the EFA images.
+  - 'container/templates/wheel_builder.Dockerfile'

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -197,6 +197,7 @@ RUN if [ ! -e /usr/bin/python3 ]; then \
 # Copy NIXL SDK material for dev stage compilation.
 # cargo build needs NIXL headers plus linkable -lnixl, -lnixl_build, and -lnixl_common.
 # - SGLang: Copy NIXL/UCX/libfabric/gdrcopy binaries from wheel_builder (not in upstream lmsysorg/sglang runtime).
+#   EFA builds have no from-source libfabric; the aws stage installs the EFA one on top.
 # - vLLM CUDA: Reuse upstream vLLM's Python-wheel NIXL libs and copy only headers beside them.
 # - trtllm/none: NIXL/UCX are already present in runtime (no-op).
 ARG TARGETARCH
@@ -212,8 +213,8 @@ RUN --mount=from=wheel_builder,target=/wheel_builder \
         mkdir -p /opt/nvidia /usr/include /usr/lib64 /etc/ld.so.conf.d; \
         cp -r /wheel_builder/opt/nvidia/nvda_nixl /opt/nvidia/; \
         cp -r /wheel_builder/usr/local/ucx /usr/local/; \
-        cp -r /wheel_builder/usr/local/libfabric /usr/local/; \
-        cp /wheel_builder/usr/include/gdrapi.h /usr/include/; \
+{% if make_efa != true %}        cp -r /wheel_builder/usr/local/libfabric /usr/local/; \
+{% endif %}        cp /wheel_builder/usr/include/gdrapi.h /usr/include/; \
         cp /wheel_builder/usr/lib64/libgdrapi.so* /usr/lib64/; \
         echo "/usr/lib64" >> /etc/ld.so.conf.d/gdrcopy.conf; \
 {% if framework == "vllm" and device == "cuda" %}

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -16,6 +16,30 @@ FROM --platform=linux/amd64 quay.io/pypa/manylinux_2_28_x86_64 AS manylinux_amd6
 FROM --platform=linux/arm64 quay.io/pypa/manylinux_2_28_aarch64 AS manylinux_arm64
 {% endif %}
 
+{% if device == "cuda" and make_efa == true %}
+# EFA images load libfabric from the /opt/amazon/efa prefix that the AWS EFA
+# Installer lays down in templates/aws.Dockerfile, so NIXL's LIBFABRIC plugin has
+# to be built against that same prefix. The installer is Debian-packaged, so
+# materialize it in an Ubuntu stage and copy the prefix into the AlmaLinux wheel
+# builder. Same installer invocation as templates/aws.Dockerfile.
+FROM ubuntu:24.04 AS efa_sdk
+
+ARG EFA_VERSION
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl && \
+    curl --retry 3 --retry-delay 2 -fsSL -o aws-efa-installer-${EFA_VERSION}.tar.gz \
+        https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_VERSION}.tar.gz && \
+    tar -xf aws-efa-installer-${EFA_VERSION}.tar.gz && \
+    cd aws-efa-installer && \
+    ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify && \
+    cd .. && rm -rf aws-efa-installer* && \
+    rm -rf /var/lib/apt/lists/*
+{% endif %}
+
 ##################################
 ##### wheel_builder_base #########
 ##################################
@@ -192,6 +216,14 @@ ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}" \
     CC="/opt/rh/gcc-toolset-14/root/usr/bin/gcc" \
     CXX="/opt/rh/gcc-toolset-14/root/usr/bin/g++"
+
+{% if make_efa == true %}
+COPY --from=efa_sdk /opt/amazon/efa /opt/amazon/efa
+# Register the prefix the way the from-source build below registers
+# /usr/local/libfabric, so loader and pkg-config lookups behave the same.
+RUN printf '%s\n' /opt/amazon/efa/lib > /etc/ld.so.conf.d/000_efa.conf && ldconfig
+ENV PKG_CONFIG_PATH="/opt/amazon/efa/lib/pkgconfig:${PKG_CONFIG_PATH}"
+{% endif %}
 {% endif %}
 
 # Ensure a modern protoc is available (required for --experimental_allow_proto3_optional)
@@ -489,7 +521,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
      echo "/usr/local/ucx/lib/ucx" >> /etc/ld.so.conf.d/ucx.conf && \
      ldconfig
 
-{% if device == "cuda" %}
+{% if device == "cuda" and make_efa != true %}
 ARG NIXL_LIBFABRIC_REPO
 ARG NIXL_LIBFABRIC_REF
 RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token \
@@ -737,7 +769,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
             -Dcudapath_lib="/usr/local/cuda/lib64" \
             -Dcudapath_inc="/usr/local/cuda/include" \
             -Ducx_path="/usr/local/ucx" \
-            -Dlibfabric_path="/usr/local/libfabric"; \
+            -Dlibfabric_path="{% if make_efa == true %}/opt/amazon/efa{% else %}/usr/local/libfabric{% endif %}"; \
     elif [ "$DEVICE" = "xpu" ]; then \
         meson setup build/ --prefix=/opt/intel/intel_nixl --buildtype=release \
             -Ducx_path="/usr/local/ucx"; \


### PR DESCRIPTION
## Overview:

NIXL's LIBFABRIC plugin was built against `/usr/local/libfabric`, a generic from-source libfabric compiled in the manylinux wheel stage. EFA images load libfabric from `/opt/amazon/efa`, laid down by the AWS EFA Installer in the `aws` stage. The plugin is `dlopen`'d at runtime, so its HMEM/CUDA dmabuf ABI never matched what it actually resolved against, and EFA GPU RDMA failed silently for disaggregated KV transfer on GB200 (`p6e-gb200.36xlarge`).

This builds NIXL against the same libfabric the EFA image loads.

## Details:

- Adds an `efa_sdk` Ubuntu stage that runs the same EFA Installer invocation `templates/aws.Dockerfile` already uses, and copies the resulting `/opt/amazon/efa` prefix into `wheel_builder_base`. The installer is Debian-packaged, so it cannot run directly in the AlmaLinux manylinux builder.
- Registers that prefix with `ld.so.conf` and pkg-config, matching what the from-source build does for `/usr/local/libfabric`.
- Skips the from-source libfabric build for EFA builds, and points NIXL's meson at `/opt/amazon/efa` instead.
- Stops copying `/usr/local/libfabric` into the SGLang dev stage for EFA builds, since that path is no longer produced. The `aws` stage layered on top installs the EFA prefix.

**Scope.** Only `trtllm-runtime-efa` changes at runtime — it is the one image whose `aws` stage replaces `/opt/nvidia/nvda_nixl` with the wheel-builder copy. CUDA SGLang and vLLM runtimes ship their upstream NIXL and are unaffected, though all three EFA builds now link the EFA prefix.

**Blast radius.** Every non-EFA render is byte-identical to `main` apart from one added comment line, on CUDA and non-CUDA alike. Nothing outside `make_efa` builds changes.

## Where should the reviewer start?

`container/templates/wheel_builder.Dockerfile` — the `efa_sdk` stage and the three `make_efa` conditionals are the whole change. `container/templates/dev.Dockerfile` is a one-line consequence of skipping the source build.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Tracked in Linear as DYN-3842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for installing the Elastic Fabric Adapter (EFA) SDK in CUDA-enabled builds.
  - EFA-enabled builds now use the provided SDK directly, reducing the need to compile networking components from source.
  - Added configurable installer checksum and size validation for more reliable builds.

- **Bug Fixes**
  - Improved handling of conflicting or legacy EFA, libfabric, and NCCL OFI packages.
  - Added post-installation checks to verify required versions, symbols, links, and package state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
