### PR TITLE
docs(trtllm): correct cache_transceiver_config.backend behavior

### DIFF
--- a/docs/fern/pages/developer-guide/additional-resources/tensorrt-llm-details/kv-cache-transfer.md
+++ b/docs/fern/pages/developer-guide/additional-resources/tensorrt-llm-details/kv-cache-transfer.md
@@ -29,8 +29,13 @@ TensorRT-LLM supports two NIXL communication backends: UCX and LIBFABRIC. By def
 
 TensorRT-LLM can also leverage **UCX** (Unified Communication X) directly for KV cache transfer between prefill and decode workers. To enable UCX as the KV cache transfer backend, set `cache_transceiver_config.backend: UCX` in your engine configuration YAML file.
 
-> [!NOTE]
-> The environment variable `TRTLLM_USE_UCX_KVCACHE=1` with `cache_transceiver_config.backend: DEFAULT` does not enable UCX. You must explicitly set `backend: UCX` in the configuration.
+`cache_transceiver_config.backend` accepts the following values:
+
+| Value | Behavior |
+|-------|----------|
+| Not set | KV cache transfer is disabled. |
+| `DEFAULT` | Uses the backend named by the first of `TRTLLM_USE_NIXL_KVCACHE`, `TRTLLM_USE_UCX_KVCACHE`, `TRTLLM_USE_MOONCAKE_KVCACHE`, or `TRTLLM_USE_MPI_KVCACHE` that is set to `1`. Uses NIXL when none of them is set. |
+| `UCX`, `NIXL`, `MOONCAKE`, or `MPI` | Uses that backend and ignores the environment variables above. |
 
 ## AWS EFA
 

--- a/docs/fern/pages/developer-guide/additional-resources/tensorrt-llm-details/kv-cache-transfer.md
+++ b/docs/fern/pages/developer-guide/additional-resources/tensorrt-llm-details/kv-cache-transfer.md
@@ -37,6 +37,8 @@ TensorRT-LLM can also leverage **UCX** (Unified Communication X) directly for KV
 | `DEFAULT` | Uses the backend named by the first of `TRTLLM_USE_NIXL_KVCACHE`, `TRTLLM_USE_UCX_KVCACHE`, `TRTLLM_USE_MOONCAKE_KVCACHE`, or `TRTLLM_USE_MPI_KVCACHE` that is set to `1`. Uses NIXL when none of them is set. |
 | `UCX`, `NIXL`, `MOONCAKE`, or `MPI` | Uses that backend and ignores the environment variables above. |
 
+The precedence above matches TensorRT-LLM 1.3.0rc22; check `CacheTransceiverConfig._resolve_default_backend` in `tensorrt_llm/llmapi/llm_args.py`.
+
 ## AWS EFA
 
 On AWS, UCX uses the **SRD (Scalable Reliable Datagram)** transport over EFA devices. NIXL discovers EFA `rdmap*` devices automatically through UCX — no NIXL-level configuration changes are needed.


### PR DESCRIPTION
## Overview:

Fix [DYN-3855](https://linear.app/nvidia/issue/DYN-3855/dynamorelease140doctensorrt-llm-kv-cache-transfer-doc-inverts-the)

At [kv-cache-transfer.md](https://github.com/ai-dynamo/dynamo/blob/7a4e47ead90ec6b479e397996f6479ce7d251510/docs/fern/pages/developer-guide/additional-resources/tensorrt-llm-details/kv-cache-transfer.md?plain=1#L32-L33), The NOTE stated that "TRTLLM_USE_UCX_KVCACHE=1 with cache_transceiver_config.backend: DEFAULT does not enable UCX." It does. DEFAULT resolves the backend from the TRTLLM_USE_*_KVCACHE variables, so that combination selects UCX and produces the same transceiver as setting backend: UCX explicitly.

Replace the NOTE with the values the field accepts and what each one does, including the disabled case when the field is unset and the two backends the page did not previously mention.

## Validation

- backend: DEFAULT, no env var → both workers log `NixlTransferAgent` using NIXL backend: UCX
- backend: DEFAULT + `TRTLLM_USE_UCX_KVCACHE=1` → both workers log `UcxConnectionManager::UcxConnectionManager`, no `NixlTransferAgent`
- backend: UCX → identical markers to the previous case
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded UCX configuration guidance for KV cache transfer.
  * Documented supported backend values and their behavior, including defaults, environment-based selection, and explicit overrides.
  * Clarified that leaving the backend unset disables KV cache transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->