### PR TITLE
feat(router): add pluggable queue admission policy

### DIFF
--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -72,7 +72,9 @@ pub use scheduling::LocalScheduler;
 pub use scheduling::PrefillLoadEstimator;
 pub use scheduling::policy::{FcfsPolicy, RouterSchedulingPolicy, SchedulingPolicy, WsptPolicy};
 pub use scheduling::{
-    KvSchedulerError, PotentialLoad, SchedulingRequest, SchedulingResponse, SessionContext,
+    KvSchedulerError, PotentialLoad, QueueAdmissionDecision, QueueAdmissionEvent, QueueAdmissionId,
+    QueueAdmissionPolicy, QueueAdmissionRequest, QueueAdmissionWorker,
+    QueueAdmissionWorkerSnapshot, SchedulingRequest, SchedulingResponse, SessionContext,
     WorkerSelectionInputTrigger, WorkerSelectionKvHints, WorkerSelectionPolicyError,
 };
 pub use selector::{

--- a/lib/kv-router/src/scheduling/mod.rs
+++ b/lib/kv-router/src/scheduling/mod.rs
@@ -8,10 +8,13 @@ pub mod overlap;
 pub mod overlap_refresh;
 pub mod policy;
 pub mod policy_config;
-pub mod policy_queue;
 pub mod prefill_load;
 pub mod queue;
-mod queue_admission;
+pub mod queue_admission;
+#[deprecated(note = "use scheduling::queue_admission instead")]
+pub mod policy_queue {
+    pub use super::queue_admission::policy_queue::*;
+}
 pub mod selector;
 
 mod worker_selection_config;
@@ -30,12 +33,14 @@ pub use policy_config::{
     PolicyClassConfig, PolicyProfile, RouterPolicyConfig, RouterPolicyConfigError,
     WorkerSelectionConfig, WorkerSelectionInstance,
 };
-pub use policy_queue::{
-    PolicyQueue, PolicyQueueEntry, QueueLimitKind, QueueRejection, QueueSnapshot,
-};
 pub use prefill_load::{
     InvalidEffectivePrefillTokens, PrefillLoadEstimator, effective_prefill_tokens,
     prefill_load_hint_from_effective_tokens,
 };
-pub use queue_admission::{RequestProgress, RequestProgressUpdater, WorkerPlacement};
+pub use queue_admission::{
+    PolicyQueue, PolicyQueueEntry, QueueAdmissionDecision, QueueAdmissionEvent, QueueAdmissionId,
+    QueueAdmissionPolicy, QueueAdmissionRequest, QueueAdmissionWorker,
+    QueueAdmissionWorkerSnapshot, QueueLimitKind, QueueRejection, QueueSnapshot, RequestProgress,
+    RequestProgressUpdater, WorkerPlacement,
+};
 pub use types::*;

--- a/lib/kv-router/src/scheduling/mod.rs
+++ b/lib/kv-router/src/scheduling/mod.rs
@@ -11,10 +11,6 @@ pub mod policy_config;
 pub mod prefill_load;
 pub mod queue;
 pub mod queue_admission;
-#[deprecated(note = "use scheduling::queue_admission instead")]
-pub mod policy_queue {
-    pub use super::queue_admission::policy_queue::*;
-}
 pub mod selector;
 
 mod worker_selection_config;

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -18,9 +18,9 @@ use super::overlap_refresh::{
     NoopOverlapScoresRefresh, OverlapScoresRefresh, read_overlap_refresh_after, refresh_overlap,
 };
 use super::policy_config::{PolicyClassConfig, PolicyProfile};
-use super::policy_queue::{PolicyQueue, QueueSnapshot};
 use super::prefill_load::{PrefillLoadEstimator, effective_prefill_tokens};
 use super::queue_admission::WorkerPlacement;
+use super::queue_admission::{PolicyQueue, QueueSnapshot};
 use super::selector::{DefaultWorkerSelector, WorkerSelector};
 use super::types::{
     AdvisorySchedulingResponse, AdvisoryWorkerLoad, KvSchedulerError, NonMaxOverlapSelection,

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -1,10 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Host activation lands separately; preserve the internal policy state in this
-// foundation without forcing the public contract through a fake call site.
-#![allow(dead_code)]
-
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -29,6 +25,10 @@ impl QueueAdmissionId {
         Self(value)
     }
 
+    #[allow(
+        dead_code,
+        reason = "the queue-admission host activates this internal identity in the next stacked PR"
+    )]
     pub(crate) fn get(self) -> u64 {
         self.0
     }
@@ -174,6 +174,10 @@ impl<'a> QueueAdmissionRequest<'a> {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(
+        dead_code,
+        reason = "the queue-admission host constructs policy requests in the next stacked PR"
+    )]
     pub(crate) fn new_with_eligibility(
         id: QueueAdmissionId,
         request_id: &'a str,

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -302,6 +302,9 @@ pub enum QueueAdmissionDecision {
     /// Make the request runnable under Dynamo's built-in queue ordering.
     Ready,
     /// Keep the request in host-owned deferred storage until the policy wakes it.
+    ///
+    /// Deferred requests remain bounded queue residents and count toward the configured queue
+    /// limits until they are woken or receive a terminal event.
     Defer,
 }
 

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -1,10 +1,351 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Host activation lands separately; preserve the internal policy state in this
+// foundation without forcing the public contract through a fake call site.
+#![allow(dead_code)]
+
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
-use crate::protocols::WorkerWithDpRank;
+use crate::protocols::{WorkerId, WorkerWithDpRank};
+use crate::scheduling::types::SessionContext;
+
+pub mod policy_queue;
+
+pub use policy_queue::{
+    PolicyQueue, PolicyQueueEntry, QueueLimitKind, QueueRejection, QueueSnapshot,
+};
+
+/// Scheduler-assigned identity for one request managed by a [`QueueAdmissionPolicy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct QueueAdmissionId(u64);
+
+impl QueueAdmissionId {
+    /// Create an identity for testing an admission policy outside the scheduler host.
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// One worker/rank visible to queue admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueueAdmissionWorker {
+    worker: WorkerWithDpRank,
+    capacity_tokens: Option<usize>,
+    available: bool,
+}
+
+impl QueueAdmissionWorker {
+    /// Create a worker snapshot for testing an admission policy outside the scheduler host.
+    pub fn new(worker: WorkerWithDpRank, capacity_tokens: Option<usize>, available: bool) -> Self {
+        Self {
+            worker,
+            capacity_tokens,
+            available,
+        }
+    }
+
+    /// Return the worker and data-parallel rank.
+    pub fn worker(&self) -> WorkerWithDpRank {
+        self.worker
+    }
+
+    /// Return the worker's reported KV capacity in tokens.
+    ///
+    /// `None` means discovery did not report usable KV capacity.
+    pub fn capacity_tokens(&self) -> Option<usize> {
+        self.capacity_tokens
+    }
+
+    /// Return whether the worker is currently available, including transient overload state.
+    pub fn is_available(&self) -> bool {
+        self.available
+    }
+}
+
+/// Immutable worker state shared across queue-admission calls.
+///
+/// The host increments `generation` only when worker topology, capacity, or
+/// availability changes. Policies can retain a clone and skip rebuilding their
+/// worker state when the generation is unchanged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueAdmissionWorkerSnapshot {
+    generation: u64,
+    workers: Arc<[QueueAdmissionWorker]>,
+}
+
+impl QueueAdmissionWorkerSnapshot {
+    /// Create a sorted snapshot for testing an admission policy outside the scheduler host.
+    pub fn new(generation: u64, mut workers: Vec<QueueAdmissionWorker>) -> Self {
+        workers.sort_unstable_by_key(QueueAdmissionWorker::worker);
+        Self {
+            generation,
+            workers: workers.into(),
+        }
+    }
+
+    /// Return the host generation for this snapshot.
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Return all worker/rank entries in stable worker order.
+    pub fn workers(&self) -> &[QueueAdmissionWorker] {
+        &self.workers
+    }
+
+    /// Return one exact worker/rank entry.
+    pub fn get(&self, worker: WorkerWithDpRank) -> Option<&QueueAdmissionWorker> {
+        self.workers
+            .binary_search_by_key(&worker, QueueAdmissionWorker::worker)
+            .ok()
+            .map(|index| &self.workers[index])
+    }
+
+    fn workers_for_id(&self, worker_id: WorkerId) -> &[QueueAdmissionWorker] {
+        let start = self
+            .workers
+            .partition_point(|worker| worker.worker().worker_id < worker_id);
+        let end = self
+            .workers
+            .partition_point(|worker| worker.worker().worker_id <= worker_id);
+        &self.workers[start..end]
+    }
+}
+
+type WorkerEligibilityPredicate<'a> = dyn Fn(WorkerWithDpRank) -> bool + 'a;
+
+#[derive(Clone, Copy, Default)]
+struct QueueAdmissionEligibility<'a> {
+    pinned_worker: Option<WorkerWithDpRank>,
+    allowed_worker_ids: Option<&'a HashSet<WorkerId>>,
+    eligible_workers: Option<&'a HashSet<WorkerWithDpRank>>,
+    has_hard_constraints: bool,
+    predicate: Option<&'a WorkerEligibilityPredicate<'a>>,
+}
+
+impl QueueAdmissionEligibility<'_> {
+    fn allows(&self, worker: WorkerWithDpRank) -> bool {
+        self.pinned_worker.is_none_or(|pinned| pinned == worker)
+            && self
+                .allowed_worker_ids
+                .is_none_or(|allowed| allowed.contains(&worker.worker_id))
+            && self
+                .eligible_workers
+                .is_none_or(|eligible| eligible.contains(&worker))
+            && self.predicate.is_none_or(|predicate| predicate(worker))
+    }
+}
+
+/// Read-only request facts supplied to a queue admission policy.
+pub struct QueueAdmissionRequest<'a> {
+    id: QueueAdmissionId,
+    request_id: &'a str,
+    context_tokens: usize,
+    session_context: Option<&'a SessionContext>,
+    worker_snapshot: &'a QueueAdmissionWorkerSnapshot,
+    eligibility: QueueAdmissionEligibility<'a>,
+}
+
+impl<'a> QueueAdmissionRequest<'a> {
+    /// Create a request view for testing an admission policy outside the scheduler host.
+    pub fn new(
+        id: QueueAdmissionId,
+        request_id: &'a str,
+        context_tokens: usize,
+        session_context: Option<&'a SessionContext>,
+        worker_snapshot: &'a QueueAdmissionWorkerSnapshot,
+    ) -> Self {
+        Self {
+            id,
+            request_id,
+            context_tokens,
+            session_context,
+            worker_snapshot,
+            eligibility: QueueAdmissionEligibility::default(),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_eligibility(
+        id: QueueAdmissionId,
+        request_id: &'a str,
+        context_tokens: usize,
+        session_context: Option<&'a SessionContext>,
+        worker_snapshot: &'a QueueAdmissionWorkerSnapshot,
+        pinned_worker: Option<WorkerWithDpRank>,
+        allowed_worker_ids: Option<&'a HashSet<WorkerId>>,
+        has_hard_constraints: bool,
+        predicate: &'a WorkerEligibilityPredicate<'a>,
+    ) -> Self {
+        Self {
+            id,
+            request_id,
+            context_tokens,
+            session_context,
+            worker_snapshot,
+            eligibility: QueueAdmissionEligibility {
+                pinned_worker,
+                allowed_worker_ids,
+                eligible_workers: None,
+                has_hard_constraints,
+                predicate: Some(predicate),
+            },
+        }
+    }
+
+    pub fn id(&self) -> QueueAdmissionId {
+        self.id
+    }
+
+    /// Limit a synthetic request to an exact worker/rank set.
+    ///
+    /// This builder supports policy tests outside the scheduler host. Production
+    /// requests receive eligibility from Dynamo's routing constraints.
+    pub fn with_eligible_workers(
+        mut self,
+        eligible_workers: &'a HashSet<WorkerWithDpRank>,
+    ) -> Self {
+        self.eligibility.eligible_workers = Some(eligible_workers);
+        self
+    }
+
+    /// Return the caller-supplied request identity.
+    ///
+    /// The host rejects another admission-managed request with the same identity until this
+    /// request reaches a terminal event.
+    pub fn request_id(&self) -> &str {
+        self.request_id
+    }
+
+    pub fn context_tokens(&self) -> usize {
+        self.context_tokens
+    }
+
+    pub fn session_context(&self) -> Option<&SessionContext> {
+        self.session_context
+    }
+
+    /// Return the routing partition's current worker snapshot.
+    pub fn worker_snapshot(&self) -> &QueueAdmissionWorkerSnapshot {
+        self.worker_snapshot
+    }
+
+    /// Return the routing partition's current workers.
+    ///
+    /// Transient overload and hard availability are reported by
+    /// [`QueueAdmissionWorker::is_available`]. Use
+    /// [`Self::for_each_eligible_worker`] for request eligibility. The worker
+    /// picker validates eligibility again before final selection.
+    pub fn workers(&self) -> &[QueueAdmissionWorker] {
+        self.worker_snapshot.workers()
+    }
+
+    /// Return whether this request can use an exact worker/rank.
+    pub fn is_worker_eligible(&self, worker: WorkerWithDpRank) -> bool {
+        self.worker_snapshot.get(worker).is_some() && self.eligibility.allows(worker)
+    }
+
+    /// Visit request-eligible workers without materializing eligibility for every worker.
+    ///
+    /// Pinned requests use one exact lookup. Allow-list requests visit only the
+    /// listed worker IDs. Unrestricted requests visit the shared snapshot directly.
+    pub fn for_each_eligible_worker(&self, mut visit: impl FnMut(&QueueAdmissionWorker)) {
+        if let Some(pinned) = self.eligibility.pinned_worker {
+            if self.eligibility.allows(pinned)
+                && let Some(worker) = self.worker_snapshot.get(pinned)
+            {
+                visit(worker);
+            }
+            return;
+        }
+
+        if let Some(allowed_worker_ids) = self.eligibility.allowed_worker_ids {
+            for &worker_id in allowed_worker_ids {
+                for worker in self.worker_snapshot.workers_for_id(worker_id) {
+                    if self.eligibility.allows(worker.worker()) {
+                        visit(worker);
+                    }
+                }
+            }
+            return;
+        }
+
+        if !self.eligibility.has_hard_constraints && self.eligibility.eligible_workers.is_none() {
+            for worker in self.worker_snapshot.workers() {
+                visit(worker);
+            }
+            return;
+        }
+
+        for worker in self.worker_snapshot.workers() {
+            if self.eligibility.allows(worker.worker()) {
+                visit(worker);
+            }
+        }
+    }
+}
+
+/// Initial queue admission decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum QueueAdmissionDecision {
+    /// Do not track this request in the custom admission policy.
+    Bypass,
+    /// Make the request runnable under Dynamo's built-in queue ordering.
+    Ready,
+    /// Keep the request in host-owned deferred storage until the policy wakes it.
+    Defer,
+}
+
+/// Lifecycle input delivered serially by the scheduler queue actor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum QueueAdmissionEvent<'a> {
+    Dispatched {
+        id: QueueAdmissionId,
+        worker: WorkerWithDpRank,
+    },
+    Completed {
+        request_id: &'a str,
+        /// Final input-plus-output context when the response path observed it.
+        context_tokens: Option<usize>,
+    },
+    Aborted {
+        request_id: &'a str,
+    },
+    /// Periodic or topology-driven opportunity to reconsider deferred work.
+    Reconcile {
+        snapshot: &'a QueueAdmissionWorkerSnapshot,
+    },
+}
+
+/// Optional programmatic admission policy hosted by [`PolicyQueue`].
+///
+/// Dynamo keeps ownership of requests and deferred storage. Implementations retain only
+/// policy state and append IDs of previously deferred requests that should become ready.
+/// A policy can implement session or program fairness by controlling which requests become
+/// runnable. It does not reorder or pop runnable requests: policy-class ordering and cross-class
+/// deficit round robin remain owned by Dynamo.
+pub trait QueueAdmissionPolicy: Send {
+    fn admit(&mut self, request: QueueAdmissionRequest<'_>) -> QueueAdmissionDecision;
+
+    fn on_event(&mut self, _event: QueueAdmissionEvent<'_>, _ready: &mut Vec<QueueAdmissionId>) {}
+
+    /// Return the maximum interval between reconciliation events.
+    ///
+    /// `None` uses the host interval. A zero duration is ignored.
+    fn reconcile_interval(&self) -> Option<Duration> {
+        None
+    }
+}
 
 /// Lock-free access to the latest logical context observed for one request.
 #[derive(Debug, Clone)]
@@ -68,5 +409,47 @@ mod tests {
         updater.update_context_tokens(50);
 
         assert_eq!(progress.context_tokens(), 55);
+    }
+
+    #[test]
+    fn worker_snapshot_sorts_and_finds_exact_ranks() {
+        let first = WorkerWithDpRank::new(1, 0);
+        let second = WorkerWithDpRank::new(2, 0);
+        let snapshot = QueueAdmissionWorkerSnapshot::new(
+            7,
+            vec![
+                QueueAdmissionWorker::new(second, Some(2_000), true),
+                QueueAdmissionWorker::new(first, Some(1_000), false),
+            ],
+        );
+
+        assert_eq!(snapshot.generation(), 7);
+        assert_eq!(snapshot.workers()[0].worker(), first);
+        assert_eq!(snapshot.get(second).unwrap().capacity_tokens(), Some(2_000));
+        assert!(snapshot.get(WorkerWithDpRank::new(3, 0)).is_none());
+    }
+
+    #[test]
+    fn synthetic_request_visits_only_eligible_workers() {
+        let first = WorkerWithDpRank::new(1, 0);
+        let second = WorkerWithDpRank::new(2, 0);
+        let snapshot = QueueAdmissionWorkerSnapshot::new(
+            1,
+            vec![
+                QueueAdmissionWorker::new(first, None, true),
+                QueueAdmissionWorker::new(second, None, true),
+            ],
+        );
+        let eligible = HashSet::from([second]);
+        let request =
+            QueueAdmissionRequest::new(QueueAdmissionId::new(1), "request", 16, None, &snapshot)
+                .with_eligible_workers(&eligible);
+        let mut visited = Vec::new();
+
+        request.for_each_eligible_worker(|worker| visited.push(worker.worker()));
+
+        assert_eq!(visited, [second]);
+        assert!(!request.is_worker_eligible(first));
+        assert!(request.is_worker_eligible(second));
     }
 }

--- a/lib/kv-router/src/scheduling/queue_admission/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/policy_queue.rs
@@ -465,7 +465,7 @@ impl<T> PolicyQueue<T> {
         }
     }
 
-    #[expect(
+    #[allow(
         dead_code,
         reason = "the queue-admission host installs the policy in the next stacked PR"
     )]
@@ -474,7 +474,7 @@ impl<T> PolicyQueue<T> {
         self
     }
 
-    #[expect(
+    #[allow(
         dead_code,
         reason = "the queue-admission host invokes admission in the next stacked PR"
     )]
@@ -507,7 +507,7 @@ impl<T> PolicyQueue<T> {
         (!matches!(decision, QueueAdmissionDecision::Bypass)).then_some((id, decision))
     }
 
-    #[expect(
+    #[allow(
         dead_code,
         reason = "the queue-admission host emits lifecycle events in the next stacked PR"
     )]
@@ -640,7 +640,7 @@ impl<T> PolicyQueue<T> {
         Ok(())
     }
 
-    #[expect(
+    #[allow(
         dead_code,
         reason = "the queue-admission host stores deferred requests in the next stacked PR"
     )]

--- a/lib/kv-router/src/scheduling/queue_admission/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/policy_queue.rs
@@ -1,10 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Host activation lands separately; preserve the internal policy state in this
-// foundation without forcing the public contract through a fake call site.
-#![allow(dead_code)]
-
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, BinaryHeap, HashSet};
 
@@ -469,11 +465,19 @@ impl<T> PolicyQueue<T> {
         }
     }
 
+    #[expect(
+        dead_code,
+        reason = "the queue-admission host installs the policy in the next stacked PR"
+    )]
     pub(crate) fn with_admission_policy(mut self, policy: Box<dyn QueueAdmissionPolicy>) -> Self {
         self.admission_policy = Some(policy);
         self
     }
 
+    #[expect(
+        dead_code,
+        reason = "the queue-admission host invokes admission in the next stacked PR"
+    )]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn admit_with_admission_policy(
         &mut self,
@@ -503,6 +507,10 @@ impl<T> PolicyQueue<T> {
         (!matches!(decision, QueueAdmissionDecision::Bypass)).then_some((id, decision))
     }
 
+    #[expect(
+        dead_code,
+        reason = "the queue-admission host emits lifecycle events in the next stacked PR"
+    )]
     pub(crate) fn admission_event(&mut self, event: QueueAdmissionEvent<'_>) -> bool {
         let Some(policy) = self.admission_policy.as_mut() else {
             return false;
@@ -632,6 +640,10 @@ impl<T> PolicyQueue<T> {
         Ok(())
     }
 
+    #[expect(
+        dead_code,
+        reason = "the queue-admission host stores deferred requests in the next stacked PR"
+    )]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn enqueue_deferred(
         &mut self,

--- a/lib/kv-router/src/scheduling/queue_admission/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/policy_queue.rs
@@ -1,17 +1,25 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Host activation lands separately; preserve the internal policy state in this
+// foundation without forcing the public contract through a fake call site.
+#![allow(dead_code)]
+
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, BinaryHeap};
+use std::collections::{BTreeSet, BinaryHeap, HashSet};
 
 use ordered_float::OrderedFloat;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
-use super::config::RouterQueuePolicy;
-use super::policy_config::{PolicyClassConfig, PolicyProfile};
-use super::queue_admission::WorkerPlacement;
-use crate::protocols::WorkerWithDpRank;
+use super::{
+    QueueAdmissionDecision, QueueAdmissionEvent, QueueAdmissionId, QueueAdmissionPolicy,
+    QueueAdmissionRequest, QueueAdmissionWorkerSnapshot, WorkerPlacement,
+};
+use crate::protocols::{WorkerId, WorkerWithDpRank};
+use crate::scheduling::config::RouterQueuePolicy;
+use crate::scheduling::policy_config::{PolicyClassConfig, PolicyProfile};
+use crate::scheduling::types::SessionContext;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueueSnapshot {
@@ -414,11 +422,20 @@ impl<T> PolicyClassQueue<T> {
 
 pub struct PolicyQueue<T> {
     classes: Vec<PolicyClassQueue<T>>,
+    deferred: FxHashMap<QueueAdmissionId, DeferredAdmissionEntry<T>>,
+    admission_policy: Option<Box<dyn QueueAdmissionPolicy>>,
+    admission_ready: Vec<QueueAdmissionId>,
+    next_admission_id: u64,
     round_cursor: usize,
     carry_class: Option<usize>,
     next_enqueue_seq: u64,
     pending_count: usize,
     candidates: Vec<Option<DispatchCandidate>>,
+}
+
+struct DeferredAdmissionEntry<T> {
+    placement: WorkerPlacement,
+    entry: PolicyQueueEntry<T>,
 }
 
 impl<T> PolicyQueue<T> {
@@ -440,12 +457,75 @@ impl<T> PolicyQueue<T> {
                     deficit: 0,
                 })
                 .collect(),
+            deferred: FxHashMap::default(),
+            admission_policy: None,
+            admission_ready: Vec::new(),
+            next_admission_id: 0,
             round_cursor: 0,
             carry_class: None,
             next_enqueue_seq: 0,
             pending_count: 0,
             candidates: vec![None; class_count],
         }
+    }
+
+    pub(crate) fn with_admission_policy(mut self, policy: Box<dyn QueueAdmissionPolicy>) -> Self {
+        self.admission_policy = Some(policy);
+        self
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn admit_with_admission_policy(
+        &mut self,
+        request_id: &str,
+        context_tokens: usize,
+        session_context: Option<&SessionContext>,
+        worker_snapshot: &QueueAdmissionWorkerSnapshot,
+        pinned_worker: Option<WorkerWithDpRank>,
+        allowed_worker_ids: Option<&HashSet<WorkerId>>,
+        has_hard_constraints: bool,
+        eligibility: &dyn Fn(WorkerWithDpRank) -> bool,
+    ) -> Option<(QueueAdmissionId, QueueAdmissionDecision)> {
+        let policy = self.admission_policy.as_mut()?;
+        let id = QueueAdmissionId::new(self.next_admission_id);
+        self.next_admission_id = self.next_admission_id.wrapping_add(1);
+        let decision = policy.admit(QueueAdmissionRequest::new_with_eligibility(
+            id,
+            request_id,
+            context_tokens,
+            session_context,
+            worker_snapshot,
+            pinned_worker,
+            allowed_worker_ids,
+            has_hard_constraints,
+            eligibility,
+        ));
+        (!matches!(decision, QueueAdmissionDecision::Bypass)).then_some((id, decision))
+    }
+
+    pub(crate) fn admission_event(&mut self, event: QueueAdmissionEvent<'_>) -> bool {
+        let Some(policy) = self.admission_policy.as_mut() else {
+            return false;
+        };
+        let mut ready = std::mem::take(&mut self.admission_ready);
+        ready.clear();
+        policy.on_event(event, &mut ready);
+
+        let mut made_ready = false;
+        for id in ready.drain(..) {
+            let Some(deferred) = self.deferred.remove(&id) else {
+                tracing::debug!(
+                    queue_admission_id = id.get(),
+                    "Ignoring unknown queue wake-up"
+                );
+                continue;
+            };
+            let class_index = deferred.entry.class_index;
+            self.classes[class_index].push_ready(deferred.placement, deferred.entry);
+            made_ready = true;
+        }
+        self.admission_ready = ready;
+        made_ready
     }
 
     pub fn pending_count(&self) -> usize {
@@ -502,7 +582,10 @@ impl<T> PolicyQueue<T> {
     }
 
     pub fn entries(&self) -> impl Iterator<Item = &PolicyQueueEntry<T>> {
-        self.classes.iter().flat_map(PolicyClassQueue::entries)
+        self.classes
+            .iter()
+            .flat_map(PolicyClassQueue::entries)
+            .chain(self.deferred.values().map(|deferred| &deferred.entry))
     }
 
     /// Remove queued entries that no longer satisfy `keep`, rebuilding queue
@@ -549,6 +632,44 @@ impl<T> PolicyQueue<T> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn enqueue_deferred(
+        &mut self,
+        class_index: usize,
+        worker_count: usize,
+        snapshot: QueueSnapshot,
+        arrival_offset_secs: f64,
+        priority_jump: f64,
+        strict_priority: u32,
+        placement: WorkerPlacement,
+        id: QueueAdmissionId,
+        payload: T,
+    ) -> Result<(), (QueueRejection, T)> {
+        let class = &mut self.classes[class_index];
+        if let Some(rejection) = queue_rejection(class, worker_count) {
+            return Err((rejection, payload));
+        }
+
+        let entry = make_entry(
+            class_index,
+            snapshot,
+            arrival_offset_secs,
+            priority_jump,
+            strict_priority,
+            class.config.queue_policy,
+            self.next_enqueue_seq,
+            payload,
+        );
+        self.next_enqueue_seq = self.next_enqueue_seq.wrapping_add(1);
+        add_stats(&mut class.stats, snapshot);
+        let replaced = self
+            .deferred
+            .insert(id, DeferredAdmissionEntry { placement, entry });
+        debug_assert!(replaced.is_none(), "duplicate queue admission ID");
+        self.pending_count += 1;
+        Ok(())
+    }
+
     pub(crate) fn take_if_in_class(
         &mut self,
         class_index: usize,
@@ -560,44 +681,62 @@ impl<T> PolicyQueue<T> {
             .filter(|entry| predicate(entry.payload()))
             .map(|entry| entry.enqueue_seq)
             .collect();
-        if remove_sequences.is_empty() {
+        let remove_deferred: Vec<QueueAdmissionId> = self
+            .deferred
+            .iter()
+            .filter(|(_, deferred)| {
+                deferred.entry.class_index == class_index && predicate(deferred.entry.payload())
+            })
+            .map(|(id, _)| *id)
+            .collect();
+        if remove_sequences.is_empty() && remove_deferred.is_empty() {
             return (Vec::new(), false);
         }
 
-        let removed_ready_head = class
-            .pending
-            .peek()
-            .is_some_and(|entry| remove_sequences.contains(&entry.enqueue_seq))
-            || class.ready_by_worker.values().any(|ready| {
-                ready
-                    .peek()
-                    .is_some_and(|entry| remove_sequences.contains(&entry.enqueue_seq))
-            });
-
         let mut removed = Vec::new();
-        let mut retained = Vec::with_capacity(class.pending.len());
-        for entry in class.pending.drain() {
-            if remove_sequences.contains(&entry.enqueue_seq) {
-                removed.push(entry);
-            } else {
-                retained.push(entry);
-            }
-        }
-        class.pending = BinaryHeap::from(retained);
-
-        class.ready_by_worker.retain(|_, ready| {
-            let mut retained = Vec::with_capacity(ready.len());
-            for entry in ready.drain() {
+        let removed_ready_head = if remove_sequences.is_empty() {
+            false
+        } else {
+            let removed_ready_head = class
+                .pending
+                .peek()
+                .is_some_and(|entry| remove_sequences.contains(&entry.enqueue_seq))
+                || class.ready_by_worker.values().any(|ready| {
+                    ready
+                        .peek()
+                        .is_some_and(|entry| remove_sequences.contains(&entry.enqueue_seq))
+                });
+            let mut retained = Vec::with_capacity(class.pending.len());
+            for entry in class.pending.drain() {
                 if remove_sequences.contains(&entry.enqueue_seq) {
                     removed.push(entry);
                 } else {
                     retained.push(entry);
                 }
             }
-            *ready = BinaryHeap::from(retained);
-            !ready.is_empty()
-        });
-        class.rebuild_worker_heads();
+            class.pending = BinaryHeap::from(retained);
+
+            class.ready_by_worker.retain(|_, ready| {
+                let mut retained = Vec::with_capacity(ready.len());
+                for entry in ready.drain() {
+                    if remove_sequences.contains(&entry.enqueue_seq) {
+                        removed.push(entry);
+                    } else {
+                        retained.push(entry);
+                    }
+                }
+                *ready = BinaryHeap::from(retained);
+                !ready.is_empty()
+            });
+            class.rebuild_worker_heads();
+            removed_ready_head
+        };
+
+        for id in remove_deferred {
+            if let Some(deferred) = self.deferred.remove(&id) {
+                removed.push(deferred.entry);
+            }
+        }
 
         for entry in &removed {
             subtract_stats(&mut class.stats, entry.snapshot);
@@ -710,12 +849,15 @@ impl<T> PolicyQueue<T> {
     }
 
     pub fn drain(self) -> impl Iterator<Item = PolicyQueueEntry<T>> {
-        self.classes.into_iter().flat_map(|class| {
-            class
-                .pending
-                .into_iter()
-                .chain(class.ready_by_worker.into_values().flatten())
-        })
+        self.classes
+            .into_iter()
+            .flat_map(|class| {
+                class
+                    .pending
+                    .into_iter()
+                    .chain(class.ready_by_worker.into_values().flatten())
+            })
+            .chain(self.deferred.into_values().map(|deferred| deferred.entry))
     }
 
     fn pop_candidate(
@@ -829,7 +971,33 @@ fn subtract_stats(stats: &mut PolicyQueueStats, snapshot: QueueSnapshot) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::scheduling::RouterPolicyConfig;
+    use crate::scheduling::{
+        QueueAdmissionWorker, QueueAdmissionWorkerSnapshot, RouterPolicyConfig,
+    };
+
+    #[derive(Default)]
+    struct WakeOnReconcile {
+        deferred: Option<QueueAdmissionId>,
+    }
+
+    impl QueueAdmissionPolicy for WakeOnReconcile {
+        fn admit(&mut self, request: QueueAdmissionRequest<'_>) -> QueueAdmissionDecision {
+            assert_eq!(request.request_id(), "request-1");
+            assert_eq!(request.context_tokens(), 32);
+            assert!(request.session_context().is_none());
+            assert_eq!(request.workers().len(), 1);
+            self.deferred = Some(request.id());
+            QueueAdmissionDecision::Defer
+        }
+
+        fn on_event(&mut self, event: QueueAdmissionEvent<'_>, ready: &mut Vec<QueueAdmissionId>) {
+            if matches!(event, QueueAdmissionEvent::Reconcile { .. })
+                && let Some(id) = self.deferred.take()
+            {
+                ready.push(id);
+            }
+        }
+    }
 
     fn profile(yaml: &str) -> PolicyProfile {
         RouterPolicyConfig::from_yaml(yaml)
@@ -852,6 +1020,58 @@ policy_classes:
     quantum: 10
 "#,
         )
+    }
+
+    #[test]
+    fn admission_policy_defers_host_owned_request_until_wake() {
+        let mut queue = PolicyQueue::new(admission_profile())
+            .with_admission_policy(Box::new(WakeOnReconcile::default()));
+        let snapshot = QueueAdmissionWorkerSnapshot::new(
+            1,
+            vec![QueueAdmissionWorker::new(
+                WorkerWithDpRank::new(7, 0),
+                Some(1_024),
+                true,
+            )],
+        );
+        let (id, decision) = queue
+            .admit_with_admission_policy(
+                "request-1",
+                32,
+                None,
+                &snapshot,
+                None,
+                None,
+                false,
+                &|_| true,
+            )
+            .unwrap();
+        assert_eq!(decision, QueueAdmissionDecision::Defer);
+
+        queue
+            .enqueue_deferred(
+                0,
+                1,
+                QueueSnapshot::new(32, 0),
+                0.0,
+                0.0,
+                0,
+                WorkerPlacement::Any,
+                id,
+                "payload",
+            )
+            .unwrap();
+        assert_eq!(queue.pending_count(), 1);
+        assert!(queue.pop_next(|_, _, _| true).is_none());
+
+        assert!(queue.admission_event(QueueAdmissionEvent::Reconcile {
+            snapshot: &snapshot,
+        }));
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "payload"
+        );
+        assert_eq!(queue.pending_count(), 0);
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -18,7 +18,7 @@ use crate::protocols::{
     WorkerWithDpRank,
 };
 use crate::router_hint::RouterHintRootCandidates;
-use crate::scheduling::policy_queue::QueueRejection;
+use crate::scheduling::queue_admission::QueueRejection;
 use crate::sequences::WorkerLoadProjection;
 
 pub type OverloadedWorkerProvider =


### PR DESCRIPTION
This introduces the standalone queue-admission policy API and moves policy-queue types under `scheduling::queue_admission`. It establishes a standalone foundation for session-aware policies without activating a policy in the scheduler yet.

### How This Was Implemented

- Define the object-safe policy decisions, request views, worker snapshots, admission IDs, and lifecycle event vocabulary.
- Move policy queue primitives into `scheduling::queue_admission` and update Dynamo’s internal imports to the new module.
- Keep the foundation dormant behind the next stacked host PR, with narrow documented allowances only for host-only methods.

<details>
<summary>Walkthrough</summary>

#### Mental model

The API separates an external policy’s accounting from Dynamo’s request and worker ownership. A policy can decide `Bypass`, `Ready`, or `Defer` and later wake a request by opaque admission ID; it cannot mutate Dynamo’s queue or choose a worker directly.

```mermaid
flowchart LR
    A[External policy] -->|decision or wake ID| B[Queue-admission API]
    B -->|implemented by next PR| C[Scheduler host]
    C --> D[Existing worker selection]
```

#### Boundaries and limitations

This foundation changes no scheduler behavior by itself. The following PR activates the host inside the queue actor; the final stacked PR bridges terminal reservation state and response progress. The former `scheduling::policy_queue` module path is intentionally removed; the public queue-admission surface lives under `scheduling::queue_admission`.

</details>

### Validation

- `cargo test -p dynamo-kv-router --lib` — 885 passed.
- `cargo clippy -p dynamo-kv-router --lib -- -D warnings`.
- `cargo fmt --all --check` and `git diff --check`.