### PR TITLE
docs(agents): add Cursor Cloud CPU-only dev setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,3 +157,45 @@ Any change under `docs/`, `examples/`, or `recipes/` must follow
 [documentation style guide](docs/fern/pages/community/contributing/documentation/documentation-style-guide.md): SPDX headers, Fern
 frontmatter (no body `# H1`), GitHub-style admonitions, and backend casing
 (vLLM / SGLang / TensorRT-LLM). The deterministic subset is enforced pre-merge.
+
+## Cursor Cloud specific instructions
+
+The Cloud VM is **CPU-only (no GPU)** with **no HuggingFace Hub egress** (downloads fail
+with connection reset). GitHub and PyPI egress do work. The build is pre-done in the VM
+snapshot; the startup update script only refreshes the two editable Python installs
+(`ai-dynamo` and `lib/gpu_memory_service`) into `.venv` — it does **not** rebuild the Rust
+bindings. Activate the env with `source .venv/bin/activate` before running anything.
+
+- **Rust changes are NOT hot-reloaded into Python.** After editing anything the PyO3
+  bindings depend on (`lib/bindings/python` or any workspace crate under `lib/`),
+  rebuild with `cd lib/bindings/python && maturin develop --uv`. A plain `uv pip install -e .`
+  will not pick up Rust changes. First build is ~3–5 min; incremental is faster.
+- **`cc`/`c++` are pointed at gcc/g++** (via `update-alternatives`, baked into the
+  snapshot). This is required because the default clang can't find libstdc++ headers when
+  cc-rs passes `--target=...`, which breaks C/C++ deps like the vendored ZeroMQ. If you
+  rebuild in a context where those alternatives aren't set, prefix builds with
+  `CC=gcc CXX=g++`.
+- **Run the product locally without GPU/etcd/NATS** using the mocker worker + file-based
+  discovery. HF Hub is blocked, so point `--model-path` at a local sample-model dir that
+  contains a `chat_template` (the frontend refuses to materialize a model without one).
+  `lib/llm/tests/data/sample-models/mock-llama-3.1-8b-instruct` works; `TinyLlama_v1.1`
+  does **not** (no `chat_template`). Do **not** pass `--model-name` — let the model id
+  default to the path so the frontend loads the tokenizer from disk instead of trying HF.
+  Set `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`. Example (two shells):
+  `python -m dynamo.frontend --http-port 8000 --discovery-backend file` and
+  `python -m dynamo.mocker --model-path lib/llm/tests/data/sample-models/mock-llama-3.1-8b-instruct --discovery-backend file`,
+  then `curl localhost:8000/v1/chat/completions`. The mocker simulates scheduling/KV/timing
+  and emits synthetic token IDs, so response `content` is `null`/garbage — the meaningful
+  signal is the request lifecycle and token/latency metrics, not the text. Real inference
+  (vLLM/SGLang/TensorRT-LLM) and anything needing Kubernetes require a GPU/cluster and are
+  out of scope here.
+- **Unit tests** (`pytest -m unit tests/`, see [Test](#test)) need
+  `--continue-on-collection-errors` on CPU-only: `tests/serve/test_{vllm,sglang,trtllm}.py`
+  and `tests/fault_tolerance/test_canary_rank_pause.py` fail to import (`torch`/
+  `tensorrt_llm` absent). Three unit tests fail by design in this env and are not setup
+  problems: `test_kvbm_wheel_exists`/`test_kvbm_imports` (expect a prebuilt KVBM wheel in
+  `/opt/dynamo/wheelhouse/`, only present in the container image) and
+  `test_aiconfigurator_consistency` (optional `aiconfigurator` sibling package not
+  installed).
+- **Lint**: `cargo fmt --all -- --check` and `cargo clippy --workspace` work directly;
+  `pre-commit` hooks fetch their environments from GitHub on first run (egress works).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview:

Documents how to set up, run, and test Dynamo in a Cursor Cloud (CPU-only, no-GPU, no
HuggingFace-Hub-egress) environment, captured while bringing the dev environment up from
scratch. Docs-only change (`AGENTS.md`); no code is modified.

## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering the
non-obvious gotchas discovered during setup:

- Rust bindings are **not** hot-reloaded into Python — rebuild with `maturin develop --uv`
  after editing anything under `lib/`.
- `cc`/`c++` must resolve to gcc/g++ (default clang can't find libstdc++ headers when
  cc-rs passes `--target=...`, breaking the vendored ZeroMQ C++ build).
- Running the product locally with no GPU/etcd/NATS via `dynamo.mocker` +
  `--discovery-backend file`, pointing `--model-path` at a local sample model that has a
  `chat_template` (HF Hub is blocked), and letting the model id default to the path.
- CPU-only `pytest -m unit` needs `--continue-on-collection-errors`, plus the three
  container/optional-package unit failures that are expected in this env.
- Lint entry points (`cargo fmt`/`clippy`, `pre-commit`).

## Details:

The Cloud VM had `uv`, `maturin`, `protoc`, and `python3-dev` missing; `cc`/`c++` pointed
at clang without discoverable libstdc++ headers. After installing those and repointing the
compiler alternatives, the PyO3 bindings build (`maturin develop --uv`), the editable
`ai-dynamo` + `gpu_memory_service` installs, lint, and unit tests all succeed. The core
serving path was validated end-to-end on CPU with `dynamo.frontend` + `dynamo.mocker`.

## Validation

- `cargo fmt --all -- --check` — passes.
- `pre-commit run --files AGENTS.md` — all applicable hooks pass (including `codespell`
  and `validate-skills`).
- `pytest -m unit tests/ --continue-on-collection-errors` — 116 passed, 26 skipped; the
  3 failures are container/optional-package checks unrelated to dev setup.
- End-to-end: `dynamo.frontend` + `dynamo.mocker` (file discovery) served both
  non-streaming and streaming `/v1/chat/completions` requests; frontend metrics show
  `input_tokens=6 output_tokens=16 ttft_ms=33.79 ... decode_worker_id=...` with matching
  worker-side `request received`/`request completed` log lines.

## Where should the reviewer start?

`AGENTS.md` — the new `## Cursor Cloud specific instructions` section.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fcf18c2-b8fe-4505-99e4-e1e34fa124a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fcf18c2-b8fe-4505-99e4-e1e34fa124a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

