### PR TITLE
chore(recipes): cherry-pick Nemotron-3.5-Lightning recipe corrections (#13022, #13031)

### DIFF
--- a/docs/fern/pages/recipes/_catalog/recipes/nemotron-3-5-lightning.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/nemotron-3-5-lightning.yaml
@@ -341,6 +341,326 @@ targets:
   expected_performance:
     available: true
     summary: 1478.67 output tok/s/GPU, 123.22 tok/s/user, TTFT p50 250.66ms @ concurrency 12
+- id: vllm-disagg-b200-dspark
+  recommended: true
+  hardware:
+    gpu: B200
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - speculative-decoding
+  - dspark
+  - prefix-caching
+  - nixl
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/vllm/disagg-b200-dspark/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 904.03 output tok/s/GPU, 226.01 tok/s/user, TTFT p50 236.43ms @ concurrency 8
+- id: vllm-disagg-gb200-dflash
+  recommended: true
+  hardware:
+    gpu: GB200
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - speculative-decoding
+  - dflash
+  - prefix-caching
+  - nixl
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/vllm/disagg-gb200-dflash/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 584.85 output tok/s/GPU, 292.43 tok/s/user, TTFT p50 491.40ms @ concurrency 4
+- id: vllm-disagg-gb200-dspark
+  recommended: true
+  hardware:
+    gpu: GB200
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - speculative-decoding
+  - dspark
+  - prefix-caching
+  - nixl
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/vllm/disagg-gb200-dspark/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 939.28 output tok/s/GPU, 234.82 tok/s/user, TTFT p50 599.17ms @ concurrency 8
+- id: vllm-disagg-h100-dflash
+  recommended: true
+  hardware:
+    gpu: H100
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - speculative-decoding
+  - dflash
+  - prefix-caching
+  - nixl
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/vllm/disagg-h100-dflash/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 1117.29 output tok/s/GPU, 186.21 tok/s/user, TTFT p50 542.71ms @ concurrency 12
+- id: vllm-disagg-h100-dspark
+  recommended: true
+  hardware:
+    gpu: H100
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - speculative-decoding
+  - dspark
+  - prefix-caching
+  - nixl
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/vllm/disagg-h100-dspark/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 1445.29 output tok/s/GPU, 120.44 tok/s/user, TTFT p50 2028.23ms @ concurrency 24
+- id: vllm-disagg-h100-mtp
+  recommended: true
+  hardware:
+    gpu: H100
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - speculative-decoding
+  - mtp
+  - prefix-caching
+  - nixl
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/vllm/disagg-h100-mtp/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 1055.68 output tok/s/GPU, 175.95 tok/s/user, TTFT p50 493.52ms @ concurrency 12
+- id: vllm-disagg-h200-dflash
+  recommended: true
+  hardware:
+    gpu: H200
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - speculative-decoding
+  - dflash
+  - prefix-caching
+  - nixl
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/vllm/disagg-h200-dflash/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 1277.86 output tok/s/GPU, 212.98 tok/s/user, TTFT p50 408.30ms @ concurrency 12
+- id: vllm-disagg-h200-dspark
+  recommended: true
+  hardware:
+    gpu: H200
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - speculative-decoding
+  - dspark
+  - prefix-caching
+  - nixl
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/vllm/disagg-h200-dspark/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 1656.90 output tok/s/GPU, 138.08 tok/s/user, TTFT p50 834.80ms @ concurrency 24
+- id: vllm-disagg-h200-mtp
+  recommended: true
+  hardware:
+    gpu: H200
+    count: 2
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - speculative-decoding
+  - mtp
+  - prefix-caching
+  - nixl
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/vllm/disagg-h200-mtp/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 1203.97 output tok/s/GPU, 200.66 tok/s/user, TTFT p50 424.66ms @ concurrency 12
+- id: trtllm-agg-b200
+  recommended: false
+  hardware:
+    gpu: B200
+    count: 1
+  runtime:
+    framework: TensorRT-LLM
+  topology: aggregated
+  techniques:
+  - tensorrt-llm
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/trtllm/agg-b200/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 386.998 output tok/s/GPU, 21.50 tok/s/user, TTFT p50 377.68ms @ concurrency 18; experimental smoke result
+- id: trtllm-agg-b200-mtp
+  recommended: false
+  hardware:
+    gpu: B200
+    count: 1
+  runtime:
+    framework: TensorRT-LLM
+  topology: aggregated
+  techniques:
+  - tensorrt-llm
+  - speculative-decoding
+  - mtp
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/trtllm/agg-b200-mtp/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 427.82 output tok/s/GPU, 23.77 tok/s/user, TTFT p50 446.88ms @ concurrency 18; experimental smoke result
+- id: trtllm-agg-gb200
+  recommended: false
+  hardware:
+    gpu: GB200
+    count: 1
+  runtime:
+    framework: TensorRT-LLM
+  topology: aggregated
+  techniques:
+  - tensorrt-llm
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/trtllm/agg-gb200/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 280.10 output tok/s/GPU, 15.56 tok/s/user, TTFT p50 318.88ms @ concurrency 18; experimental smoke result
+- id: trtllm-agg-gb200-mtp
+  recommended: false
+  hardware:
+    gpu: GB200
+    count: 1
+  runtime:
+    framework: TensorRT-LLM
+  topology: aggregated
+  techniques:
+  - tensorrt-llm
+  - speculative-decoding
+  - mtp
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/trtllm/agg-gb200-mtp/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 580.09 output tok/s/GPU, 32.23 tok/s/user, TTFT p50 400.88ms @ concurrency 18; experimental smoke result
+- id: trtllm-agg-h100-mtp
+  recommended: false
+  hardware:
+    gpu: H100
+    count: 1
+  runtime:
+    framework: TensorRT-LLM
+  topology: aggregated
+  techniques:
+  - tensorrt-llm
+  - speculative-decoding
+  - mtp
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/trtllm/agg-h100-mtp/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 264.87 output tok/s/GPU, 22.07 tok/s/user, TTFT p50 1757.00ms @ concurrency 12; experimental smoke result
+- id: trtllm-agg-h200-mtp
+  recommended: false
+  hardware:
+    gpu: H200
+    count: 1
+  runtime:
+    framework: TensorRT-LLM
+  topology: aggregated
+  techniques:
+  - tensorrt-llm
+  - speculative-decoding
+  - mtp
+  workload:
+    type: agentic
+    traffic: 64K/400 Mooncake-format agentic trace, 90% KV reuse
+    sla: TTFT p50 < 5000ms and >= 50 tok/s/user
+  deploy:
+    asset: recipes/nemotron-3.5-lightning/trtllm/agg-h200-mtp/deploy.yaml
+  expected_performance:
+    available: true
+    summary: 269.26 output tok/s/GPU, 22.44 tok/s/user, TTFT p50 1630.96ms @ concurrency 12; experimental smoke result
 related_benchmarks: []
 maintainer: null
 gaps:

--- a/docs/fern/pages/recipes/model-recipes/nemotron-3-5-lightning.mdx
+++ b/docs/fern/pages/recipes/model-recipes/nemotron-3-5-lightning.mdx
@@ -82,7 +82,7 @@ This recipe deploys `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`, a 30B 
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 2x GB200</span>
 <span><b>Runtime</b> vLLM, 1 prefill + 1 decode</span>
-<span><b>Transport</b> IB/RDMA with UCX starting point</span>
+<span><b>Transport</b> UCX/NIXL with cluster-specific fabric resources</span>
 <span><b>Spec decode</b> DFlash or DSpark</span>
 </div>
 <div className="dynamo-target-picker-summary" data-sku="b200" data-variant="trtllm-agg">
@@ -125,12 +125,19 @@ This recipe deploys `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`, a 30B 
 <div data-sku="h100" data-variant="vllm-disagg">
 
 - AWS EFA/LIBFABRIC resources exposed as `vpc.amazonaws.com/efa` for the H100 disaggregated manifests.
+- AWS EFA userspace available in the runtime image or installed by your cluster bootstrap flow before pod startup. The manifests do not download or install EFA packages. Use the [EFA check helper](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/vllm/check-efa-userspace.sh) to validate a prepared image or running pod; its install mode requires a pinned `EFA_INSTALLER_VERSION` and `EFA_INSTALLER_SHA256`.
 
 </div>
 
 <div data-sku="h200 b200" data-variant="vllm-disagg">
 
 - IB/RDMA resources exposed as `rdma/ib` for the H200 and B200 disaggregated manifests.
+
+</div>
+
+<div data-sku="gb200" data-variant="vllm-disagg">
+
+- GB200 disaggregated manifests leave fabric resources cluster-specific. Add the UCX/NIXL resource claims or network resources required by your platform.
 
 </div>
 
@@ -145,7 +152,7 @@ kubectl create secret generic hf-token-secret \
 ```
 
 <Warning>
-Edit storage class, image pull secret names, node selectors, RDMA resources, and cluster-specific placement before applying these manifests.
+Edit storage class, image pull secret names, node selectors, fabric resources, and cluster-specific placement before applying these manifests.
 </Warning>
 
 ## Deploy
@@ -212,18 +219,18 @@ kubectl apply -f recipes/nemotron-3.5-lightning/vllm/disagg-b200-dspark/deploy.y
 kubectl get dgd vllm-disagg-b200-dspark -n ${NAMESPACE} -w
 ```
 
-The checked-in B200 disaggregated DSpark row produced a 500-request smoke result.
+Use this target for B200 disaggregated vLLM validation with DSpark speculative decoding.
 
 </div>
 
 <div data-sku="h100" data-variant="vllm-disagg">
 
 ```bash
-kubectl apply -f recipes/nemotron-3.5-lightning/vllm/disagg-h100-dflash/deploy.yaml -n ${NAMESPACE}
-kubectl get dgd vllm-disagg-h100-dflash -n ${NAMESPACE} -w
+kubectl apply -f recipes/nemotron-3.5-lightning/vllm/disagg-h100-dspark/deploy.yaml -n ${NAMESPACE}
+kubectl get dgd vllm-disagg-h100-dspark -n ${NAMESPACE} -w
 ```
 
-DFlash is the highest-throughput H100 disaggregated row in the source inventory. Use `disagg-h100-mtp` or `disagg-h100-dspark` to compare the other speculative decoding modes.
+DSpark is the highest-output-throughput H100 disaggregated row in the source inventory. Use `disagg-h100-dflash` or `disagg-h100-mtp` to compare the other speculative decoding modes.
 
 </div>
 
@@ -340,7 +347,7 @@ kubectl port-forward svc/vllm-disagg-b200-dspark-frontend 8000:8000 -n ${NAMESPA
 <div data-sku="h100" data-variant="vllm-disagg">
 
 ```bash
-kubectl port-forward svc/vllm-disagg-h100-dflash-frontend 8000:8000 -n ${NAMESPACE}
+kubectl port-forward svc/vllm-disagg-h100-dspark-frontend 8000:8000 -n ${NAMESPACE}
 ```
 
 </div>
@@ -409,7 +416,7 @@ curl http://localhost:8000/v1/chat/completions \
 
 ## Benchmark
 
-The checked-in recipe includes benchmark results in [`recipes/nemotron-3.5-lightning/perf/README.md`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/perf/README.md), but it does not include a runnable benchmark Job manifest. Most rows replay the 3,541-request Mooncake-format agentic trace; the source performance README records request counts for shorter smoke rows. The pass criteria are `tok/s/user >= 50` and TTFT p50 under 5 seconds.
+The checked-in recipe includes benchmark results in [`recipes/nemotron-3.5-lightning/perf/README.md`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/perf/README.md). The pass criteria are `tok/s/user >= 50` and TTFT p50 under 5 seconds.
 
 To reproduce the shape, run AIPerf against the selected frontend with a Mooncake trace replay and the target concurrency from the table.
 
@@ -419,7 +426,7 @@ To reproduce the shape, run AIPerf against the selected frontend with a Mooncake
 aiperf profile \
   -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
   --custom-dataset-type mooncake_trace \
-  --num-requests 500 \
+  --num-requests 3541 \
   --endpoint-type chat \
   --streaming \
   --use-server-token-count \
@@ -515,8 +522,8 @@ aiperf profile \
   --use-server-token-count \
   --extra-inputs ignore_eos:true \
   --request-timeout-seconds 1200 \
-  --url http://vllm-disagg-h100-dflash-frontend:8000 \
-  --concurrency 12
+  --url http://vllm-disagg-h100-dspark-frontend:8000 \
+  --concurrency 24
 ```
 
 </div>
@@ -597,9 +604,10 @@ TensorRT-LLM rows are experimental smoke or inventory results in the source READ
 <tr data-sku="gb200" data-variant="vllm-disagg"><td><code>vllm/disagg-gb200-dspark/deploy.yaml</code></td><td>DSpark</td><td>1P1D</td><td>8</td><td>599.17</td><td>939.28</td><td>234.82</td></tr>
 <tr data-sku="b200" data-variant="trtllm-agg"><td><code>trtllm/agg-b200/deploy.yaml</code></td><td>None</td><td>Single worker</td><td>18</td><td>377.68</td><td>386.998</td><td>21.50</td></tr>
 <tr data-sku="b200" data-variant="trtllm-agg"><td><code>trtllm/agg-b200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>18</td><td>446.88</td><td>427.82</td><td>23.77</td></tr>
-<tr data-sku="h100" data-variant="trtllm-agg"><td><code>trtllm/agg-h100-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>12</td><td>30570.70</td><td>380.91</td><td>31.74</td></tr>
-<tr data-sku="h200" data-variant="trtllm-agg"><td><code>trtllm/agg-h200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>12</td><td>473.46</td><td>484.34</td><td>40.36</td></tr>
-<tr data-sku="gb200" data-variant="trtllm-agg"><td><code>trtllm/agg-gb200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>18</td><td>304.49</td><td>940.30</td><td>52.24</td></tr>
+<tr data-sku="h100" data-variant="trtllm-agg"><td><code>trtllm/agg-h100-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>12</td><td>1757.00</td><td>264.87</td><td>22.07</td></tr>
+<tr data-sku="h200" data-variant="trtllm-agg"><td><code>trtllm/agg-h200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>12</td><td>1630.96</td><td>269.26</td><td>22.44</td></tr>
+<tr data-sku="gb200" data-variant="trtllm-agg"><td><code>trtllm/agg-gb200/deploy.yaml</code></td><td>None</td><td>Single worker</td><td>18</td><td>318.88</td><td>280.10</td><td>15.56</td></tr>
+<tr data-sku="gb200" data-variant="trtllm-agg"><td><code>trtllm/agg-gb200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>18</td><td>400.88</td><td>580.09</td><td>32.23</td></tr>
 </tbody>
 </table>
 </div>
@@ -617,7 +625,7 @@ TensorRT-LLM rows are experimental smoke or inventory results in the source READ
 <tr data-sku="h200" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>H200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-h200-dspark-kv-router/deploy.yaml</code> (DSpark + KV router)<br /><code>vllm/agg-h200-dspark/deploy.yaml</code><br /><code>vllm/agg-h200-dflash/deploy.yaml</code><br /><code>vllm/agg-h200-mtp/deploy.yaml</code></td></tr>
 <tr data-sku="gb200" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>GB200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-gb200-dspark/deploy.yaml</code><br /><code>vllm/agg-gb200-dflash/deploy.yaml</code><br /><code>vllm/agg-gb200-mtp/deploy.yaml</code></td></tr>
 <tr data-sku="b200" data-variant="vllm-disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>B200</td><td>DSpark</td><td><code>vllm/disagg-b200-dspark/deploy.yaml</code></td></tr>
-<tr data-sku="h100" data-variant="vllm-disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>H100</td><td>MTP, DFlash, DSpark</td><td><code>vllm/disagg-h100-dflash/deploy.yaml</code><br /><code>vllm/disagg-h100-dspark/deploy.yaml</code><br /><code>vllm/disagg-h100-mtp/deploy.yaml</code></td></tr>
+<tr data-sku="h100" data-variant="vllm-disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>H100</td><td>MTP, DFlash, DSpark</td><td><code>vllm/disagg-h100-dspark/deploy.yaml</code><br /><code>vllm/disagg-h100-dflash/deploy.yaml</code><br /><code>vllm/disagg-h100-mtp/deploy.yaml</code></td></tr>
 <tr data-sku="h200" data-variant="vllm-disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>H200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/disagg-h200-dspark/deploy.yaml</code><br /><code>vllm/disagg-h200-dflash/deploy.yaml</code><br /><code>vllm/disagg-h200-mtp/deploy.yaml</code></td></tr>
 <tr data-sku="gb200" data-variant="vllm-disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>GB200</td><td>DFlash, DSpark</td><td><code>vllm/disagg-gb200-dspark/deploy.yaml</code><br /><code>vllm/disagg-gb200-dflash/deploy.yaml</code></td></tr>
 <tr data-sku="b200" data-variant="trtllm-agg"><td>TensorRT-LLM</td><td>Aggregated</td><td>B200</td><td>MTP, no-spec fallback</td><td><code>trtllm/agg-b200-mtp/deploy.yaml</code><br /><code>trtllm/agg-b200/deploy.yaml</code></td></tr>
@@ -650,6 +658,7 @@ TensorRT-LLM rows are experimental smoke or inventory results in the source READ
 
 - Source README: [recipes/nemotron-3.5-lightning/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/README.md)
 - vLLM README: [recipes/nemotron-3.5-lightning/vllm/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/vllm/README.md)
+- EFA check helper: [recipes/nemotron-3.5-lightning/vllm/check-efa-userspace.sh](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/vllm/check-efa-userspace.sh)
 - TensorRT-LLM README: [recipes/nemotron-3.5-lightning/trtllm/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/trtllm/README.md)
 - Performance notes: [recipes/nemotron-3.5-lightning/perf/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/perf/README.md)
 - Model cache manifests: [model-cache](https://github.com/ai-dynamo/dynamo/tree/main/recipes/nemotron-3.5-lightning/model-cache)

--- a/docs/fern/pages/recipes/model-recipes/overview.mdx
+++ b/docs/fern/pages/recipes/model-recipes/overview.mdx
@@ -41,7 +41,7 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
       <p>Filter by provider, runtime, and hardware. Each card notes its serving technique and workload shape.</p>
     </div>
     <div className="dynamo-catalog-facts">
-      <strong>58</strong>
+      <strong>80</strong>
       <span>Deployable configurations</span>
       <button className="dynamo-filter-reset" type="reset">Reset filters</button>
     </div>

--- a/recipes/nemotron-3.5-lightning/README.md
+++ b/recipes/nemotron-3.5-lightning/README.md
@@ -48,6 +48,7 @@ Create the shared model cache and populate it with the target and draft models:
 
 ```bash
 export NAMESPACE=your-namespace
+# Replace your-storage-class-name in model-cache/model-cache.yaml first.
 kubectl apply -n "${NAMESPACE}" -f model-cache/model-cache.yaml
 kubectl apply -n "${NAMESPACE}" -f model-cache/model-download.yaml
 kubectl wait -n "${NAMESPACE}" --for=condition=Complete job/model-download --timeout=3600s
@@ -58,6 +59,7 @@ Deploy a recipe:
 ```bash
 RECIPE=vllm/agg-b200-dspark
 kubectl apply -n "${NAMESPACE}" -f "${RECIPE}/deploy.yaml"
+kubectl get dgd -n "${NAMESPACE}" vllm-agg-b200-dspark -w
 ```
 
 Port-forward the frontend service and send a chat request:

--- a/recipes/nemotron-3.5-lightning/model-cache/model-cache.yaml
+++ b/recipes/nemotron-3.5-lightning/model-cache/model-cache.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Shared Hugging Face cache for Nemotron 3.5 Nano base and draft models.
+# Shared Hugging Face cache for Nemotron 3.5 Lightning base and draft models.
 # Edit storageClassName to match your cluster:
 #   kubectl get storageclass
 apiVersion: v1

--- a/recipes/nemotron-3.5-lightning/model-cache/model-download.yaml
+++ b/recipes/nemotron-3.5-lightning/model-cache/model-download.yaml
@@ -11,16 +11,23 @@ spec:
   backoffLimit: 3
   completions: 1
   parallelism: 1
+  activeDeadlineSeconds: 3600
   template:
     metadata:
       labels:
         app: model-download
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+        - name: your-image-pull-secret
       containers:
         - name: model-download
-          image: python:3.10-slim
-          command: ["sh", "-c"]
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
+          command: ["python3", "-c"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           envFrom:
             - secretRef:
                 name: hf-token-secret
@@ -37,12 +44,17 @@ spec:
               value: "1"
           args:
             - |
-              set -eux
-              pip install --no-cache-dir huggingface_hub==1.16.4
-              hf download "$BASE_MODEL"
-              hf download "$DFLASH_MODEL"
-              hf download "$DSPARK_MODEL"
-              find /model-cache/hub -maxdepth 3 -type d -name snapshots -print
+              import os
+              from pathlib import Path
+              from huggingface_hub import snapshot_download
+
+              for env_name in ("BASE_MODEL", "DFLASH_MODEL", "DSPARK_MODEL"):
+                  repo_id = os.environ[env_name]
+                  print(f"Downloading {repo_id}", flush=True)
+                  snapshot_download(repo_id=repo_id)
+
+              for path in Path("/model-cache/hub").glob("*/snapshots"):
+                  print(path)
           volumeMounts:
             - name: shared-model-cache
               mountPath: /model-cache

--- a/recipes/nemotron-3.5-lightning/trtllm/agg-b200-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/trtllm/agg-b200-mtp/deploy.yaml
@@ -44,7 +44,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -94,7 +93,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/trtllm/agg-b200/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/trtllm/agg-b200/deploy.yaml
@@ -39,7 +39,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -89,7 +88,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/trtllm/agg-gb200-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/trtllm/agg-gb200-mtp/deploy.yaml
@@ -44,7 +44,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -94,7 +93,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/trtllm/agg-gb200/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/trtllm/agg-gb200/deploy.yaml
@@ -39,7 +39,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -89,7 +88,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/trtllm/agg-h100-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/trtllm/agg-h100-mtp/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Experimental aggregated TRT-LLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H100.
+# Experimental aggregated TRT-LLM MTP deployment for Nemotron 3.5 Lightning NVFP4 on 1x H100.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/recipes/nemotron-3.5-lightning/trtllm/agg-h200-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/trtllm/agg-h200-mtp/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Experimental aggregated TRT-LLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H200.
+# Experimental aggregated TRT-LLM MTP deployment for Nemotron 3.5 Lightning NVFP4 on 1x H200.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -39,7 +39,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -89,7 +88,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/vllm/README.md
+++ b/recipes/nemotron-3.5-lightning/vllm/README.md
@@ -18,7 +18,7 @@ hardware and speculative decoding combinations.
 | H100 | `agg-h100-{mtp,dflash,dspark}` | `disagg-h100-{mtp,dflash,dspark}` | AWS EFA / Libfabric |
 | H200 | `agg-h200-{mtp,dflash,dspark}` | `disagg-h200-{mtp,dflash,dspark}` | UCX over IB/RDMA |
 | B200 | `agg-b200-{mtp,dflash,dspark}` | `disagg-b200-dspark` | UCX over IB/RDMA |
-| GB200 | `agg-gb200-{mtp,dflash,dspark}` | `disagg-gb200-{dflash,dspark}` | UCX |
+| GB200 | `agg-gb200-{mtp,dflash,dspark}` | `disagg-gb200-{dflash,dspark}` | UCX/NIXL, cluster-specific fabric resources |
 
 Each recipe identifier corresponds to `identifier/deploy.yaml` in this directory.
 
@@ -58,6 +58,18 @@ more GPUs.
    populated with `../model-cache/model-download.yaml`.
 3. A Hugging Face secret named `hf-token-secret` and an image-pull secret when
    required by the cluster.
+4. For H100 disaggregated recipes, AWS EFA userspace must already be available
+   in the runtime image or installed through your cluster's approved bootstrap
+   flow. These manifests request `vpc.amazonaws.com/efa` and select the NIXL
+   LIBFABRIC backend, but they do not install EFA packages during pod startup.
+   Use `check-efa-userspace.sh` to validate a prepared image or running pod. If
+   you use its install mode, set `EFA_INSTALLER_VERSION` and
+   `EFA_INSTALLER_SHA256` to pin and verify the installer archive.
+
+```bash
+kubectl exec -i -n "${NAMESPACE}" <h100-worker-pod> -- \
+  bash -s -- check < check-efa-userspace.sh
+```
 
 ## Quick start
 
@@ -113,5 +125,6 @@ ConfigMap key.
 - B200 DFlash recipes disable the FlashInfer FP8 ScaledMM linear kernel.
 - Disaggregated recipes require matching speculative-decoding settings on the
   prefill and decode workers for compatible NIXL cache metadata.
+- H100 disaggregated recipes require the EFA userspace stack before deployment.
 - Replace `your-image-pull-secret` and any cluster-specific networking resource
   names with values available in the target cluster.

--- a/recipes/nemotron-3.5-lightning/vllm/agg-b200-dflash/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-b200-dflash/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x B200.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x B200.
 # The B200 recipes in this repo disable the FlashInfer FP8 ScaledMM path to
 # keep CUDA graphs enabled for this configuration.
 apiVersion: v1

--- a/recipes/nemotron-3.5-lightning/vllm/agg-b200-dspark-kv-router/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-b200-dspark-kv-router/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x B200 with DSpark speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x B200 with DSpark speculative decoding.
 # The B200 recipes in this repo disable the FlashInfer FP8 ScaledMM path to
 # keep CUDA graphs enabled for this configuration.
 apiVersion: v1

--- a/recipes/nemotron-3.5-lightning/vllm/agg-b200-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-b200-dspark/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x B200 with DSpark speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x B200 with DSpark speculative decoding.
 # The B200 recipes in this repo disable the FlashInfer FP8 ScaledMM path to
 # keep CUDA graphs enabled for this configuration.
 apiVersion: v1

--- a/recipes/nemotron-3.5-lightning/vllm/agg-b200-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-b200-mtp/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x B200 with built-in MTP speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x B200 with built-in MTP speculative decoding.
 # The B200 recipes in this repo disable the FlashInfer FP8 ScaledMM path to
 # keep CUDA graphs enabled for this configuration.
 apiVersion: v1

--- a/recipes/nemotron-3.5-lightning/vllm/agg-gb200-dflash/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-gb200-dflash/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x GB200.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x GB200.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,7 +37,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -100,7 +99,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/vllm/agg-gb200-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-gb200-dspark/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x GB200 with DSpark speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x GB200 with DSpark speculative decoding.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,7 +37,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -100,7 +99,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/vllm/agg-gb200-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-gb200-mtp/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x GB200 with built-in MTP speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x GB200 with built-in MTP speculative decoding.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,7 +33,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -96,7 +95,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/vllm/agg-h100-dflash/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-h100-dflash/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H100.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x H100.
 # The model must already be present in shared-model-cache.
 apiVersion: v1
 kind: ConfigMap

--- a/recipes/nemotron-3.5-lightning/vllm/agg-h100-dspark-kv-router/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-h100-dspark-kv-router/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H100 with DSpark speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x H100 with DSpark speculative decoding.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/recipes/nemotron-3.5-lightning/vllm/agg-h100-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-h100-dspark/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H100 with DSpark speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x H100 with DSpark speculative decoding.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/recipes/nemotron-3.5-lightning/vllm/agg-h100-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-h100-mtp/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H100 with built-in MTP speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x H100 with built-in MTP speculative decoding.
 # The model must already be present in shared-model-cache.
 apiVersion: v1
 kind: ConfigMap

--- a/recipes/nemotron-3.5-lightning/vllm/agg-h200-dflash/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-h200-dflash/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H200.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x H200.
 # The model must already be present in shared-model-cache.
 apiVersion: v1
 kind: ConfigMap
@@ -36,7 +36,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -83,7 +82,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/vllm/agg-h200-dspark-kv-router/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-h200-dspark-kv-router/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H200 with DSpark speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x H200 with DSpark speculative decoding.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,7 +37,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -89,7 +88,6 @@ spec:
     - name: agg
       type: worker
       replicas: 4
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/vllm/agg-h200-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-h200-dspark/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H200 with DSpark speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x H200 with DSpark speculative decoding.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,7 +37,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -84,7 +83,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/vllm/agg-h200-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-h200-mtp/deploy.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Aggregated vLLM deployment for Nemotron 3.5 Nano NVFP4 on 1x H200 with built-in MTP speculative decoding.
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x H200 with built-in MTP speculative decoding.
 # The model must already be present in shared-model-cache.
 apiVersion: v1
 kind: ConfigMap
@@ -34,7 +34,6 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       podTemplate:
         spec:
           imagePullSecrets:
@@ -81,7 +80,6 @@ spec:
     - name: agg
       type: worker
       replicas: 1
-      runtimeVersionOverride: 1.4.0
       sharedMemorySize: 40Gi
       podTemplate:
         spec:

--- a/recipes/nemotron-3.5-lightning/vllm/check-efa-userspace.sh
+++ b/recipes/nemotron-3.5-lightning/vllm/check-efa-userspace.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+export PATH="/opt/amazon/efa/bin:${PATH}"
+export LD_LIBRARY_PATH="/opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  check-efa-userspace.sh check
+  EFA_INSTALLER_VERSION=<version> EFA_INSTALLER_SHA256=<sha256> check-efa-userspace.sh install
+
+The default mode is check. Install mode downloads a versioned AWS EFA installer
+archive, verifies its SHA-256 checksum, and runs the installer without kernel
+module or limit configuration changes.
+EOF
+}
+
+check_efa_userspace() {
+  if ! command -v fi_info >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+EFA userspace is not installed: fi_info was not found.
+
+Install the AWS EFA userspace stack in the runtime image or by using your
+cluster's approved node/container bootstrap flow before deploying the H100
+disaggregated manifests.
+EOF
+    exit 1
+  fi
+
+  if ! fi_info -p efa >/tmp/dynamo-efa-fi-info.txt 2>&1; then
+    cat >&2 <<'EOF'
+The EFA provider is not available to libfabric.
+
+Check that the runtime image contains the EFA userspace libraries and that the
+pod requests the EFA device resources exposed by the cluster.
+EOF
+    cat /tmp/dynamo-efa-fi-info.txt >&2
+    exit 1
+  fi
+
+  echo "EFA userspace detected."
+  fi_info -p efa | head -80
+}
+
+install_efa_userspace() {
+  if [ "$(id -u)" != "0" ]; then
+    echo "Install mode must run as root." >&2
+    exit 1
+  fi
+
+  : "${EFA_INSTALLER_VERSION:?Set EFA_INSTALLER_VERSION to a pinned AWS EFA installer version.}"
+  : "${EFA_INSTALLER_SHA256:?Set EFA_INSTALLER_SHA256 to the installer archive SHA-256.}"
+
+  for tool in curl sha256sum tar; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+      echo "Install mode requires ${tool} in the runtime image." >&2
+      exit 1
+    fi
+  done
+
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "${workdir}"' EXIT
+
+  archive="${workdir}/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz"
+  curl -fsSL \
+    "https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz" \
+    -o "${archive}"
+  printf '%s  %s\n' "${EFA_INSTALLER_SHA256}" "${archive}" | sha256sum -c -
+  tar -xzf "${archive}" -C "${workdir}"
+
+  cd "${workdir}/aws-efa-installer"
+  ./efa_installer.sh -y --skip-kmod --skip-limit-conf
+  check_efa_userspace
+}
+
+case "${1:-check}" in
+  check)
+    check_efa_userspace
+    ;;
+  install)
+    install_efa_userspace
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-b200-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-b200-dspark/deploy.yaml
@@ -153,8 +153,6 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
           - --disaggregation-mode
           - prefill
-          - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
           env:
           - name: POD_UID
             valueFrom:

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-gb200-dflash/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-gb200-dflash/deploy.yaml
@@ -34,7 +34,6 @@ spec:
   - name: Frontend
     type: frontend
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     podTemplate:
       spec:
         imagePullSecrets:
@@ -91,7 +90,6 @@ spec:
     type: prefill
     replicas: 1
     sharedMemorySize: 40Gi
-    runtimeVersionOverride: 1.4.0
     podTemplate:
       spec:
         imagePullSecrets:
@@ -172,8 +170,6 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
           - --disaggregation-mode
           - prefill
-          - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
           env:
           - name: POD_UID
             valueFrom:
@@ -244,7 +240,6 @@ spec:
     type: decode
     replicas: 1
     sharedMemorySize: 40Gi
-    runtimeVersionOverride: 1.4.0
     podTemplate:
       spec:
         imagePullSecrets:

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-gb200-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-gb200-dspark/deploy.yaml
@@ -36,7 +36,6 @@ spec:
   - name: Frontend
     type: frontend
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     podTemplate:
       spec:
         imagePullSecrets:
@@ -93,7 +92,6 @@ spec:
     type: prefill
     replicas: 1
     sharedMemorySize: 40Gi
-    runtimeVersionOverride: 1.4.0
     podTemplate:
       spec:
         imagePullSecrets:
@@ -174,8 +172,6 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
           - --disaggregation-mode
           - prefill
-          - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
           env:
           - name: POD_UID
             valueFrom:
@@ -246,7 +242,6 @@ spec:
     type: decode
     replicas: 1
     sharedMemorySize: 40Gi
-    runtimeVersionOverride: 1.4.0
     podTemplate:
       spec:
         imagePullSecrets:

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-h100-dflash/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-h100-dflash/deploy.yaml
@@ -184,13 +184,11 @@ spec:
           - name: PYTHONHASHSEED
             value: '0'
           # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # If EFA is unpacked under /opt/amazon/efa without ldconfig registration,
+          # add PATH and LD_LIBRARY_PATH entries for that location here.
           # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
-          - name: PATH
-            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - name: LD_LIBRARY_PATH
-            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE
@@ -337,13 +335,11 @@ spec:
           - name: PYTHONHASHSEED
             value: '0'
           # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # If EFA is unpacked under /opt/amazon/efa without ldconfig registration,
+          # add PATH and LD_LIBRARY_PATH entries for that location here.
           # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
-          - name: PATH
-            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - name: LD_LIBRARY_PATH
-            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-h100-dflash/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-h100-dflash/deploy.yaml
@@ -20,36 +20,6 @@ data:
       "rejection_sample_method": "synthetic",
       "synthetic_acceptance_length": 2.73
     }
-  efa-entrypoint.sh: |
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    export DEBIAN_FRONTEND=noninteractive
-
-    install_efa_userspace() {
-      if [ -x /opt/amazon/efa/bin/fi_info ]; then
-        return 0
-      fi
-
-      apt-get update
-      apt-get install -y --no-install-recommends ca-certificates curl tar gzip
-      cd /tmp
-      curl -fsSL https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz -o aws-efa-installer-latest.tar.gz
-      tar -xzf aws-efa-installer-latest.tar.gz
-      cd aws-efa-installer
-      ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify || ./efa_installer.sh -y --skip-kmod --skip-limit-conf
-    }
-
-    install_efa_userspace
-
-    export PATH="/opt/amazon/efa/bin:${PATH}"
-    export LD_LIBRARY_PATH="/opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
-    export UCX_RCACHE_MAX_UNRELEASED="${UCX_RCACHE_MAX_UNRELEASED:-1024}"
-
-    echo "LOI_LIBFABRIC_DEBUG FI_PROVIDER=${FI_PROVIDER:-unset} NIXL_LIBFABRIC_USE_DEVICE_RDMA=${NIXL_LIBFABRIC_USE_DEVICE_RDMA:-unset} UCX_RCACHE_MAX_UNRELEASED=${UCX_RCACHE_MAX_UNRELEASED:-unset}"
-    fi_info -p efa | head -80 || true
-
-    exec "$@"
 ---
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
@@ -136,22 +106,14 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 40Gi
-        - name: efa-entrypoint
-          configMap:
-            name: vllm-disagg-h100-dflash-config
-            defaultMode: 0555
-            items:
-            - key: efa-entrypoint.sh
-              path: efa-entrypoint.sh
         containers:
         - name: main
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/
           command:
-          - /opt/dynamo/efa/efa-entrypoint.sh
-          args:
           - python3
+          args:
           - -m
           - dynamo.vllm
           - --model
@@ -191,8 +153,6 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           - --disaggregation-mode
           - prefill
-          - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
           env:
           - name: POD_UID
             valueFrom:
@@ -223,8 +183,14 @@ spec:
             value: DS
           - name: PYTHONHASHSEED
             value: '0'
+          # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
+          - name: PATH
+            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          - name: LD_LIBRARY_PATH
+            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE
@@ -263,9 +229,6 @@ spec:
             mountPath: /model-cache
           - name: dshm
             mountPath: /dev/shm
-          - name: efa-entrypoint
-            mountPath: /opt/dynamo/efa
-            readOnly: true
   - name: VllmDecodeWorker
     type: decode
     replicas: 1
@@ -296,22 +259,14 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 40Gi
-        - name: efa-entrypoint
-          configMap:
-            name: vllm-disagg-h100-dflash-config
-            defaultMode: 0555
-            items:
-            - key: efa-entrypoint.sh
-              path: efa-entrypoint.sh
         containers:
         - name: main
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/
           command:
-          - /opt/dynamo/efa/efa-entrypoint.sh
-          args:
           - python3
+          args:
           - -m
           - dynamo.vllm
           - --model
@@ -381,8 +336,14 @@ spec:
             value: DS
           - name: PYTHONHASHSEED
             value: '0'
+          # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
+          - name: PATH
+            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          - name: LD_LIBRARY_PATH
+            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE
@@ -421,6 +382,3 @@ spec:
             mountPath: /model-cache
           - name: dshm
             mountPath: /dev/shm
-          - name: efa-entrypoint
-            mountPath: /opt/dynamo/efa
-            readOnly: true

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-h100-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-h100-dspark/deploy.yaml
@@ -186,13 +186,11 @@ spec:
           - name: PYTHONHASHSEED
             value: '0'
           # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # If EFA is unpacked under /opt/amazon/efa without ldconfig registration,
+          # add PATH and LD_LIBRARY_PATH entries for that location here.
           # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
-          - name: PATH
-            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - name: LD_LIBRARY_PATH
-            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE
@@ -339,13 +337,11 @@ spec:
           - name: PYTHONHASHSEED
             value: '0'
           # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # If EFA is unpacked under /opt/amazon/efa without ldconfig registration,
+          # add PATH and LD_LIBRARY_PATH entries for that location here.
           # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
-          - name: PATH
-            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - name: LD_LIBRARY_PATH
-            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-h100-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-h100-dspark/deploy.yaml
@@ -22,36 +22,6 @@ data:
       "synthetic_acceptance_length": 1.83,
       "attention_backend": "TRITON_ATTN"
     }
-  efa-entrypoint.sh: |
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    export DEBIAN_FRONTEND=noninteractive
-
-    install_efa_userspace() {
-      if [ -x /opt/amazon/efa/bin/fi_info ]; then
-        return 0
-      fi
-
-      apt-get update
-      apt-get install -y --no-install-recommends ca-certificates curl tar gzip
-      cd /tmp
-      curl -fsSL https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz -o aws-efa-installer-latest.tar.gz
-      tar -xzf aws-efa-installer-latest.tar.gz
-      cd aws-efa-installer
-      ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify || ./efa_installer.sh -y --skip-kmod --skip-limit-conf
-    }
-
-    install_efa_userspace
-
-    export PATH="/opt/amazon/efa/bin:${PATH}"
-    export LD_LIBRARY_PATH="/opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
-    export UCX_RCACHE_MAX_UNRELEASED="${UCX_RCACHE_MAX_UNRELEASED:-1024}"
-
-    echo "LOI_LIBFABRIC_DEBUG FI_PROVIDER=${FI_PROVIDER:-unset} NIXL_LIBFABRIC_USE_DEVICE_RDMA=${NIXL_LIBFABRIC_USE_DEVICE_RDMA:-unset} UCX_RCACHE_MAX_UNRELEASED=${UCX_RCACHE_MAX_UNRELEASED:-unset}"
-    fi_info -p efa | head -80 || true
-
-    exec "$@"
 ---
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
@@ -138,22 +108,14 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 40Gi
-        - name: efa-entrypoint
-          configMap:
-            name: vllm-disagg-h100-dspark-config
-            defaultMode: 0555
-            items:
-            - key: efa-entrypoint.sh
-              path: efa-entrypoint.sh
         containers:
         - name: main
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/
           command:
-          - /opt/dynamo/efa/efa-entrypoint.sh
-          args:
           - python3
+          args:
           - -m
           - dynamo.vllm
           - --model
@@ -193,8 +155,6 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           - --disaggregation-mode
           - prefill
-          - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
           env:
           - name: POD_UID
             valueFrom:
@@ -225,8 +185,14 @@ spec:
             value: DS
           - name: PYTHONHASHSEED
             value: '0'
+          # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
+          - name: PATH
+            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          - name: LD_LIBRARY_PATH
+            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE
@@ -265,9 +231,6 @@ spec:
             mountPath: /model-cache
           - name: dshm
             mountPath: /dev/shm
-          - name: efa-entrypoint
-            mountPath: /opt/dynamo/efa
-            readOnly: true
   - name: VllmDecodeWorker
     type: decode
     replicas: 1
@@ -298,22 +261,14 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 40Gi
-        - name: efa-entrypoint
-          configMap:
-            name: vllm-disagg-h100-dspark-config
-            defaultMode: 0555
-            items:
-            - key: efa-entrypoint.sh
-              path: efa-entrypoint.sh
         containers:
         - name: main
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/
           command:
-          - /opt/dynamo/efa/efa-entrypoint.sh
-          args:
           - python3
+          args:
           - -m
           - dynamo.vllm
           - --model
@@ -383,8 +338,14 @@ spec:
             value: DS
           - name: PYTHONHASHSEED
             value: '0'
+          # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
+          - name: PATH
+            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          - name: LD_LIBRARY_PATH
+            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE
@@ -423,6 +384,3 @@ spec:
             mountPath: /model-cache
           - name: dshm
             mountPath: /dev/shm
-          - name: efa-entrypoint
-            mountPath: /opt/dynamo/efa
-            readOnly: true

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-h100-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-h100-mtp/deploy.yaml
@@ -178,13 +178,11 @@ spec:
           - name: NIXL_LOG_LEVEL
             value: INFO
           # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # If EFA is unpacked under /opt/amazon/efa without ldconfig registration,
+          # add PATH and LD_LIBRARY_PATH entries for that location here.
           # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
-          - name: PATH
-            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - name: LD_LIBRARY_PATH
-            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE
@@ -331,13 +329,11 @@ spec:
           - name: NIXL_LOG_LEVEL
             value: INFO
           # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # If EFA is unpacked under /opt/amazon/efa without ldconfig registration,
+          # add PATH and LD_LIBRARY_PATH entries for that location here.
           # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
-          - name: PATH
-            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - name: LD_LIBRARY_PATH
-            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-h100-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-h100-mtp/deploy.yaml
@@ -18,36 +18,6 @@ data:
       "rejection_sample_method": "synthetic",
       "synthetic_acceptance_length": 3.421
     }
-  efa-entrypoint.sh: |
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    export DEBIAN_FRONTEND=noninteractive
-
-    install_efa_userspace() {
-      if [ -x /opt/amazon/efa/bin/fi_info ]; then
-        return 0
-      fi
-
-      apt-get update
-      apt-get install -y --no-install-recommends ca-certificates curl tar gzip
-      cd /tmp
-      curl -fsSL https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz -o aws-efa-installer-latest.tar.gz
-      tar -xzf aws-efa-installer-latest.tar.gz
-      cd aws-efa-installer
-      ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify || ./efa_installer.sh -y --skip-kmod --skip-limit-conf
-    }
-
-    install_efa_userspace
-
-    export PATH="/opt/amazon/efa/bin:${PATH}"
-    export LD_LIBRARY_PATH="/opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
-    export UCX_RCACHE_MAX_UNRELEASED="${UCX_RCACHE_MAX_UNRELEASED:-1024}"
-
-    echo "LOI_LIBFABRIC_DEBUG FI_PROVIDER=${FI_PROVIDER:-unset} NIXL_LIBFABRIC_USE_DEVICE_RDMA=${NIXL_LIBFABRIC_USE_DEVICE_RDMA:-unset} UCX_RCACHE_MAX_UNRELEASED=${UCX_RCACHE_MAX_UNRELEASED:-unset}"
-    fi_info -p efa | head -80 || true
-
-    exec "$@"
 ---
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
@@ -134,22 +104,14 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 40Gi
-        - name: efa-entrypoint
-          configMap:
-            name: vllm-disagg-h100-mtp-config
-            defaultMode: 0555
-            items:
-            - key: efa-entrypoint.sh
-              path: efa-entrypoint.sh
         containers:
         - name: main
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/
           command:
-          - /opt/dynamo/efa/efa-entrypoint.sh
-          args:
           - python3
+          args:
           - -m
           - dynamo.vllm
           - --model
@@ -189,8 +151,6 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           - --disaggregation-mode
           - prefill
-          - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
           env:
           - name: POD_UID
             valueFrom:
@@ -217,8 +177,14 @@ spec:
             value: '1'
           - name: NIXL_LOG_LEVEL
             value: INFO
+          # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
+          - name: PATH
+            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          - name: LD_LIBRARY_PATH
+            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE
@@ -261,9 +227,6 @@ spec:
             mountPath: /model-cache
           - name: dshm
             mountPath: /dev/shm
-          - name: efa-entrypoint
-            mountPath: /opt/dynamo/efa
-            readOnly: true
   - name: VllmDecodeWorker
     type: decode
     replicas: 1
@@ -294,22 +257,14 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 40Gi
-        - name: efa-entrypoint
-          configMap:
-            name: vllm-disagg-h100-mtp-config
-            defaultMode: 0555
-            items:
-            - key: efa-entrypoint.sh
-              path: efa-entrypoint.sh
         containers:
         - name: main
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/
           command:
-          - /opt/dynamo/efa/efa-entrypoint.sh
-          args:
           - python3
+          args:
           - -m
           - dynamo.vllm
           - --model
@@ -375,8 +330,14 @@ spec:
             value: '1'
           - name: NIXL_LOG_LEVEL
             value: INFO
+          # Assumes AWS EFA userspace is present in the image or installed by cluster bootstrap.
+          # This manifest does not download or install EFA packages at pod startup.
           - name: FI_PROVIDER
             value: efa
+          - name: PATH
+            value: /opt/amazon/efa/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          - name: LD_LIBRARY_PATH
+            value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/lib/x86_64-linux-gnu
           - name: FI_EFA_USE_DEVICE_RDMA
             value: '1'
           - name: FI_EFA_FORK_SAFE
@@ -419,6 +380,3 @@ spec:
             mountPath: /model-cache
           - name: dshm
             mountPath: /dev/shm
-          - name: efa-entrypoint
-            mountPath: /opt/dynamo/efa
-            readOnly: true

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-h200-dflash/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-h200-dflash/deploy.yaml
@@ -34,7 +34,6 @@ spec:
   - name: Frontend
     type: frontend
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     podTemplate:
       spec:
         imagePullSecrets:
@@ -80,7 +79,6 @@ spec:
   - name: VllmPrefillWorker
     type: prefill
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     sharedMemorySize: 40Gi
     podTemplate:
       spec:
@@ -153,8 +151,6 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
           - --disaggregation-mode
           - prefill
-          - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
           env:
           - name: POD_UID
             valueFrom:
@@ -220,7 +216,6 @@ spec:
   - name: VllmDecodeWorker
     type: decode
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     sharedMemorySize: 40Gi
     podTemplate:
       spec:

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-h200-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-h200-dspark/deploy.yaml
@@ -36,7 +36,6 @@ spec:
   - name: Frontend
     type: frontend
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     podTemplate:
       spec:
         imagePullSecrets:
@@ -82,7 +81,6 @@ spec:
   - name: VllmPrefillWorker
     type: prefill
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     sharedMemorySize: 40Gi
     podTemplate:
       spec:
@@ -155,8 +153,6 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
           - --disaggregation-mode
           - prefill
-          - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
           env:
           - name: POD_UID
             valueFrom:
@@ -222,7 +218,6 @@ spec:
   - name: VllmDecodeWorker
     type: decode
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     sharedMemorySize: 40Gi
     podTemplate:
       spec:

--- a/recipes/nemotron-3.5-lightning/vllm/disagg-h200-mtp/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/disagg-h200-mtp/deploy.yaml
@@ -32,7 +32,6 @@ spec:
   - name: Frontend
     type: frontend
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     podTemplate:
       spec:
         imagePullSecrets:
@@ -78,7 +77,6 @@ spec:
   - name: VllmPrefillWorker
     type: prefill
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     sharedMemorySize: 40Gi
     podTemplate:
       spec:
@@ -151,8 +149,6 @@ spec:
           - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
           - --disaggregation-mode
           - prefill
-          - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
           env:
           - name: POD_UID
             valueFrom:
@@ -218,7 +214,6 @@ spec:
   - name: VllmDecodeWorker
     type: decode
     replicas: 1
-    runtimeVersionOverride: 1.4.0
     sharedMemorySize: 40Gi
     podTemplate:
       spec:


### PR DESCRIPTION
## Summary

Cherry-picks two commits onto `release/1.5.0-nemotron-3.5-lightning-dev.1`:

- Merged #13022 commit (`f210e402b5a7af4b315d6845f6134e4b8fc520c5`) — recipe corrections across Nemotron-3.5-Lightning vLLM/TRT-LLM profiles, README, and Fern updates
- Commit `f0065bba36286051169546b81a1133c0c1e513f1` (#13031) — clarify H100 EFA environment setup in the three H100 disagg deploy manifests
- Uses signed-off cherry-pick commits

## Verification

- [x] Changed paths are byte-identical to the source commits
- [x] `git diff --check` passes