### PR TITLE
test(kv-router): stabilize concurrent rank reset test

### DIFF
--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -544,6 +544,7 @@ mod tests {
                 ))
                 .await;
         }
+        flush_indexer(&indexer).await;
 
         indexer
             .reset_worker_dp_rank_and_wait(reset_rank.worker_id, reset_rank.dp_rank)


### PR DESCRIPTION
## Summary

Flush all concurrent indexer queues after arranging the reset and retained ranks in the rank-reset test fixture. This prevents the retained-rank assertions from racing asynchronous stores on a sibling worker lane while preserving the production reset contract and implementation.

## Validation

- Ran `concurrent_rank_reset_waits_for_all_local_tiers` successfully 1,000 consecutive times; the unfixed test reproduced by iteration 32.
- Ran `cargo clippy --no-default-features -- -D warnings` from `lib/llm`.
- Ran `cargo fmt -- --check` and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved rank-reset validation by ensuring queued indexer events are processed before the reset is checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->