### PR TITLE
feat(snapshot): checkpoint CUDA multicast mappings

### DIFF
--- a/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
@@ -8,11 +8,12 @@ SPDX-License-Identifier: Apache-2.0
 
 This launcher-scoped `LD_PRELOAD` interposer checkpoints complete CUDA Driver
 API VMM allocations shared through either POSIX file descriptors or single-node
-`CU_MEM_HANDLE_TYPE_FABRIC`/IMEX unicast handles. It is transparent to
-inference frameworks: applications do not call checkpoint hooks. The
-interposer composes with `cuda-checkpoint --launch-job`; Redis replaces the
-CUDA job-file role only for shim-managed VMM state. CUDA checkpoint continues
-to own unrelated CUDA state, including legacy CUDA IPC.
+`CU_MEM_HANDLE_TYPE_FABRIC`/IMEX handles. It also checkpoints the exact
+same-node, handle-based CUDA multicast lifecycle used by FlashInfer. It is
+transparent to inference frameworks: applications do not call checkpoint
+hooks. The interposer composes with `cuda-checkpoint --launch-job`; Redis
+replaces the CUDA job-file role only for shim-managed VMM state. CUDA
+checkpoint continues to own unrelated CUDA state, including legacy CUDA IPC.
 
 ## Enablement and flow
 
@@ -34,12 +35,14 @@ operations. At that boundary:
 
 1. Each shim reports owner/importer mappings to the Snapshot coordinator over
    its runtime `/snapshot-control/cuda-vmm-PID.sock`.
-2. The coordinator groups this captured generation by the allocation UUID in
-   each shim record, assigns logical resource IDs, and validates exactly one
-   owner per UUID.
-3. Each owner's bytes are copied once into Redis.
-4. Importer mappings are detached in resource/participant order, followed by owners.
-   CUDA virtual-address reservations remain in place.
+2. The coordinator groups this captured generation by allocation or multicast
+   UUID, assigns logical resource IDs, resolves every multicast
+   backing-allocation reference, and validates exactly one owner per resource.
+3. Each allocation owner's bytes are copied once into Redis. Multicast
+   resources are byte-less and have no content key.
+4. Multicast importers and owners are unbound, unmapped, and released first.
+   Allocation importers and owners are then detached while CUDA
+   virtual-address reservations remain in place.
 5. The coordinator records metadata and content in Redis, runs `SAVE`, and
    copies the RDB into the checkpoint as `cuda-vmm.rdb`.
 6. Normal `cuda-checkpoint` and CRIU capture all remaining supported state.
@@ -68,36 +71,52 @@ restore on the source node under the authoritative placement plan.
 
 After all preflight checks pass, the coordinator unlocks the CUDA processes
 immediately before the first owner replay request. This is required because
-owner and importer replay invokes ordinary CUDA Driver APIs in the restored
-processes. During this brief unlocked window, it recreates all owner
-allocations before any importer, restores each owner at its exact VA, installs
-temporary owner-location read/write access only while copying bytes, then
-applies the recorded final access. Importers receive only their exact recorded
-access. Every fresh broker FD is released and every shim passes one final
-health check before the restore succeeds. Application-released generic handles
-use temporary restore handles, which are released after remap. Application-live
-logical handles are rebound to their new real handle and can be released
-normally after restore.
+replay invokes ordinary CUDA Driver APIs in the restored processes. During
+this brief unlocked window:
+
+1. It recreates all allocation owners before any allocation importer, restores
+   each owner at its exact VA, copies owner bytes under temporary access, and
+   applies every participant's recorded final access.
+2. It creates multicast owners, imports multicast importers, and adds each
+   participant's recorded local device. No multicast bind or map occurs until
+   every participant has completed this membership phase.
+3. It replays each exact full-range bind, mapping, and access update.
+4. It releases temporary backing-allocation handles only after every multicast
+   resource has bound. This preserves allocations shared by FlashInfer's full
+   and tensor-parallel multicast groups.
+5. It verifies every shim's final health and only then marks Redis restored.
+
+After unlock, any multicast owner/importer, bind, broker, finalize, or health
+failure triggers a best-effort abort request to every restored process. The
+abort leaves each shim failed and removes recreated/imported multicast groups,
+their mappings and binds, and temporary retained backing handles. This
+distributed cleanup is specific to the multicast restore transaction; it does
+not roll back unrelated ordinary allocation replay.
+
+Every fresh broker value is closed or wiped. Application-released allocation
+handles referenced by multicast binds are retained only through the explicit
+finalize phase. Application-live logical handles are rebound to their new real
+handle and can be released normally after restore.
 
 The application never observes a real UMD
-`CUmemGenericAllocationHandle` for managed allocations. The shim returns a
-tagged process-local logical token from supported `cuMemCreate` and
-`cuMemImportFromShareableHandle` calls and translates it for map, export,
-release, and allocation-property queries. Unknown tagged tokens fail closed;
+`CUmemGenericAllocationHandle` for managed allocations or multicast objects.
+The shim returns a tagged process-local logical token from supported
+`cuMemCreate`, `cuMulticastCreate`, and `cuMemImportFromShareableHandle` calls
+and translates it for supported operations. Unknown tagged tokens fail closed;
 logical tokens are never passed to the UMD.
 
 The application never observes a raw CUDA POSIX export FD or raw CUDA FABRIC
 handle. On the first successful owner export, the shim assigns that allocation
 a random nonzero 128-bit UUID.
 
-- A POSIX export returns the existing fresh 256-byte sealed memfd capability
-  containing the UUID, exact owner control-socket path, and owner participant
-  ID. The application can transport this opaque capability with `SCM_RIGHTS`;
-  it remains caller-owned and open after import.
+- A POSIX export returns a fresh 256-byte sealed memfd capability containing
+  the UUID, object-kind discriminator, exact owner control-socket path, and
+  owner participant ID. The application can transport this opaque capability
+  with `SCM_RIGHTS`; it remains caller-owned and open after import.
 - A FABRIC export calls the real driver on every attempt, then returns an exact
   64-byte logical token containing a magic/version/type discriminator, UUID,
   32 lowercase hexadecimal participant bytes, positive namespace PID, and
-  zero reserved word. The driver-produced 64 bytes are immediately discarded.
+  object kind. The driver-produced 64 bytes are immediately discarded.
   Repeated exports reuse the logical UUID and route identity.
 
 The POSIX capability and FABRIC token are bearer values. Control-socket
@@ -115,8 +134,8 @@ own socket. The private protocol is typed:
 
 | Handle type | Broker result |
 |---|---|
-| POSIX FD (`1`) | Exactly one `SCM_RIGHTS` FD and no payload |
-| FABRIC (`8`) | No FD and exactly 64 payload bytes |
+| POSIX FD (`1`) | Exact allocation or multicast object kind, one `SCM_RIGHTS` FD, and no payload |
+| FABRIC (`8`) | Exact allocation or multicast object kind, no FD, and exactly 64 payload bytes |
 
 The owner binds responses to operation, exact handle type, allocation UUID, and
 participant ID. Raw FD copies are closed and raw FABRIC bytes are wiped and
@@ -144,29 +163,32 @@ copy framework, or CUDA job-file fallback.
 
 Redis keys are generation-scoped and contain one JSON graph/state record plus
 one binary value per logical allocation. The typed JSON graph contains stable
-participant and allocation-resource IDs, logical node placement, stable GPU
+participant and resource IDs, resource kind, logical node placement, stable GPU
 UUID placement, exact VAs, allocation-property bytes, requested handle type,
-application-handle liveness, and access descriptors. It does not persist
-PIDs, FD numbers, capture allocation UUIDs, real CUDA handles, CUDA contexts,
-or opaque transport handles. Device ordinals can occur inside opaque
+application-handle liveness, access descriptors, and multicast object,
+membership, and backing-allocation binding metadata. Multicast groups have no
+`resource:<id>` content value or content digest object; their serialized
+metadata remains covered by the ledger digest. The ledger does not persist
+PIDs, FD numbers, capture UUIDs, real CUDA handles, CUDA contexts, socket
+paths, or POSIX/FABRIC transport bytes. Device ordinals can occur inside opaque
 allocation-property and access-descriptor replay records, but they are not
 durable identity. The shim admits only an access descriptor whose ordinal matches
 the allocation's transient validated device ordinal; restore uses an ordinal
 only after validating the controller-supplied source/target UUID plan. A
 deterministic SHA-256 digest over that graph
-metadata and every allocation byte is stored in Redis and the checkpoint manifest. Redis
-stores the allocation graph and contents, never POSIX FDs, logical FABRIC
-tokens, raw FABRIC handles, PIDs, or socket paths. Ledger version 2 and private
-control protocol version 4 are required; cross-version artifact restore is
-unsupported. The artifact requires the same architecture, CUDA ABI, and shim
-build.
+metadata and every allocation byte is stored in Redis and the checkpoint
+manifest. Redis stores the resource graph and allocation contents, never POSIX
+FDs, logical FABRIC tokens, raw FABRIC handles, PIDs, or socket paths. Ledger
+version 3 and private control protocol version 5 are required; cross-version
+artifact restore is unsupported. The artifact requires the same architecture,
+CUDA ABI, and shim build.
 
 ## Supported contract
 
 - CUDA Driver API VMM with `requestedHandleTypes` exactly POSIX FD (`1`) or
   exactly FABRIC (`8`). Zero, combined bitmasks such as `9`, and every other
   type are rejected.
-- FABRIC is single-node M2 IMEX unicast only. Exporter and importer must use
+- FABRIC is single-node IMEX only. Exporter and importer must use
   fabric-ready hardware and have access to the same IMEX channel.
 - One owner physical allocation, one complete offset-zero mapping per
   participant, all participants launched through the shim, and one
@@ -186,10 +208,15 @@ build.
   restore frames add only one exact record, property, and access descriptor.
 - Legacy CUDA IPC passes through unchanged to CUDA checkpoint's native
   job-file support.
-- `cuMulticastBindMem` and its available `_v2` resolver entry are poison-only:
-  binding a managed allocation is rejected before the UMD because the shim does not
-  capture or replay multicast state. Calls with unrelated real handles pass
-  through unchanged.
+- Handle-based multicast supports one owner and one or more importers on the
+  same logical node. Each participant adds exactly one stable member GPU,
+  binds one tracked allocation at offsets zero for the complete object size
+  with flags zero, maps the complete object once, and applies one full-range
+  same-GPU read/write access update. Both legacy `cuMulticastBindMem` and its
+  available `_v2` form are supported; `_v2` must name the recorded member.
+- Multiple multicast resources can bind the same backing allocation, as in
+  FlashInfer's full and tensor-parallel groups. `cuMulticastGetGranularity`
+  and entirely unmanaged multicast objects pass through unchanged.
 
 On restore, owner reconstruction remains one path: create, exact-VA map,
 temporary write access, content copy, final access, and logical-handle rebind.
@@ -212,6 +239,10 @@ The implementation detects and rejects:
   result is returned unchanged;
 - partial, repeated, overlapping, or nonzero-offset tracked mappings and
   incomplete access metadata;
+- missing, duplicate, or post-bind multicast membership; mixed
+  managed/unmanaged multicast operations; partial, repeated, nonzero-offset,
+  wrong-device, wrong-backing, or wrong-size multicast binds; incomplete
+  multicast graphs; and managed `cuMulticastBindAddr` variants;
 - partial, gapped, mixed managed/unmanaged, or repeated access-update ranges;
 - host, other-device, multi-device, non-read/write, or otherwise non-FlashInfer
   access descriptors; the shim requires exactly one read/write DEVICE descriptor on
@@ -219,11 +250,11 @@ The implementation detects and rejects:
 - missing owners/importers or local detached records that do not match the
   allocation UUID, logical object, role, exact VA, and size;
 - zero allocation UUIDs, invalid FABRIC token magic/version/type/participant/PID
-  or reserved word, multiple owners for one UUID, owner endpoint or participant
-  mismatches, unavailable owners, broker timeouts, FABRIC responses carrying an
-  FD or not exactly 64 bytes, POSIX responses carrying a payload or not exactly
-  one FD, and any attempt to fall back to importing an application token
-  directly;
+  or object-kind discrimination, multiple owners for one UUID, owner endpoint
+  or participant mismatches, unavailable owners, broker timeouts, FABRIC
+  responses carrying an FD or not exactly 64 bytes, POSIX responses carrying a
+  payload or not exactly one FD, and any attempt to fall back to importing an
+  application token directly;
 - real CUDA FABRIC export/import failure, including
   `CUDA_ERROR_NOT_PERMITTED` when the CUDA FABRIC-support attribute, fabric
   state, or accessible IMEX channel is absent or mismatched, or when exporter
@@ -247,9 +278,13 @@ The implementation detects and rejects:
 
 Preflight errors abort while CUDA remains locked, and an unlock error prevents
 all owner/importer replay. Replay and final-health errors occur after CUDA
-unlock. Partial detach/restore has no rollback: Snapshot fails closed by
-withholding the `restore-complete` sentinel and tearing down the restore
-container.
+unlock. On a partial multicast restore, the coordinator best-effort sends the
+idempotent abort operation to every restored process; each shim unbinds, unmaps,
+and releases newly created/imported groups and temporary allocation handles.
+Cleanup failures are reported with the original replay failure. The shims
+remain failed, Snapshot withholds the `restore-complete` sentinel, and the
+restore container is torn down. The abort does not undo unrelated ordinary
+allocation replay.
 
 `UnlockProcessTree` unlocks one process at a time. If a later PID fails, earlier
 PIDs can remain running, but no VMM replay is sent, `restore-complete` is
@@ -260,7 +295,9 @@ The wrappers are limited to `cuMemCreate`, `cuMemRelease`, `cuMemMap`,
 `cuMemUnmap`, `cuMemSetAccess`, `cuMemExportToShareableHandle`,
 `cuMemImportFromShareableHandle`, the poison-only
 `cuMemRetainAllocationHandle`, `cuMemGetAllocationPropertiesFromHandle`,
-poison-only `cuMulticastBindMem` variants, and CUDA driver/runtime resolver
+`cuMulticastCreate`, `cuMulticastAddDevice`, `cuMulticastBindMem`,
+`cuMulticastUnbind`, poison-only `cuMulticastBindAddr` variants, and CUDA
+driver/runtime resolver
 entry points needed to return those wrappers. The shim narrowly interposes
 `dlsym` for cuda-python's explicit `libcuda` lookup of
 `cuGetProcAddress`, `cuGetProcAddress_v2`, or
@@ -285,7 +322,7 @@ must enforce these assumptions:
 | No FD has been received but not imported. | The untracked capability can survive outside the logical graph and later import stale backing. |
 | Applications treat sharing FDs as opaque transport capabilities and do not require raw CUDA-FD `fstat`, `ioctl`, or `poll` behavior. | The returned FD is a sealed memfd, not the NVIDIA character-device export. Unsupported inspection or raw-FD bypass cannot be associated safely and must not be used. |
 | Every managed allocation has one complete offset-zero mapping and one full-range access update, either individually or through an exact contiguous union. | Partial, gapped, mixed, repeated, or unobserved shape cannot be reconstructed exactly. Observed wrapped violations fail admission; bypassed calls can replay incorrectly without detection. |
-| Shared resources use only exact POSIX-FD or FABRIC allocation types through the wrapped Driver APIs. | Multicast APIs/state, mempools, external memory, arrays, native FlashInfer checkpoint hooks, retained/queued transport objects, or unwrapped allocation-derived handles bypass the graph and can restore incomplete or stale sharing state. |
+| Shared resources use only exact POSIX-FD or FABRIC handle types through the wrapped Driver APIs. Multicast follows the one-member, one-full-bind, one-map contract above. | Address-bound multicast, multicast shapes outside that contract, mempools, external memory, arrays, native FlashInfer checkpoint hooks, retained/queued transport objects, or unwrapped allocation-derived handles bypass the graph and can restore incomplete or stale sharing state. |
 | Every participating process uses the launcher and resolves managed APIs through the preload/resolver path. | Static binaries, alternate loader namespaces, preload suppression, explicit-handle `dlvsym`, or direct explicit-handle lookup of a managed API can bypass tracking and produce an incomplete graph. cuda-python's explicit `dlsym` lookup of the CUDA resolver is supported. |
 | A process does not fork before CUDA use and then continue without `exec`. | The child inherits the parent's participant ID, listener FD, and socket path but not the control thread. It cannot create an independent endpoint, and checkpoint eventually fails through participant/process-set drift. Fork followed by `exec` reinitializes the launcher-scoped shim. |
 | Checkpoint and restore run on one logical node, with the same accessible IMEX channel and ready fabric state for FABRIC resources. | Cross-node routing is unsupported. A node, GPU, IMEX channel, or fabric-state change invalidates local brokerage and can cause `CUDA_ERROR_NOT_PERMITTED` or restore failure. |
@@ -298,11 +335,13 @@ identity is unavailable. The implementation remains single-node.
 
 ## Non-goals
 
-The interposer does not support cross-node routing, multinode IMEX, multicast
-objects or APIs/state, CUDA mempools, unobservable retained, dangling, queued,
-or received-but-not-imported transport capabilities, repeated checkpoint/restore
-cycles, cross-version artifacts, or native application checkpoint hooks,
-including native FlashInfer hooks. It does not remove CUDA's native checkpoint
-responsibility for unrelated CUDA state or legacy CUDA IPC.
+The interposer does not support cross-node routing, multinode IMEX,
+`cuMulticastBindAddr` replay, partial or repeated multicast membership/binds,
+CUDA mempools, external memory, arrays, unobservable retained, dangling,
+queued, or received-but-not-imported transport capabilities, repeated
+checkpoint/restore cycles, cross-version artifacts, or native application
+checkpoint hooks, including native FlashInfer hooks. It does not remove
+CUDA's native checkpoint responsibility for unrelated CUDA state or legacy
+CUDA IPC.
 
 Deployment admission and workload discipline must enforce these assumptions.

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
@@ -31,7 +31,11 @@
 #include "protocol.h"
 
 #undef cuGetProcAddress
+#undef cuMulticastAddDevice
+#undef cuMulticastBindAddr
 #undef cuMulticastBindMem
+#undef cuMulticastCreate
+#undef cuMulticastUnbind
 #undef cudaGetDriverEntryPoint
 #undef cudaGetDriverEntryPointByVersion
 
@@ -53,10 +57,22 @@ CUresult CUDAAPI cuGetProcAddress_v2_ptsz(
 CUresult CUDAAPI cuMulticastBindMem(
     CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t,
     size_t, unsigned long long);
+CUresult CUDAAPI cuMulticastCreate(
+    CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+CUresult CUDAAPI cuMulticastAddDevice(
+    CUmemGenericAllocationHandle, CUdevice);
+CUresult CUDAAPI cuMulticastBindAddr(
+    CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t,
+    unsigned long long);
+CUresult CUDAAPI cuMulticastUnbind(
+    CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
 #if CUDA_VERSION >= 13010
 CUresult CUDAAPI cuMulticastBindMem_v2(
     CUmemGenericAllocationHandle, CUdevice, size_t,
     CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+CUresult CUDAAPI cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t,
+    unsigned long long);
 #endif
 CUresult CUDAAPI cuMemRetainAllocationHandle(
     CUmemGenericAllocationHandle*, void*);
@@ -79,6 +95,7 @@ struct allocation {
   size_t size;
   size_t offset;
   CUmemAllocationProp properties;
+  CUmulticastObjectProp multicast_properties;
   CUmemAccessDesc* access;
   size_t access_count;
   uint32_t role;
@@ -91,6 +108,18 @@ struct allocation {
   bool application_handle_live;
   bool mapped;
   bool detached;
+  bool member_added;
+  bool bound;
+  bool temporary_restore_handle;
+  CUdevice member_device;
+  uint8_t backing_allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
+  uint64_t backing_object_id;
+  uint32_t backing_role;
+  uint32_t bind_api;
+  size_t multicast_offset;
+  size_t memory_offset;
+  size_t bind_size;
+  unsigned long long bind_flags;
   struct allocation* next;
 };
 
@@ -101,9 +130,22 @@ struct access_update {
 
 struct broker_result {
   CUmemAllocationHandleType handle_type;
+  uint32_t object_kind;
   int fd;
   uint8_t bytes[DYN_VMM_FABRIC_HANDLE_SIZE];
   size_t bytes_size;
+  CUmulticastObjectProp multicast_properties;
+  bool has_multicast_properties;
+};
+
+struct unmanaged_multicast {
+  CUmemGenericAllocationHandle handle;
+  struct unmanaged_multicast* next;
+};
+
+struct context_scope {
+  CUcontext previous;
+  bool changed;
 };
 
 typedef CUresult(CUDAAPI* create_fn)(
@@ -122,14 +164,17 @@ typedef CUresult(CUDAAPI* properties_fn)(
     CUmemAllocationProp*, CUmemGenericAllocationHandle);
 typedef CUresult(CUDAAPI* device_get_fn)(CUdevice*, int);
 typedef CUresult(CUDAAPI* device_uuid_fn)(CUuuid*, CUdevice);
+typedef CUresult(CUDAAPI* device_count_fn)(int*);
 
 struct device_identity_api {
   device_get_fn get_device;
   device_uuid_fn get_uuid;
+  device_count_fn get_count;
 };
 
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static struct allocation* allocations;
+static struct unmanaged_multicast* unmanaged_multicasts;
 static bool enabled;
 static bool cuda_seen;
 static bool forked_after_cuda;
@@ -153,6 +198,22 @@ static int send_header(int, const struct dyn_vmm_header*, int);
 static int close_owned_fd(int*, const char*);
 static void set_error(struct dyn_vmm_header*, const char*);
 static bool all_zero(const void*, size_t);
+static int resolve_device_identity_api(struct device_identity_api*);
+static struct allocation* find_logical_handle(
+    CUmemGenericAllocationHandle);
+static struct allocation* find_logical_resource(
+    uint64_t, uint32_t, uint32_t);
+static bool is_logical_handle(CUmemGenericAllocationHandle);
+static CUresult unknown_logical_handle(void);
+static CUresult unavailable(void);
+static void fail(const char*);
+static void fail_cleanup(const char*);
+static int enter_context(CUcontext, struct context_scope*);
+static int leave_context(const struct context_scope*);
+static int send_broker_result(
+    int, struct dyn_vmm_header*, const struct broker_result*);
+static int cleanup_multicast_restore(void);
+static bool test_response_send_failure(void);
 
 static void
 initialize_real_dlsym(void)
@@ -200,7 +261,11 @@ resolve_device_identity_api(struct device_identity_api* api)
   api->get_uuid = (device_uuid_fn)real_symbol("cuDeviceGetUuid_v2");
   if (api->get_uuid == NULL)
     api->get_uuid = (device_uuid_fn)real_symbol("cuDeviceGetUuid");
-  return api->get_device != NULL && api->get_uuid != NULL ? 0 : -1;
+  api->get_count = (device_count_fn)real_symbol("cuDeviceGetCount");
+  return api->get_device != NULL && api->get_uuid != NULL &&
+                 api->get_count != NULL
+             ? 0
+             : -1;
 }
 
 static CUresult
@@ -323,6 +388,17 @@ supported_handle_type(CUmemAllocationHandleType type)
 }
 
 static bool
+valid_multicast_properties(const CUmulticastObjectProp* properties)
+{
+  return properties != NULL && properties->flags == 0 &&
+      properties->size != 0 && properties->numDevices != 0 &&
+      (properties->handleTypes ==
+           (unsigned long long)CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ||
+       properties->handleTypes ==
+           (unsigned long long)CU_MEM_HANDLE_TYPE_FABRIC);
+}
+
+static bool
 valid_broker_shape(CUmemAllocationHandleType type, int fd, uint64_t bytes_size)
 {
   return (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR && fd >= 0 && bytes_size == 0) ||
@@ -330,10 +406,13 @@ valid_broker_shape(CUmemAllocationHandleType type, int fd, uint64_t bytes_size)
 }
 
 static void
-initialize_broker_result(struct broker_result* result, CUmemAllocationHandleType type)
+initialize_broker_result(
+    struct broker_result* result, CUmemAllocationHandleType type,
+    uint32_t object_kind)
 {
   memset(result, 0, sizeof(*result));
   result->handle_type = type;
+  result->object_kind = object_kind;
   result->fd = -1;
 }
 
@@ -345,7 +424,11 @@ clear_broker_result(struct broker_result* result, const char* close_error)
   if (result->fd >= 0 && close_owned_fd(&result->fd, close_error) != 0)
     status = -1;
   explicit_bzero(result->bytes, sizeof(result->bytes));
+  explicit_bzero(
+      &result->multicast_properties,
+      sizeof(result->multicast_properties));
   result->bytes_size = 0;
+  result->has_multicast_properties = false;
   return status;
 }
 
@@ -441,7 +524,9 @@ valid_socket_path(const char path[sizeof(((struct sockaddr_un*)0)->sun_path)])
 }
 
 static int
-create_capability(const uint8_t uuid[DYN_VMM_ALLOCATION_UUID_SIZE], int* output)
+create_capability(
+    const uint8_t uuid[DYN_VMM_ALLOCATION_UUID_SIZE], uint32_t object_kind,
+    int* output)
 {
   const int required_seals = F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL;
   struct dyn_vmm_capability capability;
@@ -452,6 +537,7 @@ create_capability(const uint8_t uuid[DYN_VMM_ALLOCATION_UUID_SIZE], int* output)
   memset(&capability, 0, sizeof(capability));
   capability.magic = DYN_VMM_CAPABILITY_MAGIC;
   capability.version = DYN_VMM_CAPABILITY_VERSION;
+  capability.object_kind = (uint16_t)object_kind;
   memcpy(capability.allocation_uuid, uuid, sizeof(capability.allocation_uuid));
   snprintf(capability.owner_socket_path, sizeof(capability.owner_socket_path), "%s", socket_path);
   snprintf(capability.owner_participant_id, sizeof(capability.owner_participant_id), "%s", participant_id);
@@ -484,7 +570,9 @@ read_capability(int fd, struct dyn_vmm_capability* capability)
   if (seals < 0 || (seals & required_seals) != required_seals || fstat(fd, &status) != 0 ||
       status.st_size != (off_t)sizeof(*capability) || pread_all(fd, capability, sizeof(*capability)) != 0 ||
       capability->magic != DYN_VMM_CAPABILITY_MAGIC || capability->version != DYN_VMM_CAPABILITY_VERSION ||
-      capability->reserved != 0 || all_zero(capability->allocation_uuid, sizeof(capability->allocation_uuid)) ||
+      (capability->object_kind != DYN_VMM_ALLOCATION &&
+       capability->object_kind != DYN_VMM_MULTICAST) ||
+      all_zero(capability->allocation_uuid, sizeof(capability->allocation_uuid)) ||
       !valid_socket_path(capability->owner_socket_path) || !valid_participant_id(capability->owner_participant_id) ||
       !all_zero(capability->reserved_identity, sizeof(capability->reserved_identity)))
     return -1;
@@ -492,7 +580,9 @@ read_capability(int fd, struct dyn_vmm_capability* capability)
 }
 
 static int
-create_fabric_token(const uint8_t uuid[DYN_VMM_ALLOCATION_UUID_SIZE], struct dyn_vmm_fabric_token* token)
+create_fabric_token(
+    const uint8_t uuid[DYN_VMM_ALLOCATION_UUID_SIZE], uint32_t object_kind,
+    struct dyn_vmm_fabric_token* token)
 {
   pid_t pid = getpid();
 
@@ -505,6 +595,7 @@ create_fabric_token(const uint8_t uuid[DYN_VMM_ALLOCATION_UUID_SIZE], struct dyn
   memcpy(token->allocation_uuid, uuid, sizeof(token->allocation_uuid));
   memcpy(token->owner_participant_id, participant_id, sizeof(token->owner_participant_id));
   token->owner_namespace_pid = (uint32_t)pid;
+  token->object_kind = object_kind;
   return 0;
 }
 
@@ -520,7 +611,9 @@ read_fabric_token(
       token->handle_type != CU_MEM_HANDLE_TYPE_FABRIC ||
       all_zero(token->allocation_uuid, sizeof(token->allocation_uuid)) ||
       !valid_fabric_participant_id(token->owner_participant_id) || token->owner_namespace_pid == 0 ||
-      token->owner_namespace_pid > INT_MAX || token->reserved != 0 ||
+      token->owner_namespace_pid > INT_MAX ||
+      (token->object_kind != DYN_VMM_ALLOCATION &&
+       token->object_kind != DYN_VMM_MULTICAST) ||
       format_socket_path(owner_socket, sizeof(((struct sockaddr_un*)0)->sun_path), token->owner_namespace_pid) != 0)
     return -1;
   memcpy(owner_participant, token->owner_participant_id, sizeof(token->owner_participant_id));
@@ -543,7 +636,6 @@ dyn_vmm_test_fabric_token_valid(const void* encoded)
   struct dyn_vmm_fabric_token token;
   char owner_participant[DYN_VMM_PARTICIPANT_ID_SIZE];
   char owner_socket[sizeof(((struct sockaddr_un*)0)->sun_path)];
-
   return read_fabric_token(encoded, &token, owner_participant, owner_socket) == 0;
 }
 
@@ -582,6 +674,109 @@ dyn_vmm_test_corrupt_detached_placement(
 }
 #endif
 
+CUresult CUDAAPI
+cuMulticastBindAddr(
+    CUmemGenericAllocationHandle multicast_handle, size_t multicast_offset,
+    CUdeviceptr address, size_t size, unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t,
+      unsigned long long);
+  function_type function =
+      (function_type)real_symbol("cuMulticastBindAddr");
+
+  if (!enabled || !is_logical_handle(multicast_handle))
+    return function != NULL
+        ? function(multicast_handle, multicast_offset, address, size, flags)
+        : unavailable();
+  pthread_mutex_lock(&lock);
+  cuda_seen = true;
+  if (find_logical_handle(multicast_handle) == NULL)
+    (void)unknown_logical_handle();
+  else
+    fail("managed CUDA multicast address binding is unsupported");
+  pthread_mutex_unlock(&lock);
+  return CUDA_ERROR_NOT_SUPPORTED;
+}
+
+#if CUDA_VERSION >= 13010
+CUresult CUDAAPI
+cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle multicast_handle, CUdevice device,
+    size_t multicast_offset, CUdeviceptr address, size_t size,
+    unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t,
+      unsigned long long);
+  function_type function =
+      (function_type)real_symbol("cuMulticastBindAddr_v2");
+
+  if (!enabled || !is_logical_handle(multicast_handle))
+    return function != NULL
+        ? function(
+              multicast_handle, device, multicast_offset, address, size,
+              flags)
+        : unavailable();
+  pthread_mutex_lock(&lock);
+  cuda_seen = true;
+  if (find_logical_handle(multicast_handle) == NULL)
+    (void)unknown_logical_handle();
+  else
+    fail("managed CUDA multicast address binding is unsupported");
+  pthread_mutex_unlock(&lock);
+  return CUDA_ERROR_NOT_SUPPORTED;
+}
+#endif
+
+CUresult CUDAAPI
+cuMulticastUnbind(
+    CUmemGenericAllocationHandle multicast_handle, CUdevice device,
+    size_t multicast_offset, size_t size)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
+  function_type function =
+      (function_type)real_symbol("cuMulticastUnbind");
+  struct allocation* multicast;
+  CUresult result;
+
+  if (!enabled || !is_logical_handle(multicast_handle))
+    return function != NULL
+        ? function(multicast_handle, device, multicast_offset, size)
+        : unavailable();
+  pthread_mutex_lock(&lock);
+  cuda_seen = true;
+  multicast = find_logical_handle(multicast_handle);
+  if (multicast == NULL) {
+    result = unknown_logical_handle();
+  } else if (multicast->object_kind != DYN_VMM_MULTICAST ||
+             !multicast->application_handle_live ||
+             multicast->real_handle == 0 || !multicast->bound ||
+             device != multicast->member_device ||
+             multicast_offset != multicast->multicast_offset ||
+             size != multicast->bind_size) {
+    fail("invalid managed CUDA multicast unbind");
+    result = CUDA_ERROR_INVALID_VALUE;
+  } else {
+    result = function != NULL
+                 ? function(
+                       multicast->real_handle, device, multicast_offset, size)
+                 : unavailable();
+    if (result == CUDA_SUCCESS) {
+      multicast->bound = false;
+      memset(
+          multicast->backing_allocation_uuid, 0,
+          sizeof(multicast->backing_allocation_uuid));
+      multicast->backing_role = 0;
+      multicast->bind_api = 0;
+      multicast->bind_size = 0;
+    }
+  }
+  pthread_mutex_unlock(&lock);
+  return result;
+}
+
 static const struct dyn_vmm_placement*
 find_placement(const struct dyn_vmm_placement* placements, size_t count, const CUuuid* gpu_uuid)
 {
@@ -601,6 +796,13 @@ set_placement(
 {
   const struct allocation* previous;
   struct allocation* allocation;
+  struct device_identity_api identity_api;
+  struct target_member {
+    struct allocation* allocation;
+    CUdevice device;
+  } *target_members = NULL;
+  size_t multicast_count = 0;
+  size_t target_member_index = 0;
   size_t index;
 
   for (index = 0; index < request->count; index++) {
@@ -631,6 +833,10 @@ set_placement(
       }
     }
   }
+  if (resolve_device_identity_api(&identity_api) != 0) {
+    set_error(response, "cannot resolve CUDA device identity API");
+    return send_header(client, response, -1);
+  }
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
     const struct dyn_vmm_placement* placement;
     size_t access_index;
@@ -640,8 +846,13 @@ set_placement(
     placement = find_placement(placements, request->count, &allocation->gpu_uuid);
     if (placement == NULL ||
         allocation->device_ordinal != allocation->source_device_ordinal ||
-        allocation->properties.location.type != CU_MEM_LOCATION_TYPE_DEVICE ||
-        allocation->properties.location.id != allocation->device_ordinal ||
+        (allocation->object_kind == DYN_VMM_ALLOCATION &&
+         (allocation->properties.location.type !=
+              CU_MEM_LOCATION_TYPE_DEVICE ||
+          allocation->properties.location.id !=
+              allocation->device_ordinal)) ||
+        (allocation->object_kind == DYN_VMM_MULTICAST &&
+         (!allocation->member_added || !allocation->bound)) ||
         (allocation->access_count != 0 && allocation->access == NULL)) {
       set_error(response, "detached CUDA placement metadata is inconsistent");
       return send_header(client, response, -1);
@@ -661,6 +872,8 @@ set_placement(
         return send_header(client, response, -1);
       }
     }
+    if (allocation->object_kind == DYN_VMM_MULTICAST)
+      multicast_count++;
   }
   for (index = 0; index < request->count; index++) {
     bool found = false;
@@ -679,6 +892,34 @@ set_placement(
       return send_header(client, response, -1);
     }
   }
+  if (multicast_count != 0) {
+    target_members =
+        malloc(multicast_count * sizeof(*target_members));
+    if (target_members == NULL) {
+      set_error(response, "cannot resolve CUDA multicast placement devices");
+      return send_header(client, response, -1);
+    }
+    for (allocation = allocations; allocation != NULL;
+         allocation = allocation->next) {
+      const struct dyn_vmm_placement* placement;
+
+      if (!allocation->detached ||
+          allocation->object_kind != DYN_VMM_MULTICAST)
+        continue;
+      placement = find_placement(
+          placements, request->count, &allocation->gpu_uuid);
+      target_members[target_member_index].allocation = allocation;
+      if (identity_api.get_device(
+              &target_members[target_member_index].device,
+              placement->device_ordinal) != CUDA_SUCCESS) {
+        free(target_members);
+        set_error(response, "cannot resolve target CUDA multicast member");
+        return send_header(client, response, -1);
+      }
+      target_member_index++;
+    }
+  }
+  target_member_index = 0;
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
     const struct dyn_vmm_placement* placement;
     size_t access_index;
@@ -687,12 +928,328 @@ set_placement(
       continue;
     placement = find_placement(placements, request->count, &allocation->gpu_uuid);
     allocation->device_ordinal = placement->device_ordinal;
-    allocation->properties.location.id = placement->device_ordinal;
+    if (allocation->object_kind == DYN_VMM_ALLOCATION) {
+      allocation->properties.location.id = placement->device_ordinal;
+    } else {
+      if (target_member_index >= multicast_count ||
+          target_members[target_member_index].allocation != allocation) {
+        free(target_members);
+        set_error(response, "inconsistent CUDA multicast placement plan");
+        return send_header(client, response, -1);
+      }
+      allocation->member_device =
+          target_members[target_member_index].device;
+      target_member_index++;
+    }
     for (access_index = 0; access_index < allocation->access_count; access_index++) {
       if (allocation->access[access_index].location.type == CU_MEM_LOCATION_TYPE_DEVICE)
         allocation->access[access_index].location.id = placement->device_ordinal;
     }
   }
+  free(target_members);
+  return send_header(client, response, -1);
+}
+
+static int
+decode_multicast_record(
+    const struct dyn_vmm_header* request, char* payload,
+    struct dyn_vmm_record* record, CUmulticastObjectProp** properties,
+    CUmemAccessDesc** access,
+    struct dyn_vmm_multicast_record** multicast, size_t* metadata_size)
+{
+  uint64_t decoded_size;
+
+  if (request->payload_size < sizeof(*record))
+    return -1;
+  memcpy(record, payload, sizeof(*record));
+  decoded_size = sizeof(*record) + record->properties_size +
+      (uint64_t)record->access_count * record->access_size +
+      sizeof(**multicast);
+  if (decoded_size > request->payload_size || decoded_size > SIZE_MAX ||
+      record->object_kind != DYN_VMM_MULTICAST ||
+      record->access_size != sizeof(**access) ||
+      !supported_handle_type(
+          (CUmemAllocationHandleType)record->requested_handle_type) ||
+      (record->flags &
+       ~(DYN_VMM_APPLICATION_HANDLE_LIVE |
+         DYN_VMM_RETAIN_RESTORE_HANDLE)) != 0)
+    return -1;
+  *properties = record->properties_size == 0
+      ? NULL
+      : (CUmulticastObjectProp*)(payload + sizeof(*record));
+  *access = (CUmemAccessDesc*)(
+      payload + sizeof(*record) + record->properties_size);
+  *multicast = (struct dyn_vmm_multicast_record*)(
+      (char*)*access + record->access_count * record->access_size);
+  *metadata_size = (size_t)decoded_size;
+  return 0;
+}
+
+static int
+reconcile_multicast_metadata(
+    struct allocation* allocation, const struct dyn_vmm_record* record,
+    const CUmulticastObjectProp* properties, CUmemAccessDesc* access,
+    const struct dyn_vmm_multicast_record* multicast, bool owner)
+{
+  size_t index;
+
+  if ((owner && (properties == NULL ||
+                 record->properties_size != sizeof(*properties))) ||
+      (!owner && properties != NULL) ||
+      record->access_count != allocation->access_count ||
+      record->offset != 0 || record->address != allocation->address ||
+      record->size != allocation->size ||
+      record->device_ordinal != allocation->device_ordinal ||
+      memcmp(
+          record->gpu_uuid, allocation->gpu_uuid.bytes,
+          sizeof(record->gpu_uuid)) != 0 ||
+      multicast->reserved != 0 ||
+      !all_zero(
+          multicast->backing_allocation_uuid,
+          sizeof(multicast->backing_allocation_uuid)) ||
+      multicast->backing_object_id == 0 ||
+      multicast->multicast_offset != 0 ||
+      multicast->memory_offset != 0 ||
+      multicast->bind_size != allocation->size ||
+      multicast->bind_flags != 0 ||
+      multicast->object_flags != allocation->multicast_properties.flags ||
+      multicast->object_handle_types !=
+          allocation->multicast_properties.handleTypes ||
+      multicast->object_size != allocation->multicast_properties.size ||
+      multicast->num_devices !=
+          allocation->multicast_properties.numDevices ||
+      multicast->backing_role != allocation->backing_role ||
+      (multicast->bind_api != DYN_VMM_MULTICAST_BIND_MEM &&
+       multicast->bind_api != DYN_VMM_MULTICAST_BIND_MEM_V2) ||
+      (owner &&
+       memcmp(
+           properties, &allocation->multicast_properties,
+           sizeof(*properties)) != 0))
+    return -1;
+  for (index = 0; index < record->access_count; index++) {
+    if (access[index].location.type == CU_MEM_LOCATION_TYPE_DEVICE) {
+      if (access[index].location.id != allocation->source_device_ordinal)
+        return -1;
+      access[index].location.id = allocation->device_ordinal;
+    }
+  }
+  return memcmp(
+             access, allocation->access,
+             record->access_count * sizeof(*access)) == 0
+      ? 0
+      : -1;
+}
+
+static int
+restore_multicast_owner(
+    int client, const struct dyn_vmm_header* request,
+    struct dyn_vmm_header* response, char* payload, int passed_fd)
+{
+  typedef CUresult(CUDAAPI * create_type)(
+      CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+  typedef CUresult(CUDAAPI * add_type)(
+      CUmemGenericAllocationHandle, CUdevice);
+  create_type create = (create_type)real_symbol("cuMulticastCreate");
+  add_type add = (add_type)real_symbol("cuMulticastAddDevice");
+  export_fn export_handle =
+      (export_fn)real_symbol("cuMemExportToShareableHandle");
+  release_fn release = (release_fn)real_symbol("cuMemRelease");
+  struct dyn_vmm_record record;
+  struct dyn_vmm_multicast_record* multicast;
+  CUmulticastObjectProp* properties;
+  CUmemAccessDesc* access;
+  struct allocation* allocation;
+  struct broker_result exported;
+  struct context_scope scope;
+  CUmemGenericAllocationHandle handle = 0;
+  size_t metadata_size;
+  bool context_entered = false;
+  bool owns_handle = false;
+  const char* primary_error =
+      "multicast owner restore failed; process must not resume";
+
+  initialize_broker_result(
+      &exported, (CUmemAllocationHandleType)request->handle_type,
+      DYN_VMM_MULTICAST);
+  if (passed_fd >= 0 || request->object_kind != DYN_VMM_MULTICAST ||
+      decode_multicast_record(
+          request, payload, &record, &properties, &access, &multicast,
+          &metadata_size) != 0 ||
+      metadata_size != request->payload_size ||
+      record.role != DYN_VMM_OWNER ||
+      request->handle_type != record.requested_handle_type) {
+    set_error(response, "invalid multicast owner restore payload");
+    return send_header(client, response, -1);
+  }
+  allocation = find_logical_resource(
+      record.object_id, DYN_VMM_OWNER, DYN_VMM_MULTICAST);
+  if (allocation == NULL || !allocation->detached ||
+      allocation->requested_handle_type !=
+          (CUmemAllocationHandleType)record.requested_handle_type ||
+      allocation->application_handle_live !=
+          ((record.flags & DYN_VMM_APPLICATION_HANDLE_LIVE) != 0) ||
+      reconcile_multicast_metadata(
+          allocation, &record, properties, access, multicast, true) != 0 ||
+      create == NULL || add == NULL || export_handle == NULL ||
+      release == NULL || enter_context(allocation->context, &scope) != 0)
+    goto failed;
+  context_entered = true;
+  if (create(&handle, properties) != CUDA_SUCCESS)
+    goto failed;
+  owns_handle = true;
+  if (add(handle, allocation->member_device) != CUDA_SUCCESS)
+    goto failed;
+  if (exported.handle_type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+    if (export_handle(
+            &exported.fd, handle, exported.handle_type, 0) != CUDA_SUCCESS)
+      goto failed;
+  } else {
+    if (export_handle(
+            exported.bytes, handle, exported.handle_type, 0) != CUDA_SUCCESS)
+      goto failed;
+    exported.bytes_size = sizeof(exported.bytes);
+  }
+  allocation->real_handle = handle;
+  allocation->backing_object_id = multicast->backing_object_id;
+  allocation->bind_api = multicast->bind_api;
+  allocation->member_added = true;
+  owns_handle = false;
+  if (leave_context(&scope) != 0)
+    goto failed;
+  context_entered = false;
+  if (send_broker_result(client, response, &exported) != 0 ||
+      clear_broker_result(
+          &exported, "cannot close multicast owner restore broker") != 0)
+    goto failed;
+  return 0;
+
+failed:
+  fail(primary_error);
+  phase = DYN_VMM_FAILED;
+  if (allocation != NULL && allocation->real_handle == handle) {
+    allocation->real_handle = 0;
+    allocation->member_added = false;
+  }
+  if ((owns_handle || handle != 0) && release != NULL &&
+      release(handle) != CUDA_SUCCESS)
+    fail_cleanup("cannot release failed multicast owner handle");
+  (void)clear_broker_result(
+      &exported, "cannot close failed multicast owner broker");
+  if (context_entered && leave_context(&scope) != 0)
+    fail_cleanup("cannot restore context after multicast owner failure");
+  (void)cleanup_multicast_restore();
+  set_error(response, primary_error);
+  return send_header(client, response, -1);
+}
+
+static int
+restore_multicast_importer(
+    int client, const struct dyn_vmm_header* request,
+    struct dyn_vmm_header* response, char* payload, int* imported_fd)
+{
+  typedef CUresult(CUDAAPI * add_type)(
+      CUmemGenericAllocationHandle, CUdevice);
+  import_fn import_handle =
+      (import_fn)real_symbol("cuMemImportFromShareableHandle");
+  add_type add = (add_type)real_symbol("cuMulticastAddDevice");
+  release_fn release = (release_fn)real_symbol("cuMemRelease");
+  struct dyn_vmm_record record;
+  struct dyn_vmm_multicast_record* multicast;
+  CUmulticastObjectProp* properties;
+  CUmemAccessDesc* access;
+  struct allocation* allocation;
+  struct context_scope scope;
+  CUmemGenericAllocationHandle handle = 0;
+  size_t metadata_size;
+  size_t broker_size;
+  void* import_value;
+  bool context_entered = false;
+  const char* primary_error =
+      "multicast importer restore failed; process must not resume";
+
+  if (request->object_kind != DYN_VMM_MULTICAST ||
+      decode_multicast_record(
+          request, payload, &record, &properties, &access, &multicast,
+          &metadata_size) != 0 ||
+      record.role != DYN_VMM_IMPORTER || properties != NULL ||
+      request->handle_type != record.requested_handle_type) {
+    set_error(response, "invalid multicast importer restore payload");
+    return send_header(client, response, -1);
+  }
+  broker_size = (size_t)request->payload_size - metadata_size;
+  if ((record.requested_handle_type ==
+           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
+       (broker_size != 0 || *imported_fd < 0)) ||
+      (record.requested_handle_type == CU_MEM_HANDLE_TYPE_FABRIC &&
+       (broker_size != DYN_VMM_FABRIC_HANDLE_SIZE ||
+        *imported_fd >= 0))) {
+    set_error(response, "invalid multicast importer broker");
+    return send_header(client, response, -1);
+  }
+  import_value =
+      record.requested_handle_type ==
+              CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+          ? (void*)(uintptr_t)*imported_fd
+          : payload + metadata_size;
+  allocation = find_logical_resource(
+      record.object_id, DYN_VMM_IMPORTER, DYN_VMM_MULTICAST);
+  if (allocation == NULL || !allocation->detached ||
+      allocation->requested_handle_type !=
+          (CUmemAllocationHandleType)record.requested_handle_type ||
+      allocation->application_handle_live !=
+          ((record.flags & DYN_VMM_APPLICATION_HANDLE_LIVE) != 0) ||
+      reconcile_multicast_metadata(
+          allocation, &record, properties, access, multicast, false) != 0 ||
+      import_handle == NULL || add == NULL || release == NULL ||
+      enter_context(allocation->context, &scope) != 0)
+    goto failed;
+  context_entered = true;
+  if (import_handle(
+          &handle, import_value,
+          (CUmemAllocationHandleType)record.requested_handle_type) !=
+      CUDA_SUCCESS)
+    goto failed;
+  if (record.requested_handle_type ==
+          CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
+      close_owned_fd(
+          imported_fd,
+          "cannot close multicast importer broker FD") != 0)
+    goto failed;
+  if (record.requested_handle_type == CU_MEM_HANDLE_TYPE_FABRIC)
+    explicit_bzero(payload + metadata_size, broker_size);
+  if (add(handle, allocation->member_device) != CUDA_SUCCESS)
+    goto failed;
+  allocation->real_handle = handle;
+  allocation->backing_object_id = multicast->backing_object_id;
+  allocation->bind_api = multicast->bind_api;
+  allocation->member_added = true;
+  if (leave_context(&scope) != 0)
+    goto failed;
+  context_entered = false;
+  if (send_header(client, response, -1) != 0)
+    goto failed;
+  return 0;
+
+failed:
+  fail(primary_error);
+  phase = DYN_VMM_FAILED;
+  if (allocation != NULL && allocation->real_handle == handle) {
+    allocation->real_handle = 0;
+    allocation->member_added = false;
+  }
+  if (handle != 0 && release != NULL &&
+      release(handle) != CUDA_SUCCESS)
+    fail_cleanup("cannot release failed multicast importer handle");
+  if (close_owned_fd(
+          imported_fd,
+          "cannot close failed multicast importer broker FD") != 0)
+    fail_cleanup("cannot close failed multicast importer broker FD");
+  if (record.requested_handle_type == CU_MEM_HANDLE_TYPE_FABRIC)
+    explicit_bzero(payload + metadata_size, broker_size);
+  if (context_entered && leave_context(&scope) != 0)
+    fail_cleanup("cannot restore context after multicast importer failure");
+  (void)cleanup_multicast_restore();
+  set_error(response, primary_error);
   return send_header(client, response, -1);
 }
 
@@ -803,6 +1360,61 @@ find_logical_handle(CUmemGenericAllocationHandle handle)
   return NULL;
 }
 
+static struct allocation*
+find_logical_resource(
+    uint64_t object_id, uint32_t role, uint32_t object_kind)
+{
+  struct allocation* allocation = find_logical_object(object_id, role);
+
+  return allocation != NULL && allocation->object_kind == object_kind
+             ? allocation
+             : NULL;
+}
+
+static struct unmanaged_multicast*
+find_unmanaged_multicast(CUmemGenericAllocationHandle handle)
+{
+  struct unmanaged_multicast* object;
+
+  for (object = unmanaged_multicasts; object != NULL;
+       object = object->next) {
+    if (object->handle == handle)
+      return object;
+  }
+  return NULL;
+}
+
+static void
+record_unmanaged_multicast(CUmemGenericAllocationHandle handle)
+{
+  struct unmanaged_multicast* object = calloc(1, sizeof(*object));
+
+  if (object == NULL) {
+    fail("cannot record unmanaged CUDA multicast object");
+    return;
+  }
+  object->handle = handle;
+  object->next = unmanaged_multicasts;
+  unmanaged_multicasts = object;
+}
+
+static void
+remove_unmanaged_multicast(CUmemGenericAllocationHandle handle)
+{
+  struct unmanaged_multicast** cursor = &unmanaged_multicasts;
+
+  while (*cursor != NULL) {
+    if ((*cursor)->handle == handle) {
+      struct unmanaged_multicast* object = *cursor;
+
+      *cursor = object->next;
+      free(object);
+      return;
+    }
+    cursor = &(*cursor)->next;
+  }
+}
+
 static bool
 is_logical_handle(CUmemGenericAllocationHandle handle)
 {
@@ -845,6 +1457,33 @@ record_gpu_identity(struct allocation* allocation)
                  device_uuid(&identity_api, allocation->device_ordinal, &allocation->gpu_uuid) == CUDA_SUCCESS
              ? 0
              : -1;
+}
+
+static int
+record_multicast_member(
+    struct allocation* allocation, CUdevice device)
+{
+  struct device_identity_api identity_api;
+  int count;
+  int ordinal;
+
+  if (resolve_device_identity_api(&identity_api) != 0 ||
+      identity_api.get_count(&count) != CUDA_SUCCESS || count <= 0 ||
+      identity_api.get_uuid(&allocation->gpu_uuid, device) != CUDA_SUCCESS)
+    return -1;
+  for (ordinal = 0; ordinal < count; ordinal++) {
+    CUdevice candidate;
+
+    if (identity_api.get_device(&candidate, ordinal) == CUDA_SUCCESS &&
+        candidate == device)
+      break;
+  }
+  if (ordinal == count)
+    return -1;
+  allocation->device_ordinal = ordinal;
+  allocation->source_device_ordinal = ordinal;
+  allocation->member_device = device;
+  return 0;
 }
 
 static struct allocation*
@@ -896,11 +1535,6 @@ current_context(CUcontext* context)
 
   return function != NULL && function(context) == CUDA_SUCCESS && *context != NULL ? 0 : -1;
 }
-
-struct context_scope {
-  CUcontext previous;
-  bool changed;
-};
 
 static int
 enter_context(CUcontext context, struct context_scope* scope)
@@ -1093,6 +1727,8 @@ send_header(int fd, const struct dyn_vmm_header* header, int passed_fd)
   struct msghdr message = {.msg_iov = &vector, .msg_iovlen = 1};
   ssize_t size;
 
+  if (test_response_send_failure())
+    return -1;
   if (passed_fd >= 0) {
     struct cmsghdr* item;
     message.msg_control = control;
@@ -1142,7 +1778,11 @@ export_raw_owner(struct allocation* allocation, struct broker_result* output)
   struct context_scope scope;
   CUresult result;
 
-  initialize_broker_result(output, allocation == NULL ? CU_MEM_HANDLE_TYPE_NONE : allocation->requested_handle_type);
+  initialize_broker_result(
+      output,
+      allocation == NULL ? CU_MEM_HANDLE_TYPE_NONE
+                         : allocation->requested_handle_type,
+      allocation == NULL ? 0 : allocation->object_kind);
   if (allocation == NULL || allocation->role != DYN_VMM_OWNER || !allocation->exported ||
       all_zero(allocation->allocation_uuid, sizeof(allocation->allocation_uuid)) ||
       !allocation->application_handle_live || allocation->real_handle == 0 || allocation->detached ||
@@ -1163,6 +1803,10 @@ export_raw_owner(struct allocation* allocation, struct broker_result* output)
   }
   if (result == CUDA_SUCCESS && !valid_broker_shape(output->handle_type, output->fd, output->bytes_size))
     return CUDA_ERROR_INVALID_VALUE;
+  if (result == CUDA_SUCCESS && allocation->object_kind == DYN_VMM_MULTICAST) {
+    output->multicast_properties = allocation->multicast_properties;
+    output->has_multicast_properties = true;
+  }
   return result;
 }
 
@@ -1170,6 +1814,13 @@ static int
 send_broker_result(int client, struct dyn_vmm_header* response, const struct broker_result* result)
 {
   response->handle_type = (uint32_t)result->handle_type;
+  response->object_kind = result->object_kind;
+  if (response->operation == DYN_VMM_EXPORT_OWNER &&
+      result->has_multicast_properties) {
+    memcpy(
+        response->reserved_identity, &result->multicast_properties,
+        sizeof(result->multicast_properties));
+  }
   response->payload_size = result->bytes_size;
   if (send_header(client, response, result->fd) != 0)
     return -1;
@@ -1183,12 +1834,16 @@ export_owner(int client, const struct dyn_vmm_header* request, struct dyn_vmm_he
   struct broker_result exported;
   int result;
 
-  initialize_broker_result(&exported, (CUmemAllocationHandleType)request->handle_type);
+  initialize_broker_result(
+      &exported, (CUmemAllocationHandleType)request->handle_type,
+      request->object_kind);
 
   memcpy(response->allocation_uuid, request->allocation_uuid, sizeof(response->allocation_uuid));
   if (passed_fd >= 0 || request->payload_size != 0 || request->count != 0 || request->status != 0 ||
       request->object_id != 0 || !supported_handle_type((CUmemAllocationHandleType)request->handle_type) ||
-      request->reserved != 0 || !all_zero(request->message, sizeof(request->message)) ||
+      (request->object_kind != DYN_VMM_ALLOCATION &&
+       request->object_kind != DYN_VMM_MULTICAST) ||
+      !all_zero(request->message, sizeof(request->message)) ||
       !all_zero(request->reserved_identity, sizeof(request->reserved_identity)) ||
       memcmp(request->participant_id, participant_id, sizeof(request->participant_id)) != 0 ||
       all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) || failed || forked_after_cuda ||
@@ -1199,6 +1854,7 @@ export_owner(int client, const struct dyn_vmm_header* request, struct dyn_vmm_he
   allocation = find_object(request->allocation_uuid, DYN_VMM_OWNER);
   if (allocation == NULL ||
       memcmp(allocation->allocation_uuid, request->allocation_uuid, sizeof(allocation->allocation_uuid)) != 0 ||
+      allocation->object_kind != request->object_kind ||
       allocation->requested_handle_type != (CUmemAllocationHandleType)request->handle_type ||
       export_raw_owner(allocation, &exported) != CUDA_SUCCESS) {
     (void)clear_broker_result(&exported, "cannot close failed owner raw export FD");
@@ -1215,7 +1871,8 @@ static int
 request_owner_export(
     const uint8_t allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE],
     const char owner_participant[DYN_VMM_PARTICIPANT_ID_SIZE], const char* owner_socket,
-    CUmemAllocationHandleType handle_type, struct broker_result* exported)
+    CUmemAllocationHandleType handle_type, uint32_t object_kind,
+    struct broker_result* exported)
 {
   struct sockaddr_un address = {.sun_family = AF_UNIX};
   struct dyn_vmm_header request;
@@ -1223,12 +1880,13 @@ request_owner_export(
   int client = -1;
   int result = -1;
 
-  initialize_broker_result(exported, handle_type);
+  initialize_broker_result(exported, handle_type, object_kind);
   memset(&request, 0, sizeof(request));
   request.magic = DYN_VMM_MAGIC;
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_EXPORT_OWNER;
   request.handle_type = (uint32_t)handle_type;
+  request.object_kind = object_kind;
   memcpy(request.allocation_uuid, allocation_uuid, sizeof(request.allocation_uuid));
   snprintf(request.participant_id, sizeof(request.participant_id), "%s", owner_participant);
   snprintf(address.sun_path, sizeof(address.sun_path), "%s", owner_socket);
@@ -1239,14 +1897,34 @@ request_owner_export(
     goto done;
   if (response.magic != DYN_VMM_MAGIC || response.version != DYN_VMM_VERSION ||
       response.operation != DYN_VMM_EXPORT_OWNER || response.status != 0 || response.count != 0 ||
-      response.object_id != 0 || response.handle_type != (uint32_t)handle_type || response.reserved != 0 ||
+      response.object_id != 0 ||
+      response.handle_type != (uint32_t)handle_type ||
+      response.object_kind != object_kind ||
       !all_zero(response.message, sizeof(response.message)) ||
-      !all_zero(response.reserved_identity, sizeof(response.reserved_identity)) ||
       memcmp(response.allocation_uuid, allocation_uuid, sizeof(response.allocation_uuid)) != 0 ||
       !valid_participant_id(response.participant_id) ||
       memcmp(response.participant_id, owner_participant, sizeof(response.participant_id)) != 0 ||
       !valid_broker_shape(handle_type, exported->fd, response.payload_size))
     goto done;
+  if (object_kind == DYN_VMM_MULTICAST) {
+    if (!all_zero(
+            response.reserved_identity +
+                sizeof(exported->multicast_properties),
+            sizeof(response.reserved_identity) -
+                sizeof(exported->multicast_properties)))
+      goto done;
+    memcpy(
+        &exported->multicast_properties, response.reserved_identity,
+        sizeof(exported->multicast_properties));
+    if (!valid_multicast_properties(
+            &exported->multicast_properties))
+      goto done;
+    exported->has_multicast_properties = true;
+  } else if (!all_zero(
+                 response.reserved_identity,
+                 sizeof(response.reserved_identity))) {
+    goto done;
+  }
   if (handle_type == CU_MEM_HANDLE_TYPE_FABRIC) {
     if (read_all(client, exported->bytes, sizeof(exported->bytes)) != 0)
       goto done;
@@ -1288,7 +1966,24 @@ validate_admission(struct dyn_vmm_header* response)
       continue;
     if (!allocation->mapped || allocation->offset != 0 || allocation->address == 0 ||
         allocation->access_count == 0) {
-      set_error(response, "managed allocation is not one complete offset-zero mapping with access");
+      set_error(response, "managed object is not one complete offset-zero mapping with access");
+      return -1;
+    }
+    if (allocation->object_kind == DYN_VMM_MULTICAST &&
+        (!allocation->member_added || !allocation->bound ||
+         allocation->multicast_properties.flags != 0 ||
+         allocation->multicast_properties.size != allocation->size ||
+         allocation->multicast_properties.numDevices == 0 ||
+         allocation->multicast_properties.handleTypes !=
+             (unsigned long long)allocation->requested_handle_type ||
+         all_zero(
+             allocation->backing_allocation_uuid,
+             sizeof(allocation->backing_allocation_uuid)) ||
+         allocation->multicast_offset != 0 ||
+         allocation->memory_offset != 0 ||
+         allocation->bind_size != allocation->size ||
+         allocation->bind_flags != 0)) {
+      set_error(response, "managed multicast object is incomplete");
       return -1;
     }
     if (allocation->access_count != 1 ||
@@ -1320,8 +2015,15 @@ inspect(int client, struct dyn_vmm_header* response)
       continue;
     response->count++;
     payload_size += sizeof(struct dyn_vmm_record) +
-        (allocation->role == DYN_VMM_OWNER ? sizeof(allocation->properties) : 0) +
-        allocation->access_count * sizeof(*allocation->access);
+        (allocation->role == DYN_VMM_OWNER
+             ? (allocation->object_kind == DYN_VMM_MULTICAST
+                    ? sizeof(allocation->multicast_properties)
+                    : sizeof(allocation->properties))
+             : 0) +
+        allocation->access_count * sizeof(*allocation->access) +
+        (allocation->object_kind == DYN_VMM_MULTICAST
+             ? sizeof(struct dyn_vmm_multicast_record)
+             : 0);
   }
   payload = malloc(payload_size == 0 ? 1 : payload_size);
   if (payload == NULL) {
@@ -1337,7 +2039,11 @@ inspect(int client, struct dyn_vmm_header* response)
     if (!allocation->exported && allocation->role == DYN_VMM_OWNER)
       continue;
     properties_size =
-        allocation->role == DYN_VMM_OWNER ? sizeof(allocation->properties) : 0;
+        allocation->role == DYN_VMM_OWNER
+        ? (allocation->object_kind == DYN_VMM_MULTICAST
+               ? sizeof(allocation->multicast_properties)
+               : sizeof(allocation->properties))
+        : 0;
     access_size = allocation->access_count * sizeof(*allocation->access);
     memset(&record, 0, sizeof(record));
     memcpy(record.allocation_uuid, allocation->allocation_uuid, sizeof(record.allocation_uuid));
@@ -1359,11 +2065,39 @@ inspect(int client, struct dyn_vmm_header* response)
     memcpy(cursor, &record, sizeof(record));
     cursor += sizeof(record);
     if (properties_size != 0) {
-      memcpy(cursor, &allocation->properties, properties_size);
+      memcpy(
+          cursor,
+          allocation->object_kind == DYN_VMM_MULTICAST
+              ? (void*)&allocation->multicast_properties
+              : (void*)&allocation->properties,
+          properties_size);
       cursor += properties_size;
     }
     memcpy(cursor, allocation->access, access_size);
     cursor += access_size;
+    if (allocation->object_kind == DYN_VMM_MULTICAST) {
+      struct dyn_vmm_multicast_record multicast;
+
+      memset(&multicast, 0, sizeof(multicast));
+      memcpy(
+          multicast.backing_allocation_uuid,
+          allocation->backing_allocation_uuid,
+          sizeof(multicast.backing_allocation_uuid));
+      multicast.multicast_offset = allocation->multicast_offset;
+      multicast.memory_offset = allocation->memory_offset;
+      multicast.bind_size = allocation->bind_size;
+      multicast.bind_flags = allocation->bind_flags;
+      multicast.object_flags = allocation->multicast_properties.flags;
+      multicast.object_handle_types =
+          allocation->multicast_properties.handleTypes;
+      multicast.object_size = allocation->multicast_properties.size;
+      multicast.num_devices =
+          allocation->multicast_properties.numDevices;
+      multicast.backing_role = allocation->backing_role;
+      multicast.bind_api = allocation->bind_api;
+      memcpy(cursor, &multicast, sizeof(multicast));
+      cursor += sizeof(multicast);
+    }
   }
   response->payload_size = payload_size;
   if (send_header(client, response, -1) != 0 ||
@@ -1386,7 +2120,9 @@ read_owner(int client, const struct dyn_vmm_header* request, struct dyn_vmm_head
   size_t offset;
   int result = 0;
 
-  if (allocation == NULL || !allocation->exported || !allocation->mapped ||
+  if (allocation == NULL ||
+      allocation->object_kind != DYN_VMM_ALLOCATION ||
+      !allocation->exported || !allocation->mapped ||
       allocation->detached) {
     set_error(response, "owner allocation is unavailable");
     return send_header(client, response, -1);
@@ -1422,6 +2158,10 @@ detach(
 {
   unmap_fn unmap = (unmap_fn)real_symbol("cuMemUnmap");
   release_fn release = (release_fn)real_symbol("cuMemRelease");
+  typedef CUresult(CUDAAPI * unbind_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
+  unbind_type unbind =
+      (unbind_type)real_symbol("cuMulticastUnbind");
   struct allocation* allocation = find_object(request->allocation_uuid, role);
   struct context_scope scope;
 
@@ -1434,7 +2174,14 @@ detach(
     return send_header(client, response, -1);
   }
   if (unmap == NULL || release == NULL ||
+      (allocation->object_kind == DYN_VMM_MULTICAST &&
+       (unbind == NULL || !allocation->bound)) ||
       enter_context(allocation->context, &scope) != 0 ||
+      (allocation->object_kind == DYN_VMM_MULTICAST &&
+       unbind(
+           allocation->real_handle, allocation->member_device,
+           allocation->multicast_offset, allocation->bind_size) !=
+           CUDA_SUCCESS) ||
       unmap(allocation->address, allocation->size) != CUDA_SUCCESS ||
       (allocation->real_handle != 0 &&
        release(allocation->real_handle) != CUDA_SUCCESS) ||
@@ -1445,6 +2192,8 @@ detach(
     return send_header(client, response, -1);
   }
   allocation->mapped = false;
+  if (allocation->object_kind == DYN_VMM_MULTICAST)
+    allocation->bound = false;
   allocation->detached = true;
   allocation->real_handle = 0;
   allocation->object_id = request->object_id;
@@ -1475,9 +2224,12 @@ decode_record(
   *access = (CUmemAccessDesc*)(
       payload + sizeof(*record) + record->properties_size);
   *metadata_size = (size_t)decoded_size;
-  if (record->object_kind != DYN_VMM_ALLOCATION ||
+  if ((record->object_kind != DYN_VMM_ALLOCATION &&
+       record->object_kind != DYN_VMM_MULTICAST) ||
       !supported_handle_type((CUmemAllocationHandleType)record->requested_handle_type) ||
-      (record->flags & ~DYN_VMM_APPLICATION_HANDLE_LIVE) != 0)
+      (record->flags &
+       ~(DYN_VMM_APPLICATION_HANDLE_LIVE |
+         DYN_VMM_RETAIN_RESTORE_HANDLE)) != 0)
     return -1;
   return 0;
 }
@@ -1510,6 +2262,21 @@ reconcile_restore_metadata(
 }
 
 #ifdef DYN_VMM_TESTING
+static atomic_bool fail_next_response_send;
+
+int
+dyn_vmm_test_fail_next_response_send(void)
+{
+  atomic_store(&fail_next_response_send, true);
+  return 0;
+}
+
+static bool
+test_response_send_failure(void)
+{
+  return atomic_exchange(&fail_next_response_send, false);
+}
+
 static bool
 test_failure(const char* stage)
 {
@@ -1518,6 +2285,12 @@ test_failure(const char* stage)
   return configured != NULL && strcmp(configured, stage) == 0;
 }
 #else
+static bool
+test_response_send_failure(void)
+{
+  return false;
+}
+
 static bool
 test_failure(const char* stage)
 {
@@ -1559,9 +2332,11 @@ restore_owner(
   struct broker_result exported;
   const char* primary_error = "owner VMM restore failed; process must not resume";
 
-  initialize_broker_result(&exported, (CUmemAllocationHandleType)request->handle_type);
+  initialize_broker_result(
+      &exported, (CUmemAllocationHandleType)request->handle_type,
+      request->object_kind);
 
-  if (passed_fd >= 0 || request->reserved != 0 ||
+  if (passed_fd >= 0 || request->object_kind != DYN_VMM_ALLOCATION ||
       decode_record(request, payload, &record, &properties, &access, &metadata_size) != 0 || properties == NULL ||
       record.properties_size != sizeof(*properties) || record.role != DYN_VMM_OWNER || record.offset != 0 ||
       request->handle_type != record.requested_handle_type ||
@@ -1641,9 +2416,12 @@ restore_owner(
   }
   if (test_failure("owner-export"))
     goto failed;
-  if (allocation->application_handle_live) {
+  if (allocation->application_handle_live ||
+      (record.flags & DYN_VMM_RETAIN_RESTORE_HANDLE) != 0) {
     allocation->real_handle = handle;
     logical_rebound = true;
+    allocation->temporary_restore_handle =
+        !allocation->application_handle_live;
     owns_handle = false;
   } else {
     if (release(handle) != CUDA_SUCCESS)
@@ -1743,7 +2521,7 @@ restore_importer(
   size_t broker_size;
   const char* primary_error = "importer VMM restore failed; process must not resume";
 
-  if (request->reserved != 0 ||
+  if (request->object_kind != DYN_VMM_ALLOCATION ||
       decode_record(request, payload, &record, &properties, &access, &metadata_size) != 0) {
     set_error(response, "invalid importer restore payload");
     return send_header(client, response, -1);
@@ -1807,9 +2585,12 @@ restore_importer(
     goto failed;
   if (test_failure("importer-access"))
     goto failed;
-  if (allocation->application_handle_live) {
+  if (allocation->application_handle_live ||
+      (record.flags & DYN_VMM_RETAIN_RESTORE_HANDLE) != 0) {
     allocation->real_handle = handle;
     logical_rebound = true;
+    allocation->temporary_restore_handle =
+        !allocation->application_handle_live;
     owns_handle = false;
   } else {
     if (release(handle) != CUDA_SUCCESS)
@@ -1868,6 +2649,280 @@ failed:
   return send_header(client, response, -1);
 }
 
+static int
+cleanup_multicast_restore(void)
+{
+  typedef CUresult(CUDAAPI * unbind_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
+  unbind_type unbind =
+      (unbind_type)real_symbol("cuMulticastUnbind");
+  unmap_fn unmap = (unmap_fn)real_symbol("cuMemUnmap");
+  release_fn release = (release_fn)real_symbol("cuMemRelease");
+  struct allocation* allocation;
+  int result = 0;
+
+  for (allocation = allocations; allocation != NULL;
+       allocation = allocation->next) {
+    struct context_scope scope;
+    bool entered = false;
+
+    if (allocation->object_kind == DYN_VMM_MULTICAST &&
+        allocation->real_handle != 0) {
+      if (enter_context(allocation->context, &scope) == 0)
+        entered = true;
+      else {
+        fail_cleanup("cannot enter multicast cleanup context");
+        result = -1;
+      }
+      if (entered && allocation->bound &&
+          (unbind == NULL ||
+           unbind(
+               allocation->real_handle, allocation->member_device,
+               allocation->multicast_offset, allocation->bind_size) !=
+               CUDA_SUCCESS)) {
+        fail_cleanup("cannot unbind failed multicast restore");
+        result = -1;
+      } else if (entered) {
+        allocation->bound = false;
+      }
+      if (entered && allocation->mapped &&
+          (unmap == NULL ||
+           unmap(allocation->address, allocation->size) != CUDA_SUCCESS)) {
+        fail_cleanup("cannot unmap failed multicast restore");
+        result = -1;
+      } else if (entered) {
+        allocation->mapped = false;
+      }
+      if (entered &&
+          (release == NULL ||
+           release(allocation->real_handle) != CUDA_SUCCESS)) {
+        fail_cleanup("cannot release failed multicast restore");
+        result = -1;
+      } else if (entered) {
+        allocation->real_handle = 0;
+        allocation->member_added = false;
+        allocation->bound = false;
+        allocation->mapped = false;
+        allocation->backing_object_id = 0;
+        allocation->temporary_restore_handle = false;
+      }
+      allocation->detached = true;
+      if (entered && leave_context(&scope) != 0) {
+        fail_cleanup("cannot leave multicast cleanup context");
+        result = -1;
+      }
+    }
+    if (allocation->object_kind == DYN_VMM_ALLOCATION &&
+        allocation->temporary_restore_handle &&
+        allocation->real_handle != 0) {
+      if (release == NULL ||
+          release(allocation->real_handle) != CUDA_SUCCESS) {
+        fail_cleanup("cannot release temporary backing handle");
+        result = -1;
+      } else {
+        allocation->real_handle = 0;
+        allocation->temporary_restore_handle = false;
+      }
+    }
+  }
+  return result;
+}
+
+static int
+restore_multicast_binding(
+    int client, const struct dyn_vmm_header* request,
+    struct dyn_vmm_header* response, char* payload)
+{
+  typedef CUresult(CUDAAPI * legacy_bind_type)(
+      CUmemGenericAllocationHandle, size_t,
+      CUmemGenericAllocationHandle, size_t, size_t,
+      unsigned long long);
+#if CUDA_VERSION >= 13010
+  typedef CUresult(CUDAAPI * v2_bind_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t,
+      CUmemGenericAllocationHandle, size_t, size_t,
+      unsigned long long);
+#endif
+  legacy_bind_type bind =
+      (legacy_bind_type)real_symbol("cuMulticastBindMem");
+#if CUDA_VERSION >= 13010
+  v2_bind_type bind_v2 =
+      (v2_bind_type)real_symbol("cuMulticastBindMem_v2");
+#endif
+  map_fn map = (map_fn)real_symbol("cuMemMap");
+  unmap_fn unmap = (unmap_fn)real_symbol("cuMemUnmap");
+  access_fn set_access = (access_fn)real_symbol("cuMemSetAccess");
+  typedef CUresult(CUDAAPI * unbind_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
+  unbind_type unbind =
+      (unbind_type)real_symbol("cuMulticastUnbind");
+  struct dyn_vmm_record record;
+  struct dyn_vmm_multicast_record* multicast;
+  CUmulticastObjectProp* properties;
+  CUmemAccessDesc* access;
+  struct allocation* allocation;
+  struct allocation* backing;
+  struct context_scope scope;
+  size_t metadata_size;
+  bool entered = false;
+  bool bound = false;
+  bool mapped = false;
+  CUresult result;
+  const char* primary_error =
+      "multicast binding restore failed; process must not resume";
+
+  if (request->object_kind != DYN_VMM_MULTICAST ||
+      decode_multicast_record(
+          request, payload, &record, &properties, &access, &multicast,
+          &metadata_size) != 0 ||
+      metadata_size != request->payload_size ||
+      request->object_id != record.object_id ||
+      request->handle_type != record.requested_handle_type) {
+    set_error(response, "invalid multicast binding restore payload");
+    return send_header(client, response, -1);
+  }
+  allocation = find_logical_resource(
+      record.object_id, record.role, DYN_VMM_MULTICAST);
+  backing = find_logical_resource(
+      multicast->backing_object_id, multicast->backing_role,
+      DYN_VMM_ALLOCATION);
+  if (allocation == NULL || backing == NULL ||
+      allocation->real_handle == 0 || backing->real_handle == 0 ||
+      !allocation->member_added || allocation->bound ||
+      allocation->mapped || allocation->detached == false ||
+      backing->detached || !backing->mapped ||
+      backing->requested_handle_type !=
+          allocation->requested_handle_type ||
+      backing->size != allocation->size ||
+      backing->device_ordinal != allocation->device_ordinal ||
+      reconcile_multicast_metadata(
+          allocation, &record, properties, access, multicast,
+          record.role == DYN_VMM_OWNER) != 0 ||
+      map == NULL || unmap == NULL || set_access == NULL ||
+      unbind == NULL ||
+      enter_context(allocation->context, &scope) != 0)
+    goto failed;
+  entered = true;
+  if (multicast->bind_api == DYN_VMM_MULTICAST_BIND_MEM) {
+    result = bind != NULL
+        ? bind(
+              allocation->real_handle, multicast->multicast_offset,
+              backing->real_handle, multicast->memory_offset,
+              multicast->bind_size, multicast->bind_flags)
+        : CUDA_ERROR_NOT_SUPPORTED;
+  } else {
+#if CUDA_VERSION >= 13010
+    result = bind_v2 != NULL
+        ? bind_v2(
+              allocation->real_handle, allocation->member_device,
+              multicast->multicast_offset, backing->real_handle,
+              multicast->memory_offset, multicast->bind_size,
+              multicast->bind_flags)
+        : CUDA_ERROR_NOT_SUPPORTED;
+#else
+    result = CUDA_ERROR_NOT_SUPPORTED;
+#endif
+  }
+  if (result != CUDA_SUCCESS)
+    goto failed;
+  bound = true;
+  if (test_failure("multicast-bind"))
+    goto failed;
+  if (map(
+          (CUdeviceptr)record.address, (size_t)record.size, 0,
+          allocation->real_handle, 0) != CUDA_SUCCESS)
+    goto failed;
+  mapped = true;
+  if (set_access(
+          (CUdeviceptr)record.address, (size_t)record.size, access,
+          record.access_count) != CUDA_SUCCESS)
+    goto failed;
+  allocation->backing_object_id = multicast->backing_object_id;
+  allocation->bound = true;
+  allocation->mapped = true;
+  allocation->detached = false;
+  allocation->temporary_restore_handle =
+      !allocation->application_handle_live;
+  if (leave_context(&scope) != 0)
+    goto failed;
+  entered = false;
+  if (send_header(client, response, -1) != 0)
+    goto failed;
+  return 0;
+
+failed:
+  fail(primary_error);
+  phase = DYN_VMM_FAILED;
+  if (entered && bound) {
+    if (unbind(
+            allocation->real_handle, allocation->member_device,
+            multicast->multicast_offset, multicast->bind_size) !=
+        CUDA_SUCCESS)
+      fail_cleanup("cannot unbind partial multicast replay");
+    else {
+      bound = false;
+      allocation->bound = false;
+    }
+  }
+  if (entered && mapped) {
+    if (unmap((CUdeviceptr)record.address, (size_t)record.size) !=
+        CUDA_SUCCESS)
+      fail_cleanup("cannot unmap partial multicast replay");
+    else {
+      mapped = false;
+      allocation->mapped = false;
+    }
+  }
+  if (entered && leave_context(&scope) != 0)
+    fail_cleanup("cannot restore context after multicast bind failure");
+  (void)cleanup_multicast_restore();
+  set_error(response, primary_error);
+  return send_header(client, response, -1);
+}
+
+static int
+abort_restore(int client, struct dyn_vmm_header* response)
+{
+  fail("CUDA VMM multicast restore aborted; process must not resume");
+  phase = DYN_VMM_FAILED;
+  if (cleanup_multicast_restore() != 0)
+    set_error(response, failure);
+  return send_header(client, response, -1);
+}
+
+static int
+finalize_restore(int client, struct dyn_vmm_header* response)
+{
+  release_fn release = (release_fn)real_symbol("cuMemRelease");
+  struct allocation* allocation;
+
+  if (failed || phase == DYN_VMM_FAILED || release == NULL) {
+    set_error(
+        response,
+        failure[0] != '\0' ? failure : "CUDA VMM shim is unhealthy");
+    return send_header(client, response, -1);
+  }
+  for (allocation = allocations; allocation != NULL;
+       allocation = allocation->next) {
+    if (!allocation->temporary_restore_handle)
+      continue;
+    if ((allocation->object_kind != DYN_VMM_ALLOCATION &&
+         allocation->object_kind != DYN_VMM_MULTICAST) ||
+        allocation->real_handle == 0 ||
+        release(allocation->real_handle) != CUDA_SUCCESS) {
+      fail("cannot finalize temporary CUDA VMM backing handle");
+      phase = DYN_VMM_FAILED;
+      (void)cleanup_multicast_restore();
+      set_error(response, failure);
+      return send_header(client, response, -1);
+    }
+    allocation->real_handle = 0;
+    allocation->temporary_restore_handle = false;
+  }
+  phase = DYN_VMM_RESTORED;
+  return send_header(client, response, -1);
+}
+
 static bool
 valid_request_shape(const struct dyn_vmm_header* request, int passed_fd)
 {
@@ -1875,6 +2930,12 @@ valid_request_shape(const struct dyn_vmm_header* request, int passed_fd)
       sizeof(struct dyn_vmm_record) + sizeof(CUmemAllocationProp) + sizeof(CUmemAccessDesc);
   const uint64_t importer_metadata_size =
       sizeof(struct dyn_vmm_record) + sizeof(CUmemAccessDesc);
+  const uint64_t multicast_owner_metadata_size =
+      sizeof(struct dyn_vmm_record) + sizeof(CUmulticastObjectProp) +
+      sizeof(CUmemAccessDesc) + sizeof(struct dyn_vmm_multicast_record);
+  const uint64_t multicast_importer_metadata_size =
+      sizeof(struct dyn_vmm_record) + sizeof(CUmemAccessDesc) +
+      sizeof(struct dyn_vmm_multicast_record);
   bool bootstrap_identify =
       request->operation == DYN_VMM_IDENTIFY &&
       all_zero(request->participant_id, sizeof(request->participant_id));
@@ -1882,7 +2943,6 @@ valid_request_shape(const struct dyn_vmm_header* request, int passed_fd)
   if (request->magic != DYN_VMM_MAGIC || request->version != DYN_VMM_VERSION ||
       request->status != 0 ||
       (request->operation != DYN_VMM_SET_PLACEMENT && request->count != 0) ||
-      request->reserved != 0 ||
       !all_zero(request->message, sizeof(request->message)) ||
       !all_zero(request->reserved_identity, sizeof(request->reserved_identity)) ||
       (!bootstrap_identify &&
@@ -1892,13 +2952,15 @@ valid_request_shape(const struct dyn_vmm_header* request, int passed_fd)
   switch (request->operation) {
     case DYN_VMM_IDENTIFY:
       return passed_fd < 0 && request->payload_size == 0 && request->handle_type == 0 &&
+          request->object_kind == 0 &&
           all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id == 0;
     case DYN_VMM_INSPECT:
       return !bootstrap_identify && passed_fd < 0 && request->payload_size == 0 &&
-          request->handle_type == 0 && all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) &&
+          request->handle_type == 0 && request->object_kind == 0 &&
+          all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) &&
           request->object_id == 0;
     case DYN_VMM_SET_PLACEMENT:
-      return !bootstrap_identify && passed_fd < 0 && request->handle_type == 0 &&
+      return !bootstrap_identify && passed_fd < 0 && request->handle_type == 0 && request->object_kind == 0 &&
           all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id == 0 &&
           request->payload_size <= SIZE_MAX &&
           request->payload_size <= DYN_VMM_MAXIMUM_ALLOCATION_SIZE &&
@@ -1908,25 +2970,61 @@ valid_request_shape(const struct dyn_vmm_header* request, int passed_fd)
     case DYN_VMM_DETACH_IMPORTS:
     case DYN_VMM_DETACH_OWNERS:
       return !bootstrap_identify && passed_fd < 0 && request->payload_size == 0 &&
-          request->handle_type == 0 && !all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) &&
+          request->handle_type == 0 && request->object_kind == 0 &&
+          !all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) &&
           request->object_id != 0;
     case DYN_VMM_RESTORE_OWNER:
       return !bootstrap_identify && passed_fd < 0 &&
           supported_handle_type((CUmemAllocationHandleType)request->handle_type) &&
           all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id != 0 &&
-          request->payload_size >= owner_metadata_size &&
-          request->payload_size <= owner_metadata_size + DYN_VMM_MAXIMUM_ALLOCATION_SIZE;
+          ((request->object_kind == DYN_VMM_ALLOCATION &&
+            request->payload_size >= owner_metadata_size &&
+            request->payload_size <=
+                owner_metadata_size + DYN_VMM_MAXIMUM_ALLOCATION_SIZE) ||
+           (request->object_kind == DYN_VMM_MULTICAST &&
+            request->payload_size == multicast_owner_metadata_size));
     case DYN_VMM_RESTORE_IMPORT:
       return !bootstrap_identify &&
           ((request->handle_type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR && passed_fd >= 0) ||
            (request->handle_type == CU_MEM_HANDLE_TYPE_FABRIC && passed_fd < 0)) &&
           all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id != 0 &&
-          request->payload_size ==
-              importer_metadata_size +
-                  (request->handle_type == CU_MEM_HANDLE_TYPE_FABRIC ? DYN_VMM_FABRIC_HANDLE_SIZE : 0);
+          ((request->object_kind == DYN_VMM_ALLOCATION &&
+            request->payload_size ==
+                importer_metadata_size +
+                    (request->handle_type == CU_MEM_HANDLE_TYPE_FABRIC
+                         ? DYN_VMM_FABRIC_HANDLE_SIZE
+                         : 0)) ||
+           (request->object_kind == DYN_VMM_MULTICAST &&
+            request->payload_size ==
+                multicast_importer_metadata_size +
+                    (request->handle_type == CU_MEM_HANDLE_TYPE_FABRIC
+                         ? DYN_VMM_FABRIC_HANDLE_SIZE
+                         : 0)));
+    case DYN_VMM_RESTORE_MULTICAST:
+      return !bootstrap_identify && passed_fd < 0 &&
+          request->object_kind == DYN_VMM_MULTICAST &&
+          supported_handle_type(
+              (CUmemAllocationHandleType)request->handle_type) &&
+          all_zero(
+              request->allocation_uuid,
+              sizeof(request->allocation_uuid)) &&
+          request->object_id != 0 &&
+          (request->payload_size == multicast_owner_metadata_size ||
+           request->payload_size == multicast_importer_metadata_size);
+    case DYN_VMM_FINALIZE_RESTORE:
+    case DYN_VMM_ABORT_RESTORE:
+      return !bootstrap_identify && passed_fd < 0 &&
+          request->payload_size == 0 && request->handle_type == 0 &&
+          request->object_kind == 0 &&
+          all_zero(
+              request->allocation_uuid,
+              sizeof(request->allocation_uuid)) &&
+          request->object_id == 0;
     case DYN_VMM_EXPORT_OWNER:
       return !bootstrap_identify && passed_fd < 0 && request->payload_size == 0 &&
           supported_handle_type((CUmemAllocationHandleType)request->handle_type) &&
+          (request->object_kind == DYN_VMM_ALLOCATION ||
+           request->object_kind == DYN_VMM_MULTICAST) &&
           !all_zero(request->allocation_uuid, sizeof(request->allocation_uuid)) && request->object_id == 0;
     default:
       return false;
@@ -1975,10 +3073,30 @@ serve(int client)
       (void)detach(client, &request, &response, DYN_VMM_OWNER);
       break;
     case DYN_VMM_RESTORE_OWNER:
-      (void)restore_owner(client, &request, &response, payload, passed_fd);
+      if (request.object_kind == DYN_VMM_MULTICAST)
+        (void)restore_multicast_owner(
+            client, &request, &response, payload, passed_fd);
+      else
+        (void)restore_owner(
+            client, &request, &response, payload, passed_fd);
       break;
     case DYN_VMM_RESTORE_IMPORT:
-      (void)restore_importer(client, &request, &response, payload, &passed_fd);
+      if (request.object_kind == DYN_VMM_MULTICAST)
+        (void)restore_multicast_importer(
+            client, &request, &response, payload, &passed_fd);
+      else
+        (void)restore_importer(
+            client, &request, &response, payload, &passed_fd);
+      break;
+    case DYN_VMM_RESTORE_MULTICAST:
+      (void)restore_multicast_binding(
+          client, &request, &response, payload);
+      break;
+    case DYN_VMM_FINALIZE_RESTORE:
+      (void)finalize_restore(client, &response);
+      break;
+    case DYN_VMM_ABORT_RESTORE:
+      (void)abort_restore(client, &response);
       break;
     case DYN_VMM_IDENTIFY:
       if (failed || phase == DYN_VMM_FAILED)
@@ -2119,6 +3237,186 @@ finalize(void)
 }
 
 CUresult CUDAAPI
+cuMulticastCreate(
+    CUmemGenericAllocationHandle* output,
+    const CUmulticastObjectProp* properties)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+  function_type function =
+      (function_type)real_symbol("cuMulticastCreate");
+  struct allocation* allocation;
+  CUmemGenericAllocationHandle real_handle = 0;
+  CUmemAllocationHandleType handle_type;
+  CUresult result;
+
+  if (!enabled)
+    return function != NULL ? function(output, properties) : unavailable();
+  if (output == NULL || properties == NULL)
+    return function != NULL ? function(output, properties) : unavailable();
+  if (!valid_multicast_properties(properties)) {
+    pthread_mutex_lock(&lock);
+    cuda_seen = true;
+    result = function != NULL ? function(output, properties) : unavailable();
+    if (result == CUDA_SUCCESS)
+      record_unmanaged_multicast(*output);
+    pthread_mutex_unlock(&lock);
+    return result;
+  }
+  handle_type = (CUmemAllocationHandleType)properties->handleTypes;
+  pthread_mutex_lock(&lock);
+  cuda_seen = true;
+  result =
+      function != NULL ? function(&real_handle, properties) : unavailable();
+  if (result == CUDA_SUCCESS) {
+    allocation = calloc(1, sizeof(*allocation));
+    if (is_logical_handle(real_handle) || allocation == NULL ||
+        current_context(&allocation->context) != 0 ||
+        allocate_logical_handle(&allocation->logical_handle) !=
+            CUDA_SUCCESS) {
+      release_fn release = (release_fn)real_symbol("cuMemRelease");
+
+      if (release != NULL)
+        (void)release(real_handle);
+      free(allocation);
+      fail("cannot record cuMulticastCreate metadata");
+      result = CUDA_ERROR_OUT_OF_MEMORY;
+    } else {
+      allocation->real_handle = real_handle;
+      allocation->application_handle_live = true;
+      allocation->size = properties->size;
+      allocation->multicast_properties = *properties;
+      allocation->role = DYN_VMM_OWNER;
+      allocation->object_kind = DYN_VMM_MULTICAST;
+      allocation->requested_handle_type = handle_type;
+      allocation->next = allocations;
+      allocations = allocation;
+      *output = allocation->logical_handle;
+    }
+  }
+  pthread_mutex_unlock(&lock);
+  return result;
+}
+
+CUresult CUDAAPI
+cuMulticastAddDevice(
+    CUmemGenericAllocationHandle handle, CUdevice device)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, CUdevice);
+  function_type function =
+      (function_type)real_symbol("cuMulticastAddDevice");
+  struct allocation* allocation;
+  CUresult result;
+
+  if (!enabled || !is_logical_handle(handle))
+    return function != NULL ? function(handle, device) : unavailable();
+  pthread_mutex_lock(&lock);
+  cuda_seen = true;
+  allocation = find_logical_handle(handle);
+  if (allocation == NULL) {
+    result = unknown_logical_handle();
+  } else if (allocation->object_kind != DYN_VMM_MULTICAST ||
+             !allocation->application_handle_live ||
+             allocation->real_handle == 0 || allocation->member_added ||
+             allocation->bound) {
+    fail("invalid managed CUDA multicast device addition");
+    result = CUDA_ERROR_INVALID_HANDLE;
+  } else {
+    result = function != NULL
+                 ? function(allocation->real_handle, device)
+                 : unavailable();
+    if (result == CUDA_SUCCESS) {
+      if (record_multicast_member(allocation, device) != 0) {
+        fail("cannot record CUDA multicast member identity");
+        result = CUDA_ERROR_INVALID_DEVICE;
+      } else {
+        allocation->member_added = true;
+      }
+    }
+  }
+  pthread_mutex_unlock(&lock);
+  return result;
+}
+
+static CUresult
+bind_multicast_memory(
+    CUmemGenericAllocationHandle multicast_handle, CUdevice device,
+    bool explicit_device, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory_handle, size_t memory_offset,
+    size_t size, unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * legacy_type)(
+      CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle,
+      size_t, size_t, unsigned long long);
+#if CUDA_VERSION >= 13010
+  typedef CUresult(CUDAAPI * v2_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t,
+      CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+#endif
+  struct allocation* multicast = find_logical_handle(multicast_handle);
+  struct allocation* memory = find_logical_handle(memory_handle);
+  CUresult result;
+
+  if (multicast == NULL || memory == NULL) {
+    result = unknown_logical_handle();
+  } else if (multicast->object_kind != DYN_VMM_MULTICAST ||
+             memory->object_kind != DYN_VMM_ALLOCATION ||
+             !multicast->application_handle_live ||
+             !memory->application_handle_live ||
+             multicast->real_handle == 0 || memory->real_handle == 0 ||
+             !multicast->member_added || multicast->bound ||
+             !memory->exported ||
+             multicast->requested_handle_type !=
+                 memory->requested_handle_type ||
+             multicast_offset != 0 || memory_offset != 0 || flags != 0 ||
+             size == 0 || size != multicast->multicast_properties.size ||
+             size != memory->size ||
+             memcmp(
+                 multicast->gpu_uuid.bytes, memory->gpu_uuid.bytes,
+                 sizeof(multicast->gpu_uuid.bytes)) != 0 ||
+             (explicit_device && device != multicast->member_device)) {
+    fail("invalid managed CUDA multicast memory binding");
+    result = CUDA_ERROR_INVALID_VALUE;
+  } else if (explicit_device) {
+#if CUDA_VERSION >= 13010
+    v2_type function =
+        (v2_type)real_symbol("cuMulticastBindMem_v2");
+    result = function != NULL
+                 ? function(
+                       multicast->real_handle, device, multicast_offset,
+                       memory->real_handle, memory_offset, size, flags)
+                 : unavailable();
+#else
+    result = unavailable();
+#endif
+  } else {
+    legacy_type function =
+        (legacy_type)real_symbol("cuMulticastBindMem");
+    result = function != NULL
+                 ? function(
+                       multicast->real_handle, multicast_offset,
+                       memory->real_handle, memory_offset, size, flags)
+                 : unavailable();
+  }
+  if (result == CUDA_SUCCESS) {
+    memcpy(
+        multicast->backing_allocation_uuid, memory->allocation_uuid,
+        sizeof(multicast->backing_allocation_uuid));
+    multicast->backing_role = memory->role;
+    multicast->bind_api = explicit_device
+        ? DYN_VMM_MULTICAST_BIND_MEM_V2
+        : DYN_VMM_MULTICAST_BIND_MEM;
+    multicast->multicast_offset = multicast_offset;
+    multicast->memory_offset = memory_offset;
+    multicast->bind_size = size;
+    multicast->bind_flags = flags;
+    multicast->bound = true;
+  }
+  return result;
+}
+
+CUresult CUDAAPI
 cuMemCreate(
     CUmemGenericAllocationHandle* output, size_t size,
     const CUmemAllocationProp* properties, unsigned long long flags)
@@ -2194,6 +3492,8 @@ cuMemRelease(CUmemGenericAllocationHandle handle)
   cuda_seen = true;
   if (!is_logical_handle(handle)) {
     result = function != NULL ? function(handle) : unavailable();
+    if (result == CUDA_SUCCESS)
+      remove_unmanaged_multicast(handle);
     pthread_mutex_unlock(&lock);
     return result;
   }
@@ -2203,11 +3503,30 @@ cuMemRelease(CUmemGenericAllocationHandle handle)
   } else if (allocation->real_handle == 0) {
     fail("logical generic allocation handle has no real backing");
     result = CUDA_ERROR_INVALID_HANDLE;
+  } else if (
+      allocation->object_kind == DYN_VMM_MULTICAST &&
+      allocation->mapped) {
+    fail("managed CUDA multicast release requires unmap");
+    result = CUDA_ERROR_INVALID_VALUE;
   } else {
     result = function != NULL
         ? function(allocation->real_handle)
         : unavailable();
     if (result == CUDA_SUCCESS) {
+      if (allocation->object_kind == DYN_VMM_MULTICAST) {
+        allocation->bound = false;
+        allocation->member_added = false;
+        memset(
+            allocation->backing_allocation_uuid, 0,
+            sizeof(allocation->backing_allocation_uuid));
+        allocation->backing_object_id = 0;
+        allocation->backing_role = 0;
+        allocation->bind_api = 0;
+        allocation->multicast_offset = 0;
+        allocation->memory_offset = 0;
+        allocation->bind_size = 0;
+        allocation->bind_flags = 0;
+      }
       allocation->real_handle = 0;
       allocation->application_handle_live = false;
       if (!allocation->mapped)
@@ -2231,7 +3550,8 @@ cuMemMap(
   pthread_mutex_lock(&lock);
   cuda_seen = true;
   if (!is_logical_handle(handle)) {
-    fail("cuMemMap used an untracked real generic handle");
+    if (find_unmanaged_multicast(handle) == NULL)
+      fail("cuMemMap used an untracked real generic handle");
     result = function != NULL
         ? function(address, size, offset, handle, flags)
         : unavailable();
@@ -2434,8 +3754,11 @@ cuMemExportToShareableHandle(
     } else {
       memcpy(uuid, allocation->allocation_uuid, sizeof(uuid));
       if ((!allocation->exported && random_uuid(uuid) != 0) ||
-          (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ? create_capability(uuid, &capability_fd)
-                                                            : create_fabric_token(uuid, &fabric_token)) != 0) {
+          (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+               ? create_capability(
+                     uuid, allocation->object_kind, &capability_fd)
+               : create_fabric_token(
+                     uuid, allocation->object_kind, &fabric_token)) != 0) {
         fail("cannot create CUDA VMM allocation capability");
         result = CUDA_ERROR_OUT_OF_MEMORY;
       }
@@ -2485,17 +3808,20 @@ cuMemImportFromShareableHandle(
   uint8_t allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
   char owner_participant[DYN_VMM_PARTICIPANT_ID_SIZE];
   char owner_socket[sizeof(((struct sockaddr_un*)0)->sun_path)];
+  CUmulticastObjectProp multicast_properties;
+  uint32_t object_kind = 0;
   bool local_owner;
   CUresult result;
 
   if (!enabled)
     return function != NULL ? function(output, os_handle, type) : unavailable();
-  initialize_broker_result(&broker, type);
+  initialize_broker_result(&broker, type, 0);
   memset(&fabric_token, 0, sizeof(fabric_token));
   memset(&capability, 0, sizeof(capability));
   memset(allocation_uuid, 0, sizeof(allocation_uuid));
   memset(owner_participant, 0, sizeof(owner_participant));
   memset(owner_socket, 0, sizeof(owner_socket));
+  memset(&multicast_properties, 0, sizeof(multicast_properties));
   if (!supported_handle_type(type) || output == NULL) {
     pthread_mutex_lock(&lock);
     cuda_seen = true;
@@ -2512,6 +3838,7 @@ cuMemImportFromShareableHandle(
       goto done;
     }
     memcpy(allocation_uuid, capability.allocation_uuid, sizeof(allocation_uuid));
+    object_kind = capability.object_kind;
     snprintf(owner_participant, sizeof(owner_participant), "%s", capability.owner_participant_id);
     snprintf(owner_socket, sizeof(owner_socket), "%s", capability.owner_socket_path);
   } else if (read_fabric_token(os_handle, &fabric_token, owner_participant, owner_socket) != 0) {
@@ -2520,7 +3847,9 @@ cuMemImportFromShareableHandle(
     goto done;
   } else {
     memcpy(allocation_uuid, fabric_token.allocation_uuid, sizeof(allocation_uuid));
+    object_kind = fabric_token.object_kind;
   }
+  broker.object_kind = object_kind;
   if (failed || forked_after_cuda || phase != DYN_VMM_ACTIVE) {
     result = CUDA_ERROR_INVALID_VALUE;
     goto done;
@@ -2528,7 +3857,8 @@ cuMemImportFromShareableHandle(
   local_owner = strcmp(owner_socket, socket_path) == 0 && strcmp(owner_participant, participant_id) == 0;
   if (local_owner) {
     owner = find_object(allocation_uuid, DYN_VMM_OWNER);
-    if (owner == NULL || owner->requested_handle_type != type)
+    if (owner == NULL || owner->requested_handle_type != type ||
+        owner->object_kind != object_kind)
       result = CUDA_ERROR_INVALID_HANDLE;
     else
       result = export_raw_owner(owner, &broker);
@@ -2539,7 +3869,9 @@ cuMemImportFromShareableHandle(
     }
   } else {
     pthread_mutex_unlock(&lock);
-    result = request_owner_export(allocation_uuid, owner_participant, owner_socket, type, &broker) == 0
+    result = request_owner_export(
+                 allocation_uuid, owner_participant, owner_socket, type,
+                 object_kind, &broker) == 0
                  ? CUDA_SUCCESS
                  : CUDA_ERROR_INVALID_VALUE;
     pthread_mutex_lock(&lock);
@@ -2555,6 +3887,9 @@ cuMemImportFromShareableHandle(
                                                                                    : (void*)broker.bytes,
                                   type)
                             : unavailable();
+  if (result == CUDA_SUCCESS && object_kind == DYN_VMM_MULTICAST &&
+      broker.has_multicast_properties)
+    multicast_properties = broker.multicast_properties;
   if (clear_broker_result(&broker, "cannot close imported raw CUDA broker FD") != 0) {
     if (result == CUDA_SUCCESS && (release == NULL || release(real_handle) != CUDA_SUCCESS))
       fail_cleanup("cannot release failed imported CUDA handle");
@@ -2564,10 +3899,17 @@ cuMemImportFromShareableHandle(
   }
   if (result == CUDA_SUCCESS) {
     allocation = calloc(1, sizeof(*allocation));
-    if (allocation == NULL || get_properties == NULL ||
-        get_properties(&allocation->properties, real_handle) != CUDA_SUCCESS ||
+    if (allocation == NULL ||
+        (object_kind == DYN_VMM_ALLOCATION &&
+         (get_properties == NULL ||
+          get_properties(&allocation->properties, real_handle) !=
+              CUDA_SUCCESS)) ||
+        (object_kind == DYN_VMM_MULTICAST &&
+         multicast_properties.size == 0) ||
         current_context(&allocation->context) != 0 ||
-        allocate_logical_handle(&allocation->logical_handle) != CUDA_SUCCESS || record_gpu_identity(allocation) != 0) {
+        allocate_logical_handle(&allocation->logical_handle) != CUDA_SUCCESS ||
+        (object_kind == DYN_VMM_ALLOCATION &&
+         record_gpu_identity(allocation) != 0)) {
       if (release == NULL || release(real_handle) != CUDA_SUCCESS)
         fail_cleanup("cannot release untracked imported CUDA handle");
       free(allocation);
@@ -2579,7 +3921,11 @@ cuMemImportFromShareableHandle(
       allocation->real_handle = real_handle;
       allocation->application_handle_live = true;
       allocation->role = DYN_VMM_IMPORTER;
-      allocation->object_kind = DYN_VMM_ALLOCATION;
+      allocation->object_kind = object_kind;
+      if (object_kind == DYN_VMM_MULTICAST) {
+        allocation->size = multicast_properties.size;
+        allocation->multicast_properties = multicast_properties;
+      }
       /* CUDA reports re-exportable types, not the transport used to import. */
       allocation->requested_handle_type = type;
       allocation->next = allocations;
@@ -2595,6 +3941,7 @@ done:
     phase = DYN_VMM_FAILED;
   }
   explicit_bzero(&fabric_token, sizeof(fabric_token));
+  explicit_bzero(&multicast_properties, sizeof(multicast_properties));
   pthread_mutex_unlock(&lock);
   return result;
 }
@@ -2650,22 +3997,32 @@ cuMulticastBindMem(
   typedef CUresult(CUDAAPI * function_type)(
       CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle,
       size_t, size_t, unsigned long long);
-  function_type function = (function_type)real_symbol("cuMulticastBindMem");
   CUresult result;
 
-  if (!enabled || !is_logical_handle(memory_handle))
+  if (!enabled ||
+      (!is_logical_handle(multicast_handle) &&
+       !is_logical_handle(memory_handle))) {
+    function_type function =
+        (function_type)real_symbol("cuMulticastBindMem");
     return function != NULL
         ? function(
               multicast_handle, multicast_offset, memory_handle, memory_offset,
               size, flags)
         : unavailable();
+  }
   pthread_mutex_lock(&lock);
   cuda_seen = true;
-  if (find_logical_handle(memory_handle) == NULL)
+  if (!is_logical_handle(multicast_handle) ||
+      !is_logical_handle(memory_handle)) {
+    fail("mixed managed and unmanaged CUDA multicast binding");
+    result = CUDA_ERROR_INVALID_HANDLE;
+  } else if (find_logical_handle(multicast_handle) == NULL ||
+             find_logical_handle(memory_handle) == NULL) {
     result = unknown_logical_handle();
-  else {
-    fail("multicast binding of managed allocations is unsupported");
-    result = CUDA_ERROR_NOT_SUPPORTED;
+  } else {
+    result = bind_multicast_memory(
+        multicast_handle, 0, false, multicast_offset, memory_handle,
+        memory_offset, size, flags);
   }
   pthread_mutex_unlock(&lock);
   return result;
@@ -2681,22 +4038,32 @@ cuMulticastBindMem_v2(
   typedef CUresult(CUDAAPI * function_type)(
       CUmemGenericAllocationHandle, CUdevice, size_t,
       CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
-  function_type function = (function_type)real_symbol("cuMulticastBindMem_v2");
   CUresult result;
 
-  if (!enabled || !is_logical_handle(memory_handle))
+  if (!enabled ||
+      (!is_logical_handle(multicast_handle) &&
+       !is_logical_handle(memory_handle))) {
+    function_type function =
+        (function_type)real_symbol("cuMulticastBindMem_v2");
     return function != NULL
         ? function(
               multicast_handle, device, multicast_offset, memory_handle,
               memory_offset, size, flags)
         : unavailable();
+  }
   pthread_mutex_lock(&lock);
   cuda_seen = true;
-  if (find_logical_handle(memory_handle) == NULL)
+  if (!is_logical_handle(multicast_handle) ||
+      !is_logical_handle(memory_handle)) {
+    fail("mixed managed and unmanaged CUDA multicast binding");
+    result = CUDA_ERROR_INVALID_HANDLE;
+  } else if (find_logical_handle(multicast_handle) == NULL ||
+             find_logical_handle(memory_handle) == NULL) {
     result = unknown_logical_handle();
-  else {
-    fail("multicast binding of managed allocations is unsupported");
-    result = CUDA_ERROR_NOT_SUPPORTED;
+  } else {
+    result = bind_multicast_memory(
+        multicast_handle, device, true, multicast_offset, memory_handle,
+        memory_offset, size, flags);
   }
   pthread_mutex_unlock(&lock);
   return result;
@@ -2720,8 +4087,13 @@ replacement(const char* symbol, int version)
   ENTRY(cuMemImportFromShareableHandle);
   ENTRY(cuMemRetainAllocationHandle);
   ENTRY(cuMemGetAllocationPropertiesFromHandle);
+  ENTRY(cuMulticastCreate);
+  ENTRY(cuMulticastAddDevice);
+  ENTRY(cuMulticastBindAddr);
+  ENTRY(cuMulticastUnbind);
 #if CUDA_VERSION >= 13010
   ENTRY(cuMulticastBindMem_v2);
+  ENTRY(cuMulticastBindAddr_v2);
 #endif
   ENTRY(cuGetProcAddress_v2);
   ENTRY(cuGetProcAddress_v2_ptsz);
@@ -2732,6 +4104,13 @@ replacement(const char* symbol, int version)
       return (void*)&cuMulticastBindMem_v2;
 #endif
     return (void*)&cuMulticastBindMem;
+  }
+  if (strcmp(symbol, "cuMulticastBindAddr") == 0) {
+#if CUDA_VERSION >= 13010
+    if (version >= 13010)
+      return (void*)&cuMulticastBindAddr_v2;
+#endif
+    return (void*)&cuMulticastBindAddr;
   }
   if (strcmp(symbol, "cuGetProcAddress") == 0)
     return version >= 12000 ? (void*)&cuGetProcAddress_v2 : (void*)&cuGetProcAddress;

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
@@ -12,11 +12,11 @@
 #include <sys/un.h>
 
 #define DYN_VMM_MAGIC 0x44564d4dU
-#define DYN_VMM_VERSION 4U
+#define DYN_VMM_VERSION 5U
 #define DYN_VMM_CAPABILITY_MAGIC 0x44564d43U
-#define DYN_VMM_CAPABILITY_VERSION 1U
+#define DYN_VMM_CAPABILITY_VERSION 2U
 #define DYN_VMM_FABRIC_TOKEN_MAGIC 0x44564d46U
-#define DYN_VMM_FABRIC_TOKEN_VERSION 1U
+#define DYN_VMM_FABRIC_TOKEN_VERSION 2U
 #define DYN_VMM_FABRIC_HANDLE_SIZE 64U
 #define DYN_VMM_SOCKET_PREFIX "cuda-vmm-"
 #define DYN_VMM_PARTICIPANT_ID_SIZE 33U
@@ -35,6 +35,9 @@ enum dyn_vmm_operation {
   DYN_VMM_IDENTIFY = 7,
   DYN_VMM_SET_PLACEMENT = 8,
   DYN_VMM_EXPORT_OWNER = 9,
+  DYN_VMM_RESTORE_MULTICAST = 10,
+  DYN_VMM_FINALIZE_RESTORE = 11,
+  DYN_VMM_ABORT_RESTORE = 12,
 };
 
 enum dyn_vmm_role {
@@ -51,10 +54,17 @@ enum dyn_vmm_phase {
 
 enum dyn_vmm_object_kind {
   DYN_VMM_ALLOCATION = 1,
+  DYN_VMM_MULTICAST = 2,
 };
 
 enum dyn_vmm_record_flags {
   DYN_VMM_APPLICATION_HANDLE_LIVE = 1U << 0,
+  DYN_VMM_RETAIN_RESTORE_HANDLE = 1U << 1,
+};
+
+enum dyn_vmm_multicast_bind_api {
+  DYN_VMM_MULTICAST_BIND_MEM = 1,
+  DYN_VMM_MULTICAST_BIND_MEM_V2 = 2,
 };
 
 struct dyn_vmm_header {
@@ -64,7 +74,7 @@ struct dyn_vmm_header {
   int32_t status;
   uint32_t count;
   uint32_t handle_type;
-  uint32_t reserved;
+  uint32_t object_kind;
   uint8_t allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
   uint64_t object_id;
   uint64_t payload_size;
@@ -97,7 +107,7 @@ struct dyn_vmm_record {
 struct dyn_vmm_capability {
   uint32_t magic;
   uint16_t version;
-  uint16_t reserved;
+  uint16_t object_kind;
   uint8_t allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
   char owner_socket_path[sizeof(((struct sockaddr_un*)0)->sun_path)];
   char owner_participant_id[DYN_VMM_PARTICIPANT_ID_SIZE];
@@ -111,6 +121,27 @@ struct dyn_vmm_fabric_token {
   uint8_t allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
   char owner_participant_id[DYN_VMM_FABRIC_PARTICIPANT_ID_SIZE];
   uint32_t owner_namespace_pid;
+  uint32_t object_kind;
+};
+
+/*
+ * One fixed multicast extension follows each multicast record's opaque
+ * properties and access bytes. Capture uses backing_allocation_uuid; restore
+ * uses backing_object_id and requires the UUID bytes to be otherwise zero.
+ */
+struct dyn_vmm_multicast_record {
+  uint8_t backing_allocation_uuid[DYN_VMM_ALLOCATION_UUID_SIZE];
+  uint64_t backing_object_id;
+  uint64_t multicast_offset;
+  uint64_t memory_offset;
+  uint64_t bind_size;
+  uint64_t bind_flags;
+  uint64_t object_flags;
+  uint64_t object_handle_types;
+  uint64_t object_size;
+  uint32_t num_devices;
+  uint32_t backing_role;
+  uint32_t bind_api;
   uint32_t reserved;
 };
 
@@ -123,7 +154,7 @@ struct dyn_vmm_placement {
 
 _Static_assert(sizeof(struct dyn_vmm_header) == 256, "VMM header layout changed");
 _Static_assert(offsetof(struct dyn_vmm_header, handle_type) == 16, "VMM header handle type offset changed");
-_Static_assert(offsetof(struct dyn_vmm_header, reserved) == 20, "VMM header reserved offset changed");
+_Static_assert(offsetof(struct dyn_vmm_header, object_kind) == 20, "VMM header object kind offset changed");
 _Static_assert(offsetof(struct dyn_vmm_header, allocation_uuid) == 24, "VMM header UUID offset changed");
 _Static_assert(offsetof(struct dyn_vmm_header, object_id) == 40, "VMM header object ID offset changed");
 _Static_assert(offsetof(struct dyn_vmm_header, payload_size) == 48, "VMM header payload size offset changed");
@@ -136,6 +167,7 @@ _Static_assert(
         sizeof(struct dyn_vmm_header),
     "VMM header reserved identity must end at the header boundary");
 _Static_assert(sizeof(struct dyn_vmm_record) == 96, "VMM record layout changed");
+_Static_assert(sizeof(struct dyn_vmm_multicast_record) == 96, "VMM multicast record layout changed");
 _Static_assert(sizeof(struct dyn_vmm_capability) == 256, "VMM capability layout changed");
 _Static_assert(sizeof(struct dyn_vmm_fabric_token) == DYN_VMM_FABRIC_HANDLE_SIZE, "VMM FABRIC token layout changed");
 _Static_assert(offsetof(struct dyn_vmm_fabric_token, magic) == 0, "VMM FABRIC token magic offset changed");
@@ -145,7 +177,7 @@ _Static_assert(offsetof(struct dyn_vmm_fabric_token, allocation_uuid) == 8, "VMM
 _Static_assert(
     offsetof(struct dyn_vmm_fabric_token, owner_participant_id) == 24, "VMM FABRIC token participant offset changed");
 _Static_assert(offsetof(struct dyn_vmm_fabric_token, owner_namespace_pid) == 56, "VMM FABRIC token PID offset changed");
-_Static_assert(offsetof(struct dyn_vmm_fabric_token, reserved) == 60, "VMM FABRIC token reserved offset changed");
+_Static_assert(offsetof(struct dyn_vmm_fabric_token, object_kind) == 60, "VMM FABRIC token kind offset changed");
 _Static_assert(sizeof(struct dyn_vmm_placement) == 40, "VMM placement layout changed");
 
 #endif

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/explicit_loader_test.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/explicit_loader_test.c
@@ -12,8 +12,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
+#undef cuMulticastAddDevice
+#undef cuMulticastBindAddr
 #undef cuMulticastBindMem
+#undef cuMulticastCreate
+#undef cuMulticastUnbind
 
 typedef CUresult(CUDAAPI* resolver_v2_fn)(
     const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
@@ -23,9 +28,26 @@ typedef CUresult(CUDAAPI* create_fn)(
 typedef CUresult(CUDAAPI* map_fn)(
     CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle,
     unsigned long long);
+typedef CUresult(CUDAAPI* export_fn)(
+    void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType,
+    unsigned long long);
+typedef CUresult(CUDAAPI* multicast_create_fn)(
+    CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+typedef CUresult(CUDAAPI* multicast_add_fn)(
+    CUmemGenericAllocationHandle, CUdevice);
 typedef CUresult(CUDAAPI* multicast_bind_fn)(
     CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t,
     size_t, unsigned long long);
+typedef CUresult(CUDAAPI* multicast_bind_addr_fn)(
+    CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t,
+    unsigned long long);
+#if CUDA_VERSION >= 13010
+typedef CUresult(CUDAAPI* multicast_bind_addr_v2_fn)(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t,
+    unsigned long long);
+#endif
+typedef CUresult(CUDAAPI* multicast_unbind_fn)(
+    CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
 #if CUDA_VERSION >= 13010
 typedef CUresult(CUDAAPI* multicast_bind_v2_fn)(
     CUmemGenericAllocationHandle, CUdevice, size_t,
@@ -52,9 +74,17 @@ main(void)
   void* (*unknown_address)(void);
   unsigned int (*logical_forward_count)(void);
   unsigned int (*multicast_bind_count)(void);
+  unsigned int (*multicast_bind_addr_count)(void);
+  unsigned int (*multicast_create_count)(void);
+  unsigned int (*multicast_add_count)(void);
+  unsigned int (*multicast_unbind_count)(void);
+  CUdevice (*multicast_device)(unsigned int);
   CUdriverProcAddressQueryResult status;
   CUmemAllocationProp properties;
+  CUmulticastObjectProp multicast_properties;
   CUmemGenericAllocationHandle logical;
+  CUmemGenericAllocationHandle multicast;
+  int capability_fd;
 
   require(cuda != NULL, dlerror());
   real_create = dlsym(cuda, "cuMemCreate");
@@ -63,10 +93,23 @@ main(void)
       (unsigned int (*)(void))dlsym(cuda, "fake_cuda_logical_forward_count");
   multicast_bind_count =
       (unsigned int (*)(void))dlsym(cuda, "fake_cuda_multicast_bind_count");
+  multicast_bind_addr_count = (unsigned int (*)(void))dlsym(
+      cuda, "fake_cuda_multicast_bind_addr_count");
+  multicast_create_count = (unsigned int (*)(void))dlsym(
+      cuda, "fake_cuda_multicast_create_count");
+  multicast_add_count = (unsigned int (*)(void))dlsym(
+      cuda, "fake_cuda_multicast_add_count");
+  multicast_unbind_count = (unsigned int (*)(void))dlsym(
+      cuda, "fake_cuda_multicast_unbind_count");
+  multicast_device =
+      (CUdevice(*)(unsigned int))dlsym(cuda, "fake_cuda_multicast_device");
   resolve = (resolver_v2_fn)dlsym(cuda, "cuGetProcAddress_v2");
   require(
       real_create != NULL && unknown_address != NULL &&
           logical_forward_count != NULL && multicast_bind_count != NULL &&
+          multicast_bind_addr_count != NULL &&
+          multicast_create_count != NULL && multicast_add_count != NULL &&
+          multicast_unbind_count != NULL && multicast_device != NULL &&
           resolve != NULL,
       "explicit libcuda lookups failed");
 
@@ -104,16 +147,88 @@ main(void)
       "cached managed map PFN bypassed logical-handle translation");
 
   require(
+      resolve(
+          "cuMemExportToShareableHandle", &entry, CUDA_VERSION, 0,
+          &status) == CUDA_SUCCESS &&
+          ((export_fn)entry)(
+              &capability_fd, logical,
+              CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) == CUDA_SUCCESS,
+      "cached managed export PFN did not export a capability");
+  close(capability_fd);
+  memset(&multicast_properties, 0, sizeof(multicast_properties));
+  multicast_properties.handleTypes =
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  multicast_properties.size = 4096;
+  multicast_properties.numDevices = 1;
+  require(
+      resolve("cuMulticastCreate", &entry, CUDA_VERSION, 0, &status) ==
+              CUDA_SUCCESS &&
+          ((multicast_create_fn)entry)(
+              &multicast, &multicast_properties) == CUDA_SUCCESS &&
+          multicast != 0x1235 && multicast_create_count() == 1,
+      "cached multicast create PFN did not return a logical handle");
+  require(
+      resolve("cuMulticastAddDevice", &entry, CUDA_VERSION, 0, &status) ==
+              CUDA_SUCCESS &&
+          ((multicast_add_fn)entry)(multicast, 0) == CUDA_SUCCESS &&
+          multicast_add_count() == 1 && multicast_device(0) == 0,
+      "cached multicast add PFN did not translate the logical handle");
+  require(
+      resolve("cuMulticastBindMem", &entry, 12010, 0, &status) ==
+              CUDA_SUCCESS &&
+          ((multicast_bind_fn)entry)(
+              multicast, 0, logical, 0, 4096, 0) == CUDA_SUCCESS &&
+          multicast_bind_count() == 1 && logical_forward_count() == 0,
+      "cached multicast bind PFN did not translate logical handles");
+  require(
+      resolve("cuMulticastUnbind", &entry, CUDA_VERSION, 0, &status) ==
+              CUDA_SUCCESS &&
+          ((multicast_unbind_fn)entry)(multicast, 0, 0, 4096) ==
+              CUDA_SUCCESS &&
+          multicast_unbind_count() == 1 && logical_forward_count() == 0,
+      "cached multicast unbind PFN did not translate the logical handle");
+  require(
+      resolve("cuMulticastBindAddr", &entry, 12010, 0, &status) ==
+              CUDA_SUCCESS &&
+          ((multicast_bind_addr_fn)entry)(
+              UINT64_C(0x8000), 0, 0x2000, 4096, 0) == CUDA_SUCCESS &&
+          multicast_bind_addr_count() == 1,
+      "unmanaged multicast address bind was not forwarded unchanged");
+  require(
+      ((multicast_bind_addr_fn)entry)(
+          multicast, 0, 0x2000, 4096, 0) == CUDA_ERROR_NOT_SUPPORTED &&
+          multicast_bind_addr_count() == 1 &&
+          logical_forward_count() == 0,
+      "managed multicast address bind reached the fake UMD");
+
+#if CUDA_VERSION >= 13010
+  require(
+      resolve("cuMulticastBindAddr", &entry, 13010, 0, &status) ==
+              CUDA_SUCCESS &&
+          ((multicast_bind_addr_v2_fn)entry)(
+              UINT64_C(0x8000), 0, 0, 0x2000, 4096, 0) == CUDA_SUCCESS &&
+          multicast_bind_addr_count() == 2,
+      "unmanaged multicast address bind v2 was not forwarded unchanged");
+  require(
+      ((multicast_bind_addr_v2_fn)entry)(
+          multicast, 0, 0, 0x2000, 4096, 0) ==
+              CUDA_ERROR_NOT_SUPPORTED &&
+          multicast_bind_addr_count() == 2 &&
+          logical_forward_count() == 0,
+      "managed multicast address bind v2 reached the fake UMD");
+#endif
+
+  require(
       resolve("cuMulticastBindMem", &entry, 12010, 0, &status) ==
               CUDA_SUCCESS &&
           ((multicast_bind_fn)entry)(0x8000, 0, logical, 0, 4096, 0) ==
-              CUDA_ERROR_NOT_SUPPORTED &&
-          multicast_bind_count() == 0 && logical_forward_count() == 0,
+              CUDA_ERROR_INVALID_HANDLE &&
+          multicast_bind_count() == 1 && logical_forward_count() == 0,
       "managed multicast bind reached the fake UMD");
   require(
       ((multicast_bind_fn)entry)(0x8000, 0, 0x9000, 0, 4096, 0) ==
               CUDA_SUCCESS &&
-          multicast_bind_count() == 1,
+          multicast_bind_count() == 2,
       "unmanaged multicast bind was not forwarded unchanged");
 
 #if CUDA_VERSION >= 13010
@@ -122,8 +237,8 @@ main(void)
               CUDA_SUCCESS &&
           ((multicast_bind_v2_fn)entry)(
               0x8000, 0, 0, logical, 0, 4096, 0) ==
-              CUDA_ERROR_NOT_SUPPORTED &&
-          multicast_bind_count() == 1 && logical_forward_count() == 0,
+              CUDA_ERROR_INVALID_HANDLE &&
+          multicast_bind_count() == 2 && logical_forward_count() == 0,
       "cuda-python-style managed multicast bind v2 reached the fake UMD");
 #endif
   require(dlclose(cuda) == 0, "cannot close explicit libcuda handle");

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/fake_cuda.c
@@ -10,6 +10,7 @@
 #include <cuda_runtime_api.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -18,7 +19,10 @@
 #include <unistd.h>
 
 #undef cuGetProcAddress
+#undef cuMulticastAddDevice
+#undef cuMulticastCreate
 #undef cuMulticastBindMem
+#undef cuMulticastUnbind
 #undef cudaGetDriverEntryPoint
 #undef cudaGetDriverEntryPointByVersion
 
@@ -40,11 +44,38 @@ static unsigned int logical_forward_count;
 static unsigned int active_handle_count;
 static unsigned int active_mapping_count;
 static unsigned int multicast_bind_count;
+static unsigned int multicast_create_count;
+static unsigned int multicast_add_count;
+static unsigned int multicast_bind_addr_count;
+static unsigned int multicast_unbind_count;
+static unsigned int active_multicast_count;
+static unsigned int active_multicast_bind_count;
+static CUmulticastObjectProp multicast_properties[16];
+static CUdevice multicast_devices[16];
+static CUmemGenericAllocationHandle created_multicast_handles[16];
+static CUmemGenericAllocationHandle multicast_handles[16];
+static CUmemGenericAllocationHandle multicast_memory_handles[16];
+static bool multicast_bind_active[16];
+static size_t multicast_offsets[16];
+static size_t multicast_memory_offsets[16];
+static size_t multicast_sizes[16];
+static unsigned long long multicast_flags[16];
+static CUdevice multicast_bind_devices[16];
+static CUmemGenericAllocationHandle multicast_unbind_handles[16];
+static CUdevice multicast_unbind_devices[16];
+static size_t multicast_unbind_offsets[16];
+static size_t multicast_unbind_sizes[16];
+static CUdeviceptr multicast_map_addresses[16];
+static unsigned int multicast_map_address_count;
+static char multicast_events[64];
+static unsigned int multicast_event_count;
 static int last_exported_fd = -1;
 static int last_internal_export_alias = -1;
 static int internal_export_aliases[32];
 static CUmemAllocationHandleType handle_types[32];
+static CUdevice handle_devices[32];
 static CUdevice create_devices[32];
+static CUdevice import_device;
 static int last_imported_fd = -1;
 static unsigned char last_imported_fabric[CU_IPC_HANDLE_SIZE];
 static int colliding_export_source = -1;
@@ -67,6 +98,152 @@ static CUdevice device_identities[16];
 static unsigned int device_get_calls;
 static unsigned int device_uuid_calls;
 static unsigned int device_count_calls;
+
+unsigned int
+fake_cuda_multicast_create_count(void)
+{
+  return multicast_create_count;
+}
+
+unsigned int
+fake_cuda_multicast_add_count(void)
+{
+  return multicast_add_count;
+}
+
+unsigned int
+fake_cuda_multicast_bind_addr_count(void)
+{
+  return multicast_bind_addr_count;
+}
+
+CUdevice
+fake_cuda_multicast_device(unsigned int index)
+{
+  return index < multicast_add_count ? multicast_devices[index] : -1;
+}
+
+unsigned int
+fake_cuda_multicast_unbind_count(void)
+{
+  return multicast_unbind_count;
+}
+
+unsigned int
+fake_cuda_active_multicast_count(void)
+{
+  return active_multicast_count;
+}
+
+unsigned int
+fake_cuda_active_multicast_bind_count(void)
+{
+  return active_multicast_bind_count;
+}
+
+char
+fake_cuda_multicast_event(unsigned int index)
+{
+  return index < multicast_event_count ? multicast_events[index] : '\0';
+}
+
+unsigned int
+fake_cuda_multicast_event_count(void)
+{
+  return multicast_event_count;
+}
+
+CUmemGenericAllocationHandle
+fake_cuda_multicast_handle(unsigned int index)
+{
+  return index < multicast_bind_count ? multicast_handles[index] : 0;
+}
+
+CUmemGenericAllocationHandle
+fake_cuda_multicast_memory_handle(unsigned int index)
+{
+  return index < multicast_bind_count ? multicast_memory_handles[index] : 0;
+}
+
+size_t
+fake_cuda_multicast_offset(unsigned int index)
+{
+  return index < multicast_bind_count ? multicast_offsets[index] : 0;
+}
+
+size_t
+fake_cuda_multicast_memory_offset(unsigned int index)
+{
+  return index < multicast_bind_count ? multicast_memory_offsets[index] : 0;
+}
+
+size_t
+fake_cuda_multicast_size(unsigned int index)
+{
+  return index < multicast_bind_count ? multicast_sizes[index] : 0;
+}
+
+unsigned long long
+fake_cuda_multicast_flags(unsigned int index)
+{
+  return index < multicast_bind_count ? multicast_flags[index] : 0;
+}
+
+CUdevice
+fake_cuda_multicast_bind_device(unsigned int index)
+{
+  return index < multicast_bind_count ? multicast_bind_devices[index] : -1;
+}
+
+CUmemGenericAllocationHandle
+fake_cuda_multicast_unbind_handle(unsigned int index)
+{
+  return index < multicast_unbind_count
+      ? multicast_unbind_handles[index]
+      : 0;
+}
+
+CUdevice
+fake_cuda_multicast_unbind_device(unsigned int index)
+{
+  return index < multicast_unbind_count ? multicast_unbind_devices[index] : -1;
+}
+
+size_t
+fake_cuda_multicast_unbind_offset(unsigned int index)
+{
+  return index < multicast_unbind_count ? multicast_unbind_offsets[index] : 0;
+}
+
+size_t
+fake_cuda_multicast_unbind_size(unsigned int index)
+{
+  return index < multicast_unbind_count ? multicast_unbind_sizes[index] : 0;
+}
+
+static void
+record_multicast_event(char event)
+{
+  if (multicast_event_count < sizeof(multicast_events))
+    multicast_events[multicast_event_count] = event;
+  multicast_event_count++;
+}
+
+static int
+known_multicast_handle(CUmemGenericAllocationHandle handle)
+{
+  size_t index;
+
+  for (index = 0; index < multicast_create_count; index++) {
+    if (created_multicast_handles[index] == handle)
+      return 1;
+  }
+  for (index = 0; index < multicast_bind_count; index++) {
+    if (multicast_handles[index] == handle)
+      return 1;
+  }
+  return 0;
+}
 
 __attribute__((constructor)) static void
 initialize_fake_cuda(void)
@@ -251,6 +428,12 @@ fake_cuda_create_device(unsigned int index)
 }
 
 void
+fake_cuda_set_import_device(CUdevice device)
+{
+  import_device = device;
+}
+
+void
 fake_cuda_set_device_count(int count)
 {
   device_count = count;
@@ -335,6 +518,33 @@ cuCtxGetCurrent(CUcontext* context)
   return CUDA_SUCCESS;
 }
 
+#if CUDA_VERSION >= 13010
+CUresult CUDAAPI
+cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle multicast_handle, CUdevice device,
+    size_t multicast_offset, CUdeviceptr address, size_t size,
+    unsigned long long flags)
+{
+  (void)device;
+  return cuMulticastBindAddr(
+      multicast_handle, multicast_offset, address, size, flags);
+}
+#endif
+
+CUresult CUDAAPI
+cuMulticastBindAddr(
+    CUmemGenericAllocationHandle multicast_handle, size_t multicast_offset,
+    CUdeviceptr address, size_t size, unsigned long long flags)
+{
+  (void)multicast_handle;
+  (void)multicast_offset;
+  (void)address;
+  (void)size;
+  (void)flags;
+  multicast_bind_addr_count++;
+  return CUDA_SUCCESS;
+}
+
 CUresult CUDAAPI
 cuCtxSetCurrent(CUcontext context)
 {
@@ -393,8 +603,10 @@ cuMemCreate(
   active_handle_count++;
   *output = next_handle++;
   index = (size_t)(*output - UINT64_C(0x1234));
-  if (index < sizeof(handle_types) / sizeof(handle_types[0]))
+  if (index < sizeof(handle_types) / sizeof(handle_types[0])) {
     handle_types[index] = properties->requestedHandleTypes;
+    handle_devices[index] = properties->location.id;
+  }
   return CUDA_SUCCESS;
 }
 
@@ -407,6 +619,22 @@ cuMemRelease(CUmemGenericAllocationHandle handle)
     released_handles[release_count] = handle;
   release_count++;
   active_handle_count--;
+  if (known_multicast_handle(handle)) {
+    for (size_t binding = 0; binding < multicast_bind_count; binding++) {
+      if (multicast_bind_active[binding] &&
+          multicast_handles[binding] == handle) {
+        multicast_bind_active[binding] = false;
+        active_multicast_bind_count--;
+      }
+    }
+  }
+  for (size_t index = 0; index < multicast_create_count; index++) {
+    if (created_multicast_handles[index] == handle) {
+      active_multicast_count--;
+      record_multicast_event('r');
+      break;
+    }
+  }
   return CUDA_SUCCESS;
 }
 
@@ -425,6 +653,14 @@ cuMemMap(
     map_addresses[map_count] = address;
   map_count++;
   active_mapping_count++;
+  if (known_multicast_handle(handle)) {
+    if (multicast_map_address_count <
+        sizeof(multicast_map_addresses) /
+            sizeof(multicast_map_addresses[0]))
+      multicast_map_addresses[multicast_map_address_count] = address;
+    multicast_map_address_count++;
+    record_multicast_event('m');
+  }
   return CUDA_SUCCESS;
 }
 
@@ -451,6 +687,12 @@ cuMemSetAccess(
       access_descriptors[set_access_count] = descriptors[0];
   }
   set_access_count++;
+  for (size_t index = 0; index < multicast_map_address_count; index++) {
+    if (multicast_map_addresses[index] == address) {
+      record_multicast_event('x');
+      break;
+    }
+  }
   return CUDA_SUCCESS;
 }
 
@@ -515,8 +757,10 @@ cuMemImportFromShareableHandle(
   active_handle_count++;
   *output = next_handle++;
   index = (size_t)(*output - UINT64_C(0x1234));
-  if (index < sizeof(handle_types) / sizeof(handle_types[0]))
+  if (index < sizeof(handle_types) / sizeof(handle_types[0])) {
     handle_types[index] = CU_MEM_HANDLE_TYPE_NONE;
+    handle_devices[index] = import_device;
+  }
   return CUDA_SUCCESS;
 }
 
@@ -531,7 +775,10 @@ cuMemGetAllocationPropertiesFromHandle(
   memset(properties, 0, sizeof(*properties));
   properties->type = CU_MEM_ALLOCATION_TYPE_PINNED;
   properties->location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  properties->location.id = 0;
+  properties->location.id =
+      index < sizeof(handle_devices) / sizeof(handle_devices[0])
+          ? handle_devices[index]
+          : 0;
   properties->requestedHandleTypes =
       index < sizeof(handle_types) / sizeof(handle_types[0])
           ? handle_types[index]
@@ -575,19 +822,59 @@ cuIpcGetMemHandle(CUipcMemHandle* handle, CUdeviceptr address)
 }
 
 CUresult CUDAAPI
+cuMulticastCreate(
+    CUmemGenericAllocationHandle* output,
+    const CUmulticastObjectProp* properties)
+{
+  unsigned int index = multicast_create_count++;
+
+  active_handle_count++;
+  active_multicast_count++;
+  *output = next_handle++;
+  if (index < sizeof(multicast_properties) / sizeof(multicast_properties[0])) {
+    multicast_properties[index] = *properties;
+    created_multicast_handles[index] = *output;
+  }
+  record_multicast_event('c');
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMulticastAddDevice(
+    CUmemGenericAllocationHandle handle, CUdevice device)
+{
+  if (!real_handle(handle))
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (multicast_add_count <
+      sizeof(multicast_devices) / sizeof(multicast_devices[0]))
+    multicast_devices[multicast_add_count] = device;
+  multicast_add_count++;
+  record_multicast_event('a');
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
 cuMulticastBindMem(
     CUmemGenericAllocationHandle multicast_handle, size_t multicast_offset,
     CUmemGenericAllocationHandle memory_handle, size_t memory_offset,
     size_t size, unsigned long long flags)
 {
-  (void)multicast_handle;
-  (void)multicast_offset;
-  (void)memory_offset;
-  (void)size;
-  (void)flags;
-  if (!real_handle(memory_handle))
+  if (!real_handle(multicast_handle) || !real_handle(memory_handle))
     return CUDA_ERROR_INVALID_HANDLE;
+  if (multicast_bind_count <
+      sizeof(multicast_handles) / sizeof(multicast_handles[0])) {
+    multicast_handles[multicast_bind_count] = multicast_handle;
+    multicast_memory_handles[multicast_bind_count] = memory_handle;
+    multicast_offsets[multicast_bind_count] = multicast_offset;
+    multicast_memory_offsets[multicast_bind_count] = memory_offset;
+    multicast_sizes[multicast_bind_count] = size;
+    multicast_flags[multicast_bind_count] = flags;
+    multicast_bind_devices[multicast_bind_count] = -1;
+    multicast_bind_active[multicast_bind_count] = true;
+  }
   multicast_bind_count++;
+  active_multicast_bind_count++;
+  record_multicast_event('b');
   return CUDA_SUCCESS;
 }
 
@@ -598,12 +885,47 @@ cuMulticastBindMem_v2(
     size_t multicast_offset, CUmemGenericAllocationHandle memory_handle,
     size_t memory_offset, size_t size, unsigned long long flags)
 {
-  (void)device;
-  return cuMulticastBindMem(
+  CUresult result = cuMulticastBindMem(
       multicast_handle, multicast_offset, memory_handle, memory_offset, size,
       flags);
+  if (result == CUDA_SUCCESS &&
+      multicast_bind_count <=
+          sizeof(multicast_bind_devices) / sizeof(multicast_bind_devices[0]))
+    multicast_bind_devices[multicast_bind_count - 1] = device;
+  return result;
 }
 #endif
+
+CUresult CUDAAPI
+cuMulticastUnbind(
+    CUmemGenericAllocationHandle multicast_handle, CUdevice device,
+    size_t multicast_offset, size_t size)
+{
+  (void)device;
+  (void)multicast_offset;
+  (void)size;
+  if (!real_handle(multicast_handle))
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (multicast_unbind_count <
+      sizeof(multicast_unbind_handles) /
+          sizeof(multicast_unbind_handles[0])) {
+    multicast_unbind_handles[multicast_unbind_count] = multicast_handle;
+    multicast_unbind_devices[multicast_unbind_count] = device;
+    multicast_unbind_offsets[multicast_unbind_count] = multicast_offset;
+    multicast_unbind_sizes[multicast_unbind_count] = size;
+  }
+  multicast_unbind_count++;
+  for (size_t index = 0; index < multicast_bind_count; index++) {
+    if (multicast_bind_active[index] &&
+        multicast_handles[index] == multicast_handle) {
+      multicast_bind_active[index] = false;
+      active_multicast_bind_count--;
+      break;
+    }
+  }
+  record_multicast_event('u');
+  return CUDA_SUCCESS;
+}
 
 void*
 fake_cuda_ipc_entry(void)
@@ -676,6 +998,24 @@ cuGetProcAddress_v2(
     *output = (void*)&cuMemcpyDtoH_v2;
   else if (strcmp(symbol, "cuMemcpyHtoD_v2") == 0)
     *output = (void*)&cuMemcpyHtoD_v2;
+  else if (strcmp(symbol, "cuMulticastCreate") == 0)
+    *output = (void*)&cuMulticastCreate;
+  else if (strcmp(symbol, "cuMulticastAddDevice") == 0)
+    *output = (void*)&cuMulticastAddDevice;
+  else if (strcmp(symbol, "cuMulticastUnbind") == 0)
+    *output = (void*)&cuMulticastUnbind;
+  else if (strcmp(symbol, "cuMulticastBindAddr") == 0) {
+#if CUDA_VERSION >= 13010
+    if (version >= 13010)
+      *output = (void*)&cuMulticastBindAddr_v2;
+    else
+#endif
+      *output = (void*)&cuMulticastBindAddr;
+  }
+#if CUDA_VERSION >= 13010
+  else if (strcmp(symbol, "cuMulticastBindAddr_v2") == 0)
+    *output = (void*)&cuMulticastBindAddr_v2;
+#endif
   else if (strcmp(symbol, "cuMulticastBindMem") == 0) {
 #if CUDA_VERSION >= 13010
     if (version >= 13010)

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/lifecycle_test.c
@@ -30,6 +30,7 @@ CUdevice fake_cuda_create_device(unsigned int);
 void fake_cuda_set_device_count(int);
 void fake_cuda_set_device_handle(int, CUdevice);
 void fake_cuda_set_device_identity(CUdevice, CUdevice);
+void fake_cuda_set_import_device(CUdevice);
 unsigned int fake_cuda_device_get_calls(void);
 unsigned int fake_cuda_device_uuid_calls(void);
 unsigned int fake_cuda_device_count_calls(void);
@@ -41,6 +42,24 @@ unsigned int fake_cuda_logical_forward_count(void);
 unsigned int fake_cuda_active_handle_count(void);
 unsigned int fake_cuda_active_mapping_count(void);
 unsigned int fake_cuda_multicast_bind_count(void);
+unsigned int fake_cuda_multicast_create_count(void);
+unsigned int fake_cuda_multicast_add_count(void);
+unsigned int fake_cuda_multicast_unbind_count(void);
+unsigned int fake_cuda_active_multicast_count(void);
+unsigned int fake_cuda_active_multicast_bind_count(void);
+char fake_cuda_multicast_event(unsigned int);
+unsigned int fake_cuda_multicast_event_count(void);
+CUmemGenericAllocationHandle fake_cuda_multicast_handle(unsigned int);
+CUmemGenericAllocationHandle fake_cuda_multicast_memory_handle(unsigned int);
+size_t fake_cuda_multicast_offset(unsigned int);
+size_t fake_cuda_multicast_memory_offset(unsigned int);
+size_t fake_cuda_multicast_size(unsigned int);
+unsigned long long fake_cuda_multicast_flags(unsigned int);
+CUdevice fake_cuda_multicast_bind_device(unsigned int);
+CUmemGenericAllocationHandle fake_cuda_multicast_unbind_handle(unsigned int);
+CUdevice fake_cuda_multicast_unbind_device(unsigned int);
+size_t fake_cuda_multicast_unbind_offset(unsigned int);
+size_t fake_cuda_multicast_unbind_size(unsigned int);
 CUmemGenericAllocationHandle fake_cuda_last_consumed_handle(void);
 CUcontext fake_cuda_last_context(void);
 int fake_cuda_last_exported_fd(void);
@@ -64,8 +83,21 @@ static char coordinator_participant[DYN_VMM_PARTICIPANT_ID_SIZE];
 static void establish_mapping(CUmemGenericAllocationHandle*, int*, CUdeviceptr);
 static void establish_fabric_mapping(CUmemGenericAllocationHandle*, struct dyn_vmm_fabric_token*, CUdeviceptr);
 static int fabric_token_is_valid(const struct dyn_vmm_fabric_token*);
+static void require(int, const char*);
 static struct dyn_vmm_header exchange_fd(
     const struct dyn_vmm_header*, const void*, void**, int, int*, int);
+
+static void
+fail_next_response_send(void)
+{
+  typedef int (*function_type)(void);
+  function_type function = (function_type)dlsym(
+      RTLD_DEFAULT, "dyn_vmm_test_fail_next_response_send");
+
+  require(
+      function != NULL && function() == 0,
+      "cannot arm response-send failure test seam");
+}
 
 static void
 require(int condition, const char* message)
@@ -358,6 +390,47 @@ connect_control(void)
   return client;
 }
 
+static void
+send_without_response(
+    const struct dyn_vmm_header* request, const void* payload, int passed_fd)
+{
+  struct dyn_vmm_header bound_request = *request;
+  char control[CMSG_SPACE(sizeof(int))] = {0};
+  struct iovec vector = {
+      .iov_base = &bound_request,
+      .iov_len = sizeof(bound_request),
+  };
+  struct msghdr message = {
+      .msg_iov = &vector,
+      .msg_iovlen = 1,
+  };
+  int client = connect_control();
+
+  memcpy(
+      bound_request.participant_id, coordinator_participant,
+      sizeof(bound_request.participant_id));
+  if (passed_fd >= 0) {
+    struct cmsghdr* item;
+
+    message.msg_control = control;
+    message.msg_controllen = sizeof(control);
+    item = CMSG_FIRSTHDR(&message);
+    item->cmsg_level = SOL_SOCKET;
+    item->cmsg_type = SCM_RIGHTS;
+    item->cmsg_len = CMSG_LEN(sizeof(passed_fd));
+    memcpy(CMSG_DATA(item), &passed_fd, sizeof(passed_fd));
+  }
+  require(
+      sendmsg(client, &message, 0) == (ssize_t)sizeof(bound_request),
+      "cannot send no-response VMM request header");
+  if (request->payload_size != 0)
+    require(
+        write(client, payload, (size_t)request->payload_size) ==
+            (ssize_t)request->payload_size,
+        "cannot send no-response VMM request payload");
+  close(client);
+}
+
 static struct dyn_vmm_header
 exchange_fd(
     const struct dyn_vmm_header* request, const void* payload,
@@ -551,15 +624,15 @@ test_control_request_validation(void)
   (void)exchange_header_only(request, -1);
 
   request.payload_size = 0;
-  request.reserved = 1;
+  request.object_kind = DYN_VMM_ALLOCATION;
   (void)exchange_header_only(request, -1);
 
-  request.reserved = 0;
+  request.object_kind = 0;
   request.version = DYN_VMM_VERSION - 1;
   (void)exchange_header_only(request, -1);
 
   request.version = DYN_VMM_VERSION;
-  request.reserved = 0;
+  request.object_kind = 0;
   request.reserved_identity[0] = 1;
   (void)exchange_header_only(request, -1);
 
@@ -584,6 +657,7 @@ test_control_request_validation(void)
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
   request.handle_type = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  request.object_kind = DYN_VMM_ALLOCATION;
   request.object_id = 1;
   request.payload_size = sizeof(struct dyn_vmm_record) +
       sizeof(CUmemAllocationProp) + sizeof(CUmemAccessDesc);
@@ -642,9 +716,9 @@ test_control_request_validation(void)
 }
 
 static void
-establish_mapping(
+establish_mapping_on_device(
     CUmemGenericAllocationHandle* logical, int* export_fd,
-    CUdeviceptr address)
+    CUdeviceptr address, CUdevice device)
 {
   CUmemAllocationProp properties;
   CUmemAccessDesc access;
@@ -652,7 +726,7 @@ establish_mapping(
   memset(&properties, 0, sizeof(properties));
   properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
   properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  properties.location.id = 0;
+  properties.location.id = device;
   properties.requestedHandleTypes =
       CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
   memset(&access, 0, sizeof(access));
@@ -666,6 +740,14 @@ establish_mapping(
               export_fd, *logical,
               CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) == CUDA_SUCCESS,
       "cannot establish managed mapping");
+}
+
+static void
+establish_mapping(
+    CUmemGenericAllocationHandle* logical, int* export_fd,
+    CUdeviceptr address)
+{
+  establish_mapping_on_device(logical, export_fd, address, 0);
 }
 
 static void
@@ -1034,6 +1116,40 @@ restore_payload(
   return payload;
 }
 
+static size_t
+vmm_record_size(const struct dyn_vmm_record* record)
+{
+  return sizeof(*record) + record->properties_size +
+      (size_t)record->access_count * record->access_size +
+      (record->object_kind == DYN_VMM_MULTICAST
+           ? sizeof(struct dyn_vmm_multicast_record)
+           : 0);
+}
+
+static void*
+restore_multicast_payload(
+    const struct dyn_vmm_record* record, size_t* payload_size,
+    uint64_t object_id, uint64_t backing_object_id)
+{
+  struct dyn_vmm_record* restored;
+  struct dyn_vmm_multicast_record* multicast;
+  size_t extension_offset = sizeof(*record) + record->properties_size +
+      (size_t)record->access_count * record->access_size;
+
+  *payload_size = extension_offset + sizeof(*multicast);
+  restored = malloc(*payload_size);
+  require(restored != NULL, "cannot allocate multicast restore payload");
+  memcpy(restored, record, *payload_size);
+  restored->object_id = object_id;
+  multicast = (struct dyn_vmm_multicast_record*)(
+      (char*)restored + extension_offset);
+  memset(
+      multicast->backing_allocation_uuid, 0,
+      sizeof(multicast->backing_allocation_uuid));
+  multicast->backing_object_id = backing_object_id;
+  return restored;
+}
+
 static void
 test_owner_restore_failure(const char* stage)
 {
@@ -1066,6 +1182,7 @@ test_owner_restore_failure(const char* stage)
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
   request.handle_type = record->requested_handle_type;
+  request.object_kind = DYN_VMM_ALLOCATION;
   request.object_id = 1;
   request.payload_size = payload_size;
   response = exchange_fd(
@@ -1160,6 +1277,7 @@ test_importer_restore_failure(const char* stage)
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
   request.handle_type = owner_record->requested_handle_type;
+  request.object_kind = DYN_VMM_ALLOCATION;
   request.object_id = 1;
   request.payload_size = owner_payload_size;
   (void)exchange(
@@ -1322,6 +1440,7 @@ test_owner_importer_success(void)
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
   request.handle_type = owner_record->requested_handle_type;
+  request.object_kind = DYN_VMM_ALLOCATION;
   request.object_id = 1;
   request.payload_size = owner_payload_size;
   (void)exchange(
@@ -1397,6 +1516,486 @@ test_owner_importer_success(void)
   free(importer_payload);
   free(owner_payload);
   free(owner_bytes);
+  free(inspect_payload);
+}
+
+static void
+test_mnnvl_multicast_teardown(void)
+{
+  CUmemGenericAllocationHandle backing;
+  CUmemGenericAllocationHandle multicast;
+  CUmulticastObjectProp multicast_properties;
+  CUmemAccessDesc access;
+  int capability;
+  void* ignored;
+  int received_fd;
+  struct dyn_vmm_header response;
+  struct dyn_vmm_header identify = {
+      .magic = DYN_VMM_MAGIC,
+      .version = DYN_VMM_VERSION,
+      .operation = DYN_VMM_IDENTIFY,
+  };
+
+  fake_cuda_set_device_count(1);
+  establish_mapping(&backing, &capability, 0x100000);
+  memset(&multicast_properties, 0, sizeof(multicast_properties));
+  multicast_properties.handleTypes =
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  multicast_properties.size = 4096;
+  multicast_properties.numDevices = 1;
+  memset(&access, 0, sizeof(access));
+  access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access.location.id = 0;
+  access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  require(
+      cuMulticastCreate(&multicast, &multicast_properties) == CUDA_SUCCESS &&
+          cuMulticastAddDevice(multicast, 0) == CUDA_SUCCESS &&
+          cuMemMap(0x200000, 4096, 0, multicast, 0) == CUDA_SUCCESS &&
+          cuMemSetAccess(0x200000, 4096, &access, 1) == CUDA_SUCCESS &&
+          cuMulticastBindMem(multicast, 0, backing, 0, 4096, 0) ==
+              CUDA_SUCCESS,
+      "cannot establish MNNVL-style multicast mapping");
+  require(
+      cuMemUnmap(0x200000, 4096) == CUDA_SUCCESS &&
+          cuMemRelease(multicast) == CUDA_SUCCESS &&
+          fake_cuda_active_multicast_count() == 0 &&
+          fake_cuda_active_multicast_bind_count() == 0 &&
+          fake_cuda_multicast_unbind_count() == 0,
+      "MNNVL-style multicast release required an explicit unbind or leaked state");
+  (void)exchange(&identify, NULL, &ignored, &received_fd);
+  require(
+      received_fd < 0, "MNNVL-style multicast teardown poisoned the shim");
+  identify.operation = DYN_VMM_INSPECT;
+  response = exchange(&identify, NULL, &ignored, &received_fd);
+  require(
+      response.count == 1 && received_fd < 0 && ignored != NULL,
+      "released MNNVL multicast logical object remained in shim state");
+  free(ignored);
+  close(capability);
+  require(
+      cuMemUnmap(0x100000, 4096) == CUDA_SUCCESS &&
+          cuMemRelease(backing) == CUDA_SUCCESS,
+      "cannot clean up MNNVL multicast backing allocation");
+}
+
+static void
+test_multicast_restore(
+    bool fail_second_bind, bool fail_importer_response,
+    bool fail_binding_response, bool abort_after_first_bind)
+{
+  CUmemGenericAllocationHandle backing_owner;
+  CUmemGenericAllocationHandle backing_importer;
+  CUmemGenericAllocationHandle multicast_owner;
+  CUmemGenericAllocationHandle multicast_importer;
+  CUmulticastObjectProp multicast_properties;
+  CUmemAccessDesc access;
+  struct dyn_vmm_header request = {
+      .magic = DYN_VMM_MAGIC,
+      .version = DYN_VMM_VERSION,
+      .operation = DYN_VMM_INSPECT,
+  };
+  struct dyn_vmm_header response;
+  struct dyn_vmm_record* backing_owner_record = NULL;
+  struct dyn_vmm_record* backing_importer_record = NULL;
+  struct dyn_vmm_record* multicast_owner_record = NULL;
+  struct dyn_vmm_record* multicast_importer_record = NULL;
+  struct dyn_vmm_multicast_record* owner_bind;
+  struct dyn_vmm_multicast_record* importer_bind;
+  char* cursor;
+  void* inspect_payload;
+  void* payload;
+  void* ignored;
+  size_t payload_size;
+  size_t record_size;
+  unsigned int replay_bind;
+  unsigned int replay_event;
+  int backing_capability;
+  int multicast_capability;
+  int broker_fd;
+  int received_fd;
+
+  fake_cuda_set_device_count(2);
+  establish_mapping(&backing_owner, &backing_capability, 0x100000);
+  fake_cuda_set_import_device(1);
+  require(
+      cuMemImportFromShareableHandle(
+          &backing_importer, (void*)(uintptr_t)backing_capability,
+          CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) == CUDA_SUCCESS,
+      "cannot import multicast backing allocation");
+  close(backing_capability);
+  memset(&access, 0, sizeof(access));
+  access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access.location.id = 1;
+  access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  require(
+      cuMemMap(0x200000, 4096, 0, backing_importer, 0) == CUDA_SUCCESS &&
+          cuMemSetAccess(0x200000, 4096, &access, 1) == CUDA_SUCCESS,
+      "cannot map multicast backing importer");
+
+  memset(&multicast_properties, 0, sizeof(multicast_properties));
+  multicast_properties.handleTypes =
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  multicast_properties.size = 4096;
+  multicast_properties.numDevices = 2;
+  require(
+      cuMulticastCreate(&multicast_owner, &multicast_properties) ==
+              CUDA_SUCCESS &&
+          cuMemExportToShareableHandle(
+              &multicast_capability, multicast_owner,
+              CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0) == CUDA_SUCCESS &&
+          cuMemImportFromShareableHandle(
+              &multicast_importer, (void*)(uintptr_t)multicast_capability,
+              CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) == CUDA_SUCCESS,
+      "cannot create and share managed multicast object");
+  close(multicast_capability);
+  require(
+      cuMulticastAddDevice(multicast_owner, 0) == CUDA_SUCCESS &&
+          cuMulticastAddDevice(multicast_importer, 1) == CUDA_SUCCESS,
+      "cannot add multicast members");
+  access.location.id = 0;
+  require(
+      cuMemMap(0x300000, 4096, 0, multicast_owner, 0) == CUDA_SUCCESS &&
+          cuMemSetAccess(0x300000, 4096, &access, 1) == CUDA_SUCCESS,
+      "cannot map multicast owner before bind");
+  access.location.id = 1;
+  require(
+      cuMemMap(0x400000, 4096, 0, multicast_importer, 0) == CUDA_SUCCESS &&
+          cuMemSetAccess(0x400000, 4096, &access, 1) == CUDA_SUCCESS,
+      "cannot map multicast importer before bind");
+  require(
+      cuMulticastBindMem(
+          multicast_owner, 0, backing_owner, 0, 4096, 0) == CUDA_SUCCESS,
+      "cannot bind multicast owner");
+#if CUDA_VERSION >= 13010
+  require(
+      cuMulticastBindMem_v2(
+          multicast_importer, 1, 0, backing_importer, 0, 4096, 0) ==
+          CUDA_SUCCESS,
+      "cannot bind multicast importer with v2");
+#else
+  require(
+      cuMulticastBindMem(
+          multicast_importer, 0, backing_importer, 0, 4096, 0) ==
+          CUDA_SUCCESS,
+      "cannot bind multicast importer");
+#endif
+  require(
+      cuMemRelease(backing_owner) == CUDA_SUCCESS &&
+          cuMemRelease(backing_importer) == CUDA_SUCCESS,
+      "cannot release multicast backing handles");
+
+  response = exchange(&request, NULL, &inspect_payload, &received_fd);
+  require(
+      response.count == 4 && received_fd < 0,
+      "multicast inspect did not return the complete graph");
+  cursor = inspect_payload;
+  for (uint32_t index = 0; index < response.count; index++) {
+    struct dyn_vmm_record* record = (struct dyn_vmm_record*)cursor;
+
+    record_size = vmm_record_size(record);
+    require(
+        cursor + record_size <=
+            (char*)inspect_payload + response.payload_size,
+        "multicast inspect returned invalid record lengths");
+    if (record->object_kind == DYN_VMM_ALLOCATION &&
+        record->role == DYN_VMM_OWNER)
+      backing_owner_record = record;
+    else if (record->object_kind == DYN_VMM_ALLOCATION &&
+             record->role == DYN_VMM_IMPORTER)
+      backing_importer_record = record;
+    else if (record->object_kind == DYN_VMM_MULTICAST &&
+             record->role == DYN_VMM_OWNER)
+      multicast_owner_record = record;
+    else if (record->object_kind == DYN_VMM_MULTICAST &&
+             record->role == DYN_VMM_IMPORTER)
+      multicast_importer_record = record;
+    cursor += record_size;
+  }
+  require(
+      cursor == (char*)inspect_payload + response.payload_size &&
+          backing_owner_record != NULL &&
+          backing_importer_record != NULL &&
+          multicast_owner_record != NULL &&
+          multicast_importer_record != NULL &&
+          backing_owner_record->flags == 0 &&
+          backing_importer_record->flags == 0 &&
+          multicast_owner_record->flags == DYN_VMM_APPLICATION_HANDLE_LIVE &&
+          multicast_importer_record->flags ==
+              DYN_VMM_APPLICATION_HANDLE_LIVE,
+      "multicast inspect returned incomplete roles or handle state");
+  owner_bind = (struct dyn_vmm_multicast_record*)(
+      (char*)multicast_owner_record + sizeof(*multicast_owner_record) +
+      multicast_owner_record->properties_size +
+      (size_t)multicast_owner_record->access_count *
+          multicast_owner_record->access_size);
+  importer_bind = (struct dyn_vmm_multicast_record*)(
+      (char*)multicast_importer_record + sizeof(*multicast_importer_record) +
+      multicast_importer_record->properties_size +
+      (size_t)multicast_importer_record->access_count *
+          multicast_importer_record->access_size);
+  require(
+      memcmp(
+          owner_bind->backing_allocation_uuid,
+          backing_owner_record->allocation_uuid,
+          sizeof(owner_bind->backing_allocation_uuid)) == 0 &&
+          owner_bind->backing_role == DYN_VMM_OWNER &&
+          memcmp(
+              importer_bind->backing_allocation_uuid,
+              backing_importer_record->allocation_uuid,
+              sizeof(importer_bind->backing_allocation_uuid)) == 0 &&
+          importer_bind->backing_role == DYN_VMM_IMPORTER &&
+          owner_bind->bind_size == 4096 &&
+          importer_bind->bind_size == 4096 &&
+          owner_bind->bind_api == DYN_VMM_MULTICAST_BIND_MEM &&
+          importer_bind->bind_api ==
+#if CUDA_VERSION >= 13010
+              DYN_VMM_MULTICAST_BIND_MEM_V2,
+#else
+              DYN_VMM_MULTICAST_BIND_MEM,
+#endif
+      "multicast inspect lost exact backing bindings");
+
+  detach_record(
+      multicast_importer_record, DYN_VMM_DETACH_IMPORTS, 2);
+  detach_record(multicast_owner_record, DYN_VMM_DETACH_OWNERS, 2);
+  require(
+      fake_cuda_multicast_unbind_count() == 2 &&
+          fake_cuda_multicast_unbind_device(0) == 1 &&
+          fake_cuda_multicast_unbind_device(1) == 0 &&
+          fake_cuda_multicast_unbind_offset(0) == 0 &&
+          fake_cuda_multicast_unbind_offset(1) == 0 &&
+          fake_cuda_multicast_unbind_size(0) == 4096 &&
+          fake_cuda_multicast_unbind_size(1) == 4096,
+      "multicast detach did not unbind exact importer/owner ranges");
+  detach_record(backing_importer_record, DYN_VMM_DETACH_IMPORTS, 1);
+  detach_record(backing_owner_record, DYN_VMM_DETACH_OWNERS, 1);
+  require(
+      fake_cuda_active_handle_count() == 0 &&
+          fake_cuda_active_mapping_count() == 0 &&
+          fake_cuda_active_multicast_bind_count() == 0,
+      "multicast detach left active handles, mappings, or bindings");
+
+  payload = restore_payload(
+      backing_owner_record, backing_owner_record, &payload_size, 1, 1);
+  ((struct dyn_vmm_record*)payload)->flags |=
+      DYN_VMM_RETAIN_RESTORE_HANDLE;
+  memset(&request, 0, sizeof(request));
+  request.magic = DYN_VMM_MAGIC;
+  request.version = DYN_VMM_VERSION;
+  request.operation = DYN_VMM_RESTORE_OWNER;
+  request.handle_type = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  request.object_kind = DYN_VMM_ALLOCATION;
+  request.object_id = 1;
+  request.payload_size = payload_size;
+  (void)exchange(&request, payload, &ignored, &broker_fd);
+  free(payload);
+  require(broker_fd >= 0, "allocation owner replay returned no broker");
+
+  payload = restore_payload(
+      backing_importer_record, backing_importer_record, &payload_size, 1, 0);
+  ((struct dyn_vmm_record*)payload)->flags |=
+      DYN_VMM_RETAIN_RESTORE_HANDLE;
+  request.operation = DYN_VMM_RESTORE_IMPORT;
+  request.payload_size = payload_size;
+  (void)exchange_fd(
+      &request, payload, &ignored, broker_fd, &received_fd, 1);
+  free(payload);
+  close(broker_fd);
+  require(
+      received_fd < 0 && fake_cuda_active_handle_count() == 2 &&
+          fake_cuda_active_mapping_count() == 2,
+      "allocation replay did not retain both multicast backing handles");
+
+  replay_bind = fake_cuda_multicast_bind_count();
+  replay_event = fake_cuda_multicast_event_count();
+  payload = restore_multicast_payload(
+      multicast_owner_record, &payload_size, 2, 1);
+  request.operation = DYN_VMM_RESTORE_OWNER;
+  request.object_kind = DYN_VMM_MULTICAST;
+  request.object_id = 2;
+  request.payload_size = payload_size;
+  (void)exchange(&request, payload, &ignored, &broker_fd);
+  free(payload);
+  require(broker_fd >= 0, "multicast owner replay returned no broker");
+
+  payload = restore_multicast_payload(
+      multicast_importer_record, &payload_size, 2, 1);
+  request.operation = DYN_VMM_RESTORE_IMPORT;
+  request.payload_size = payload_size;
+  if (fail_importer_response) {
+    fail_next_response_send();
+    send_without_response(&request, payload, broker_fd);
+  } else {
+    (void)exchange_fd(
+        &request, payload, &ignored, broker_fd, &received_fd, 1);
+  }
+  free(payload);
+  close(broker_fd);
+  if (fail_importer_response) {
+    require_identify_failure("multicast importer restore failed");
+    require(
+        fake_cuda_active_handle_count() == 0 &&
+            fake_cuda_active_multicast_count() == 0 &&
+            fake_cuda_active_multicast_bind_count() == 0 &&
+            fake_cuda_active_mapping_count() == 2,
+        "multicast importer response failure leaked restored CUDA state");
+    free(inspect_payload);
+    return;
+  }
+  require(
+      received_fd < 0 &&
+          fake_cuda_multicast_bind_count() == replay_bind,
+      "multicast membership replay bound before every member was added");
+
+  request.operation = DYN_VMM_RESTORE_MULTICAST;
+  payload = restore_multicast_payload(
+      multicast_owner_record, &payload_size, 2, 1);
+  request.payload_size = payload_size;
+  response = exchange_fd(
+      &request, payload, &ignored, -1, &received_fd, 1);
+  free(payload);
+  require(
+      response.status == 0 && received_fd < 0 &&
+          fake_cuda_multicast_bind_count() == replay_bind + 1,
+      "multicast owner binding replay failed");
+  if (abort_after_first_bind) {
+    memset(&request, 0, sizeof(request));
+    request.magic = DYN_VMM_MAGIC;
+    request.version = DYN_VMM_VERSION;
+    request.operation = DYN_VMM_ABORT_RESTORE;
+    (void)exchange(&request, NULL, &ignored, &received_fd);
+    (void)exchange(&request, NULL, &ignored, &received_fd);
+    require(
+        received_fd < 0 && fake_cuda_active_handle_count() == 0 &&
+            fake_cuda_active_multicast_count() == 0 &&
+            fake_cuda_active_multicast_bind_count() == 0 &&
+            fake_cuda_active_mapping_count() == 2,
+        "multicast restore abort leaked successfully replayed CUDA state");
+    require_identify_failure("multicast restore aborted");
+    free(inspect_payload);
+    return;
+  }
+  if (fail_second_bind)
+    require(
+        setenv(
+            "DYN_SNAPSHOT_CUDA_VMM_FAIL_STAGE", "multicast-bind", 1) == 0,
+        "cannot configure multicast replay failure");
+  request.operation = DYN_VMM_RESTORE_MULTICAST;
+  {
+    void* importer_replay = restore_multicast_payload(
+        multicast_importer_record, &payload_size, 2, 1);
+
+    request.payload_size = payload_size;
+    if (fail_binding_response) {
+      fail_next_response_send();
+      send_without_response(&request, importer_replay, -1);
+    } else {
+      response = exchange_fd(
+          &request, importer_replay, &ignored, -1, &received_fd,
+          !fail_second_bind);
+    }
+    free(importer_replay);
+  }
+  if (fail_binding_response) {
+    require_identify_failure("multicast binding restore failed");
+    require(
+        fake_cuda_active_handle_count() == 0 &&
+            fake_cuda_active_multicast_count() == 0 &&
+            fake_cuda_active_multicast_bind_count() == 0 &&
+            fake_cuda_active_mapping_count() == 2,
+        "multicast binding response failure leaked restored CUDA state");
+    free(inspect_payload);
+    return;
+  }
+  if (fail_second_bind) {
+    require(
+        response.status != 0 && received_fd < 0 &&
+            fake_cuda_active_handle_count() == 0 &&
+            fake_cuda_active_multicast_count() == 0 &&
+            fake_cuda_active_multicast_bind_count() == 0 &&
+            fake_cuda_active_mapping_count() == 2,
+        "partial multicast replay rollback leaked transient handles");
+    require_identify_failure("multicast binding restore failed");
+    memset(&request, 0, sizeof(request));
+    request.magic = DYN_VMM_MAGIC;
+    request.version = DYN_VMM_VERSION;
+    request.operation = DYN_VMM_ABORT_RESTORE;
+    (void)exchange(&request, NULL, &ignored, &received_fd);
+    (void)exchange(&request, NULL, &ignored, &received_fd);
+    require(
+        received_fd < 0 && fake_cuda_active_handle_count() == 0 &&
+            fake_cuda_active_multicast_count() == 0 &&
+            fake_cuda_active_multicast_bind_count() == 0 &&
+            fake_cuda_active_mapping_count() == 2,
+        "repeated multicast restore abort was not idempotent");
+    free(inspect_payload);
+    return;
+  }
+  require(
+      response.status == 0 && received_fd < 0 &&
+          fake_cuda_multicast_bind_count() == replay_bind + 2 &&
+          fake_cuda_multicast_offset(replay_bind) == 0 &&
+          fake_cuda_multicast_offset(replay_bind + 1) == 0 &&
+          fake_cuda_multicast_memory_offset(replay_bind) == 0 &&
+          fake_cuda_multicast_memory_offset(replay_bind + 1) == 0 &&
+          fake_cuda_multicast_size(replay_bind) == 4096 &&
+          fake_cuda_multicast_size(replay_bind + 1) == 4096 &&
+          fake_cuda_multicast_flags(replay_bind) == 0 &&
+          fake_cuda_multicast_flags(replay_bind + 1) == 0 &&
+          fake_cuda_multicast_handle(replay_bind) != 0 &&
+          fake_cuda_multicast_handle(replay_bind + 1) != 0 &&
+          fake_cuda_multicast_memory_handle(replay_bind) != 0 &&
+          fake_cuda_multicast_memory_handle(replay_bind + 1) != 0 &&
+          fake_cuda_logical_forward_count() == 0,
+      "multicast replay changed exact bind arguments or forwarded a logical handle");
+#if CUDA_VERSION >= 13010
+  require(
+      fake_cuda_multicast_bind_device(replay_bind) == -1 &&
+          fake_cuda_multicast_bind_device(replay_bind + 1) == 1,
+      "multicast v2 replay did not preserve the recorded member device");
+#endif
+  require(
+      fake_cuda_multicast_event_count() == replay_event + 9 &&
+          fake_cuda_multicast_event(replay_event + 0) == 'c' &&
+          fake_cuda_multicast_event(replay_event + 1) == 'a' &&
+          fake_cuda_multicast_event(replay_event + 2) == 'a' &&
+          fake_cuda_multicast_event(replay_event + 3) == 'b' &&
+          fake_cuda_multicast_event(replay_event + 4) == 'm' &&
+          fake_cuda_multicast_event(replay_event + 5) == 'x' &&
+          fake_cuda_multicast_event(replay_event + 6) == 'b' &&
+          fake_cuda_multicast_event(replay_event + 7) == 'm' &&
+          fake_cuda_multicast_event(replay_event + 8) == 'x',
+      "multicast UMD ordering was not create/add-all/bind/map/access");
+
+  memset(&request, 0, sizeof(request));
+  request.magic = DYN_VMM_MAGIC;
+  request.version = DYN_VMM_VERSION;
+  request.operation = DYN_VMM_FINALIZE_RESTORE;
+  (void)exchange(&request, NULL, &ignored, &received_fd);
+  require(
+      received_fd < 0 && fake_cuda_active_handle_count() == 2 &&
+          fake_cuda_active_mapping_count() == 4 &&
+          fake_cuda_active_multicast_bind_count() == 2,
+      "multicast finalize did not release only temporary backing handles");
+  request.operation = DYN_VMM_IDENTIFY;
+  (void)exchange(&request, NULL, &ignored, &received_fd);
+
+  require(
+      cuMulticastUnbind(multicast_owner, 0, 0, 4096) == CUDA_SUCCESS &&
+          cuMulticastUnbind(multicast_importer, 1, 0, 4096) ==
+              CUDA_SUCCESS &&
+          cuMemUnmap(0x300000, 4096) == CUDA_SUCCESS &&
+          cuMemUnmap(0x400000, 4096) == CUDA_SUCCESS &&
+          cuMemRelease(multicast_owner) == CUDA_SUCCESS &&
+          cuMemRelease(multicast_importer) == CUDA_SUCCESS &&
+          cuMemUnmap(0x100000, 4096) == CUDA_SUCCESS &&
+          cuMemUnmap(0x200000, 4096) == CUDA_SUCCESS &&
+          fake_cuda_active_handle_count() == 0 &&
+          fake_cuda_active_mapping_count() == 0 &&
+          fake_cuda_active_multicast_count() == 0 &&
+          fake_cuda_active_multicast_bind_count() == 0 &&
+          fake_cuda_logical_forward_count() == 0,
+      "restored multicast teardown leaked state or forwarded logical handles");
   free(inspect_payload);
 }
 
@@ -1484,6 +2083,7 @@ test_fabric_owner_importer_restore(bool fail_import, bool reindex)
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
   request.handle_type = CU_MEM_HANDLE_TYPE_FABRIC;
+  request.object_kind = DYN_VMM_ALLOCATION;
   request.object_id = 1;
   request.payload_size = owner_payload_size;
   response = exchange(&request, owner_payload, &broker_bytes, &received_fd);
@@ -1771,7 +2371,7 @@ test_invalid_fabric_token(const char* shape)
   } else if (strcmp(shape, "zero-pid") == 0) {
     token.owner_namespace_pid = 0;
   } else if (strcmp(shape, "reserved") == 0) {
-    token.reserved = 1;
+    token.object_kind = 99;
   } else if (strcmp(shape, "unavailable-owner") == 0) {
     token.owner_namespace_pid = INT_MAX;
   } else if (strcmp(shape, "raw") == 0) {
@@ -2148,6 +2748,30 @@ main(int argc, char** argv)
     test_owner_importer_success();
     return 0;
   }
+  if (argc == 2 && strcmp(argv[1], "multicast-success") == 0) {
+    test_multicast_restore(false, false, false, false);
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "multicast-rollback") == 0) {
+    test_multicast_restore(true, false, false, false);
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "multicast-abort") == 0) {
+    test_multicast_restore(false, false, false, true);
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "multicast-importer-response-failure") == 0) {
+    test_multicast_restore(false, true, false, false);
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "multicast-binding-response-failure") == 0) {
+    test_multicast_restore(false, false, true, false);
+    return 0;
+  }
+  if (argc == 2 && strcmp(argv[1], "mnnvl-multicast-teardown") == 0) {
+    test_mnnvl_multicast_teardown();
+    return 0;
+  }
   if (argc == 2 && strcmp(argv[1], "gpu-identity-capture") == 0) {
     test_gpu_identity_capture();
     return 0;
@@ -2262,6 +2886,7 @@ main(int argc, char** argv)
   request.version = DYN_VMM_VERSION;
   request.operation = DYN_VMM_RESTORE_OWNER;
   request.handle_type = record->requested_handle_type;
+  request.object_kind = DYN_VMM_ALLOCATION;
   request.object_id = 1;
   request.payload_size = metadata_size + record->size;
   (void)exchange(&request, restore_payload, &ignored, &received_fd);

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/test/run.sh
@@ -116,6 +116,16 @@ DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
 LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
   "$build/lifecycle_test" owner-importer-success
 
+for scenario in \
+  multicast-success multicast-rollback multicast-abort \
+  multicast-importer-response-failure multicast-binding-response-failure \
+  mnnvl-multicast-teardown; do
+  DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
+  DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
+  LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \
+    "$build/lifecycle_test" "$scenario"
+done
+
 DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1 \
 DYN_SNAPSHOT_CONTROL_DIR="$build/control" \
 LD_PRELOAD="$build/libdynamo_snapshot_cuda_vmm.so" \

--- a/deploy/snapshot/internal/cuda/vmm_interpose.go
+++ b/deploy/snapshot/internal/cuda/vmm_interpose.go
@@ -39,10 +39,11 @@ const (
 	vmmArtifactName     = "cuda-vmm.rdb"
 	vmmRestorePoison    = "dynamo:cuda-vmm:restore-poison"
 	vmmProtocolMagic    = 0x44564d4d
-	vmmProtocolVersion  = 4
-	vmmLedgerVersion    = 2
+	vmmProtocolVersion  = 5
+	vmmLedgerVersion    = 3
 	vmmHeaderSize       = 256
 	vmmRecordSize       = 96
+	vmmMulticastSize    = 96
 	vmmPlacementSize    = 40
 	vmmFabricHandleSize = 64
 	vmmMessageSize      = 96
@@ -54,21 +55,29 @@ const (
 	vmmMaximumRESPLine  = 4 << 10
 	vmmMaximumRightsFDs = 253
 
-	vmmInspect         = 1
-	vmmReadOwner       = 2
-	vmmDetachImporters = 3
-	vmmDetachOwners    = 4
-	vmmRestoreOwner    = 5
-	vmmRestoreImporter = 6
-	vmmIdentify        = 7
-	vmmSetPlacement    = 8
+	vmmInspect          = 1
+	vmmReadOwner        = 2
+	vmmDetachImporters  = 3
+	vmmDetachOwners     = 4
+	vmmRestoreOwner     = 5
+	vmmRestoreImporter  = 6
+	vmmIdentify         = 7
+	vmmSetPlacement     = 8
+	vmmRestoreMulticast = 10
+	vmmFinalizeRestore  = 11
+	vmmAbortRestore     = 12
 
 	vmmOwner    = 1
 	vmmImporter = 2
 
 	vmmAllocation = 1
+	vmmMulticast  = 2
 
 	vmmApplicationHandleLive = 1
+	vmmRetainRestoreHandle   = 2
+
+	vmmMulticastBindMem   = 1
+	vmmMulticastBindMemV2 = 2
 
 	vmmHandlePOSIX  = 1
 	vmmHandleFabric = 8
@@ -81,8 +90,29 @@ type VMMProcess struct {
 	Participant  string
 }
 
+func vmmMappingBacksMulticast(
+	ledger vmmLedger,
+	resourceID uint64,
+	participant string,
+) bool {
+	for _, resource := range ledger.Resources {
+		if resource.Kind != "multicast" {
+			continue
+		}
+		mappings := append([]vmmMapping{resource.Owner}, resource.Importers...)
+		for _, mapping := range mappings {
+			if mapping.Participant == participant &&
+				mapping.Multicast.BackingResourceID == resourceID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type vmmBrokerResult struct {
 	handleType uint32
+	objectKind uint32
 	fd         int
 	bytes      []byte
 }
@@ -94,9 +124,15 @@ func supportedVMMHandleType(handleType uint32) bool {
 func takeVMMBrokerResult(
 	response *vmmResponse,
 	handleType uint32,
+	objectKind uint32,
 ) (vmmBrokerResult, error) {
-	result := vmmBrokerResult{handleType: handleType, fd: -1}
-	valid := response.header.HandleType == handleType
+	result := vmmBrokerResult{
+		handleType: handleType,
+		objectKind: objectKind,
+		fd:         -1,
+	}
+	valid := response.header.HandleType == handleType &&
+		response.header.ObjectKind == objectKind
 	switch handleType {
 	case vmmHandlePOSIX:
 		valid = valid && response.fd >= 0 && len(response.payload) == 0
@@ -170,6 +206,82 @@ func verifyVMMHealth(ctx context.Context, processes []VMMProcess) error {
 	return nil
 }
 
+func abortVMMRestore(ctx context.Context, processes []VMMProcess) error {
+	var result error
+	for _, process := range processes {
+		requestCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx), vmmTimeout,
+		)
+		_, err := exchangeVMM(
+			requestCtx,
+			process,
+			vmmHeader{Operation: vmmAbortRestore},
+			nil,
+			-1,
+			vmmResponseEmpty,
+		)
+		cancel()
+		if err != nil {
+			result = errors.Join(
+				result,
+				fmt.Errorf(
+					"abort CUDA VMM multicast restore participant %s: %w",
+					process.Participant, err,
+				),
+			)
+		}
+	}
+	return result
+}
+
+func validateVMMMulticastMapping(
+	ledger vmmLedger,
+	resource vmmResource,
+	mapping vmmMapping,
+) error {
+	bind := mapping.Multicast
+	if bind == nil || bind.BackingResourceID == 0 ||
+		bind.BackingResourceID > uint64(len(ledger.Resources)) ||
+		(bind.BackingRole != vmmOwner && bind.BackingRole != vmmImporter) ||
+		bind.MulticastOffset != 0 || bind.MemoryOffset != 0 ||
+		bind.Size != mapping.Size || bind.Flags != 0 ||
+		(bind.BindAPI != vmmMulticastBindMem &&
+			bind.BindAPI != vmmMulticastBindMemV2) {
+		return fmt.Errorf(
+			"ledger multicast resource %d has invalid bind for participant %q",
+			resource.ID, mapping.Participant,
+		)
+	}
+	backing := ledger.Resources[bind.BackingResourceID-1]
+	if backing.Kind != "allocation" {
+		return fmt.Errorf(
+			"ledger multicast resource %d bind references non-allocation resource %d",
+			resource.ID, bind.BackingResourceID,
+		)
+	}
+	var backingMapping vmmMapping
+	if bind.BackingRole == vmmOwner {
+		backingMapping = backing.Owner
+	} else {
+		for _, importer := range backing.Importers {
+			if importer.Participant == mapping.Participant {
+				backingMapping = importer
+				break
+			}
+		}
+	}
+	if backingMapping.Participant != mapping.Participant ||
+		backingMapping.GPUUUID != mapping.GPUUUID ||
+		backingMapping.Size != mapping.Size ||
+		backingMapping.RequestedHandleType != mapping.RequestedHandleType {
+		return fmt.Errorf(
+			"ledger multicast resource %d bind does not match backing resource %d participant %q",
+			resource.ID, bind.BackingResourceID, mapping.Participant,
+		)
+	}
+	return nil
+}
+
 type vmmExecutionPlacement map[string]map[string]int32
 
 type vmmPlacementSetup struct {
@@ -195,21 +307,28 @@ func isLowerHex(value string) bool {
 
 func vmmDetachPlan(ledger vmmLedger) []vmmDetach {
 	var plan []vmmDetach
-	for _, resource := range ledger.Resources {
-		for _, importer := range resource.Importers {
-			plan = append(plan, vmmDetach{
-				resourceID:  resource.ID,
-				participant: importer.Participant,
-				role:        vmmImporter,
-			})
+	for _, kind := range []string{"multicast", "allocation"} {
+		for _, resource := range ledger.Resources {
+			if resource.Kind != kind {
+				continue
+			}
+			for _, importer := range resource.Importers {
+				plan = append(plan, vmmDetach{
+					resourceID:  resource.ID,
+					participant: importer.Participant,
+					role:        vmmImporter,
+				})
+			}
 		}
-	}
-	for _, resource := range ledger.Resources {
-		plan = append(plan, vmmDetach{
-			resourceID:  resource.ID,
-			participant: resource.Owner.Participant,
-			role:        vmmOwner,
-		})
+		for _, resource := range ledger.Resources {
+			if resource.Kind == kind {
+				plan = append(plan, vmmDetach{
+					resourceID:  resource.ID,
+					participant: resource.Owner.Participant,
+					role:        vmmOwner,
+				})
+			}
+		}
 	}
 	return plan
 }
@@ -226,6 +345,7 @@ type vmmRestorePlan struct {
 	process       VMMProcess
 	payload       []byte
 	handleType    uint32
+	objectKind    uint32
 }
 
 func ValidateVMMProcessSet(expected, current []int) error {
@@ -261,6 +381,7 @@ type vmmHeader struct {
 	Status         int32
 	Count          uint32
 	HandleType     uint32
+	ObjectKind     uint32
 	AllocationUUID [16]byte
 	ObjectID       uint64
 	PayloadSize    uint64
@@ -283,26 +404,65 @@ type vmmCaptureRecord struct {
 	access         []byte
 	accessCount    uint32
 	accessSize     uint32
+	multicast      *vmmCaptureMulticast
+}
+
+type vmmCaptureMulticast struct {
+	backingUUID       [16]byte
+	backingObjectID   uint64
+	multicastOffset   uint64
+	memoryOffset      uint64
+	bindSize          uint64
+	bindFlags         uint64
+	objectFlags       uint64
+	objectHandleTypes uint64
+	objectSize        uint64
+	numDevices        uint32
+	backingRole       uint32
+	bindAPI           uint32
 }
 
 type vmmMapping struct {
-	Participant           string `json:"participant"`
-	Address               uint64 `json:"address"`
-	Size                  uint64 `json:"size"`
-	GPUUUID               string `json:"gpuUUID"`
-	RequestedHandleType   uint32 `json:"requestedHandleType"`
-	ApplicationHandleLive bool   `json:"applicationHandleLive"`
-	Properties            []byte `json:"properties,omitempty"`
-	Access                []byte `json:"access"`
-	AccessCount           uint32 `json:"accessCount"`
-	AccessSize            uint32 `json:"accessSize"`
+	Participant           string               `json:"participant"`
+	Address               uint64               `json:"address"`
+	Size                  uint64               `json:"size"`
+	GPUUUID               string               `json:"gpuUUID"`
+	RequestedHandleType   uint32               `json:"requestedHandleType"`
+	ApplicationHandleLive bool                 `json:"applicationHandleLive"`
+	Properties            []byte               `json:"properties,omitempty"`
+	Access                []byte               `json:"access"`
+	AccessCount           uint32               `json:"accessCount"`
+	AccessSize            uint32               `json:"accessSize"`
+	Multicast             *vmmMulticastMapping `json:"multicast,omitempty"`
+
+	retainRestoreHandle bool
+}
+
+type vmmMulticastMapping struct {
+	BackingResourceID uint64 `json:"backingResourceID"`
+	BackingRole       uint32 `json:"backingRole"`
+	MulticastOffset   uint64 `json:"multicastOffset"`
+	MemoryOffset      uint64 `json:"memoryOffset"`
+	Size              uint64 `json:"size"`
+	Flags             uint64 `json:"flags"`
+	BindAPI           uint32 `json:"bindAPI"`
+
+	backingUUID [16]byte
+}
+
+type vmmMulticastProperties struct {
+	Flags       uint64 `json:"flags"`
+	HandleTypes uint64 `json:"handleTypes"`
+	NumDevices  uint32 `json:"numDevices"`
+	Size        uint64 `json:"size"`
 }
 
 type vmmResource struct {
-	ID        uint64       `json:"id"`
-	Kind      string       `json:"kind"`
-	Owner     vmmMapping   `json:"owner"`
-	Importers []vmmMapping `json:"importers"`
+	ID        uint64                  `json:"id"`
+	Kind      string                  `json:"kind"`
+	Owner     vmmMapping              `json:"owner"`
+	Importers []vmmMapping            `json:"importers"`
+	Multicast *vmmMulticastProperties `json:"multicast,omitempty"`
 
 	captureUUID [16]byte
 }
@@ -559,6 +719,9 @@ func PrepareVMM(
 	writeVMMDigestPart(digest, encoded)
 	for index := range ledger.Resources {
 		resource := &ledger.Resources[index]
+		if resource.Kind == "multicast" {
+			continue
+		}
 		owner, err := findVMMProcess(processes, resource.Owner.Participant)
 		if err != nil {
 			return "", err
@@ -756,8 +919,8 @@ func RestoreVMM(
 	writeVMMDigestPart(digest, encoded)
 	contentsByResource := make([][]byte, len(ledger.Resources))
 	for index, resource := range ledger.Resources {
-		if resource.Kind != "allocation" {
-			return fmt.Errorf("CUDA VMM resource %d has unsupported kind %q", resource.ID, resource.Kind)
+		if resource.Kind == "multicast" {
+			continue
 		}
 		contents, err := client.get(vmmRedisKey(generation, fmt.Sprintf("resource:%d", resource.ID)))
 		if err != nil {
@@ -786,6 +949,12 @@ func RestoreVMM(
 	for index := range brokers {
 		brokers[index].fd = -1
 	}
+	abortMulticastRestore := false
+	defer func() {
+		if abortMulticastRestore && retErr != nil {
+			retErr = errors.Join(retErr, abortVMMRestore(ctx, processes))
+		}
+	}()
 	defer func() {
 		for index := range brokers {
 			if err := closeVMMBrokerResult(&brokers[index]); err != nil {
@@ -800,104 +969,191 @@ func RestoreVMM(
 			}
 		}
 	}()
-	ownerPlans := make([]vmmRestorePlan, 0, len(ledger.Resources))
-	var importerPlans []vmmRestorePlan
+	var allocationOwnerPlans []vmmRestorePlan
+	var allocationImporterPlans []vmmRestorePlan
+	var multicastOwnerPlans []vmmRestorePlan
+	var multicastImporterPlans []vmmRestorePlan
+	var multicastReplayPlans []vmmRestorePlan
 	for index, resource := range ledger.Resources {
+		kind := uint32(vmmAllocation)
+		if resource.Kind == "multicast" {
+			kind = vmmMulticast
+		}
 		owner, err := findVMMProcess(processes, resource.Owner.Participant)
 		if err != nil {
 			return err
 		}
-		payload := encodeVMMRestoreRecord(
+		ownerMapping := resource.Owner
+		ownerMapping.retainRestoreHandle =
+			resource.Kind == "allocation" &&
+				vmmMappingBacksMulticast(ledger, resource.ID, ownerMapping.Participant)
+		payload := encodeVMMResourceRecord(
 			resource.ID,
 			vmmOwner,
-			resource.Owner,
+			kind,
+			ownerMapping,
 			placement[resource.Owner.Participant][resource.Owner.GPUUUID],
+			resource.Multicast,
 			contentsByResource[index],
 		)
 		contentsByResource[index] = nil
-		ownerPlans = append(ownerPlans, vmmRestorePlan{
+		ownerPlan := vmmRestorePlan{
 			resourceID:    resource.ID,
 			resourceIndex: index,
 			process:       owner,
 			payload:       payload,
 			handleType:    resource.Owner.RequestedHandleType,
-		})
+			objectKind:    kind,
+		}
+		if kind == vmmAllocation {
+			allocationOwnerPlans = append(allocationOwnerPlans, ownerPlan)
+		} else {
+			multicastOwnerPlans = append(multicastOwnerPlans, ownerPlan)
+			multicastReplayPlans = append(multicastReplayPlans, ownerPlan)
+		}
 		for _, mapping := range resource.Importers {
 			importer, err := findVMMProcess(processes, mapping.Participant)
 			if err != nil {
 				return err
 			}
-			importerPlans = append(importerPlans, vmmRestorePlan{
+			importerMapping := mapping
+			importerMapping.retainRestoreHandle =
+				resource.Kind == "allocation" &&
+					vmmMappingBacksMulticast(
+						ledger, resource.ID, importerMapping.Participant,
+					)
+			importerPlan := vmmRestorePlan{
 				resourceID:    resource.ID,
 				resourceIndex: index,
 				process:       importer,
 				handleType:    mapping.RequestedHandleType,
-				payload: encodeVMMRestoreRecord(
+				objectKind:    kind,
+				payload: encodeVMMResourceRecord(
 					resource.ID,
 					vmmImporter,
-					mapping,
+					kind,
+					importerMapping,
 					placement[mapping.Participant][mapping.GPUUUID],
+					resource.Multicast,
 					nil,
 				),
-			})
+			}
+			if kind == vmmAllocation {
+				allocationImporterPlans = append(
+					allocationImporterPlans, importerPlan,
+				)
+			} else {
+				multicastImporterPlans = append(
+					multicastImporterPlans, importerPlan,
+				)
+				multicastReplayPlans = append(
+					multicastReplayPlans, importerPlan,
+				)
+			}
 		}
 	}
 	if err := unlock(); err != nil {
 		return fmt.Errorf("unlock CUDA processes before VMM replay: %w", err)
 	}
-	for _, plan := range ownerPlans {
-		response, err := exchangeVMM(
+	abortMulticastRestore = len(multicastReplayPlans) != 0
+	restoreOwners := func(plans []vmmRestorePlan) error {
+		for _, plan := range plans {
+			response, err := exchangeVMM(
+				ctx,
+				plan.process,
+				vmmHeader{
+					Operation:  vmmRestoreOwner,
+					ObjectID:   plan.resourceID,
+					HandleType: plan.handleType,
+					ObjectKind: plan.objectKind,
+				},
+				plan.payload,
+				-1,
+				vmmBrokerResponseExpectation(plan.handleType),
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"restore CUDA VMM resource %d owner: %w",
+					plan.resourceID, err,
+				)
+			}
+			broker, err := takeVMMBrokerResult(
+				&response, plan.handleType, plan.objectKind,
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"restore CUDA VMM resource %d owner broker: %w",
+					plan.resourceID, err,
+				)
+			}
+			brokers[plan.resourceIndex] = broker
+		}
+		return nil
+	}
+	restoreImporters := func(plans []vmmRestorePlan) error {
+		for _, plan := range plans {
+			payload, fd, err := vmmImporterTransport(
+				plan.payload, brokers[plan.resourceIndex],
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"prepare CUDA VMM resource %d importer transport: %w",
+					plan.resourceID, err,
+				)
+			}
+			_, err = exchangeVMM(
+				ctx,
+				plan.process,
+				vmmHeader{
+					Operation:  vmmRestoreImporter,
+					ObjectID:   plan.resourceID,
+					HandleType: plan.handleType,
+					ObjectKind: plan.objectKind,
+				},
+				payload,
+				fd,
+				vmmResponseUntyped,
+			)
+			if plan.handleType == vmmHandleFabric {
+				clearVMMBytes(payload)
+			}
+			if err != nil {
+				return fmt.Errorf(
+					"restore CUDA VMM resource %d importer participant %s: %w",
+					plan.resourceID, plan.process.Participant, err,
+				)
+			}
+		}
+		return nil
+	}
+	if err := restoreOwners(allocationOwnerPlans); err != nil {
+		return err
+	}
+	if err := restoreImporters(allocationImporterPlans); err != nil {
+		return err
+	}
+	if err := restoreOwners(multicastOwnerPlans); err != nil {
+		return err
+	}
+	if err := restoreImporters(multicastImporterPlans); err != nil {
+		return err
+	}
+	for _, plan := range multicastReplayPlans {
+		if _, err := exchangeVMM(
 			ctx,
 			plan.process,
 			vmmHeader{
-				Operation:  vmmRestoreOwner,
+				Operation:  vmmRestoreMulticast,
 				ObjectID:   plan.resourceID,
 				HandleType: plan.handleType,
+				ObjectKind: vmmMulticast,
 			},
 			plan.payload,
 			-1,
-			vmmBrokerResponseExpectation(plan.handleType),
-		)
-		if err != nil {
-			return fmt.Errorf("restore CUDA VMM resource %d owner: %w", plan.resourceID, err)
-		}
-		broker, err := takeVMMBrokerResult(&response, plan.handleType)
-		if err != nil {
+			vmmResponseEmpty,
+		); err != nil {
 			return fmt.Errorf(
-				"restore CUDA VMM resource %d owner broker: %w",
-				plan.resourceID, err,
-			)
-		}
-		brokers[plan.resourceIndex] = broker
-	}
-	for _, plan := range importerPlans {
-		payload, fd, err := vmmImporterTransport(
-			plan.payload, brokers[plan.resourceIndex],
-		)
-		if err != nil {
-			return fmt.Errorf(
-				"prepare CUDA VMM resource %d importer transport: %w",
-				plan.resourceID, err,
-			)
-		}
-		_, err = exchangeVMM(
-			ctx,
-			plan.process,
-			vmmHeader{
-				Operation:  vmmRestoreImporter,
-				ObjectID:   plan.resourceID,
-				HandleType: plan.handleType,
-			},
-			payload,
-			fd,
-			vmmResponseUntyped,
-		)
-		if plan.handleType == vmmHandleFabric {
-			clearVMMBytes(payload)
-		}
-		if err != nil {
-			return fmt.Errorf(
-				"restore CUDA VMM resource %d importer participant %s: %w",
+				"restore CUDA VMM multicast resource %d participant %s binding: %w",
 				plan.resourceID, plan.process.Participant, err,
 			)
 		}
@@ -908,6 +1164,23 @@ func RestoreVMM(
 				"close CUDA VMM resource %d broker result: %w",
 				ledger.Resources[index].ID, err,
 			)
+		}
+	}
+	if len(multicastReplayPlans) != 0 {
+		for _, process := range processes {
+			if _, err := exchangeVMM(
+				ctx,
+				process,
+				vmmHeader{Operation: vmmFinalizeRestore},
+				nil,
+				-1,
+				vmmResponseEmpty,
+			); err != nil {
+				return fmt.Errorf(
+					"finalize CUDA VMM restore participant %s: %w",
+					process.Participant, err,
+				)
+			}
 		}
 	}
 	if err := verifyVMMHealth(ctx, processes); err != nil {
@@ -921,6 +1194,7 @@ func RestoreVMM(
 		"generation", generation,
 		"resources", len(ledger.Resources),
 	)
+	abortMulticastRestore = false
 	return nil
 }
 
@@ -954,7 +1228,8 @@ func validateVMMLedger(ledger vmmLedger) error {
 		usedParticipantGPUs[participant.ID] = make(map[string]struct{}, len(gpus))
 	}
 	for index, resource := range ledger.Resources {
-		if resource.ID != uint64(index+1) || resource.Kind != "allocation" ||
+		if resource.ID != uint64(index+1) ||
+			(resource.Kind != "allocation" && resource.Kind != "multicast") ||
 			resource.Owner.Participant == "" || len(resource.Importers) == 0 {
 			return fmt.Errorf("ledger resource %d is incomplete or unsupported", resource.ID)
 		}
@@ -966,6 +1241,7 @@ func validateVMMLedger(ledger vmmLedger) error {
 		}
 		mappings := append([]vmmMapping{resource.Owner}, resource.Importers...)
 		seen := make(map[string]struct{}, len(mappings))
+		memberGPUs := make(map[string]struct{}, len(mappings))
 		for _, mapping := range mappings {
 			if _, ok := participants[mapping.Participant]; !ok {
 				return fmt.Errorf(
@@ -987,6 +1263,15 @@ func validateVMMLedger(ledger vmmLedger) error {
 				)
 			}
 			seen[mapping.Participant] = struct{}{}
+			if resource.Kind == "multicast" {
+				if _, duplicate := memberGPUs[mapping.GPUUUID]; duplicate {
+					return fmt.Errorf(
+						"ledger multicast resource %d repeats member GPU %q",
+						resource.ID, mapping.GPUUUID,
+					)
+				}
+				memberGPUs[mapping.GPUUUID] = struct{}{}
+			}
 			if mapping.Size > vmmMaximumRedisBulk {
 				return fmt.Errorf(
 					"ledger resource %d mapping for participant %q exceeds the %d-byte allocation limit",
@@ -1005,6 +1290,45 @@ func validateVMMLedger(ledger vmmLedger) error {
 					resource.ID, mapping.Participant,
 				)
 			}
+			if resource.Kind == "allocation" {
+				if mapping.Multicast != nil {
+					return fmt.Errorf(
+						"ledger allocation resource %d has multicast metadata",
+						resource.ID,
+					)
+				}
+			} else if err := validateVMMMulticastMapping(
+				ledger, resource, mapping,
+			); err != nil {
+				return err
+			}
+		}
+		if resource.Kind == "allocation" {
+			if resource.Multicast != nil {
+				return fmt.Errorf(
+					"ledger allocation resource %d has multicast properties",
+					resource.ID,
+				)
+			}
+		} else if resource.Multicast == nil ||
+			resource.Multicast.Flags != 0 ||
+			!supportedVMMHandleType(uint32(resource.Multicast.HandleTypes)) ||
+			resource.Multicast.HandleTypes !=
+				uint64(resource.Owner.RequestedHandleType) ||
+			resource.Multicast.NumDevices != uint32(len(mappings)) ||
+			resource.Multicast.NumDevices == 0 ||
+			resource.Multicast.Size == 0 ||
+			resource.Multicast.Size != resource.Owner.Size ||
+			slices.ContainsFunc(
+				resource.Importers,
+				func(mapping vmmMapping) bool {
+					return mapping.Size != resource.Multicast.Size
+				},
+			) {
+			return fmt.Errorf(
+				"ledger multicast resource %d has invalid object properties",
+				resource.ID,
+			)
 		}
 	}
 	if len(ledger.Resources) == 0 {
@@ -1086,15 +1410,29 @@ func inspectVMM(
 	participants := make(map[string]vmmParticipant, len(captures))
 	ledger := vmmLedger{Version: vmmLedgerVersion, Generation: generation}
 	for index, id := range ids {
+		kind := grouped[id][0].record.kind
+		kindName := ""
+		switch kind {
+		case vmmAllocation:
+			kindName = "allocation"
+		case vmmMulticast:
+			kindName = "multicast"
+		default:
+			return vmmLedger{}, fmt.Errorf(
+				"CUDA VMM capture has unsupported object kind %d",
+				kind,
+			)
+		}
 		resource := vmmResource{
 			ID:          uint64(index + 1),
-			Kind:        "allocation",
+			Kind:        kindName,
 			captureUUID: id,
 		}
 		for _, capture := range grouped[id] {
-			if capture.record.kind != vmmAllocation {
+			if capture.record.kind != kind {
 				return vmmLedger{}, fmt.Errorf(
-					"CUDA VMM capture has unsupported object kind %d",
+					"CUDA VMM object mixes capture kinds %d and %d",
+					kind,
 					capture.record.kind,
 				)
 			}
@@ -1127,12 +1465,49 @@ func inspectVMM(
 					)
 				}
 				resource.Owner = mapping
+				if kind == vmmMulticast {
+					multicast := capture.record.multicast
+					if multicast == nil {
+						return vmmLedger{}, errors.New(
+							"CUDA VMM multicast owner has no object metadata",
+						)
+					}
+					resource.Multicast = &vmmMulticastProperties{
+						Flags:       multicast.objectFlags,
+						HandleTypes: multicast.objectHandleTypes,
+						NumDevices:  multicast.numDevices,
+						Size:        multicast.objectSize,
+					}
+				}
 			case vmmImporter:
 				resource.Importers = append(resource.Importers, mapping)
 			default:
 				return vmmLedger{}, fmt.Errorf(
 					"CUDA VMM capture has unknown role %d", capture.record.role,
 				)
+			}
+		}
+		if kind == vmmMulticast {
+			if resource.Multicast == nil {
+				return vmmLedger{}, fmt.Errorf(
+					"CUDA VMM multicast resource %d has no owner properties",
+					resource.ID,
+				)
+			}
+			for _, capture := range grouped[id] {
+				multicast := capture.record.multicast
+				if multicast == nil ||
+					multicast.objectFlags != resource.Multicast.Flags ||
+					multicast.objectHandleTypes !=
+						resource.Multicast.HandleTypes ||
+					multicast.numDevices !=
+						resource.Multicast.NumDevices ||
+					multicast.objectSize != resource.Multicast.Size {
+					return vmmLedger{}, fmt.Errorf(
+						"CUDA VMM multicast resource %d has inconsistent object properties",
+						resource.ID,
+					)
+				}
 			}
 		}
 		if resource.Owner.Participant == "" || len(resource.Importers) == 0 {
@@ -1145,6 +1520,7 @@ func inspectVMM(
 			return strings.Compare(left.Participant, right.Participant)
 		})
 		resourceParticipants := map[string]struct{}{resource.Owner.Participant: {}}
+		resourceGPUs := map[string]struct{}{resource.Owner.GPUUUID: {}}
 		for _, importer := range resource.Importers {
 			if importer.Size != resource.Owner.Size {
 				return vmmLedger{}, fmt.Errorf(
@@ -1167,8 +1543,47 @@ func inspectVMM(
 				)
 			}
 			resourceParticipants[importer.Participant] = struct{}{}
+			if resource.Kind == "multicast" {
+				if _, duplicate := resourceGPUs[importer.GPUUUID]; duplicate {
+					return vmmLedger{}, fmt.Errorf(
+						"CUDA VMM multicast resource %d repeats member GPU %s",
+						resource.ID, importer.GPUUUID,
+					)
+				}
+				resourceGPUs[importer.GPUUUID] = struct{}{}
+			}
 		}
 		ledger.Resources = append(ledger.Resources, resource)
+	}
+	resourcesByCapture := make(map[[16]byte]uint64, len(ledger.Resources))
+	for _, resource := range ledger.Resources {
+		resourcesByCapture[resource.captureUUID] = resource.ID
+	}
+	for resourceIndex := range ledger.Resources {
+		resource := &ledger.Resources[resourceIndex]
+		if resource.Kind != "multicast" {
+			continue
+		}
+		mappings := []*vmmMapping{&resource.Owner}
+		for importerIndex := range resource.Importers {
+			mappings = append(mappings, &resource.Importers[importerIndex])
+		}
+		for _, mapping := range mappings {
+			if mapping.Multicast == nil {
+				return vmmLedger{}, fmt.Errorf(
+					"CUDA VMM multicast resource %d has incomplete participant metadata",
+					resource.ID,
+				)
+			}
+			backingID, ok := resourcesByCapture[mapping.Multicast.backingUUID]
+			if !ok {
+				return vmmLedger{}, fmt.Errorf(
+					"CUDA VMM multicast resource %d references unknown backing allocation",
+					resource.ID,
+				)
+			}
+			mapping.Multicast.BackingResourceID = backingID
+		}
 	}
 	if len(ledger.Resources) == 0 {
 		return vmmLedger{}, errors.New("no CUDA VMM sharing graph discovered")
@@ -1192,7 +1607,7 @@ func inspectVMM(
 }
 
 func mappingFromCapture(participant string, record vmmCaptureRecord) vmmMapping {
-	return vmmMapping{
+	mapping := vmmMapping{
 		Participant:           participant,
 		Address:               record.address,
 		Size:                  record.size,
@@ -1204,6 +1619,18 @@ func mappingFromCapture(participant string, record vmmCaptureRecord) vmmMapping 
 		AccessCount:           record.accessCount,
 		AccessSize:            record.accessSize,
 	}
+	if record.multicast != nil {
+		mapping.Multicast = &vmmMulticastMapping{
+			BackingRole:     record.multicast.backingRole,
+			MulticastOffset: record.multicast.multicastOffset,
+			MemoryOffset:    record.multicast.memoryOffset,
+			Size:            record.multicast.bindSize,
+			Flags:           record.multicast.bindFlags,
+			BindAPI:         record.multicast.bindAPI,
+			backingUUID:     record.multicast.backingUUID,
+		}
+	}
+	return mapping
 }
 
 func readVMMRESPLine(reader *bufio.Reader) (string, error) {
@@ -1473,6 +1900,9 @@ func decodeVMMRecords(count uint32, payload []byte) ([]vmmCaptureRecord, error) 
 		propertiesSize := binary.LittleEndian.Uint32(payload[68:72])
 		metadataSize := uint64(vmmRecordSize) + uint64(propertiesSize) +
 			uint64(record.accessCount)*uint64(record.accessSize)
+		if record.kind == vmmMulticast {
+			metadataSize += vmmMulticastSize
+		}
 		if metadataSize > uint64(len(payload)) {
 			return nil, errors.New("invalid VMM record lengths")
 		}
@@ -1484,10 +1914,38 @@ func decodeVMMRecords(count uint32, payload []byte) ([]vmmCaptureRecord, error) 
 			[]byte(nil),
 			payload[vmmRecordSize+int(propertiesSize):int(metadataSize)]...,
 		)
+		if record.kind == vmmMulticast {
+			extensionOffset := vmmRecordSize + int(propertiesSize) +
+				int(record.accessCount)*int(record.accessSize)
+			extension := payload[extensionOffset : extensionOffset+vmmMulticastSize]
+			record.access = record.access[:len(record.access)-vmmMulticastSize]
+			record.multicast = &vmmCaptureMulticast{
+				backingObjectID:   binary.LittleEndian.Uint64(extension[16:24]),
+				multicastOffset:   binary.LittleEndian.Uint64(extension[24:32]),
+				memoryOffset:      binary.LittleEndian.Uint64(extension[32:40]),
+				bindSize:          binary.LittleEndian.Uint64(extension[40:48]),
+				bindFlags:         binary.LittleEndian.Uint64(extension[48:56]),
+				objectFlags:       binary.LittleEndian.Uint64(extension[56:64]),
+				objectHandleTypes: binary.LittleEndian.Uint64(extension[64:72]),
+				objectSize:        binary.LittleEndian.Uint64(extension[72:80]),
+				numDevices:        binary.LittleEndian.Uint32(extension[80:84]),
+				backingRole:       binary.LittleEndian.Uint32(extension[84:88]),
+				bindAPI:           binary.LittleEndian.Uint32(extension[88:92]),
+			}
+			copy(record.multicast.backingUUID[:], extension[0:16])
+			if binary.LittleEndian.Uint32(extension[92:96]) != 0 ||
+				record.multicast.backingUUID == ([16]byte{}) ||
+				record.multicast.backingObjectID != 0 {
+				return nil, errors.New("invalid VMM multicast capture metadata")
+			}
+		}
 		if record.allocationUUID == ([16]byte{}) || record.address == 0 ||
 			record.size == 0 || record.offset != 0 || record.accessCount == 0 ||
 			record.accessSize == 0 || record.kind == 0 || record.gpuUUID == "" {
 			return nil, errors.New("unsupported incomplete VMM mapping metadata")
+		}
+		if record.kind != vmmAllocation && record.kind != vmmMulticast {
+			return nil, fmt.Errorf("unsupported VMM object kind %d", record.kind)
 		}
 		payload = payload[metadataSize:]
 		records = append(records, record)
@@ -1498,25 +1956,38 @@ func decodeVMMRecords(count uint32, payload []byte) ([]vmmCaptureRecord, error) 
 	return records, nil
 }
 
-func encodeVMMRestoreRecord(
+func encodeVMMResourceRecord(
 	objectID uint64,
 	role uint32,
+	kind uint32,
 	mapping vmmMapping,
 	deviceOrdinal int32,
+	multicast *vmmMulticastProperties,
 	contents []byte,
 ) []byte {
+	extensionSize := 0
+	if kind == vmmMulticast {
+		extensionSize = vmmMulticastSize
+	}
 	payload := make(
 		[]byte,
-		vmmRecordSize+len(mapping.Properties)+len(mapping.Access)+len(contents),
+		vmmRecordSize+len(mapping.Properties)+len(mapping.Access)+
+			extensionSize+len(contents),
 	)
 	binary.LittleEndian.PutUint64(payload[16:24], objectID)
 	binary.LittleEndian.PutUint64(payload[24:32], mapping.Address)
 	binary.LittleEndian.PutUint64(payload[32:40], mapping.Size)
 	binary.LittleEndian.PutUint32(payload[48:52], role)
-	binary.LittleEndian.PutUint32(payload[52:56], vmmAllocation)
+	binary.LittleEndian.PutUint32(payload[52:56], kind)
 	binary.LittleEndian.PutUint32(payload[56:60], mapping.RequestedHandleType)
 	if mapping.ApplicationHandleLive {
 		binary.LittleEndian.PutUint32(payload[60:64], vmmApplicationHandleLive)
+	}
+	if mapping.retainRestoreHandle {
+		binary.LittleEndian.PutUint32(
+			payload[60:64],
+			binary.LittleEndian.Uint32(payload[60:64])|vmmRetainRestoreHandle,
+		)
 	}
 	binary.LittleEndian.PutUint32(payload[64:68], uint32(deviceOrdinal))
 	binary.LittleEndian.PutUint32(payload[68:72], uint32(len(mapping.Properties)))
@@ -1528,6 +1999,21 @@ func encodeVMMRestoreRecord(
 	cursor += len(mapping.Properties)
 	copy(payload[cursor:], mapping.Access)
 	cursor += len(mapping.Access)
+	if kind == vmmMulticast {
+		bind := mapping.Multicast
+		binary.LittleEndian.PutUint64(payload[cursor+16:cursor+24], bind.BackingResourceID)
+		binary.LittleEndian.PutUint64(payload[cursor+24:cursor+32], bind.MulticastOffset)
+		binary.LittleEndian.PutUint64(payload[cursor+32:cursor+40], bind.MemoryOffset)
+		binary.LittleEndian.PutUint64(payload[cursor+40:cursor+48], bind.Size)
+		binary.LittleEndian.PutUint64(payload[cursor+48:cursor+56], bind.Flags)
+		binary.LittleEndian.PutUint64(payload[cursor+56:cursor+64], multicast.Flags)
+		binary.LittleEndian.PutUint64(payload[cursor+64:cursor+72], multicast.HandleTypes)
+		binary.LittleEndian.PutUint64(payload[cursor+72:cursor+80], multicast.Size)
+		binary.LittleEndian.PutUint32(payload[cursor+80:cursor+84], multicast.NumDevices)
+		binary.LittleEndian.PutUint32(payload[cursor+84:cursor+88], bind.BackingRole)
+		binary.LittleEndian.PutUint32(payload[cursor+88:cursor+92], bind.BindAPI)
+		cursor += vmmMulticastSize
+	}
 	copy(payload[cursor:], contents)
 	return payload
 }
@@ -1609,6 +2095,7 @@ func validateVMMResponseShape(
 		(response.Count != 0 ||
 			response.PayloadSize != 0 ||
 			response.ObjectID != 0 ||
+			response.ObjectKind != 0 ||
 			response.AllocationUUID != ([16]byte{}) ||
 			response.Message != "") {
 		return 0, fmt.Errorf(
@@ -1842,6 +2329,7 @@ func encodeVMMHeader(header vmmHeader) []byte {
 	binary.LittleEndian.PutUint32(buffer[8:12], uint32(header.Status))
 	binary.LittleEndian.PutUint32(buffer[12:16], header.Count)
 	binary.LittleEndian.PutUint32(buffer[16:20], header.HandleType)
+	binary.LittleEndian.PutUint32(buffer[20:24], header.ObjectKind)
 	copy(buffer[24:40], header.AllocationUUID[:])
 	binary.LittleEndian.PutUint64(buffer[40:48], header.ObjectID)
 	binary.LittleEndian.PutUint64(buffer[48:56], header.PayloadSize)
@@ -1854,7 +2342,6 @@ func decodeVMMHeader(buffer []byte) (vmmHeader, error) {
 	if len(buffer) != vmmHeaderSize ||
 		binary.LittleEndian.Uint32(buffer[0:4]) != vmmProtocolMagic ||
 		binary.LittleEndian.Uint16(buffer[4:6]) != vmmProtocolVersion ||
-		binary.LittleEndian.Uint32(buffer[20:24]) != 0 ||
 		!bytes.Equal(buffer[185:256], make([]byte, 71)) {
 		return vmmHeader{}, errors.New("invalid VMM response protocol")
 	}
@@ -1863,6 +2350,7 @@ func decodeVMMHeader(buffer []byte) (vmmHeader, error) {
 		Status:      int32(binary.LittleEndian.Uint32(buffer[8:12])),
 		Count:       binary.LittleEndian.Uint32(buffer[12:16]),
 		HandleType:  binary.LittleEndian.Uint32(buffer[16:20]),
+		ObjectKind:  binary.LittleEndian.Uint32(buffer[20:24]),
 		ObjectID:    binary.LittleEndian.Uint64(buffer[40:48]),
 		PayloadSize: binary.LittleEndian.Uint64(buffer[48:56]),
 		Message:     strings.TrimRight(string(buffer[56:56+vmmMessageSize]), "\x00"),

--- a/deploy/snapshot/internal/cuda/vmm_interpose_test.go
+++ b/deploy/snapshot/internal/cuda/vmm_interpose_test.go
@@ -52,6 +52,130 @@ func TestDetectVMMInterposeRequiresUniformLauncherScope(t *testing.T) {
 	}
 }
 
+func TestValidateVMMLedgerMulticastGraph(t *testing.T) {
+	const (
+		owner       = "11111111111111111111111111111111"
+		importer    = "22222222222222222222222222222222"
+		ownerGPU    = "00112233-4455-6677-8899-aabbccddeeff"
+		importerGPU = "ffeeddcc-bbaa-9988-7766-554433221100"
+		size        = uint64(4096)
+	)
+	mapping := func(participant, gpu string) vmmMapping {
+		return vmmMapping{
+			Participant:         participant,
+			Address:             0x1000,
+			Size:                size,
+			GPUUUID:             gpu,
+			RequestedHandleType: vmmHandleFabric,
+			Access:              []byte{1},
+			AccessCount:         1,
+			AccessSize:          1,
+		}
+	}
+	valid := func() vmmLedger {
+		allocationOwner := mapping(owner, ownerGPU)
+		allocationImporter := mapping(importer, importerGPU)
+		multicastOwner := mapping(owner, ownerGPU)
+		multicastOwner.Multicast = &vmmMulticastMapping{
+			BackingResourceID: 1,
+			BackingRole:       vmmOwner,
+			Size:              size,
+			BindAPI:           vmmMulticastBindMem,
+		}
+		multicastImporter := mapping(importer, importerGPU)
+		multicastImporter.Multicast = &vmmMulticastMapping{
+			BackingResourceID: 1,
+			BackingRole:       vmmImporter,
+			Size:              size,
+			BindAPI:           vmmMulticastBindMemV2,
+		}
+		return vmmLedger{
+			Version: vmmLedgerVersion,
+			Participants: []vmmParticipant{
+				{
+					ID: owner,
+					Placement: vmmPlacement{
+						Node: "node-a", GPUUUIDs: []string{ownerGPU},
+					},
+				},
+				{
+					ID: importer,
+					Placement: vmmPlacement{
+						Node: "node-a", GPUUUIDs: []string{importerGPU},
+					},
+				},
+			},
+			Resources: []vmmResource{
+				{
+					ID:        1,
+					Kind:      "allocation",
+					Owner:     allocationOwner,
+					Importers: []vmmMapping{allocationImporter},
+				},
+				{
+					ID:        2,
+					Kind:      "multicast",
+					Owner:     multicastOwner,
+					Importers: []vmmMapping{multicastImporter},
+					Multicast: &vmmMulticastProperties{
+						HandleTypes: vmmHandleFabric,
+						NumDevices:  2,
+						Size:        size,
+					},
+				},
+			},
+		}
+	}
+	if err := validateVMMLedger(valid()); err != nil {
+		t.Fatalf("valid multicast graph rejected: %v", err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*vmmLedger)
+	}{
+		{
+			name: "unknown backing resource",
+			mutate: func(ledger *vmmLedger) {
+				ledger.Resources[1].Owner.Multicast.BackingResourceID = 3
+			},
+		},
+		{
+			name: "duplicate member GPU",
+			mutate: func(ledger *vmmLedger) {
+				ledger.Resources[1].Importers[0].GPUUUID = ownerGPU
+				ledger.Participants[1].Placement.GPUUUIDs[0] = ownerGPU
+			},
+		},
+		{
+			name: "partial bind",
+			mutate: func(ledger *vmmLedger) {
+				ledger.Resources[1].Owner.Multicast.Size--
+			},
+		},
+		{
+			name: "nonzero multicast offset",
+			mutate: func(ledger *vmmLedger) {
+				ledger.Resources[1].Owner.Multicast.MulticastOffset = 1
+			},
+		},
+		{
+			name: "duplicate participant bind role",
+			mutate: func(ledger *vmmLedger) {
+				ledger.Resources[1].Importers[0].Multicast.BackingRole = vmmOwner
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ledger := valid()
+			test.mutate(&ledger)
+			if err := validateVMMLedger(ledger); err == nil {
+				t.Fatal("malformed multicast graph was accepted")
+			}
+		})
+	}
+}
+
 func TestExchangeVMMRejectsNonemptySuccessBeforeReadingPayload(t *testing.T) {
 	const participant = "11111111111111111111111111111111"
 	path := filepath.Join(t.TempDir(), "vmm.sock")
@@ -318,6 +442,11 @@ func TestRestoreVMMFabricTransport(t *testing.T) {
 					header: vmmHeader{Operation: vmmSetPlacement},
 					fd:     -1,
 				}, nil
+			case vmmFinalizeRestore:
+				return vmmResponse{
+					header: vmmHeader{Operation: vmmFinalizeRestore},
+					fd:     -1,
+				}, nil
 			case vmmRestoreOwner:
 				if request.header.HandleType != vmmHandleFabric ||
 					request.fd >= 0 {
@@ -333,6 +462,7 @@ func TestRestoreVMMFabricTransport(t *testing.T) {
 					header: vmmHeader{
 						Operation:  vmmRestoreOwner,
 						HandleType: vmmHandleFabric,
+						ObjectKind: vmmAllocation,
 					},
 					payload: append([]byte(nil), raw...),
 					fd:      -1,
@@ -390,6 +520,11 @@ func TestRestoreVMMFabricTransport(t *testing.T) {
 					header: vmmHeader{Operation: vmmRestoreImporter},
 					fd:     -1,
 				}, nil
+			case vmmFinalizeRestore:
+				return vmmResponse{
+					header: vmmHeader{Operation: vmmFinalizeRestore},
+					fd:     -1,
+				}, nil
 			case vmmIdentify:
 				return vmmResponse{
 					header: vmmHeader{
@@ -442,19 +577,20 @@ func TestRestoreVMMFabricTransport(t *testing.T) {
 	}
 }
 
-func TestVMMProtocolV4HandleTypeLayout(t *testing.T) {
+func TestVMMProtocolV5ObjectKindLayout(t *testing.T) {
 	encoded := encodeVMMHeader(vmmHeader{
 		Operation:  vmmRestoreOwner,
 		HandleType: vmmHandleFabric,
+		ObjectKind: vmmMulticast,
 	})
-	if got := binary.LittleEndian.Uint16(encoded[4:6]); got != 4 {
-		t.Fatalf("protocol version = %d, want 4", got)
+	if got := binary.LittleEndian.Uint16(encoded[4:6]); got != 5 {
+		t.Fatalf("protocol version = %d, want 5", got)
 	}
 	if got := binary.LittleEndian.Uint32(encoded[16:20]); got != vmmHandleFabric {
 		t.Fatalf("header handle type = %d, want %d", got, vmmHandleFabric)
 	}
-	if got := binary.LittleEndian.Uint32(encoded[20:24]); got != 0 {
-		t.Fatalf("header reserved word = %d, want 0", got)
+	if got := binary.LittleEndian.Uint32(encoded[20:24]); got != vmmMulticast {
+		t.Fatalf("header object kind = %d, want %d", got, vmmMulticast)
 	}
 	if len(encoded) != vmmHeaderSize {
 		t.Fatalf("header size = %d, want %d", len(encoded), vmmHeaderSize)
@@ -467,6 +603,12 @@ func TestVMMProtocolV4HandleTypeLayout(t *testing.T) {
 		t.Fatalf(
 			"decoded handle type = %d, want %d",
 			decoded.HandleType, vmmHandleFabric,
+		)
+	}
+	if decoded.ObjectKind != vmmMulticast {
+		t.Fatalf(
+			"decoded object kind = %d, want %d",
+			decoded.ObjectKind, vmmMulticast,
 		)
 	}
 	encoded[255] = 1
@@ -560,11 +702,16 @@ func TestVMMBrokerResultShapesAndCleanup(t *testing.T) {
 	t.Run("fabric", func(t *testing.T) {
 		raw := bytes.Repeat([]byte{0xa5}, vmmFabricHandleSize)
 		response := vmmResponse{
-			header:  vmmHeader{HandleType: vmmHandleFabric},
+			header: vmmHeader{
+				HandleType: vmmHandleFabric,
+				ObjectKind: vmmAllocation,
+			},
 			payload: raw,
 			fd:      -1,
 		}
-		result, err := takeVMMBrokerResult(&response, vmmHandleFabric)
+		result, err := takeVMMBrokerResult(
+			&response, vmmHandleFabric, vmmAllocation,
+		)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -585,12 +732,15 @@ func TestVMMBrokerResultShapesAndCleanup(t *testing.T) {
 		}
 		payload := []byte{1}
 		response := vmmResponse{
-			header:  vmmHeader{HandleType: vmmHandlePOSIX},
+			header: vmmHeader{
+				HandleType: vmmHandlePOSIX,
+				ObjectKind: vmmAllocation,
+			},
 			payload: payload,
 			fd:      fd,
 		}
 		if _, err := takeVMMBrokerResult(
-			&response, vmmHandlePOSIX,
+			&response, vmmHandlePOSIX, vmmAllocation,
 		); err == nil {
 			t.Fatal("POSIX broker response with payload was accepted")
 		}
@@ -785,6 +935,85 @@ func TestVMMStateDigestBindsMetadataAndBytes(t *testing.T) {
 	}
 	if baseline == digest([]byte("ledger"), []byte("changed")) {
 		t.Fatal("digest did not bind allocation contents")
+	}
+}
+
+func TestVMMDurableMulticastMetadataBindsDigestWithoutRuntimeIdentity(t *testing.T) {
+	ledger := vmmLedger{
+		Version:    vmmLedgerVersion,
+		Generation: "00112233445566778899aabbccddeeff",
+		Resources: []vmmResource{
+			{
+				ID:   1,
+				Kind: "allocation",
+			},
+			{
+				ID:   2,
+				Kind: "multicast",
+				Owner: vmmMapping{
+					Participant:         "11111111111111111111111111111111",
+					RequestedHandleType: vmmHandleFabric,
+					Multicast: &vmmMulticastMapping{
+						BackingResourceID: 1,
+						BackingRole:       vmmOwner,
+						Size:              4096,
+						BindAPI:           vmmMulticastBindMem,
+						backingUUID:       [16]byte{0xaa},
+					},
+					retainRestoreHandle: true,
+				},
+				Multicast: &vmmMulticastProperties{
+					HandleTypes: vmmHandleFabric,
+					NumDevices:  2,
+					Size:        4096,
+				},
+				captureUUID: [16]byte{0xbb},
+			},
+		},
+	}
+	encoded, err := json.Marshal(ledger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(encoded)
+	for _, want := range []string{
+		`"kind":"multicast"`,
+		`"backingResourceID":1`,
+		`"bindAPI":1`,
+		`"numDevices":2`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("durable multicast JSON %s does not contain %s", text, want)
+		}
+	}
+	for _, forbidden := range []string{
+		"captureUUID",
+		"backingUUID",
+		"retainRestoreHandle",
+		"fabricToken",
+		"rawHandle",
+		"socket",
+		"context",
+		"pid",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("durable multicast JSON contains runtime field %q: %s", forbidden, text)
+		}
+	}
+	digest := func(metadata []byte) string {
+		hash := sha256.New()
+		writeVMMDigestPart(hash, metadata)
+		writeVMMDigestObject(hash, 1, []byte("allocation bytes"))
+		return hex.EncodeToString(hash.Sum(nil))
+	}
+	baseline := digest(encoded)
+	ledger.Resources[1].Owner.Multicast.BindAPI = vmmMulticastBindMemV2
+	changed, err := json.Marshal(ledger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseline == digest(changed) {
+		t.Fatal("digest did not bind durable multicast metadata")
 	}
 }
 
@@ -990,25 +1219,483 @@ func TestRestoreVMMUnlockBoundary(t *testing.T) {
 	}
 }
 
+func TestRestoreVMMMulticastReplayOrder(t *testing.T) {
+	const (
+		generation   = "00112233445566778899aabbccddeeff"
+		participantA = "11111111111111111111111111111111"
+		participantB = "22222222222222222222222222222222"
+		gpuA         = "00112233-4455-6677-8899-aabbccddeeff"
+		gpuB         = "ffeeddcc-bbaa-9988-7766-554433221100"
+	)
+	mapping := func(participant, gpu string, address uint64) vmmMapping {
+		return vmmMapping{
+			Participant:         participant,
+			Address:             address,
+			Size:                4,
+			GPUUUID:             gpu,
+			RequestedHandleType: vmmHandlePOSIX,
+			Access:              []byte{1, 2, 3, 4},
+			AccessCount:         1,
+			AccessSize:          4,
+		}
+	}
+	allocationOwner := mapping(participantA, gpuA, 0x1000)
+	allocationImporter := mapping(participantB, gpuB, 0x2000)
+	multicastOwner := mapping(participantA, gpuA, 0x3000)
+	multicastOwner.Multicast = &vmmMulticastMapping{
+		BackingResourceID: 1,
+		BackingRole:       vmmOwner,
+		Size:              4,
+		BindAPI:           vmmMulticastBindMem,
+	}
+	multicastImporter := mapping(participantB, gpuB, 0x4000)
+	multicastImporter.Multicast = &vmmMulticastMapping{
+		BackingResourceID: 1,
+		BackingRole:       vmmImporter,
+		Size:              4,
+		BindAPI:           vmmMulticastBindMemV2,
+	}
+	ledger := vmmLedger{
+		Version:    vmmLedgerVersion,
+		Generation: generation,
+		Participants: []vmmParticipant{
+			{
+				ID: participantA,
+				Placement: vmmPlacement{
+					Node: "node-a", GPUUUIDs: []string{gpuA},
+				},
+			},
+			{
+				ID: participantB,
+				Placement: vmmPlacement{
+					Node: "node-a", GPUUUIDs: []string{gpuB},
+				},
+			},
+		},
+		Resources: []vmmResource{
+			{
+				ID:        1,
+				Kind:      "allocation",
+				Owner:     allocationOwner,
+				Importers: []vmmMapping{allocationImporter},
+			},
+			{
+				ID:        2,
+				Kind:      "multicast",
+				Owner:     multicastOwner,
+				Importers: []vmmMapping{multicastImporter},
+				Multicast: &vmmMulticastProperties{
+					HandleTypes: vmmHandlePOSIX,
+					NumDevices:  2,
+					Size:        4,
+				},
+			},
+		},
+	}
+	if err := validateVMMLedger(ledger); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(ledger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := []byte{9, 8, 7, 6}
+	digest := sha256.New()
+	writeVMMDigestPart(digest, encoded)
+	writeVMMDigestObject(digest, 1, contents)
+	expectedDigest := hex.EncodeToString(digest.Sum(nil))
+	events := make(chan string, 32)
+	t.Setenv(VMMRedisAddressEnv, serveVMMRestoreRedis(t, map[string][]byte{
+		vmmRedisKey(generation, "state"):      []byte("detached"),
+		vmmRedisKey(generation, "ledger"):     encoded,
+		vmmRedisKey(generation, "digest"):     []byte(expectedDigest),
+		vmmRedisKey(generation, "resource:1"): contents,
+	}, events))
+	t.Setenv(VMMRedisRDBPathEnv, "")
+	t.Setenv(VMMRedisRestoreCmdEnv, "/bin/true")
+	t.Setenv("NODE_NAME", "node-a")
+
+	serve := func(participant, gpu string, ordinal int32) VMMProcess {
+		return serveVMMProcess(
+			t, "", participant,
+			func(request vmmResponse) (vmmResponse, error) {
+				response := vmmResponse{
+					header: vmmHeader{Operation: request.header.Operation},
+					fd:     -1,
+				}
+				switch request.header.Operation {
+				case vmmSetPlacement:
+					if err := validateVMMPlacementRequest(
+						request, gpu, gpu, ordinal,
+					); err != nil {
+						return response, err
+					}
+					events <- "placement:" + participant
+				case vmmRestoreOwner:
+					if participant != participantA ||
+						(request.header.ObjectID != 1 &&
+							request.header.ObjectID != 2) {
+						return response, errors.New("unexpected restore owner")
+					}
+					if request.header.ObjectKind == vmmAllocation {
+						if request.header.ObjectID != 1 ||
+							request.header.HandleType != vmmHandlePOSIX ||
+							binary.LittleEndian.Uint32(request.payload[60:64])&
+								vmmRetainRestoreHandle == 0 {
+							return response, errors.New("invalid retained allocation owner")
+						}
+						events <- "allocation-owner"
+					} else if request.header.ObjectKind == vmmMulticast {
+						if err := validateMulticastRestoreRequest(
+							request, 2, vmmOwner, 1,
+						); err != nil {
+							return response, err
+						}
+						events <- "multicast-owner-add"
+					} else {
+						return response, errors.New("unexpected owner object kind")
+					}
+					response.header.HandleType = vmmHandlePOSIX
+					response.header.ObjectKind = request.header.ObjectKind
+					var err error
+					response.fd, err = unix.MemfdCreate(
+						"vmm-multicast-restore", unix.MFD_CLOEXEC,
+					)
+					if err != nil {
+						return response, err
+					}
+				case vmmRestoreImporter:
+					if participant != participantB || request.fd < 0 {
+						return response, errors.New("unexpected restore importer")
+					}
+					if request.header.ObjectKind == vmmAllocation {
+						if request.header.ObjectID != 1 ||
+							binary.LittleEndian.Uint32(request.payload[60:64])&
+								vmmRetainRestoreHandle == 0 {
+							return response, errors.New("invalid retained allocation importer")
+						}
+						events <- "allocation-importer"
+					} else if request.header.ObjectKind == vmmMulticast {
+						if err := validateMulticastRestoreRequest(
+							request, 2, vmmImporter, 1,
+						); err != nil {
+							return response, err
+						}
+						events <- "multicast-importer-add"
+					} else {
+						return response, errors.New("unexpected importer object kind")
+					}
+				case vmmRestoreMulticast:
+					if err := validateMulticastRestoreRequest(
+						request, 2,
+						map[bool]uint32{true: vmmOwner, false: vmmImporter}[participant == participantA],
+						1,
+					); err != nil {
+						return response, err
+					}
+					events <- "multicast-bind:" + participant
+				case vmmFinalizeRestore:
+					events <- "finalize:" + participant
+				case vmmIdentify:
+					events <- "health:" + participant
+				default:
+					return response, fmt.Errorf(
+						"unexpected VMM operation %d", request.header.Operation,
+					)
+				}
+				return response, nil
+			},
+		)
+	}
+	processes := []VMMProcess{
+		serve(participantA, gpuA, 0),
+		serve(participantB, gpuB, 1),
+	}
+	if err := RestoreVMM(
+		context.Background(),
+		processes,
+		generation,
+		expectedDigest,
+		t.TempDir(),
+		[]types.VMMPlacement{
+			{SourceGPUUUID: gpuA, TargetGPUUUID: gpuA, TargetOrdinal: 0},
+			{SourceGPUUUID: gpuB, TargetGPUUUID: gpuB, TargetOrdinal: 1},
+		},
+		func() error {
+			events <- "unlock"
+			return nil
+		},
+		logr.Discard(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for range len(events) {
+		got = append(got, <-events)
+	}
+	want := []string{
+		"content:1",
+		"placement:" + participantA,
+		"placement:" + participantB,
+		"unlock",
+		"allocation-owner",
+		"allocation-importer",
+		"multicast-owner-add",
+		"multicast-importer-add",
+		"multicast-bind:" + participantA,
+		"multicast-bind:" + participantB,
+		"finalize:" + participantA,
+		"finalize:" + participantB,
+		"health:" + participantA,
+		"health:" + participantB,
+		"redis-restored",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("multicast restore events = %v, want %v", got, want)
+	}
+}
+
+func TestRestoreVMMMulticastFailureAbortsParticipants(t *testing.T) {
+	const (
+		generation   = "00112233445566778899aabbccddeeff"
+		participantA = "11111111111111111111111111111111"
+		participantB = "22222222222222222222222222222222"
+		gpuA         = "00112233-4455-6677-8899-aabbccddeeff"
+		gpuB         = "ffeeddcc-bbaa-9988-7766-554433221100"
+	)
+	mapping := func(participant, gpu string, address uint64) vmmMapping {
+		return vmmMapping{
+			Participant:         participant,
+			Address:             address,
+			Size:                4,
+			GPUUUID:             gpu,
+			RequestedHandleType: vmmHandlePOSIX,
+			Access:              []byte{1, 2, 3, 4},
+			AccessCount:         1,
+			AccessSize:          4,
+		}
+	}
+	allocationOwner := mapping(participantA, gpuA, 0x1000)
+	allocationImporter := mapping(participantB, gpuB, 0x2000)
+	multicastOwner := mapping(participantA, gpuA, 0x3000)
+	multicastOwner.Multicast = &vmmMulticastMapping{
+		BackingResourceID: 1,
+		BackingRole:       vmmOwner,
+		Size:              4,
+		BindAPI:           vmmMulticastBindMem,
+	}
+	multicastImporter := mapping(participantB, gpuB, 0x4000)
+	multicastImporter.Multicast = &vmmMulticastMapping{
+		BackingResourceID: 1,
+		BackingRole:       vmmImporter,
+		Size:              4,
+		BindAPI:           vmmMulticastBindMemV2,
+	}
+	ledger := vmmLedger{
+		Version:    vmmLedgerVersion,
+		Generation: generation,
+		Participants: []vmmParticipant{
+			{
+				ID: participantA,
+				Placement: vmmPlacement{
+					Node: "node-a", GPUUUIDs: []string{gpuA},
+				},
+			},
+			{
+				ID: participantB,
+				Placement: vmmPlacement{
+					Node: "node-a", GPUUUIDs: []string{gpuB},
+				},
+			},
+		},
+		Resources: []vmmResource{
+			{
+				ID:        1,
+				Kind:      "allocation",
+				Owner:     allocationOwner,
+				Importers: []vmmMapping{allocationImporter},
+			},
+			{
+				ID:        2,
+				Kind:      "multicast",
+				Owner:     multicastOwner,
+				Importers: []vmmMapping{multicastImporter},
+				Multicast: &vmmMulticastProperties{
+					HandleTypes: vmmHandlePOSIX,
+					NumDevices:  2,
+					Size:        4,
+				},
+			},
+		},
+	}
+	encoded, err := json.Marshal(ledger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := []byte{9, 8, 7, 6}
+	digest := sha256.New()
+	writeVMMDigestPart(digest, encoded)
+	writeVMMDigestObject(digest, 1, contents)
+	expectedDigest := hex.EncodeToString(digest.Sum(nil))
+	events := make(chan string, 32)
+	t.Setenv(VMMRedisAddressEnv, serveVMMRestoreRedis(t, map[string][]byte{
+		vmmRedisKey(generation, "state"):      []byte("detached"),
+		vmmRedisKey(generation, "ledger"):     encoded,
+		vmmRedisKey(generation, "digest"):     []byte(expectedDigest),
+		vmmRedisKey(generation, "resource:1"): contents,
+	}, events))
+	t.Setenv(VMMRedisRDBPathEnv, "")
+	t.Setenv(VMMRedisRestoreCmdEnv, "/bin/true")
+	t.Setenv("NODE_NAME", "node-a")
+
+	serve := func(participant, gpu string, ordinal int32) VMMProcess {
+		return serveVMMProcess(
+			t, "", participant,
+			func(request vmmResponse) (vmmResponse, error) {
+				response := vmmResponse{
+					header: vmmHeader{Operation: request.header.Operation},
+					fd:     -1,
+				}
+				switch request.header.Operation {
+				case vmmSetPlacement:
+					if err := validateVMMPlacementRequest(
+						request, gpu, gpu, ordinal,
+					); err != nil {
+						return response, err
+					}
+				case vmmRestoreOwner:
+					if participant != participantA {
+						return response, errors.New("unexpected restore owner")
+					}
+					response.header.HandleType = vmmHandlePOSIX
+					response.header.ObjectKind = request.header.ObjectKind
+					var err error
+					response.fd, err = unix.MemfdCreate(
+						"vmm-multicast-abort", unix.MFD_CLOEXEC,
+					)
+					return response, err
+				case vmmRestoreImporter:
+					if participant != participantB || request.fd < 0 {
+						return response, errors.New("unexpected restore importer")
+					}
+				case vmmRestoreMulticast:
+					events <- "bind:" + participant
+					if participant == participantB {
+						response.header.Status = 1
+						response.header.Message = "participant B bind failed"
+					}
+				case vmmAbortRestore:
+					events <- "abort:" + participant
+					if participant == participantB {
+						response.header.Status = 1
+						response.header.Message = "participant B abort failed"
+					}
+				case vmmFinalizeRestore:
+					events <- "finalize:" + participant
+				case vmmIdentify:
+					events <- "health:" + participant
+				default:
+					return response, fmt.Errorf(
+						"unexpected VMM operation %d", request.header.Operation,
+					)
+				}
+				return response, nil
+			},
+		)
+	}
+	processes := []VMMProcess{
+		serve(participantA, gpuA, 0),
+		serve(participantB, gpuB, 1),
+	}
+	err = RestoreVMM(
+		context.Background(),
+		processes,
+		generation,
+		expectedDigest,
+		t.TempDir(),
+		[]types.VMMPlacement{
+			{SourceGPUUUID: gpuA, TargetGPUUUID: gpuA, TargetOrdinal: 0},
+			{SourceGPUUUID: gpuB, TargetGPUUUID: gpuB, TargetOrdinal: 1},
+		},
+		func() error {
+			events <- "unlock"
+			return nil
+		},
+		logr.Discard(),
+	)
+	if err == nil ||
+		!strings.Contains(err.Error(), "participant B bind failed") ||
+		!strings.Contains(err.Error(), "participant B abort failed") {
+		t.Fatalf("RestoreVMM error = %v, want bind and abort failures", err)
+	}
+	var got []string
+	for range len(events) {
+		got = append(got, <-events)
+	}
+	want := []string{
+		"content:1",
+		"unlock",
+		"bind:" + participantA,
+		"bind:" + participantB,
+		"abort:" + participantA,
+		"abort:" + participantB,
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("multicast abort events = %v, want %v", got, want)
+	}
+}
+
+func validateMulticastRestoreRequest(
+	request vmmResponse,
+	resourceID uint64,
+	role uint32,
+	backingResourceID uint64,
+) error {
+	if request.header.ObjectID != resourceID ||
+		request.header.ObjectKind != vmmMulticast ||
+		request.header.HandleType != vmmHandlePOSIX ||
+		len(request.payload) < vmmRecordSize+vmmMulticastSize {
+		return errors.New("invalid multicast restore header")
+	}
+	if binary.LittleEndian.Uint64(request.payload[16:24]) != resourceID ||
+		binary.LittleEndian.Uint32(request.payload[48:52]) != role ||
+		binary.LittleEndian.Uint32(request.payload[52:56]) != vmmMulticast {
+		return errors.New("invalid multicast restore record")
+	}
+	extension := vmmRecordSize +
+		int(binary.LittleEndian.Uint32(request.payload[68:72])) +
+		int(binary.LittleEndian.Uint32(request.payload[72:76]))*
+			int(binary.LittleEndian.Uint32(request.payload[76:80]))
+	if extension+vmmMulticastSize != len(request.payload) ||
+		binary.LittleEndian.Uint64(
+			request.payload[extension+16:extension+24],
+		) != backingResourceID {
+		return errors.New("invalid multicast restore bind")
+	}
+	return nil
+}
+
 func TestVMMDetachPlanOrdersImportersBeforeOwners(t *testing.T) {
 	plan := vmmDetachPlan(vmmLedger{Resources: []vmmResource{
 		{
 			ID:        1,
+			Kind:      "allocation",
 			Owner:     vmmMapping{Participant: "owner-a"},
 			Importers: []vmmMapping{{Participant: "importer-a"}, {Participant: "importer-b"}},
 		},
 		{
 			ID:        2,
+			Kind:      "multicast",
 			Owner:     vmmMapping{Participant: "owner-b"},
 			Importers: []vmmMapping{{Participant: "importer-c"}},
 		},
 	}})
 	want := []vmmDetach{
+		{resourceID: 2, participant: "importer-c", role: vmmImporter},
+		{resourceID: 2, participant: "owner-b", role: vmmOwner},
 		{resourceID: 1, participant: "importer-a", role: vmmImporter},
 		{resourceID: 1, participant: "importer-b", role: vmmImporter},
-		{resourceID: 2, participant: "importer-c", role: vmmImporter},
 		{resourceID: 1, participant: "owner-a", role: vmmOwner},
-		{resourceID: 2, participant: "owner-b", role: vmmOwner},
 	}
 	if fmt.Sprint(plan) != fmt.Sprint(want) {
 		t.Fatalf("detach plan = %#v, want %#v", plan, want)
@@ -1196,6 +1883,73 @@ func TestInspectVMMBuildsDeterministicGraph(t *testing.T) {
 		if strings.Contains(strings.ToLower(string(encoded)), strings.ToLower(forbidden)) {
 			t.Fatalf("persistent ledger contains forbidden runtime identity %s: %s", forbidden, encoded)
 		}
+	}
+}
+
+func TestInspectVMMRejectsMulticastPropertyDisagreement(t *testing.T) {
+	const (
+		owner       = "11111111111111111111111111111111"
+		importer    = "22222222222222222222222222222222"
+		ownerGPU    = "00112233-4455-6677-8899-aabbccddeeff"
+		importerGPU = "ffeeddcc-bbaa-9988-7766-554433221100"
+	)
+	allocationUUID := [16]byte{1}
+	multicastUUID := [16]byte{2}
+	record := func(
+		role uint32,
+		kind uint32,
+		address uint64,
+		gpu string,
+	) vmmCaptureRecord {
+		result := vmmCaptureRecord{
+			allocationUUID: allocationUUID,
+			address:        address,
+			size:           4096,
+			role:           role,
+			kind:           kind,
+			handleType:     vmmHandleFabric,
+			gpuUUID:        gpu,
+			access:         []byte{1},
+			accessCount:    1,
+			accessSize:     1,
+		}
+		if role == vmmOwner {
+			result.properties = []byte{1}
+		}
+		if kind == vmmMulticast {
+			result.allocationUUID = multicastUUID
+			result.multicast = &vmmCaptureMulticast{
+				backingUUID:       allocationUUID,
+				bindSize:          4096,
+				objectHandleTypes: vmmHandleFabric,
+				objectSize:        4096,
+				numDevices:        2,
+				backingRole:       role,
+				bindAPI:           vmmMulticastBindMem,
+			}
+		}
+		return result
+	}
+	ownerRecords := []vmmCaptureRecord{
+		record(vmmOwner, vmmAllocation, 0x1000, ownerGPU),
+		record(vmmOwner, vmmMulticast, 0x3000, ownerGPU),
+	}
+	importerRecords := []vmmCaptureRecord{
+		record(vmmImporter, vmmAllocation, 0x2000, importerGPU),
+		record(vmmImporter, vmmMulticast, 0x4000, importerGPU),
+	}
+	importerRecords[1].multicast.numDevices = 3
+	_, err := inspectVMM(
+		context.Background(),
+		[]VMMProcess{
+			serveVMMInspectAs(t, owner, ownerRecords),
+			serveVMMInspectAs(t, importer, importerRecords),
+		},
+		"generation",
+		"node-a",
+	)
+	if err == nil || !strings.Contains(err.Error(), "inconsistent object properties") {
+		t.Fatalf("multicast property disagreement error = %v", err)
 	}
 }
 
@@ -2043,7 +2797,14 @@ func encodeVMMRecordsForTest(records []vmmCaptureRecord) []byte {
 		if record.handleType == 0 {
 			record.handleType = 1
 		}
-		encoded := make([]byte, vmmRecordSize+len(record.properties)+len(record.access))
+		extensionSize := 0
+		if record.kind == vmmMulticast {
+			extensionSize = vmmMulticastSize
+		}
+		encoded := make(
+			[]byte,
+			vmmRecordSize+len(record.properties)+len(record.access)+extensionSize,
+		)
 		copy(encoded[0:16], record.allocationUUID[:])
 		binary.LittleEndian.PutUint64(encoded[24:32], record.address)
 		binary.LittleEndian.PutUint64(encoded[32:40], record.size)
@@ -2058,6 +2819,44 @@ func encodeVMMRecordsForTest(records []vmmCaptureRecord) []byte {
 		copy(encoded[80:96], parseGPUUUID(record.gpuUUID))
 		copy(encoded[vmmRecordSize:], record.properties)
 		copy(encoded[vmmRecordSize+len(record.properties):], record.access)
+		if record.multicast != nil {
+			offset := vmmRecordSize + len(record.properties) + len(record.access)
+			extension := encoded[offset : offset+vmmMulticastSize]
+			copy(extension[0:16], record.multicast.backingUUID[:])
+			binary.LittleEndian.PutUint64(
+				extension[16:24], record.multicast.backingObjectID,
+			)
+			binary.LittleEndian.PutUint64(
+				extension[24:32], record.multicast.multicastOffset,
+			)
+			binary.LittleEndian.PutUint64(
+				extension[32:40], record.multicast.memoryOffset,
+			)
+			binary.LittleEndian.PutUint64(
+				extension[40:48], record.multicast.bindSize,
+			)
+			binary.LittleEndian.PutUint64(
+				extension[48:56], record.multicast.bindFlags,
+			)
+			binary.LittleEndian.PutUint64(
+				extension[56:64], record.multicast.objectFlags,
+			)
+			binary.LittleEndian.PutUint64(
+				extension[64:72], record.multicast.objectHandleTypes,
+			)
+			binary.LittleEndian.PutUint64(
+				extension[72:80], record.multicast.objectSize,
+			)
+			binary.LittleEndian.PutUint32(
+				extension[80:84], record.multicast.numDevices,
+			)
+			binary.LittleEndian.PutUint32(
+				extension[84:88], record.multicast.backingRole,
+			)
+			binary.LittleEndian.PutUint32(
+				extension[88:92], record.multicast.bindAPI,
+			)
+		}
 		payload = append(payload, encoded...)
 	}
 	return payload
@@ -2224,6 +3023,7 @@ func serveVMMRestoreProcess(
 			}
 			var err error
 			response.header.HandleType = request.header.HandleType
+			response.header.ObjectKind = vmmAllocation
 			response.fd, err = unix.MemfdCreate("vmm-restore-owner", unix.MFD_CLOEXEC)
 			return response, err
 		case vmmRestoreImporter:
@@ -2234,6 +3034,9 @@ func serveVMMRestoreProcess(
 				return response, err
 			}
 			events <- fmt.Sprintf("importer:%d", importerResource)
+			return response, nil
+		case vmmFinalizeRestore:
+			events <- "finalize:" + roleSummary
 			return response, nil
 		case vmmIdentify:
 			events <- "health:" + roleSummary


### PR DESCRIPTION
## Summary

- add same-node CUDA multicast teams, membership, mappings, and `cuMulticastBindMem` relationships to the launcher-scoped VMM ledger
- restore backing allocations before multicast create/import, add every member before bind replay, and finalize temporary backing handles before health checks
- keep multicast objects byte-less in Redis and keep raw FDs, FABRIC bytes, PIDs, sockets, contexts, and real CUDA handles out of durable state
- fail closed for mixed managed/unmanaged state and managed `cuMulticastBindAddr`; preserve unmanaged pass-through
- add distributed abort cleanup for partial post-unlock multicast replay and support both FlashInfer MNNVL release and mixed-comm explicit-unbind teardown

This is M3 from #12866, stacked on M2 #12893, which is stacked on M1 #12485. It is intentionally limited to the single-node FlashInfer handle-based multicast profile; multinode routing, mempools, external memory, retained capabilities, address binds, and native FlashInfer checkpoint hooks remain unsupported.

Duplicate-work check: no other open multicast checkpoint PR was found. The existing #12866 DEP is the umbrella proposal for this three-PR stack.

## Validation

- `cd deploy/snapshot && go vet ./internal/cuda`
- `cd deploy/snapshot && go test ./internal/cuda -count=1`
- focused protocol-v5, ledger-validation, digest/privacy, replay-order, and distributed-abort Go tests
- CUDA 13.0.2 fake-UMD suite: 90/90 executions passed
- CUDA 13.1.0 fake-UMD suite: 90/90 executions passed, including `_v2` entry points
- production interposer DSO strict compile with `-Wall -Wextra -Werror` under CUDA 13.0.2 and 13.1.0
- verified zero exported `dyn_vmm_test_*` symbols in both production DSOs
- `bash -n deploy/snapshot/cmd/cuda-vmm-interpose/{launch.sh,test/run.sh}`
- `git diff --check`

Hardware MNNVL checkpoint/restore qualification on AWS GB200 will be added after the draft branch image/artifact is built.
