### PR TITLE
test(snapshot): add PageBroker daemon tests

### DIFF
--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -67,7 +67,15 @@ RUN golangci-lint run --timeout=5m
 # =============================================================================
 FROM go-base AS tester
 
-RUN go test ./... -v
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    libgtest-dev \
+    libprotobuf-dev \
+    pkg-config \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN go test ./... -v && make -C pagebroker test
 
 # =============================================================================
 # Stage: Builder - Build Go binaries

--- a/deploy/snapshot/pagebroker/Makefile
+++ b/deploy/snapshot/pagebroker/Makefile
@@ -1,6 +1,13 @@
 PROTO := v1/pagebroker.proto
+GTEST_FLAGS := $(shell pkg-config --cflags --libs gtest_main)
+BROKER_SOURCES := broker.cpp checkpoint_transaction_descriptor.cpp posix_copy_engine.cpp restore_transaction_descriptor.cpp transfer_engine.cpp
 
-.PHONY: generate
+.PHONY: generate test
 
 generate:
 	protoc --proto_path=. --cpp_out=. $(PROTO)
+
+test: generate $(BROKER_SOURCES) daemon_test.cpp
+	mkdir -p build
+	c++ -I. -std=c++20 -Wall -Werror $(BROKER_SOURCES) daemon_test.cpp v1/pagebroker.pb.cc -lprotobuf $(GTEST_FLAGS) -o build/pagebroker-test
+	./build/pagebroker-test

--- a/deploy/snapshot/pagebroker/broker.hpp
+++ b/deploy/snapshot/pagebroker/broker.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "checkpoint_transaction_descriptor.hpp"
-#include "pagebroker.pb.h"
+#include "pagebroker_types.hpp"
 #include "restore_transaction_descriptor.hpp"
 #include "transfer_engine.hpp"
 

--- a/deploy/snapshot/pagebroker/checkpoint_transaction_descriptor.hpp
+++ b/deploy/snapshot/pagebroker/checkpoint_transaction_descriptor.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "pagebroker.pb.h"
+#include "pagebroker_types.hpp"
 #include "transfer_engine.hpp"
 
 namespace snapshot::pagebroker {

--- a/deploy/snapshot/pagebroker/daemon_test.cpp
+++ b/deploy/snapshot/pagebroker/daemon_test.cpp
@@ -1,0 +1,194 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+
+#include "broker.hpp"
+
+namespace fs = std::filesystem;
+using namespace snapshot::pagebroker;
+
+namespace {
+
+class BrokerTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    root_ = fs::temp_directory_path() / "pagebroker-daemon-tests" /
+            ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    fs::remove_all(root_);
+    source_ = root_ / "storage" / "source";
+    fs::create_directories(source_);
+    std::ofstream(source_ / "image") << "image";
+    broker_.emplace(root_ / "tmpfs");
+  }
+
+  void TearDown() override { fs::remove_all(root_); }
+
+  Request RequestFor(const std::string& id)
+  {
+    Request request;
+    request.set_request_id("request-" + id + "-" + std::to_string(++request_number_));
+    request.set_transaction_id(id);
+    return request;
+  }
+
+  void Configure(StorageBackend* storage, IOEngine* engine, const fs::path& directory)
+  {
+    storage->mutable_filesystem()->set_directory(directory.string());
+    engine->mutable_posix_copy();
+  }
+
+  Broker& broker() { return *broker_; }
+
+  fs::path root_;
+  fs::path source_;
+  std::optional<Broker> broker_;
+  unsigned request_number_ = 0;
+};
+
+TEST_F(BrokerTest, StagesRestoreAndCleansUpOnCommit)
+{
+  auto restore = RequestFor("restore");
+  Configure(
+      restore.mutable_staged_restore()->mutable_source(), restore.mutable_staged_restore()->mutable_io_engine(),
+      source_);
+  const auto staged = broker().HandleRequest(restore);
+  ASSERT_TRUE(staged.has_staged_restore_directory());
+  const fs::path staging_directory(staged.staged_restore_directory().image_directory());
+  EXPECT_TRUE(fs::exists(staging_directory / "image"));
+
+  const auto conflict = broker().HandleRequest(restore);
+  ASSERT_TRUE(conflict.has_failure());
+  EXPECT_EQ(conflict.failure().code(), Failure::TRANSACTION_CONFLICT);
+
+  auto commit = RequestFor("restore");
+  commit.mutable_commit();
+  EXPECT_TRUE(broker().HandleRequest(commit).has_commit_complete());
+  EXPECT_TRUE(broker().HandleRequest(commit).has_commit_complete());
+  EXPECT_FALSE(fs::exists(staging_directory));
+
+  auto abort = RequestFor("restore");
+  abort.mutable_abort();
+  const auto abort_response = broker().HandleRequest(abort);
+  ASSERT_TRUE(abort_response.has_failure());
+  EXPECT_EQ(abort_response.failure().code(), Failure::TRANSACTION_NOT_FOUND);
+}
+
+TEST_F(BrokerTest, RejectsUnsafeTransactionIDs)
+{
+  for (const auto& id :
+       {std::string("../escape"), std::string("nested/name"), std::string("nested\\name"),
+        std::string("nul\0suffix", 10)}) {
+    auto abort = RequestFor(id);
+    abort.mutable_abort();
+    const auto response = broker().HandleRequest(abort);
+    EXPECT_TRUE(response.has_failure());
+    EXPECT_EQ(response.failure().code(), Failure::INVALID_REQUEST);
+  }
+}
+
+TEST_F(BrokerTest, RejectsSymlinkInRestoreSource)
+{
+  fs::create_symlink(root_ / "storage" / "elsewhere", source_ / "link");
+  auto restore = RequestFor("symlink");
+  Configure(
+      restore.mutable_staged_restore()->mutable_source(), restore.mutable_staged_restore()->mutable_io_engine(),
+      source_);
+  const auto response = broker().HandleRequest(restore);
+  ASSERT_TRUE(response.has_failure());
+  EXPECT_EQ(response.failure().code(), Failure::STORAGE_ERROR);
+}
+
+TEST_F(BrokerTest, PublishesCheckpoint)
+{
+  const fs::path published = root_ / "storage" / "published";
+  auto prepare = RequestFor("checkpoint");
+  Configure(
+      prepare.mutable_prepare_staged_checkpoint()->mutable_destination(),
+      prepare.mutable_prepare_staged_checkpoint()->mutable_io_engine(), published);
+  const auto output = broker().HandleRequest(prepare);
+  ASSERT_TRUE(output.has_staged_checkpoint_directory());
+  const fs::path staging_directory(output.staged_checkpoint_directory().image_directory());
+  std::ofstream(staging_directory / "image") << "image";
+  std::ofstream(staging_directory / ".destination") << "image";
+
+  auto commit = RequestFor("checkpoint");
+  commit.mutable_commit();
+  EXPECT_TRUE(broker().HandleRequest(commit).has_commit_complete());
+  EXPECT_TRUE(fs::exists(published / "image"));
+  EXPECT_TRUE(fs::exists(published / ".destination"));
+  EXPECT_FALSE(fs::exists(staging_directory));
+}
+
+TEST_F(BrokerTest, ReplacesExistingCheckpoint)
+{
+  const fs::path published = root_ / "storage" / "published";
+  fs::create_directories(published);
+  std::ofstream(published / "old") << "old";
+
+  auto prepare = RequestFor("checkpoint");
+  Configure(
+      prepare.mutable_prepare_staged_checkpoint()->mutable_destination(),
+      prepare.mutable_prepare_staged_checkpoint()->mutable_io_engine(), published);
+  const auto output = broker().HandleRequest(prepare);
+  ASSERT_TRUE(output.has_staged_checkpoint_directory());
+  std::ofstream(fs::path(output.staged_checkpoint_directory().image_directory()) / "new") << "new";
+
+  auto commit = RequestFor("checkpoint");
+  commit.mutable_commit();
+  EXPECT_TRUE(broker().HandleRequest(commit).has_commit_complete());
+  EXPECT_FALSE(fs::exists(published / "old"));
+  EXPECT_TRUE(fs::exists(published / "new"));
+}
+
+TEST_F(BrokerTest, PreservesExistingPartialCheckpointDestination)
+{
+  const fs::path destination = root_ / "storage" / "blocked";
+  auto prepare = RequestFor("checkpoint");
+  Configure(
+      prepare.mutable_prepare_staged_checkpoint()->mutable_destination(),
+      prepare.mutable_prepare_staged_checkpoint()->mutable_io_engine(), destination);
+  const auto output = broker().HandleRequest(prepare);
+  ASSERT_TRUE(output.has_staged_checkpoint_directory());
+  std::ofstream(fs::path(output.staged_checkpoint_directory().image_directory()) / "image") << "image";
+  const fs::path partial = destination.string() + ".pagebroker-partial";
+  std::ofstream(partial) << "keep";
+
+  auto commit = RequestFor("checkpoint");
+  commit.mutable_commit();
+  const auto response = broker().HandleRequest(commit);
+  ASSERT_TRUE(response.has_failure());
+  EXPECT_EQ(response.failure().code(), Failure::TRANSACTION_CONFLICT);
+  EXPECT_TRUE(fs::exists(partial));
+  std::string partial_contents;
+  std::ifstream(partial) >> partial_contents;
+  EXPECT_EQ(partial_contents, "keep");
+}
+
+TEST_F(BrokerTest, AbortsRestore)
+{
+  auto restore = RequestFor("restore");
+  Configure(
+      restore.mutable_staged_restore()->mutable_source(), restore.mutable_staged_restore()->mutable_io_engine(),
+      source_);
+  const auto staged = broker().HandleRequest(restore);
+  ASSERT_TRUE(staged.has_staged_restore_directory());
+  const fs::path staging_directory(staged.staged_restore_directory().image_directory());
+
+  auto abort = RequestFor("restore");
+  abort.mutable_abort();
+  EXPECT_TRUE(broker().HandleRequest(abort).has_abort_complete());
+  EXPECT_TRUE(broker().HandleRequest(abort).has_abort_complete());
+  EXPECT_FALSE(fs::exists(staging_directory));
+
+  auto commit = RequestFor("restore");
+  commit.mutable_commit();
+  const auto commit_response = broker().HandleRequest(commit);
+  ASSERT_TRUE(commit_response.has_failure());
+  EXPECT_EQ(commit_response.failure().code(), Failure::TRANSACTION_NOT_FOUND);
+}
+
+}  // namespace

--- a/deploy/snapshot/pagebroker/pagebroker_types.hpp
+++ b/deploy/snapshot/pagebroker/pagebroker_types.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "v1/pagebroker.pb.h"
+
+namespace snapshot::pagebroker {
+using v1::Failure;
+using v1::IOEngine;
+using v1::PrepareStagedCheckpointRequest;
+using v1::Request;
+using v1::Response;
+using v1::StagedRestoreRequest;
+using v1::StorageBackend;
+}  // namespace snapshot::pagebroker


### PR DESCRIPTION
## What

GoogleTest coverage for the PageBroker daemon. Snapshot CI installs the C++ test dependencies in its tester image and runs `make -C pagebroker test`.

## Cases

- Restore staging, duplicate transaction rejection, Commit retry, and cleanup
- Abort retry and rejection of the opposite terminal operation
- Unsafe transaction ID rejection
- Symlink rejection in a restore source
- Checkpoint publication, including a `.destination` image file
- Preservation of a pre-existing partial checkpoint destination

## Requirement and validation

The tester image installs `g++`, `libgtest-dev`, `libprotobuf-dev`, `protobuf-compiler`, and `pkg-config`.

Passed:

- `pre-commit run --all-files`
- `make -C deploy/snapshot/pagebroker test`
- `docker build --target tester --tag pagebroker-tester-ci:check --build-context operator=deploy/operator -f deploy/snapshot/Dockerfile deploy/snapshot`