### PR TITLE
docs(vllm): document current benchmark sampling flags and fix the timeout default

### DIFF
--- a/docs/fern/pages/reference/backends/vllm-configuration.mdx
+++ b/docs/fern/pages/reference/backends/vllm-configuration.mdx
@@ -259,10 +259,10 @@ These flags are retained for backward compatibility and will be removed in a fut
   Environment variable: `MODEL_EXPRESS_URL`
 </ParamField>
 
-The five `--benchmark-*-granularity` flags below are the previous names for the benchmark sampling limits. Each is translated to its replacement at startup, with a deprecation warning. They are accepted in the range 1 to 1024; a value outside it raises a `ValueError`. Because the four uniform-sampling limits need both endpoints of their axis, a legacy value of `1` maps to `2` for those flags.
+The five `--benchmark-*-granularity` flags below are the previous names for the benchmark sampling limits. They are read only when `--benchmark-mode` is set and `--benchmark-points-file` is not; otherwise they are ignored entirely, and none of the translation, range checking, or deprecation warnings described here takes place. Under those conditions each is translated to its replacement at startup, with a deprecation warning, and is accepted in the range 1 to 1024; a value outside it raises a `ValueError`. Because the four uniform-sampling limits need both endpoints of their axis, a legacy value of `1` maps to `2` for those flags.
 
 <Warning>
-Passing a legacy flag together with its replacement raises a `ValueError` at startup — `cannot combine --benchmark-decode-length-granularity with --decode-max-kv-read-token-samples`, and likewise for each of the other pairs. Migrate to the replacement rather than setting both. All five are ignored when `--benchmark-points-file` is set.
+With `--benchmark-mode` set and no points file, passing a legacy flag together with its replacement raises a `ValueError` at startup — `cannot combine --benchmark-decode-length-granularity with --decode-max-kv-read-token-samples`, and likewise for each of the other pairs. Migrate to the replacement rather than setting both. All five are ignored when `--benchmark-points-file` is set.
 </Warning>
 
 <ParamField path="--benchmark-prefill-granularity" type="integer" default="null" deprecated={true}>

--- a/docs/fern/pages/reference/backends/vllm-configuration.mdx
+++ b/docs/fern/pages/reference/backends/vllm-configuration.mdx
@@ -183,6 +183,8 @@ These flags control which role this worker plays in a disaggregated deployment. 
 
 These flags control the self-benchmark sweep that runs on startup before the worker begins accepting production requests.
 
+The sweep does not walk a fixed grid of sample counts. Each axis is derived from the engine's own limits — CUDA-graph axes include every `{capture size, capture size + 1}` boundary and then continue geometrically to the engine limit, and KV-read axes use complete power-of-two block ladders plus their exact feasible maxima. The flags below are per-axis *sample limits* applied to those derived axes: if an axis has more points than its limit allows, points are selected uniformly across the sorted axis while the endpoints are retained. Raising a limit therefore measures more of the same axis; it does not change the axis itself.
+
 <ParamField path="--benchmark-mode" type="string" default="null">
   Run a self-benchmark on startup before accepting requests. Sweeps prefill input sequence lengths (ISLs) and/or decode `(context_length × batch_size)` operating points, collecting `ForwardPassMetrics` at each point.
 
@@ -191,22 +193,42 @@ These flags control the self-benchmark sweep that runs on startup before the wor
   Environment variable: `DYN_BENCHMARK_MODE`
 </ParamField>
 
-<ParamField path="--benchmark-prefill-granularity" type="integer" default="16">
-  Number of ISL sample points for the prefill sweep.
+<ParamField path="--benchmark-points-file" type="string" default="null">
+  JSON file of explicit pure prefill and decode benchmark points, applied uniformly to every data-parallel rank. The file is read and normalized once before the vLLM workers start, then the same contents are forwarded to every rank.
 
-  Environment variable: `DYN_BENCHMARK_PREFILL_GRANULARITY`
+  The file completely replaces generated grid sampling for the phases selected by `--benchmark-mode`, so all of the sample-limit flags below — and the deprecated granularity flags — are ignored when it is set. Setting it without `--benchmark-mode` raises a `ValueError`.
+
+  Environment variable: `DYN_BENCHMARK_POINTS_FILE`
 </ParamField>
 
-<ParamField path="--benchmark-decode-length-granularity" type="integer" default="6">
-  Number of context length sample points for the decode sweep.
+<ParamField path="--prefill-max-new-token-samples" type="integer" default="64">
+  Maximum number of iteration-total prefill new-token samples. Must be at least 2, so that both endpoints of the axis are always retained.
 
-  Environment variable: `DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY`
+  Environment variable: `DYN_PREFILL_MAX_NEW_TOKEN_SAMPLES`
 </ParamField>
 
-<ParamField path="--benchmark-decode-batch-granularity" type="integer" default="6">
-  Number of batch size sample points per context length for the decode sweep.
+<ParamField path="--prefill-max-kv-read-token-samples" type="integer" default="16">
+  Maximum number of iteration-total prefill KV-read-token samples, applied for each `(new tokens, batch size)` pair. Sampling always retains zero and the feasible maximum. Must be at least 2.
 
-  Environment variable: `DYN_BENCHMARK_DECODE_BATCH_GRANULARITY`
+  Environment variable: `DYN_PREFILL_MAX_KV_READ_TOKEN_SAMPLES`
+</ParamField>
+
+<ParamField path="--decode-max-kv-read-token-samples" type="integer" default="128">
+  Maximum number of iteration-total decode KV-read-token samples, applied for each batch size. Sampling always retains the minimum and the feasible maximum. Must be at least 2.
+
+  Environment variable: `DYN_DECODE_MAX_KV_READ_TOKEN_SAMPLES`
+</ParamField>
+
+<ParamField path="--decode-max-batch-size-samples" type="integer" default="128">
+  Maximum number of decode batch-size samples over the CUDA-graph-aware axis. Sampling always retains the minimum and the feasible maximum. Must be at least 2.
+
+  Environment variable: `DYN_DECODE_MAX_BATCH_SIZE_SAMPLES`
+</ParamField>
+
+<ParamField path="--prefix-max-batch-size-samples" type="integer" default="3">
+  Maximum number of prefill request-batch-size samples for each new-token point. Unlike the limits above, this one keeps the first N values of the sorted power-of-two-plus-legal-maximum axis rather than sampling uniformly, so the default of 3 selects `[1, 2, 4]` when all three are legal. Must be positive.
+
+  Environment variable: `DYN_PREFIX_MAX_BATCH_SIZE_SAMPLES`
 </ParamField>
 
 <ParamField path="--benchmark-warmup-iterations" type="integer" default="5">
@@ -221,8 +243,8 @@ These flags control the self-benchmark sweep that runs on startup before the wor
   Environment variable: `DYN_BENCHMARK_OUTPUT_PATH`
 </ParamField>
 
-<ParamField path="--benchmark-timeout" type="integer" default="300">
-  Maximum seconds to wait for the benchmark to complete. Worker startup fails if this limit is exceeded.
+<ParamField path="--benchmark-timeout" type="integer" default="900">
+  Soft limit, in seconds, for the self-benchmark. Reaching it does not fail worker startup: the iteration being measured finishes, the partial results collected so far are returned, and engine startup continues. A bounded cleanup grace still fails closed if no result is written at all. Must be positive.
 
   Environment variable: `DYN_BENCHMARK_TIMEOUT`
 </ParamField>
@@ -235,6 +257,42 @@ These flags are retained for backward compatibility and will be removed in a fut
   **Deprecated** — accepted for compatibility with older ModelExpress manifests only. The vLLM ModelExpress plugin reads its own configuration.
 
   Environment variable: `MODEL_EXPRESS_URL`
+</ParamField>
+
+The five `--benchmark-*-granularity` flags below are the previous names for the benchmark sampling limits. Each is translated to its replacement at startup, with a deprecation warning. They are accepted in the range 1 to 1024; a value outside it raises a `ValueError`. Because the four uniform-sampling limits need both endpoints of their axis, a legacy value of `1` maps to `2` for those flags.
+
+<Warning>
+Passing a legacy flag together with its replacement raises a `ValueError` at startup — `cannot combine --benchmark-decode-length-granularity with --decode-max-kv-read-token-samples`, and likewise for each of the other pairs. Migrate to the replacement rather than setting both. All five are ignored when `--benchmark-points-file` is set.
+</Warning>
+
+<ParamField path="--benchmark-prefill-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--prefill-max-new-token-samples` instead.
+
+  Environment variable: `DYN_BENCHMARK_PREFILL_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-prefill-kv-read-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--prefill-max-kv-read-token-samples` instead.
+
+  Environment variable: `DYN_BENCHMARK_PREFILL_KV_READ_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-prefill-batch-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--prefix-max-batch-size-samples` instead. This is the one legacy flag whose replacement does not sample uniformly, so a legacy value of `1` is carried across unchanged.
+
+  Environment variable: `DYN_BENCHMARK_PREFILL_BATCH_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-decode-length-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--decode-max-kv-read-token-samples` instead.
+
+  Environment variable: `DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY`
+</ParamField>
+
+<ParamField path="--benchmark-decode-batch-granularity" type="integer" default="null" deprecated={true}>
+  **Deprecated** — use `--decode-max-batch-size-samples` instead.
+
+  Environment variable: `DYN_BENCHMARK_DECODE_BATCH_GRANULARITY`
 </ParamField>
 
 ## Validation rules


### PR DESCRIPTION
## Overview:

The `## Benchmarking` section of the vLLM configuration reference documented three
`--benchmark-*-granularity` flags as current options with defaults (`16`, `6`, `6`) that
the shipped parser does not set, while the six flags that actually control benchmark
sampling today were undocumented. `--benchmark-timeout` was also documented with the
wrong default and the wrong semantics. This updates the page to match
`components/src/dynamo/vllm/backend_args.py`.

Documentation only — one file, no code or behaviour changes.

## Details:

`docs/fern/pages/reference/backends/vllm-configuration.mdx` (+69 / −11):

- **Document the current sampling flags.** Adds `--benchmark-points-file`,
  `--prefill-max-new-token-samples` (64), `--prefill-max-kv-read-token-samples` (16),
  `--decode-max-kv-read-token-samples` (128), `--decode-max-batch-size-samples` (128),
  and `--prefix-max-batch-size-samples` (3). Every default is taken from the parser as
  built by `DynamoVllmArgGroup.add_arguments`, not transcribed by hand.
- **Explain what the limits mean.** A new lead paragraph states that the sweep derives
  each axis from the engine's own limits and that these flags are per-axis *sample
  limits* over those derived axes — raising one measures more of the same axis rather
  than changing it. `--prefix-max-batch-size-samples` is called out as keeping the
  first N values instead of sampling uniformly, matching the head slice in
  `instrumented_scheduler.py`.
- **Demote the five legacy flags.** All five `--benchmark-*-granularity` flags move to
  the existing `## Deprecated` section with `deprecated={true}` and their replacement
  mapping. Two of them (`--benchmark-prefill-kv-read-granularity`,
  `--benchmark-prefill-batch-granularity`) were not on the page at all, so readers
  migrating off them had nowhere to look. A `<Warning>` records that combining a legacy
  flag with its replacement raises, quoting the parser's own message.
- **Correct `--benchmark-timeout`.** Default `300` → `900`, and the description changes
  from a hard limit ("worker startup fails") to the soft limit the code implements: the
  measured iteration finishes, partial results are returned, engine startup continues,
  and only a bounded cleanup grace fails closed if nothing was written.

### Overlap with #12979 — please read before merging

<https://github.com/ai-dynamo/dynamo/pull/12979> (branch
`dagil-nvidia/fix-6572846-planner-docs`) is open against this same file and covers three
of the same moves: documenting the current sampling flags, demoting the legacy aliases,
and leaving mode/warmup/output-path alone. It does **not** carry the
`--benchmark-timeout` correction, which is an independent defect of the same class.

Whichever is more convenient is fine — merging #12979 and cherry-picking the timeout
hunk from here is an entirely acceptable outcome. Flagging it so no reviewer has to
discover the collision themselves.

### Not changed

Three related reference-page defects reported alongside this one were checked against
`main` and are already correct there (planner capacity metric names, the CA-bundle
description, and the planner CLI examples); they were `release/1.4.0`-only. No
`release/1.4.0` file is touched here.

## Where should the reviewer start?

`docs/fern/pages/reference/backends/vllm-configuration.mdx` is the only file. Start with
the `## Benchmarking` section, then the five demoted entries in `## Deprecated`. The
defaults and the behavioural sentences are checkable against
`components/src/dynamo/vllm/backend_args.py` (flag registration around L244–L419, legacy
resolution in `_resolve_legacy_benchmark_sampling`) and
`components/src/dynamo/vllm/instrumented_scheduler.py:2474` for the
`--prefix-max-batch-size-samples` head-slice behaviour.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<sub>Tracked internally; no public GitHub issue exists for this documentation drift.</sub>

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added support for configuring benchmark points through a dedicated file.
  * Documented per-axis limits for benchmark sampling.
  * Clarified that sampling axes are derived from the engine.
  * Marked legacy granularity options as deprecated, including validation and conflict behavior.
  * Updated benchmark timeout guidance: the default is now 900 seconds, with soft-timeout and partial-result behavior described.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->