### PR TITLE
docs(router): document select session_id and fix admin-API env var

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
@@ -68,6 +68,7 @@ For basic model registration without KV routing, use `--router-mode round-robin`
 - **[Router Operations](router-operations.md)**: Replicas, persistence, and recovery
 - **[Router Examples](router-examples.md)**: Python API usage, K8s examples, and custom routing patterns
 - **[Router Testing](router-testing.md)**: Test layers from Rust unit tests to fixture-backed replay and full process E2E
+- **[Multi-DC KV Routing](multi-dc-kv-routing.md)**: Cross-datacenter KV routing and the DC Relay (experimental)
 - **[Standalone Indexer](standalone-indexer.md)**: Run the KV indexer as a separate service for independent scaling
 - **[Standalone Selection Service](standalone-selection.md)**: Expose KV-aware selection and reservation accounting over HTTP
 - **[Standalone Slot Tracker](standalone-slot-tracker.md)**: Run active-request load accounting as a separate HTTP service

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
@@ -133,7 +133,8 @@ Select a worker without booking active load:
   "routing_group": "default",
   "block_hashes": [11, 12, 13, 14, 15, 16, 17, 18],
   "sequence_hashes": [21, 22, 23, 24, 25, 26, 27, 28],
-  "isl_tokens": 512
+  "isl_tokens": 512,
+  "session_id": "session-abc"
 }
 ```
 
@@ -149,7 +150,8 @@ globally unique `selection_id`, or allow the service to generate one:
   "routing_group": "default",
   "block_hashes": [11, 12, 13, 14, 15, 16, 17, 18],
   "sequence_hashes": [21, 22, 23, 24, 25, 26, 27, 28],
-  "isl_tokens": 512
+  "isl_tokens": 512,
+  "session_id": "session-abc"
 }
 ```
 
@@ -201,6 +203,28 @@ lookups. Requests that instead supply `block_hashes`, `sequence_hashes`, and
 `isl_tokens` remain trusted precomputed inputs. The service does not reject,
 rewrite, or label those identities in keyed mode. Configure every precomputed
 hash producer with the same algorithm, key, and key ID as the selector.
+
+### `session_id`
+
+Both `POST /select` and `POST /select_and_reserve` accept an optional
+`session_id` string. It defaults to absent, and omitting it does not change
+selection. The selector carries the value through scheduling and exposes it to
+worker-selection policy as `WorkerSelectionContext::session_id()`, so a custom
+picker or scorer can implement session affinity by preferring the worker a
+session used previously.
+
+> [!NOTE]
+> `session_id` is an input to policy, not an affinity mechanism in itself. The
+> built-in selector ignores it, so it changes the chosen worker only when you
+> supply a custom picker or scorer that reads it. See
+> [Write Custom Routing Strategies](../../../advanced-customizations/custom-worker-selection.mdx).
+> It is also distinct from the frontend's own session affinity, which binds
+> sessions from request headers rather than from this API; see
+> [Configuration and Tuning](configuration-and-tuning.md).
+
+The selection service does not persist, replicate, or expire `session_id`
+bindings. It is not part of the selection response and is not retained by the
+pending-selection cache, so a `POST /reservations` replay does not carry it.
 
 ## Ray Select-Then-Reserve Flow
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
@@ -207,11 +207,12 @@ hash producer with the same algorithm, key, and key ID as the selector.
 ### `session_id`
 
 Both `POST /select` and `POST /select_and_reserve` accept an optional
-`session_id` string. It defaults to absent, and omitting it does not change
-selection. The selector carries the value through scheduling and exposes it to
-worker-selection policy as `WorkerSelectionContext::session_id()`, so a custom
-picker or scorer can implement session affinity by preferring the worker a
-session used previously.
+`session_id` string. It defaults to absent. Under the built-in selector,
+omitting it does not change selection; a custom policy that reads the field can
+select differently depending on whether it is present. The selector carries the
+value through scheduling and exposes it to worker-selection policy as
+`WorkerSelectionContext::session_id()`, so a custom picker or scorer can
+implement session affinity by preferring the worker a session used previously.
 
 > [!NOTE]
 > `session_id` is an input to policy, not an affinity mechanism in itself. The

--- a/docs/fern/pages/kubernetes/fault-tolerance/request-rejection.md
+++ b/docs/fern/pages/kubernetes/fault-tolerance/request-rejection.md
@@ -82,7 +82,8 @@ for the complete flag, environment-variable, and validation reference.
 <Step title="Adjust thresholds at runtime">
 
 Optional. Use the Frontend admin API to change thresholds for a discovered model without redeploying.
-The API is available when `DYN_ENABLE_FRONTEND_ADMIN_API=true`, which is the default.
+The API is available by default. Set `DYN_DISABLE_FRONTEND_ADMIN_API` to a truthy value to turn it
+off, which unregisters both `busy_threshold` routes so they return 404.
 
 ```bash
 kubectl port-forward svc/<deployment-name>-frontend 8000:8000 -n ${NAMESPACE}


### PR DESCRIPTION
## Overview:

Docs-only fix for two router/frontend documentation defects that mislead users:
an environment variable documented with the wrong name and polarity, and a
request field that ships on the standalone Selection API but is documented
nowhere. Also adds a missing entry to a "Next Steps" index list. No runtime
behavior changes.

## Details:

**`docs/fern/pages/kubernetes/fault-tolerance/request-rejection.md`** — the page
said the `busy_threshold` admin routes are "available when
`DYN_ENABLE_FRONTEND_ADMIN_API=true`, which is the default". No code reads a
variable of that name, so a reader who sets it observes a silent no-op. The real
control is the inverse: the admin API is on by default and is disabled by a
truthy `DYN_DISABLE_FRONTEND_ADMIN_API`
(`lib/runtime/src/config/environment_names.rs:348`,
`lib/llm/src/http/service/service_v2.rs:1072-1073`), which unregisters both
`busy_threshold` routes so they return 404 (`service_v2.rs:1185-1195`). The
wording now matches the canonical reference in `frontend-configuration.mdx`.

**`docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md`**
— `session_id` is an optional field on both `POST /select` and
`POST /select_and_reserve` (`lib/kv-router/src/services/selection/types.rs:411`,
`:439`) and reaches worker-selection policy via `WorkerSelectionContext::session_id()`
(`lib/kv-router/src/scheduling/selector/policy.rs:144-145`), but it appeared in
neither request example nor the field documentation. Adds it to both examples
and a `### session_id` subsection describing it as optional and defaulting to
absent. The subsection carries a NOTE recording two limits verified in source:
the built-in selector never reads the field (every occurrence in
`scheduling/selector/default.rs` is a `session_id: None` test fixture below
`#[cfg(test)]`), and this field is distinct from the frontend's header-driven
session affinity in `lib/llm/src/session_affinity/`. Documenting it as
"session affinity" would have promised behavior that does not exist.

**`docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md`**
— one line: the Multi-DC KV Routing page was missing from the "Next Steps" list.
Placed in the same relative position as the parallel list in `router-guide.md`
so the two stay in sync.

Scope note: an open PR (#12975) covers the sibling nvext environment-variable
defect, the CKF metrics tables, and the `router-guide.md` half of the index-list
gap. The three files here are disjoint from that PR's five files, so the two
branches merge in either order.

## Where should the reviewer start?

`docs/fern/pages/kubernetes/fault-tolerance/request-rejection.md` — the smallest
diff and the one with the clearest user impact; check the env-var name, polarity,
and default against `service_v2.rs:670` and `:1072-1073`.

Then the `### session_id` subsection at the end of the Selection API section in
`standalone-selection.md` — specifically whether the NOTE's two caveats are worth
keeping at that length, since they are the part most likely to age.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<sub>Raised from an internal documentation report (DYN-3799) against 1.4.0; no
public GitHub issue tracks it.</sub>

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for cross-datacenter key-value routing and DC Relay.
  * Documented optional session IDs for worker selection requests, including their handling and limitations.
  * Clarified that the runtime threshold API is enabled by default and how to disable it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->