### PR TITLE
fix: make vLLM runtime cache dirs writable for arbitrary UIDs

### DIFF
--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -86,9 +86,11 @@ ENV PATH=/opt/uv/bin:${PATH}
 RUN userdel -r ubuntu > /dev/null 2>&1 || true \
     && useradd -u 1000 -m -s /bin/bash -g 0 dynamo \
     && [ `id -u dynamo` -eq 1000 ] \
-    && mkdir -p /home/dynamo/.cache /opt/dynamo \
+    && mkdir -p /home/dynamo/.cache/vllm /opt/dynamo \
     && ln -sf /usr/bin/python3 /usr/local/bin/python \
-    && chown dynamo:0 /home/dynamo /home/dynamo/.cache /opt/dynamo /workspace \
+    && chown dynamo:0 /home/dynamo /home/dynamo/.cache /home/dynamo/.cache/vllm /opt/dynamo /workspace \
+    # Arbitrary OpenShift UIDs need to create the vLLM and Triton caches under $HOME.
+    && chmod g+rwx /home/dynamo /home/dynamo/.cache /home/dynamo/.cache/vllm \
     && mkdir -p /etc/profile.d \
     && echo 'umask 002' > /etc/profile.d/00-umask.sh
 


### PR DESCRIPTION
The image creates /home/dynamo and /home/dynamo/.cache owned by dynamo:0 with no group write bit, and does not create the vLLM cache root at all. A pod running under a UID other than 1000 with gid 0 therefore cannot create $VLLM_CACHE_ROOT or $HOME/.triton, and the worker aborts during engine initialization with EACCES on the first torch compile.

Pre-create the vLLM cache root and grant group 0 write access on it and its parents, matching the frontend and planner images.

ref: OPS-8186
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility in OpenShift environments by ensuring vLLM and Triton cache directories are writable for arbitrary container user IDs.
  * Prevented cache-related permission errors during runtime operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->