### PR TITLE
fix(epp): reserve prefill load during routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,7 @@ dependencies = [
  "anyhow",
  "axum 0.8.4",
  "bytes",
+ "dashmap",
  "dynamo-kv-router",
  "dynamo-llm",
  "dynamo-protocols",

--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -27,6 +27,7 @@ dynamo-runtime = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true }
 bytes = { workspace = true }
+dashmap = { workspace = true }
 futures = { workspace = true }
 hyper-util = { workspace = true, features = ["tokio", "http2", "server-auto"] }
 k8s-openapi = { workspace = true }

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -8,6 +8,7 @@
 //! ext_proc server calls these types directly as async Rust.
 
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -119,16 +120,39 @@ pub struct Router {
     served_model: String,
 }
 
-/// Releases a prefill booking if routing fails before the ext-proc server adopts it.
+/// A prefill booking that can be asynchronously released.
 ///
-/// After [`Self::disarm`] transfers the booking into [`Router::prefill_bookings`],
-/// response callbacks own its lifecycle instead.
-struct PrefillReservationGuard {
-    reservation: Option<PrefillReservation>,
+/// Kept monomorphized so the guard and booking map do not allocate a boxed
+/// cleanup closure on the routing path.
+trait PrefillBooking: Send + 'static {
+    fn release(self) -> impl Future<Output = Result<()>> + Send;
+    fn worker_id(&self) -> u64;
+    fn dp_rank(&self) -> u32;
 }
 
-impl PrefillReservationGuard {
-    fn new(reservation: PrefillReservation) -> Self {
+impl PrefillBooking for PrefillReservation {
+    fn release(self) -> impl Future<Output = Result<()>> + Send {
+        async move { PrefillReservation::release(&self).await }
+    }
+
+    fn worker_id(&self) -> u64 {
+        PrefillReservation::worker_id(self)
+    }
+
+    fn dp_rank(&self) -> u32 {
+        PrefillReservation::dp_rank(self)
+    }
+}
+
+/// Releases a prefill booking if routing fails before the ext-proc server adopts it.
+/// After [`Self::disarm`] transfers the booking into [`Router::prefill_bookings`],
+/// response callbacks own its lifecycle instead.
+struct PrefillReservationGuard<R: PrefillBooking = PrefillReservation> {
+    reservation: Option<R>,
+}
+
+impl<R: PrefillBooking> PrefillReservationGuard<R> {
+    fn new(reservation: R) -> Self {
         Self {
             reservation: Some(reservation),
         }
@@ -148,14 +172,14 @@ impl PrefillReservationGuard {
             .dp_rank()
     }
 
-    fn disarm(&mut self) -> PrefillReservation {
+    fn disarm(&mut self) -> R {
         self.reservation
             .take()
             .expect("reservation guard is disarmed once")
     }
 }
 
-impl Drop for PrefillReservationGuard {
+impl<R: PrefillBooking> Drop for PrefillReservationGuard<R> {
     fn drop(&mut self) {
         if let Some(reservation) = self.reservation.take() {
             tokio::spawn(async move {
@@ -167,6 +191,23 @@ impl Drop for PrefillReservationGuard {
     }
 }
 
+/// Remove and release a booking once. Both response lifecycle callbacks use
+/// this helper so terminal completion before first output and duplicate signals
+/// have identical behavior.
+async fn release_prefill_booking<R: PrefillBooking>(
+    prefill_bookings: &DashMap<String, R>,
+    booking_id: &str,
+) {
+    if let Some((_, reservation)) = prefill_bookings.remove(booking_id)
+        && let Err(error) = reservation.release().await
+    {
+        tracing::debug!(
+            reservation_id = booking_id,
+            %error,
+            "Failed to release native EPP prefill reservation"
+        );
+    }
+}
 impl Router {
     /// Initialize the router from discovery.
     ///
@@ -1623,15 +1664,7 @@ impl EndpointPicker for Router {
         if booking_id.is_empty() {
             return;
         }
-        if let Some((_, reservation)) = self.prefill_bookings.remove(booking_id)
-            && let Err(error) = reservation.release().await
-        {
-            tracing::debug!(
-                reservation_id = booking_id,
-                %error,
-                "Failed to release native EPP prefill reservation"
-            );
-        }
+        release_prefill_booking(&self.prefill_bookings, booking_id).await;
         if let Err(e) = self.mark_prefill_complete(booking_id).await {
             tracing::debug!(
                 reservation_id = booking_id,
@@ -1655,15 +1688,7 @@ impl EndpointPicker for Router {
                 "Request complete with usage"
             );
         }
-        if let Some((_, reservation)) = self.prefill_bookings.remove(booking_id)
-            && let Err(error) = reservation.release().await
-        {
-            tracing::debug!(
-                reservation_id = booking_id,
-                %error,
-                "Failed to release native EPP prefill reservation"
-            );
-        }
+        release_prefill_booking(&self.prefill_bookings, booking_id).await;
         if let Err(e) = self.free_request(booking_id).await {
             tracing::debug!(
                 reservation_id = booking_id,
@@ -1678,6 +1703,83 @@ impl EndpointPicker for Router {
 mod tests {
     use super::*;
     use k8s_openapi::api::core::v1::Pod;
+
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    struct StubPrefillBooking {
+        releases: Arc<AtomicUsize>,
+    }
+
+    impl PrefillBooking for StubPrefillBooking {
+        fn release(self) -> impl Future<Output = Result<()>> + Send {
+            async move {
+                self.releases.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        fn worker_id(&self) -> u64 {
+            0
+        }
+
+        fn dp_rank(&self) -> u32 {
+            0
+        }
+    }
+
+    async fn wait_for_release(releases: &AtomicUsize, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while releases.load(Ordering::SeqCst) != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("prefill booking release should complete");
+    }
+
+    #[tokio::test]
+    async fn prefill_reservation_guard_releases_only_when_armed() {
+        let releases = Arc::new(AtomicUsize::new(0));
+
+        {
+            let _guard = PrefillReservationGuard::new(StubPrefillBooking {
+                releases: Arc::clone(&releases),
+            });
+        }
+        wait_for_release(&releases, 1).await;
+
+        let mut guard = PrefillReservationGuard::new(StubPrefillBooking {
+            releases: Arc::clone(&releases),
+        });
+        let booking = guard.disarm();
+        drop(guard);
+        tokio::task::yield_now().await;
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+        drop(booking);
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn prefill_booking_map_releases_terminal_before_first_output_once() {
+        let releases = Arc::new(AtomicUsize::new(0));
+        let bookings = DashMap::new();
+        bookings.insert(
+            "booking".to_string(),
+            StubPrefillBooking {
+                releases: Arc::clone(&releases),
+            },
+        );
+
+        release_prefill_booking(&bookings, "booking").await;
+        assert!(bookings.is_empty());
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+
+        release_prefill_booking(&bookings, "booking").await;
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+    }
 
     #[test]
     fn tenant_header_overrides_body_cache_namespace() {

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -8,7 +8,6 @@
 //! ext_proc server calls these types directly as async Rust.
 
 use std::collections::{HashMap, HashSet};
-use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -120,82 +119,11 @@ pub struct Router {
     served_model: String,
 }
 
-/// A prefill booking that can be asynchronously released.
-///
-/// Kept monomorphized so the guard and booking map do not allocate a boxed
-/// cleanup closure on the routing path.
-trait PrefillBooking: Send + 'static {
-    fn release(self) -> impl Future<Output = Result<()>> + Send;
-    fn worker_id(&self) -> u64;
-    fn dp_rank(&self) -> u32;
-}
-
-impl PrefillBooking for PrefillReservation {
-    fn release(self) -> impl Future<Output = Result<()>> + Send {
-        async move { PrefillReservation::release(&self).await }
-    }
-
-    fn worker_id(&self) -> u64 {
-        PrefillReservation::worker_id(self)
-    }
-
-    fn dp_rank(&self) -> u32 {
-        PrefillReservation::dp_rank(self)
-    }
-}
-
-/// Releases a prefill booking if routing fails before the ext-proc server adopts it.
-/// After [`Self::disarm`] transfers the booking into [`Router::prefill_bookings`],
-/// response callbacks own its lifecycle instead.
-struct PrefillReservationGuard<R: PrefillBooking = PrefillReservation> {
-    reservation: Option<R>,
-}
-
-impl<R: PrefillBooking> PrefillReservationGuard<R> {
-    fn new(reservation: R) -> Self {
-        Self {
-            reservation: Some(reservation),
-        }
-    }
-
-    fn worker_id(&self) -> u64 {
-        self.reservation
-            .as_ref()
-            .expect("reservation guard is accessed only before disarm")
-            .worker_id()
-    }
-
-    fn dp_rank(&self) -> u32 {
-        self.reservation
-            .as_ref()
-            .expect("reservation guard is accessed only before disarm")
-            .dp_rank()
-    }
-
-    fn disarm(&mut self) -> R {
-        self.reservation
-            .take()
-            .expect("reservation guard is disarmed once")
-    }
-}
-
-impl<R: PrefillBooking> Drop for PrefillReservationGuard<R> {
-    fn drop(&mut self) {
-        if let Some(reservation) = self.reservation.take() {
-            tokio::spawn(async move {
-                if let Err(error) = reservation.release().await {
-                    tracing::debug!(%error, "Failed to release unadopted prefill reservation");
-                }
-            });
-        }
-    }
-}
-
 /// Remove and release a booking once. Both response lifecycle callbacks use
 /// this helper so terminal completion before first output and duplicate signals
 /// have identical behavior.
-async fn release_prefill_booking<R: PrefillBooking>(
-    prefill_bookings: &DashMap<String, R>,
+async fn release_prefill_booking(
+    prefill_bookings: &DashMap<String, PrefillReservation>,
     booking_id: &str,
 ) {
     if let Some((_, reservation)) = prefill_bookings.remove(booking_id)
@@ -1505,7 +1433,7 @@ impl EndpointPicker for Router {
         //
         // If the prefill router is not activated (no prefill workers discovered yet, or the inner
         // router has been deactivated), fall back to aggregated routing.
-        let mut prefill_booking = self
+        let prefill_booking = self
             .route_prefill(
                 &format!("epp-prefill/{reservation_id}"),
                 &tokens,
@@ -1515,8 +1443,7 @@ impl EndpointPicker for Router {
                 allowed_worker_ids.clone(),
                 routing_constraints.clone(),
             )
-            .await
-            .map(PrefillReservationGuard::new);
+            .await;
 
         let is_disaggregated = match &prefill_booking {
             Ok(_) => true,
@@ -1590,9 +1517,9 @@ impl EndpointPicker for Router {
             .as_ref()
             .ok()
             .map(|booking| (booking.worker_id(), booking.dp_rank()));
-        if let Ok(booking) = &mut prefill_booking {
+        if let Ok(booking) = prefill_booking {
             self.prefill_bookings
-                .insert(reservation_id.clone(), booking.disarm());
+                .insert(reservation_id.clone(), booking);
         }
 
         // Build routing headers: x-dynamo-worker-instance-id, x-dynamo-dp-rank,
@@ -1704,82 +1631,7 @@ mod tests {
     use super::*;
     use k8s_openapi::api::core::v1::Pod;
 
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
-
-    struct StubPrefillBooking {
-        releases: Arc<AtomicUsize>,
-    }
-
-    impl PrefillBooking for StubPrefillBooking {
-        fn release(self) -> impl Future<Output = Result<()>> + Send {
-            async move {
-                self.releases.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            }
-        }
-
-        fn worker_id(&self) -> u64 {
-            0
-        }
-
-        fn dp_rank(&self) -> u32 {
-            0
-        }
-    }
-
-    async fn wait_for_release(releases: &AtomicUsize, expected: usize) {
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while releases.load(Ordering::SeqCst) != expected {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("prefill booking release should complete");
-    }
-
-    #[tokio::test]
-    async fn prefill_reservation_guard_releases_only_when_armed() {
-        let releases = Arc::new(AtomicUsize::new(0));
-
-        {
-            let _guard = PrefillReservationGuard::new(StubPrefillBooking {
-                releases: Arc::clone(&releases),
-            });
-        }
-        wait_for_release(&releases, 1).await;
-
-        let mut guard = PrefillReservationGuard::new(StubPrefillBooking {
-            releases: Arc::clone(&releases),
-        });
-        let booking = guard.disarm();
-        drop(guard);
-        tokio::task::yield_now().await;
-        assert_eq!(releases.load(Ordering::SeqCst), 1);
-        drop(booking);
-        assert_eq!(releases.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn prefill_booking_map_releases_terminal_before_first_output_once() {
-        let releases = Arc::new(AtomicUsize::new(0));
-        let bookings = DashMap::new();
-        bookings.insert(
-            "booking".to_string(),
-            StubPrefillBooking {
-                releases: Arc::clone(&releases),
-            },
-        );
-
-        release_prefill_booking(&bookings, "booking").await;
-        assert!(bookings.is_empty());
-        assert_eq!(releases.load(Ordering::SeqCst), 1);
-
-        release_prefill_booking(&bookings, "booking").await;
-        assert_eq!(releases.load(Ordering::SeqCst), 1);
-    }
+    use std::sync::{Arc, atomic::Ordering};
 
     #[test]
     fn tenant_header_overrides_body_cache_namespace() {

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -1545,10 +1545,12 @@ impl EndpointPicker for Router {
                 "x-dynamo-prefill-instance-id".to_string(),
                 format!("{}", prefill_worker_id),
             ));
-            headers.push((
-                "x-dynamo-prefill-dp-rank".to_string(),
-                prefill_dp_rank.to_string(),
-            ));
+            if let Some(prefill_dp_rank) = prefill_dp_rank {
+                headers.push((
+                    "x-dynamo-prefill-dp-rank".to_string(),
+                    prefill_dp_rank.to_string(),
+                ));
+            }
         } else {
             headers.push((
                 "x-dynamo-routing-mode".to_string(),

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -462,6 +462,7 @@ impl Router {
     /// tier. `routing_constraints` carries the request's required/preferred
     /// taints (lifted from `nvext.routing_constraints`); a hard `required_taints`
     /// mismatch excludes a worker from selection.
+    #[expect(clippy::too_many_arguments)]
     pub async fn route_prefill(
         &self,
         reservation_id: &str,

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -14,10 +14,11 @@ use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 
 use anyhow::Result;
+use dashmap::DashMap;
 use dynamo_kv_router::config::{RouterConfigOverride, try_kv_router_config_from_dynamo_env};
 use dynamo_kv_router::protocols::{RoutingConstraints, WorkerWithDpRank};
 use dynamo_llm::discovery::{ModelManager, WORKER_TYPE_DECODE};
-use dynamo_llm::kv_router::prefill_router::PrefillQueryOutcome;
+use dynamo_llm::kv_router::prefill_router::PrefillReservation;
 use dynamo_llm::kv_router::{ManagedKvRouter, PrefillRouter};
 use dynamo_llm::model_card::ModelDeploymentCard;
 use dynamo_llm::preprocessor::OpenAIPreprocessor;
@@ -32,6 +33,7 @@ use dynamo_runtime::discovery::{
 };
 use dynamo_runtime::pipeline::RouterMode;
 use dynamo_runtime::{DistributedRuntime, Runtime};
+use uuid::Uuid;
 
 use crate::epp_router::endpoint_in_subset;
 use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo, ResponseUsage};
@@ -108,12 +110,61 @@ const DYNAMO_CONTAINER_PORT_NAME: &str = "http";
 /// without the `block_on` / unsafe FFI overhead.
 pub struct Router {
     prefill_router: Arc<PrefillRouter>,
+    prefill_bookings: DashMap<String, PrefillReservation>,
     decode_router: ManagedKvRouter,
     preprocessor: Arc<OpenAIPreprocessor>,
     runtime: Runtime,
     worker_index: Arc<RwLock<WorkerEndpointIndex>>,
     pod_store_ready: Arc<AtomicBool>,
     served_model: String,
+}
+
+/// Releases a prefill booking if routing fails before the ext-proc server adopts it.
+///
+/// After [`Self::disarm`] transfers the booking into [`Router::prefill_bookings`],
+/// response callbacks own its lifecycle instead.
+struct PrefillReservationGuard {
+    reservation: Option<PrefillReservation>,
+}
+
+impl PrefillReservationGuard {
+    fn new(reservation: PrefillReservation) -> Self {
+        Self {
+            reservation: Some(reservation),
+        }
+    }
+
+    fn worker_id(&self) -> u64 {
+        self.reservation
+            .as_ref()
+            .expect("reservation guard is accessed only before disarm")
+            .worker_id()
+    }
+
+    fn dp_rank(&self) -> u32 {
+        self.reservation
+            .as_ref()
+            .expect("reservation guard is accessed only before disarm")
+            .dp_rank()
+    }
+
+    fn disarm(&mut self) -> PrefillReservation {
+        self.reservation
+            .take()
+            .expect("reservation guard is disarmed once")
+    }
+}
+
+impl Drop for PrefillReservationGuard {
+    fn drop(&mut self) {
+        if let Some(reservation) = self.reservation.take() {
+            tokio::spawn(async move {
+                if let Err(error) = reservation.release().await {
+                    tracing::debug!(%error, "Failed to release unadopted prefill reservation");
+                }
+            });
+        }
+    }
 }
 
 impl Router {
@@ -218,6 +269,7 @@ impl Router {
         // does not tear down any background work.
         Ok(Self {
             prefill_router,
+            prefill_bookings: DashMap::new(),
             decode_router,
             preprocessor: bootstrap.preprocessor,
             runtime,
@@ -434,7 +486,7 @@ impl Router {
             .collect()
     }
 
-    /// Route a prefill request. Returns (worker_id, dp_rank).
+    /// Atomically select and reserve a prefill worker.
     ///
     /// Queue priorities are forwarded to the prefill scheduler. `priority_jump`
     /// adjusts the policy score, while `strict_priority` selects the primary
@@ -443,22 +495,21 @@ impl Router {
     /// mismatch excludes a worker from selection.
     pub async fn route_prefill(
         &self,
+        reservation_id: &str,
         tokens: &[u32],
         cache_namespace: Option<String>,
         priority_jump: f64,
         strict_priority: u32,
         allowed_worker_ids: Option<HashSet<u64>>,
         routing_constraints: RoutingConstraints,
-    ) -> Result<(u64, Option<u32>)> {
+    ) -> Result<PrefillReservation> {
         if let Some(ref ids) = allowed_worker_ids {
             self.prefill_router.register_workers(ids);
         }
 
-        // TODO(epp-prefill-booking): Atomically reserve the selected prefill worker
-        // and release it on first output, cancellation, or routing failure.
-        let outcome = self
-            .prefill_router
-            .query_prefill_worker(
+        self.prefill_router
+            .reserve_prefill_worker(
+                reservation_id,
                 tokens,
                 None,
                 None,
@@ -469,19 +520,7 @@ impl Router {
                 routing_constraints,
             )
             .await
-            .map_err(|e| anyhow::anyhow!("Prefill query failed: {:?}", e))?;
-
-        match outcome {
-            // Advisory only: the gateway owns dispatch and lifecycle state.
-            PrefillQueryOutcome::Routed { worker_id, dp_rank } => Ok((worker_id, dp_rank)),
-            PrefillQueryOutcome::QueueRejected { rejection } => Err(anyhow::anyhow!(
-                "Prefill router policy-class queue rejection: policy_class={}, limit_kind={}, current={}, limit={}",
-                rejection.policy_class,
-                rejection.limit_kind,
-                rejection.current,
-                rejection.limit
-            )),
-        }
+            .map_err(|e| anyhow::anyhow!("Prefill reservation failed: {e}"))
     }
 
     /// Route a decode request. Returns (WorkerWithDpRank, overlap_blocks).
@@ -1419,13 +1458,15 @@ impl EndpointPicker for Router {
             .map_err(|e| PickError::TokenizationFailed(e.to_string()))?;
         let cache_namespace =
             cache_namespace_with_header_override(&req.headers, body_cache_namespace);
+        let reservation_id = Uuid::new_v4().to_string();
 
         // Try prefill routing first (disaggregated mode).
         //
         // If the prefill router is not activated (no prefill workers discovered yet, or the inner
         // router has been deactivated), fall back to aggregated routing.
-        let prefill_result = self
+        let mut prefill_booking = self
             .route_prefill(
+                &format!("epp-prefill/{reservation_id}"),
                 &tokens,
                 cache_namespace.clone(),
                 priority_jump,
@@ -1433,9 +1474,10 @@ impl EndpointPicker for Router {
                 allowed_worker_ids.clone(),
                 routing_constraints.clone(),
             )
-            .await;
+            .await
+            .map(PrefillReservationGuard::new);
 
-        let is_disaggregated = match &prefill_result {
+        let is_disaggregated = match &prefill_booking {
             Ok(_) => true,
             Err(e) => {
                 tracing::debug!(
@@ -1446,10 +1488,6 @@ impl EndpointPicker for Router {
             }
         };
 
-        // TODO(epp-atomic-admission): Replace query-only selection plus add_request
-        // with one tracked operation. Propagate booking failures, use an internal
-        // booking ID independent of x-request-id, handle cancellation races, roll
-        // back endpoint-resolution failures, and never forward to an unbooked fallback.
         let (decode_worker, _overlap) = self
             .route_decode(
                 &tokens,
@@ -1489,23 +1527,31 @@ impl EndpointPicker for Router {
         };
 
         // Register the request with the router for bookkeeping (load tracking).
-        if !req.request_id.is_empty()
-            && let Err(e) = self
-                .add_request(
-                    &req.request_id,
-                    &tokens,
-                    decode_worker.worker_id,
-                    decode_worker.dp_rank,
-                    is_disaggregated,
-                    cache_namespace,
-                )
-                .await
+        if let Err(e) = self
+            .add_request(
+                &reservation_id,
+                &tokens,
+                decode_worker.worker_id,
+                decode_worker.dp_rank,
+                is_disaggregated,
+                cache_namespace,
+            )
+            .await
         {
             tracing::warn!(
                 request_id = %req.request_id,
                 error = %e,
                 "Failed to register request with router bookkeeping"
             );
+        }
+
+        let prefill_worker = prefill_booking
+            .as_ref()
+            .ok()
+            .map(|booking| (booking.worker_id(), booking.dp_rank()));
+        if let Ok(booking) = &mut prefill_booking {
+            self.prefill_bookings
+                .insert(reservation_id.clone(), booking.disarm());
         }
 
         // Build routing headers: x-dynamo-worker-instance-id, x-dynamo-dp-rank,
@@ -1521,7 +1567,7 @@ impl EndpointPicker for Router {
             ),
         ];
 
-        if let Ok((prefill_worker_id, prefill_dp_rank)) = &prefill_result {
+        if let Some((prefill_worker_id, prefill_dp_rank)) = prefill_worker {
             headers.push((
                 "x-dynamo-routing-mode".to_string(),
                 "disaggregated".to_string(),
@@ -1530,9 +1576,10 @@ impl EndpointPicker for Router {
                 "x-dynamo-prefill-instance-id".to_string(),
                 format!("{}", prefill_worker_id),
             ));
-            if let Some(rank) = prefill_dp_rank {
-                headers.push(("x-dynamo-prefill-dp-rank".to_string(), rank.to_string()));
-            }
+            headers.push((
+                "x-dynamo-prefill-dp-rank".to_string(),
+                prefill_dp_rank.to_string(),
+            ));
         } else {
             headers.push((
                 "x-dynamo-routing-mode".to_string(),
@@ -1568,30 +1615,39 @@ impl EndpointPicker for Router {
             fallbacks: vec![],
             headers,
             token_ids,
-            reservation_id: None,
+            reservation_id: Some(reservation_id),
         })
     }
 
-    async fn on_prefill_complete(&self, request_id: &str) {
-        if request_id.is_empty() {
+    async fn on_prefill_complete(&self, booking_id: &str) {
+        if booking_id.is_empty() {
             return;
         }
-        if let Err(e) = self.mark_prefill_complete(request_id).await {
+        if let Some((_, reservation)) = self.prefill_bookings.remove(booking_id)
+            && let Err(error) = reservation.release().await
+        {
             tracing::debug!(
-                request_id,
+                reservation_id = booking_id,
+                %error,
+                "Failed to release native EPP prefill reservation"
+            );
+        }
+        if let Err(e) = self.mark_prefill_complete(booking_id).await {
+            tracing::debug!(
+                reservation_id = booking_id,
                 error = %e,
                 "Failed to mark prefill complete in router bookkeeping"
             );
         }
     }
 
-    async fn on_request_complete_with_usage(&self, request_id: &str, usage: Option<ResponseUsage>) {
-        if request_id.is_empty() {
+    async fn on_request_complete_with_usage(&self, booking_id: &str, usage: Option<ResponseUsage>) {
+        if booking_id.is_empty() {
             return;
         }
         if let Some(usage) = usage {
             tracing::debug!(
-                request_id,
+                reservation_id = booking_id,
                 prompt_tokens = ?usage.prompt_tokens,
                 completion_tokens = ?usage.completion_tokens,
                 total_tokens = ?usage.total_tokens,
@@ -1599,9 +1655,18 @@ impl EndpointPicker for Router {
                 "Request complete with usage"
             );
         }
-        if let Err(e) = self.free_request(request_id).await {
+        if let Some((_, reservation)) = self.prefill_bookings.remove(booking_id)
+            && let Err(error) = reservation.release().await
+        {
             tracing::debug!(
-                request_id,
+                reservation_id = booking_id,
+                %error,
+                "Failed to release native EPP prefill reservation"
+            );
+        }
+        if let Err(e) = self.free_request(booking_id).await {
+            tracing::debug!(
+                reservation_id = booking_id,
                 error = %e,
                 "Failed to free request from router bookkeeping"
             );

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -789,9 +789,6 @@ impl<
         &self,
         request_id: Option<&str>,
     ) -> Option<Box<RequestLifecycleLease>> {
-        if !self.queueing_enabled {
-            return None;
-        }
         let request_id = request_id?;
         Some(Box::new(RequestLifecycleLease {
             cleanup: Arc::clone(&self.cleanup),
@@ -2523,14 +2520,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn disabled_queueing_has_no_cancellation_lease() {
-        let (queue, _slots) = make_queue(1, 16, 64, None);
+    async fn disabled_queueing_lifecycle_lease_releases_an_admitted_booking_on_cancellation() {
+        let isl = 512;
+        let (queue, slots) = make_queue(1, 16, isl, None);
+        let request_id = "default-path-cancelled";
+        let (mut request, response_rx) = make_request(request_id, isl);
+        request.mode = ScheduleMode::TrackedWithLifecycle {
+            request_id: request_id.to_string(),
+        };
 
-        assert!(
-            queue
-                .new_request_lifecycle_lease(Some("default-path"))
-                .is_none()
-        );
+        let lease = queue
+            .new_request_lifecycle_lease(Some(request_id))
+            .expect("lifecycle-tracked request must receive a cancellation lease");
+        let lease = queue
+            .enqueue_with_block_hashes_and_lease(request, None, Some(lease))
+            .await
+            .expect("scheduler must return the admitted request lease");
+        response_rx
+            .await
+            .expect("scheduler response sender dropped")
+            .expect("request should be admitted before cancellation");
+
+        drop(lease);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while slots.any_worker_matches_active_tokens(Instant::now(), |_, tokens| tokens != 0) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancellation lease cleanup did not release the admitted booking");
+        slots.assert_completely_drained(decay_now());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -1296,6 +1296,61 @@ where
         .await
     }
 
+    /// Admit a best-match request with scheduler-owned cancellation cleanup.
+    ///
+    /// If the returned future is dropped while queueing is enabled, the scheduler
+    /// retracts the pending request. Callers own normal lifecycle cleanup after
+    /// this method returns a routed booking.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn find_best_match_details_with_lifecycle(
+        &self,
+        context_id: Option<&str>,
+        tokens: &[u32],
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        router_config_override: Option<&RouterConfigOverride>,
+        update_states: bool,
+        return_routing_hashes: bool,
+        lora_name: Option<String>,
+        cache_namespace: Option<String>,
+        priority_jump: f64,
+        strict_priority: u32,
+        expected_output_tokens: Option<u32>,
+        pinned_worker: Option<WorkerWithDpRank>,
+        allowed_worker_ids: Option<HashSet<WorkerId>>,
+        routing_constraints: RoutingConstraints,
+    ) -> anyhow::Result<FindBestMatchOutcome> {
+        match self
+            .find_best_match_details_with_policy_class_inner(
+                context_id,
+                tokens,
+                block_mm_infos,
+                router_config_override,
+                update_states,
+                return_routing_hashes,
+                lora_name,
+                cache_namespace,
+                priority_jump,
+                strict_priority,
+                None,
+                None,
+                expected_output_tokens,
+                None,
+                pinned_worker,
+                allowed_worker_ids,
+                routing_constraints,
+                FindBestMatchAdmission::WithAdmission {
+                    track_lifecycle: true,
+                },
+            )
+            .await?
+        {
+            FindBestMatchInnerOutcome::WithAdmission(outcome) => Ok(outcome.into_parts().0),
+            FindBestMatchInnerOutcome::WithoutAdmission(_) => {
+                unreachable!("with-admission routing returned advisory outcome")
+            }
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn find_best_match_details_with_policy_class(
         &self,

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -1298,9 +1298,9 @@ where
 
     /// Admit a best-match request with scheduler-owned cancellation cleanup.
     ///
-    /// If the returned future is dropped while queueing is enabled, the scheduler
-    /// retracts the pending request. Callers own normal lifecycle cleanup after
-    /// this method returns a routed booking.
+    /// If the future is dropped before it returns, the scheduler retracts any
+    /// pending or admitted booking. After success, the returned outcome carries
+    /// the tracked attempt identity required for exact lifecycle cleanup.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn find_best_match_details_with_lifecycle(
         &self,
@@ -1318,7 +1318,7 @@ where
         pinned_worker: Option<WorkerWithDpRank>,
         allowed_worker_ids: Option<HashSet<WorkerId>>,
         routing_constraints: RoutingConstraints,
-    ) -> anyhow::Result<FindBestMatchOutcome> {
+    ) -> anyhow::Result<AdmittedFindBestMatchOutcome> {
         match self
             .find_best_match_details_with_policy_class_inner(
                 context_id,
@@ -1344,7 +1344,7 @@ where
             )
             .await?
         {
-            FindBestMatchInnerOutcome::WithAdmission(outcome) => Ok(outcome.into_parts().0),
+            FindBestMatchInnerOutcome::WithAdmission(outcome) => Ok(outcome),
             FindBestMatchInnerOutcome::WithoutAdmission(_) => {
                 unreachable!("with-admission routing returned advisory outcome")
             }
@@ -1929,6 +1929,11 @@ where
         worker: WorkerWithDpRank,
     ) -> Result<(), SequenceError> {
         self.scheduler.free_if_worker(request_id, worker).await
+    }
+
+    #[doc(hidden)]
+    pub(crate) fn booking_cleanup(&self) -> scheduler::SchedulerBookingCleanup {
+        self.scheduler.booking_cleanup()
     }
 
     pub(crate) fn request_lease_manager(&self) -> &request_lease::RequestLeaseManager {

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -45,6 +45,7 @@ mod activation;
 mod admission;
 mod conditional_bypass;
 mod query;
+pub use query::PrefillReservation;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -1,45 +1,42 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 
 use anyhow::Result;
 use dynamo_kv_router::{
     protocols::{BlockExtraInfo, RoutingConstraints, WorkerId, WorkerWithDpRank},
+    scheduling::{
+        AdmissionAttempt,
+        queue::{SchedulerBookingCleanup, SchedulerBookingDescriptor},
+    },
     selector::WorkerSelector,
 };
 
 use super::{PrefillError, PrefillLifecycleState, PrefillQueryOutcome, PrefillRouter};
-use crate::{
-    kv_router::{KvRouter, sequence::SequenceError},
-    local_model::runtime_config::ModelRuntimeConfig,
-};
+use crate::local_model::runtime_config::ModelRuntimeConfig;
 
-/// A prefill booking that remains tied to the chooser that admitted it.
+/// A prefill booking that owns cleanup of the exact scheduler attempt it admitted.
 ///
-/// KV-routed bookings retain their admitting chooser so cleanup is independent
-/// of a later [`PrefillRouter`] binding change. Built-in router modes use an
-/// untracked, advisory booking whose release is a no-op.
-pub struct PrefillReservation<Sel = dynamo_kv_router::selector::DefaultWorkerSelector>
-where
-    Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
-{
+/// KV-routed bookings retain their exact scheduler booking descriptor, so
+/// cleanup is independent of a later [`PrefillRouter`] binding change and
+/// cannot release a newer booking that reused its request ID and worker.
+/// Built-in router modes use an untracked, advisory booking whose release is a no-op.
+#[must_use]
+pub struct PrefillReservation {
     worker: WorkerWithDpRank,
-    release: ReservationRelease<Sel>,
+    release: ReservationRelease,
 }
 
-enum ReservationRelease<Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static> {
+enum ReservationRelease {
     Kv {
-        chooser: Arc<KvRouter<Sel>>,
-        scheduler_id: String,
+        cleanup: SchedulerBookingCleanup,
+        booking: Option<SchedulerBookingDescriptor>,
     },
     None,
 }
 
-impl<Sel> PrefillReservation<Sel>
-where
-    Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
-{
+impl PrefillReservation {
     pub fn worker_id(&self) -> WorkerId {
         self.worker.worker_id
     }
@@ -48,17 +45,23 @@ where
         self.worker.dp_rank
     }
 
-    /// Free this booking from the chooser that admitted it, when tracked.
-    pub async fn release(&self) -> Result<()> {
-        match &self.release {
-            ReservationRelease::Kv {
-                chooser,
-                scheduler_id,
-            } => match chooser.free_if_worker(scheduler_id, self.worker).await {
-                Ok(()) | Err(SequenceError::RequestNotFound { .. }) => Ok(()),
-                Err(error) => Err(error.into()),
-            },
-            ReservationRelease::None => Ok(()),
+    /// Release this booking and wait for the scheduler to acknowledge it.
+    pub async fn release(mut self) -> Result<()> {
+        if let ReservationRelease::Kv { cleanup, booking } = &mut self.release
+            && let Some(booking) = booking.take()
+        {
+            cleanup.enqueue_acknowledged(booking).wait().await?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for PrefillReservation {
+    fn drop(&mut self) {
+        if let ReservationRelease::Kv { cleanup, booking } = &mut self.release
+            && let Some(booking) = booking.take()
+        {
+            cleanup.enqueue(booking);
         }
     }
 }
@@ -69,12 +72,12 @@ where
 {
     /// Select a prefill worker and reserve it when KV routing is enabled.
     ///
-    /// KV-routed reservations own the exact chooser selected at admission
-    /// time. If this future is dropped while queued, the scheduler retracts
-    /// its pending admission; after success, the caller must release the
-    /// reservation on first output, terminal completion, or an abandoned
-    /// request. Built-in modes retain their existing advisory selection
-    /// semantics and return an untracked reservation.
+    /// If this future is dropped while queued, the scheduler retracts its
+    /// pending admission. After success, the returned reservation owns the
+    /// exact scheduler booking and enqueues cleanup when dropped; explicit
+    /// release waits for that cleanup to be acknowledged. Built-in modes retain
+    /// their existing advisory selection semantics and return an untracked
+    /// reservation.
     #[expect(clippy::too_many_arguments)]
     pub async fn reserve_prefill_worker(
         &self,
@@ -87,7 +90,7 @@ where
         strict_priority: u32,
         allowed_worker_ids: Option<HashSet<WorkerId>>,
         routing_constraints: RoutingConstraints,
-    ) -> Result<PrefillReservation<Sel>> {
+    ) -> Result<PrefillReservation> {
         if reservation_id.is_empty() {
             anyhow::bail!("prefill reservation ID must not be empty");
         }
@@ -108,8 +111,7 @@ where
                 release: ReservationRelease::None,
             });
         };
-        let chooser = Arc::clone(chooser);
-        let outcome = chooser
+        let admitted = chooser
             .find_best_match_details_with_lifecycle(
                 Some(reservation_id),
                 token_ids,
@@ -127,13 +129,21 @@ where
                 routing_constraints,
             )
             .await?;
+        let (outcome, attempt) = admitted.into_parts();
         match outcome {
             crate::kv_router::FindBestMatchOutcome::Routed { worker, .. } => {
+                let AdmissionAttempt::Tracked(attempt_id) = attempt else {
+                    anyhow::bail!("prefill reservation admission did not return a tracked attempt");
+                };
                 Ok(PrefillReservation {
                     worker,
                     release: ReservationRelease::Kv {
-                        chooser,
-                        scheduler_id: reservation_id.to_string(),
+                        cleanup: chooser.booking_cleanup(),
+                        booking: Some(SchedulerBookingDescriptor {
+                            request_id: reservation_id.to_string(),
+                            worker,
+                            attempt_id,
+                        }),
                     },
                 })
             }
@@ -553,11 +563,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prefill_reservation_releases_the_admitting_chooser_after_rebind() {
+    async fn prefill_reservation_cleans_exact_bookings_after_rebind() {
         let (router, original_chooser) = tracked_prefill_router().await;
         let reservation = router
             .reserve_prefill_worker(
                 "epp-prefill/rebind",
+                &[1u32; 64],
+                None,
+                None,
+                None,
+                0.0,
+                0,
+                None,
+                RoutingConstraints::default(),
+            )
+            .await
+            .unwrap();
+
+        let dropped_reservation = router
+            .reserve_prefill_worker(
+                "epp-prefill/drop",
                 &[1u32; 64],
                 None,
                 None,
@@ -583,15 +608,21 @@ mod tests {
         router.binding.store(Some(replacement));
         reservation.release().await.unwrap();
 
-        let loads = original_chooser
-            .get_potential_loads(&[], None, None, None, None)
-            .await
-            .unwrap();
-        assert!(loads.iter().all(|load| load.potential_prefill_tokens == 0));
-
-        // A terminal callback may arrive after first output already released the
-        // booking; the second release must be an idempotent no-op.
-        reservation.release().await.unwrap();
+        drop(dropped_reservation);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let loads = original_chooser
+                    .get_potential_loads(&[], None, None, None, None)
+                    .await
+                    .unwrap();
+                if loads.iter().all(|load| load.potential_prefill_tokens == 0) {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped reservation must release its admitted booking");
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -568,6 +568,10 @@ mod tests {
             .await
             .unwrap();
         assert!(loads.iter().all(|load| load.potential_prefill_tokens == 0));
+
+        // A terminal callback may arrive after first output already released the
+        // booking; the second release must be an idempotent no-op.
+        reservation.release().await.unwrap();
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -17,15 +17,23 @@ use crate::{
 
 /// A prefill booking that remains tied to the chooser that admitted it.
 ///
-/// The caller owns this value until it is released. Keeping the chooser here
-/// makes cleanup independent of a later [`PrefillRouter`] binding change.
+/// KV-routed bookings retain their admitting chooser so cleanup is independent
+/// of a later [`PrefillRouter`] binding change. Built-in router modes use an
+/// untracked, advisory booking whose release is a no-op.
 pub struct PrefillReservation<Sel = dynamo_kv_router::selector::DefaultWorkerSelector>
 where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
-    chooser: Arc<KvRouter<Sel>>,
-    scheduler_id: String,
     worker: WorkerWithDpRank,
+    release: ReservationRelease<Sel>,
+}
+
+enum ReservationRelease<Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static> {
+    Kv {
+        chooser: Arc<KvRouter<Sel>>,
+        scheduler_id: String,
+    },
+    None,
 }
 
 impl<Sel> PrefillReservation<Sel>
@@ -40,15 +48,17 @@ where
         self.worker.dp_rank
     }
 
-    /// Free this booking from the chooser that admitted it.
+    /// Free this booking from the chooser that admitted it, when tracked.
     pub async fn release(&self) -> Result<()> {
-        match self
-            .chooser
-            .free_if_worker(&self.scheduler_id, self.worker)
-            .await
-        {
-            Ok(()) | Err(SequenceError::RequestNotFound { .. }) => Ok(()),
-            Err(error) => Err(error.into()),
+        match &self.release {
+            ReservationRelease::Kv {
+                chooser,
+                scheduler_id,
+            } => match chooser.free_if_worker(scheduler_id, self.worker).await {
+                Ok(()) | Err(SequenceError::RequestNotFound { .. }) => Ok(()),
+                Err(error) => Err(error.into()),
+            },
+            ReservationRelease::None => Ok(()),
         }
     }
 }
@@ -57,13 +67,14 @@ impl<Sel> PrefillRouter<Sel>
 where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
-    /// Atomically select and reserve a KV-routed prefill worker.
+    /// Select a prefill worker and reserve it when KV routing is enabled.
     ///
-    /// The returned [`PrefillReservation`] owns the exact chooser selected at
-    /// admission time. If this future is dropped while queued, the scheduler
-    /// retracts its pending admission; after success, the caller must release
-    /// the reservation on first output, terminal completion, or an abandoned
-    /// request.
+    /// KV-routed reservations own the exact chooser selected at admission
+    /// time. If this future is dropped while queued, the scheduler retracts
+    /// its pending admission; after success, the caller must release the
+    /// reservation on first output, terminal completion, or an abandoned
+    /// request. Built-in modes retain their existing advisory selection
+    /// semantics and return an untracked reservation.
     #[expect(clippy::too_many_arguments)]
     pub async fn reserve_prefill_worker(
         &self,
@@ -87,8 +98,15 @@ where
             .binding
             .load_full()
             .ok_or_else(|| anyhow::anyhow!(PrefillError::NotActivated))?;
-        let Some(chooser) = binding.router.kv_router_if_enabled() else {
-            anyhow::bail!("prefill reservation requires KV routing");
+        let router = &binding.router;
+        let Some(chooser) = router.kv_router_if_enabled() else {
+            let worker_id = router
+                .peek_next_worker()
+                .ok_or_else(|| anyhow::anyhow!("No workers available for prefill"))?;
+            return Ok(PrefillReservation {
+                worker: WorkerWithDpRank::new(worker_id, 0),
+                release: ReservationRelease::None,
+            });
         };
         let chooser = Arc::clone(chooser);
         let outcome = chooser
@@ -112,9 +130,11 @@ where
         match outcome {
             crate::kv_router::FindBestMatchOutcome::Routed { worker, .. } => {
                 Ok(PrefillReservation {
-                    chooser,
-                    scheduler_id: reservation_id.to_string(),
                     worker,
+                    release: ReservationRelease::Kv {
+                        chooser,
+                        scheduler_id: reservation_id.to_string(),
+                    },
                 })
             }
             crate::kv_router::FindBestMatchOutcome::QueueRejected { rejection } => {
@@ -575,7 +595,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rr_prefill_queries_do_not_advance_shared_dispatch_cursor() {
+    async fn rr_prefill_queries_and_reservations_do_not_advance_dispatch_cursor() {
         let runtime = Runtime::from_current().unwrap();
         let discovery_root = tempfile::tempdir().unwrap();
         let namespace = "prefill-query-rr";
@@ -588,6 +608,23 @@ mod tests {
             dispatch.clone(),
         )
         .await;
+
+        let reservation = prefill_router
+            .reserve_prefill_worker(
+                "non-kv-reservation",
+                &[1, 2, 3],
+                None,
+                None,
+                None,
+                0.0,
+                0,
+                None,
+                RoutingConstraints::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(reservation.worker_id(), expected_workers[0]);
+        reservation.release().await.unwrap();
 
         let concurrent_peeks = join_all((0..16).map(|_| query_worker(&prefill_router))).await;
         assert!(

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -25,6 +25,7 @@ use crate::local_model::runtime_config::ModelRuntimeConfig;
 #[must_use]
 pub struct PrefillReservation {
     worker: WorkerWithDpRank,
+    dp_rank: Option<u32>,
     release: ReservationRelease,
 }
 
@@ -41,8 +42,8 @@ impl PrefillReservation {
         self.worker.worker_id
     }
 
-    pub fn dp_rank(&self) -> u32 {
-        self.worker.dp_rank
+    pub fn dp_rank(&self) -> Option<u32> {
+        self.dp_rank
     }
 
     /// Release this booking and wait for the scheduler to acknowledge it.
@@ -108,6 +109,7 @@ where
                 .ok_or_else(|| anyhow::anyhow!("No workers available for prefill"))?;
             return Ok(PrefillReservation {
                 worker: WorkerWithDpRank::new(worker_id, 0),
+                dp_rank: None,
                 release: ReservationRelease::None,
             });
         };
@@ -137,6 +139,7 @@ where
                 };
                 Ok(PrefillReservation {
                     worker,
+                    dp_rank: Some(worker.dp_rank),
                     release: ReservationRelease::Kv {
                         cleanup: chooser.booking_cleanup(),
                         booking: Some(SchedulerBookingDescriptor {
@@ -580,6 +583,7 @@ mod tests {
             .await
             .unwrap();
 
+        assert!(reservation.dp_rank().is_some());
         let dropped_reservation = router
             .reserve_prefill_worker(
                 "epp-prefill/drop",
@@ -655,6 +659,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(reservation.worker_id(), expected_workers[0]);
+        assert_eq!(reservation.dp_rank(), None);
         reservation.release().await.unwrap();
 
         let concurrent_peeks = join_all((0..16).map(|_| query_worker(&prefill_router))).await;

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -1,19 +1,134 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use anyhow::Result;
-use dynamo_kv_router::protocols::{BlockExtraInfo, RoutingConstraints, WorkerId};
-use dynamo_kv_router::selector::WorkerSelector;
+use dynamo_kv_router::{
+    protocols::{BlockExtraInfo, RoutingConstraints, WorkerId, WorkerWithDpRank},
+    selector::WorkerSelector,
+};
 
 use super::{PrefillError, PrefillLifecycleState, PrefillQueryOutcome, PrefillRouter};
-use crate::local_model::runtime_config::ModelRuntimeConfig;
+use crate::{
+    kv_router::{KvRouter, sequence::SequenceError},
+    local_model::runtime_config::ModelRuntimeConfig,
+};
+
+/// A prefill booking that remains tied to the chooser that admitted it.
+///
+/// The caller owns this value until it is released. Keeping the chooser here
+/// makes cleanup independent of a later [`PrefillRouter`] binding change.
+pub struct PrefillReservation<Sel = dynamo_kv_router::selector::DefaultWorkerSelector>
+where
+    Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
+{
+    chooser: Arc<KvRouter<Sel>>,
+    scheduler_id: String,
+    worker: WorkerWithDpRank,
+}
+
+impl<Sel> PrefillReservation<Sel>
+where
+    Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
+{
+    pub fn worker_id(&self) -> WorkerId {
+        self.worker.worker_id
+    }
+
+    pub fn dp_rank(&self) -> u32 {
+        self.worker.dp_rank
+    }
+
+    /// Free this booking from the chooser that admitted it.
+    pub async fn release(&self) -> Result<()> {
+        match self
+            .chooser
+            .free_if_worker(&self.scheduler_id, self.worker)
+            .await
+        {
+            Ok(()) | Err(SequenceError::RequestNotFound { .. }) => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+}
 
 impl<Sel> PrefillRouter<Sel>
 where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
+    /// Atomically select and reserve a KV-routed prefill worker.
+    ///
+    /// The returned [`PrefillReservation`] owns the exact chooser selected at
+    /// admission time. If this future is dropped while queued, the scheduler
+    /// retracts its pending admission; after success, the caller must release
+    /// the reservation on first output, terminal completion, or an abandoned
+    /// request.
+    #[expect(clippy::too_many_arguments)]
+    pub async fn reserve_prefill_worker(
+        &self,
+        reservation_id: &str,
+        token_ids: &[u32],
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        lora_name: Option<String>,
+        cache_namespace: Option<String>,
+        priority_jump: f64,
+        strict_priority: u32,
+        allowed_worker_ids: Option<HashSet<WorkerId>>,
+        routing_constraints: RoutingConstraints,
+    ) -> Result<PrefillReservation<Sel>> {
+        if reservation_id.is_empty() {
+            anyhow::bail!("prefill reservation ID must not be empty");
+        }
+        if self.lifecycle_state() != PrefillLifecycleState::Active {
+            return Err(anyhow::anyhow!(PrefillError::NotActivated));
+        }
+        let binding = self
+            .binding
+            .load_full()
+            .ok_or_else(|| anyhow::anyhow!(PrefillError::NotActivated))?;
+        let Some(chooser) = binding.router.kv_router_if_enabled() else {
+            anyhow::bail!("prefill reservation requires KV routing");
+        };
+        let chooser = Arc::clone(chooser);
+        let outcome = chooser
+            .find_best_match_details_with_lifecycle(
+                Some(reservation_id),
+                token_ids,
+                block_mm_infos,
+                None,
+                true,
+                false,
+                lora_name,
+                cache_namespace,
+                priority_jump,
+                strict_priority,
+                None,
+                None,
+                allowed_worker_ids,
+                routing_constraints,
+            )
+            .await?;
+        match outcome {
+            crate::kv_router::FindBestMatchOutcome::Routed { worker, .. } => {
+                Ok(PrefillReservation {
+                    chooser,
+                    scheduler_id: reservation_id.to_string(),
+                    worker,
+                })
+            }
+            crate::kv_router::FindBestMatchOutcome::QueueRejected { rejection } => {
+                anyhow::bail!(
+                    "prefill router policy-class queue rejection: policy_class={}, limit_kind={}, current={}, limit={}",
+                    rejection.policy_class,
+                    rejection.limit_kind,
+                    rejection.current,
+                    rejection.limit,
+                )
+            }
+        }
+    }
+
     /// Query the best prefill worker without executing a request.
     ///
     /// This query is advisory and does not book scheduler or occupancy state;
@@ -91,11 +206,13 @@ where
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::HashMap,
         sync::{Arc, Mutex},
         time::Duration,
     };
 
     use async_trait::async_trait;
+    use dynamo_kv_router::{config::KvRouterConfig, selector::DefaultWorkerSelector};
     use dynamo_runtime::{
         DistributedRuntime, Runtime,
         component::Instance,
@@ -110,14 +227,17 @@ mod tests {
         traits::DistributedRuntimeProvider,
     };
     use futures::{StreamExt, future::join_all};
+    use tokio::sync::watch;
 
     use super::*;
     use crate::{
         discovery::ModelManager,
-        kv_router::{RouterLoadSource, RoutingHost, RoutingLoadContext},
+        kv_router::prefill_router::PrefillBinding,
+        kv_router::{KvPushRouter, KvRouter, RouterLoadSource, RoutingHost, RoutingLoadContext},
         protocols::common::{
             FinishReason, llm_backend::LLMEngineOutput, preprocessor::PreprocessedRequest,
         },
+        worker_type::WorkerType,
     };
 
     type LlmResponse = dynamo_runtime::protocols::annotated::Annotated<LLMEngineOutput>;
@@ -330,6 +450,124 @@ mod tests {
         );
         worker_runtimes.push(router_runtime);
         (shared, prefill, worker_runtimes, workers)
+    }
+
+    async fn tracked_binding(
+        label: &str,
+    ) -> (
+        Arc<PrefillBinding<DefaultWorkerSelector>>,
+        Arc<KvRouter<DefaultWorkerSelector>>,
+    ) {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed = DistributedRuntime::new(runtime, DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let component = distributed
+            .namespace(format!(
+                "prefill-reservation-{label}-{}",
+                uuid::Uuid::new_v4()
+            ))
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap();
+        let endpoint = component.endpoint("generate");
+        let endpoint_id = endpoint.id();
+        let client = endpoint.client().await.unwrap();
+        let (_workers_tx, workers_rx) = watch::channel(HashMap::from([
+            (7, ModelRuntimeConfig::default()),
+            (8, ModelRuntimeConfig::default()),
+        ]));
+        let config = KvRouterConfig {
+            overlap_score_credit: 0.0,
+            router_temperature: 0.0,
+            use_kv_events: false,
+            router_track_active_blocks: false,
+            router_track_prefill_tokens: true,
+            skip_initial_worker_wait: true,
+            ..Default::default()
+        };
+        let chooser = Arc::new(
+            KvRouter::new_with_worker_role(
+                endpoint,
+                client.clone(),
+                workers_rx,
+                None,
+                16,
+                DefaultWorkerSelector::new(Some(config.clone()), "prefill"),
+                Some(config),
+                None,
+                Some(WorkerType::Prefill),
+                "prefill",
+                Some(format!("prefill-reservation-{label}")),
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let push_router =
+            PushRouter::<PreprocessedRequest, LlmResponse>::from_client(client, RouterMode::KV)
+                .await
+                .unwrap();
+        let binding = Arc::new(PrefillBinding {
+            endpoint_id,
+            router: Arc::new(KvPushRouter::new(push_router, chooser.clone(), None).unwrap()),
+            prefill_router_mode: RouterMode::KV,
+        });
+        (binding, chooser)
+    }
+
+    async fn tracked_prefill_router() -> (
+        Arc<PrefillRouter<DefaultWorkerSelector>>,
+        Arc<KvRouter<DefaultWorkerSelector>>,
+    ) {
+        let (binding, chooser) = tracked_binding("primary").await;
+        let router = PrefillRouter::disabled(Arc::new(ModelManager::new()), RouterMode::KV, None);
+        router.binding.store(Some(binding));
+        router.lifecycle.store(
+            PrefillLifecycleState::Active as u8,
+            std::sync::atomic::Ordering::Release,
+        );
+        (router, chooser)
+    }
+
+    #[tokio::test]
+    async fn prefill_reservation_releases_the_admitting_chooser_after_rebind() {
+        let (router, original_chooser) = tracked_prefill_router().await;
+        let reservation = router
+            .reserve_prefill_worker(
+                "epp-prefill/rebind",
+                &[1u32; 64],
+                None,
+                None,
+                None,
+                0.0,
+                0,
+                None,
+                RoutingConstraints::default(),
+            )
+            .await
+            .unwrap();
+
+        let loads = original_chooser
+            .get_potential_loads(&[], None, None, None, None)
+            .await
+            .unwrap();
+        assert!(
+            loads.iter().any(|load| load.potential_prefill_tokens > 0),
+            "reservation did not add prefill load: {loads:?}"
+        );
+
+        let (replacement, _) = tracked_binding("replacement").await;
+        router.binding.store(Some(replacement));
+        reservation.release().await.unwrap();
+
+        let loads = original_chooser
+            .get_potential_loads(&[], None, None, None, None)
+            .await
+            .unwrap();
+        assert!(loads.iter().all(|load| load.potential_prefill_tokens == 0));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #12864.

Native Rust EPP previously queried a prefill worker without admitting it into scheduler state. Concurrent cache-hot requests could therefore select the same prefill worker before prior choices contributed projected prefill load.

This PR makes native EPP atomically reserve KV-routed prefill capacity and carries that booking through the request lifecycle.

- EPP creates an internal UUID reservation ID and routes prefill through `PrefillRouter::reserve_prefill_worker`.
- KV routing atomically selects and admits the worker; EPP retains the resulting booking until a prefill-complete or terminal request callback.
- `PrefillReservation` is the RAII owner of its scheduler booking. It stores an attempt-fenced descriptor `(request ID, worker, attempt ID)`:
  - `Drop` enqueues non-blocking cleanup.
  - `release(self)` consumes the reservation and waits for acknowledged cleanup.
  - The attempt ID prevents delayed cleanup from releasing a newer booking that reused the same request ID and worker.
- Scheduler lifecycle leases now exist for every `TrackedWithLifecycle` admission, including when queueing is disabled, so cancellation during admission retracts an admitted booking rather than retaining prefill load until stale expiry.
- Built-in non-KV prefill modes continue to use the existing advisory selection path and return an untracked, no-op reservation. This preserves disaggregation instead of silently falling back to aggregated execution.

EPP no longer owns a separate `tokio::spawn`-based reservation guard. Any early return or cancellation after successful admission drops the reservation, which enqueues cleanup through the scheduler’s existing channel.

## Follow-up

The non-KV compatibility behavior is intentionally advisory. A follow-up should add a stateful non-KV select-and-reserve API that:

- advances round-robin selection exactly once;
- retains and releases occupancy reservations for least-loaded, P2C, and device-aware routing; and
- selects without dispatching through `PushRouter`, because EPP owns downstream HTTP dispatch.

## Scope

This is intentionally limited to native Rust EPP and the existing KV-router lifecycle machinery. It does not add that broader non-KV routing-lifecycle abstraction.

## Validation

- `cargo test -p dynamo-kv-router --lib` — 946 passed, 2 ignored
- `cargo test -p dynamo-llm kv_router::prefill_router::query::tests --lib` — 3 passed
- `cargo test -p dynamo-ext-proc epp --lib` — 63 passed
- `cargo check -p dynamo-llm -p dynamo-ext-proc`
- `cargo fmt --all --check`
- `git diff --check`