### PR TITLE
fix(recipes): declare decode mode in the DeepSeek-R1 vLLM disagg recipe (cherry-pick #13037)

### DIFF
--- a/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
+++ b/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
@@ -74,6 +74,8 @@ spec:
           args:
             - --model
             - /model-cache/deepseek-r1
+            - --disaggregation-mode
+            - decode
             - --served-model-name
             - deepseek-ai/DeepSeek-R1
             - --all2all-backend


### PR DESCRIPTION
## Summary

Cherry-pick of #13037 to `release/1.4.0`. The pick applies cleanly and the diff is identical to the main-side change.

The decode worker in `recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml` never received `--disaggregation-mode`, so it registered as `worker_type: aggregated` instead of `decode`. The prefill worker declares `needs: [["decode"]]`, so the frontend readiness check found no decode worker and the model was never exposed.

The failure presents as healthy: every pod reaches `1/1 Running` and `/health` reports all instances up, while `/v1/models` returns an empty list and `/v1/chat/completions` returns 503 `"Model not ready"`. The real cause only shows in `/v1/models/deepseek-ai%2FDeepSeek-R1/ready`, as `"no namespace has all required worker types live"`.

## Change

```yaml
- --disaggregation-mode
- decode
```

Added immediately after `--model`, matching where the prefill worker in the same file declares its own mode.

## Scope

Every deployment under `recipes/` on this branch was parsed and its `decode` and `prefill` services compared. This file was the only one where one role declares the mode and its peer does not.

## Verification

YAML parses and the asymmetry check reports zero on this branch. Reproducing the original failure needs 32 H200 GPUs across 4 nodes, so a cluster run before close is still worthwhile.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->