### PR TITLE
fix(vllm): measure self-benchmark decode after admission

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -2886,7 +2886,14 @@ class InstrumentedScheduler(AsyncScheduler):
         )
         if max_model_len < 3:
             return 0
-        min_blocks_per_request = self._bench_blocks_per_req(2)
+        # The smallest steady decode request has two resident main-model
+        # tokens, then allocates one new token plus speculative lookahead.
+        min_blocks_per_request = self._bench_blocks_per_req(
+            min(
+                3 + getattr(self, "num_lookahead_tokens", 0),
+                max_model_len,
+            )
+        )
         if min_blocks_per_request < 1:
             feasible_max_batch = max_num_running_reqs
         else:
@@ -2945,19 +2952,23 @@ class InstrumentedScheduler(AsyncScheduler):
         except ValueError:
             return False
         # A decode point admits at max(1, ctx-1) and measures its steady step
-        # one position later, so a request occupies max(ctx, 2) + 1 slots and
-        # the runner's post-step bookkeeping writes through slot
-        # max(ctx, 2) + 2, which must stay within the negotiated
-        # max_model_len (ctx + 2 for the ordinary ctx >= 2 case; one extra
-        # slot for clamped ctx = 1 entries, which run one token deeper than
-        # their nominal coordinate).
+        # one position later. The steady allocation reserves one new token
+        # plus speculative lookahead after max(ctx, 2) resident tokens. The
+        # runner's post-step bookkeeping writes through slot max(ctx, 2) + 2,
+        # which must stay within the negotiated max_model_len.
         max_model_len = self._bench_capacity_limit("max_model_len")
         if any(
             max(context_len, 2) + 2 > max_model_len for context_len in context_lengths
         ):
             return False
+        lookahead_tokens = getattr(self, "num_lookahead_tokens", 0)
         required_blocks = sum(
-            self._bench_blocks_per_req(max(context_len, 2) + 1)
+            self._bench_blocks_per_req(
+                min(
+                    max(context_len, 2) + 1 + lookahead_tokens,
+                    max_model_len,
+                )
+            )
             for context_len in context_lengths
         )
         return required_blocks <= self._bench_grid_usable_blocks(

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -3729,10 +3729,13 @@ class InstrumentedScheduler(AsyncScheduler):
             pass  # fall through to inject next point
 
         elif self._bench_active_req_ids:
+            # The point deadline is rank-local. READY must unconditionally
+            # proceed to the re-armed ADP barrier; otherwise one rank can send
+            # a result while a peer sends ready. Soft timeouts stop the sweep
+            # at the next synchronized point boundary instead.
             if (
                 self._bench_decode_stage == _DecodePointStage.READY
                 and getattr(self, "_bench_extra_steps_left", 0) > 0
-                and not self._bench_point_result_timed_out()
             ):
                 steady = self._bench_make_steady_step()
                 if steady is not None:

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -1570,10 +1570,8 @@ class InstrumentedScheduler(AsyncScheduler):
                 empty = SchedulerOutput(
                     scheduled_new_reqs=[],
                     scheduled_cached_reqs=CachedRequestData.make_empty(),
-                    # vLLM's persistent input batch retains rows by membership
-                    # in this map. Keep the benchmark requests resident while
-                    # an async admission or measurement output is in flight,
-                    # but schedule zero model work for them.
+                    # Zero-valued membership retains benchmark rows in vLLM's
+                    # persistent input batch without scheduling model work.
                     num_scheduled_tokens=dict.fromkeys(self._bench_active_req_ids, 0),
                     total_num_scheduled_tokens=0,
                     scheduled_spec_decode_tokens={},
@@ -1600,10 +1598,8 @@ class InstrumentedScheduler(AsyncScheduler):
                     empty.ec_connector_metadata = (
                         self.ec_connector.build_connector_meta(empty)
                     )
-                # This frame does not advance scheduler request state and must
-                # not create AsyncScheduler output placeholders. The map is a
-                # worker-side residency signal only; update_from_output passes
-                # a sanitized copy into normal scheduler output processing.
+                # Do not advance request state or create async placeholders.
+                # The parent update receives a copy without retention entries.
                 return empty
 
         return self._schedule_and_record_time(throttle_prefills)
@@ -3733,10 +3729,8 @@ class InstrumentedScheduler(AsyncScheduler):
             pass  # fall through to inject next point
 
         elif self._bench_active_req_ids:
-            # The point deadline is rank-local. READY must unconditionally
-            # proceed to the re-armed ADP barrier; otherwise one rank can send
-            # a result while a peer sends ready. Soft timeouts stop the sweep
-            # at the next synchronized point boundary instead.
+            # Rank-local deadlines cannot decide whether READY enters the ADP
+            # measurement barrier. Soft timeouts stop between points.
             if (
                 self._bench_decode_stage == _DecodePointStage.READY
                 and getattr(self, "_bench_extra_steps_left", 0) > 0
@@ -3755,15 +3749,10 @@ class InstrumentedScheduler(AsyncScheduler):
                         )
                     self._bench_extra_steps_left -= 1
                     self._bench_decode_stage = _DecodePointStage.MEASURING
-                    # Re-arm the READY/GO barrier so attention-DP ranks cannot
-                    # run a retention frame on one rank while peers run the
-                    # measured batch. schedule() records the timestamp after
-                    # this barrier, keeping synchronization out of the sample.
+                    # Re-arm the ADP barrier; schedule() timestamps after it.
                     self._bench_sync_pending = True
                     return steady
-                # Feasibility reserves the steady step's slots. Failing fast
-                # lets _bench_abort notify attention-DP peers instead of making
-                # one rank wait on a barrier that another rank never enters.
+                # Abort a reserved-slot failure so ADP peers do not wait.
                 raise RuntimeError(
                     "failed to allocate the reserved steady-state decode slots"
                 )
@@ -3771,8 +3760,7 @@ class InstrumentedScheduler(AsyncScheduler):
                 _DecodePointStage.ADMITTING,
                 _DecodePointStage.MEASURING,
             }:
-                # The scheduler emits retention-only empty outputs while these
-                # GPU passes are in flight, so neither pass is dispatched twice.
+                # Wait without redispatching an in-flight pass.
                 return None
             if len(self._bench_current_fpms) < getattr(self, "_bench_expected_fpms", 1):
                 if not self._bench_point_result_timed_out():

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -1602,8 +1602,8 @@ class InstrumentedScheduler(AsyncScheduler):
                     )
                 # This frame does not advance scheduler request state and must
                 # not create AsyncScheduler output placeholders. The map is a
-                # worker-side residency signal only; update_from_output clears
-                # it before normal scheduler output processing.
+                # worker-side residency signal only; update_from_output passes
+                # a sanitized copy into normal scheduler output processing.
                 return empty
 
         return self._schedule_and_record_time(throttle_prefills)
@@ -1666,6 +1666,7 @@ class InstrumentedScheduler(AsyncScheduler):
         model_output_arrival = (
             time.monotonic() if scheduler_output.total_num_scheduled_tokens > 0 else 0.0
         )
+        scheduler_update_output = scheduler_output
         if (
             scheduler_output.total_num_scheduled_tokens == 0
             and scheduler_output.num_scheduled_tokens
@@ -1674,8 +1675,10 @@ class InstrumentedScheduler(AsyncScheduler):
                 raise RuntimeError(
                     "zero-token benchmark retention output contains positive work"
                 )
-            scheduler_output.num_scheduled_tokens = {}
-        result = super().update_from_output(scheduler_output, model_runner_output)
+            scheduler_update_output = replace(scheduler_output, num_scheduled_tokens={})
+        result = super().update_from_output(
+            scheduler_update_output, model_runner_output
+        )
 
         if scheduler_output.total_num_scheduled_tokens > 0:
             t_sched = self._schedule_times.popleft() if self._schedule_times else 0.0
@@ -1697,7 +1700,8 @@ class InstrumentedScheduler(AsyncScheduler):
                 scheduled=scheduled,
             )
             self._publish_or_record_metrics(metrics)
-            self._bench_advance_decode_stage_after_output()
+            if is_benchmark_point:
+                self._bench_advance_decode_stage_after_output()
         else:
             self._last_update_time = 0.0
 

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -1455,6 +1455,8 @@ class _FpmPublisherThread:
 
 
 class InstrumentedScheduler(AsyncScheduler):
+    _bench_decode_stage: _DecodePointStage
+
     def __init__(
         self,
         vllm_config: "VllmConfig",

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -1579,7 +1579,7 @@ class InstrumentedScheduler(AsyncScheduler):
                     num_common_prefix_blocks=(
                         [0] * self.kv_cache_manager.num_kv_cache_groups
                     ),
-                    finished_req_ids=self.finished_req_ids,
+                    finished_req_ids=set(self.finished_req_ids),
                     free_encoder_mm_hashes=[],
                 )
                 # See _bench_inject_fake_decode for the rationale; the
@@ -1696,8 +1696,7 @@ class InstrumentedScheduler(AsyncScheduler):
                 scheduled=scheduled,
             )
             self._publish_or_record_metrics(metrics)
-            if is_benchmark_point:
-                self._bench_advance_decode_stage_after_output()
+            self._bench_advance_decode_stage_after_output()
         else:
             self._last_update_time = 0.0
 

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -165,6 +165,16 @@ class _BenchPhase(enum.Enum):
     DONE = "done"
 
 
+class _DecodePointStage(enum.Enum):
+    """Lifecycle of one two-pass decode benchmark point."""
+
+    IDLE = "idle"
+    ADMITTING = "admitting"
+    READY = "ready"
+    MEASURING = "measuring"
+    COMPLETE = "complete"
+
+
 @dataclass
 class BenchmarkPoint:
     point_type: str  # "prefill" or "decode"
@@ -1560,7 +1570,11 @@ class InstrumentedScheduler(AsyncScheduler):
                 empty = SchedulerOutput(
                     scheduled_new_reqs=[],
                     scheduled_cached_reqs=CachedRequestData.make_empty(),
-                    num_scheduled_tokens={},
+                    # vLLM's persistent input batch retains rows by membership
+                    # in this map. Keep the benchmark requests resident while
+                    # an async admission or measurement output is in flight,
+                    # but schedule zero model work for them.
+                    num_scheduled_tokens=dict.fromkeys(self._bench_active_req_ids, 0),
                     total_num_scheduled_tokens=0,
                     scheduled_spec_decode_tokens={},
                     scheduled_encoder_inputs={},
@@ -1586,7 +1600,10 @@ class InstrumentedScheduler(AsyncScheduler):
                     empty.ec_connector_metadata = (
                         self.ec_connector.build_connector_meta(empty)
                     )
-                self._update_after_schedule(empty)
+                # This frame does not advance scheduler request state and must
+                # not create AsyncScheduler output placeholders. The map is a
+                # worker-side residency signal only; update_from_output clears
+                # it before normal scheduler output processing.
                 return empty
 
         return self._schedule_and_record_time(throttle_prefills)
@@ -1649,6 +1666,15 @@ class InstrumentedScheduler(AsyncScheduler):
         model_output_arrival = (
             time.monotonic() if scheduler_output.total_num_scheduled_tokens > 0 else 0.0
         )
+        if (
+            scheduler_output.total_num_scheduled_tokens == 0
+            and scheduler_output.num_scheduled_tokens
+        ):
+            if any(scheduler_output.num_scheduled_tokens.values()):
+                raise RuntimeError(
+                    "zero-token benchmark retention output contains positive work"
+                )
+            scheduler_output.num_scheduled_tokens = {}
         result = super().update_from_output(scheduler_output, model_runner_output)
 
         if scheduler_output.total_num_scheduled_tokens > 0:
@@ -1657,20 +1683,11 @@ class InstrumentedScheduler(AsyncScheduler):
             is_benchmark_point = self._bench_active and (
                 self._bench_should_record_scheduled(scheduled)
             )
-            if is_benchmark_point and self._bench_steady_fpm_expected():
-                # Steady-state sample of a two-step decode point. Under async
-                # scheduling its schedule() ran while the admission step was
-                # still on the GPU, so the narrow schedule->output span would
-                # also count that wait; the inter-update period is the true
-                # iteration time (and is what the non-benchmark path reports
-                # for production steps).
-                wall_time = model_output_arrival - self._last_update_time
-            else:
-                wall_time = self._iteration_wall_time(
-                    model_output_arrival,
-                    t_sched,
-                    is_benchmark_point=is_benchmark_point,
-                )
+            wall_time = self._iteration_wall_time(
+                model_output_arrival,
+                t_sched,
+                is_benchmark_point=is_benchmark_point,
+            )
             self._last_update_time = model_output_arrival
 
             metrics = self._extract_metrics(
@@ -1680,11 +1697,20 @@ class InstrumentedScheduler(AsyncScheduler):
                 scheduled=scheduled,
             )
             self._publish_or_record_metrics(metrics)
+            self._bench_advance_decode_stage_after_output()
         else:
             self._last_update_time = 0.0
 
         self._cleanup_finished(scheduler_output)
         return result
+
+    def _bench_advance_decode_stage_after_output(self) -> None:
+        if not self._bench_active or self._bench_phase != _BenchPhase.DECODE_SWEEP:
+            return
+        if self._bench_decode_stage == _DecodePointStage.ADMITTING:
+            self._bench_decode_stage = _DecodePointStage.READY
+        elif self._bench_decode_stage == _DecodePointStage.MEASURING:
+            self._bench_decode_stage = _DecodePointStage.COMPLETE
 
     def _publish_or_record_metrics(self, metrics: ForwardPassMetrics) -> None:
         """Keep benchmark FPMs local; publish only post-benchmark traffic."""
@@ -1791,29 +1817,6 @@ class InstrumentedScheduler(AsyncScheduler):
     def _bench_should_record_fpm(self, metrics: ForwardPassMetrics) -> bool:
         """Keep only the forward-pass type represented by the current point."""
         return self._bench_should_record_scheduled(metrics.scheduled_requests)
-
-    def _bench_steady_fpm_expected(self) -> bool:
-        """True when the FPM about to be recorded is a steady-state sample.
-
-        The admission FPM of a two-step decode point is already in
-        ``_bench_current_fpms``, so the update being processed belongs to
-        the steady step. ``_last_update_time`` is the admission step's
-        arrival: the steady step is dispatched by the first ``schedule()``
-        call after the admission step, so the two updates are adjacent in
-        the engine's FIFO and the empty-step zeroing of
-        ``_last_update_time`` (empty outputs DO flow through
-        ``update_from_output``) can only happen after the steady update.
-        Should that adjacency ever break, the ``> 0`` guard fails closed
-        to the narrow window instead of recording a garbage timestamp.
-        """
-        point = getattr(self, "_bench_current_point", None)
-        return (
-            point is not None
-            and point.point_type == "decode"
-            and getattr(self, "_bench_expected_fpms", 1) > 1
-            and len(getattr(self, "_bench_current_fpms", [])) >= 1
-            and self._last_update_time > 0
-        )
 
     def _bench_should_record_scheduled(
         self, scheduled: ScheduledRequestMetrics
@@ -2073,6 +2076,7 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_stop_requested = False
         self._bench_stop_reason: str | None = None
         self._bench_point_deadline = 0.0
+        self._bench_decode_stage = _DecodePointStage.IDLE
         # Steady-state decode measurement (see _bench_make_steady_step):
         # how many extra production-shaped steps remain to dispatch for the
         # current point, and how many FPMs the point must collect before it
@@ -3264,6 +3268,7 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_active_req_ids.clear()
         self._schedule_times.clear()
         self._bench_extra_steps_left = 0
+        self._bench_decode_stage = _DecodePointStage.IDLE
 
     def _bench_clear_prefix_cache(self) -> None:
         """Remove all synthetic prefix entries before normal serving starts."""
@@ -3320,16 +3325,18 @@ class InstrumentedScheduler(AsyncScheduler):
                 "sum_decode_kv_tokens": 0,
             }
         else:
-            # The synchronized output is the ADMISSION step, which runs one
-            # token short of the point's coordinate (the steady step measured
-            # afterwards reads the full context).
+            measured_pass = self._bench_decode_stage == _DecodePointStage.MEASURING
             expected = {
                 "total_num_scheduled_tokens": point.batch_size,
                 "num_prefill_requests": 0,
                 "sum_prefill_tokens": 0,
                 "sum_prefill_kv_tokens": 0,
                 "num_decode_requests": point.batch_size,
-                "sum_decode_kv_tokens": self._bench_admission_kv_tokens,
+                "sum_decode_kv_tokens": (
+                    point.total_kv_read_tokens
+                    if measured_pass
+                    else self._bench_admission_kv_tokens
+                ),
             }
         if summary == expected:
             return None
@@ -3347,6 +3354,7 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_sync_pending = False
         self._bench_extra_steps_left = 0
         self._bench_expected_fpms = 1
+        self._bench_decode_stage = _DecodePointStage.IDLE
         self._schedule_times.clear()
         self._last_update_time = 0.0
         if resume_publisher:
@@ -3722,24 +3730,42 @@ class InstrumentedScheduler(AsyncScheduler):
 
         elif self._bench_active_req_ids:
             if (
-                getattr(self, "_bench_extra_steps_left", 0) > 0
+                self._bench_decode_stage == _DecodePointStage.READY
+                and getattr(self, "_bench_extra_steps_left", 0) > 0
                 and not self._bench_point_result_timed_out()
             ):
-                # The steady step deliberately does NOT re-arm the READY/GO
-                # barrier: production decode steps have no per-step barrier
-                # either (ranks stay aligned through the collectives), and a
-                # ZMQ round between the admission and steady updates would be
-                # counted into the steady step's inter-update wall_time under
-                # synchronous scheduling. Group agreement on the point is
-                # still enforced at collect_result.
                 steady = self._bench_make_steady_step()
                 if steady is not None:
+                    point = self._bench_current_point
+                    if (
+                        point is None
+                        or steady.total_num_scheduled_tokens != point.batch_size
+                    ):
+                        raise RuntimeError(
+                            "steady-state decode scheduled "
+                            f"{steady.total_num_scheduled_tokens} of "
+                            f"{point.batch_size if point is not None else 0} requests"
+                        )
                     self._bench_extra_steps_left -= 1
+                    self._bench_decode_stage = _DecodePointStage.MEASURING
+                    # Re-arm the READY/GO barrier so attention-DP ranks cannot
+                    # run a retention frame on one rank while peers run the
+                    # measured batch. schedule() records the timestamp after
+                    # this barrier, keeping synchronization out of the sample.
+                    self._bench_sync_pending = True
                     return steady
-                # Defensive: feasibility reserved ctx+1 slots per request, so
-                # this should be unreachable. Wait out the point deadline; the
-                # admission-only FPM then fails shape validation and the point
-                # is skipped through the normal group-synchronized save path.
+                # Feasibility reserves the steady step's slots. Failing fast
+                # lets _bench_abort notify attention-DP peers instead of making
+                # one rank wait on a barrier that another rank never enters.
+                raise RuntimeError(
+                    "failed to allocate the reserved steady-state decode slots"
+                )
+            if self._bench_decode_stage in {
+                _DecodePointStage.ADMITTING,
+                _DecodePointStage.MEASURING,
+            }:
+                # The scheduler emits retention-only empty outputs while these
+                # GPU passes are in flight, so neither pass is dispatched twice.
                 return None
             if len(self._bench_current_fpms) < getattr(self, "_bench_expected_fpms", 1):
                 if not self._bench_point_result_timed_out():
@@ -3799,6 +3825,7 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_current_point = None
             self._bench_extra_steps_left = 0
             return None
+        self._bench_decode_stage = _DecodePointStage.ADMITTING
         self._bench_sync_pending = True
         return output
 

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -1502,6 +1502,7 @@ def _grid_stub_with_kv_capacity(num_gpu_blocks: int, block_size: int):
     stub.block_size = block_size
     stub.max_model_len = 256
     stub.max_num_scheduled_tokens = 10_000
+    stub.num_lookahead_tokens = 0
     # Generous so the KV cap (not max_num_running_reqs) drives the boundary.
     stub.max_num_running_reqs = 10_000
     stub._bench_decode_capture_sizes = [8]
@@ -1551,6 +1552,18 @@ def test_decode_grid_first_ctx_yields_block_aligned_capacity():
     assert not InstrumentedScheduler._bench_decode_point_feasible(
         stub, 50, 50 * block_size
     )
+
+
+def test_decode_grid_reserves_speculative_lookahead():
+    """The feasibility check must match steady-step slot allocation."""
+    stub = _grid_stub_with_kv_capacity(num_gpu_blocks=5, block_size=4)
+    stub.num_lookahead_tokens = 2
+
+    # One block is reserved as the null sentinel, leaving four. At the
+    # minimum context, each request needs ceil((2 + 1 + 2) / 4) == 2 blocks.
+    assert InstrumentedScheduler._bench_decode_feasible_max_batch_size(stub) == 2
+    assert InstrumentedScheduler._bench_decode_point_feasible(stub, 2, 4)
+    assert not InstrumentedScheduler._bench_decode_point_feasible(stub, 3, 6)
 
 
 def test_decode_grid_reserves_padding_and_sample_under_model_length():

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -1327,11 +1327,14 @@ def test_decode_sweep_empty_frame_no_connector_leaves_metadata_none():
     guard in the fix.
     """
     stub = _make_decode_sweep_stub(connector=None)
+    stub.finished_req_ids.add("finished")
     out = InstrumentedScheduler.schedule(stub)
 
     assert out.kv_connector_metadata is None
     assert out.ec_connector_metadata is None
     assert out.num_scheduled_tokens == {"__bench_0": 0}
+    assert out.finished_req_ids == {"finished"}
+    assert out.finished_req_ids is not stub.finished_req_ids
     stub._update_after_schedule.assert_not_called()
 
 
@@ -1362,7 +1365,7 @@ def test_decode_retention_map_is_sanitized_without_mutating_original(monkeypatch
     stub._cleanup_finished.assert_called_once_with(output)
 
 
-def test_non_benchmark_output_does_not_advance_decode_stage(monkeypatch):
+def test_completed_pass_advances_stage_without_recording_fpm(monkeypatch):
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_active = True
     stub._bench_phase = _BenchPhase.DECODE_SWEEP
@@ -1370,14 +1373,15 @@ def test_non_benchmark_output_does_not_advance_decode_stage(monkeypatch):
     stub._bench_current_point = BenchmarkPoint(point_type="decode")
     stub._schedule_times = deque([1.0])
     stub._last_update_time = 0.0
-    stub._extract_scheduled = MagicMock(
-        return_value=instrumented_scheduler_module.ScheduledRequestMetrics(
-            num_prefill_requests=1
-        )
+    scheduled = instrumented_scheduler_module.ScheduledRequestMetrics(
+        num_prefill_requests=1
     )
+    stub._extract_scheduled = MagicMock(return_value=scheduled)
     stub._compute_queued = MagicMock(return_value=None)
-    stub._extract_metrics = MagicMock(return_value="metrics")
-    stub._publish_or_record_metrics = MagicMock()
+    stub._extract_metrics = MagicMock(
+        return_value=SimpleNamespace(scheduled_requests=scheduled)
+    )
+    stub._bench_current_fpms = []
     stub._cleanup_finished = MagicMock()
     monkeypatch.setattr(
         instrumented_scheduler_module.AsyncScheduler,
@@ -1389,7 +1393,8 @@ def test_non_benchmark_output_does_not_advance_decode_stage(monkeypatch):
     result = InstrumentedScheduler._update_from_output(stub, output, object())
 
     assert result == "parent-result"
-    assert stub._bench_decode_stage == _DecodePointStage.ADMITTING
+    assert stub._bench_current_fpms == []
+    assert stub._bench_decode_stage == _DecodePointStage.READY
 
 
 def test_decode_retention_map_rejects_positive_work(monkeypatch):

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -1335,18 +1335,16 @@ def test_decode_sweep_empty_frame_no_connector_leaves_metadata_none():
     stub._update_after_schedule.assert_not_called()
 
 
-def test_decode_retention_map_is_cleared_before_parent_output_update(monkeypatch):
+def test_decode_retention_map_is_sanitized_without_mutating_original(monkeypatch):
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_active = True
     stub._last_update_time = 1.0
     stub._cleanup_finished = MagicMock()
-    output = SimpleNamespace(
-        total_num_scheduled_tokens=0,
-        num_scheduled_tokens={"__bench_0": 0},
-        finished_req_ids=set(),
-    )
+    output = instrumented_scheduler_module.SchedulerOutput.make_empty()
+    output.num_scheduled_tokens = {"__bench_0": 0}
 
     def parent_update(_self, scheduler_output, _model_runner_output):
+        assert scheduler_output is not output
         assert scheduler_output.num_scheduled_tokens == {}
         return "parent-result"
 
@@ -1359,8 +1357,39 @@ def test_decode_retention_map_is_cleared_before_parent_output_update(monkeypatch
     result = InstrumentedScheduler._update_from_output(stub, output, object())
 
     assert result == "parent-result"
+    assert output.num_scheduled_tokens == {"__bench_0": 0}
     assert stub._last_update_time == 0.0
     stub._cleanup_finished.assert_called_once_with(output)
+
+
+def test_non_benchmark_output_does_not_advance_decode_stage(monkeypatch):
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_active = True
+    stub._bench_phase = _BenchPhase.DECODE_SWEEP
+    stub._bench_decode_stage = _DecodePointStage.ADMITTING
+    stub._bench_current_point = BenchmarkPoint(point_type="decode")
+    stub._schedule_times = deque([1.0])
+    stub._last_update_time = 0.0
+    stub._extract_scheduled = MagicMock(
+        return_value=instrumented_scheduler_module.ScheduledRequestMetrics(
+            num_prefill_requests=1
+        )
+    )
+    stub._compute_queued = MagicMock(return_value=None)
+    stub._extract_metrics = MagicMock(return_value="metrics")
+    stub._publish_or_record_metrics = MagicMock()
+    stub._cleanup_finished = MagicMock()
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "update_from_output",
+        MagicMock(return_value="parent-result"),
+    )
+
+    output = SimpleNamespace(total_num_scheduled_tokens=1)
+    result = InstrumentedScheduler._update_from_output(stub, output, object())
+
+    assert result == "parent-result"
+    assert stub._bench_decode_stage == _DecodePointStage.ADMITTING
 
 
 def test_decode_retention_map_rejects_positive_work(monkeypatch):

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3473,7 +3473,9 @@ def test_decode_ctx1_point_is_clamped_and_recorded_at_measured_coordinate():
     assert stub._bench_current_point.benchmark_id == 6
 
 
-def test_steady_step_dispatch_then_wait_then_save():
+def test_steady_step_dispatches_after_local_deadline_then_waits_then_saves():
+    import time
+
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_drain_pending = False
     stub._bench_active_req_ids = {"__bench_0"}
@@ -3481,7 +3483,10 @@ def test_steady_step_dispatch_then_wait_then_save():
     stub._bench_extra_steps_left = 1
     stub._bench_expected_fpms = 2
     stub._bench_decode_stage = _DecodePointStage.READY
-    stub._bench_point_deadline = 0.0
+    # The point deadline is rank-local. Once admission has completed, it must
+    # not let one ADP rank skip the measurement READY barrier while its peers
+    # enter it.
+    stub._bench_point_deadline = time.monotonic() - 1.0
     stub._bench_current_point = BenchmarkPoint(point_type="decode", batch_size=1)
     stub._bench_sync_pending = False
     steady_output = SimpleNamespace(total_num_scheduled_tokens=1)
@@ -3508,7 +3513,7 @@ def test_steady_step_dispatch_then_wait_then_save():
     assert stub._bench_drain_pending is True
 
 
-def test_steady_step_unavailable_fails_before_the_adp_measurement_barrier():
+def test_steady_step_unavailable_fails_even_after_the_local_deadline():
     import time
 
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
@@ -3518,7 +3523,7 @@ def test_steady_step_unavailable_fails_before_the_adp_measurement_barrier():
     stub._bench_extra_steps_left = 1
     stub._bench_expected_fpms = 2
     stub._bench_decode_stage = _DecodePointStage.READY
-    stub._bench_point_deadline = 0.0  # no deadline yet -> not timed out
+    stub._bench_point_deadline = time.monotonic() - 1.0
     stub._bench_make_steady_step = MagicMock(return_value=None)
     stub._bench_save_current_point = MagicMock()
 
@@ -3529,14 +3534,7 @@ def test_steady_step_unavailable_fails_before_the_adp_measurement_barrier():
     stub._bench_save_current_point.assert_not_called()
     assert stub._bench_extra_steps_left == 1
 
-    # Once the deadline passes, the point flows into the normal save path
-    # (where the admission-only FPM fails shape validation and the group
-    # skips together).
-    stub._bench_point_deadline = time.monotonic() - 1.0
-    stub._bench_cleanup_requests = MagicMock()
-    stub._bench_transition_to_timeout_done = MagicMock(return_value=False)
-    assert InstrumentedScheduler._bench_step_decode(stub) is None
-    stub._bench_save_current_point.assert_called_once_with()
+    stub._bench_save_current_point.assert_not_called()
 
 
 def test_steady_step_rejects_a_partial_batch_before_dispatch():

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3512,9 +3512,7 @@ def test_steady_step_dispatches_after_local_deadline_then_waits_then_saves():
     stub._bench_extra_steps_left = 1
     stub._bench_expected_fpms = 2
     stub._bench_decode_stage = _DecodePointStage.READY
-    # The point deadline is rank-local. Once admission has completed, it must
-    # not let one ADP rank skip the measurement READY barrier while its peers
-    # enter it.
+    # Expiry must not let an ADP rank skip the measurement barrier.
     stub._bench_point_deadline = time.monotonic() - 1.0
     stub._bench_current_point = BenchmarkPoint(point_type="decode", batch_size=1)
     stub._bench_sync_pending = False
@@ -3556,8 +3554,7 @@ def test_steady_step_unavailable_fails_even_after_the_local_deadline():
     stub._bench_make_steady_step = MagicMock(return_value=None)
     stub._bench_save_current_point = MagicMock()
 
-    # Feasibility reserved this allocation. Fail fast so the schedule wrapper
-    # can abort peers instead of letting another rank wait at the barrier.
+    # A reserved-slot failure must abort rather than strand ADP peers.
     with pytest.raises(RuntimeError, match="reserved steady-state decode slots"):
         InstrumentedScheduler._bench_step_decode(stub)
     stub._bench_save_current_point.assert_not_called()

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -42,6 +42,7 @@ from dynamo.vllm.instrumented_scheduler import (  # noqa: E402
     InstrumentedScheduler,
     SkippedBenchmarkPoint,
     _BenchPhase,
+    _DecodePointStage,
 )
 
 pytestmark = [
@@ -268,6 +269,8 @@ def test_benchmark_timing_stops_before_vllm_state_update(monkeypatch):
     stub._schedule_times = deque([10.0])
     stub._last_update_time = 0.0
     stub._bench_active = True
+    stub._bench_phase = _BenchPhase.DECODE_SWEEP
+    stub._bench_decode_stage = _DecodePointStage.COMPLETE
     stub._bench_current_point = BenchmarkPoint(point_type="decode", benchmark_id=1)
     stub._extract_scheduled = MagicMock(
         return_value=instrumented_scheduler_module.ScheduledRequestMetrics(
@@ -1139,6 +1142,7 @@ def test_benchmark_output_summary_must_match_point_before_go():
     # The synchronized output is the admission step, which runs one token
     # short per request (the steady step reads the full 128 afterwards).
     stub._bench_admission_kv_tokens = 126
+    stub._bench_decode_stage = _DecodePointStage.ADMITTING
     matching = {
         "total_num_scheduled_tokens": 2,
         "num_prefill_requests": 0,
@@ -1164,6 +1168,12 @@ def test_benchmark_output_summary_must_match_point_before_go():
         stub, point, full_context
     )
     assert error is not None, "the admission step must run one token short"
+
+    stub._bench_decode_stage = _DecodePointStage.MEASURING
+    assert (
+        InstrumentedScheduler._bench_output_validation_error(stub, point, full_context)
+        is None
+    )
 
 
 def test_dp_rank_falls_back_to_rank_when_index_absent():
@@ -1284,6 +1294,8 @@ def test_decode_sweep_empty_frame_attaches_kv_connector_metadata():
     out = InstrumentedScheduler.schedule(stub)
 
     assert out.kv_connector_metadata is sentinel
+    assert out.num_scheduled_tokens == {"__bench_0": 0}
+    stub._update_after_schedule.assert_not_called()
     connector.build_connector_meta.assert_called_once_with(out)
     # ec_connector is None on the stub; the ec field stays untouched.
     assert out.ec_connector_metadata is None
@@ -1302,6 +1314,8 @@ def test_decode_sweep_empty_frame_attaches_ec_connector_metadata_when_set():
 
     assert out.kv_connector_metadata is kv_meta
     assert out.ec_connector_metadata is ec_meta
+    assert out.num_scheduled_tokens == {"__bench_0": 0}
+    stub._update_after_schedule.assert_not_called()
     connector.build_connector_meta.assert_called_once_with(out)
     ec_connector.build_connector_meta.assert_called_once_with(out)
 
@@ -1317,6 +1331,57 @@ def test_decode_sweep_empty_frame_no_connector_leaves_metadata_none():
 
     assert out.kv_connector_metadata is None
     assert out.ec_connector_metadata is None
+    assert out.num_scheduled_tokens == {"__bench_0": 0}
+    stub._update_after_schedule.assert_not_called()
+
+
+def test_decode_retention_map_is_cleared_before_parent_output_update(monkeypatch):
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_active = True
+    stub._last_update_time = 1.0
+    stub._cleanup_finished = MagicMock()
+    output = SimpleNamespace(
+        total_num_scheduled_tokens=0,
+        num_scheduled_tokens={"__bench_0": 0},
+        finished_req_ids=set(),
+    )
+
+    def parent_update(_self, scheduler_output, _model_runner_output):
+        assert scheduler_output.num_scheduled_tokens == {}
+        return "parent-result"
+
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "update_from_output",
+        parent_update,
+    )
+
+    result = InstrumentedScheduler._update_from_output(stub, output, object())
+
+    assert result == "parent-result"
+    assert stub._last_update_time == 0.0
+    stub._cleanup_finished.assert_called_once_with(output)
+
+
+def test_decode_retention_map_rejects_positive_work(monkeypatch):
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_active = True
+    stub._last_update_time = 1.0
+    output = SimpleNamespace(
+        total_num_scheduled_tokens=0,
+        num_scheduled_tokens={"__bench_0": 1},
+    )
+    parent_update = MagicMock()
+    monkeypatch.setattr(
+        instrumented_scheduler_module.AsyncScheduler,
+        "update_from_output",
+        parent_update,
+    )
+
+    with pytest.raises(RuntimeError, match="contains positive work"):
+        InstrumentedScheduler._update_from_output(stub, output, object())
+
+    parent_update.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -3217,6 +3282,7 @@ def test_decode_point_with_no_fpm_stops_waiting_at_deadline(monkeypatch):
     stub._bench_active_req_ids = {"request"}
     stub._bench_current_point = point
     stub._bench_current_fpms = []
+    stub._bench_decode_stage = _DecodePointStage.COMPLETE
     stub._bench_point_deadline = 1.0
     stub._bench_save_current_point = MagicMock(
         side_effect=RuntimeError("exactly one FPM")
@@ -3380,6 +3446,7 @@ def test_decode_injection_admits_one_token_short():
     assert stub._bench_admission_kv_tokens == 126
     assert stub._bench_extra_steps_left == 1
     assert stub._bench_expected_fpms == 2
+    assert stub._bench_decode_stage == _DecodePointStage.ADMITTING
     # No clamping: the point keeps its grid coordinate.
     assert stub._bench_current_point.total_kv_read_tokens == 128
     assert "context_clamped" not in stub._bench_current_point.sample_reasons
@@ -3413,20 +3480,26 @@ def test_steady_step_dispatch_then_wait_then_save():
     stub._bench_current_fpms = []
     stub._bench_extra_steps_left = 1
     stub._bench_expected_fpms = 2
+    stub._bench_decode_stage = _DecodePointStage.READY
     stub._bench_point_deadline = 0.0
-    steady_output = object()
+    stub._bench_current_point = BenchmarkPoint(point_type="decode", batch_size=1)
+    stub._bench_sync_pending = False
+    steady_output = SimpleNamespace(total_num_scheduled_tokens=1)
     stub._bench_make_steady_step = MagicMock(return_value=steady_output)
 
     assert InstrumentedScheduler._bench_step_decode(stub) is steady_output
     assert stub._bench_extra_steps_left == 0
+    assert stub._bench_decode_stage == _DecodePointStage.MEASURING
+    assert stub._bench_sync_pending is True
 
-    # Only the admission FPM has arrived: keep waiting, no save.
+    # The measured pass is in flight: keep waiting, no save.
     stub._bench_save_current_point = MagicMock()
     stub._bench_current_fpms = [{"admission": True}]
     assert InstrumentedScheduler._bench_step_decode(stub) is None
     stub._bench_save_current_point.assert_not_called()
 
-    # Second (steady) FPM arrived: save and enter drain.
+    # The measured pass completed: save and enter drain.
+    stub._bench_decode_stage = _DecodePointStage.COMPLETE
     stub._bench_current_fpms = [{"admission": True}, {"steady": True}]
     stub._bench_cleanup_requests = MagicMock()
     stub._bench_transition_to_timeout_done = MagicMock(return_value=False)
@@ -3435,7 +3508,7 @@ def test_steady_step_dispatch_then_wait_then_save():
     assert stub._bench_drain_pending is True
 
 
-def test_steady_step_unavailable_waits_out_the_deadline():
+def test_steady_step_unavailable_fails_before_the_adp_measurement_barrier():
     import time
 
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
@@ -3444,12 +3517,15 @@ def test_steady_step_unavailable_waits_out_the_deadline():
     stub._bench_current_fpms = [{"admission": True}]
     stub._bench_extra_steps_left = 1
     stub._bench_expected_fpms = 2
+    stub._bench_decode_stage = _DecodePointStage.READY
     stub._bench_point_deadline = 0.0  # no deadline yet -> not timed out
     stub._bench_make_steady_step = MagicMock(return_value=None)
     stub._bench_save_current_point = MagicMock()
 
-    # Builder failed: no dispatch, no save, state intact for a retry.
-    assert InstrumentedScheduler._bench_step_decode(stub) is None
+    # Feasibility reserved this allocation. Fail fast so the schedule wrapper
+    # can abort peers instead of letting another rank wait at the barrier.
+    with pytest.raises(RuntimeError, match="reserved steady-state decode slots"):
+        InstrumentedScheduler._bench_step_decode(stub)
     stub._bench_save_current_point.assert_not_called()
     assert stub._bench_extra_steps_left == 1
 
@@ -3461,6 +3537,27 @@ def test_steady_step_unavailable_waits_out_the_deadline():
     stub._bench_transition_to_timeout_done = MagicMock(return_value=False)
     assert InstrumentedScheduler._bench_step_decode(stub) is None
     stub._bench_save_current_point.assert_called_once_with()
+
+
+def test_steady_step_rejects_a_partial_batch_before_dispatch():
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_drain_pending = False
+    stub._bench_active_req_ids = {"__bench_0", "__bench_1"}
+    stub._bench_current_point = BenchmarkPoint(point_type="decode", batch_size=2)
+    stub._bench_current_fpms = [{"admission": True}]
+    stub._bench_extra_steps_left = 1
+    stub._bench_expected_fpms = 2
+    stub._bench_decode_stage = _DecodePointStage.READY
+    stub._bench_point_deadline = 0.0
+    stub._bench_make_steady_step = MagicMock(
+        return_value=SimpleNamespace(total_num_scheduled_tokens=1)
+    )
+
+    with pytest.raises(RuntimeError, match="scheduled 1 of 2 requests"):
+        InstrumentedScheduler._bench_step_decode(stub)
+
+    assert stub._bench_extra_steps_left == 1
+    assert stub._bench_decode_stage == _DecodePointStage.READY
 
 
 def test_make_steady_step_builds_production_shaped_output():
@@ -3625,25 +3722,30 @@ def test_two_step_group_skip_traverses_barrier_without_deadlock():
         ]
 
 
-def test_steady_fpm_gate_only_fires_for_two_step_decode_points():
+def test_benchmark_stays_schedulable_while_decode_passes_are_in_flight():
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
-    stub._last_update_time = 100.0
-    stub._bench_current_point = BenchmarkPoint(point_type="decode")
-    stub._bench_expected_fpms = 2
-    stub._bench_current_fpms = [{"admission": True}]
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is True
+    stub._bench_active = True
 
-    stub._bench_current_fpms = []  # admission FPM not recorded yet
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
+    for stage in (
+        _DecodePointStage.IDLE,
+        _DecodePointStage.ADMITTING,
+        _DecodePointStage.READY,
+        _DecodePointStage.MEASURING,
+        _DecodePointStage.COMPLETE,
+    ):
+        stub._bench_decode_stage = stage
+        assert InstrumentedScheduler.has_requests(stub) is True
 
-    stub._bench_current_fpms = [{"admission": True}]
-    stub._bench_expected_fpms = 1  # single-step point
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
 
-    stub._bench_expected_fpms = 2
-    stub._bench_current_point = BenchmarkPoint(point_type="prefill")
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
+def test_completed_decode_outputs_advance_the_point_stage():
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_active = True
+    stub._bench_phase = _BenchPhase.DECODE_SWEEP
 
-    stub._bench_current_point = BenchmarkPoint(point_type="decode")
-    stub._last_update_time = 0.0  # previous update was an empty step
-    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
+    stub._bench_decode_stage = _DecodePointStage.ADMITTING
+    InstrumentedScheduler._bench_advance_decode_stage_after_output(stub)
+    assert stub._bench_decode_stage == _DecodePointStage.READY
+
+    stub._bench_decode_stage = _DecodePointStage.MEASURING
+    InstrumentedScheduler._bench_advance_decode_stage_after_output(stub)
+    assert stub._bench_decode_stage == _DecodePointStage.COMPLETE


### PR DESCRIPTION
## Summary

Measure vLLM decode self-benchmark points on a steady-state cached-request pass after synthetic request admission completes.

This supersedes #12982 with a smaller implementation that keeps the benchmark's scheduling path explicit and separates admission, retention, measurement, and completion states.

## Why

The existing benchmark measures synthetic requests on their first scheduled pass. That pass includes request registration and model-runner state population that production decode does not repeat, so its host overhead scales with context length and inflates the fitted KV-read cost.

In controlled TP1 H100 runs with FP8 KV cache, the upstream async benchmark fitted approximately 6.03 ns per KV token. Measuring the subsequent resident decode pass fitted 1.19 ns per KV token asynchronously and 1.20 ns per KV token synchronously. Phase tracing also showed that the measured pass reused the cached-request path without `add_request` work.

## What changed

- Admit each synthetic decode batch one token before the requested measurement coordinate.
- Track decode points through explicit `ADMITTING`, `READY`, `MEASURING`, and `COMPLETE` stages.
- Emit zero-work retention frames while admission or measurement is in flight so async model-runner rows remain resident without creating output placeholders.
- Build the measured pass in the same cached-request shape as production decode and record only that pass's forward-pass metrics.
- Re-arm the attention-DP READY/GO barrier before measurement and require every rank to traverse it, independent of rank-local point deadlines.
- Validate complete batch and KV-read shapes before accepting a measurement.
- Sanitize retention outputs through a shallow copy and advance decode stages only for outputs classified as the current benchmark type.

No ForwardPassMetrics or benchmark-result schema changes are included.

## Impact

The decode cost model now represents steady-state resident decode rather than one-time request admission. This removes context-dependent host setup work from the fitted KV-read coefficient while preserving existing benchmark output formats.

## Validation

- `150 passed` in `test_vllm_instrumented_scheduler.py`
- Focused regressions for async retention, stage transitions, ADP measurement-barrier traversal, output-shape validation, and retention-output sanitization
- TP1 H100 async and sync benchmark runs produced consistent resident-decode slopes
- Repository isort, Black, Flake8, Ruff, codespell, pytest-marker, and other applicable pre-commit hooks passed

## Related issues

This PR is not linked to an issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decode benchmark tracking across admission, readiness, measurement, and completion stages.
  * Preserved request membership when no tokens are produced and removed internal retention data from scheduler outputs.
  * Added validation for incomplete allocations, unavailable capacity, and invalid decode work.
  * Improved handling of padded allocations, empty decode frames, synchronization, and completed benchmark results.

* **Tests**
  * Expanded coverage for decode-stage transitions, capacity limits, output handling, timing, and distributed synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->