### PR TITLE
docs(trtllm): correct the UCX env-var note and the EFA image facts on 1.4.0

### DIFF
--- a/docs/fern/backends/trtllm/trtllm-kv-cache-transfer.md
+++ b/docs/fern/backends/trtllm/trtllm-kv-cache-transfer.md
@@ -30,7 +30,9 @@ TensorRT-LLM supports two NIXL communication backends: UCX and LIBFABRIC. By def
 TensorRT-LLM can also leverage **UCX** (Unified Communication X) directly for KV cache transfer between prefill and decode workers. To enable UCX as the KV cache transfer backend, set `cache_transceiver_config.backend: UCX` in your engine configuration YAML file.
 
 > [!NOTE]
-> The environment variable `TRTLLM_USE_UCX_KVCACHE=1` with `cache_transceiver_config.backend: DEFAULT` does not enable UCX. You must explicitly set `backend: UCX` in the configuration.
+> Setting `TRTLLM_USE_UCX_KVCACHE=1` while `cache_transceiver_config.backend` is `DEFAULT` selects direct UCX, and is equivalent to setting `backend: UCX` in the configuration. Both produce a `UcxConnectionManager`.
+>
+> This is a different transport from the default. With `backend: DEFAULT` and no environment variable, TensorRT-LLM uses the NIXL transfer agent with UCX underneath, which logs `NixlTransferAgent ... using NIXL backend: UCX`. To confirm which one a worker chose, read its startup log for the transceiver class rather than inferring it from the configuration.
 
 ## AWS EFA
 
@@ -38,15 +40,17 @@ On AWS, UCX uses the **SRD (Scalable Reliable Datagram)** transport over EFA dev
 
 **Image options:**
 
-- **Pre-built EFA image (AMD64 only):** A dedicated EFA image with the EFA SDK baked in is available on NGC. This is recommended for AMD64 instances (e.g. `p5.48xlarge`):
+- **Pre-built EFA image:** A dedicated EFA image with the EFA SDK baked in is available on NGC, for both AMD64 and ARM64:
 
 ```
-nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1-efa-amd64
+nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-efa
 ```
+
+On 1.2.1 the same image is tagged `1.2.1-efa-amd64`. Despite the suffix that tag is a multi-arch manifest covering AMD64 and ARM64; the name was corrected to `-efa` in 1.3.0. Pull the tag exactly as written, since `1.2.1-efa` was never published.
 
 See [Release Artifacts](../../reference/release-artifacts.mdx) for all available EFA images.
 
-- **Host-mount approach (ARM64 / GB200):** No pre-built EFA ARM64 image is published. Use the standard `tensorrtllm-runtime` image and mount the EFA SDK from the host node. This is what we tested on GB200 NVL72:
+- **Host-mount approach (ARM64 / GB200):** Instead of the pre-built image, you can run the standard `tensorrtllm-runtime` image and mount the EFA SDK from the host node, which keeps the SDK in step with the host driver:
 
 ```yaml
 volumeMounts:
@@ -57,6 +61,11 @@ volumes:
     hostPath:
       path: /opt/amazon/efa
 ```
+
+> [!WARNING]
+> Do not use this host mount with the LIBFABRIC backend on ARM64 / GB200. With `cache_transceiver_config.backend: NIXL` and `TRTLLM_NIXL_KVCACHE_BACKEND=LIBFABRIC`, mounting the host `/opt/amazon/efa` makes NIXL fail to register CUDA VRAM with `fi_mr_reg failed: Bad address`. TensorRT-LLM asserts immediately after, and both the prefill and decode workers enter `CrashLoopBackOff`.
+>
+> Use the pre-built `-efa` image instead. Removing the mount and relying on the EFA SDK shipped in that image makes an otherwise identical deployment serve inference on the same pair of nodes.
 
 **EFA resource requests:**
 

--- a/docs/fern/backends/trtllm/trtllm-kv-cache-transfer.md
+++ b/docs/fern/backends/trtllm/trtllm-kv-cache-transfer.md
@@ -29,10 +29,17 @@ TensorRT-LLM supports two NIXL communication backends: UCX and LIBFABRIC. By def
 
 TensorRT-LLM can also leverage **UCX** (Unified Communication X) directly for KV cache transfer between prefill and decode workers. To enable UCX as the KV cache transfer backend, set `cache_transceiver_config.backend: UCX` in your engine configuration YAML file.
 
-> [!NOTE]
-> Setting `TRTLLM_USE_UCX_KVCACHE=1` while `cache_transceiver_config.backend` is `DEFAULT` selects direct UCX, and is equivalent to setting `backend: UCX` in the configuration. Both produce a `UcxConnectionManager`.
->
-> This is a different transport from the default. With `backend: DEFAULT` and no environment variable, TensorRT-LLM uses the NIXL transfer agent with UCX underneath, which logs `NixlTransferAgent ... using NIXL backend: UCX`. To confirm which one a worker chose, read its startup log for the transceiver class rather than inferring it from the configuration.
+`cache_transceiver_config.backend` accepts the following values:
+
+| Value | Behavior |
+|-------|----------|
+| Not set | KV cache transfer is disabled. |
+| `DEFAULT` | Uses the backend named by the first of `TRTLLM_USE_NIXL_KVCACHE`, `TRTLLM_USE_UCX_KVCACHE`, `TRTLLM_USE_MOONCAKE_KVCACHE`, or `TRTLLM_USE_MPI_KVCACHE` that is set to `1`. Uses NIXL when none of them is set. |
+| `UCX`, `NIXL`, `MOONCAKE`, or `MPI` | Uses that backend and ignores the environment variables above. |
+
+The precedence above matches TensorRT-LLM 1.3.0rc22; check `CacheTransceiverConfig._resolve_default_backend` in `tensorrt_llm/llmapi/llm_args.py`.
+
+The two paths produce different transceivers, which is how you tell them apart at runtime: direct UCX logs `UcxConnectionManager`, while NIXL with UCX underneath logs `NixlTransferAgent ... using NIXL backend: UCX`. Read the worker's startup log for the transceiver class rather than inferring it from the configuration.
 
 ## AWS EFA
 


### PR DESCRIPTION
Adapted port of #13048. The page sits at a different path on this branch, and the release-branch copy is staler than main in a way that changes the fix, so this is not a clean pick.

## 1. The `TRTLLM_USE_UCX_KVCACHE` note said the opposite of the truth

Three deployments differing only in that variable, transceiver class read from each startup log:

| Deployment | engine backend | env var | observed transceiver |
|---|---|---|---|
| A | `DEFAULT` | none | `NixlTransferAgent ... using NIXL backend: UCX` |
| B | `DEFAULT` | `TRTLLM_USE_UCX_KVCACHE=1` | `UcxConnectionManager` |
| C | `UCX` | none | `UcxConnectionManager` |

B and C are the same, so the variable does select direct UCX.

## 2. The EFA image facts were wrong, and that is load-bearing here

This branch says the pre-built EFA image is **AMD64 only** and that **no pre-built ARM64 image is published**. Both are false. Verified against the registry:

| Tag | Architectures |
|---|---|
| `1.3.1-efa` | amd64, arm64 |
| `1.3.0-efa` | amd64, arm64 |
| `1.2.1-efa-amd64` | amd64, arm64 |

`1.2.1-efa-amd64` is multi-arch despite its suffix. This is not a cosmetic correction: the page told ARM64 readers the host mount was their only option, so the warning below would otherwise leave them with no path at all. Main already carries the corrected text and this brings the branch in line with it.

## 3. The ARM64 host mount breaks LIBFABRIC

With `backend: NIXL` and `TRTLLM_NIXL_KVCACHE_BACKEND=LIBFABRIC`, mounting the host `/opt/amazon/efa` makes NIXL fail to register CUDA VRAM with `fi_mr_reg failed: Bad address`. TensorRT-LLM asserts immediately after and both workers enter `CrashLoopBackOff`. Removing the mount and using the SDK in the pre-built `-efa` image makes the identical deployment serve on the identical nodes.

The mount stays documented with a warning scoped to that backend, rather than deleted, since it is still how you keep the SDK in step with the host driver.

## Notes

Docs only. The relative link to Release Artifacts was repointed to this branch layout and the target exists. This converges the page toward main, which is the direction #12950 takes the tree anyway.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->