### PR TITLE
fix(mocker): truncate disagg prefill output plan

### DIFF
--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -299,6 +299,31 @@ impl DirectRequest {
     pub fn router_priorities(&self) -> (f64, u32) {
         (f64::from(self.priority.max(0)), self.strict_priority)
     }
+
+    #[inline]
+    pub(crate) fn effective_max_output_tokens(&self) -> usize {
+        self.output_token_ids
+            .as_ref()
+            .map_or(self.max_output_tokens, Vec::len)
+    }
+
+    pub(crate) fn clone_with_output_limit(&self, limit: usize) -> Self {
+        let max_output_tokens = self.effective_max_output_tokens().min(limit);
+        Self {
+            tokens: self.tokens.clone(),
+            max_output_tokens,
+            output_token_ids: self
+                .output_token_ids
+                .as_ref()
+                .map(|ids| ids[..max_output_tokens].to_vec()),
+            uuid: self.uuid,
+            dp_rank: self.dp_rank,
+            arrival_timestamp_ms: self.arrival_timestamp_ms,
+            priority: self.priority,
+            strict_priority: self.strict_priority,
+            policy_class: self.policy_class.clone(),
+        }
+    }
 }
 
 fn is_zero_i32(value: &i32) -> bool {
@@ -1571,6 +1596,39 @@ mod tests {
 
         assert_eq!(error.to_string(), "injected raw sink failure");
         assert_eq!(*sink.attempts.lock().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn direct_request_output_plan_is_authoritative_when_limited() {
+        let request = DirectRequest {
+            tokens: vec![1, 2],
+            max_output_tokens: 0,
+            output_token_ids: Some(vec![7, 8]),
+            ..Default::default()
+        };
+
+        assert_eq!(request.effective_max_output_tokens(), 2);
+        let limited = request.clone_with_output_limit(1);
+        assert_eq!(limited.max_output_tokens, 1);
+        assert_eq!(limited.output_token_ids.as_deref(), Some(&[7][..]));
+        assert_eq!(limited.output_token_ids.unwrap().capacity(), 1);
+        assert_eq!(request.output_token_ids.as_deref(), Some(&[7, 8][..]));
+
+        let empty_plan = DirectRequest {
+            max_output_tokens: 4,
+            output_token_ids: Some(Vec::new()),
+            ..Default::default()
+        };
+        assert_eq!(empty_plan.effective_max_output_tokens(), 0);
+        let limited = empty_plan.clone_with_output_limit(1);
+        assert_eq!(limited.max_output_tokens, 0);
+        assert_eq!(limited.output_token_ids.as_deref(), Some(&[][..]));
+
+        let unplanned = DirectRequest::default();
+        assert_eq!(unplanned.effective_max_output_tokens(), 0);
+        let limited = unplanned.clone_with_output_limit(1);
+        assert_eq!(limited.max_output_tokens, 0);
+        assert!(limited.output_token_ids.is_none());
     }
 
     #[test]

--- a/lib/mocker/src/live.rs
+++ b/lib/mocker/src/live.rs
@@ -297,10 +297,7 @@ impl LiveEngine {
             !self.inner.cancel.is_cancelled(),
             "live Mocker engine is not running"
         );
-        let output_length = request
-            .output_token_ids
-            .as_ref()
-            .map_or(request.max_output_tokens, Vec::len);
+        let output_length = request.effective_max_output_tokens();
         anyhow::ensure!(
             self.inner.allow_zero_output || output_length > 0,
             "live requests must generate at least one output token"

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -422,7 +422,7 @@ where
     ) -> anyhow::Result<Uuid> {
         let uuid = request.metadata().uuid.unwrap_or_else(Uuid::new_v4);
         let input_length = request.input_length();
-        let output_length = request.metadata().max_output_tokens;
+        let output_length = request.metadata().effective_max_output_tokens();
         request.metadata_mut().uuid = Some(uuid);
         if matches!(self.admission.mode(), ReplayMode::Concurrency { .. }) {
             request.metadata_mut().arrival_timestamp_ms = Some(arrival_time_ms);
@@ -1761,6 +1761,39 @@ mod tests {
         let report = collector.finish();
         assert_eq!(report.request_counts.completed_requests, 2);
         assert_eq!(report.request_counts.total_output_tokens, 1);
+    }
+
+    #[rstest]
+    #[case(EngineType::Vllm)]
+    #[case(EngineType::Sglang)]
+    fn planned_output_length_controls_aggregate_accounting(#[case] engine_type: EngineType) {
+        let args = match engine_type {
+            EngineType::Vllm => MockEngineArgs::builder()
+                .block_size(4)
+                .num_gpu_blocks(32)
+                .max_num_batched_tokens(Some(16))
+                .max_num_seqs(Some(1))
+                .speedup_ratio(1000.0)
+                .build()
+                .unwrap(),
+            EngineType::Sglang => sglang_replay_args(),
+            EngineType::Trtllm => unreachable!(),
+        };
+        let requests = vec![DirectRequest {
+            tokens: vec![1; 4],
+            max_output_tokens: 1,
+            output_token_ids: Some(vec![7, 8, 9]),
+            uuid: Some(Uuid::from_u128(9_002)),
+            arrival_timestamp_ms: Some(0.0),
+            ..Default::default()
+        }];
+
+        let (collector, _) =
+            run_trace_multi_collect_with_stats(&args, requests, 1, ReplayRouterMode::RoundRobin);
+        let snapshot = collector.snapshot(Uuid::from_u128(9_002)).unwrap();
+        assert_eq!(snapshot.requested_output_length, 3);
+        assert_eq!(snapshot.output_length, 3);
+        assert_eq!(collector.finish().request_counts.total_output_tokens, 3);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -612,7 +612,7 @@ impl DisaggFlowState {
     ) -> Result<Uuid> {
         let uuid = request.metadata().uuid.unwrap_or_else(Uuid::new_v4);
         let input_length = request.input_length();
-        let output_length = request.metadata().max_output_tokens;
+        let output_length = request.metadata().effective_max_output_tokens();
         request.metadata_mut().uuid = Some(uuid);
         request.metadata_mut().arrival_timestamp_ms = Some(arrival_time_ms);
 
@@ -801,7 +801,10 @@ impl DisaggFlowState {
             let (input_tokens, requested_output_tokens) = {
                 let state = self.state(signal.uuid)?;
                 let original = state.original_request()?;
-                (original.tokens.len(), original.max_output_tokens)
+                (
+                    original.tokens.len(),
+                    original.effective_max_output_tokens(),
+                )
             };
             let actual_output_tokens =
                 collector.actual_output_length(signal.uuid).ok_or_else(|| {

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -466,7 +466,9 @@ fn test_derive_stage_router_configs_force_required_overrides() {
 #[case(ReplayRouterMode::KvRouter)]
 fn test_trace_smoke_reports_decode_only_tokens(#[case] router_mode: ReplayRouterMode) {
     let config = disagg_config();
-    let requests = vec![request(1, 128, 3, 5.0)];
+    let mut planned = request(1, 128, 1, 5.0);
+    planned.output_token_ids = Some(vec![11, 12, 13]);
+    let requests = vec![planned];
 
     let router_config = (router_mode == ReplayRouterMode::KvRouter).then(router_config);
     let (collector, stats) = run_trace_collect(&config, requests, router_config, 1.0, router_mode);
@@ -1356,9 +1358,10 @@ fn destination_first_workload_materializes_for_decode_reservation_then_completes
     );
 
     runtime.apply_scaling(1, 1).unwrap();
-    let (_, stats) = runtime.run().unwrap();
+    let (collector, stats) = runtime.run().unwrap();
 
     assert_eq!(stats.request_snapshots[&uuid].phase, DisaggPhase::Done);
+    assert_eq!(collector.finish().request_counts.total_output_tokens, 4);
 }
 
 #[test]

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -146,6 +146,7 @@ pub fn run_offline_handoff_conformance(
     let request = DirectRequest {
         tokens: (0..8).collect(),
         max_output_tokens: 2,
+        output_token_ids: Some(vec![7, 8]),
         uuid: Some(uuid::Uuid::from_u128(1)),
         arrival_timestamp_ms: Some(0.0),
         ..Default::default()

--- a/lib/mocker/src/replay/offline/extensions/kv_events/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_events/mod.rs
@@ -222,18 +222,19 @@ pub(in crate::replay) fn generate_trace_worker_artifacts_with_visibility(
             let replay_hashes = ready_turn
                 .replay_hashes
                 .ok_or_else(|| anyhow::anyhow!("offline artifacts require synthesized hashes"))?;
+            let output_length = ready_turn.request.effective_max_output_tokens();
             collector.on_arrival(
                 ready_turn.request_uuid,
                 ready_turn.scheduled_ready_at_ms,
                 ready_turn.request.tokens.len(),
-                ready_turn.request.max_output_tokens,
+                output_length,
             );
             artifacts.requests.push(ReplayTimedRequest {
                 uuid: ready_turn.request_uuid,
                 timestamp_us: timestamp_us_from_ms(current_time_ms),
                 scheduled_ready_at_ms: ready_turn.scheduled_ready_at_ms,
                 input_length: ready_turn.request.tokens.len(),
-                output_length: ready_turn.request.max_output_tokens,
+                output_length,
                 replay_hashes,
             });
             worker.receive(ready_turn.request);

--- a/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
@@ -423,10 +423,11 @@ impl<Request: PlacementRequestView> PlacementPolicy<Request> for KvRouterPlaceme
         now_ms: f64,
     ) -> Result<PlacementEffects> {
         let request_metadata = request.metadata();
+        let effective_max_output_tokens = request_metadata.effective_max_output_tokens();
         let max_output_tokens = metadata
             .max_output_tokens_override()
-            .map_or(request_metadata.max_output_tokens, |override_tokens| {
-                request_metadata.max_output_tokens.min(override_tokens)
+            .map_or(effective_max_output_tokens, |override_tokens| {
+                effective_max_output_tokens.min(override_tokens)
             });
         let request_id = request_metadata
             .uuid
@@ -555,7 +556,7 @@ impl OfflineReplayRouter {
     ) -> Result<RouterEffects> {
         self.on_compact_request_arrival_for_session(
             request,
-            request.max_output_tokens,
+            request.effective_max_output_tokens(),
             replay_hashes,
             session_id,
             now_ms,

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -179,7 +179,7 @@ impl SingleRuntime {
 
     fn record_arrival(&mut self, request: DirectRequest, arrival_ms: f64) -> Uuid {
         let input_length = request.tokens.len();
-        let output_length = request.max_output_tokens;
+        let output_length = request.effective_max_output_tokens();
         let uuid = self.worker.receive(request);
         self.collector
             .on_arrival(uuid, arrival_ms, input_length, output_length);
@@ -398,7 +398,7 @@ mod tests {
                 .arrival_timestamp_ms
                 .expect("trace replay requests must have an arrival timestamp");
             let input_length = request.tokens.len();
-            let output_length = request.max_output_tokens;
+            let output_length = request.effective_max_output_tokens();
             let uuid = worker.receive(request);
             collector.on_arrival(uuid, arrival_ms, input_length, output_length);
         }
@@ -418,7 +418,7 @@ mod tests {
 
             request.arrival_timestamp_ms = Some(current_time_ms);
             let input_length = request.tokens.len();
-            let output_length = request.max_output_tokens;
+            let output_length = request.effective_max_output_tokens();
             let uuid = worker.receive(request);
             collector.on_arrival(uuid, current_time_ms, input_length, output_length);
         }

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -184,6 +184,9 @@ impl DisaggRequestState {
     pub(crate) fn build_prefill_request(&mut self) -> Result<DirectRequest> {
         let mut request = self.materialize_original_request()?.clone();
         request.max_output_tokens = request.max_output_tokens.min(1);
+        if let Some(output_token_ids) = request.output_token_ids.as_mut() {
+            output_token_ids.truncate(request.max_output_tokens);
+        }
         Ok(request)
     }
 
@@ -642,6 +645,11 @@ mod tests {
         let request = state.build_prefill_request().unwrap();
 
         assert_eq!(request.max_output_tokens, 1);
+        assert_eq!(
+            request.output_token_ids.as_ref().map(Vec::len),
+            Some(1),
+            "prefill request must retain only its one planned output token"
+        );
         assert!(request.tokens[..64].iter().all(|token| *token == 21));
         assert!(request.tokens[64..].iter().all(|token| *token == 22));
         assert!(state.materialized_tokens().unwrap().is_some());

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -32,7 +32,7 @@ pub(crate) struct AggRequestState {
 impl AggRequestState {
     pub(crate) fn new_queued(request: ReplayRequestPayload) -> Self {
         let input_tokens = request.input_length();
-        let output_tokens = request.metadata().max_output_tokens;
+        let output_tokens = request.metadata().effective_max_output_tokens();
         Self {
             request: Some(request),
             phase: AggRequestPhase::QueuedAtRouter,
@@ -182,12 +182,9 @@ impl DisaggRequestState {
     }
 
     pub(crate) fn build_prefill_request(&mut self) -> Result<DirectRequest> {
-        let mut request = self.materialize_original_request()?.clone();
-        request.max_output_tokens = request.max_output_tokens.min(1);
-        if let Some(output_token_ids) = request.output_token_ids.as_mut() {
-            output_token_ids.truncate(request.max_output_tokens);
-        }
-        Ok(request)
+        Ok(self
+            .materialize_original_request()?
+            .clone_with_output_limit(1))
     }
 
     pub(crate) fn take_replay_hashes(&mut self) -> Option<ReplayRequestHashes> {
@@ -630,6 +627,8 @@ mod tests {
         };
         let mut driver = WorkloadDriver::new_trace(trace, 64).unwrap();
         let compact = driver.pop_ready_compact(0.0, 1).pop().unwrap();
+        let original_output_token_ids =
+            compact.request.metadata().output_token_ids.clone().unwrap();
         let mut state = DisaggRequestState::new(
             compact.request,
             0.0,
@@ -646,9 +645,20 @@ mod tests {
 
         assert_eq!(request.max_output_tokens, 1);
         assert_eq!(
-            request.output_token_ids.as_ref().map(Vec::len),
-            Some(1),
-            "prefill request must retain only its one planned output token"
+            request.output_token_ids.as_deref(),
+            Some(&original_output_token_ids[..1]),
+            "prefill request must retain the original first planned output token"
+        );
+        let prefill_plan = request.output_token_ids.as_ref().unwrap();
+        assert_eq!(prefill_plan.capacity(), prefill_plan.len());
+        assert_eq!(
+            state
+                .original_request()
+                .unwrap()
+                .output_token_ids
+                .as_deref(),
+            Some(original_output_token_ids.as_slice()),
+            "decode must retain the complete original output plan"
         );
         assert!(request.tokens[..64].iter().all(|token| *token == 21));
         assert!(request.tokens[64..].iter().all(|token| *token == 22));

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -379,10 +379,7 @@ impl SglangCore {
     }
 
     fn build_request(&self, request: DirectRequest) -> SglangRequest {
-        let max_output_tokens = request
-            .output_token_ids
-            .as_ref()
-            .map_or(request.max_output_tokens, Vec::len);
+        let max_output_tokens = request.effective_max_output_tokens();
         let output_storage_hint = self.config.output_storage_hint(
             request.tokens.len(),
             max_output_tokens,

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -26,10 +26,7 @@ pub(super) struct SglangRequest {
 impl SglangRequest {
     pub(super) fn new(req: DirectRequest, block_size: usize, output_storage_hint: usize) -> Self {
         let prompt_len = req.tokens.len();
-        let max_output_tokens = req
-            .output_token_ids
-            .as_ref()
-            .map_or(req.max_output_tokens, Vec::len);
+        let max_output_tokens = req.effective_max_output_tokens();
         let output_capacity = output_storage_hint.min(max_output_tokens);
         let mut sequence_tokens = req.tokens;
         sequence_tokens.reserve_exact(output_capacity);

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -895,18 +895,16 @@ impl VllmCore {
     ) -> VllmRequestState {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
         let prompt_len = request.tokens.len();
-        let mut max_output_tokens = request.max_output_tokens;
+        let requested_max_output_tokens = request.max_output_tokens;
+        let mut max_output_tokens = request.effective_max_output_tokens();
         let planned_output_ids = request.output_token_ids;
-        if let Some(planned_output_ids) = planned_output_ids.as_ref()
-            && planned_output_ids.len() != max_output_tokens
-        {
+        if planned_output_ids.is_some() && max_output_tokens != requested_max_output_tokens {
             tracing::warn!(
                 %uuid,
-                requested = max_output_tokens,
-                planned = planned_output_ids.len(),
+                requested = requested_max_output_tokens,
+                planned = max_output_tokens,
                 "planned output token count differs from max_output_tokens; using planned count"
             );
-            max_output_tokens = planned_output_ids.len();
         }
         if let Some(clamped) = policy::normalize_max_output_tokens(
             self.args.scheduling_policy(),


### PR DESCRIPTION
## Overview

Fix offline disaggregated replay so the prefill source emits one hidden bootstrap token and the decode destination emits the complete visible output plan. This prevents both stages from generating the full planned output.

## Details

- Add private `DirectRequest` helpers that make `output_token_ids.len()` authoritative when a plan exists and otherwise use `max_output_tokens`.
- Use that effective length in mocker scheduling, routing, arrival accounting, trace artifacts, and terminal accounting.
- Build the source-stage request as a new one-token clone with only the first planned token and exact-size output-plan storage. The stored original request remains unchanged for decode.
- Keep the router's one-token prefill estimate as a stage-specific override.
- Preserve the vLLM mismatch warning, zero-output behavior, backend behavior, public formats, and decode-only public disaggregated reports.

The source token is an internal handoff bootstrap token. It is not reported as visible output. The decode destination retains and emits the complete planned output.

## Where should the reviewer start?

Start with the shared request helpers in `lib/mocker/src/common/protocols.rs`, then the source-stage clone in `lib/mocker/src/replay/offline/state.rs`. The cross-backend conformance fixture is in `lib/mocker/src/replay/offline/entrypoints.rs`.

## Summary

- Centralize output-plan length and prefix-clone behavior.
- Prevent full-plan ownership from leaking into the disaggregated prefill request.
- Make aggregate and disaggregated accounting follow the same planned length as the schedulers.
- Strengthen vLLM and SGLang regression coverage for planned, empty, mismatched, and destination output behavior.

## Validation

- Exact PR-base regression proof at `b4f66adf11`: the two-token conformance fixture fails with `normalized source output count mismatch: expected 1, got 2`.
- Fixed head `6f61740f04`: `cargo test -p dynamo-llm live_and_offline_handoff_surfaces_share_one_conformance_report` passes for vLLM and SGLang.
- `cargo test -p dynamo-mocker`: 722 passed.
- `cargo test -p dynamo-mocker --features kvbm-offload replay::offline`: 194 passed; two unrelated KVBM lifecycle tests fail and reproduce unchanged at `d95e98aa73`.
- `cargo clippy -p dynamo-mocker -p dynamo-llm --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

No performance comparison or old-versus-new parity run was used because this is a correctness repair and disaggregated timing is expected to change.

## Related Issues

Relates to #13058.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected prefill request handling to limit planned output tokens to the configured maximum.
  * Ensured requests retain exactly the allowed number of output tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
