### PR TITLE
refactor(router): add residency domains and scoped engine resets

### DIFF
--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -680,6 +680,7 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
             let shard_event = RouterEvent {
                 worker_id: event.worker_id,
                 storage_tier: event.storage_tier,
+                residency_domain: event.residency_domain.clone(),
                 event: KvCacheEvent {
                     event_id: event.event.event_id,
                     dp_rank: event.event.dp_rank,
@@ -699,6 +700,7 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
                 let broadcast_event = RouterEvent {
                     worker_id: event.worker_id,
                     storage_tier: event.storage_tier,
+                    residency_domain: event.residency_domain.clone(),
                     event: KvCacheEvent {
                         event_id: event.event.event_id,
                         dp_rank: event.event.dp_rank,

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -516,6 +516,9 @@ impl ConcurrentRadixTree {
                 let event = RouterEvent {
                     worker_id: worker.worker_id,
                     storage_tier: crate::protocols::StorageTier::Device,
+                    residency_domain: crate::protocols::WireResidencyDomain::explicit(
+                        crate::protocols::ResidencyDomain::Worker,
+                    ),
                     event: KvCacheEvent {
                         event_id,
                         data: KvCacheEventData::Stored(KvCacheStoreData {

--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -342,6 +342,12 @@ impl KvIndexer {
                             }
 
                             Some(dump_req) = dump_rx.recv() => {
+                                // NOTE: Dump requests use a separate channel from mutations, so the
+                                // actor may observe one while already-accepted mutations are still
+                                // queued. Drain them before reading the tree to guarantee the snapshot
+                                // is at least as advanced as its advertised recovery watermark.
+                                // Including later queued mutations is allowed because recovery replays
+                                // the complete tail.
                                 drain_pending_mutations(
                                     &mut trie,
                                     PendingMutationReceivers {

--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -23,7 +23,7 @@ fn apply_event_with_counters(
     trie: &mut RadixTree,
     event: RouterEvent,
     counters: &PreBoundEventCounters,
-) {
+) -> bool {
     let kind = EventKind::of(&event.event.data);
     let event_id = event.event.event_id;
     let worker_id = event.worker_id;
@@ -36,6 +36,7 @@ fn apply_event_with_counters(
         );
     }
     counters.inc(kind, result);
+    result_is_ok
 }
 
 fn apply_routing_decision_with_prune_tracking(
@@ -127,6 +128,10 @@ struct PendingMutationReceivers<'a> {
 
 enum MutationRequest {
     Event(RouterEvent),
+    EventWithAck {
+        event: RouterEvent,
+        resp: oneshot::Sender<bool>,
+    },
     ResetWorkerDpRank {
         worker_id: WorkerId,
         dp_rank: DpRank,
@@ -150,7 +155,8 @@ impl KvEventSender {
             .await
             .map_err(|error| match error.0 {
                 MutationRequest::Event(event) => mpsc::error::SendError(event),
-                MutationRequest::ResetWorkerDpRank { .. } => {
+                MutationRequest::EventWithAck { .. }
+                | MutationRequest::ResetWorkerDpRank { .. } => {
                     unreachable!("event sender only submits event mutations")
                 }
             })
@@ -168,7 +174,12 @@ fn apply_mutation(
     prune_manager: &Option<WorkerPruneManager>,
 ) {
     match mutation {
-        MutationRequest::Event(event) => apply_event_with_counters(trie, event, counters),
+        MutationRequest::Event(event) => {
+            apply_event_with_counters(trie, event, counters);
+        }
+        MutationRequest::EventWithAck { event, resp } => {
+            let _ = resp.send(apply_event_with_counters(trie, event, counters));
+        }
         MutationRequest::ResetWorkerDpRank {
             worker_id,
             dp_rank,
@@ -705,6 +716,25 @@ impl KvIndexerInterface for KvIndexer {
 }
 
 impl KvIndexer {
+    /// Apply one event on the mutation queue and wait for its backend result.
+    pub async fn apply_event_and_wait(&self, event: RouterEvent) -> Result<(), KvRouterError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.mutation_tx
+            .send(MutationRequest::EventWithAck {
+                event,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| KvRouterError::IndexerOffline)?;
+        if !resp_rx
+            .await
+            .map_err(|_| KvRouterError::IndexerDroppedRequest)?
+        {
+            return Err(KvRouterError::IndexerDroppedRequest);
+        }
+        Ok(())
+    }
+
     /// Process a routing decision with pre-computed hashes.
     pub async fn process_routing_decision_with_hashes(
         &self,

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -655,11 +655,13 @@ impl LocalKvIndexer {
         };
 
         // NOTE: This is intentionally not an atomic cross-tier snapshot. Watermark N is captured
-        // only after events through N have been enqueued. Each physical index dump request is its
-        // own FIFO barrier, so every returned tier is at least N but may include a different suffix
-        // after N. Recovery replays the complete tail after N; ownership mutations converge under
-        // duplicate replay. Do not add a global application lock merely to align snapshot times.
-        // Any tier dump failure fails this complete response; the recovery cursor must not advance.
+        // only after events through N have been enqueued. The primary drains its accepted mutation
+        // channels before dumping; each lower tier handles its dump request behind prior mutations
+        // on every FIFO lane. Every returned tier is therefore at least N but may include a
+        // different suffix after N. Recovery replays the complete tail after N, and ownership
+        // mutations converge under duplicate replay. Do not add a global application lock merely
+        // to align snapshot times. Any tier dump failure fails this complete response; the recovery
+        // cursor must not advance.
         let mut events = indexer.dump_events().await?;
         for (tier, lower_tier) in lower_tiers {
             let tier_events = lower_tier.dump_events().await?;

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -14,8 +14,11 @@ use tokio_util::sync::CancellationToken;
 use super::{
     GetWorkersRequest, KvEventSender, KvIndexer, KvIndexerInterface, KvIndexerMetrics,
     KvRouterError, LowerTierIndexer, ThreadPoolIndexer, WorkerKvQueryResponse,
+    record_unsupported_residency_event,
 };
 use crate::protocols::*;
+
+type LowerTierRegistry = Arc<Mutex<HashMap<StorageTier, Arc<ThreadPoolIndexer<LowerTierIndexer>>>>>;
 
 #[cfg(test)]
 use super::DumpRequest;
@@ -40,6 +43,7 @@ impl CachedRecoverySnapshot {
         WorkerKvQueryResponse::TreeDump {
             events: self.events.as_ref().clone(),
             last_event_id: self.last_event_id,
+            reset_scope: ResetScope::All,
         }
     }
 }
@@ -131,6 +135,7 @@ impl RecoverySnapshotCache {
                     return CacheReuseDecision::ReturnExtended(WorkerKvQueryResponse::TreeDump {
                         events: shared_events.as_ref().clone(),
                         last_event_id,
+                        reset_scope: ResetScope::All,
                     });
                 }
                 TailAppendSafety::Invalidate => {
@@ -206,12 +211,12 @@ pub struct LocalKvIndexer {
     /// The underlying indexer
     indexer: KvIndexer,
     /// Lazily-created exact lower-tier indexes partitioned by storage tier.
-    lower_tier_indexers: Arc<Mutex<HashMap<StorageTier, Arc<ThreadPoolIndexer<LowerTierIndexer>>>>>,
+    lower_tier_indexers: LowerTierRegistry,
     /// Circular buffer of recent events.
     ///
     /// NOTE: One `LocalKvIndexer` belongs to one rank publisher, so its sequence and any latest
     /// `Cleared` event are rank-local. Do not merge independent rank streams into this buffer.
-    pub(super) event_buffer: Mutex<VecDeque<RouterEvent>>,
+    pub(super) event_buffer: Arc<Mutex<VecDeque<RouterEvent>>>,
     /// Coordinates single-flight tree dumps and the cached recovery snapshot.
     /// This stays separate from `event_buffer` so dump wait/build state can be
     /// managed on the async path without holding the buffer lock across `.await`.
@@ -239,7 +244,7 @@ impl LocalKvIndexer {
             indexer: KvIndexer::new(token, kv_block_size, metrics.clone()),
             metrics,
             lower_tier_indexers: Arc::new(Mutex::new(HashMap::new())),
-            event_buffer: Mutex::new(VecDeque::with_capacity(max_buffer_size)),
+            event_buffer: Arc::new(Mutex::new(VecDeque::with_capacity(max_buffer_size))),
             recovery_cache: Arc::new(RecoverySnapshotCache::new()),
             max_buffer_size,
             #[cfg(test)]
@@ -267,9 +272,9 @@ impl LocalKvIndexer {
     /// ### Returns
     ///
     /// - `Events`: Buffered events with original IDs through the current buffered tail,
-    ///   plus the buffered `last_event_id`. If the buffered suffix contains one or more
-    ///   `Cleared` events, events before the last clear may be omitted because this local indexer
-    ///   and recovery history belong to one rank publisher.
+    ///   plus the buffered `last_event_id`. If the buffered suffix contains an all-domain
+    ///   `Cleared` event, events before the last such clear may be omitted because it supersedes
+    ///   every residency owned by this rank publisher.
     /// - `TreeDump`: Full tree dump with synthetic IDs and the worker's latest real event ID (when range is too old or unspecified)
     /// - `TooNew`: Error when requested range is newer than available data
     /// - `InvalidRange`: Error when end_id < start_id
@@ -443,7 +448,12 @@ impl LocalKvIndexer {
         buffer
             .iter()
             .skip(start_idx)
-            .rposition(|event| matches!(&event.event.data, KvCacheEventData::Cleared))
+            .rposition(|event| {
+                matches!(
+                    event.reset_scope(),
+                    Ok(Some(crate::protocols::ResetScope::All))
+                )
+            })
             .map_or(start_idx, |idx| start_idx + idx)
     }
 
@@ -555,6 +565,8 @@ impl LocalKvIndexer {
         last_event_id: u64,
     ) -> tokio::task::JoinHandle<BuildTaskResult> {
         let indexer = self.indexer.clone();
+        let lower_tier_indexers = self.lower_tier_indexers.clone();
+        let event_buffer = self.event_buffer.clone();
         let recovery_cache = self.recovery_cache.clone();
         #[cfg(test)]
         let build_delay = *self.dump_build_delay.lock().unwrap();
@@ -567,7 +579,9 @@ impl LocalKvIndexer {
                 tokio::time::sleep(delay).await;
             }
 
-            let build_output = Self::build_fresh_dump(indexer, last_event_id).await;
+            let build_output =
+                Self::build_fresh_dump(indexer, lower_tier_indexers, event_buffer, last_event_id)
+                    .await;
             let notify = build.notify.clone();
             let result = recovery_cache.finish_build(&build, build_output).await;
 
@@ -576,8 +590,18 @@ impl LocalKvIndexer {
         })
     }
 
-    async fn build_fresh_dump(indexer: KvIndexer, last_event_id: u64) -> FreshDumpOutput {
-        match indexer.dump_events().await {
+    async fn build_fresh_dump(
+        indexer: KvIndexer,
+        lower_tier_indexers: LowerTierRegistry,
+        event_buffer: Arc<Mutex<VecDeque<RouterEvent>>>,
+        fallback_last_event_id: u64,
+    ) -> FreshDumpOutput {
+        let last_event_id = event_buffer
+            .lock()
+            .unwrap()
+            .back()
+            .map_or(fallback_last_event_id, |event| event.event.event_id);
+        match Self::dump_all_tiers(&indexer, &lower_tier_indexers).await {
             Ok(events) => {
                 let represented_blocks = events
                     .iter()
@@ -596,6 +620,7 @@ impl LocalKvIndexer {
                     response: WorkerKvQueryResponse::TreeDump {
                         events: events.clone(),
                         last_event_id,
+                        reset_scope: ResetScope::All,
                     },
                     snapshot: Some(CachedRecoverySnapshot {
                         events: Arc::new(events),
@@ -615,6 +640,35 @@ impl LocalKvIndexer {
                 }
             }
         }
+    }
+
+    async fn dump_all_tiers(
+        indexer: &KvIndexer,
+        lower_tier_indexers: &LowerTierRegistry,
+    ) -> Result<Vec<RouterEvent>, KvRouterError> {
+        let lower_tiers: Vec<_> = {
+            let indexers = lower_tier_indexers.lock().unwrap();
+            indexers
+                .iter()
+                .map(|(&tier, indexer)| (tier, indexer.clone()))
+                .collect()
+        };
+
+        // NOTE: This is intentionally not an atomic cross-tier snapshot. Watermark N is captured
+        // only after events through N have been enqueued. Each physical index dump request is its
+        // own FIFO barrier, so every returned tier is at least N but may include a different suffix
+        // after N. Recovery replays the complete tail after N; ownership mutations converge under
+        // duplicate replay. Do not add a global application lock merely to align snapshot times.
+        // Any tier dump failure fails this complete response; the recovery cursor must not advance.
+        let mut events = indexer.dump_events().await?;
+        for (tier, lower_tier) in lower_tiers {
+            let tier_events = lower_tier.dump_events().await?;
+            events.extend(tier_events.into_iter().map(|mut event| {
+                event.storage_tier = tier;
+                event
+            }));
+        }
+        Ok(events)
     }
 
     #[cfg(test)]
@@ -669,16 +723,27 @@ impl LocalKvIndexer {
     }
 
     async fn apply_event_by_tier(&self, event: &RouterEvent) -> Result<(), KvRouterError> {
-        match &event.event.data {
-            KvCacheEventData::Cleared => {
-                self.apply_event_to_primary(event.clone()).await?;
-                for indexer in self.all_lower_tier_indexers() {
-                    indexer.apply_event(event.clone()).await;
-                }
-                Ok(())
+        let targets_primary = match event.targets_primary() {
+            Ok(targets_primary) => targets_primary,
+            Err(_) => {
+                record_unsupported_residency_event(Some(&self.metrics), event);
+                return Ok(());
             }
-            _ if event.storage_tier.is_gpu() => self.apply_event_to_primary(event.clone()).await,
-            _ => self.apply_event_to_lower_tier(event.clone()).await,
+        };
+        if matches!(&event.event.data, KvCacheEventData::Cleared) {
+            if targets_primary {
+                self.indexer
+                    .reset_worker_dp_rank_and_wait(event.worker_id, event.event.dp_rank)
+                    .await?;
+            }
+            for indexer in self.all_lower_tier_indexers() {
+                indexer.apply_event_and_wait(event.clone()).await?;
+            }
+            Ok(())
+        } else if targets_primary {
+            self.apply_event_to_primary(event.clone()).await
+        } else {
+            self.apply_event_to_lower_tier(event.clone()).await
         }
     }
 
@@ -753,27 +818,7 @@ impl KvIndexerInterface for LocalKvIndexer {
     }
 
     async fn dump_events(&self) -> Result<Vec<RouterEvent>, KvRouterError> {
-        let mut events = self.indexer.dump_events().await?;
-
-        // Also dump lower-tier indexer state so the router receives
-        // host-pinned / disk block information during recovery.
-        let lower_tiers: Vec<(StorageTier, Arc<ThreadPoolIndexer<LowerTierIndexer>>)> = {
-            let indexers = self.lower_tier_indexers.lock().unwrap();
-            indexers
-                .iter()
-                .map(|(&tier, idx)| (tier, idx.clone()))
-                .collect()
-        };
-        for (tier, indexer) in lower_tiers {
-            if let Ok(tier_events) = indexer.dump_events().await {
-                for mut event in tier_events {
-                    event.storage_tier = tier;
-                    events.push(event);
-                }
-            }
-        }
-
-        Ok(events)
+        Self::dump_all_tiers(&self.indexer, &self.lower_tier_indexers).await
     }
 
     async fn process_routing_decision_for_request(
@@ -791,7 +836,7 @@ impl KvIndexerInterface for LocalKvIndexer {
     async fn flush(&self) -> usize {
         let queued = self.indexer.flush().await;
         for indexer in self.all_lower_tier_indexers() {
-            let _ = indexer.dump_events().await;
+            let _ = indexer.flush_and_wait().await;
         }
         queued
     }
@@ -805,10 +850,13 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::LocalKvIndexer;
-    use crate::indexer::{KvIndexerInterface, KvIndexerMetrics, LowerTierContinuation};
+    use crate::indexer::{
+        KvIndexerInterface, KvIndexerMetrics, LowerTierContinuation, WorkerKvQueryResponse,
+    };
     use crate::protocols::{
         ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
-        KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, WorkerWithDpRank,
+        KvCacheStoredBlockData, LocalBlockHash, ResetScope, ResidencyDomain, RouterEvent,
+        StorageTier, WorkerWithDpRank,
     };
 
     fn lower_tier_store_event(
@@ -836,6 +884,34 @@ mod tests {
                 dp_rank,
             },
             storage_tier,
+        )
+    }
+
+    fn lower_tier_store_event_in_domain(
+        worker_id: u64,
+        event_id: u64,
+        parent_hash: u64,
+        tokens_hash: u64,
+        block_hash: u64,
+        residency_domain: ResidencyDomain,
+    ) -> RouterEvent {
+        RouterEvent::with_residency_domain(
+            worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: Some(ExternalSequenceBlockHash(parent_hash)),
+                    start_position: None,
+                    blocks: vec![KvCacheStoredBlockData {
+                        block_hash: ExternalSequenceBlockHash(block_hash),
+                        tokens_hash: LocalBlockHash(tokens_hash),
+                        mm_extra_info: None,
+                    }],
+                }),
+                dp_rank: 0,
+            },
+            StorageTier::HostPinned,
+            residency_domain,
         )
     }
 
@@ -957,6 +1033,124 @@ mod tests {
             lower_tier_hits(&indexer, StorageTier::Disk, 19, 0, 1000, 31),
             0
         );
+    }
+
+    #[tokio::test]
+    async fn scoped_clear_history_and_all_tier_snapshot_preserve_cache_owner() {
+        let make_indexer = || {
+            LocalKvIndexer::new(
+                CancellationToken::new(),
+                4,
+                Arc::new(KvIndexerMetrics::new_unregistered()),
+                16,
+            )
+        };
+        let indexer = make_indexer();
+        let worker = WorkerWithDpRank::new(19, 0);
+
+        indexer
+            .apply_event_with_buffer(lower_tier_store_event_in_domain(
+                19,
+                1,
+                900,
+                11,
+                101,
+                ResidencyDomain::CacheOwner,
+            ))
+            .await
+            .unwrap();
+        indexer
+            .apply_event_with_buffer(lower_tier_store_event_in_domain(
+                19,
+                2,
+                900,
+                11,
+                101,
+                ResidencyDomain::Worker,
+            ))
+            .await
+            .unwrap();
+        indexer
+            .apply_event_with_buffer(RouterEvent::with_residency_domain(
+                19,
+                KvCacheEvent {
+                    event_id: 3,
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: 0,
+                },
+                StorageTier::Device,
+                ResidencyDomain::Worker,
+            ))
+            .await
+            .unwrap();
+        indexer
+            .apply_event_with_buffer(lower_tier_store_event_in_domain(
+                19,
+                4,
+                101,
+                12,
+                102,
+                ResidencyDomain::CacheOwner,
+            ))
+            .await
+            .unwrap();
+
+        let WorkerKvQueryResponse::Events { events, .. } =
+            indexer.get_events_in_id_range(Some(1), Some(4)).await
+        else {
+            panic!("history should be served from the recovery buffer");
+        };
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.event.event_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4]
+        );
+
+        let WorkerKvQueryResponse::TreeDump {
+            events,
+            last_event_id,
+            reset_scope,
+        } = indexer.get_events_in_id_range(None, None).await
+        else {
+            panic!("full recovery should return a tree dump");
+        };
+        assert_eq!(last_event_id, 4);
+        assert_eq!(reset_scope, ResetScope::All);
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|event| {
+            event.storage_tier == StorageTier::HostPinned
+                && event.resolved_residency_domain() == Ok(ResidencyDomain::CacheOwner)
+        }));
+
+        let restored = make_indexer();
+        for event in events {
+            restored.apply_event_with_buffer(event).await.unwrap();
+        }
+        let _ = restored.flush().await;
+        let continuations = FxHashMap::from_iter([(
+            worker,
+            LowerTierContinuation::new(0, ExternalSequenceBlockHash(900)),
+        )]);
+        for candidate in [&indexer, &restored] {
+            let tier = candidate
+                .lower_tier_indexers
+                .lock()
+                .unwrap()
+                .get(&StorageTier::HostPinned)
+                .cloned()
+                .unwrap();
+            assert_eq!(
+                tier.backend()
+                    .query_contiguous_hits(
+                        &[LocalBlockHash(11), LocalBlockHash(12)],
+                        &continuations
+                    )
+                    .get(&worker),
+                Some(&2)
+            );
+        }
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -736,9 +736,7 @@ impl LocalKvIndexer {
         };
         if matches!(&event.event.data, KvCacheEventData::Cleared) {
             if targets_primary {
-                self.indexer
-                    .reset_worker_dp_rank_and_wait(event.worker_id, event.event.dp_rank)
-                    .await?;
+                self.indexer.apply_event_and_wait(event.clone()).await?;
             }
             for indexer in self.all_lower_tier_indexers() {
                 indexer.apply_event_and_wait(event.clone()).await?;

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -659,9 +659,11 @@ impl LocalKvIndexer {
         // channels before dumping; each lower tier handles its dump request behind prior mutations
         // on every FIFO lane. Every returned tier is therefore at least N but may include a
         // different suffix after N. Recovery replays the complete tail after N, and ownership
-        // mutations converge under duplicate replay. Do not add a global application lock merely
-        // to align snapshot times. Any tier dump failure fails this complete response; the recovery
-        // cursor must not advance.
+        // mutations converge under duplicate replay. A duplicate remove may report BlockNotFound;
+        // any ownership it encounters from ahead of that remove was created by a later tail store,
+        // which ordered replay reapplies. Do not add a global application lock merely to align
+        // snapshot times. Any tier dump failure fails this complete response; the recovery cursor
+        // must not advance.
         let mut events = indexer.dump_events().await?;
         for (tier, lower_tier) in lower_tiers {
             let tier_events = lower_tier.dump_events().await?;

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -63,8 +63,8 @@ impl RouterHintExtensions {
         }
     }
 }
-type WorkerBlockIndex =
-    FxHashMap<ResidencyOwner, FxHashMap<ExternalSequenceBlockHash, TransitionKey>>;
+type OwnerBlockIndex = FxHashMap<ExternalSequenceBlockHash, TransitionKey>;
+type WorkerBlockIndex = FxHashMap<ResidencyOwner, OwnerBlockIndex>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct TransitionKey {
@@ -441,6 +441,9 @@ impl LowerTierIndexer {
 
         for (owner, block_map) in worker_blocks {
             for (block_hash, key) in block_map {
+                // NOTE: LowerTierIndexer intentionally has no physical-tier identity. Device is
+                // a placeholder here; every recovery/export boundary must retag these events with
+                // the registry tier before validating or replaying them.
                 events.push(RouterEvent::with_residency_domain(
                     owner.worker.worker_id,
                     KvCacheEvent {
@@ -464,6 +467,44 @@ impl LowerTierIndexer {
         }
 
         events
+    }
+
+    fn worker_block_counts(worker_blocks: &WorkerBlockIndex) -> FxHashMap<WorkerWithDpRank, usize> {
+        let mut domain_blocks: FxHashMap<
+            WorkerWithDpRank,
+            (Option<&OwnerBlockIndex>, Option<&OwnerBlockIndex>),
+        > = FxHashMap::default();
+
+        for (owner, blocks) in worker_blocks {
+            let entry = domain_blocks.entry(owner.worker).or_default();
+            match owner.domain {
+                ResidencyDomain::Worker => entry.0 = Some(blocks),
+                ResidencyDomain::CacheOwner => entry.1 = Some(blocks),
+            }
+        }
+
+        domain_blocks
+            .into_iter()
+            .map(|(worker, (worker_blocks, cache_owner_blocks))| {
+                let count = match (worker_blocks, cache_owner_blocks) {
+                    (Some(blocks), None) | (None, Some(blocks)) => blocks.len(),
+                    (Some(worker_blocks), Some(cache_owner_blocks)) => {
+                        let (smaller, larger) = if worker_blocks.len() <= cache_owner_blocks.len() {
+                            (worker_blocks, cache_owner_blocks)
+                        } else {
+                            (cache_owner_blocks, worker_blocks)
+                        };
+                        worker_blocks.len() + cache_owner_blocks.len()
+                            - smaller
+                                .keys()
+                                .filter(|block_hash| larger.contains_key(*block_hash))
+                                .count()
+                    }
+                    (None, None) => 0,
+                };
+                (worker, count)
+            })
+            .collect()
     }
 
     pub fn query_contiguous_hits<S>(
@@ -693,20 +734,8 @@ impl SyncIndexer for LowerTierIndexer {
                     let _ = sender.send(Ok(Self::dump_events(&worker_blocks)));
                 }
                 WorkerTask::Stats(sender) => {
-                    let mut worker_blocks_by_owner: FxHashMap<
-                        WorkerWithDpRank,
-                        FxHashSet<ExternalSequenceBlockHash>,
-                    > = FxHashMap::default();
-                    for (owner, blocks) in &worker_blocks {
-                        worker_blocks_by_owner
-                            .entry(owner.worker)
-                            .or_default()
-                            .extend(blocks.keys().copied());
-                    }
                     let stats = WorkerLookupStats::from_worker_block_counts(
-                        worker_blocks_by_owner
-                            .iter()
-                            .map(|(worker, blocks)| (*worker, blocks.len())),
+                        Self::worker_block_counts(&worker_blocks),
                     );
                     let _ = sender.send(stats);
                 }
@@ -1137,6 +1166,11 @@ mod tests {
                 .get(&worker),
             Some(&2),
             "one physical walk may cross ownership domains for the same routing worker"
+        );
+        assert_eq!(
+            LowerTierIndexer::worker_block_counts(&index.worker_blocks).get(&worker),
+            Some(&4),
+            "statistics project duplicate domain ownership as one physical block"
         );
 
         index

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -25,7 +25,8 @@ use super::WorkerObservationState;
 use super::{EventKind, KvIndexerMetrics, SyncIndexer, WorkerLookupStats, WorkerTask};
 use crate::protocols::{
     ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheEventError, KvCacheStoreData,
-    KvCacheStoredBlockData, LocalBlockHash, OverlapScores, RouterEvent, WorkerWithDpRank,
+    KvCacheStoredBlockData, LocalBlockHash, OverlapScores, ResetScope, ResidencyDomain,
+    ResidencyOwner, RouterEvent, WorkerWithDpRank,
 };
 use crate::router_hint::RouterHintRootCandidates;
 
@@ -63,7 +64,7 @@ impl RouterHintExtensions {
     }
 }
 type WorkerBlockIndex =
-    FxHashMap<WorkerWithDpRank, FxHashMap<ExternalSequenceBlockHash, TransitionKey>>;
+    FxHashMap<ResidencyOwner, FxHashMap<ExternalSequenceBlockHash, TransitionKey>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct TransitionKey {
@@ -75,17 +76,49 @@ struct TransitionKey {
 enum EdgeOwnersEntry {
     Single {
         child_hash: ExternalSequenceBlockHash,
-        owner: WorkerWithDpRank,
+        worker: WorkerWithDpRank,
+        domains: ResidencyDomainSet,
     },
     Multi {
         child_hash: ExternalSequenceBlockHash,
-        owners: WorkerSet,
+        owners: FxHashMap<WorkerWithDpRank, ResidencyDomainSet>,
     },
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+struct ResidencyDomainSet(u8);
+
+impl ResidencyDomainSet {
+    fn new(domain: ResidencyDomain) -> Self {
+        let mut domains = Self::default();
+        domains.insert(domain);
+        domains
+    }
+
+    fn bit(domain: ResidencyDomain) -> u8 {
+        match domain {
+            ResidencyDomain::Worker => 1,
+            ResidencyDomain::CacheOwner => 2,
+        }
+    }
+
+    fn insert(&mut self, domain: ResidencyDomain) {
+        self.0 |= Self::bit(domain);
+    }
+
+    fn remove(&mut self, domain: ResidencyDomain) -> bool {
+        self.0 &= !Self::bit(domain);
+        self.0 == 0
+    }
+}
+
 impl EdgeOwnersEntry {
-    fn new(child_hash: ExternalSequenceBlockHash, owner: WorkerWithDpRank) -> Self {
-        Self::Single { child_hash, owner }
+    fn new(child_hash: ExternalSequenceBlockHash, owner: ResidencyOwner) -> Self {
+        Self::Single {
+            child_hash,
+            worker: owner.worker,
+            domains: ResidencyDomainSet::new(owner.domain),
+        }
     }
 
     fn child_hash(&self) -> ExternalSequenceBlockHash {
@@ -94,23 +127,25 @@ impl EdgeOwnersEntry {
         }
     }
 
-    fn insert(&mut self, child_hash: ExternalSequenceBlockHash, owner: WorkerWithDpRank) -> bool {
+    fn insert(&mut self, child_hash: ExternalSequenceBlockHash, owner: ResidencyOwner) -> bool {
         match self {
             Self::Single {
                 child_hash: existing_hash,
-                owner: existing_owner,
+                worker,
+                domains,
             } => {
                 if *existing_hash != child_hash {
                     return false;
                 }
 
-                if *existing_owner == owner {
+                if *worker == owner.worker {
+                    domains.insert(owner.domain);
                     return true;
                 }
 
-                let mut owners = WorkerSet::default();
-                owners.insert(*existing_owner);
-                owners.insert(owner);
+                let mut owners = FxHashMap::default();
+                owners.insert(*worker, *domains);
+                owners.insert(owner.worker, ResidencyDomainSet::new(owner.domain));
                 *self = Self::Multi { child_hash, owners };
                 true
             }
@@ -121,21 +156,23 @@ impl EdgeOwnersEntry {
                 if *existing_hash != child_hash {
                     return false;
                 }
-                owners.insert(owner);
+                owners.entry(owner.worker).or_default().insert(owner.domain);
                 true
             }
         }
     }
 
-    fn remove(&mut self, owner: WorkerWithDpRank) -> bool {
+    fn remove(&mut self, owner: ResidencyOwner) -> bool {
         match self {
             Self::Single {
-                owner: existing_owner,
-                ..
-            } => *existing_owner == owner,
+                worker, domains, ..
+            } => *worker == owner.worker && domains.remove(owner.domain),
             Self::Multi { child_hash, owners } => {
-                if !owners.remove(&owner) {
+                let Some(domains) = owners.get_mut(&owner.worker) else {
                     return false;
+                };
+                if domains.remove(owner.domain) {
+                    owners.remove(&owner.worker);
                 }
 
                 if owners.is_empty() {
@@ -143,10 +180,11 @@ impl EdgeOwnersEntry {
                 }
 
                 if owners.len() == 1 {
-                    let remaining_owner = owners.iter().next().copied().unwrap();
+                    let (&worker, &domains) = owners.iter().next().unwrap();
                     *self = Self::Single {
                         child_hash: *child_hash,
-                        owner: remaining_owner,
+                        worker,
+                        domains,
                     };
                 }
 
@@ -155,20 +193,20 @@ impl EdgeOwnersEntry {
         }
     }
 
-    fn contains(&self, owner: &WorkerWithDpRank) -> bool {
+    fn contains_worker(&self, worker: &WorkerWithDpRank) -> bool {
         match self {
             Self::Single {
-                owner: existing_owner,
+                worker: existing_worker,
                 ..
-            } => existing_owner == owner,
-            Self::Multi { owners, .. } => owners.contains(owner),
+            } => existing_worker == worker,
+            Self::Multi { owners, .. } => owners.contains_key(worker),
         }
     }
 
     fn collect_workers(&self) -> Vec<WorkerWithDpRank> {
         match self {
-            Self::Single { owner, .. } => vec![*owner],
-            Self::Multi { owners, .. } => owners.iter().copied().collect(),
+            Self::Single { worker, .. } => vec![*worker],
+            Self::Multi { owners, .. } => owners.keys().copied().collect(),
         }
     }
 }
@@ -222,29 +260,43 @@ impl LowerTierIndexer {
     ) -> Result<(), KvCacheEventError> {
         let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
 
+        if matches!(&event.event.data, KvCacheEventData::Cleared) {
+            let scope = event
+                .reset_scope()
+                .map_err(|_| KvCacheEventError::UnsupportedResidencyDomain)?
+                .expect("Cleared events always resolve a reset scope");
+            match scope {
+                ResetScope::All => self.remove_worker_dp_rank_impl(worker_blocks, worker),
+                ResetScope::Domain(domain) => {
+                    self.remove_owner_impl(worker_blocks, ResidencyOwner::new(worker, domain))
+                }
+            }
+            return Ok(());
+        }
+
+        let owner = event
+            .residency_owner()
+            .map_err(|_| KvCacheEventError::UnsupportedResidencyDomain)?;
         match event.event.data {
             KvCacheEventData::Stored(store_data) => {
-                self.store_blocks_impl(worker_blocks, worker, store_data);
+                self.store_blocks_impl(worker_blocks, owner, store_data);
                 Ok(())
             }
             KvCacheEventData::Removed(remove_data) => {
-                self.remove_blocks_impl(worker_blocks, worker, &remove_data.block_hashes)
+                self.remove_blocks_impl(worker_blocks, owner, &remove_data.block_hashes)
             }
-            KvCacheEventData::Cleared => {
-                self.remove_worker_dp_rank_impl(worker_blocks, worker);
-                Ok(())
-            }
+            KvCacheEventData::Cleared => unreachable!("Cleared returned above"),
         }
     }
 
     fn store_blocks_impl(
         &self,
         worker_blocks: &mut WorkerBlockIndex,
-        worker: WorkerWithDpRank,
+        owner: ResidencyOwner,
         store_data: KvCacheStoreData,
     ) {
         let mut parent_hash = store_data.parent_hash;
-        let worker_map = worker_blocks.entry(worker).or_default();
+        let worker_map = worker_blocks.entry(owner).or_default();
 
         for block in store_data.blocks {
             let key = TransitionKey {
@@ -265,10 +317,10 @@ impl LowerTierIndexer {
 
             let inserted = match self.edges.entry(key) {
                 dashmap::mapref::entry::Entry::Occupied(mut edge) => {
-                    edge.get_mut().insert(block.block_hash, worker)
+                    edge.get_mut().insert(block.block_hash, owner)
                 }
                 dashmap::mapref::entry::Entry::Vacant(edge) => {
-                    edge.insert(EdgeOwnersEntry::new(block.block_hash, worker));
+                    edge.insert(EdgeOwnersEntry::new(block.block_hash, owner));
                     true
                 }
             };
@@ -285,11 +337,11 @@ impl LowerTierIndexer {
     fn remove_blocks_impl(
         &self,
         worker_blocks: &mut WorkerBlockIndex,
-        worker: WorkerWithDpRank,
+        owner: ResidencyOwner,
         block_hashes: &[ExternalSequenceBlockHash],
     ) -> Result<(), KvCacheEventError> {
         let remove_worker_entry = {
-            let Some(worker_map) = worker_blocks.get_mut(&worker) else {
+            let Some(worker_map) = worker_blocks.get_mut(&owner) else {
                 return Err(KvCacheEventError::BlockNotFound);
             };
 
@@ -298,28 +350,28 @@ impl LowerTierIndexer {
                     return Err(KvCacheEventError::BlockNotFound);
                 };
 
-                self.remove_worker_from_edge(key, worker);
+                self.remove_owner_from_edge(key, owner);
             }
 
             worker_map.is_empty()
         };
 
         if remove_worker_entry {
-            worker_blocks.remove(&worker);
+            worker_blocks.remove(&owner);
         }
 
         Ok(())
     }
 
     fn clear_worker_impl(&self, worker_blocks: &mut WorkerBlockIndex, worker_id: u64) {
-        let workers: Vec<_> = worker_blocks
+        let owners: Vec<_> = worker_blocks
             .keys()
             .copied()
-            .filter(|worker| worker.worker_id == worker_id)
+            .filter(|owner| owner.worker.worker_id == worker_id)
             .collect();
 
-        for worker in workers {
-            self.remove_worker_dp_rank_impl(worker_blocks, worker);
+        for owner in owners {
+            self.remove_owner_impl(worker_blocks, owner);
         }
     }
 
@@ -328,18 +380,30 @@ impl LowerTierIndexer {
         worker_blocks: &mut WorkerBlockIndex,
         worker: WorkerWithDpRank,
     ) {
-        let Some(worker_map) = worker_blocks.remove(&worker) else {
+        let owners: Vec<_> = worker_blocks
+            .keys()
+            .copied()
+            .filter(|owner| owner.worker == worker)
+            .collect();
+
+        for owner in owners {
+            self.remove_owner_impl(worker_blocks, owner);
+        }
+    }
+
+    fn remove_owner_impl(&self, worker_blocks: &mut WorkerBlockIndex, owner: ResidencyOwner) {
+        let Some(worker_map) = worker_blocks.remove(&owner) else {
             return;
         };
 
         for (_, key) in worker_map {
-            self.remove_worker_from_edge(key, worker);
+            self.remove_owner_from_edge(key, owner);
         }
     }
 
-    fn remove_worker_from_edge(&self, key: TransitionKey, worker: WorkerWithDpRank) {
+    fn remove_owner_from_edge(&self, key: TransitionKey, owner: ResidencyOwner) {
         if let dashmap::mapref::entry::Entry::Occupied(mut edge) = self.edges.entry(key)
-            && edge.get_mut().remove(worker)
+            && edge.get_mut().remove(owner)
         {
             edge.remove();
         }
@@ -375,10 +439,10 @@ impl LowerTierIndexer {
         let mut events = Vec::new();
         let mut event_id = 0u64;
 
-        for (worker, block_map) in worker_blocks {
+        for (owner, block_map) in worker_blocks {
             for (block_hash, key) in block_map {
-                events.push(RouterEvent::new(
-                    worker.worker_id,
+                events.push(RouterEvent::with_residency_domain(
+                    owner.worker.worker_id,
                     KvCacheEvent {
                         event_id,
                         data: KvCacheEventData::Stored(KvCacheStoreData {
@@ -390,8 +454,10 @@ impl LowerTierIndexer {
                                 mm_extra_info: None,
                             }],
                         }),
-                        dp_rank: worker.dp_rank,
+                        dp_rank: owner.worker.dp_rank,
                     },
+                    crate::protocols::StorageTier::Device,
+                    owner.domain,
                 ));
                 event_id += 1;
             }
@@ -627,10 +693,20 @@ impl SyncIndexer for LowerTierIndexer {
                     let _ = sender.send(Ok(Self::dump_events(&worker_blocks)));
                 }
                 WorkerTask::Stats(sender) => {
+                    let mut worker_blocks_by_owner: FxHashMap<
+                        WorkerWithDpRank,
+                        FxHashSet<ExternalSequenceBlockHash>,
+                    > = FxHashMap::default();
+                    for (owner, blocks) in &worker_blocks {
+                        worker_blocks_by_owner
+                            .entry(owner.worker)
+                            .or_default()
+                            .extend(blocks.keys().copied());
+                    }
                     let stats = WorkerLookupStats::from_worker_block_counts(
-                        worker_blocks
+                        worker_blocks_by_owner
                             .iter()
-                            .map(|(worker, worker_map)| (*worker, worker_map.len())),
+                            .map(|(worker, blocks)| (*worker, blocks.len())),
                     );
                     let _ = sender.send(stats);
                 }
@@ -736,10 +812,10 @@ fn advance_state_to_breakpoint(
         // iterating all active workers. For multi-owner edges we iterate
         // whichever side is smaller.
         match edge.value() {
-            EdgeOwnersEntry::Single { owner, .. } => {
-                if active.remove(owner) {
+            EdgeOwnersEntry::Single { worker, .. } => {
+                if active.remove(worker) {
                     finalize_workers(final_states, active.drain(), cur_pos, cur_hash);
-                    active.insert(*owner);
+                    active.insert(*worker);
                 } else {
                     finalize_workers(final_states, active.drain(), cur_pos, cur_hash);
                     break;
@@ -748,9 +824,9 @@ fn advance_state_to_breakpoint(
             EdgeOwnersEntry::Multi { owners, .. } => {
                 if owners.len() <= active.len() {
                     scratch.clear();
-                    for owner in owners {
-                        if active.remove(owner) {
-                            scratch.insert(*owner);
+                    for worker in owners.keys() {
+                        if active.remove(worker) {
+                            scratch.insert(*worker);
                         }
                     }
                     finalize_workers(final_states, active.drain(), cur_pos, cur_hash);
@@ -758,7 +834,7 @@ fn advance_state_to_breakpoint(
                 } else {
                     scratch.clear();
                     for worker in active.drain() {
-                        if owners.contains(&worker) {
+                        if owners.contains_key(&worker) {
                             scratch.insert(worker);
                         } else {
                             final_states.insert(worker, (cur_pos, cur_hash));
@@ -837,7 +913,7 @@ fn advance_single_worker(
             return;
         };
 
-        if !edge.contains(&worker) {
+        if !edge.contains_worker(&worker) {
             final_states.insert(worker, (*cur_pos, *cur_hash));
             return;
         }
@@ -876,7 +952,7 @@ mod tests {
     use crate::indexer::{KvIndexerInterface, ThreadPoolIndexer};
     use crate::protocols::{
         ExternalSequenceBlockHash, KvCacheEventData, KvCacheStoreData, LocalBlockHash,
-        WorkerWithDpRank,
+        ResidencyDomain, RouterEvent, StorageTier, WireResidencyDomain, WorkerWithDpRank,
     };
     use crate::test_utils::{remove_event, router_event, stored_blocks_with_sequence_hashes};
 
@@ -904,6 +980,33 @@ mod tests {
                     external_hashes,
                 ),
             }),
+        )
+    }
+
+    fn store_event_in_domain(
+        worker_id: u64,
+        event_id: u64,
+        parent_hash: Option<u64>,
+        local_values: &[u64],
+        external_hashes: &[u64],
+        domain: ResidencyDomain,
+    ) -> RouterEvent {
+        RouterEvent::with_residency_domain(
+            worker_id,
+            crate::protocols::KvCacheEvent {
+                event_id,
+                dp_rank: 0,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: parent_hash.map(ExternalSequenceBlockHash),
+                    start_position: None,
+                    blocks: stored_blocks_with_sequence_hashes(
+                        &local_hashes(local_values),
+                        external_hashes,
+                    ),
+                }),
+            },
+            StorageTier::HostPinned,
+            domain,
         )
     }
 
@@ -981,6 +1084,99 @@ mod tests {
         let workers = index.root_workers(LocalBlockHash(11));
         assert_eq!(workers.len(), 1);
         assert!(workers.contains(&WorkerWithDpRank::new(7, 0)));
+    }
+
+    #[test]
+    fn logical_domains_share_one_tree_without_sharing_ownership() {
+        let mut index = TestLowerTierIndex::new();
+        let worker = WorkerWithDpRank::new(7, 0);
+
+        for domain in [ResidencyDomain::Worker, ResidencyDomain::CacheOwner] {
+            index
+                .apply_event(store_event_in_domain(
+                    7,
+                    1,
+                    None,
+                    &[11, 12],
+                    &[101, 102],
+                    domain,
+                ))
+                .unwrap();
+        }
+        index
+            .apply_event(store_event_in_domain(
+                7,
+                2,
+                None,
+                &[21],
+                &[201],
+                ResidencyDomain::Worker,
+            ))
+            .unwrap();
+        index
+            .apply_event(store_event_in_domain(
+                7,
+                3,
+                Some(201),
+                &[22],
+                &[202],
+                ResidencyDomain::CacheOwner,
+            ))
+            .unwrap();
+
+        let continuations = FxHashMap::from_iter([(worker, LowerTierContinuation::from_root(0))]);
+        assert_eq!(
+            index
+                .query_contiguous_hits(&local_hashes(&[11, 12]), &continuations)
+                .get(&worker),
+            Some(&2)
+        );
+        assert_eq!(
+            index
+                .query_contiguous_hits(&local_hashes(&[21, 22]), &continuations)
+                .get(&worker),
+            Some(&2),
+            "one physical walk may cross ownership domains for the same routing worker"
+        );
+
+        index
+            .apply_event(RouterEvent::with_residency_domain(
+                7,
+                crate::protocols::KvCacheEvent {
+                    event_id: 4,
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: 0,
+                },
+                StorageTier::Device,
+                ResidencyDomain::Worker,
+            ))
+            .unwrap();
+        assert_eq!(
+            index
+                .query_contiguous_hits(&local_hashes(&[11, 12]), &continuations)
+                .get(&worker),
+            Some(&2),
+            "Worker reset must retain duplicate CacheOwner ownership"
+        );
+
+        index
+            .apply_event(RouterEvent {
+                worker_id: 7,
+                storage_tier: StorageTier::Device,
+                residency_domain: WireResidencyDomain::default(),
+                event: crate::protocols::KvCacheEvent {
+                    event_id: 5,
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: 0,
+                },
+            })
+            .unwrap();
+        assert_eq!(
+            index
+                .query_contiguous_hits(&local_hashes(&[11, 12]), &continuations)
+                .get(&worker),
+            Some(&0)
+        );
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/indexer/lower_tier_indexers.rs
+++ b/lib/kv-router/src/indexer/lower_tier_indexers.rs
@@ -19,9 +19,9 @@ use std::sync::{Arc, RwLock};
 
 use crate::indexer::{
     KvIndexerMetrics, LowerTierContinuation, LowerTierIndexer, LowerTierMatchDetails, MatchDetails,
-    ThreadPoolIndexer, WireTieredMatchDetails,
+    ThreadPoolIndexer, WireTieredMatchDetails, record_unsupported_residency_event,
 };
-use crate::protocols::{LocalBlockHash, StorageTier, WorkerWithDpRank};
+use crate::protocols::{LocalBlockHash, RouterEvent, StorageTier, WorkerWithDpRank};
 use crate::router_hint::RouterHintRootCandidates;
 use rustc_hash::FxHashMap;
 
@@ -111,6 +111,10 @@ impl LowerTierIndexers {
         storage_tier: StorageTier,
     ) -> Option<Arc<ThreadPoolIndexer<LowerTierIndexer>>> {
         self.indexers.read().unwrap().get(&storage_tier).cloned()
+    }
+
+    pub fn record_unsupported_residency_event(&self, event: &RouterEvent) {
+        record_unsupported_residency_event(self.metrics.as_deref(), event);
     }
 }
 

--- a/lib/kv-router/src/indexer/metrics.rs
+++ b/lib/kv-router/src/indexer/metrics.rs
@@ -5,8 +5,7 @@
 use std::sync::Arc;
 #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
 use std::sync::OnceLock;
-#[cfg(feature = "bench")]
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[cfg(feature = "runtime-protocols")]
 use dynamo_runtime::component::Component;
@@ -15,7 +14,9 @@ use dynamo_runtime::metrics::MetricsHierarchy;
 #[cfg(feature = "metrics")]
 use prometheus::{IntCounter, IntCounterVec, Opts};
 
-use crate::protocols::{KvCacheEventData, KvCacheEventError};
+use crate::protocols::{KvCacheEventData, KvCacheEventError, RouterEvent};
+
+static IGNORED_RESIDENCY_EVENT_COUNT: AtomicU64 = AtomicU64::new(0);
 
 /// Lightweight, `Copy` discriminant for [`KvCacheEventData`].
 ///
@@ -41,15 +42,41 @@ impl EventKind {
             KvCacheEventData::Cleared => Self::Cleared,
         }
     }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Stored => METRIC_EVENT_STORED,
+            Self::Removed => METRIC_EVENT_REMOVED,
+            Self::Cleared => METRIC_EVENT_CLEARED,
+        }
+    }
 }
 
 impl std::fmt::Display for EventKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Stored => f.write_str(METRIC_EVENT_STORED),
-            Self::Removed => f.write_str(METRIC_EVENT_REMOVED),
-            Self::Cleared => f.write_str(METRIC_EVENT_CLEARED),
-        }
+        f.write_str(self.label())
+    }
+}
+
+/// Record and rate-limit diagnostics for a wire event that cannot enter the
+/// canonical residency model. The metric label has fixed cardinality.
+pub fn record_unsupported_residency_event(metrics: Option<&KvIndexerMetrics>, event: &RouterEvent) {
+    if let Some(metrics) = metrics {
+        metrics.increment_event_applied(
+            EventKind::of(&event.event.data).label(),
+            Err(KvCacheEventError::UnsupportedResidencyDomain),
+        );
+    }
+
+    let ignored_count = IGNORED_RESIDENCY_EVENT_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+    if ignored_count.is_power_of_two() {
+        tracing::warn!(
+            ignored_count,
+            worker_id = event.worker_id,
+            dp_rank = event.event.dp_rank,
+            storage_tier = ?event.storage_tier,
+            "Ignoring KV event with unsupported residency domain"
+        );
     }
 }
 
@@ -162,6 +189,7 @@ pub const METRIC_STATUS_CAPACITY_EXHAUSTED: &str = "capacity_exhausted";
 pub const METRIC_STATUS_ALLOCATION_FAILED: &str = "allocation_failed";
 pub const METRIC_STATUS_OWNERSHIP_DEGREE_OVERFLOW: &str = "ownership_degree_overflow";
 pub const METRIC_STATUS_INDEXER_INVARIANT_VIOLATION: &str = "indexer_invariant_violation";
+pub const METRIC_STATUS_UNSUPPORTED_RESIDENCY_DOMAIN: &str = "unsupported_residency_domain";
 
 /// Metric event labels.
 pub const METRIC_EVENT_STORED: &str = "stored";
@@ -339,6 +367,9 @@ impl KvIndexerMetrics {
                         KvCacheEventError::IndexerInvariantViolation => {
                             METRIC_STATUS_INDEXER_INVARIANT_VIOLATION
                         }
+                        KvCacheEventError::UnsupportedResidencyDomain => {
+                            METRIC_STATUS_UNSUPPORTED_RESIDENCY_DOMAIN
+                        }
                     };
                     self.kv_cache_events_applied
                         .with_label_values(&[event_type, error_label])
@@ -405,6 +436,7 @@ struct ResultCounters {
     allocation_failed: IntCounter,
     ownership_degree_overflow: IntCounter,
     indexer_invariant_violation: IntCounter,
+    unsupported_residency_domain: IntCounter,
 }
 
 #[cfg(feature = "metrics")]
@@ -425,6 +457,8 @@ impl ResultCounters {
                 .with_label_values(&[event_type, METRIC_STATUS_OWNERSHIP_DEGREE_OVERFLOW]),
             indexer_invariant_violation: counters
                 .with_label_values(&[event_type, METRIC_STATUS_INDEXER_INVARIANT_VIOLATION]),
+            unsupported_residency_domain: counters
+                .with_label_values(&[event_type, METRIC_STATUS_UNSUPPORTED_RESIDENCY_DOMAIN]),
         }
     }
 
@@ -438,6 +472,9 @@ impl ResultCounters {
             Err(KvCacheEventError::AllocationFailed) => &self.allocation_failed,
             Err(KvCacheEventError::OwnershipDegreeOverflow) => &self.ownership_degree_overflow,
             Err(KvCacheEventError::IndexerInvariantViolation) => &self.indexer_invariant_violation,
+            Err(KvCacheEventError::UnsupportedResidencyDomain) => {
+                &self.unsupported_residency_domain
+            }
         }
     }
 }

--- a/lib/kv-router/src/indexer/positional.rs
+++ b/lib/kv-router/src/indexer/positional.rs
@@ -527,6 +527,9 @@ impl PositionalIndexer {
                 events.push(RouterEvent {
                     worker_id: worker.worker_id,
                     storage_tier: crate::protocols::StorageTier::Device,
+                    residency_domain: crate::protocols::WireResidencyDomain::explicit(
+                        crate::protocols::ResidencyDomain::Worker,
+                    ),
                     event: KvCacheEvent {
                         event_id,
                         data: KvCacheEventData::Stored(KvCacheStoreData {

--- a/lib/kv-router/src/indexer/radix_tree.rs
+++ b/lib/kv-router/src/indexer/radix_tree.rs
@@ -950,10 +950,12 @@ mod tests {
         let compact = WorkerKvQueryResponse::TreeDump {
             events,
             last_event_id: 42,
+            reset_scope: ResetScope::All,
         };
         let uncompressed = WorkerKvQueryResponse::TreeDump {
             events: uncompressed_events,
             last_event_id: 42,
+            reset_scope: ResetScope::All,
         };
         assert!(
             serde_json::to_vec(&compact).unwrap().len()

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -2492,14 +2492,16 @@ mod local_indexer_tests {
     }
 
     fn make_local_clear_event(event_id: u64) -> RouterEvent {
-        RouterEvent::new(
-            0,
-            KvCacheEvent {
+        RouterEvent {
+            worker_id: 0,
+            storage_tier: StorageTier::Device,
+            residency_domain: WireResidencyDomain::default(),
+            event: KvCacheEvent {
                 event_id,
                 data: KvCacheEventData::Cleared,
                 dp_rank: 0,
             },
-        )
+        }
     }
 
     #[tokio::test]
@@ -2606,6 +2608,7 @@ mod local_indexer_tests {
             WorkerKvQueryResponse::TreeDump {
                 events,
                 last_event_id,
+                ..
             } => {
                 assert_eq!(events.len(), 10);
                 assert_eq!(last_event_id, 14);
@@ -2618,6 +2621,7 @@ mod local_indexer_tests {
             WorkerKvQueryResponse::TreeDump {
                 events,
                 last_event_id,
+                ..
             } => {
                 assert_eq!(events.len(), 10);
                 assert_eq!(last_event_id, 14);
@@ -2643,6 +2647,7 @@ mod local_indexer_tests {
             WorkerKvQueryResponse::TreeDump {
                 last_event_id,
                 events,
+                ..
             } => {
                 assert_eq!(
                     last_event_id, 0,
@@ -2655,7 +2660,7 @@ mod local_indexer_tests {
     }
 
     #[tokio::test]
-    async fn test_local_indexer_buffer_response_starts_at_last_clear() {
+    async fn test_local_indexer_buffer_response_starts_at_last_all_domain_clear() {
         let indexer = LocalKvIndexer::new(
             CancellationToken::new(),
             4,
@@ -2987,6 +2992,7 @@ mod local_indexer_tests {
             WorkerKvQueryResponse::TreeDump {
                 events,
                 last_event_id,
+                ..
             } => {
                 assert_eq!(last_event_id, 2);
                 assert!(events.iter().any(|event| event.event.event_id == 2));

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -506,6 +506,7 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
                 resp: resp_tx,
             })
             .map_err(|_| KvRouterError::IndexerOffline)?;
+        self.maybe_enqueue_cleanup(thread_idx);
         let applied = resp_rx
             .await
             .map_err(|_| KvRouterError::IndexerDroppedRequest)?;

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -490,6 +490,31 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
         Ok(())
     }
 
+    /// Apply one event on its worker lane and wait for the backend result.
+    pub async fn apply_event_and_wait(&self, event: RouterEvent) -> Result<(), KvRouterError> {
+        let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
+        let thread_idx = Self::get_or_assign_thread_idx(
+            &self.worker_assignments,
+            &self.worker_assignment_count,
+            worker,
+            self.num_workers,
+        );
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.worker_event_channels[thread_idx]
+            .send(WorkerTask::EventWithAck {
+                event,
+                resp: resp_tx,
+            })
+            .map_err(|_| KvRouterError::IndexerOffline)?;
+        let applied = resp_rx
+            .await
+            .map_err(|_| KvRouterError::IndexerDroppedRequest)?;
+        if !applied {
+            return Err(KvRouterError::IndexerDroppedRequest);
+        }
+        Ok(())
+    }
+
     /// Wait until every worker queue has completed tasks accepted before this call.
     ///
     /// This is a FIFO progress barrier, not an event-result acknowledgement. Ordinary

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -93,10 +93,11 @@ pub enum WorkerKvQueryResponse {
     /// Events served from the circular buffer with original event IDs. The batch
     /// is recovery-equivalent to replaying the requested `start_event_id` through
     /// the current buffered tail. If the rank stream contains one or more `Cleared`
-    /// events, the source may omit events before the latest clear while preserving
-    /// that clear event and all following events. `last_event_id` is taken from the
-    /// same buffer snapshot and should be used as the recovery watermark after
-    /// applying the batch.
+    /// all-domain `Cleared` events, the source may omit events before the latest such
+    /// clear while preserving that clear event and all following events. Domain-scoped
+    /// clears remain ordinary ordered events. `last_event_id` is taken from the same
+    /// buffer snapshot and should be used as the recovery watermark after applying the
+    /// batch.
     Events {
         events: Vec<RouterEvent>,
         last_event_id: u64,
@@ -107,10 +108,14 @@ pub enum WorkerKvQueryResponse {
     TreeDump {
         events: Vec<RouterEvent>,
         last_event_id: u64,
+        /// Scope authoritatively represented by this snapshot. Legacy responses
+        /// omitted this field and always represented the whole rank.
+        #[serde(default)]
+        reset_scope: ResetScope,
     },
     /// The exact tree dump could not be produced. This is distinct from an
-    /// authoritative empty tree so recovery can apply its explicit fail-open
-    /// reset policy without mistaking an indexer failure for exact state.
+    /// authoritative empty tree; recovery must leave indexed state and its
+    /// admission cursor unchanged.
     TreeDumpFailed { last_event_id: u64, message: String },
     /// Requested range is newer than available data
     TooNew {

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -500,17 +500,14 @@ pub enum ResetScope {
 pub enum WireResidencyDomain {
     #[default]
     Missing,
-    Value(Box<str>),
+    Known(ResidencyDomain),
+    Unknown(Box<str>),
     Invalid,
 }
 
 impl WireResidencyDomain {
     pub fn explicit(domain: ResidencyDomain) -> Self {
-        let value = match domain {
-            ResidencyDomain::Worker => "worker",
-            ResidencyDomain::CacheOwner => "cache_owner",
-        };
-        Self::Value(value.into())
+        Self::Known(domain)
     }
 
     fn is_missing(&self) -> bool {
@@ -520,11 +517,8 @@ impl WireResidencyDomain {
     pub fn parse(&self) -> Result<Option<ResidencyDomain>, UnsupportedResidencyDomain> {
         match self {
             Self::Missing => Ok(None),
-            Self::Value(value) if value.as_ref() == "worker" => Ok(Some(ResidencyDomain::Worker)),
-            Self::Value(value) if value.as_ref() == "cache_owner" => {
-                Ok(Some(ResidencyDomain::CacheOwner))
-            }
-            Self::Value(_) | Self::Invalid => Err(UnsupportedResidencyDomain),
+            Self::Known(domain) => Ok(Some(*domain)),
+            Self::Unknown(_) | Self::Invalid => Err(UnsupportedResidencyDomain),
         }
     }
 }
@@ -536,7 +530,9 @@ impl Serialize for WireResidencyDomain {
     {
         match self {
             Self::Missing | Self::Invalid => serializer.serialize_none(),
-            Self::Value(value) => serializer.serialize_str(value),
+            Self::Known(ResidencyDomain::Worker) => serializer.serialize_str("worker"),
+            Self::Known(ResidencyDomain::CacheOwner) => serializer.serialize_str("cache_owner"),
+            Self::Unknown(value) => serializer.serialize_str(value),
         }
     }
 }
@@ -551,11 +547,19 @@ impl<'de> Visitor<'de> for WireResidencyDomainVisitor {
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
-        Ok(WireResidencyDomain::Value(value.into()))
+        Ok(match value {
+            "worker" => WireResidencyDomain::Known(ResidencyDomain::Worker),
+            "cache_owner" => WireResidencyDomain::Known(ResidencyDomain::CacheOwner),
+            value => WireResidencyDomain::Unknown(value.into()),
+        })
     }
 
     fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
-        Ok(WireResidencyDomain::Value(value.into_boxed_str()))
+        Ok(match value.as_str() {
+            "worker" => WireResidencyDomain::Known(ResidencyDomain::Worker),
+            "cache_owner" => WireResidencyDomain::Known(ResidencyDomain::CacheOwner),
+            _ => WireResidencyDomain::Unknown(value.into_boxed_str()),
+        })
     }
 
     fn visit_char<E>(self, _value: char) -> Result<Self::Value, E> {

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 
 use dynamo_tokens::{SequenceHash, Token, compute_hash_v2, compute_next_sequence_hash};
 use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
+use serde::de::{IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use xxhash_rust::xxh3;
 
 const fn default_track_prefill_tokens() -> bool {
@@ -460,6 +461,169 @@ pub enum StorageTier {
     External,
 }
 
+/// Logical lifetime that owns a cache residency independently of its physical tier.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ResidencyDomain {
+    #[default]
+    Worker,
+    CacheOwner,
+}
+
+/// Exact logical owner recorded inside a physical-tier index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ResidencyOwner {
+    pub worker: WorkerWithDpRank,
+    pub domain: ResidencyDomain,
+}
+
+impl ResidencyOwner {
+    pub fn new(worker: WorkerWithDpRank, domain: ResidencyDomain) -> Self {
+        Self { worker, domain }
+    }
+}
+
+/// Scope of a cache-residency reset.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ResetScope {
+    #[default]
+    All,
+    Domain(ResidencyDomain),
+}
+
+/// Tolerant wire representation for the additive `residency_domain` field.
+///
+/// `Missing` is the legacy compatibility signal. Unsupported values stay at
+/// the wire boundary and never enter [`ResidencyDomain`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum WireResidencyDomain {
+    #[default]
+    Missing,
+    Value(Box<str>),
+    Invalid,
+}
+
+impl WireResidencyDomain {
+    pub fn explicit(domain: ResidencyDomain) -> Self {
+        let value = match domain {
+            ResidencyDomain::Worker => "worker",
+            ResidencyDomain::CacheOwner => "cache_owner",
+        };
+        Self::Value(value.into())
+    }
+
+    fn is_missing(&self) -> bool {
+        matches!(self, Self::Missing)
+    }
+
+    pub fn parse(&self) -> Result<Option<ResidencyDomain>, UnsupportedResidencyDomain> {
+        match self {
+            Self::Missing => Ok(None),
+            Self::Value(value) if value.as_ref() == "worker" => Ok(Some(ResidencyDomain::Worker)),
+            Self::Value(value) if value.as_ref() == "cache_owner" => {
+                Ok(Some(ResidencyDomain::CacheOwner))
+            }
+            Self::Value(_) | Self::Invalid => Err(UnsupportedResidencyDomain),
+        }
+    }
+}
+
+impl Serialize for WireResidencyDomain {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Missing | Self::Invalid => serializer.serialize_none(),
+            Self::Value(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+struct WireResidencyDomainVisitor;
+
+impl<'de> Visitor<'de> for WireResidencyDomainVisitor {
+    type Value = WireResidencyDomain;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a residency-domain string")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Value(value.into()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Value(value.into_boxed_str()))
+    }
+
+    fn visit_char<E>(self, _value: char) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_bytes<E>(self, _value: &[u8]) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_byte_buf<E>(self, _value: Vec<u8>) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while sequence.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(WireResidencyDomain::Invalid)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
+        Ok(WireResidencyDomain::Invalid)
+    }
+}
+
+impl<'de> Deserialize<'de> for WireResidencyDomain {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(WireResidencyDomainVisitor)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("unsupported residency domain")]
+pub struct UnsupportedResidencyDomain;
+
 impl StorageTier {
     pub fn from_kv_medium(medium: &str) -> Option<Self> {
         match medium {
@@ -497,6 +661,8 @@ pub enum PlacementOwner {
 pub struct Placement {
     pub owner: PlacementOwner,
     pub tier: StorageTier,
+    #[serde(default)]
+    pub residency_domain: ResidencyDomain,
 }
 
 impl Placement {
@@ -504,6 +670,7 @@ impl Placement {
         Self {
             owner: PlacementOwner::LocalWorker(WorkerWithDpRank::new(worker_id, dp_rank)),
             tier,
+            residency_domain: ResidencyDomain::Worker,
         }
     }
 
@@ -535,10 +702,11 @@ impl PlacementEvent {
         let PlacementOwner::LocalWorker(worker) = self.placement.owner else {
             return None;
         };
-        Some(RouterEvent::with_storage_tier(
+        Some(RouterEvent::with_residency_domain(
             worker.worker_id,
             self.event,
             self.placement.tier,
+            self.placement.residency_domain,
         ))
     }
 }
@@ -1029,6 +1197,9 @@ pub enum KvCacheEventError {
 
     #[error("Indexer invariant violated")]
     IndexerInvariantViolation,
+
+    #[error("Unsupported residency domain")]
+    UnsupportedResidencyDomain,
 }
 
 /// A [`KvCacheEvent`] on a specific LLM worker denoted by [`WorkerId`].
@@ -1039,6 +1210,10 @@ pub struct RouterEvent {
     /// The storage tier associated with the event.
     #[serde(default)]
     pub storage_tier: StorageTier,
+    /// Optional logical residency owner. Absence is interpreted by event kind
+    /// for compatibility with domainless publishers.
+    #[serde(default, skip_serializing_if = "WireResidencyDomain::is_missing")]
+    pub residency_domain: WireResidencyDomain,
     /// The cache event associated with the worker.
     pub event: KvCacheEvent,
 }
@@ -1063,11 +1238,59 @@ impl RouterEvent {
         event: KvCacheEvent,
         storage_tier: StorageTier,
     ) -> Self {
+        Self::with_residency_domain(worker_id, event, storage_tier, ResidencyDomain::Worker)
+    }
+
+    pub fn with_residency_domain(
+        worker_id: WorkerId,
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+        residency_domain: ResidencyDomain,
+    ) -> Self {
         Self {
             worker_id,
             storage_tier,
+            residency_domain: WireResidencyDomain::explicit(residency_domain),
             event,
         }
+    }
+
+    /// Resolve a storage mutation to its canonical logical domain.
+    pub fn resolved_residency_domain(&self) -> Result<ResidencyDomain, UnsupportedResidencyDomain> {
+        let domain = self.residency_domain.parse()?.unwrap_or_default();
+        if domain == ResidencyDomain::CacheOwner && self.storage_tier.is_gpu() {
+            return Err(UnsupportedResidencyDomain);
+        }
+        Ok(domain)
+    }
+
+    pub fn residency_owner(&self) -> Result<ResidencyOwner, UnsupportedResidencyDomain> {
+        Ok(ResidencyOwner::new(
+            WorkerWithDpRank::new(self.worker_id, self.event.dp_rank),
+            self.resolved_residency_domain()?,
+        ))
+    }
+
+    /// Resolve `Cleared` semantics while preserving legacy all-domain clears.
+    pub fn reset_scope(&self) -> Result<Option<ResetScope>, UnsupportedResidencyDomain> {
+        if !matches!(self.event.data, KvCacheEventData::Cleared) {
+            return Ok(None);
+        }
+        Ok(Some(match self.residency_domain.parse()? {
+            Some(domain) => ResetScope::Domain(domain),
+            None => ResetScope::All,
+        }))
+    }
+
+    pub fn targets_primary(&self) -> Result<bool, UnsupportedResidencyDomain> {
+        if let Some(scope) = self.reset_scope()? {
+            return Ok(!matches!(
+                scope,
+                ResetScope::Domain(ResidencyDomain::CacheOwner)
+            ));
+        }
+        self.resolved_residency_domain()?;
+        Ok(self.storage_tier.is_gpu())
     }
 }
 
@@ -1327,6 +1550,110 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json;
+
+    // Temporary N/N-1 fixtures. Remove this module when domainless RouterEvent
+    // is outside the supported mixed-version window.
+    mod residency_domain_compat {
+        use super::*;
+
+        #[derive(Serialize, Deserialize)]
+        struct LegacyRouterEvent {
+            worker_id: WorkerId,
+            #[serde(default)]
+            storage_tier: StorageTier,
+            event: KvCacheEvent,
+        }
+
+        #[derive(Serialize)]
+        struct ExplicitDomainEvent {
+            worker_id: WorkerId,
+            storage_tier: StorageTier,
+            residency_domain: serde_json::Value,
+            event: KvCacheEvent,
+        }
+
+        fn event(event_id: u64, data: KvCacheEventData) -> KvCacheEvent {
+            KvCacheEvent {
+                event_id,
+                data,
+                dp_rank: 0,
+            }
+        }
+
+        fn stored(event_id: u64) -> KvCacheEvent {
+            event(
+                event_id,
+                KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    start_position: None,
+                    blocks: Vec::new(),
+                }),
+            )
+        }
+
+        #[test]
+        fn named_messagepack_keeps_worker_only_mixed_versions_operational() {
+            let legacy = vec![
+                LegacyRouterEvent {
+                    worker_id: 7,
+                    storage_tier: StorageTier::HostPinned,
+                    event: stored(1),
+                },
+                LegacyRouterEvent {
+                    worker_id: 7,
+                    storage_tier: StorageTier::Device,
+                    event: event(2, KvCacheEventData::Cleared),
+                },
+            ];
+            let decoded: Vec<RouterEvent> =
+                rmp_serde::from_slice(&rmp_serde::to_vec_named(&legacy).unwrap()).unwrap();
+            assert_eq!(
+                decoded[0].resolved_residency_domain(),
+                Ok(ResidencyDomain::Worker)
+            );
+            assert_eq!(decoded[1].reset_scope(), Ok(Some(ResetScope::All)));
+
+            let explicit_worker = RouterEvent::with_residency_domain(
+                7,
+                stored(3),
+                StorageTier::Disk,
+                ResidencyDomain::Worker,
+            );
+            let old_reader: LegacyRouterEvent =
+                rmp_serde::from_slice(&rmp_serde::to_vec_named(&explicit_worker).unwrap()).unwrap();
+            assert_eq!(old_reader.event.event_id, 3);
+            assert_eq!(old_reader.storage_tier, StorageTier::Disk);
+
+            let mixed = vec![
+                ExplicitDomainEvent {
+                    worker_id: 7,
+                    storage_tier: StorageTier::HostPinned,
+                    residency_domain: serde_json::json!("worker"),
+                    event: stored(4),
+                },
+                ExplicitDomainEvent {
+                    worker_id: 7,
+                    storage_tier: StorageTier::HostPinned,
+                    residency_domain: serde_json::json!("future_owner"),
+                    event: stored(5),
+                },
+                ExplicitDomainEvent {
+                    worker_id: 7,
+                    storage_tier: StorageTier::HostPinned,
+                    residency_domain: serde_json::json!("worker"),
+                    event: stored(6),
+                },
+            ];
+            let decoded: Vec<RouterEvent> =
+                rmp_serde::from_slice(&rmp_serde::to_vec_named(&mixed).unwrap()).unwrap();
+            let applied_ids: Vec<_> = decoded
+                .iter()
+                .filter(|event| event.resolved_residency_domain().is_ok())
+                .map(|event| event.event.event_id)
+                .collect();
+            assert_eq!(applied_ids, vec![4, 6]);
+        }
+    }
 
     /// Pin the sglang pad_value constants and formula against upstream
     /// `MultimodalItem._compute_pad_value`. If sglang bumps a constant, this

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -571,10 +571,14 @@ impl<'de> Visitor<'de> for WireResidencyDomainVisitor {
     }
 
     fn visit_none<E>(self) -> Result<Self::Value, E> {
+        // Explicit null is malformed. Only an omitted field selects legacy
+        // semantics; treating null as omission would turn a malformed clear
+        // into an all-domain reset.
         Ok(WireResidencyDomain::Invalid)
     }
 
     fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        // MessagePack nil follows the same contract as JSON null above.
         Ok(WireResidencyDomain::Invalid)
     }
 
@@ -1238,6 +1242,8 @@ impl RouterEvent {
         event: KvCacheEvent,
         storage_tier: StorageTier,
     ) -> Self {
+        // Canonical in-process events are worker-owned, including clears. A
+        // missing domain is reserved for decoding legacy wire payloads.
         Self::with_residency_domain(worker_id, event, storage_tier, ResidencyDomain::Worker)
     }
 
@@ -1640,8 +1646,14 @@ mod tests {
                 ExplicitDomainEvent {
                     worker_id: 7,
                     storage_tier: StorageTier::HostPinned,
-                    residency_domain: serde_json::json!("worker"),
+                    residency_domain: serde_json::Value::Null,
                     event: stored(6),
+                },
+                ExplicitDomainEvent {
+                    worker_id: 7,
+                    storage_tier: StorageTier::HostPinned,
+                    residency_domain: serde_json::json!("worker"),
+                    event: stored(7),
                 },
             ];
             let decoded: Vec<RouterEvent> =
@@ -1651,7 +1663,7 @@ mod tests {
                 .filter(|event| event.resolved_residency_domain().is_ok())
                 .map(|event| event.event.event_id)
                 .collect();
-            assert_eq!(applied_ids, vec![4, 6]);
+            assert_eq!(applied_ids, vec![4, 7]);
         }
     }
 

--- a/lib/kv-router/src/services/indexer/backend.rs
+++ b/lib/kv-router/src/services/indexer/backend.rs
@@ -67,14 +67,13 @@ impl Indexer {
                 lower_tier,
             } => {
                 if is_clear {
-                    if targets_primary {
-                        if let Err(error) = primary
+                    if targets_primary
+                        && let Err(error) = primary
                             .reset_worker_dp_rank_and_wait(event.worker_id, event.event.dp_rank)
                             .await
-                        {
-                            tracing::warn!(%error, "Failed to reset primary residency");
-                            return;
-                        }
+                    {
+                        tracing::warn!(%error, "Failed to reset primary residency");
+                        return;
                     }
                     for indexer in lower_tier.all() {
                         if let Err(error) = indexer.apply_event_and_wait(event.clone()).await {
@@ -96,11 +95,11 @@ impl Indexer {
                 lower_tier,
             } => {
                 if is_clear {
-                    if targets_primary {
-                        if let Err(error) = primary.apply_event_and_wait(event.clone()).await {
-                            tracing::warn!(%error, "Failed to reset primary residency");
-                            return;
-                        }
+                    if targets_primary
+                        && let Err(error) = primary.apply_event_and_wait(event.clone()).await
+                    {
+                        tracing::warn!(%error, "Failed to reset primary residency");
+                        return;
                     }
                     for indexer in lower_tier.all() {
                         if let Err(error) = indexer.apply_event_and_wait(event.clone()).await {

--- a/lib/kv-router/src/services/indexer/backend.rs
+++ b/lib/kv-router/src/services/indexer/backend.rs
@@ -68,14 +68,11 @@ impl Indexer {
             } => {
                 if is_clear {
                     let mut reset_error = None;
-                    if targets_primary {
-                        if let Err(error) = primary
-                            .reset_worker_dp_rank_and_wait(event.worker_id, event.event.dp_rank)
-                            .await
-                        {
-                            tracing::warn!(%error, "Failed to reset primary residency");
-                            reset_error = Some(error);
-                        }
+                    if targets_primary
+                        && let Err(error) = primary.apply_event_and_wait(event.clone()).await
+                    {
+                        tracing::warn!(%error, "Failed to reset primary residency");
+                        reset_error = Some(error);
                     }
                     for indexer in lower_tier.all() {
                         if let Err(error) = indexer.apply_event_and_wait(event.clone()).await {
@@ -101,11 +98,11 @@ impl Indexer {
             } => {
                 if is_clear {
                     let mut reset_error = None;
-                    if targets_primary {
-                        if let Err(error) = primary.apply_event_and_wait(event.clone()).await {
-                            tracing::warn!(%error, "Failed to reset primary residency");
-                            reset_error = Some(error);
-                        }
+                    if targets_primary
+                        && let Err(error) = primary.apply_event_and_wait(event.clone()).await
+                    {
+                        tracing::warn!(%error, "Failed to reset primary residency");
+                        reset_error = Some(error);
                     }
                     for indexer in lower_tier.all() {
                         if let Err(error) = indexer.apply_event_and_wait(event.clone()).await {
@@ -335,6 +332,8 @@ mod tests {
     use super::test_util::store_event;
     use super::*;
     use crate::indexer::KvIndexerInterface;
+    #[cfg(feature = "metrics")]
+    use crate::indexer::{METRIC_EVENT_CLEARED, METRIC_STATUS_OK};
     use crate::protocols::{
         KvCacheEvent, LocalBlockHash, ResidencyDomain, StorageTier, WorkerWithDpRank,
     };
@@ -564,6 +563,38 @@ mod tests {
 
         assert!(matches!(error, KvRouterError::IndexerOffline));
         assert!(healthy_tier.dump_events().await.unwrap().is_empty());
+    }
+
+    #[cfg(feature = "metrics")]
+    #[tokio::test]
+    async fn acknowledged_clear_records_primary_event_for_both_indexers() {
+        for num_threads in [1, 2] {
+            let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
+            let indexer = create_indexer_with_metrics(4, num_threads, metrics.clone());
+            indexer
+                .apply_event_routed(RouterEvent::with_residency_domain(
+                    7,
+                    KvCacheEvent {
+                        event_id: 1,
+                        data: KvCacheEventData::Cleared,
+                        dp_rank: 0,
+                    },
+                    StorageTier::Device,
+                    ResidencyDomain::Worker,
+                ))
+                .await
+                .unwrap();
+
+            assert_eq!(
+                metrics
+                    .kv_cache_events_applied
+                    .get_metric_with_label_values(&[METRIC_EVENT_CLEARED, METRIC_STATUS_OK])
+                    .unwrap()
+                    .get(),
+                1,
+                "clear metric mismatch for {num_threads} indexer thread(s)"
+            );
+        }
     }
 }
 

--- a/lib/kv-router/src/services/indexer/backend.rs
+++ b/lib/kv-router/src/services/indexer/backend.rs
@@ -46,50 +46,77 @@ impl Indexer {
 
     /// Apply an event, routing to the device-tier primary when
     /// `event.storage_tier.is_gpu()` and to the appropriate lower-tier
-    /// indexer otherwise. `Cleared` events fan out to every tier so per-tier
-    /// state stays consistent with the primary.
+    /// indexer otherwise. `Cleared` events fan out to their applicable physical
+    /// indexes according to the event's reset scope.
     pub async fn apply_event_routed(&self, event: RouterEvent) {
+        let targets_primary = match event.targets_primary() {
+            Ok(targets_primary) => targets_primary,
+            Err(_) => {
+                match self {
+                    Self::Single { lower_tier, .. } | Self::Concurrent { lower_tier, .. } => {
+                        lower_tier.record_unsupported_residency_event(&event);
+                    }
+                }
+                return;
+            }
+        };
+        let is_clear = matches!(&event.event.data, KvCacheEventData::Cleared);
         match self {
             Indexer::Single {
                 primary,
                 lower_tier,
-            } => match &event.event.data {
-                KvCacheEventData::Cleared => {
-                    primary.apply_event(event.clone()).await;
-                    for indexer in lower_tier.all() {
-                        indexer.apply_event(event.clone()).await;
+            } => {
+                if is_clear {
+                    if targets_primary {
+                        if let Err(error) = primary
+                            .reset_worker_dp_rank_and_wait(event.worker_id, event.event.dp_rank)
+                            .await
+                        {
+                            tracing::warn!(%error, "Failed to reset primary residency");
+                            return;
+                        }
                     }
-                }
-                _ if event.storage_tier.is_gpu() => {
+                    for indexer in lower_tier.all() {
+                        if let Err(error) = indexer.apply_event_and_wait(event.clone()).await {
+                            tracing::warn!(%error, "Failed to reset lower-tier residency");
+                            return;
+                        }
+                    }
+                } else if targets_primary {
                     primary.apply_event(event).await;
-                }
-                _ => {
+                } else {
                     lower_tier
                         .get_or_create(event.storage_tier)
                         .apply_event(event)
                         .await;
                 }
-            },
+            }
             Indexer::Concurrent {
                 primary,
                 lower_tier,
-            } => match &event.event.data {
-                KvCacheEventData::Cleared => {
-                    primary.apply_event(event.clone()).await;
-                    for indexer in lower_tier.all() {
-                        indexer.apply_event(event.clone()).await;
+            } => {
+                if is_clear {
+                    if targets_primary {
+                        if let Err(error) = primary.apply_event_and_wait(event.clone()).await {
+                            tracing::warn!(%error, "Failed to reset primary residency");
+                            return;
+                        }
                     }
-                }
-                _ if event.storage_tier.is_gpu() => {
+                    for indexer in lower_tier.all() {
+                        if let Err(error) = indexer.apply_event_and_wait(event.clone()).await {
+                            tracing::warn!(%error, "Failed to reset lower-tier residency");
+                            return;
+                        }
+                    }
+                } else if targets_primary {
                     primary.apply_event(event).await;
-                }
-                _ => {
+                } else {
                     lower_tier
                         .get_or_create(event.storage_tier)
                         .apply_event(event)
                         .await;
                 }
-            },
+            }
         }
     }
 

--- a/lib/kv-router/src/services/indexer/backend.rs
+++ b/lib/kv-router/src/services/indexer/backend.rs
@@ -48,7 +48,7 @@ impl Indexer {
     /// `event.storage_tier.is_gpu()` and to the appropriate lower-tier
     /// indexer otherwise. `Cleared` events fan out to their applicable physical
     /// indexes according to the event's reset scope.
-    pub async fn apply_event_routed(&self, event: RouterEvent) {
+    pub async fn apply_event_routed(&self, event: RouterEvent) -> Result<(), KvRouterError> {
         let targets_primary = match event.targets_primary() {
             Ok(targets_primary) => targets_primary,
             Err(_) => {
@@ -57,7 +57,7 @@ impl Indexer {
                         lower_tier.record_unsupported_residency_event(&event);
                     }
                 }
-                return;
+                return Ok(());
             }
         };
         let is_clear = matches!(&event.event.data, KvCacheEventData::Cleared);
@@ -67,19 +67,24 @@ impl Indexer {
                 lower_tier,
             } => {
                 if is_clear {
-                    if targets_primary
-                        && let Err(error) = primary
+                    let mut reset_error = None;
+                    if targets_primary {
+                        if let Err(error) = primary
                             .reset_worker_dp_rank_and_wait(event.worker_id, event.event.dp_rank)
                             .await
-                    {
-                        tracing::warn!(%error, "Failed to reset primary residency");
-                        return;
+                        {
+                            tracing::warn!(%error, "Failed to reset primary residency");
+                            reset_error = Some(error);
+                        }
                     }
                     for indexer in lower_tier.all() {
                         if let Err(error) = indexer.apply_event_and_wait(event.clone()).await {
                             tracing::warn!(%error, "Failed to reset lower-tier residency");
-                            return;
+                            reset_error.get_or_insert(error);
                         }
+                    }
+                    if let Some(error) = reset_error {
+                        return Err(error);
                     }
                 } else if targets_primary {
                     primary.apply_event(event).await;
@@ -95,17 +100,21 @@ impl Indexer {
                 lower_tier,
             } => {
                 if is_clear {
-                    if targets_primary
-                        && let Err(error) = primary.apply_event_and_wait(event.clone()).await
-                    {
-                        tracing::warn!(%error, "Failed to reset primary residency");
-                        return;
+                    let mut reset_error = None;
+                    if targets_primary {
+                        if let Err(error) = primary.apply_event_and_wait(event.clone()).await {
+                            tracing::warn!(%error, "Failed to reset primary residency");
+                            reset_error = Some(error);
+                        }
                     }
                     for indexer in lower_tier.all() {
                         if let Err(error) = indexer.apply_event_and_wait(event.clone()).await {
                             tracing::warn!(%error, "Failed to reset lower-tier residency");
-                            return;
+                            reset_error.get_or_insert(error);
                         }
+                    }
+                    if let Some(error) = reset_error {
+                        return Err(error);
                     }
                 } else if targets_primary {
                     primary.apply_event(event).await;
@@ -117,6 +126,7 @@ impl Indexer {
                 }
             }
         }
+        Ok(())
     }
 
     pub async fn remove_worker(&self, worker_id: WorkerId) {
@@ -325,7 +335,9 @@ mod tests {
     use super::test_util::store_event;
     use super::*;
     use crate::indexer::KvIndexerInterface;
-    use crate::protocols::{LocalBlockHash, StorageTier, WorkerWithDpRank};
+    use crate::protocols::{
+        KvCacheEvent, LocalBlockHash, ResidencyDomain, StorageTier, WorkerWithDpRank,
+    };
 
     /// Apply a Device store and a HostPinned store anchored on it. The tiered
     /// query must surface both tier hits, and the device-tier `find_matches`
@@ -345,7 +357,8 @@ mod tests {
                 &[11, 12],
                 StorageTier::Device,
             ))
-            .await;
+            .await
+            .unwrap();
 
         indexer
             .apply_event_routed(store_event(
@@ -356,7 +369,8 @@ mod tests {
                 &[13],
                 StorageTier::HostPinned,
             ))
-            .await;
+            .await
+            .unwrap();
 
         // Flush primary so the in-flight events are observable by the query.
         if let Indexer::Single { primary, .. } = &indexer {
@@ -407,7 +421,8 @@ mod tests {
                 &[11, 12],
                 StorageTier::Device,
             ))
-            .await;
+            .await
+            .unwrap();
         source
             .apply_event_routed(store_event(
                 worker.worker_id,
@@ -417,7 +432,8 @@ mod tests {
                 &[13],
                 StorageTier::HostPinned,
             ))
-            .await;
+            .await
+            .unwrap();
         source
             .apply_event_routed(store_event(
                 worker.worker_id,
@@ -427,7 +443,8 @@ mod tests {
                 &[14],
                 StorageTier::Disk,
             ))
-            .await;
+            .await
+            .unwrap();
 
         if let Indexer::Single {
             primary,
@@ -461,7 +478,7 @@ mod tests {
 
         let replayed = create_indexer(block_size, 1);
         for event in dump {
-            replayed.apply_event_routed(event).await;
+            replayed.apply_event_routed(event).await.unwrap();
         }
         if let Indexer::Single {
             primary,
@@ -503,6 +520,50 @@ mod tests {
             Some(1),
             "disk should report 1 additional block after replay"
         );
+    }
+
+    #[tokio::test]
+    async fn clear_reports_partial_failure_after_attempting_every_tier() {
+        let indexer = create_indexer(4, 1);
+        let worker = WorkerWithDpRank::new(7, 0);
+        let (failed_tier, healthy_tier) = match &indexer {
+            Indexer::Single { lower_tier, .. } => (
+                lower_tier.get_or_create(StorageTier::HostPinned),
+                lower_tier.get_or_create(StorageTier::Disk),
+            ),
+            Indexer::Concurrent { .. } => unreachable!("test creates the single indexer"),
+        };
+
+        indexer
+            .apply_event_routed(store_event(
+                worker.worker_id,
+                worker.dp_rank,
+                1,
+                &[],
+                &[11],
+                StorageTier::Disk,
+            ))
+            .await
+            .unwrap();
+        let _ = healthy_tier.dump_events().await.unwrap();
+        failed_tier.shutdown();
+
+        let error = indexer
+            .apply_event_routed(RouterEvent::with_residency_domain(
+                worker.worker_id,
+                KvCacheEvent {
+                    event_id: 2,
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: worker.dp_rank,
+                },
+                StorageTier::Device,
+                ResidencyDomain::Worker,
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, KvRouterError::IndexerOffline));
+        assert!(healthy_tier.dump_events().await.unwrap().is_empty());
     }
 }
 

--- a/lib/kv-router/src/services/indexer/listener.rs
+++ b/lib/kv-router/src/services/indexer/listener.rs
@@ -185,7 +185,7 @@ impl ListenerLoop {
         cursor_from_watermark(self.watermark.load(Ordering::Acquire))
     }
 
-    async fn replay_gap(&mut self, start_seq: u64, end_seq: u64) -> u64 {
+    async fn replay_gap(&mut self, start_seq: u64, end_seq: u64) -> Result<u64, String> {
         tracing::info!(
             self.worker_id,
             self.dp_rank,
@@ -201,7 +201,7 @@ impl ListenerLoop {
                 gap_size = end_seq.saturating_sub(start_seq),
                 "No replay endpoint configured; batches lost"
             );
-            return 0;
+            return Ok(0);
         };
 
         let worker_id = self.worker_id;
@@ -212,7 +212,7 @@ impl ListenerLoop {
         let req_frames = vec![Vec::new(), start_seq.to_be_bytes().to_vec()];
         if let Err(error) = send_multipart(replay_socket, req_frames).await {
             tracing::error!(worker_id, dp_rank, error = %error, "Failed to send replay request");
-            return 0;
+            return Ok(0);
         }
 
         let mut replay_progress = ReplayRecoveryProgress::new(start_seq, end_seq);
@@ -278,7 +278,14 @@ impl ListenerLoop {
                 let router_event = placement_event
                     .into_router_event()
                     .expect("local worker placement must convert to router event");
-                indexer.apply_event_routed(router_event).await;
+                indexer
+                    .apply_event_routed(router_event)
+                    .await
+                    .map_err(|error| {
+                        format!(
+                            "failed to apply replayed event for worker {worker_id} dp_rank {dp_rank}: {error}"
+                        )
+                    })?;
             }
             watermark.store(seq, Ordering::Release);
             replay_progress.record_batch(seq);
@@ -288,10 +295,10 @@ impl ListenerLoop {
 
         let replayed = replay_progress.replayed();
         tracing::info!(worker_id, dp_rank, replayed, "Replay complete");
-        replayed
+        Ok(replayed)
     }
 
-    async fn handle_gap(&mut self, seq: u64) {
+    async fn handle_gap(&mut self, seq: u64) -> Result<(), String> {
         match self.cursor().observe(seq) {
             CursorObservation::Initial { got } if got > 0 => {
                 tracing::warn!(
@@ -301,7 +308,7 @@ impl ListenerLoop {
                     got,
                     "Gap detected: expected seq 0, got {got}"
                 );
-                self.replay_gap(0, got).await;
+                self.replay_gap(0, got).await?;
             }
             CursorObservation::Gap { expected, got } => {
                 tracing::warn!(
@@ -311,15 +318,16 @@ impl ListenerLoop {
                     got,
                     "Gap detected: expected seq {expected}, got {got}"
                 );
-                self.replay_gap(expected, got).await;
+                self.replay_gap(expected, got).await?;
             }
             CursorObservation::Initial { .. }
             | CursorObservation::Contiguous { .. }
             | CursorObservation::Stale { .. } => {}
         }
+        Ok(())
     }
 
-    async fn apply_live_batch(&mut self, seq: u64, payload: &[u8]) {
+    async fn apply_live_batch(&mut self, seq: u64, payload: &[u8]) -> Result<(), String> {
         let batch = match decode_event_batch(payload) {
             Ok(batch) => batch,
             Err(error) => {
@@ -328,7 +336,7 @@ impl ListenerLoop {
                     self.dp_rank,
                     "Failed to decode KvEventBatch: {error}"
                 );
-                return;
+                return Ok(());
             }
         };
 
@@ -346,13 +354,22 @@ impl ListenerLoop {
             let router_event = placement_event
                 .into_router_event()
                 .expect("local worker placement must convert to router event");
-            self.indexer.apply_event_routed(router_event).await;
+            self.indexer
+                .apply_event_routed(router_event)
+                .await
+                .map_err(|error| {
+                    format!(
+                        "failed to apply live event for worker {} dp_rank {}: {error}",
+                        self.worker_id, self.dp_rank
+                    )
+                })?;
             self.messages_processed += 1;
         }
         self.watermark.store(seq, Ordering::Release);
+        Ok(())
     }
 
-    async fn handle_message(&mut self, msg: MultipartMessage) {
+    async fn handle_message(&mut self, msg: MultipartMessage) -> Result<(), String> {
         if msg.len() != 3 {
             tracing::warn!(
                 self.worker_id,
@@ -360,7 +377,7 @@ impl ListenerLoop {
                 "Unexpected ZMQ frame count: {}",
                 msg.len()
             );
-            return;
+            return Ok(());
         }
 
         let seq_bytes = msg.get(1).expect("frame count checked above");
@@ -371,18 +388,18 @@ impl ListenerLoop {
                 "Invalid sequence number length: {}",
                 seq_bytes.len()
             );
-            return;
+            return Ok(());
         }
 
         let seq = u64::from_be_bytes(seq_bytes[..8].try_into().expect("length checked above"));
-        self.handle_gap(seq).await;
+        self.handle_gap(seq).await?;
 
         if matches!(self.cursor().observe(seq), CursorObservation::Stale { .. }) {
-            return;
+            return Ok(());
         }
 
         let payload = msg.get(2).expect("frame count checked above");
-        self.apply_live_batch(seq, payload).await;
+        self.apply_live_batch(seq, payload).await
     }
 
     async fn run(mut self) -> Result<(), String> {
@@ -414,7 +431,7 @@ impl ListenerLoop {
                 }
             };
 
-            self.handle_message(msg).await;
+            self.handle_message(msg).await?;
         }
     }
 }

--- a/lib/kv-router/src/services/indexer/recovery.rs
+++ b/lib/kv-router/src/services/indexer/recovery.rs
@@ -75,7 +75,10 @@ async fn try_recover_from_peer(
             // peer's dump land in the matching lower-tier slot rather than the
             // device primary. The peer side retags lower-tier events in
             // `Indexer::dump_events`, so the `storage_tier` here is correct.
-            indexer.apply_event_routed(event).await;
+            indexer
+                .apply_event_routed(event)
+                .await
+                .context("peer recovery event was rejected by the local indexer")?;
             total_events += 1;
         }
     }

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -1601,7 +1601,8 @@ mod tests {
         entry
             .indexer
             .apply_event_routed(store_event(1, 0, 1, &[], &[11], StorageTier::Device))
-            .await;
+            .await
+            .unwrap();
         entry.indexer.dump_events().await.expect("flush indexer");
 
         for worker_id in [1, 2] {
@@ -1665,7 +1666,8 @@ mod tests {
         entry
             .indexer
             .apply_event_routed(store_event(2, 0, 1, &[], &[11, 12], StorageTier::Device))
-            .await;
+            .await
+            .unwrap();
         entry.indexer.dump_events().await.expect("flush indexer");
         tokio::time::advance(Duration::from_secs(11)).await;
         core.free_reservation("occupy-2")

--- a/lib/kv-router/tests/standalone_indexer_http.rs
+++ b/lib/kv-router/tests/standalone_indexer_http.rs
@@ -131,7 +131,10 @@ async fn add_group_events(
     let indexer =
         registry.get_or_create_indexer(RoutingPartitionId::new(model, routing_group), block_size);
     for event in events {
-        indexer.apply_event_routed(event).await;
+        indexer
+            .apply_event_routed(event)
+            .await
+            .expect("apply routed event");
     }
     // Force the in-flight events through KvIndexer's mpsc channel before the
     // first query lands; otherwise the test races the indexer worker.
@@ -491,10 +494,12 @@ async fn duplicate_store_warning_is_exported() {
         .get_or_create_indexer(key.clone(), BLOCK_SIZE);
     indexer
         .apply_event_routed(store_event(7, 0, 1, &[], &[11, 12], StorageTier::Device))
-        .await;
+        .await
+        .expect("apply first store");
     indexer
         .apply_event_routed(store_event(7, 0, 2, &[], &[11, 12], StorageTier::Device))
-        .await;
+        .await
+        .expect("apply duplicate store");
 
     let entry = state
         .registry

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -10,9 +10,9 @@ use dynamo_kv_router::{
     config::KvRouterConfig,
     indexer::{
         KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError, LowerTierIndexers,
-        ThreadPoolIndexer,
+        ThreadPoolIndexer, record_unsupported_residency_event,
     },
-    protocols::{DpRank, RouterEvent, WorkerId},
+    protocols::{DpRank, KvCacheEventData, RouterEvent, WorkerId},
 };
 
 // Re-export tiered-match types so internal callers (`indexer::TieredMatchDetails`)
@@ -240,57 +240,70 @@ impl Indexer {
     }
 
     pub(crate) async fn try_apply_event(&self, event: RouterEvent) -> Result<(), KvRouterError> {
+        let targets_primary = match event.targets_primary() {
+            Ok(targets_primary) => targets_primary,
+            Err(_) => {
+                match self {
+                    Self::KvIndexer { lower_tier, .. } | Self::Concurrent { lower_tier, .. } => {
+                        lower_tier.record_unsupported_residency_event(&event);
+                    }
+                    Self::Remote { .. } | Self::None => {
+                        record_unsupported_residency_event(None, &event);
+                    }
+                }
+                return Ok(());
+            }
+        };
+        let is_clear = matches!(&event.event.data, KvCacheEventData::Cleared);
         match self {
             Self::KvIndexer {
                 primary,
                 lower_tier,
                 ..
-            } => match &event.event.data {
-                dynamo_kv_router::protocols::KvCacheEventData::Cleared => {
-                    primary
-                        .event_sender()
-                        .send(event.clone())
-                        .await
-                        .map_err(|_| KvRouterError::IndexerOffline)?;
+            } => {
+                if is_clear {
+                    if targets_primary {
+                        primary
+                            .reset_worker_dp_rank_and_wait(event.worker_id, event.event.dp_rank)
+                            .await?;
+                    }
 
                     for indexer in lower_tier.all() {
-                        indexer.enqueue_event(event.clone())?;
+                        indexer.apply_event_and_wait(event.clone()).await?;
                     }
-                }
-                _ if event.storage_tier.is_gpu() => {
+                } else if targets_primary {
                     primary
                         .event_sender()
                         .send(event)
                         .await
                         .map_err(|_| KvRouterError::IndexerOffline)?;
-                }
-                _ => {
+                } else {
                     lower_tier
                         .get_or_create(event.storage_tier)
                         .enqueue_event(event)?;
                 }
-            },
+            }
             Self::Concurrent {
                 primary,
                 lower_tier,
                 ..
-            } => match &event.event.data {
-                dynamo_kv_router::protocols::KvCacheEventData::Cleared => {
-                    primary.enqueue_event(event.clone())?;
+            } => {
+                if is_clear {
+                    if targets_primary {
+                        primary.apply_event_and_wait(event.clone()).await?;
+                    }
 
                     for indexer in lower_tier.all() {
-                        indexer.enqueue_event(event.clone())?;
+                        indexer.apply_event_and_wait(event.clone()).await?;
                     }
-                }
-                _ if event.storage_tier.is_gpu() => {
+                } else if targets_primary {
                     primary.enqueue_event(event)?;
-                }
-                _ => {
+                } else {
                     lower_tier
                         .get_or_create(event.storage_tier)
                         .enqueue_event(event)?;
                 }
-            },
+            }
             Self::Remote { .. } | Self::None => {}
         }
         Ok(())

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -10,7 +10,9 @@ use std::{
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use dynamo_kv_router::{
-    indexer::WorkerKvQueryResponse, protocols::RouterEvent, recovery::CursorState,
+    indexer::WorkerKvQueryResponse,
+    protocols::{ResetScope, RouterEvent},
+    recovery::CursorState,
 };
 use dynamo_runtime::component::{Component, Instance};
 use rand::Rng;
@@ -842,7 +844,18 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
             Ok(WorkerKvQueryResponse::TreeDump {
                 events,
                 last_event_id,
+                reset_scope,
             }) => {
+                if reset_scope != ResetScope::All {
+                    tracing::error!(
+                        worker_id = key.0,
+                        dp_rank = key.1,
+                        ?reset_scope,
+                        "Ignoring unsupported domain-scoped recovery snapshot"
+                    );
+                    slot.rank.retry_after_failed_snapshot();
+                    return;
+                }
                 if !recovery_events_match_source(key, &events) {
                     tracing::error!(
                         worker_id = key.0,
@@ -874,21 +887,10 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                     dp_rank = key.1,
                     last_event_id,
                     %message,
-                    "Worker tree dump failed; applying explicit degraded rank reset"
+                    "Worker tree dump failed; leaving authoritative state and cursor unchanged"
                 );
-                if let Err(error) = self
-                    .reset_rank_for_reason_or_fence(
-                        key,
-                        &binding.source_id,
-                        &mut slot,
-                        RecoveryResetReason::TreeDumpFailed,
-                    )
-                    .await
-                {
-                    tracing::error!(%error, worker_id = key.0, dp_rank = key.1, "Failed degraded rank reset; recovery cursor remains unchanged");
-                    return;
-                }
-                (Vec::new(), CursorState::Initial.advance_to(last_event_id))
+                slot.rank.retry_after_failed_snapshot();
+                return;
             }
             Ok(response) => {
                 tracing::warn!(
@@ -1052,7 +1054,8 @@ mod tests {
         indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics, WorkerKvQueryRequest},
         protocols::{
             DpRank, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
-            KvCacheStoredBlockData, LocalBlockHash, WorkerId, WorkerWithDpRank,
+            KvCacheStoredBlockData, LocalBlockHash, ResidencyDomain, StorageTier, WorkerId,
+            WorkerWithDpRank,
         },
     };
     use dynamo_runtime::{
@@ -1572,6 +1575,7 @@ mod tests {
             .push(WorkerKvQueryResponse::TreeDump {
                 events: vec![store(100)],
                 last_event_id: 100,
+                reset_scope: ResetScope::All,
             });
 
         client.reconcile_view(initial).await;
@@ -1615,6 +1619,7 @@ mod tests {
                 Ok(WorkerKvQueryResponse::TreeDump {
                     events: vec![store(100)],
                     last_event_id: 100,
+                    reset_scope: ResetScope::All,
                 }),
             )
             .await;
@@ -1712,6 +1717,67 @@ mod tests {
             .await;
         assert!(target.calls.lock().await.is_empty());
         assert!(client.publisher_bindings.contains_key(&205));
+    }
+
+    #[tokio::test]
+    async fn discovery_removal_resets_all_residency_domains() {
+        let serving = EndpointId::from("test.router.generate");
+        let kv_endpoint = EndpointId::from("test.router.kv");
+        let worker = WorkerWithDpRank::new(42, 4);
+        let initial = membership_view(
+            &serving,
+            &kv_endpoint,
+            [(
+                worker,
+                KvSourceStatus::ActiveLiveOnly(source_for(&kv_endpoint, worker, 100, None)),
+            )],
+        );
+        let (_tx, rx) = watch::channel(initial.clone());
+        let (_primary, indexer) = indexer();
+        let lower_tier = match &indexer {
+            Indexer::KvIndexer { lower_tier, .. } => lower_tier.clone(),
+            _ => unreachable!(),
+        };
+        let client =
+            WorkerQueryClient::new_for_test(indexer, rx, Arc::new(MockTransport::default()));
+
+        client.reconcile_view(initial).await;
+        let domain_store = |event_id, domain| {
+            RouterEvent::with_residency_domain(
+                worker.worker_id,
+                KvCacheEvent {
+                    event_id,
+                    data: KvCacheEventData::Stored(KvCacheStoreData {
+                        parent_hash: None,
+                        start_position: None,
+                        blocks: vec![KvCacheStoredBlockData {
+                            block_hash: ExternalSequenceBlockHash(event_id),
+                            tokens_hash: LocalBlockHash(event_id),
+                            mm_extra_info: None,
+                        }],
+                    }),
+                    dp_rank: worker.dp_rank,
+                },
+                StorageTier::HostPinned,
+                domain,
+            )
+        };
+        client
+            .handle_live_batch(
+                100,
+                vec![
+                    domain_store(1, ResidencyDomain::Worker),
+                    domain_store(2, ResidencyDomain::CacheOwner),
+                ],
+            )
+            .await;
+        let host_index = lower_tier.get_or_create(StorageTier::HostPinned);
+        assert_eq!(host_index.dump_events().await.unwrap().len(), 2);
+
+        client
+            .reconcile_view(membership_view(&serving, &kv_endpoint, std::iter::empty()))
+            .await;
+        assert!(host_index.dump_events().await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -2070,6 +2136,7 @@ mod tests {
                 Ok(WorkerKvQueryResponse::TreeDump {
                     events: vec![clear_for(worker, 2)],
                     last_event_id: 2,
+                    reset_scope: ResetScope::All,
                 }),
             )
             .await;
@@ -2086,7 +2153,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_dump_failure_resets_with_reason_then_drains_newer_events_once() {
+    async fn explicit_dump_failure_leaves_state_and_cursor_non_authoritative() {
         let serving = EndpointId::from("test.router.generate");
         let kv_endpoint = EndpointId::from("test.router.kv");
         let worker = WorkerWithDpRank::new(42, 4);
@@ -2120,20 +2187,14 @@ mod tests {
             )
             .await;
 
-        assert_eq!(
-            *target.calls.lock().await,
-            vec![
-                TargetCall::Reset(100, RecoveryResetReason::TreeDumpFailed),
-                TargetCall::Admit(100, 2),
-            ]
-        );
+        assert!(target.calls.lock().await.is_empty());
         let slot = client
             .slots
             .get(&(worker.worker_id, worker.dp_rank))
             .unwrap()
             .clone();
         let slot = slot.lock().await;
-        assert_eq!(slot.rank.last_admitted_id(), Some(2));
+        assert_eq!(slot.rank.last_admitted_id(), None);
         assert!(!slot.rank.recovery_inflight);
         assert!(slot.pending_reset.is_none());
         drop(slot);
@@ -2171,6 +2232,7 @@ mod tests {
                 Ok(WorkerKvQueryResponse::TreeDump {
                     events: vec![store(1)],
                     last_event_id: 1,
+                    reset_scope: ResetScope::All,
                 }),
             )
             .await;
@@ -2195,6 +2257,7 @@ mod tests {
                 Ok(WorkerKvQueryResponse::TreeDump {
                     events: vec![store(1), store(2)],
                     last_event_id: 2,
+                    reset_scope: ResetScope::All,
                 }),
             )
             .await;
@@ -2205,6 +2268,73 @@ mod tests {
         }
         let slot = slot.lock().await;
         assert_eq!(slot.rank.last_admitted_id(), Some(4));
+        assert!(!slot.rank.recovery_inflight);
+        drop(slot);
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn ahead_tree_dump_and_duplicate_tail_replay_converge() {
+        let serving = EndpointId::from("test.router.generate");
+        let kv_endpoint = EndpointId::from("test.router.kv");
+        let worker = WorkerWithDpRank::new(42, 4);
+        let view = membership_view(
+            &serving,
+            &kv_endpoint,
+            [(
+                worker,
+                KvSourceStatus::ActiveRecoverable(source(&kv_endpoint, 100)),
+            )],
+        );
+        let (_tx, rx) = watch::channel(view.clone());
+        let (kv_indexer, indexer) = indexer();
+        let transport = Arc::new(MockTransport::default());
+        *transport.release.lock().await = Some(Arc::new(Notify::new()));
+        let client = WorkerQueryClient::new_for_test(indexer, rx, transport);
+        client.reconcile_view(view).await;
+        let binding = client.publisher_bindings.get(&100).unwrap().binding.clone();
+
+        // The source captured watermark 1, but its independently advancing index dump already
+        // contains event 2. The complete tail after 1 therefore replays event 2 before event 3.
+        client
+            .handle_live_batch(100, vec![store(2), store(3)])
+            .await;
+        client
+            .clone()
+            .finish_recovery(
+                (worker.worker_id, worker.dp_rank),
+                binding,
+                CancellationToken::new(),
+                Ok(WorkerKvQueryResponse::TreeDump {
+                    events: vec![store(1), store(2)],
+                    last_event_id: 1,
+                    reset_scope: ResetScope::All,
+                }),
+            )
+            .await;
+
+        let events = kv_indexer.dump_events().await.unwrap();
+        for block in 1..=3 {
+            assert!(contains_block(&events, block));
+        }
+        let duplicate_count = events
+            .iter()
+            .filter_map(|event| match &event.event.data {
+                KvCacheEventData::Stored(data) => Some(&data.blocks),
+                _ => None,
+            })
+            .flatten()
+            .filter(|block| block.block_hash == ExternalSequenceBlockHash(2))
+            .count();
+        assert_eq!(duplicate_count, 1);
+
+        let slot = client
+            .slots
+            .get(&(worker.worker_id, worker.dp_rank))
+            .unwrap()
+            .clone();
+        let slot = slot.lock().await;
+        assert_eq!(slot.rank.last_admitted_id(), Some(3));
         assert!(!slot.rank.recovery_inflight);
         drop(slot);
         client.shutdown().await;
@@ -2359,6 +2489,7 @@ mod tests {
                 WorkerKvQueryResponse::TreeDump {
                     events: Vec::new(),
                     last_event_id: 0,
+                    reset_scope: ResetScope::All,
                 }
             } else {
                 let _finished = NotifyOnDrop(&self.delayed_finished);

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -37,6 +37,12 @@ pub(crate) const DEFAULT_RECOVERY_ATTEMPT_TIMEOUT: Duration = Duration::from_sec
 #[cfg(test)]
 const KV_EVENT_TOPIC: &str = dynamo_kv_router::protocols::KV_EVENT_SUBJECT;
 
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+struct NonAuthoritativeRecoveryError {
+    message: String,
+}
+
 #[derive(Debug)]
 struct SourceBinding {
     source: KvEventSource,
@@ -903,6 +909,11 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                     .await;
                 return true;
             }
+            Err(error) if error.is::<NonAuthoritativeRecoveryError>() => {
+                tracing::warn!(%error, worker_id = key.0, dp_rank = key.1, publisher_id = binding.source.publisher_id, "Authoritative KV recovery snapshot remained unavailable after bounded retries; leaving state and cursor unchanged");
+                slot.rank.retry_after_failed_snapshot();
+                return false;
+            }
             Err(error) => {
                 tracing::warn!(%error, worker_id = key.0, dp_rank = key.1, publisher_id = binding.source.publisher_id, "KV recovery failed; continuing with degraded live events");
                 self.finish_degraded_locked(key, &binding.source_id, &mut slot)
@@ -982,6 +993,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
         end_event_id: Option<u64>,
     ) -> Result<WorkerKvQueryResponse> {
         let mut last_error = None;
+        let mut saw_non_authoritative_failure = false;
         for attempt in 0..RECOVERY_MAX_RETRIES {
             let result = {
                 // Limit only the in-flight RPC. The shared permit is deliberately released
@@ -1019,6 +1031,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                     last_error = Some(anyhow::anyhow!(
                         "worker tree dump failed at event {last_event_id}: {message}"
                     ));
+                    saw_non_authoritative_failure = true;
                 }
                 Ok(WorkerKvQueryResponse::TreeDump { reset_scope, .. })
                     if reset_scope != ResetScope::All =>
@@ -1026,6 +1039,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                     last_error = Some(anyhow::anyhow!(
                         "worker returned unsupported recovery snapshot scope {reset_scope:?}"
                     ));
+                    saw_non_authoritative_failure = true;
                 }
                 Ok(response) => return Ok(response),
                 Err(error) => {
@@ -1037,7 +1051,15 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                 tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
             }
         }
-        Err(last_error.unwrap_or_else(|| anyhow::anyhow!("KV recovery returned no response")))
+        let error =
+            last_error.unwrap_or_else(|| anyhow::anyhow!("KV recovery returned no response"));
+        if saw_non_authoritative_failure {
+            return Err(NonAuthoritativeRecoveryError {
+                message: error.to_string(),
+            }
+            .into());
+        }
+        Err(error)
     }
 }
 
@@ -1867,6 +1889,34 @@ mod tests {
         ));
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn exhausted_dump_failures_remain_non_authoritative() {
+        let serving = EndpointId::from("test.router.generate");
+        let kv_endpoint = EndpointId::from("test.router.kv");
+        let (_tx, rx) = watch::channel(membership_view(&serving, &kv_endpoint, std::iter::empty()));
+        let transport = Arc::new(MockTransport::default());
+        transport
+            .responses
+            .lock()
+            .await
+            .extend(
+                (0..RECOVERY_MAX_RETRIES).map(|_| WorkerKvQueryResponse::TreeDumpFailed {
+                    last_event_id: 6,
+                    message: "snapshot unavailable".to_string(),
+                }),
+            );
+        let client =
+            WorkerQueryClient::new_target_for_test(RecordingTarget::default(), rx, transport);
+        let target = source(&kv_endpoint, 1).recovery_target.unwrap();
+
+        let error = client
+            .fetch_recovery_response((1, 0), target, None, None)
+            .await
+            .unwrap_err();
+
+        assert!(error.is::<NonAuthoritativeRecoveryError>());
+    }
+
     #[tokio::test]
     async fn stale_target_fault_does_not_reset_or_fence_the_replacement_source() {
         let serving = EndpointId::from("test.router.generate");
@@ -2205,7 +2255,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_dump_failure_leaves_state_and_cursor_non_authoritative() {
+    async fn non_authoritative_dump_failure_leaves_state_and_cursor_unchanged() {
         let serving = EndpointId::from("test.router.generate");
         let kv_endpoint = EndpointId::from("test.router.kv");
         let worker = WorkerWithDpRank::new(42, 4);
@@ -2232,10 +2282,10 @@ mod tests {
                 (worker.worker_id, worker.dp_rank),
                 binding,
                 CancellationToken::new(),
-                Ok(WorkerKvQueryResponse::TreeDumpFailed {
-                    last_event_id: 1,
+                Err(NonAuthoritativeRecoveryError {
                     message: "snapshot unavailable".to_string(),
-                }),
+                }
+                .into()),
             )
             .await;
         assert!(!complete_initial);

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -751,11 +751,11 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
             if task_cancel.is_cancelled() {
                 return;
             }
-            client
+            let complete_initial = client
                 .clone()
                 .finish_recovery(key, binding, task_cancel, result)
                 .await;
-            if initial_recovery {
+            if initial_recovery && complete_initial {
                 client.target.complete_initial_recovery(key.0, key.1).await;
             }
         });
@@ -801,12 +801,12 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
         binding: Arc<SourceBinding>,
         cancel: CancellationToken,
         result: Result<WorkerKvQueryResponse>,
-    ) {
+    ) -> bool {
         if cancel.is_cancelled() {
-            return;
+            return false;
         }
         let Some(slot) = self.slots.get(&key).map(|entry| entry.clone()) else {
-            return;
+            return false;
         };
         let mut slot = slot.lock().await;
         if cancel.is_cancelled()
@@ -815,7 +815,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                 .as_ref()
                 .is_some_and(|active| Arc::ptr_eq(active, &binding))
         {
-            return;
+            return false;
         }
 
         let (recovered_events, recovered_cursor) = match result {
@@ -832,7 +832,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                     );
                     self.fence_corrupt_recovery_locked(key, &binding.source_id, &mut slot)
                         .await;
-                    return;
+                    return true;
                 }
                 (
                     events,
@@ -854,7 +854,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                         "Ignoring unsupported domain-scoped recovery snapshot"
                     );
                     slot.rank.retry_after_failed_snapshot();
-                    return;
+                    return false;
                 }
                 if !recovery_events_match_source(key, &events) {
                     tracing::error!(
@@ -865,7 +865,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                     );
                     self.fence_corrupt_recovery_locked(key, &binding.source_id, &mut slot)
                         .await;
-                    return;
+                    return true;
                 }
                 if let Err(error) = self
                     .target
@@ -874,7 +874,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                 {
                     slot.fence_for_reset(binding.source_id.clone());
                     tracing::error!(%error, worker_id = key.0, dp_rank = key.1, "Failed to transactionally replace rank from recovery tree dump; rank remains fenced");
-                    return;
+                    return true;
                 }
                 (Vec::new(), CursorState::Initial.advance_to(last_event_id))
             }
@@ -890,7 +890,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                     "Worker tree dump failed; leaving authoritative state and cursor unchanged"
                 );
                 slot.rank.retry_after_failed_snapshot();
-                return;
+                return false;
             }
             Ok(response) => {
                 tracing::warn!(
@@ -901,13 +901,13 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                 );
                 self.finish_degraded_locked(key, &binding.source_id, &mut slot)
                     .await;
-                return;
+                return true;
             }
             Err(error) => {
                 tracing::warn!(%error, worker_id = key.0, dp_rank = key.1, publisher_id = binding.source.publisher_id, "KV recovery failed; continuing with degraded live events");
                 self.finish_degraded_locked(key, &binding.source_id, &mut slot)
                     .await;
-                return;
+                return true;
             }
         };
 
@@ -931,13 +931,14 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
         {
             slot.fence_for_reset(binding.source_id.clone());
             tracing::error!(%error, worker_id = key.0, dp_rank = key.1, "KV indexer rejected a recovery event; rank remains fenced");
-            return;
+            return true;
         }
         slot.rank = rank_after_admission;
         drop(slot);
         if let Some(start_event_id) = next_recovery_start {
             self.schedule_recovery_after_current(key, binding, start_event_id);
         }
+        true
     }
 
     async fn finish_degraded_locked(
@@ -1011,14 +1012,29 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                 .and_then(|result| result)
             };
             match result {
+                Ok(WorkerKvQueryResponse::TreeDumpFailed {
+                    last_event_id,
+                    message,
+                }) => {
+                    last_error = Some(anyhow::anyhow!(
+                        "worker tree dump failed at event {last_event_id}: {message}"
+                    ));
+                }
+                Ok(WorkerKvQueryResponse::TreeDump { reset_scope, .. })
+                    if reset_scope != ResetScope::All =>
+                {
+                    last_error = Some(anyhow::anyhow!(
+                        "worker returned unsupported recovery snapshot scope {reset_scope:?}"
+                    ));
+                }
                 Ok(response) => return Ok(response),
                 Err(error) => {
                     last_error = Some(error);
-                    if attempt + 1 < RECOVERY_MAX_RETRIES {
-                        let backoff_ms = RECOVERY_INITIAL_BACKOFF_MS * 2_u64.pow(attempt);
-                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-                    }
                 }
+            }
+            if attempt + 1 < RECOVERY_MAX_RETRIES {
+                let backoff_ms = RECOVERY_INITIAL_BACKOFF_MS * 2_u64.pow(attempt);
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
             }
         }
         Err(last_error.unwrap_or_else(|| anyhow::anyhow!("KV recovery returned no response")))
@@ -1271,9 +1287,10 @@ mod tests {
                 self.slow_started.notify_one();
                 std::future::pending().await
             } else {
-                Ok(WorkerKvQueryResponse::TreeDumpFailed {
-                    last_event_id: 0,
-                    message: "test".to_string(),
+                Ok(WorkerKvQueryResponse::TooNew {
+                    requested_start: None,
+                    requested_end: None,
+                    newest_available: 0,
                 })
             }
         }
@@ -1810,11 +1827,44 @@ mod tests {
         .await
         .expect("healthy recovery remained blocked behind another target's retry backoff")
         .unwrap();
+        assert!(matches!(response, WorkerKvQueryResponse::TooNew { .. }));
+        slow.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn explicit_dump_failure_is_retried_before_degraded_fallback() {
+        let serving = EndpointId::from("test.router.generate");
+        let kv_endpoint = EndpointId::from("test.router.kv");
+        let (_tx, rx) = watch::channel(membership_view(&serving, &kv_endpoint, std::iter::empty()));
+        let transport = Arc::new(MockTransport::default());
+        transport.responses.lock().await.extend([
+            WorkerKvQueryResponse::TreeDump {
+                events: Vec::new(),
+                last_event_id: 7,
+                reset_scope: ResetScope::All,
+            },
+            WorkerKvQueryResponse::TreeDumpFailed {
+                last_event_id: 6,
+                message: "snapshot temporarily unavailable".to_string(),
+            },
+        ]);
+        let client =
+            WorkerQueryClient::new_target_for_test(RecordingTarget::default(), rx, transport);
+        let target = source(&kv_endpoint, 1).recovery_target.unwrap();
+
+        let response = client
+            .fetch_recovery_response((1, 0), target, None, None)
+            .await
+            .unwrap();
+
         assert!(matches!(
             response,
-            WorkerKvQueryResponse::TreeDumpFailed { .. }
+            WorkerKvQueryResponse::TreeDump {
+                last_event_id: 7,
+                reset_scope: ResetScope::All,
+                ..
+            }
         ));
-        slow.abort();
     }
 
     #[tokio::test]
@@ -2078,7 +2128,7 @@ mod tests {
         client.handle_live_batch(100, vec![store(1)]).await;
         let binding = client.publisher_bindings.get(&100).unwrap().binding.clone();
 
-        client
+        let complete_initial = client
             .clone()
             .finish_recovery(
                 (worker.worker_id, worker.dp_rank),
@@ -2090,6 +2140,7 @@ mod tests {
                 }),
             )
             .await;
+        assert!(complete_initial);
 
         let events = kv_indexer.dump_events().await.unwrap();
         assert!(!contains_block(&events, 1));
@@ -2127,7 +2178,7 @@ mod tests {
         kv_indexer.shutdown();
         kv_indexer.event_sender().closed().await;
 
-        client
+        let complete_initial = client
             .clone()
             .finish_recovery(
                 (worker.worker_id, worker.dp_rank),
@@ -2140,6 +2191,7 @@ mod tests {
                 }),
             )
             .await;
+        assert!(complete_initial);
 
         let slot = client
             .slots
@@ -2174,7 +2226,7 @@ mod tests {
         client.handle_live_batch(100, vec![store(2)]).await;
         let binding = client.publisher_bindings.get(&100).unwrap().binding.clone();
 
-        client
+        let complete_initial = client
             .clone()
             .finish_recovery(
                 (worker.worker_id, worker.dp_rank),
@@ -2186,6 +2238,7 @@ mod tests {
                 }),
             )
             .await;
+        assert!(!complete_initial);
 
         assert!(target.calls.lock().await.is_empty());
         let slot = client

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_endpoint.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_endpoint.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use dynamo_kv_router::{
     indexer::{LocalKvIndexer, WorkerKvQueryRequest, WorkerKvQueryResponse},
-    protocols::DpRank,
+    protocols::{DpRank, ResetScope},
 };
 use dynamo_runtime::{
     component::{Component, StartedEndpoint},
@@ -165,6 +165,7 @@ fn negotiate_tree_dump_failure(
             WorkerKvQueryResponse::TreeDump {
                 events: Vec::new(),
                 last_event_id,
+                reset_scope: ResetScope::All,
             }
         }
         response => response,
@@ -220,6 +221,7 @@ mod tests {
             WorkerKvQueryResponse::TreeDump {
                 events,
                 last_event_id: 17,
+                ..
             } if events.is_empty()
         ));
     }

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_endpoint.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_endpoint.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use dynamo_kv_router::{
     indexer::{LocalKvIndexer, WorkerKvQueryRequest, WorkerKvQueryResponse},
-    protocols::{DpRank, ResetScope},
+    protocols::DpRank,
 };
 use dynamo_runtime::{
     component::{Component, StartedEndpoint},
@@ -159,14 +159,10 @@ fn negotiate_tree_dump_failure(
     supports_tree_dump_failed: bool,
 ) -> WorkerKvQueryResponse {
     match response {
-        WorkerKvQueryResponse::TreeDumpFailed { last_event_id, .. }
-            if !supports_tree_dump_failed =>
-        {
-            WorkerKvQueryResponse::TreeDump {
-                events: Vec::new(),
-                last_event_id,
-                reset_scope: ResetScope::All,
-            }
+        WorkerKvQueryResponse::TreeDumpFailed { message, .. } if !supports_tree_dump_failed => {
+            // Error predates TreeDumpFailed and remains non-authoritative for legacy readers.
+            // Never translate snapshot failure into an empty all-domain replacement.
+            WorkerKvQueryResponse::Error(format!("worker tree dump failed: {message}"))
         }
         response => response,
     }
@@ -218,11 +214,8 @@ mod tests {
         ));
         assert!(matches!(
             negotiate_tree_dump_failure(failure(), false),
-            WorkerKvQueryResponse::TreeDump {
-                events,
-                last_event_id: 17,
-                ..
-            } if events.is_empty()
+            WorkerKvQueryResponse::Error(message)
+                if message == "worker tree dump failed: offline"
         ));
     }
 }

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs
@@ -219,7 +219,12 @@ impl RankState {
     }
 
     /// Leave authoritative state and the admission cursor unchanged after a
-    /// non-authoritative snapshot failure. A later live event may trigger a retry.
+    /// non-authoritative snapshot failure.
+    ///
+    /// The production fetch path performs bounded retries before completion. This
+    /// transition is the defensive fallback for a failure delivered directly to
+    /// the state machine; it deliberately waits for the next live event instead of
+    /// starting an unbounded autonomous retry loop.
     pub(super) fn retry_after_failed_snapshot(&mut self) {
         self.recovery_inflight = false;
     }

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs
@@ -3,8 +3,10 @@
 
 use std::collections::VecDeque;
 
+#[cfg(test)]
+use dynamo_kv_router::protocols::KvCacheEventData;
 use dynamo_kv_router::{
-    protocols::{DpRank, KvCacheEventData, RouterEvent, WorkerId},
+    protocols::{DpRank, ResetScope, RouterEvent, WorkerId},
     recovery::{CursorObservation, CursorState},
 };
 
@@ -76,7 +78,7 @@ impl RankState {
     ) -> LiveEventAction {
         let event_id = event.event.event_id;
 
-        if matches!(&event.event.data, KvCacheEventData::Cleared) {
+        if matches!(event.reset_scope(), Ok(Some(ResetScope::All))) {
             if self
                 .last_admitted_id()
                 .is_some_and(|last_admitted_id| event_id <= last_admitted_id)
@@ -214,6 +216,12 @@ impl RankState {
         self.recovery_inflight = false;
         self.pending_live_events.clear();
         self.max_seen_live_id = None;
+    }
+
+    /// Leave authoritative state and the admission cursor unchanged after a
+    /// non-authoritative snapshot failure. A later live event may trigger a retry.
+    pub(super) fn retry_after_failed_snapshot(&mut self) {
+        self.recovery_inflight = false;
     }
 
     pub(super) fn take_failed_recovery_degraded(&mut self) -> Vec<RouterEvent> {
@@ -358,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_supersedes_same_rank_gap_recovery() {
+    fn only_all_domain_clear_supersedes_same_rank_gap_recovery() {
         let mut state = RankState::default();
         assert!(matches!(
             state.observe_live_event(store(1), false),
@@ -370,19 +378,27 @@ mod tests {
             LiveEventAction::Recover { reset: true, .. }
         ));
 
-        let mut clear = store(5);
+        let mut worker_clear = store(5);
+        worker_clear.event.data = KvCacheEventData::Cleared;
+        assert!(matches!(
+            state.observe_live_event(worker_clear, true),
+            LiveEventAction::Ignore
+        ));
+
+        let mut clear = store(6);
         clear.event.data = KvCacheEventData::Cleared;
+        clear.residency_domain = Default::default();
         assert!(matches!(
             state.observe_live_event(clear, true),
-            LiveEventAction::Clear { event_id: 5, .. }
+            LiveEventAction::Clear { event_id: 6, .. }
         ));
         state.discard_recovery_before_clear();
-        state.commit_live_admission(5);
+        state.commit_live_admission(6);
 
         assert!(!state.recovery_inflight);
         assert!(matches!(
-            state.observe_live_event(store(6), true),
-            LiveEventAction::Apply { event_id: 6, .. }
+            state.observe_live_event(store(7), true),
+            LiveEventAction::Apply { event_id: 7, .. }
         ));
     }
 }

--- a/lib/llm/src/kv_router/publisher/batching.rs
+++ b/lib/llm/src/kv_router/publisher/batching.rs
@@ -6,7 +6,8 @@ use std::time::{Duration, Instant};
 
 use dynamo_kv_router::indexer::LocalKvIndexer;
 use dynamo_kv_router::protocols::{
-    KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData, RouterEvent, StorageTier,
+    KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData, ResidencyDomain,
+    RouterEvent, StorageTier,
 };
 
 use super::dedup::EventDedupFilter;
@@ -21,6 +22,7 @@ pub(super) struct BatchingState {
     pub(super) next_publish_id: u64,
     pub(super) last_dp_rank: u32,
     pub(super) last_storage_tier: StorageTier,
+    pub(super) last_residency_domain: ResidencyDomain,
     pub(super) last_flush_time: Instant,
 }
 
@@ -32,6 +34,7 @@ impl BatchingState {
             next_publish_id: 1,
             last_dp_rank: 0,
             last_storage_tier: StorageTier::Device,
+            last_residency_domain: ResidencyDomain::Worker,
             last_flush_time: Instant::now(),
         }
     }
@@ -83,12 +86,18 @@ impl BatchingState {
         let dp_rank = self.last_dp_rank;
         let mut emitted = false;
         if let Some(data) = self.pending_removed.take()
-            && let Some(filtered) = dedup.filter_remove(dp_rank, self.last_storage_tier, data)
+            && let Some(filtered) = dedup.filter_remove_in_domain(
+                dp_rank,
+                self.last_storage_tier,
+                self.last_residency_domain,
+                data,
+            )
         {
-            emit(
+            let _ = emit(
                 local_indexer,
                 worker_id,
                 self.last_storage_tier,
+                self.last_residency_domain,
                 KvCacheEvent {
                     event_id: self.next_publish_id,
                     data: KvCacheEventData::Removed(filtered),
@@ -100,11 +109,17 @@ impl BatchingState {
             emitted = true;
         }
         if let Some(data) = self.pending_stored.take() {
-            dedup.track_store(dp_rank, self.last_storage_tier, &data);
-            emit(
+            dedup.track_store_in_domain(
+                dp_rank,
+                self.last_storage_tier,
+                self.last_residency_domain,
+                &data,
+            );
+            let _ = emit(
                 local_indexer,
                 worker_id,
                 self.last_storage_tier,
+                self.last_residency_domain,
                 KvCacheEvent {
                     event_id: self.next_publish_id,
                     data: KvCacheEventData::Stored(data),

--- a/lib/llm/src/kv_router/publisher/dedup.rs
+++ b/lib/llm/src/kv_router/publisher/dedup.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
 use dynamo_kv_router::protocols::{
-    ExternalSequenceBlockHash, KvCacheRemoveData, KvCacheStoreData, StorageTier,
+    ExternalSequenceBlockHash, KvCacheRemoveData, KvCacheStoreData, ResidencyDomain, StorageTier,
 };
 
 /// Reference-counting filter that deduplicates KV cache events.
@@ -16,10 +16,11 @@ use dynamo_kv_router::protocols::{
 ///
 /// - **Store**: always passes through; increments refcount for the rank.
 /// - **Remove**: only passes through when refcount decrements to 0.
-/// - **Cleared**: resets refcounts for the emitting rank across storage tiers.
+/// - **Cleared**: resets refcounts for the emitting rank and domain across storage tiers.
 pub(super) struct EventDedupFilter {
-    /// Per-(dp_rank, storage_tier) refcounts.
-    per_rank_tier: HashMap<(u32, StorageTier), HashMap<ExternalSequenceBlockHash, usize>>,
+    /// Per-(dp_rank, storage_tier, residency_domain) refcounts.
+    per_rank_tier:
+        HashMap<(u32, StorageTier, ResidencyDomain), HashMap<ExternalSequenceBlockHash, usize>>,
 }
 
 impl EventDedupFilter {
@@ -32,15 +33,16 @@ impl EventDedupFilter {
     /// Track a store event. Increments refcount for each block hash on the
     /// given (DP rank, storage tier). Stores always pass through — this only
     /// updates bookkeeping.
-    pub(super) fn track_store(
+    pub(super) fn track_store_in_domain(
         &mut self,
         dp_rank: u32,
         storage_tier: StorageTier,
+        residency_domain: ResidencyDomain,
         data: &KvCacheStoreData,
     ) {
         let refcounts = self
             .per_rank_tier
-            .entry((dp_rank, storage_tier))
+            .entry((dp_rank, storage_tier, residency_domain))
             .or_default();
         for block in &data.blocks {
             *refcounts.entry(block.block_hash).or_insert(0) += 1;
@@ -50,15 +52,16 @@ impl EventDedupFilter {
     /// Filter a remove event. Retains only block hashes whose refcount on the
     /// given (DP rank, storage tier) decrements to 0 (removing them from the
     /// map). Returns `None` if no hashes survive filtering.
-    pub(super) fn filter_remove(
+    pub(super) fn filter_remove_in_domain(
         &mut self,
         dp_rank: u32,
         storage_tier: StorageTier,
+        residency_domain: ResidencyDomain,
         mut data: KvCacheRemoveData,
     ) -> Option<KvCacheRemoveData> {
         let refcounts = self
             .per_rank_tier
-            .entry((dp_rank, storage_tier))
+            .entry((dp_rank, storage_tier, residency_domain))
             .or_default();
         data.block_hashes.retain(|hash| {
             match refcounts.entry(*hash) {
@@ -83,9 +86,37 @@ impl EventDedupFilter {
         }
     }
 
-    /// Clear refcounts for one DP rank across all storage tiers.
+    /// Clear refcounts for one DP rank and residency domain across storage tiers.
+    pub(super) fn clear_rank_domain(&mut self, dp_rank: u32, domain: ResidencyDomain) {
+        self.per_rank_tier
+            .retain(|(tracked_dp_rank, _, tracked_domain), _| {
+                *tracked_dp_rank != dp_rank || *tracked_domain != domain
+            });
+    }
+
+    #[cfg(test)]
+    pub(super) fn track_store(
+        &mut self,
+        dp_rank: u32,
+        storage_tier: StorageTier,
+        data: &KvCacheStoreData,
+    ) {
+        self.track_store_in_domain(dp_rank, storage_tier, ResidencyDomain::Worker, data);
+    }
+
+    #[cfg(test)]
+    pub(super) fn filter_remove(
+        &mut self,
+        dp_rank: u32,
+        storage_tier: StorageTier,
+        data: KvCacheRemoveData,
+    ) -> Option<KvCacheRemoveData> {
+        self.filter_remove_in_domain(dp_rank, storage_tier, ResidencyDomain::Worker, data)
+    }
+
+    #[cfg(test)]
     pub(super) fn clear_rank(&mut self, dp_rank: u32) {
         self.per_rank_tier
-            .retain(|(tracked_dp_rank, _), _| *tracked_dp_rank != dp_rank);
+            .retain(|(tracked_dp_rank, _, _), _| *tracked_dp_rank != dp_rank);
     }
 }

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -51,7 +51,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
 
                 // Process the complete source list before returning to `select!` so
                 // another channel item, the timeout, or cancellation cannot split it.
-                for placement_event in event_batch {
+                'event_batch: for placement_event in event_batch {
                     let raw_event_id = placement_event.event.event_id;
                     if let Some(last_id) = last_raw_input_id
                         && raw_event_id > last_id + 1
@@ -77,6 +77,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
                     last_raw_input_id = Some(raw_event_id);
 
                     let storage_tier = placement_event.placement.tier;
+                    let residency_domain = placement_event.placement.residency_domain;
                     let event = placement_event.event;
                     tracing::trace!(
                         "Event processor for worker_id {} processing event: {:?}",
@@ -88,12 +89,15 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
                         batching_state.has_pending() && event.dp_rank != batching_state.last_dp_rank;
                     let storage_tier_changed = batching_state.has_pending()
                         && storage_tier != batching_state.last_storage_tier;
+                    let residency_domain_changed = batching_state.has_pending()
+                        && residency_domain != batching_state.last_residency_domain;
 
                     match event.data {
                         KvCacheEventData::Removed(data) => {
                             if batching_state.pending_stored.is_some()
                                 || dp_rank_changed
                                 || storage_tier_changed
+                                || residency_domain_changed
                             {
                                 batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
                             }
@@ -107,6 +111,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
                         KvCacheEventData::Stored(data) => {
                             let should_flush = dp_rank_changed
                                 || storage_tier_changed
+                                || residency_domain_changed
                                 || batching_state.pending_removed.is_some()
                                 || batching_state.pending_stored.as_ref().is_some_and(|p| {
                                     data.parent_hash != p.blocks.last().map(|b| b.block_hash)
@@ -123,11 +128,12 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
                         }
                         KvCacheEventData::Cleared => {
                             batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
-                            dedup.clear_rank(event.dp_rank);
-                            emit(
+                            dedup.clear_rank_domain(event.dp_rank, residency_domain);
+                            let applied = emit(
                                 &local_indexer,
                                 worker_id,
                                 storage_tier,
+                                residency_domain,
                                 KvCacheEvent {
                                     event_id: batching_state.next_publish_id,
                                     data: KvCacheEventData::Cleared,
@@ -136,12 +142,24 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
                                 &mut output,
                             )
                             .await;
+                            if !applied {
+                                output.pop();
+                                tracing::error!(
+                                    worker_id,
+                                    dp_rank = event.dp_rank,
+                                    ?residency_domain,
+                                    "Fencing KV event publisher after local reset failure"
+                                );
+                                cancellation_token.cancel();
+                                break 'event_batch;
+                            }
                             batching_state.next_publish_id += 1;
                         }
                     }
 
                     batching_state.last_dp_rank = event.dp_rank;
                     batching_state.last_storage_tier = storage_tier;
+                    batching_state.last_residency_domain = residency_domain;
 
                     // Bound coalesced output without splitting an individual source
                     // event or returning to `select!` midway through the native list.

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -150,6 +150,10 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
                                     ?residency_domain,
                                     "Fencing KV event publisher after local reset failure"
                                 );
+                                // NOTE: This token owns the publisher's discovery and recovery
+                                // advertisement too. Once the local reset barrier fails, withdrawing
+                                // the complete source is the only safe way to avoid advertising a
+                                // cursor whose local snapshot has diverged.
                                 cancellation_token.cancel();
                                 break 'event_batch;
                             }

--- a/lib/llm/src/kv_router/publisher/sinks.rs
+++ b/lib/llm/src/kv_router/publisher/sinks.rs
@@ -8,7 +8,9 @@ use anyhow::Result;
 
 use dynamo_kv_router::RouterEventSink;
 use dynamo_kv_router::indexer::LocalKvIndexer;
-use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, RouterEvent, StorageTier};
+use dynamo_kv_router::protocols::{
+    KvCacheEvent, KvCacheEventData, ResidencyDomain, RouterEvent, StorageTier,
+};
 use dynamo_runtime::transports::event_plane::EventPublisher;
 
 pub(super) struct EventPlanePublisher(pub(super) EventPublisher);
@@ -143,14 +145,23 @@ pub(super) async fn emit(
     local_indexer: &Option<Arc<LocalKvIndexer>>,
     worker_id: u64,
     storage_tier: StorageTier,
+    residency_domain: ResidencyDomain,
     event: KvCacheEvent,
     output: &mut Vec<RouterEvent>,
-) {
-    let router_event = RouterEvent::with_storage_tier(worker_id, event, storage_tier);
-    if let Some(indexer) = local_indexer
-        && let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await
-    {
-        tracing::warn!(worker_id, error = %e, "Failed to apply event to local indexer");
-    }
+) -> bool {
+    let router_event =
+        RouterEvent::with_residency_domain(worker_id, event, storage_tier, residency_domain);
+    let applied = if let Some(indexer) = local_indexer {
+        match indexer.apply_event_with_buffer(router_event.clone()).await {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(worker_id, %error, "Failed to apply event to local indexer");
+                false
+            }
+        }
+    } else {
+        true
+    };
     output.push(router_event);
+    applied
 }

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -561,6 +561,7 @@ mod test_event_processing {
         )
         .unwrap();
         assert!(matches!(out.event.data, KvCacheEventData::Cleared));
+        assert_eq!(out.placement.residency_domain, ResidencyDomain::Worker);
     }
 
     #[test]
@@ -2452,7 +2453,7 @@ mod event_processor_tests {
 
         let host_removed = removed_event(5, 51, 1);
         let clear = KvCacheEvent {
-            event_id: 6,
+            event_id: 7,
             data: KvCacheEventData::Cleared,
             dp_rank: 1,
         };
@@ -2470,18 +2471,20 @@ mod event_processor_tests {
                 Placement::local_worker(1, 1, StorageTier::HostPinned),
                 host_removed,
             ),
-            // Clear boundary.
+            // A second physical lower tier remains in the Worker domain.
             PlacementEvent::new(
-                Placement::local_worker(1, 1, StorageTier::HostPinned),
-                clear,
+                Placement::local_worker(1, 1, StorageTier::Disk),
+                removed_event(6, 52, 1),
             ),
+            // Clear boundary.
+            PlacementEvent::new(Placement::local_worker(1, 1, StorageTier::Device), clear),
         ])
         .unwrap();
         drop(tx);
         handle.await.unwrap();
 
         let events = publisher.get_events();
-        assert_eq!(events.len(), 6);
+        assert_eq!(events.len(), 7);
         assert!(matches!(events[0].event.data, KvCacheEventData::Stored(_)));
         let KvCacheEventData::Stored(first) = &events[0].event.data else {
             unreachable!();
@@ -2492,13 +2495,23 @@ mod event_processor_tests {
         assert_eq!(events[3].event.dp_rank, 1);
         assert_eq!(events[3].storage_tier, StorageTier::Device);
         assert_eq!(events[4].storage_tier, StorageTier::HostPinned);
-        assert!(matches!(events[5].event.data, KvCacheEventData::Cleared));
+        assert_eq!(events[5].storage_tier, StorageTier::Disk);
+        assert!(matches!(events[6].event.data, KvCacheEventData::Cleared));
+        assert!(
+            events
+                .iter()
+                .all(|event| { event.resolved_residency_domain() == Ok(ResidencyDomain::Worker) })
+        );
+        assert_eq!(
+            events[6].reset_scope(),
+            Ok(Some(ResetScope::Domain(ResidencyDomain::Worker)))
+        );
         assert_eq!(
             events
                 .iter()
                 .map(|event| event.event.event_id)
                 .collect::<Vec<_>>(),
-            vec![1, 2, 3, 4, 5, 6]
+            vec![1, 2, 3, 4, 5, 6, 7]
         );
         assert_eq!(publisher.get_batches().len(), 1);
         assert_eq!(publisher.get_batches()[0], events);

--- a/lib/mocker/src/replay/offline/extensions/kv_events/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_events/mod.rs
@@ -298,6 +298,7 @@ mod canonical_digest_tests {
             RouterEvent {
                 worker_id: 7,
                 storage_tier: StorageTier::Device,
+                residency_domain: Default::default(),
                 event: KvCacheEvent {
                     event_id: 11,
                     dp_rank: 2,
@@ -320,6 +321,7 @@ mod canonical_digest_tests {
             RouterEvent {
                 worker_id: 7,
                 storage_tier: StorageTier::HostPinned,
+                residency_domain: Default::default(),
                 event: KvCacheEvent {
                     event_id: 12,
                     dp_rank: 2,
@@ -334,6 +336,7 @@ mod canonical_digest_tests {
             RouterEvent {
                 worker_id: 8,
                 storage_tier: StorageTier::Device,
+                residency_domain: Default::default(),
                 event: KvCacheEvent {
                     event_id: 13,
                     dp_rank: 0,


### PR DESCRIPTION
## Summary

- Separate physical `StorageTier` selection from logical `ResidencyDomain::{Worker, CacheOwner}` ownership inside each tier index.
- Normalize all current engine Device, HostPinned, Disk, and External events to `Worker`; engine clears now publish `ResetScope::Domain(Worker)` after acknowledged local reset, while discovery/source lifecycle teardown remains `ResetScope::All`.
- Preserve one physical lower-tier index per storage tier while tracking exact domain ownership internally and projecting routing matches back to the worker without double counting.
- Recover every allocated physical tier with exact tier/domain tags. The snapshot intentionally uses independently advanced per-index FIFO cuts: watermark `N` is captured after enqueue, each tier may include a different suffix after `N`, and replay of the complete tail after `N` converges duplicate mutations.
- Treat unsupported domain values as consumed no-op events with fixed-cardinality metrics and rate-limited diagnostics; a failed tier dump is non-authoritative and cannot reset state or advance the cursor.

Tracks #13044.

## Compatibility and rollout

Worker-only N/N-1 operation remains non-failing:

- New readers map domainless Stored/Removed events to `Worker` and domainless Cleared events to `All`.
- Old readers ignore the additive explicit `worker` domain field and retain existing behavior.
- Unknown, null, empty, and unsupported domain/tier combinations skip only that event while preserving stream sequence progress.

The small hand-written MessagePack compatibility fixtures are temporary and should be removed when domainless `RouterEvent` is outside the supported N/N-1 window.

Do not enable `CacheOwner` producers until all consumers on the stream are domain-aware: an N-1 clear remains all-domain, and an N-1 consumer cannot preserve CacheOwner attribution.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-kv-router` (861 passed, 2 ignored)
- `cargo test -p dynamo-llm --no-default-features kv_router::indexer::recovery` (35 passed)
- `cargo test -p dynamo-llm --no-default-features kv_router::indexer::tests` (15 passed)
- `cargo test -p dynamo-llm --no-default-features kv_router::publisher` (83 passed)
- `cargo clippy -p dynamo-kv-router --all-targets -- -D warnings`
- `cargo clippy -p dynamo-llm --no-default-features --lib --tests -- -D warnings`

The repository-wide pytest marker commit hook was skipped because the existing local Python extension is stale and lacks `update_model_taints`; this PR changes Rust only, and all other commit hooks passed.

## Deferred

Stable CacheOwner identity, discovery attachment reconciliation, dual ZMQ ingress, zero-engine persistent index lifetime, engine epochs, and shared/global cache ownership remain follow-up work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for worker- and cache-owner residency domains across placement, event routing, batching, and deduplication.
  * Added domain-aware clear operations for targeted or all-domain resets.
  * Added metrics and diagnostics for unsupported residency events.

* **Bug Fixes**
  * Improved recovery handling to preserve state after failed snapshots and retry safely.
  * Ensured event routing, ownership, and removal behavior remain consistent across storage tiers and residency domains.
  * Improved synchronization when applying clear events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->