### PR TITLE
fix(vllm): keep cyclic GC outside benchmark measurements

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -78,6 +78,7 @@ Inject via:
 from __future__ import annotations
 
 import enum
+import gc
 import hashlib
 import json
 import logging
@@ -133,6 +134,7 @@ DEFAULT_FPM_PORT = 20380
 ENV_FPM_PORT = "DYN_FORWARDPASS_METRIC_PORT"
 ENV_FPM_WORKER_ID = "DYN_FPM_WORKER_ID"
 ENV_FPM_BENCHMARK_OUTPUT_PATH = "DYN_FPM_BENCHMARK_OUTPUT_PATH"
+ENV_FPM_BENCHMARK_MANAGE_GC = "DYN_FPM_BENCHMARK_MANAGE_GC"
 
 
 def _utc_now_rfc3339() -> str:
@@ -2061,6 +2063,8 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_grid_built = False
         self._bench_expected_points = 0
         self._bench_drain_pending = False
+        self._bench_gc_paused = False
+        self._bench_gc_was_enabled = False
         self._bench_prefix_cache_cleared = False
         self._bench_grid_error: str | None = None
         self._bench_grid_digest: str | None = None
@@ -3346,6 +3350,7 @@ class InstrumentedScheduler(AsyncScheduler):
         )
 
     def _bench_deactivate(self, *, resume_publisher: bool = True) -> None:
+        self._bench_resume_gc()
         if self._bench_synchronizer is not None:
             self._bench_synchronizer.close()
             self._bench_synchronizer = None
@@ -3510,9 +3515,38 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_transition_after_warmup()
         return None
 
+    def _bench_pause_gc(self) -> None:
+        """Keep cyclic GC outside measured passes."""
+        if (
+            self._bench_gc_paused
+            or os.environ.get(ENV_FPM_BENCHMARK_MANAGE_GC, "1") != "1"
+        ):
+            return
+        self._bench_gc_was_enabled = gc.isenabled()
+        gc.collect()
+        # vLLM owns the permanent generation and unfreezes it at shutdown.
+        gc.freeze()
+        if self._bench_gc_was_enabled:
+            gc.disable()
+        self._bench_gc_paused = True
+        logger.info("Benchmark: automatic cyclic GC paused")
+
+    def _bench_resume_gc(self) -> None:
+        """Restore the collector's pre-benchmark enabled state."""
+        if not self._bench_gc_paused:
+            return
+        self._bench_gc_paused = False
+        if self._bench_gc_was_enabled:
+            gc.enable()
+
+    def _bench_collect_between_points(self) -> None:
+        if self._bench_gc_paused:
+            gc.collect()
+
     def _bench_transition_after_warmup(self) -> None:
         self._bench_cleanup_requests()
         self._bench_current_fpms.clear()
+        self._bench_pause_gc()
         mode = self._bench_config.mode
         if mode in ("prefill", "agg"):
             self._bench_phase = _BenchPhase.PREFILL_SWEEP
@@ -3528,6 +3562,7 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_drain_pending = False
         self._bench_current_fpms.clear()
         self._schedule_times.clear()
+        self._bench_collect_between_points()
         return True
 
     def _bench_step_prefill(self) -> SchedulerOutput | None:

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -2869,6 +2869,96 @@ def test_benchmark_clear_prefix_cache_is_required_and_idempotent():
         InstrumentedScheduler._bench_clear_prefix_cache(failed)
 
 
+@pytest.mark.parametrize("gc_was_enabled", [True, False])
+def test_benchmark_gc_is_collected_between_points_and_restored(
+    monkeypatch, gc_was_enabled
+):
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_gc_paused = False
+    stub._bench_gc_was_enabled = False
+    collect = MagicMock()
+    freeze = MagicMock()
+    disable = MagicMock()
+    enable = MagicMock()
+    monkeypatch.delenv(
+        instrumented_scheduler_module.ENV_FPM_BENCHMARK_MANAGE_GC,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        instrumented_scheduler_module.gc, "isenabled", lambda: gc_was_enabled
+    )
+    monkeypatch.setattr(instrumented_scheduler_module.gc, "collect", collect)
+    monkeypatch.setattr(instrumented_scheduler_module.gc, "freeze", freeze)
+    monkeypatch.setattr(instrumented_scheduler_module.gc, "disable", disable)
+    monkeypatch.setattr(instrumented_scheduler_module.gc, "enable", enable)
+
+    InstrumentedScheduler._bench_pause_gc(stub)
+    InstrumentedScheduler._bench_collect_between_points(stub)
+    InstrumentedScheduler._bench_resume_gc(stub)
+
+    assert collect.call_count == 2
+    freeze.assert_called_once_with()
+    assert disable.call_count == int(gc_was_enabled)
+    assert enable.call_count == int(gc_was_enabled)
+    assert stub._bench_gc_paused is False
+
+
+def test_benchmark_gc_management_can_be_disabled(monkeypatch):
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_gc_paused = False
+    collect = MagicMock()
+    monkeypatch.setenv(instrumented_scheduler_module.ENV_FPM_BENCHMARK_MANAGE_GC, "0")
+    monkeypatch.setattr(instrumented_scheduler_module.gc, "collect", collect)
+
+    InstrumentedScheduler._bench_pause_gc(stub)
+
+    collect.assert_not_called()
+    assert stub._bench_gc_paused is False
+
+
+def test_benchmark_gc_hooks_wrap_the_measurement_sweep():
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_cleanup_requests = MagicMock()
+    stub._bench_current_fpms = [{"warmup": True}]
+    stub._bench_pause_gc = MagicMock()
+    stub._bench_config = BenchmarkConfig(mode="decode")
+
+    InstrumentedScheduler._bench_transition_after_warmup(stub)
+
+    stub._bench_cleanup_requests.assert_called_once_with()
+    assert stub._bench_current_fpms == []
+    stub._bench_pause_gc.assert_called_once_with()
+    assert stub._bench_phase == _BenchPhase.DECODE_SWEEP
+
+    stub._bench_drain_pending = True
+    stub._bench_current_fpms = [{"point": True}]
+    stub._schedule_times = deque([1.0])
+    stub._bench_collect_between_points = MagicMock()
+
+    assert InstrumentedScheduler._bench_drain_if_pending(stub) is True
+    stub._bench_collect_between_points.assert_called_once_with()
+
+
+def test_benchmark_deactivation_restores_gc():
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_resume_gc = MagicMock()
+    stub._bench_synchronizer = None
+    stub._bench_active = True
+    stub._bench_phase = _BenchPhase.DECODE_SWEEP
+    stub._bench_sync_pending = True
+    stub._bench_extra_steps_left = 1
+    stub._bench_expected_fpms = 2
+    stub._bench_decode_stage = _DecodePointStage.MEASURING
+    stub._schedule_times = deque([1.0])
+    stub._last_update_time = 1.0
+    stub._publisher = MagicMock()
+
+    InstrumentedScheduler._bench_deactivate(stub)
+
+    stub._bench_resume_gc.assert_called_once_with()
+    stub._publisher.resume.assert_called_once_with()
+
+
 def test_benchmark_abort_clears_synthetic_prefix_cache_before_deactivation():
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_synchronizer = None


### PR DESCRIPTION
## Overview

Keep automatic cyclic garbage collection outside vLLM self-benchmark measurements.

This PR is stacked on #13047. GC tracing during the decode-cost investigation observed unmanaged generation-2 pauses as long as 658 ms. Because automatic collection is unrelated to benchmark point boundaries, those pauses can land in a measured pass and become cost-model outliers.

## Details

- After benchmark warmup, collect once, freeze the remaining warmup object graph, and pause automatic cyclic GC.
- Run explicit collections only on the drain cycle between benchmark points.
- Restore the collector's pre-benchmark enabled or disabled state on normal completion and abort paths.
- Leave the permanent generation owned by vLLM, which unfreezes it during engine shutdown.
- Allow controlled comparisons with `DYN_FPM_BENCHMARK_MANAGE_GC=0`.

This changes only when GC work runs during the startup benchmark; serving behavior is restored before the scheduler resumes normal traffic.

## Where should the reviewer start?

- `InstrumentedScheduler._bench_pause_gc`
- `InstrumentedScheduler._bench_collect_between_points`
- `InstrumentedScheduler._bench_deactivate`

## Validation

- `155 passed` in `test_vllm_instrumented_scheduler.py`
- Coverage for initially enabled and disabled collectors, the opt-out, between-point collection, and deactivation restoration
- Repository isort, Black, Flake8, Ruff, codespell, pytest-marker, and other applicable pre-commit hooks passed

## Related Issues

🚫 This PR is not linked to an issue:

- [x] Confirmed — no related issue
