### PR TITLE
fix(sglang): publish ratio-based HiCache capacity (cherry-pick #12953)

### DIFF
--- a/components/src/dynamo/sglang/capacity.py
+++ b/components/src/dynamo/sglang/capacity.py
@@ -140,13 +140,33 @@ def get_hicache_native_offloading_capacity(
     if device_capacity is None:
         return None
 
-    host_capacity = native_offloading_capacity(
-        scheduler_info.get("hicache_host_total_tokens")
-    )
+    host_tokens = scheduler_info.get("hicache_host_total_tokens")
+    policy = getattr(server_args, "hicache_write_policy", None)
+    if "hicache_host_total_tokens" not in scheduler_info:
+        model_config = getattr(server_args, "model_config", None)
+        if (
+            not getattr(server_args, "enable_hierarchical_cache", False)
+            or getattr(server_args, "hicache_size", None) != 0
+            or policy not in ("write_back", "write_through")
+            or (getattr(server_args, "dcp_size", 1) or 1) > 1
+            or getattr(model_config, "is_deepseek_v4_arch", False)
+        ):
+            return None
+        page_size = getattr(server_args, "page_size", None)
+        ratio = getattr(server_args, "hicache_ratio", None)
+        if not page_size or ratio is None:
+            return None
+        try:
+            host_tokens = int(device_capacity["total_tokens"] * ratio)
+            # Match SGLang HostKVCache's realized ratio-based allocation.
+            host_tokens = (host_tokens // page_size + 1) * page_size
+        except (TypeError, ValueError, OverflowError):
+            return None
+
+    host_capacity = native_offloading_capacity(host_tokens)
     if host_capacity is None:
         return None
 
-    policy = getattr(server_args, "hicache_write_policy", None)
     host_tokens = host_capacity["total_tokens"]
     # The router already counts device capacity: write-back adds the disjoint host
     # pool, write-through subtracts its device mirror, and selective overlap is dynamic.

--- a/components/src/dynamo/sglang/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/sglang/tests/test_runtime_metadata.py
@@ -97,14 +97,17 @@ def test_hicache_native_offloading_capacity_ignores_invalid_values(value):
     )
 
 
-def test_hicache_requires_reported_host_capacity():
-    assert (
-        get_hicache_native_offloading_capacity(
-            SimpleNamespace(hicache_write_policy="write_back"),
-            {"max_total_num_tokens": 100},
-        )
-        is None
-    )
+def test_hicache_derives_ratio_based_capacity():
+    assert get_hicache_native_offloading_capacity(
+        SimpleNamespace(
+            enable_hierarchical_cache=True,
+            hicache_size=0,
+            hicache_write_policy="write_back",
+            hicache_ratio=3.0,
+            page_size=16,
+        ),
+        {"max_total_num_tokens": 100},
+    ) == {"total_tokens": 304}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Cherry-pick of #12953 to `release/1.4.0`. Clean pick, no conflicts.

## Why this is needed

The fix merged to `main` this morning and had no pick behind it, so 6588979 aside this was the only 1.4.0 bug whose fix was on `main` with nothing carrying it to the release branch. Without this, 6568524 ships unfixed while the tracker shows a merged fix, which is the quiet kind of miss.

## What it does

Publishes SGLang HiCache capacity when the scheduler initialization handshake omits the metrics-only `hicache_host_total_tokens` field, so ThunderAgent gets the complete device-plus-host token budget for ratio-sized HiCache deployments. Scheduler-reported host capacity is preserved when available; otherwise it mirrors SGLang's ratio sizing and page rounding in the existing capacity helper. Unsupported explicit-size, selective-write-through, DCP, and DeepSeek V4 configurations stay unpublished.

Closes 6568524 (DYN-3793).

## Pick fidelity

Verified on the diff rather than the file blob: the added lines on this branch are identical to the 35 added by `0e8ad35` on `main`. Two files, `capacity.py` and `test_runtime_metadata.py`, and the main-side test comes along with it.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->