### PR TITLE
fix(planner): stop the GPU ceiling clamp from growing decode replicas

### DIFF
--- a/components/src/dynamo/planner/core/budget.py
+++ b/components/src/dynamo/planner/core/budget.py
@@ -148,7 +148,12 @@ def proportional_clamp_pair(
         max_p = math.floor((target - decode_min_endpoint * d_gpu) / p_gpu)
         new_p = max(prefill_min_endpoint, min(max_p, math.floor(num_p * scale)))
         remaining = target - new_p * p_gpu
-        new_d = max(decode_min_endpoint, math.floor(remaining / d_gpu))
+        # Cap new_d at num_d, mirroring _shrink_pair: when p_gpu >> d_gpu the
+        # proportional shrink lands new_p near decode_min_endpoint, leaving a
+        # large remaining budget that would push floor(remaining / d_gpu) above
+        # the requested num_d. This is the strict-shrink path, so it must never
+        # hand back more decode replicas than were asked for.
+        new_d = min(num_d, max(decode_min_endpoint, math.floor(remaining / d_gpu)))
         return new_p, new_d
 
     # Floor path — proportional grow toward min_gpus.

--- a/components/src/dynamo/planner/core/budget.py
+++ b/components/src/dynamo/planner/core/budget.py
@@ -153,7 +153,13 @@ def proportional_clamp_pair(
         # large remaining budget that would push floor(remaining / d_gpu) above
         # the requested num_d. This is the strict-shrink path, so it must never
         # hand back more decode replicas than were asked for.
-        new_d = min(num_d, max(decode_min_endpoint, math.floor(remaining / d_gpu)))
+        #
+        # decode_min_endpoint stays the outer bound rather than the cap, so
+        # this branch preserves the floor like every other branch here. All
+        # three callers floor num_d at their decode minimum before calling, so
+        # the two orderings agree today; keeping the floor outermost means this
+        # does not silently depend on that precondition holding forever.
+        new_d = max(decode_min_endpoint, min(num_d, math.floor(remaining / d_gpu)))
         return new_p, new_d
 
     # Floor path — proportional grow toward min_gpus.

--- a/components/src/dynamo/planner/tests/unit/test_budget.py
+++ b/components/src/dynamo/planner/tests/unit/test_budget.py
@@ -158,6 +158,16 @@ def test_clamp_pair_ceiling_never_grows_decode():
     assert new_p * 8 + new_d * 1 <= 20
 
 
+def test_clamp_pair_ceiling_cap_preserves_min_endpoint():
+    # The decode cap must not defeat the min_endpoint floor that every other
+    # branch of this function preserves. All current callers floor num_d at
+    # min_endpoint before calling, so this guards the ordering rather than a
+    # reachable caller today.
+    new_p, new_d = proportional_clamp_pair(10, 0, 8, 1, -1, 20, 1)
+    assert new_d >= 1
+    assert new_p * 8 + new_d * 1 <= 20
+
+
 def test_clamp_pair_ceiling_never_grows_either_pool():
     # Same invariant across a range of asymmetric shapes: the ceiling path is
     # a shrink, so neither pool may exceed its requested count.

--- a/components/src/dynamo/planner/tests/unit/test_budget.py
+++ b/components/src/dynamo/planner/tests/unit/test_budget.py
@@ -147,6 +147,34 @@ def test_clamp_pair_asymmetric_overshoot_shrinks_to_strict_ceiling():
     assert new_p >= 1 and new_d >= 1  # min_endpoint preserved when feasible
 
 
+def test_clamp_pair_ceiling_never_grows_decode():
+    # prefill 8 GPU/worker, decode 1 GPU/worker, ceiling 20. Desired (10, 1)
+    # = 81 GPUs overshoots, so the strict-shrink path runs. The proportional
+    # shrink lands new_p at 2 (16 GPUs), leaving 4 GPUs of headroom — enough
+    # for 4 decode replicas, but only 1 was asked for. A ceiling clamp must
+    # not seat replicas nobody requested.
+    new_p, new_d = proportional_clamp_pair(10, 1, 8, 1, -1, 20, 1)
+    assert new_p <= 10 and new_d <= 1
+    assert new_p * 8 + new_d * 1 <= 20
+
+
+def test_clamp_pair_ceiling_never_grows_either_pool():
+    # Same invariant across a range of asymmetric shapes: the ceiling path is
+    # a shrink, so neither pool may exceed its requested count.
+    for num_p, num_d, p_gpu, d_gpu, ceiling in [
+        (12, 1, 8, 1, 32),
+        (8, 2, 8, 1, 20),
+        (6, 1, 4, 1, 12),
+        (5, 5, 1, 1, 4),
+    ]:
+        new_p, new_d = proportional_clamp_pair(
+            num_p, num_d, p_gpu, d_gpu, -1, ceiling, 1
+        )
+        assert new_p <= num_p, (num_p, num_d, p_gpu, d_gpu, ceiling, new_p)
+        assert new_d <= num_d, (num_p, num_d, p_gpu, d_gpu, ceiling, new_d)
+        assert new_p * p_gpu + new_d * d_gpu <= ceiling
+
+
 def test_clamp_pair_asymmetric_floor_grows():
     # prefill=1, decode=2. min=max=5. desired (1,1)=3 < min=5. tol=2 → [3, 5].
     # Floor logic pushes up; result must stay at or below the strict ceiling.


### PR DESCRIPTION
## Summary

`proportional_clamp_pair`'s ceiling path is documented as a strict shrink — "Ceiling path — strict shrink", and `max_gpus` is described as "a hard hardware/capacity bound". But it recomputes decode from whatever budget is left over after prefill has been shrunk:

```python
max_p = math.floor((target - min_endpoint * d_gpu) / p_gpu)
new_p = max(min_endpoint, min(max_p, math.floor(num_p * scale)))
remaining = target - new_p * p_gpu
new_d = max(min_endpoint, math.floor(remaining / d_gpu))   # unbounded above
```

`new_p` is bounded by `math.floor(num_p * scale)` with `scale = target / total < 1`, so prefill can only fall. `new_d` has no corresponding bound. When `p_gpu >> d_gpu` the proportional shrink lands `new_p` near `min_endpoint`, and the leftover budget is spent seating decode replicas that were never requested.

With prefill at 8 GPUs/replica, decode at 1, and a 20-GPU ceiling, a desired `(10P, 1D)` clamps to `(2P, 4D)` — decode quadruples on the code path whose job is to reduce GPU usage. `(12P, 1D)` under a 32-GPU ceiling becomes `(3P, 8D)`, an 8× decode scale-up.

This is reachable from both production callers. `p_gpu`/`d_gpu` come from `capabilities.prefill.num_gpu` / `capabilities.decode.num_gpu` (`state_machine.py:405-408`), so an asymmetric disagg deployment — high-TP prefill, low-TP decode — is exactly the shape that triggers it. `StateMachine._apply_global_budget` and the orchestrator adapter both act on the returned pair, and the local planner then logs the result as a clamp:

```
GPU budget band [min=-1, max=20] clamped (10P + 1D = 81) -> (2P + 4D = 20)
```

The total does land under the ceiling, which is why this hides: the invariant that fails is not the budget, it is that a shrink handed back more decode replicas than were asked for.

The sibling power-budget helper in the same module, `_shrink_pair`, already caps this exact case and documents the reasoning:

```python
# Cap new_d at num_d: when p_watts >> d_watts the proportional shrink lands
# new_p near min_endpoint, leaving a large remaining budget that would push
# floor(remaining / d_watts) above num_d.
new_d = min(num_d, max(min_endpoint, math.floor(remaining / d_watts)))
```

This applies the same cap to the GPU path. One line, plus the comment explaining why it is there.

## Validation

Ran locally on macOS (CPU-only), Python 3.12:

```
$ pytest components/src/dynamo/planner/tests/unit/test_budget.py
35 passed
```

Behaviour before and after, via the two production-shaped cases:

| desired | p_gpu / d_gpu | ceiling | before | after |
|---|---|---|---|---|
| (10P, 1D) | 8 / 1 | 20 | (2P, **4D**) | (2P, 1D) |
| (12P, 1D) | 8 / 1 | 32 | (3P, **8D**) | (3P, 1D) |
| (8P, 2D) | 8 / 1 | 20 | (2P, **4D**) | (2P, 2D) |
| (6P, 1D) | 4 / 1 | 12 | (2P, **4D**) | (2P, 1D) |

Both new tests were confirmed to fail without the one-line change and pass with it, so they are genuine regressions rather than assertions that hold either way:

```
$ git stash push components/src/dynamo/planner/core/budget.py
$ pytest components/src/dynamo/planner/tests/unit/test_budget.py -k never_grows
FAILED test_clamp_pair_ceiling_never_grows_decode
FAILED test_clamp_pair_ceiling_never_grows_either_pool
2 failed
```

The 33 pre-existing `test_budget.py` cases are unchanged and still pass, including the existing ceiling tests (`test_clamp_pair_shrinks_to_ceiling_when_only_max_set`, `test_clamp_pair_asymmetric_overshoot_shrinks_to_strict_ceiling`) — the cap is a no-op whenever the leftover budget would not have exceeded `num_d`.

Wider planner suite: `pytest components/src/dynamo/planner/tests/unit` → **582 passed, 1 failed, 3 errors**. That failure (`test_load_based_scaling.py::TestRefreshWorkerInfoFromConnector::test_updates_engine_capabilities`) and the 3 collection errors are pre-existing and unrelated — I reproduced them on a clean `main` with this change stashed; they are `ModuleNotFoundError`s for optional deps not installed in my environment.

`pre-commit run --files <the two changed files>` passes (ruff included).

Not verified here: I have no GPU or Kubernetes cluster, so this is validated at the level of the pure function and its callers' arguments, not an end-to-end planner scale-down against a live DGD.

### Note on overlap

PR #13038 edits this same line to make `min_endpoint` per-role (`min_endpoint` → `decode_min_endpoint`). It does not add the cap, so the two changes are orthogonal, but whichever lands second will need a one-line rebase. Happy to rebase on top of it if you would rather take that one first.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource planning so reducing the prefill pool cannot unintentionally increase decode capacity.
  * Ensured capacity reductions never exceed the originally requested replica counts, including asymmetric configurations.

* **Tests**
  * Added coverage for ceiling-based reductions to verify neither pool grows beyond its requested capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->