### PR TITLE
feat(vllm): route RL controls through sidecar

### DIFF
--- a/.github/workflows/copyright-check.ps1
+++ b/.github/workflows/copyright-check.ps1
@@ -84,7 +84,7 @@ $global:copyright_results = @{
 
 $ignored_files = @('.clang-format', '.gitattributes', '.gitignore', '.gitkeep', '.patch', 'Cargo.lock', 'LICENSE', 'uv.lock', 'rust-toolchain.toml', 'codespell.txt', 'exclusions.txt')
 write-debug "<copyright-check> ignored_files = ['$($ignored_files -join "','")']."
-$ignored_paths = @('.github', '.mypy_cache', '.pytest_cache', 'lib/llm/tests/data/sample-models', 'lib/llm/tests/data/deepseek-v3.2', 'lib/llm/tests/data/deepseek-v4', 'container/compliance/spdx_licenses', 'lib/sidecar/vllm/proto/vllm_grpc.proto')
+$ignored_paths = @('.github', '.mypy_cache', '.pytest_cache', 'lib/llm/tests/data/sample-models', 'lib/llm/tests/data/deepseek-v3.2', 'lib/llm/tests/data/deepseek-v4', 'container/compliance/spdx_licenses', 'lib/sidecar/vllm/proto/control.proto', 'lib/sidecar/vllm/proto/inference.proto')
 write-debug "<copyright-check> ignored_paths = ['$($ignored_paths -join "','")']."
 $ignored_types = @('.bat', '.gif', '.ico', '.ipynb', '.jpg', '.jpeg', '.patch', '.png', '.pyc', '.pyi', '.rst', '.zip', '.md', '.json')
 write-debug "<copyright-check> ignored_types = ['$($ignored_types -join "', '")']."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 default_install_hook_types: [pre-commit, commit-msg]
-exclude: ^(src/grpc_generated|.*\.patch$|.*/connect/.*\.py|components/src/dynamo/planner/plugins/proto/v1/plugin_pb2(_grpc)?\.pyi?$|lib/sidecar/vllm/proto/vllm_grpc\.proto$|lib/sidecar/trtllm/proto/trtllm_service\.proto$)
+exclude: ^(src/grpc_generated|.*\.patch$|.*/connect/.*\.py|components/src/dynamo/planner/plugins/proto/v1/plugin_pb2(_grpc)?\.pyi?$|lib/sidecar/vllm/proto/(control|inference)\.proto$|lib/sidecar/trtllm/proto/trtllm_service\.proto$)
 repos:
 - repo: https://github.com/timothycrosley/isort
   rev: 5.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,6 +3109,7 @@ dependencies = [
  "tokio-util",
  "tonic 0.13.1",
  "tonic-build 0.13.1",
+ "tonic-health",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,6 +3084,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.13.1",
+ "tonic-health",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/lib/backend-common/examples/mocker/src/engine.rs
+++ b/lib/backend-common/examples/mocker/src/engine.rs
@@ -275,6 +275,7 @@ impl MockerBackend {
             custom_jinja_template: args.common.custom_jinja_template,
             disaggregation_mode,
             route_to_encoder: args.common.route_to_encoder,
+            enable_rl: args.common.enable_rl,
             model_name: args.model_path,
             served_model_name: Some(args.model_name),
             tool_call_parser,

--- a/lib/backend-common/src/args.rs
+++ b/lib/backend-common/src/args.rs
@@ -90,4 +90,8 @@ pub struct CommonArgs {
     /// shim does not read this env var.
     #[arg(long, default_value_t = false, env = "DYN_ROUTE_TO_ENCODER")]
     pub route_to_encoder: bool,
+
+    /// Publish this worker's engine control/update routes on the RL request-plane endpoint.
+    #[arg(long, default_value_t = false, env = "DYN_ENABLE_RL")]
+    pub enable_rl: bool,
 }

--- a/lib/backend-common/src/lib.rs
+++ b/lib/backend-common/src/lib.rs
@@ -19,6 +19,7 @@ pub mod engine;
 pub mod error;
 pub mod metrics;
 mod publisher;
+mod rl;
 pub mod run;
 pub mod snapshot_publisher;
 pub mod telemetry;

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dynamo_runtime::component::{Endpoint, StartedEndpoint};
+use dynamo_runtime::engine_routes::EngineRouteRegistry;
+use dynamo_runtime::pipeline::network::Ingress;
+use dynamo_runtime::pipeline::{
+    AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn,
+};
+use dynamo_runtime::protocols::annotated::Annotated;
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use futures::stream;
+use serde_json::{Value, json};
+
+const DEFAULT_RL_ENDPOINT: &str = "rl";
+
+pub(crate) struct RlServeEndpoint {
+    started: StartedEndpoint,
+}
+
+impl RlServeEndpoint {
+    pub(crate) async fn shutdown(self) -> anyhow::Result<()> {
+        self.started.shutdown().await
+    }
+}
+
+pub(crate) async fn serve_endpoint(primary: &Endpoint) -> anyhow::Result<RlServeEndpoint> {
+    let endpoint_name = resolve_endpoint_name(&primary.id().name)?;
+    let endpoint = primary.component().endpoint(endpoint_name);
+    let system_url = self_host_base_url(primary.drt());
+    let handler = Arc::new(RlRouteHandler {
+        routes: primary.drt().engine_routes().clone(),
+        system_url,
+    });
+    let ingress = Ingress::for_engine(handler)?;
+    let started = endpoint
+        .endpoint_builder()
+        .handler(ingress)
+        .graceful_shutdown(true)
+        .start_with_registration()
+        .await?;
+    Ok(RlServeEndpoint { started })
+}
+
+fn self_host_base_url(drt: &dynamo_runtime::DistributedRuntime) -> Option<String> {
+    let info = drt.system_status_server_info()?;
+    let configured = dynamo_runtime::RuntimeConfig::from_settings()
+        .unwrap_or_default()
+        .system_host;
+    let host = match configured.as_str() {
+        "0.0.0.0" | "::" | "[::]" => dynamo_runtime::utils::local_ip_for_advertise(),
+        _ => configured,
+    };
+    Some(format!("http://{host}:{}", info.port()))
+}
+
+fn resolve_endpoint_name(primary_name: &str) -> anyhow::Result<String> {
+    let endpoint_name =
+        std::env::var("DYN_RL_ENDPOINT").unwrap_or_else(|_| DEFAULT_RL_ENDPOINT.into());
+    validate_endpoint_name(endpoint_name.trim(), primary_name)
+}
+
+fn validate_endpoint_name(endpoint_name: &str, primary_name: &str) -> anyhow::Result<String> {
+    if endpoint_name.is_empty() {
+        anyhow::bail!("DYN_RL_ENDPOINT must not be empty");
+    }
+    if endpoint_name == primary_name {
+        anyhow::bail!("DYN_RL_ENDPOINT `{endpoint_name}` collides with the serving endpoint");
+    }
+    if !endpoint_name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        anyhow::bail!("DYN_RL_ENDPOINT must contain only letters, digits, '-' or '_'");
+    }
+    Ok(endpoint_name.to_string())
+}
+
+struct RlRouteHandler {
+    routes: EngineRouteRegistry,
+    system_url: Option<String>,
+}
+
+impl RlRouteHandler {
+    fn dispatch(&self, request: &Value) -> Value {
+        let Some(method) = request
+            .as_object()
+            .and_then(|request| request.get("method"))
+            .and_then(Value::as_str)
+        else {
+            return json!({"status": "error", "message": "rl_dispatch: missing 'method' (str)"});
+        };
+        if method != "routes" {
+            return json!({
+                "status": "error",
+                "method": method,
+                "message": "rl request-plane endpoint only supports method='routes'",
+            });
+        }
+
+        let mut routes = self.routes.routes().into_iter().collect::<Vec<_>>();
+        routes.sort();
+        routes.dedup();
+        json!({
+            "status": "ok",
+            "routes": routes,
+            "system_url": self.system_url,
+        })
+    }
+}
+
+#[async_trait]
+impl AsyncEngine<SingleIn<Value>, ManyOut<Annotated<Value>>, anyhow::Error> for RlRouteHandler {
+    async fn generate(&self, input: SingleIn<Value>) -> anyhow::Result<ManyOut<Annotated<Value>>> {
+        let (request, context) = input.into_parts();
+        let response = self.dispatch(&request);
+        Ok(ResponseStream::new(
+            Box::pin(stream::once(async move { Annotated::from_data(response) })),
+            context.context(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routes_request_describes_the_worker_engine_surface() {
+        let routes = EngineRouteRegistry::new();
+        routes.register(
+            "control/pause_generation",
+            Arc::new(|_| Box::pin(async { Ok(json!({"status": "ok"})) })),
+        );
+        let handler = RlRouteHandler {
+            routes,
+            system_url: Some("http://worker:8080".to_string()),
+        };
+
+        assert_eq!(
+            handler.dispatch(&json!({"method": "routes"})),
+            json!({
+                "status": "ok",
+                "routes": ["control/pause_generation"],
+                "system_url": "http://worker:8080",
+            })
+        );
+    }
+}

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -187,6 +187,8 @@ pub struct WorkerConfig {
     /// roles -- setting it on `Decode` or `Encode` is rejected at
     /// `Worker::run` validation time with `BackendError::InvalidArgument`.
     pub route_to_encoder: bool,
+    /// Publish the worker's engine routes through an auxiliary RL discovery endpoint.
+    pub enable_rl: bool,
     /// Optional frontend media decoding and fetch policy advertised on the
     /// model deployment card.
     pub media_decoder: Option<MediaDecoder>,
@@ -231,6 +233,7 @@ impl Default for WorkerConfig {
             structural_tag_schema: StructuralTagSchemaMode::Auto,
             runtime: RuntimeConfig::default(),
             route_to_encoder: false,
+            enable_rl: false,
             media_decoder: None,
             media_fetcher: None,
             default_thinking_mode: None,
@@ -982,7 +985,22 @@ impl Worker {
         let serve_fut = builder.start();
         tokio::pin!(serve_fut);
 
-        tokio::select! {
+        let rl_endpoint = if self.config.enable_rl {
+            match crate::rl::serve_endpoint(&endpoint).await {
+                Ok(endpoint) => Some(endpoint),
+                Err(error) => {
+                    self.orchestrator_steps(&endpoint).await;
+                    return Err(err(
+                        ErrorType::Backend(BackendError::Unknown),
+                        format!("RL endpoint setup: {error}"),
+                    ));
+                }
+            }
+        } else {
+            None
+        };
+
+        let serve_result = tokio::select! {
             biased;
             result = &mut serve_fut => {
                 match result {
@@ -993,23 +1011,31 @@ impl Worker {
                         tracing::info!(
                             "Endpoint completed gracefully; running shutdown orchestration"
                         );
+                        Ok(())
                     }
                     // Serve errored; cleanup_once in run() is the safety net.
                     Err(e) => {
-                        return Err(err(
+                        Err(err(
                             ErrorType::Backend(BackendError::Unknown),
                             format!("serve: {e}"),
-                        ));
+                        ))
                     }
                 }
             }
             _ = shutdown.cancelled() => {
                 tracing::info!("Received shutdown signal; running graceful orchestration");
+                Ok(())
             }
+        };
+
+        if let Some(rl_endpoint) = rl_endpoint
+            && let Err(error) = rl_endpoint.shutdown().await
+        {
+            tracing::warn!(%error, "RL discovery endpoint shutdown failed");
         }
 
         self.orchestrator_steps(&endpoint).await;
-        Ok(())
+        serve_result
     }
 
     /// Engine-facing shutdown sequence: grace period sleep → drain loop on
@@ -1287,8 +1313,12 @@ fn engine_control_policy(control: &str) -> EngineControlPolicy {
         // Pause controls make the engine unsafe for new requests, so remove
         // the endpoint before they mutate engine state. Resume controls make
         // the engine serving-safe again, so advertise it only after success.
-        "sleep" | "release_memory_occupation" => EngineControlPolicy::UnregisterBefore,
-        "wake_up" | "resume_memory_occupation" => EngineControlPolicy::RegisterAfter,
+        "pause_generation" | "sleep" | "release_memory_occupation" => {
+            EngineControlPolicy::UnregisterBefore
+        }
+        "resume_generation" | "wake_up" | "resume_memory_occupation" => {
+            EngineControlPolicy::RegisterAfter
+        }
         _ => EngineControlPolicy::Direct,
     }
 }
@@ -1826,11 +1856,19 @@ mod tests {
             EngineControlPolicy::UnregisterBefore
         );
         assert_eq!(
+            engine_control_policy("pause_generation"),
+            EngineControlPolicy::UnregisterBefore
+        );
+        assert_eq!(
             engine_control_policy("release_memory_occupation"),
             EngineControlPolicy::UnregisterBefore
         );
         assert_eq!(
             engine_control_policy("wake_up"),
+            EngineControlPolicy::RegisterAfter
+        );
+        assert_eq!(
+            engine_control_policy("resume_generation"),
             EngineControlPolicy::RegisterAfter
         );
         assert_eq!(

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -460,6 +460,9 @@ impl WorkerConfig {
                 structural_tag_schema: st_schema,
                 runtime: runtime.map(|r| r.inner).unwrap_or_default(),
                 route_to_encoder,
+                // Python vLLM owns and serves its existing `.rl` endpoint.
+                // The shared Rust endpoint is opt-in for Rust sidecars only.
+                enable_rl: false,
                 media_decoder: media_decoder.map(|decoder| decoder.inner),
                 media_fetcher: media_fetcher.map(|fetcher| fetcher.inner),
             },

--- a/lib/mocker/servers/vllm/Cargo.toml
+++ b/lib/mocker/servers/vllm/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Mocker-backed implementation of vLLM's native Generate gRPC API"
+description = "Mocker-backed implementation of vLLM's native gRPC API"
 readme = "README.md"
 
 [[bin]]
@@ -28,6 +28,7 @@ futures = { workspace = true }
 prost-types = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
+tonic-health = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/lib/mocker/servers/vllm/README.md
+++ b/lib/mocker/servers/vllm/README.md
@@ -5,14 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Mocker-backed vLLM gRPC server
 
-`dynamo-vllm-mocker-server` implements vLLM's native `Generate` and
-`GenerateStream` RPCs on CPU, using the Dynamo Mocker scheduler for batching,
-KV-capacity, prefix-cache, and timing behavior. Its primary purpose is fast,
-repeatable testing of `dynamo-vllm-sidecar` without a model or GPU.
+`dynamo-vllm-mocker-server` implements vLLM's native Inference and Control services plus standard gRPC health on CPU. It uses the Dynamo Mocker scheduler for batching, KV capacity, prefix cache, and timing behavior.
 
-The mock server temporarily imports the generated types exposed by
-`dynamo-vllm-sidecar`, whose proto is vendored unchanged from vLLM v0.25.1.
-Both consumers will move to vLLM's upstream package once it is published.
+The mock server imports the generated types exposed by `dynamo-vllm-sidecar`. The proto files are vendored unchanged from vLLM.
 
 ## Aggregated serving
 
@@ -29,8 +24,7 @@ Point the existing Dynamo sidecar at it:
 
 ```bash
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50051 \
-  --model-path mocker-model
+  --vllm-endpoint 127.0.0.1:50051
 ```
 
 `--extra-engine-args` accepts inline JSON or a JSON file path. The values use
@@ -62,13 +56,15 @@ Then start one sidecar for each endpoint:
 
 ```bash
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50051 --model-path mocker-model \
+  --vllm-endpoint 127.0.0.1:50051 \
   --disaggregation-mode prefill
 
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50052 --model-path mocker-model \
+  --vllm-endpoint 127.0.0.1:50052 \
   --disaggregation-mode decode
 ```
+
+The sidecar discovers model identity through Control. Keep `--disaggregation-mode` for prefill and decode because the current discovery API does not report engine role.
 
 The prefill endpoint returns an opaque vLLM-shaped `kv_transfer_params`
 payload, and the decode endpoint validates that the sidecar forwarded it

--- a/lib/mocker/servers/vllm/src/main.rs
+++ b/lib/mocker/servers/vllm/src/main.rs
@@ -7,20 +7,21 @@ use anyhow::Context;
 use clap::Parser;
 use dynamo_mocker::common::protocols::MockEngineArgs;
 use dynamo_vllm_mocker::{MockerServerConfig, ServerMode, VllmMockerService};
-use dynamo_vllm_sidecar::proto::generate_server::GenerateServer;
+use dynamo_vllm_sidecar::proto::control_server::ControlServer;
+use dynamo_vllm_sidecar::proto::inference_server::InferenceServer;
+use tonic_health::ServingStatus;
 
 #[derive(Parser, Debug)]
 #[command(
     name = "dynamo-vllm-mocker-server",
-    about = "Run a CPU-only, Mocker-backed implementation of vLLM's native Generate gRPC API"
+    about = "Run a CPU-only, Mocker-backed implementation of vLLM's native gRPC API"
 )]
 struct Args {
     /// Address on which to expose the vLLM-compatible gRPC service.
     #[arg(long, default_value = "127.0.0.1:50051")]
     listen: SocketAddr,
 
-    /// Model name accepted in Generate requests. The empty model used by the
-    /// Dynamo vLLM sidecar is always accepted.
+    /// Model name exposed by the mock server.
     #[arg(long, default_value = "mocker-model")]
     model: String,
 
@@ -81,8 +82,17 @@ async fn main() -> anyhow::Result<()> {
         mode = %service.config().mode,
         "starting Mocker-backed vLLM gRPC server"
     );
+    let (health, health_service) = tonic_health::server::health_reporter();
+    health
+        .set_service_status("vllm.Control", ServingStatus::Serving)
+        .await;
+    health
+        .set_service_status("vllm.Inference", ServingStatus::Serving)
+        .await;
     tonic::transport::Server::builder()
-        .add_service(GenerateServer::new(service))
+        .add_service(InferenceServer::new(service.clone()))
+        .add_service(ControlServer::new(service))
+        .add_service(health_service)
         .serve_with_shutdown(args.listen, async {
             let _ = tokio::signal::ctrl_c().await;
         })

--- a/lib/mocker/servers/vllm/src/server.rs
+++ b/lib/mocker/servers/vllm/src/server.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use clap::ValueEnum;
 use dynamo_mocker::common::protocols::{EngineType, MockEngineArgs, OutputSignal, WorkerType};
-use dynamo_mocker::live::{LiveEngine, LiveRequest};
+use dynamo_mocker::live::{LiveEngine, LiveRequest, stable_request_uuid};
 use dynamo_mocker::scheduler::MockerMetrics;
 use dynamo_vllm_sidecar::proto as pb;
 use futures::Stream;
@@ -60,10 +60,12 @@ impl Default for MockerServerConfig {
     }
 }
 
-/// vLLM-compatible Generate service driven by one shared Mocker scheduler.
+/// Mocker-backed vLLM services.
 #[derive(Clone)]
 pub struct VllmMockerService {
     config: Arc<MockerServerConfig>,
+    model_info: Arc<pb::ModelInfo>,
+    server_info: Arc<pb::ServerInfo>,
     engine: LiveEngine,
     request_permits: Arc<Semaphore>,
 }
@@ -84,8 +86,57 @@ impl VllmMockerService {
             "Mocker worker_type must be aggregated; use the server mode for the emulated wire role"
         );
         let max_concurrent_requests = config.max_concurrent_requests;
+        let model_info = pb::ModelInfo {
+            model_id: config.model.clone(),
+            served_model_name: config.model.clone(),
+            served_model_aliases: Vec::new(),
+            supports_text_input: true,
+            supports_token_ids_input: true,
+            supports_multimodal: false,
+            reasoning_parser: String::new(),
+            tool_call_parser: String::new(),
+        };
+        let server_info = pb::ServerInfo {
+            engine_version: env!("CARGO_PKG_VERSION").to_string(),
+            api_version: "vllm".to_string(),
+            instance_id: format!("dynamo-vllm-mocker-{}", config.mode),
+            parallelism: Some(pb::ParallelismInfo {
+                tensor_parallel_size: 1,
+                pipeline_parallel_size: 1,
+                data_parallel_size: engine_args.dp_size,
+                data_parallel_rank: DP_RANK,
+                decode_context_parallel_size: 1,
+            }),
+            max_model_len: engine_args
+                .max_model_len
+                .map(u32::try_from)
+                .transpose()
+                .map_err(|_| anyhow::anyhow!("max_model_len exceeds the Control API range"))?
+                .unwrap_or_default(),
+            kv_block_size: u32::try_from(engine_args.block_size)
+                .map_err(|_| anyhow::anyhow!("block_size exceeds the Control API range"))?,
+            total_kv_blocks: u64::try_from(engine_args.num_gpu_blocks)
+                .map_err(|_| anyhow::anyhow!("num_gpu_blocks exceeds the Control API range"))?,
+            max_running_requests: engine_args
+                .max_num_seqs
+                .map(u64::try_from)
+                .transpose()
+                .map_err(|_| anyhow::anyhow!("max_num_seqs exceeds the Control API range"))?
+                .unwrap_or_default(),
+            max_batched_tokens: engine_args
+                .max_num_batched_tokens
+                .map(u64::try_from)
+                .transpose()
+                .map_err(|_| {
+                    anyhow::anyhow!("max_num_batched_tokens exceeds the Control API range")
+                })?
+                .unwrap_or_default(),
+            supports_explicit_data_parallel_rank: true,
+        };
         Ok(Self {
             config: Arc::new(config),
+            model_info: Arc::new(model_info),
+            server_info: Arc::new(server_info),
             engine: LiveEngine::start(engine_args, DP_RANK)?,
             request_permits: Arc::new(Semaphore::new(max_concurrent_requests)),
         })
@@ -125,7 +176,7 @@ impl VllmMockerService {
 }
 
 #[tonic::async_trait]
-impl pb::generate_server::Generate for VllmMockerService {
+impl pb::inference_server::Inference for VllmMockerService {
     type GenerateStreamStream =
         Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send + 'static>>;
 
@@ -206,6 +257,45 @@ impl pb::generate_server::Generate for VllmMockerService {
             ))?;
         };
         Ok(Response::new(Box::pin(stream)))
+    }
+}
+
+#[tonic::async_trait]
+impl pb::control_server::Control for VllmMockerService {
+    async fn get_server_info(
+        &self,
+        _request: Request<pb::GetServerInfoRequest>,
+    ) -> Result<Response<pb::ServerInfo>, Status> {
+        Ok(Response::new((*self.server_info).clone()))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<pb::GetModelInfoRequest>,
+    ) -> Result<Response<pb::ModelInfo>, Status> {
+        Ok(Response::new((*self.model_info).clone()))
+    }
+
+    async fn abort(
+        &self,
+        request: Request<pb::AbortRequest>,
+    ) -> Result<Response<pb::AbortResponse>, Status> {
+        for request_id in request.into_inner().request_ids {
+            self.engine
+                .cancel(stable_request_uuid(self.config.seed, &request_id))
+                .await
+                .map_err(|error| Status::internal(format!("Mocker abort failed: {error}")))?;
+        }
+        Ok(Response::new(pb::AbortResponse {}))
+    }
+
+    async fn get_kv_event_sources(
+        &self,
+        _request: Request<pb::GetKvEventSourcesRequest>,
+    ) -> Result<Response<pb::GetKvEventSourcesResponse>, Status> {
+        Ok(Response::new(pb::GetKvEventSourcesResponse {
+            sources: Vec::new(),
+        }))
     }
 }
 

--- a/lib/mocker/servers/vllm/src/server.rs
+++ b/lib/mocker/servers/vllm/src/server.rs
@@ -90,7 +90,7 @@ impl VllmMockerService {
             model_id: config.model.clone(),
             served_model_name: config.model.clone(),
             served_model_aliases: Vec::new(),
-            supports_text_input: true,
+            supports_text_input: false,
             supports_token_ids_input: true,
             supports_multimodal: false,
             reasoning_parser: String::new(),

--- a/lib/mocker/servers/vllm/src/server.rs
+++ b/lib/mocker/servers/vllm/src/server.rs
@@ -132,6 +132,7 @@ impl VllmMockerService {
                 })?
                 .unwrap_or_default(),
             supports_explicit_data_parallel_rank: true,
+            rl_capabilities: None,
         };
         Ok(Self {
             config: Arc::new(config),
@@ -297,6 +298,101 @@ impl pb::control_server::Control for VllmMockerService {
             sources: Vec::new(),
         }))
     }
+
+    async fn pause_generation(
+        &self,
+        _request: Request<pb::PauseGenerationRequest>,
+    ) -> Result<Response<pb::PauseGenerationResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn resume_generation(
+        &self,
+        _request: Request<pb::ResumeGenerationRequest>,
+    ) -> Result<Response<pb::ResumeGenerationResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn is_paused(
+        &self,
+        _request: Request<pb::IsPausedRequest>,
+    ) -> Result<Response<pb::IsPausedResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn sleep(
+        &self,
+        _request: Request<pb::SleepRequest>,
+    ) -> Result<Response<pb::SleepResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn wake_up(
+        &self,
+        _request: Request<pb::WakeUpRequest>,
+    ) -> Result<Response<pb::WakeUpResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn is_sleeping(
+        &self,
+        _request: Request<pb::IsSleepingRequest>,
+    ) -> Result<Response<pb::IsSleepingResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn init_weight_transfer_engine(
+        &self,
+        _request: Request<pb::InitWeightTransferEngineRequest>,
+    ) -> Result<Response<pb::InitWeightTransferEngineResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn start_weight_update(
+        &self,
+        _request: Request<pb::StartWeightUpdateRequest>,
+    ) -> Result<Response<pb::StartWeightUpdateResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn start_draft_weight_update(
+        &self,
+        _request: Request<pb::StartDraftWeightUpdateRequest>,
+    ) -> Result<Response<pb::StartDraftWeightUpdateResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn update_weights(
+        &self,
+        _request: Request<pb::UpdateWeightsRequest>,
+    ) -> Result<Response<pb::UpdateWeightsResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn finish_weight_update(
+        &self,
+        _request: Request<pb::FinishWeightUpdateRequest>,
+    ) -> Result<Response<pb::FinishWeightUpdateResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn update_weight_version(
+        &self,
+        _request: Request<pb::UpdateWeightVersionRequest>,
+    ) -> Result<Response<pb::UpdateWeightVersionResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn get_weight_version(
+        &self,
+        _request: Request<pb::GetWeightVersionRequest>,
+    ) -> Result<Response<pb::GetWeightVersionResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+}
+
+fn rl_control_unavailable() -> Status {
+    Status::failed_precondition("the vLLM mocker does not advertise RL control capabilities")
 }
 
 fn checked_token(signal: &OutputSignal) -> BoxedStatusResult<u32> {

--- a/lib/mocker/servers/vllm/src/server_request.rs
+++ b/lib/mocker/servers/vllm/src/server_request.rs
@@ -75,6 +75,14 @@ impl PreparedRequest {
             ))
             .into());
         }
+        if let Some(rank) = request.data_parallel_rank
+            && rank != DP_RANK
+        {
+            return Err(Status::invalid_argument(format!(
+                "data_parallel_rank {rank} is not served; expected {DP_RANK}"
+            ))
+            .into());
+        }
         let mut prompt_tokens = match request.prompt.take() {
             Some(pb::generate_request::Prompt::TokenIds(tokens)) => tokens.ids,
             Some(pb::generate_request::Prompt::Text(_)) => {
@@ -291,6 +299,7 @@ impl PreparedRequest {
                 finish_reason: pb::finish_info::FinishReason::Length as i32,
                 stop_reason: None,
                 kv_transfer_params: (self.mode == ServerMode::Prefill).then(|| self.handoff()),
+                ec_transfer_params: None,
             }),
         }
     }

--- a/lib/mocker/servers/vllm/src/server_tests.rs
+++ b/lib/mocker/servers/vllm/src/server_tests.rs
@@ -219,7 +219,7 @@ async fn unary_generate_maps_capacity_rejection_to_resource_exhausted() {
         ids: vec![1, 2, 3, 4, 5],
     }));
 
-    let error = pb::generate_server::Generate::generate(&service, Request::new(oversized))
+    let error = pb::inference_server::Inference::generate(&service, Request::new(oversized))
         .await
         .unwrap_err();
     assert_eq!(error.code(), tonic::Code::ResourceExhausted);
@@ -245,18 +245,18 @@ async fn concurrent_request_limit_rejects_a_stalled_stream() {
     let mut first_request = request("stalled");
     first_request.stopping.as_mut().unwrap().max_new_tokens = 100;
     let first =
-        pb::generate_server::Generate::generate_stream(&service, Request::new(first_request))
+        pb::inference_server::Inference::generate_stream(&service, Request::new(first_request))
             .await
             .unwrap();
 
     let mut queued_request = request("queued");
     queued_request.stopping.as_mut().unwrap().max_new_tokens = 100;
     let queued =
-        pb::generate_server::Generate::generate_stream(&service, Request::new(queued_request))
+        pb::inference_server::Inference::generate_stream(&service, Request::new(queued_request))
             .await
             .unwrap();
 
-    let error = match pb::generate_server::Generate::generate_stream(
+    let error = match pb::inference_server::Inference::generate_stream(
         &service,
         Request::new(request("rejected")),
     )
@@ -312,7 +312,7 @@ async fn unary_generate_accumulates_output_and_terminal_metadata() {
     let service = VllmMockerService::new(MockerServerConfig::default(), admitting_args()).unwrap();
 
     let response =
-        pb::generate_server::Generate::generate(&service, Request::new(request("unary")))
+        pb::inference_server::Inference::generate(&service, Request::new(request("unary")))
             .await
             .unwrap()
             .into_inner();
@@ -355,7 +355,7 @@ async fn streaming_generate_maps_capacity_rejection_to_resource_exhausted() {
     }));
 
     let mut stream =
-        pb::generate_server::Generate::generate_stream(&service, Request::new(oversized))
+        pb::inference_server::Inference::generate_stream(&service, Request::new(oversized))
             .await
             .expect("streaming RPC opens before the scheduler rejects")
             .into_inner();
@@ -384,10 +384,11 @@ async fn streaming_survives_a_producer_that_outruns_a_stalled_consumer() {
     let mut bursty = request("bursty");
     bursty.stopping.as_mut().unwrap().max_new_tokens = 50;
 
-    let mut stream = pb::generate_server::Generate::generate_stream(&service, Request::new(bursty))
-        .await
-        .unwrap()
-        .into_inner();
+    let mut stream =
+        pb::inference_server::Inference::generate_stream(&service, Request::new(bursty))
+            .await
+            .unwrap()
+            .into_inner();
 
     // Stall the consumer so the instant producer fills and overflows the fixed
     // per-request buffer before we read anything.

--- a/lib/mocker/servers/vllm/tests/sidecar.rs
+++ b/lib/mocker/servers/vllm/tests/sidecar.rs
@@ -10,11 +10,13 @@ use dynamo_backend_common::{
 use dynamo_mocker::common::protocols::MockEngineArgs;
 use dynamo_vllm_mocker::{MockerServerConfig, ServerMode, VllmMockerService};
 use dynamo_vllm_sidecar::VllmSidecarEngine;
-use dynamo_vllm_sidecar::proto::generate_server::GenerateServer;
+use dynamo_vllm_sidecar::proto::control_server::ControlServer;
+use dynamo_vllm_sidecar::proto::inference_server::InferenceServer;
 use futures::StreamExt;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
+use tonic_health::ServingStatus;
 
 struct RunningServer {
     endpoint: String,
@@ -35,10 +37,20 @@ impl RunningServer {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (shutdown, shutdown_rx) = oneshot::channel();
-        let server_service = service.clone();
+        let inference_service = service.clone();
+        let control_service = service.clone();
+        let (health, health_service) = tonic_health::server::health_reporter();
+        health
+            .set_service_status("vllm.Control", ServingStatus::Serving)
+            .await;
+        health
+            .set_service_status("vllm.Inference", ServingStatus::Serving)
+            .await;
         tokio::spawn(async move {
             tonic::transport::Server::builder()
-                .add_service(GenerateServer::new(server_service))
+                .add_service(InferenceServer::new(inference_service))
+                .add_service(ControlServer::new(control_service))
+                .add_service(health_service)
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     let _ = shutdown_rx.await;
                 })
@@ -73,13 +85,11 @@ fn fast_engine_args() -> MockEngineArgs {
         .unwrap()
 }
 
-fn sidecar(endpoint: &str, mode: DisaggregationMode) -> VllmSidecarEngine {
+async fn sidecar(endpoint: &str, mode: DisaggregationMode) -> VllmSidecarEngine {
     let mut argv = vec![
         "dynamo-vllm-sidecar".to_string(),
         "--vllm-endpoint".to_string(),
         endpoint.to_string(),
-        "--model-path".to_string(),
-        "mocker-model".to_string(),
         "--grpc-connections".to_string(),
         "1".to_string(),
         "--grpc-startup-deadline-secs".to_string(),
@@ -90,7 +100,11 @@ fn sidecar(endpoint: &str, mode: DisaggregationMode) -> VllmSidecarEngine {
     if mode != DisaggregationMode::Aggregated {
         argv.extend(["--disaggregation-mode".to_string(), mode.to_string()]);
     }
-    VllmSidecarEngine::from_args(Some(argv)).unwrap().0
+    tokio::task::spawn_blocking(move || VllmSidecarEngine::from_args(Some(argv)))
+        .await
+        .unwrap()
+        .unwrap()
+        .0
 }
 
 fn request(max_tokens: u32) -> PreprocessedRequest {
@@ -132,7 +146,7 @@ async fn collect(
 #[tokio::test]
 async fn sidecar_streams_mocker_tokens_logprobs_and_usage() {
     let server = RunningServer::start(ServerMode::Aggregated, fast_engine_args()).await;
-    let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated);
+    let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated).await;
     engine.start(0).await.unwrap();
 
     let outputs = collect(&engine, request(3)).await;
@@ -160,8 +174,8 @@ async fn sidecar_streams_mocker_tokens_logprobs_and_usage() {
 async fn prefill_handoff_round_trips_through_a_decode_server() {
     let prefill_server = RunningServer::start(ServerMode::Prefill, fast_engine_args()).await;
     let decode_server = RunningServer::start(ServerMode::Decode, fast_engine_args()).await;
-    let prefill = sidecar(&prefill_server.endpoint, DisaggregationMode::Prefill);
-    let decode = sidecar(&decode_server.endpoint, DisaggregationMode::Decode);
+    let prefill = sidecar(&prefill_server.endpoint, DisaggregationMode::Prefill).await;
+    let decode = sidecar(&decode_server.endpoint, DisaggregationMode::Decode).await;
     prefill.start(0).await.unwrap();
     decode.start(1).await.unwrap();
 
@@ -199,7 +213,7 @@ async fn dropping_sidecar_stream_cancels_mocker_work() {
     let mut args = fast_engine_args();
     args.speedup_ratio = 0.1;
     let server = RunningServer::start(ServerMode::Aggregated, args).await;
-    let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated);
+    let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated).await;
     engine.start(0).await.unwrap();
 
     let context = dynamo_backend_common::testing::mock_context();

--- a/lib/sidecar/common/src/args.rs
+++ b/lib/sidecar/common/src/args.rs
@@ -43,7 +43,7 @@ pub struct GrpcTransportArgs {
     )]
     pub grpc_retry_interval_secs: u64,
 
-    /// Maximum total duration for sidecar gRPC startup.
+    /// Maximum duration for each sidecar gRPC startup phase.
     #[arg(
         long = "grpc-startup-deadline-secs",
         env = "DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS",

--- a/lib/sidecar/trtllm/src/engine.rs
+++ b/lib/sidecar/trtllm/src/engine.rs
@@ -111,6 +111,7 @@ impl TrtllmSidecarEngine {
             enable_kv_routing: false,
             disaggregation_mode: DisaggregationMode::Aggregated,
             route_to_encoder: false,
+            enable_rl: args.sidecar.common.enable_rl,
             ..Default::default()
         };
         Ok((engine, config))

--- a/lib/sidecar/vllm/Cargo.toml
+++ b/lib/sidecar/vllm/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 tonic = { workspace = true }
+tonic-health = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -10,8 +10,13 @@ SPDX-License-Identifier: Apache-2.0
 > and not yet packaged for distribution. The manifests, flags, and behavior may
 > change without notice.
 
-`dynamo-vllm-sidecar` connects a Dynamo worker to vLLM's native gRPC
-`Generate` service. It is a standalone Rust executable.
+`dynamo-vllm-sidecar` connects a Dynamo worker to vLLM's native gRPC services:
+
+- `vllm.Inference` for generation
+- `vllm.Control` for model and server discovery
+- Standard gRPC health for startup readiness
+
+It is a standalone Rust executable.
 
 ## Supported
 
@@ -40,12 +45,17 @@ Start the Dynamo worker explicitly:
 
 ```bash
 dynamo-vllm-sidecar \
-  --vllm-endpoint 127.0.0.1:50051 \
-  --model-path Qwen/Qwen3-0.6B
+  --vllm-endpoint 127.0.0.1:50051
 ```
 
 Use `VLLM_GRPC_ENDPOINT` instead of `--vllm-endpoint` when the endpoint is
 provided through the environment.
+
+The sidecar discovers `model_id`, the served name, context length, KV capacity, and scheduler limits through `vllm.Control`. `model_id` must be readable locally or fetchable by Dynamo for tokenization and chat templates. Parser defaults are not advertised because the current inference protocol cannot preserve all parser-related request semantics.
+
+Data-parallel registration is omitted because Control reports global topology, not the rank range hosted by the connected frontend.
+
+Aggregated serving is the default. Set the existing `--disaggregation-mode` to `prefill` or `decode` only for non-aggregated deployments; the current Control API does not report engine role.
 
 The sidecar opens eight gRPC connections by default. This avoided
 connection-level throttling in high-concurrency sidecar tests. Override the
@@ -59,8 +69,7 @@ corresponding `DYN_SIDECAR_GRPC_*` environment variables.
 
 ## Test without vLLM or a GPU
 
-Use the CPU-only `dynamo-vllm-mocker-server` to exercise this sidecar against
-the same `Generate` gRPC contract:
+Use the CPU-only `dynamo-vllm-mocker-server` to exercise the same Inference, Control, and health contracts:
 
 ```bash
 cargo run -p dynamo-vllm-mocker --bin dynamo-vllm-mocker-server -- \
@@ -69,8 +78,7 @@ cargo run -p dynamo-vllm-mocker --bin dynamo-vllm-mocker-server -- \
   --extra-engine-args '{"speedup_ratio":1000}'
 
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50051 \
-  --model-path mocker-model
+  --vllm-endpoint 127.0.0.1:50051
 ```
 
 See [`../../mocker/servers/vllm/README.md`](../../mocker/servers/vllm/README.md)
@@ -86,11 +94,7 @@ disaggregated prefill/decode with NIXL KV transfer.
 There is no published vLLM sidecar image yet, so you build and push your own from
 `Dockerfile` — the same pattern as the TensorRT-LLM and SGLang sidecars.
 
-> [!NOTE]
-> vLLM's `vllm-rs` exposes no gRPC health method, so the engine's probes can only
-> confirm the gRPC port accepts connections (not that the model is loaded) —
-> weaker than the TensorRT-LLM and SGLang sidecars, which make a real HealthCheck
-> RPC. The engine image must be a stock vLLM build that ships `vllm-rs` (v0.26.0+).
+The sidecar waits for both the Control and Inference services through the standard gRPC health API before registering the worker. The deployment manifests retain lightweight socket probes for container lifecycle monitoring. The engine image must include a `vllm-rs` build compatible with the vendored protocol.
 
 ### Prerequisites
 

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -25,6 +25,7 @@ It is a standalone Rust executable.
 - Token and text requests through Dynamo preprocessing
 - Sampling, stop conditions, structured output, logprobs, cache options, and priority
 - Opaque `kv_transfer_params` handoff
+- Capability-gated RL pause/resume, sleep/wake, weight-transfer, and weight-version controls through native gRPC
 
 The initial protocol does not support multimodal input, LoRA, KV-aware data
 parallel routing, encode workers, beam search, or `n > 1`.
@@ -50,6 +51,28 @@ dynamo-vllm-sidecar \
 
 Use `VLLM_GRPC_ENDPOINT` instead of `--vllm-endpoint` when the endpoint is
 provided through the environment.
+
+### RL workflows
+
+Start vLLM with the capabilities required by the workflow, then opt the sidecar into RL discovery:
+
+```bash
+vllm-rs serve Qwen/Qwen3-0.6B \
+  --host 127.0.0.1 \
+  --grpc-port 50051 \
+  --enable-sleep-mode \
+  --weight-transfer-config '{"backend":"nccl"}'
+
+dynamo-vllm-sidecar \
+  --vllm-endpoint 127.0.0.1:50051 \
+  --enable-rl
+```
+
+`--enable-rl` (or `DYN_ENABLE_RL=true`) registers `dyn://<namespace>.<component>.rl`, which lets the Dynamo frontend discover this worker and its `/engine/control/*` and `/engine/update/*` routes through `/v1/rl/workers`. The sidecar advertises pause/resume and weight-version queries when the vLLM server reports the RL gRPC API, sleep routes only with `--enable-sleep-mode`, weight-update routes only with `--weight-transfer-config`, and draft updates only when speculative decoding supports them.
+
+The update request bodies match vLLM's RL HTTP schemas: `init_weight_transfer_engine` requires `{"init_info": {...}}`, `update_weights` requires `{"update_info": {...}}`, `finish_weight_update` accepts `{"weight_version": "..."}`, and `update_weight_version` requires `{"new_version": "..."}`. Weight tensors remain on the configured NCCL, IPC, or sparse-NCCL transport; only backend metadata crosses gRPC.
+
+The RL endpoint and engine routes are unauthenticated administrative surfaces that can pause serving, release GPU memory, and replace model weights. Enable them only on trusted request and system networks.
 
 The sidecar discovers `model_id`, the served name, context length, KV capacity, and scheduler limits through `vllm.Control`. `model_id` must be readable locally or fetchable by Dynamo for tokenization and chat templates. Parser defaults are not advertised because the current inference protocol cannot preserve all parser-related request semantics.
 
@@ -80,6 +103,8 @@ cargo run -p dynamo-vllm-mocker --bin dynamo-vllm-mocker-server -- \
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
   --vllm-endpoint 127.0.0.1:50051
 ```
+
+The mocker does not advertise RL capabilities; use a compatible vLLM server for RL route testing.
 
 See [`../../mocker/servers/vllm/README.md`](../../mocker/servers/vllm/README.md)
 for aggregated and prefill/decode examples, supported Mocker configuration,

--- a/lib/sidecar/vllm/build.rs
+++ b/lib/sidecar/vllm/build.rs
@@ -4,7 +4,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile_protos(&["proto/vllm_grpc.proto"], &["proto"])?;
-    println!("cargo:rerun-if-changed=proto/vllm_grpc.proto");
+        .compile_protos(
+            &["proto/inference.proto", "proto/control.proto"],
+            &["proto"],
+        )?;
+    println!("cargo:rerun-if-changed=proto/inference.proto");
+    println!("cargo:rerun-if-changed=proto/control.proto");
     Ok(())
 }

--- a/lib/sidecar/vllm/deploy/agg.yaml
+++ b/lib/sidecar/vllm/deploy/agg.yaml
@@ -44,13 +44,9 @@ spec:
         - name: vllm-engine
           image: vllm/vllm-openai:v0.26.0
           restartPolicy: Always
-          # vllm-rs exposes no gRPC health method (grpc.health.v1 and any Generate
-          # HealthCheck both return UNIMPLEMENTED), so unlike the TensorRT-LLM and
-          # SGLang sidecars these probes can only confirm the gRPC port accepts a
-          # connection, not that the model is loaded. exec (not tcpSocket) because
-          # the loopback-bound listener is unreachable from the pod IP. The
-          # readinessProbe still drops the worker if the engine dies at runtime
-          # (port closes -> pod NotReady -> frontend stops routing to it).
+          # These lightweight lifecycle probes confirm that the loopback listener
+          # accepts connections. The Dynamo sidecar independently waits for both
+          # services through the standard gRPC health API before registration.
           startupProbe:
             exec:
               command:
@@ -98,10 +94,6 @@ spec:
           args:
           - --vllm-endpoint
           - 127.0.0.1:50051
-          # vLLM's gRPC does not expose model metadata; the sidecar needs the
-          # model for tokenization, chat templates, and registration.
-          - --model-path
-          - Qwen/Qwen3-0.6B
           envFrom:
           - secretRef:
               name: hf-token-secret

--- a/lib/sidecar/vllm/deploy/disagg.yaml
+++ b/lib/sidecar/vllm/deploy/disagg.yaml
@@ -67,8 +67,8 @@ spec:
             runAsUser: 0
             capabilities:
               add: ["IPC_LOCK", "SYS_RESOURCE"]
-          # vllm-rs has no gRPC health method (see agg.yaml), so these probes only
-          # confirm the port accepts a connection. readiness drops a dead engine.
+          # The socket probes cover container lifecycle. The Dynamo sidecar also
+          # checks both services through the standard gRPC health API.
           startupProbe:
             exec:
               command:
@@ -137,8 +137,6 @@ spec:
           args:
           - --vllm-endpoint
           - 127.0.0.1:50051
-          - --model-path
-          - Qwen/Qwen3-0.6B
           - --disaggregation-mode
           - prefill
           envFrom:
@@ -163,8 +161,8 @@ spec:
             runAsUser: 0
             capabilities:
               add: ["IPC_LOCK", "SYS_RESOURCE"]
-          # vllm-rs has no gRPC health method (see agg.yaml), so these probes only
-          # confirm the port accepts a connection. readiness drops a dead engine.
+          # The socket probes cover container lifecycle. The Dynamo sidecar also
+          # checks both services through the standard gRPC health API.
           startupProbe:
             exec:
               command:
@@ -230,8 +228,6 @@ spec:
           args:
           - --vllm-endpoint
           - 127.0.0.1:50051
-          - --model-path
-          - Qwen/Qwen3-0.6B
           - --disaggregation-mode
           - decode
           envFrom:

--- a/lib/sidecar/vllm/launch/agg.sh
+++ b/lib/sidecar/vllm/launch/agg.sh
@@ -91,7 +91,6 @@ vllm-rs serve "$MODEL" \
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "127.0.0.1:${VLLM_GRPC_PORT}" \
-    --model-path "$MODEL" &
+    --vllm-endpoint "127.0.0.1:${VLLM_GRPC_PORT}" &
 
 wait_any_exit

--- a/lib/sidecar/vllm/launch/disagg.sh
+++ b/lib/sidecar/vllm/launch/disagg.sh
@@ -125,7 +125,6 @@ OTEL_SERVICE_NAME=dynamo-worker-decode \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT1:-8081}" \
     dynamo-vllm-sidecar \
     --vllm-endpoint "127.0.0.1:${VLLM_DECODE_GRPC_PORT}" \
-    --model-path "$MODEL" \
     --disaggregation-mode decode &
 
 # Register prefill separately so the frontend routes each disaggregated stage.
@@ -133,7 +132,6 @@ OTEL_SERVICE_NAME=dynamo-worker-prefill \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT2:-8082}" \
     dynamo-vllm-sidecar \
     --vllm-endpoint "127.0.0.1:${VLLM_PREFILL_GRPC_PORT}" \
-    --model-path "$MODEL" \
     --component prefill \
     --disaggregation-mode prefill &
 

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,12 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Source: `rust/proto/vllm_grpc.proto`
-- Release: `v0.25.1`
-- Commit: `752a3a504485790a2e8491cacbb35c137339ad34`
-- SHA-256: `7cccd0e1b2e54f189550e1090cc80321fc2bbd188c98a4e22701b28fdeb177b6`
+- Source: [`rust/proto/inference.proto`](https://github.com/connorcarpenter15/vllm/blob/2d2c3af18c52e8e4efa4b0b4903843b15c0dba0e/rust/proto/inference.proto) and [`rust/proto/control.proto`](https://github.com/connorcarpenter15/vllm/blob/2d2c3af18c52e8e4efa4b0b4903843b15c0dba0e/rust/proto/control.proto)
+- Commit: `2d2c3af18c52e8e4efa4b0b4903843b15c0dba0e`
+- `inference.proto` SHA-256: `a0d196dc240683e1c09abb54f324d4428d0c122a6802b44916ad2d96b491b06c`
+- `control.proto` SHA-256: `cd4e7a8043f19d05929a2f59f5a5442894a037ef2d65832d3f7099992b1f1dbd`
 
-The file is copied without modification. Update the revision and checksum when
-updating the protocol. `dynamo-vllm-sidecar` generates and temporarily exports
-these types for `dynamo-vllm-mocker-server`; both consumers will move to the
-upstream package once vLLM publishes it.
+The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Source: [`rust/proto/inference.proto`](https://github.com/connorcarpenter15/vllm/blob/2d2c3af18c52e8e4efa4b0b4903843b15c0dba0e/rust/proto/inference.proto) and [`rust/proto/control.proto`](https://github.com/connorcarpenter15/vllm/blob/2d2c3af18c52e8e4efa4b0b4903843b15c0dba0e/rust/proto/control.proto)
-- Commit: `2d2c3af18c52e8e4efa4b0b4903843b15c0dba0e`
+- Inference source: [`rust/proto/inference.proto`](https://github.com/connorcarpenter15/vllm/blob/2d2c3af18c52e8e4efa4b0b4903843b15c0dba0e/rust/proto/inference.proto) at `2d2c3af18c52e8e4efa4b0b4903843b15c0dba0e`
+- RL Control source: [`rust/proto/control.proto`](https://github.com/connorcarpenter15/vllm/blob/7f3ab290464ac319e867b0d011d11dd6b2ff37f4/rust/proto/control.proto) from [connorcarpenter15/vllm#22](https://github.com/connorcarpenter15/vllm/pull/22) at `7f3ab290464ac319e867b0d011d11dd6b2ff37f4`
 - `inference.proto` SHA-256: `a0d196dc240683e1c09abb54f324d4428d0c122a6802b44916ad2d96b491b06c`
-- `control.proto` SHA-256: `cd4e7a8043f19d05929a2f59f5a5442894a037ef2d65832d3f7099992b1f1dbd`
+- `control.proto` SHA-256: `ec414b622e2412c59215aa0de4413625be5c0fdd32ccb4f6102dd4418127aa64`
 
-The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.
+The vendored Control schema composes the RL RPCs above with field 10 from [vllm-project/vllm#51178](https://github.com/vllm-project/vllm/pull/51178), which advertises explicit data-parallel rank routing. Update the source revisions and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/control.proto
+++ b/lib/sidecar/vllm/proto/control.proto
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+syntax = "proto3";
+package vllm;
+
+service Control {
+  rpc GetServerInfo (GetServerInfoRequest) returns (ServerInfo) {}
+  rpc GetModelInfo (GetModelInfoRequest) returns (ModelInfo) {}
+  rpc Abort (AbortRequest) returns (AbortResponse) {}
+  rpc GetKvEventSources (GetKvEventSourcesRequest) returns (GetKvEventSourcesResponse) {}
+}
+
+message GetServerInfoRequest {}
+
+message ServerInfo {
+  string engine_version = 1;
+  string api_version = 2;
+  string instance_id = 3;
+  ParallelismInfo parallelism = 4;
+  uint32 max_model_len = 5;
+  uint32 kv_block_size = 6;
+  uint64 total_kv_blocks = 7;
+  uint64 max_running_requests = 8;
+  uint64 max_batched_tokens = 9;
+  // GenerateRequest.data_parallel_rank is honored by this server. Clients
+  // that require deterministic rank routing must fail closed when this is
+  // false, because older servers accept and silently discard the field.
+  bool supports_explicit_data_parallel_rank = 10;
+}
+
+message ParallelismInfo {
+  uint32 tensor_parallel_size = 1;
+  uint32 pipeline_parallel_size = 2;
+  uint32 data_parallel_size = 3;
+  uint32 data_parallel_rank = 4;
+  uint32 decode_context_parallel_size = 5;
+}
+
+message GetModelInfoRequest {}
+
+message ModelInfo {
+  string model_id = 1;
+  string served_model_name = 2;
+  repeated string served_model_aliases = 3;
+
+  bool supports_text_input = 20;
+  bool supports_token_ids_input = 21;
+  bool supports_multimodal = 23;
+  string reasoning_parser = 24;
+  string tool_call_parser = 25;
+}
+
+message AbortRequest {
+  repeated string request_ids = 1;
+}
+
+message AbortResponse {}
+
+// ======================================================================================
+// KV discovery
+// ======================================================================================
+
+message GetKvEventSourcesRequest {}
+message GetKvEventSourcesResponse { repeated KvEventSource sources = 1; }
+
+message KvEventSource {
+  string transport = 1;
+  string endpoint = 2;
+  string topic = 3;
+  string replay_endpoint = 4;
+  optional uint32 data_parallel_rank = 5;
+  string encoding = 6;
+  uint32 schema_version = 7;
+  uint32 buffer_steps = 8;
+  uint32 hwm = 9;
+  uint32 max_queue_size = 10;
+}

--- a/lib/sidecar/vllm/proto/control.proto
+++ b/lib/sidecar/vllm/proto/control.proto
@@ -9,6 +9,19 @@ service Control {
   rpc GetModelInfo (GetModelInfoRequest) returns (ModelInfo) {}
   rpc Abort (AbortRequest) returns (AbortResponse) {}
   rpc GetKvEventSources (GetKvEventSourcesRequest) returns (GetKvEventSourcesResponse) {}
+  rpc PauseGeneration (PauseGenerationRequest) returns (PauseGenerationResponse) {}
+  rpc ResumeGeneration (ResumeGenerationRequest) returns (ResumeGenerationResponse) {}
+  rpc IsPaused (IsPausedRequest) returns (IsPausedResponse) {}
+  rpc Sleep (SleepRequest) returns (SleepResponse) {}
+  rpc WakeUp (WakeUpRequest) returns (WakeUpResponse) {}
+  rpc IsSleeping (IsSleepingRequest) returns (IsSleepingResponse) {}
+  rpc InitWeightTransferEngine (InitWeightTransferEngineRequest) returns (InitWeightTransferEngineResponse) {}
+  rpc StartWeightUpdate (StartWeightUpdateRequest) returns (StartWeightUpdateResponse) {}
+  rpc StartDraftWeightUpdate (StartDraftWeightUpdateRequest) returns (StartDraftWeightUpdateResponse) {}
+  rpc UpdateWeights (UpdateWeightsRequest) returns (UpdateWeightsResponse) {}
+  rpc FinishWeightUpdate (FinishWeightUpdateRequest) returns (FinishWeightUpdateResponse) {}
+  rpc UpdateWeightVersion (UpdateWeightVersionRequest) returns (UpdateWeightVersionResponse) {}
+  rpc GetWeightVersion (GetWeightVersionRequest) returns (GetWeightVersionResponse) {}
 }
 
 message GetServerInfoRequest {}
@@ -27,6 +40,14 @@ message ServerInfo {
   // that require deterministic rank routing must fail closed when this is
   // false, because older servers accept and silently discard the field.
   bool supports_explicit_data_parallel_rank = 10;
+  RlCapabilities rl_capabilities = 11;
+}
+
+message RlCapabilities {
+  bool weight_transfer_enabled = 1;
+  string weight_transfer_backend = 2;
+  bool sleep_mode_enabled = 3;
+  bool draft_weight_updates_enabled = 4;
 }
 
 message ParallelismInfo {
@@ -76,3 +97,59 @@ message KvEventSource {
   uint32 hwm = 9;
   uint32 max_queue_size = 10;
 }
+
+// ======================================================================================
+// Reinforcement-learning lifecycle control
+// ======================================================================================
+
+enum PauseMode {
+  PAUSE_MODE_UNSPECIFIED = 0;
+  PAUSE_MODE_ABORT = 1;
+  PAUSE_MODE_WAIT = 2;
+  PAUSE_MODE_KEEP = 3;
+}
+
+message PauseGenerationRequest {
+  PauseMode mode = 1;
+  optional bool clear_cache = 2;
+}
+message PauseGenerationResponse {}
+
+message ResumeGenerationRequest {}
+message ResumeGenerationResponse {}
+
+message IsPausedRequest {}
+message IsPausedResponse { bool paused = 1; }
+
+message SleepRequest {
+  optional uint32 level = 1;
+  PauseMode mode = 2;
+}
+message SleepResponse {}
+
+message WakeUpRequest { repeated string tags = 1; }
+message WakeUpResponse {}
+
+message IsSleepingRequest {}
+message IsSleepingResponse { bool sleeping = 1; }
+
+message InitWeightTransferEngineRequest { bytes init_info_json = 1; }
+message InitWeightTransferEngineResponse {}
+
+message StartWeightUpdateRequest {}
+message StartWeightUpdateResponse {}
+
+message StartDraftWeightUpdateRequest {}
+message StartDraftWeightUpdateResponse {}
+
+message UpdateWeightsRequest { bytes update_info_json = 1; }
+message UpdateWeightsResponse {}
+
+message FinishWeightUpdateRequest { optional string weight_version = 1; }
+message FinishWeightUpdateResponse {}
+
+message UpdateWeightVersionRequest { string weight_version = 1; }
+message UpdateWeightVersionResponse {}
+
+message GetWeightVersionRequest {}
+message GetWeightVersionResponse { string weight_version = 1; }

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -1,10 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 syntax = "proto3";
 package vllm;
 
 import "google/protobuf/struct.proto";
 
 
-service Generate {
+service Inference {
   // Generates text given a prompt
   rpc Generate (GenerateRequest) returns (GenerateResponse) {}
   // Generates text given a prompt, streaming the outputs
@@ -42,6 +45,14 @@ message GenerateRequest {
   uint32 truncate_prompt_tokens = 11;
 
   int32 priority = 12;
+
+  optional string session_id = 13;
+
+  // Multimodal inputs aligned with placeholder markers in token_ids.
+  repeated MediaItem media = 14;
+
+  // Global data-parallel rank advertised by the Control service.
+  optional uint32 data_parallel_rank = 15;
 }
 
 message RandomSampling {
@@ -107,6 +118,9 @@ message KVCacheParameters {
 
   // KV Connector transfer parameters
   google.protobuf.Struct kv_transfer_params = 3;
+
+  // Encoder cache connector transfer parameters
+  google.protobuf.Struct ec_transfer_params = 4;
 }
 
 // Controls which extra candidate tokens at each position should be returned
@@ -173,6 +187,7 @@ message FinishInfo {
 
   google.protobuf.Struct kv_transfer_params = 6;
   //uint64 seed = 7;
+  google.protobuf.Struct ec_transfer_params = 8;
 }
 
 // Info for candidate tokens other than the input/sampled
@@ -194,3 +209,24 @@ message TokenIds {
   repeated uint32 ids = 1;
 }
 
+// ======================================================================================
+// Media
+// ======================================================================================
+
+enum Modality {
+  MODALITY_UNSPECIFIED = 0;
+  MODALITY_IMAGE = 1;
+  MODALITY_VIDEO = 2;
+  MODALITY_AUDIO = 3;
+}
+
+message MediaItem {
+  Modality modality = 1;
+  oneof source {
+    string url = 2;       // http:// or https://
+    string data_uri = 3;  // data:
+    bytes raw_bytes = 4;
+  }
+  string mime_type = 5;
+  string uuid = 6;
+}

--- a/lib/sidecar/vllm/src/args.rs
+++ b/lib/sidecar/vllm/src/args.rs
@@ -15,12 +15,4 @@ pub(crate) struct Args {
     /// vLLM gRPC endpoint as host:port or an http:// URL.
     #[arg(long, env = "VLLM_GRPC_ENDPOINT")]
     pub vllm_endpoint: String,
-
-    /// Hugging Face model ID or local path used by Dynamo for model-card
-    /// registration, tokenization, and chat templates. The released vLLM gRPC
-    /// API does not expose this metadata, so it cannot be inferred from the
-    /// endpoint. This flag is temporary and can be removed once vLLM exposes
-    /// model and tokenizer metadata over gRPC.
-    #[arg(long)]
-    pub model_path: String,
 }

--- a/lib/sidecar/vllm/src/client.rs
+++ b/lib/sidecar/vllm/src/client.rs
@@ -1,14 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 use dynamo_backend_common::DynamoError;
 use dynamo_sidecar_common::{
     DEFAULT_MAX_GRPC_MESSAGE_SIZE, GrpcChannelPool, GrpcEndpoint, GrpcTransportConfig,
 };
+use tokio::time::{Instant, sleep_until, timeout_at};
+use tonic_health::pb::health_check_response::ServingStatus;
+use tonic_health::pb::{HealthCheckRequest, health_client::HealthClient};
 
 pub(crate) use dynamo_sidecar_common::{engine_shutdown, invalid_argument, status_to_dynamo};
 
 use crate::proto as pb;
+
+pub(crate) const CONTROL_SERVICE: &str = "vllm.Control";
+pub(crate) const INFERENCE_SERVICE: &str = "vllm.Inference";
 
 pub(crate) struct VllmClient {
     pool: GrpcChannelPool,
@@ -18,13 +26,122 @@ impl VllmClient {
     pub(crate) async fn connect(
         endpoint: &GrpcEndpoint,
         transport: GrpcTransportConfig,
+        startup_deadline: Instant,
     ) -> Result<Self, DynamoError> {
-        let pool = GrpcChannelPool::connect("vLLM", endpoint, transport).await?;
+        let pool = timeout_at(
+            startup_deadline,
+            GrpcChannelPool::connect("vLLM", endpoint, transport),
+        )
+        .await
+        .map_err(|_| {
+            dynamo_sidecar_common::connection_timeout(format!(
+                "vLLM gRPC connection pool to {endpoint} exceeded the total startup deadline"
+            ))
+        })??;
         Ok(Self { pool })
     }
 
     pub(crate) fn connection_count(&self) -> usize {
         self.pool.len()
+    }
+
+    pub(crate) async fn wait_for_services(
+        &self,
+        services: &[&str],
+        startup_deadline: Instant,
+        retry_interval: Duration,
+    ) -> Result<(), DynamoError> {
+        for service in services {
+            self.wait_for_service(service, startup_deadline, retry_interval)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn wait_for_service(
+        &self,
+        service: &str,
+        deadline: Instant,
+        retry_interval: Duration,
+    ) -> Result<(), DynamoError> {
+        let started = Instant::now();
+        loop {
+            let mut client = HealthClient::new(self.pool.next_channel());
+            let last_status = match timeout_at(
+                deadline,
+                client.check(HealthCheckRequest {
+                    service: service.to_string(),
+                }),
+            )
+            .await
+            {
+                Ok(Ok(response)) => {
+                    let status = ServingStatus::try_from(response.into_inner().status)
+                        .unwrap_or(ServingStatus::Unknown);
+                    if status == ServingStatus::Serving {
+                        return Ok(());
+                    }
+                    format!("reported {}", status.as_str_name())
+                }
+                Ok(Err(status))
+                    if matches!(
+                        status.code(),
+                        tonic::Code::NotFound | tonic::Code::Unimplemented
+                    ) =>
+                {
+                    return Err(protocol_error(format!(
+                        "{service} is unavailable through the standard gRPC health API: {status}"
+                    )));
+                }
+                Ok(Err(status)) => format!("health check failed: {status}"),
+                Err(_) => "health check exceeded the startup deadline".to_string(),
+            };
+
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(dynamo_sidecar_common::cannot_connect(format!(
+                    "{service} did not become SERVING before the total vLLM startup deadline after {:?}: {last_status}",
+                    started.elapsed()
+                )));
+            }
+            let retry_at = now.checked_add(retry_interval).unwrap_or(deadline);
+            sleep_until(retry_at.min(deadline)).await;
+        }
+    }
+
+    pub(crate) async fn discover(
+        &self,
+        startup_deadline: Instant,
+    ) -> Result<(pb::ModelInfo, pb::ServerInfo), DynamoError> {
+        let channel = self.pool.next_channel();
+        let mut client = pb::control_client::ControlClient::new(channel)
+            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+        let model = timeout_at(
+            startup_deadline,
+            client.get_model_info(pb::GetModelInfoRequest {}),
+        )
+        .await
+        .map_err(|_| {
+            dynamo_sidecar_common::connection_timeout(
+                "GetModelInfo exceeded the total vLLM startup deadline",
+            )
+        })?
+        .map(tonic::Response::into_inner)
+        .map_err(|status| status_to_dynamo("GetModelInfo", status))?;
+        let server = timeout_at(
+            startup_deadline,
+            client.get_server_info(pb::GetServerInfoRequest {}),
+        )
+        .await
+        .map_err(|_| {
+            dynamo_sidecar_common::connection_timeout(
+                "GetServerInfo exceeded the total vLLM startup deadline",
+            )
+        })?
+        .map(tonic::Response::into_inner)
+        .map_err(|status| status_to_dynamo("GetServerInfo", status))?;
+        Ok((model, server))
     }
 
     pub(crate) async fn generate_stream(
@@ -40,6 +157,14 @@ impl VllmClient {
             .map(tonic::Response::into_inner)
             .map_err(|status| status_to_dynamo("GenerateStream", status))
     }
+}
+
+pub(crate) fn startup_deadline(duration: Duration) -> Result<Instant, DynamoError> {
+    Instant::now().checked_add(duration).ok_or_else(|| {
+        invalid_argument(format!(
+            "gRPC startup deadline {duration:?} exceeds the supported monotonic clock range"
+        ))
+    })
 }
 
 pub(crate) fn protocol_error(message: impl Into<String>) -> DynamoError {

--- a/lib/sidecar/vllm/src/client.rs
+++ b/lib/sidecar/vllm/src/client.rs
@@ -31,7 +31,7 @@ impl VllmClient {
         &self,
         request: pb::GenerateRequest,
     ) -> Result<tonic::Streaming<pb::GenerateResponse>, DynamoError> {
-        let mut client = pb::generate_client::GenerateClient::new(self.pool.next_channel())
+        let mut client = pb::inference_client::InferenceClient::new(self.pool.next_channel())
             .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
             .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
         client

--- a/lib/sidecar/vllm/src/client.rs
+++ b/lib/sidecar/vllm/src/client.rs
@@ -8,6 +8,7 @@ use dynamo_sidecar_common::{
     DEFAULT_MAX_GRPC_MESSAGE_SIZE, GrpcChannelPool, GrpcEndpoint, GrpcTransportConfig,
 };
 use tokio::time::{Instant, sleep_until, timeout_at};
+use tonic::transport::Channel;
 use tonic_health::pb::health_check_response::ServingStatus;
 use tonic_health::pb::{HealthCheckRequest, health_client::HealthClient};
 
@@ -43,6 +44,12 @@ impl VllmClient {
 
     pub(crate) fn connection_count(&self) -> usize {
         self.pool.len()
+    }
+
+    pub(crate) fn control_client(&self) -> pb::control_client::ControlClient<Channel> {
+        pb::control_client::ControlClient::new(self.pool.next_channel())
+            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
     }
 
     pub(crate) async fn wait_for_services(
@@ -113,10 +120,7 @@ impl VllmClient {
         &self,
         startup_deadline: Instant,
     ) -> Result<(pb::ModelInfo, pb::ServerInfo), DynamoError> {
-        let channel = self.pool.next_channel();
-        let mut client = pb::control_client::ControlClient::new(channel)
-            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
-            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+        let mut client = self.control_client();
         let model = timeout_at(
             startup_deadline,
             client.get_model_info(pb::GetModelInfoRequest {}),

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -90,6 +90,9 @@ pub(crate) fn build_generate_request(
         kv: Some(kv),
         truncate_prompt_tokens: 0,
         priority,
+        session_id: None,
+        media: Vec::new(),
+        data_parallel_rank: None,
     })
 }
 
@@ -241,6 +244,7 @@ fn build_kv_parameters(
         bypass_prefix_cache,
         cache_salt: cache_salt.unwrap_or_default(),
         kv_transfer_params: kv_transfer_params.map(json_to_struct).transpose()?,
+        ec_transfer_params: None,
     })
 }
 

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -9,16 +9,17 @@ use dynamo_backend_common::{
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::stream::BoxStream;
 use tokio::sync::OnceCell;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use crate::args::Args;
-use crate::client::{self, VllmClient};
+use crate::client::{self, CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
 use crate::convert::{ResponseState, build_generate_request};
-use crate::model::ConfiguredModel;
+use crate::model::DiscoveredModel;
 
 pub struct VllmSidecarEngine {
     endpoint: GrpcEndpoint,
-    model: ConfiguredModel,
+    model: DiscoveredModel,
     mode: DisaggregationMode,
     transport: GrpcTransportConfig,
     client: OnceCell<VllmClient>,
@@ -35,7 +36,7 @@ fn cancelled(state: &ResponseState) -> LLMEngineOutput {
 impl VllmSidecarEngine {
     pub(crate) fn new(
         endpoint: GrpcEndpoint,
-        model: ConfiguredModel,
+        model: DiscoveredModel,
         mode: DisaggregationMode,
         transport: GrpcTransportConfig,
     ) -> Self {
@@ -73,9 +74,6 @@ impl VllmSidecarEngine {
     }
 
     fn from_parsed(args: Args) -> Result<(Self, WorkerConfig), DynamoError> {
-        if args.model_path.trim().is_empty() {
-            return Err(client::invalid_argument("model-path must not be empty"));
-        }
         if args.sidecar.common.disaggregation_mode.is_encode() {
             return Err(client::invalid_argument(
                 "encode mode is not supported by the vLLM sidecar",
@@ -86,22 +84,24 @@ impl VllmSidecarEngine {
                 "route-to-encoder is not supported by the vLLM sidecar",
             ));
         }
+        if args.sidecar.common.dyn_tool_call_parser.is_some()
+            || args.sidecar.common.dyn_reasoning_parser.is_some()
+        {
+            return Err(client::invalid_argument(
+                "vLLM gRPC does not preserve the request options required by Dynamo tool-call and reasoning parsers",
+            ));
+        }
 
         let endpoint = GrpcEndpoint::parse(&args.vllm_endpoint, "--vllm-endpoint")?;
         let transport = args.sidecar.grpc.config();
-        let model = ConfiguredModel {
-            source: args.model_path,
-        };
+        let bootstrap_deadline = client::startup_deadline(transport.startup_deadline)?;
+        eprintln!(
+            "Discovering vLLM model metadata from {endpoint}; startup deadline: {:?}",
+            transport.startup_deadline
+        );
+        let model = bootstrap_discover(&endpoint, transport, bootstrap_deadline)?;
         let mode = args.sidecar.common.disaggregation_mode;
         let engine = Self::new(endpoint, model.clone(), mode, transport);
-        let (tool_call_parser, reasoning_parser) = if mode.is_prefill() {
-            (None, None)
-        } else {
-            (
-                args.sidecar.common.dyn_tool_call_parser,
-                args.sidecar.common.dyn_reasoning_parser,
-            )
-        };
         let config = WorkerConfig {
             namespace: args.sidecar.common.namespace,
             // Prefill/decode must register under fixed role components so the
@@ -115,9 +115,9 @@ impl VllmSidecarEngine {
             endpoint_types: args.sidecar.common.endpoint_types,
             custom_jinja_template: args.sidecar.common.custom_jinja_template,
             model_name: model.source.clone(),
-            served_model_name: None,
-            tool_call_parser,
-            reasoning_parser,
+            served_model_name: Some(model.served_name.clone()),
+            tool_call_parser: None,
+            reasoning_parser: None,
             exclude_tools_when_tool_choice_none: args
                 .sidecar
                 .common
@@ -146,7 +146,18 @@ impl LLMEngine for VllmSidecarEngine {
             mode = %self.mode,
             "connecting to vLLM gRPC"
         );
-        let client = VllmClient::connect(&self.endpoint, self.transport).await?;
+        let startup_deadline = client::startup_deadline(self.transport.startup_deadline)?;
+        let client = VllmClient::connect(&self.endpoint, self.transport, startup_deadline).await?;
+        client
+            .wait_for_services(
+                &[CONTROL_SERVICE, INFERENCE_SERVICE],
+                startup_deadline,
+                self.transport.retry_interval,
+            )
+            .await?;
+        let (model, server) = client.discover(startup_deadline).await?;
+        let observed = DiscoveredModel::from_proto(model, server)?;
+        self.model.ensure_same_identity(&observed)?;
         let connection_count = client.connection_count();
         self.client
             .set(client)
@@ -154,11 +165,12 @@ impl LLMEngine for VllmSidecarEngine {
         tracing::info!(
             endpoint = %self.endpoint,
             connections = connection_count,
-            configured_model_source = %self.model.source,
+            model = %observed.source,
+            served_model_name = %observed.served_name,
             mode = %self.mode,
-            "vLLM gRPC transport connected"
+            "vLLM gRPC services are ready"
         );
-        Ok(self.model.engine_config())
+        Ok(observed.engine_config())
     }
 
     async fn generate(
@@ -172,7 +184,8 @@ impl LLMEngine for VllmSidecarEngine {
             .ok_or_else(|| client::engine_shutdown("vLLM sidecar is not started"))?;
         let request_id = ctx.id().to_string();
         let mut state = ResponseState::new(&request, self.mode);
-        let proto_request = build_generate_request(request, request_id, self.mode)?;
+        let mut proto_request = build_generate_request(request, request_id, self.mode)?;
+        proto_request.model.clone_from(&self.model.served_name);
         let stopped_ctx = ctx.inner_arc();
         let shutdown = self.cancel.clone();
         let mut cancellation = Box::pin(async move {
@@ -236,4 +249,31 @@ impl LLMEngine for VllmSidecarEngine {
         self.cancel.cancel();
         Ok(())
     }
+}
+
+fn bootstrap_discover(
+    endpoint: &GrpcEndpoint,
+    transport: GrpcTransportConfig,
+    startup_deadline: Instant,
+) -> Result<DiscoveredModel, DynamoError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| client::engine_shutdown(format!("bootstrap runtime: {error}")))?;
+    runtime.block_on(async {
+        let bootstrap_transport = GrpcTransportConfig {
+            connections: std::num::NonZeroUsize::MIN,
+            ..transport
+        };
+        let client = VllmClient::connect(endpoint, bootstrap_transport, startup_deadline).await?;
+        client
+            .wait_for_services(
+                &[CONTROL_SERVICE],
+                startup_deadline,
+                transport.retry_interval,
+            )
+            .await?;
+        let (model, server) = client.discover(startup_deadline).await?;
+        DiscoveredModel::from_proto(model, server)
+    })
 }

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -8,6 +8,7 @@ use dynamo_backend_common::{
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::stream::BoxStream;
+use serde_json::{Map, Value, json};
 use tokio::sync::OnceCell;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -130,9 +131,16 @@ impl VllmSidecarEngine {
             enable_kv_routing: false,
             disaggregation_mode: mode,
             route_to_encoder: false,
+            enable_rl: args.sidecar.common.enable_rl,
             ..Default::default()
         };
         Ok((engine, config))
+    }
+
+    fn started_client(&self) -> Result<&VllmClient, DynamoError> {
+        self.client
+            .get()
+            .ok_or_else(|| client::engine_shutdown("vLLM sidecar is not started"))
     }
 }
 
@@ -250,10 +258,270 @@ impl LLMEngine for VllmSidecarEngine {
         }))
     }
 
+    async fn supported_controls(&self) -> Result<Vec<String>, DynamoError> {
+        let Some(capabilities) = self.model.rl_capabilities() else {
+            return Ok(Vec::new());
+        };
+        let mut controls = vec![
+            "pause_generation".to_string(),
+            "resume_generation".to_string(),
+            "is_paused".to_string(),
+            "get_weight_version".to_string(),
+        ];
+        if capabilities.sleep_mode_enabled {
+            controls.extend([
+                "sleep".to_string(),
+                "wake_up".to_string(),
+                "is_sleeping".to_string(),
+            ]);
+        }
+        Ok(controls)
+    }
+
+    async fn engine_control(&self, control: String, body: Value) -> Result<Value, DynamoError> {
+        if !self.supported_controls().await?.contains(&control) {
+            return Ok(unsupported("control", &control));
+        }
+        let body = request_object(&body)?;
+        let mut grpc = self.started_client()?.control_client();
+        match control.as_str() {
+            "pause_generation" => {
+                let mode = pause_mode(body, "pause_generation")?;
+                let clear_cache = optional_bool(body, "clear_cache")?;
+                grpc.pause_generation(crate::proto::PauseGenerationRequest {
+                    mode: mode as i32,
+                    clear_cache,
+                })
+                .await
+                .map_err(|status| client::status_to_dynamo("PauseGeneration", status))?;
+                Ok(json!({"status": "paused"}))
+            }
+            "resume_generation" => {
+                grpc.resume_generation(crate::proto::ResumeGenerationRequest {})
+                    .await
+                    .map_err(|status| client::status_to_dynamo("ResumeGeneration", status))?;
+                Ok(json!({"status": "resumed"}))
+            }
+            "is_paused" => {
+                let response = grpc
+                    .is_paused(crate::proto::IsPausedRequest {})
+                    .await
+                    .map_err(|status| client::status_to_dynamo("IsPaused", status))?
+                    .into_inner();
+                Ok(json!({"is_paused": response.paused}))
+            }
+            "sleep" => {
+                let level = optional_u32(body, "level")?;
+                let mode = pause_mode(body, "sleep")?;
+                grpc.sleep(crate::proto::SleepRequest {
+                    level,
+                    mode: mode as i32,
+                })
+                .await
+                .map_err(|status| client::status_to_dynamo("Sleep", status))?;
+                Ok(json!({"status": "sleeping"}))
+            }
+            "wake_up" => {
+                let tags = optional_strings(body, "tags")?.unwrap_or_default();
+                grpc.wake_up(crate::proto::WakeUpRequest { tags })
+                    .await
+                    .map_err(|status| client::status_to_dynamo("WakeUp", status))?;
+                Ok(json!({"status": "awake"}))
+            }
+            "is_sleeping" => {
+                let response = grpc
+                    .is_sleeping(crate::proto::IsSleepingRequest {})
+                    .await
+                    .map_err(|status| client::status_to_dynamo("IsSleeping", status))?
+                    .into_inner();
+                Ok(json!({"is_sleeping": response.sleeping}))
+            }
+            "get_weight_version" => {
+                let response = grpc
+                    .get_weight_version(crate::proto::GetWeightVersionRequest {})
+                    .await
+                    .map_err(|status| client::status_to_dynamo("GetWeightVersion", status))?
+                    .into_inner();
+                Ok(json!({"weight_version": response.weight_version}))
+            }
+            _ => Ok(unsupported("control", &control)),
+        }
+    }
+
+    async fn supported_updates(&self) -> Result<Vec<String>, DynamoError> {
+        let Some(capabilities) = self.model.rl_capabilities() else {
+            return Ok(Vec::new());
+        };
+        if !capabilities.weight_transfer_enabled {
+            return Ok(Vec::new());
+        }
+        let mut updates = vec![
+            "init_weight_transfer_engine".to_string(),
+            "start_weight_update".to_string(),
+            "update_weights".to_string(),
+            "finish_weight_update".to_string(),
+            "update_weight_version".to_string(),
+        ];
+        if capabilities.draft_weight_updates_enabled {
+            updates.push("start_draft_weight_update".to_string());
+        }
+        Ok(updates)
+    }
+
+    async fn engine_update(&self, update: String, body: Value) -> Result<Value, DynamoError> {
+        if !self.supported_updates().await?.contains(&update) {
+            return Ok(unsupported("update", &update));
+        }
+        let body = request_object(&body)?;
+        let mut grpc = self.started_client()?.control_client();
+        match update.as_str() {
+            "init_weight_transfer_engine" => {
+                let init_info_json = required_object_json(body, "init_info")?;
+                grpc.init_weight_transfer_engine(crate::proto::InitWeightTransferEngineRequest {
+                    init_info_json,
+                })
+                .await
+                .map_err(|status| client::status_to_dynamo("InitWeightTransferEngine", status))?;
+                Ok(json!({"message": "Weight transfer initialized"}))
+            }
+            "start_weight_update" => {
+                grpc.start_weight_update(crate::proto::StartWeightUpdateRequest {})
+                    .await
+                    .map_err(|status| client::status_to_dynamo("StartWeightUpdate", status))?;
+                Ok(json!({"message": "Weight update started"}))
+            }
+            "start_draft_weight_update" => {
+                grpc.start_draft_weight_update(crate::proto::StartDraftWeightUpdateRequest {})
+                    .await
+                    .map_err(|status| client::status_to_dynamo("StartDraftWeightUpdate", status))?;
+                Ok(json!({"message": "Draft weight update started"}))
+            }
+            "update_weights" => {
+                let update_info_json = required_object_json(body, "update_info")?;
+                grpc.update_weights(crate::proto::UpdateWeightsRequest { update_info_json })
+                    .await
+                    .map_err(|status| client::status_to_dynamo("UpdateWeights", status))?;
+                Ok(json!({"message": "Weights updated"}))
+            }
+            "finish_weight_update" => {
+                let weight_version = optional_string(body, "weight_version")?;
+                grpc.finish_weight_update(crate::proto::FinishWeightUpdateRequest {
+                    weight_version,
+                })
+                .await
+                .map_err(|status| client::status_to_dynamo("FinishWeightUpdate", status))?;
+                Ok(json!({"message": "Weight update finished"}))
+            }
+            "update_weight_version" => {
+                let weight_version = required_string(body, "new_version")?;
+                grpc.update_weight_version(crate::proto::UpdateWeightVersionRequest {
+                    weight_version: weight_version.clone(),
+                })
+                .await
+                .map_err(|status| client::status_to_dynamo("UpdateWeightVersion", status))?;
+                Ok(json!({"success": true, "new_version": weight_version}))
+            }
+            _ => Ok(unsupported("update", &update)),
+        }
+    }
+
     async fn cleanup(&self) -> Result<(), DynamoError> {
         self.cancel.cancel();
         Ok(())
     }
+}
+
+fn unsupported(kind: &str, name: &str) -> Value {
+    json!({
+        "status": "error",
+        "message": format!("unsupported engine {kind}: {name}"),
+    })
+}
+
+fn request_object(body: &Value) -> Result<&Map<String, Value>, DynamoError> {
+    body.as_object()
+        .ok_or_else(|| client::invalid_argument("engine request body must be a JSON object"))
+}
+
+fn optional_bool(body: &Map<String, Value>, field: &str) -> Result<Option<bool>, DynamoError> {
+    match body.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(_) => Err(client::invalid_argument(format!(
+            "`{field}` must be a boolean"
+        ))),
+    }
+}
+
+fn optional_u32(body: &Map<String, Value>, field: &str) -> Result<Option<u32>, DynamoError> {
+    match body.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_u64()
+            .and_then(|value| u32::try_from(value).ok())
+            .map(Some)
+            .ok_or_else(|| client::invalid_argument(format!("`{field}` must be a uint32"))),
+    }
+}
+
+fn optional_string(body: &Map<String, Value>, field: &str) -> Result<Option<String>, DynamoError> {
+    match body.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(client::invalid_argument(format!(
+            "`{field}` must be a string"
+        ))),
+    }
+}
+
+fn required_string(body: &Map<String, Value>, field: &str) -> Result<String, DynamoError> {
+    optional_string(body, field)?
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| client::invalid_argument(format!("missing non-empty `{field}` string")))
+}
+
+fn pause_mode(
+    body: &Map<String, Value>,
+    operation: &str,
+) -> Result<crate::proto::PauseMode, DynamoError> {
+    match optional_string(body, "mode")?.as_deref().unwrap_or("abort") {
+        "abort" => Ok(crate::proto::PauseMode::Abort),
+        "wait" => Ok(crate::proto::PauseMode::Wait),
+        "keep" => Ok(crate::proto::PauseMode::Keep),
+        value => Err(client::invalid_argument(format!(
+            "{operation} mode must be abort, wait, or keep; got `{value}`"
+        ))),
+    }
+}
+
+fn optional_strings(
+    body: &Map<String, Value>,
+    field: &str,
+) -> Result<Option<Vec<String>>, DynamoError> {
+    match body.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Array(values)) => values
+            .iter()
+            .map(|value| {
+                value.as_str().map(ToString::to_string).ok_or_else(|| {
+                    client::invalid_argument(format!("`{field}` must contain only strings"))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some),
+        Some(_) => Err(client::invalid_argument(format!(
+            "`{field}` must be an array of strings"
+        ))),
+    }
+}
+
+fn required_object_json(body: &Map<String, Value>, field: &str) -> Result<Vec<u8>, DynamoError> {
+    let value = body
+        .get(field)
+        .and_then(Value::as_object)
+        .ok_or_else(|| client::invalid_argument(format!("missing `{field}` JSON object")))?;
+    serde_json::to_vec(value)
+        .map_err(|error| client::invalid_argument(format!("invalid `{field}`: {error}")))
 }
 
 fn bootstrap_discover(

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -50,6 +50,11 @@ impl VllmSidecarEngine {
         }
     }
 
+    /// Parse arguments and synchronously discover the vLLM model.
+    ///
+    /// Call this before `dynamo_backend_common::run`. Async callers must use
+    /// `spawn_blocking` or a dedicated thread because discovery uses
+    /// `Runtime::block_on`.
     pub fn from_args(argv: Option<Vec<String>>) -> Result<(Self, WorkerConfig), DynamoError> {
         let parsing_process_args = argv.is_none();
         let parsed = match argv {

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -1,20 +1,108 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_backend_common::{EngineConfig, LlmRegistration};
+use dynamo_backend_common::{DynamoError, EngineConfig, LlmRegistration};
 
-#[derive(Clone, Debug)]
-pub(crate) struct ConfiguredModel {
-    pub source: String,
+use crate::client;
+use crate::proto as pb;
+
+const SUPPORTED_API_VERSION: &str = "vllm";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ModelIdentity {
+    source: String,
+    served_name: String,
+    aliases: Vec<String>,
+    reasoning_parser: Option<String>,
+    tool_call_parser: Option<String>,
 }
 
-impl ConfiguredModel {
+#[derive(Clone, Debug)]
+pub(crate) struct DiscoveredModel {
+    pub source: String,
+    pub served_name: String,
+    identity: ModelIdentity,
+    server: pb::ServerInfo,
+}
+
+impl DiscoveredModel {
+    pub(crate) fn from_proto(
+        model: pb::ModelInfo,
+        server: pb::ServerInfo,
+    ) -> Result<Self, DynamoError> {
+        if server.api_version != SUPPORTED_API_VERSION {
+            return Err(client::protocol_error(format!(
+                "unsupported Control API version `{}`; expected `{SUPPORTED_API_VERSION}`",
+                server.api_version
+            )));
+        }
+        let source = required("model_id", model.model_id)?;
+        let served_name = required("served_model_name", model.served_model_name)?;
+        if !model.supports_token_ids_input {
+            return Err(client::protocol_error(
+                "the discovered model does not support token-ID input",
+            ));
+        }
+        let reasoning_parser = nonempty(model.reasoning_parser);
+        let tool_call_parser = nonempty(model.tool_call_parser);
+        let identity = ModelIdentity {
+            source: source.clone(),
+            served_name: served_name.clone(),
+            aliases: model.served_model_aliases,
+            reasoning_parser: reasoning_parser.clone(),
+            tool_call_parser: tool_call_parser.clone(),
+        };
+        Ok(Self {
+            source,
+            served_name,
+            identity,
+            server,
+        })
+    }
+
+    pub(crate) fn ensure_same_identity(&self, observed: &Self) -> Result<(), DynamoError> {
+        if self.identity != observed.identity {
+            return Err(client::protocol_error(format!(
+                "model identity changed between bootstrap and startup: expected `{}` served as `{}`, observed `{}` served as `{}`",
+                self.source, self.served_name, observed.source, observed.served_name
+            )));
+        }
+        Ok(())
+    }
+
     pub(crate) fn engine_config(&self) -> EngineConfig {
         EngineConfig {
             model: self.source.clone(),
-            served_model_name: None,
+            served_model_name: Some(self.served_name.clone()),
             runtime_data: Default::default(),
-            llm: Some(LlmRegistration::default()),
+            llm: Some(LlmRegistration {
+                context_length: nonzero(self.server.max_model_len),
+                kv_cache_block_size: nonzero(self.server.kv_block_size),
+                total_kv_blocks: nonzero(self.server.total_kv_blocks),
+                max_num_seqs: nonzero(self.server.max_running_requests),
+                max_num_batched_tokens: nonzero(self.server.max_batched_tokens),
+                ..Default::default()
+            }),
         }
     }
+}
+
+fn required(field: &str, value: String) -> Result<String, DynamoError> {
+    if value.trim().is_empty() {
+        return Err(client::protocol_error(format!(
+            "Control returned an empty {field}"
+        )));
+    }
+    Ok(value)
+}
+
+fn nonempty(value: String) -> Option<String> {
+    (!value.trim().is_empty()).then_some(value)
+}
+
+fn nonzero<T>(value: T) -> Option<T>
+where
+    T: Default + PartialEq,
+{
+    (value != T::default()).then_some(value)
 }

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -63,8 +63,8 @@ impl DiscoveredModel {
     pub(crate) fn ensure_same_identity(&self, observed: &Self) -> Result<(), DynamoError> {
         if self.identity != observed.identity {
             return Err(client::protocol_error(format!(
-                "model identity changed between bootstrap and startup: expected `{}` served as `{}`, observed `{}` served as `{}`",
-                self.source, self.served_name, observed.source, observed.served_name
+                "model identity changed between bootstrap and startup: expected {:?}, observed {:?}",
+                self.identity, observed.identity
             )));
         }
         Ok(())

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -67,7 +67,17 @@ impl DiscoveredModel {
                 self.identity, observed.identity
             )));
         }
+        if self.server.rl_capabilities != observed.server.rl_capabilities {
+            return Err(client::protocol_error(format!(
+                "RL capabilities changed between bootstrap and startup: expected {:?}, observed {:?}",
+                self.server.rl_capabilities, observed.server.rl_capabilities
+            )));
+        }
         Ok(())
+    }
+
+    pub(crate) fn rl_capabilities(&self) -> Option<&pb::RlCapabilities> {
+        self.server.rl_capabilities.as_ref()
     }
 
     pub(crate) fn engine_config(&self) -> EngineConfig {

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -19,18 +19,20 @@ use tokio::net::TcpListener;
 use tokio::sync::{Mutex, Notify, oneshot};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
+use tonic_health::ServingStatus as HealthServingStatus;
 
-use crate::client::VllmClient;
+use crate::client::{CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
 use crate::convert::{ResponseState, build_generate_request};
 use crate::engine::VllmSidecarEngine;
 use crate::json::{json_to_struct, struct_to_json};
-use crate::model::ConfiguredModel;
+use crate::model::DiscoveredModel;
 use crate::proto as pb;
 
 #[derive(Clone, Default)]
-struct FakeGenerate {
+struct FakeVllm {
     requests: Arc<Mutex<Vec<pb::GenerateRequest>>>,
     peers: Arc<Mutex<Vec<SocketAddr>>>,
+    model_info_override: Arc<Mutex<Option<pb::ModelInfo>>>,
     reject: Arc<AtomicBool>,
     hang: Arc<AtomicBool>,
     hang_before_headers: Arc<AtomicBool>,
@@ -48,7 +50,7 @@ impl Drop for DropSignal {
 }
 
 #[tonic::async_trait]
-impl pb::inference_server::Inference for FakeGenerate {
+impl pb::inference_server::Inference for FakeVllm {
     type GenerateStreamStream =
         Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send>>;
 
@@ -158,6 +160,79 @@ impl pb::inference_server::Inference for FakeGenerate {
             }
         };
         Ok(Response::new(Box::pin(stream)))
+    }
+}
+
+#[tonic::async_trait]
+impl pb::control_server::Control for FakeVllm {
+    async fn get_server_info(
+        &self,
+        _request: Request<pb::GetServerInfoRequest>,
+    ) -> Result<Response<pb::ServerInfo>, Status> {
+        Ok(Response::new(server_info()))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<pb::GetModelInfoRequest>,
+    ) -> Result<Response<pb::ModelInfo>, Status> {
+        let model = self
+            .model_info_override
+            .lock()
+            .await
+            .clone()
+            .unwrap_or_else(model_info);
+        Ok(Response::new(model))
+    }
+
+    async fn abort(
+        &self,
+        _request: Request<pb::AbortRequest>,
+    ) -> Result<Response<pb::AbortResponse>, Status> {
+        Ok(Response::new(pb::AbortResponse {}))
+    }
+
+    async fn get_kv_event_sources(
+        &self,
+        _request: Request<pb::GetKvEventSourcesRequest>,
+    ) -> Result<Response<pb::GetKvEventSourcesResponse>, Status> {
+        Ok(Response::new(pb::GetKvEventSourcesResponse {
+            sources: Vec::new(),
+        }))
+    }
+}
+
+fn model_info() -> pb::ModelInfo {
+    pb::ModelInfo {
+        model_id: "model-source".to_string(),
+        served_model_name: "served-model".to_string(),
+        served_model_aliases: vec!["model-alias".to_string()],
+        supports_text_input: true,
+        supports_token_ids_input: true,
+        supports_multimodal: false,
+        reasoning_parser: "deepseek_r1".to_string(),
+        tool_call_parser: "hermes".to_string(),
+    }
+}
+
+fn server_info() -> pb::ServerInfo {
+    pb::ServerInfo {
+        engine_version: "test-vllm".to_string(),
+        api_version: "vllm".to_string(),
+        instance_id: "test-instance".to_string(),
+        parallelism: Some(pb::ParallelismInfo {
+            tensor_parallel_size: 2,
+            pipeline_parallel_size: 1,
+            data_parallel_size: 4,
+            data_parallel_rank: 2,
+            decode_context_parallel_size: 1,
+        }),
+        max_model_len: 8192,
+        kv_block_size: 16,
+        total_kv_blocks: 4096,
+        max_running_requests: 128,
+        max_batched_tokens: 2048,
+        supports_explicit_data_parallel_rank: false,
     }
 }
 
@@ -314,23 +389,33 @@ fn oversized_logprob_counts_are_rejected() {
 
 struct FakeServer {
     endpoint: String,
-    service: FakeGenerate,
+    service: FakeVllm,
     shutdown: Option<oneshot::Sender<()>>,
 }
 
 impl FakeServer {
-    async fn start(service: FakeGenerate) -> Self {
+    async fn start(service: FakeVllm) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let address = listener.local_addr().expect("address");
         let (shutdown, shutdown_rx) = oneshot::channel();
-        let server_service = service.clone();
+        let inference_service = service.clone();
+        let control_service = service.clone();
+        let (health, health_service) = tonic_health::server::health_reporter();
+        health
+            .set_service_status(CONTROL_SERVICE, HealthServingStatus::Serving)
+            .await;
+        health
+            .set_service_status(INFERENCE_SERVICE, HealthServingStatus::Serving)
+            .await;
         tokio::spawn(async move {
             tonic::transport::Server::builder()
                 .add_service(
-                    pb::inference_server::InferenceServer::new(server_service)
+                    pb::inference_server::InferenceServer::new(inference_service)
                         .max_encoding_message_size(64 * 1024 * 1024)
                         .max_decoding_message_size(64 * 1024 * 1024),
                 )
+                .add_service(pb::control_server::ControlServer::new(control_service))
+                .add_service(health_service)
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     let _ = shutdown_rx.await;
                 })
@@ -398,17 +483,36 @@ fn request() -> PreprocessedRequest {
 }
 
 fn engine(endpoint: &str, mode: DisaggregationMode, connections: usize) -> VllmSidecarEngine {
+    let transport = GrpcTransportConfig {
+        connections: NonZeroUsize::new(connections).expect("non-zero connection count"),
+        ..Default::default()
+    };
     VllmSidecarEngine::new(
         GrpcEndpoint::parse(endpoint, "--vllm-endpoint").expect("valid test endpoint"),
-        ConfiguredModel {
-            source: "model-source".to_string(),
-        },
+        DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery"),
         mode,
-        GrpcTransportConfig {
-            connections: NonZeroUsize::new(connections).expect("non-zero connection count"),
-            ..Default::default()
-        },
+        transport,
     )
+}
+
+async fn engine_from_args(
+    endpoint: &str,
+) -> (VllmSidecarEngine, dynamo_backend_common::WorkerConfig) {
+    let argv = vec![
+        "dynamo-vllm-sidecar".to_string(),
+        "--vllm-endpoint".to_string(),
+        endpoint.to_string(),
+        "--grpc-connections".to_string(),
+        "2".to_string(),
+        "--grpc-startup-deadline-secs".to_string(),
+        "5".to_string(),
+        "--grpc-connect-attempt-timeout-secs".to_string(),
+        "1".to_string(),
+    ];
+    tokio::task::spawn_blocking(move || VllmSidecarEngine::from_args(Some(argv)))
+        .await
+        .expect("bootstrap task")
+        .expect("bootstrap discovery")
 }
 
 async fn collect(
@@ -427,11 +531,23 @@ async fn collect(
 
 #[tokio::test]
 async fn aggregated_generation_converts_request_stream_and_usage() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 2);
+    let server = FakeServer::start(FakeVllm::default()).await;
+    let (engine, worker) = engine_from_args(&server.endpoint).await;
+    assert_eq!(worker.model_name, "model-source");
+    assert_eq!(worker.served_model_name.as_deref(), Some("served-model"));
+    assert!(worker.reasoning_parser.is_none());
+    assert!(worker.tool_call_parser.is_none());
     let config = engine.start(0).await.expect("start");
     assert_eq!(config.model, "model-source");
-    assert_eq!(config.served_model_name, None);
+    assert_eq!(config.served_model_name.as_deref(), Some("served-model"));
+    let registration = config.llm.expect("LLM registration");
+    assert_eq!(registration.context_length, Some(8192));
+    assert_eq!(registration.kv_cache_block_size, Some(16));
+    assert_eq!(registration.total_kv_blocks, Some(4096));
+    assert_eq!(registration.max_num_seqs, Some(128));
+    assert_eq!(registration.max_num_batched_tokens, Some(2048));
+    assert_eq!(registration.data_parallel_size, None);
+    assert_eq!(registration.data_parallel_start_rank, None);
 
     let outputs = collect(&engine, request()).await;
     assert_eq!(outputs.len(), 1);
@@ -447,7 +563,7 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
 
     let requests = server.service.requests.lock().await;
     let sent = requests.first().expect("recorded request");
-    assert!(sent.model.is_empty());
+    assert_eq!(sent.model, "served-model");
     assert_eq!(sent.priority, 0);
     let sampling = sent.sampling.as_ref().unwrap();
     assert_eq!(
@@ -484,7 +600,7 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
 
 #[tokio::test]
 async fn grpc_request_errors_are_propagated() {
-    let service = FakeGenerate::default();
+    let service = FakeVllm::default();
     service.reject.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
@@ -500,7 +616,7 @@ async fn grpc_request_errors_are_propagated() {
 
 #[tokio::test]
 async fn prefill_decode_handoff_is_opaque_and_repeatable() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeVllm::default()).await;
     let prefill = engine(&server.endpoint, DisaggregationMode::Prefill, 1);
     let decode = engine(&server.endpoint, DisaggregationMode::Decode, 1);
     prefill.start(0).await.expect("start prefill");
@@ -535,40 +651,43 @@ async fn prefill_decode_handoff_is_opaque_and_repeatable() {
     }
 }
 
-#[test]
-fn component_honors_config_for_aggregated_but_fixes_disagg_roles() {
-    let component = |extra: &[&str]| {
+#[tokio::test]
+async fn component_honors_config_for_aggregated_but_fixes_disagg_roles() {
+    let server = FakeServer::start(FakeVllm::default()).await;
+    for (extra, expected) in [
+        (Vec::<&str>::new(), "custom"),
+        (vec!["--disaggregation-mode", "prefill"], "prefill"),
+        (vec!["--disaggregation-mode", "decode"], "backend"),
+    ] {
         let mut argv = vec![
-            "dynamo-vllm-sidecar",
-            "--vllm-endpoint",
-            "127.0.0.1:50051",
-            "--model-path",
-            "test-model",
-            "--component",
-            "custom",
+            "dynamo-vllm-sidecar".to_string(),
+            "--vllm-endpoint".to_string(),
+            server.endpoint.clone(),
+            "--component".to_string(),
+            "custom".to_string(),
         ];
-        argv.extend_from_slice(extra);
-        VllmSidecarEngine::from_args(Some(argv.iter().map(|s| s.to_string()).collect()))
-            .expect("from_args")
-            .1
-            .component
-    };
-    // Aggregated keeps the operator-configured component.
-    assert_eq!(component(&[]), "custom");
-    // Disaggregated roles override to fixed names so the frontend can route.
-    assert_eq!(component(&["--disaggregation-mode", "prefill"]), "prefill");
-    assert_eq!(component(&["--disaggregation-mode", "decode"]), "backend");
+        argv.extend(extra.into_iter().map(str::to_string));
+        let component =
+            tokio::task::spawn_blocking(move || VllmSidecarEngine::from_args(Some(argv)))
+                .await
+                .expect("bootstrap task")
+                .expect("from_args")
+                .1
+                .component;
+        assert_eq!(component, expected);
+    }
 }
 
 #[tokio::test]
 async fn pool_uses_each_configured_connection() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeVllm::default()).await;
     let transport = GrpcTransportConfig {
         connections: NonZeroUsize::new(2).unwrap(),
         ..Default::default()
     };
     let endpoint = GrpcEndpoint::parse(&server.endpoint, "--vllm-endpoint").unwrap();
-    let client = VllmClient::connect(&endpoint, transport)
+    let deadline = crate::client::startup_deadline(transport.startup_deadline).unwrap();
+    let client = VllmClient::connect(&endpoint, transport, deadline)
         .await
         .expect("connect pool");
     assert_eq!(client.connection_count(), 2);
@@ -598,7 +717,7 @@ async fn pool_uses_each_configured_connection() {
 
 #[tokio::test]
 async fn cancellation_drops_the_remote_stream() {
-    let service = FakeGenerate::default();
+    let service = FakeVllm::default();
     service.hang.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
@@ -627,7 +746,7 @@ async fn cancellation_drops_the_remote_stream() {
 
 #[tokio::test]
 async fn cancellation_interrupts_pending_response_headers() {
-    let service = FakeGenerate::default();
+    let service = FakeVllm::default();
     service.hang_before_headers.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
@@ -658,7 +777,7 @@ async fn cancellation_interrupts_pending_response_headers() {
 
 #[tokio::test]
 async fn unsupported_features_fail_before_rpc_submission() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeVllm::default()).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
     engine.start(0).await.expect("start");
 

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -48,7 +48,7 @@ impl Drop for DropSignal {
 }
 
 #[tonic::async_trait]
-impl pb::generate_server::Generate for FakeGenerate {
+impl pb::inference_server::Inference for FakeGenerate {
     type GenerateStreamStream =
         Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send>>;
 
@@ -189,6 +189,7 @@ fn sequence_response(
                 finish_reason: pb::finish_info::FinishReason::Stop as i32,
                 stop_reason: Some(pb::finish_info::StopReason::StopTokenId(2)),
                 kv_transfer_params,
+                ec_transfer_params: None,
             }),
         }),
     }
@@ -326,7 +327,7 @@ impl FakeServer {
         tokio::spawn(async move {
             tonic::transport::Server::builder()
                 .add_service(
-                    pb::generate_server::GenerateServer::new(server_service)
+                    pb::inference_server::InferenceServer::new(server_service)
                         .max_encoding_message_size(64 * 1024 * 1024)
                         .max_decoding_message_size(64 * 1024 * 1024),
                 )

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -39,6 +39,19 @@ struct FakeVllm {
     headers_pending: Arc<AtomicBool>,
     release_headers: Arc<Notify>,
     server_stream_dropped: Arc<AtomicBool>,
+    control_calls: Arc<Mutex<Vec<(String, serde_json::Value)>>>,
+    paused: Arc<AtomicBool>,
+    sleeping: Arc<AtomicBool>,
+    weight_version: Arc<Mutex<String>>,
+}
+
+impl FakeVllm {
+    async fn record_control(&self, name: &str, body: serde_json::Value) {
+        self.control_calls
+            .lock()
+            .await
+            .push((name.to_string(), body));
+    }
 }
 
 struct DropSignal(Arc<AtomicBool>);
@@ -200,6 +213,142 @@ impl pb::control_server::Control for FakeVllm {
             sources: Vec::new(),
         }))
     }
+
+    async fn pause_generation(
+        &self,
+        request: Request<pb::PauseGenerationRequest>,
+    ) -> Result<Response<pb::PauseGenerationResponse>, Status> {
+        let request = request.into_inner();
+        self.paused.store(true, Ordering::SeqCst);
+        self.record_control(
+            "pause_generation",
+            json!({"mode": request.mode, "clear_cache": request.clear_cache}),
+        )
+        .await;
+        Ok(Response::new(pb::PauseGenerationResponse {}))
+    }
+
+    async fn resume_generation(
+        &self,
+        _request: Request<pb::ResumeGenerationRequest>,
+    ) -> Result<Response<pb::ResumeGenerationResponse>, Status> {
+        self.paused.store(false, Ordering::SeqCst);
+        self.record_control("resume_generation", json!({})).await;
+        Ok(Response::new(pb::ResumeGenerationResponse {}))
+    }
+
+    async fn is_paused(
+        &self,
+        _request: Request<pb::IsPausedRequest>,
+    ) -> Result<Response<pb::IsPausedResponse>, Status> {
+        Ok(Response::new(pb::IsPausedResponse {
+            paused: self.paused.load(Ordering::SeqCst),
+        }))
+    }
+
+    async fn sleep(
+        &self,
+        request: Request<pb::SleepRequest>,
+    ) -> Result<Response<pb::SleepResponse>, Status> {
+        let request = request.into_inner();
+        self.sleeping.store(true, Ordering::SeqCst);
+        self.record_control(
+            "sleep",
+            json!({"level": request.level, "mode": request.mode}),
+        )
+        .await;
+        Ok(Response::new(pb::SleepResponse {}))
+    }
+
+    async fn wake_up(
+        &self,
+        request: Request<pb::WakeUpRequest>,
+    ) -> Result<Response<pb::WakeUpResponse>, Status> {
+        self.sleeping.store(false, Ordering::SeqCst);
+        self.record_control("wake_up", json!({"tags": request.into_inner().tags}))
+            .await;
+        Ok(Response::new(pb::WakeUpResponse {}))
+    }
+
+    async fn is_sleeping(
+        &self,
+        _request: Request<pb::IsSleepingRequest>,
+    ) -> Result<Response<pb::IsSleepingResponse>, Status> {
+        Ok(Response::new(pb::IsSleepingResponse {
+            sleeping: self.sleeping.load(Ordering::SeqCst),
+        }))
+    }
+
+    async fn init_weight_transfer_engine(
+        &self,
+        request: Request<pb::InitWeightTransferEngineRequest>,
+    ) -> Result<Response<pb::InitWeightTransferEngineResponse>, Status> {
+        let body = serde_json::from_slice(&request.into_inner().init_info_json)
+            .map_err(|error| Status::invalid_argument(error.to_string()))?;
+        self.record_control("init_weight_transfer_engine", body)
+            .await;
+        Ok(Response::new(pb::InitWeightTransferEngineResponse {}))
+    }
+
+    async fn start_weight_update(
+        &self,
+        _request: Request<pb::StartWeightUpdateRequest>,
+    ) -> Result<Response<pb::StartWeightUpdateResponse>, Status> {
+        self.record_control("start_weight_update", json!({})).await;
+        Ok(Response::new(pb::StartWeightUpdateResponse {}))
+    }
+
+    async fn start_draft_weight_update(
+        &self,
+        _request: Request<pb::StartDraftWeightUpdateRequest>,
+    ) -> Result<Response<pb::StartDraftWeightUpdateResponse>, Status> {
+        self.record_control("start_draft_weight_update", json!({}))
+            .await;
+        Ok(Response::new(pb::StartDraftWeightUpdateResponse {}))
+    }
+
+    async fn update_weights(
+        &self,
+        request: Request<pb::UpdateWeightsRequest>,
+    ) -> Result<Response<pb::UpdateWeightsResponse>, Status> {
+        let body = serde_json::from_slice(&request.into_inner().update_info_json)
+            .map_err(|error| Status::invalid_argument(error.to_string()))?;
+        self.record_control("update_weights", body).await;
+        Ok(Response::new(pb::UpdateWeightsResponse {}))
+    }
+
+    async fn finish_weight_update(
+        &self,
+        request: Request<pb::FinishWeightUpdateRequest>,
+    ) -> Result<Response<pb::FinishWeightUpdateResponse>, Status> {
+        let version = request.into_inner().weight_version;
+        if let Some(version) = &version {
+            self.weight_version.lock().await.clone_from(version);
+        }
+        self.record_control("finish_weight_update", json!({"weight_version": version}))
+            .await;
+        Ok(Response::new(pb::FinishWeightUpdateResponse {}))
+    }
+
+    async fn update_weight_version(
+        &self,
+        request: Request<pb::UpdateWeightVersionRequest>,
+    ) -> Result<Response<pb::UpdateWeightVersionResponse>, Status> {
+        let version = request.into_inner().weight_version;
+        self.weight_version.lock().await.clone_from(&version);
+        self.record_control("update_weight_version", json!({"new_version": version}))
+            .await;
+        Ok(Response::new(pb::UpdateWeightVersionResponse {}))
+    }
+
+    async fn get_weight_version(
+        &self,
+        _request: Request<pb::GetWeightVersionRequest>,
+    ) -> Result<Response<pb::GetWeightVersionResponse>, Status> {
+        Ok(Response::new(pb::GetWeightVersionResponse {
+            weight_version: self.weight_version.lock().await.clone(),
+        }))
+    }
 }
 
 fn model_info() -> pb::ModelInfo {
@@ -233,6 +382,12 @@ fn server_info() -> pb::ServerInfo {
         max_running_requests: 128,
         max_batched_tokens: 2048,
         supports_explicit_data_parallel_rank: false,
+        rl_capabilities: Some(pb::RlCapabilities {
+            weight_transfer_enabled: true,
+            weight_transfer_backend: "nccl".to_string(),
+            sleep_mode_enabled: true,
+            draft_weight_updates_enabled: true,
+        }),
     }
 }
 
@@ -508,6 +663,7 @@ async fn engine_from_args(
         "5".to_string(),
         "--grpc-connect-attempt-timeout-secs".to_string(),
         "1".to_string(),
+        "--enable-rl".to_string(),
     ];
     tokio::task::spawn_blocking(move || VllmSidecarEngine::from_args(Some(argv)))
         .await
@@ -535,6 +691,7 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
     let (engine, worker) = engine_from_args(&server.endpoint).await;
     assert_eq!(worker.model_name, "model-source");
     assert_eq!(worker.served_model_name.as_deref(), Some("served-model"));
+    assert!(worker.enable_rl);
     assert!(worker.reasoning_parser.is_none());
     assert!(worker.tool_call_parser.is_none());
     let config = engine.start(0).await.expect("start");
@@ -595,6 +752,93 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
     assert_eq!(
         struct_to_json(kv.kv_transfer_params.clone().unwrap()).unwrap(),
         json!({"connector_data": {"values": [1, true, null]}})
+    );
+}
+
+#[tokio::test]
+async fn rl_engine_routes_preserve_lifecycle_payloads_and_version() {
+    let server = FakeServer::start(FakeVllm::default()).await;
+    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    engine.start(0).await.expect("start");
+
+    assert!(
+        engine
+            .supported_controls()
+            .await
+            .unwrap()
+            .contains(&"pause_generation".to_string())
+    );
+    assert!(
+        engine
+            .supported_updates()
+            .await
+            .unwrap()
+            .contains(&"update_weights".to_string())
+    );
+    assert_eq!(
+        engine
+            .engine_control(
+                "pause_generation".to_string(),
+                json!({"mode": "keep", "clear_cache": false}),
+            )
+            .await
+            .unwrap(),
+        json!({"status": "paused"})
+    );
+    engine
+        .engine_update(
+            "init_weight_transfer_engine".to_string(),
+            json!({"init_info": {"master_addr": "trainer", "master_port": 1234}}),
+        )
+        .await
+        .unwrap();
+    engine
+        .engine_update("start_weight_update".to_string(), json!({}))
+        .await
+        .unwrap();
+    engine
+        .engine_update(
+            "update_weights".to_string(),
+            json!({"update_info": {"names": ["layer.weight"], "shape": [4, 8]}}),
+        )
+        .await
+        .unwrap();
+    engine
+        .engine_update(
+            "finish_weight_update".to_string(),
+            json!({"weight_version": "step-42"}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        engine
+            .engine_control("get_weight_version".to_string(), json!({}))
+            .await
+            .unwrap(),
+        json!({"weight_version": "step-42"})
+    );
+
+    assert_eq!(
+        *server.service.control_calls.lock().await,
+        vec![
+            (
+                "pause_generation".to_string(),
+                json!({"mode": pb::PauseMode::Keep as i32, "clear_cache": false}),
+            ),
+            (
+                "init_weight_transfer_engine".to_string(),
+                json!({"master_addr": "trainer", "master_port": 1234}),
+            ),
+            ("start_weight_update".to_string(), json!({})),
+            (
+                "update_weights".to_string(),
+                json!({"names": ["layer.weight"], "shape": [4, 8]}),
+            ),
+            (
+                "finish_weight_update".to_string(),
+                json!({"weight_version": "step-42"}),
+            ),
+        ]
     );
 }
 

--- a/lib/sidecar/vllm/tests/executable.rs
+++ b/lib/sidecar/vllm/tests/executable.rs
@@ -19,7 +19,6 @@ fn executable_exposes_native_grpc_configuration() {
     for flag in [
         "--vllm-endpoint",
         "--grpc-connections",
-        "--model-path",
         "--disaggregation-mode",
         "--grpc-connect-attempt-timeout-secs",
         "--grpc-retry-interval-secs",
@@ -27,7 +26,6 @@ fn executable_exposes_native_grpc_configuration() {
     ] {
         assert!(stdout.contains(flag), "missing {flag} in help output");
     }
-
     for env in [
         "DYN_SIDECAR_GRPC_CONNECTIONS",
         "DYN_SIDECAR_GRPC_CONNECT_ATTEMPT_TIMEOUT_SECS",


### PR DESCRIPTION
## Summary

- Route Dynamo vLLM sidecar RL controls and updates through the companion native `vllm.Control` gRPC API instead of a development HTTP admin server.
- Advertise only server-reported pause/resume, sleep/wake, weight-transfer, draft-update, and weight-version capabilities; preserve vLLM's RL HTTP request schemas at the Dynamo `/engine/*` boundary.
- Add opt-in Rust worker RL discovery at `dyn://<namespace>.<component>.rl`, including safe endpoint shutdown and discovery unregister/register ordering around pause, sleep, resume, and wake operations.
- Keep the generic vLLM mocker fail-closed while adding a focused sidecar fake that verifies route payloads reach the expected protobuf calls.

## Dependencies and overlap

- Companion vLLM implementation: [connorcarpenter15/vllm#22](https://github.com/connorcarpenter15/vllm/pull/22), pinned in the vendored protocol README at commit `7f3ab290464ac319e867b0d011d11dd6b2ff37f4`.
- This branch is based on current `main` and includes the four commits from [ai-dynamo/dynamo#12734](https://github.com/ai-dynamo/dynamo/pull/12734) because the split native Control/Inference protocol is a prerequisite. Once that PR merges, GitHub should reduce this PR to the RL-specific diff.
- [ai-dynamo/dynamo#11804](https://github.com/ai-dynamo/dynamo/pull/11804) also explores RL discovery but publishes a vLLM HTTP admin URL. This PR is materially different: it keeps administration on the native gRPC sidecar channel, capability-gates every route, and publishes only Dynamo engine routes plus the existing system URL.

## Validation

- `cargo fmt --all -- --check` — passed.
- `cargo check -p dynamo-vllm-sidecar -p dynamo-backend-common -p dynamo-vllm-mocker -p dynamo-trtllm-sidecar -p dynamo-mocker-backend` — passed.
- `cargo check --manifest-path lib/bindings/python/Cargo.toml` — passed.
- `cargo clippy -p dynamo-vllm-sidecar -p dynamo-backend-common -p dynamo-vllm-mocker -p dynamo-trtllm-sidecar -p dynamo-mocker-backend --all-targets -- -D warnings` — passed.
- `cargo test -p dynamo-vllm-sidecar rl_engine_routes_preserve_lifecycle_payloads_and_version -- --nocapture` — passed, 1 test.
- `cargo test -p dynamo-vllm-sidecar aggregated_generation_converts_request_stream_and_usage -- --nocapture` — passed, 1 test.
- `cargo test -p dynamo-backend-common routes_request_describes_the_worker_engine_surface -- --nocapture` — passed, 1 test.
- `cargo test -p dynamo-backend-common engine_control_policy_wraps_discovery_mutating_controls -- --nocapture` — passed, 1 test.

## Not run

- No GPU/real-engine test was run locally. The cross-process request and lifecycle contracts are covered with the in-process tonic fake; end-to-end validation requires a vLLM build containing the companion draft PR.

## AI assistance disclosure

This implementation was prepared with OpenAI Codex assistance and requires human review before merge.
