### PR TITLE
docs(skill): make KV replay parity native-only

### DIFF
--- a/.agents/skills/dynamo-kv-replay-parity/SKILL.md
+++ b/.agents/skills/dynamo-kv-replay-parity/SKILL.md
@@ -134,17 +134,19 @@ configuration, prove that it exercised every applicable path:
 
 - KV-overlap-sensitive routing;
 - immediate placement, plus queued placement only when queueing is explicitly enabled;
-- a small, bounded number of preemptions at the block-capacity edge;
+- the row's bounded preemption or retraction band at the block-capacity edge;
 - disaggregated prefill/decode handoff;
 - terminal cleanup.
 
 Use coverage counters, lifecycle traces, or report evidence rather than inferring these
-paths from successful completion. Target one to three preemptions per configuration. Zero
-means the edge was not exercised; repeated preempt/re-admit cycling, a rapidly growing
-preemption count, or failure to advance virtual time invalidates the fixture. Tune capacity
-or concurrency minimally and identically for baseline and candidate within the row or
-family, and back off rather than accepting a preemption flood. Never tune the revisions
-separately.
+paths from successful completion. Target the bounded pressure band recorded for the
+qualified seed. When no seed exists, start with one to three pressure events to prove the
+lifecycle. For throttle-oriented disaggregated vLLM and SGLang seeds, target 10 to 20 fully
+readmitted pressure events so repeated scheduling is exercised. Zero means the edge was
+not exercised; repeated preempt/re-admit cycling, a rapidly growing pressure count, or
+failure to advance virtual time invalidates the fixture. Tune capacity or concurrency
+minimally and identically for baseline and candidate within the row or family, and back
+off rather than accepting a pressure flood. Never tune the revisions separately.
 
 The offline replay CLI leaves the router queue threshold unset by default. In that mode,
 all route decisions are immediate and zero queued placements are expected; engine-side
@@ -169,7 +171,9 @@ cross-revision parity are established.
 
 ## Stage 4: Run byte parity
 
-Run the 5,000-request corpus for this authoritative matrix:
+Run the 5,000-request corpus for this authoritative matrix. Treat both disaggregated rows
+as the primary scheduler and handoff requalification. Keep the aggregated rows as
+secondary parity coverage for the corresponding engine semantics.
 
 | Engine semantics | Topology | Memory path | Routing |
 | --- | --- | --- | --- |

--- a/.agents/skills/dynamo-kv-replay-parity/SKILL.md
+++ b/.agents/skills/dynamo-kv-replay-parity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dynamo-kv-replay-parity
-description: Runs deterministic byte-parity and paired performance campaigns for Dynamo offline KV-aware replay across native vLLM and SGLang configurations plus supported vLLM KVBM offload paths, including forced preemption and offload lifecycles. It is used when validating replay refactors, routing changes, scheduler-event changes, or performance-sensitive offline simulation changes against a baseline revision.
+description: Runs deterministic byte-parity and paired performance campaigns for Dynamo offline KV-aware replay across native vLLM and SGLang configurations, including forced scheduler-pressure lifecycles. It is used when validating replay refactors, routing changes, scheduler-event changes, or performance-sensitive offline simulation changes against a baseline revision.
 license: Apache-2.0
 metadata:
   author: NVIDIA
@@ -8,7 +8,6 @@ metadata:
     - dynamo
     - offline-replay
     - kv-router
-    - kvbm
     - parity
     - performance
 ---
@@ -31,15 +30,14 @@ Resolve and record before running anything:
 - Rust toolchain, build profile, flags, and host characteristics;
 - each artifact's exact Cargo features from the relevant manifests;
 - Mooncake trace path, SHA-256 checksum, and deterministic slice rule;
-- engine, topology, concurrency, worker counts, block sizes, and KVBM capacities;
+- engine, topology, concurrency, worker counts, block sizes, and G1 capacities;
 - the canonical-report exclusion allowlist; and
 - the performance run-order seed, CPU placement, timing scope, and invalidation rules.
 
 Use the project root `.venv/bin/python` for Python analysis and `uv pip` for any approved
 installation. Do not compare against moving branches or reuse a binary after changing its
 checkout. Do not describe the configuration as "all features"; record explicit feature
-names. Typical plumbing includes replay determinism plus KVBM offload, but feature names
-can differ between `dynamo-mocker` and `dynamo-bench`.
+names. Feature names can differ between `dynamo-mocker` and `dynamo-bench`.
 
 ## Stage 1: Pin revisions and artifacts
 
@@ -47,19 +45,23 @@ can differ between `dynamo-mocker` and `dynamo-bench`.
 2. Create isolated checkouts for both revisions using the same host and toolchain.
 3. Apply any temporary determinism correction identically to both revisions. Keep it out
    of the measured semantic delta and record its patch checksum.
-4. For the current `dynamo-bench` harness on Linux, build one feature-superset release
-   artifact per revision with exactly `replay-bench,mocker-kvbm-offload` and no default
-   features. `--canonical-reports-jsonl` requires `replay-bench`, which also selects the
-   seeded router. Compiled KVBM support attaches an offload engine only when runtime
-   arguments provide a positive `--num-g2-blocks` and `--kv-bytes-per-token`; omit
-   `--num-g2-blocks` for native rows.
-5. Reuse that artifact across native and KVBM correctness and performance rows. Do not
-   build separate native, KVBM, or production-routing artifacts. If the named manifest
-   features or runtime opt-in contract no longer exist, stop and report that this protocol
-   needs updating rather than guessing a replacement matrix.
+4. For the current `dynamo-bench` harness, build one release artifact per revision with
+   exactly `replay-bench` and no default features. `--canonical-reports-jsonl` requires
+   `replay-bench`, which also selects the seeded router.
+5. Reuse that artifact across all native correctness and performance rows. Do not build
+   separate topology or production-routing artifacts. If the named manifest feature no
+   longer exists, stop and report that this protocol needs updating rather than guessing a
+   replacement matrix.
 6. Copy the artifacts to a temporary campaign directory. Record exact features, binary
    SHA-256, binary size, and `.text` size.
 7. Return each checkout to its original branch after extracting the binaries.
+
+Build the current benchmark artifact with:
+
+```bash
+cargo build --release -p dynamo-bench --no-default-features \
+  --features replay-bench --bench offline_replay_bench
+```
 
 Never build while collecting performance samples.
 
@@ -73,13 +75,9 @@ evidence for one row on the same node. Use the same prebuilt revision artifacts 
 throughout the campaign, and record the node characteristics and CPU placement for every
 row.
 
-Native replay is normally single-core: pin each native process to one physical core after
-confirming that assumption during preflight. KVBM replay also owns a one-worker Tokio
-runtime for background pipeline and session tasks. Pin each KVBM process to a fixed,
-disjoint CPU set containing at least two physical cores for the main replay thread and the
-background worker. Expand that set if thread inspection shows additional runnable workers.
-Keep the CPU-set size, NUMA placement, and affinity identical between baseline and candidate
-for a row.
+Native replay is normally single-core: pin each process to one physical core after
+confirming that assumption during preflight. Keep the CPU-set size, NUMA placement, and
+affinity identical between baseline and candidate for a row.
 
 For correctness, run the baseline and candidate repetitions for a row concurrently when
 its node has sufficient resources. Pin concurrent processes to disjoint CPU sets, give each
@@ -135,12 +133,10 @@ configuration family when rows genuinely share every relevant parameter. For eac
 configuration, prove that it exercised every applicable path:
 
 - KV-overlap-sensitive routing;
-- immediate and queued placement;
+- immediate placement, plus queued placement only when queueing is explicitly enabled;
 - a small, bounded number of preemptions at the block-capacity edge;
 - disaggregated prefill/decode handoff;
-- terminal cleanup;
-- G1 to G2 eviction on KVBM rows; and
-- G2 to G1 restoration on KVBM rows.
+- terminal cleanup.
 
 Use coverage counters, lifecycle traces, or report evidence rather than inferring these
 paths from successful completion. Target one to three preemptions per configuration. Zero
@@ -150,6 +146,13 @@ or concurrency minimally and identically for baseline and candidate within the r
 family, and back off rather than accepting a preemption flood. Never tune the revisions
 separately.
 
+The offline replay CLI leaves the router queue threshold unset by default. In that mode,
+all route decisions are immediate and zero queued placements are expected; engine-side
+scheduler waiting is not router queue coverage. If queue lifecycle coverage is required,
+enable it through an explicit queue-capable harness or forced fixture and record the exact
+threshold. Account for every route decision, but never relabel scheduler waiting as queued
+placement.
+
 ### Start from qualified internal-polynomial seeds
 
 For the canonical 5,000-row Mooncake window with the internal polynomial mocker, read
@@ -158,10 +161,10 @@ before searching for capacity edges. Treat those configurations and observed cou
 suggested starting points, not universal constants or substitutes for qualification on the
 pinned baseline. Requalify one frozen configuration identically on both revisions.
 
-Use the reference's expected preemption, retraction, queue, reuse, worker, and handoff
-signals as drift detectors. For KVBM rows, also require deterministic nonzero G1-to-G2 and
-G2-to-G1 activity. Matching lifecycle counts do not waive an unstable canonical digest;
-stop correctness and performance work for that row until both internal determinism and
+Use the reference's expected preemption, retraction, reuse, worker, and handoff signals as
+drift detectors. Treat queue counts as expected signals only when queueing was explicitly
+enabled. Matching lifecycle counts do not waive an unstable canonical digest; stop
+correctness and performance work for that row until both internal determinism and
 cross-revision parity are established.
 
 ## Stage 4: Run byte parity
@@ -174,13 +177,8 @@ Run the 5,000-request corpus for this authoritative matrix:
 | vLLM pass-start | Disaggregated | Native G1 | KV-aware |
 | SGLang pass-end | Aggregated | Native G1 | KV-aware |
 | SGLang pass-end | Disaggregated | Native G1 | KV-aware |
-| vLLM pass-start | Aggregated | KVBM G1 to G2 and G2 to G1 | KV-aware |
-| vLLM pass-start | Disaggregated | KVBM G1 to G2 and G2 to G1 | KV-aware |
 
-The current harness supports KVBM offload only for vLLM. Record SGLang plus KVBM as
-`UNSUPPORTED`; do not require an impossible lifecycle and do not count that unsupported
-combination as an authoritative row. Run the two KVBM rows only on supported Linux hosts
-and require the Stage 3 eviction and restoration evidence. For each row:
+For each row:
 
 1. Produce canonical baseline and candidate outputs with the frozen configuration.
 2. Compare their bytes or SHA-256 digests exactly.
@@ -195,7 +193,7 @@ authoritative engine semantic.
 
 Byte mismatch is a review gate, not an instruction to preserve incorrect behavior. Allow
 an intentional mismatch only when the candidate is demonstrably more faithful to the
-specified engine, scheduler, routing, or KVBM semantics.
+specified engine, scheduler, or routing semantics.
 
 For every proposed exception, record:
 
@@ -216,15 +214,13 @@ candidate back to known-wrong behavior just to obtain identical bytes.
 Use small deterministic fixtures only for required paths the long corpus cannot reliably
 trigger:
 
-- single-worker KV-router queueing;
+- single-worker KV-router queueing with an explicit queue threshold;
 - a preemption-edge fixture that targets one to three preemptions and then completes;
 - scale-to-zero followed by scale-up and pending-work release;
-- G1 to G2 eviction followed by G2 to G1 restoration; and
 - backend-specific prefill/decode handoff ordering.
 
 Assert bounded preemption, continued virtual-time progress, and the lifecycle itself. A
-final-completion smoke test does not prove offload, preemption, queueing, or restoration
-occurred.
+final-completion smoke test does not prove preemption or queueing occurred.
 
 ## Stage 7: Measure performance
 
@@ -240,10 +236,9 @@ The primary metric is replay execution time. Start its timer after trace normali
 workload construction, and engine/runtime preparation, immediately before
 `prepared.run(...)`; stop it immediately after that call returns and before collector
 finalization or report aggregation. Emit this value as `replay_execution_ms`. Record setup
-and end-to-end time separately as diagnostics. In particular, do not let KVBM messenger
-initialization or its fixed readiness delay dilute a replay-loop regression. If the harness
-does not expose this exact timing boundary, extend it before running the campaign; do not
-substitute the existing broader `wall_time_ms`.
+and end-to-end time separately as diagnostics. If the harness does not expose this exact
+timing boundary, extend it before running the campaign; do not substitute the existing
+broader `wall_time_ms`.
 
 Stage binaries and trace inputs on node-local storage and verify their checksums before
 warmups. File transfer is campaign setup, not a sample. For each measured invocation, pass

--- a/.agents/skills/dynamo-kv-replay-parity/references/internal-polynomial-golden-points.md
+++ b/.agents/skills/dynamo-kv-replay-parity/references/internal-polynomial-golden-points.md
@@ -26,12 +26,31 @@ configuration. Never tune the revisions separately.
 | Engine and topology | Starting configuration | Expected pressure and nearest boundaries |
 | --- | --- | --- |
 | vLLM aggregated | 4 workers; engine block 64; G1 blocks 6,144; max sequences 16; batch tokens 8,192 | 1 preemption; 4,096 produced 21 and 8,192 produced 0 |
-| vLLM disaggregated | 2 prefill + 2 decode; engine block 64; G1 blocks 40,964; max sequences 16; batch tokens 8,192; KV bytes/token 1; 100 GB/s full-prompt transfer | 4 preemptions; exact next integer capacity 40,965 produced 0. This is a documented nearest-feasible exception to the 1–3 target: max sequences 15 produced 9–13 near the edge and max sequences 17 produced 0 |
+| vLLM disaggregated | 2 prefill + 2 decode; engine block 64; G1 blocks 16,000; max sequences 16; batch tokens 8,192; KV bytes/token 1; 100 GB/s full-prompt transfer | 1 fully readmitted preemption; 10 fresh-process repetitions produced one digest and identical counters; 18,000 produced 0 |
 | SGLang aggregated | 4 workers; engine/page block 512; G1 blocks 1,536; max sequences 256; batch tokens 32,768 | 1 retraction; 1,024 produced 8 and 2,048 produced 0 |
 | SGLang disaggregated | 2 prefill + 2 decode; engine/page block 512; G1 blocks 17,408; max sequences 256; batch tokens 32,768; KV bytes/token 262,144; 100 GB/s full-prompt transfer | 2 retractions; 16,384 produced 12 and 18,432 produced 0 |
 
 The vLLM configurations rely on native/default G1 selection. An experiment-only
 `--g1-backend` switch is not required to reproduce the native seeds.
+
+The vLLM disaggregated row was requalified at commit
+`d95e98aa732c50909dd2f7777172c604066c8307` after PR #13052 made prefill replay exactly
+one output token. The former 40,964-block seed now produces zero preemptions and no longer
+exercises the pressure edge. The requalified 16,000-block seed completed all requests with
+exact token totals, 5,000 immediate and zero queued placements in each pool, 4,991 requests
+with reuse, and canonical report SHA-256
+`c60365af08f856d939fd87c30e1b55049630a0e22cf1b371a5c9a5acee82a6cd` in all ten runs.
+
+For a post-qualification throttle soak, run the same 16,000-block configuration against
+the complete 23,608-row Mooncake trace, SHA-256
+`b434f1816a707f4bac697235588184ebc374c9907cb981bb65fb0643471fe711`. Three fresh
+processes each completed all requests with exact totals of 202,791,701 input and 4,299,817
+output tokens, 23 fully readmitted preemptions, 23,608 immediate and zero queued
+placements in each pool, and canonical report SHA-256
+`e4bb70b88b25986beda2df602fb5b813e57393101c10caa9eace3429667b3eab`.
+The one-to-three pressure target applies to the 5,000-row parity fixture; the full-trace
+soak may exceed it when every pressure event is bounded, readmitted, and followed by exact
+completion.
 
 ### CLI templates
 
@@ -73,7 +92,7 @@ vLLM disaggregated:
   --num-decode-workers 2 \
   --engine-type vllm \
   --block-size 64 \
-  --num-gpu-blocks 40964 \
+  --num-gpu-blocks 16000 \
   --max-num-seqs 16 \
   --max-num-batched-tokens 8192 \
   --kv-bytes-per-token 1 \
@@ -119,35 +138,19 @@ SGLang disaggregated:
 With the exact corpus and internal model above, use these observed values as drift
 detectors:
 
-| Engine and topology | Immediate / queued | Requests with reuse | Worker and handoff evidence |
-| --- | --- | --- | --- |
-| vLLM aggregated | 8 / 4,992 | 4,918 | decode workers 0–3 |
-| vLLM disaggregated | 4 / 4,996 | 4,991 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
-| SGLang aggregated | 5 / 4,995 | 4,840 | decode workers 0–3 |
-| SGLang disaggregated | 2 / 4,998 | 4,992 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
+| Engine and topology | Requests with reuse | Worker and handoff evidence |
+| --- | --- | --- |
+| vLLM aggregated | 4,918 | decode workers 0–3 |
+| vLLM disaggregated | 4,991 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
+| SGLang aggregated | 4,840 | decode workers 0–3 |
+| SGLang disaggregated | 4,992 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
+
+The offline replay CLI defaults `router_queue_threshold` to unset, so these templates do
+not exercise router queueing. In the requalified vLLM disaggregated runs, every placement
+in both pools was immediate and zero was queued. Require queued-placement evidence only
+when an explicit queue-capable harness or forced fixture enables it; scheduler waiting is
+not router queueing.
 
 Every row must complete all 5,000 requests with no rejected, canceled, failed, or stranded
 requests. A changed counter is not automatically a product failure, but it means the seed
 must be requalified and the cause recorded before freezing the row.
-
-## Derive and sanity-check KVBM rows
-
-Derive each vLLM KVBM row from its corresponding native seed by enabling G2 and modestly
-reducing or limiting G1. Keep the topology fixed; start disaggregated qualification at
-exactly 2 prefill + 2 decode workers. Tune capacity or concurrency identically for both
-revisions.
-
-Require all of the following before freezing a KVBM row:
-
-- all 5,000 requests complete;
-- one to three bounded preemptions, without repeated preempt/re-admit cycling;
-- nonzero G1-to-G2 eviction completion;
-- nonzero G2-to-G1 restoration hits;
-- identical lifecycle counts across repeated baseline and candidate runs;
-- 5,000 complete, backend-valid handoffs for disaggregated replay; and
-- one canonical digest per revision, with baseline and candidate digests matching.
-
-Do not infer offload coverage from successful completion. Do not proceed to performance
-when lifecycle counters match but a revision's canonical repetitions differ; that is an
-internal determinism failure. SGLang KVBM offload is unsupported by the current harness
-and must be reported as `UNSUPPORTED`, not simulated by toggling an ignored G1 option.

--- a/.agents/skills/dynamo-kv-replay-parity/references/internal-polynomial-golden-points.md
+++ b/.agents/skills/dynamo-kv-replay-parity/references/internal-polynomial-golden-points.md
@@ -26,31 +26,31 @@ configuration. Never tune the revisions separately.
 | Engine and topology | Starting configuration | Expected pressure and nearest boundaries |
 | --- | --- | --- |
 | vLLM aggregated | 4 workers; engine block 64; G1 blocks 6,144; max sequences 16; batch tokens 8,192 | 1 preemption; 4,096 produced 21 and 8,192 produced 0 |
-| vLLM disaggregated | 2 prefill + 2 decode; engine block 64; G1 blocks 16,000; max sequences 16; batch tokens 8,192; KV bytes/token 1; 100 GB/s full-prompt transfer | 1 fully readmitted preemption; 10 fresh-process repetitions produced one digest and identical counters; 18,000 produced 0 |
+| vLLM disaggregated | 2 prefill + 2 decode; engine block 64; G1 blocks 5,500; max sequences 16; batch tokens 8,192; KV bytes/token 1; 100 GB/s full-prompt transfer | 14 fully readmitted preemptions; 10 fresh-process repetitions produced one digest and identical counters; nearby probes produced 11 at 5,000, 6 at 6,000, 16 at 4,500, and 24 at 4,000 |
 | SGLang aggregated | 4 workers; engine/page block 512; G1 blocks 1,536; max sequences 256; batch tokens 32,768 | 1 retraction; 1,024 produced 8 and 2,048 produced 0 |
-| SGLang disaggregated | 2 prefill + 2 decode; engine/page block 512; G1 blocks 17,408; max sequences 256; batch tokens 32,768; KV bytes/token 262,144; 100 GB/s full-prompt transfer | 2 retractions; 16,384 produced 12 and 18,432 produced 0 |
+| SGLang disaggregated | 2 prefill + 2 decode; engine/page block 512; G1 blocks 11,264; max sequences 256; batch tokens 32,768; KV bytes/token 262,144; 100 GB/s full-prompt transfer | 14 fully readmitted retractions; 10 fresh-process repetitions produced one digest and identical counters; nearby probes produced 11 at 10,752, 7 at 11,776, 6 at 12,288, and 33 at 10,240 |
 
 The vLLM configurations rely on native/default G1 selection. An experiment-only
 `--g1-backend` switch is not required to reproduce the native seeds.
 
-The vLLM disaggregated row was requalified at commit
-`d95e98aa732c50909dd2f7777172c604066c8307` after PR #13052 made prefill replay exactly
-one output token. The former 40,964-block seed now produces zero preemptions and no longer
-exercises the pressure edge. The requalified 16,000-block seed completed all requests with
-exact token totals, 5,000 immediate and zero queued placements in each pool, 4,991 requests
-with reuse, and canonical report SHA-256
-`c60365af08f856d939fd87c30e1b55049630a0e22cf1b371a5c9a5acee82a6cd` in all ten runs.
+At the vLLM disaggregated seed, ten fresh processes completed all requests with exact
+totals of 46,542,297 input and 922,544 output tokens, 14 fully readmitted preemptions,
+5,000 immediate and zero queued placements in each pool, 4,988 requests with reuse, and
+canonical report SHA-256
+`dd693851bdc43cff67fe049ef77cf0f4d41e85c869a0bfd995a85d72147e6ec0` in every run.
 
-For a post-qualification throttle soak, run the same 16,000-block configuration against
-the complete 23,608-row Mooncake trace, SHA-256
-`b434f1816a707f4bac697235588184ebc374c9907cb981bb65fb0643471fe711`. Three fresh
-processes each completed all requests with exact totals of 202,791,701 input and 4,299,817
-output tokens, 23 fully readmitted preemptions, 23,608 immediate and zero queued
-placements in each pool, and canonical report SHA-256
-`e4bb70b88b25986beda2df602fb5b813e57393101c10caa9eace3429667b3eab`.
-The one-to-three pressure target applies to the 5,000-row parity fixture; the full-trace
-soak may exceed it when every pressure event is bounded, readmitted, and followed by exact
-completion.
+At the SGLang disaggregated seed, ten fresh processes completed all requests with exact
+totals of 46,542,297 input and 922,544 output tokens, 14 fully readmitted retractions,
+5,000 immediate and zero queued placements in each pool, 4,990 requests with reuse, and
+canonical report SHA-256
+`c0488fcb82bb5c66b1c0d13b6b0b9c043fdadbf6f90ea171a763c38b70027afd` in every run.
+
+The 5,000-row seeds are deliberately tight and are not universal full-trace capacities.
+For a throttle soak against the complete 23,608-row Mooncake trace, SHA-256
+`b434f1816a707f4bac697235588184ebc374c9907cb981bb65fb0643471fe711`, requalify a
+separate capacity instead of copying these values automatically. A full-trace pressure
+count may exceed the 10-to-20 target only when every event is bounded, readmitted, and
+followed by exact completion without pathological replay-loop growth.
 
 ### CLI templates
 
@@ -92,7 +92,7 @@ vLLM disaggregated:
   --num-decode-workers 2 \
   --engine-type vllm \
   --block-size 64 \
-  --num-gpu-blocks 16000 \
+  --num-gpu-blocks 5500 \
   --max-num-seqs 16 \
   --max-num-batched-tokens 8192 \
   --kv-bytes-per-token 1 \
@@ -124,7 +124,7 @@ SGLang disaggregated:
   --num-decode-workers 2 \
   --engine-type sglang \
   --block-size 512 \
-  --num-gpu-blocks 17408 \
+  --num-gpu-blocks 11264 \
   --max-num-seqs 256 \
   --max-num-batched-tokens 32768 \
   --kv-bytes-per-token 262144 \
@@ -141,15 +141,15 @@ detectors:
 | Engine and topology | Requests with reuse | Worker and handoff evidence |
 | --- | --- | --- |
 | vLLM aggregated | 4,918 | decode workers 0–3 |
-| vLLM disaggregated | 4,991 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
+| vLLM disaggregated | 4,988 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
 | SGLang aggregated | 4,840 | decode workers 0–3 |
-| SGLang disaggregated | 4,992 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
+| SGLang disaggregated | 4,990 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
 
 The offline replay CLI defaults `router_queue_threshold` to unset, so these templates do
-not exercise router queueing. In the requalified vLLM disaggregated runs, every placement
-in both pools was immediate and zero was queued. Require queued-placement evidence only
-when an explicit queue-capable harness or forced fixture enables it; scheduler waiting is
-not router queueing.
+not exercise router queueing. At both qualified disaggregated seeds, every placement in
+both pools was immediate and zero was queued. Require queued-placement evidence only when
+an explicit queue-capable harness or forced fixture enables it; scheduler waiting is not
+router queueing.
 
 Every row must complete all 5,000 requests with no rejected, canceled, failed, or stranded
 requests. A changed counter is not automatically a product failure, but it means the seed


### PR DESCRIPTION
## Summary

- make the offline KV replay parity workflow native-only now that the KVBM integration is being retired and no separate native offload path exists
- build the authoritative artifact with only `replay-bench`, remove offload matrix/lifecycle requirements, and require explicit queue enablement before claiming queued-placement coverage
- requalify the post-#13052 vLLM disaggregated pressure edge at 16,000 G1 blocks and record a full-trace throttle-soak prescription

This changes only the agent skill and its golden-point reference. It does not add or replace an offload implementation.

## Validation

- Canonical 5,000-row Mooncake window: 10/10 fresh native-only processes completed all requests with exact token totals, one fully readmitted preemption, 5,000 immediate and zero queued placements per pool, and identical report SHA-256 `c60365af08f856d939fd87c30e1b55049630a0e22cf1b371a5c9a5acee82a6cd`.
- Full 23,608-row throttle soak: 3/3 fresh processes completed with exact totals of 202,791,701 input and 4,299,817 output tokens, 23 fully readmitted preemptions, and identical report SHA-256 `e4bb70b88b25986beda2df602fb5b813e57393101c10caa9eace3429667b3eab` on a CPU-only ARM64 Neoverse V2 host.
- `scripts/validate_skills.py`: `validated 18 skills: OK`; skill quick validation, commit hooks, and `git diff --check` passed.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated replay guidance to focus on native vLLM and SGLang workflows.
  * Simplified build and configuration instructions for replay benchmarking.
  * Clarified queued-placement requirements and rare-lifecycle fixture configuration.
  * Refined performance measurement guidance to focus on replay-loop timing.
  * Updated golden-point examples, qualification results, reuse expectations, and worker/handoff verification details.
  * Documented default routing behavior for immediate placement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->