### PR TITLE
refactor: Use explicit list control_ports for vLLM router hints

### DIFF
--- a/components/src/dynamo/vllm/router_hints.py
+++ b/components/src/dynamo/vllm/router_hints.py
@@ -69,26 +69,17 @@ def _router_hint_source_host(host: str | None) -> str | None:
     return address.compressed
 
 
-def _router_hint_source_control_endpoint(
-    tier: Mapping[str, Any], port_offset: int = 0
-) -> str | None:
-    """Build one advertisable source-control endpoint for a tier and DP offset."""
-    configured_port = tier.get("control_port")
-    if not isinstance(configured_port, (int, str)):
+def _router_hint_source_port(configured_port: object) -> int | None:
+    """Normalize one configured source-control port."""
+    if isinstance(configured_port, bool) or not isinstance(configured_port, (int, str)):
         return None
     try:
-        control_port = int(configured_port) + port_offset
+        control_port = int(configured_port)
     except ValueError:
         return None
     if not 0 < control_port <= 65535:
         return None
-    configured_host = tier.get("control_advertise_host") or tier.get("control_host")
-    host = _router_hint_source_host(
-        configured_host if isinstance(configured_host, str) else None
-    )
-    if host is None:
-        return None
-    return f"tcp://{host}:{control_port}"
+    return control_port
 
 
 def _router_hint_source_control_endpoints(
@@ -98,12 +89,28 @@ def _router_hint_source_control_endpoints(
     dp_start, dp_size = dp_range
     if dp_start < 0 or dp_size <= 0:
         return None
+    control_ports = tier.get("control_ports")
+    if not isinstance(control_ports, list):
+        raise ValueError("router_hint support requires control_ports to be a list")
+    dp_end = dp_start + dp_size
+    if len(control_ports) < dp_end:
+        raise ValueError(
+            "router_hint support requires control_ports to contain at least "
+            f"{dp_end} entries because ports are indexed by global DP rank; "
+            f"got {len(control_ports)}"
+        )
+    configured_host = tier.get("control_advertise_host")
+    host = _router_hint_source_host(
+        configured_host if isinstance(configured_host, str) else None
+    )
+    if host is None:
+        return None
     endpoints: dict[str, str] = {}
-    for local_dp_rank in range(dp_size):
-        endpoint = _router_hint_source_control_endpoint(tier, local_dp_rank)
-        if endpoint is None:
+    for global_dp_rank in range(dp_start, dp_end):
+        control_port = _router_hint_source_port(control_ports[global_dp_rank])
+        if control_port is None:
             return None
-        endpoints[str(dp_start + local_dp_rank)] = endpoint
+        endpoints[str(global_dp_rank)] = f"tcp://{host}:{control_port}"
     return endpoints
 
 

--- a/components/src/dynamo/vllm/router_hints.py
+++ b/components/src/dynamo/vllm/router_hints.py
@@ -85,18 +85,22 @@ def _router_hint_source_port(configured_port: object) -> int | None:
 def _router_hint_source_control_endpoints(
     tier: Mapping[str, Any], dp_range: tuple[int, int]
 ) -> dict[str, str] | None:
-    """Build source-control endpoints keyed by global DP rank."""
+    """Build source-control endpoints keyed by global DP rank.
+
+    ``control_ports`` is local to this worker: entry 0 belongs to dp_start,
+    entry 1 belongs to dp_start + 1, and so on. vLLM/KVCC selects from the
+    same list with data_parallel_rank_local.
+    """
     dp_start, dp_size = dp_range
     if dp_start < 0 or dp_size <= 0:
         return None
     control_ports = tier.get("control_ports")
     if not isinstance(control_ports, list):
         raise ValueError("router_hint support requires control_ports to be a list")
-    dp_end = dp_start + dp_size
-    if len(control_ports) < dp_end:
+    if len(control_ports) != dp_size:
         raise ValueError(
-            "router_hint support requires control_ports to contain at least "
-            f"{dp_end} entries because ports are indexed by global DP rank; "
+            "router_hint support requires control_ports to contain exactly "
+            f"{dp_size} entries for the worker-local DP ranks; "
             f"got {len(control_ports)}"
         )
     configured_host = tier.get("control_advertise_host")
@@ -106,8 +110,8 @@ def _router_hint_source_control_endpoints(
     if host is None:
         return None
     endpoints: dict[str, str] = {}
-    for global_dp_rank in range(dp_start, dp_end):
-        control_port = _router_hint_source_port(control_ports[global_dp_rank])
+    for local_dp_rank, global_dp_rank in enumerate(range(dp_start, dp_start + dp_size)):
+        control_port = _router_hint_source_port(control_ports[local_dp_rank])
         if control_port is None:
             return None
         endpoints[str(global_dp_rank)] = f"tcp://{host}:{control_port}"

--- a/components/src/dynamo/vllm/tests/test_router_hints.py
+++ b/components/src/dynamo/vllm/tests/test_router_hints.py
@@ -71,21 +71,14 @@ pytestmark = [
             {"0": "tcp://worker-a:23280"},
             id="decode-worker-type",
         ),
-        # A worker managing global DP ranks 4 and 5 uses control_ports[4:6].
+        # A worker managing global DP ranks 4 and 5 uses local ports[0:2].
         pytest.param(
             {
                 "type": "custom",
                 "router_capabilities": ["router_hint"],
                 "control_host": "0.0.0.0",
                 "control_advertise_host": "worker-a",
-                "control_ports": [
-                    "23280",
-                    "23281",
-                    "23282",
-                    "23283",
-                    "24000",
-                    "24001",
-                ],
+                "control_ports": ["24000", "24001"],
             },
             WorkerType.Prefill,
             (4, 2),
@@ -213,25 +206,19 @@ def test_enable_router_hint_support_skips_without_supported_hint_participant(
             "router_hint support requires",
             id="invalid-control-port",
         ),
-        # Global-DP-indexed lists must include entries for every managed rank.
+        # The port list is worker-local, so it must match this worker's DP size.
         pytest.param(
             [
                 {
                     "type": "custom",
                     "router_capabilities": ["router_hint"],
                     "control_advertise_host": "worker-a",
-                    "control_ports": [
-                        "23280",
-                        "23281",
-                        "23282",
-                        "23283",
-                        "24000",
-                    ],
+                    "control_ports": ["24000"],
                 }
             ],
             (4, 2),
             "router_hint support requires",
-            id="missing-ports-for-managed-dp-range",
+            id="wrong-local-port-count-for-managed-dp-range",
         ),
         # Exactly one secondary tier may provide router-hint source endpoints.
         pytest.param(

--- a/components/src/dynamo/vllm/tests/test_router_hints.py
+++ b/components/src/dynamo/vllm/tests/test_router_hints.py
@@ -23,267 +23,279 @@ pytestmark = [
 ]
 
 
-def test_enable_router_hint_support_publishes_single_dp_rank_endpoint():
+# Success cases: a router-hint-capable tier publishes capability, worker role,
+# and source-control endpoints keyed by global DP rank.
+@pytest.mark.parametrize(
+    ("tier", "worker_type", "dp_range", "expected_worker_type", "expected_endpoints"),
+    [
+        # Single-rank prefill worker publishes rank 0 with the advertise host.
+        pytest.param(
+            {
+                "type": "custom",
+                "router_capabilities": ["router_hint"],
+                "control_host": "0.0.0.0",
+                "control_advertise_host": "127.0.0.1",
+                "control_ports": ["23280"],
+            },
+            WorkerType.Prefill,
+            (0, 1),
+            "prefill",
+            {"0": "tcp://127.0.0.1:23280"},
+            id="single-dp-prefill",
+        ),
+        # Aggregated workers are valid hint participants and publish that role.
+        pytest.param(
+            {
+                "type": "custom",
+                "router_capabilities": ["router_hint"],
+                "control_advertise_host": "worker-a",
+                "control_ports": ["23280"],
+            },
+            WorkerType.Aggregated,
+            (0, 1),
+            "aggregated",
+            {"0": "tcp://worker-a:23280"},
+            id="aggregated-worker-type",
+        ),
+        # Decode workers are valid hint participants and publish that role.
+        pytest.param(
+            {
+                "type": "custom",
+                "router_capabilities": ["router_hint"],
+                "control_advertise_host": "worker-a",
+                "control_ports": ["23280"],
+            },
+            WorkerType.Decode,
+            (0, 1),
+            "decode",
+            {"0": "tcp://worker-a:23280"},
+            id="decode-worker-type",
+        ),
+        # A worker managing global DP ranks 4 and 5 uses control_ports[4:6].
+        pytest.param(
+            {
+                "type": "custom",
+                "router_capabilities": ["router_hint"],
+                "control_host": "0.0.0.0",
+                "control_advertise_host": "worker-a",
+                "control_ports": [
+                    "23280",
+                    "23281",
+                    "23282",
+                    "23283",
+                    "24000",
+                    "24001",
+                ],
+            },
+            WorkerType.Prefill,
+            (4, 2),
+            "prefill",
+            {"4": "tcp://worker-a:24000", "5": "tcp://worker-a:24001"},
+            id="global-dp-rank-endpoints",
+        ),
+        # IPv6 advertise hosts are bracketed before publishing tcp:// endpoints.
+        pytest.param(
+            {
+                "type": "custom",
+                "router_capabilities": ["router_hint"],
+                "control_advertise_host": "2001:db8::1",
+                "control_ports": ["23280"],
+            },
+            WorkerType.Prefill,
+            (0, 1),
+            "prefill",
+            {"0": "tcp://[2001:db8::1]:23280"},
+            id="ipv6-advertise-host",
+        ),
+    ],
+)
+def test_enable_router_hint_support_publishes_runtime_metadata(
+    tier, worker_type, dp_range, expected_worker_type, expected_endpoints
+):
     runtime_config = MagicMock()
     engine_args = SimpleNamespace(
         kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "custom",
-                        "router_capabilities": ["router_hint"],
-                        "control_host": "0.0.0.0",
-                        "control_advertise_host": "127.0.0.1",
-                        "control_port": "23280",
-                    }
-                ]
-            }
+            kv_connector_extra_config={"secondary_tiers": [tier]}
         )
     )
 
-    enable_router_hint_support(runtime_config, engine_args, WorkerType.Prefill)
+    enable_router_hint_support(
+        runtime_config, engine_args, worker_type, dp_range=dp_range
+    )
 
     runtime_config.set_engine_specific.assert_any_call(
         ROUTER_HINT_RUNTIME_CAPABILITY_KEY, json.dumps(True)
     )
     runtime_config.set_engine_specific.assert_any_call(
-        ROUTER_HINT_WORKER_TYPE_RUNTIME_KEY, json.dumps("prefill")
+        ROUTER_HINT_WORKER_TYPE_RUNTIME_KEY, json.dumps(expected_worker_type)
     )
     runtime_config.set_engine_specific.assert_any_call(
         ROUTER_HINT_SOURCE_CONTROL_ENDPOINTS_RUNTIME_KEY,
-        json.dumps({"0": "tcp://127.0.0.1:23280"}),
+        json.dumps(expected_endpoints),
     )
 
 
+# Skip cases: without both router-hint capability and a supported worker role,
+# registration leaves runtime metadata untouched instead of failing.
 @pytest.mark.parametrize(
-    ("worker_type", "expected_runtime_value"),
+    ("tier", "worker_type"),
     [
-        (WorkerType.Aggregated, "aggregated"),
-        (WorkerType.Decode, "decode"),
+        # Tier does not opt in with router_capabilities=["router_hint"].
+        pytest.param(
+            {
+                "type": "custom",
+                "control_host": "0.0.0.0",
+                "control_advertise_host": "127.0.0.1",
+                "control_ports": ["23280"],
+            },
+            WorkerType.Prefill,
+            id="without-router-hint-capability",
+        ),
+        # Encode workers do not consume or serve router hints today.
+        pytest.param(
+            {
+                "type": "custom",
+                "router_capabilities": ["router_hint"],
+                "control_host": "0.0.0.0",
+                "control_advertise_host": "127.0.0.1",
+                "control_ports": ["23280"],
+            },
+            WorkerType.Encode,
+            id="unsupported-encode-worker",
+        ),
     ],
 )
-def test_enable_router_hint_support_publishes_worker_type(
-    worker_type, expected_runtime_value
+def test_enable_router_hint_support_skips_without_supported_hint_participant(
+    tier, worker_type
 ):
     runtime_config = MagicMock()
     engine_args = SimpleNamespace(
         kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "custom",
-                        "router_capabilities": ["router_hint"],
-                        "control_advertise_host": "worker-a",
-                        "control_port": "23280",
-                    }
-                ]
-            }
+            kv_connector_extra_config={"secondary_tiers": [tier]}
         )
     )
 
     enable_router_hint_support(runtime_config, engine_args, worker_type)
 
-    runtime_config.set_engine_specific.assert_any_call(
-        ROUTER_HINT_WORKER_TYPE_RUNTIME_KEY, json.dumps(expected_runtime_value)
-    )
-
-
-def test_enable_router_hint_support_publishes_dp_rank_endpoints():
-    runtime_config = MagicMock()
-    engine_args = SimpleNamespace(
-        kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "custom",
-                        "router_capabilities": ["router_hint"],
-                        "control_host": "0.0.0.0",
-                        "control_advertise_host": "worker-a",
-                        "control_port": "23280",
-                    }
-                ]
-            }
-        )
-    )
-
-    enable_router_hint_support(
-        runtime_config, engine_args, WorkerType.Prefill, dp_range=(4, 2)
-    )
-
-    runtime_config.set_engine_specific.assert_any_call(
-        ROUTER_HINT_SOURCE_CONTROL_ENDPOINTS_RUNTIME_KEY,
-        json.dumps({"4": "tcp://worker-a:23280", "5": "tcp://worker-a:23281"}),
-    )
-
-
-def test_enable_router_hint_support_brackets_ipv6_endpoint():
-    runtime_config = MagicMock()
-    engine_args = SimpleNamespace(
-        kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "custom",
-                        "router_capabilities": ["router_hint"],
-                        "control_advertise_host": "2001:db8::1",
-                        "control_port": "23280",
-                    }
-                ]
-            }
-        )
-    )
-
-    enable_router_hint_support(runtime_config, engine_args, WorkerType.Prefill)
-
-    runtime_config.set_engine_specific.assert_any_call(
-        ROUTER_HINT_SOURCE_CONTROL_ENDPOINTS_RUNTIME_KEY,
-        json.dumps({"0": "tcp://[2001:db8::1]:23280"}),
-    )
-
-
-def test_enable_router_hint_support_rejects_dp_offset_port_overflow():
-    runtime_config = MagicMock()
-    engine_args = SimpleNamespace(
-        kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "custom",
-                        "router_capabilities": ["router_hint"],
-                        "control_advertise_host": "worker-a",
-                        "control_port": "65535",
-                    }
-                ]
-            }
-        )
-    )
-
-    with pytest.raises(ValueError, match="router_hint support requires"):
-        enable_router_hint_support(
-            runtime_config, engine_args, WorkerType.Prefill, dp_range=(0, 2)
-        )
-
     runtime_config.set_engine_specific.assert_not_called()
 
 
-@pytest.mark.parametrize("dp_range", [(-1, 1), (0, 0)])
-def test_enable_router_hint_support_rejects_invalid_dp_range(dp_range):
+# Fail cases: once a supported worker opts into router hints, the advertised
+# endpoint metadata must be complete and internally consistent.
+@pytest.mark.parametrize(
+    ("secondary_tiers", "dp_range", "error_match"),
+    [
+        # control_host is bind-only; router hints require control_advertise_host.
+        pytest.param(
+            [
+                {
+                    "type": "custom",
+                    "router_capabilities": ["router_hint"],
+                    "control_host": "worker-a",
+                    "control_ports": [23280],
+                }
+            ],
+            (0, 1),
+            "router_hint support requires",
+            id="without-advertise-host",
+        ),
+        # Every published endpoint port must be in the valid TCP port range.
+        pytest.param(
+            [
+                {
+                    "type": "custom",
+                    "router_capabilities": ["router_hint"],
+                    "control_advertise_host": "worker-a",
+                    "control_ports": ["65535", "65536"],
+                }
+            ],
+            (0, 2),
+            "router_hint support requires",
+            id="invalid-control-port",
+        ),
+        # Global-DP-indexed lists must include entries for every managed rank.
+        pytest.param(
+            [
+                {
+                    "type": "custom",
+                    "router_capabilities": ["router_hint"],
+                    "control_advertise_host": "worker-a",
+                    "control_ports": [
+                        "23280",
+                        "23281",
+                        "23282",
+                        "23283",
+                        "24000",
+                    ],
+                }
+            ],
+            (4, 2),
+            "router_hint support requires",
+            id="missing-ports-for-managed-dp-range",
+        ),
+        # Exactly one secondary tier may provide router-hint source endpoints.
+        pytest.param(
+            [
+                {
+                    "type": "custom-a",
+                    "router_capabilities": ["router_hint"],
+                    "control_advertise_host": "127.0.0.1",
+                    "control_ports": ["23280"],
+                },
+                {
+                    "type": "custom-b",
+                    "router_capabilities": ["router_hint"],
+                    "control_advertise_host": "127.0.0.1",
+                    "control_ports": ["23281"],
+                },
+            ],
+            (0, 1),
+            "exactly one router-hint-capable",
+            id="multiple-router-hint-tiers",
+        ),
+        # DP start rank must be non-negative.
+        pytest.param(
+            [
+                {
+                    "type": "custom",
+                    "router_capabilities": ["router_hint"],
+                    "control_advertise_host": "worker-a",
+                    "control_ports": ["23280"],
+                }
+            ],
+            (-1, 1),
+            "router_hint support requires",
+            id="negative-dp-start",
+        ),
+        # DP size must be positive.
+        pytest.param(
+            [
+                {
+                    "type": "custom",
+                    "router_capabilities": ["router_hint"],
+                    "control_advertise_host": "worker-a",
+                    "control_ports": ["23280"],
+                }
+            ],
+            (0, 0),
+            "router_hint support requires",
+            id="zero-dp-size",
+        ),
+    ],
+)
+def test_enable_router_hint_support_fails_with_invalid_router_hint_config(
+    secondary_tiers, dp_range, error_match
+):
     runtime_config = MagicMock()
     engine_args = SimpleNamespace(
         kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "custom",
-                        "router_capabilities": ["router_hint"],
-                        "control_advertise_host": "worker-a",
-                        "control_port": "23280",
-                    }
-                ]
-            }
+            kv_connector_extra_config={"secondary_tiers": secondary_tiers}
         )
     )
 
-    with pytest.raises(ValueError, match="router_hint support requires"):
+    with pytest.raises(ValueError, match=error_match):
         enable_router_hint_support(
             runtime_config, engine_args, WorkerType.Prefill, dp_range=dp_range
         )
-
-    runtime_config.set_engine_specific.assert_not_called()
-
-
-def test_enable_router_hint_support_fails_with_multiple_router_hint_tiers():
-    runtime_config = MagicMock()
-    engine_args = SimpleNamespace(
-        kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "custom-a",
-                        "router_capabilities": ["router_hint"],
-                        "control_advertise_host": "127.0.0.1",
-                        "control_port": "23280",
-                    },
-                    {
-                        "type": "custom-b",
-                        "router_capabilities": ["router_hint"],
-                        "control_advertise_host": "127.0.0.1",
-                        "control_port": "23281",
-                    },
-                ]
-            }
-        )
-    )
-
-    with pytest.raises(ValueError, match="exactly one router-hint-capable"):
-        enable_router_hint_support(runtime_config, engine_args, WorkerType.Prefill)
-
-    runtime_config.set_engine_specific.assert_not_called()
-
-
-def test_enable_router_hint_support_skips_for_unsupported_worker_roles():
-    runtime_config = MagicMock()
-    engine_args = SimpleNamespace(
-        kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "kvcc",
-                        "router_capabilities": ["router_hint"],
-                        "control_host": "0.0.0.0",
-                        "control_advertise_host": "127.0.0.1",
-                        "control_port": "23280",
-                    }
-                ]
-            }
-        )
-    )
-
-    enable_router_hint_support(runtime_config, engine_args, WorkerType.Encode)
-
-    runtime_config.set_engine_specific.assert_not_called()
-
-
-def test_enable_router_hint_support_skips_without_router_hint_capability():
-    runtime_config = MagicMock()
-    engine_args = SimpleNamespace(
-        kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "kvcc",
-                        "control_host": "0.0.0.0",
-                        "control_advertise_host": "127.0.0.1",
-                        "control_port": "23280",
-                    }
-                ]
-            }
-        )
-    )
-
-    enable_router_hint_support(runtime_config, engine_args, WorkerType.Prefill)
-
-    runtime_config.set_engine_specific.assert_not_called()
-
-
-def test_enable_router_hint_support_fails_without_advertisable_endpoint():
-    runtime_config = MagicMock()
-    engine_args = SimpleNamespace(
-        kv_transfer_config=SimpleNamespace(
-            kv_connector_extra_config={
-                "secondary_tiers": [
-                    {
-                        "type": "kvcc",
-                        "router_capabilities": ["router_hint"],
-                        "control_host": "0.0.0.0",
-                        "control_port": 23280,
-                    }
-                ]
-            }
-        )
-    )
-
-    with pytest.raises(ValueError, match="router_hint support requires"):
-        enable_router_hint_support(runtime_config, engine_args, WorkerType.Prefill)
 
     runtime_config.set_engine_specific.assert_not_called()

--- a/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
@@ -119,8 +119,8 @@ async def test_prefill_load_records_and_publishes_without_eager_engine_add(
 async def test_prefill_lora_registration_preserves_worker_dp_range(monkeypatch):
     # LoRA registration builds a fresh ModelRuntimeConfig for the adapter card.
     # This checks that a parent worker owning global DP ranks 4 and 5 publishes
-    # the same range on the LoRA card, with router-hint endpoints keyed as
-    # {"4": "tcp://...:24000", "5": "tcp://...:24001"}.
+    # the same range on the LoRA card, with local control ports mapped onto
+    # global endpoints as {"4": "tcp://...:24000", "5": "tcp://...:24001"}.
     handler = _make_prefill_handler()
     handler.dp_range = (4, 2)
     handler.config.engine_args.kv_transfer_config = SimpleNamespace(
@@ -130,14 +130,7 @@ async def test_prefill_lora_registration_preserves_worker_dp_range(monkeypatch):
                     "type": "custom",
                     "router_capabilities": ["router_hint"],
                     "control_advertise_host": "worker-a",
-                    "control_ports": [
-                        "23280",
-                        "23281",
-                        "23282",
-                        "23283",
-                        "24000",
-                        "24001",
-                    ],
+                    "control_ports": ["24000", "24001"],
                 }
             ]
         }

--- a/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
@@ -166,7 +166,7 @@ async def test_prefill_lora_registration_preserves_worker_dp_range(monkeypatch):
     assert runtime_config.data_parallel_size == 2
     assert json.loads(
         runtime_config.runtime_data[ROUTER_HINT_SOURCE_CONTROL_ENDPOINTS_RUNTIME_KEY]
-    ) == {"4": "tcp://worker-a:23280", "5": "tcp://worker-a:23281"}
+    ) == {"4": "tcp://worker-a:24000", "5": "tcp://worker-a:24001"}
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
@@ -120,7 +120,7 @@ async def test_prefill_lora_registration_preserves_worker_dp_range(monkeypatch):
     # LoRA registration builds a fresh ModelRuntimeConfig for the adapter card.
     # This checks that a parent worker owning global DP ranks 4 and 5 publishes
     # the same range on the LoRA card, with router-hint endpoints keyed as
-    # {"4": "tcp://...:23280", "5": "tcp://...:23281"}.
+    # {"4": "tcp://...:24000", "5": "tcp://...:24001"}.
     handler = _make_prefill_handler()
     handler.dp_range = (4, 2)
     handler.config.engine_args.kv_transfer_config = SimpleNamespace(
@@ -130,7 +130,14 @@ async def test_prefill_lora_registration_preserves_worker_dp_range(monkeypatch):
                     "type": "custom",
                     "router_capabilities": ["router_hint"],
                     "control_advertise_host": "worker-a",
-                    "control_port": "23280",
+                    "control_ports": [
+                        "23280",
+                        "23281",
+                        "23282",
+                        "23283",
+                        "24000",
+                        "24001",
+                    ],
                 }
             ]
         }


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This PR updates vLLM router-hint endpoint publication to use explicit list of per-DP-rank control_ports instead of deriving ports with control_port + rank_offset.

This matches the recent contract change where each DP rank selects its control port from the configured control_ports list.

## Details:

<!-- Describe the changes made in this PR. -->

have some test refactoring as well

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Router endpoints now support individually configured control ports for each data-parallel rank.
  * Added validation for control ports, advertised hosts, endpoint formatting, and data-parallel ranges.
  * IPv6 control endpoints are now supported.

* **Bug Fixes**
  * Prevented invalid or incomplete endpoint configurations from being accepted.
  * Corrected endpoint selection for workers using global data-parallel ranks.
  * Router metadata is no longer registered for unsupported worker types or configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->