### PR TITLE
feat(workflow): add vLLM decoder stage adapter

### DIFF
--- a/components/src/dynamo/vllm/decoder_stage.py
+++ b/components/src/dynamo/vllm/decoder_stage.py
@@ -40,17 +40,18 @@ class VllmDecoderStage:
 
     def __init__(self, runtime: VllmDecoderRuntime) -> None:
         self._runtime = runtime
-        self._active_requests: dict[str, str] = {}
+        self._active_requests: dict[str, set[str]] = {}
 
     async def run(
         self, inputs: Mapping[str, Any], context: StageContext
     ) -> Mapping[str, Any]:
         native_request_id = self._native_request_id(context)
-        if context.attempt_id in self._active_requests:
+        active = self._active_requests.setdefault(context.attempt_id, set())
+        if native_request_id in active:
             raise RuntimeError(
-                f"decoder attempt {context.attempt_id!r} is already active"
+                f"decoder invocation {native_request_id!r} is already active"
             )
-        self._active_requests[context.attempt_id] = native_request_id
+        active.add(native_request_id)
         try:
             chunk = await self._generate_final(
                 cast(GenerateRequest, inputs["request"]),
@@ -59,7 +60,9 @@ class VllmDecoderStage:
             )
             return {"chunk": chunk}
         finally:
-            self._active_requests.pop(context.attempt_id, None)
+            active.discard(native_request_id)
+            if not active:
+                self._active_requests.pop(context.attempt_id, None)
 
     @property
     def model_config(self) -> ModelConfig:
@@ -70,9 +73,10 @@ class VllmDecoderStage:
     async def abort_attempt(self, attempt_id: str) -> None:
         """Abort this stage's active native request for a workflow attempt."""
 
-        request_id = self._active_requests.get(attempt_id)
-        if request_id is not None:
-            await self._runtime.abort(request_id)
+        request_ids = tuple(self._active_requests.get(attempt_id, ()))
+        await asyncio.gather(
+            *(self._runtime.abort(request_id) for request_id in request_ids)
+        )
 
     async def _generate_final(
         self,
@@ -144,4 +148,4 @@ class VllmDecoderStage:
 
     @staticmethod
     def _native_request_id(context: StageContext) -> str:
-        return f"{context.attempt_id}:{context.stage_id}"
+        return context.invocation_id

--- a/components/src/dynamo/vllm/decoder_stage.py
+++ b/components/src/dynamo/vllm/decoder_stage.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workflow adapter for an in-process vLLM decoder runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Mapping
+from typing import Any, cast
+
+from vllm.config import ModelConfig
+
+from dynamo.common.backend import GenerateChunk, GenerateRequest
+from dynamo.llm.exceptions import InvalidArgument
+from dynamo.vllm.decoder_runtime import DecodeOutputMode, VllmDecoderRuntime
+from dynamo.workflow import StageContext, StageContract, ValueSpec
+
+logger = logging.getLogger(__name__)
+
+
+class VllmDecoderStage:
+    """Adapt a borrowed decoder runtime to the local workflow stage contract."""
+
+    contract = StageContract(
+        id="vllm-decoder",
+        inputs={
+            "request": ValueSpec(
+                type="object", class_id="dynamo.common.backend.GenerateRequest"
+            ),
+            "prompt": ValueSpec(type="object", class_id="dynamo.vllm.PreparedPrompt"),
+        },
+        outputs={
+            "chunk": ValueSpec(
+                type="object", class_id="dynamo.common.backend.GenerateChunk"
+            )
+        },
+    )
+
+    def __init__(self, runtime: VllmDecoderRuntime) -> None:
+        self._runtime = runtime
+        self._active_requests: dict[str, str] = {}
+
+    async def run(
+        self, inputs: Mapping[str, Any], context: StageContext
+    ) -> Mapping[str, Any]:
+        native_request_id = self._native_request_id(context)
+        if context.attempt_id in self._active_requests:
+            raise RuntimeError(
+                f"decoder attempt {context.attempt_id!r} is already active"
+            )
+        self._active_requests[context.attempt_id] = native_request_id
+        try:
+            chunk = await self._generate_final(
+                cast(GenerateRequest, inputs["request"]),
+                inputs["prompt"],
+                native_request_id,
+            )
+            return {"chunk": chunk}
+        finally:
+            self._active_requests.pop(context.attempt_id, None)
+
+    @property
+    def model_config(self) -> ModelConfig:
+        """Resolved decoder model configuration for prompt adapters."""
+
+        return self._runtime.model_config
+
+    async def abort_attempt(self, attempt_id: str) -> None:
+        """Abort this stage's active native request for a workflow attempt."""
+
+        request_id = self._active_requests.get(attempt_id)
+        if request_id is not None:
+            await self._runtime.abort(request_id)
+
+    async def _generate_final(
+        self,
+        request: GenerateRequest,
+        prompt: Any,
+        request_id: str,
+    ) -> GenerateChunk:
+        prompt_token_ids = prompt.get("prompt_token_ids")
+        if not isinstance(prompt_token_ids, list):
+            raise InvalidArgument(
+                "prepared decoder prompt must contain prompt_token_ids"
+            )
+
+        self._validate_final_request(request)
+        sampling_params = self._runtime.prepare_sampling_params(
+            request,
+            prompt=prompt,
+            output_mode=DecodeOutputMode.FINAL_ONLY,
+        )
+        completed = False
+        final_chunk: GenerateChunk | None = None
+        try:
+            async for chunk in self._runtime.decode(
+                prompt,
+                sampling_params,
+                request_id,
+            ):
+                if final_chunk is not None:
+                    raise RuntimeError(
+                        "vLLM returned multiple chunks for final-only generation"
+                    )
+                final_chunk = chunk
+            if final_chunk is None:
+                raise RuntimeError("vLLM returned no final output")
+            finish_reason = final_chunk.get("finish_reason")
+            if not finish_reason:
+                raise RuntimeError("vLLM final output did not include a finish reason")
+            if str(finish_reason).startswith("error"):
+                raise RuntimeError(str(finish_reason))
+            if final_chunk.get("index", 0) != 0:
+                raise RuntimeError(
+                    "vLLM returned unexpected output index "
+                    f"{final_chunk.get('index')}"
+                )
+            completed = True
+            return final_chunk
+        finally:
+            if not completed:
+                try:
+                    await asyncio.shield(self._runtime.abort(request_id))
+                except Exception:
+                    logger.exception("Failed to abort vLLM request %s", request_id)
+
+    @staticmethod
+    def _validate_final_request(request: GenerateRequest) -> None:
+        sampling_options = request.get("sampling_options") or {}
+        n = sampling_options.get("n")
+        if n not in (None, 1):
+            raise InvalidArgument(
+                f"VllmDecoderStage supports exactly one choice; got n={n}"
+            )
+
+        output_options = request.get("output_options") or {}
+        if (
+            output_options.get("logprobs") is not None
+            or output_options.get("prompt_logprobs") is not None
+        ):
+            raise InvalidArgument("VllmDecoderStage does not support logprobs")
+
+    @staticmethod
+    def _native_request_id(context: StageContext) -> str:
+        return f"{context.attempt_id}:{context.stage_id}"

--- a/components/src/dynamo/vllm/tests/test_vllm_decoder_stage.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_decoder_stage.py
@@ -250,10 +250,7 @@ async def test_repeated_attempt_can_run_concurrent_decoder_invocations() -> None
     engine.started = asyncio.Event()
     engine.release = asyncio.Event()
     stage = VllmDecoderStage(runtime)
-    inputs = {
-        "request": _request(),
-        "prompt": {"prompt_token_ids": [1]},
-    }
+    inputs = _inputs([1])
     first = asyncio.create_task(
         stage.run(inputs, _context("attempt-8", invocation_id="attempt-8:1"))
     )

--- a/components/src/dynamo/vllm/tests/test_vllm_decoder_stage.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_decoder_stage.py
@@ -250,7 +250,10 @@ async def test_repeated_attempt_can_run_concurrent_decoder_invocations() -> None
     engine.started = asyncio.Event()
     engine.release = asyncio.Event()
     stage = VllmDecoderStage(runtime)
-    inputs = _inputs([1])
+    inputs = {
+        "request": _request(),
+        "prompt": {"prompt_token_ids": [1]},
+    }
     first = asyncio.create_task(
         stage.run(inputs, _context("attempt-8", invocation_id="attempt-8:1"))
     )

--- a/components/src/dynamo/vllm/tests/test_vllm_decoder_stage.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_decoder_stage.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+pytest.importorskip(
+    "dynamo._core.backend",
+    reason="dynamo._core.backend not built — run maturin develop first",
+)
+pytest.importorskip(
+    "vllm.engine.arg_utils",
+    reason="a full vLLM installation is required by the decoder stage",
+)
+
+from vllm.sampling_params import RequestOutputKind  # noqa: E402
+
+from dynamo.llm.exceptions import InvalidArgument  # noqa: E402
+from dynamo.vllm.decoder_runtime import VllmDecoderRuntime  # noqa: E402
+from dynamo.vllm.decoder_stage import VllmDecoderStage  # noqa: E402
+from dynamo.workflow import StageContext  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+]
+
+
+class _FakeEngine:
+    tokenizer = None
+
+    def __init__(self) -> None:
+        self.sampling_params: Any = None
+        self.request_ids: list[str] = []
+        self.abort_ids: list[str] = []
+        self.failure: Exception | None = None
+        self.started: asyncio.Event | None = None
+        self.release: asyncio.Event | None = None
+
+    def generate(self, prompt, sampling_params, request_id, **_options):
+        self.sampling_params = sampling_params
+        self.request_ids.append(request_id)
+
+        async def stream():
+            if self.started is not None:
+                self.started.set()
+            if self.release is not None:
+                await self.release.wait()
+            if self.failure is not None:
+                raise self.failure
+            yield SimpleNamespace(
+                prompt_token_ids=prompt["prompt_token_ids"],
+                prompt_logprobs=None,
+                num_cached_tokens=None,
+                outputs=[
+                    SimpleNamespace(
+                        index=0,
+                        token_ids=[4, 2],
+                        finish_reason="stop",
+                        stop_reason=None,
+                        logprobs=None,
+                        routed_experts=None,
+                    )
+                ],
+            )
+
+        return stream()
+
+    async def abort(self, request_id: str) -> None:
+        self.abort_ids.append(request_id)
+
+    def shutdown(self, *, timeout: float) -> None:
+        del timeout
+
+
+def _runtime(
+    *, max_model_len: int = 128, defaults: dict[str, Any] | None = None
+) -> tuple[VllmDecoderRuntime, _FakeEngine]:
+    engine = _FakeEngine()
+    runtime = VllmDecoderRuntime(
+        engine=cast(Any, engine),
+        vllm_config=cast(
+            Any,
+            SimpleNamespace(
+                model_config=SimpleNamespace(max_model_len=max_model_len),
+                shutdown_timeout=1.0,
+            ),
+        ),
+        default_sampling_params=defaults,
+    )
+    return runtime, engine
+
+
+def _request(*, max_tokens: int | None = 8, n: int | None = 1) -> dict[str, Any]:
+    stop_conditions: dict[str, Any] = {}
+    if max_tokens is not None:
+        stop_conditions["max_tokens"] = max_tokens
+    return {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {"n": n, "temperature": 0.25},
+        "stop_conditions": stop_conditions,
+        "output_options": {},
+    }
+
+
+def _context(attempt_id: str = "request-1", stage_id: str = "decoder") -> StageContext:
+    return StageContext(
+        workflow_name="test-workflow",
+        stage_id=stage_id,
+        attempt_id=attempt_id,
+        deadline=None,
+        _cancelled=asyncio.Event(),
+    )
+
+
+async def test_stage_uses_shared_final_decode_and_names_native_request() -> None:
+    runtime, engine = _runtime()
+    stage = VllmDecoderStage(runtime)
+
+    result = await stage.run(
+        {
+            "request": _request(),
+            "prompt": {"prompt_token_ids": [1, 2, 3, 99]},
+        },
+        _context(),
+    )
+
+    assert engine.request_ids == ["request-1:decoder"]
+    assert engine.sampling_params.temperature == 0.25
+    assert engine.sampling_params.max_tokens == 8
+    assert engine.sampling_params.detokenize is False
+    assert engine.sampling_params.output_kind == RequestOutputKind.FINAL_ONLY
+    assert result == {
+        "chunk": {
+            "token_ids": [4, 2],
+            "index": 0,
+            "finish_reason": "stop",
+            "completion_usage": {
+                "prompt_tokens": 4,
+                "completion_tokens": 2,
+                "total_tokens": 6,
+                "prompt_tokens_details": None,
+            },
+        }
+    }
+
+
+async def test_default_output_limit_uses_prepared_prompt_length() -> None:
+    runtime, engine = _runtime(max_model_len=10, defaults={"max_tokens": 20})
+
+    await VllmDecoderStage(runtime).run(
+        {
+            "request": _request(max_tokens=None),
+            "prompt": {"prompt_token_ids": [1, 2, 3, 4]},
+        },
+        _context(),
+    )
+
+    assert engine.sampling_params.max_tokens == 6
+
+
+async def test_rejects_requested_output_beyond_prepared_prompt_budget() -> None:
+    runtime, _ = _runtime(max_model_len=10)
+
+    with pytest.raises(InvalidArgument, match="prepared prompt budget"):
+        await VllmDecoderStage(runtime).run(
+            {
+                "request": _request(max_tokens=7),
+                "prompt": {"prompt_token_ids": [1, 2, 3, 4]},
+            },
+            _context(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("request_update", "message"),
+    [
+        ({"sampling_options": {"n": 2}}, "exactly one choice"),
+        ({"output_options": {"logprobs": 1}}, "does not support logprobs"),
+    ],
+)
+async def test_rejects_unsupported_final_output_options(
+    request_update: dict[str, Any],
+    message: str,
+) -> None:
+    request = _request()
+    request.update(request_update)
+    runtime, _ = _runtime()
+
+    with pytest.raises(InvalidArgument, match=message):
+        await VllmDecoderStage(runtime).run(
+            {"request": request, "prompt": {"prompt_token_ids": [1]}},
+            _context(),
+        )
+
+
+async def test_failure_aborts_native_request() -> None:
+    runtime, engine = _runtime()
+    engine.failure = RuntimeError("decode failed")
+
+    with pytest.raises(RuntimeError, match="decode failed"):
+        await VllmDecoderStage(runtime).run(
+            {
+                "request": _request(),
+                "prompt": {"prompt_token_ids": [1]},
+            },
+            _context(),
+        )
+
+    assert engine.abort_ids == ["request-1:decoder"]
+
+
+async def test_external_abort_uses_active_stage_request_id() -> None:
+    runtime, engine = _runtime()
+    engine.started = asyncio.Event()
+    engine.release = asyncio.Event()
+    stage = VllmDecoderStage(runtime)
+    task = asyncio.create_task(
+        stage.run(
+            {
+                "request": _request(),
+                "prompt": {"prompt_token_ids": [1]},
+            },
+            _context("attempt-7", "generator"),
+        )
+    )
+    await engine.started.wait()
+
+    await stage.abort_attempt("attempt-7")
+    engine.release.set()
+    await task
+
+    assert engine.abort_ids == ["attempt-7:generator"]

--- a/components/src/dynamo/vllm/tests/test_vllm_decoder_stage.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_decoder_stage.py
@@ -110,11 +110,16 @@ def _request(*, max_tokens: int | None = 8, n: int | None = 1) -> dict[str, Any]
     }
 
 
-def _context(attempt_id: str = "request-1", stage_id: str = "decoder") -> StageContext:
+def _context(
+    attempt_id: str = "request-1",
+    stage_id: str = "decoder",
+    invocation_id: str | None = None,
+) -> StageContext:
     return StageContext(
         workflow_name="test-workflow",
         stage_id=stage_id,
         attempt_id=attempt_id,
+        invocation_id=invocation_id or f"{attempt_id}:{stage_id}",
         deadline=None,
         _cancelled=asyncio.Event(),
     )
@@ -238,3 +243,30 @@ async def test_external_abort_uses_active_stage_request_id() -> None:
     await task
 
     assert engine.abort_ids == ["attempt-7:generator"]
+
+
+async def test_repeated_attempt_can_run_concurrent_decoder_invocations() -> None:
+    runtime, engine = _runtime()
+    engine.started = asyncio.Event()
+    engine.release = asyncio.Event()
+    stage = VllmDecoderStage(runtime)
+    inputs = {
+        "request": _request(),
+        "prompt": {"prompt_token_ids": [1]},
+    }
+    first = asyncio.create_task(
+        stage.run(inputs, _context("attempt-8", invocation_id="attempt-8:1"))
+    )
+    second = asyncio.create_task(
+        stage.run(inputs, _context("attempt-8", invocation_id="attempt-8:2"))
+    )
+    await engine.started.wait()
+    while len(engine.request_ids) < 2:
+        await asyncio.sleep(0)
+
+    await stage.abort_attempt("attempt-8")
+    engine.release.set()
+    await asyncio.gather(first, second)
+
+    assert set(engine.request_ids) == {"attempt-8:1", "attempt-8:2"}
+    assert set(engine.abort_ids) == {"attempt-8:1", "attempt-8:2"}

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1466,6 +1466,14 @@ def test_build_sampling_params_caps_omitted_max_tokens_to_generation_default():
     sp = build_sampling_params(make({}), {}, model_max_len)
     assert sp.max_tokens == remaining
 
+    sp = build_sampling_params(
+        make({}),
+        defaults,
+        model_max_len,
+        prompt_token_count_override=90,
+    )
+    assert sp.max_tokens == 10
+
 
 def _make_dynamo_config(**overrides):
     """Build a minimal fake DynamoConfig for update_engine_config_with_dynamo tests."""


### PR DESCRIPTION
_Based on #12922._

## Why

Workflow stages need to adapt prepared prompts and typed requests to the shared decoder runtime without duplicating engine behavior. Repeated or concurrent calls in one imperative attempt also require per-invocation native request identity.

## What Change

- Adapt contracted workflow inputs to final-only shared decoder generation.
- Key native requests by workflow invocation identity.
- Track and abort every active decoder invocation per attempt.
- Cover concurrent invocations using the current embeddings and prompt-layout contract.

```mermaid
classDiagram
    VllmDecoderStage --> VllmDecoderRuntime : prepares and runs decode
    VllmDecoderStage ..> StageContext : derives invocation identity
    VllmDecoderRuntime --> AsyncLLM : drives native generation

    note for VllmDecoderStage "Adapts workflow calls and tracks active requests"
```

## Test Plan

- Built H100 decoder runtime/stage suite: 13 passed; pre-commit passed on the direct diff.
- Built stack-tip H100 qualification: 107 workflow, ensemble, and decoder tests passed.
