### PR TITLE
refactor(operator): simplify runtime scale client

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -34,13 +34,9 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/restmapper"
-	"k8s.io/client-go/scale"
 	k8sCache "k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -111,34 +107,6 @@ func LoadAndValidateOperatorConfig(path string) (*configv1alpha1.OperatorConfigu
 	}
 
 	return cfg, nil
-}
-
-func createScalesGetter(mgr ctrl.Manager) (scale.ScalesGetter, error) {
-	config := mgr.GetConfig()
-
-	// Create kubernetes client for discovery
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create cached discovery client
-	cachedDiscovery := memory.NewMemCacheClient(kubeClient.Discovery())
-
-	// Create REST mapper
-	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscovery)
-
-	scalesGetter, err := scale.NewForConfig(
-		config,
-		restMapper,
-		dynamic.LegacyAPIPathResolverFunc,
-		scale.NewDiscoveryScaleKindResolver(cachedDiscovery),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return scalesGetter, nil
 }
 
 func initCRDSchemes() {
@@ -635,17 +603,11 @@ func registerControllers(
 		return err
 	}
 
-	scaleClient, err := createScalesGetter(mgr)
-	if err != nil {
-		return fmt.Errorf("unable to create scale client: %w", err)
-	}
-
 	rbacManager := rbac.NewManager(mgr.GetClient())
 
 	if err := controller.SetupDynamoGraphDeployment(mgr, controller.DynamoGraphDeploymentSetupOptions{
 		SetupOptions:          setupOptions,
 		DockerSecretRetriever: dockerSecretRetriever,
-		ScaleClient:           scaleClient,
 		RBACManager:           rbacManager,
 		SSHKeyManager:         sshKeyManager,
 	}); err != nil {

--- a/deploy/operator/internal/controller/clusterenv_test.go
+++ b/deploy/operator/internal/controller/clusterenv_test.go
@@ -210,13 +210,9 @@ func TestClusterDynamoGraphDeploymentRequestProfilesAndCreatesWorkloadManifests(
 				t.Fatalf("select profiler image: %v", err)
 			}
 
-			t.Log("Create the scale client and start the production DGDR-to-terminal-workload controller chain")
+			t.Log("Start the production DGDR-to-terminal-workload controller chain")
 			operatorConfig := clusterTestRestrictedConfig(env.Namespace())
 			runtimeConfig := &commoncontroller.RuntimeConfig{Gate: features.Gates{Grove: true, LWS: true}}
-			scaleClient, err := env.ScaleClient()
-			if err != nil {
-				t.Fatalf("create scale client: %v", err)
-			}
 			env.StartManager(func(mgr ctrl.Manager) error {
 				setupOptions := SetupOptions{Config: operatorConfig, RuntimeConfig: runtimeConfig}
 				if err := SetupDynamoGraphDeploymentRequest(mgr, DynamoGraphDeploymentRequestSetupOptions{
@@ -228,7 +224,6 @@ func TestClusterDynamoGraphDeploymentRequestProfilesAndCreatesWorkloadManifests(
 				}
 				if err := SetupDynamoGraphDeployment(mgr, DynamoGraphDeploymentSetupOptions{
 					SetupOptions: setupOptions,
-					ScaleClient:  scaleClient,
 				}); err != nil {
 					return err
 				}

--- a/deploy/operator/internal/controller/dgd_grove_program.go
+++ b/deploy/operator/internal/controller/dgd_grove_program.go
@@ -61,7 +61,6 @@ func (r *DynamoGraphDeploymentReconciler) newGroveProgram() *groveProgram {
 			r.Config,
 			r.RuntimeConfig,
 			r.DockerSecretRetriever,
-			r.ScaleClient,
 		),
 		scalingAdapters: newDGDScalingAdaptersReconciler(r.Client, r.Recorder),
 		topology:        newDGDGroveTopologyConditionReconciler(r.Client),

--- a/deploy/operator/internal/controller/dgd_grove_scaler.go
+++ b/deploy/operator/internal/controller/dgd_grove_scaler.go
@@ -29,16 +29,16 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/scale"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type groveScaler struct {
-	scaleClient scale.ScalesGetter
+	client client.Client
 }
 
-func newGroveScaler(scaleClient scale.ScalesGetter) *groveScaler {
-	return &groveScaler{scaleClient: scaleClient}
+func newGroveScaler(kubeClient client.Client) *groveScaler {
+	return &groveScaler{client: kubeClient}
 }
 
 // Reconcile applies component replica changes to the Grove resources created
@@ -108,7 +108,7 @@ func (s *groveScaler) scaleResource(
 	namespace string,
 	newReplicas int32,
 ) error {
-	err := commoncontroller.ScaleResource(ctx, s.scaleClient, gvr, namespace, resourceName, newReplicas)
+	err := commoncontroller.ScaleResource(ctx, s.client, gvr, namespace, resourceName, newReplicas)
 	if apierrors.IsNotFound(err) {
 		// Grove creates these resources asynchronously after the PodCliqueSet.
 		// A later reconciliation retries the scale once the child exists.

--- a/deploy/operator/internal/controller/dgd_grove_scaler_clustertest_test.go
+++ b/deploy/operator/internal/controller/dgd_grove_scaler_clustertest_test.go
@@ -1,0 +1,58 @@
+//go:build clustertest
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestClusterGroveScalerUsesScaleSubresource(t *testing.T) {
+	env := clusterTestEnv.RunT(t)
+	ctx := context.Background()
+
+	t.Log("Create a real Grove PodClique through the cluster API server")
+	dgd := betaDGD(t, &nvidiacomv1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "graph", Namespace: env.Namespace()},
+		Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+			Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(3)),
+				},
+			},
+		},
+	})
+	podClique := &grovev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: "graph-0-worker", Namespace: env.Namespace()},
+		Spec: grovev1alpha1.PodCliqueSpec{
+			RoleName: "worker",
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "worker", Image: "example.invalid/worker:test"}},
+			},
+			Replicas: 1,
+		},
+	}
+	require.NoError(t, env.Client().Create(ctx, podClique))
+
+	t.Log("Scale the PodClique through the production controller-runtime subresource path")
+	require.NoError(t, newGroveScaler(env.Client()).Reconcile(ctx, dgd, nil))
+
+	t.Log("Read the PodClique back and verify the API server applied the scale update")
+	require.NoError(t, env.Client().Get(ctx, client.ObjectKeyFromObject(podClique), podClique))
+	require.Equal(t, int32(3), podClique.Spec.Replicas)
+}

--- a/deploy/operator/internal/controller/dgd_grove_scaler_test.go
+++ b/deploy/operator/internal/controller/dgd_grove_scaler_test.go
@@ -31,7 +31,6 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -114,12 +113,10 @@ func groveScaleInterceptor(funcs interceptor.Funcs, onUpdate func()) interceptor
 			ResourceVersion: object.GetResourceVersion(),
 		}
 		switch resource := object.(type) {
-		case *unstructured.Unstructured:
-			replicas, found, err := unstructured.NestedInt64(resource.Object, "spec", "replicas")
-			if err != nil || !found {
-				return errors.New("scale resource has no replicas")
-			}
-			scaleObject.Spec.Replicas = int32(replicas)
+		case *grovev1alpha1.PodClique:
+			scaleObject.Spec.Replicas = resource.Spec.Replicas
+		case *grovev1alpha1.PodCliqueScalingGroup:
+			scaleObject.Spec.Replicas = resource.Spec.Replicas
 		default:
 			return errors.New("unexpected scale resource")
 		}
@@ -142,10 +139,10 @@ func groveScaleInterceptor(funcs interceptor.Funcs, onUpdate func()) interceptor
 			return err
 		}
 		switch resource := object.(type) {
-		case *unstructured.Unstructured:
-			if err := unstructured.SetNestedField(resource.Object, int64(scaleObject.Spec.Replicas), "spec", "replicas"); err != nil {
-				return err
-			}
+		case *grovev1alpha1.PodClique:
+			resource.Spec.Replicas = scaleObject.Spec.Replicas
+		case *grovev1alpha1.PodCliqueScalingGroup:
+			resource.Spec.Replicas = scaleObject.Spec.Replicas
 		default:
 			return errors.New("unexpected scale resource")
 		}

--- a/deploy/operator/internal/controller/dgd_grove_scaler_test.go
+++ b/deploy/operator/internal/controller/dgd_grove_scaler_test.go
@@ -25,79 +25,19 @@ import (
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/scale"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
-
-type groveScaleUpdate struct {
-	namespace string
-	resource  schema.GroupResource
-	name      string
-	replicas  int32
-}
-
-type recordingGroveScaleClient struct {
-	currentReplicas int32
-	getErrors       map[string]error
-	updates         []groveScaleUpdate
-}
-
-func (c *recordingGroveScaleClient) Scales(namespace string) scale.ScaleInterface {
-	return &recordingGroveScaleInterface{client: c, namespace: namespace}
-}
-
-type recordingGroveScaleInterface struct {
-	client    *recordingGroveScaleClient
-	namespace string
-}
-
-func (s *recordingGroveScaleInterface) Get(
-	_ context.Context,
-	resource schema.GroupResource,
-	name string,
-	_ metav1.GetOptions,
-) (*autoscalingv1.Scale, error) {
-	if err := s.client.getErrors[name]; err != nil {
-		return nil, err
-	}
-	return &autoscalingv1.Scale{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
-		Spec:       autoscalingv1.ScaleSpec{Replicas: s.client.currentReplicas},
-	}, nil
-}
-
-func (s *recordingGroveScaleInterface) Update(
-	_ context.Context,
-	resource schema.GroupResource,
-	scaleObject *autoscalingv1.Scale,
-	_ metav1.UpdateOptions,
-) (*autoscalingv1.Scale, error) {
-	s.client.updates = append(s.client.updates, groveScaleUpdate{
-		namespace: s.namespace,
-		resource:  resource,
-		name:      scaleObject.Name,
-		replicas:  scaleObject.Spec.Replicas,
-	})
-	return scaleObject, nil
-}
-
-func (*recordingGroveScaleInterface) Patch(
-	context.Context,
-	schema.GroupVersionResource,
-	string,
-	types.PatchType,
-	[]byte,
-	metav1.PatchOptions,
-) (*autoscalingv1.Scale, error) {
-	return nil, errors.New("unexpected scale patch")
-}
 
 func TestGroveScaler_ReconcileTargetsExpectedGroveChildren(t *testing.T) {
 	dgd := betaDGD(t, &nvidiacomv1alpha1.DynamoGraphDeployment{
@@ -122,9 +62,17 @@ func TestGroveScaler_ReconcileTargetsExpectedGroveChildren(t *testing.T) {
 			},
 		},
 	})
-	scaleClient := &recordingGroveScaleClient{currentReplicas: 1}
+	frontend := &grovev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{Name: "graph-0-frontend", Namespace: "default"}, Spec: grovev1alpha1.PodCliqueSpec{Replicas: 1}}
+	worker := &grovev1alpha1.PodCliqueScalingGroup{ObjectMeta: metav1.ObjectMeta{Name: "graph-0-worker", Namespace: "default"}, Spec: grovev1alpha1.PodCliqueScalingGroupSpec{Replicas: 1}}
+	gated := &grovev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{Name: "graph-0-gated", Namespace: "default"}, Spec: grovev1alpha1.PodCliqueSpec{Replicas: 1}}
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+		WithRESTMapper(groveScaleRESTMapper()).
+		WithObjects(frontend, worker, gated).
+		WithInterceptorFuncs(groveScaleInterceptor(interceptor.Funcs{}, nil)).
+		Build()
 
-	err := newGroveScaler(scaleClient).Reconcile(
+	err := newGroveScaler(kubeClient).Reconcile(
 		context.Background(),
 		dgd,
 		map[string]*checkpoint.CheckpointInfo{
@@ -136,26 +84,77 @@ func TestGroveScaler_ReconcileTargetsExpectedGroveChildren(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, []groveScaleUpdate{
-		{
-			namespace: "default",
-			resource:  consts.PodCliqueGVR.GroupResource(),
-			name:      "graph-0-frontend",
-			replicas:  2,
-		},
-		{
-			namespace: "default",
-			resource:  consts.PodCliqueScalingGroupGVR.GroupResource(),
-			name:      "graph-0-worker",
-			replicas:  3,
-		},
-		{
-			namespace: "default",
-			resource:  consts.PodCliqueGVR.GroupResource(),
-			name:      "graph-0-gated",
-			replicas:  0,
-		},
-	}, scaleClient.updates)
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(frontend), frontend))
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(worker), worker))
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(gated), gated))
+	assert.Equal(t, int32(2), frontend.Spec.Replicas)
+	assert.Equal(t, int32(3), worker.Spec.Replicas)
+	assert.Equal(t, int32(0), gated.Spec.Replicas)
+}
+
+func groveScaleInterceptor(funcs interceptor.Funcs, onUpdate func()) interceptor.Funcs {
+	funcs.SubResourceGet = func(
+		ctx context.Context,
+		reader client.Client,
+		subResourceName string,
+		object client.Object,
+		subResource client.Object,
+		_ ...client.SubResourceGetOption,
+	) error {
+		if subResourceName != "scale" {
+			return errors.New("unexpected subresource get")
+		}
+		if err := reader.Get(ctx, client.ObjectKeyFromObject(object), object); err != nil {
+			return err
+		}
+		scaleObject := subResource.(*autoscalingv1.Scale)
+		scaleObject.ObjectMeta = metav1.ObjectMeta{
+			Name:            object.GetName(),
+			Namespace:       object.GetNamespace(),
+			ResourceVersion: object.GetResourceVersion(),
+		}
+		switch resource := object.(type) {
+		case *unstructured.Unstructured:
+			replicas, found, err := unstructured.NestedInt64(resource.Object, "spec", "replicas")
+			if err != nil || !found {
+				return errors.New("scale resource has no replicas")
+			}
+			scaleObject.Spec.Replicas = int32(replicas)
+		default:
+			return errors.New("unexpected scale resource")
+		}
+		return nil
+	}
+	funcs.SubResourceUpdate = func(
+		ctx context.Context,
+		writer client.Client,
+		subResourceName string,
+		object client.Object,
+		options ...client.SubResourceUpdateOption,
+	) error {
+		if subResourceName != "scale" {
+			return errors.New("unexpected subresource update")
+		}
+		updateOptions := &client.SubResourceUpdateOptions{}
+		updateOptions.ApplyOptions(options)
+		scaleObject := updateOptions.SubResourceBody.(*autoscalingv1.Scale)
+		if err := writer.Get(ctx, client.ObjectKeyFromObject(object), object); err != nil {
+			return err
+		}
+		switch resource := object.(type) {
+		case *unstructured.Unstructured:
+			if err := unstructured.SetNestedField(resource.Object, int64(scaleObject.Spec.Replicas), "spec", "replicas"); err != nil {
+				return err
+			}
+		default:
+			return errors.New("unexpected scale resource")
+		}
+		if onUpdate != nil {
+			onUpdate()
+		}
+		return writer.Update(ctx, object)
+	}
+	return funcs
 }
 
 func TestGroveScaler_ReconcileHandlesScaleReadErrors(t *testing.T) {
@@ -172,23 +171,42 @@ func TestGroveScaler_ReconcileHandlesScaleReadErrors(t *testing.T) {
 	})
 
 	t.Run("not found is retried by a later reconciliation", func(t *testing.T) {
-		scaleClient := &recordingGroveScaleClient{
-			getErrors: map[string]error{
-				"graph-0-worker": apierrors.NewNotFound(
-					consts.PodCliqueGVR.GroupResource(),
-					"graph-0-worker",
-				),
-			},
-		}
-		require.NoError(t, newGroveScaler(scaleClient).Reconcile(context.Background(), dgd, nil))
-		assert.Empty(t, scaleClient.updates)
+		kubeClient := fake.NewClientBuilder().
+			WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+			WithRESTMapper(groveScaleRESTMapper()).
+			Build()
+		require.NoError(t, newGroveScaler(kubeClient).Reconcile(context.Background(), dgd, nil))
 	})
 
 	t.Run("other errors are propagated", func(t *testing.T) {
-		scaleClient := &recordingGroveScaleClient{
-			getErrors: map[string]error{"graph-0-worker": errors.New("scale read failed")},
-		}
-		err := newGroveScaler(scaleClient).Reconcile(context.Background(), dgd, nil)
+		kubeClient := fake.NewClientBuilder().
+			WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+			WithRESTMapper(groveScaleRESTMapper()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourceGet: func(context.Context, client.Client, string, client.Object, client.Object, ...client.SubResourceGetOption) error {
+					return errors.New("scale read failed")
+				},
+			}).
+			Build()
+		err := newGroveScaler(kubeClient).Reconcile(context.Background(), dgd, nil)
 		require.ErrorContains(t, err, "scale read failed")
 	})
+}
+
+func groveScaleRESTMapper() meta.RESTMapper {
+	groupVersion := schema.GroupVersion{Group: consts.PodCliqueGVR.Group, Version: consts.PodCliqueGVR.Version}
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{groupVersion})
+	mapper.AddSpecific(
+		groupVersion.WithKind("PodClique"),
+		consts.PodCliqueGVR,
+		consts.PodCliqueGVR,
+		meta.RESTScopeNamespace,
+	)
+	mapper.AddSpecific(
+		groupVersion.WithKind("PodCliqueScalingGroup"),
+		consts.PodCliqueScalingGroupGVR,
+		consts.PodCliqueScalingGroupGVR,
+		meta.RESTScopeNamespace,
+	)
+	return mapper
 }

--- a/deploy/operator/internal/controller/dgd_grove_scaler_test.go
+++ b/deploy/operator/internal/controller/dgd_grove_scaler_test.go
@@ -72,7 +72,7 @@ func TestGroveScaler_ReconcileTargetsExpectedGroveChildren(t *testing.T) {
 		Build()
 
 	err := newGroveScaler(kubeClient).Reconcile(
-		context.Background(),
+		t.Context(),
 		dgd,
 		map[string]*checkpoint.CheckpointInfo{
 			"gated": {
@@ -83,9 +83,9 @@ func TestGroveScaler_ReconcileTargetsExpectedGroveChildren(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(frontend), frontend))
-	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(worker), worker))
-	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(gated), gated))
+	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(frontend), frontend))
+	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(worker), worker))
+	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(gated), gated))
 	assert.Equal(t, int32(2), frontend.Spec.Replicas)
 	assert.Equal(t, int32(3), worker.Spec.Replicas)
 	assert.Equal(t, int32(0), gated.Spec.Replicas)
@@ -172,7 +172,7 @@ func TestGroveScaler_ReconcileHandlesScaleReadErrors(t *testing.T) {
 			WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
 			WithRESTMapper(groveScaleRESTMapper()).
 			Build()
-		require.NoError(t, newGroveScaler(kubeClient).Reconcile(context.Background(), dgd, nil))
+		require.NoError(t, newGroveScaler(kubeClient).Reconcile(t.Context(), dgd, nil))
 	})
 
 	t.Run("other errors are propagated", func(t *testing.T) {
@@ -185,7 +185,7 @@ func TestGroveScaler_ReconcileHandlesScaleReadErrors(t *testing.T) {
 				},
 			}).
 			Build()
-		err := newGroveScaler(kubeClient).Reconcile(context.Background(), dgd, nil)
+		err := newGroveScaler(kubeClient).Reconcile(t.Context(), dgd, nil)
 		require.ErrorContains(t, err, "scale read failed")
 	})
 }

--- a/deploy/operator/internal/controller/dgd_grove_workloads_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_grove_workloads_reconciler.go
@@ -27,7 +27,6 @@ import (
 	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -49,7 +48,6 @@ func newGroveWorkloadsReconciler(
 	config *configv1alpha1.OperatorConfiguration,
 	runtimeConfig *commoncontroller.RuntimeConfig,
 	dockerSecretRetriever DockerSecretRetriever,
-	scaleClient scale.ScalesGetter,
 ) *groveWorkloadsReconciler {
 	return &groveWorkloadsReconciler{
 		syncer: newDGDResourceSyncer(kubeClient, recorder),
@@ -60,7 +58,7 @@ func newGroveWorkloadsReconciler(
 			runtimeConfig,
 			dockerSecretRetriever,
 		),
-		scaler:          newGroveScaler(scaleClient),
+		scaler:          newGroveScaler(kubeClient),
 		stableResources: newGroveStableResourcesReconciler(kubeClient, recorder, config),
 	}
 }

--- a/deploy/operator/internal/controller/dgd_grove_workloads_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_grove_workloads_reconciler_test.go
@@ -56,7 +56,7 @@ func TestGroveWorkloadsReconciler_EvaluatesReadinessOnce(t *testing.T) {
 			Namespace:  "default",
 			Generation: 1,
 		},
-		Spec: grovev1alpha1.PodCliqueSpec{Replicas: 1},
+		Spec: grovev1alpha1.PodCliqueSpec{Replicas: 0},
 		Status: grovev1alpha1.PodCliqueStatus{
 			Replicas:           1,
 			ReadyReplicas:      1,
@@ -67,12 +67,13 @@ func TestGroveWorkloadsReconciler_EvaluatesReadinessOnce(t *testing.T) {
 	}
 
 	podCliqueReads := 0
-	scaleClient := &recordingGroveScaleClient{}
+	scaleUpdates := 0
 	kubeClient := fake.NewClientBuilder().
 		WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+		WithRESTMapper(groveScaleRESTMapper()).
 		WithObjects(dgd, podClique).
 		WithStatusSubresource(dgd, podClique).
-		WithInterceptorFuncs(interceptor.Funcs{
+		WithInterceptorFuncs(groveScaleInterceptor(interceptor.Funcs{
 			Get: func(
 				ctx context.Context,
 				reader client.WithWatch,
@@ -81,19 +82,17 @@ func TestGroveWorkloadsReconciler_EvaluatesReadinessOnce(t *testing.T) {
 				options ...client.GetOption,
 			) error {
 				if _, ok := object.(*grovev1alpha1.PodClique); ok {
-					require.Len(t, scaleClient.updates, 1, "readiness must be observed after scaling")
 					podCliqueReads++
 				}
 				return reader.Get(ctx, key, object, options...)
 			},
-		}).
+		}, func() { scaleUpdates++ })).
 		Build()
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        kubeClient,
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		Recorder:      events.NewFakeRecorder(10),
 		RuntimeConfig: &commoncontroller.RuntimeConfig{},
-		ScaleClient:   scaleClient,
 		DockerSecretRetriever: &mockDockerSecretRetriever{
 			GetSecretsFunc: func(string, string) ([]string, error) {
 				return nil, nil
@@ -109,5 +108,6 @@ func TestGroveWorkloadsReconciler_EvaluatesReadinessOnce(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, nvidiacomv1beta1.DGDStateSuccessful, result.State)
+	assert.Equal(t, 1, scaleUpdates)
 	assert.Equal(t, 1, podCliqueReads)
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -29,7 +29,6 @@ import (
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -77,7 +76,6 @@ type DynamoGraphDeploymentReconciler struct {
 	RestConfig            *rest.Config
 	Recorder              events.EventRecorder
 	DockerSecretRetriever DockerSecretRetriever
-	ScaleClient           scale.ScalesGetter
 	SSHKeyManager         *secret.SSHKeyManager
 	RBACManager           rbacManager
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -659,31 +658,6 @@ func TestDynamoGraphDeploymentReconciler_mapAutoCheckpointToDGDRequestsAllowsRet
 	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "test-dgd"}, got[0].NamespacedName)
 }
 
-// mockScaleClient implements scale.ScalesGetter for testing
-type mockScaleClient struct{}
-
-func (m *mockScaleClient) Scales(namespace string) scale.ScaleInterface {
-	return &mockScaleInterface{}
-}
-
-// mockScaleInterface implements scale.ScaleInterface for testing
-type mockScaleInterface struct{}
-
-func (m *mockScaleInterface) Get(ctx context.Context, resource schema.GroupResource, name string, opts metav1.GetOptions) (*autoscalingv1.Scale, error) {
-	// Return a dummy scale object - we don't actually need scaling in the test
-	return &autoscalingv1.Scale{}, nil
-}
-
-func (m *mockScaleInterface) Update(ctx context.Context, resource schema.GroupResource, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
-	// Return success without actually doing anything
-	return scale, nil
-}
-
-func (m *mockScaleInterface) Patch(ctx context.Context, gvr schema.GroupVersionResource, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*autoscalingv1.Scale, error) {
-	// Return a dummy scale object
-	return &autoscalingv1.Scale{}, nil
-}
-
 func TestGroveWorkloadsReconciler_Reconcile(t *testing.T) {
 	ctx := context.Background()
 
@@ -1022,9 +996,10 @@ func TestGroveWorkloadsReconciler_Reconcile(t *testing.T) {
 
 			fakeKubeClient := fake.NewClientBuilder().
 				WithScheme(s).
+				WithRESTMapper(groveScaleRESTMapper()).
 				WithObjects(objects...).
 				WithStatusSubresource(objects...).
-				WithInterceptorFuncs(tt.interceptorFuncs).
+				WithInterceptorFuncs(groveScaleInterceptor(tt.interceptorFuncs, nil)).
 				Build()
 
 			recorder := events.NewFakeRecorder(100)
@@ -1033,7 +1008,6 @@ func TestGroveWorkloadsReconciler_Reconcile(t *testing.T) {
 				Recorder:      recorder,
 				Config:        &configv1alpha1.OperatorConfiguration{},
 				RuntimeConfig: &controller_common.RuntimeConfig{Gate: features.Gates{DRA: tt.draEnabled}},
-				ScaleClient:   &mockScaleClient{},
 				DockerSecretRetriever: &mockDockerSecretRetriever{
 					GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
 						return []string{}, nil
@@ -1100,6 +1074,7 @@ func TestGroveWorkloadsReconciler_UsesPreservedAlphaServiceIngress(t *testing.T)
 
 	fakeKubeClient := fake.NewClientBuilder().
 		WithScheme(s).
+		WithRESTMapper(groveScaleRESTMapper()).
 		WithObjects(dgd).
 		Build()
 
@@ -1108,7 +1083,6 @@ func TestGroveWorkloadsReconciler_UsesPreservedAlphaServiceIngress(t *testing.T)
 		Recorder:      events.NewFakeRecorder(100),
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		RuntimeConfig: &controller_common.RuntimeConfig{},
-		ScaleClient:   &mockScaleClient{},
 		DockerSecretRetriever: &mockDockerSecretRetriever{
 			GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
 				return []string{}, nil

--- a/deploy/operator/internal/controller/setup.go
+++ b/deploy/operator/internal/controller/setup.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/modelendpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/scale"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -31,7 +30,6 @@ type DynamoComponentDeploymentSetupOptions struct {
 type DynamoGraphDeploymentSetupOptions struct {
 	SetupOptions
 	DockerSecretRetriever DockerSecretRetriever
-	ScaleClient           scale.ScalesGetter
 	RBACManager           RBACManager
 	SSHKeyManager         *secret.SSHKeyManager
 }
@@ -92,7 +90,6 @@ func SetupDynamoGraphDeployment(mgr ctrl.Manager, opts DynamoGraphDeploymentSetu
 		RuntimeConfig:         opts.RuntimeConfig,
 		RestConfig:            mgr.GetConfig(),
 		DockerSecretRetriever: opts.DockerSecretRetriever,
-		ScaleClient:           opts.ScaleClient,
 		SSHKeyManager:         opts.SSHKeyManager,
 		RBACManager:           opts.RBACManager,
 	}).SetupWithManager(mgr); err != nil {

--- a/deploy/operator/internal/controller_common/scale.go
+++ b/deploy/operator/internal/controller_common/scale.go
@@ -23,23 +23,29 @@ import (
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/scale"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ScaleResource scales any Kubernetes resource using the Scale subresource
-func ScaleResource(ctx context.Context, scaleClient scale.ScalesGetter, gvr schema.GroupVersionResource, namespace, name string, replicas int32) error {
+func ScaleResource(ctx context.Context, kubeClient client.Client, gvr schema.GroupVersionResource, namespace, name string, replicas int32) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Scaling resource", "gvr", gvr, "name", name, "namespace", namespace, "replicas", replicas)
 
-	if scaleClient == nil {
-		logger.Error(nil, "Scale client is nil")
-		return fmt.Errorf("scale client is nil")
-	}
-
-	currentScale, err := scaleClient.Scales(namespace).Get(ctx, gvr.GroupResource(), name, metav1.GetOptions{})
+	// Build the parent resource used to address its scale subresource.
+	gvk, err := kubeClient.RESTMapper().KindFor(gvr)
 	if err != nil {
+		return fmt.Errorf("failed to resolve kind for %s: %w", gvr.String(), err)
+	}
+	resource := &unstructured.Unstructured{}
+	resource.SetGroupVersionKind(gvk)
+	resource.SetNamespace(namespace)
+	resource.SetName(name)
+
+	currentScale := &autoscalingv1.Scale{}
+	if err := kubeClient.SubResource("scale").Get(ctx, resource, currentScale); err != nil {
 		logger.Error(err, "Failed to get current scale - resource may not support scale subresource", "gvr", gvr, "name", name, "namespace", namespace, "groupResource", gvr.GroupResource())
 		return fmt.Errorf("failed to get current scale for %s %s (resource may not support scale subresource): %w", gvr.Resource, name, err)
 	}
@@ -65,8 +71,7 @@ func ScaleResource(ctx context.Context, scaleClient scale.ScalesGetter, gvr sche
 	}
 
 	logger.V(1).Info("Updating scale", "gvr", gvr, "name", name, "newReplicas", replicas)
-	_, err = scaleClient.Scales(namespace).Update(ctx, gvr.GroupResource(), scaleObj, metav1.UpdateOptions{})
-	if err != nil {
+	if err := kubeClient.SubResource("scale").Update(ctx, resource, client.WithSubResourceBody(scaleObj)); err != nil {
 		logger.Error(err, "Failed to update scale", "gvr", gvr, "name", name, "replicas", replicas)
 		return fmt.Errorf("failed to update scale for %s %s: %w", gvr.Resource, name, err)
 	}

--- a/deploy/operator/internal/controller_common/scale.go
+++ b/deploy/operator/internal/controller_common/scale.go
@@ -23,7 +23,6 @@ import (
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,8 +38,14 @@ func ScaleResource(ctx context.Context, kubeClient client.Client, gvr schema.Gro
 	if err != nil {
 		return fmt.Errorf("failed to resolve kind for %s: %w", gvr.String(), err)
 	}
-	resource := &unstructured.Unstructured{}
-	resource.SetGroupVersionKind(gvk)
+	resourceObject, err := kubeClient.Scheme().New(gvk)
+	if err != nil {
+		return fmt.Errorf("failed to create resource object for %s: %w", gvk.String(), err)
+	}
+	resource, ok := resourceObject.(client.Object)
+	if !ok {
+		return fmt.Errorf("resource object for %s does not implement client.Object", gvk.String())
+	}
 	resource.SetNamespace(namespace)
 	resource.SetName(name)
 

--- a/deploy/operator/internal/testing/clusterenv/env.go
+++ b/deploy/operator/internal/testing/clusterenv/env.go
@@ -23,12 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
-	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -227,22 +223,6 @@ func (e *TestEnv) Client() client.Client {
 // RESTConfig returns a copy of the selected cluster REST configuration.
 func (e *TestEnv) RESTConfig() *rest.Config {
 	return rest.CopyConfig(e.rt.config)
-}
-
-// ScaleClient returns a scale client configured for the selected cluster.
-func (e *TestEnv) ScaleClient() (scale.ScalesGetter, error) {
-	kubeClient, err := kubernetes.NewForConfig(e.rt.config)
-	if err != nil {
-		return nil, err
-	}
-	cachedDiscovery := memory.NewMemCacheClient(kubeClient.Discovery())
-	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscovery)
-	return scale.NewForConfig(
-		e.rt.config,
-		restMapper,
-		dynamic.LegacyAPIPathResolverFunc,
-		scale.NewDiscoveryScaleKindResolver(cachedDiscovery),
-	)
 }
 
 // BlockWorkloads prevents controllers from creating ReplicaSets and Pods in

--- a/deploy/operator/internal/testing/operatorenv/env.go
+++ b/deploy/operator/internal/testing/operatorenv/env.go
@@ -26,12 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
-	"k8s.io/client-go/scale"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -362,11 +357,6 @@ func (e *TestEnv) RuntimeConfig() *commoncontroller.RuntimeConfig {
 	return e.rt.runtimeConfig
 }
 
-// ScaleClient returns a scale client configured for this envtest API server.
-func (e *TestEnv) ScaleClient() (scale.ScalesGetter, error) {
-	return newScaleClient(e.rt.config)
-}
-
 // StartManager starts a namespace-scoped controller manager configured by setup.
 func (e *TestEnv) StartManager(setup func(ctrl.Manager) error) {
 	e.tb.Helper()
@@ -476,21 +466,6 @@ func defaultRuntimeConfig(cfg *configv1alpha1.OperatorConfiguration) *commoncont
 	gate.Checkpoint = cfg.Checkpoint.Enabled
 	gate.GPUDiscovery = cfg.Namespace.Restricted == "" || ptr.Deref(cfg.GPU.DiscoveryEnabled, true)
 	return &commoncontroller.RuntimeConfig{Gate: gate}
-}
-
-func newScaleClient(config *rest.Config) (scale.ScalesGetter, error) {
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	cachedDiscovery := memory.NewMemCacheClient(kubeClient.Discovery())
-	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscovery)
-	return scale.NewForConfig(
-		config,
-		restMapper,
-		dynamic.LegacyAPIPathResolverFunc,
-		scale.NewDiscoveryScaleKindResolver(cachedDiscovery),
-	)
 }
 
 func crdDirectoryPaths(opts Options) []string {


### PR DESCRIPTION
## Summary

- replace `scale.ScalesGetter` usage in the operator scaling path with the controller-runtime `client.Client`
- reuse the manager client and access scale through `SubResource("scale")`
- remove dedicated discovery, REST mapper, scale-client setup, and obsolete test helpers
- update Grove scaling tests to exercise controller-runtime subresource behavior

## Validation

- `gofmt` on affected Go files
- `git diff --check`
- `GOCACHE=/tmp/dynamo-go-cache go test ./internal/controller_common`
- `GOCACHE=/tmp/dynamo-go-cache go test ./internal/controller -run 'TestGroveScaler|TestGroveWorkloadsReconciler'`\n- `GOCACHE=/tmp/dynamo-go-cache go test ./... -run '^$'`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined workload scaling through the operator’s existing Kubernetes client.
  * Removed redundant scale-client setup and configuration.
  * Preserved scaling behavior while simplifying controller and test-environment integration.
* **Tests**
  * Updated scaling and readiness coverage to validate replica changes directly on workload resources.
  * Added realistic handling for scale reads and updates in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->