### PR TITLE
refactor(vllm): extract decoder mechanics

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -229,6 +229,7 @@ areas:
   - components/src/dynamo/common/memory/
   - components/src/dynamo/common/tests/
   - components/src/dynamo/common/utils/
+  - components/src/dynamo/workflow/
   - examples/backends/sample/
   - examples/backends/tritonserver/
   - examples/common/

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -160,6 +160,7 @@ core:
   - 'components/src/dynamo/replay/**'
   - 'components/src/dynamo/frontend/**'
   - 'components/src/dynamo/common/**'
+  - 'components/src/dynamo/workflow/**'
   - 'components/src/dynamo/gpu_memory_service/**'
   # TODO(will): Move TokenSpeed to a dedicated framework filter once CI has
   # TokenSpeed Docker images and backend-specific build/test jobs.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -236,6 +236,7 @@
 /components/src/dynamo/common/                                               @ai-dynamo/dynamo-runtime-codeowners
 /tests/test_models_dir_flag.py                                               @ai-dynamo/dynamo-runtime-codeowners
 /tests/report_pytest_markers.py                                              @ai-dynamo/dynamo-runtime-codeowners
+/components/src/dynamo/workflow/                                             @ai-dynamo/dynamo-runtime-codeowners
 /examples/backends/tritonserver/                                             @ai-dynamo/dynamo-runtime-codeowners
 /tests/serve/multimodal_profiles/                                            @ai-dynamo/dynamo-runtime-codeowners
 /tests/test_predownload_models.py                                            @ai-dynamo/dynamo-runtime-codeowners

--- a/components/src/dynamo/vllm/decoder_output.py
+++ b/components/src/dynamo/vllm/decoder_output.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared conversion from native vLLM outputs to Dynamo token chunks."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import math
+from collections.abc import Callable
+from typing import Any, Dict, Optional
+
+from vllm.outputs import RequestOutput
+from vllm.sampling_params import SamplingParams
+
+from dynamo.common.utils.engine_response import normalize_finish_reason
+
+logger = logging.getLogger(__name__)
+
+# Logprobs can be -inf (log of probability 0) for masked/disallowed tokens.
+# JSON has no inf/nan, so clamp non-finite values before Rust deserialization.
+_MIN_FINITE_LOGPROB = -1e30
+
+
+def _finite_logprob(value: Any) -> float:
+    lp = float(value)
+    return lp if math.isfinite(lp) else _MIN_FINITE_LOGPROB
+
+
+def _serialize_prompt_logprobs(raw_prompt_logprobs: list) -> list:
+    """Convert vLLM prompt logprobs into Dynamo's transport-safe shape."""
+
+    result: list = []
+    for entry in raw_prompt_logprobs:
+        if entry is None:
+            result.append(None)
+            continue
+
+        converted: Dict[str, Dict[str, Any]] = {}
+        for token_id, logprob_obj in entry.items():
+            try:
+                key = str(int(token_id))
+            except (TypeError, ValueError):
+                continue
+            lp_dict: Dict[str, Any] = {
+                "logprob": _finite_logprob(logprob_obj.logprob),
+            }
+            rank = getattr(logprob_obj, "rank", None)
+            if rank is not None:
+                lp_dict["rank"] = int(rank)
+            decoded = getattr(logprob_obj, "decoded_token", None)
+            if decoded is not None:
+                lp_dict["decoded_token"] = decoded
+            converted[key] = lp_dict
+        result.append(converted)
+    return result
+
+
+def _attach_prompt_logprobs_engine_data(
+    chunk: Dict[str, Any], prompt_logprobs: list
+) -> None:
+    engine_data = chunk.setdefault("engine_data", {})
+    if isinstance(engine_data, dict):
+        engine_data["prompt_logprobs"] = prompt_logprobs
+
+
+def _serialize_routed_experts(
+    routed_experts: Any, start: int = 0
+) -> Optional[Dict[str, Any]]:
+    if routed_experts is None:
+        return None
+
+    shape = getattr(routed_experts, "shape", None)
+    tobytes = getattr(routed_experts, "tobytes", None)
+    if shape is None or not callable(tobytes):
+        logger.warning(
+            "Unable to serialize routed_experts of type %s",
+            type(routed_experts).__name__,
+        )
+        return None
+
+    return {
+        "data": base64.b64encode(tobytes()).decode("ascii"),
+        "shape": [int(dim) for dim in shape],
+        "start": int(start),
+        "dtype": str(getattr(routed_experts, "dtype", "")),
+    }
+
+
+def _attach_routed_experts_engine_data(
+    chunk: Dict[str, Any], routed_experts: Dict[str, Any]
+) -> None:
+    engine_data = chunk.setdefault("engine_data", {})
+    if isinstance(engine_data, dict):
+        engine_data["routed_experts"] = routed_experts
+
+
+def build_prompt_tokens_details(
+    num_cached_tokens: int | None,
+) -> dict[str, int] | None:
+    """Preserve the distinction between unavailable and zero cached tokens."""
+
+    if num_cached_tokens is None:
+        return None
+    return {"cached_tokens": num_cached_tokens}
+
+
+def build_completion_usage(
+    request_output: RequestOutput,
+    completion_token_counts: dict[int, int] | None = None,
+) -> Dict[str, Any]:
+    """Build Dynamo completion usage from a native vLLM output."""
+
+    prompt_tokens = (
+        len(request_output.prompt_token_ids)
+        if request_output.prompt_token_ids
+        else None
+    )
+    if completion_token_counts is not None:
+        completion_tokens = sum(completion_token_counts.values())
+    else:
+        completion_tokens = sum(
+            len(output.token_ids) for output in request_output.outputs
+        )
+
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": (
+            prompt_tokens + completion_tokens if prompt_tokens is not None else None
+        ),
+        "prompt_tokens_details": build_prompt_tokens_details(
+            getattr(request_output, "num_cached_tokens", None)
+        ),
+    }
+
+
+ExtractLogprobs = Callable[
+    [Any, int, Any], tuple[list[float] | None, list[list[dict]] | None]
+]
+
+
+class _VllmDecodeOutputAdapter:
+    """Statefully convert one native vLLM request stream into Dynamo chunks."""
+
+    def __init__(
+        self,
+        sampling_params: SamplingParams,
+        *,
+        tokenizer: Any,
+        extract_logprobs: ExtractLogprobs,
+    ) -> None:
+        self._sampling_params = sampling_params
+        self._tokenizer = tokenizer
+        self._extract_logprobs = extract_logprobs
+        self._completion_tokens_by_index: dict[int, int] = {}
+        self._routed_experts_by_index: dict[int, Any] = {}
+        self._prompt_logprobs: list | None = None
+
+    def completion_tokens(self, output_index: int) -> int:
+        return self._completion_tokens_by_index.get(output_index, 0)
+
+    def convert(self, response: RequestOutput) -> list[Dict[str, Any]]:
+        """Convert one native response, retaining state needed by final chunks."""
+
+        if (
+            self._prompt_logprobs is None
+            and getattr(response, "prompt_logprobs", None) is not None
+        ):
+            self._prompt_logprobs = _serialize_prompt_logprobs(response.prompt_logprobs)
+
+        if not response.outputs:
+            return [
+                {
+                    "finish_reason": "error: No outputs from vLLM engine",
+                    "index": 0,
+                    "token_ids": [],
+                }
+            ]
+
+        # Account for the complete native response before emitting any of its
+        # chunks. A single response can finish one output index while advancing
+        # another, and completion usage is request-wide rather than per-index.
+        for output in response.outputs:
+            output_index = getattr(output, "index", 0) or 0
+            self._completion_tokens_by_index[
+                output_index
+            ] = self._completion_tokens_by_index.get(output_index, 0) + len(
+                output.token_ids or []
+            )
+
+        chunks: list[Dict[str, Any]] = []
+        for output in response.outputs:
+            output_index = getattr(output, "index", 0) or 0
+            token_ids = list(output.token_ids or [])
+            finish_reason = getattr(output, "finish_reason", None)
+            stop_reason = getattr(output, "stop_reason", None)
+            if not token_ids and not finish_reason and not stop_reason:
+                continue
+
+            chunk: Dict[str, Any] = {
+                "index": output_index,
+                "token_ids": token_ids,
+            }
+            routed_experts = getattr(output, "routed_experts", None)
+            if routed_experts is not None:
+                self._routed_experts_by_index[output_index] = routed_experts
+
+            log_probs, top_logprobs = self._extract_logprobs(output, 0, self._tokenizer)
+            if log_probs is not None:
+                chunk["log_probs"] = log_probs
+            if top_logprobs is not None:
+                chunk["top_logprobs"] = top_logprobs
+
+            if finish_reason:
+                chunk["finish_reason"] = normalize_finish_reason(finish_reason)
+                chunk["completion_usage"] = build_completion_usage(
+                    response,
+                    completion_token_counts=self._completion_tokens_by_index,
+                )
+                if self._prompt_logprobs is not None:
+                    _attach_prompt_logprobs_engine_data(chunk, self._prompt_logprobs)
+                raw_start = int(
+                    getattr(
+                        self._sampling_params,
+                        "routed_experts_prompt_start",
+                        0,
+                    )
+                    or 0
+                )
+                prompt_length = len(getattr(response, "prompt_token_ids", None) or [])
+                serialized_routed_experts = _serialize_routed_experts(
+                    self._routed_experts_by_index.get(output_index),
+                    start=min(raw_start, prompt_length),
+                )
+                if serialized_routed_experts is not None:
+                    _attach_routed_experts_engine_data(chunk, serialized_routed_experts)
+            if stop_reason:
+                chunk["stop_reason"] = stop_reason
+            chunks.append(chunk)
+
+        return chunks

--- a/components/src/dynamo/vllm/decoder_sampling.py
+++ b/components/src/dynamo/vllm/decoder_sampling.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared Dynamo request to native vLLM sampling conversion."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any, Dict, Final
+
+from vllm.sampling_params import (
+    RequestOutputKind,
+    SamplingParams,
+    StructuredOutputsParams,
+)
+
+from dynamo.common.backend import logprobs as _shared_logprobs
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
+from dynamo.common.utils.structural_tag import serialize_structural_tag
+
+logger = logging.getLogger(__name__)
+
+_DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
+_KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY: Final = "kv_transfer_params"
+_ROUTER_HINT_EXTRA_ARGS_KEY: Final = "router_hint"
+
+
+def _iter_nvext_sources(request: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+    """Yield request ``nvext`` dictionaries in protocol priority order."""
+
+    extra_args = request.get("extra_args")
+    for source in (
+        request.get("nvext"),
+        extra_args.get("nvext") if isinstance(extra_args, dict) else None,
+    ):
+        if isinstance(source, dict):
+            yield source
+
+
+def _is_token_in_request(request: Dict[str, Any]) -> bool:
+    return any(
+        source.get("token_data") or source.get("token_in")
+        for source in _iter_nvext_sources(request)
+    )
+
+
+def build_sampling_params(
+    request: Dict[str, Any],
+    default_sampling_params: Dict[str, Any],
+    model_max_len: int | None = None,
+    enable_rl: bool = False,
+    *,
+    prompt_token_count_override: int | None = None,
+) -> SamplingParams:
+    """Build native vLLM sampling parameters from a Dynamo request."""
+
+    if enable_rl and _is_token_in_request(request):
+        sampling_params = SamplingParams()
+    else:
+        sampling_params = SamplingParams(**default_sampling_params)
+
+    sampling_options = dict(request.get("sampling_options") or {})
+    extra_args = request.get("extra_args") or {}
+    if isinstance(extra_args, dict):
+        passthrough_sampling_options = extra_args.get("sampling_options")
+        if isinstance(passthrough_sampling_options, dict):
+            sampling_options.update(passthrough_sampling_options)
+    guided_decoding = sampling_options.get("guided_decoding")
+    if guided_decoding is not None and isinstance(guided_decoding, dict):
+        json_schema = guided_decoding.get("json")
+        if json_schema is not None:
+            reject_nonprogressing_guided_json_ref_cycles(json_schema)
+        sampling_params.structured_outputs = StructuredOutputsParams(
+            json=json_schema,
+            regex=guided_decoding.get("regex"),
+            choice=guided_decoding.get("choice"),
+            grammar=guided_decoding.get("grammar"),
+            whitespace_pattern=guided_decoding.get("whitespace_pattern"),
+            structural_tag=serialize_structural_tag(
+                guided_decoding.get("structural_tag")
+            ),
+        )
+
+    for key, value in sampling_options.items():
+        if key == "guided_decoding":
+            continue
+        if key == "bad_words_token_ids" and value is not None:
+            if not hasattr(sampling_params, "_bad_words_token_ids"):
+                raise AttributeError(
+                    "vLLM SamplingParams._bad_words_token_ids missing; TITO "
+                    "bad_words_token_ids passthrough needs updating for this "
+                    "vLLM version"
+                )
+            sampling_params._bad_words_token_ids = value
+            continue
+        if value is not None and hasattr(sampling_params, key):
+            setattr(sampling_params, key, value)
+
+    routed_experts_start = getattr(sampling_params, "routed_experts_prompt_start", None)
+    if routed_experts_start is not None and (
+        isinstance(routed_experts_start, bool)
+        or not isinstance(routed_experts_start, int)
+        or routed_experts_start < 0
+    ):
+        logger.warning(
+            "Ignoring invalid routed_experts_prompt_start=%r "
+            "(want non-negative int)",
+            routed_experts_start,
+        )
+        sampling_params.routed_experts_prompt_start = 0
+
+    for key, value in request.get("stop_conditions", {}).items():
+        if value is not None and hasattr(sampling_params, key):
+            if key == "stop":
+                continue
+            setattr(sampling_params, key, value)
+        if (
+            key == "stop_token_ids_hidden"
+            and value is not None
+            and hasattr(sampling_params, "stop_token_ids")
+        ):
+            existing = sampling_params.stop_token_ids or []
+            sampling_params.stop_token_ids = list(set(existing).union(value))
+        if (
+            key == "max_thinking_tokens"
+            and value is not None
+            and hasattr(sampling_params, "thinking_token_budget")
+        ):
+            sampling_params.thinking_token_budget = value
+
+    output_options = request.get("output_options", {}) or {}
+    logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(output_options)
+    if logprobs is not None:
+        sampling_params.logprobs = logprobs
+    if prompt_logprobs is not None:
+        sampling_params.prompt_logprobs = prompt_logprobs
+
+    provided_max_tokens = request.get("stop_conditions", {}).get("max_tokens", None)
+    token_ids = request.get("token_ids", [])
+    input_length = (
+        prompt_token_count_override
+        if prompt_token_count_override is not None
+        else len(token_ids)
+    )
+    if model_max_len is not None and provided_max_tokens is None:
+        dynamic_default = max(1, model_max_len - input_length)
+        configured_default = default_sampling_params.get("max_tokens", dynamic_default)
+        sampling_params.max_tokens = min(configured_default, dynamic_default)
+
+    if isinstance(extra_args, dict):
+        request_kv_transfer_params = extra_args.get(_KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY)
+        if isinstance(request_kv_transfer_params, dict):
+            passthrough_router_hint = request_kv_transfer_params.get(
+                _ROUTER_HINT_EXTRA_ARGS_KEY
+            )
+            if isinstance(passthrough_router_hint, dict):
+                passthrough_extra_args = (
+                    dict(sampling_params.extra_args)
+                    if isinstance(sampling_params.extra_args, dict)
+                    else {}
+                )
+                existing_kv_transfer_params = passthrough_extra_args.get(
+                    _KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY
+                )
+                passthrough_kv_transfer_params = (
+                    dict(existing_kv_transfer_params)
+                    if isinstance(existing_kv_transfer_params, dict)
+                    else {}
+                )
+                passthrough_kv_transfer_params[
+                    _ROUTER_HINT_EXTRA_ARGS_KEY
+                ] = passthrough_router_hint
+                passthrough_extra_args[
+                    _KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY
+                ] = passthrough_kv_transfer_params
+                sampling_params.extra_args = passthrough_extra_args
+
+    sampling_params.detokenize = False
+    sampling_params.output_kind = _DELTA_REQUEST_OUTPUT_KIND
+    return sampling_params

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -7,7 +7,6 @@ import functools
 import importlib
 import inspect
 import logging
-import math
 import os
 import struct
 import tempfile
@@ -37,11 +36,7 @@ from vllm.inputs import EmbedsPrompt, TextPrompt, TokensPrompt
 from vllm.lora.request import LoRARequest
 from vllm.outputs import RequestOutput
 from vllm.renderers.embed_utils import safe_load_prompt_embeds
-from vllm.sampling_params import (
-    RequestOutputKind,
-    SamplingParams,
-    StructuredOutputsParams,
-)
+from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo._core import Context
@@ -64,9 +59,7 @@ from dynamo.common.rl import (
 )
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.engine_response import normalize_finish_reason
-from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.common.utils.input_params import InputParamManager
-from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.common.utils.time_section import time_and_log_code_section
 from dynamo.llm import (
     KvEventPublisher,
@@ -87,6 +80,8 @@ from dynamo.vllm.kv_connector_protocols import (
 )
 from dynamo.vllm.router_hints import enable_router_hint_support
 
+from . import decoder_output as _decoder_output
+from . import decoder_sampling as _decoder_sampling
 from .args import Config
 from .cache_info import get_configured_kv_event_block_size
 from .capacity import publish_vllm_token_budget
@@ -110,6 +105,20 @@ from .multimodal_utils.request_processor import (
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
+# Preserve the existing handlers-module import surface while the implementation
+# moves behind a reusable decoder boundary.
+_MIN_FINITE_LOGPROB = _decoder_output._MIN_FINITE_LOGPROB
+_attach_prompt_logprobs_engine_data = (
+    _decoder_output._attach_prompt_logprobs_engine_data
+)
+_attach_routed_experts_engine_data = _decoder_output._attach_routed_experts_engine_data
+_finite_logprob = _decoder_output._finite_logprob
+_serialize_prompt_logprobs = _decoder_output._serialize_prompt_logprobs
+_serialize_routed_experts = _decoder_output._serialize_routed_experts
+_VllmDecodeOutputAdapter = _decoder_output._VllmDecodeOutputAdapter
+build_completion_usage = _decoder_output.build_completion_usage
+build_prompt_tokens_details = _decoder_output.build_prompt_tokens_details
+
 # Marker set by the Rust conditional-disagg bypass path. When present on a
 # DECODE-mode worker, the request runs as local prefill+decode instead of
 # expecting KV-transfer metadata from an upstream prefill worker.
@@ -119,10 +128,12 @@ _GENERATE_REASONING_SUPPORT_CACHE_ATTR = "_dynamo_generate_reasoning_support"
 _DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
 _RL_INIT_WEIGHTS_TIMEOUT_ENV = "DYN_RL_INIT_WEIGHTS_TIMEOUT_S"
 _RL_INIT_WEIGHTS_TIMEOUT_DEFAULT_S = 30.0
-_KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY: Final = "kv_transfer_params"
+_KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY: Final = (
+    _decoder_sampling._KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY
+)
 # Request payload key under extra_args.kv_transfer_params. This intentionally
 # matches the runtime capability string, but it lives in a different namespace.
-_ROUTER_HINT_EXTRA_ARGS_KEY: Final = "router_hint"
+_ROUTER_HINT_EXTRA_ARGS_KEY: Final = _decoder_sampling._ROUTER_HINT_EXTRA_ARGS_KEY
 _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
     {
         "allow_unpaused",
@@ -131,15 +142,6 @@ _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
         "weight_version",
     }
 )
-
-
-def build_prompt_tokens_details(
-    num_cached_tokens: int | None,
-) -> dict[str, int] | None:
-    """Preserve the distinction between unavailable and zero cached tokens."""
-    if num_cached_tokens is None:
-        return None
-    return {"cached_tokens": num_cached_tokens}
 
 
 def _rl_init_weights_timeout_s() -> float:
@@ -395,109 +397,10 @@ class VllmEnginePauseController:
 # Helpers for nvext response fields requested through `nvext.extra_fields`.
 
 
-# Logprobs can be -inf (log of probability 0) for masked/disallowed tokens (e.g.
-# via bad_words_token_ids / allowed_token_ids) or full-vocab prompt logprobs.
-# JSON has no inf/nan, so pythonize -> serde_json rewrites them to `null`, which
-# then fails typed deserialization on the Rust side and SILENTLY DROPS the whole
-# logprobs payload. Clamp non-finite logprobs to a large finite-negative
-# sentinel so the value survives transport while still meaning "effectively
-# impossible".
-_MIN_FINITE_LOGPROB = -1e30
-
-
-def _finite_logprob(value: Any) -> float:
-    lp = float(value)
-    return lp if math.isfinite(lp) else _MIN_FINITE_LOGPROB
-
-
-def _serialize_prompt_logprobs(
-    raw_prompt_logprobs: list,
-) -> list:
-    """Convert vLLM's ``RequestOutput.prompt_logprobs`` into the dict shape
-    expected by Dynamo's Rust ``PromptLogprobEntry`` (serde deserialization).
-
-    vLLM shape: ``list[dict[int, Logprob] | None]`` where ``Logprob`` has
-    ``.logprob``, ``.rank``, ``.decoded_token`` attributes.
-
-    Output shape: ``list[dict[str, {"logprob": float, ...}] | None]``.
-    Workers carry it under ``engine_data.prompt_logprobs`` so the Rust
-    postprocessor can surface it on ``NvExtResponse.prompt_logprobs`` without
-    changing the public ``LLMEngineOutput`` struct shape.
-
-    NOTE: token_id keys are emitted as **strings** (not ints) so that
-    pythonize → serde → JSON survives the worker→frontend transport. JSON
-    object keys are required to be strings; ``HashMap<u32, _>`` on the Rust
-    side deserializes string keys via ``u32::from_str``. Emitting int keys
-    here causes the chunk to be silently dropped on pythonize → JSON, which
-    surfaces as ``"Stream ended before generation completed"`` on the
-    frontend (worker emits cleanly, frontend never sees ``complete_final``).
-    """
-    result: list = []
-    for entry in raw_prompt_logprobs:
-        if entry is None:
-            result.append(None)
-        else:
-            converted: Dict[str, Dict[str, Any]] = {}
-            for token_id, logprob_obj in entry.items():
-                try:
-                    key = str(int(token_id))
-                except (TypeError, ValueError):
-                    # vLLM only emits int token-id keys; skip a non-int key
-                    # rather than aborting the whole prompt_logprobs payload.
-                    continue
-                lp_dict: Dict[str, Any] = {
-                    "logprob": _finite_logprob(logprob_obj.logprob),
-                }
-                rank = getattr(logprob_obj, "rank", None)
-                if rank is not None:
-                    lp_dict["rank"] = int(rank)
-                decoded = getattr(logprob_obj, "decoded_token", None)
-                if decoded is not None:
-                    lp_dict["decoded_token"] = decoded
-                converted[key] = lp_dict
-            result.append(converted)
-    return result
-
-
-def _attach_prompt_logprobs_engine_data(
-    tok: Dict[str, Any], prompt_logprobs: list
-) -> None:
-    engine_data = tok.setdefault("engine_data", {})
-    if isinstance(engine_data, dict):
-        engine_data["prompt_logprobs"] = prompt_logprobs
-
-
-def _attach_routed_experts_engine_data(
-    tok: Dict[str, Any], routed_experts: Dict[str, Any]
-) -> None:
-    # routed_experts rides the engine's opaque engine_data passthrough (surfaced
-    # by the Rust postprocessor as nvext.routed_experts); disaggregated_params
-    # stays KV-transfer only. Merge via setdefault so we don't clobber any
-    # prompt_logprobs already attached to engine_data on the final chunk.
-    engine_data = tok.setdefault("engine_data", {})
-    if isinstance(engine_data, dict):
-        engine_data["routed_experts"] = routed_experts
-
-
 def _iter_nvext_sources(request: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
-    """Yield each nvext dict on the request, in priority order:
+    """Yield each request nvext dictionary in protocol priority order."""
 
-      1. ``request["nvext"]``               — raw OpenAI shape (SGLang / tests).
-      2. ``request["extra_args"]["nvext"]`` — what the Rust preprocessor stashes
-         when building PreprocessedRequest from an OpenAI request
-         (PreprocessedRequest itself has no nvext field).
-
-    Centralizing this lookup keeps ``_nvext_extra_field_requested``,
-    ``_is_token_in_request`` and ``_apply_nvext_cache_salt`` consistent so an
-    nvext field is never honored by one helper but silently missed by another.
-    """
-    extra_args = request.get("extra_args")
-    for source in (
-        request.get("nvext"),
-        extra_args.get("nvext") if isinstance(extra_args, dict) else None,
-    ):
-        if isinstance(source, dict):
-            yield source
+    yield from _decoder_sampling._iter_nvext_sources(request)
 
 
 def _nvext_extra_field_requested(request: Dict[str, Any], field: str) -> bool:
@@ -586,10 +489,7 @@ def _flatten_logprobs(
 
 
 def _is_token_in_request(request: Dict[str, Any]) -> bool:
-    return any(
-        source.get("token_data") or source.get("token_in")
-        for source in _iter_nvext_sources(request)
-    )
+    return _decoder_sampling._is_token_in_request(request)
 
 
 def _accumulate_engine_data(
@@ -655,210 +555,23 @@ def _accumulate_engine_data(
     tok["engine_data"] = engine_data
 
 
-def _serialize_routed_experts(
-    routed_experts: Any, start: int = 0
-) -> Optional[Dict[str, Any]]:
-    if routed_experts is None:
-        return None
-
-    shape = getattr(routed_experts, "shape", None)
-    tobytes = getattr(routed_experts, "tobytes", None)
-    if shape is None or not callable(tobytes):
-        logger.warning(
-            "Unable to serialize routed_experts of type %s",
-            type(routed_experts).__name__,
-        )
-        return None
-
-    return {
-        # base64, matching vLLM-native encoding.
-        "data": base64.b64encode(tobytes()).decode("ascii"),
-        "shape": [int(dim) for dim in shape],
-        # Row offset of the first returned routing entry within the full
-        # sequence (= SamplingParams.routed_experts_prompt_start; vLLM trims the
-        # leading prompt rows). Lets the RL consumer align the completion.
-        "start": int(start),
-        # Encode dtype so the consumer decodes the raw bytes with the right
-        # element type instead of assuming a fixed width.
-        "dtype": str(getattr(routed_experts, "dtype", "")),
-    }
-
-
 def build_sampling_params(
     request: Dict[str, Any],
     default_sampling_params: Dict[str, Any],
     model_max_len: int | None = None,
     enable_rl: bool = False,
+    *,
+    prompt_token_count_override: int | None = None,
 ) -> SamplingParams:
-    """
-    Build SamplingParams from a PreprocessedRequest (internal protocol format).
+    """Build native vLLM sampling parameters from a Dynamo request."""
 
-    Args:
-        request: The PreprocessedRequest dict with 'sampling_options', 'stop_conditions',
-                 and 'output_options'
-        default_sampling_params: Default sampling parameters from the model's
-            ``generation_config.json`` (vLLM ``ModelConfig.get_diff_sampling_param``).
-            Used for non-RL/chat clients that want the model's recommended
-            sampling defaults applied transparently.
-
-    Returns:
-        SamplingParams configured from the request
-
-    RL token-in requests use vLLM's default sampling values instead of model
-    `generation_config.json` sampling overrides. Ordinary token-data requests
-    keep generation_config defaults for Gateway/backward-compatible traffic.
-    Stop-token defaults from the model config are still applied later.
-    """
-    if enable_rl and _is_token_in_request(request):
-        # Use vLLM defaults without model generation_config overlays.
-        sampling_params = SamplingParams()
-    else:
-        sampling_params = SamplingParams(**default_sampling_params)
-
-    # Handle guided_decoding - convert to StructuredOutputsParams
-    sampling_options = dict(request.get("sampling_options") or {})
-    extra_args = request.get("extra_args") or {}
-    if isinstance(extra_args, dict):
-        passthrough_sampling_options = extra_args.get("sampling_options")
-        if isinstance(passthrough_sampling_options, dict):
-            sampling_options.update(passthrough_sampling_options)
-    guided_decoding = sampling_options.get("guided_decoding")
-    if guided_decoding is not None and isinstance(guided_decoding, dict):
-        json_schema = guided_decoding.get("json")
-        if json_schema is not None:
-            reject_nonprogressing_guided_json_ref_cycles(json_schema)
-        sampling_params.structured_outputs = StructuredOutputsParams(
-            json=json_schema,
-            regex=guided_decoding.get("regex"),
-            choice=guided_decoding.get("choice"),
-            grammar=guided_decoding.get("grammar"),
-            whitespace_pattern=guided_decoding.get("whitespace_pattern"),
-            structural_tag=serialize_structural_tag(
-                guided_decoding.get("structural_tag")
-            ),
-        )
-
-    # Apply remaining sampling_options
-    for key, value in sampling_options.items():
-        # Skip guided_decoding - already handled above
-        if key == "guided_decoding":
-            continue
-        if key == "bad_words_token_ids" and value is not None:
-            # vLLM has no public setter for token-id bad words; we write the
-            # private field directly. Guard so a vLLM upgrade that renames it
-            # fails loudly here instead of silently dropping the constraint.
-            if not hasattr(sampling_params, "_bad_words_token_ids"):
-                raise AttributeError(
-                    "vLLM SamplingParams._bad_words_token_ids missing; TITO "
-                    "bad_words_token_ids passthrough needs updating for this "
-                    "vLLM version"
-                )
-            sampling_params._bad_words_token_ids = value
-            continue
-        if value is not None and hasattr(sampling_params, key):
-            setattr(sampling_params, key, value)
-
-    # routed_experts_prompt_start (RL capture offset) must be a non-negative
-    # int; reject bad client values so the worker emits a sane `start` instead
-    # of a bogus offset the consumer cannot align (vLLM clamps the upper bound).
-    reps = getattr(sampling_params, "routed_experts_prompt_start", None)
-    if reps is not None and (
-        isinstance(reps, bool) or not isinstance(reps, int) or reps < 0
-    ):
-        logger.warning(
-            "Ignoring invalid routed_experts_prompt_start=%r (want non-negative int)",
-            reps,
-        )
-        sampling_params.routed_experts_prompt_start = 0
-
-    # Apply stop_conditions
-    for key, value in request.get("stop_conditions", {}).items():
-        if value is not None and hasattr(sampling_params, key):
-            # Do not add stop key to sampling params - dynamo handles stop conditions directly
-            if key == "stop":
-                continue
-            setattr(sampling_params, key, value)
-        if (
-            key == "stop_token_ids_hidden"
-            and value is not None
-            and hasattr(sampling_params, "stop_token_ids")
-        ):
-            existing = sampling_params.stop_token_ids or []
-            sampling_params.stop_token_ids = list(set(existing).union(value))
-        # Dynamo's StopConditions uses `max_thinking_tokens`; vLLM 0.20+ exposes
-        # the same concept as `thinking_token_budget` on SamplingParams and
-        # enforces it via the builtin thinking-budget logits processor.
-        if (
-            key == "max_thinking_tokens"
-            and value is not None
-            and hasattr(sampling_params, "thinking_token_budget")
-        ):
-            sampling_params.thinking_token_budget = value
-
-    # Apply output_options (logprobs, prompt_logprobs, etc.)
-    output_options = request.get("output_options", {}) or {}
-    logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(output_options)
-    if logprobs is not None:
-        sampling_params.logprobs = logprobs
-    if prompt_logprobs is not None:
-        sampling_params.prompt_logprobs = prompt_logprobs
-
-    # skip_special_tokens is intentionally NOT forwarded to vLLM here: this path
-    # forces detokenize=False (below), so vLLM never detokenizes and ignores it.
-    # Dynamo detokenizes in the Rust backend, which reads skip_special_tokens
-    # directly from the request output_options (lib/llm/src/backend.rs).
-
-    # If max_tokens wasn't provided (None or missing), compute a dynamic default
-    provided_max_tokens = request.get("stop_conditions", {}).get("max_tokens", None)
-    token_ids = request.get("token_ids", [])
-    input_length = len(token_ids)
-    if model_max_len is not None and provided_max_tokens is None:
-        # Ensure at least 1 token generation by default when possible
-        dynamic_default = max(1, model_max_len - input_length)
-        configured_default = default_sampling_params.get("max_tokens", dynamic_default)
-        sampling_params.max_tokens = min(configured_default, dynamic_default)
-
-    # Forward only Dynamo's router-generated hint from
-    # request.extra_args.kv_transfer_params into vLLM SamplingParams. Today,
-    # router_hint is the only kv_transfer_params key the Rust preprocessor adds,
-    # so do not pass through any other request-provided connector inputs. Copy
-    # extra_args before mutation because SamplingParams may reuse the
-    # default_sampling_params dict across requests.
-    if isinstance(extra_args, dict):
-        request_kv_transfer_params = extra_args.get(_KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY)
-        if isinstance(request_kv_transfer_params, dict):
-            passthrough_router_hint = request_kv_transfer_params.get(
-                _ROUTER_HINT_EXTRA_ARGS_KEY
-            )
-            if isinstance(passthrough_router_hint, dict):
-                passthrough_extra_args = (
-                    dict(sampling_params.extra_args)
-                    if isinstance(sampling_params.extra_args, dict)
-                    else {}
-                )
-                existing_kv_transfer_params = passthrough_extra_args.get(
-                    _KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY
-                )
-                passthrough_kv_transfer_params = (
-                    dict(existing_kv_transfer_params)
-                    if isinstance(existing_kv_transfer_params, dict)
-                    else {}
-                )
-                passthrough_kv_transfer_params[
-                    _ROUTER_HINT_EXTRA_ARGS_KEY
-                ] = passthrough_router_hint
-                passthrough_extra_args[
-                    _KV_TRANSFER_PARAMS_EXTRA_ARGS_KEY
-                ] = passthrough_kv_transfer_params
-                sampling_params.extra_args = passthrough_extra_args
-
-    # Dynamo's internal token path consumes disjoint token deltas. This mirrors
-    # the SGLang integration and lets vLLM's stream_interval gate reduce backend
-    # bridge pressure before chunks cross into Dynamo.
-    sampling_params.detokenize = False
-    sampling_params.output_kind = _DELTA_REQUEST_OUTPUT_KIND
-
-    return sampling_params
+    return _decoder_sampling.build_sampling_params(
+        request,
+        default_sampling_params,
+        model_max_len,
+        enable_rl,
+        prompt_token_count_override=prompt_token_count_override,
+    )
 
 
 def _update_kv_transfer_params(
@@ -2875,41 +2588,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         request_output: RequestOutput,
         completion_token_counts: dict[int, int] | None = None,
     ) -> Dict[str, Any]:
-        """
-        Build completion usage statistics.
-
-        Args:
-            request_output: vLLM RequestOutput object
-            completion_token_counts: Optional cumulative generated-token counts by
-                                     output index. DELTA-mode streams need this
-                                     because the final vLLM chunk is not cumulative.
-
-        Returns:
-            Dict with prompt_tokens, completion_tokens, total_tokens, prompt_tokens_details
-        """
-        prompt_tokens = (
-            len(request_output.prompt_token_ids)
-            if request_output.prompt_token_ids
-            else None
-        )
-
-        if completion_token_counts is not None:
-            completion_tokens = sum(completion_token_counts.values())
-        else:
-            completion_tokens = sum(
-                len(output.token_ids) for output in request_output.outputs
-            )
-
-        return {
-            "prompt_tokens": prompt_tokens,
-            "completion_tokens": completion_tokens,
-            "total_tokens": (
-                prompt_tokens + completion_tokens if prompt_tokens is not None else None
-            ),
-            "prompt_tokens_details": build_prompt_tokens_details(
-                getattr(request_output, "num_cached_tokens", None)
-            ),
-        }
+        return build_completion_usage(request_output, completion_token_counts)
 
     @staticmethod
     def _extract_logprobs(
@@ -2995,126 +2674,36 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 ),
             )
 
-            total_output_tokens_by_index: dict[int, int] = {}
-            raw_routed_experts_by_output: dict[int, Any] = {}
-            # vLLM surfaces prompt_logprobs once (at end-of-prefill) and clears
-            # them on subsequent chunks, so the generation-finish chunk often
-            # carries None. Capture the first non-None payload and attach it to
-            # the final chunk instead of reading res.prompt_logprobs there.
-            prompt_logprobs_payload: Optional[list] = None
+            output_adapter = _VllmDecodeOutputAdapter(
+                sampling_params,
+                tokenizer=getattr(self.engine_client, "tokenizer", None),
+                extract_logprobs=self._extract_logprobs,
+            )
             async for res in gen:
-                # res is vllm's RequestOutput
-                if (
-                    prompt_logprobs_payload is None
-                    and getattr(res, "prompt_logprobs", None) is not None
-                ):
-                    prompt_logprobs_payload = _serialize_prompt_logprobs(
-                        res.prompt_logprobs
-                    )
-
                 if not res.outputs:
                     self._log_with_lora_context(
                         "Request {request_id}{lora_info} returned no outputs",
                         request_id,
                         lora_request,
                     )
-                    # Use string format "error: message" for consistency with vLLM's string-based finish_reason
-                    # Rust will parse this into FinishReason::Error(message)
-                    yield {
-                        "finish_reason": "error: No outputs from vLLM engine",
-                        "index": 0,
-                        "token_ids": [],
-                    }
+                    for chunk in output_adapter.convert(res):
+                        yield chunk
                     break
-
-                prepared_outputs = []
-                for output in res.outputs:
-                    output_idx = getattr(output, "index", 0) or 0
-                    token_ids = list(output.token_ids or [])
-                    total_output_tokens_by_index[
-                        output_idx
-                    ] = total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
-                    finish_reason = getattr(output, "finish_reason", None)
-                    stop_reason = getattr(output, "stop_reason", None)
-                    if not token_ids and not finish_reason and not stop_reason:
-                        continue
-                    prepared_outputs.append(
-                        (output, output_idx, token_ids, finish_reason, stop_reason)
-                    )
-
-                for (
-                    output,
-                    output_idx,
-                    token_ids,
-                    finish_reason,
-                    stop_reason,
-                ) in prepared_outputs:
-                    out = {
-                        "index": output_idx,
-                        "token_ids": token_ids,
-                    }
-                    # Capture the raw routed_experts cheaply here; serialize it
-                    # only once on the final chunk (base64-encoding a tensor on
-                    # every streamed chunk would be wasted work, since only the
-                    # final value is emitted).
-                    raw_routed_experts = getattr(output, "routed_experts", None)
-                    if raw_routed_experts is not None:
-                        raw_routed_experts_by_output[output_idx] = raw_routed_experts
-
-                    # vLLM DELTA outputs already align token_ids/logprobs to this chunk.
-                    tokenizer = getattr(self.engine_client, "tokenizer", None)
-                    log_probs, top_logprobs = self._extract_logprobs(
-                        output, 0, tokenizer=tokenizer
-                    )
-                    if log_probs is not None:
-                        out["log_probs"] = log_probs
-                    if top_logprobs is not None:
-                        out["top_logprobs"] = top_logprobs
-
+                for chunk in output_adapter.convert(res):
+                    finish_reason = chunk.get("finish_reason")
                     if finish_reason:
-                        out["finish_reason"] = normalize_finish_reason(finish_reason)
-                        out[
-                            "completion_usage"
-                        ] = BaseWorkerHandler._build_completion_usage(
-                            request_output=res,
-                            completion_token_counts=total_output_tokens_by_index,
-                        )
-                        if prompt_logprobs_payload is not None:
-                            _attach_prompt_logprobs_engine_data(
-                                out, prompt_logprobs_payload
-                            )
-                        # Emit the EFFECTIVE trim offset: clamp the requested
-                        # routed_experts_prompt_start to the prompt length. vLLM
-                        # clamps the returned routing rows the same way, so an
-                        # out-of-range request (e.g. start=999 on a 100-token
-                        # prompt) would otherwise publish a `start` the consumer
-                        # cannot align to the (clamped) tensor.
-                        raw_start = int(
-                            getattr(sampling_params, "routed_experts_prompt_start", 0)
-                            or 0
-                        )
-                        prompt_len = len(getattr(res, "prompt_token_ids", None) or [])
-                        effective_start = min(raw_start, prompt_len)
-                        routed_experts = _serialize_routed_experts(
-                            raw_routed_experts_by_output.get(output_idx),
-                            start=effective_start,
-                        )
-                        if routed_experts is not None:
-                            _attach_routed_experts_engine_data(out, routed_experts)
-                        # Log completion with LoRA info (debug level to avoid log spam)
+                        output_index = int(chunk.get("index") or 0)
                         self._log_with_lora_context(
                             "Completed token generation for request {request_id}{lora_info}: "
                             "{output_tokens} output tokens, finish_reason={finish_reason}",
                             request_id,
                             lora_request,
-                            output_tokens=total_output_tokens_by_index.get(
-                                output_idx, 0
+                            output_tokens=output_adapter.completion_tokens(
+                                output_index
                             ),
                             finish_reason=finish_reason,
                         )
-                    if stop_reason:
-                        out["stop_reason"] = stop_reason
-                    yield out
+                    yield chunk
 
         except EngineDeadError as e:
             logger.error(f"vLLM EngineDeadError: {e}")

--- a/components/src/dynamo/workflow/__init__.py
+++ b/components/src/dynamo/workflow/__init__.py
@@ -9,7 +9,7 @@ from dynamo.workflow.builder import (
     Workflow,
     WorkflowBuilder,
 )
-from dynamo.workflow.ir import WORKFLOW_SCHEMA, WORKFLOW_VERSION, StageIR, WorkflowIR
+from dynamo.workflow.ir import StageIR, WorkflowIR
 from dynamo.workflow.types import (
     StageContract,
     ValueRef,
@@ -18,8 +18,6 @@ from dynamo.workflow.types import (
 )
 
 __all__ = [
-    "WORKFLOW_SCHEMA",
-    "WORKFLOW_VERSION",
     "StageContract",
     "StageDefinition",
     "StageHandle",

--- a/components/src/dynamo/workflow/__init__.py
+++ b/components/src/dynamo/workflow/__init__.py
@@ -3,12 +3,8 @@
 
 """Authoring and canonical IR for Dynamo inference workflows."""
 
-from dynamo.workflow.builder import (
-    StageDefinition,
-    StageHandle,
-    Workflow,
-    WorkflowBuilder,
-)
+from dynamo.workflow.builder import StageDefinition, StageHandle, Workflow
+from dynamo.workflow.definition import StageRef, WorkflowDefinition, WorkflowHandler
 from dynamo.workflow.ir import StageIR, WorkflowIR
 from dynamo.workflow.types import (
     StageContract,
@@ -22,10 +18,12 @@ __all__ = [
     "StageDefinition",
     "StageHandle",
     "StageIR",
+    "StageRef",
     "ValueRef",
     "ValueSpec",
     "Workflow",
-    "WorkflowBuilder",
+    "WorkflowDefinition",
+    "WorkflowHandler",
     "WorkflowIR",
     "WorkflowValidationError",
 ]

--- a/components/src/dynamo/workflow/__init__.py
+++ b/components/src/dynamo/workflow/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authoring and canonical IR for Dynamo inference workflows."""
+
+from dynamo.workflow.builder import (
+    StageDefinition,
+    StageHandle,
+    Workflow,
+    WorkflowBuilder,
+)
+from dynamo.workflow.ir import WORKFLOW_SCHEMA, WORKFLOW_VERSION, StageIR, WorkflowIR
+from dynamo.workflow.types import (
+    StageContract,
+    ValueRef,
+    ValueSpec,
+    WorkflowValidationError,
+)
+
+__all__ = [
+    "WORKFLOW_SCHEMA",
+    "WORKFLOW_VERSION",
+    "StageContract",
+    "StageDefinition",
+    "StageHandle",
+    "StageIR",
+    "ValueRef",
+    "ValueSpec",
+    "Workflow",
+    "WorkflowBuilder",
+    "WorkflowIR",
+    "WorkflowValidationError",
+]

--- a/components/src/dynamo/workflow/__init__.py
+++ b/components/src/dynamo/workflow/__init__.py
@@ -1,19 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Authoring and canonical IR for Dynamo inference workflows."""
+"""Authoring, compilation, and execution for Dynamo inference workflows."""
 
 from dynamo.workflow.builder import StageDefinition, StageHandle, Workflow
-from dynamo.workflow.definition import StageRef, WorkflowDefinition, WorkflowHandler
 from dynamo.workflow.compiler import DeploymentSpec, compile_workflow
+from dynamo.workflow.definition import StageRef, WorkflowDefinition, WorkflowHandler
+from dynamo.workflow.executor import WorkflowContext, WorkflowExecutor
 from dynamo.workflow.ir import StageIR, WorkflowIR
 from dynamo.workflow.plan import EdgePlan, ExecutionPlan, LocalBinding
-from dynamo.workflow.runtime import (
-    StageContext,
-    StageRunner,
-    WorkflowExecutionError,
-    WorkflowExecutor,
-)
+from dynamo.workflow.runtime import StageContext, StageRunner, WorkflowExecutionError
 from dynamo.workflow.types import (
     StageContract,
     ValueRef,
@@ -36,6 +32,7 @@ __all__ = [
     "Workflow",
     "WorkflowDefinition",
     "WorkflowHandler",
+    "WorkflowContext",
     "WorkflowIR",
     "WorkflowExecutionError",
     "WorkflowExecutor",

--- a/components/src/dynamo/workflow/__init__.py
+++ b/components/src/dynamo/workflow/__init__.py
@@ -6,6 +6,14 @@
 from dynamo.workflow.builder import StageDefinition, StageHandle, Workflow
 from dynamo.workflow.definition import StageRef, WorkflowDefinition, WorkflowHandler
 from dynamo.workflow.ir import StageIR, WorkflowIR
+from dynamo.workflow.runtime import (
+    ExecutionPlan,
+    LocalBinding,
+    StageContext,
+    StageRunner,
+    WorkflowExecutionError,
+    compile_workflow,
+)
 from dynamo.workflow.types import (
     StageContract,
     ValueRef,
@@ -19,11 +27,17 @@ __all__ = [
     "StageHandle",
     "StageIR",
     "StageRef",
+    "StageContext",
+    "StageRunner",
     "ValueRef",
     "ValueSpec",
     "Workflow",
     "WorkflowDefinition",
     "WorkflowHandler",
     "WorkflowIR",
+    "WorkflowExecutionError",
     "WorkflowValidationError",
+    "ExecutionPlan",
+    "LocalBinding",
+    "compile_workflow",
 ]

--- a/components/src/dynamo/workflow/__init__.py
+++ b/components/src/dynamo/workflow/__init__.py
@@ -5,14 +5,14 @@
 
 from dynamo.workflow.builder import StageDefinition, StageHandle, Workflow
 from dynamo.workflow.definition import StageRef, WorkflowDefinition, WorkflowHandler
+from dynamo.workflow.compiler import DeploymentSpec, compile_workflow
 from dynamo.workflow.ir import StageIR, WorkflowIR
+from dynamo.workflow.plan import EdgePlan, ExecutionPlan, LocalBinding
 from dynamo.workflow.runtime import (
-    ExecutionPlan,
-    LocalBinding,
     StageContext,
     StageRunner,
     WorkflowExecutionError,
-    compile_workflow,
+    WorkflowExecutor,
 )
 from dynamo.workflow.types import (
     StageContract,
@@ -22,6 +22,8 @@ from dynamo.workflow.types import (
 )
 
 __all__ = [
+    "DeploymentSpec",
+    "EdgePlan",
     "StageContract",
     "StageDefinition",
     "StageHandle",
@@ -36,6 +38,7 @@ __all__ = [
     "WorkflowHandler",
     "WorkflowIR",
     "WorkflowExecutionError",
+    "WorkflowExecutor",
     "WorkflowValidationError",
     "ExecutionPlan",
     "LocalBinding",

--- a/components/src/dynamo/workflow/builder.py
+++ b/components/src/dynamo/workflow/builder.py
@@ -1,13 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Readable Python authoring helpers for canonical workflow IR."""
+"""Readable Python authoring for declarative and imperative workflows."""
 
 from __future__ import annotations
 
 import keyword
+from collections.abc import Callable
 from typing import Mapping, Optional, Protocol, Tuple, Union, cast, runtime_checkable
 
+from dynamo.workflow.definition import (
+    StageRef,
+    WorkflowDefinition,
+    WorkflowHandler,
+    WorkflowHandlerCallback,
+    _freeze_specs,
+)
 from dynamo.workflow.ir import StageIR, WorkflowIR
 from dynamo.workflow.types import (
     StageContract,
@@ -70,8 +78,8 @@ class StageHandle:
         )
 
 
-class WorkflowBuilder:
-    """Build a validated static workflow using declared stage contracts."""
+class Workflow:
+    """Author either a declarative graph or an imperative workflow handler."""
 
     def __init__(self, name: str) -> None:
         validate_name(name, "workflow name")
@@ -81,10 +89,16 @@ class WorkflowBuilder:
         self._stages: dict[str, StageIR] = {}
         self._contracts: dict[str, StageContract] = {}
         self._outputs: dict[str, ValueRef] = {}
+        self._mode: Optional[str] = None
+        self._handler_inputs: Mapping[str, ValueSpec] = {}
+        self._handler_outputs: Mapping[str, ValueSpec] = {}
+        self._handler_stages: dict[str, StageContract] = {}
+        self._handler_callback: Optional[WorkflowHandlerCallback] = None
 
     def add_input(self, name: str, spec: ValueSpec) -> ValueRef:
         """Declare and reference a workflow input."""
 
+        self._select_mode("graph")
         validate_name(name, "workflow input")
         if name in self._inputs:
             raise WorkflowValidationError(f"duplicate workflow input {name!r}")
@@ -125,6 +139,7 @@ class WorkflowBuilder:
     ) -> StageHandle:
         """Add a stage whose named inputs exactly match its contract."""
 
+        self._select_mode("graph")
         validate_name(stage_id, "stage id")
         if stage_id in self._stages:
             raise WorkflowValidationError(f"duplicate stage id {stage_id!r}")
@@ -165,19 +180,62 @@ class WorkflowBuilder:
     ) -> StageHandle:
         """Add a contracted worker or contract using keyword input ports."""
 
-        if isinstance(stage, StageContract):
-            contract = stage
-        elif isinstance(stage, StageDefinition):
-            contract = stage.contract
-        else:
-            raise WorkflowValidationError(
-                "stage must be a StageContract or carry a StageContract"
-            )
+        contract = self._resolve_contract(stage)
         return self.add_stage(stage_id, contract, inputs=inputs)
+
+    def use(
+        self,
+        stage_id: str,
+        stage: Union[StageContract, StageDefinition],
+    ) -> StageRef:
+        """Declare one stage available to an imperative workflow handler."""
+
+        self._select_mode("handler")
+        validate_name(stage_id, "stage id")
+        if stage_id in self._handler_stages:
+            raise WorkflowValidationError(f"duplicate stage id {stage_id!r}")
+        contract = self._resolve_contract(stage)
+        prior = self._contracts.get(contract.id)
+        if prior is not None and prior != contract:
+            raise WorkflowValidationError(
+                f"contract id {contract.id!r} has conflicting schemas"
+            )
+        self._contracts[contract.id] = contract
+        self._handler_stages[stage_id] = contract
+        return StageRef(stage_id, contract, self._owner)
+
+    def handler(
+        self,
+        *,
+        inputs: Mapping[str, ValueSpec],
+        outputs: Mapping[str, ValueSpec],
+    ) -> Callable[[WorkflowHandlerCallback], WorkflowHandlerCallback]:
+        """Register the single async callback for an imperative workflow."""
+
+        self._select_mode("handler")
+        if self._handler_callback is not None:
+            raise WorkflowValidationError("workflow already has a handler")
+        normalized_inputs = _freeze_specs(inputs, "workflow input")
+        normalized_outputs = _freeze_specs(outputs, "workflow output")
+        if not normalized_outputs:
+            raise WorkflowValidationError(
+                "workflow handlers require at least one output"
+            )
+
+        def register(callback: WorkflowHandlerCallback) -> WorkflowHandlerCallback:
+            if self._handler_callback is not None:
+                raise WorkflowValidationError("workflow already has a handler")
+            self._handler_inputs = normalized_inputs
+            self._handler_outputs = normalized_outputs
+            self._handler_callback = callback
+            return callback
+
+        return register
 
     def add_output(self, name: str, reference: ValueRef) -> None:
         """Expose a workflow input or stage output as a workflow output."""
 
+        self._select_mode("graph")
         validate_name(name, "workflow output")
         if name in self._outputs:
             raise WorkflowValidationError(f"duplicate workflow output {name!r}")
@@ -189,8 +247,22 @@ class WorkflowBuilder:
 
         self.add_output(name, reference)
 
-    def build(self) -> WorkflowIR:
-        """Return canonical, fully validated workflow IR."""
+    def build(self) -> WorkflowDefinition:
+        """Return the selected immutable workflow definition."""
+
+        if self._mode == "handler":
+            if self._handler_callback is None:
+                raise WorkflowValidationError("imperative workflow requires a handler")
+            return WorkflowHandler(
+                name=self._name,
+                inputs=self._handler_inputs,
+                outputs=self._handler_outputs,
+                stages=self._handler_stages,
+                callback=self._handler_callback,
+                _owner=self._owner,
+            )
+        if self._mode is None:
+            raise WorkflowValidationError("workflow has no graph or handler definition")
 
         return WorkflowIR(
             name=self._name,
@@ -199,10 +271,29 @@ class WorkflowBuilder:
             outputs=self._outputs,
         )
 
+    def _select_mode(self, mode: str) -> None:
+        if self._mode is not None and self._mode != mode:
+            raise WorkflowValidationError(
+                "workflow cannot mix declarative graph and imperative handler authoring"
+            )
+        self._mode = mode
+
+    @staticmethod
+    def _resolve_contract(
+        stage: Union[StageContract, StageDefinition],
+    ) -> StageContract:
+        if isinstance(stage, StageContract):
+            return stage
+        if isinstance(stage, StageDefinition):
+            return stage.contract
+        raise WorkflowValidationError(
+            "stage must be a StageContract or carry a StageContract"
+        )
+
     def _resolve_owned_reference(self, reference: ValueRef) -> ValueSpec:
         if not isinstance(reference, ValueRef) or reference._owner is not self._owner:
             raise WorkflowValidationError(
-                "value reference belongs to a different workflow builder"
+                "value reference belongs to a different workflow"
             )
         if reference.input_name is not None:
             if reference.input_name not in self._inputs:
@@ -220,7 +311,3 @@ class WorkflowBuilder:
                 f"unknown output {output_name!r} on stage {stage_id!r}"
             )
         return stage.contract.outputs[output_name]
-
-
-class Workflow(WorkflowBuilder):
-    """The user-facing workflow authoring surface."""

--- a/components/src/dynamo/workflow/builder.py
+++ b/components/src/dynamo/workflow/builder.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Readable Python authoring helpers for canonical workflow IR."""
+
+from __future__ import annotations
+
+import keyword
+from typing import Mapping, Optional, Protocol, Tuple, Union, cast, runtime_checkable
+
+from dynamo.workflow.ir import StageIR, WorkflowIR
+from dynamo.workflow.types import (
+    StageContract,
+    ValueRef,
+    ValueSpec,
+    WorkflowValidationError,
+    compatibility_error,
+    validate_name,
+)
+
+_RESERVED_OUTPUT_ATTRIBUTES = frozenset({"output", "output_names"})
+
+
+@runtime_checkable
+class StageDefinition(Protocol):
+    """Anything that carries a reusable stage contract, including a worker."""
+
+    contract: StageContract
+
+
+class StageHandle:
+    """References the outputs declared by one stage contract."""
+
+    def __init__(self, stage_id: str, contract: StageContract, owner: object) -> None:
+        self._stage_id = stage_id
+        self._outputs = {
+            name: ValueRef.for_stage_output(stage_id, name, owner)
+            for name in contract.outputs
+        }
+
+    @property
+    def output_names(self) -> tuple[str, ...]:
+        """Return the declared output names."""
+
+        return tuple(self._outputs)
+
+    def output(self, name: str) -> ValueRef:
+        """Reference a declared output, including names unsafe as attributes."""
+
+        try:
+            return self._outputs[name]
+        except KeyError as error:
+            raise WorkflowValidationError(
+                f"stage {self._stage_id!r} has no output {name!r}; "
+                f"declared outputs are {list(self._outputs)}"
+            ) from error
+
+    def __getattr__(self, name: str) -> ValueRef:
+        reference = self._outputs.get(name)
+        if (
+            reference is not None
+            and name.isidentifier()
+            and not keyword.iskeyword(name)
+            and name not in _RESERVED_OUTPUT_ATTRIBUTES
+        ):
+            return reference
+        raise AttributeError(
+            f"stage {self._stage_id!r} has no attribute-safe output {name!r}; "
+            "use stage.output(name) for the explicit form"
+        )
+
+
+class WorkflowBuilder:
+    """Build a validated static workflow using declared stage contracts."""
+
+    def __init__(self, name: str) -> None:
+        validate_name(name, "workflow name")
+        self._name = name
+        self._owner = object()
+        self._inputs: dict[str, ValueSpec] = {}
+        self._stages: dict[str, StageIR] = {}
+        self._contracts: dict[str, StageContract] = {}
+        self._outputs: dict[str, ValueRef] = {}
+
+    def add_input(self, name: str, spec: ValueSpec) -> ValueRef:
+        """Declare and reference a workflow input."""
+
+        validate_name(name, "workflow input")
+        if name in self._inputs:
+            raise WorkflowValidationError(f"duplicate workflow input {name!r}")
+        if not isinstance(spec, ValueSpec):
+            raise WorkflowValidationError("workflow inputs must use ValueSpec")
+        self._inputs[name] = spec
+        return ValueRef.for_input(name, self._owner)
+
+    def input(
+        self,
+        name: str,
+        *,
+        type: str,
+        dtype: Optional[str] = None,
+        shape: Optional[Tuple[Union[int, str], ...]] = None,
+        mode: Optional[str] = None,
+        class_id: Optional[str] = None,
+    ) -> ValueRef:
+        """Declare an input without constructing ``ValueSpec`` explicitly."""
+
+        return self.add_input(
+            name,
+            ValueSpec(
+                type=type,
+                dtype=dtype,
+                shape=shape,
+                mode=mode,
+                class_id=class_id,
+            ),
+        )
+
+    def add_stage(
+        self,
+        stage_id: str,
+        contract: StageContract,
+        *,
+        inputs: Mapping[str, ValueRef],
+    ) -> StageHandle:
+        """Add a stage whose named inputs exactly match its contract."""
+
+        validate_name(stage_id, "stage id")
+        if stage_id in self._stages:
+            raise WorkflowValidationError(f"duplicate stage id {stage_id!r}")
+        if not isinstance(contract, StageContract):
+            raise WorkflowValidationError("stage contract must use StageContract")
+        prior = self._contracts.get(contract.id)
+        if prior is not None and prior != contract:
+            raise WorkflowValidationError(
+                f"contract id {contract.id!r} has conflicting schemas"
+            )
+        expected = set(contract.inputs)
+        actual = set(inputs)
+        if actual != expected:
+            raise WorkflowValidationError(
+                f"stage {stage_id!r} inputs differ from its contract; "
+                f"missing={sorted(expected - actual)}, extra={sorted(actual - expected)}"
+            )
+
+        for port_name, reference in inputs.items():
+            producer_spec = self._resolve_owned_reference(reference)
+            error = compatibility_error(producer_spec, contract.inputs[port_name])
+            if error is not None:
+                raise WorkflowValidationError(
+                    f"stage {stage_id!r} input {port_name!r} is incompatible: {error}"
+                )
+
+        self._contracts[contract.id] = contract
+        self._stages[stage_id] = StageIR(
+            id=stage_id, contract=contract, inputs=dict(inputs)
+        )
+        return StageHandle(stage_id, contract, self._owner)
+
+    def stage(
+        self,
+        stage_id: str,
+        stage: Union[StageContract, StageDefinition],
+        **inputs: ValueRef,
+    ) -> StageHandle:
+        """Add a contracted worker or contract using keyword input ports."""
+
+        if isinstance(stage, StageContract):
+            contract = stage
+        elif isinstance(stage, StageDefinition):
+            contract = stage.contract
+        else:
+            raise WorkflowValidationError(
+                "stage must be a StageContract or carry a StageContract"
+            )
+        return self.add_stage(stage_id, contract, inputs=inputs)
+
+    def add_output(self, name: str, reference: ValueRef) -> None:
+        """Expose a workflow input or stage output as a workflow output."""
+
+        validate_name(name, "workflow output")
+        if name in self._outputs:
+            raise WorkflowValidationError(f"duplicate workflow output {name!r}")
+        self._resolve_owned_reference(reference)
+        self._outputs[name] = reference
+
+    def output(self, name: str, reference: ValueRef) -> None:
+        """Expose a workflow result."""
+
+        self.add_output(name, reference)
+
+    def build(self) -> WorkflowIR:
+        """Return canonical, fully validated workflow IR."""
+
+        return WorkflowIR(
+            name=self._name,
+            inputs=self._inputs,
+            stages=tuple(self._stages.values()),
+            outputs=self._outputs,
+        )
+
+    def _resolve_owned_reference(self, reference: ValueRef) -> ValueSpec:
+        if not isinstance(reference, ValueRef) or reference._owner is not self._owner:
+            raise WorkflowValidationError(
+                "value reference belongs to a different workflow builder"
+            )
+        if reference.input_name is not None:
+            if reference.input_name not in self._inputs:
+                raise WorkflowValidationError(
+                    f"unknown workflow input {reference.input_name!r}"
+                )
+            return self._inputs[reference.input_name]
+        stage_id = cast(str, reference.stage_id)
+        output_name = cast(str, reference.output_name)
+        if stage_id not in self._stages:
+            raise WorkflowValidationError(f"unknown stage {stage_id!r}")
+        stage = self._stages[stage_id]
+        if output_name not in stage.contract.outputs:
+            raise WorkflowValidationError(
+                f"unknown output {output_name!r} on stage {stage_id!r}"
+            )
+        return stage.contract.outputs[output_name]
+
+
+class Workflow(WorkflowBuilder):
+    """The user-facing workflow authoring surface."""

--- a/components/src/dynamo/workflow/compiler.py
+++ b/components/src/dynamo/workflow/compiler.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Mapping, Union
+from typing import Mapping, Optional, Union
 
 from dynamo.workflow.builder import WorkflowBuilder
 from dynamo.workflow.ir import WorkflowIR
@@ -54,15 +54,19 @@ class DeploymentSpec:
 
 def compile_workflow(
     workflow: Union[WorkflowBuilder, WorkflowIR],
-    deployment: DeploymentSpec,
+    deployment: Optional[DeploymentSpec] = None,
 ) -> ExecutionPlan:
-    """Compile one logical workflow using explicit placement bindings."""
+    """Compile one logical workflow, defaulting every stage to local placement."""
 
     workflow_ir = (
         workflow.build() if isinstance(workflow, WorkflowBuilder) else workflow
     )
     if not isinstance(workflow_ir, WorkflowIR):
         raise TypeError("workflow must be a Workflow or WorkflowIR")
+    if deployment is None:
+        deployment = DeploymentSpec.local(
+            **{stage.id: stage.id for stage in workflow_ir.stages}
+        )
     if not isinstance(deployment, DeploymentSpec):
         raise TypeError("deployment must use DeploymentSpec")
 

--- a/components/src/dynamo/workflow/compiler.py
+++ b/components/src/dynamo/workflow/compiler.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Mapping, Optional, Union
 
-from dynamo.workflow.builder import WorkflowBuilder
+from dynamo.workflow.builder import Workflow
+from dynamo.workflow.definition import WorkflowDefinition, WorkflowHandler
 from dynamo.workflow.ir import WorkflowIR
 from dynamo.workflow.plan import (
     LOCAL_CARRIER,
@@ -53,24 +54,26 @@ class DeploymentSpec:
 
 
 def compile_workflow(
-    workflow: Union[WorkflowBuilder, WorkflowIR],
+    workflow: Union[Workflow, WorkflowDefinition],
     deployment: Optional[DeploymentSpec] = None,
 ) -> ExecutionPlan:
     """Compile one logical workflow, defaulting every stage to local placement."""
 
-    workflow_ir = (
-        workflow.build() if isinstance(workflow, WorkflowBuilder) else workflow
-    )
-    if not isinstance(workflow_ir, WorkflowIR):
-        raise TypeError("workflow must be a Workflow or WorkflowIR")
+    definition = workflow.build() if isinstance(workflow, Workflow) else workflow
+    if not isinstance(definition, (WorkflowIR, WorkflowHandler)):
+        raise TypeError("workflow must be a Workflow or WorkflowDefinition")
+    if isinstance(definition, WorkflowIR):
+        stage_ids = tuple(stage.id for stage in definition.stages)
+    else:
+        stage_ids = tuple(definition.stages)
     if deployment is None:
         deployment = DeploymentSpec.local(
-            **{stage.id: stage.id for stage in workflow_ir.stages}
+            **{stage_id: stage_id for stage_id in stage_ids}
         )
     if not isinstance(deployment, DeploymentSpec):
         raise TypeError("deployment must use DeploymentSpec")
 
-    expected = {stage.id for stage in workflow_ir.stages}
+    expected = set(stage_ids)
     actual = set(deployment.bindings)
     if actual != expected:
         raise WorkflowValidationError(
@@ -78,14 +81,17 @@ def compile_workflow(
             f"missing={sorted(expected - actual)}, extra={sorted(actual - expected)}"
         )
 
-    edges = tuple(
-        EdgePlan(
-            source=source,
-            target_stage=stage.id,
-            target_port=port,
-            carrier=LOCAL_CARRIER,
+    if isinstance(definition, WorkflowIR):
+        edges = tuple(
+            EdgePlan(
+                source=source,
+                target_stage=stage.id,
+                target_port=port,
+                carrier=LOCAL_CARRIER,
+            )
+            for stage in definition.stages
+            for port, source in stage.inputs.items()
         )
-        for stage in workflow_ir.stages
-        for port, source in stage.inputs.items()
-    )
-    return ExecutionPlan(workflow_ir, deployment.bindings, edges)
+    else:
+        edges = ()
+    return ExecutionPlan(definition, deployment.bindings, edges)

--- a/components/src/dynamo/workflow/compiler.py
+++ b/components/src/dynamo/workflow/compiler.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lower placement-neutral workflows into physical execution plans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping, Union
+
+from dynamo.workflow.builder import WorkflowBuilder
+from dynamo.workflow.ir import WorkflowIR
+from dynamo.workflow.plan import (
+    LOCAL_CARRIER,
+    Binding,
+    EdgePlan,
+    ExecutionPlan,
+    LocalBinding,
+)
+from dynamo.workflow.types import WorkflowValidationError, validate_name
+
+
+@dataclass(frozen=True)
+class DeploymentSpec:
+    """Stage placement requested when compiling one WorkflowIR."""
+
+    bindings: Mapping[str, Binding]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.bindings, Mapping):
+            raise WorkflowValidationError("deployment bindings must be a mapping")
+        bindings: dict[str, Binding] = {}
+        for stage_id, binding in sorted(self.bindings.items()):
+            validate_name(stage_id, "deployment stage id")
+            if not isinstance(binding, LocalBinding):
+                raise WorkflowValidationError(
+                    f"binding for stage {stage_id!r} uses an unsupported type"
+                )
+            bindings[stage_id] = binding
+        object.__setattr__(self, "bindings", MappingProxyType(bindings))
+
+    @classmethod
+    def local(cls, **runner_keys: str) -> "DeploymentSpec":
+        """Build local bindings whose values name executor runner keys."""
+
+        return cls(
+            bindings={
+                stage_id: LocalBinding(runner_key)
+                for stage_id, runner_key in runner_keys.items()
+            }
+        )
+
+
+def compile_workflow(
+    workflow: Union[WorkflowBuilder, WorkflowIR],
+    deployment: DeploymentSpec,
+) -> ExecutionPlan:
+    """Compile one logical workflow using explicit placement bindings."""
+
+    workflow_ir = (
+        workflow.build() if isinstance(workflow, WorkflowBuilder) else workflow
+    )
+    if not isinstance(workflow_ir, WorkflowIR):
+        raise TypeError("workflow must be a Workflow or WorkflowIR")
+    if not isinstance(deployment, DeploymentSpec):
+        raise TypeError("deployment must use DeploymentSpec")
+
+    expected = {stage.id for stage in workflow_ir.stages}
+    actual = set(deployment.bindings)
+    if actual != expected:
+        raise WorkflowValidationError(
+            "deployment bindings differ from workflow stages; "
+            f"missing={sorted(expected - actual)}, extra={sorted(actual - expected)}"
+        )
+
+    edges = tuple(
+        EdgePlan(
+            source=source,
+            target_stage=stage.id,
+            target_port=port,
+            carrier=LOCAL_CARRIER,
+        )
+        for stage in workflow_ir.stages
+        for port, source in stage.inputs.items()
+    )
+    return ExecutionPlan(workflow_ir, deployment.bindings, edges)

--- a/components/src/dynamo/workflow/definition.py
+++ b/components/src/dynamo/workflow/definition.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-memory workflow definitions that are not canonical graph IR."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Union
+
+from dynamo.workflow.ir import WorkflowIR
+from dynamo.workflow.types import (
+    StageContract,
+    ValueSpec,
+    WorkflowValidationError,
+    validate_name,
+)
+
+WorkflowHandlerCallback = Callable[
+    [Mapping[str, Any], Any], Awaitable[Mapping[str, Any]]
+]
+
+
+def _freeze_specs(specs: Mapping[str, ValueSpec], kind: str) -> Mapping[str, ValueSpec]:
+    if not isinstance(specs, Mapping):
+        raise WorkflowValidationError(f"{kind}s must be a mapping")
+    frozen: dict[str, ValueSpec] = {}
+    for name, spec in sorted(specs.items()):
+        validate_name(name, kind)
+        if not isinstance(spec, ValueSpec):
+            raise WorkflowValidationError(f"{kind} {name!r} must use ValueSpec")
+        frozen[name] = spec
+    return MappingProxyType(frozen)
+
+
+@dataclass(frozen=True)
+class StageRef:
+    """Reference one stage declared in an imperative workflow catalog."""
+
+    id: str
+    contract: StageContract
+    _owner: object = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        validate_name(self.id, "stage id")
+        if not isinstance(self.contract, StageContract):
+            raise WorkflowValidationError("stage reference must use StageContract")
+
+
+@dataclass(frozen=True)
+class WorkflowHandler:
+    """An imperative Python handler with a fixed contracted stage catalog."""
+
+    name: str
+    inputs: Mapping[str, ValueSpec]
+    outputs: Mapping[str, ValueSpec]
+    stages: Mapping[str, StageContract]
+    callback: WorkflowHandlerCallback = field(repr=False, compare=False)
+    _owner: object = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        validate_name(self.name, "workflow name")
+        inputs = _freeze_specs(self.inputs, "workflow input")
+        outputs = _freeze_specs(self.outputs, "workflow output")
+        if not outputs:
+            raise WorkflowValidationError(
+                "workflow handlers require at least one output"
+            )
+        if not isinstance(self.stages, Mapping):
+            raise WorkflowValidationError("workflow handler stages must be a mapping")
+
+        stages: dict[str, StageContract] = {}
+        contracts: dict[str, StageContract] = {}
+        for stage_id, contract in sorted(self.stages.items()):
+            validate_name(stage_id, "stage id")
+            if not isinstance(contract, StageContract):
+                raise WorkflowValidationError(
+                    f"handler stage {stage_id!r} must use StageContract"
+                )
+            prior = contracts.get(contract.id)
+            if prior is not None and prior != contract:
+                raise WorkflowValidationError(
+                    f"contract id {contract.id!r} has conflicting schemas"
+                )
+            contracts[contract.id] = contract
+            stages[stage_id] = contract
+
+        if not callable(self.callback) or not inspect.iscoroutinefunction(
+            self.callback
+        ):
+            raise WorkflowValidationError("workflow handler must be an async function")
+
+        object.__setattr__(self, "inputs", inputs)
+        object.__setattr__(self, "outputs", outputs)
+        object.__setattr__(self, "stages", MappingProxyType(stages))
+
+
+WorkflowDefinition = Union[WorkflowIR, WorkflowHandler]

--- a/components/src/dynamo/workflow/dispatcher.py
+++ b/components/src/dynamo/workflow/dispatcher.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime-bound workflow stage dispatch."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any
+
+from dynamo.workflow.plan import ExecutionPlan, LocalBinding
+from dynamo.workflow.runtime import (
+    StageContext,
+    StageRunner,
+    WorkflowExecutionError,
+    _validate_value,
+)
+from dynamo.workflow.types import StageContract, WorkflowValidationError
+
+
+class StageDispatcher:
+    """Validate and invoke stages through their compiled bindings."""
+
+    def __init__(
+        self,
+        plan: ExecutionPlan,
+        local_runners: Mapping[str, StageRunner],
+    ) -> None:
+        if not isinstance(plan, ExecutionPlan):
+            raise TypeError("plan must use ExecutionPlan")
+        if not isinstance(local_runners, Mapping):
+            raise TypeError("local_runners must be a mapping")
+
+        expected_keys = {
+            binding.runner_key
+            for binding in plan.bindings.values()
+            if isinstance(binding, LocalBinding)
+        }
+        actual_keys = set(local_runners)
+        if actual_keys != expected_keys:
+            raise WorkflowValidationError(
+                "local runners differ from execution plan; "
+                f"missing={sorted(expected_keys - actual_keys)}, "
+                f"extra={sorted(actual_keys - expected_keys)}"
+            )
+
+        runners = dict(local_runners)
+        for stage_id, contract in plan.stage_contracts.items():
+            binding = plan.bindings[stage_id]
+            if not isinstance(binding, LocalBinding):
+                raise WorkflowValidationError(
+                    f"dispatcher does not support binding for stage {stage_id!r}"
+                )
+            runner = runners[binding.runner_key]
+            if not isinstance(runner, StageRunner):
+                raise WorkflowValidationError(
+                    f"runner {binding.runner_key!r} must implement StageRunner"
+                )
+            if runner.contract != contract:
+                raise WorkflowValidationError(
+                    f"runner {binding.runner_key!r} for stage {stage_id!r} "
+                    "does not match its authored contract"
+                )
+
+        self._plan = plan
+        self._local_runners = MappingProxyType(runners)
+
+    async def call(
+        self,
+        stage_id: str,
+        contract: StageContract,
+        inputs: Mapping[str, Any],
+        context: StageContext,
+    ) -> dict[str, Any]:
+        """Invoke one stage and validate its complete input/output contract."""
+
+        context.raise_if_cancelled()
+        expected_inputs = set(contract.inputs)
+        actual_inputs = set(inputs)
+        if actual_inputs != expected_inputs:
+            raise WorkflowExecutionError(
+                f"stage {stage_id!r} inputs differ from its contract; "
+                f"missing={sorted(expected_inputs - actual_inputs)}, "
+                f"extra={sorted(actual_inputs - expected_inputs)}"
+            )
+        for input_name, spec in contract.inputs.items():
+            _validate_value(
+                spec, inputs[input_name], f"stage {stage_id!r} input {input_name!r}"
+            )
+
+        binding = self._plan.bindings[stage_id]
+        if not isinstance(binding, LocalBinding):
+            raise WorkflowExecutionError(f"unsupported binding for stage {stage_id!r}")
+        result = await self._local_runners[binding.runner_key].run(
+            MappingProxyType(dict(inputs)), context
+        )
+        if not isinstance(result, Mapping):
+            raise WorkflowExecutionError(
+                f"stage {stage_id!r} returned a non-mapping result"
+            )
+        expected_outputs = set(contract.outputs)
+        actual_outputs = set(result)
+        if actual_outputs != expected_outputs:
+            raise WorkflowExecutionError(
+                f"stage {stage_id!r} outputs differ from its contract; "
+                f"missing={sorted(expected_outputs - actual_outputs)}, "
+                f"extra={sorted(actual_outputs - expected_outputs)}"
+            )
+        outputs = dict(result)
+        for output_name, spec in contract.outputs.items():
+            _validate_value(
+                spec,
+                outputs[output_name],
+                f"stage {stage_id!r} output {output_name!r}",
+            )
+        return outputs

--- a/components/src/dynamo/workflow/executor.py
+++ b/components/src/dynamo/workflow/executor.py
@@ -178,6 +178,8 @@ class WorkflowExecutor:
         )
 
         async def execute() -> dict[str, Any]:
+            result: Mapping[str, Any]
+            output_specs: Mapping[str, ValueSpec]
             if isinstance(definition, WorkflowIR):
                 result = await GraphScheduler(definition, self._dispatcher).run(
                     MappingProxyType(input_values), attempt

--- a/components/src/dynamo/workflow/executor.py
+++ b/components/src/dynamo/workflow/executor.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unified execution for declarative and imperative workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any
+
+from dynamo.workflow.definition import StageRef, WorkflowHandler
+from dynamo.workflow.dispatcher import StageDispatcher
+from dynamo.workflow.ir import WorkflowIR
+from dynamo.workflow.plan import ExecutionPlan
+from dynamo.workflow.runtime import (
+    StageContext,
+    StageRunner,
+    WorkflowAttempt,
+    WorkflowExecutionError,
+    _validate_value,
+)
+from dynamo.workflow.scheduler import GraphScheduler
+from dynamo.workflow.types import ValueSpec
+
+
+class WorkflowContext:
+    """Per-attempt imperative API and child-invocation lifetime owner."""
+
+    def __init__(
+        self,
+        definition: WorkflowHandler,
+        dispatcher: StageDispatcher,
+        attempt: WorkflowAttempt,
+    ) -> None:
+        self._definition = definition
+        self._dispatcher = dispatcher
+        self._attempt = attempt
+        self._next_invocation = 0
+        self._active: set[asyncio.Task[dict[str, Any]]] = set()
+        self._closed = False
+
+    @property
+    def attempt_id(self) -> str:
+        return self._attempt.attempt_id
+
+    @property
+    def deadline(self) -> float | None:
+        return self._attempt.deadline
+
+    @property
+    def cancelled(self) -> bool:
+        return self._attempt.cancelled.is_set()
+
+    def remaining_time(self) -> float | None:
+        """Return seconds until the workflow deadline, when one exists."""
+
+        if self.deadline is None:
+            return None
+        return max(0.0, self.deadline - asyncio.get_running_loop().time())
+
+    def raise_if_cancelled(self) -> None:
+        """Cooperatively stop handler work after cancellation or deadline."""
+
+        if self.cancelled:
+            raise asyncio.CancelledError
+        if self.deadline is not None and self.remaining_time() == 0:
+            raise asyncio.TimeoutError
+
+    async def call(self, stage: StageRef, **inputs: Any) -> dict[str, Any]:
+        """Invoke one catalog stage and return its complete output mapping."""
+
+        if self._closed:
+            raise WorkflowExecutionError("workflow context is closed")
+        if (
+            not isinstance(stage, StageRef)
+            or stage._owner is not self._definition._owner
+        ):
+            raise WorkflowExecutionError(
+                "stage reference belongs to a different workflow handler"
+            )
+        contract = self._definition.stages.get(stage.id)
+        if contract is None or contract != stage.contract:
+            raise WorkflowExecutionError(
+                f"stage reference {stage.id!r} is not in the workflow catalog"
+            )
+
+        self._next_invocation += 1
+        invocation_id = f"{self.attempt_id}:{self._next_invocation}"
+        context = StageContext(
+            workflow_name=self._definition.name,
+            stage_id=stage.id,
+            attempt_id=self.attempt_id,
+            invocation_id=invocation_id,
+            deadline=self.deadline,
+            _cancelled=self._attempt.cancelled,
+            request_context=self._attempt.request_context,
+        )
+        task = asyncio.create_task(
+            self._dispatcher.call(stage.id, contract, inputs, context),
+            name=f"workflow:{stage.id}:{invocation_id}",
+        )
+        self._active.add(task)
+        try:
+            return await task
+        finally:
+            if task.done():
+                self._active.discard(task)
+
+    async def close(self) -> None:
+        """Reject new calls and cancel and await unfinished invocations."""
+
+        self._closed = True
+        active = tuple(task for task in self._active if not task.done())
+        if active:
+            self._attempt.cancelled.set()
+            for task in active:
+                task.cancel()
+            await asyncio.gather(*active, return_exceptions=True)
+        self._active.clear()
+
+
+class WorkflowExecutor:
+    """Own one compiled workflow's request and result lifecycle."""
+
+    def __init__(self, plan: ExecutionPlan, dispatcher: StageDispatcher) -> None:
+        self._plan = plan
+        self._dispatcher = dispatcher
+
+    @classmethod
+    async def bind(
+        cls,
+        plan: ExecutionPlan,
+        *,
+        local_runners: Mapping[str, StageRunner] = MappingProxyType({}),
+    ) -> "WorkflowExecutor":
+        """Bind initialized resources to an immutable execution plan."""
+
+        return cls(plan, StageDispatcher(plan, local_runners))
+
+    @property
+    def plan(self) -> ExecutionPlan:
+        return self._plan
+
+    async def run(
+        self,
+        inputs: Mapping[str, Any],
+        *,
+        timeout: float | None = None,
+        attempt_id: str | None = None,
+        request_context: Any = None,
+    ) -> dict[str, Any]:
+        """Execute one graph or handler request and return one named result."""
+
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout must be positive")
+        definition = self._plan.definition
+        input_values = dict(inputs)
+        expected_inputs = set(definition.inputs)
+        actual_inputs = set(input_values)
+        if actual_inputs != expected_inputs:
+            raise WorkflowExecutionError(
+                "workflow inputs differ from its definition; "
+                f"missing={sorted(expected_inputs - actual_inputs)}, "
+                f"extra={sorted(actual_inputs - expected_inputs)}"
+            )
+        for name, spec in definition.inputs.items():
+            _validate_value(spec, input_values[name], f"workflow input {name!r}")
+
+        loop = asyncio.get_running_loop()
+        attempt = WorkflowAttempt(
+            attempt_id=attempt_id or uuid.uuid4().hex,
+            deadline=None if timeout is None else loop.time() + timeout,
+            cancelled=asyncio.Event(),
+            request_context=request_context,
+        )
+
+        async def execute() -> dict[str, Any]:
+            if isinstance(definition, WorkflowIR):
+                result = await GraphScheduler(definition, self._dispatcher).run(
+                    MappingProxyType(input_values), attempt
+                )
+                output_specs = {
+                    name: definition.output_spec(name) for name in definition.outputs
+                }
+            else:
+                context = WorkflowContext(definition, self._dispatcher, attempt)
+                try:
+                    result = await definition.callback(
+                        MappingProxyType(input_values), context
+                    )
+                finally:
+                    await context.close()
+                output_specs = definition.outputs
+            return _validate_result(output_specs, result)
+
+        execution = asyncio.create_task(
+            execute(), name=f"workflow-attempt:{attempt.attempt_id}"
+        )
+        try:
+            if timeout is None:
+                return await asyncio.shield(execution)
+            return await asyncio.wait_for(asyncio.shield(execution), timeout=timeout)
+        except BaseException:
+            attempt.cancelled.set()
+            if not execution.done():
+                execution.cancel()
+            await asyncio.gather(execution, return_exceptions=True)
+            raise
+
+
+def _validate_result(
+    specs: Mapping[str, ValueSpec], result: Mapping[str, Any]
+) -> dict[str, Any]:
+    if not isinstance(result, Mapping):
+        raise WorkflowExecutionError("workflow returned a non-mapping result")
+    expected = set(specs)
+    actual = set(result)
+    if actual != expected:
+        raise WorkflowExecutionError(
+            "workflow outputs differ from its definition; "
+            f"missing={sorted(expected - actual)}, extra={sorted(actual - expected)}"
+        )
+    outputs = dict(result)
+    for name, spec in specs.items():
+        _validate_value(spec, outputs[name], f"workflow output {name!r}")
+    return outputs

--- a/components/src/dynamo/workflow/ir.py
+++ b/components/src/dynamo/workflow/ir.py
@@ -6,11 +6,9 @@
 from __future__ import annotations
 
 import heapq
-import json
 from dataclasses import dataclass, field
-from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Mapping, Optional, Sequence, Tuple, cast
+from typing import Mapping, Optional, Sequence, Tuple, TypeVar, cast
 
 from dynamo.workflow.types import (
     StageContract,
@@ -21,21 +19,10 @@ from dynamo.workflow.types import (
     validate_name,
 )
 
-WORKFLOW_SCHEMA = "dynamo.workflow.ir"
-WORKFLOW_VERSION = 0
+_T = TypeVar("_T")
 
 
-def _check_keys(data: Mapping[str, Any], required: set[str]) -> None:
-    keys = set(data)
-    missing = required - keys
-    unknown = keys - required
-    if missing:
-        raise WorkflowValidationError(f"missing fields: {sorted(missing)}")
-    if unknown:
-        raise WorkflowValidationError(f"unknown fields: {sorted(unknown)}")
-
-
-def _freeze_mapping(values: Mapping[str, Any]) -> Mapping[str, Any]:
+def _freeze_mapping(values: Mapping[str, _T]) -> Mapping[str, _T]:
     return MappingProxyType(dict(sorted(values.items())))
 
 
@@ -60,33 +47,6 @@ class StageIR:
                 raise WorkflowValidationError(f"stage input {name!r} must use ValueRef")
             frozen[name] = reference
         object.__setattr__(self, "inputs", MappingProxyType(frozen))
-
-    def to_dict(self) -> dict[str, Any]:
-        """Return the canonical JSON-ready representation."""
-
-        return {
-            "id": self.id,
-            "contract": self.contract.to_dict(),
-            "inputs": {
-                name: reference.to_dict() for name, reference in self.inputs.items()
-            },
-        }
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> "StageIR":
-        """Parse one stage instance."""
-
-        if not isinstance(data, Mapping):
-            raise WorkflowValidationError("stage must be an object")
-        _check_keys(data, {"id", "contract", "inputs"})
-        inputs = data["inputs"]
-        if not isinstance(inputs, Mapping):
-            raise WorkflowValidationError("stage inputs must be an object")
-        return cls(
-            id=data["id"],
-            contract=StageContract.from_dict(data["contract"]),
-            inputs={name: ValueRef.from_dict(ref) for name, ref in inputs.items()},
-        )
 
 
 @dataclass(frozen=True)
@@ -268,102 +228,3 @@ class WorkflowIR:
         by_id = {stage.id: stage for stage in self.stages}
         spec, _ = self._resolve_reference(self.outputs[name], self.inputs, by_id)
         return spec
-
-    def to_dict(self) -> dict[str, Any]:
-        """Return the canonical JSON-ready representation."""
-
-        return {
-            "schema": WORKFLOW_SCHEMA,
-            "version": WORKFLOW_VERSION,
-            "name": self.name,
-            "inputs": {name: spec.to_dict() for name, spec in self.inputs.items()},
-            "stages": [stage.to_dict() for stage in self.stages],
-            "outputs": {
-                name: reference.to_dict() for name, reference in self.outputs.items()
-            },
-        }
-
-    def to_json(self, indent: Optional[int] = None) -> str:
-        """Serialize deterministically as JSON."""
-
-        separators = None if indent is not None else (",", ":")
-        return json.dumps(
-            self.to_dict(),
-            allow_nan=False,
-            ensure_ascii=False,
-            indent=indent,
-            separators=separators,
-            sort_keys=True,
-        )
-
-    def write_json(self, path: Path) -> None:
-        """Write pretty, deterministic JSON to a file."""
-
-        path.write_text(f"{self.to_json(indent=2)}\n", encoding="utf-8")
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> "WorkflowIR":
-        """Parse and validate a canonical workflow object."""
-
-        if not isinstance(data, Mapping):
-            raise WorkflowValidationError("workflow IR must be an object")
-        _check_keys(data, {"schema", "version", "name", "inputs", "stages", "outputs"})
-        if data["schema"] != WORKFLOW_SCHEMA:
-            raise WorkflowValidationError(
-                f"unsupported workflow schema {data['schema']!r}"
-            )
-        version = data["version"]
-        if (
-            not isinstance(version, int)
-            or isinstance(version, bool)
-            or version != WORKFLOW_VERSION
-        ):
-            raise WorkflowValidationError(f"unsupported workflow version {version!r}")
-        inputs = data["inputs"]
-        stages = data["stages"]
-        outputs = data["outputs"]
-        if not isinstance(inputs, Mapping) or not isinstance(outputs, Mapping):
-            raise WorkflowValidationError("workflow inputs and outputs must be objects")
-        if not isinstance(stages, list):
-            raise WorkflowValidationError("workflow stages must be an array")
-        return cls(
-            name=data["name"],
-            inputs={name: ValueSpec.from_dict(spec) for name, spec in inputs.items()},
-            stages=tuple(StageIR.from_dict(stage) for stage in stages),
-            outputs={name: ValueRef.from_dict(ref) for name, ref in outputs.items()},
-        )
-
-    @classmethod
-    def from_json(cls, value: str) -> "WorkflowIR":
-        """Parse strict JSON while rejecting duplicate object keys."""
-
-        def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-            result: dict[str, Any] = {}
-            for key, item in pairs:
-                if key in result:
-                    raise WorkflowValidationError(f"duplicate JSON key {key!r}")
-                result[key] = item
-            return result
-
-        def reject_non_finite(constant: str) -> None:
-            raise WorkflowValidationError(
-                f"non-finite JSON constant {constant!r} is not supported"
-            )
-
-        try:
-            data = json.loads(
-                value,
-                object_pairs_hook=reject_duplicates,
-                parse_constant=reject_non_finite,
-            )
-        except json.JSONDecodeError as error:
-            raise WorkflowValidationError(
-                f"invalid workflow JSON: {error.msg}"
-            ) from error
-        return cls.from_dict(data)
-
-    @classmethod
-    def read_json(cls, path: Path) -> "WorkflowIR":
-        """Read and validate workflow JSON from a file."""
-
-        return cls.from_json(path.read_text(encoding="utf-8"))

--- a/components/src/dynamo/workflow/ir.py
+++ b/components/src/dynamo/workflow/ir.py
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical, placement-neutral workflow IR."""
+
+from __future__ import annotations
+
+import heapq
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping, Optional, Sequence, Tuple, cast
+
+from dynamo.workflow.types import (
+    StageContract,
+    ValueRef,
+    ValueSpec,
+    WorkflowValidationError,
+    compatibility_error,
+    validate_name,
+)
+
+WORKFLOW_SCHEMA = "dynamo.workflow.ir"
+WORKFLOW_VERSION = 0
+
+
+def _check_keys(data: Mapping[str, Any], required: set[str]) -> None:
+    keys = set(data)
+    missing = required - keys
+    unknown = keys - required
+    if missing:
+        raise WorkflowValidationError(f"missing fields: {sorted(missing)}")
+    if unknown:
+        raise WorkflowValidationError(f"unknown fields: {sorted(unknown)}")
+
+
+def _freeze_mapping(values: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType(dict(sorted(values.items())))
+
+
+@dataclass(frozen=True)
+class StageIR:
+    """One contracted stage instance in a workflow graph."""
+
+    id: str
+    contract: StageContract
+    inputs: Mapping[str, ValueRef] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        validate_name(self.id, "stage id")
+        if not isinstance(self.contract, StageContract):
+            raise WorkflowValidationError("stage contract must use StageContract")
+        if not isinstance(self.inputs, Mapping):
+            raise WorkflowValidationError("stage inputs must be a mapping")
+        frozen: dict[str, ValueRef] = {}
+        for name, reference in sorted(self.inputs.items()):
+            validate_name(name, "stage input")
+            if not isinstance(reference, ValueRef):
+                raise WorkflowValidationError(f"stage input {name!r} must use ValueRef")
+            frozen[name] = reference
+        object.__setattr__(self, "inputs", MappingProxyType(frozen))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-ready representation."""
+
+        return {
+            "id": self.id,
+            "contract": self.contract.to_dict(),
+            "inputs": {
+                name: reference.to_dict() for name, reference in self.inputs.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "StageIR":
+        """Parse one stage instance."""
+
+        if not isinstance(data, Mapping):
+            raise WorkflowValidationError("stage must be an object")
+        _check_keys(data, {"id", "contract", "inputs"})
+        inputs = data["inputs"]
+        if not isinstance(inputs, Mapping):
+            raise WorkflowValidationError("stage inputs must be an object")
+        return cls(
+            id=data["id"],
+            contract=StageContract.from_dict(data["contract"]),
+            inputs={name: ValueRef.from_dict(ref) for name, ref in inputs.items()},
+        )
+
+
+@dataclass(frozen=True)
+class WorkflowIR:
+    """A validated, deterministic workflow graph without placement details."""
+
+    name: str
+    inputs: Mapping[str, ValueSpec]
+    stages: Tuple[StageIR, ...]
+    outputs: Mapping[str, ValueRef]
+
+    def __post_init__(self) -> None:
+        validate_name(self.name, "workflow name")
+        if not isinstance(self.inputs, Mapping) or not isinstance(
+            self.outputs, Mapping
+        ):
+            raise WorkflowValidationError(
+                "workflow inputs and outputs must be mappings"
+            )
+
+        inputs: dict[str, ValueSpec] = {}
+        for name, spec in sorted(self.inputs.items()):
+            validate_name(name, "workflow input")
+            if not isinstance(spec, ValueSpec):
+                raise WorkflowValidationError(
+                    f"workflow input {name!r} must use ValueSpec"
+                )
+            inputs[name] = spec
+
+        outputs: dict[str, ValueRef] = {}
+        for name, reference in sorted(self.outputs.items()):
+            validate_name(name, "workflow output")
+            if not isinstance(reference, ValueRef):
+                raise WorkflowValidationError(
+                    f"workflow output {name!r} must use ValueRef"
+                )
+            outputs[name] = reference
+        if not outputs:
+            raise WorkflowValidationError("workflow requires at least one output")
+
+        stages = tuple(self.stages)
+        ordered = self._validate_and_order(inputs, stages, outputs)
+        object.__setattr__(self, "inputs", _freeze_mapping(inputs))
+        object.__setattr__(self, "stages", ordered)
+        object.__setattr__(self, "outputs", _freeze_mapping(outputs))
+
+    @staticmethod
+    def _validate_and_order(
+        workflow_inputs: Mapping[str, ValueSpec],
+        stages: Sequence[StageIR],
+        workflow_outputs: Mapping[str, ValueRef],
+    ) -> Tuple[StageIR, ...]:
+        by_id: dict[str, StageIR] = {}
+        contracts: dict[str, StageContract] = {}
+        for stage in stages:
+            if not isinstance(stage, StageIR):
+                raise WorkflowValidationError("workflow stages must use StageIR")
+            if stage.id in by_id:
+                raise WorkflowValidationError(f"duplicate stage id {stage.id!r}")
+            prior_contract = contracts.get(stage.contract.id)
+            if prior_contract is not None and prior_contract != stage.contract:
+                raise WorkflowValidationError(
+                    f"contract id {stage.contract.id!r} has conflicting schemas"
+                )
+            contracts[stage.contract.id] = stage.contract
+            by_id[stage.id] = stage
+
+        dependencies: dict[str, set[str]] = {stage_id: set() for stage_id in by_id}
+        consumers: dict[str, set[str]] = {stage_id: set() for stage_id in by_id}
+        input_reachable: set[str] = set()
+
+        for stage in stages:
+            expected = set(stage.contract.inputs)
+            actual = set(stage.inputs)
+            if actual != expected:
+                raise WorkflowValidationError(
+                    f"stage {stage.id!r} inputs differ from its contract; "
+                    f"missing={sorted(expected - actual)}, extra={sorted(actual - expected)}"
+                )
+            for port_name, reference in stage.inputs.items():
+                producer_spec, producer_stage = WorkflowIR._resolve_reference(
+                    reference, workflow_inputs, by_id
+                )
+                error = compatibility_error(
+                    producer_spec, stage.contract.inputs[port_name]
+                )
+                if error is not None:
+                    raise WorkflowValidationError(
+                        f"stage {stage.id!r} input {port_name!r} is incompatible: {error}"
+                    )
+                if producer_stage is None:
+                    input_reachable.add(stage.id)
+                else:
+                    dependencies[stage.id].add(producer_stage)
+                    consumers[producer_stage].add(stage.id)
+
+        indegree = {
+            stage_id: len(required) for stage_id, required in dependencies.items()
+        }
+        ready = [stage_id for stage_id, count in indegree.items() if count == 0]
+        heapq.heapify(ready)
+        ordered_ids: list[str] = []
+        while ready:
+            stage_id = heapq.heappop(ready)
+            ordered_ids.append(stage_id)
+            for consumer in sorted(consumers[stage_id]):
+                indegree[consumer] -= 1
+                if indegree[consumer] == 0:
+                    heapq.heappush(ready, consumer)
+        if len(ordered_ids) != len(stages):
+            cyclic = sorted(
+                stage_id for stage_id, count in indegree.items() if count > 0
+            )
+            raise WorkflowValidationError(
+                f"workflow contains a cycle involving {cyclic}"
+            )
+
+        reachable = set(input_reachable)
+        for stage_id in ordered_ids:
+            if dependencies[stage_id] & reachable:
+                reachable.add(stage_id)
+        unreachable = set(by_id) - reachable
+        if unreachable:
+            raise WorkflowValidationError(
+                f"stages are not reachable from workflow inputs: {sorted(unreachable)}"
+            )
+
+        live: set[str] = set()
+        pending: list[str] = []
+        for reference in workflow_outputs.values():
+            _, producer_stage = WorkflowIR._resolve_reference(
+                reference, workflow_inputs, by_id
+            )
+            if producer_stage is not None:
+                pending.append(producer_stage)
+        while pending:
+            stage_id = pending.pop()
+            if stage_id in live:
+                continue
+            live.add(stage_id)
+            pending.extend(dependencies[stage_id])
+        dead = set(by_id) - live
+        if dead:
+            raise WorkflowValidationError(
+                f"stages do not contribute to workflow outputs: {sorted(dead)}"
+            )
+
+        return tuple(by_id[stage_id] for stage_id in ordered_ids)
+
+    @staticmethod
+    def _resolve_reference(
+        reference: ValueRef,
+        workflow_inputs: Mapping[str, ValueSpec],
+        stages: Mapping[str, StageIR],
+    ) -> tuple[ValueSpec, Optional[str]]:
+        if reference.input_name is not None:
+            if reference.input_name not in workflow_inputs:
+                raise WorkflowValidationError(
+                    f"unknown workflow input {reference.input_name!r}"
+                )
+            return workflow_inputs[reference.input_name], None
+
+        stage_id = cast(str, reference.stage_id)
+        output_name = cast(str, reference.output_name)
+        if stage_id not in stages:
+            raise WorkflowValidationError(f"unknown stage {stage_id!r}")
+        stage = stages[stage_id]
+        if output_name not in stage.contract.outputs:
+            raise WorkflowValidationError(
+                f"unknown output {output_name!r} on stage {stage_id!r}"
+            )
+        return stage.contract.outputs[output_name], stage_id
+
+    def output_spec(self, name: str) -> ValueSpec:
+        """Return the value description inferred for one workflow output."""
+
+        if name not in self.outputs:
+            raise KeyError(name)
+        by_id = {stage.id: stage for stage in self.stages}
+        spec, _ = self._resolve_reference(self.outputs[name], self.inputs, by_id)
+        return spec
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-ready representation."""
+
+        return {
+            "schema": WORKFLOW_SCHEMA,
+            "version": WORKFLOW_VERSION,
+            "name": self.name,
+            "inputs": {name: spec.to_dict() for name, spec in self.inputs.items()},
+            "stages": [stage.to_dict() for stage in self.stages],
+            "outputs": {
+                name: reference.to_dict() for name, reference in self.outputs.items()
+            },
+        }
+
+    def to_json(self, indent: Optional[int] = None) -> str:
+        """Serialize deterministically as JSON."""
+
+        separators = None if indent is not None else (",", ":")
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            indent=indent,
+            separators=separators,
+            sort_keys=True,
+        )
+
+    def write_json(self, path: Path) -> None:
+        """Write pretty, deterministic JSON to a file."""
+
+        path.write_text(f"{self.to_json(indent=2)}\n", encoding="utf-8")
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "WorkflowIR":
+        """Parse and validate a canonical workflow object."""
+
+        if not isinstance(data, Mapping):
+            raise WorkflowValidationError("workflow IR must be an object")
+        _check_keys(data, {"schema", "version", "name", "inputs", "stages", "outputs"})
+        if data["schema"] != WORKFLOW_SCHEMA:
+            raise WorkflowValidationError(
+                f"unsupported workflow schema {data['schema']!r}"
+            )
+        if data["version"] != WORKFLOW_VERSION:
+            raise WorkflowValidationError(
+                f"unsupported workflow version {data['version']!r}"
+            )
+        inputs = data["inputs"]
+        stages = data["stages"]
+        outputs = data["outputs"]
+        if not isinstance(inputs, Mapping) or not isinstance(outputs, Mapping):
+            raise WorkflowValidationError("workflow inputs and outputs must be objects")
+        if not isinstance(stages, list):
+            raise WorkflowValidationError("workflow stages must be an array")
+        return cls(
+            name=data["name"],
+            inputs={name: ValueSpec.from_dict(spec) for name, spec in inputs.items()},
+            stages=tuple(StageIR.from_dict(stage) for stage in stages),
+            outputs={name: ValueRef.from_dict(ref) for name, ref in outputs.items()},
+        )
+
+    @classmethod
+    def from_json(cls, value: str) -> "WorkflowIR":
+        """Parse JSON while rejecting duplicate object keys."""
+
+        def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for key, item in pairs:
+                if key in result:
+                    raise WorkflowValidationError(f"duplicate JSON key {key!r}")
+                result[key] = item
+            return result
+
+        try:
+            data = json.loads(value, object_pairs_hook=reject_duplicates)
+        except json.JSONDecodeError as error:
+            raise WorkflowValidationError(
+                f"invalid workflow JSON: {error.msg}"
+            ) from error
+        return cls.from_dict(data)
+
+    @classmethod
+    def read_json(cls, path: Path) -> "WorkflowIR":
+        """Read and validate workflow JSON from a file."""
+
+        return cls.from_json(path.read_text(encoding="utf-8"))

--- a/components/src/dynamo/workflow/ir.py
+++ b/components/src/dynamo/workflow/ir.py
@@ -289,6 +289,7 @@ class WorkflowIR:
         separators = None if indent is not None else (",", ":")
         return json.dumps(
             self.to_dict(),
+            allow_nan=False,
             ensure_ascii=False,
             indent=indent,
             separators=separators,
@@ -311,10 +312,13 @@ class WorkflowIR:
             raise WorkflowValidationError(
                 f"unsupported workflow schema {data['schema']!r}"
             )
-        if data["version"] != WORKFLOW_VERSION:
-            raise WorkflowValidationError(
-                f"unsupported workflow version {data['version']!r}"
-            )
+        version = data["version"]
+        if (
+            not isinstance(version, int)
+            or isinstance(version, bool)
+            or version != WORKFLOW_VERSION
+        ):
+            raise WorkflowValidationError(f"unsupported workflow version {version!r}")
         inputs = data["inputs"]
         stages = data["stages"]
         outputs = data["outputs"]
@@ -331,7 +335,7 @@ class WorkflowIR:
 
     @classmethod
     def from_json(cls, value: str) -> "WorkflowIR":
-        """Parse JSON while rejecting duplicate object keys."""
+        """Parse strict JSON while rejecting duplicate object keys."""
 
         def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
             result: dict[str, Any] = {}
@@ -341,8 +345,17 @@ class WorkflowIR:
                 result[key] = item
             return result
 
+        def reject_non_finite(constant: str) -> None:
+            raise WorkflowValidationError(
+                f"non-finite JSON constant {constant!r} is not supported"
+            )
+
         try:
-            data = json.loads(value, object_pairs_hook=reject_duplicates)
+            data = json.loads(
+                value,
+                object_pairs_hook=reject_duplicates,
+                parse_constant=reject_non_finite,
+            )
         except json.JSONDecodeError as error:
             raise WorkflowValidationError(
                 f"invalid workflow JSON: {error.msg}"

--- a/components/src/dynamo/workflow/plan.py
+++ b/components/src/dynamo/workflow/plan.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-memory physical plans for Dynamo workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Mapping, Tuple
+
+from dynamo.workflow.ir import WorkflowIR
+from dynamo.workflow.types import ValueRef, WorkflowValidationError, validate_name
+
+LOCAL_CARRIER = "local"
+
+
+@dataclass(frozen=True)
+class LocalBinding:
+    """Resolve one logical stage to a named in-process runner at hydration time."""
+
+    runner_key: str
+
+    def __post_init__(self) -> None:
+        validate_name(self.runner_key, "local runner key")
+
+
+Binding = LocalBinding
+
+
+@dataclass(frozen=True)
+class EdgePlan:
+    """One physical producer-to-consumer connection in an execution plan."""
+
+    source: ValueRef
+    target_stage: str
+    target_port: str
+    carrier: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source, ValueRef):
+            raise WorkflowValidationError("edge source must use ValueRef")
+        validate_name(self.target_stage, "edge target stage")
+        validate_name(self.target_port, "edge target port")
+        if self.carrier != LOCAL_CARRIER:
+            raise WorkflowValidationError(f"unsupported edge carrier {self.carrier!r}")
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """A workflow plus in-memory placement and carrier decisions."""
+
+    workflow: WorkflowIR
+    bindings: Mapping[str, Binding]
+    edges: Tuple[EdgePlan, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.workflow, WorkflowIR):
+            raise WorkflowValidationError("execution plan requires WorkflowIR")
+        if not isinstance(self.bindings, Mapping):
+            raise WorkflowValidationError("execution plan bindings must be a mapping")
+
+        bindings: dict[str, Binding] = {}
+        for stage_id, binding in sorted(self.bindings.items()):
+            validate_name(stage_id, "binding stage id")
+            if not isinstance(binding, LocalBinding):
+                raise WorkflowValidationError(
+                    f"binding for stage {stage_id!r} uses an unsupported type"
+                )
+            bindings[stage_id] = binding
+
+        expected_stages = {stage.id for stage in self.workflow.stages}
+        actual_stages = set(bindings)
+        if actual_stages != expected_stages:
+            raise WorkflowValidationError(
+                "execution plan bindings differ from workflow stages; "
+                f"missing={sorted(expected_stages - actual_stages)}, "
+                f"extra={sorted(actual_stages - expected_stages)}"
+            )
+
+        edges = tuple(self.edges)
+        actual_edges: dict[tuple[str, str], EdgePlan] = {}
+        for edge in edges:
+            if not isinstance(edge, EdgePlan):
+                raise WorkflowValidationError("execution plan edges must use EdgePlan")
+            key = (edge.target_stage, edge.target_port)
+            if key in actual_edges:
+                raise WorkflowValidationError(
+                    f"duplicate edge targeting stage {key[0]!r} port {key[1]!r}"
+                )
+            actual_edges[key] = edge
+
+        expected_edges = {
+            (stage.id, port): source
+            for stage in self.workflow.stages
+            for port, source in stage.inputs.items()
+        }
+        if set(actual_edges) != set(expected_edges):
+            missing = sorted(set(expected_edges) - set(actual_edges))
+            extra = sorted(set(actual_edges) - set(expected_edges))
+            raise WorkflowValidationError(
+                "execution plan edges differ from workflow inputs; "
+                f"missing={missing}, extra={extra}"
+            )
+        for key, source in expected_edges.items():
+            edge = actual_edges[key]
+            if edge.source != source:
+                raise WorkflowValidationError(
+                    f"edge targeting stage {key[0]!r} port {key[1]!r} "
+                    "does not match WorkflowIR"
+                )
+            if edge.carrier != LOCAL_CARRIER:
+                raise WorkflowValidationError(
+                    f"local stage {key[0]!r} port {key[1]!r} requires local carrier"
+                )
+
+        object.__setattr__(self, "bindings", MappingProxyType(bindings))
+        object.__setattr__(
+            self,
+            "edges",
+            tuple(
+                sorted(edges, key=lambda edge: (edge.target_stage, edge.target_port))
+            ),
+        )

--- a/components/src/dynamo/workflow/plan.py
+++ b/components/src/dynamo/workflow/plan.py
@@ -9,15 +9,21 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Mapping, Tuple
 
+from dynamo.workflow.definition import WorkflowDefinition, WorkflowHandler
 from dynamo.workflow.ir import WorkflowIR
-from dynamo.workflow.types import ValueRef, WorkflowValidationError, validate_name
+from dynamo.workflow.types import (
+    StageContract,
+    ValueRef,
+    WorkflowValidationError,
+    validate_name,
+)
 
 LOCAL_CARRIER = "local"
 
 
 @dataclass(frozen=True)
 class LocalBinding:
-    """Resolve one logical stage to a named in-process runner at hydration time."""
+    """Resolve one logical stage to a named in-process runner at bind time."""
 
     runner_key: str
 
@@ -50,13 +56,15 @@ class EdgePlan:
 class ExecutionPlan:
     """A workflow plus in-memory placement and carrier decisions."""
 
-    workflow: WorkflowIR
+    definition: WorkflowDefinition
     bindings: Mapping[str, Binding]
     edges: Tuple[EdgePlan, ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.workflow, WorkflowIR):
-            raise WorkflowValidationError("execution plan requires WorkflowIR")
+        if not isinstance(self.definition, (WorkflowIR, WorkflowHandler)):
+            raise WorkflowValidationError(
+                "execution plan requires WorkflowIR or WorkflowHandler"
+            )
         if not isinstance(self.bindings, Mapping):
             raise WorkflowValidationError("execution plan bindings must be a mapping")
 
@@ -69,7 +77,7 @@ class ExecutionPlan:
                 )
             bindings[stage_id] = binding
 
-        expected_stages = {stage.id for stage in self.workflow.stages}
+        expected_stages = set(self.stage_contracts)
         actual_stages = set(bindings)
         if actual_stages != expected_stages:
             raise WorkflowValidationError(
@@ -90,11 +98,14 @@ class ExecutionPlan:
                 )
             actual_edges[key] = edge
 
-        expected_edges = {
-            (stage.id, port): source
-            for stage in self.workflow.stages
-            for port, source in stage.inputs.items()
-        }
+        if isinstance(self.definition, WorkflowIR):
+            expected_edges = {
+                (stage.id, port): source
+                for stage in self.definition.stages
+                for port, source in stage.inputs.items()
+            }
+        else:
+            expected_edges = {}
         if set(actual_edges) != set(expected_edges):
             missing = sorted(set(expected_edges) - set(actual_edges))
             extra = sorted(set(actual_edges) - set(expected_edges))
@@ -107,7 +118,7 @@ class ExecutionPlan:
             if edge.source != source:
                 raise WorkflowValidationError(
                     f"edge targeting stage {key[0]!r} port {key[1]!r} "
-                    "does not match WorkflowIR"
+                    "does not match the workflow definition"
                 )
             if edge.carrier != LOCAL_CARRIER:
                 raise WorkflowValidationError(
@@ -122,3 +133,13 @@ class ExecutionPlan:
                 sorted(edges, key=lambda edge: (edge.target_stage, edge.target_port))
             ),
         )
+
+    @property
+    def stage_contracts(self) -> Mapping[str, StageContract]:
+        """Return every stage contract keyed by its authored stage ID."""
+
+        if isinstance(self.definition, WorkflowIR):
+            return MappingProxyType(
+                {stage.id: stage.contract for stage in self.definition.stages}
+            )
+        return self.definition.stages

--- a/components/src/dynamo/workflow/runtime.py
+++ b/components/src/dynamo/workflow/runtime.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Aggregated execution for authored workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Optional, Protocol, Union, cast, runtime_checkable
+
+from dynamo.workflow.builder import StageDefinition, WorkflowBuilder
+from dynamo.workflow.ir import StageIR, WorkflowIR
+from dynamo.workflow.types import (
+    StageContract,
+    ValueRef,
+    ValueSpec,
+    WorkflowValidationError,
+)
+
+
+class WorkflowExecutionError(RuntimeError):
+    """Raised when runtime values do not honor the authored workflow."""
+
+
+@dataclass(frozen=True)
+class StageContext:
+    """Attempt metadata available to a running stage."""
+
+    workflow_name: str
+    stage_id: str
+    attempt_id: str
+    deadline: Optional[float]
+    _cancelled: asyncio.Event
+
+    @property
+    def cancelled(self) -> bool:
+        """Whether the workflow attempt is terminating."""
+
+        return self._cancelled.is_set()
+
+    def remaining_time(self) -> Optional[float]:
+        """Return seconds until the attempt deadline, when one exists."""
+
+        if self.deadline is None:
+            return None
+        return max(0.0, self.deadline - asyncio.get_running_loop().time())
+
+    def raise_if_cancelled(self) -> None:
+        """Cooperatively stop work after cancellation or deadline expiry."""
+
+        if self.cancelled:
+            raise asyncio.CancelledError
+        if self.deadline is not None and self.remaining_time() == 0:
+            raise asyncio.TimeoutError
+
+
+@runtime_checkable
+class StageRunner(StageDefinition, Protocol):
+    """The small interface implemented by custom and Dynamo-provided workers."""
+
+    contract: StageContract
+
+    async def run(
+        self, inputs: Mapping[str, Any], context: StageContext
+    ) -> Mapping[str, Any]:
+        """Run one stage attempt and return all declared outputs."""
+
+        ...
+
+
+@dataclass(frozen=True)
+class LocalBinding:
+    """Bind one logical stage to an in-process worker."""
+
+    runner: StageRunner
+
+
+@runtime_checkable
+class _TensorValue(Protocol):
+    shape: Any
+    dtype: Any
+
+
+@runtime_checkable
+class _ImageValue(Protocol):
+    mode: str
+    size: Any
+
+
+class ExecutionPlan:
+    """A compiled aggregated workflow ready to execute requests."""
+
+    def __init__(
+        self, workflow: WorkflowIR, bindings: Mapping[str, LocalBinding]
+    ) -> None:
+        self._workflow = workflow
+        self._bindings = MappingProxyType(dict(bindings))
+
+    @property
+    def workflow(self) -> WorkflowIR:
+        """Return the logical workflow compiled into this plan."""
+
+        return self._workflow
+
+    async def run(
+        self,
+        inputs: Mapping[str, Any],
+        *,
+        timeout: Optional[float] = None,
+        attempt_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Execute one request, scheduling independent branches concurrently."""
+
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout must be positive")
+        input_values = dict(inputs)
+        expected_inputs = set(self._workflow.inputs)
+        actual_inputs = set(input_values)
+        if actual_inputs != expected_inputs:
+            raise WorkflowExecutionError(
+                "workflow inputs differ from the authored graph; "
+                f"missing={sorted(expected_inputs - actual_inputs)}, "
+                f"extra={sorted(actual_inputs - expected_inputs)}"
+            )
+        for name, spec in self._workflow.inputs.items():
+            _validate_value(spec, input_values[name], f"workflow input {name!r}")
+
+        loop = asyncio.get_running_loop()
+        deadline = None if timeout is None else loop.time() + timeout
+        cancelled = asyncio.Event()
+        resolved_attempt_id = attempt_id or uuid.uuid4().hex
+
+        async def execute() -> dict[str, Any]:
+            tasks: dict[str, asyncio.Task[dict[str, Any]]] = {}
+
+            async def run_stage(stage: StageIR) -> dict[str, Any]:
+                stage_inputs: dict[str, Any] = {}
+                for port_name, reference in stage.inputs.items():
+                    stage_inputs[port_name] = await resolve(reference)
+                context = StageContext(
+                    workflow_name=self._workflow.name,
+                    stage_id=stage.id,
+                    attempt_id=resolved_attempt_id,
+                    deadline=deadline,
+                    _cancelled=cancelled,
+                )
+                result = await self._bindings[stage.id].runner.run(
+                    MappingProxyType(stage_inputs), context
+                )
+                if not isinstance(result, Mapping):
+                    raise WorkflowExecutionError(
+                        f"stage {stage.id!r} returned a non-mapping result"
+                    )
+                expected_outputs = set(stage.contract.outputs)
+                actual_outputs = set(result)
+                if actual_outputs != expected_outputs:
+                    raise WorkflowExecutionError(
+                        f"stage {stage.id!r} outputs differ from its contract; "
+                        f"missing={sorted(expected_outputs - actual_outputs)}, "
+                        f"extra={sorted(actual_outputs - expected_outputs)}"
+                    )
+                outputs = dict(result)
+                for output_name, spec in stage.contract.outputs.items():
+                    _validate_value(
+                        spec,
+                        outputs[output_name],
+                        f"stage {stage.id!r} output {output_name!r}",
+                    )
+                return outputs
+
+            async def resolve(reference: ValueRef) -> Any:
+                if reference.input_name is not None:
+                    return input_values[reference.input_name]
+                stage_id = cast(str, reference.stage_id)
+                output_name = cast(str, reference.output_name)
+                stage_outputs = await asyncio.shield(tasks[stage_id])
+                return stage_outputs[output_name]
+
+            for stage in self._workflow.stages:
+                tasks[stage.id] = asyncio.create_task(
+                    run_stage(stage), name=f"workflow:{stage.id}"
+                )
+
+            try:
+                output_values = await asyncio.gather(
+                    *(
+                        resolve(reference)
+                        for reference in self._workflow.outputs.values()
+                    )
+                )
+                return dict(zip(self._workflow.outputs, output_values))
+            except BaseException:
+                cancelled.set()
+                for task in tasks.values():
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*tasks.values(), return_exceptions=True)
+                raise
+
+        if timeout is None:
+            return await execute()
+        return await asyncio.wait_for(execute(), timeout=timeout)
+
+
+def compile_workflow(
+    workflow: Union[WorkflowBuilder, WorkflowIR],
+    bindings: Optional[Mapping[str, Union[StageRunner, LocalBinding]]] = None,
+    **workers: StageRunner,
+) -> ExecutionPlan:
+    """Compile a workflow by binding each stage to a reusable local worker.
+
+    Keyword workers are the concise path when stage IDs are valid Python names::
+
+        plan = compile_workflow(workflow, encoder=encoder, decoder=decoder)
+
+    The ``bindings`` mapping supports all portable stage names.
+    """
+
+    workflow_ir = (
+        workflow.build() if isinstance(workflow, WorkflowBuilder) else workflow
+    )
+    if not isinstance(workflow_ir, WorkflowIR):
+        raise TypeError("workflow must be a Workflow or WorkflowIR")
+
+    combined: dict[str, Union[StageRunner, LocalBinding]] = dict(bindings or {})
+    overlap = set(combined) & set(workers)
+    if overlap:
+        raise WorkflowValidationError(
+            f"duplicate local bindings for stages {sorted(overlap)}"
+        )
+    combined.update(workers)
+
+    expected = {stage.id for stage in workflow_ir.stages}
+    actual = set(combined)
+    if actual != expected:
+        raise WorkflowValidationError(
+            "local bindings differ from workflow stages; "
+            f"missing={sorted(expected - actual)}, extra={sorted(actual - expected)}"
+        )
+
+    local_bindings: dict[str, LocalBinding] = {}
+    for stage in workflow_ir.stages:
+        candidate = combined[stage.id]
+        binding = (
+            candidate
+            if isinstance(candidate, LocalBinding)
+            else LocalBinding(candidate)
+        )
+        if not isinstance(binding.runner, StageRunner):
+            raise WorkflowValidationError(
+                f"binding for stage {stage.id!r} must implement StageRunner"
+            )
+        if binding.runner.contract != stage.contract:
+            raise WorkflowValidationError(
+                f"binding for stage {stage.id!r} does not match its authored contract"
+            )
+        local_bindings[stage.id] = binding
+
+    return ExecutionPlan(workflow_ir, local_bindings)
+
+
+def _validate_value(spec: ValueSpec, value: Any, location: str) -> None:
+    if spec.type == "text" and not isinstance(value, str):
+        raise WorkflowExecutionError(f"{location} must be text")
+    if spec.type == "bytes" and not isinstance(value, (bytes, bytearray, memoryview)):
+        raise WorkflowExecutionError(f"{location} must be bytes-like")
+    if spec.type == "json":
+        try:
+            json.dumps(value, allow_nan=False)
+        except (TypeError, ValueError) as error:
+            raise WorkflowExecutionError(
+                f"{location} must be JSON-serializable"
+            ) from error
+    if spec.type == "tensor":
+        if not isinstance(value, _TensorValue):
+            raise WorkflowExecutionError(f"{location} must be tensor-like")
+        actual_dtype = str(value.dtype).rsplit(".", 1)[-1]
+        if spec.dtype is not None and actual_dtype != spec.dtype:
+            raise WorkflowExecutionError(
+                f"{location} has dtype {actual_dtype!r}, expected {spec.dtype!r}"
+            )
+        actual_shape = tuple(value.shape)
+        if spec.shape is not None:
+            if len(actual_shape) != len(spec.shape) or any(
+                expected != "dynamic" and expected != actual
+                for actual, expected in zip(actual_shape, spec.shape)
+            ):
+                raise WorkflowExecutionError(
+                    f"{location} has shape {actual_shape!r}, expected {spec.shape!r}"
+                )
+    if spec.type == "image":
+        if not isinstance(value, _ImageValue):
+            raise WorkflowExecutionError(f"{location} must be image-like")
+        if spec.mode is not None and value.mode != spec.mode:
+            raise WorkflowExecutionError(
+                f"{location} has image mode {value.mode!r}, expected {spec.mode!r}"
+            )

--- a/components/src/dynamo/workflow/runtime.py
+++ b/components/src/dynamo/workflow/runtime.py
@@ -7,24 +7,25 @@ from __future__ import annotations
 
 import asyncio
 import math
-import uuid
 from dataclasses import dataclass
-from types import MappingProxyType
-from typing import Any, Mapping, Optional, Protocol, cast, runtime_checkable
+from typing import Any, Mapping, Optional, Protocol, runtime_checkable
 
 from dynamo.workflow.builder import StageDefinition
-from dynamo.workflow.ir import StageIR
-from dynamo.workflow.plan import ExecutionPlan, LocalBinding
-from dynamo.workflow.types import (
-    StageContract,
-    ValueRef,
-    ValueSpec,
-    WorkflowValidationError,
-)
+from dynamo.workflow.types import StageContract, ValueSpec
 
 
 class WorkflowExecutionError(RuntimeError):
     """Raised when runtime values do not honor the authored workflow."""
+
+
+@dataclass(frozen=True)
+class WorkflowAttempt:
+    """Shared attempt identity, deadline, and cancellation state."""
+
+    attempt_id: str
+    deadline: Optional[float]
+    cancelled: asyncio.Event
+    request_context: Any = None
 
 
 @dataclass(frozen=True)
@@ -34,8 +35,10 @@ class StageContext:
     workflow_name: str
     stage_id: str
     attempt_id: str
+    invocation_id: str
     deadline: Optional[float]
     _cancelled: asyncio.Event
+    request_context: Any = None
 
     @property
     def cancelled(self) -> bool:
@@ -83,162 +86,6 @@ class _TensorValue(Protocol):
 class _ImageValue(Protocol):
     mode: str
     size: Any
-
-
-class WorkflowExecutor:
-    """Bind runtime resources and execute one compiled workflow plan."""
-
-    def __init__(
-        self,
-        plan: ExecutionPlan,
-        local_runners: Mapping[str, StageRunner],
-    ) -> None:
-        if not isinstance(plan, ExecutionPlan):
-            raise TypeError("plan must use ExecutionPlan")
-        if not isinstance(local_runners, Mapping):
-            raise TypeError("local_runners must be a mapping")
-
-        expected_keys = {
-            binding.runner_key
-            for binding in plan.bindings.values()
-            if isinstance(binding, LocalBinding)
-        }
-        actual_keys = set(local_runners)
-        if actual_keys != expected_keys:
-            raise WorkflowValidationError(
-                "local runners differ from execution plan; "
-                f"missing={sorted(expected_keys - actual_keys)}, "
-                f"extra={sorted(actual_keys - expected_keys)}"
-            )
-
-        runners = dict(local_runners)
-        for stage in plan.workflow.stages:
-            binding = plan.bindings[stage.id]
-            if not isinstance(binding, LocalBinding):
-                raise WorkflowValidationError(
-                    f"executor does not support binding for stage {stage.id!r}"
-                )
-            runner = runners[binding.runner_key]
-            if not isinstance(runner, StageRunner):
-                raise WorkflowValidationError(
-                    f"runner {binding.runner_key!r} must implement StageRunner"
-                )
-            if runner.contract != stage.contract:
-                raise WorkflowValidationError(
-                    f"runner {binding.runner_key!r} for stage {stage.id!r} "
-                    "does not match its authored contract"
-                )
-
-        self._plan = plan
-        self._local_runners = MappingProxyType(runners)
-
-    @property
-    def plan(self) -> ExecutionPlan:
-        """Return the physical plan hydrated by this executor."""
-
-        return self._plan
-
-    async def run(
-        self,
-        inputs: Mapping[str, Any],
-        *,
-        timeout: Optional[float] = None,
-        attempt_id: Optional[str] = None,
-    ) -> dict[str, Any]:
-        """Execute one request, scheduling independent branches concurrently."""
-
-        if timeout is not None and timeout <= 0:
-            raise ValueError("timeout must be positive")
-        input_values = dict(inputs)
-        workflow = self._plan.workflow
-        expected_inputs = set(workflow.inputs)
-        actual_inputs = set(input_values)
-        if actual_inputs != expected_inputs:
-            raise WorkflowExecutionError(
-                "workflow inputs differ from the authored graph; "
-                f"missing={sorted(expected_inputs - actual_inputs)}, "
-                f"extra={sorted(actual_inputs - expected_inputs)}"
-            )
-        for name, spec in workflow.inputs.items():
-            _validate_value(spec, input_values[name], f"workflow input {name!r}")
-
-        loop = asyncio.get_running_loop()
-        deadline = None if timeout is None else loop.time() + timeout
-        cancelled = asyncio.Event()
-        resolved_attempt_id = attempt_id or uuid.uuid4().hex
-
-        async def execute() -> dict[str, Any]:
-            tasks: dict[str, asyncio.Task[dict[str, Any]]] = {}
-
-            async def run_stage(stage: StageIR) -> dict[str, Any]:
-                stage_inputs: dict[str, Any] = {}
-                for port_name, reference in stage.inputs.items():
-                    stage_inputs[port_name] = await resolve(reference)
-                context = StageContext(
-                    workflow_name=workflow.name,
-                    stage_id=stage.id,
-                    attempt_id=resolved_attempt_id,
-                    deadline=deadline,
-                    _cancelled=cancelled,
-                )
-                binding = self._plan.bindings[stage.id]
-                if not isinstance(binding, LocalBinding):
-                    raise WorkflowExecutionError(
-                        f"unsupported binding for stage {stage.id!r}"
-                    )
-                result = await self._local_runners[binding.runner_key].run(
-                    MappingProxyType(stage_inputs), context
-                )
-                if not isinstance(result, Mapping):
-                    raise WorkflowExecutionError(
-                        f"stage {stage.id!r} returned a non-mapping result"
-                    )
-                expected_outputs = set(stage.contract.outputs)
-                actual_outputs = set(result)
-                if actual_outputs != expected_outputs:
-                    raise WorkflowExecutionError(
-                        f"stage {stage.id!r} outputs differ from its contract; "
-                        f"missing={sorted(expected_outputs - actual_outputs)}, "
-                        f"extra={sorted(actual_outputs - expected_outputs)}"
-                    )
-                outputs = dict(result)
-                for output_name, spec in stage.contract.outputs.items():
-                    _validate_value(
-                        spec,
-                        outputs[output_name],
-                        f"stage {stage.id!r} output {output_name!r}",
-                    )
-                return outputs
-
-            async def resolve(reference: ValueRef) -> Any:
-                if reference.input_name is not None:
-                    return input_values[reference.input_name]
-                stage_id = cast(str, reference.stage_id)
-                output_name = cast(str, reference.output_name)
-                stage_outputs = await asyncio.shield(tasks[stage_id])
-                return stage_outputs[output_name]
-
-            for stage in workflow.stages:
-                tasks[stage.id] = asyncio.create_task(
-                    run_stage(stage), name=f"workflow:{stage.id}"
-                )
-
-            try:
-                output_values = await asyncio.gather(
-                    *(resolve(reference) for reference in workflow.outputs.values())
-                )
-                return dict(zip(workflow.outputs, output_values))
-            except BaseException:
-                cancelled.set()
-                for task in tasks.values():
-                    if not task.done():
-                        task.cancel()
-                await asyncio.gather(*tasks.values(), return_exceptions=True)
-                raise
-
-        if timeout is None:
-            return await execute()
-        return await asyncio.wait_for(execute(), timeout=timeout)
 
 
 def _validate_value(spec: ValueSpec, value: Any, location: str) -> None:

--- a/components/src/dynamo/workflow/runtime.py
+++ b/components/src/dynamo/workflow/runtime.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import asyncio
-import json
+import math
 import uuid
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -268,13 +268,8 @@ def _validate_value(spec: ValueSpec, value: Any, location: str) -> None:
         raise WorkflowExecutionError(f"{location} must be text")
     if spec.type == "bytes" and not isinstance(value, (bytes, bytearray, memoryview)):
         raise WorkflowExecutionError(f"{location} must be bytes-like")
-    if spec.type == "json":
-        try:
-            json.dumps(value, allow_nan=False)
-        except (TypeError, ValueError) as error:
-            raise WorkflowExecutionError(
-                f"{location} must be JSON-serializable"
-            ) from error
+    if spec.type == "json" and not _is_json_value(value, set()):
+        raise WorkflowExecutionError(f"{location} must use the JSON data model")
     if spec.type == "tensor":
         if not isinstance(value, _TensorValue):
             raise WorkflowExecutionError(f"{location} must be tensor-like")
@@ -299,3 +294,26 @@ def _validate_value(spec: ValueSpec, value: Any, location: str) -> None:
             raise WorkflowExecutionError(
                 f"{location} has image mode {value.mode!r}, expected {spec.mode!r}"
             )
+
+
+def _is_json_value(value: Any, active_containers: set[int]) -> bool:
+    if value is None or isinstance(value, (bool, int, str)):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if not isinstance(value, (list, dict)):
+        return False
+
+    container_id = id(value)
+    if container_id in active_containers:
+        return False
+    active_containers.add(container_id)
+    try:
+        if isinstance(value, list):
+            return all(_is_json_value(item, active_containers) for item in value)
+        return all(
+            isinstance(key, str) and _is_json_value(item, active_containers)
+            for key, item in value.items()
+        )
+    finally:
+        active_containers.remove(container_id)

--- a/components/src/dynamo/workflow/runtime.py
+++ b/components/src/dynamo/workflow/runtime.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Aggregated execution for authored workflows."""
+"""Hydration and execution for compiled Dynamo workflows."""
 
 from __future__ import annotations
 
@@ -10,10 +10,11 @@ import math
 import uuid
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, Mapping, Optional, Protocol, Union, cast, runtime_checkable
+from typing import Any, Mapping, Optional, Protocol, cast, runtime_checkable
 
-from dynamo.workflow.builder import StageDefinition, WorkflowBuilder
-from dynamo.workflow.ir import StageIR, WorkflowIR
+from dynamo.workflow.builder import StageDefinition
+from dynamo.workflow.ir import StageIR
+from dynamo.workflow.plan import ExecutionPlan, LocalBinding
 from dynamo.workflow.types import (
     StageContract,
     ValueRef,
@@ -72,13 +73,6 @@ class StageRunner(StageDefinition, Protocol):
         ...
 
 
-@dataclass(frozen=True)
-class LocalBinding:
-    """Bind one logical stage to an in-process worker."""
-
-    runner: StageRunner
-
-
 @runtime_checkable
 class _TensorValue(Protocol):
     shape: Any
@@ -91,20 +85,58 @@ class _ImageValue(Protocol):
     size: Any
 
 
-class ExecutionPlan:
-    """A compiled aggregated workflow ready to execute requests."""
+class WorkflowExecutor:
+    """Hydrate and execute one compiled workflow plan."""
 
     def __init__(
-        self, workflow: WorkflowIR, bindings: Mapping[str, LocalBinding]
+        self,
+        plan: ExecutionPlan,
+        local_runners: Mapping[str, StageRunner],
     ) -> None:
-        self._workflow = workflow
-        self._bindings = MappingProxyType(dict(bindings))
+        if not isinstance(plan, ExecutionPlan):
+            raise TypeError("plan must use ExecutionPlan")
+        if not isinstance(local_runners, Mapping):
+            raise TypeError("local_runners must be a mapping")
+
+        expected_keys = {
+            binding.runner_key
+            for binding in plan.bindings.values()
+            if isinstance(binding, LocalBinding)
+        }
+        actual_keys = set(local_runners)
+        if actual_keys != expected_keys:
+            raise WorkflowValidationError(
+                "local runners differ from execution plan; "
+                f"missing={sorted(expected_keys - actual_keys)}, "
+                f"extra={sorted(actual_keys - expected_keys)}"
+            )
+
+        runners = dict(local_runners)
+        for stage in plan.workflow.stages:
+            binding = plan.bindings[stage.id]
+            if not isinstance(binding, LocalBinding):
+                raise WorkflowValidationError(
+                    f"executor does not support binding for stage {stage.id!r}"
+                )
+            runner = runners[binding.runner_key]
+            if not isinstance(runner, StageRunner):
+                raise WorkflowValidationError(
+                    f"runner {binding.runner_key!r} must implement StageRunner"
+                )
+            if runner.contract != stage.contract:
+                raise WorkflowValidationError(
+                    f"runner {binding.runner_key!r} for stage {stage.id!r} "
+                    "does not match its authored contract"
+                )
+
+        self._plan = plan
+        self._local_runners = MappingProxyType(runners)
 
     @property
-    def workflow(self) -> WorkflowIR:
-        """Return the logical workflow compiled into this plan."""
+    def plan(self) -> ExecutionPlan:
+        """Return the physical plan hydrated by this executor."""
 
-        return self._workflow
+        return self._plan
 
     async def run(
         self,
@@ -118,7 +150,8 @@ class ExecutionPlan:
         if timeout is not None and timeout <= 0:
             raise ValueError("timeout must be positive")
         input_values = dict(inputs)
-        expected_inputs = set(self._workflow.inputs)
+        workflow = self._plan.workflow
+        expected_inputs = set(workflow.inputs)
         actual_inputs = set(input_values)
         if actual_inputs != expected_inputs:
             raise WorkflowExecutionError(
@@ -126,7 +159,7 @@ class ExecutionPlan:
                 f"missing={sorted(expected_inputs - actual_inputs)}, "
                 f"extra={sorted(actual_inputs - expected_inputs)}"
             )
-        for name, spec in self._workflow.inputs.items():
+        for name, spec in workflow.inputs.items():
             _validate_value(spec, input_values[name], f"workflow input {name!r}")
 
         loop = asyncio.get_running_loop()
@@ -142,13 +175,18 @@ class ExecutionPlan:
                 for port_name, reference in stage.inputs.items():
                     stage_inputs[port_name] = await resolve(reference)
                 context = StageContext(
-                    workflow_name=self._workflow.name,
+                    workflow_name=workflow.name,
                     stage_id=stage.id,
                     attempt_id=resolved_attempt_id,
                     deadline=deadline,
                     _cancelled=cancelled,
                 )
-                result = await self._bindings[stage.id].runner.run(
+                binding = self._plan.bindings[stage.id]
+                if not isinstance(binding, LocalBinding):
+                    raise WorkflowExecutionError(
+                        f"unsupported binding for stage {stage.id!r}"
+                    )
+                result = await self._local_runners[binding.runner_key].run(
                     MappingProxyType(stage_inputs), context
                 )
                 if not isinstance(result, Mapping):
@@ -180,19 +218,16 @@ class ExecutionPlan:
                 stage_outputs = await asyncio.shield(tasks[stage_id])
                 return stage_outputs[output_name]
 
-            for stage in self._workflow.stages:
+            for stage in workflow.stages:
                 tasks[stage.id] = asyncio.create_task(
                     run_stage(stage), name=f"workflow:{stage.id}"
                 )
 
             try:
                 output_values = await asyncio.gather(
-                    *(
-                        resolve(reference)
-                        for reference in self._workflow.outputs.values()
-                    )
+                    *(resolve(reference) for reference in workflow.outputs.values())
                 )
-                return dict(zip(self._workflow.outputs, output_values))
+                return dict(zip(workflow.outputs, output_values))
             except BaseException:
                 cancelled.set()
                 for task in tasks.values():
@@ -204,63 +239,6 @@ class ExecutionPlan:
         if timeout is None:
             return await execute()
         return await asyncio.wait_for(execute(), timeout=timeout)
-
-
-def compile_workflow(
-    workflow: Union[WorkflowBuilder, WorkflowIR],
-    bindings: Optional[Mapping[str, Union[StageRunner, LocalBinding]]] = None,
-    **workers: StageRunner,
-) -> ExecutionPlan:
-    """Compile a workflow by binding each stage to a reusable local worker.
-
-    Keyword workers are the concise path when stage IDs are valid Python names::
-
-        plan = compile_workflow(workflow, encoder=encoder, decoder=decoder)
-
-    The ``bindings`` mapping supports all portable stage names.
-    """
-
-    workflow_ir = (
-        workflow.build() if isinstance(workflow, WorkflowBuilder) else workflow
-    )
-    if not isinstance(workflow_ir, WorkflowIR):
-        raise TypeError("workflow must be a Workflow or WorkflowIR")
-
-    combined: dict[str, Union[StageRunner, LocalBinding]] = dict(bindings or {})
-    overlap = set(combined) & set(workers)
-    if overlap:
-        raise WorkflowValidationError(
-            f"duplicate local bindings for stages {sorted(overlap)}"
-        )
-    combined.update(workers)
-
-    expected = {stage.id for stage in workflow_ir.stages}
-    actual = set(combined)
-    if actual != expected:
-        raise WorkflowValidationError(
-            "local bindings differ from workflow stages; "
-            f"missing={sorted(expected - actual)}, extra={sorted(actual - expected)}"
-        )
-
-    local_bindings: dict[str, LocalBinding] = {}
-    for stage in workflow_ir.stages:
-        candidate = combined[stage.id]
-        binding = (
-            candidate
-            if isinstance(candidate, LocalBinding)
-            else LocalBinding(candidate)
-        )
-        if not isinstance(binding.runner, StageRunner):
-            raise WorkflowValidationError(
-                f"binding for stage {stage.id!r} must implement StageRunner"
-            )
-        if binding.runner.contract != stage.contract:
-            raise WorkflowValidationError(
-                f"binding for stage {stage.id!r} does not match its authored contract"
-            )
-        local_bindings[stage.id] = binding
-
-    return ExecutionPlan(workflow_ir, local_bindings)
 
 
 def _validate_value(spec: ValueSpec, value: Any, location: str) -> None:

--- a/components/src/dynamo/workflow/runtime.py
+++ b/components/src/dynamo/workflow/runtime.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Hydration and execution for compiled Dynamo workflows."""
+"""Runtime binding and execution for compiled Dynamo workflows."""
 
 from __future__ import annotations
 
@@ -86,7 +86,7 @@ class _ImageValue(Protocol):
 
 
 class WorkflowExecutor:
-    """Hydrate and execute one compiled workflow plan."""
+    """Bind runtime resources and execute one compiled workflow plan."""
 
     def __init__(
         self,

--- a/components/src/dynamo/workflow/scheduler.py
+++ b/components/src/dynamo/workflow/scheduler.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency scheduling for declarative workflow graphs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any, cast
+
+from dynamo.workflow.dispatcher import StageDispatcher
+from dynamo.workflow.ir import StageIR, WorkflowIR
+from dynamo.workflow.runtime import StageContext, WorkflowAttempt
+from dynamo.workflow.types import ValueRef
+
+
+class GraphScheduler:
+    """Resolve static dependencies and run ready graph stages concurrently."""
+
+    def __init__(self, workflow: WorkflowIR, dispatcher: StageDispatcher) -> None:
+        self._workflow = workflow
+        self._dispatcher = dispatcher
+
+    async def run(
+        self, inputs: Mapping[str, Any], attempt: WorkflowAttempt
+    ) -> dict[str, Any]:
+        tasks: dict[str, asyncio.Task[dict[str, Any]]] = {}
+
+        async def run_stage(stage: StageIR) -> dict[str, Any]:
+            stage_inputs = {
+                name: await resolve(reference)
+                for name, reference in stage.inputs.items()
+            }
+            return await self._dispatcher.call(
+                stage.id,
+                stage.contract,
+                stage_inputs,
+                StageContext(
+                    workflow_name=self._workflow.name,
+                    stage_id=stage.id,
+                    attempt_id=attempt.attempt_id,
+                    invocation_id=f"{attempt.attempt_id}:{stage.id}",
+                    deadline=attempt.deadline,
+                    _cancelled=attempt.cancelled,
+                    request_context=attempt.request_context,
+                ),
+            )
+
+        async def resolve(reference: ValueRef) -> Any:
+            if reference.input_name is not None:
+                return inputs[reference.input_name]
+            stage_id = cast(str, reference.stage_id)
+            output_name = cast(str, reference.output_name)
+            stage_outputs = await asyncio.shield(tasks[stage_id])
+            return stage_outputs[output_name]
+
+        for stage in self._workflow.stages:
+            tasks[stage.id] = asyncio.create_task(
+                run_stage(stage), name=f"workflow:{stage.id}"
+            )
+
+        try:
+            output_values = await asyncio.gather(
+                *(resolve(reference) for reference in self._workflow.outputs.values())
+            )
+            return dict(zip(self._workflow.outputs, output_values))
+        except BaseException:
+            attempt.cancelled.set()
+            for task in tasks.values():
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks.values(), return_exceptions=True)
+            raise

--- a/components/src/dynamo/workflow/tests/__init__.py
+++ b/components/src/dynamo/workflow/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/components/src/dynamo/workflow/tests/test_authoring.py
+++ b/components/src/dynamo/workflow/tests/test_authoring.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from dynamo.workflow import (
+    StageContract,
+    StageIR,
+    ValueRef,
+    ValueSpec,
+    Workflow,
+    WorkflowBuilder,
+    WorkflowIR,
+    WorkflowValidationError,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
+
+
+def _contracts():
+    embedding = ValueSpec(type="tensor", dtype="float32", shape=("dynamic", 4))
+    encoder = StageContract(
+        id="encoder",
+        inputs={"image": ValueSpec(type="image", mode="RGB")},
+        outputs={"embedding": embedding},
+    )
+    classifier = StageContract(
+        id="classifier",
+        inputs={"embedding": embedding},
+        outputs={"scores": ValueSpec(type="json")},
+    )
+    generator = StageContract(
+        id="generator",
+        inputs={
+            "embedding": embedding,
+            "prompt": ValueSpec(type="text"),
+        },
+        outputs={"text": ValueSpec(type="text")},
+    )
+    return encoder, classifier, generator
+
+
+def _workflow() -> WorkflowIR:
+    encoder_contract, classifier_contract, generator_contract = _contracts()
+
+    class EncoderWorker:
+        contract = encoder_contract
+
+    workflow = Workflow("vision-response")
+    image = workflow.input("image", type="image", mode="RGB")
+    prompt = workflow.input("prompt", type="text")
+    encoder = workflow.stage("encoder", EncoderWorker, image=image)
+    classifier = workflow.stage(
+        "classifier",
+        classifier_contract,
+        embedding=encoder.embedding,
+    )
+    generator = workflow.stage(
+        "generator",
+        generator_contract,
+        embedding=encoder.embedding,
+        prompt=prompt,
+    )
+    workflow.output("scores", classifier.scores)
+    workflow.output("text", generator.text)
+    return workflow.build()
+
+
+def test_builds_fanout_workflow_from_declared_output_attributes():
+    workflow = _workflow()
+
+    assert [stage.id for stage in workflow.stages] == [
+        "encoder",
+        "classifier",
+        "generator",
+    ]
+    assert workflow.output_spec("scores") == ValueSpec(type="json")
+    encoder_ref = workflow.stages[1].inputs["embedding"]
+    assert encoder_ref.to_dict() == {"stage": "encoder", "output": "embedding"}
+
+
+def test_json_is_deterministic_and_round_trips_unicode():
+    workflow = _workflow()
+    encoded = workflow.to_json()
+
+    assert encoded == workflow.to_json()
+    assert WorkflowIR.from_json(encoded).to_dict() == workflow.to_dict()
+    assert WorkflowIR.from_json(
+        encoded.replace("vision-response", "视觉-workflow")
+    ).name == ("视觉-workflow")
+
+
+def test_output_method_handles_attribute_collisions_and_invalid_names():
+    contract = StageContract(
+        id="producer",
+        outputs={
+            "output": ValueSpec(type="text"),
+            "hyphen-name": ValueSpec(type="text"),
+            "text": ValueSpec(type="text"),
+        },
+    )
+    workflow = WorkflowBuilder("fallback")
+    seed = workflow.add_input("seed", ValueSpec(type="text"))
+    passthrough = StageContract(
+        id="passthrough",
+        inputs={"seed": ValueSpec(type="text")},
+        outputs=contract.outputs,
+    )
+    producer = workflow.add_stage("producer", passthrough, inputs={"seed": seed})
+
+    assert producer.text == producer.output("text")
+    assert producer.output("output").output_name == "output"
+    assert producer.output("hyphen-name").output_name == "hyphen-name"
+    with pytest.raises(WorkflowValidationError, match="no output"):
+        producer.output("missing")
+
+
+def test_contracts_are_deeply_immutable():
+    contract = StageContract(id="source", outputs={"text": ValueSpec(type="text")})
+
+    with pytest.raises(TypeError):
+        contract.outputs["other"] = ValueSpec(type="text")
+    with pytest.raises(FrozenInstanceError):
+        contract.id = "changed"
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"type": "meaning"},
+        {"type": "text", "dtype": "float32"},
+        {"type": "tensor", "dtype": "fp8"},
+        {"type": "tensor", "shape": [-1, 4]},
+        {"type": "object"},
+    ],
+)
+def test_rejects_invalid_value_specs(spec):
+    with pytest.raises(WorkflowValidationError):
+        ValueSpec.from_dict(spec)
+
+
+def test_rejects_incompatible_edge_and_foreign_reference():
+    consumer = StageContract(
+        id="consumer",
+        inputs={"value": ValueSpec(type="tensor", dtype="float32", shape=(4,))},
+        outputs={"text": ValueSpec(type="text")},
+    )
+    workflow = WorkflowBuilder("incompatible")
+    value = workflow.add_input(
+        "value", ValueSpec(type="tensor", dtype="float16", shape=(4,))
+    )
+    other = WorkflowBuilder("other")
+    foreign = other.add_input("value", ValueSpec(type="tensor"))
+
+    with pytest.raises(WorkflowValidationError, match="incompatible"):
+        workflow.add_stage("consumer", consumer, inputs={"value": value})
+    with pytest.raises(WorkflowValidationError, match="different workflow"):
+        workflow.add_stage("consumer", consumer, inputs={"value": foreign})
+
+
+def test_rejects_missing_inputs_and_conflicting_contract_ids():
+    first = StageContract(
+        id="shared",
+        inputs={"value": ValueSpec(type="text")},
+        outputs={"text": ValueSpec(type="text")},
+    )
+    conflicting = StageContract(
+        id="shared",
+        inputs={"value": ValueSpec(type="text")},
+        outputs={"json": ValueSpec(type="json")},
+    )
+    workflow = WorkflowBuilder("contracts")
+    value = workflow.add_input("value", ValueSpec(type="text"))
+    first_stage = workflow.add_stage("first", first, inputs={"value": value})
+
+    with pytest.raises(WorkflowValidationError, match="missing"):
+        workflow.add_stage("missing", first, inputs={})
+    with pytest.raises(WorkflowValidationError, match="conflicting schemas"):
+        workflow.add_stage("second", conflicting, inputs={"value": first_stage.text})
+
+
+def test_parser_rejects_unknown_fields_and_duplicate_json_keys():
+    data = _workflow().to_dict()
+    data["placement"] = {"gpu": 0}
+    with pytest.raises(WorkflowValidationError, match="unknown fields"):
+        WorkflowIR.from_dict(data)
+    with pytest.raises(WorkflowValidationError, match="duplicate JSON key"):
+        WorkflowIR.from_json('{"schema":"one","schema":"two"}')
+
+
+def test_parser_rejects_cycles_unreachable_and_dead_stages():
+    text = ValueSpec(type="text")
+    contract = StageContract(id="node", inputs={"value": text}, outputs={"value": text})
+    cycle = (
+        StageIR(
+            id="a",
+            contract=contract,
+            inputs={"value": ValueRef.for_stage_output("b", "value")},
+        ),
+        StageIR(
+            id="b",
+            contract=contract,
+            inputs={"value": ValueRef.for_stage_output("a", "value")},
+        ),
+    )
+    with pytest.raises(WorkflowValidationError, match="cycle"):
+        WorkflowIR(
+            name="cycle",
+            inputs={"seed": text},
+            stages=cycle,
+            outputs={"value": ValueRef.for_stage_output("a", "value")},
+        )
+
+    source = StageContract(id="source", outputs={"value": text})
+    with pytest.raises(WorkflowValidationError, match="not reachable"):
+        WorkflowIR(
+            name="unreachable",
+            inputs={"seed": text},
+            stages=(StageIR(id="source", contract=source),),
+            outputs={"value": ValueRef.for_stage_output("source", "value")},
+        )
+
+    dead_stage = StageIR(
+        id="dead", contract=contract, inputs={"value": ValueRef.for_input("seed")}
+    )
+    with pytest.raises(WorkflowValidationError, match="do not contribute"):
+        WorkflowIR(
+            name="dead",
+            inputs={"seed": text},
+            stages=(dead_stage,),
+            outputs={"value": ValueRef.for_input("seed")},
+        )
+
+
+def test_parser_rejects_unknown_references_and_schema_version():
+    data = _workflow().to_dict()
+    data["outputs"]["text"] = {"stage": "missing", "output": "text"}
+    with pytest.raises(WorkflowValidationError, match="unknown stage"):
+        WorkflowIR.from_dict(data)
+
+    data = _workflow().to_dict()
+    data["version"] = 1
+    with pytest.raises(WorkflowValidationError, match="unsupported workflow version"):
+        WorkflowIR.from_dict(data)
+
+    malformed = json.loads(_workflow().to_json())
+    malformed["stages"][0]["contract"]["outputs"]["embedding"]["extra"] = "x"
+    with pytest.raises(WorkflowValidationError, match="unknown fields"):
+        WorkflowIR.from_dict(malformed)

--- a/components/src/dynamo/workflow/tests/test_authoring.py
+++ b/components/src/dynamo/workflow/tests/test_authoring.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 from dataclasses import FrozenInstanceError
+from typing import Any
 
 import pytest
 
@@ -84,22 +84,10 @@ def test_builds_fanout_workflow_from_declared_output_attributes():
     ]
     assert workflow.output_spec("scores") == ValueSpec(type="json")
     encoder_ref = workflow.stages[1].inputs["embedding"]
-    assert encoder_ref.to_dict() == {"stage": "encoder", "output": "embedding"}
+    assert encoder_ref == ValueRef.for_stage_output("encoder", "embedding")
 
 
-def test_json_is_deterministic_and_round_trips() -> None:
-    workflow = _workflow()
-    encoded = workflow.to_json()
-
-    assert encoded == workflow.to_json()
-    assert WorkflowIR.from_json(encoded).to_dict() == workflow.to_dict()
-    assert (
-        WorkflowIR.from_json(encoded.replace("vision-response", "视觉-workflow")).name
-        == "视觉-workflow"
-    )
-
-
-def test_json_schema_keeps_complete_contracts_inline() -> None:
+def test_ir_keeps_complete_contracts_inline() -> None:
     workflow = Workflow("echo-flow")
     value = workflow.input("text", type="text")
     echo = workflow.stage(
@@ -113,13 +101,19 @@ def test_json_schema_keeps_complete_contracts_inline() -> None:
     )
     workflow.output("text", echo.text)
 
-    assert workflow.build().to_json() == (
-        '{"inputs":{"text":{"type":"text"}},"name":"echo-flow",'
-        '"outputs":{"text":{"output":"text","stage":"echo"}},'
-        '"schema":"dynamo.workflow.ir","stages":[{"contract":'
-        '{"id":"echo-contract","inputs":{"text":{"type":"text"}},'
-        '"outputs":{"text":{"type":"text"}}},"id":"echo",'
-        '"inputs":{"text":{"input":"text"}}}],"version":0}'
+    workflow_ir = workflow.build()
+    assert workflow_ir.inputs == {"text": ValueSpec(type="text")}
+    assert workflow_ir.outputs == {"text": ValueRef.for_stage_output("echo", "text")}
+    assert workflow_ir.stages == (
+        StageIR(
+            id="echo",
+            contract=StageContract(
+                id="echo-contract",
+                inputs={"text": ValueSpec(type="text")},
+                outputs={"text": ValueSpec(type="text")},
+            ),
+            inputs={"text": ValueRef.for_input("text")},
+        ),
     )
 
 
@@ -175,9 +169,9 @@ def test_contracts_are_deeply_immutable():
         {"type": "object", "class_id": "\ud800"},
     ],
 )
-def test_rejects_invalid_value_specs(spec: dict[str, object]) -> None:
+def test_rejects_invalid_value_specs(spec: dict[str, Any]) -> None:
     with pytest.raises(WorkflowValidationError):
-        ValueSpec.from_dict(spec)
+        ValueSpec(**spec)
 
 
 def test_rejects_incompatible_edge_and_foreign_reference():
@@ -220,30 +214,30 @@ def test_rejects_missing_inputs_and_conflicting_contract_ids():
         workflow.add_stage("second", conflicting, inputs={"value": first_stage.text})
 
 
-def test_parser_rejects_conflicting_inline_contracts() -> None:
-    data = _workflow().to_dict()
-    data["stages"][2]["contract"]["id"] = "classifier"
+def test_ir_rejects_conflicting_inline_contracts() -> None:
+    workflow = _workflow()
+    stages = list(workflow.stages)
+    generator = stages[2]
+    stages[2] = StageIR(
+        id=generator.id,
+        contract=StageContract(
+            id="classifier",
+            inputs=generator.contract.inputs,
+            outputs=generator.contract.outputs,
+        ),
+        inputs=generator.inputs,
+    )
 
     with pytest.raises(WorkflowValidationError, match="conflicting schemas"):
-        WorkflowIR.from_dict(data)
+        WorkflowIR(
+            name=workflow.name,
+            inputs=workflow.inputs,
+            stages=tuple(stages),
+            outputs=workflow.outputs,
+        )
 
 
-def test_parser_rejects_unknown_fields_and_duplicate_json_keys():
-    data = _workflow().to_dict()
-    data["placement"] = {"gpu": 0}
-    with pytest.raises(WorkflowValidationError, match="unknown fields"):
-        WorkflowIR.from_dict(data)
-    with pytest.raises(WorkflowValidationError, match="duplicate JSON key"):
-        WorkflowIR.from_json('{"schema":"one","schema":"two"}')
-
-
-@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
-def test_parser_rejects_non_finite_json_constants(constant: str) -> None:
-    with pytest.raises(WorkflowValidationError, match="non-finite JSON constant"):
-        WorkflowIR.from_json(_workflow().to_json().replace('"RGB"', constant))
-
-
-def test_parser_rejects_cycles_unreachable_and_dead_stages():
+def test_ir_rejects_cycles_unreachable_and_dead_stages():
     text = ValueSpec(type="text")
     contract = StageContract(id="node", inputs={"value": text}, outputs={"value": text})
     cycle = (
@@ -287,27 +281,14 @@ def test_parser_rejects_cycles_unreachable_and_dead_stages():
         )
 
 
-def test_parser_rejects_unknown_references_and_schema_version():
-    data = _workflow().to_dict()
-    data["outputs"]["text"] = {"stage": "missing", "output": "text"}
+def test_ir_rejects_unknown_references():
+    workflow = _workflow()
+    outputs = dict(workflow.outputs)
+    outputs["text"] = ValueRef.for_stage_output("missing", "text")
     with pytest.raises(WorkflowValidationError, match="unknown stage"):
-        WorkflowIR.from_dict(data)
-
-    data = _workflow().to_dict()
-    data["version"] = 1
-    with pytest.raises(WorkflowValidationError, match="unsupported workflow version"):
-        WorkflowIR.from_dict(data)
-
-    malformed = json.loads(_workflow().to_json())
-    malformed["stages"][0]["contract"]["outputs"]["embedding"]["extra"] = "x"
-    with pytest.raises(WorkflowValidationError, match="unknown fields"):
-        WorkflowIR.from_dict(malformed)
-
-
-@pytest.mark.parametrize("version", [False, 0.0])
-def test_parser_rejects_non_integer_version_zero(version: object) -> None:
-    data = _workflow().to_dict()
-    data["version"] = version
-
-    with pytest.raises(WorkflowValidationError, match="unsupported workflow version"):
-        WorkflowIR.from_dict(data)
+        WorkflowIR(
+            name=workflow.name,
+            inputs=workflow.inputs,
+            stages=workflow.stages,
+            outputs=outputs,
+        )

--- a/components/src/dynamo/workflow/tests/test_authoring.py
+++ b/components/src/dynamo/workflow/tests/test_authoring.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Mapping
 from dataclasses import FrozenInstanceError
 from typing import Any
 
@@ -9,10 +10,11 @@ import pytest
 from dynamo.workflow import (
     StageContract,
     StageIR,
+    StageRef,
     ValueRef,
     ValueSpec,
     Workflow,
-    WorkflowBuilder,
+    WorkflowHandler,
     WorkflowIR,
     WorkflowValidationError,
 )
@@ -126,7 +128,7 @@ def test_output_method_handles_attribute_collisions_and_invalid_names():
             "text": ValueSpec(type="text"),
         },
     )
-    workflow = WorkflowBuilder("fallback")
+    workflow = Workflow("fallback")
     seed = workflow.add_input("seed", ValueSpec(type="text"))
     passthrough = StageContract(
         id="passthrough",
@@ -180,11 +182,11 @@ def test_rejects_incompatible_edge_and_foreign_reference():
         inputs={"value": ValueSpec(type="tensor", dtype="float32", shape=(4,))},
         outputs={"text": ValueSpec(type="text")},
     )
-    workflow = WorkflowBuilder("incompatible")
+    workflow = Workflow("incompatible")
     value = workflow.add_input(
         "value", ValueSpec(type="tensor", dtype="float16", shape=(4,))
     )
-    other = WorkflowBuilder("other")
+    other = Workflow("other")
     foreign = other.add_input("value", ValueSpec(type="tensor"))
 
     with pytest.raises(WorkflowValidationError, match="incompatible"):
@@ -204,7 +206,7 @@ def test_rejects_missing_inputs_and_conflicting_contract_ids():
         inputs={"value": ValueSpec(type="text")},
         outputs={"json": ValueSpec(type="json")},
     )
-    workflow = WorkflowBuilder("contracts")
+    workflow = Workflow("contracts")
     value = workflow.add_input("value", ValueSpec(type="text"))
     first_stage = workflow.add_stage("first", first, inputs={"value": value})
 
@@ -291,4 +293,106 @@ def test_ir_rejects_unknown_references():
             inputs=workflow.inputs,
             stages=workflow.stages,
             outputs=outputs,
+        )
+
+
+def test_builds_imperative_handler_with_fixed_stage_catalog() -> None:
+    contract = StageContract(
+        id="echo",
+        inputs={"text": ValueSpec(type="text")},
+        outputs={"text": ValueSpec(type="text")},
+    )
+    workflow = Workflow("imperative")
+    echo = workflow.use("echo", contract)
+
+    @workflow.handler(
+        inputs={"request": ValueSpec(type="json")},
+        outputs={"result": ValueSpec(type="text")},
+    )
+    async def run(inputs: Mapping[str, Any], context: Any) -> Mapping[str, Any]:
+        return {"result": inputs["request"]["text"]}
+
+    definition = workflow.build()
+
+    assert isinstance(definition, WorkflowHandler)
+    assert isinstance(echo, StageRef)
+    assert echo.id == "echo"
+    assert definition.inputs == {"request": ValueSpec(type="json")}
+    assert definition.outputs == {"result": ValueSpec(type="text")}
+    assert definition.stages == {"echo": contract}
+    assert definition.callback is run
+
+
+def test_handler_catalog_accepts_use_after_decorator() -> None:
+    contract = StageContract(id="source", outputs={"text": ValueSpec(type="text")})
+    workflow = Workflow("handler-first")
+
+    @workflow.handler(inputs={}, outputs={"text": ValueSpec(type="text")})
+    async def run(inputs: Mapping[str, Any], context: Any) -> Mapping[str, Any]:
+        return {"text": "ready"}
+
+    source = workflow.use("source", contract)
+    definition = workflow.build()
+
+    assert isinstance(definition, WorkflowHandler)
+    assert source.contract is contract
+    assert definition.stages == {"source": contract}
+
+
+def test_rejects_mixed_graph_and_handler_authoring() -> None:
+    contract = StageContract(id="source", outputs={"text": ValueSpec(type="text")})
+
+    graph = Workflow("graph")
+    graph.input("request", type="json")
+    with pytest.raises(WorkflowValidationError, match="cannot mix"):
+        graph.use("source", contract)
+
+    handler = Workflow("handler")
+    handler.use("source", contract)
+    with pytest.raises(WorkflowValidationError, match="cannot mix"):
+        handler.input("request", type="json")
+
+
+def test_rejects_missing_duplicate_and_synchronous_handlers() -> None:
+    workflow = Workflow("missing")
+    workflow.use(
+        "source",
+        StageContract(id="source", outputs={"text": ValueSpec(type="text")}),
+    )
+    with pytest.raises(WorkflowValidationError, match="requires a handler"):
+        workflow.build()
+
+    duplicate = Workflow("duplicate")
+
+    @duplicate.handler(inputs={}, outputs={"text": ValueSpec(type="text")})
+    async def first(inputs: Mapping[str, Any], context: Any) -> Mapping[str, Any]:
+        return {"text": "first"}
+
+    with pytest.raises(WorkflowValidationError, match="already has a handler"):
+        duplicate.handler(inputs={}, outputs={"text": ValueSpec(type="text")})
+
+    synchronous = Workflow("synchronous")
+
+    @synchronous.handler(inputs={}, outputs={"text": ValueSpec(type="text")})
+    def sync_handler(inputs: Mapping[str, Any], context: Any) -> Mapping[str, Any]:
+        return {"text": "invalid"}
+
+    with pytest.raises(WorkflowValidationError, match="async function"):
+        synchronous.build()
+
+
+def test_handler_definition_is_deeply_immutable() -> None:
+    workflow = Workflow("immutable-handler")
+
+    @workflow.handler(inputs={}, outputs={"text": ValueSpec(type="text")})
+    async def run(inputs: Mapping[str, Any], context: Any) -> Mapping[str, Any]:
+        return {"text": "ready"}
+
+    definition = workflow.build()
+    assert isinstance(definition, WorkflowHandler)
+    with pytest.raises(TypeError):
+        definition.outputs["other"] = ValueSpec(type="text")
+    with pytest.raises(TypeError):
+        definition.stages["other"] = StageContract(
+            id="other", outputs={"text": ValueSpec(type="text")}
         )

--- a/components/src/dynamo/workflow/tests/test_authoring.py
+++ b/components/src/dynamo/workflow/tests/test_authoring.py
@@ -87,15 +87,40 @@ def test_builds_fanout_workflow_from_declared_output_attributes():
     assert encoder_ref.to_dict() == {"stage": "encoder", "output": "embedding"}
 
 
-def test_json_is_deterministic_and_round_trips_unicode():
+def test_json_is_deterministic_and_round_trips() -> None:
     workflow = _workflow()
     encoded = workflow.to_json()
 
     assert encoded == workflow.to_json()
     assert WorkflowIR.from_json(encoded).to_dict() == workflow.to_dict()
-    assert WorkflowIR.from_json(
-        encoded.replace("vision-response", "视觉-workflow")
-    ).name == ("视觉-workflow")
+    assert (
+        WorkflowIR.from_json(encoded.replace("vision-response", "视觉-workflow")).name
+        == "视觉-workflow"
+    )
+
+
+def test_json_schema_keeps_complete_contracts_inline() -> None:
+    workflow = Workflow("echo-flow")
+    value = workflow.input("text", type="text")
+    echo = workflow.stage(
+        "echo",
+        StageContract(
+            id="echo-contract",
+            inputs={"text": ValueSpec(type="text")},
+            outputs={"text": ValueSpec(type="text")},
+        ),
+        text=value,
+    )
+    workflow.output("text", echo.text)
+
+    assert workflow.build().to_json() == (
+        '{"inputs":{"text":{"type":"text"}},"name":"echo-flow",'
+        '"outputs":{"text":{"output":"text","stage":"echo"}},'
+        '"schema":"dynamo.workflow.ir","stages":[{"contract":'
+        '{"id":"echo-contract","inputs":{"text":{"type":"text"}},'
+        '"outputs":{"text":{"type":"text"}}},"id":"echo",'
+        '"inputs":{"text":{"input":"text"}}}],"version":0}'
+    )
 
 
 def test_output_method_handles_attribute_collisions_and_invalid_names():
@@ -135,14 +160,22 @@ def test_contracts_are_deeply_immutable():
 @pytest.mark.parametrize(
     "spec",
     [
+        {"type": []},
         {"type": "meaning"},
         {"type": "text", "dtype": "float32"},
+        {"type": "tensor", "dtype": []},
         {"type": "tensor", "dtype": "fp8"},
+        {"type": "tensor", "shape": "dynamic"},
         {"type": "tensor", "shape": [-1, 4]},
+        {"type": "image", "mode": 123},
+        {"type": "image", "mode": float("nan")},
+        {"type": "image", "mode": "\ud800"},
         {"type": "object"},
+        {"type": "object", "class_id": 123},
+        {"type": "object", "class_id": "\ud800"},
     ],
 )
-def test_rejects_invalid_value_specs(spec):
+def test_rejects_invalid_value_specs(spec: dict[str, object]) -> None:
     with pytest.raises(WorkflowValidationError):
         ValueSpec.from_dict(spec)
 
@@ -187,6 +220,14 @@ def test_rejects_missing_inputs_and_conflicting_contract_ids():
         workflow.add_stage("second", conflicting, inputs={"value": first_stage.text})
 
 
+def test_parser_rejects_conflicting_inline_contracts() -> None:
+    data = _workflow().to_dict()
+    data["stages"][2]["contract"]["id"] = "classifier"
+
+    with pytest.raises(WorkflowValidationError, match="conflicting schemas"):
+        WorkflowIR.from_dict(data)
+
+
 def test_parser_rejects_unknown_fields_and_duplicate_json_keys():
     data = _workflow().to_dict()
     data["placement"] = {"gpu": 0}
@@ -194,6 +235,12 @@ def test_parser_rejects_unknown_fields_and_duplicate_json_keys():
         WorkflowIR.from_dict(data)
     with pytest.raises(WorkflowValidationError, match="duplicate JSON key"):
         WorkflowIR.from_json('{"schema":"one","schema":"two"}')
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_parser_rejects_non_finite_json_constants(constant: str) -> None:
+    with pytest.raises(WorkflowValidationError, match="non-finite JSON constant"):
+        WorkflowIR.from_json(_workflow().to_json().replace('"RGB"', constant))
 
 
 def test_parser_rejects_cycles_unreachable_and_dead_stages():
@@ -255,3 +302,12 @@ def test_parser_rejects_unknown_references_and_schema_version():
     malformed["stages"][0]["contract"]["outputs"]["embedding"]["extra"] = "x"
     with pytest.raises(WorkflowValidationError, match="unknown fields"):
         WorkflowIR.from_dict(malformed)
+
+
+@pytest.mark.parametrize("version", [False, 0.0])
+def test_parser_rejects_non_integer_version_zero(version: object) -> None:
+    data = _workflow().to_dict()
+    data["version"] = version
+
+    with pytest.raises(WorkflowValidationError, match="unsupported workflow version"):
+        WorkflowIR.from_dict(data)

--- a/components/src/dynamo/workflow/tests/test_plan.py
+++ b/components/src/dynamo/workflow/tests/test_plan.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.workflow import (
+    DeploymentSpec,
+    EdgePlan,
+    ExecutionPlan,
+    LocalBinding,
+    StageContract,
+    ValueRef,
+    ValueSpec,
+    Workflow,
+    WorkflowValidationError,
+    compile_workflow,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
+
+
+def _workflow() -> Workflow:
+    workflow = Workflow("physical-plan")
+    text = workflow.input("text", type="text")
+    stage = workflow.stage(
+        "normalize",
+        StageContract(
+            id="normalize",
+            inputs={"text": ValueSpec(type="text")},
+            outputs={"normalized": ValueSpec(type="text")},
+        ),
+        text=text,
+    )
+    workflow.output("text", stage.normalized)
+    return workflow
+
+
+def test_execution_plan_contains_only_in_memory_decisions() -> None:
+    plan = compile_workflow(_workflow(), DeploymentSpec.local(normalize="normalizer"))
+
+    assert plan.bindings == {"normalize": LocalBinding(runner_key="normalizer")}
+    assert plan.edges == (
+        EdgePlan(
+            source=ValueRef.for_input("text"),
+            target_stage="normalize",
+            target_port="text",
+            carrier="local",
+        ),
+    )
+
+
+def test_execution_plan_rejects_invalid_physical_edges() -> None:
+    plan = compile_workflow(_workflow(), DeploymentSpec.local(normalize="normalizer"))
+
+    with pytest.raises(WorkflowValidationError, match="does not match WorkflowIR"):
+        ExecutionPlan(
+            workflow=plan.workflow,
+            bindings=plan.bindings,
+            edges=(
+                EdgePlan(
+                    source=ValueRef.for_input("other"),
+                    target_stage="normalize",
+                    target_port="text",
+                    carrier="local",
+                ),
+            ),
+        )

--- a/components/src/dynamo/workflow/tests/test_plan.py
+++ b/components/src/dynamo/workflow/tests/test_plan.py
@@ -54,6 +54,13 @@ def test_execution_plan_contains_only_in_memory_decisions() -> None:
     )
 
 
+def test_compilation_defaults_to_stage_id_local_bindings() -> None:
+    plan = compile_workflow(_workflow())
+
+    assert plan.bindings == {"normalize": LocalBinding(runner_key="normalize")}
+    assert all(edge.carrier == "local" for edge in plan.edges)
+
+
 def test_execution_plan_rejects_invalid_physical_edges() -> None:
     plan = compile_workflow(_workflow(), DeploymentSpec.local(normalize="normalizer"))
 

--- a/components/src/dynamo/workflow/tests/test_plan.py
+++ b/components/src/dynamo/workflow/tests/test_plan.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Mapping
+from typing import Any
+
 import pytest
 
 from dynamo.workflow import (
@@ -64,9 +67,9 @@ def test_compilation_defaults_to_stage_id_local_bindings() -> None:
 def test_execution_plan_rejects_invalid_physical_edges() -> None:
     plan = compile_workflow(_workflow(), DeploymentSpec.local(normalize="normalizer"))
 
-    with pytest.raises(WorkflowValidationError, match="does not match WorkflowIR"):
+    with pytest.raises(WorkflowValidationError, match="does not match"):
         ExecutionPlan(
-            workflow=plan.workflow,
+            definition=plan.definition,
             bindings=plan.bindings,
             edges=(
                 EdgePlan(
@@ -77,3 +80,26 @@ def test_execution_plan_rejects_invalid_physical_edges() -> None:
                 ),
             ),
         )
+
+
+def test_handler_plan_contains_bindings_without_graph_edges() -> None:
+    workflow = Workflow("imperative-plan")
+    echo = StageContract(
+        id="echo",
+        inputs={"text": ValueSpec(type="text")},
+        outputs={"text": ValueSpec(type="text")},
+    )
+    workflow.use("echo", echo)
+
+    @workflow.handler(
+        inputs={"text": ValueSpec(type="text")},
+        outputs={"text": ValueSpec(type="text")},
+    )
+    async def run(inputs: Mapping[str, Any], context: Any) -> Mapping[str, Any]:
+        return {"text": inputs["text"]}
+
+    plan = compile_workflow(workflow)
+
+    assert plan.bindings == {"echo": LocalBinding(runner_key="echo")}
+    assert plan.stage_contracts == {"echo": echo}
+    assert plan.edges == ()

--- a/components/src/dynamo/workflow/tests/test_runtime.py
+++ b/components/src/dynamo/workflow/tests/test_runtime.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.workflow import (
+    StageContext,
+    StageContract,
+    ValueSpec,
+    Workflow,
+    WorkflowExecutionError,
+    WorkflowValidationError,
+    compile_workflow,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
+
+
+EMBEDDING = ValueSpec(type="object", class_id="embedding")
+ENCODER = StageContract(
+    id="encoder-worker",
+    inputs={"text": ValueSpec(type="text")},
+    outputs={"embedding": EMBEDDING},
+)
+CLASSIFIER = StageContract(
+    id="classifier-worker",
+    inputs={"embedding": EMBEDDING},
+    outputs={"scores": ValueSpec(type="json")},
+)
+GENERATOR = StageContract(
+    id="generator-worker",
+    inputs={"embedding": EMBEDDING},
+    outputs={"text": ValueSpec(type="text")},
+)
+
+
+def _workflow() -> Workflow:
+    workflow = Workflow("local-execution")
+    text = workflow.input("text", type="text")
+    encoder = workflow.stage("encoder", _Encoder, text=text)
+    classifier = workflow.stage("classifier", _Classifier, embedding=encoder.embedding)
+    generator = workflow.stage("generator", _Generator, embedding=encoder.embedding)
+    workflow.output("scores", classifier.scores)
+    workflow.output("text", generator.text)
+    return workflow
+
+
+@dataclass
+class _Encoder:
+    contract = ENCODER
+    embedding: object
+
+    async def run(self, inputs, context: StageContext):
+        assert context.stage_id == "encoder"
+        return {"embedding": self.embedding}
+
+
+@dataclass
+class _Classifier:
+    contract = CLASSIFIER
+    expected: object
+
+    async def run(self, inputs, context: StageContext):
+        assert inputs["embedding"] is self.expected
+        return {"scores": {"class-a": 0.75, "class-b": 0.25}}
+
+
+@dataclass
+class _Generator:
+    contract = GENERATOR
+    expected: object
+
+    async def run(self, inputs, context: StageContext):
+        assert inputs["embedding"] is self.expected
+        return {"text": "generated"}
+
+
+async def test_concise_compile_and_run_preserve_fanout_value_identity():
+    embedding = object()
+    plan = compile_workflow(
+        _workflow(),
+        encoder=_Encoder(embedding),
+        classifier=_Classifier(embedding),
+        generator=_Generator(embedding),
+    )
+
+    result = await plan.run({"text": "hello"}, attempt_id="request-1")
+
+    assert result == {
+        "scores": {"class-a": 0.75, "class-b": 0.25},
+        "text": "generated",
+    }
+
+
+class _BranchBarrier:
+    def __init__(self, count: int) -> None:
+        self._remaining = count
+        self.open = asyncio.Event()
+
+    async def enter(self) -> None:
+        self._remaining -= 1
+        if self._remaining == 0:
+            self.open.set()
+        await self.open.wait()
+
+
+@dataclass
+class _BarrierClassifier:
+    contract = CLASSIFIER
+    barrier: _BranchBarrier
+
+    async def run(self, inputs, context: StageContext):
+        await self.barrier.enter()
+        return {"scores": {"ok": True}}
+
+
+@dataclass
+class _BarrierGenerator:
+    contract = GENERATOR
+    barrier: _BranchBarrier
+
+    async def run(self, inputs, context: StageContext):
+        await self.barrier.enter()
+        return {"text": "joined"}
+
+
+async def test_independent_branches_run_concurrently_before_join():
+    embedding = object()
+    barrier = _BranchBarrier(2)
+    plan = compile_workflow(
+        _workflow(),
+        encoder=_Encoder(embedding),
+        classifier=_BarrierClassifier(barrier),
+        generator=_BarrierGenerator(barrier),
+    )
+
+    assert await plan.run({"text": "hello"}) == {
+        "scores": {"ok": True},
+        "text": "joined",
+    }
+
+
+class WorkerFailure(RuntimeError):
+    pass
+
+
+@dataclass
+class _FailingClassifier:
+    contract = CLASSIFIER
+    barrier: _BranchBarrier
+
+    async def run(self, inputs, context: StageContext):
+        await self.barrier.enter()
+        raise WorkerFailure("classifier failed")
+
+
+@dataclass
+class _CancelledGenerator:
+    contract = GENERATOR
+    barrier: _BranchBarrier
+    cancelled: asyncio.Event
+
+    async def run(self, inputs, context: StageContext):
+        await self.barrier.enter()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+
+
+async def test_first_worker_failure_cancels_and_awaits_sibling():
+    embedding = object()
+    barrier = _BranchBarrier(2)
+    cancelled = asyncio.Event()
+    plan = compile_workflow(
+        _workflow(),
+        encoder=_Encoder(embedding),
+        classifier=_FailingClassifier(barrier),
+        generator=_CancelledGenerator(barrier, cancelled),
+    )
+
+    with pytest.raises(WorkerFailure, match="classifier failed"):
+        await plan.run({"text": "hello"})
+
+    assert cancelled.is_set()
+
+
+@dataclass
+class _BlockingClassifier:
+    contract = CLASSIFIER
+    started: asyncio.Event
+    cancelled: asyncio.Event
+
+    async def run(self, inputs, context: StageContext):
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            assert context.cancelled
+            self.cancelled.set()
+            raise
+
+
+async def test_timeout_cancels_and_awaits_running_stages():
+    embedding = object()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    plan = compile_workflow(
+        _workflow(),
+        encoder=_Encoder(embedding),
+        classifier=_BlockingClassifier(started, cancelled),
+        generator=_Generator(embedding),
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await plan.run({"text": "hello"}, timeout=0.01)
+
+    assert started.is_set()
+    assert cancelled.is_set()
+
+
+async def test_caller_cancellation_cleans_up_running_stages():
+    embedding = object()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    plan = compile_workflow(
+        _workflow(),
+        encoder=_Encoder(embedding),
+        classifier=_BlockingClassifier(started, cancelled),
+        generator=_Generator(embedding),
+    )
+    task = asyncio.create_task(plan.run({"text": "hello"}))
+    await started.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cancelled.is_set()
+
+
+def test_compile_requires_exact_bindings_and_matching_contracts():
+    with pytest.raises(WorkflowValidationError, match="missing"):
+        compile_workflow(_workflow(), encoder=_Encoder(object()))
+
+    wrong = SimpleNamespace(contract=CLASSIFIER, run=_Generator(object()).run)
+    with pytest.raises(WorkflowValidationError, match="does not match"):
+        compile_workflow(
+            _workflow(),
+            encoder=_Encoder(object()),
+            classifier=_Classifier(object()),
+            generator=wrong,
+        )
+
+
+async def test_runtime_rejects_bad_inputs_and_worker_outputs():
+    embedding = object()
+    plan = compile_workflow(
+        _workflow(),
+        encoder=_Encoder(embedding),
+        classifier=_Classifier(embedding),
+        generator=_Generator(embedding),
+    )
+    with pytest.raises(WorkflowExecutionError, match="must be text"):
+        await plan.run({"text": b"not text"})
+    with pytest.raises(WorkflowExecutionError, match="extra"):
+        await plan.run({"text": "hello", "extra": "value"})
+
+    class BadGenerator:
+        contract = GENERATOR
+
+        async def run(self, inputs, context):
+            return {"wrong": "value"}
+
+    bad_plan = compile_workflow(
+        _workflow(),
+        encoder=_Encoder(embedding),
+        classifier=_Classifier(embedding),
+        generator=BadGenerator(),
+    )
+    with pytest.raises(WorkflowExecutionError, match="outputs differ"):
+        await bad_plan.run({"text": "hello"})
+
+
+async def test_tensor_and_image_constraints_are_checked_without_framework_imports():
+    tensor_contract = StageContract(
+        id="tensor",
+        inputs={
+            "tensor": ValueSpec(type="tensor", dtype="float32", shape=("dynamic", 4))
+        },
+        outputs={"image": ValueSpec(type="image", mode="RGB")},
+    )
+    workflow = Workflow("runtime-types")
+    tensor = workflow.input(
+        "tensor", type="tensor", dtype="float32", shape=("dynamic", 4)
+    )
+    stage = workflow.stage("convert", tensor_contract, tensor=tensor)
+    workflow.output("image", stage.image)
+
+    class Converter:
+        contract = tensor_contract
+
+        async def run(self, inputs, context):
+            return {"image": SimpleNamespace(mode="RGB", size=(10, 10))}
+
+    plan = compile_workflow(workflow, convert=Converter())
+    value = SimpleNamespace(dtype="float32", shape=(2, 4))
+
+    assert (await plan.run({"tensor": value}))["image"].mode == "RGB"
+    with pytest.raises(WorkflowExecutionError, match="shape"):
+        await plan.run({"tensor": SimpleNamespace(dtype="float32", shape=(2, 3))})

--- a/components/src/dynamo/workflow/tests/test_runtime.py
+++ b/components/src/dynamo/workflow/tests/test_runtime.py
@@ -8,11 +8,14 @@ from types import SimpleNamespace
 import pytest
 
 from dynamo.workflow import (
+    DeploymentSpec,
     StageContext,
     StageContract,
+    StageRunner,
     ValueSpec,
     Workflow,
     WorkflowExecutionError,
+    WorkflowExecutor,
     WorkflowValidationError,
     compile_workflow,
 )
@@ -54,6 +57,14 @@ def _workflow() -> Workflow:
     return workflow
 
 
+def _compile_local(workflow: Workflow, **runners: StageRunner) -> WorkflowExecutor:
+    plan = compile_workflow(
+        workflow,
+        DeploymentSpec.local(**{stage_id: stage_id for stage_id in runners}),
+    )
+    return WorkflowExecutor(plan, runners)
+
+
 @dataclass
 class _Encoder:
     contract = ENCODER
@@ -86,7 +97,7 @@ class _Generator:
 
 async def test_concise_compile_and_run_preserve_fanout_value_identity():
     embedding = object()
-    plan = compile_workflow(
+    plan = _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_Classifier(embedding),
@@ -136,7 +147,7 @@ class _BarrierGenerator:
 async def test_independent_branches_run_concurrently_before_join():
     embedding = object()
     barrier = _BranchBarrier(2)
-    plan = compile_workflow(
+    plan = _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_BarrierClassifier(barrier),
@@ -182,7 +193,7 @@ async def test_first_worker_failure_cancels_and_awaits_sibling():
     embedding = object()
     barrier = _BranchBarrier(2)
     cancelled = asyncio.Event()
-    plan = compile_workflow(
+    plan = _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_FailingClassifier(barrier),
@@ -215,7 +226,7 @@ async def test_timeout_cancels_and_awaits_running_stages():
     embedding = object()
     started = asyncio.Event()
     cancelled = asyncio.Event()
-    plan = compile_workflow(
+    plan = _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_BlockingClassifier(started, cancelled),
@@ -233,7 +244,7 @@ async def test_caller_cancellation_cleans_up_running_stages():
     embedding = object()
     started = asyncio.Event()
     cancelled = asyncio.Event()
-    plan = compile_workflow(
+    plan = _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_BlockingClassifier(started, cancelled),
@@ -251,21 +262,30 @@ async def test_caller_cancellation_cleans_up_running_stages():
 
 def test_compile_requires_exact_bindings_and_matching_contracts():
     with pytest.raises(WorkflowValidationError, match="missing"):
-        compile_workflow(_workflow(), encoder=_Encoder(object()))
+        compile_workflow(_workflow(), DeploymentSpec.local(encoder="encoder"))
 
     wrong = SimpleNamespace(contract=CLASSIFIER, run=_Generator(object()).run)
     with pytest.raises(WorkflowValidationError, match="does not match"):
-        compile_workflow(
-            _workflow(),
-            encoder=_Encoder(object()),
-            classifier=_Classifier(object()),
-            generator=wrong,
+        WorkflowExecutor(
+            compile_workflow(
+                _workflow(),
+                DeploymentSpec.local(
+                    encoder="encoder",
+                    classifier="classifier",
+                    generator="generator",
+                ),
+            ),
+            {
+                "encoder": _Encoder(object()),
+                "classifier": _Classifier(object()),
+                "generator": wrong,
+            },
         )
 
 
 async def test_runtime_rejects_bad_inputs_and_worker_outputs():
     embedding = object()
-    plan = compile_workflow(
+    plan = _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_Classifier(embedding),
@@ -282,7 +302,7 @@ async def test_runtime_rejects_bad_inputs_and_worker_outputs():
         async def run(self, inputs, context):
             return {"wrong": "value"}
 
-    bad_plan = compile_workflow(
+    bad_plan = _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_Classifier(embedding),
@@ -296,7 +316,7 @@ async def test_runtime_enforces_json_data_model() -> None:
     workflow = Workflow("json-values")
     value = workflow.input("value", type="json")
     workflow.output("value", value)
-    plan = compile_workflow(workflow)
+    plan = _compile_local(workflow)
 
     shared = [1, 2]
     valid = {"none": None, "bool": True, "number": 1.5, "shared": [shared, shared]}
@@ -337,7 +357,7 @@ async def test_tensor_and_image_constraints_are_checked_without_framework_import
         async def run(self, inputs, context):
             return {"image": SimpleNamespace(mode="RGB", size=(10, 10))}
 
-    plan = compile_workflow(workflow, convert=Converter())
+    plan = _compile_local(workflow, convert=Converter())
     value = SimpleNamespace(dtype="float32", shape=(2, 4))
 
     assert (await plan.run({"tensor": value}))["image"].mode == "RGB"

--- a/components/src/dynamo/workflow/tests/test_runtime.py
+++ b/components/src/dynamo/workflow/tests/test_runtime.py
@@ -292,6 +292,30 @@ async def test_runtime_rejects_bad_inputs_and_worker_outputs():
         await bad_plan.run({"text": "hello"})
 
 
+async def test_runtime_enforces_json_data_model() -> None:
+    workflow = Workflow("json-values")
+    value = workflow.input("value", type="json")
+    workflow.output("value", value)
+    plan = compile_workflow(workflow)
+
+    shared = [1, 2]
+    valid = {"none": None, "bool": True, "number": 1.5, "shared": [shared, shared]}
+    assert await plan.run({"value": valid}) == {"value": valid}
+
+    cyclic: list[object] = []
+    cyclic.append(cyclic)
+    invalid_values: list[object] = [
+        (1, 2),
+        {1: "non-string key"},
+        float("nan"),
+        float("inf"),
+        cyclic,
+    ]
+    for invalid in invalid_values:
+        with pytest.raises(WorkflowExecutionError, match="JSON data model"):
+            await plan.run({"value": invalid})
+
+
 async def test_tensor_and_image_constraints_are_checked_without_framework_imports():
     tensor_contract = StageContract(
         id="tensor",

--- a/components/src/dynamo/workflow/tests/test_runtime.py
+++ b/components/src/dynamo/workflow/tests/test_runtime.py
@@ -4,6 +4,7 @@
 import asyncio
 from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -57,12 +58,14 @@ def _workflow() -> Workflow:
     return workflow
 
 
-def _compile_local(workflow: Workflow, **runners: StageRunner) -> WorkflowExecutor:
+async def _compile_local(
+    workflow: Workflow, **runners: StageRunner
+) -> WorkflowExecutor:
     plan = compile_workflow(
         workflow,
         DeploymentSpec.local(**{stage_id: stage_id for stage_id in runners}),
     )
-    return WorkflowExecutor(plan, runners)
+    return await WorkflowExecutor.bind(plan, local_runners=runners)
 
 
 @dataclass
@@ -97,7 +100,7 @@ class _Generator:
 
 async def test_concise_compile_and_run_preserve_fanout_value_identity():
     embedding = object()
-    plan = _compile_local(
+    plan = await _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_Classifier(embedding),
@@ -147,7 +150,7 @@ class _BarrierGenerator:
 async def test_independent_branches_run_concurrently_before_join():
     embedding = object()
     barrier = _BranchBarrier(2)
-    plan = _compile_local(
+    plan = await _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_BarrierClassifier(barrier),
@@ -193,7 +196,7 @@ async def test_first_worker_failure_cancels_and_awaits_sibling():
     embedding = object()
     barrier = _BranchBarrier(2)
     cancelled = asyncio.Event()
-    plan = _compile_local(
+    plan = await _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_FailingClassifier(barrier),
@@ -226,7 +229,7 @@ async def test_timeout_cancels_and_awaits_running_stages():
     embedding = object()
     started = asyncio.Event()
     cancelled = asyncio.Event()
-    plan = _compile_local(
+    plan = await _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_BlockingClassifier(started, cancelled),
@@ -244,7 +247,7 @@ async def test_caller_cancellation_cleans_up_running_stages():
     embedding = object()
     started = asyncio.Event()
     cancelled = asyncio.Event()
-    plan = _compile_local(
+    plan = await _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_BlockingClassifier(started, cancelled),
@@ -260,13 +263,13 @@ async def test_caller_cancellation_cleans_up_running_stages():
     assert cancelled.is_set()
 
 
-def test_compile_requires_exact_bindings_and_matching_contracts():
+async def test_compile_requires_exact_bindings_and_matching_contracts():
     with pytest.raises(WorkflowValidationError, match="missing"):
         compile_workflow(_workflow(), DeploymentSpec.local(encoder="encoder"))
 
     wrong = SimpleNamespace(contract=CLASSIFIER, run=_Generator(object()).run)
     with pytest.raises(WorkflowValidationError, match="does not match"):
-        WorkflowExecutor(
+        await WorkflowExecutor.bind(
             compile_workflow(
                 _workflow(),
                 DeploymentSpec.local(
@@ -275,7 +278,7 @@ def test_compile_requires_exact_bindings_and_matching_contracts():
                     generator="generator",
                 ),
             ),
-            {
+            local_runners={
                 "encoder": _Encoder(object()),
                 "classifier": _Classifier(object()),
                 "generator": wrong,
@@ -285,7 +288,7 @@ def test_compile_requires_exact_bindings_and_matching_contracts():
 
 async def test_runtime_rejects_bad_inputs_and_worker_outputs():
     embedding = object()
-    plan = _compile_local(
+    plan = await _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_Classifier(embedding),
@@ -302,7 +305,7 @@ async def test_runtime_rejects_bad_inputs_and_worker_outputs():
         async def run(self, inputs, context):
             return {"wrong": "value"}
 
-    bad_plan = _compile_local(
+    bad_plan = await _compile_local(
         _workflow(),
         encoder=_Encoder(embedding),
         classifier=_Classifier(embedding),
@@ -316,7 +319,7 @@ async def test_runtime_enforces_json_data_model() -> None:
     workflow = Workflow("json-values")
     value = workflow.input("value", type="json")
     workflow.output("value", value)
-    plan = _compile_local(workflow)
+    plan = await _compile_local(workflow)
 
     shared = [1, 2]
     valid = {"none": None, "bool": True, "number": 1.5, "shared": [shared, shared]}
@@ -357,9 +360,230 @@ async def test_tensor_and_image_constraints_are_checked_without_framework_import
         async def run(self, inputs, context):
             return {"image": SimpleNamespace(mode="RGB", size=(10, 10))}
 
-    plan = _compile_local(workflow, convert=Converter())
+    plan = await _compile_local(workflow, convert=Converter())
     value = SimpleNamespace(dtype="float32", shape=(2, 4))
 
     assert (await plan.run({"tensor": value}))["image"].mode == "RGB"
     with pytest.raises(WorkflowExecutionError, match="shape"):
         await plan.run({"tensor": SimpleNamespace(dtype="float32", shape=(2, 3))})
+
+
+ECHO = StageContract(
+    id="echo-worker",
+    inputs={"text": ValueSpec(type="text")},
+    outputs={"text": ValueSpec(type="text")},
+)
+
+
+class _Echo:
+    contract = ECHO
+
+    def __init__(self) -> None:
+        self.contexts: list[StageContext] = []
+
+    async def run(self, inputs, context: StageContext):
+        self.contexts.append(context)
+        return {"text": inputs["text"]}
+
+
+class _SometimesFailingEcho(_Echo):
+    async def run(self, inputs, context: StageContext):
+        self.contexts.append(context)
+        if inputs["text"] == "fail":
+            raise WorkerFailure("requested failure")
+        return {"text": inputs["text"]}
+
+
+async def test_handler_supports_branches_loops_and_catchable_stage_errors() -> None:
+    workflow = Workflow("imperative-local")
+    echo = workflow.use("echo", ECHO)
+
+    @workflow.handler(
+        inputs={"request": ValueSpec(type="json")},
+        outputs={"result": ValueSpec(type="text")},
+    )
+    async def run(inputs, context):
+        request = inputs["request"]
+        if request["fallback"]:
+            try:
+                await context.call(echo, text="fail")
+            except WorkerFailure:
+                return {"result": (await context.call(echo, text="fallback"))["text"]}
+
+        result = ""
+        for index in range(request["count"]):
+            result = (await context.call(echo, text=f"step-{index}"))["text"]
+        return {"result": result}
+
+    runner = _SometimesFailingEcho()
+    executor = await _compile_local(workflow, echo=runner)
+
+    assert await executor.run(
+        {"request": {"fallback": False, "count": 3}}, attempt_id="loop"
+    ) == {"result": "step-2"}
+    assert await executor.run(
+        {"request": {"fallback": True, "count": 0}}, attempt_id="fallback"
+    ) == {"result": "fallback"}
+    assert [context.invocation_id for context in runner.contexts] == [
+        "loop:1",
+        "loop:2",
+        "loop:3",
+        "fallback:1",
+        "fallback:2",
+    ]
+
+
+async def test_handler_rejects_foreign_stage_reference() -> None:
+    workflow = Workflow("owner")
+    workflow.use("echo", ECHO)
+    other = Workflow("other-owner")
+    foreign = other.use("echo", ECHO)
+
+    @workflow.handler(inputs={}, outputs={"result": ValueSpec(type="text")})
+    async def run(inputs, context):
+        return {"result": (await context.call(foreign, text="bad"))["text"]}
+
+    executor = await _compile_local(workflow, echo=_Echo())
+    with pytest.raises(WorkflowExecutionError, match="different workflow"):
+        await executor.run({})
+
+
+class _BlockingEcho:
+    contract = ECHO
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+
+    async def run(self, inputs, context: StageContext):
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            assert context.cancelled
+            self.cancelled.set()
+            raise
+
+
+async def test_handler_return_cancels_unfinished_child_invocations() -> None:
+    workflow = Workflow("handler-cleanup")
+    echo = workflow.use("echo", ECHO)
+    runner = _BlockingEcho()
+
+    @workflow.handler(inputs={}, outputs={"result": ValueSpec(type="text")})
+    async def run(inputs, context):
+        asyncio.create_task(context.call(echo, text="background"))
+        await runner.started.wait()
+        return {"result": "done"}
+
+    executor = await _compile_local(workflow, echo=runner)
+    assert await executor.run({}) == {"result": "done"}
+    assert runner.cancelled.is_set()
+
+
+@dataclass
+class _ConcurrentEcho:
+    contract = ECHO
+    barrier: _BranchBarrier
+    contexts: list[StageContext]
+
+    async def run(self, inputs, context: StageContext):
+        self.contexts.append(context)
+        await self.barrier.enter()
+        return {"text": inputs["text"]}
+
+
+async def test_handler_runs_concurrent_calls_with_unique_invocation_ids() -> None:
+    workflow = Workflow("handler-concurrency")
+    echo = workflow.use("echo", ECHO)
+
+    @workflow.handler(inputs={}, outputs={"result": ValueSpec(type="json")})
+    async def run(inputs, context):
+        left, right = await asyncio.gather(
+            context.call(echo, text="left"),
+            context.call(echo, text="right"),
+        )
+        return {"result": [left["text"], right["text"]]}
+
+    contexts: list[StageContext] = []
+    executor = await _compile_local(
+        workflow,
+        echo=_ConcurrentEcho(_BranchBarrier(2), contexts),
+    )
+
+    assert await executor.run({}, attempt_id="parallel") == {
+        "result": ["left", "right"]
+    }
+    assert {context.invocation_id for context in contexts} == {
+        "parallel:1",
+        "parallel:2",
+    }
+
+
+async def test_handler_timeout_signals_and_awaits_active_call() -> None:
+    workflow = Workflow("handler-timeout")
+    echo = workflow.use("echo", ECHO)
+    runner = _BlockingEcho()
+
+    @workflow.handler(inputs={}, outputs={"result": ValueSpec(type="text")})
+    async def run(inputs, context):
+        return {"result": (await context.call(echo, text="wait"))["text"]}
+
+    executor = await _compile_local(workflow, echo=runner)
+    with pytest.raises(asyncio.TimeoutError):
+        await executor.run({}, timeout=0.01)
+    assert runner.started.is_set()
+    assert runner.cancelled.is_set()
+
+
+RICH_VALUES = StageContract(
+    id="rich-values",
+    inputs={
+        "tensor": ValueSpec(type="tensor"),
+        "image": ValueSpec(type="image"),
+        "object": ValueSpec(type="object", class_id="opaque"),
+    },
+    outputs={"result": ValueSpec(type="text")},
+)
+
+
+@dataclass
+class _RichValueRunner:
+    contract = RICH_VALUES
+    tensor: Any
+    image: Any
+    opaque: object
+
+    async def run(self, inputs, context: StageContext):
+        assert inputs["tensor"] is self.tensor
+        assert inputs["image"] is self.image
+        assert inputs["object"] is self.opaque
+        return {"result": "same objects"}
+
+
+async def test_local_handler_preserves_rich_value_identity() -> None:
+    workflow = Workflow("rich-local")
+    stage = workflow.use("inspect", RICH_VALUES)
+
+    @workflow.handler(
+        inputs={
+            "tensor": ValueSpec(type="tensor"),
+            "image": ValueSpec(type="image"),
+            "object": ValueSpec(type="object", class_id="opaque"),
+        },
+        outputs={"result": ValueSpec(type="text")},
+    )
+    async def run(inputs, context):
+        return await context.call(stage, **inputs)
+
+    tensor = SimpleNamespace(dtype="float32", shape=(2, 4))
+    image = SimpleNamespace(mode="RGB", size=(10, 10))
+    opaque = object()
+    executor = await _compile_local(
+        workflow,
+        inspect=_RichValueRunner(tensor=tensor, image=image, opaque=opaque),
+    )
+
+    assert await executor.run({"tensor": tensor, "image": image, "object": opaque}) == {
+        "result": "same objects"
+    }

--- a/components/src/dynamo/workflow/types.py
+++ b/components/src/dynamo/workflow/types.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Portable value and stage contracts for Dynamo workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Mapping, Optional, Tuple, Union
+
+
+class WorkflowValidationError(ValueError):
+    """Raised when a workflow contract or graph is invalid."""
+
+
+ShapeDimension = Union[int, str]
+_VALUE_TYPES = frozenset({"tensor", "text", "image", "bytes", "json", "object"})
+_TENSOR_DTYPES = frozenset(
+    {
+        "bool",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "float16",
+        "bfloat16",
+        "float32",
+        "float64",
+    }
+)
+
+
+def _check_keys(
+    data: Mapping[str, Any], required: set[str], optional: set[str]
+) -> None:
+    keys = set(data)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise WorkflowValidationError(f"missing fields: {sorted(missing)}")
+    if unknown:
+        raise WorkflowValidationError(f"unknown fields: {sorted(unknown)}")
+
+
+def validate_name(name: str, kind: str) -> None:
+    """Validate a portable workflow identifier."""
+
+    if not isinstance(name, str) or not name:
+        raise WorkflowValidationError(f"{kind} must be a non-empty string")
+    if not name[0].isalpha() or not all(
+        char.isalnum() or char in "_-" for char in name
+    ):
+        raise WorkflowValidationError(
+            f"{kind} {name!r} must start with a letter and contain only letters, "
+            "digits, '_' or '-'"
+        )
+
+
+@dataclass(frozen=True)
+class ValueSpec:
+    """A small, serializable description of a value crossing a workflow port."""
+
+    type: str
+    dtype: Optional[str] = None
+    shape: Optional[Tuple[ShapeDimension, ...]] = None
+    mode: Optional[str] = None
+    class_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.type not in _VALUE_TYPES:
+            raise WorkflowValidationError(
+                f"unsupported value type {self.type!r}; expected one of {sorted(_VALUE_TYPES)}"
+            )
+
+        if self.shape is not None:
+            object.__setattr__(self, "shape", tuple(self.shape))
+
+        if self.type == "tensor":
+            self._validate_tensor()
+            self._reject("mode", self.mode)
+            self._reject("class_id", self.class_id)
+        elif self.type == "image":
+            self._reject("dtype", self.dtype)
+            self._reject("shape", self.shape)
+            self._reject("class_id", self.class_id)
+            if self.mode is not None and not self.mode:
+                raise WorkflowValidationError("image mode must be non-empty when set")
+        elif self.type == "object":
+            self._reject("dtype", self.dtype)
+            self._reject("shape", self.shape)
+            self._reject("mode", self.mode)
+            if not isinstance(self.class_id, str) or not self.class_id:
+                raise WorkflowValidationError(
+                    "object values require a non-empty class_id"
+                )
+        else:
+            self._reject("dtype", self.dtype)
+            self._reject("shape", self.shape)
+            self._reject("mode", self.mode)
+            self._reject("class_id", self.class_id)
+
+    @staticmethod
+    def _reject(field_name: str, value: object) -> None:
+        if value is not None:
+            raise WorkflowValidationError(
+                f"{field_name} is not valid for this value type"
+            )
+
+    def _validate_tensor(self) -> None:
+        if self.dtype is not None and self.dtype not in _TENSOR_DTYPES:
+            raise WorkflowValidationError(
+                f"unsupported tensor dtype {self.dtype!r}; expected one of "
+                f"{sorted(_TENSOR_DTYPES)}"
+            )
+        if self.shape is None:
+            return
+        for dimension in self.shape:
+            if dimension == "dynamic":
+                continue
+            if isinstance(dimension, bool) or not isinstance(dimension, int):
+                raise WorkflowValidationError(
+                    "tensor shape dimensions must be non-negative integers or 'dynamic'"
+                )
+            if dimension < 0:
+                raise WorkflowValidationError(
+                    "tensor shape dimensions must be non-negative integers or 'dynamic'"
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-ready representation."""
+
+        data: dict[str, Any] = {"type": self.type}
+        if self.dtype is not None:
+            data["dtype"] = self.dtype
+        if self.shape is not None:
+            data["shape"] = list(self.shape)
+        if self.mode is not None:
+            data["mode"] = self.mode
+        if self.class_id is not None:
+            data["class_id"] = self.class_id
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ValueSpec":
+        """Parse a value description while rejecting unknown fields."""
+
+        if not isinstance(data, Mapping):
+            raise WorkflowValidationError("value spec must be an object")
+        _check_keys(data, {"type"}, {"dtype", "shape", "mode", "class_id"})
+        shape = data.get("shape")
+        if shape is not None and (
+            not isinstance(shape, list) or isinstance(shape, (str, bytes))
+        ):
+            raise WorkflowValidationError("tensor shape must be a JSON array")
+        return cls(
+            type=data["type"],
+            dtype=data.get("dtype"),
+            shape=None if shape is None else tuple(shape),
+            mode=data.get("mode"),
+            class_id=data.get("class_id"),
+        )
+
+
+def compatibility_error(producer: ValueSpec, consumer: ValueSpec) -> Optional[str]:
+    """Explain why a producer cannot satisfy a consumer, or return ``None``."""
+
+    if producer.type != consumer.type:
+        return f"type {producer.type!r} does not satisfy {consumer.type!r}"
+
+    if consumer.type == "tensor":
+        if consumer.dtype is not None and producer.dtype != consumer.dtype:
+            return (
+                f"producer dtype {producer.dtype!r} does not guarantee "
+                f"consumer dtype {consumer.dtype!r}"
+            )
+        if consumer.shape is not None:
+            if producer.shape is None:
+                return "producer does not guarantee the consumer tensor shape"
+            if len(producer.shape) != len(consumer.shape):
+                return "producer and consumer tensor ranks differ"
+            for produced, consumed in zip(producer.shape, consumer.shape):
+                if consumed != "dynamic" and produced != consumed:
+                    return (
+                        f"producer dimension {produced!r} does not guarantee "
+                        f"consumer dimension {consumed!r}"
+                    )
+
+    if consumer.type == "image" and consumer.mode is not None:
+        if producer.mode != consumer.mode:
+            return (
+                f"producer mode {producer.mode!r} does not guarantee "
+                f"consumer mode {consumer.mode!r}"
+            )
+
+    if consumer.type == "object" and producer.class_id != consumer.class_id:
+        return (
+            f"producer class_id {producer.class_id!r} does not satisfy "
+            f"consumer class_id {consumer.class_id!r}"
+        )
+
+    return None
+
+
+@dataclass(frozen=True)
+class StageContract:
+    """The complete named input and output surface of a workflow stage."""
+
+    id: str
+    inputs: Mapping[str, ValueSpec] = field(default_factory=dict)
+    outputs: Mapping[str, ValueSpec] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        validate_name(self.id, "contract id")
+        inputs = self._freeze_ports(self.inputs, "input port")
+        outputs = self._freeze_ports(self.outputs, "output port")
+        if not outputs:
+            raise WorkflowValidationError("stage contracts require at least one output")
+        object.__setattr__(self, "inputs", inputs)
+        object.__setattr__(self, "outputs", outputs)
+
+    @staticmethod
+    def _freeze_ports(
+        ports: Mapping[str, ValueSpec], kind: str
+    ) -> Mapping[str, ValueSpec]:
+        if not isinstance(ports, Mapping):
+            raise WorkflowValidationError(f"{kind}s must be a mapping")
+        frozen: dict[str, ValueSpec] = {}
+        for name, spec in sorted(ports.items()):
+            validate_name(name, kind)
+            if not isinstance(spec, ValueSpec):
+                raise WorkflowValidationError(f"{kind} {name!r} must use ValueSpec")
+            frozen[name] = spec
+        return MappingProxyType(frozen)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-ready representation."""
+
+        return {
+            "id": self.id,
+            "inputs": {name: spec.to_dict() for name, spec in self.inputs.items()},
+            "outputs": {name: spec.to_dict() for name, spec in self.outputs.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "StageContract":
+        """Parse a stage contract while rejecting unknown fields."""
+
+        if not isinstance(data, Mapping):
+            raise WorkflowValidationError("stage contract must be an object")
+        _check_keys(data, {"id", "inputs", "outputs"}, set())
+        inputs = data["inputs"]
+        outputs = data["outputs"]
+        if not isinstance(inputs, Mapping) or not isinstance(outputs, Mapping):
+            raise WorkflowValidationError("contract inputs and outputs must be objects")
+        return cls(
+            id=data["id"],
+            inputs={name: ValueSpec.from_dict(spec) for name, spec in inputs.items()},
+            outputs={name: ValueSpec.from_dict(spec) for name, spec in outputs.items()},
+        )
+
+
+@dataclass(frozen=True)
+class ValueRef:
+    """A structured reference to a workflow input or stage output."""
+
+    input_name: Optional[str] = None
+    stage_id: Optional[str] = None
+    output_name: Optional[str] = None
+    _owner: Optional[object] = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        is_input = self.input_name is not None
+        is_stage = self.stage_id is not None or self.output_name is not None
+        if is_input == is_stage:
+            raise WorkflowValidationError(
+                "a value reference must name exactly one workflow input or stage output"
+            )
+        if self.input_name is not None:
+            validate_name(self.input_name, "workflow input reference")
+            return
+        if self.stage_id is None or self.output_name is None:
+            raise WorkflowValidationError(
+                "stage references require stage and output names"
+            )
+        validate_name(self.stage_id, "stage reference")
+        validate_name(self.output_name, "stage output reference")
+
+    @classmethod
+    def for_input(cls, name: str, owner: Optional[object] = None) -> "ValueRef":
+        """Create a workflow-input reference."""
+
+        return cls(input_name=name, _owner=owner)
+
+    @classmethod
+    def for_stage_output(
+        cls, stage_id: str, output_name: str, owner: Optional[object] = None
+    ) -> "ValueRef":
+        """Create a stage-output reference."""
+
+        return cls(stage_id=stage_id, output_name=output_name, _owner=owner)
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the canonical JSON-ready representation."""
+
+        if self.input_name is not None:
+            return {"input": self.input_name}
+        return {"stage": self.stage_id, "output": self.output_name}  # type: ignore[dict-item]
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ValueRef":
+        """Parse a structured reference."""
+
+        if not isinstance(data, Mapping):
+            raise WorkflowValidationError("value reference must be an object")
+        if set(data) == {"input"}:
+            return cls.for_input(data["input"])
+        if set(data) == {"stage", "output"}:
+            return cls.for_stage_output(data["stage"], data["output"])
+        raise WorkflowValidationError(
+            "value reference must contain either 'input' or both 'stage' and 'output'"
+        )

--- a/components/src/dynamo/workflow/types.py
+++ b/components/src/dynamo/workflow/types.py
@@ -52,6 +52,7 @@ def validate_name(name: str, kind: str) -> None:
 
     if not isinstance(name, str) or not name:
         raise WorkflowValidationError(f"{kind} must be a non-empty string")
+    _validate_utf8(name, kind)
     if not name[0].isalpha() or not all(
         char.isalnum() or char in "_-" for char in name
     ):
@@ -59,6 +60,15 @@ def validate_name(name: str, kind: str) -> None:
             f"{kind} {name!r} must start with a letter and contain only letters, "
             "digits, '_' or '-'"
         )
+
+
+def _validate_utf8(value: str, kind: str) -> None:
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise WorkflowValidationError(
+            f"{kind} must contain valid Unicode scalar values"
+        ) from error
 
 
 @dataclass(frozen=True)
@@ -72,12 +82,16 @@ class ValueSpec:
     class_id: Optional[str] = None
 
     def __post_init__(self) -> None:
+        if not isinstance(self.type, str):
+            raise WorkflowValidationError("value type must be a string")
         if self.type not in _VALUE_TYPES:
             raise WorkflowValidationError(
                 f"unsupported value type {self.type!r}; expected one of {sorted(_VALUE_TYPES)}"
             )
 
         if self.shape is not None:
+            if not isinstance(self.shape, (list, tuple)):
+                raise WorkflowValidationError("tensor shape must be a list or tuple")
             object.__setattr__(self, "shape", tuple(self.shape))
 
         if self.type == "tensor":
@@ -88,8 +102,14 @@ class ValueSpec:
             self._reject("dtype", self.dtype)
             self._reject("shape", self.shape)
             self._reject("class_id", self.class_id)
-            if self.mode is not None and not self.mode:
-                raise WorkflowValidationError("image mode must be non-empty when set")
+            if self.mode is not None and (
+                not isinstance(self.mode, str) or not self.mode
+            ):
+                raise WorkflowValidationError(
+                    "image mode must be a non-empty string when set"
+                )
+            if self.mode is not None:
+                _validate_utf8(self.mode, "image mode")
         elif self.type == "object":
             self._reject("dtype", self.dtype)
             self._reject("shape", self.shape)
@@ -98,6 +118,7 @@ class ValueSpec:
                 raise WorkflowValidationError(
                     "object values require a non-empty class_id"
                 )
+            _validate_utf8(self.class_id, "object class_id")
         else:
             self._reject("dtype", self.dtype)
             self._reject("shape", self.shape)
@@ -112,11 +133,14 @@ class ValueSpec:
             )
 
     def _validate_tensor(self) -> None:
-        if self.dtype is not None and self.dtype not in _TENSOR_DTYPES:
-            raise WorkflowValidationError(
-                f"unsupported tensor dtype {self.dtype!r}; expected one of "
-                f"{sorted(_TENSOR_DTYPES)}"
-            )
+        if self.dtype is not None:
+            if not isinstance(self.dtype, str):
+                raise WorkflowValidationError("tensor dtype must be a string")
+            if self.dtype not in _TENSOR_DTYPES:
+                raise WorkflowValidationError(
+                    f"unsupported tensor dtype {self.dtype!r}; expected one of "
+                    f"{sorted(_TENSOR_DTYPES)}"
+                )
         if self.shape is None:
             return
         for dimension in self.shape:

--- a/components/src/dynamo/workflow/types.py
+++ b/components/src/dynamo/workflow/types.py
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Portable value and stage contracts for Dynamo workflows."""
+"""Logical value and stage contracts for Dynamo workflows."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Mapping, Optional, Tuple, Union
+from typing import Mapping, Optional, Tuple, Union
 
 
 class WorkflowValidationError(ValueError):
@@ -33,18 +33,6 @@ _TENSOR_DTYPES = frozenset(
         "float64",
     }
 )
-
-
-def _check_keys(
-    data: Mapping[str, Any], required: set[str], optional: set[str]
-) -> None:
-    keys = set(data)
-    missing = required - keys
-    unknown = keys - required - optional
-    if missing:
-        raise WorkflowValidationError(f"missing fields: {sorted(missing)}")
-    if unknown:
-        raise WorkflowValidationError(f"unknown fields: {sorted(unknown)}")
 
 
 def validate_name(name: str, kind: str) -> None:
@@ -73,7 +61,7 @@ def _validate_utf8(value: str, kind: str) -> None:
 
 @dataclass(frozen=True)
 class ValueSpec:
-    """A small, serializable description of a value crossing a workflow port."""
+    """A small logical description of a value crossing a workflow port."""
 
     type: str
     dtype: Optional[str] = None
@@ -155,40 +143,6 @@ class ValueSpec:
                     "tensor shape dimensions must be non-negative integers or 'dynamic'"
                 )
 
-    def to_dict(self) -> dict[str, Any]:
-        """Return the canonical JSON-ready representation."""
-
-        data: dict[str, Any] = {"type": self.type}
-        if self.dtype is not None:
-            data["dtype"] = self.dtype
-        if self.shape is not None:
-            data["shape"] = list(self.shape)
-        if self.mode is not None:
-            data["mode"] = self.mode
-        if self.class_id is not None:
-            data["class_id"] = self.class_id
-        return data
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> "ValueSpec":
-        """Parse a value description while rejecting unknown fields."""
-
-        if not isinstance(data, Mapping):
-            raise WorkflowValidationError("value spec must be an object")
-        _check_keys(data, {"type"}, {"dtype", "shape", "mode", "class_id"})
-        shape = data.get("shape")
-        if shape is not None and (
-            not isinstance(shape, list) or isinstance(shape, (str, bytes))
-        ):
-            raise WorkflowValidationError("tensor shape must be a JSON array")
-        return cls(
-            type=data["type"],
-            dtype=data.get("dtype"),
-            shape=None if shape is None else tuple(shape),
-            mode=data.get("mode"),
-            class_id=data.get("class_id"),
-        )
-
 
 def compatibility_error(producer: ValueSpec, consumer: ValueSpec) -> Optional[str]:
     """Explain why a producer cannot satisfy a consumer, or return ``None``."""
@@ -261,32 +215,6 @@ class StageContract:
             frozen[name] = spec
         return MappingProxyType(frozen)
 
-    def to_dict(self) -> dict[str, Any]:
-        """Return the canonical JSON-ready representation."""
-
-        return {
-            "id": self.id,
-            "inputs": {name: spec.to_dict() for name, spec in self.inputs.items()},
-            "outputs": {name: spec.to_dict() for name, spec in self.outputs.items()},
-        }
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> "StageContract":
-        """Parse a stage contract while rejecting unknown fields."""
-
-        if not isinstance(data, Mapping):
-            raise WorkflowValidationError("stage contract must be an object")
-        _check_keys(data, {"id", "inputs", "outputs"}, set())
-        inputs = data["inputs"]
-        outputs = data["outputs"]
-        if not isinstance(inputs, Mapping) or not isinstance(outputs, Mapping):
-            raise WorkflowValidationError("contract inputs and outputs must be objects")
-        return cls(
-            id=data["id"],
-            inputs={name: ValueSpec.from_dict(spec) for name, spec in inputs.items()},
-            outputs={name: ValueSpec.from_dict(spec) for name, spec in outputs.items()},
-        )
-
 
 @dataclass(frozen=True)
 class ValueRef:
@@ -327,24 +255,3 @@ class ValueRef:
         """Create a stage-output reference."""
 
         return cls(stage_id=stage_id, output_name=output_name, _owner=owner)
-
-    def to_dict(self) -> dict[str, str]:
-        """Return the canonical JSON-ready representation."""
-
-        if self.input_name is not None:
-            return {"input": self.input_name}
-        return {"stage": self.stage_id, "output": self.output_name}  # type: ignore[dict-item]
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> "ValueRef":
-        """Parse a structured reference."""
-
-        if not isinstance(data, Mapping):
-            raise WorkflowValidationError("value reference must be an object")
-        if set(data) == {"input"}:
-            return cls.for_input(data["input"])
-        if set(data) == {"stage", "output"}:
-            return cls.for_stage_output(data["stage"], data["output"])
-        raise WorkflowValidationError(
-            "value reference must contain either 'input' or both 'stage' and 'output'"
-        )


### PR DESCRIPTION
_Based on #12921._

## Why

The production vLLM handler mixed transport policy with reusable sampling and output conversion. Other adapters should share the subtle streaming, usage, logprob, routed-expert, and router-hint behavior instead of copying it.

## What Change

- Extract request-to-vLLM sampling conversion into `decoder_sampling.py`.
- Extract stateful native-output conversion into `decoder_output.py`.
- Keep compatibility aliases and delegate the existing handler path to the extracted mechanics.

```mermaid
classDiagram
    DecodeWorkerHandler ..> SamplingParams : builds through shared helper
    DecodeWorkerHandler --> _VllmDecodeOutputAdapter : converts native stream
    _VllmDecodeOutputAdapter ..> RequestOutput : adapts output

    note for DecodeWorkerHandler "Retains production transport behavior"
    note for _VllmDecodeOutputAdapter "Owns stateful output conversion"
```

## Test Plan

- Focused vLLM behavior qualification: 226 passed and 5 intentionally skipped; source-aware mypy and pre-commit passed.
- Built stack-tip H100 qualification: 107 workflow, ensemble, and decoder tests passed.
