### PR TITLE
feat(workflow): add remote stage bindings

### DIFF
--- a/components/src/dynamo/experimental/workflow/__init__.py
+++ b/components/src/dynamo/experimental/workflow/__init__.py
@@ -3,7 +3,7 @@
 
 """Experimental inference workflow APIs."""
 
-from dynamo.experimental.workflow.bindings import InlineBinding
+from dynamo.experimental.workflow.bindings import InlineBinding, RemoteBinding
 from dynamo.experimental.workflow.builder import StageHandle, Workflow
 from dynamo.experimental.workflow.ir import StageIR, WorkflowIR
 from dynamo.experimental.workflow.orchestrator import WorkflowOrchestrator
@@ -31,4 +31,5 @@ __all__ = [
     "WorkflowOrchestrator",
     "WorkflowValidationError",
     "InlineBinding",
+    "RemoteBinding",
 ]

--- a/components/src/dynamo/experimental/workflow/bindings.py
+++ b/components/src/dynamo/experimental/workflow/bindings.py
@@ -6,9 +6,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Union
 
 from dynamo.experimental.workflow.runtime import StageRunner
-from dynamo.experimental.workflow.types import WorkflowValidationError
+from dynamo.experimental.workflow.types import WorkflowValidationError, validate_name
 
 
 @dataclass(frozen=True)
@@ -22,4 +23,31 @@ class InlineBinding:
             raise WorkflowValidationError("inline runner must implement StageRunner")
 
 
-Binding = InlineBinding
+def _validate_endpoint_id(endpoint_id: str) -> None:
+    if not isinstance(endpoint_id, str):
+        raise WorkflowValidationError("remote endpoint id must be a string")
+    parts = endpoint_id.split(".")
+    if len(parts) != 3:
+        raise WorkflowValidationError(
+            "remote endpoint id must use 'namespace.component.endpoint'"
+        )
+    for kind, part in zip(("namespace", "component", "endpoint"), parts):
+        validate_name(part, f"remote {kind}")
+
+
+@dataclass(frozen=True)
+class RemoteBinding:
+    """Bind one logical stage to a discovered Dynamo endpoint."""
+
+    endpoint_id: str
+    routing_policy: str = "round_robin"
+
+    def __post_init__(self) -> None:
+        _validate_endpoint_id(self.endpoint_id)
+        if self.routing_policy != "round_robin":
+            raise WorkflowValidationError(
+                f"unsupported remote routing policy {self.routing_policy!r}"
+            )
+
+
+Binding = Union[InlineBinding, RemoteBinding]

--- a/components/src/dynamo/experimental/workflow/tests/test_bindings.py
+++ b/components/src/dynamo/experimental/workflow/tests/test_bindings.py
@@ -5,7 +5,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from dynamo.experimental.workflow import InlineBinding, WorkflowValidationError
+from dynamo.experimental.workflow import (
+    InlineBinding,
+    RemoteBinding,
+    WorkflowValidationError,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -24,3 +28,17 @@ def test_inline_binding_owns_initialized_runner() -> None:
 def test_inline_binding_rejects_non_runner() -> None:
     with pytest.raises(WorkflowValidationError, match="implement StageRunner"):
         InlineBinding(object())
+
+
+def test_remote_binding_uses_stable_discovery_identity() -> None:
+    binding = RemoteBinding("namespace.component.endpoint")
+
+    assert binding.endpoint_id == "namespace.component.endpoint"
+    assert binding.routing_policy == "round_robin"
+
+
+def test_remote_binding_rejects_invalid_endpoint_and_routing_policy() -> None:
+    with pytest.raises(WorkflowValidationError, match="namespace.component.endpoint"):
+        RemoteBinding("component.endpoint")
+    with pytest.raises(WorkflowValidationError, match="unsupported"):
+        RemoteBinding("namespace.component.endpoint", routing_policy="random")


### PR DESCRIPTION
_Based on #12921._

## Why

A placement-neutral graph needs a stable way to name discovered stage endpoints without adding addresses or transport details to `WorkflowIR`. Remote capability belongs to the stage binding, while logical dataflow remains solely in the authored graph. This creates the small configuration boundary used by the remote dispatcher in the next layer.

> Experimental: This workflow API is under active development and may evolve based on feedback. It is an optional orchestration layer over Dynamo's discoverable workers and endpoints; applications may compose those primitives directly when they prefer to own the orchestration logic.

## What Change

- Add discovery-backed `RemoteBinding` targets.
- Validate endpoint identities and routing policies.
- Freeze authored input names at the IR boundary.

```mermaid
classDiagram
    WorkflowIR --> WorkflowOrchestrator : supplies logical dataflow
    WorkflowOrchestrator --> InlineBinding : binds local stage
    WorkflowOrchestrator --> RemoteBinding : binds discovered stage

    note for WorkflowIR "Owns stage inputs and ValueRefs"
    note for InlineBinding "Carries an initialized runner"
    note for RemoteBinding "Names a stable discovered endpoint"
```

## Test Plan

- GPU-free tests cover endpoint identities, policies, authoring, and local execution.
- Applicable pre-commit hooks pass.
