### PR TITLE
feat(workflow): serve orchestrators through model endpoints

### DIFF
--- a/components/src/dynamo/experimental/workflow/__init__.py
+++ b/components/src/dynamo/experimental/workflow/__init__.py
@@ -5,6 +5,7 @@
 
 from dynamo.experimental.workflow.bindings import InlineBinding, RemoteBinding
 from dynamo.experimental.workflow.builder import StageHandle, Workflow
+from dynamo.experimental.workflow.endpoint import WorkflowEndpointHandler
 from dynamo.experimental.workflow.ir import StageIR, WorkflowIR
 from dynamo.experimental.workflow.orchestrator import WorkflowOrchestrator
 from dynamo.experimental.workflow.remote import RemoteStageClient, RemoteStageServer
@@ -28,6 +29,7 @@ __all__ = [
     "ValueRef",
     "Workflow",
     "WorkflowIR",
+    "WorkflowEndpointHandler",
     "WorkflowExecutionError",
     "WorkflowOrchestrator",
     "WorkflowValidationError",

--- a/components/src/dynamo/experimental/workflow/endpoint.py
+++ b/components/src/dynamo/experimental/workflow/endpoint.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serve a bound workflow through a Dynamo model endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+from typing import Any
+
+from dynamo.experimental.workflow.orchestrator import WorkflowOrchestrator
+from dynamo.experimental.workflow.types import WorkflowValidationError
+
+
+class WorkflowEndpointHandler:
+    """Adapt a request/chunk workflow to Dynamo's endpoint handler ABI."""
+
+    def __init__(self, orchestrator: WorkflowOrchestrator) -> None:
+        if not isinstance(orchestrator, WorkflowOrchestrator):
+            raise TypeError("orchestrator must use WorkflowOrchestrator")
+        _validate_endpoint_abi(orchestrator)
+        self._orchestrator = orchestrator
+
+    async def generate(
+        self, request: Mapping[str, Any], context: Any
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Execute one workflow attempt and yield its terminal chunk."""
+
+        if not isinstance(request, Mapping):
+            raise TypeError("workflow endpoint request must be a mapping")
+
+        attempt_id = context.id()
+        execution = asyncio.create_task(
+            self._orchestrator.run(
+                {"request": request},
+                attempt_id=attempt_id,
+                request_context=context,
+            ),
+            name=f"workflow-endpoint:{attempt_id}",
+        )
+        cancellation = asyncio.ensure_future(context.async_killed_or_stopped())
+        try:
+            done, _ = await asyncio.wait(
+                {execution, cancellation}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if execution not in done:
+                execution.cancel()
+                await asyncio.gather(execution, return_exceptions=True)
+                return
+            result = await execution
+        except BaseException:
+            if not execution.done():
+                execution.cancel()
+                await asyncio.gather(execution, return_exceptions=True)
+            raise
+        finally:
+            if not cancellation.done():
+                cancellation.cancel()
+            await asyncio.gather(cancellation, return_exceptions=True)
+
+        chunk = result["chunk"]
+        if not isinstance(chunk, Mapping):
+            raise TypeError("workflow 'chunk' output must be a mapping")
+        yield dict(chunk)
+
+
+def _validate_endpoint_abi(orchestrator: WorkflowOrchestrator) -> None:
+    workflow = orchestrator.workflow_ir
+    if workflow.inputs != frozenset({"request"}):
+        raise WorkflowValidationError(
+            "workflow endpoints require exactly one 'request' input"
+        )
+    if set(workflow.outputs) != {"chunk"}:
+        raise WorkflowValidationError(
+            "workflow endpoints require exactly one 'chunk' output"
+        )

--- a/components/src/dynamo/experimental/workflow/tests/test_endpoint.py
+++ b/components/src/dynamo/experimental/workflow/tests/test_endpoint.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+
+import pytest
+
+from dynamo.experimental.workflow import (
+    InlineBinding,
+    StageContract,
+    Workflow,
+    WorkflowEndpointHandler,
+    WorkflowOrchestrator,
+    WorkflowValidationError,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
+
+
+CONTRACT = StageContract(
+    id="token-stage",
+    inputs={"request"},
+    outputs={"chunk"},
+)
+
+
+class _Runner:
+    contract = CONTRACT
+
+    async def run(self, inputs, context):
+        return {
+            "chunk": {
+                "token_ids": [inputs["request"]["token_ids"][0] + 1],
+                "index": 0,
+                "finish_reason": "stop",
+            }
+        }
+
+
+async def _orchestrator(runner=None) -> WorkflowOrchestrator:
+    workflow = Workflow("endpoint-workflow")
+    request = workflow.input("request")
+    stage = workflow.stage("generate", CONTRACT, request=request)
+    workflow.output("chunk", stage.chunk)
+    return await WorkflowOrchestrator.bind(
+        workflow,
+        bindings={"generate": InlineBinding(runner or _Runner())},
+    )
+
+
+class _Context:
+    def __init__(self) -> None:
+        self.stopped = asyncio.Event()
+
+    def id(self):
+        return "request-7"
+
+    async def async_killed_or_stopped(self):
+        await self.stopped.wait()
+        return True
+
+
+class _FutureContext(_Context):
+    def async_killed_or_stopped(self):
+        return asyncio.get_running_loop().create_future()
+
+
+@pytest.mark.parametrize("context_type", [_Context, _FutureContext])
+async def test_endpoint_handler_runs_fixed_request_and_chunk_abi(
+    context_type,
+) -> None:
+    context = context_type()
+    chunks = [
+        chunk
+        async for chunk in WorkflowEndpointHandler(await _orchestrator()).generate(
+            {"token_ids": [41]}, context
+        )
+    ]
+
+    assert chunks == [{"token_ids": [42], "index": 0, "finish_reason": "stop"}]
+
+
+async def test_endpoint_handler_rejects_noncanonical_workflow_abi() -> None:
+    workflow = Workflow("wrong-endpoint-abi")
+    request = workflow.input("payload")
+    stage = workflow.stage("generate", CONTRACT, request=request)
+    workflow.output("chunk", stage.chunk)
+    orchestrator = await WorkflowOrchestrator.bind(
+        workflow, bindings={"generate": InlineBinding(_Runner())}
+    )
+
+    with pytest.raises(WorkflowValidationError, match="'request' input"):
+        WorkflowEndpointHandler(orchestrator)
+
+
+async def test_endpoint_handler_cancels_workflow_when_context_stops() -> None:
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class BlockingRunner:
+        contract = CONTRACT
+
+        async def run(self, inputs, context):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    context = _Context()
+
+    async def stop():
+        await started.wait()
+        context.stopped.set()
+
+    stop_task = asyncio.create_task(stop())
+    chunks = [
+        chunk
+        async for chunk in WorkflowEndpointHandler(
+            await _orchestrator(BlockingRunner())
+        ).generate({"token_ids": [1]}, context)
+    ]
+    await stop_task
+
+    assert chunks == []
+    assert cancelled.is_set()


### PR DESCRIPTION
_Based on #13081._

## Why

The generic frontend should remain independent of workflow authoring and deployment. A workflow orchestrator running as an ordinary discovered model worker still needs a small boundary between Dynamo's endpoint generator ABI and the orchestrator's unary request/chunk contract.

> Experimental: This workflow API is under active development and may evolve based on feedback. It is an optional orchestration layer over Dynamo's discoverable workers and endpoints; applications may compose those primitives directly when they prefer to own the orchestration logic.

## What Change

- Add `WorkflowEndpointHandler` for bound orchestrators.
- Validate the endpoint ABI from `WorkflowIR`.
- Propagate request identity, cancellation, and terminal chunks.

```mermaid
classDiagram
    WorkflowEndpointHandler --> WorkflowOrchestrator : executes request/chunk ABI
    WorkflowOrchestrator --> WorkflowIR : exposes logical endpoint contract
    WorkflowOrchestrator --> GraphScheduler : schedules bound graph
    WorkflowEndpointHandler ..> Endpoint : served by worker

    note for WorkflowEndpointHandler "Adapts discovered endpoint requests"
    note for WorkflowOrchestrator "Owns one bound workflow"
```

## Test Plan

- Focused CPU workflow and endpoint-handler tests pass.
- Applicable pre-commit hooks pass.
