### PR TITLE
fix(vllm): allow connector metric prefixes

### DIFF
--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -6,6 +6,7 @@
 import argparse
 import logging
 import os
+import re
 import warnings
 from typing import List, Optional, Union
 
@@ -27,6 +28,12 @@ from .constants import DisaggregationMode, EmbeddingTransferMode
 
 logger = logging.getLogger(__name__)
 PREFILL_DECODE_DISAGGREGATION_MODE = "pd"
+
+
+def parse_connector_metric_prefixes(value: str) -> list[str]:
+    """Parse comma- or whitespace-separated connector metric prefixes."""
+    prefixes = [prefix for prefix in re.split(r"[\s,]+", value.strip()) if prefix]
+    return list(dict.fromkeys(prefixes))
 
 
 def _warn_deprecated(message: str) -> None:
@@ -229,6 +236,18 @@ class DynamoVllmArgGroup(ArgGroup):
                 "allocation at startup, automatically pause after initialization, "
                 "and resume on demand when the active engine dies. "
                 "Requires --load-format=gms."
+            ),
+        )
+
+        add_argument(
+            g,
+            flag_name="--connector-metric-prefixes",
+            env_var="DYN_VLLM_CONNECTOR_METRIC_PREFIXES",
+            default=None,
+            arg_type=parse_connector_metric_prefixes,
+            help=(
+                "Comma- or whitespace-separated metric name prefixes to append "
+                "to the vLLM worker metrics allowlist for external KV connectors."
             ),
         )
 
@@ -462,6 +481,9 @@ class DynamoVllmConfig(ConfigBase):
 
     # ModelExpress P2P
     model_express_url: Optional[str] = None
+
+    # Additional Prometheus prefixes exposed for external KV connectors.
+    connector_metric_prefixes: Optional[List[str]] = None
 
     # GMS shadow mode
     gms_shadow_mode: bool = False

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -197,7 +197,7 @@ async def worker(argv: list[str] | None = None) -> None:
 def setup_metrics_collection(
     config: "Config | OmniConfig", generate_endpoint: Endpoint, logger: logging.Logger
 ) -> None:
-    """Set up metrics collection for vLLM and LMCache metrics.
+    """Set up metrics collection for vLLM and connector metrics.
 
     In multiprocess mode (PROMETHEUS_MULTIPROC_DIR set), metrics are stored:
       1. In-memory: Metric objects in global REGISTRY
@@ -218,18 +218,7 @@ def setup_metrics_collection(
     """
     metrics_model_name = get_metrics_model_name(config)
 
-    # The DynamoMultimodalEmbeddingCacheConnector (scheduler side, EngineCore
-    # process) publishes its cache metrics through the multiprocess .db files.
-    # Forward that family only when the connector is configured — the
-    # encode-routing path exposes the same metric names in-process via
-    # register_embedding_cache_metrics instead.
-    engine_metric_prefixes = ["vllm:", "lmcache:"]
-    ec_config = getattr(config.engine_args, "ec_transfer_config", None)
-    if (
-        getattr(ec_config, "ec_connector", None)
-        == "DynamoMultimodalEmbeddingCacheConnector"
-    ):
-        engine_metric_prefixes.append(EMBEDDING_CACHE_METRIC_PREFIX)
+    engine_metric_prefixes = _get_engine_metric_prefixes(config)
 
     if config.engine_args.disable_log_stats is False:
         # Register the dedicated dynamo_component registry callback
@@ -275,22 +264,26 @@ def setup_metrics_collection(
                 multiproc_registry = CollectorRegistry()
                 multiprocess.MultiProcessCollector(multiproc_registry)
 
-                # Register both registries to collect all metrics
-                # Global REGISTRY has in-memory metrics (vllm)
+                # Keep in-process vLLM and external connector metrics in the
+                # global registry.
                 register_engine_metrics_callback(
                     endpoint=generate_endpoint,
                     registry=REGISTRY,
-                    metric_prefix_filters=["vllm:"],
+                    metric_prefix_filters=_get_in_process_metric_prefixes(config),
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
                     model_name=metrics_model_name,
                 )
-                # Multiproc registry has .db file metrics (lmcache, possibly vllm duplicates)
+                # The conflict may come from duplicate in-memory series rather
+                # than an existing MultiProcessCollector. Include vLLM so its
+                # .db-only metrics are not dropped, but exclude external
+                # connector prefixes because those are registered in-process.
                 register_engine_metrics_callback(
                     endpoint=generate_endpoint,
                     registry=multiproc_registry,
-                    metric_prefix_filters=engine_metric_prefixes,
+                    metric_prefix_filters=["vllm:"]
+                    + _get_multiprocess_only_metric_prefixes(config),
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
@@ -312,6 +305,46 @@ def setup_metrics_collection(
                 endpoint_name=config.endpoint,
                 model_name=metrics_model_name,
             )
+
+
+def _get_engine_metric_prefixes(config: "Config | OmniConfig") -> list[str]:
+    """Build the metric allowlist, including user-supplied connector prefixes."""
+    connector_prefixes = getattr(config, "connector_metric_prefixes", None) or []
+    return list(
+        dict.fromkeys(
+            ["vllm:"]
+            + _get_multiprocess_only_metric_prefixes(config)
+            + connector_prefixes
+        )
+    )
+
+
+def _get_in_process_metric_prefixes(config: "Config | OmniConfig") -> list[str]:
+    """Return vLLM and external connector prefixes from the global registry."""
+    prefixes = ["vllm:"]
+    prefixes.extend(getattr(config, "connector_metric_prefixes", None) or [])
+    return list(dict.fromkeys(prefixes))
+
+
+def _get_multiprocess_only_metric_prefixes(
+    config: "Config | OmniConfig",
+) -> list[str]:
+    """Return prefixes for integrations that publish only through .db files."""
+    prefixes = ["lmcache:"]
+
+    # The DynamoMultimodalEmbeddingCacheConnector (scheduler side, EngineCore
+    # process) publishes its cache metrics through the multiprocess .db files.
+    # Forward that family only when the connector is configured — the
+    # encode-routing path exposes the same metric names in-process via
+    # register_embedding_cache_metrics instead.
+    ec_config = getattr(config.engine_args, "ec_transfer_config", None)
+    if (
+        getattr(ec_config, "ec_connector", None)
+        == "DynamoMultimodalEmbeddingCacheConnector"
+    ):
+        prefixes.append(EMBEDDING_CACHE_METRIC_PREFIX)
+
+    return prefixes
 
 
 def _resolve_image_token_id(config: Config, vllm_config: VllmConfig) -> Optional[int]:

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -19,6 +19,7 @@ from dynamo.vllm.backend_args import (
     DynamoVllmArgGroup,
     DynamoVllmConfig,
     _reject_removed_multimodal_env_vars,
+    parse_connector_metric_prefixes,
 )
 
 pytestmark = [
@@ -145,6 +146,49 @@ def test_removed_multimodal_env_var_falsy_value_is_ignored(monkeypatch):
     monkeypatch.setenv("DYN_VLLM_MULTIMODAL_WORKER", "false")
 
     _reject_removed_multimodal_env_vars()
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("external_connector_", ["external_connector_"]),
+        (
+            "external_connector_, another_connector_ custom:",
+            ["external_connector_", "another_connector_", "custom:"],
+        ),
+        ("external_connector_,external_connector_", ["external_connector_"]),
+        ("  ", []),
+    ],
+)
+def test_parse_connector_metric_prefixes(value, expected):
+    assert parse_connector_metric_prefixes(value) == expected
+
+
+def test_connector_metric_prefixes_cli_appends_external_prefixes():
+    parser = argparse.ArgumentParser()
+    DynamoVllmArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        ["--connector-metric-prefixes", "external_connector_,custom:"]
+    )
+
+    assert args.connector_metric_prefixes == ["external_connector_", "custom:"]
+
+
+def test_connector_metric_prefixes_env_appends_external_prefixes(monkeypatch):
+    monkeypatch.setenv(
+        "DYN_VLLM_CONNECTOR_METRIC_PREFIXES",
+        "external_connector_ custom_connector_",
+    )
+    parser = argparse.ArgumentParser()
+    DynamoVllmArgGroup().add_arguments(parser)
+
+    args = parser.parse_args([])
+
+    assert args.connector_metric_prefixes == [
+        "external_connector_",
+        "custom_connector_",
+    ]
 
 
 class TestResolveDisaggregationMode:

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -94,6 +94,82 @@ def test_base_model_lora_capacity(enable_lora, model_type, expected):
     assert _load_vllm_main()._base_model_lora_capacity(config, model_type) == expected
 
 
+def test_engine_metric_prefixes_include_external_connector_prefixes():
+    config = SimpleNamespace(
+        connector_metric_prefixes=["external_connector_", "custom:", "vllm:"],
+        engine_args=SimpleNamespace(ec_transfer_config=None),
+    )
+
+    assert _load_vllm_main()._get_engine_metric_prefixes(config) == [
+        "vllm:",
+        "lmcache:",
+        "external_connector_",
+        "custom:",
+    ]
+
+
+def test_engine_metric_prefixes_support_omni_config_without_external_prefixes():
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(ec_transfer_config=None),
+    )
+
+    assert _load_vllm_main()._get_engine_metric_prefixes(config) == [
+        "vllm:",
+        "lmcache:",
+    ]
+
+
+def test_external_connector_prefixes_are_read_from_global_registry():
+    config = SimpleNamespace(
+        connector_metric_prefixes=["external_connector_"],
+        engine_args=SimpleNamespace(ec_transfer_config=None),
+    )
+    main = _load_vllm_main()
+
+    assert main._get_in_process_metric_prefixes(config) == [
+        "vllm:",
+        "external_connector_",
+    ]
+    assert main._get_multiprocess_only_metric_prefixes(config) == ["lmcache:"]
+
+
+def test_metrics_fallback_exposes_external_prefixes_without_duplicates(
+    tmp_path, monkeypatch
+):
+    main = _load_vllm_main()
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+    config = SimpleNamespace(
+        connector_metric_prefixes=["external_connector_"],
+        engine_args=SimpleNamespace(
+            disable_log_stats=False,
+            ec_transfer_config=None,
+        ),
+        namespace="test-namespace",
+        component="backend",
+        endpoint="generate",
+    )
+
+    with (
+        patch.object(main, "get_metrics_model_name", return_value="test-model"),
+        patch.object(main, "register_engine_metrics_callback") as register,
+        patch.object(
+            main.multiprocess,
+            "MultiProcessCollector",
+            side_effect=[ValueError("already registered"), None],
+        ),
+    ):
+        main.setup_metrics_collection(config, SimpleNamespace(), logging.getLogger())
+
+    assert register.call_args_list[1].kwargs["metric_prefix_filters"] == [
+        "vllm:",
+        "external_connector_",
+    ]
+    assert register.call_args_list[2].kwargs["metric_prefix_filters"] == [
+        "vllm:",
+        "lmcache:",
+    ]
+
+
 def test_kv_event_block_size_prefers_cached_main_attention_value():
     """LoRA MDC registration relies on this: the cached main-attention block
     size (configured at engine setup) wins over cache_config.block_size, so


### PR DESCRIPTION
## Overview:

Allow Dynamo vLLM workers to expose Prometheus metrics from external KV connectors by extending the existing metric-prefix allowlist.

## Details:

- Add `--connector-metric-prefixes` to append external connector metric prefixes.
- Add the corresponding `DYN_VLLM_CONNECTOR_METRIC_PREFIXES` environment variable.
- Accept comma- or whitespace-separated prefixes.
- Remove empty entries and duplicate prefixes while preserving order.
- Preserve the default `vllm:` and `lmcache:` prefixes.
- Add unit coverage for CLI parsing, environment-variable parsing, deduplication, and allowlist construction.

Example:

```bash
python3 -m dynamo.vllm \
  --connector-metric-prefixes external_connector_,custom:
```

Or:

```bash
export DYN_VLLM_CONNECTOR_METRIC_PREFIXES="external_connector_,custom:"
```

Validation:

- `git diff --check`
- Python syntax compilation for all modified files
- Targeted unit tests were added. Local execution could not complete because the local environment does not contain the compiled `dynamo._core` extension.

## Where should the reviewer start?

- `components/src/dynamo/vllm/backend_args.py` — new CLI/environment configuration and prefix parser.
- `components/src/dynamo/vllm/main.py` — construction of the extended metrics allowlist.
- `components/src/dynamo/vllm/tests/test_backend_args.py` — configuration parsing tests.
- `components/src/dynamo/vllm/tests/test_vllm_unit.py` — metric allowlist tests.

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring connector-specific metric prefixes through the command line or environment variables.
  - Prefix values can be separated by commas or whitespace, with duplicates automatically removed.
  - Connector metrics are now included alongside standard vLLM and LMCache metrics.
  - Multimodal embedding-cache metrics are included when applicable.

- **Tests**
  - Added coverage for prefix parsing, configuration input methods, deduplication, and metric collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->