### PR TITLE
fix(runtime): cancel requests when workers leave discovery

### DIFF
--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -764,6 +764,15 @@ impl Client {
         }
     }
 
+    /// Current unfiltered endpoint membership from the shared discovery
+    /// source. This stays independent of admission-filtered client views.
+    pub(crate) fn discovered_instances(&self) -> Vec<Instance> {
+        self.endpoint_discovery_source
+            .instance_source
+            .borrow()
+            .clone()
+    }
+
     /// Wait for at least one Instance to be available for this Endpoint
     pub async fn wait_for_instances(&self) -> Result<Vec<Instance>> {
         tracing::trace!(
@@ -965,48 +974,71 @@ impl Client {
             tracing::trace!("endpoint_watcher: Starting for discovery query: {:?}", discovery_query);
             let mut map: HashMap<u64, Instance> = HashMap::new();
 
-            loop {
-                let discovery_event = tokio::select! {
-                    _ = watch_tx.closed() => {
-                        break;
-                    }
-                    discovery_event = discovery_stream.next() => {
-                        match discovery_event {
-                            Some(Ok(event)) => {
-                                event
-                            },
-                            Some(Err(e)) => {
-                                tracing::error!("endpoint_watcher: discovery stream error: {}; shutting down for discovery query: {:?}", e, discovery_query);
-                                break;
+            const RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
+            'reconnect: loop {
+                loop {
+                    let discovery_event = tokio::select! {
+                        _ = watch_tx.closed() => {
+                            break 'reconnect;
+                        }
+                        discovery_event = discovery_stream.next() => {
+                            match discovery_event {
+                                Some(Ok(event)) => event,
+                                Some(Err(e)) => {
+                                    tracing::warn!("endpoint_watcher: discovery stream error: {}; reconnecting for discovery query: {:?}", e, discovery_query);
+                                    break;
+                                }
+                                None => {
+                                    tracing::warn!("endpoint_watcher: discovery stream ended; reconnecting for discovery query: {:?}", discovery_query);
+                                    break;
+                                }
                             }
-                            None => {
-                                break;
+                        }
+                    };
+
+                    match &discovery_event {
+                        DiscoveryEvent::Added(DiscoveryInstance::Endpoint(instance)) => {
+                            map.insert(instance.instance_id, instance.clone());
+                        }
+                        DiscoveryEvent::Added(_) => {}
+                        DiscoveryEvent::ModelTaintsUpdated(_) => {}
+                        DiscoveryEvent::Removed(id) => {
+                            if let DiscoveryInstanceId::Endpoint(endpoint_id) = id {
+                                map.remove(&endpoint_id.instance_id);
+                            }
+                        }
+                    }
+
+                    let instances: Vec<Instance> = map.values().cloned().collect();
+                    if watch_tx.send(instances).is_err() {
+                        break 'reconnect;
+                    }
+
+                    // Publish the snapshot before the raw event. A consumer that
+                    // subscribes between these operations sees either the updated
+                    // snapshot or the event (possibly both), never neither.
+                    if let Some(discovery_source) = discovery_source_task.upgrade() {
+                        discovery_source.broadcast_event(&discovery_event);
+                    }
+                }
+
+                tokio::select! {
+                    _ = watch_tx.closed() => break 'reconnect,
+                    _ = tokio::time::sleep(RECONNECT_BACKOFF) => {}
+                }
+
+                discovery_stream = loop {
+                    match discovery.list_and_watch(discovery_query.clone(), None).await {
+                        Ok(stream) => break stream,
+                        Err(e) => {
+                            tracing::warn!("endpoint_watcher: failed to reconnect discovery stream: {}; retrying for discovery query: {:?}", e, discovery_query);
+                            tokio::select! {
+                                _ = watch_tx.closed() => break 'reconnect,
+                                _ = tokio::time::sleep(RECONNECT_BACKOFF) => {}
                             }
                         }
                     }
                 };
-
-                if let Some(discovery_source) = discovery_source_task.upgrade() {
-                    discovery_source.broadcast_event(&discovery_event);
-                }
-
-                match discovery_event {
-                    DiscoveryEvent::Added(DiscoveryInstance::Endpoint(instance)) => {
-                        map.insert(instance.instance_id, instance);
-                    }
-                    DiscoveryEvent::Added(_) => {}
-                    DiscoveryEvent::ModelTaintsUpdated(_) => {}
-                    DiscoveryEvent::Removed(id) => {
-                        if let DiscoveryInstanceId::Endpoint(endpoint_id) = id {
-                            map.remove(&endpoint_id.instance_id);
-                        }
-                    }
-                }
-
-                let instances: Vec<Instance> = map.values().cloned().collect();
-                if watch_tx.send(instances).is_err() {
-                    break;
-                }
             }
             let _ = watch_tx.send(vec![]);
         });

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -244,6 +244,14 @@ impl<T> RegisteredStream<T> {
         cleanup.0.take();
         (connection_info, stream_provider)
     }
+
+    /// Await the stream provider while keeping registration cleanup armed.
+    ///
+    /// If the returned future is dropped before the provider resolves, the
+    /// registration is removed from the transport's pending-subject tables.
+    pub async fn wait(self) -> Result<Result<T, String>, tokio::sync::oneshot::error::RecvError> {
+        self.stream_provider.await
+    }
 }
 
 /// After registering a stream, the [`PendingConnections`] object is returned to the caller. This
@@ -321,6 +329,27 @@ mod registered_stream_tests {
         assert!(
             !flag.load(Ordering::SeqCst),
             "into_parts() must disarm the cleanup closure"
+        );
+    }
+
+    /// Cancelling a wait must retain the cleanup responsibility that
+    /// `into_parts()` deliberately transfers to its caller.
+    #[tokio::test]
+    async fn dropped_wait_runs_cleanup() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_clone = flag.clone();
+
+        let (_tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
+        let stream = RegisteredStream::new(dummy_conn_info(), rx).with_cleanup(move || {
+            flag_clone.store(true, Ordering::SeqCst);
+        });
+
+        let wait = stream.wait();
+        drop(wait);
+
+        assert!(
+            flag.load(Ordering::SeqCst),
+            "dropping the wait future must clean up the registration"
         );
     }
 

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -419,7 +419,7 @@ impl AddressedPushRouter {
         Self::new(req_client, resp_transport)
     }
 
-    /// Cancel all pending response-stream registrations for an instance.
+    /// Cancel pending response-stream handshakes for an instance.
     pub async fn cancel_instance_streams(&self, instance_id: &EndpointInstanceId) -> usize {
         self.resp_transport
             .cancel_instance_streams(instance_id)
@@ -576,12 +576,11 @@ impl AddressedPushRouter {
         let _nvtx_wait = dynamo_nvtx_range!("transport.tcp.wait_backend");
         tracing::trace!(request_id = context.id(), "awaiting transport handshake");
 
-        // Disarms the recv-side cleanup; see the holding rationale above.
-        let (_recv_conn_info, response_stream_provider) = recv_registered.into_parts();
-
         // RecvError → migratable Disconnected (watcher cancelled the subject
         // or the worker died before establishing the response stream).
-        let response_stream = match response_stream_provider.await {
+        // `wait()` keeps the registration cleanup armed so cancellation of
+        // this request before worker call-home cannot leak the subject.
+        let response_stream = match recv_registered.wait().await {
             Ok(Ok(stream)) => stream,
             Ok(Err(e)) => {
                 // generate() failed before any response bytes; migrate via
@@ -810,7 +809,8 @@ where
     ) -> Result<ManyOut<U>, Error>;
 
     /// Discovery-driven cleanup when an instance leaves — the request plane
-    /// cancels its call-home streams; another transport frees per-instance state.
+    /// cancels pending call-home handshakes; another transport frees
+    /// per-instance state.
     async fn on_instance_removed(&self, _id: &EndpointInstanceId) {}
 
     /// Discovery-driven notification when an instance (re)appears — the request
@@ -851,7 +851,7 @@ where
                 endpoint = %id.endpoint,
                 instance_id = id.instance_id,
                 cancelled = n,
-                "Cancelled pending response streams for removed instance (discovery-driven cleanup)"
+                "Cancelled pending stream handshakes for removed instance (discovery-driven cleanup)"
             );
         }
     }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -281,9 +281,9 @@ fn p2c_select_from(occupancy_state: &RoutingOccupancyState, instance_ids: &[u64]
         .worker_id
 }
 
-/// At most one `list_and_watch` per endpoint, across all `PushRouter`
+/// At most one discovery watcher per runtime endpoint, across all `PushRouter`
 /// instances. Entry removed on watcher exit so a later router can re-arm.
-static ENDPOINT_WATCHER_ACTIVE: std::sync::OnceLock<dashmap::DashMap<EndpointId, ()>> =
+static ENDPOINT_WATCHER_ACTIVE: std::sync::OnceLock<dashmap::DashMap<RuntimeEndpointId, ()>> =
     std::sync::OnceLock::new();
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -306,41 +306,43 @@ static ENDPOINT_CACHE_INDEXER_WATCHER_ACTIVE: std::sync::OnceLock<
     dashmap::DashMap<RuntimeEndpointId, ()>,
 > = std::sync::OnceLock::new();
 
-/// Watch discovery for instance removals and cancel pending response-stream
-/// registrations on the removed instance, unblocking queued requests with
-/// a migratable `Disconnected` error. Uses raw `list_and_watch` events
-/// (not a coalesced snapshot diff) so a rapid remove→re-add of the same
-/// identity is not silently swallowed. Keyed by full `EndpointInstanceId`.
+/// Watch explicit discovery events, cancelling response handshakes on removal
+/// and clearing the instance tombstone on add. Both operations are idempotent,
+/// so they do not depend on the client's potentially admission-filtered view.
 fn spawn_instance_removal_watcher<T, U>(
-    endpoint: Endpoint,
+    client: &Client,
     dispatch: Arc<dyn StreamingDispatch<T, U>>,
     cancel_token: tokio_util::sync::CancellationToken,
 ) where
     T: Data + Serialize + 'static,
     U: Data + for<'de> Deserialize<'de> + MaybeError + 'static,
 {
-    use crate::discovery::{
-        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
-    };
-    use tokio_stream::StreamExt as _;
+    use crate::discovery::{DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId};
 
     // One watcher per endpoint: if one is already running, skip.
     let guard = ENDPOINT_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new);
-    let endpoint_id = endpoint.id();
-    if guard.insert(endpoint_id.clone(), ()).is_some() {
+    let endpoint = &client.endpoint;
+    let watcher_id = RuntimeEndpointId::for_endpoint(endpoint);
+    if guard.insert(watcher_id.clone(), ()).is_some() {
         tracing::debug!(
-            ?endpoint_id,
-            "Instance removal watcher already running for this endpoint, skipping"
+            connection_id = watcher_id.connection_id,
+            ?watcher_id.endpoint_id,
+            "Instance removal watcher already running for this runtime endpoint, skipping"
         );
         return;
     }
 
     let endpoint_name = endpoint.name().to_string();
+    // Subscribe before yielding to the scheduler. The shared discovery source
+    // buffers every subsequent event in this receiver, closing the startup
+    // race that a separately spawned list_and_watch task would have.
+    let mut events = client.subscribe_discovery_events();
+    let initial_instances = client.discovered_instances();
 
     tokio::spawn(async move {
         // Release on every exit path (including panic); a leaked entry
         // silently disables removal cancellation until process restart.
-        struct GuardRelease(EndpointId);
+        struct GuardRelease(RuntimeEndpointId);
         impl Drop for GuardRelease {
             fn drop(&mut self) {
                 if let Some(map) = ENDPOINT_WATCHER_ACTIVE.get() {
@@ -348,66 +350,31 @@ fn spawn_instance_removal_watcher<T, U>(
                 }
             }
         }
-        let _release = GuardRelease(endpoint_id);
+        let _release = GuardRelease(watcher_id);
 
-        let namespace = endpoint.component().namespace().name();
-        let component = endpoint.component().name().to_string();
+        for instance in initial_instances {
+            dispatch
+                .on_instance_added(&instance.endpoint_instance_id())
+                .await;
+        }
 
-        // Reconnect on transient discovery failure; cancel-aware backoff.
-        const RECONNECT_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
-        'reconnect: loop {
-            let query = DiscoveryQuery::Endpoint {
-                namespace: namespace.clone(),
-                component: component.clone(),
-                endpoint: endpoint_name.clone(),
-            };
-
-            let mut stream = match endpoint.drt().discovery().list_and_watch(query, None).await {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!(
-                        endpoint = %endpoint_name,
-                        "Failed to start instance removal watcher (will retry): {e}"
-                    );
-                    tokio::select! {
-                        _ = tokio::time::sleep(RECONNECT_BACKOFF) => continue 'reconnect,
-                        _ = cancel_token.cancelled() => break 'reconnect,
+        loop {
+            tokio::select! {
+                event = events.recv() => {
+                    match event {
+                        Some(DiscoveryEvent::Removed(DiscoveryInstanceId::Endpoint(eid))) => {
+                            dispatch.on_instance_removed(&eid).await;
+                        }
+                        Some(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst))) => {
+                            let id = inst.endpoint_instance_id();
+                            dispatch.on_instance_added(&id).await;
+                        }
+                        Some(_) => {}
+                        None => break,
                     }
                 }
-            };
-
-            loop {
-                tokio::select! {
-                    event = stream.next() => {
-                        match event {
-                            Some(Ok(DiscoveryEvent::Removed(id))) => {
-                                if let DiscoveryInstanceId::Endpoint(eid) = &id {
-                                    dispatch.on_instance_removed(eid).await;
-                                }
-                            }
-                            Some(Ok(DiscoveryEvent::Added(DiscoveryInstance::Endpoint(inst)))) => {
-                                let eid: EndpointInstanceId = inst.endpoint_instance_id();
-                                dispatch.on_instance_added(&eid).await;
-                            }
-                            Some(Ok(_)) => {}
-                            Some(Err(e)) => {
-                                tracing::warn!(
-                                    endpoint = %endpoint_name,
-                                    "Instance removal watcher stream error: {e}"
-                                );
-                            }
-                            None => {
-                                tracing::warn!(
-                                    endpoint = %endpoint_name,
-                                    "Instance removal watcher stream ended; reconnecting"
-                                );
-                                continue 'reconnect;
-                            }
-                        }
-                    }
-                    _ = cancel_token.cancelled() => {
-                        break 'reconnect;
-                    }
+                _ = cancel_token.cancelled() => {
+                    break;
                 }
             }
         }
@@ -545,7 +512,7 @@ where
         // Type-erase to the seam so discovery-removal cleanup runs through it.
         let addressed: Arc<dyn StreamingDispatch<T, U>> = addressed;
         spawn_instance_removal_watcher(
-            client.endpoint.clone(),
+            &client,
             addressed.clone(),
             client.endpoint.drt().primary_token(),
         );
@@ -610,7 +577,7 @@ where
         // Type-erase to the seam so discovery-removal cleanup runs through it.
         let addressed: Arc<dyn StreamingDispatch<T, U>> = addressed;
         spawn_instance_removal_watcher(
-            client.endpoint.clone(),
+            &client,
             addressed.clone(),
             client.endpoint.drt().primary_token(),
         );
@@ -667,7 +634,7 @@ where
         };
 
         spawn_instance_removal_watcher(
-            client.endpoint.clone(),
+            &client,
             dispatch.clone(),
             client.endpoint.drt().primary_token(),
         );
@@ -2950,20 +2917,23 @@ mod tests {
     /// orphan-cancellation tests would fail.
     #[tokio::test]
     async fn watcher_dedup_guard_released_on_panic() {
-        let endpoint_id = EndpointId {
-            namespace: "panic-test-ns".to_string(),
-            component: "panic-test-comp".to_string(),
-            name: "panic-test-endpoint".to_string(),
+        let watcher_id = RuntimeEndpointId {
+            connection_id: 1,
+            endpoint_id: EndpointId {
+                namespace: "panic-test-ns".to_string(),
+                component: "panic-test-comp".to_string(),
+                name: "panic-test-endpoint".to_string(),
+            },
         };
 
         // Mimic the production code's pre-spawn dedup insert.
         let map = ENDPOINT_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new);
-        map.insert(endpoint_id.clone(), ());
+        map.insert(watcher_id.clone(), ());
 
-        let endpoint_id_clone = endpoint_id.clone();
+        let watcher_id_clone = watcher_id.clone();
         let join = tokio::spawn(async move {
             // Same shape as in spawn_instance_removal_watcher.
-            struct GuardRelease(EndpointId);
+            struct GuardRelease(RuntimeEndpointId);
             impl Drop for GuardRelease {
                 fn drop(&mut self) {
                     if let Some(map) = ENDPOINT_WATCHER_ACTIVE.get() {
@@ -2971,14 +2941,14 @@ mod tests {
                     }
                 }
             }
-            let _release = GuardRelease(endpoint_id_clone);
+            let _release = GuardRelease(watcher_id_clone);
             panic!("simulated watcher-task panic");
         });
 
         let result = join.await;
         assert!(result.is_err() && result.unwrap_err().is_panic());
         assert!(
-            !map.contains_key(&endpoint_id),
+            !map.contains_key(&watcher_id),
             "Drop guard must release the dedup entry even on panic"
         );
     }
@@ -2988,18 +2958,21 @@ mod tests {
     /// fires or discovery stream closes).
     #[tokio::test]
     async fn watcher_dedup_guard_released_on_normal_exit() {
-        let endpoint_id = EndpointId {
-            namespace: "normal-test-ns".to_string(),
-            component: "normal-test-comp".to_string(),
-            name: "normal-test-endpoint".to_string(),
+        let watcher_id = RuntimeEndpointId {
+            connection_id: 2,
+            endpoint_id: EndpointId {
+                namespace: "normal-test-ns".to_string(),
+                component: "normal-test-comp".to_string(),
+                name: "normal-test-endpoint".to_string(),
+            },
         };
 
         let map = ENDPOINT_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new);
-        map.insert(endpoint_id.clone(), ());
+        map.insert(watcher_id.clone(), ());
 
-        let endpoint_id_clone = endpoint_id.clone();
+        let watcher_id_clone = watcher_id.clone();
         tokio::spawn(async move {
-            struct GuardRelease(EndpointId);
+            struct GuardRelease(RuntimeEndpointId);
             impl Drop for GuardRelease {
                 fn drop(&mut self) {
                     if let Some(map) = ENDPOINT_WATCHER_ACTIVE.get() {
@@ -3007,13 +2980,13 @@ mod tests {
                     }
                 }
             }
-            let _release = GuardRelease(endpoint_id_clone);
+            let _release = GuardRelease(watcher_id_clone);
             // task body returns normally
         })
         .await
         .unwrap();
 
-        assert!(!map.contains_key(&endpoint_id));
+        assert!(!map.contains_key(&watcher_id));
     }
 
     #[tokio::test]
@@ -3174,6 +3147,53 @@ mod tests {
         assert!(
             poll_until(|| dispatch.added.lock().unwrap().len() > adds_before).await,
             "on_instance_added (re-registration) not delivered to the supplied dispatch"
+        );
+
+        rt.shutdown();
+    }
+
+    /// Removal handling must use the shared, unfiltered discovery source. The
+    /// frontend constructs routers while their admission view is still empty,
+    /// so using that derived view would miss workers that already exist.
+    #[tokio::test]
+    async fn removal_watcher_ignores_admission_filter_for_membership() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("test_removal_unfiltered_discovery".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+
+        endpoint.register_endpoint_instance().await.unwrap();
+        let instance_id = client.wait_for_instances().await.unwrap()[0].id();
+
+        let (_admission_tx, admission_rx) = tokio::sync::watch::channel(Vec::new());
+        let admitted_client = client.with_admitted_instances(admission_rx);
+        assert!(admitted_client.instances().is_empty());
+
+        let dispatch = Arc::new(RecordingDispatch::default());
+        let _router = PushRouter::<u64, TestResponse>::from_client_with_dispatch(
+            admitted_client,
+            RouterMode::RoundRobin,
+            dispatch.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            poll_until(|| dispatch.added.lock().unwrap().contains(&instance_id)).await,
+            "unfiltered initial discovery membership was not delivered"
+        );
+
+        endpoint.unregister_endpoint_instance().await.unwrap();
+        assert!(
+            poll_until(|| dispatch.removed.lock().unwrap().contains(&instance_id)).await,
+            "removal was lost while the admitted client view was empty"
         );
 
         rt.shutdown();

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -113,6 +113,9 @@ struct RequestedSendConnection {
 struct RequestedRecvConnection {
     context: Arc<dyn AsyncEngineContext>,
     connection: oneshot::Sender<Result<StreamReceiver, String>>,
+    /// Remains addressable after the worker's TCP call-home so discovery
+    /// removal can interrupt a stalled response prologue.
+    cancellation: tokio_util::sync::CancellationToken,
     /// Capacity of the per-stream mpsc buffer between the socket task and the
     /// engine consumer; carried from the registration [`StreamOptions`].
     send_buffer_count: usize,
@@ -151,6 +154,9 @@ fn data_plane_channel<T>(send_buffer_count: usize) -> (mpsc::Sender<T>, mpsc::Re
 struct State {
     tx_subjects: HashMap<String, RequestedSendConnection>,
     rx_subjects: HashMap<String, RequestedRecvConnection>,
+    /// Response registrations remain cancellable after `rx_subjects` is
+    /// consumed by call-home and until the response prologue is accepted.
+    rx_cancellations: HashMap<String, tokio_util::sync::CancellationToken>,
     /// subject UUID -> EndpointInstanceId. Full 4-field key isolates services
     /// that share an endpoint name across namespaces/components.
     subject_instance: HashMap<String, EndpointInstanceId>,
@@ -164,6 +170,17 @@ struct State {
     /// after [`TOMBSTONE_TTL`].
     removed_instances: HashMap<EndpointInstanceId, Instant>,
     handle: Option<tokio::task::JoinHandle<Result<()>>>,
+}
+
+struct ResponseRegistrationGuard {
+    state: Arc<Mutex<State>>,
+    subject: String,
+}
+
+impl Drop for ResponseRegistrationGuard {
+    fn drop(&mut self) {
+        TcpStreamServer::finish_response_stream(&self.state, &self.subject);
+    }
 }
 
 /// Drop tombstones older than [`TOMBSTONE_TTL`]. Called lazily on every
@@ -281,6 +298,9 @@ impl TcpStreamServer {
                 "Cancelling subject immediately: instance already removed (tombstoned)"
             );
             state.rx_subjects.remove(recv_subject);
+            if let Some(token) = state.rx_cancellations.remove(recv_subject) {
+                token.cancel();
+            }
             if let Some(s) = send_subject {
                 state.tx_subjects.remove(s);
             }
@@ -305,6 +325,9 @@ impl TcpStreamServer {
     pub async fn cancel_recv_stream(&self, subject: &str) {
         let mut state = self.state.lock();
         state.rx_subjects.remove(subject);
+        if let Some(token) = state.rx_cancellations.remove(subject) {
+            token.cancel();
+        }
         if let Some(key) = state.subject_instance.remove(subject)
             && let Some(subjects) = state.instance_subjects.get_mut(&key)
         {
@@ -333,8 +356,8 @@ impl TcpStreamServer {
         }
     }
 
-    /// Cancel all pending streams for an instance — both response-side and
-    /// request-side halves of any bidirectional sessions tracked by
+    /// Cancel all pending stream handshakes for an instance — both response-
+    /// side and request-side halves of any bidirectional sessions tracked by
     /// `associate_instance` — and tombstone the id so any racing associate
     /// for the same id cancels too. Returns the number of streams cancelled.
     pub async fn cancel_instance_streams(&self, id: &EndpointInstanceId) -> usize {
@@ -351,6 +374,9 @@ impl TcpStreamServer {
             match kind {
                 StreamType::Response => {
                     state.rx_subjects.remove(subject);
+                    if let Some(token) = state.rx_cancellations.remove(subject) {
+                        token.cancel();
+                    }
                 }
                 StreamType::Request => {
                     state.tx_subjects.remove(subject);
@@ -416,7 +442,10 @@ impl TcpStreamServer {
     }
 
     fn insert_response_stream(&self, subject: String, connection: RequestedRecvConnection) {
-        self.state.lock().rx_subjects.insert(subject, connection);
+        let cancellation = connection.cancellation.clone();
+        let mut state = self.state.lock();
+        state.rx_subjects.insert(subject.clone(), connection);
+        state.rx_cancellations.insert(subject, cancellation);
     }
 
     fn take_request_stream(state: &Mutex<State>, subject: &str) -> Option<RequestedSendConnection> {
@@ -437,8 +466,14 @@ impl TcpStreamServer {
         state: &Mutex<State>,
         subject: &str,
     ) -> Option<RequestedRecvConnection> {
+        state.lock().rx_subjects.remove(subject)
+    }
+
+    /// Finish tracking a response registration after its prologue is accepted
+    /// or its connection handler exits.
+    fn finish_response_stream(state: &Mutex<State>, subject: &str) {
         let mut state = state.lock();
-        let connection = state.rx_subjects.remove(subject);
+        state.rx_cancellations.remove(subject);
         if let Some(key) = state.subject_instance.remove(subject)
             && let Some(subjects) = state.instance_subjects.get_mut(&key)
         {
@@ -447,7 +482,6 @@ impl TcpStreamServer {
                 state.instance_subjects.remove(&key);
             }
         }
-        connection
     }
 }
 
@@ -535,6 +569,7 @@ impl ResponseService for TcpStreamServer {
             let connection_info = RequestedRecvConnection {
                 context: options.context.clone(),
                 connection: pending_recver_tx,
+                cancellation: tokio_util::sync::CancellationToken::new(),
                 send_buffer_count: options.send_buffer_count,
             };
 
@@ -555,6 +590,9 @@ impl ResponseService for TcpStreamServer {
                 tokio::spawn(async move {
                     let mut state = cleanup_state.lock();
                     state.rx_subjects.remove(&cleanup_subject);
+                    if let Some(token) = state.rx_cancellations.remove(&cleanup_subject) {
+                        token.cancel();
+                    }
                     if let Some(key) = state.subject_instance.remove(&cleanup_subject)
                         && let Some(subjects) = state.instance_subjects.get_mut(&key)
                     {
@@ -1057,16 +1095,21 @@ async fn tcp_listener(
         subject: String,
         state: Arc<Mutex<State>>,
         mut reader: FramedRead<BoxRead, TwoPartCodec>,
-        writer: FramedWrite<BoxWrite, TwoPartCodec>,
+        mut writer: FramedWrite<BoxWrite, TwoPartCodec>,
     ) -> Result<()> {
         let response_stream = TcpStreamServer::take_response_stream(&state, &subject).ok_or_else(|| {
             error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject)
         })?;
+        let registration_guard = ResponseRegistrationGuard {
+            state: state.clone(),
+            subject: subject.clone(),
+        };
 
         // unwrap response_stream
         let RequestedRecvConnection {
             context,
             connection,
+            cancellation,
             send_buffer_count,
         } = response_stream;
 
@@ -1074,10 +1117,30 @@ async fn tcp_listener(
         // there must be a second control message it indicate the other segment's generate method was successful
         // No timeout here: the worker sends the prologue only after generate() setup completes,
         // which can take arbitrarily long (model load, queue delay, cold start).
-        let prologue = reader
-            .next()
-            .await
-            .ok_or(error!("Connection closed without a ControlMessge"))??;
+        let prologue: Result<TwoPartMessage> = tokio::select! {
+            _ = cancellation.cancelled() => {
+                // Dropping `connection` resolves the requester with RecvError,
+                // which the addressed router maps to `Disconnected`.
+                // Tell a still-live worker to stop the in-flight generation;
+                // discovery removal only means it is no longer routable.
+                if let Ok(bytes) = serde_json::to_vec(&ControlMessage::Kill) {
+                    let _ = writer
+                        .send(TwoPartMessage::from_header(bytes.into()))
+                        .await;
+                }
+                let mut inner = writer.into_inner();
+                let _ = inner.shutdown().await;
+                return Ok(());
+            }
+            item = reader.next() => {
+                match item {
+                    Some(Ok(message)) => Ok(message),
+                    Some(Err(err)) => Err(err.into()),
+                    None => Err(error!("Connection closed without a ControlMessage")),
+                }
+            }
+        };
+        let prologue = prologue?;
 
         // deserialize prologue
         let prologue = match prologue.into_message_type() {
@@ -1107,6 +1170,11 @@ async fn tcp_listener(
             let _ = connection.send(Err(error.clone()));
             return Err(error!("Received error prologue: {}", error));
         }
+
+        // Discovery removal prevents new work but does not abort an established
+        // response stream. From this point normal transport failure or the
+        // request context owns cancellation.
+        drop(registration_guard);
 
         // Buffer size is driven by the registration options
         // ([`StreamOptions::send_buffer_count`]) rather than hard-coded; the
@@ -1883,6 +1951,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_dropped_registered_stream_wait_cleans_instance_indexes() {
+        let server = test_server().await;
+        let context = Context::new(());
+        let options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(false)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+
+        let pending = server.register(options).await;
+        let recv_stream = pending.recv_stream.unwrap();
+        let tcp_info: TcpStreamConnectionInfo =
+            recv_stream.connection_info.clone().try_into().unwrap();
+        let subject = tcp_info.subject;
+        let instance = make_eid("ns", "comp", "generate", 42);
+        assert!(server.associate_instance(&subject, None, &instance).await);
+
+        let wait = recv_stream.wait();
+        drop(wait);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let cleaned = {
+                    let state = server.state.lock();
+                    !state.rx_subjects.contains_key(&subject)
+                        && !state.rx_cancellations.contains_key(&subject)
+                        && !state.subject_instance.contains_key(&subject)
+                        && !state.instance_subjects.contains_key(&instance)
+                };
+                if cleaned {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled wait did not clean response registration indexes");
+    }
+
+    #[tokio::test]
     async fn test_associate_after_cancel_is_immediately_cancelled() {
         // Simulates the race: cancel_instance_streams fires before associate_instance.
         let server = test_server().await;
@@ -2241,6 +2350,54 @@ mod tests {
             recv_control_message(&mut framed_reader).await,
             ControlMessage::Kill,
             "unexpected control message should kill only this stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tcp_stream_server_sends_kill_when_prologue_wait_is_cancelled() {
+        let server = test_server().await;
+        let context = Context::new(());
+        let options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(false)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+        let pending = server.register(options).await;
+        let registered_stream = pending.recv_stream.unwrap();
+        let (connection_info, stream_provider) = registered_stream.into_parts();
+        let tcp_info: TcpStreamConnectionInfo = connection_info.try_into().unwrap();
+        let subject = tcp_info.subject.clone();
+
+        let stream = TcpStream::connect(&tcp_info.address).await.unwrap();
+        let (read_half, write_half) = tokio::io::split(stream);
+        let mut framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
+        let mut framed_writer = FramedWrite::new(write_half, TwoPartCodec::default());
+        let handshake = CallHomeHandshake {
+            subject: subject.clone(),
+            stream_type: StreamType::Response,
+        };
+        framed_writer
+            .send(TwoPartMessage::from_header(
+                serde_json::to_vec(&handshake).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while server.state.lock().rx_subjects.contains_key(&subject) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("server did not accept response call-home");
+
+        server.cancel_recv_stream(&subject).await;
+        assert!(stream_provider.await.is_err());
+        assert_eq!(
+            recv_control_message(&mut framed_reader).await,
+            ControlMessage::Kill,
+            "cancelling the prologue wait should stop worker generation"
         );
     }
 

--- a/lib/runtime/tests/worker_removal_cancellation.rs
+++ b/lib/runtime/tests/worker_removal_cancellation.rs
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end coverage for discovery-driven cancellation while establishing a
+//! response stream and graceful draining after the stream is established.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Error;
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+use dynamo_runtime::pipeline::network::egress::push_router::{PushRouter, RouterMode};
+use dynamo_runtime::{
+    DistributedRuntime, Runtime,
+    distributed::DistributedConfig,
+    engine::{AsyncEngine, AsyncEngineContextProvider},
+    error::{DynamoError, ErrorType, match_error_chain},
+    pipeline::{ManyOut, ResponseStream, SingleIn, network::Ingress},
+    protocols::maybe_error::MaybeError,
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct TestResponse {
+    #[serde(default)]
+    error: Option<DynamoError>,
+}
+
+impl MaybeError for TestResponse {
+    fn from_err(err: impl std::error::Error + 'static) -> Self {
+        Self {
+            error: Some(DynamoError::from(
+                Box::new(err) as Box<dyn std::error::Error + 'static>
+            )),
+        }
+    }
+
+    fn err(&self) -> Option<DynamoError> {
+        self.error.clone()
+    }
+}
+
+struct StalledEngine {
+    request_received: Arc<Notify>,
+    release_request: Arc<Notify>,
+}
+
+struct HangingResponseEngine {
+    release_stream: Arc<Notify>,
+}
+
+#[async_trait]
+impl AsyncEngine<SingleIn<u64>, ManyOut<TestResponse>, Error> for HangingResponseEngine {
+    async fn generate(&self, input: SingleIn<u64>) -> Result<ManyOut<TestResponse>, Error> {
+        let (_request, context) = input.into_parts();
+        let release_stream = self.release_stream.clone();
+        let stream = futures::stream::once(async move {
+            release_stream.notified().await;
+            TestResponse { error: None }
+        });
+        Ok(ResponseStream::new(Box::pin(stream), context.context()))
+    }
+}
+
+#[async_trait]
+impl AsyncEngine<SingleIn<u64>, ManyOut<TestResponse>, Error> for StalledEngine {
+    async fn generate(&self, input: SingleIn<u64>) -> Result<ManyOut<TestResponse>, Error> {
+        self.request_received.notify_one();
+        self.release_request.notified().await;
+        let (_request, context) = input.into_parts();
+        Ok(ResponseStream::new(
+            Box::pin(futures::stream::empty()),
+            context.context(),
+        ))
+    }
+}
+
+async fn assert_removal_cancels_request_waiting_for_response_stream(
+    distributed: &DistributedRuntime,
+) {
+    let endpoint = distributed
+        .namespace("worker_removal_cancellation".to_string())
+        .unwrap()
+        .component("backend".to_string())
+        .unwrap()
+        .endpoint("stalled_generate".to_string());
+
+    let request_received = Arc::new(Notify::new());
+    let release_request = Arc::new(Notify::new());
+    let ingress = Ingress::for_engine(Arc::new(StalledEngine {
+        request_received: request_received.clone(),
+        release_request: release_request.clone(),
+    }))
+    .unwrap();
+    let started = endpoint
+        .clone()
+        .endpoint_builder()
+        .handler(ingress)
+        .graceful_shutdown(false)
+        .start_with_registration()
+        .await
+        .unwrap();
+
+    let client = endpoint.client().await.unwrap();
+    client.wait_for_instances().await.unwrap();
+    let mut instance_updates = client.instance_source.as_ref().clone();
+    let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::RoundRobin)
+        .await
+        .unwrap();
+
+    let request = tokio::spawn(async move { router.generate(SingleIn::new(42)).await });
+    tokio::time::timeout(Duration::from_secs(5), request_received.notified())
+        .await
+        .expect("worker did not receive the request");
+
+    endpoint.unregister_endpoint_instance().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !instance_updates.borrow_and_update().is_empty() {
+            instance_updates.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("client did not observe the worker leaving discovery");
+
+    let error = tokio::time::timeout(Duration::from_secs(5), request)
+        .await
+        .expect("request remained blocked after its worker left discovery")
+        .expect("request task panicked")
+        .expect_err("request unexpectedly succeeded after its worker was removed");
+    assert!(
+        match_error_chain(error.as_ref(), &[ErrorType::Disconnected], &[]),
+        "expected a disconnected error, got: {error:#}"
+    );
+
+    release_request.notify_one();
+    tokio::time::timeout(Duration::from_secs(5), started.shutdown())
+        .await
+        .expect("worker endpoint did not shut down after releasing the request")
+        .unwrap();
+}
+
+async fn assert_removal_drains_established_response_stream(distributed: &DistributedRuntime) {
+    let endpoint = distributed
+        .namespace("active_worker_removal_cancellation".to_string())
+        .unwrap()
+        .component("backend".to_string())
+        .unwrap()
+        .endpoint("active_generate".to_string());
+
+    let release_stream = Arc::new(Notify::new());
+    let ingress = Ingress::for_engine(Arc::new(HangingResponseEngine {
+        release_stream: release_stream.clone(),
+    }))
+    .unwrap();
+    let started = endpoint
+        .clone()
+        .endpoint_builder()
+        .handler(ingress)
+        .graceful_shutdown(false)
+        .start_with_registration()
+        .await
+        .unwrap();
+
+    let client = endpoint.client().await.unwrap();
+    client.wait_for_instances().await.unwrap();
+    let mut instance_updates = client.instance_source.as_ref().clone();
+    let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::RoundRobin)
+        .await
+        .unwrap();
+    let mut response =
+        tokio::time::timeout(Duration::from_secs(5), router.generate(SingleIn::new(42)))
+            .await
+            .expect("worker did not establish its response stream")
+            .unwrap();
+
+    endpoint.unregister_endpoint_instance().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !instance_updates.borrow_and_update().is_empty() {
+            instance_updates.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("client did not observe the worker leaving discovery");
+
+    release_stream.notify_one();
+    let response = tokio::time::timeout(Duration::from_secs(5), response.next())
+        .await
+        .expect("established response stream did not drain after worker removal")
+        .expect("established response stream ended before yielding its response");
+    assert!(
+        response.err().is_none(),
+        "established response stream unexpectedly failed: {:?}",
+        response.err()
+    );
+
+    tokio::time::timeout(Duration::from_secs(5), started.shutdown())
+        .await
+        .expect("worker endpoint did not shut down after draining the stream")
+        .unwrap();
+}
+
+#[tokio::test]
+async fn worker_removal_cancels_request_waiting_for_response_stream() {
+    let runtime = Runtime::from_current().unwrap();
+    let distributed = DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+        .await
+        .unwrap();
+
+    assert_removal_cancels_request_waiting_for_response_stream(&distributed).await;
+
+    runtime.shutdown();
+}
+
+#[tokio::test]
+async fn worker_removal_drains_established_response_stream() {
+    let runtime = Runtime::from_current().unwrap();
+    let distributed = DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+        .await
+        .unwrap();
+
+    assert_removal_drains_established_response_stream(&distributed).await;
+
+    runtime.shutdown();
+}


### PR DESCRIPTION
## Overview

Requests could hang after being routed to a worker that subsequently left discovery. In #13088 this showed up during heavy worker churn: the request had already selected its workers, but then made no further progress until the HTTP client disconnected.

Two gaps allowed that to happen. Worker-removal handling maintained a separate discovery watcher, so it could miss a removal around startup or observe different membership from an admission-filtered client. On the response path, cancellation stopped too early: TCP call-home could complete while the frontend was still waiting for the worker's response prologue.

Worker removal now follows the client's shared discovery lifecycle, and a pending response remains cancellable until the prologue is received. Once the response stream is established, it keeps its existing drain behavior.

## Details

### Discovery removal

The removal path previously started another `list_and_watch` and maintained its own view of endpoint membership. Besides the startup race, that does not work reliably for admission-filtered clients: the router-visible instance set can still be empty while the underlying discovery source already knows about the worker.

The watcher now consumes the discovery events already maintained by `Client` and initializes from the same unfiltered membership. The shared source publishes the updated snapshot before its corresponding raw event, so a watcher starting concurrently with a membership change cannot miss both.

This also means removal is driven by an explicit `Removed` event. An empty snapshot or discovery stream termination is not interpreted as a worker leaving.

The watcher dedup key is now runtime-scoped as well, so the same logical endpoint on different runtime connections does not share watcher state.

### Response handshake

TCP call-home happens before the response prologue, so it is not yet the point where discovery-driven cancellation should stop.

Previously the addressed router split the registered response before waiting for it:

```diff
- let (_recv_conn_info, response_stream_provider) = recv_registered.into_parts();
- let response_stream = match response_stream_provider.await {
+ let response_stream = match recv_registered.wait().await {
```

`into_parts()` transfers cleanup responsibility away from `RegisteredStream`. That meant a request could still be waiting for the response prologue after call-home, but worker removal could no longer reach that pending registration.

`RegisteredStream::wait()` keeps the registration cleanup armed, while the TCP response path keeps a cancellation token after call-home until the prologue is accepted. If the worker is explicitly removed during that window, the pending handshake is cancelled and the requester receives a migratable `Disconnected` error.

Cancellation also sends `Kill` on the still-open worker connection before shutting it down, so work that is no longer routable is not left running unnecessarily.

After the prologue is accepted, the response stream is established and discovery removal no longer cancels it.

## Where should the reviewer start?

`spawn_instance_removal_watcher()` in `lib/runtime/src/pipeline/network/egress/push_router.rs` contains the discovery-side change, including the switch to the shared unfiltered discovery source.

`RegisteredStream::wait()` in `lib/runtime/src/pipeline/network.rs` and the response path in `lib/runtime/src/pipeline/network/tcp/server.rs` cover the cancellation lifetime between TCP call-home and the response prologue.

`lib/runtime/src/component/client.rs` contains the snapshot/event ordering used by the shared discovery source.

## Validation

Regression coverage includes:

- removing a worker while its response handshake is still pending returns `Disconnected` instead of leaving the request blocked;
- removing a worker after its response stream is established still allows the stream to drain;
- removal is still observed when the router uses an admission-filtered client whose visible membership is empty;
- cancelling a pending response cleans up the response registration and sends `Kill` to the worker.

## Related Issues

Relates to #13088