### PR TITLE
feat(runtime): add TLS support to NATS transport

### DIFF
--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -64,6 +64,8 @@ class DynamoRuntimeConfig(ConfigBase):
     tcp_tls_insecure: bool = False
     tcp_tls_server_name: Optional[str] = None
     tcp_tls_handshake_timeout_secs: Optional[int] = None
+    nats_tls_ca_cert_path: Optional[str] = None
+    nats_tls_insecure: bool = False
 
     def validate(self) -> None:
         self.namespace = get_worker_namespace(self.namespace)
@@ -119,6 +121,14 @@ class DynamoRuntimeConfig(ConfigBase):
             os.environ["DYN_TCP_TLS_HANDSHAKE_TIMEOUT_SECS"] = str(
                 self.tcp_tls_handshake_timeout_secs
             )
+
+        # Propagate NATS TLS CLI flags.
+        if self.nats_tls_ca_cert_path:
+            os.environ["NATS_TLS_CA_CERT_PATH"] = self.nats_tls_ca_cert_path
+        if self.nats_tls_insecure:
+            os.environ["NATS_TLS_INSECURE"] = "1"
+        else:
+            os.environ.pop("NATS_TLS_INSECURE", None)
 
     def _validate_output_modalities(self) -> None:
         """Validate --output-modalities values."""
@@ -427,4 +437,20 @@ class DynamoRuntimeArgGroup(ArgGroup):
             arg_type=int,
             dest="tcp_tls_handshake_timeout_secs",
             help="TLS handshake timeout in seconds (default: 3).",
+        )
+
+        add_argument(
+            g,
+            flag_name="--nats-tls-ca-cert-path",
+            env_var="NATS_TLS_CA_CERT_PATH",
+            default=None,
+            help="Path to PEM CA certificate for verifying the NATS server.",
+        )
+
+        add_negatable_bool_argument(
+            g,
+            flag_name="--nats-tls-insecure",
+            env_var="NATS_TLS_INSECURE",
+            default=False,
+            help="Disable NATS TLS certificate verification. For local development only.",
         )

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -64,6 +64,8 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     tcp_tls_cert_path: Optional[str] = None
     tcp_tls_key_path: Optional[str] = None
     tcp_tls_ca_cert_path: Optional[str] = None
+    nats_tls_ca_cert_path: Optional[str] = None
+    nats_tls_insecure: bool = False
 
     namespace: Optional[str] = None
     namespace_prefix: Optional[str] = None
@@ -311,6 +313,22 @@ class FrontendArgGroup(ArgGroup):
             env_var="DYN_TCP_TLS_CA_CERT_PATH",
             default=None,
             help="Path to PEM CA certificate used to verify the TCP peer's certificate.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--nats-tls-ca-cert-path",
+            env_var="NATS_TLS_CA_CERT_PATH",
+            default=None,
+            help="Path to PEM CA certificate for verifying the NATS server.",
+        )
+
+        add_negatable_bool_argument(
+            g,
+            flag_name="--nats-tls-insecure",
+            env_var="NATS_TLS_INSECURE",
+            default=False,
+            help="Disable NATS TLS certificate verification. For local development only.",
         )
 
         # Router options (shared with dynamo.router)

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -408,6 +408,14 @@ async def async_main():
         os.environ["DYN_TCP_TLS_KEY_PATH"] = config.tcp_tls_key_path
     if config.tcp_tls_ca_cert_path:
         os.environ["DYN_TCP_TLS_CA_CERT_PATH"] = config.tcp_tls_ca_cert_path
+    if config.nats_tls_ca_cert_path:
+        os.environ["NATS_TLS_CA_CERT_PATH"] = config.nats_tls_ca_cert_path
+    if config.nats_tls_insecure:
+        os.environ["NATS_TLS_INSECURE"] = "1"
+    else:
+        # Clear any inherited NATS_TLS_INSECURE so --no-nats-tls-insecure can
+        # override it before the Rust runtime reads the env var.
+        os.environ.pop("NATS_TLS_INSECURE", None)
     if config.namespace:
         kwargs["namespace"] = config.namespace
     if config.namespace_prefix:

--- a/docs/fern/pages/reference/api/python/frontend.mdx
+++ b/docs/fern/pages/reference/api/python/frontend.mdx
@@ -52,7 +52,7 @@ Frontend configuration parameters.
 from dynamo.frontend.frontend_args import FrontendArgGroup
 ```
 
-[`components/src/dynamo/frontend/frontend_args.py#L212`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/frontend_args.py#L212)
+[`components/src/dynamo/frontend/frontend_args.py#L214`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/frontend_args.py#L214)
 
 **Public methods**
 
@@ -64,7 +64,7 @@ add_arguments(parser) -> None
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/frontend_args.py#L215)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/frontend_args.py#L217)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-frontend-args-frontendconfig" title="FrontendConfig (class)">
@@ -86,7 +86,7 @@ validate() -> None
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/frontend_args.py#L100)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/frontend_args.py#L102)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-utils-preprocesserror" title="PreprocessError (class)">
@@ -565,7 +565,7 @@ graceful_shutdown(runtime: DistributedRuntime) -> None
 The DistributedRuntime instance to shut down.
 </ParamField>
 
-[`components/src/dynamo/frontend/main.py#L460`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/main.py#L460)
+[`components/src/dynamo/frontend/main.py#L468`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/main.py#L468)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-utils-handle-engine-error" title="handle_engine_error (function)">
@@ -612,7 +612,7 @@ from dynamo.frontend.main import main
 main() -> None
 ```
 
-[`components/src/dynamo/frontend/main.py#L469`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/main.py#L469)
+[`components/src/dynamo/frontend/main.py#L477`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/main.py#L477)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-utils-make-backend-error" title="make_backend_error (function)">

--- a/docs/fern/pages/reference/components/tls-configuration.mdx
+++ b/docs/fern/pages/reference/components/tls-configuration.mdx
@@ -5,19 +5,20 @@ title: TLS
 subtitle: Encrypt the TCP request/response streams and NATS connections
 ---
 
-Dynamo supports opt-in TLS encryption on the TCP request and response streams
-between frontends and workers. When enabled, both the **request plane**
+Dynamo supports opt-in TLS encryption on the network transports between its
+components: the TCP request and response streams between frontends and workers,
+and connections to NATS. On the TCP transport, both the **request plane**
 (frontend → worker inference requests) and the **response stream** (worker →
 frontend inference output) are encrypted using
 [rustls](https://github.com/rustls/rustls) with the `ring` cryptographic
-provider. When no TLS configuration is provided, these streams operate in
+provider. When no TLS configuration is provided, these transports operate in
 plaintext exactly as before.
 
-The same `DYN_TCP_TLS_*` environment variables apply to both transports — a
-single set of certificates encrypts the frontend↔worker TCP request and
-response streams. This does **not** cover the KV event plane, which is carried
-over ZMQ or NATS Core depending on setup and is a separate transport; those
-paths are not encrypted by this configuration.
+The `DYN_TCP_TLS_*` environment variables encrypt the frontend↔worker TCP
+request and response streams; NATS traffic is encrypted separately via NATS TLS
+(see the NATS TLS section below). The KV event plane is a separate transport:
+when it runs over ZMQ it is **not** encrypted, and when it runs over NATS it is
+encrypted only if NATS TLS is configured.
 
 ## Environment variables
 
@@ -143,8 +144,9 @@ server and client depending on the stream direction.
 
 ## NATS TLS
 
-NATS is used for JetStream indexer recovery/replay and the audit sink. TLS
-is configured separately from TCP:
+NATS carries JetStream indexer recovery/replay, the audit sink, and — when the
+request plane is set to NATS (`--request-plane nats`) — inference request
+distribution. TLS is configured separately from TCP:
 
 | Variable | Description |
 |---|---|
@@ -158,22 +160,25 @@ The `NATS_SERVER` URL accepts both `nats://` and `tls://` schemes.
 
 CLI flags (all backends via `DynamoRuntimeArgGroup`):
 
-```
+```text
 --nats-tls-ca-cert-path PATH   CA certificate for NATS server verification (PEM)
 --nats-tls-insecure             Disable NATS certificate verification
 ```
 
+The frontend (`dynamo.frontend`) also accepts `--nats-tls-ca-cert-path` and
+`--nats-tls-insecure`.
+
 ## Encrypted paths
 
-When TLS is configured, all communication between Dynamo components is
-encrypted:
+When TLS is configured, the following transports are encrypted (the ZMQ event
+plane is not covered):
 
 | Path | Direction | Data | Transport |
 |---|---|---|---|
 | Request plane | Frontend → Worker | User prompts, request metadata | `egress/tcp_client` → `ingress/shared_tcp_endpoint` |
 | Response stream | Worker → Frontend | Inference output tokens | `tcp/client` → `tcp/server` |
 | Request stream | Frontend → Worker | Streaming input (bidirectional) | `tcp/client` → `tcp/server` |
-| NATS | Frontend/Worker ↔ NATS | JetStream recovery, audit logs | `transports/nats` |
+| NATS | Frontend/Worker ↔ NATS | Inference requests (when `--request-plane nats`), JetStream recovery, audit logs | `transports/nats` |
 
 ## Design notes
 

--- a/docs/fern/pages/reference/components/tls-configuration.mdx
+++ b/docs/fern/pages/reference/components/tls-configuration.mdx
@@ -1,8 +1,8 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: TCP TLS
-subtitle: Encrypt the TCP request and response streams between frontend and workers
+title: TLS
+subtitle: Encrypt the TCP request/response streams and NATS connections
 ---
 
 Dynamo supports opt-in TLS encryption on the TCP request and response streams

--- a/docs/fern/pages/reference/components/tls-configuration.mdx
+++ b/docs/fern/pages/reference/components/tls-configuration.mdx
@@ -141,15 +141,39 @@ server and client depending on the stream direction.
 > allowing TLS to be configured once at the platform level and auto-injected
 > into all DGD pods without per-component env var setup.
 
+## NATS TLS
+
+NATS is used for JetStream indexer recovery/replay and the audit sink. TLS
+is configured separately from TCP:
+
+| Variable | Description |
+|---|---|
+| `NATS_TLS_CA_CERT_PATH` | CA certificate to verify the NATS server. When set, a custom TLS config is applied. |
+| `NATS_TLS_INSECURE` | Skip NATS server certificate verification (dev only). |
+
+When only the `tls://` URL scheme is used without explicit TLS env vars,
+async-nats handles TLS natively with system roots.
+
+The `NATS_SERVER` URL accepts both `nats://` and `tls://` schemes.
+
+CLI flags (all backends via `DynamoRuntimeArgGroup`):
+
+```
+--nats-tls-ca-cert-path PATH   CA certificate for NATS server verification (PEM)
+--nats-tls-insecure             Disable NATS certificate verification
+```
+
 ## Encrypted paths
 
-When TLS is configured, the following frontend↔worker streams are encrypted:
+When TLS is configured, all communication between Dynamo components is
+encrypted:
 
 | Path | Direction | Data | Transport |
 |---|---|---|---|
 | Request plane | Frontend → Worker | User prompts, request metadata | `egress/tcp_client` → `ingress/shared_tcp_endpoint` |
 | Response stream | Worker → Frontend | Inference output tokens | `tcp/client` → `tcp/server` |
 | Request stream | Frontend → Worker | Streaming input (bidirectional) | `tcp/client` → `tcp/server` |
+| NATS | Frontend/Worker ↔ NATS | JetStream recovery, audit logs | `transports/nats` |
 
 ## Design notes
 

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -176,6 +176,17 @@ pub mod nats {
         /// Maximum age for messages in NATS stream (in seconds)
         pub const DYN_NATS_STREAM_MAX_AGE: &str = "DYN_NATS_STREAM_MAX_AGE";
     }
+
+    /// NATS TLS configuration
+    pub mod tls {
+        /// Path to the PEM CA certificate used to verify the NATS server's certificate.
+        /// When set, a custom TLS config with this CA is applied to the NATS connection.
+        pub const NATS_TLS_CA_CERT_PATH: &str = "NATS_TLS_CA_CERT_PATH";
+
+        /// Disable TLS certificate verification. Set to a truthy value to skip.
+        /// WARNING: Only for local development. Never use in production.
+        pub const NATS_TLS_INSECURE: &str = "NATS_TLS_INSECURE";
+    }
 }
 
 /// ETCD transport environment variables
@@ -867,6 +878,8 @@ mod tests {
             nats::auth::NATS_AUTH_NKEY,
             nats::auth::NATS_AUTH_CREDENTIALS_FILE,
             nats::stream::DYN_NATS_STREAM_MAX_AGE,
+            nats::tls::NATS_TLS_CA_CERT_PATH,
+            nats::tls::NATS_TLS_INSECURE,
             // ETCD
             etcd::ETCD_ENDPOINTS,
             etcd::ETCD_LEASE_TTL,

--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -16,6 +16,16 @@
 //! - `NATS_AUTH_CREDENTIALS_FILE`: the path to the credentials file
 //!
 //! Note: `NATS_AUTH_USERNAME` and `NATS_AUTH_PASSWORD` must be used together.
+//!
+//! ## TLS
+//!
+//! A custom TLS config is applied when `NATS_TLS_CA_CERT_PATH` is set or
+//! `NATS_TLS_INSECURE` is truthy. When only the `tls://` URL scheme is used
+//! without explicit TLS env vars, async-nats handles TLS natively with system
+//! roots.
+//!
+//! - `NATS_TLS_CA_CERT_PATH`: path to the CA cert PEM used to verify the server
+//! - `NATS_TLS_INSECURE`: set to a truthy value to skip certificate verification (dev only)
 use crate::metrics::MetricsHierarchy;
 use crate::protocols::EndpointId;
 
@@ -280,6 +290,15 @@ pub struct ClientOptions {
 
     #[builder(default)]
     auth: NatsAuth,
+
+    /// Path to PEM CA certificate for TLS. When set, TLS is required and
+    /// `NATS_SERVER` must use the `tls://` scheme.
+    #[builder(default = "default_nats_tls_ca_cert_path()")]
+    tls_ca_cert_path: Option<PathBuf>,
+
+    /// Skip TLS certificate verification. For development only.
+    #[builder(default = "default_nats_tls_insecure()")]
+    tls_insecure: bool,
 }
 
 fn default_server() -> String {
@@ -291,11 +310,23 @@ fn default_server() -> String {
 }
 
 fn validate_nats_server(server: &str) -> Result<(), ValidationError> {
-    if server.starts_with("nats://") {
+    if server.starts_with("nats://") || server.starts_with("tls://") {
         Ok(())
     } else {
-        Err(ValidationError::new("server must start with 'nats://'"))
+        Err(ValidationError::new(
+            "server must start with 'nats://' or 'tls://'",
+        ))
     }
+}
+
+fn default_nats_tls_ca_cert_path() -> Option<PathBuf> {
+    std::env::var(env_nats::tls::NATS_TLS_CA_CERT_PATH)
+        .ok()
+        .map(PathBuf::from)
+}
+
+fn default_nats_tls_insecure() -> bool {
+    crate::config::env_is_truthy(env_nats::tls::NATS_TLS_INSECURE)
 }
 
 // TODO(jthomson04): We really shouldn't be hardcoding this.
@@ -311,7 +342,21 @@ impl ClientOptions {
     pub async fn connect(self) -> Result<Client> {
         self.validate()?;
 
-        let client = match self.auth {
+        let custom_tls = self.tls_ca_cert_path.is_some() || self.tls_insecure;
+        let tls_url = self.server.starts_with("tls://");
+
+        // Custom TLS settings imply an encrypted connection, so the server URL
+        // must use the tls:// scheme. Reject the mismatch up front with a clear
+        // error instead of silently forcing TLS onto a nats:// URL.
+        if custom_tls && !tls_url {
+            anyhow::bail!(
+                "NATS TLS is configured (NATS_TLS_CA_CERT_PATH or NATS_TLS_INSECURE) but \
+                 NATS_SERVER does not use the 'tls://' scheme: {}",
+                self.server
+            );
+        }
+
+        let mut options = match self.auth {
             NatsAuth::UserPass(username, password) => {
                 async_nats::ConnectOptions::with_user_and_password(username, password)
             }
@@ -322,20 +367,48 @@ impl ClientOptions {
             }
         };
 
+        // Install the ring crypto provider as the process-level default, but
+        // only when this connection actually uses TLS. async-nats calls
+        // ClientConfig::builder() internally for a tls:// URL and panics if no
+        // provider is installed; both ring and aws-lc-rs are compiled in (via
+        // async-nats and kube respectively), so rustls 0.23 cannot auto-detect.
+        // Gating on TLS avoids clobbering another component's provider choice
+        // (e.g. the HTTPS frontend's aws-lc-rs) for plaintext nats:// use.
+        // Silently ignored if a provider is already installed.
+        if custom_tls || tls_url {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        }
+
+        // Apply a custom TLS config when a CA cert or insecure mode is explicitly
+        // configured. When only a tls:// URL is used without explicit TLS env vars,
+        // let async-nats handle TLS natively (it uses its own rustls setup with
+        // system roots).
+        if custom_tls {
+            let tls_config = crate::tls_utils::client_tls_config(
+                self.tls_ca_cert_path.as_deref(),
+                self.tls_insecure,
+            )?;
+            options = options.tls_client_config(tls_config).require_tls(true);
+        } else if tls_url {
+            // tls:// URL implies TLS but no custom CA — async-nats will use its
+            // built-in rustls with system roots. Just require TLS on the connection.
+            options = options.require_tls(true);
+        }
+
         // 0 is treated as unset — Duration::from_secs(0) would time out every request immediately.
         let request_timeout = std::env::var(env_nats::DYN_NATS_REQUEST_TIMEOUT_SECS)
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .filter(|&secs| secs > 0)
             .map(time::Duration::from_secs);
-        let client = match request_timeout {
-            Some(timeout) => client.request_timeout(Some(timeout)),
-            None => client,
+        let options = match request_timeout {
+            Some(timeout) => options.request_timeout(Some(timeout)),
+            None => options,
         };
 
         let (client, _) = build_in_runtime(
             async move {
-                client
+                options
                     .connect(self.server)
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to connect to NATS: {e}. Verify NATS server is running and accessible."))
@@ -355,6 +428,8 @@ impl Default for ClientOptions {
         ClientOptions {
             server: default_server(),
             auth: NatsAuth::default(),
+            tls_ca_cert_path: default_nats_tls_ca_cert_path(),
+            tls_insecure: default_nats_tls_insecure(),
         }
     }
 }
@@ -943,6 +1018,94 @@ mod tests {
 
             Ok(())
         });
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn test_client_options_tls_url_validation() {
+        // tls:// is accepted by the validator
+        assert!(validate_nats_server("tls://nats:4222").is_ok());
+        assert!(validate_nats_server("nats://nats:4222").is_ok());
+        assert!(validate_nats_server("tcp://nats:4222").is_err());
+        assert!(validate_nats_server("http://nats:4222").is_err());
+
+        // tls:// URL is preserved in options
+        Jail::expect_with(|jail| {
+            jail.set_env(env_nats::NATS_SERVER, "tls://nats:4222");
+            let opts = ClientOptions::builder().build().unwrap();
+            assert_eq!(opts.server, "tls://nats:4222");
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn test_client_options_tls_ca_from_env() {
+        Jail::expect_with(|jail| {
+            jail.set_env(env_nats::NATS_SERVER, "tls://nats:4222");
+            jail.set_env(env_nats::tls::NATS_TLS_CA_CERT_PATH, "/etc/certs/ca.pem");
+            let opts = ClientOptions::builder().build().unwrap();
+            assert_eq!(
+                opts.tls_ca_cert_path,
+                Some(PathBuf::from("/etc/certs/ca.pem"))
+            );
+            assert!(!opts.tls_insecure);
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn test_client_options_tls_insecure_from_env() {
+        Jail::expect_with(|jail| {
+            jail.set_env(env_nats::NATS_SERVER, "tls://nats:4222");
+            jail.set_env(env_nats::tls::NATS_TLS_INSECURE, "1");
+            let opts = ClientOptions::builder().build().unwrap();
+            assert!(opts.tls_insecure);
+            assert!(opts.tls_ca_cert_path.is_none());
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn test_client_options_no_tls_by_default() {
+        Jail::expect_with(|_jail| {
+            let opts = ClientOptions::builder().build().unwrap();
+            assert!(opts.tls_ca_cert_path.is_none());
+            assert!(!opts.tls_insecure);
+            Ok(())
+        });
+    }
+
+    #[tokio::test]
+    async fn test_connect_rejects_custom_tls_with_nats_url() {
+        // Client is not Debug, so match rather than use unwrap_err/expect_err.
+        fn assert_scheme_error(result: Result<Client>, case: &str) {
+            match result {
+                Ok(_) => panic!("{case}: expected an error, got a connection"),
+                Err(e) => assert!(
+                    e.to_string().contains("tls://"),
+                    "{case}: unexpected error: {e}"
+                ),
+            }
+        }
+
+        // CA cert set but server is nats:// (not tls://) → rejected before connecting.
+        let opts = ClientOptions::builder()
+            .server("nats://localhost:4222".to_string())
+            .tls_ca_cert_path(Some(PathBuf::from("/etc/certs/ca.pem")))
+            .build()
+            .unwrap();
+        assert_scheme_error(opts.connect().await, "nats:// + CA cert");
+
+        // Insecure mode set but server is nats:// → also rejected.
+        let opts = ClientOptions::builder()
+            .server("nats://localhost:4222".to_string())
+            .tls_insecure(true)
+            .build()
+            .unwrap();
+        assert_scheme_error(opts.connect().await, "nats:// + insecure");
     }
 
     // Integration test for object store data operations using bincode


### PR DESCRIPTION
> **Tracking issue:** #10809 — [CONTRIBUTION]: Add opt-in TLS and mTLS support to NATS and TCP transports.
> Part of the TLS stack: #10921 (TCP response streams, merged) → #12533 (TCP request plane, merged) → **this PR** (NATS) → mTLS → operator injection.

## What

Adds opt-in TLS for Dynamo's **NATS transport** (JetStream indexer recovery/replay + audit sink), continuing the TLS stack after the TCP response streams (#10921) and TCP request plane (#12533).

- New `NATS_TLS_CA_CERT_PATH` / `NATS_TLS_INSECURE` env vars, plus `--nats-tls-ca-cert-path` / `--nats-tls-insecure` CLI flags on all backends via `DynamoRuntimeArgGroup`.
- `NATS_SERVER` now accepts the `tls://` scheme in addition to `nats://`. A `tls://` URL without explicit TLS env vars lets `async-nats` handle TLS natively with system roots; a `NATS_TLS_CA_CERT_PATH` (or insecure mode) applies a custom rustls client config and requires TLS.
- Installs the `ring` crypto provider as the process default so `async-nats` doesn't panic on `CryptoProvider` lookup when it sees a `tls://` URL (both `ring` and `aws-lc-rs` are compiled in transitively, so rustls 0.23 can't auto-detect).
- Docs: generalizes the TLS page (title `TCP TLS` → `TLS`, intro now covers all transports), adds a **NATS TLS** section, and clarifies the KV/ZMQ event-plane boundary.

## Notes on cert handling

Dynamo is a NATS **client** here: it verifies the NATS server against `NATS_TLS_CA_CERT_PATH` and presents **no client identity** (`with_no_client_auth`). So the server-cert hot-reload from #12533 doesn't apply to this path — there's no served leaf cert to rotate. The CA trust anchor is loaded once (rotating the CA requires a restart, same as the TCP client). Client-identity certs (and their reload) arrive with the upcoming NATS/TCP mTLS PR.

## Testing

`cargo test -p dynamo-runtime --lib nats` — 8 pass (2 ignored; they require a live NATS server). `cargo fmt --check` and `cargo build -p dynamo-runtime` clean.

Part of #10809.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TLS encryption support for NATS connections using `tls://` URLs.
  * Added options for custom CA certificates and disabling certificate verification when needed.
  * Added runtime and environment configuration for NATS TLS settings.

* **Documentation**
  * Expanded TLS guidance to cover NATS connections, TCP streams, supported URL schemes, configuration options, and encrypted event-plane paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->