### PR TITLE
docs: fix broken TensorRT-LLM recipe link

### DIFF
--- a/docs/fern/pages/developer-guide/additional-resources/tensorrt-llm-details/multinode-examples.md
+++ b/docs/fern/pages/developer-guide/additional-resources/tensorrt-llm-details/multinode-examples.md
@@ -20,7 +20,7 @@ The main TRT-LLM recipe entrypoints are:
 - [Qwen3-235B-A22B-FP8 aggregated, Hopper](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/deploy.yaml)
 - [Qwen3-235B-A22B-FP8 aggregated, Blackwell](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/deploy.yaml)
 - [Qwen3-235B-A22B-FP8 disaggregated, Hopper](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml)
-- [Qwen3-235B-A22B-FP8 disaggregated, Blackwell](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy.yaml)
+- [Qwen3-235B-A22B-FP8 disaggregated, Blackwell](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-generic.yaml)
 - [Qwen3-32B-FP8 aggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml)
 - [Qwen3-32B-FP8 disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml)
 - [GPT-OSS-120B aggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml)


### PR DESCRIPTION
## Summary

Fix the Qwen3-235B-A22B-FP8 disaggregated Blackwell recipe link that caused a 404 in the docs link check.

Closes #13104.

## Validation

- Confirmed the target manifest exists
- Confirmed the GitHub URL returns HTTP 200
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Qwen3-235B-A22B-FP8 disaggregated Blackwell recipe reference to use the generic deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->