### PR TITLE
test: create parent basetemp root before spawning GPU-parallel children

### DIFF
--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -577,6 +577,10 @@ def run_parallel(
         test.w_id = idx
 
     os.makedirs(_JUNIT_DIR, exist_ok=True)
+    # Children mkdir their nested --basetemp non-recursively, so the root
+    # has to exist first.
+    if parent_basetemp:
+        os.makedirs(parent_basetemp, exist_ok=True)
 
     # --- Plan header ---
     n_run = len(tests)


### PR DESCRIPTION
## Summary

`run_parallel` gives each child pytest a nested `--basetemp` of `<parent_basetemp>/w<id>-<test>` ([`pytest_parallel_gpu.py:739`](https://github.com/ai-dynamo/dynamo/blob/main/tests/utils/pytest_parallel_gpu.py#L739)), but nothing ever created `<parent_basetemp>` itself. pytest's `TempPathFactory.getbasetemp()` calls `basetemp.mkdir(mode=0o700)` **without** `parents=True`, so every child whose test touches `tmp_path` / `tmp_path_factory` died at setup:

```
E FileNotFoundError: [Errno 2] No such file or directory:
  '/scratch/pytest_temp/w0-tests_frontend_test_frontend_api_surface_compliance.py__...'
```

The sibling `_JUNIT_DIR` already gets `os.makedirs(..., exist_ok=True)`; `parent_basetemp` was simply missed. This adds the matching call.

This only reproduces in parallel mode. The sequential step (`-n 0`) passes `--basetemp` straight to a single pytest process, which owns that directory and creates it itself — which is why the same nightly job shows zero of these errors sequentially and 5 of 7 failures in parallel.

### Impact

7 failures across all three H100 nightly jobs in [run 31578523985](https://github.com/ai-dynamo/dynamo/actions/runs/31578523985), and the same set in the Aug 11 nightly — deterministic, not flake:

| Job | Tests |
|---|---|
| vLLM | `test_token_budget_parity[vllm-default]`, `test_rl_worker_discovery_and_engine_admin_routes`, `test_vllm_prepost_integration` (×2), `test_self_benchmark_agg_serves_after_bench` |
| SGLang | `test_frontend_api_surface_compliance`, `test_token_budget_parity[sglang-default]`, `[sglang-auto-truncate]` |
| TRT-LLM | `test_token_budget_parity[trtllm-default]` |

## Validation

Reproduced the exact CI signature locally against the same pytest code path — a nested `--basetemp` whose parent does not exist:

```
$ pytest repro_test.py --basetemp=/tmp/scratch/pytest_temp/w0-repro
/usr/lib/python3.12/pathlib.py:1313: FileNotFoundError
1 failed in 0.02s
```

Same `pathlib.py:1313` frame as the nightly logs. With the parent root pre-created (what this patch does):

```
1 passed in 0.00s
```

Also confirmed `parent_basetemp` is in scope at the insertion point (it is a `run_parallel` parameter), the module compiles, and `ruff` reports no new findings — the two it flags are pre-existing at lines 41 and 235.

Not fixed here (separate root causes found in the same nightly, filed for follow-up): TRT-LLM hanging at MPI engine spawn, `CUDA_VISIBLE_DEVICES` pinning a single GPU for `gpu_2` tests, SGLang's memory-balance check under GPU sharing, and expired LoRA S3 credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parallel GPU test execution now creates the configured temporary directory automatically when it does not already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->