### PR TITLE
feat(observability): configure S3 trace uploads

### DIFF
--- a/docs/fern/pages/reference/observability/environment-variables.mdx
+++ b/docs/fern/pages/reference/observability/environment-variables.mdx
@@ -340,6 +340,32 @@ See [Forward Pass Metrics Trace Reference](forward-pass-metrics-traces.mdx) for 
   Periodic flush interval for the `s3` sink in milliseconds. A partial batch is uploaded when this elapses so low-volume traces still reach S3.
 </ParamField>
 
+<ParamField path="DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS" type="integer" default="30000">
+  Timeout for one S3 upload attempt in milliseconds. Values must be from `1000` through `90000` and cannot exceed `DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS`.
+</ParamField>
+
+<ParamField path="DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS" type="integer" default="90000">
+  Total timeout for an S3 upload, including retries, in milliseconds. Values must be from `1000` through `300000` and cannot be shorter than `DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS`.
+</ParamField>
+
+<ParamField path="DYN_REQUEST_TRACE_S3_MAX_RETRIES" type="integer" default="2">
+  Number of S3 upload retries after the initial attempt. Values from `0` through `10` are accepted; the default permits three total attempts.
+</ParamField>
+
+<ParamField path="DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS" type="integer" default="100">
+  Initial decorrelated-jitter backoff between S3 retries, in milliseconds. Values must be from `10` through `10000`.
+</ParamField>
+
+<ParamField path="DYN_REQUEST_TRACE_S3_RETRY_MAX_BACKOFF_MS" type="integer" default="15000">
+  Maximum decorrelated-jitter backoff between S3 retries, in milliseconds. Values must be from `10` through `60000` and cannot be shorter than `DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS`.
+</ParamField>
+
+<ParamField path="DYN_REQUEST_TRACE_S3_RETRY_BACKOFF_BASE" type="number" default="2.0">
+  Decorrelated-jitter backoff multiplier. Values must be from `1.1` through `10.0`.
+</ParamField>
+
+Out-of-range values use their defaults. If either maximum duration is shorter than its corresponding attempt or initial duration, Dynamo uses the default maximum duration.
+
 <ParamField path="DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT" type="string">
   Optional ZMQ PULL bind address for harness tool events. Configure it on only one process.
 </ParamField>

--- a/docs/fern/pages/reference/observability/request-traces.mdx
+++ b/docs/fern/pages/reference/observability/request-traces.mdx
@@ -54,7 +54,12 @@ elapses. Object keys are `{prefix}/{yyyy}/{mm}/{dd}/{host}-{HHMMSS}-{run_id}-{se
 earlier batches. Credentials come from the shared object-store client's provider chain (environment
 variables, IMDS, IRSA, and Pod Identity). Shared AWS config and credential profiles are not loaded;
 how the frontend pod is credentialed is a deployment concern. On terminal upload failure the batch
-is dropped and a warning is logged; no on-disk retry queue is kept.
+is dropped and a warning is logged; no on-disk retry queue is kept. The default policy uses a
+30-second timeout per attempt, a 90-second total operation timeout, and two retries after the first
+attempt. Retries use decorrelated jitter with a 100-millisecond initial backoff, 15-second maximum
+backoff, and a multiplier of 2.0. Configure those limits with the
+`DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS`, `DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS`,
+`DYN_REQUEST_TRACE_S3_MAX_RETRIES`, and `DYN_REQUEST_TRACE_S3_RETRY_*` variables.
 
 ```bash
 export DYN_REQUEST_TRACE=1

--- a/lib/llm/src/request_trace/config.rs
+++ b/lib/llm/src/request_trace/config.rs
@@ -118,12 +118,6 @@ pub struct RequestTracePolicy {
     pub s3_prefix: Option<String>,
     pub s3_roll_uncompressed_bytes: u64,
     pub s3_flush_interval_ms: u64,
-    pub s3_attempt_timeout_ms: u64,
-    pub s3_operation_timeout_ms: u64,
-    pub s3_max_retries: usize,
-    pub s3_retry_initial_backoff_ms: u64,
-    pub s3_retry_max_backoff_ms: u64,
-    pub s3_retry_backoff_base: f64,
 }
 
 impl RequestTracePolicy {
@@ -149,10 +143,26 @@ impl RequestTracePolicy {
     }
 }
 
-static POLICY: OnceLock<RequestTracePolicy> = OnceLock::new();
+#[derive(Clone, Debug)]
+pub(super) struct S3UploadPolicy {
+    pub(super) attempt_timeout_ms: u64,
+    pub(super) operation_timeout_ms: u64,
+    pub(super) max_retries: usize,
+    pub(super) retry_initial_backoff_ms: u64,
+    pub(super) retry_max_backoff_ms: u64,
+    pub(super) retry_backoff_base: f64,
+}
+
+#[derive(Clone, Debug)]
+struct RequestTraceRuntimePolicy {
+    policy: RequestTracePolicy,
+    s3_upload: S3UploadPolicy,
+}
+
+static POLICY: OnceLock<RequestTraceRuntimePolicy> = OnceLock::new();
 static CAPTURE_STATE: AtomicU8 = AtomicU8::new(CAPTURE_UNINITIALIZED);
 
-fn load_from_env() -> RequestTracePolicy {
+fn load_runtime_policy_from_env() -> RequestTraceRuntimePolicy {
     let legacy_audit_sinks = env_trimmed(env_audit::DYN_AUDIT_SINKS);
     let request_trace_enabled = env_is_truthy(env_request_trace::DYN_REQUEST_TRACE);
     let audit_force_logging = env_is_truthy(env_audit::DYN_AUDIT_FORCE_LOGGING);
@@ -316,33 +326,37 @@ fn load_from_env() -> RequestTracePolicy {
         MAX_S3_RETRY_BACKOFF_BASE,
     );
 
-    RequestTracePolicy {
-        enabled,
-        records,
-        sinks,
-        file_path,
-        file_format,
-        capacity,
-        file_buffer_bytes,
-        file_flush_interval_ms,
-        file_roll_bytes,
-        file_roll_lines,
-        nats_subject,
-        otel_max_payload_bytes,
-        http_header_capture_list,
-        tool_events_zmq_endpoint,
-        tool_events_zmq_topic,
-        s3_bucket,
-        s3_region,
-        s3_prefix,
-        s3_roll_uncompressed_bytes,
-        s3_flush_interval_ms,
-        s3_attempt_timeout_ms,
-        s3_operation_timeout_ms,
-        s3_max_retries,
-        s3_retry_initial_backoff_ms,
-        s3_retry_max_backoff_ms,
-        s3_retry_backoff_base,
+    RequestTraceRuntimePolicy {
+        policy: RequestTracePolicy {
+            enabled,
+            records,
+            sinks,
+            file_path,
+            file_format,
+            capacity,
+            file_buffer_bytes,
+            file_flush_interval_ms,
+            file_roll_bytes,
+            file_roll_lines,
+            nats_subject,
+            otel_max_payload_bytes,
+            http_header_capture_list,
+            tool_events_zmq_endpoint,
+            tool_events_zmq_topic,
+            s3_bucket,
+            s3_region,
+            s3_prefix,
+            s3_roll_uncompressed_bytes,
+            s3_flush_interval_ms,
+        },
+        s3_upload: S3UploadPolicy {
+            attempt_timeout_ms: s3_attempt_timeout_ms,
+            operation_timeout_ms: s3_operation_timeout_ms,
+            max_retries: s3_max_retries,
+            retry_initial_backoff_ms: s3_retry_initial_backoff_ms,
+            retry_max_backoff_ms: s3_retry_max_backoff_ms,
+            retry_backoff_base: s3_retry_backoff_base,
+        },
     }
 }
 
@@ -550,8 +564,20 @@ fn parse_file_format(value: &str) -> RequestTraceFileFormat {
     }
 }
 
+#[cfg(test)]
+fn load_from_env() -> RequestTracePolicy {
+    load_runtime_policy_from_env().policy
+}
+
 pub fn policy() -> &'static RequestTracePolicy {
-    POLICY.get_or_init(load_from_env)
+    &POLICY.get_or_init(load_runtime_policy_from_env).policy
+}
+
+pub(super) fn s3_upload_policy() -> S3UploadPolicy {
+    POLICY
+        .get_or_init(load_runtime_policy_from_env)
+        .s3_upload
+        .clone()
 }
 
 pub fn is_enabled() -> bool {
@@ -667,22 +693,22 @@ mod tests {
     #[serial_test::serial]
     fn s3_upload_policy_defaults_preserve_existing_behavior() {
         with_request_trace_env(&[], || {
-            let policy = load_from_env();
-            assert_eq!(policy.s3_attempt_timeout_ms, DEFAULT_S3_ATTEMPT_TIMEOUT_MS);
+            let s3_upload = load_runtime_policy_from_env().s3_upload;
+            assert_eq!(s3_upload.attempt_timeout_ms, DEFAULT_S3_ATTEMPT_TIMEOUT_MS);
             assert_eq!(
-                policy.s3_operation_timeout_ms,
+                s3_upload.operation_timeout_ms,
                 DEFAULT_S3_OPERATION_TIMEOUT_MS
             );
-            assert_eq!(policy.s3_max_retries, DEFAULT_S3_MAX_RETRIES);
+            assert_eq!(s3_upload.max_retries, DEFAULT_S3_MAX_RETRIES);
             assert_eq!(
-                policy.s3_retry_initial_backoff_ms,
+                s3_upload.retry_initial_backoff_ms,
                 DEFAULT_S3_RETRY_INITIAL_BACKOFF_MS
             );
             assert_eq!(
-                policy.s3_retry_max_backoff_ms,
+                s3_upload.retry_max_backoff_ms,
                 DEFAULT_S3_RETRY_MAX_BACKOFF_MS
             );
-            assert_eq!(policy.s3_retry_backoff_base, DEFAULT_S3_RETRY_BACKOFF_BASE);
+            assert_eq!(s3_upload.retry_backoff_base, DEFAULT_S3_RETRY_BACKOFF_BASE);
         });
     }
 
@@ -714,13 +740,13 @@ mod tests {
                 ),
             ],
             || {
-                let policy = load_from_env();
-                assert_eq!(policy.s3_attempt_timeout_ms, 5_000);
-                assert_eq!(policy.s3_operation_timeout_ms, 12_000);
-                assert_eq!(policy.s3_max_retries, 0);
-                assert_eq!(policy.s3_retry_initial_backoff_ms, 250);
-                assert_eq!(policy.s3_retry_max_backoff_ms, 5_000);
-                assert_eq!(policy.s3_retry_backoff_base, 3.5);
+                let s3_upload = load_runtime_policy_from_env().s3_upload;
+                assert_eq!(s3_upload.attempt_timeout_ms, 5_000);
+                assert_eq!(s3_upload.operation_timeout_ms, 12_000);
+                assert_eq!(s3_upload.max_retries, 0);
+                assert_eq!(s3_upload.retry_initial_backoff_ms, 250);
+                assert_eq!(s3_upload.retry_max_backoff_ms, 5_000);
+                assert_eq!(s3_upload.retry_backoff_base, 3.5);
             },
         );
     }
@@ -753,22 +779,22 @@ mod tests {
                 ),
             ],
             || {
-                let policy = load_from_env();
-                assert_eq!(policy.s3_attempt_timeout_ms, DEFAULT_S3_ATTEMPT_TIMEOUT_MS);
+                let s3_upload = load_runtime_policy_from_env().s3_upload;
+                assert_eq!(s3_upload.attempt_timeout_ms, DEFAULT_S3_ATTEMPT_TIMEOUT_MS);
                 assert_eq!(
-                    policy.s3_operation_timeout_ms,
+                    s3_upload.operation_timeout_ms,
                     DEFAULT_S3_OPERATION_TIMEOUT_MS
                 );
-                assert_eq!(policy.s3_max_retries, DEFAULT_S3_MAX_RETRIES);
+                assert_eq!(s3_upload.max_retries, DEFAULT_S3_MAX_RETRIES);
                 assert_eq!(
-                    policy.s3_retry_initial_backoff_ms,
+                    s3_upload.retry_initial_backoff_ms,
                     DEFAULT_S3_RETRY_INITIAL_BACKOFF_MS
                 );
                 assert_eq!(
-                    policy.s3_retry_max_backoff_ms,
+                    s3_upload.retry_max_backoff_ms,
                     DEFAULT_S3_RETRY_MAX_BACKOFF_MS
                 );
-                assert_eq!(policy.s3_retry_backoff_base, DEFAULT_S3_RETRY_BACKOFF_BASE);
+                assert_eq!(s3_upload.retry_backoff_base, DEFAULT_S3_RETRY_BACKOFF_BASE);
             },
         );
 
@@ -792,15 +818,15 @@ mod tests {
                 ),
             ],
             || {
-                let policy = load_from_env();
-                assert_eq!(policy.s3_attempt_timeout_ms, 5_000);
+                let s3_upload = load_runtime_policy_from_env().s3_upload;
+                assert_eq!(s3_upload.attempt_timeout_ms, 5_000);
                 assert_eq!(
-                    policy.s3_operation_timeout_ms,
+                    s3_upload.operation_timeout_ms,
                     DEFAULT_S3_OPERATION_TIMEOUT_MS
                 );
-                assert_eq!(policy.s3_retry_initial_backoff_ms, 5_000);
+                assert_eq!(s3_upload.retry_initial_backoff_ms, 5_000);
                 assert_eq!(
-                    policy.s3_retry_max_backoff_ms,
+                    s3_upload.retry_max_backoff_ms,
                     DEFAULT_S3_RETRY_MAX_BACKOFF_MS
                 );
             },

--- a/lib/llm/src/request_trace/config.rs
+++ b/lib/llm/src/request_trace/config.rs
@@ -23,6 +23,21 @@ const DEFAULT_LEGACY_AUDIT_NATS_SUBJECT: &str = "dynamo.audit.v1";
 const DEFAULT_OTEL_MAX_PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
 const DEFAULT_S3_ROLL_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
 const DEFAULT_S3_FLUSH_INTERVAL_MS: u64 = 10_000;
+const DEFAULT_S3_ATTEMPT_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_S3_OPERATION_TIMEOUT_MS: u64 = 90_000;
+const DEFAULT_S3_MAX_RETRIES: usize = 2;
+const DEFAULT_S3_RETRY_INITIAL_BACKOFF_MS: u64 = 100;
+const DEFAULT_S3_RETRY_MAX_BACKOFF_MS: u64 = 15_000;
+const DEFAULT_S3_RETRY_BACKOFF_BASE: f64 = 2.0;
+const MIN_S3_TIMEOUT_MS: u64 = 1_000;
+const MAX_S3_ATTEMPT_TIMEOUT_MS: u64 = 90_000;
+const MAX_S3_OPERATION_TIMEOUT_MS: u64 = 300_000;
+const MAX_S3_RETRIES: usize = 10;
+const MIN_S3_RETRY_BACKOFF_MS: u64 = 10;
+const MAX_S3_RETRY_INITIAL_BACKOFF_MS: u64 = 10_000;
+const MAX_S3_RETRY_MAX_BACKOFF_MS: u64 = 60_000;
+const MIN_S3_RETRY_BACKOFF_BASE: f64 = 1.1;
+const MAX_S3_RETRY_BACKOFF_BASE: f64 = 10.0;
 
 const CAPTURE_UNINITIALIZED: u8 = 0;
 const CAPTURE_ACTIVE: u8 = 1;
@@ -103,6 +118,12 @@ pub struct RequestTracePolicy {
     pub s3_prefix: Option<String>,
     pub s3_roll_uncompressed_bytes: u64,
     pub s3_flush_interval_ms: u64,
+    pub s3_attempt_timeout_ms: u64,
+    pub s3_operation_timeout_ms: u64,
+    pub s3_max_retries: usize,
+    pub s3_retry_initial_backoff_ms: u64,
+    pub s3_retry_max_backoff_ms: u64,
+    pub s3_retry_backoff_base: f64,
 }
 
 impl RequestTracePolicy {
@@ -234,6 +255,66 @@ fn load_from_env() -> RequestTracePolicy {
         env_u64(&[env_request_trace::DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS])
             .filter(|value| *value > 0)
             .unwrap_or(DEFAULT_S3_FLUSH_INTERVAL_MS);
+    let s3_attempt_timeout_ms = env_bounded_u64(
+        env_request_trace::DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS,
+        DEFAULT_S3_ATTEMPT_TIMEOUT_MS,
+        MIN_S3_TIMEOUT_MS,
+        MAX_S3_ATTEMPT_TIMEOUT_MS,
+    );
+    let configured_s3_operation_timeout_ms = env_bounded_u64(
+        env_request_trace::DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS,
+        DEFAULT_S3_OPERATION_TIMEOUT_MS,
+        MIN_S3_TIMEOUT_MS,
+        MAX_S3_OPERATION_TIMEOUT_MS,
+    );
+    let s3_operation_timeout_ms = if configured_s3_operation_timeout_ms < s3_attempt_timeout_ms {
+        tracing::warn!(
+            attempt_timeout_ms = s3_attempt_timeout_ms,
+            operation_timeout_ms = configured_s3_operation_timeout_ms,
+            default_operation_timeout_ms = DEFAULT_S3_OPERATION_TIMEOUT_MS,
+            "request trace: S3 operation timeout must not be shorter than the attempt timeout; using default"
+        );
+        DEFAULT_S3_OPERATION_TIMEOUT_MS
+    } else {
+        configured_s3_operation_timeout_ms
+    };
+    let s3_max_retries = env_bounded_usize(
+        env_request_trace::DYN_REQUEST_TRACE_S3_MAX_RETRIES,
+        DEFAULT_S3_MAX_RETRIES,
+        0,
+        MAX_S3_RETRIES,
+    );
+    let s3_retry_initial_backoff_ms = env_bounded_u64(
+        env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS,
+        DEFAULT_S3_RETRY_INITIAL_BACKOFF_MS,
+        MIN_S3_RETRY_BACKOFF_MS,
+        MAX_S3_RETRY_INITIAL_BACKOFF_MS,
+    );
+    let configured_s3_retry_max_backoff_ms = env_bounded_u64(
+        env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_MAX_BACKOFF_MS,
+        DEFAULT_S3_RETRY_MAX_BACKOFF_MS,
+        MIN_S3_RETRY_BACKOFF_MS,
+        MAX_S3_RETRY_MAX_BACKOFF_MS,
+    );
+    let s3_retry_max_backoff_ms = if configured_s3_retry_max_backoff_ms
+        < s3_retry_initial_backoff_ms
+    {
+        tracing::warn!(
+            initial_backoff_ms = s3_retry_initial_backoff_ms,
+            max_backoff_ms = configured_s3_retry_max_backoff_ms,
+            default_max_backoff_ms = DEFAULT_S3_RETRY_MAX_BACKOFF_MS,
+            "request trace: S3 retry maximum backoff must not be shorter than the initial backoff; using default"
+        );
+        DEFAULT_S3_RETRY_MAX_BACKOFF_MS
+    } else {
+        configured_s3_retry_max_backoff_ms
+    };
+    let s3_retry_backoff_base = env_bounded_f64(
+        env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_BACKOFF_BASE,
+        DEFAULT_S3_RETRY_BACKOFF_BASE,
+        MIN_S3_RETRY_BACKOFF_BASE,
+        MAX_S3_RETRY_BACKOFF_BASE,
+    );
 
     RequestTracePolicy {
         enabled,
@@ -256,6 +337,12 @@ fn load_from_env() -> RequestTracePolicy {
         s3_prefix,
         s3_roll_uncompressed_bytes,
         s3_flush_interval_ms,
+        s3_attempt_timeout_ms,
+        s3_operation_timeout_ms,
+        s3_max_retries,
+        s3_retry_initial_backoff_ms,
+        s3_retry_max_backoff_ms,
+        s3_retry_backoff_base,
     }
 }
 
@@ -392,6 +479,63 @@ fn env_u64(names: &[&str]) -> Option<u64> {
     })
 }
 
+fn env_bounded_u64(name: &str, default: u64, min: u64, max: u64) -> u64 {
+    let Some(raw) = env_trimmed(name) else {
+        return default;
+    };
+    match raw.parse::<u64>() {
+        Ok(value) if (min..=max).contains(&value) => value,
+        _ => {
+            tracing::warn!(
+                env = name,
+                min,
+                max,
+                default,
+                "request trace: invalid bounded S3 configuration; using default"
+            );
+            default
+        }
+    }
+}
+
+fn env_bounded_usize(name: &str, default: usize, min: usize, max: usize) -> usize {
+    let Some(raw) = env_trimmed(name) else {
+        return default;
+    };
+    match raw.parse::<usize>() {
+        Ok(value) if (min..=max).contains(&value) => value,
+        _ => {
+            tracing::warn!(
+                env = name,
+                min,
+                max,
+                default,
+                "request trace: invalid bounded S3 configuration; using default"
+            );
+            default
+        }
+    }
+}
+
+fn env_bounded_f64(name: &str, default: f64, min: f64, max: f64) -> f64 {
+    let Some(raw) = env_trimmed(name) else {
+        return default;
+    };
+    match raw.parse::<f64>() {
+        Ok(value) if value.is_finite() && (min..=max).contains(&value) => value,
+        _ => {
+            tracing::warn!(
+                env = name,
+                min,
+                max,
+                default,
+                "request trace: invalid bounded S3 configuration; using default"
+            );
+            default
+        }
+    }
+}
+
 fn parse_file_format(value: &str) -> RequestTraceFileFormat {
     match value.trim().to_lowercase().as_str() {
         "jsonl" => RequestTraceFileFormat::Jsonl,
@@ -455,6 +599,12 @@ mod tests {
         env_request_trace::DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT,
         env_request_trace::DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_TOPIC,
         env_request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST,
+        env_request_trace::DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS,
+        env_request_trace::DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS,
+        env_request_trace::DYN_REQUEST_TRACE_S3_MAX_RETRIES,
+        env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS,
+        env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_MAX_BACKOFF_MS,
+        env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_BACKOFF_BASE,
         env_audit::DYN_AUDIT_SINKS,
         env_audit::DYN_AUDIT_FORCE_LOGGING,
         env_audit::DYN_AUDIT_CAPACITY,
@@ -511,6 +661,150 @@ mod tests {
                 DEFAULT_OTEL_MAX_PAYLOAD_BYTES
             );
         });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn s3_upload_policy_defaults_preserve_existing_behavior() {
+        with_request_trace_env(&[], || {
+            let policy = load_from_env();
+            assert_eq!(policy.s3_attempt_timeout_ms, DEFAULT_S3_ATTEMPT_TIMEOUT_MS);
+            assert_eq!(
+                policy.s3_operation_timeout_ms,
+                DEFAULT_S3_OPERATION_TIMEOUT_MS
+            );
+            assert_eq!(policy.s3_max_retries, DEFAULT_S3_MAX_RETRIES);
+            assert_eq!(
+                policy.s3_retry_initial_backoff_ms,
+                DEFAULT_S3_RETRY_INITIAL_BACKOFF_MS
+            );
+            assert_eq!(
+                policy.s3_retry_max_backoff_ms,
+                DEFAULT_S3_RETRY_MAX_BACKOFF_MS
+            );
+            assert_eq!(policy.s3_retry_backoff_base, DEFAULT_S3_RETRY_BACKOFF_BASE);
+        });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn s3_upload_policy_accepts_bounded_overrides() {
+        with_request_trace_env(
+            &[
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS,
+                    "5000",
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS,
+                    "12000",
+                ),
+                (env_request_trace::DYN_REQUEST_TRACE_S3_MAX_RETRIES, "0"),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS,
+                    "250",
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_MAX_BACKOFF_MS,
+                    "5000",
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_BACKOFF_BASE,
+                    "3.5",
+                ),
+            ],
+            || {
+                let policy = load_from_env();
+                assert_eq!(policy.s3_attempt_timeout_ms, 5_000);
+                assert_eq!(policy.s3_operation_timeout_ms, 12_000);
+                assert_eq!(policy.s3_max_retries, 0);
+                assert_eq!(policy.s3_retry_initial_backoff_ms, 250);
+                assert_eq!(policy.s3_retry_max_backoff_ms, 5_000);
+                assert_eq!(policy.s3_retry_backoff_base, 3.5);
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn s3_upload_policy_rejects_out_of_range_or_incompatible_values() {
+        with_request_trace_env(
+            &[
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS,
+                    "999",
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS,
+                    "300001",
+                ),
+                (env_request_trace::DYN_REQUEST_TRACE_S3_MAX_RETRIES, "11"),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS,
+                    "9",
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_MAX_BACKOFF_MS,
+                    "60001",
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_BACKOFF_BASE,
+                    "1.0",
+                ),
+            ],
+            || {
+                let policy = load_from_env();
+                assert_eq!(policy.s3_attempt_timeout_ms, DEFAULT_S3_ATTEMPT_TIMEOUT_MS);
+                assert_eq!(
+                    policy.s3_operation_timeout_ms,
+                    DEFAULT_S3_OPERATION_TIMEOUT_MS
+                );
+                assert_eq!(policy.s3_max_retries, DEFAULT_S3_MAX_RETRIES);
+                assert_eq!(
+                    policy.s3_retry_initial_backoff_ms,
+                    DEFAULT_S3_RETRY_INITIAL_BACKOFF_MS
+                );
+                assert_eq!(
+                    policy.s3_retry_max_backoff_ms,
+                    DEFAULT_S3_RETRY_MAX_BACKOFF_MS
+                );
+                assert_eq!(policy.s3_retry_backoff_base, DEFAULT_S3_RETRY_BACKOFF_BASE);
+            },
+        );
+
+        with_request_trace_env(
+            &[
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS,
+                    "5000",
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS,
+                    "4999",
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS,
+                    "5000",
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_MAX_BACKOFF_MS,
+                    "4999",
+                ),
+            ],
+            || {
+                let policy = load_from_env();
+                assert_eq!(policy.s3_attempt_timeout_ms, 5_000);
+                assert_eq!(
+                    policy.s3_operation_timeout_ms,
+                    DEFAULT_S3_OPERATION_TIMEOUT_MS
+                );
+                assert_eq!(policy.s3_retry_initial_backoff_ms, 5_000);
+                assert_eq!(
+                    policy.s3_retry_max_backoff_ms,
+                    DEFAULT_S3_RETRY_MAX_BACKOFF_MS
+                );
+            },
+        );
     }
 
     #[test]

--- a/lib/llm/src/request_trace/config.rs
+++ b/lib/llm/src/request_trace/config.rs
@@ -23,20 +23,35 @@ const DEFAULT_LEGACY_AUDIT_NATS_SUBJECT: &str = "dynamo.audit.v1";
 const DEFAULT_OTEL_MAX_PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
 const DEFAULT_S3_ROLL_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
 const DEFAULT_S3_FLUSH_INTERVAL_MS: u64 = 10_000;
+#[cfg(feature = "request-trace-s3")]
 const DEFAULT_S3_ATTEMPT_TIMEOUT_MS: u64 = 30_000;
+#[cfg(feature = "request-trace-s3")]
 const DEFAULT_S3_OPERATION_TIMEOUT_MS: u64 = 90_000;
+#[cfg(feature = "request-trace-s3")]
 const DEFAULT_S3_MAX_RETRIES: usize = 2;
+#[cfg(feature = "request-trace-s3")]
 const DEFAULT_S3_RETRY_INITIAL_BACKOFF_MS: u64 = 100;
+#[cfg(feature = "request-trace-s3")]
 const DEFAULT_S3_RETRY_MAX_BACKOFF_MS: u64 = 15_000;
+#[cfg(feature = "request-trace-s3")]
 const DEFAULT_S3_RETRY_BACKOFF_BASE: f64 = 2.0;
+#[cfg(feature = "request-trace-s3")]
 const MIN_S3_TIMEOUT_MS: u64 = 1_000;
+#[cfg(feature = "request-trace-s3")]
 const MAX_S3_ATTEMPT_TIMEOUT_MS: u64 = 90_000;
+#[cfg(feature = "request-trace-s3")]
 const MAX_S3_OPERATION_TIMEOUT_MS: u64 = 300_000;
+#[cfg(feature = "request-trace-s3")]
 const MAX_S3_RETRIES: usize = 10;
+#[cfg(feature = "request-trace-s3")]
 const MIN_S3_RETRY_BACKOFF_MS: u64 = 10;
+#[cfg(feature = "request-trace-s3")]
 const MAX_S3_RETRY_INITIAL_BACKOFF_MS: u64 = 10_000;
+#[cfg(feature = "request-trace-s3")]
 const MAX_S3_RETRY_MAX_BACKOFF_MS: u64 = 60_000;
+#[cfg(feature = "request-trace-s3")]
 const MIN_S3_RETRY_BACKOFF_BASE: f64 = 1.1;
+#[cfg(feature = "request-trace-s3")]
 const MAX_S3_RETRY_BACKOFF_BASE: f64 = 10.0;
 
 const CAPTURE_UNINITIALIZED: u8 = 0;
@@ -143,6 +158,7 @@ impl RequestTracePolicy {
     }
 }
 
+#[cfg(feature = "request-trace-s3")]
 #[derive(Clone, Debug)]
 pub(super) struct S3UploadPolicy {
     pub(super) attempt_timeout_ms: u64,
@@ -156,6 +172,7 @@ pub(super) struct S3UploadPolicy {
 #[derive(Clone, Debug)]
 struct RequestTraceRuntimePolicy {
     policy: RequestTracePolicy,
+    #[cfg(feature = "request-trace-s3")]
     s3_upload: S3UploadPolicy,
 }
 
@@ -265,18 +282,21 @@ fn load_runtime_policy_from_env() -> RequestTraceRuntimePolicy {
         env_u64(&[env_request_trace::DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS])
             .filter(|value| *value > 0)
             .unwrap_or(DEFAULT_S3_FLUSH_INTERVAL_MS);
+    #[cfg(feature = "request-trace-s3")]
     let s3_attempt_timeout_ms = env_bounded_u64(
         env_request_trace::DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS,
         DEFAULT_S3_ATTEMPT_TIMEOUT_MS,
         MIN_S3_TIMEOUT_MS,
         MAX_S3_ATTEMPT_TIMEOUT_MS,
     );
+    #[cfg(feature = "request-trace-s3")]
     let configured_s3_operation_timeout_ms = env_bounded_u64(
         env_request_trace::DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS,
         DEFAULT_S3_OPERATION_TIMEOUT_MS,
         MIN_S3_TIMEOUT_MS,
         MAX_S3_OPERATION_TIMEOUT_MS,
     );
+    #[cfg(feature = "request-trace-s3")]
     let s3_operation_timeout_ms = if configured_s3_operation_timeout_ms < s3_attempt_timeout_ms {
         tracing::warn!(
             attempt_timeout_ms = s3_attempt_timeout_ms,
@@ -288,24 +308,28 @@ fn load_runtime_policy_from_env() -> RequestTraceRuntimePolicy {
     } else {
         configured_s3_operation_timeout_ms
     };
+    #[cfg(feature = "request-trace-s3")]
     let s3_max_retries = env_bounded_usize(
         env_request_trace::DYN_REQUEST_TRACE_S3_MAX_RETRIES,
         DEFAULT_S3_MAX_RETRIES,
         0,
         MAX_S3_RETRIES,
     );
+    #[cfg(feature = "request-trace-s3")]
     let s3_retry_initial_backoff_ms = env_bounded_u64(
         env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS,
         DEFAULT_S3_RETRY_INITIAL_BACKOFF_MS,
         MIN_S3_RETRY_BACKOFF_MS,
         MAX_S3_RETRY_INITIAL_BACKOFF_MS,
     );
+    #[cfg(feature = "request-trace-s3")]
     let configured_s3_retry_max_backoff_ms = env_bounded_u64(
         env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_MAX_BACKOFF_MS,
         DEFAULT_S3_RETRY_MAX_BACKOFF_MS,
         MIN_S3_RETRY_BACKOFF_MS,
         MAX_S3_RETRY_MAX_BACKOFF_MS,
     );
+    #[cfg(feature = "request-trace-s3")]
     let s3_retry_max_backoff_ms = if configured_s3_retry_max_backoff_ms
         < s3_retry_initial_backoff_ms
     {
@@ -319,6 +343,7 @@ fn load_runtime_policy_from_env() -> RequestTraceRuntimePolicy {
     } else {
         configured_s3_retry_max_backoff_ms
     };
+    #[cfg(feature = "request-trace-s3")]
     let s3_retry_backoff_base = env_bounded_f64(
         env_request_trace::DYN_REQUEST_TRACE_S3_RETRY_BACKOFF_BASE,
         DEFAULT_S3_RETRY_BACKOFF_BASE,
@@ -349,6 +374,7 @@ fn load_runtime_policy_from_env() -> RequestTraceRuntimePolicy {
             s3_roll_uncompressed_bytes,
             s3_flush_interval_ms,
         },
+        #[cfg(feature = "request-trace-s3")]
         s3_upload: S3UploadPolicy {
             attempt_timeout_ms: s3_attempt_timeout_ms,
             operation_timeout_ms: s3_operation_timeout_ms,
@@ -493,6 +519,7 @@ fn env_u64(names: &[&str]) -> Option<u64> {
     })
 }
 
+#[cfg(feature = "request-trace-s3")]
 fn env_bounded_u64(name: &str, default: u64, min: u64, max: u64) -> u64 {
     let Some(raw) = env_trimmed(name) else {
         return default;
@@ -512,6 +539,7 @@ fn env_bounded_u64(name: &str, default: u64, min: u64, max: u64) -> u64 {
     }
 }
 
+#[cfg(feature = "request-trace-s3")]
 fn env_bounded_usize(name: &str, default: usize, min: usize, max: usize) -> usize {
     let Some(raw) = env_trimmed(name) else {
         return default;
@@ -531,6 +559,7 @@ fn env_bounded_usize(name: &str, default: usize, min: usize, max: usize) -> usiz
     }
 }
 
+#[cfg(feature = "request-trace-s3")]
 fn env_bounded_f64(name: &str, default: f64, min: f64, max: f64) -> f64 {
     let Some(raw) = env_trimmed(name) else {
         return default;
@@ -573,6 +602,7 @@ pub fn policy() -> &'static RequestTracePolicy {
     &POLICY.get_or_init(load_runtime_policy_from_env).policy
 }
 
+#[cfg(feature = "request-trace-s3")]
 pub(super) fn s3_upload_policy() -> S3UploadPolicy {
     POLICY
         .get_or_init(load_runtime_policy_from_env)
@@ -690,6 +720,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "request-trace-s3")]
     #[serial_test::serial]
     fn s3_upload_policy_defaults_preserve_existing_behavior() {
         with_request_trace_env(&[], || {
@@ -713,6 +744,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "request-trace-s3")]
     #[serial_test::serial]
     fn s3_upload_policy_accepts_bounded_overrides() {
         with_request_trace_env(
@@ -752,6 +784,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "request-trace-s3")]
     #[serial_test::serial]
     fn s3_upload_policy_rejects_out_of_range_or_incompatible_values() {
         with_request_trace_env(

--- a/lib/llm/src/request_trace/s3_sink.rs
+++ b/lib/llm/src/request_trace/s3_sink.rs
@@ -34,7 +34,7 @@ use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 use flate2::{Compression, write::GzEncoder};
 use object_store::{
-    Attribute, Attributes, ClientConfigKey, ObjectStore, RetryConfig,
+    Attribute, Attributes, BackoffConfig, ClientConfigKey, ObjectStore, RetryConfig,
     aws::{AmazonS3Builder, AmazonS3ConfigKey},
     path::Path as ObjectPath,
 };
@@ -52,11 +52,9 @@ const CHANNEL_CAPACITY: usize = 2048;
 const DEFAULT_BUFFER_INITIAL_BYTES: usize = 256 * 1024;
 // Bound S3 upload duration so a stalled endpoint or slow network cannot wedge
 // the worker task indefinitely. `attempt_timeout` covers a single HTTP attempt;
-// the outer timeout bounds the full call including retries (three total).
-// After the operation timeout expires the batch is discarded with
+// the outer timeout bounds the full call including retries. After the operation
+// timeout expires the batch is discarded with
 // a warning; a persistent retry queue is deferred to a follow-up PR.
-const S3_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(30);
-const S3_OPERATION_TIMEOUT: Duration = Duration::from_secs(90);
 
 pub struct S3RequestTraceSink {
     tx: mpsc::Sender<RequestTraceRecord>,
@@ -78,6 +76,12 @@ struct S3UploadOptions {
     /// overwrite a previous batch, and two frontends sharing a hostname
     /// stay disjoint.
     run_id: String,
+    attempt_timeout: Duration,
+    operation_timeout: Duration,
+    max_retries: usize,
+    retry_initial_backoff: Duration,
+    retry_max_backoff: Duration,
+    retry_backoff_base: f64,
 }
 
 impl S3RequestTraceSink {
@@ -94,21 +98,27 @@ impl S3RequestTraceSink {
         let run_id = Uuid::new_v4().simple().to_string();
         let roll_uncompressed_bytes = policy.s3_roll_uncompressed_bytes;
         let flush_interval = Duration::from_millis(policy.s3_flush_interval_ms.max(1));
+        let upload_options = S3UploadOptions {
+            bucket,
+            prefix,
+            host,
+            run_id,
+            attempt_timeout: Duration::from_millis(policy.s3_attempt_timeout_ms),
+            operation_timeout: Duration::from_millis(policy.s3_operation_timeout_ms),
+            max_retries: policy.s3_max_retries,
+            retry_initial_backoff: Duration::from_millis(policy.s3_retry_initial_backoff_ms),
+            retry_max_backoff: Duration::from_millis(policy.s3_retry_max_backoff_ms),
+            retry_backoff_base: policy.s3_retry_backoff_base,
+        };
 
         let store: Arc<dyn ObjectStore> = Arc::new(
-            request_trace_s3_builder(&bucket, policy.s3_region.as_deref())
+            request_trace_s3_builder(&upload_options, policy.s3_region.as_deref())
                 .build()
                 .context("building request trace S3 client")?,
         );
 
         let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
         let shutdown = CancellationToken::new();
-        let upload_options = S3UploadOptions {
-            bucket,
-            prefix,
-            host,
-            run_id,
-        };
         let worker_shutdown = shutdown.clone();
         let worker = tokio::spawn(async move {
             run_worker(
@@ -338,7 +348,7 @@ impl S3Uploader {
             .with_context(|| format!("invalid request trace S3 object key {key:?}"))?;
         let attributes = Attributes::from_iter([(Attribute::ContentType, "application/gzip")]);
         tokio::time::timeout(
-            S3_OPERATION_TIMEOUT,
+            self.options.operation_timeout,
             self.store
                 .put_opts(&location, body.into(), attributes.into()),
         )
@@ -354,25 +364,32 @@ impl S3Uploader {
     }
 }
 
-fn request_trace_s3_builder(bucket: &str, region: Option<&str>) -> AmazonS3Builder {
-    let retry_config = RetryConfig {
-        max_retries: 2,
-        retry_timeout: S3_OPERATION_TIMEOUT,
-        ..Default::default()
-    };
+fn request_trace_s3_builder(options: &S3UploadOptions, region: Option<&str>) -> AmazonS3Builder {
     let mut builder = AmazonS3Builder::from_env()
-        .with_bucket_name(bucket)
+        .with_bucket_name(&options.bucket)
         .with_config(
             AmazonS3ConfigKey::Client(ClientConfigKey::Timeout),
-            format!("{}s", S3_ATTEMPT_TIMEOUT.as_secs()),
+            format!("{}ms", options.attempt_timeout.as_millis()),
         )
-        .with_retry(retry_config);
+        .with_retry(request_trace_s3_retry_config(options));
     if let Some(region) = region {
         builder = builder.with_region(region);
     } else if let Ok(region) = std::env::var("AWS_REGION") {
         builder = builder.with_region(region);
     }
     builder
+}
+
+fn request_trace_s3_retry_config(options: &S3UploadOptions) -> RetryConfig {
+    RetryConfig {
+        backoff: BackoffConfig {
+            init_backoff: options.retry_initial_backoff,
+            max_backoff: options.retry_max_backoff,
+            base: options.retry_backoff_base,
+        },
+        max_retries: options.max_retries,
+        retry_timeout: options.operation_timeout,
+    }
 }
 
 /// Buffers raw JSONL bytes until the batch is ready to flush; gzip
@@ -576,7 +593,7 @@ mod tests {
                 ("AWS_PROXY_URL", Some("http://proxy.example:8080")),
             ],
             || {
-                let builder = request_trace_s3_builder("b", Some("us-west-2"));
+                let builder = request_trace_s3_builder(&test_options(""), Some("us-west-2"));
                 assert_eq!(
                     builder
                         .get_config_value(&AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp))
@@ -593,6 +610,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn s3_builder_applies_upload_policy() {
+        let mut options = test_options("");
+        options.attempt_timeout = Duration::from_millis(2_500);
+        options.operation_timeout = Duration::from_secs(12);
+        options.max_retries = 4;
+        options.retry_initial_backoff = Duration::from_millis(250);
+        options.retry_max_backoff = Duration::from_secs(5);
+        options.retry_backoff_base = 3.5;
+
+        let builder = request_trace_s3_builder(&options, Some("us-west-2"));
+        assert_eq!(
+            builder
+                .get_config_value(&AmazonS3ConfigKey::Client(ClientConfigKey::Timeout))
+                .as_deref(),
+            Some("2500ms")
+        );
+
+        let retry = request_trace_s3_retry_config(&options);
+        assert_eq!(retry.max_retries, 4);
+        assert_eq!(retry.retry_timeout, Duration::from_secs(12));
+        assert_eq!(retry.backoff.init_backoff, Duration::from_millis(250));
+        assert_eq!(retry.backoff.max_backoff, Duration::from_secs(5));
+        assert_eq!(retry.backoff.base, 3.5);
+    }
+
     fn test_uploader(prefix: &str) -> S3Uploader {
         S3Uploader {
             store: Arc::new(InMemory::new()),
@@ -606,6 +649,12 @@ mod tests {
             prefix: prefix.to_string(),
             host: "frontend-0".to_string(),
             run_id: "cafebabe".to_string(),
+            attempt_timeout: Duration::from_secs(30),
+            operation_timeout: Duration::from_secs(90),
+            max_retries: 2,
+            retry_initial_backoff: Duration::from_millis(100),
+            retry_max_backoff: Duration::from_secs(15),
+            retry_backoff_base: 2.0,
         }
     }
 

--- a/lib/llm/src/request_trace/s3_sink.rs
+++ b/lib/llm/src/request_trace/s3_sink.rs
@@ -45,7 +45,7 @@ use uuid::Uuid;
 use dynamo_runtime::config::environment_names::llm::request_trace as env_request_trace;
 
 use super::RequestTraceRecord;
-use super::config::RequestTracePolicy;
+use super::config::{RequestTracePolicy, s3_upload_policy};
 use super::sink::RequestTraceSink;
 
 const CHANNEL_CAPACITY: usize = 2048;
@@ -98,17 +98,18 @@ impl S3RequestTraceSink {
         let run_id = Uuid::new_v4().simple().to_string();
         let roll_uncompressed_bytes = policy.s3_roll_uncompressed_bytes;
         let flush_interval = Duration::from_millis(policy.s3_flush_interval_ms.max(1));
+        let s3_upload = s3_upload_policy();
         let upload_options = S3UploadOptions {
             bucket,
             prefix,
             host,
             run_id,
-            attempt_timeout: Duration::from_millis(policy.s3_attempt_timeout_ms),
-            operation_timeout: Duration::from_millis(policy.s3_operation_timeout_ms),
-            max_retries: policy.s3_max_retries,
-            retry_initial_backoff: Duration::from_millis(policy.s3_retry_initial_backoff_ms),
-            retry_max_backoff: Duration::from_millis(policy.s3_retry_max_backoff_ms),
-            retry_backoff_base: policy.s3_retry_backoff_base,
+            attempt_timeout: Duration::from_millis(s3_upload.attempt_timeout_ms),
+            operation_timeout: Duration::from_millis(s3_upload.operation_timeout_ms),
+            max_retries: s3_upload.max_retries,
+            retry_initial_backoff: Duration::from_millis(s3_upload.retry_initial_backoff_ms),
+            retry_max_backoff: Duration::from_millis(s3_upload.retry_max_backoff_ms),
+            retry_backoff_base: s3_upload.retry_backoff_base,
         };
 
         let store: Arc<dyn ObjectStore> = Arc::new(
@@ -297,8 +298,8 @@ async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch, 
     let key = uploader.object_key(SystemTime::now(), this_seq);
     let batch_bytes = ready.len();
     if let Err(error) = uploader.put_object(key.clone(), ready).await {
-        // The client exhausted its retries (three total attempts, bounded by
-        // the operation timeout). The batch is dropped here rather
+        // The client exhausted its configured retry limit (bounded by the
+        // operation timeout). The batch is dropped here rather
         // than requeued; a persistent retry buffer is a follow-up concern
         // tracked in the S3 layout PR.
         tracing::warn!(

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -605,6 +605,39 @@ pub mod llm {
         /// still land in S3. Default `10000` (10 s).
         pub const DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS: &str =
             "DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS";
+
+        /// Timeout for one S3 upload attempt in milliseconds. Values must be
+        /// in the inclusive range `1000..=90000`. Default `30000` (30 s).
+        pub const DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS: &str =
+            "DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS";
+
+        /// Total timeout for an S3 upload, including retries, in milliseconds.
+        /// Values must be in the inclusive range `1000..=300000` and must not
+        /// be shorter than `DYN_REQUEST_TRACE_S3_ATTEMPT_TIMEOUT_MS`. Default
+        /// `90000` (90 s).
+        pub const DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS: &str =
+            "DYN_REQUEST_TRACE_S3_OPERATION_TIMEOUT_MS";
+
+        /// Maximum S3 upload retries after the initial attempt. Values must be
+        /// in the inclusive range `0..=10`. Default `2` (three total attempts).
+        pub const DYN_REQUEST_TRACE_S3_MAX_RETRIES: &str = "DYN_REQUEST_TRACE_S3_MAX_RETRIES";
+
+        /// Initial S3 retry backoff in milliseconds. Values must be in the
+        /// inclusive range `10..=10000`. Default `100` (100 ms).
+        pub const DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS: &str =
+            "DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS";
+
+        /// Maximum S3 retry backoff in milliseconds. Values must be in the
+        /// inclusive range `10..=60000` and must not be shorter than
+        /// `DYN_REQUEST_TRACE_S3_RETRY_INITIAL_BACKOFF_MS`. Default `15000`
+        /// (15 s).
+        pub const DYN_REQUEST_TRACE_S3_RETRY_MAX_BACKOFF_MS: &str =
+            "DYN_REQUEST_TRACE_S3_RETRY_MAX_BACKOFF_MS";
+
+        /// Multiplier for the decorrelated-jitter S3 retry backoff. Values must
+        /// be in the inclusive range `1.1..=10.0`. Default `2.0`.
+        pub const DYN_REQUEST_TRACE_S3_RETRY_BACKOFF_BASE: &str =
+            "DYN_REQUEST_TRACE_S3_RETRY_BACKOFF_BASE";
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds bounded environment settings for S3 request-trace upload timeouts and the complete retry policy.
- Preserves current defaults: 30s attempt, 90s operation, two retries, 100ms/15s decorrelated-jitter backoff, multiplier 2.0.
- Documents validation behavior and adds policy plus builder coverage.

## Validation

- `cargo test -p dynamo-llm --no-default-features --features request-trace-s3 request_trace::config::tests -- --nocapture`
- `cargo test -p dynamo-llm --no-default-features --features request-trace-s3 request_trace::s3_sink::tests -- --nocapture`
- `cd docs && fern check && fern docs broken-links`

The broader request-trace run passed 74 tests; an untouched macOS ZMQ relay test timed out.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for S3 request-trace uploads, including per-attempt and total operation timeouts, retry limits, and jittered backoff settings.
  * Invalid or incompatible values now safely fall back to documented defaults with warnings.
  * S3 uploads apply the configured timeout, retry, and backoff policies.

* **Documentation**
  * Documented all new environment variables, accepted ranges, defaults, constraints, and upload retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->