### PR TITLE
feat(observability): expose S3 trace metrics

### DIFF
--- a/docs/fern/pages/reference/observability/request-traces.mdx
+++ b/docs/fern/pages/reference/observability/request-traces.mdx
@@ -15,7 +15,7 @@ one or more sinks. For the capture and replay workflow, see
 | --- | --- | --- | --- |
 | `DYN_REQUEST_TRACE` | unset | Truthy value | Master switch. When enabled and `DYN_REQUEST_TRACE_RECORDS` is unset, emits `request_end,tool`. |
 | `DYN_REQUEST_TRACE_RECORDS` | `request_end,tool` | `request_end`, `request_payload`, `tool` | Comma-separated record types. Setting the variable enables only the listed types. |
-| `DYN_REQUEST_TRACE_SINKS` | `file` | `file`, `stderr`, `nats`, `otel` | Comma-separated sinks. |
+| `DYN_REQUEST_TRACE_SINKS` | `file` | `file`, `stderr`, `nats`, `otel`, `s3` | Comma-separated sinks. |
 | `DYN_REQUEST_TRACE_FILE_PATH` | `/tmp/dynamo-request-trace` | Path or prefix | Literal path for `jsonl`; segment prefix for `jsonl_gz`. |
 | `DYN_REQUEST_TRACE_FILE_FORMAT` | `jsonl_gz` | `jsonl`, `jsonl_gz` | File encoding and rotation mode. |
 | `DYN_REQUEST_TRACE_CAPACITY` | `1024` | Positive integer | Best-effort in-process broadcast capacity. |
@@ -25,6 +25,11 @@ one or more sinks. For the capture and replay workflow, see
 | `DYN_REQUEST_TRACE_FILE_FLUSH_INTERVAL_MS` | `1000` | Integer milliseconds | Periodic file flush interval. |
 | `DYN_REQUEST_TRACE_FILE_ROLL_BYTES` | `268435456` | Positive integer bytes | Gzip roll threshold in uncompressed bytes. |
 | `DYN_REQUEST_TRACE_FILE_ROLL_LINES` | unset | Positive integer records | Optional gzip roll threshold in records. |
+| `DYN_REQUEST_TRACE_S3_BUCKET` | unset | Bucket name | Required when `DYN_REQUEST_TRACE_SINKS` includes `s3`. |
+| `DYN_REQUEST_TRACE_S3_REGION` | unset | Region | Optional S3 region override. |
+| `DYN_REQUEST_TRACE_S3_PREFIX` | unset | Key prefix | Optional prefix for S3 object keys. |
+| `DYN_REQUEST_TRACE_S3_ROLL_UNCOMPRESSED_BYTES` | `67108864` | Positive integer bytes | Uncompressed S3 batch roll threshold. |
+| `DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS` | `10000` | Positive integer milliseconds | Periodic S3 batch flush interval. |
 | `DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT` | unset | ZMQ bind address | Optional PULL endpoint for harness tool events. Configure it on only one process. |
 | `DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_TOPIC` | `agent-tool-events` | ZMQ topic | First-frame topic filter. |
 | `DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST` | unset | Header names | Comma- or whitespace-separated allowlist captured only on `request_payload` rows. Values are unredacted. |
@@ -69,6 +74,58 @@ The `s3` sink is compiled in only when `dynamo-llm` is built with the `request-t
 feature. Shipped Dynamo Python wheels enable it; local source builds pass
 `--features request-trace-s3` to `maturin develop`.
 </Note>
+
+### Prometheus Metrics and Alerts
+
+The HTTP frontend exposes these metrics at its `/metrics` endpoint when Dynamo is built with the
+`request-trace-s3` feature. They describe the S3 sink after request-trace sampling and fan-out. A
+record filtered before the S3 sink is not counted as accepted or dropped here.
+
+| Metric | Type | Description |
+| --- | --- | --- |
+| `dynamo_frontend_request_trace_s3_records_accepted_total` | Counter | Records accepted by the S3 sink queue. |
+| `dynamo_frontend_request_trace_s3_records_dropped_total{reason}` | Counter | Records lost to the bounded sink queue, broadcast lag, serialization, gzip finalization, or a terminal upload failure. `reason` has a fixed value set. |
+| `dynamo_frontend_request_trace_s3_queue_depth` | Gauge | Records in the bounded S3 sink queue. The current capacity is 2048 records. |
+| `dynamo_frontend_request_trace_s3_in_memory_batch_uncompressed_bytes` | Gauge | Bytes in the active in-memory JSONL batch before gzip compression. |
+| `dynamo_frontend_request_trace_s3_oldest_buffered_record_age_seconds` | Gauge | Age of the oldest record in the active in-memory batch. |
+| `dynamo_frontend_request_trace_s3_upload_duration_seconds` | Histogram | Duration of each completed or terminally failed S3 upload. |
+| `dynamo_frontend_request_trace_s3_uploaded_bytes_total` | Counter | Compressed bytes successfully uploaded to S3. |
+| `dynamo_frontend_request_trace_s3_upload_terminal_retry_attempts_total` | Counter | Retry attempts reported by terminal object-store upload errors. The underlying client does not expose retry attempts for uploads that eventually succeed. |
+| `dynamo_frontend_request_trace_s3_upload_terminal_failures_total` | Counter | Batches discarded after the object-store retry policy terminates. |
+
+The S3 sink has no durable disk spool or replay queue. The in-memory byte and age gauges do not
+measure a spool and reset when Dynamo begins to gzip an upload batch. A process crash, forced
+termination, or terminal upload failure can still lose records.
+
+Add rules to the Prometheus deployment that scrapes the frontend. Alert policy and routing remain a
+deployment concern; Dynamo does not install a `PrometheusRule`.
+
+```yaml
+groups:
+  - name: dynamo-request-trace-s3
+    rules:
+      - alert: DynamoRequestTraceS3RecordsDropped
+        expr: increase(dynamo_frontend_request_trace_s3_records_dropped_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Dynamo request-trace records are being dropped before S3 upload
+      - alert: DynamoRequestTraceS3UploadTerminalFailure
+        expr: increase(dynamo_frontend_request_trace_s3_upload_terminal_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Dynamo discarded a request-trace S3 batch after retries
+      - alert: DynamoRequestTraceS3QueueNearCapacity
+        expr: dynamo_frontend_request_trace_s3_queue_depth > 1638
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Dynamo request-trace S3 queue is above 80 percent capacity
+```
 
 ## Record Types
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -29,6 +29,7 @@ use crate::kv_router::metrics::{
 };
 use crate::reasoning_field::ReasoningField;
 use crate::request_template::RequestTemplate;
+use crate::request_trace::register_frontend_metrics;
 use anyhow::Result;
 use axum_server::tls_rustls::RustlsConfig;
 use derive_builder::Builder;
@@ -1167,6 +1168,9 @@ impl HttpServiceConfigBuilder {
         }
         if let Err(e) = register_lora_allocation_metrics(&registry) {
             tracing::warn!("Failed to register LoRA allocation metrics: {}", e);
+        }
+        if let Err(e) = register_frontend_metrics(&registry) {
+            tracing::warn!("Failed to register request-trace metrics: {}", e);
         }
 
         let mut all_docs = Vec::new();

--- a/lib/llm/src/request_trace/mod.rs
+++ b/lib/llm/src/request_trace/mod.rs
@@ -83,6 +83,18 @@ pub async fn init_from_env_with_shutdown(shutdown: CancellationToken) -> anyhow:
     Ok(())
 }
 
+/// Register request-trace metrics on the HTTP frontend's Prometheus registry.
+///
+/// The S3 sink is an optional build feature, so source builds without it keep
+/// the existing metrics surface unchanged.
+pub(crate) fn register_frontend_metrics(
+    registry: &prometheus::Registry,
+) -> Result<(), prometheus::Error> {
+    #[cfg(feature = "request-trace-s3")]
+    s3_sink::register_metrics(registry)?;
+    Ok(())
+}
+
 pub(crate) async fn start_tool_event_ingest_from_policy(
     drt: DistributedRuntime,
     local_model: &LocalModel,

--- a/lib/llm/src/request_trace/mod.rs
+++ b/lib/llm/src/request_trace/mod.rs
@@ -88,10 +88,10 @@ pub async fn init_from_env_with_shutdown(shutdown: CancellationToken) -> anyhow:
 /// The S3 sink is an optional build feature, so source builds without it keep
 /// the existing metrics surface unchanged.
 pub(crate) fn register_frontend_metrics(
-    registry: &prometheus::Registry,
+    _registry: &prometheus::Registry,
 ) -> Result<(), prometheus::Error> {
     #[cfg(feature = "request-trace-s3")]
-    s3_sink::register_metrics(registry)?;
+    s3_sink::register_metrics(_registry)?;
     Ok(())
 }
 

--- a/lib/llm/src/request_trace/s3_sink.rs
+++ b/lib/llm/src/request_trace/s3_sink.rs
@@ -27,8 +27,8 @@
 
 use std::io::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
@@ -58,8 +58,142 @@ const DEFAULT_BUFFER_INITIAL_BYTES: usize = 256 * 1024;
 const S3_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(30);
 const S3_OPERATION_TIMEOUT: Duration = Duration::from_secs(90);
 
+/// Prometheus metrics for the direct S3 request-trace sink.
+///
+/// These are deliberately process-wide because request tracing starts at most
+/// one worker per process. Metric labels are limited to the fixed drop reasons;
+/// bucket, object key, and error text must not become labels.
+struct S3RequestTraceMetrics {
+    records_accepted: prometheus::IntCounter,
+    records_dropped: prometheus::IntCounterVec,
+    queue_depth: prometheus::IntGauge,
+    in_memory_batch_bytes: prometheus::IntGauge,
+    oldest_buffered_record_age_seconds: prometheus::Gauge,
+    upload_duration_seconds: prometheus::Histogram,
+    uploaded_bytes: prometheus::IntCounter,
+    upload_terminal_retry_attempts: prometheus::IntCounter,
+    upload_terminal_failures: prometheus::IntCounter,
+}
+
+impl S3RequestTraceMetrics {
+    fn new() -> Self {
+        let metric = |suffix: &str| format!("dynamo_frontend_request_trace_s3_{suffix}");
+        Self {
+            records_accepted: prometheus::IntCounter::new(
+                metric("records_accepted_total"),
+                "Request-trace records accepted by the S3 sink queue",
+            )
+            .expect("valid S3 request-trace accepted-record metric"),
+            records_dropped: prometheus::IntCounterVec::new(
+                prometheus::Opts::new(
+                    metric("records_dropped_total"),
+                    "Request-trace records dropped before S3 upload",
+                ),
+                &["reason"],
+            )
+            .expect("valid S3 request-trace dropped-record metric"),
+            queue_depth: prometheus::IntGauge::new(
+                metric("queue_depth"),
+                "Current number of request-trace records queued for the S3 sink",
+            )
+            .expect("valid S3 request-trace queue-depth metric"),
+            in_memory_batch_bytes: prometheus::IntGauge::new(
+                metric("in_memory_batch_uncompressed_bytes"),
+                "Uncompressed request-trace bytes buffered in the active in-memory S3 batch",
+            )
+            .expect("valid S3 request-trace in-memory-bytes metric"),
+            oldest_buffered_record_age_seconds: prometheus::Gauge::new(
+                metric("oldest_buffered_record_age_seconds"),
+                "Age of the oldest record in the active in-memory S3 batch",
+            )
+            .expect("valid S3 request-trace oldest-buffered-record metric"),
+            upload_duration_seconds: prometheus::Histogram::with_opts(
+                prometheus::HistogramOpts::new(
+                    metric("upload_duration_seconds"),
+                    "End-to-end duration of a completed or terminally failed S3 upload",
+                )
+                .buckets(vec![
+                    0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 90.0,
+                ]),
+            )
+            .expect("valid S3 request-trace upload-duration metric"),
+            uploaded_bytes: prometheus::IntCounter::new(
+                metric("uploaded_bytes_total"),
+                "Compressed request-trace bytes successfully uploaded to S3",
+            )
+            .expect("valid S3 request-trace uploaded-bytes metric"),
+            upload_terminal_retry_attempts: prometheus::IntCounter::new(
+                metric("upload_terminal_retry_attempts_total"),
+                "Object-store retry attempts reported by terminally failed S3 uploads",
+            )
+            .expect("valid S3 request-trace terminal-retry-attempt metric"),
+            upload_terminal_failures: prometheus::IntCounter::new(
+                metric("upload_terminal_failures_total"),
+                "S3 upload batches discarded after the object-store retry policy terminates",
+            )
+            .expect("valid S3 request-trace terminal-failure metric"),
+        }
+    }
+
+    fn register(&self, registry: &prometheus::Registry) -> Result<(), prometheus::Error> {
+        registry.register(Box::new(self.records_accepted.clone()))?;
+        registry.register(Box::new(self.records_dropped.clone()))?;
+        registry.register(Box::new(self.queue_depth.clone()))?;
+        registry.register(Box::new(self.in_memory_batch_bytes.clone()))?;
+        registry.register(Box::new(self.oldest_buffered_record_age_seconds.clone()))?;
+        registry.register(Box::new(self.upload_duration_seconds.clone()))?;
+        registry.register(Box::new(self.uploaded_bytes.clone()))?;
+        registry.register(Box::new(self.upload_terminal_retry_attempts.clone()))?;
+        registry.register(Box::new(self.upload_terminal_failures.clone()))?;
+        Ok(())
+    }
+
+    fn reset_gauges(&self) {
+        self.queue_depth.set(0);
+        self.in_memory_batch_bytes.set(0);
+        self.oldest_buffered_record_age_seconds.set(0.0);
+    }
+
+    fn set_queue_depth(&self, depth: usize) {
+        self.queue_depth.set(depth.try_into().unwrap_or(i64::MAX));
+    }
+
+    fn set_batch_state(&self, bytes: u64, oldest: Option<Instant>) {
+        self.in_memory_batch_bytes
+            .set(bytes.try_into().unwrap_or(i64::MAX));
+        self.oldest_buffered_record_age_seconds.set(
+            oldest
+                .map(|enqueued_at| enqueued_at.elapsed().as_secs_f64())
+                .unwrap_or(0.0),
+        );
+    }
+
+    fn record_drop(&self, reason: &'static str, count: u64) {
+        self.records_dropped
+            .with_label_values(&[reason])
+            .inc_by(count);
+    }
+}
+
+static S3_REQUEST_TRACE_METRICS: LazyLock<S3RequestTraceMetrics> =
+    LazyLock::new(S3RequestTraceMetrics::new);
+
+pub(super) fn register_metrics(registry: &prometheus::Registry) -> Result<(), prometheus::Error> {
+    S3_REQUEST_TRACE_METRICS.register(registry)
+}
+
+pub(super) fn record_bus_lagged_records(count: u64) {
+    S3_REQUEST_TRACE_METRICS.record_drop("bus_lag", count);
+}
+
+#[derive(Clone)]
+struct QueuedRecord {
+    record: RequestTraceRecord,
+    enqueued_at: Instant,
+}
+
 pub struct S3RequestTraceSink {
-    tx: mpsc::Sender<RequestTraceRecord>,
+    tx: mpsc::Sender<QueuedRecord>,
     shutdown: CancellationToken,
     worker: Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Count of records dropped by `emit` because the batcher channel was full
@@ -102,6 +236,7 @@ impl S3RequestTraceSink {
         );
 
         let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+        S3_REQUEST_TRACE_METRICS.reset_gauges();
         let shutdown = CancellationToken::new();
         let upload_options = S3UploadOptions {
             bucket,
@@ -137,6 +272,12 @@ impl S3RequestTraceSink {
     /// cannot flood the log with one line per dropped record. Returns `true`
     /// when this call emitted the warning (i.e. it was the first drop).
     fn note_dropped(&self, reason: &str) -> bool {
+        let metric_reason = match reason {
+            "channel_full" => "channel_full",
+            "channel_closed" => "channel_closed",
+            _ => "unknown",
+        };
+        S3_REQUEST_TRACE_METRICS.record_drop(metric_reason, 1);
         if self.dropped.fetch_add(1, Ordering::Relaxed) == 0 {
             tracing::warn!(
                 target: "dynamo_llm::request_trace",
@@ -158,12 +299,18 @@ impl RequestTraceSink for S3RequestTraceSink {
     }
 
     async fn emit(&self, record: &RequestTraceRecord) {
-        if let Err(error) = self.tx.try_send(record.clone()) {
+        if let Err(error) = self.tx.try_send(QueuedRecord {
+            record: record.clone(),
+            enqueued_at: Instant::now(),
+        }) {
             let reason = match error {
                 mpsc::error::TrySendError::Full(_) => "channel_full",
                 mpsc::error::TrySendError::Closed(_) => "channel_closed",
             };
             self.note_dropped(reason);
+        } else {
+            S3_REQUEST_TRACE_METRICS.records_accepted.inc();
+            S3_REQUEST_TRACE_METRICS.set_queue_depth(CHANNEL_CAPACITY - self.tx.capacity());
         }
     }
 
@@ -200,7 +347,7 @@ impl RequestTraceSink for S3RequestTraceSink {
 async fn run_worker(
     store: Arc<dyn ObjectStore>,
     options: S3UploadOptions,
-    mut rx: mpsc::Receiver<RequestTraceRecord>,
+    mut rx: mpsc::Receiver<QueuedRecord>,
     shutdown: CancellationToken,
     roll_uncompressed_bytes: u64,
     flush_interval: Duration,
@@ -221,13 +368,15 @@ async fn run_worker(
                 // land a record after we start draining. Then `recv()` yields
                 // every already-enqueued record and returns `None` once empty.
                 rx.close();
-                while let Some(record) = rx.recv().await {
-                    if let Err(error) = batch.push(&record) {
+                while let Some(queued) = rx.recv().await {
+                    S3_REQUEST_TRACE_METRICS.set_queue_depth(rx.len());
+                    if let Err(error) = batch.push(&queued.record, queued.enqueued_at) {
                         tracing::warn!(
                             target: "dynamo_llm::request_trace",
                             %error,
                             "request trace s3: serialize failed during shutdown"
                         );
+                        S3_REQUEST_TRACE_METRICS.record_drop("serialization_failed", 1);
                     } else if batch.uncompressed_bytes() >= roll_uncompressed_bytes {
                         // Enforce the roll threshold during shutdown too, so a
                         // full channel can't collapse into one oversized PUT
@@ -248,12 +397,14 @@ async fn run_worker(
             message = rx.recv() => {
                 match message {
                     Some(record) => {
-                        if let Err(error) = batch.push(&record) {
+                        S3_REQUEST_TRACE_METRICS.set_queue_depth(rx.len());
+                        if let Err(error) = batch.push(&record.record, record.enqueued_at) {
                             tracing::warn!(
                                 target: "dynamo_llm::request_trace",
                                 %error,
                                 "request trace s3: serialize failed; dropping record"
                             );
+                            S3_REQUEST_TRACE_METRICS.record_drop("serialization_failed", 1);
                         } else if batch.uncompressed_bytes() >= roll_uncompressed_bytes {
                             upload_ready_batch(&uploader, &mut batch, &mut seq).await;
                         }
@@ -271,9 +422,11 @@ async fn run_worker(
 }
 
 async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch, seq: &mut u64) {
+    let batch_records = batch.lines();
     let ready = match batch.take_finished().await {
         Ok(bytes) => bytes,
         Err(error) => {
+            S3_REQUEST_TRACE_METRICS.record_drop("gzip_finalize_failed", batch_records);
             tracing::warn!(
                 target: "dynamo_llm::request_trace",
                 %error,
@@ -285,20 +438,58 @@ async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch, 
     let this_seq = *seq;
     *seq = seq.saturating_add(1);
     let key = uploader.object_key(SystemTime::now(), this_seq);
-    let batch_bytes = ready.len();
-    if let Err(error) = uploader.put_object(key.clone(), ready).await {
-        // The client exhausted its retries (three total attempts, bounded by
-        // the operation timeout). The batch is dropped here rather
-        // than requeued; a persistent retry buffer is a follow-up concern
-        // tracked in the S3 layout PR.
-        tracing::warn!(
-            target: "dynamo_llm::request_trace",
-            key = %key,
-            batch_bytes,
-            %error,
-            "request trace s3: put_object failed after retries; batch discarded"
-        );
+    let batch_bytes = ready.bytes.len();
+    let upload_started = Instant::now();
+    match uploader.put_object(key.clone(), ready.bytes).await {
+        Ok(()) => {
+            S3_REQUEST_TRACE_METRICS
+                .upload_duration_seconds
+                .observe(upload_started.elapsed().as_secs_f64());
+            S3_REQUEST_TRACE_METRICS
+                .uploaded_bytes
+                .inc_by(batch_bytes as u64);
+        }
+        Err(error) => {
+            S3_REQUEST_TRACE_METRICS
+                .upload_duration_seconds
+                .observe(upload_started.elapsed().as_secs_f64());
+            S3_REQUEST_TRACE_METRICS.upload_terminal_failures.inc();
+            S3_REQUEST_TRACE_METRICS.record_drop("terminal_upload_failure", ready.records);
+            S3_REQUEST_TRACE_METRICS
+                .upload_terminal_retry_attempts
+                .inc_by(terminal_retry_attempts(&error));
+            // The client exhausted its retries (three total attempts, bounded by
+            // the operation timeout). The batch is dropped here rather
+            // than requeued; a persistent retry buffer is a follow-up concern
+            // tracked in the S3 layout PR.
+            tracing::warn!(
+                target: "dynamo_llm::request_trace",
+                key = %key,
+                batch_bytes,
+                %error,
+                "request trace s3: put_object failed after retries; batch discarded"
+            );
+        }
     }
+}
+
+/// `object_store` exposes retry counts only in the terminal `RetryError`
+/// display text. Successful uploads do not surface their internal attempts.
+/// Keep this parser narrow so changes to the dependency's message fail closed
+/// to zero rather than inventing retry attempts.
+fn terminal_retry_attempts(error: &anyhow::Error) -> u64 {
+    const PREFIX: &str = "after ";
+    const SUFFIX: &str = " retries";
+
+    error
+        .chain()
+        .find_map(|cause| {
+            let message = cause.to_string();
+            let start = message.find(PREFIX)? + PREFIX.len();
+            let end = message[start..].find(SUFFIX)? + start;
+            message[start..end].parse().ok()
+        })
+        .unwrap_or(0)
 }
 
 struct S3Uploader {
@@ -381,6 +572,12 @@ fn request_trace_s3_builder(bucket: &str, region: Option<&str>) -> AmazonS3Build
 struct JsonlBatch {
     raw: Vec<u8>,
     lines: u64,
+    oldest_enqueued_at: Option<Instant>,
+}
+
+struct FinishedBatch {
+    bytes: Vec<u8>,
+    records: u64,
 }
 
 impl JsonlBatch {
@@ -388,6 +585,7 @@ impl JsonlBatch {
         Self {
             raw: Vec::with_capacity(DEFAULT_BUFFER_INITIAL_BYTES),
             lines: 0,
+            oldest_enqueued_at: None,
         }
     }
 
@@ -399,23 +597,33 @@ impl JsonlBatch {
         self.raw.len() as u64
     }
 
-    fn push(&mut self, record: &RequestTraceRecord) -> Result<()> {
+    fn lines(&self) -> u64 {
+        self.lines
+    }
+
+    fn push(&mut self, record: &RequestTraceRecord, enqueued_at: Instant) -> Result<()> {
         let mut line = serde_json::to_vec(record).context("serializing request trace record")?;
         line.push(b'\n');
         self.raw.extend_from_slice(&line);
         self.lines = self.lines.saturating_add(1);
+        self.oldest_enqueued_at.get_or_insert(enqueued_at);
+        S3_REQUEST_TRACE_METRICS
+            .set_batch_state(self.uncompressed_bytes(), self.oldest_enqueued_at);
         Ok(())
     }
 
     /// Consume the accumulated JSONL, gzip it on a blocking worker, and
     /// leave the batch empty so it can accept the next record.
-    async fn take_finished(&mut self) -> Result<Vec<u8>> {
+    async fn take_finished(&mut self) -> Result<FinishedBatch> {
         let raw = std::mem::replace(
             &mut self.raw,
             Vec::with_capacity(DEFAULT_BUFFER_INITIAL_BYTES),
         );
+        let records = self.lines;
         self.lines = 0;
-        tokio::task::spawn_blocking(move || {
+        self.oldest_enqueued_at = None;
+        S3_REQUEST_TRACE_METRICS.set_batch_state(0, None);
+        let bytes = tokio::task::spawn_blocking(move || {
             let mut encoder = GzEncoder::new(
                 Vec::with_capacity(raw.len() / 4 + DEFAULT_BUFFER_INITIAL_BYTES),
                 Compression::default(),
@@ -428,7 +636,8 @@ impl JsonlBatch {
                 .context("finalizing gzip batch for s3 upload")
         })
         .await
-        .context("gzip encoder task panicked")?
+        .context("gzip encoder task panicked")??;
+        Ok(FinishedBatch { bytes, records })
     }
 }
 
@@ -593,6 +802,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn s3_metrics_register_all_metric_families() {
+        let registry = prometheus::Registry::new();
+        S3RequestTraceMetrics::new().register(&registry).unwrap();
+        let names: Vec<_> = registry
+            .gather()
+            .into_iter()
+            .map(|family| family.name().to_string())
+            .collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "dynamo_frontend_request_trace_s3_in_memory_batch_uncompressed_bytes",
+                "dynamo_frontend_request_trace_s3_oldest_buffered_record_age_seconds",
+                "dynamo_frontend_request_trace_s3_queue_depth",
+                "dynamo_frontend_request_trace_s3_records_accepted_total",
+                "dynamo_frontend_request_trace_s3_records_dropped_total",
+                "dynamo_frontend_request_trace_s3_upload_duration_seconds",
+                "dynamo_frontend_request_trace_s3_upload_terminal_failures_total",
+                "dynamo_frontend_request_trace_s3_upload_terminal_retry_attempts_total",
+                "dynamo_frontend_request_trace_s3_uploaded_bytes_total",
+            ]
+        );
+    }
+
+    #[test]
+    fn terminal_retry_attempts_extracts_object_store_retry_count() {
+        let error = anyhow::anyhow!(
+            "Generic S3 error: Error performing PUT https://bucket.example/key in 90s, after 2 retries, max_retries: 2, retry_timeout: 90s - timeout"
+        );
+        assert_eq!(terminal_retry_attempts(&error), 2);
+        assert_eq!(
+            terminal_retry_attempts(&anyhow::anyhow!("permission denied")),
+            0
+        );
+    }
+
     fn test_uploader(prefix: &str) -> S3Uploader {
         S3Uploader {
             store: Arc::new(InMemory::new()),
@@ -613,7 +860,7 @@ mod tests {
     /// same backpressure path a stalled uploader would cause. The receiver is
     /// returned to the caller and held so the channel stays open (full), not
     /// closed. No S3 client or worker task is created.
-    fn stalled_sink(capacity: usize) -> (S3RequestTraceSink, mpsc::Receiver<RequestTraceRecord>) {
+    fn stalled_sink(capacity: usize) -> (S3RequestTraceSink, mpsc::Receiver<QueuedRecord>) {
         let (tx, rx) = mpsc::channel(capacity);
         let sink = S3RequestTraceSink {
             tx,

--- a/lib/llm/src/request_trace/s3_sink.rs
+++ b/lib/llm/src/request_trace/s3_sink.rs
@@ -50,6 +50,10 @@ use super::sink::RequestTraceSink;
 
 const CHANNEL_CAPACITY: usize = 2048;
 const DEFAULT_BUFFER_INITIAL_BYTES: usize = 256 * 1024;
+// Keep the age gauge current while a partially filled batch waits for the
+// regular flush tick. The batch is reset before gzip/upload begins, so there
+// is no active in-memory batch to report while an upload is in flight.
+const METRICS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 // Bound S3 upload duration so a stalled endpoint or slow network cannot wedge
 // the worker task indefinitely. `attempt_timeout` covers a single HTTP attempt;
 // the outer timeout bounds the full call including retries (three total).
@@ -357,8 +361,11 @@ async fn run_worker(
     let mut seq: u64 = 0;
     let mut flush_tick = tokio::time::interval(flush_interval);
     flush_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut metrics_tick = tokio::time::interval(METRICS_REFRESH_INTERVAL);
+    metrics_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // Skip the immediate tick that `interval` fires at t=0.
     flush_tick.tick().await;
+    metrics_tick.tick().await;
 
     loop {
         tokio::select! {
@@ -392,6 +399,11 @@ async fn run_worker(
             _ = flush_tick.tick() => {
                 if !batch.is_empty() {
                     upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                }
+            }
+            _ = metrics_tick.tick() => {
+                if !batch.is_empty() {
+                    batch.refresh_metrics();
                 }
             }
             message = rx.recv() => {
@@ -607,9 +619,16 @@ impl JsonlBatch {
         self.raw.extend_from_slice(&line);
         self.lines = self.lines.saturating_add(1);
         self.oldest_enqueued_at.get_or_insert(enqueued_at);
-        S3_REQUEST_TRACE_METRICS
-            .set_batch_state(self.uncompressed_bytes(), self.oldest_enqueued_at);
+        self.refresh_metrics();
         Ok(())
+    }
+
+    fn refresh_metrics(&self) {
+        self.refresh_metrics_with(&S3_REQUEST_TRACE_METRICS);
+    }
+
+    fn refresh_metrics_with(&self, metrics: &S3RequestTraceMetrics) {
+        metrics.set_batch_state(self.uncompressed_bytes(), self.oldest_enqueued_at);
     }
 
     /// Consume the accumulated JSONL, gzip it on a blocking worker, and
@@ -826,6 +845,22 @@ mod tests {
                 "dynamo_frontend_request_trace_s3_uploaded_bytes_total",
             ]
         );
+    }
+
+    #[test]
+    fn batch_metrics_refresh_advances_oldest_record_age() {
+        let metrics = S3RequestTraceMetrics::new();
+        let mut batch = JsonlBatch::new();
+        batch.raw.extend_from_slice(b"record\n");
+        batch.lines = 1;
+        batch.oldest_enqueued_at = Some(Instant::now() - Duration::from_secs(1));
+
+        batch.refresh_metrics_with(&metrics);
+        let initial_age = metrics.oldest_buffered_record_age_seconds.get();
+        std::thread::sleep(Duration::from_millis(10));
+        batch.refresh_metrics_with(&metrics);
+
+        assert!(metrics.oldest_buffered_record_age_seconds.get() > initial_age);
     }
 
     #[test]

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -253,11 +253,17 @@ async fn spawn_workers(shutdown: CancellationToken) -> anyhow::Result<()> {
                         loop {
                             match receiver.try_recv() {
                                 Ok(record) => sink.emit(&record).await,
-                                Err(broadcast::error::TryRecvError::Lagged(count)) => tracing::warn!(
-                                    sink = name,
-                                    dropped = count,
-                                    "request trace bus lagged during shutdown; dropped records"
-                                ),
+                                Err(broadcast::error::TryRecvError::Lagged(count)) => {
+                                    #[cfg(feature = "request-trace-s3")]
+                                    if name == "s3" {
+                                        super::s3_sink::record_bus_lagged_records(count);
+                                    }
+                                    tracing::warn!(
+                                        sink = name,
+                                        dropped = count,
+                                        "request trace bus lagged during shutdown; dropped records"
+                                    );
+                                }
                                 Err(
                                     broadcast::error::TryRecvError::Empty
                                     | broadcast::error::TryRecvError::Closed
@@ -269,11 +275,17 @@ async fn spawn_workers(shutdown: CancellationToken) -> anyhow::Result<()> {
                     message = receiver.recv() => {
                         match message {
                             Ok(record) => sink.emit(&record).await,
-                            Err(broadcast::error::RecvError::Lagged(count)) => tracing::warn!(
-                                sink = name,
-                                dropped = count,
-                                "request trace bus lagged; dropped records"
-                            ),
+                            Err(broadcast::error::RecvError::Lagged(count)) => {
+                                #[cfg(feature = "request-trace-s3")]
+                                if name == "s3" {
+                                    super::s3_sink::record_bus_lagged_records(count);
+                                }
+                                tracing::warn!(
+                                    sink = name,
+                                    dropped = count,
+                                    "request trace bus lagged; dropped records"
+                                );
+                            }
                             Err(broadcast::error::RecvError::Closed) => break,
                         }
                     }


### PR DESCRIPTION
## Summary
- Expose bounded, sink-level S3 request-trace metrics on the frontend Prometheus endpoint.
- Count accepted and dropped records, queue depth, in-memory batch age/bytes, upload latency/bytes, terminal failures, and terminal retry attempts.
- Document the no-spool durability boundary and deployer-owned alert rules.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo check -p dynamo-llm --no-default-features --features request-trace-s3`
- `fern check --local`
- `fern docs broken-links`
- Focused library test binary was killed by local resource limits after compilation; GitHub Actions should run it on Linux.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3 as a request-trace destination with configurable bucket, region, prefix, batching, and flushing.
  * Added Prometheus metrics for request-trace queueing, buffering, uploads, retries, drops, and failures.
  * Added alerting guidance and example rules for monitoring S3 request-trace delivery.

* **Bug Fixes**
  * Improved tracking of records dropped when request-trace processing falls behind.
  * Added visibility into serialization, compression, upload, and terminal failure outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->