### PR TITLE
docs: fix site landing and navigation styling

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -392,6 +392,12 @@ jobs:
           # a product switcher. Restore the release history in that native shape.
           yq -i '.versions = load("/tmp/preserved_versions.yml")' docs.yml
 
+          # Fern resolves a versioned site's bare URL through the default
+          # version's first page instead of the top-level landing-page. Legacy
+          # release snapshots predate the Home tab, so add the shared Home entry
+          # to the default version before publishing.
+          ../../source-checkout/docs/fern/scripts/ensure_default_version_home.sh .
+
           # Inject the private NVIDIA global theme for production builds only.
           # It is intentionally absent from the source repo's docs.yml so that
           # external contributors can run `fern docs dev` without an nvidia-org

--- a/docs/fern/components/CustomFooter.tsx
+++ b/docs/fern/components/CustomFooter.tsx
@@ -214,9 +214,16 @@ html.dark,
     padding-left: 0.25rem !important;
 }
 /* User Guide variants use collapsible top-level sections. Keep those section
-   titles visually distinct without changing flat entries in Reference. */
+   titles visually distinct. */
 #fern-sidebar:has(.fern-variant-selector)
     .fern-sidebar-link.fern-sidebar-level-1:has(.expand-indicator)
+    .fern-sidebar-link-title {
+    font-weight: 600 !important;
+}
+/* Fern semibolds sections but not pages. Reference intentionally mixes both at
+   level 1, so use one weight for a consistent top-level hierarchy. */
+#fern-sidebar
+    .fern-sidebar-link.fern-sidebar-level-1[href*="/reference/"]
     .fern-sidebar-link-title {
     font-weight: 600 !important;
 }

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -956,10 +956,12 @@ navigation:
   - tab: reference
     layout:
       - page: Compatibility
+        icon: shield-halved
         path: pages/reference/general/compatibility.mdx
         slug: compatibility
 
       - section: Releases
+        icon: tag
         slug: releases
         path: pages/reference/general/releases/release-history.mdx
         collapsed: true
@@ -984,23 +986,28 @@ navigation:
       # Machine-readable mirror of releases.data.ts for agents; reachable
       # by URL and llms indexes, not the sidebar.
       - page: Releases (machine-readable)
+        icon: database
         path: pages/reference/general/releases-machine-readable.mdx
         slug: releases-data
         hidden: true
 
       - page: Release Artifacts
+        icon: download
         path: pages/reference/general/release-artifacts.mdx
         slug: release-artifacts
 
       - page: Nightly Releases
+        icon: moon
         path: pages/reference/general/nightly-releases.md
         slug: nightly-releases
 
       - page: Model Early Access Builds
+        icon: microchip
         path: pages/reference/general/model-early-access-builds.mdx
         slug: model-early-access-builds
 
       - page: Examples
+        icon: file-code
         path: pages/reference/general/examples.md
         slug: examples
 
@@ -1019,6 +1026,7 @@ navigation:
       # the twenty anchored redirects in docs.yml that carry the retired
       # NIXL Connect class pages -- would otherwise move.
       - page: API Reference
+        icon: code
         path: pages/reference/api/README.mdx
         slug: api
 
@@ -1169,6 +1177,7 @@ navigation:
             path: pages/reference/nixl-connect/overview.mdx
 
       - page: Glossary
+        icon: book-open
         path: pages/reference/general/glossary.md
         slug: glossary
 
@@ -1218,6 +1227,7 @@ navigation:
   - tab: community
     layout:
       - page: Community
+        icon: users
         path: pages/community/community.mdx
       - section: Contributing
         icon: code-pull-request

--- a/docs/fern/main.css
+++ b/docs/fern/main.css
@@ -192,9 +192,16 @@ html.dark,
     padding-left: 0.25rem !important;
 }
 /* User Guide variants use collapsible top-level sections. Keep those section
-   titles visually distinct without changing flat entries in Reference. */
+   titles visually distinct. */
 #fern-sidebar:has(.fern-variant-selector)
     .fern-sidebar-link.fern-sidebar-level-1:has(.expand-indicator)
+    .fern-sidebar-link-title {
+    font-weight: 600 !important;
+}
+/* Fern semibolds sections but not pages. Reference intentionally mixes both at
+   level 1, so use one weight for a consistent top-level hierarchy. */
+#fern-sidebar
+    .fern-sidebar-link.fern-sidebar-level-1[href*="/reference/"]
     .fern-sidebar-link-title {
     font-weight: 600 !important;
 }

--- a/docs/fern/scripts/ensure_default_version_home.sh
+++ b/docs/fern/scripts/ensure_default_version_home.sh
@@ -7,8 +7,8 @@
 # Fern's versioned navigation resolves the bare site URL through the first page
 # of the default version; the top-level landing-page is not used for that
 # redirect. Older release snapshots predate the Home tab, so composing them as
-# the default version sends /dynamo to their Quickstart page. Add the shared
-# Home tab and navigation entry when they are missing.
+# the default version sends /dynamo to their Quickstart page. Normalize the
+# default version against dev.yml so Home is canonical, unique, and first.
 
 set -euo pipefail
 
@@ -32,42 +32,87 @@ if [ ! -f "$default_nav" ]; then
   exit 1
 fi
 
-if [ "$(yq '[.navigation[]? | select(.tab? == "home")] | length' "$default_nav")" != "0" ]; then
-  echo "Default version already includes Home: $default_nav"
-  exit 0
-fi
-
-if [ "$(yq '[.navigation[]? | select(.tab? == "home")] | length' "$dev_nav")" = "0" ]; then
-  echo "ERROR: dev navigation does not define the shared Home tab" >&2
+home_tab=$(yq -r '.tabs.home // ""' "$dev_nav")
+home_navigation=$(yq -r '.navigation[]? | select(.tab? == "home")' "$dev_nav")
+if [ -z "$home_tab" ] || [ -z "$home_navigation" ] ||
+   [ "$(yq '[.navigation[]? | select(.tab? == "home")] | length' "$dev_nav")" != "1" ]; then
+  echo "ERROR: dev navigation must define exactly one shared Home tab" >&2
   exit 1
 fi
 
-python3 - "$default_nav" <<'PY'
+if [ "$(yq '[.navigation[]? | select(.tab? == "home")] | length' "$default_nav")" = "1" ] &&
+   [ "$(yq -r '.navigation[0].tab // ""' "$default_nav")" = "home" ] &&
+   [ "$(yq -o=json '.tabs.home' "$default_nav")" = "$(yq -o=json '.tabs.home' "$dev_nav")" ] &&
+   [ "$(yq -o=json '.navigation[0]' "$default_nav")" = "$(yq -o=json '.navigation[] | select(.tab == "home")' "$dev_nav")" ]; then
+  echo "Default version already has canonical Home navigation: $default_nav"
+  exit 0
+fi
+
+HOME_TAB="$home_tab" HOME_NAVIGATION="$home_navigation" \
+  python3 - "$default_nav" <<'PY'
+import os
+import re
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
-text = path.read_text(encoding="utf-8")
+lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
 
-tabs = """tabs:
-  home:
-    display-name: Home
-    icon: house
-    skip-slug: true
-"""
-navigation = """navigation:
-  - tab: home
-    layout:
-      - page: Welcome
-        path: ../index.mdx
-"""
 
-if "\ntabs:\n" not in text or "\nnavigation:\n" not in text:
-    raise SystemExit(f"ERROR: cannot locate tabs/navigation roots in {path}")
+def root_index(name: str) -> int:
+    target = f"{name}:\n"
+    try:
+        return lines.index(target)
+    except ValueError as exc:
+        raise SystemExit(f"ERROR: cannot locate {name} root in {path}") from exc
 
-text = text.replace("\ntabs:\n", "\n" + tabs, 1)
-text = text.replace("\nnavigation:\n", "\n" + navigation, 1)
-path.write_text(text, encoding="utf-8")
+
+def remove_tab_home() -> None:
+    tabs = root_index("tabs")
+    navigation = root_index("navigation")
+    starts = [
+        i
+        for i in range(tabs + 1, navigation)
+        if re.match(r"^  home:\s*(?:#.*)?$", lines[i].rstrip("\n"))
+    ]
+    for start in reversed(starts):
+        end = start + 1
+        while end < navigation and not re.match(r"^  [^ ].*:\s*(?:#.*)?$", lines[end].rstrip("\n")):
+            end += 1
+        del lines[start:end]
+
+
+def remove_navigation_home() -> None:
+    navigation = root_index("navigation")
+    starts = [i for i in range(navigation + 1, len(lines)) if lines[i].startswith("  - ")]
+    blocks = [(start, starts[index + 1] if index + 1 < len(starts) else len(lines)) for index, start in enumerate(starts)]
+    for start, end in reversed(blocks):
+        if re.match(r"^  - tab:\s*home\s*$", lines[start].rstrip("\n")):
+            del lines[start:end]
+
+
+def indented_block(value: str, *, sequence: bool) -> list[str]:
+    source = value.rstrip("\n").splitlines()
+    if sequence:
+        return [f"  - {source[0]}\n", *[f"    {line}\n" for line in source[1:]]]
+    return ["  home:\n", *[f"    {line}\n" for line in source]]
+
+
+remove_navigation_home()
+remove_tab_home()
+lines[root_index("tabs") + 1 : root_index("tabs") + 1] = indented_block(os.environ["HOME_TAB"], sequence=False)
+lines[root_index("navigation") + 1 : root_index("navigation") + 1] = indented_block(
+    os.environ["HOME_NAVIGATION"], sequence=True
+)
+path.write_text("".join(lines), encoding="utf-8")
 PY
 
-echo "Added shared Home navigation to default version: $default_nav"
+if [ "$(yq '[.navigation[]? | select(.tab? == "home")] | length' "$default_nav")" != "1" ] || \
+   [ "$(yq -r '.navigation[0].tab // ""' "$default_nav")" != "home" ] || \
+   [ "$(yq -o=json '.tabs.home' "$default_nav")" != "$(yq -o=json '.tabs.home' "$dev_nav")" ] || \
+   [ "$(yq -o=json '.navigation[0]' "$default_nav")" != "$(yq -o=json '.navigation[] | select(.tab == "home")' "$dev_nav")" ]; then
+  echo "ERROR: failed to normalize Home navigation in $default_nav" >&2
+  exit 1
+fi
+
+echo "Normalized shared Home navigation in default version: $default_nav"

--- a/docs/fern/scripts/ensure_default_version_home.sh
+++ b/docs/fern/scripts/ensure_default_version_home.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ensure the default published version starts with the shared Home page.
+#
+# Fern's versioned navigation resolves the bare site URL through the first page
+# of the default version; the top-level landing-page is not used for that
+# redirect. Older release snapshots predate the Home tab, so composing them as
+# the default version sends /dynamo to their Quickstart page. Add the shared
+# Home tab and navigation entry when they are missing.
+
+set -euo pipefail
+
+fern_dir=${1:?usage: ensure_default_version_home.sh <fern-dir>}
+docs_file="$fern_dir/docs.yml"
+dev_nav="$fern_dir/versions/dev.yml"
+
+if [ ! -f "$docs_file" ] || [ ! -f "$dev_nav" ]; then
+  echo "ERROR: expected $docs_file and $dev_nav" >&2
+  exit 1
+fi
+
+default_path=$(yq -r '.versions[0].path // ""' "$docs_file")
+if [ -z "$default_path" ]; then
+  echo "ERROR: docs.yml has no default version path" >&2
+  exit 1
+fi
+default_nav="$fern_dir/${default_path#./}"
+if [ ! -f "$default_nav" ]; then
+  echo "ERROR: default version navigation does not exist: $default_nav" >&2
+  exit 1
+fi
+
+if [ "$(yq '[.navigation[]? | select(.tab? == "home")] | length' "$default_nav")" != "0" ]; then
+  echo "Default version already includes Home: $default_nav"
+  exit 0
+fi
+
+if [ "$(yq '[.navigation[]? | select(.tab? == "home")] | length' "$dev_nav")" = "0" ]; then
+  echo "ERROR: dev navigation does not define the shared Home tab" >&2
+  exit 1
+fi
+
+python3 - "$default_nav" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+
+tabs = """tabs:
+  home:
+    display-name: Home
+    icon: house
+    skip-slug: true
+"""
+navigation = """navigation:
+  - tab: home
+    layout:
+      - page: Welcome
+        path: ../index.mdx
+"""
+
+if "\ntabs:\n" not in text or "\nnavigation:\n" not in text:
+    raise SystemExit(f"ERROR: cannot locate tabs/navigation roots in {path}")
+
+text = text.replace("\ntabs:\n", "\n" + tabs, 1)
+text = text.replace("\nnavigation:\n", "\n" + navigation, 1)
+path.write_text(text, encoding="utf-8")
+PY
+
+echo "Added shared Home navigation to default version: $default_nav"

--- a/docs/fern/scripts/simulate_docs_website.sh
+++ b/docs/fern/scripts/simulate_docs_website.sh
@@ -156,6 +156,12 @@ yq -i '."landing-page".path = "./index.mdx"' docs.yml
 PRESERVED="$WT/.preserved_versions.yml" \
   yq -i '.versions = load(strenv(PRESERVED))' docs.yml
 "$SRC/scripts/ensure_default_version_home.sh" "$WT/fern"
+sync_default_nav=$(yq -r '.versions[0].path' docs.yml)
+sync_default_nav="${sync_default_nav#./}"
+sync_home_count=$(yq '[.navigation[] | select(.tab == "home")] | length' "$sync_default_nav")
+sync_first_tab=$(yq -r '.navigation[0].tab // ""' "$sync_default_nav")
+[ "$sync_home_count" = "1" ] && [ "$sync_first_tab" = "home" ] && s11=ok || s11=FAIL
+assert "10a. synced default version has one canonical Home tab first" "$s11"
 
 echo "=== RELEASE-VERSION JOB (replayed, tag $TAG) ==="
 cd "$WT"
@@ -218,7 +224,7 @@ default_nav=$(yq -r '.versions[0].path' fern/docs.yml)
 default_nav="fern/${default_nav#./}"
 default_first_tab=$(yq -r '.navigation[0].tab // ""' "$default_nav")
 [ "$default_first_tab" = "home" ] && s11=ok || s11=FAIL
-assert "10. default version starts with the shared Home tab" "$s11"
+assert "10b. released default version starts with the shared Home tab" "$s11"
 
 # 9 first: everything below assumes the shared group is findable at all. This is
 # the tripwire the old label-keyed selector lacked — it no-opped silently for six

--- a/docs/fern/scripts/simulate_docs_website.sh
+++ b/docs/fern/scripts/simulate_docs_website.sh
@@ -30,6 +30,8 @@
 #      because 2, 3 and 6 are vacuous without it — and because a selector that
 #      quietly stops matching is exactly how this broke: #12410 flattened the
 #      Reference tab and the old label-keyed selector no-opped for six days.
+#  10. The composed default version starts with the shared Home tab so the
+#      bare site URL renders Home instead of the release snapshot's first page.
 #
 # Usage: ./scripts/simulate_docs_website.sh [TAG]
 #   TAG defaults to v9.9.9 (must not exist on docs-website yet).
@@ -153,6 +155,7 @@ cp "$SRC/docs.yml" docs.yml
 yq -i '."landing-page".path = "./index.mdx"' docs.yml
 PRESERVED="$WT/.preserved_versions.yml" \
   yq -i '.versions = load(strenv(PRESERVED))' docs.yml
+"$SRC/scripts/ensure_default_version_home.sh" "$WT/fern"
 
 echo "=== RELEASE-VERSION JOB (replayed, tag $TAG) ==="
 cd "$WT"
@@ -211,6 +214,12 @@ yq -i ".versions[0].path = \"./versions/$TAG.yml\"" fern/docs.yml
 yq -i ".versions[0].display-name = \"Latest ($TAG)\"" fern/docs.yml
 
 echo "=== ASSERTIONS ==="
+default_nav=$(yq -r '.versions[0].path' fern/docs.yml)
+default_nav="fern/${default_nav#./}"
+default_first_tab=$(yq -r '.navigation[0].tab // ""' "$default_nav")
+[ "$default_first_tab" = "home" ] && s11=ok || s11=FAIL
+assert "10. default version starts with the shared Home tab" "$s11"
+
 # 9 first: everything below assumes the shared group is findable at all. This is
 # the tripwire the old label-keyed selector lacked — it no-opped silently for six
 # days after #12410 renamed the nav out from under it.


### PR DESCRIPTION
## Summary

- fix the composed `docs-website` navigation so the default published version starts with the shared Home tab
- keep the landing fix in `main`'s publishing workflow rather than editing the CI-managed `docs-website` branch manually
- add icons to every visible top-level Reference entry and to the Community page
- give top-level Reference pages the same semibold weight Fern applies to top-level sections
- add a regression assertion to the local docs-website composition harness

The source `landing-page` configuration is already copied correctly. The landing issue appears only after release versions are composed on `docs-website`: Fern resolves the bare URL of a multi-version site through the default version's first navigation page, and the current v1.3.0 snapshot predates the Home tab, so the root falls through to Quickstart.

Fern intentionally renders top-level sections with `font-semibold` while leaving top-level pages at normal weight. Reference mixes both node types at the same hierarchy level, so the scoped CSS override makes that tab visually consistent without changing nested pages or other tabs.

## Where should the reviewer start?

1. `docs/fern/scripts/ensure_default_version_home.sh` for the default-version normalization.
2. `.github/workflows/fern-docs.yml` and `docs/fern/scripts/simulate_docs_website.sh` for publishing integration and regression coverage.
3. `docs/fern/index.yml` and `docs/fern/main.css` for the Reference and Community navigation presentation.

## Validation

- `docs/fern/scripts/simulate_docs_website.sh` — all assertions passed, including `fern check` with 0 errors
- local preview of the composed `docs-website` tree — `/dynamo`, `/dynamo/`, `/dynamo/latest`, and `/dynamo/latest/` return the Home page with HTTP 200
- local Reference preview — every visible level-one entry renders an icon; flat pages use the scoped semibold rule
- local Community preview — the Community page renders its icon
- `fern check` — 0 errors
- `bash -n docs/fern/scripts/ensure_default_version_home.sh docs/fern/scripts/simulate_docs_website.sh`
- `git diff --check`

`fern docs broken-links` currently reports four pre-existing errors in `pages/recipes/model-recipes/qwen-3-8-2-4t-a95b.mdx`; this change does not touch that page.

## Related Issues

- Closes #13210
