### PR TITLE
fix(llm): read the FinishReason string form workers emit

### DIFF
--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -105,8 +105,6 @@ impl std::str::FromStr for FinishReason {
             "stop" => Ok(FinishReason::Stop),
             "cancelled" | "abort" => Ok(FinishReason::Cancelled),
             "content_filter" => Ok(FinishReason::ContentFilter),
-            // The `Display` form, and what the Python engine adapters emit.
-            // A bare "error" is deliberately not accepted; see the type docs.
             s if s.starts_with("error: ") => Ok(FinishReason::Error(s[7..].to_string())),
             _ => Err(anyhow::anyhow!("Invalid FinishReason variant: '{}'", s)),
         }
@@ -114,13 +112,12 @@ impl std::str::FromStr for FinishReason {
 }
 
 impl<'de> Deserialize<'de> for FinishReason {
-    // `deserialize_any` requires a self-describing format — it needs the
-    // wire data itself to say whether a string or a map follows, since
-    // `FinishReasonVisitor` handles both. The request-plane codec
-    // (`rmp_serde::to_vec_named`) is self-describing, so this holds today;
-    // a compact, non-self-describing encoding (plain `bincode`, for
-    // instance) would fail here even though the derived `Deserialize` this
-    // type replaced would have accepted it.
+    // `deserialize_any` needs a self-describing format, since the visitor
+    // decides from the wire data itself whether to expect a string or a
+    // map. The request-plane codec (`rmp_serde::to_vec_named`) is
+    // self-describing, so this holds today. A non-self-describing format
+    // (plain `bincode`, for instance) would fail here, even though the
+    // derived `Deserialize` this replaced would have accepted it.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -144,16 +141,14 @@ impl<'de> serde::de::Visitor<'de> for FinishReasonVisitor {
     where
         E: serde::de::Error,
     {
-        // `parse()` (`FromStr`) already carries the specific reason a string
-        // failed to match any known form. `E::custom` keeps that message
-        // instead of collapsing every parse failure into the generic
-        // `invalid_value` text.
+        // `parse()` carries the specific reason a string failed to match
+        // any known form. `E::custom` passes that message through instead
+        // of the generic `invalid_value` error.
         value.parse().map_err(E::custom)
     }
 
-    /// The externally tagged form that [`Serialize`] emits: exactly one entry,
-    /// which can only ever be `{"error": "<message>"}` — the unit variants
-    /// serialize as bare strings and arrive at [`Self::visit_str`].
+    /// Unit variants route to [`Self::visit_str`] instead; this method
+    /// handles only the `Error` map case.
     fn visit_map<A>(self, mut map: A) -> Result<FinishReason, A::Error>
     where
         A: serde::de::MapAccess<'de>,

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -49,30 +49,18 @@ pub trait OutputOptionsProvider {
 ///
 /// # Wire contract
 ///
-/// We serialize the externally tagged derive form: a bare string for the unit
-/// variants (`"stop"`) and a single-key map for [`FinishReason::Error`]
-/// (`{"error": "<message>"}`). That is what every Rust producer has always
-/// emitted, and changing it would break every frontend in the N-2
-/// compatibility window, so it stays fixed.
+/// Serializes as a bare string for the unit variants (`"stop"`, etc.) and a
+/// single-key map for [`FinishReason::Error`] (`{"error": "<message>"}`) —
+/// the form every Rust producer emits and every frontend expects.
 ///
-/// Deserialization additionally accepts the [`Display`] form,
-/// `"error: <message>"`, because Python engine adapters report request-level
-/// failures that way — `dynamo.vllm`'s custom-encoder path, among others. That
-/// is not a producer mistake: `Display` and [`FromStr`] define exactly that
-/// convention, so a producer matching this type's own string rendering lands on
-/// it. Rejecting it costs the caller the one thing that makes the failure
-/// actionable, since a terminal chunk the reader cannot parse fails the whole
-/// request-plane response and the backend's message is dropped for an
-/// unattributed 500.
-///
-/// Note the deliberate limit: a bare `"error"` carrying no message is *not*
-/// accepted. That form discards information at the producer, and inventing a
-/// stand-in message here would mask the bug rather than surface it. Producers
-/// should report request-level failures out of band instead — raising
-/// `dynamo._core.InvalidArgument` yields a 400 carrying the real message.
+/// Deserialization also accepts the [`Display`] form, `"error: <message>"`,
+/// since Python engine adapters (e.g. `dynamo.vllm`'s custom-encoder path)
+/// report failures that way. A bare `"error"` with no message stays
+/// rejected on purpose — producers should raise
+/// `dynamo._core.InvalidArgument` instead, which yields a 400 carrying the
+/// real message.
 ///
 /// [`Display`]: std::fmt::Display
-/// [`FromStr`]: std::str::FromStr
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub enum FinishReason {
     #[serde(rename = "eos")]
@@ -126,6 +114,13 @@ impl std::str::FromStr for FinishReason {
 }
 
 impl<'de> Deserialize<'de> for FinishReason {
+    // `deserialize_any` requires a self-describing format — it needs the
+    // wire data itself to say whether a string or a map follows, since
+    // `FinishReasonVisitor` handles both. The request-plane codec
+    // (`rmp_serde::to_vec_named`) is self-describing, so this holds today;
+    // a compact, non-self-describing encoding (plain `bincode`, for
+    // instance) would fail here even though the derived `Deserialize` this
+    // type replaced would have accepted it.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -141,7 +136,7 @@ impl<'de> serde::de::Visitor<'de> for FinishReasonVisitor {
 
     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(
-            r#"a finish reason: "eos", "length", "stop", "cancelled", "content_filter", "error: <message>", or {"error": "<message>"}"#,
+            r#"a finish reason: "eos", "length", "stop", "cancelled", "abort", "content_filter", "error: <message>", or {"error": "<message>"}"#,
         )
     }
 
@@ -149,9 +144,11 @@ impl<'de> serde::de::Visitor<'de> for FinishReasonVisitor {
     where
         E: serde::de::Error,
     {
-        value
-            .parse()
-            .map_err(|_| E::invalid_value(serde::de::Unexpected::Str(value), &self))
+        // `parse()` (`FromStr`) already carries the specific reason a string
+        // failed to match any known form. `E::custom` keeps that message
+        // instead of collapsing every parse failure into the generic
+        // `invalid_value` text.
+        value.parse().map_err(E::custom)
     }
 
     /// The externally tagged form that [`Serialize`] emits: exactly one entry,

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -55,17 +55,24 @@ pub trait OutputOptionsProvider {
 /// emitted, and changing it would break every frontend in the N-2
 /// compatibility window, so it stays fixed.
 ///
-/// Deserialization is deliberately more permissive, because Python engine
-/// adapters report request-level failures with the [`Display`] form instead —
-/// `"error: <message>"` (for example `dynamo.vllm`'s custom-encoder path) — and
-/// some report a bare `"error"` with no message at all. The derived reader
-/// rejects both, and rejecting them costs the caller the one thing that makes
-/// the failure actionable: a malformed terminal chunk fails the whole
-/// request-plane response, so the backend's message is dropped and the caller
-/// gets an unattributed 500. Accept every form the fleet emits and normalize
-/// here, at the wire boundary.
+/// Deserialization additionally accepts the [`Display`] form,
+/// `"error: <message>"`, because Python engine adapters report request-level
+/// failures that way — `dynamo.vllm`'s custom-encoder path, among others. That
+/// is not a producer mistake: `Display` and [`FromStr`] define exactly that
+/// convention, so a producer matching this type's own string rendering lands on
+/// it. Rejecting it costs the caller the one thing that makes the failure
+/// actionable, since a terminal chunk the reader cannot parse fails the whole
+/// request-plane response and the backend's message is dropped for an
+/// unattributed 500.
+///
+/// Note the deliberate limit: a bare `"error"` carrying no message is *not*
+/// accepted. That form discards information at the producer, and inventing a
+/// stand-in message here would mask the bug rather than surface it. Producers
+/// should report request-level failures out of band instead — raising
+/// `dynamo._core.InvalidArgument` yields a 400 carrying the real message.
 ///
 /// [`Display`]: std::fmt::Display
+/// [`FromStr`]: std::str::FromStr
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub enum FinishReason {
     #[serde(rename = "eos")]
@@ -86,11 +93,6 @@ pub enum FinishReason {
     #[serde(rename = "content_filter")]
     ContentFilter,
 }
-
-/// Stands in for the message when a producer reports a bare `"error"`. The
-/// failure is still surfaced as [`FinishReason::Error`]; only the detail is
-/// missing, and an empty string would reach the caller as an empty error body.
-const UNSPECIFIED_ERROR: &str = "engine reported an error without a message";
 
 impl std::fmt::Display for FinishReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -116,8 +118,8 @@ impl std::str::FromStr for FinishReason {
             "cancelled" | "abort" => Ok(FinishReason::Cancelled),
             "content_filter" => Ok(FinishReason::ContentFilter),
             // The `Display` form, and what the Python engine adapters emit.
+            // A bare "error" is deliberately not accepted; see the type docs.
             s if s.starts_with("error: ") => Ok(FinishReason::Error(s[7..].to_string())),
-            "error" => Ok(FinishReason::Error(UNSPECIFIED_ERROR.to_string())),
             _ => Err(anyhow::anyhow!("Invalid FinishReason variant: '{}'", s)),
         }
     }
@@ -855,11 +857,6 @@ mod tests {
                 r#""error: CustomEncoder failed: error: nested""#,
                 FinishReason::Error("CustomEncoder failed: error: nested".into()),
             ),
-            // Producers that signal failure without a message.
-            (
-                r#""error""#,
-                FinishReason::Error(UNSPECIFIED_ERROR.to_string()),
-            ),
         ];
         for (json, expected) in cases {
             assert_eq!(
@@ -885,9 +882,13 @@ mod tests {
         );
     }
 
+    /// A bare `"error"` stays rejected on purpose. Producers emitting it are
+    /// discarding a message they hold; accepting it here would paper over that
+    /// with invented text instead of leaving the defect visible.
     #[test]
     fn test_finish_reason_rejects_unknown_forms() {
         for json in [
+            r#""error""#,
             r#""nonsense""#,
             r#"{"nonsense":"boom"}"#,
             r#"{"error":"a","stop":"b"}"#,

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -45,7 +45,28 @@ pub trait OutputOptionsProvider {
     fn extract_output_options(&self) -> Result<OutputOptions>;
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+/// Why an engine stopped producing tokens for a request.
+///
+/// # Wire contract
+///
+/// We serialize the externally tagged derive form: a bare string for the unit
+/// variants (`"stop"`) and a single-key map for [`FinishReason::Error`]
+/// (`{"error": "<message>"}`). That is what every Rust producer has always
+/// emitted, and changing it would break every frontend in the N-2
+/// compatibility window, so it stays fixed.
+///
+/// Deserialization is deliberately more permissive, because Python engine
+/// adapters report request-level failures with the [`Display`] form instead —
+/// `"error: <message>"` (for example `dynamo.vllm`'s custom-encoder path) — and
+/// some report a bare `"error"` with no message at all. The derived reader
+/// rejects both, and rejecting them costs the caller the one thing that makes
+/// the failure actionable: a malformed terminal chunk fails the whole
+/// request-plane response, so the backend's message is dropped and the caller
+/// gets an unattributed 500. Accept every form the fleet emits and normalize
+/// here, at the wire boundary.
+///
+/// [`Display`]: std::fmt::Display
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub enum FinishReason {
     #[serde(rename = "eos")]
     EoS,
@@ -65,6 +86,11 @@ pub enum FinishReason {
     #[serde(rename = "content_filter")]
     ContentFilter,
 }
+
+/// Stands in for the message when a producer reports a bare `"error"`. The
+/// failure is still surfaced as [`FinishReason::Error`]; only the detail is
+/// missing, and an empty string would reach the caller as an empty error body.
+const UNSPECIFIED_ERROR: &str = "engine reported an error without a message";
 
 impl std::fmt::Display for FinishReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -88,9 +114,64 @@ impl std::str::FromStr for FinishReason {
             "length" => Ok(FinishReason::Length),
             "stop" => Ok(FinishReason::Stop),
             "cancelled" | "abort" => Ok(FinishReason::Cancelled),
+            "content_filter" => Ok(FinishReason::ContentFilter),
+            // The `Display` form, and what the Python engine adapters emit.
             s if s.starts_with("error: ") => Ok(FinishReason::Error(s[7..].to_string())),
+            "error" => Ok(FinishReason::Error(UNSPECIFIED_ERROR.to_string())),
             _ => Err(anyhow::anyhow!("Invalid FinishReason variant: '{}'", s)),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for FinishReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(FinishReasonVisitor)
+    }
+}
+
+struct FinishReasonVisitor;
+
+impl<'de> serde::de::Visitor<'de> for FinishReasonVisitor {
+    type Value = FinishReason;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            r#"a finish reason: "eos", "length", "stop", "cancelled", "content_filter", "error: <message>", or {"error": "<message>"}"#,
+        )
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<FinishReason, E>
+    where
+        E: serde::de::Error,
+    {
+        value
+            .parse()
+            .map_err(|_| E::invalid_value(serde::de::Unexpected::Str(value), &self))
+    }
+
+    /// The externally tagged form that [`Serialize`] emits: exactly one entry,
+    /// which can only ever be `{"error": "<message>"}` — the unit variants
+    /// serialize as bare strings and arrive at [`Self::visit_str`].
+    fn visit_map<A>(self, mut map: A) -> Result<FinishReason, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let Some(tag) = map.next_key::<String>()? else {
+            return Err(serde::de::Error::invalid_length(0, &self));
+        };
+        if tag != "error" {
+            return Err(serde::de::Error::unknown_variant(&tag, &["error"]));
+        }
+        let reason = FinishReason::Error(map.next_value()?);
+        if map.next_key::<serde::de::IgnoredAny>()?.is_some() {
+            return Err(serde::de::Error::custom(
+                "expected a finish reason map with a single key",
+            ));
+        }
+        Ok(reason)
     }
 }
 
@@ -723,6 +804,135 @@ impl From<CompletionContext> for PromptType {
 mod tests {
 
     use super::*;
+
+    fn all_finish_reasons() -> Vec<FinishReason> {
+        vec![
+            FinishReason::EoS,
+            FinishReason::Length,
+            FinishReason::Stop,
+            FinishReason::Cancelled,
+            FinishReason::ContentFilter,
+            FinishReason::Error("boom".to_string()),
+            FinishReason::Error(String::new()),
+        ]
+    }
+
+    /// The wire form Rust producers emit must not drift: every frontend in the
+    /// N-2 compatibility window still has to read it.
+    #[test]
+    fn test_finish_reason_serializes_to_the_external_tag_form() {
+        let cases = [
+            (FinishReason::EoS, r#""eos""#),
+            (FinishReason::Length, r#""length""#),
+            (FinishReason::Stop, r#""stop""#),
+            (FinishReason::Cancelled, r#""cancelled""#),
+            (FinishReason::ContentFilter, r#""content_filter""#),
+            (
+                FinishReason::Error("boom".to_string()),
+                r#"{"error":"boom"}"#,
+            ),
+        ];
+        for (reason, expected) in cases {
+            assert_eq!(serde_json::to_string(&reason).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn test_finish_reason_deserializes_every_producer_form() {
+        let cases = [
+            (r#""eos""#, FinishReason::EoS),
+            (r#""length""#, FinishReason::Length),
+            (r#""stop""#, FinishReason::Stop),
+            (r#""cancelled""#, FinishReason::Cancelled),
+            (r#""abort""#, FinishReason::Cancelled),
+            (r#""content_filter""#, FinishReason::ContentFilter),
+            // Rust producers (the `Serialize` form).
+            (r#"{"error":"boom"}"#, FinishReason::Error("boom".into())),
+            // Python engine adapters (the `Display` form).
+            (r#""error: boom""#, FinishReason::Error("boom".into())),
+            // A message that itself contains "error: " must survive intact.
+            (
+                r#""error: CustomEncoder failed: error: nested""#,
+                FinishReason::Error("CustomEncoder failed: error: nested".into()),
+            ),
+            // Producers that signal failure without a message.
+            (
+                r#""error""#,
+                FinishReason::Error(UNSPECIFIED_ERROR.to_string()),
+            ),
+        ];
+        for (json, expected) in cases {
+            assert_eq!(
+                serde_json::from_str::<FinishReason>(json).unwrap(),
+                expected,
+                "deserializing {json}"
+            );
+        }
+    }
+
+    /// The defect this guards: a backend's request-level message reaching the
+    /// frontend inside a terminal chunk rather than failing the whole response.
+    #[test]
+    fn test_engine_output_carries_string_form_error_message() {
+        use dynamo_runtime::protocols::maybe_error::MaybeError;
+
+        let chunk = r#"{"token_ids":[],"finish_reason":"error: CustomEncoder failed: placeholder tokens (0) != image tensors (1)"}"#;
+        let output: llm_backend::LLMEngineOutput = serde_json::from_str(chunk).unwrap();
+        let err = output.err().expect("error finish reason must surface");
+        assert!(
+            err.to_string().contains("placeholder tokens (0)"),
+            "message was dropped: {err}"
+        );
+    }
+
+    #[test]
+    fn test_finish_reason_rejects_unknown_forms() {
+        for json in [
+            r#""nonsense""#,
+            r#"{"nonsense":"boom"}"#,
+            r#"{"error":"a","stop":"b"}"#,
+            "{}",
+            "17",
+        ] {
+            assert!(
+                serde_json::from_str::<FinishReason>(json).is_err(),
+                "{json} should not deserialize"
+            );
+        }
+    }
+
+    #[test]
+    fn test_finish_reason_round_trips_through_json_and_msgpack() {
+        for reason in all_finish_reasons() {
+            let json = serde_json::to_string(&reason).unwrap();
+            assert_eq!(
+                serde_json::from_str::<FinishReason>(&json).unwrap(),
+                reason,
+                "json round trip"
+            );
+
+            let msgpack = rmp_serde::to_vec_named(&reason).unwrap();
+            assert_eq!(
+                rmp_serde::from_slice::<FinishReason>(&msgpack).unwrap(),
+                reason,
+                "msgpack round trip"
+            );
+        }
+    }
+
+    /// `Display` and `FromStr` are the string convention; keeping them mutually
+    /// inverse is what lets the tolerant reader defer to `FromStr`.
+    #[test]
+    fn test_finish_reason_display_round_trips_through_from_str() {
+        for reason in all_finish_reasons() {
+            let rendered = reason.to_string();
+            assert_eq!(
+                rendered.parse::<FinishReason>().unwrap(),
+                reason,
+                "{rendered} did not round trip"
+            );
+        }
+    }
 
     #[test]
     fn test_completion_context_new() {


### PR DESCRIPTION
## Overview

A request-level failure raised inside a Python worker is reported as `finish_reason = "error: <message>"`. The Rust frontend cannot deserialize that value, discards the whole response as malformed, and returns a bare `{"message":"Internal server error","code":500}`. The message the backend produced — the one naming exactly what the caller did wrong — never leaves the process.

## Root cause and fix

`FinishReason` carries two incompatible textual conventions. The derived externally tagged `Deserialize` reads only the map form `{"error": "<message>"}`; `Display`/`FromStr` define the string form `"error: <message>"`. The wire deserializes with serde, not `FromStr`, so the string form is unreadable on the only route that matters. Confirmed against the code:

```
"eos"              => Ok(EoS)
"error: boom"      => Err("unknown variant `error: boom`, expected one of `eos`, `length`, ...")
{"error":"boom"}   => Ok(Error("boom"))
```

This is not a producer mistake. `Display` writes exactly `"error: {msg}"` and `FromStr` parses exactly that back, so a Python author matching this type's own string rendering lands on the form the wire reader rejects — and `FromStr` has **zero production call sites** in the repo (its only caller is a test helper), so the convention was enforced nowhere on the request path. The seven emitting sites are all in `components/src/dynamo/vllm/handlers.py`.

This is not caught by the recent work returning 4xx instead of 500. `ErrorMessage::from_anyhow` classifies by walking the chain for typed markers, and the type it needs rides inside the payload — `FinishReason::Error(msg)`, which `MaybeError::err()` lifts into a typed `DynamoError`. Decode fails in `addressed_router.rs` before any `LLMEngineOutput` exists, and that arm builds `DynamoError::msg(...)`, defaulting to `ErrorType::Unknown`. Unknown matches no branch, so it lands in the catch-all. The backend's text does survive, embedded in serde's own complaint, but `sanitized_with_details` correctly withholds internal error text from the body (`details: None`), so the caller sees only "Internal server error".

The fix is a tolerant reader with an unchanged writer:

- Hand-written `Deserialize` accepting both forms and normalizing at the wire boundary. `visit_str` defers to `FromStr`; `visit_map` reads the external-tag form.
- `Serialize` is untouched, and a test pins the emitted bytes, so frontends across the N-2 compatibility window keep reading current workers.
- `FromStr` gained `"content_filter"`, a latent asymmetry in the same pair: `Display` emitted it and `FromStr` rejected it.

Fixing this in Rust rather than normalizing the Python emitters also covers workers already deployed inside the N-2 window, which a producer-side change cannot reach.

### What this deliberately does not do

The second commit narrows an earlier version of this PR that also accepted a bare `"error"`. That form is a **producer** defect, not a reader defect: sglang writes the real message to a sibling `error` key that `LLMEngineOutput` does not define, so accepting bare `"error"` would substitute invented text and mask a one-line bug. It stays rejected, and a test pins the rejection. Producers emitting it — `trtllm/request_handlers/handler_base.py:1269` and four sites in `sglang/request_handlers/multimodal/worker_handler.py` — should be fixed to report out of band instead.

More broadly, `FinishReason::Error(String)` is itself the design flaw: an error channel smuggled into a status enum. OpenAI's `finish_reason` has no `error` value, and neither does dynamo's own OpenAI-facing `CompletionFinishReason` — `From<FinishReason>` maps `Error(_) => Stop`. The correct channel already exists on this wire: `Annotated.error: Option<DynamoError>`, which a Python worker populates by raising `dynamo._core.InvalidArgument(msg)`, yielding a 400 carrying the real message. This PR is a compatibility fix for the deployed fleet; migrating producers to that channel is the follow-up, after which `FinishReason::Error` can be deprecated.

## Where to start

`lib/llm/src/protocols/common.rs` — the `FinishReason` doc comment states the wire contract and the deliberate limit, then the `Deserialize` impl and `FinishReasonVisitor` below it.

## Validation

- New tests in `protocols::common::tests`: the producer-form matrix (asserted against the literal strings the Python handlers write, not against Rust's own output), a pin on the emitted wire form, `Display`↔`FromStr` round trip, JSON + msgpack round trip, rejection of malformed input **including bare `"error"`**, and an end-to-end case deserializing the reported chunk and asserting `LLMEngineOutput::err()` surfaces `placeholder tokens (0)`.
- Existing Rust tests could not have caught this by construction: they round-trip through the same `Serialize`/`Deserialize` pair, so they stay green. The disagreement exists only across the Python→Rust boundary, where the Python suite pins the string form (`test_vllm_custom_encoder_handler.py`) and nothing checked the two against each other.
- `cargo test -p dynamo-llm --lib` — 2059 passed, 0 failed.
- `cargo test -p dynamo-backend-common` — 134 passed, 0 failed. `cargo check -p dynamo-trtllm-sidecar` clean.
- `cargo fmt --all`, `cargo clippy -p dynamo-llm --no-deps --all-targets -- -D warnings` clean.
- `pre-commit run --files lib/llm/src/protocols/common.rs` clean except `pytest-marker-report`, which fails identically on an unmodified tree here (Python deps absent in this worktree) and is unrelated to this Rust-only change.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
