### PR TITLE
fix(runtime): bind system status server to loopback by default

### DIFF
--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -15,7 +15,7 @@ use validator::Validate;
 pub mod environment_names;
 
 /// Default system host for health and metrics endpoints
-const DEFAULT_SYSTEM_HOST: &str = "0.0.0.0";
+const DEFAULT_SYSTEM_HOST: &str = "127.0.0.1";
 
 /// Default system port for health and metrics endpoints (-1 = disabled)
 const DEFAULT_SYSTEM_PORT: i16 = -1;


### PR DESCRIPTION
## Summary

- Change `DEFAULT_SYSTEM_HOST` from `0.0.0.0` to `127.0.0.1` so the system status server only listens on loopback by default
- The system status server exposes unauthenticated control-plane routes (`/engine/*`, `/v1/loras/*`) that can load weights, flush KV caches, pause generation, and invoke arbitrary engine callbacks
- In non-Kubernetes deployments (local dev, bare-metal), binding `0.0.0.0` exposes these routes to the entire local network
- Deployments needing external reachability (e.g. Kubernetes) can opt in with `DYN_SYSTEM_HOST=0.0.0.0`
- Local development is unaffected — all components run on the same machine

## Validation

- Verified that the Rust default (`DEFAULT_SYSTEM_HOST`) is the only place this default originates
- Confirmed the Kubernetes operator does not set `DYN_SYSTEM_HOST`, so it will need a follow-up to explicitly set `0.0.0.0` for pod health probes
- All existing tests that use `DYN_SYSTEM_PORT=0` bind to `127.0.0.1` and test via localhost, so they remain unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default system host to use the local machine address for improved security and safer default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->