### PR TITLE
fix(frontend): map Kimi K3 OpenAI fields (sglang chat processor)

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -806,7 +806,29 @@ def preprocess_chat_request(
         if chat_template_kwargs:
             template_kwargs.update(chat_template_kwargs)
 
-        if (reasoning_effort := request.get("reasoning_effort")) is not None:
+        reasoning_effort = request.get("reasoning_effort")
+        is_kimi_k3 = any(
+            _normalize_sglang_parser_name(parser_name) == "kimi_k3"
+            for parser_name in (tool_call_parser_name, reasoning_parser_name)
+        )
+        if is_kimi_k3:
+            # Native SGLang's Kimi K3 encoder names this template argument
+            # thinking_effort and supports only low, high, and max.
+            reasoning_effort = template_kwargs.pop("reasoning_effort", reasoning_effort)
+            if (
+                reasoning_effort in ("low", "high", "max")
+                and "thinking_effort" not in template_kwargs
+            ):
+                template_kwargs["thinking_effort"] = reasoning_effort
+            elif reasoning_effort not in (None, "none", "low", "high", "max"):
+                logger.warning(
+                    "Kimi K3 does not support reasoning_effort=%r; using the "
+                    "encoder default.",
+                    reasoning_effort,
+                )
+            if (response_format := request.get("response_format")) is not None:
+                template_kwargs.setdefault("response_format", response_format)
+        elif reasoning_effort is not None:
             template_kwargs["reasoning_effort"] = reasoning_effort
 
         template_messages = _normalize_messages_for_template(messages, tokenizer)

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -2931,6 +2931,123 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
         assert result.force_reasoning is expected
         assert result.reasoning_parser.force_reasoning is expected
 
+    @pytest.mark.parametrize(
+        ("reasoning_effort", "chat_template_kwargs", "expected_effort"),
+        [
+            ("low", {}, "low"),
+            ("high", {}, "high"),
+            ("low", {"thinking_effort": "max"}, "max"),
+            (None, {"reasoning_effort": "low"}, "low"),
+            (None, {"thinking_effort": "max"}, "max"),
+        ],
+    )
+    def test_kimi_k3_maps_reasoning_effort_to_thinking_effort(
+        self, reasoning_effort, chat_template_kwargs, expected_effort
+    ):
+        captured = {}
+
+        class CapturingTokenizer:
+            chat_template = "template"
+
+            def apply_chat_template(self, messages, **kwargs):
+                captured["kwargs"] = kwargs
+                return [1, 2, 3]
+
+        preprocess_chat_request(
+            {
+                "model": "moonshotai/Kimi-K3",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "reasoning_effort": reasoning_effort,
+                "chat_template_kwargs": chat_template_kwargs,
+            },
+            tokenizer=CapturingTokenizer(),
+            tool_call_parser_name="kimi_k3",
+            reasoning_parser_name=None,
+            default_thinking_mode="disabled",
+        )
+
+        assert captured["kwargs"]["thinking_effort"] == expected_effort
+        assert "reasoning_effort" not in captured["kwargs"]
+        assert "thinking" not in captured["kwargs"]
+        assert "enable_thinking" not in captured["kwargs"]
+
+    def test_kimi_k3_warns_for_unsupported_reasoning_effort(self, caplog):
+        captured = {}
+
+        class CapturingTokenizer:
+            chat_template = "template"
+
+            def apply_chat_template(self, messages, **kwargs):
+                captured["kwargs"] = kwargs
+                return [1, 2, 3]
+
+        preprocess_chat_request(
+            {
+                "model": "moonshotai/Kimi-K3",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "reasoning_effort": "medium",
+            },
+            tokenizer=CapturingTokenizer(),
+            tool_call_parser_name="kimi_k3",
+            reasoning_parser_name=None,
+        )
+
+        assert "thinking_effort" not in captured["kwargs"]
+        assert "reasoning_effort" not in captured["kwargs"]
+        assert "Kimi K3 does not support reasoning_effort='medium'" in caplog.text
+
+    def test_kimi_k3_forwards_response_format_to_chat_template(self):
+        captured = {}
+
+        class CapturingTokenizer:
+            chat_template = "template"
+
+            def apply_chat_template(self, messages, **kwargs):
+                captured["kwargs"] = kwargs
+                return [1, 2, 3]
+
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "city",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+        result = preprocess_chat_request(
+            {
+                "model": "moonshotai/Kimi-K3",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "response_format": response_format,
+            },
+            tokenizer=CapturingTokenizer(),
+            tool_call_parser_name="kimi_k3",
+            reasoning_parser_name=None,
+        )
+
+        assert captured["kwargs"]["response_format"] == response_format
+        assert result.guided_decoding == {
+            "json": response_format["json_schema"]["schema"]
+        }
+
+        template_response_format = {"type": "json_object"}
+        preprocess_chat_request(
+            {
+                "model": "moonshotai/Kimi-K3",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "response_format": response_format,
+                "chat_template_kwargs": {"response_format": template_response_format},
+            },
+            tokenizer=CapturingTokenizer(),
+            tool_call_parser_name="kimi_k3",
+            reasoning_parser_name=None,
+        )
+
+        assert captured["kwargs"]["response_format"] == template_response_format
+
     @pytest.mark.multimodal
     def test_kimi_k3_normalizes_template_media_but_forwards_original_url(
         self,

--- a/components/src/dynamo/frontend/thinking.py
+++ b/components/src/dynamo/frontend/thinking.py
@@ -14,6 +14,7 @@ THINKING_CONTROL_KEYS = (
     "enable_thinking",
     "thinking_mode",
     "reasoning_effort",
+    "thinking_effort",
 )
 
 

--- a/docs/fern/pages/reference/api/python/frontend.mdx
+++ b/docs/fern/pages/reference/api/python/frontend.mdx
@@ -285,7 +285,7 @@ Handles:
 - Reasoning content extraction via SGLang ReasoningParser
 - Tool call parsing via SGLang FunctionCallParser or JsonArrayParser
 
-[`components/src/dynamo/frontend/sglang_prepost.py#L957`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/sglang_prepost.py#L957)
+[`components/src/dynamo/frontend/sglang_prepost.py#L979`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/sglang_prepost.py#L979)
 
 **Public methods**
 
@@ -297,7 +297,7 @@ __init__(*, tokenizer, tool_call_parser: ToolCallParserType | None, reasoning_pa
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/sglang_prepost.py#L966)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/sglang_prepost.py#L988)
 
 <h4 id="api-dynamo-frontend-sglang-prepost-sglangstreamingpostprocessor-process-output">process_output</h4>
 
@@ -317,7 +317,7 @@ Dict with ``token_ids`` and optional ``finish_reason``.
 
 - `dict[str, Any] | None` — OpenAI choice dict or ``None`` if nothing to emit yet.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/sglang_prepost.py#L1224)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/sglang_prepost.py#L1246)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-prepost-streamingpostprocessor" title="StreamingPostProcessor (class)">
@@ -403,7 +403,7 @@ from dynamo.frontend.thinking import apply_default_thinking_mode_to_template_kwa
 apply_default_thinking_mode_to_template_kwargs(chat_template_kwargs: dict[str, Any], default_thinking_mode: str | None, *, request_has_root_thinking: bool = False) -> dict[str, Any]
 ```
 
-[`components/src/dynamo/frontend/thinking.py#L33`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/thinking.py#L33)
+[`components/src/dynamo/frontend/thinking.py#L34`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/thinking.py#L34)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-main-async-main" title="async_main (function)">
@@ -824,7 +824,7 @@ from dynamo.frontend.thinking import runtime_default_thinking_mode
 runtime_default_thinking_mode(runtime_config: dict[str, Any] | None) -> str | None
 ```
 
-[`components/src/dynamo/frontend/thinking.py#L20`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/thinking.py#L20)
+[`components/src/dynamo/frontend/thinking.py#L21`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/thinking.py#L21)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-main-setup-engine-factory" title="setup_engine_factory (function)">


### PR DESCRIPTION
## Summary

- Map OpenAI `reasoning_effort` to Kimi K3's `thinking_effort` chat-template argument.
- Forward the exact OpenAI `response_format` into the Kimi K3 chat template while retaining guided decoding.
- Preserve explicit `chat_template_kwargs` overrides and deployment-level thinking defaults.
- Keep string-stop handling out of this change because it is already covered by #12562.

## Validation

- Added SGLang frontend unit coverage for supported and unsupported reasoning effort values and explicit override precedence.
- Added response-format forwarding, guided-decoding, and explicit override coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for controlling Kimi K3 thinking behavior through `reasoning_effort` and `thinking_effort`.
  * Added support for forwarding response format settings, including JSON-guided responses.
  * Added recognition of `thinking_effort` as a supported thinking control.

* **Bug Fixes**
  * Unsupported reasoning effort values are now ignored with a warning.
  * Explicit thinking settings and template-level response format overrides are preserved.

* **Tests**
  * Added coverage for thinking controls, response formats, overrides, and warning behavior.

* **Documentation**
  * Updated API reference source links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->