### PR TITLE
refactor(sglang): use shared sidecar arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,6 +3018,7 @@ dependencies = [
  "clap",
  "dynamo-backend-common",
  "dynamo-runtime",
+ "dynamo-sidecar-common",
  "futures",
  "prost 0.13.5",
  "rand 0.9.4",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2661,6 +2661,7 @@ dependencies = [
  "clap",
  "dynamo-backend-common",
  "dynamo-runtime",
+ "dynamo-sidecar-common",
  "futures",
  "prost 0.13.5",
  "rand 0.9.4",
@@ -2669,6 +2670,19 @@ dependencies = [
  "tokio-util",
  "tonic 0.13.1",
  "tonic-build 0.13.1",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "dynamo-sidecar-common"
+version = "1.4.0"
+dependencies = [
+ "clap",
+ "dynamo-backend-common",
+ "futures",
+ "tokio",
+ "tonic 0.13.1",
  "tracing",
  "url",
 ]

--- a/lib/mocker/servers/sglang/tests/sidecar.rs
+++ b/lib/mocker/servers/sglang/tests/sidecar.rs
@@ -80,13 +80,13 @@ async fn sidecar(endpoint: &str, mode: DisaggregationMode) -> SglangSidecarEngin
         "dynamo-sglang-sidecar".to_string(),
         "--sglang-endpoint".to_string(),
         endpoint.to_string(),
-        "--sglang-connections".to_string(),
+        "--grpc-connections".to_string(),
         "1".to_string(),
-        "--connect-timeout-secs".to_string(),
+        "--grpc-connect-attempt-timeout-secs".to_string(),
         "1".to_string(),
-        "--health-poll-interval-secs".to_string(),
+        "--grpc-retry-interval-secs".to_string(),
         "1".to_string(),
-        "--health-deadline-secs".to_string(),
+        "--grpc-startup-deadline-secs".to_string(),
         "5".to_string(),
     ];
     if mode.is_prefill() {

--- a/lib/sidecar/sglang/Cargo.toml
+++ b/lib/sidecar/sglang/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 [dependencies]
 dynamo-backend-common = { workspace = true }
 dynamo-runtime = { workspace = true }
+dynamo-sidecar-common = { workspace = true }
 
 anyhow = { workspace = true }
 async-stream = { workspace = true }

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -22,6 +22,23 @@ cargo build --release -p dynamo-sglang-sidecar
 There is no published image yet; the "Deploy on Kubernetes" section below builds
 a minimal one from `Dockerfile`. Official packaging is deferred to a follow-up.
 
+## Configure the sidecar
+
+The SGLang sidecar uses the same Dynamo worker and gRPC transport arguments as the vLLM and TensorRT-LLM sidecars. Common worker options include `--namespace`, `--component`, `--endpoint`, `--endpoint-types`, `--custom-jinja-template`, `--dyn-tool-call-parser`, and `--dyn-reasoning-parser`. Explicit Dynamo parser options override parser names discovered from SGLang.
+
+SGLang remains the source of truth for the worker's aggregated, prefill, or decode role. The inherited `--disaggregation-mode` option and `DYN_DISAGGREGATION_MODE` environment variable have no effect in this sidecar. Disaggregated workers continue to register under their fixed role components; aggregated workers honor `--component` or `DYN_COMPONENT`.
+
+The sidecar opens eight gRPC connections by default. Override the pool size with `--grpc-connections` or `DYN_SIDECAR_GRPC_CONNECTIONS`. Connection startup uses a 30-second timeout per attempt, a one-second retry and readiness interval, and a five-minute deadline for establishing the full pool. Override these settings with `--grpc-connect-attempt-timeout-secs`, `--grpc-retry-interval-secs`, and `--grpc-startup-deadline-secs`, or the corresponding `DYN_SIDECAR_GRPC_*` environment variables.
+
+The previous SGLang-specific transport options are not accepted:
+
+| Previous option | Replacement |
+|---|---|
+| `--sglang-connections` / `SGLANG_GRPC_CONNECTIONS` | `--grpc-connections` / `DYN_SIDECAR_GRPC_CONNECTIONS` |
+| `--connect-timeout-secs` | `--grpc-connect-attempt-timeout-secs` |
+| `--health-poll-interval-secs` | `--grpc-retry-interval-secs` |
+| `--health-deadline-secs` | `--grpc-startup-deadline-secs` |
+
 ## SGLang-managed module contract
 
 SGLang can load the Python entry point and supply the gRPC endpoint arguments:

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -28,7 +28,7 @@ Use `SGLANG_GRPC_ENDPOINT` instead of `--sglang-endpoint` when the endpoint is p
 
 The sidecar discovers the model and tokenizer paths, served model name, parser defaults, worker role, context length, KV capacity, scheduler limits, data-parallel topology, and KV-event sources through SGLang's native discovery RPCs. Explicit Dynamo parser options override parser names discovered from SGLang.
 
-SGLang remains the source of truth for the worker's aggregated, prefill, or decode role. The inherited `--disaggregation-mode` option and `DYN_DISAGGREGATION_MODE` environment variable have no effect in this sidecar. Disaggregated workers continue to register under their fixed role components; aggregated workers honor `--component` or `DYN_COMPONENT`.
+SGLang remains the source of truth for the worker's aggregated, prefill, or decode role. The inherited `--disaggregation-mode` option and `DYN_DISAGGREGATION_MODE` environment variable have no effect in this sidecar. The SGLang sidecar rejects `--route-to-encoder` because its native protocol does not support encoder workers. Disaggregated workers continue to register under their fixed role components; aggregated workers honor `--component` or `DYN_COMPONENT`.
 
 The sidecar opens eight gRPC connections by default. Override the pool size with `--grpc-connections` or `DYN_SIDECAR_GRPC_CONNECTIONS`.
 

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -11,6 +11,8 @@ out-of-process SGLang engine through SGLang's native gRPC service. It is a
 standalone Rust executable and is also compiled into `ai-dynamo-runtime` for
 the importable `dynamo.sglang.sidecar` launcher.
 
+## Run
+
 Build and run it directly from the Dynamo workspace:
 
 ```bash
@@ -22,22 +24,15 @@ cargo build --release -p dynamo-sglang-sidecar
 There is no published image yet; the "Deploy on Kubernetes" section below builds
 a minimal one from `Dockerfile`. Official packaging is deferred to a follow-up.
 
-## Configure the sidecar
+Use `SGLANG_GRPC_ENDPOINT` instead of `--sglang-endpoint` when the endpoint is provided through the environment.
 
-The SGLang sidecar uses the same Dynamo worker and gRPC transport arguments as the vLLM and TensorRT-LLM sidecars. Common worker options include `--namespace`, `--component`, `--endpoint`, `--endpoint-types`, `--custom-jinja-template`, `--dyn-tool-call-parser`, and `--dyn-reasoning-parser`. Explicit Dynamo parser options override parser names discovered from SGLang.
+The sidecar discovers the model and tokenizer paths, served model name, parser defaults, worker role, context length, KV capacity, scheduler limits, data-parallel topology, and KV-event sources through SGLang's native discovery RPCs. Explicit Dynamo parser options override parser names discovered from SGLang.
 
 SGLang remains the source of truth for the worker's aggregated, prefill, or decode role. The inherited `--disaggregation-mode` option and `DYN_DISAGGREGATION_MODE` environment variable have no effect in this sidecar. Disaggregated workers continue to register under their fixed role components; aggregated workers honor `--component` or `DYN_COMPONENT`.
 
-The sidecar opens eight gRPC connections by default. Override the pool size with `--grpc-connections` or `DYN_SIDECAR_GRPC_CONNECTIONS`. Connection startup uses a 30-second timeout per attempt, a one-second retry and readiness interval, and a five-minute deadline for establishing the full pool. Override these settings with `--grpc-connect-attempt-timeout-secs`, `--grpc-retry-interval-secs`, and `--grpc-startup-deadline-secs`, or the corresponding `DYN_SIDECAR_GRPC_*` environment variables.
+The sidecar opens eight gRPC connections by default. Override the pool size with `--grpc-connections` or `DYN_SIDECAR_GRPC_CONNECTIONS`.
 
-The previous SGLang-specific transport options are not accepted:
-
-| Previous option | Replacement |
-|---|---|
-| `--sglang-connections` / `SGLANG_GRPC_CONNECTIONS` | `--grpc-connections` / `DYN_SIDECAR_GRPC_CONNECTIONS` |
-| `--connect-timeout-secs` | `--grpc-connect-attempt-timeout-secs` |
-| `--health-poll-interval-secs` | `--grpc-retry-interval-secs` |
-| `--health-deadline-secs` | `--grpc-startup-deadline-secs` |
+Connection startup uses a 30-second timeout per attempt, a one-second retry and readiness interval, and a five-minute deadline for establishing the full connection pool. Override them with `--grpc-connect-attempt-timeout-secs`, `--grpc-retry-interval-secs`, and `--grpc-startup-deadline-secs`, or with the corresponding `DYN_SIDECAR_GRPC_*` environment variables.
 
 ## SGLang-managed module contract
 

--- a/lib/sidecar/sglang/src/args.rs
+++ b/lib/sidecar/sglang/src/args.rs
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Command-line arguments and transport configuration for the SGLang sidecar.
+//! Command-line arguments for the SGLang sidecar.
 
-use std::path::PathBuf;
-use std::time::Duration;
+use dynamo_sidecar_common::SidecarArgs;
 
 /// Parsed sidecar arguments.
 #[derive(clap::Parser, Debug, Clone)]
@@ -13,13 +12,12 @@ use std::time::Duration;
     about = "Dynamo sidecar for an out-of-process SGLang native gRPC server."
 )]
 pub struct Args {
+    #[command(flatten)]
+    pub sidecar: SidecarArgs,
+
     /// `host:port` (or URL) of SGLang's native `sglang.runtime.v1` service.
     #[arg(long, visible_alias = "grpc-endpoint", env = "SGLANG_GRPC_ENDPOINT")]
     pub sglang_endpoint: String,
-
-    /// Number of independent HTTP/2 connections used for generation streams.
-    #[arg(long, env = "SGLANG_GRPC_CONNECTIONS", default_value_t = 8)]
-    pub sglang_connections: usize,
 
     /// Reachable host that decode workers use to connect to a prefill worker's
     /// SGLang disaggregation bootstrap port. By default this is derived from
@@ -28,118 +26,4 @@ pub struct Args {
     /// wildcard addresses.
     #[arg(long, env = "SGLANG_DISAGGREGATION_BOOTSTRAP_HOST")]
     pub bootstrap_host: Option<String>,
-
-    /// Dynamo namespace for discovery routing.
-    #[arg(long, env = "DYN_NAMESPACE", default_value = "dynamo")]
-    pub namespace: String,
-
-    /// Endpoint name exposed by this worker.
-    #[arg(long, env = "DYN_ENDPOINT", default_value = "generate")]
-    pub endpoint: String,
-
-    /// Comma-separated endpoint types (for example `chat,completions`).
-    #[arg(long, env = "DYN_ENDPOINT_TYPES", default_value = "chat,completions")]
-    pub endpoint_types: String,
-
-    /// Optional path to a custom Jinja chat template.
-    #[arg(long, env = "DYN_CUSTOM_JINJA_TEMPLATE")]
-    pub custom_jinja_template: Option<PathBuf>,
-
-    /// Per-attempt connection timeout in seconds.
-    #[arg(long, default_value_t = 30)]
-    pub connect_timeout_secs: u64,
-
-    /// Delay between connection/readiness attempts in seconds.
-    #[arg(long, default_value_t = 2)]
-    pub health_poll_interval_secs: u64,
-
-    /// Total startup deadline in seconds.
-    #[arg(long, default_value_t = 300)]
-    pub health_deadline_secs: u64,
-}
-
-impl Args {
-    pub fn transport(&self) -> TransportConfig {
-        TransportConfig {
-            connect_timeout: Duration::from_secs(self.connect_timeout_secs),
-            poll_interval: Duration::from_secs(self.health_poll_interval_secs.max(1)),
-            deadline: Duration::from_secs(self.health_deadline_secs),
-            connections: self.sglang_connections.max(1),
-        }
-    }
-}
-
-/// Connection and readiness tunables shared by bootstrap and `start`.
-#[derive(Debug, Clone)]
-pub struct TransportConfig {
-    pub connect_timeout: Duration,
-    pub poll_interval: Duration,
-    pub deadline: Duration,
-    pub connections: usize,
-}
-
-impl Default for TransportConfig {
-    fn default() -> Self {
-        Self {
-            connect_timeout: Duration::from_secs(30),
-            poll_interval: Duration::from_secs(2),
-            deadline: Duration::from_secs(300),
-            connections: 1,
-        }
-    }
-}
-
-/// Normalize plaintext endpoint schemes for tonic.
-///
-/// TLS is intentionally rejected until the sidecar enables and tests tonic's
-/// TLS transport feature instead of advertising an unusable `grpcs://` URL.
-pub fn normalize_endpoint(raw: &str) -> Result<String, String> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Err("SGLang gRPC endpoint must not be empty".to_string());
-    }
-    if let Some(rest) = trimmed.strip_prefix("grpc://") {
-        if rest.is_empty() {
-            return Err("SGLang gRPC endpoint host must not be empty".to_string());
-        }
-        Ok(format!("http://{rest}"))
-    } else if trimmed.starts_with("grpcs://") || trimmed.starts_with("https://") {
-        Err("TLS endpoints are not supported by the SGLang sidecar".to_string())
-    } else if let Some(rest) = trimmed.strip_prefix("http://") {
-        if rest.is_empty() {
-            return Err("SGLang gRPC endpoint host must not be empty".to_string());
-        }
-        Ok(trimmed.to_string())
-    } else if trimmed.contains("://") {
-        Err(format!(
-            "unsupported SGLang gRPC endpoint scheme: {trimmed}"
-        ))
-    } else {
-        Ok(format!("http://{trimmed}"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::normalize_endpoint;
-
-    #[test]
-    fn normalizes_bare_and_grpc_endpoints() {
-        assert_eq!(
-            normalize_endpoint("127.0.0.1:30001").unwrap(),
-            "http://127.0.0.1:30001",
-        );
-        assert_eq!(
-            normalize_endpoint("grpc://host:7").unwrap(),
-            "http://host:7"
-        );
-        assert!(normalize_endpoint("grpcs://host:8").is_err());
-        assert!(normalize_endpoint(" https://host:9 ").is_err());
-    }
-
-    #[test]
-    fn rejects_endpoints_without_hosts() {
-        assert!(normalize_endpoint("http://").is_err());
-        assert!(normalize_endpoint("grpc://").is_err());
-    }
 }

--- a/lib/sidecar/sglang/src/client.rs
+++ b/lib/sidecar/sglang/src/client.rs
@@ -8,15 +8,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use dynamo_backend_common::{BackendError, DynamoError, ErrorType};
+use dynamo_sidecar_common::{DEFAULT_MAX_GRPC_MESSAGE_SIZE, GrpcEndpoint, GrpcTransportConfig};
 use serde_json::Value;
 use tokio::time::{Instant, timeout_at};
 use tonic::transport::{Channel, Endpoint};
 
-use crate::args::TransportConfig;
 use crate::proto as pb;
 use crate::proto::sglang_service_client::SglangServiceClient;
-
-const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 
 pub type Client = SglangServiceClient<Channel>;
 
@@ -32,8 +30,8 @@ pub struct Discovery {
 }
 
 pub async fn connect(
-    uri: &str,
-    cfg: &TransportConfig,
+    uri: &GrpcEndpoint,
+    cfg: &GrpcTransportConfig,
     deadline: Instant,
 ) -> Result<Client, DynamoError> {
     let endpoint = Endpoint::from_shared(uri.to_string())
@@ -47,10 +45,10 @@ pub async fn connect(
                 if Instant::now() >= deadline {
                     return Err(cannot_connect(format!(
                         "could not reach SGLang gRPC at {uri} within {:?}: {last_err}",
-                        cfg.deadline
+                        cfg.startup_deadline
                     )));
                 }
-                tokio::time::sleep_until((Instant::now() + cfg.poll_interval).min(deadline)).await;
+                tokio::time::sleep_until((Instant::now() + cfg.retry_interval).min(deadline)).await;
             }
         }
     }
@@ -58,7 +56,7 @@ pub async fn connect(
 
 async fn try_connect_once(
     endpoint: &Endpoint,
-    cfg: &TransportConfig,
+    cfg: &GrpcTransportConfig,
     deadline: Instant,
 ) -> Result<Client, String> {
     let remaining = deadline.saturating_duration_since(Instant::now());
@@ -67,7 +65,7 @@ async fn try_connect_once(
     }
     let endpoint = endpoint
         .clone()
-        .connect_timeout(cfg.connect_timeout.min(remaining));
+        .connect_timeout(cfg.connect_attempt_timeout.min(remaining));
     let channel = timeout_at(deadline, endpoint.connect())
         .await
         .map_err(|_| "startup deadline elapsed while connecting".to_string())?
@@ -77,8 +75,8 @@ async fn try_connect_once(
 
 fn client_from_channel(channel: Channel) -> Client {
     SglangServiceClient::new(channel)
-        .max_decoding_message_size(MAX_MESSAGE_SIZE)
-        .max_encoding_message_size(MAX_MESSAGE_SIZE)
+        .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
 }
 
 /// Fixed-size pool of independent HTTP/2 connections. Generation calls are
@@ -90,12 +88,11 @@ pub struct Pool {
 
 impl Pool {
     pub async fn connect(
-        uri: &str,
-        cfg: &TransportConfig,
-        size: usize,
+        uri: &GrpcEndpoint,
+        cfg: &GrpcTransportConfig,
         deadline: Instant,
     ) -> Result<Self, DynamoError> {
-        let size = size.max(1);
+        let size = cfg.connections.get();
         let mut clients = Vec::with_capacity(size);
         for _ in 0..size {
             clients.push(connect(uri, cfg, deadline).await?);
@@ -309,14 +306,12 @@ pub fn status_to_dynamo(rpc: &str, status: tonic::Status) -> DynamoError {
 mod tests {
     use std::time::Duration;
 
-    use dynamo_backend_common::{BackendError, ErrorType};
     use serde_json::json;
     use tokio::net::TcpListener;
-    use tokio::time::{Instant, timeout};
+    use tokio::time::Instant;
     use tonic::transport::Endpoint;
 
-    use super::{client_from_channel, connect, discover, json_u32, json_u64, parse_discovery};
-    use crate::args::TransportConfig;
+    use super::{client_from_channel, discover, json_u32, json_u64, parse_discovery};
     use crate::proto as pb;
 
     #[test]
@@ -362,29 +357,5 @@ mod tests {
 
         assert!(result.is_err());
         assert!(started.elapsed() < Duration::from_secs(1));
-    }
-
-    #[tokio::test]
-    async fn malformed_endpoint_fails_before_retrying() {
-        let transport = TransportConfig {
-            poll_interval: Duration::from_secs(5),
-            deadline: Duration::from_secs(30),
-            ..TransportConfig::default()
-        };
-        let result = timeout(
-            Duration::from_secs(1),
-            connect("http://", &transport, Instant::now() + transport.deadline),
-        )
-        .await
-        .expect("invalid endpoint should not enter the retry loop");
-        let error = match result {
-            Err(error) => error,
-            Ok(_) => panic!("invalid endpoint unexpectedly connected"),
-        };
-
-        assert_eq!(
-            error.error_type(),
-            ErrorType::Backend(BackendError::InvalidArgument)
-        );
     }
 }

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -13,13 +13,14 @@ use dynamo_backend_common::{
     LLMEngineOutput, LLMEngineOutputExt, LlmRegistration, ModelInput, PreprocessedRequest,
     WorkerConfig, usage,
 };
+use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::stream::BoxStream;
 use serde_json::Value;
 use tokio::sync::OnceCell;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
-use crate::args::{Args, TransportConfig, normalize_endpoint};
+use crate::args::Args;
 use crate::client::{self, Client, Discovery, Pool};
 use crate::proto as pb;
 use crate::protocol::{
@@ -28,8 +29,8 @@ use crate::protocol::{
 };
 
 pub struct SglangSidecarEngine {
-    endpoint: String,
-    transport: TransportConfig,
+    endpoint: GrpcEndpoint,
+    transport: GrpcTransportConfig,
     disaggregation_mode: DisaggregationMode,
     bootstrap_host: Option<String>,
     bootstrap_port: Option<u16>,
@@ -39,14 +40,14 @@ pub struct SglangSidecarEngine {
 
 impl SglangSidecarEngine {
     pub(crate) fn new(
-        endpoint: impl Into<String>,
-        transport: TransportConfig,
+        endpoint: GrpcEndpoint,
+        transport: GrpcTransportConfig,
         disaggregation_mode: DisaggregationMode,
         bootstrap_host: Option<String>,
         bootstrap_port: Option<u16>,
     ) -> Self {
         Self {
-            endpoint: endpoint.into(),
+            endpoint,
             transport,
             disaggregation_mode,
             bootstrap_host,
@@ -63,12 +64,22 @@ impl SglangSidecarEngine {
             None => <Args as clap::Parser>::parse(),
         };
 
-        let endpoint = normalize_endpoint(&args.sglang_endpoint).map_err(client::invalid_arg)?;
-        let transport = args.transport();
+        if args.sidecar.common.route_to_encoder {
+            return Err(client::invalid_arg(
+                "route-to-encoder is not supported by the SGLang sidecar",
+            ));
+        }
+
+        let endpoint = GrpcEndpoint::parse(&args.sglang_endpoint, "--sglang-endpoint")?;
+        let transport = args.sidecar.grpc.config();
         let discovery = bootstrap_discover(&endpoint, &transport)?;
         let disaggregation_mode = discovery_mode(&discovery)?;
         let bootstrap_host = if disaggregation_mode.is_prefill() {
-            resolve_bootstrap_host(args.bootstrap_host.as_deref(), &endpoint, &discovery)?
+            resolve_bootstrap_host(
+                args.bootstrap_host.as_deref(),
+                endpoint.as_str(),
+                &discovery,
+            )?
         } else {
             None
         };
@@ -85,18 +96,29 @@ impl SglangSidecarEngine {
             "sglang sidecar bootstrapped native gRPC discovery"
         );
 
+        let common = args.sidecar.common;
         let config = WorkerConfig {
-            namespace: args.namespace,
-            component: disaggregation_mode.discovery_component().to_string(),
-            endpoint: args.endpoint,
-            endpoint_types: args.endpoint_types,
-            custom_jinja_template: args.custom_jinja_template,
+            namespace: common.namespace,
+            component: if disaggregation_mode == DisaggregationMode::Aggregated {
+                common.component
+            } else {
+                disaggregation_mode.discovery_component().to_string()
+            },
+            endpoint: common.endpoint,
+            endpoint_types: common.endpoint_types,
+            custom_jinja_template: common.custom_jinja_template,
             disaggregation_mode,
             model_name: discovery.tokenizer_path.clone(),
             served_model_name: discovery.served_model_name.clone(),
             model_input: ModelInput::Tokens,
-            reasoning_parser: discovery_string(&discovery.server_info, "reasoning_parser"),
-            tool_call_parser: discovery_string(&discovery.server_info, "tool_call_parser"),
+            reasoning_parser: common
+                .dyn_reasoning_parser
+                .or_else(|| discovery_string(&discovery.server_info, "reasoning_parser")),
+            tool_call_parser: common
+                .dyn_tool_call_parser
+                .or_else(|| discovery_string(&discovery.server_info, "tool_call_parser")),
+            exclude_tools_when_tool_choice_none: common.exclude_tools_when_tool_choice_none,
+            route_to_encoder: false,
             ..Default::default()
         };
 
@@ -126,11 +148,13 @@ impl SglangSidecarEngine {
             if Instant::now() >= deadline {
                 return Err(client::engine_shutdown(format!(
                     "SGLang did not become healthy within {:?}: {retry_message}",
-                    self.transport.deadline
+                    self.transport.startup_deadline
                 )));
             }
-            tokio::time::sleep_until((Instant::now() + self.transport.poll_interval).min(deadline))
-                .await;
+            tokio::time::sleep_until(
+                (Instant::now() + self.transport.retry_interval).min(deadline),
+            )
+            .await;
         }
     }
 }
@@ -142,14 +166,8 @@ impl LLMEngine for SglangSidecarEngine {
             return Err(client::engine_shutdown("sglang sidecar already started"));
         }
 
-        let deadline = Instant::now() + self.transport.deadline;
-        let pool = Pool::connect(
-            &self.endpoint,
-            &self.transport,
-            self.transport.connections,
-            deadline,
-        )
-        .await?;
+        let deadline = Instant::now() + self.transport.startup_deadline;
+        let pool = Pool::connect(&self.endpoint, &self.transport, deadline).await?;
         let mut control = pool.control_client();
         self.await_ready(&mut control, deadline).await?;
         let discovery = client::discover(&mut control, deadline).await?;
@@ -382,8 +400,12 @@ impl LLMEngine for SglangSidecarEngine {
             rid: ctx.id().to_string(),
             abort_all: false,
         };
-        if let Err(error) =
-            client::abort(&mut grpc_client, request, self.transport.connect_timeout).await
+        if let Err(error) = client::abort(
+            &mut grpc_client,
+            request,
+            self.transport.connect_attempt_timeout,
+        )
+        .await
         {
             tracing::debug!(
                 request_id = ctx.id(),
@@ -401,15 +423,15 @@ impl LLMEngine for SglangSidecarEngine {
 }
 
 fn bootstrap_discover(
-    endpoint: &str,
-    transport: &TransportConfig,
+    endpoint: &GrpcEndpoint,
+    transport: &GrpcTransportConfig,
 ) -> Result<Discovery, DynamoError> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|err| client::engine_shutdown(format!("bootstrap runtime: {err}")))?;
     runtime.block_on(async {
-        let deadline = Instant::now() + transport.deadline;
+        let deadline = Instant::now() + transport.startup_deadline;
         let mut grpc_client = client::connect(endpoint, transport, deadline).await?;
         client::discover(&mut grpc_client, deadline).await
     })

--- a/lib/sidecar/sglang/tests/executable.rs
+++ b/lib/sidecar/sglang/tests/executable.rs
@@ -22,8 +22,11 @@ fn executable_exposes_sglang_and_shared_sidecar_contracts() {
         "--grpc-connections",
         "DYN_SIDECAR_GRPC_CONNECTIONS",
         "--grpc-connect-attempt-timeout-secs",
+        "DYN_SIDECAR_GRPC_CONNECT_ATTEMPT_TIMEOUT_SECS",
         "--grpc-retry-interval-secs",
+        "DYN_SIDECAR_GRPC_RETRY_INTERVAL_SECS",
         "--grpc-startup-deadline-secs",
+        "DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS",
     ] {
         assert!(stdout.contains(expected), "help omits {expected}");
     }

--- a/lib/sidecar/sglang/tests/executable.rs
+++ b/lib/sidecar/sglang/tests/executable.rs
@@ -4,7 +4,7 @@
 use std::process::Command;
 
 #[test]
-fn executable_exposes_sglang_managed_contract() {
+fn executable_exposes_sglang_and_shared_sidecar_contracts() {
     let output = Command::new(env!("CARGO_BIN_EXE_dynamo-sglang-sidecar"))
         .arg("--help")
         .output()
@@ -16,6 +16,15 @@ fn executable_exposes_sglang_managed_contract() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8(output.stdout).expect("help output is UTF-8");
-    assert!(stdout.contains("--sglang-endpoint"));
-    assert!(stdout.contains("SGLANG_GRPC_ENDPOINT"));
+    for expected in [
+        "--sglang-endpoint",
+        "SGLANG_GRPC_ENDPOINT",
+        "--grpc-connections",
+        "DYN_SIDECAR_GRPC_CONNECTIONS",
+        "--grpc-connect-attempt-timeout-secs",
+        "--grpc-retry-interval-secs",
+        "--grpc-startup-deadline-secs",
+    ] {
+        assert!(stdout.contains(expected), "help omits {expected}");
+    }
 }


### PR DESCRIPTION
## Overview

Migrate the experimental SGLang sidecar to the shared sidecar argument and gRPC transport interface already used by the vLLM and TensorRT-LLM sidecars.

## Details

- flatten `dynamo_sidecar_common::SidecarArgs` into the SGLang sidecar CLI
- replace the SGLang-specific transport configuration and endpoint normalizer with shared `GrpcTransportConfig` and `GrpcEndpoint`
- preserve SGLang role discovery, bootstrap polling, and channel-pool behavior while honoring shared worker configuration
- intentionally replace the experimental SGLang transport flags without compatibility aliases
- update the SGLang README, executable contract test, mocker integration harness, and both Cargo lockfiles

SGLang discovery remains authoritative for worker role. The inherited disaggregation-mode option has no effect, and `--route-to-encoder` is rejected because the native protocol cannot serve encoder workers.

## Where should the reviewer start?

Start with `lib/sidecar/sglang/src/args.rs` for the shared CLI surface and `lib/sidecar/sglang/src/engine.rs` for discovery-driven `WorkerConfig` construction. Then review `lib/sidecar/sglang/src/client.rs` for the shared transport wiring.

## Related Issues

- [x] Confirmed — no related issue

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-sidecar-common -p dynamo-sglang-sidecar`
- `cargo test -p dynamo-sglang-mocker --test sidecar`
- `cargo check --manifest-path lib/bindings/python/Cargo.toml`
- `cargo clippy --manifest-path lib/bindings/python/Cargo.toml --no-deps --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`