### PR TITLE
docs(rl): recommend SGLang generate API

### DIFF
--- a/docs/fern/pages/use-cases/reinforcement-learning/implementation-guide.md
+++ b/docs/fern/pages/use-cases/reinforcement-learning/implementation-guide.md
@@ -5,7 +5,7 @@ title: RL Implementation Guide
 subtitle: Connect RL orchestrators to Dynamo inference and engine administration interfaces
 ---
 
-**Experimental.** This guide is for engineers using Dynamo to serve RL rollouts during a training loop. It covers how to return token IDs and log probabilities, expose routing or engine metadata, discover live workers, and push weight updates without restarting the serving stack. Use the frontend for rollout inference, discover vLLM workers through the read-only RL discovery API, and send lifecycle or weight updates directly to the selected worker system URL.
+**Experimental.** This guide is for engineers using Dynamo to serve RL rollouts during a training loop. It covers how to return token IDs and log probabilities, expose routing or engine metadata, discover live workers, and push weight updates without restarting the serving stack. For SGLang rollouts, use the SGLang-compatible `/generate` API as the primary inference path. Discover vLLM workers through the read-only RL discovery API. Send lifecycle or weight updates directly to the selected worker system URL.
 
 Dynamo can add value to RL rollout serving when the rollout plane needs more than a static inference endpoint. Advanced routing can steer rollout traffic across heterogeneous workers, weight synchronization with Model Express can help move updated checkpoints into serving quickly, fault tolerance can keep rollout generation available across worker failures, and autoscaling can match serving capacity to changing rollout demand during training.
 
@@ -13,6 +13,7 @@ Dynamo can add value to RL rollout serving when the rollout plane needs more tha
 
 | User need | Dynamo surface | Status |
 |---|---|---|
+| Serve SGLang token-in/token-out rollouts with native request and response shapes | Frontend `POST /generate` or `PUT /generate` | Experimental |
 | Serve rollout generation through an OpenAI-compatible endpoint | Frontend `/v1/completions` and `/v1/chat/completions` | Available |
 | Return token IDs, prompt log probabilities, and selected backend metadata | `nvext.token_data` and `nvext.extra_fields` | Available |
 | Discover live rollout workers and their direct administration URLs | `/v1/rl/workers` on the frontend RL listener | vLLM only |
@@ -23,6 +24,7 @@ Dynamo can add value to RL rollout serving when the rollout plane needs more tha
 
 | Capability | vLLM | SGLang | TensorRT-LLM |
 |---|---|---|---|
+| Engine-native token-in/token-out API | `/inference/v1/generate` | `/generate` | Not supported |
 | Token input through `prompt` token arrays | Supported | Supported | Supported |
 | `nvext.token_data` tokenizer bypass | Supported | Supported | Supported |
 | `completion_token_ids` response field | Supported | Supported | Supported |
@@ -32,13 +34,14 @@ Dynamo can add value to RL rollout serving when the rollout plane needs more tha
 | Direct RL admin routes from discovery | Supported with `--enable-rl` | Not supported | Not supported |
 | SGLang `meta_info` upload | Not applicable | Supported with `--enable-rl` | Not applicable |
 
-Experimental means the RL integration surfaces are still converging around real framework usage. Treat `nvext.token_data`, the documented `nvext.extra_fields` values, and `/v1/rl/workers` for RL-enabled vLLM workers as the API-shaped surfaces to build against first. Treat `engine_data`, SGLang uploaded `meta_info`, direct `/engine/` route bodies, custom route names, and backend-native response shapes as backend-specific escape hatches that can change independently.
+Experimental means the RL integration surfaces are still converging around real framework usage. For SGLang, build new token-in/token-out integrations on `/generate` first. This API preserves the request fields and streaming response objects from the installed SGLang version. Use the OpenAI-compatible routes when an integration needs a cross-backend schema or `nvext.metadata_upload`. Treat `engine_data`, uploaded `meta_info`, direct `/engine/` route bodies, and custom route names as backend-specific escape hatches that can change independently.
 
 ## Choose an Interface
 
 | Task | Interface | Default Port | Behavior |
 |---|---|---:|---|
-| Run rollouts | `POST /v1/completions` or `POST /v1/chat/completions` | `8000` | Routes inference through the Dynamo frontend. |
+| Run SGLang token-in/token-out rollouts | `POST /generate` or `PUT /generate` | `8000` | Routes native SGLang requests through Dynamo and returns native streaming response objects. |
+| Run rollouts through an OpenAI-compatible API | `POST /v1/completions` or `POST /v1/chat/completions` | `8000` | Provides a cross-backend request and response schema. |
 | Discover RL workers | `GET /v1/rl/workers` | `8001` | Returns live vLLM workers, their advertised routes, and direct system URLs. |
 | Administer one engine | `POST <system_url>/engine/<route>` | Worker-specific | Calls one worker without frontend routing or fan-out. |
 
@@ -46,6 +49,67 @@ The discovery API runs on a dedicated frontend listener. It is not mounted on th
 
 > [!WARNING]
 > The worker system server does not add an authentication layer to `/engine/` routes. Restrict the system port and RL discovery listener to the orchestrator network, and do not expose them through a public inference gateway.
+
+## SGLang Happy Path
+
+Use `/generate` for SGLang reinforcement learning clients that send token IDs and consume SGLang streaming responses. The same request works with aggregated and prefill/decode deployments.
+
+<Steps>
+<Step title="Enable the SGLang-compatible API">
+
+Set `DYN_SGLANG_ENABLE_GENERATE=1` on the Dynamo frontend:
+
+```bash
+DYN_SGLANG_ENABLE_GENERATE=1 python -m dynamo.frontend
+```
+
+The API uses `/generate` by default. To use a different path, set `DYN_HTTP_SVC_SGLANG_GENERATE_PATH` on the frontend.
+
+</Step>
+<Step title="Start a SGLang worker">
+
+```bash
+python -m dynamo.sglang \
+  --model-path Qwen/Qwen3-0.6B
+```
+
+The worker advertises its SGLang Generate capability during registration. The `/generate` API does not require the worker's `--enable-rl` flag.
+
+</Step>
+<Step title="Send a token-input rollout">
+
+```bash
+curl -N http://localhost:8000/generate \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "input_ids": [151644, 8948, 198],
+    "sampling_params": {
+      "max_new_tokens": 32,
+      "temperature": 0,
+      "n": 1
+    },
+    "stream": true,
+    "return_logprob": true,
+    "top_logprobs_num": 0
+  }'
+```
+
+Dynamo forwards each SGLang streaming response object as a server-sent event. The stream ends with `[DONE]`.
+
+`top_logprobs_num: 0` returns the selected-token log probability. To request top-k alternatives, set `DYN_SGL_ALLOW_TOP_LOGPROBS=1` on the worker and use a positive value.
+
+</Step>
+</Steps>
+
+The current API has these limits:
+
+- Provide one non-empty `input_ids` sequence.
+- Set `stream` to `true`.
+- Set `sampling_params.n` to `1`.
+- Use token input. Text, batched, multimodal, and non-streaming requests are not supported.
+- Use an aggregated deployment for prompt log probabilities. They are not parity-complete in prefill/decode deployments.
+
+Dynamo preserves other public SGLang request fields and validates them against the installed SGLang version at the worker. The frontend rejects Dynamo-owned bootstrap and routing fields. Dynamo injects those fields after it selects a worker.
 
 ## vLLM Happy Path
 
@@ -122,7 +186,7 @@ The full vLLM example below adds result checks and an exit trap so a failed upda
 
 ## Frontend Feature Support
 
-The OpenAI-compatible completion routes provide the current token-in/token-out interface.
+The OpenAI-compatible completion routes provide a cross-backend token-in/token-out interface. For SGLang clients that use native request and response shapes, prefer `/generate`.
 
 | Feature | Request | Response | Notes |
 |---|---|---|---|
@@ -212,7 +276,7 @@ Use `nvext.engine_data` only when the orchestrator must consume other backend-sp
 
 ## Upload SGLang Metadata
 
-SGLang can upload the final cumulative `meta_info` for each choice to any filesystem supported by the installed fsspec backend. This path keeps large log probability tensors, routed-expert data, and custom metadata out of the HTTP response.
+The SGLang metadata upload feature uses the OpenAI-compatible route and `nvext`. Use it when the rollout pipeline must store large metadata objects outside the HTTP response. SGLang can upload the final cumulative `meta_info` for each choice to any filesystem supported by the installed fsspec backend.
 
 > [!WARNING]
 > Treat `metadata_upload.url` as trusted RL control-plane input. The worker trims the value, checks that it is a non-empty string, and passes it to fsspec without restricting the storage scheme or destination. Do not allow untrusted inference callers to set this URL; fsspec can access local or remote storage with the worker's permissions and credentials.

--- a/docs/fern/pages/use-cases/reinforcement-learning/implementation-guide.md
+++ b/docs/fern/pages/use-cases/reinforcement-learning/implementation-guide.md
@@ -34,7 +34,7 @@ Dynamo can add value to RL rollout serving when the rollout plane needs more tha
 | Direct RL admin routes from discovery | Supported with `--enable-rl` | Not supported | Not supported |
 | SGLang `meta_info` upload | Not applicable | Supported with `--enable-rl` | Not applicable |
 
-Experimental means the RL integration surfaces are still converging around real framework usage. For SGLang, build new token-in/token-out integrations on `/generate` first. This API preserves the request fields and streaming response objects from the installed SGLang version. Use the OpenAI-compatible routes when an integration needs a cross-backend schema or `nvext.metadata_upload`. Treat `engine_data`, uploaded `meta_info`, direct `/engine/` route bodies, and custom route names as backend-specific escape hatches that can change independently.
+Experimental means the RL integration surfaces are still converging around real framework usage. For SGLang, build new token-in/token-out integrations on `/generate` first. This API preserves the request fields and streaming response objects from the installed SGLang version. Use the OpenAI-compatible routes when an integration needs a cross-backend schema or `nvext.metadata_upload`. Treat `engine_data`, uploaded `meta_info`, direct `/engine/` route bodies, and custom route names as backend-specific interfaces. Their contracts can change independently.
 
 ## Choose an Interface
 
@@ -52,7 +52,7 @@ The discovery API runs on a dedicated frontend listener. It is not mounted on th
 
 ## SGLang Happy Path
 
-Use `/generate` for SGLang reinforcement learning clients that send token IDs and consume SGLang streaming responses. The same request works with aggregated and prefill/decode deployments.
+Use `/generate` for SGLang reinforcement learning clients that send token IDs and consume SGLang streaming responses. Aggregated and prefill/decode deployments accept the same request.
 
 <Steps>
 <Step title="Enable the SGLang-compatible API">
@@ -73,7 +73,9 @@ python -m dynamo.sglang \
   --model-path Qwen/Qwen3-0.6B
 ```
 
-The worker advertises its SGLang Generate capability during registration. The `/generate` API does not require the worker's `--enable-rl` flag.
+When the worker accepts token input and serves a supported SGLang role, it advertises this capability. Aggregated and decode workers support chat or completions output. Prefill workers support prefill output.
+
+Do not use `--use-sglang-tokenizer`. This flag selects text input. As a result, the worker does not advertise `/generate`. The `/generate` API does not require `--enable-rl`.
 
 </Step>
 <Step title="Send a token-input rollout">
@@ -96,7 +98,7 @@ curl -N http://localhost:8000/generate \
 
 Dynamo forwards each SGLang streaming response object as a server-sent event. The stream ends with `[DONE]`.
 
-`top_logprobs_num: 0` returns the selected-token log probability. To request top-k alternatives, set `DYN_SGL_ALLOW_TOP_LOGPROBS=1` on the worker and use a positive value.
+`top_logprobs_num: 0` returns the selected-token log probability. To request top-k alternatives, set `DYN_SGL_ALLOW_TOP_LOGPROBS=1` on the worker. Then use a positive `top_logprobs_num` value.
 
 </Step>
 </Steps>
@@ -106,10 +108,10 @@ The current API has these limits:
 - Provide one non-empty `input_ids` sequence.
 - Set `stream` to `true`.
 - Set `sampling_params.n` to `1`.
-- Use token input. Text, batched, multimodal, and non-streaming requests are not supported.
+- Use token input. The API does not support text, batched, multimodal, or non-streaming requests.
 - Use an aggregated deployment for prompt log probabilities. They are not parity-complete in prefill/decode deployments.
 
-Dynamo preserves other public SGLang request fields and validates them against the installed SGLang version at the worker. The frontend rejects Dynamo-owned bootstrap and routing fields. Dynamo injects those fields after it selects a worker.
+Dynamo preserves other public SGLang request fields. The worker validates them against the installed SGLang version. The frontend rejects Dynamo-owned bootstrap and routing fields. Dynamo injects those fields after it selects a worker.
 
 ## vLLM Happy Path
 
@@ -276,7 +278,7 @@ Use `nvext.engine_data` only when the orchestrator must consume other backend-sp
 
 ## Upload SGLang Metadata
 
-The SGLang metadata upload feature uses the OpenAI-compatible route and `nvext`. Use it when the rollout pipeline must store large metadata objects outside the HTTP response. SGLang can upload the final cumulative `meta_info` for each choice to any filesystem supported by the installed fsspec backend.
+The SGLang metadata upload feature uses the OpenAI-compatible route and `nvext`. When the rollout pipeline must store large metadata objects outside the HTTP response, use this feature. SGLang can upload the final cumulative `meta_info` for each choice to any filesystem supported by the installed fsspec backend.
 
 > [!WARNING]
 > Treat `metadata_upload.url` as trusted RL control-plane input. The worker trims the value, checks that it is a non-empty string, and passes it to fsspec without restricting the storage scheme or destination. Do not allow untrusted inference callers to set this URL; fsspec can access local or remote storage with the worker's permissions and credentials.

--- a/docs/fern/pages/use-cases/reinforcement-learning/overview.md
+++ b/docs/fern/pages/use-cases/reinforcement-learning/overview.md
@@ -19,7 +19,7 @@ A typical RL setup has three planes:
 | Rollout serving | Dynamo | Routes generation requests, exposes token and log probability data, discovers live workers, and provides engine control surfaces. |
 | Operations | Platform stack | Scales capacity, observes health, handles failures, and manages deployment lifecycle. |
 
-Dynamo sits between the RL orchestrator and inference backends such as vLLM, SGLang, and TensorRT-LLM. The orchestrator sends rollout requests through Dynamo's OpenAI-compatible frontend and can use backend-specific control surfaces when it needs to pause generation, update weights, resume workers, or inspect live worker capabilities.
+Dynamo sits between the RL orchestrator and inference backends such as vLLM, SGLang, and TensorRT-LLM. For SGLang rollouts, use Dynamo's SGLang-compatible `POST /generate` or `PUT /generate` API. This API routes token-input requests through Dynamo and preserves SGLang's native streaming response objects. The OpenAI-compatible frontend remains available for cross-backend integrations. Use backend-specific control surfaces to pause generation, update weights, resume workers, or inspect live worker capabilities.
 
 ## What Dynamo Adds
 
@@ -34,11 +34,12 @@ Dynamo sits between the RL orchestrator and inference backends such as vLLM, SGL
 ## Integration Pattern
 
 1. Deploy Dynamo with the inference backend you want to use for rollouts.
-2. Send rollout generation through the Dynamo frontend using the OpenAI-compatible completion or chat routes.
-3. Request the token and log probability fields your RL pipeline needs through NVIDIA request extensions.
-4. Discover live rollout workers when the orchestrator needs direct worker administration.
-5. Pause selected workers, refresh weights, validate the update, and resume generation.
-6. Use Dynamo's routing, autoscaling, and fault-tolerance features to keep rollout serving aligned with training demand.
+2. For SGLang, enable the SGLang-compatible `/generate` API and send native token-input requests through the Dynamo frontend.
+3. For cross-backend clients, use the OpenAI-compatible completion or chat routes.
+4. Request the token and log probability fields through NVIDIA request extensions when you use the OpenAI-compatible routes.
+5. Discover live rollout workers when the orchestrator needs direct worker administration.
+6. Pause selected workers, refresh weights, validate the update, and resume generation.
+7. Use Dynamo's routing, autoscaling, and fault-tolerance features to keep rollout serving aligned with training demand.
 
 For the concrete API shapes, environment variables, and command examples, see the [RL Implementation Guide](implementation-guide.md).
 
@@ -50,12 +51,13 @@ Use Dynamo as the rollout-serving plane behind an RL framework. The framework re
 |---|---|---|
 | [verl Dynamo rollout backend recipe](https://github.com/verl-project/verl-recipe/blob/main/dynamo/README.md) | Run Dynamo as an async rollout backend with KV-aware routing, rollout token data, and weight-update control. | Available recipe |
 | [prime-rl Dynamo training recipes](https://github.com/PrimeIntellect-ai/prime-rl/pull/3180) | Train against an external Dynamo/vLLM rollout-serving stack using Dynamo worker discovery and weight-update control. The PR includes Dynamo example configs for Qwen3 0.6B Math, Qwen3 30B Thinking, and GLM-5.2 FP8 R2E. | Open PR |
-| [Slime external rollout endpoint](https://github.com/Aphoh/slime/pull/1) | Use Slime's external SGLang-compatible engine path with a shared Dynamo rollout endpoint and direct per-worker controls. | Open PR |
+| [Slime external rollout endpoint](https://github.com/Aphoh/slime/pull/1) | Point Slime's external SGLang-compatible engine path at Dynamo's `/generate` API. Use direct per-worker routes for engine controls. | Open PR |
 
 ## Backend Support Snapshot
 
 | Capability | vLLM | SGLang | TensorRT-LLM |
 |---|---|---|---|
+| Engine-native token-in/token-out API | `/inference/v1/generate` | `/generate` | Not supported |
 | Token input through `prompt` token arrays | Supported | Supported | Supported |
 | `nvext.token_data` tokenizer bypass | Supported | Supported | Supported |
 | Completion token IDs | Supported | Supported | Supported |
@@ -69,6 +71,7 @@ Use Dynamo as the rollout-serving plane behind an RL framework. The framework re
 Use the [RL Implementation Guide](implementation-guide.md) when you are ready to wire an orchestrator to Dynamo. It covers:
 
 - The vLLM happy path for token-in rollouts, worker discovery, and weight updates.
+- The recommended SGLang `/generate` path for native token-in/token-out rollouts.
 - NVIDIA request extensions for token IDs, log probabilities, routed expert data, and SGLang metadata uploads.
 - The `/v1/rl/workers` discovery API and direct `/engine/` administration routes.
 - How to register custom engine routes for framework-specific rollout control.

--- a/docs/fern/pages/use-cases/reinforcement-learning/overview.md
+++ b/docs/fern/pages/use-cases/reinforcement-learning/overview.md
@@ -19,7 +19,7 @@ A typical RL setup has three planes:
 | Rollout serving | Dynamo | Routes generation requests, exposes token and log probability data, discovers live workers, and provides engine control surfaces. |
 | Operations | Platform stack | Scales capacity, observes health, handles failures, and manages deployment lifecycle. |
 
-Dynamo sits between the RL orchestrator and inference backends such as vLLM, SGLang, and TensorRT-LLM. For SGLang rollouts, use Dynamo's SGLang-compatible `POST /generate` or `PUT /generate` API. This API routes token-input requests through Dynamo and preserves SGLang's native streaming response objects. The OpenAI-compatible frontend remains available for cross-backend integrations. Use backend-specific control surfaces to pause generation, update weights, resume workers, or inspect live worker capabilities.
+Dynamo sits between the RL orchestrator and inference backends such as vLLM, SGLang, and TensorRT-LLM. For SGLang rollouts, use Dynamo's SGLang-compatible `POST /generate` or `PUT /generate` API. This API routes token-input requests through Dynamo. It preserves SGLang's native streaming response objects. The OpenAI-compatible frontend remains available for cross-backend integrations. Use backend-specific control surfaces to manage workers.
 
 ## What Dynamo Adds
 
@@ -34,12 +34,13 @@ Dynamo sits between the RL orchestrator and inference backends such as vLLM, SGL
 ## Integration Pattern
 
 1. Deploy Dynamo with the inference backend you want to use for rollouts.
-2. For SGLang, enable the SGLang-compatible `/generate` API and send native token-input requests through the Dynamo frontend.
-3. For cross-backend clients, use the OpenAI-compatible completion or chat routes.
-4. Request the token and log probability fields through NVIDIA request extensions when you use the OpenAI-compatible routes.
-5. Discover live rollout workers when the orchestrator needs direct worker administration.
-6. Pause selected workers, refresh weights, validate the update, and resume generation.
-7. Use Dynamo's routing, autoscaling, and fault-tolerance features to keep rollout serving aligned with training demand.
+2. For SGLang, enable the SGLang-compatible `/generate` API.
+3. Send native token-input requests through the Dynamo frontend.
+4. For cross-backend clients, use the OpenAI-compatible completion or chat routes.
+5. When you use the OpenAI-compatible routes, request token and log probability fields through NVIDIA request extensions.
+6. Discover live rollout workers when the orchestrator needs direct worker administration.
+7. Pause selected workers, refresh weights, validate the update, and resume generation.
+8. Use Dynamo's routing, autoscaling, and fault-tolerance features to keep rollout serving aligned with training demand.
 
 For the concrete API shapes, environment variables, and command examples, see the [RL Implementation Guide](implementation-guide.md).
 


### PR DESCRIPTION
## Summary

- recommend Dynamo's SGLang-compatible `/generate` API as the primary RL rollout path
- add an end-to-end SGLang token-in/token-out example with enablement and current limitations
- keep the OpenAI-compatible path for cross-backend clients and `nvext.metadata_upload`

## Validation

- `git diff --check`
- `python3 docs/fern/scripts/check_asset_paths.py`
- Fern CLI checks not run (`fern` is not installed in the environment)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for using Dynamo’s native SGLang `/generate` API for reinforcement-learning rollouts.
  - Clarified when to use SGLang-native versus OpenAI-compatible interfaces.
  - Added complete SGLang setup, request, streaming, limitations, and integration instructions.
  - Updated metadata-upload guidance and Slime integration details.
  - Added a recommended SGLang rollout path to the reinforcement-learning overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->