### PR TITLE
fix(vllm): reject custom-encoder failures with InvalidArgument

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -78,7 +78,7 @@ from dynamo.llm import (
     register_model,
     unregister_model,
 )
-from dynamo.llm.exceptions import EngineShutdown
+from dynamo.llm.exceptions import EngineShutdown, InvalidArgument
 from dynamo.runtime import Client
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.vllm.kv_connector_protocols import (
@@ -3180,15 +3180,21 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         self,
         request: Dict[str, Any],
         request_id: str,
-    ) -> tuple[EmbedsPrompt | TokensPrompt | None, Dict[str, Any] | None]:
+    ) -> EmbedsPrompt | TokensPrompt | None:
         """Run the in-process CustomEncoder and prepare its engine prompt.
 
-        The CustomEncoder consumes image URLs directly and emits artifacts. Returns
-        ``(prepared_prompt, error)``:
-        - images present: ``(prepared_prompt, None)``,
-        - no image content: ``(None, None)`` — text-only request, nothing
-          to assemble or extract (non-image modalities are rejected above),
-        - failure: ``(None, error_dict)`` for the caller to yield.
+        The CustomEncoder consumes image URLs directly and emits artifacts.
+        Returns the prepared prompt when images are present, or ``None`` for a
+        text-only request with nothing to assemble (non-image modalities are
+        rejected below).
+
+        Raises:
+            InvalidArgument: the request cannot be served as given. This is the
+                request-level failure channel: the frontend maps it to HTTP 400
+                and forwards the message verbatim, so the caller learns which
+                part of their request the encoder rejected. Reporting the same
+                condition through ``finish_reason`` instead would strip the
+                message and surface an unattributed 500.
         """
         # Internal invariant: callers guard on `self._custom_encoder is not None`
         # before reaching here. Use an explicit raise (not assert, which is
@@ -3211,7 +3217,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 f"unsupported multimodal data: {unsupported}"
             )
             logger.error("Request %s: %s", request_id, msg)
-            return None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            raise InvalidArgument(msg)
 
         image_items = mm_map.get(IMAGE_URL_KEY) or []
         image_urls = [
@@ -3229,17 +3235,18 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 "'Url'; each item must be a dict with a 'Url' key"
             )
             logger.error("Request %s: %s", request_id, msg)
-            return None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            raise InvalidArgument(msg)
 
         if not image_urls:
             # No image items at all — and non-image modalities were already
             # rejected above — so there is nothing to assemble → text-only.
-            return None, None
+            return None
 
         token_ids: list[int] = request.get("token_ids") or []
         # Both encode() and adapter preparation run user/model-specific code, so
-        # keep them inside one guard. A failure becomes a structured request error
-        # instead of escaping the coroutine and tearing down the stream.
+        # keep them inside one guard. The guard exists to turn a failure into a
+        # per-request rejection carrying its message, rather than letting an
+        # arbitrary exception escape as an untyped 500.
         try:
             # AsyncVisionEncoder preprocesses off-thread; its ThreadedMicroBatcher
             # coalesces concurrent calls onto one dedicated actor thread.
@@ -3251,14 +3258,19 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         except Exception as exc:
             msg = f"CustomEncoder failed: {exc}"
             logger.exception("Request %s: %s", request_id, msg)
-            return None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            # `logger.exception` above keeps the traceback server-side; the
+            # caller gets only `msg`. Classified as a request-level rejection
+            # because this guard wraps per-request work on caller-supplied
+            # images — an encoder that cannot place this request's content
+            # will fail it again on retry, so 400 is the honest answer.
+            raise InvalidArgument(msg) from exc
 
         logger.debug(
             "Request %s: CustomEncoder prepared prompt for %d image(s)",
             request_id,
             len(artifacts),
         )
-        return prepared, None
+        return prepared
 
     async def _generate_token_mode(self, request, context, request_id):
         """Generate tokens using internal protocol format (token-in-token-out)."""
@@ -3296,13 +3308,12 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             # A configured CustomEncoder owns the aggregated image path. Bypass
             # raw-media loading and let its decoder-selected adapter prepare the
             # final engine prompt.
-            custom_prompt, assemble_error = await self._assemble_custom_encoder_prompt(
+            # A rejection raises InvalidArgument, which the bindings turn into a
+            # typed backend error the frontend answers with 400 plus the message.
+            custom_prompt = await self._assemble_custom_encoder_prompt(
                 request,
                 request_id,
             )
-            if assemble_error is not None:
-                yield assemble_error
-                return
             multi_modal_data = None
             mm_processor_kwargs = None
             pre_rendered = None

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3189,12 +3189,16 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         rejected below).
 
         Raises:
-            InvalidArgument: the request cannot be served as given. This is the
-                request-level failure channel: the frontend maps it to HTTP 400
-                and forwards the message verbatim, so the caller learns which
-                part of their request the encoder rejected. Reporting the same
-                condition through ``finish_reason`` instead would strip the
-                message and surface an unattributed 500.
+            InvalidArgument: the request's multimodal payload is malformed in a
+                way checked for directly below. The frontend maps this to HTTP
+                400 and forwards the message verbatim, so both messages are
+                built here and never interpolate foreign text.
+            Exception: whatever the encoder or adapter raised, unchanged. The
+                bindings map the exception type to a ``BackendError``, so a
+                validation fault (``ValueError``/``TypeError``, which is what
+                the adapters raise) still reaches the caller as a 400, while a
+                timeout, CUDA fault, or cancellation keeps its own type and its
+                retry semantics.
         """
         # Internal invariant: callers guard on `self._custom_encoder is not None`
         # before reaching here. Use an explicit raise (not assert, which is
@@ -3243,10 +3247,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             return None
 
         token_ids: list[int] = request.get("token_ids") or []
-        # Both encode() and adapter preparation run user/model-specific code, so
-        # keep them inside one guard. The guard exists to turn a failure into a
-        # per-request rejection carrying its message, rather than letting an
-        # arbitrary exception escape as an untyped 500.
         try:
             # AsyncVisionEncoder preprocesses off-thread; its ThreadedMicroBatcher
             # coalesces concurrent calls onto one dedicated actor thread.
@@ -3255,15 +3255,20 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 token_ids,
                 artifacts,
             )
-        except Exception as exc:
-            msg = f"CustomEncoder failed: {exc}"
-            logger.exception("Request %s: %s", request_id, msg)
-            # `logger.exception` above keeps the traceback server-side; the
-            # caller gets only `msg`. Classified as a request-level rejection
-            # because this guard wraps per-request work on caller-supplied
-            # images — an encoder that cannot place this request's content
-            # will fail it again on retry, so 400 is the honest answer.
-            raise InvalidArgument(msg) from exc
+        except Exception:
+            # Log with the traceback here — this is the last frame that knows
+            # which request and which encoder — then re-raise unchanged.
+            #
+            # Deliberately not converted to `InvalidArgument`. The adapters
+            # raise `ValueError`/`TypeError` for genuine input faults, which the
+            # bindings already map to `Backend(InvalidArgument)` → 400 carrying
+            # the message, so the actionable case needs no help. Coercing the
+            # rest would relabel timeouts, CUDA faults, batcher shutdown and
+            # cancellations as client errors, suppressing retries — and since
+            # `encode()` is co-batched, it could blame a caller for a failure
+            # that originated in someone else's request.
+            logger.exception("Request %s: CustomEncoder failed", request_id)
+            raise
 
         logger.debug(
             "Request %s: CustomEncoder prepared prompt for %d image(s)",
@@ -3308,8 +3313,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             # A configured CustomEncoder owns the aggregated image path. Bypass
             # raw-media loading and let its decoder-selected adapter prepare the
             # final engine prompt.
-            # A rejection raises InvalidArgument, which the bindings turn into a
-            # typed backend error the frontend answers with 400 plus the message.
+            # Failures propagate as exceptions; the bindings map the type to a
+            # typed backend error, so an input fault answers 400 with its
+            # message and an engine fault stays a retryable 5xx.
             custom_prompt = await self._assemble_custom_encoder_prompt(
                 request,
                 request_id,

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/base.py
@@ -24,9 +24,30 @@ class CustomEncoderAdapter(ABC, Generic[ArtifactT]):
     ) -> EmbedsPrompt | TokensPrompt:
         """Validate encoder artifacts and build the final vLLM prompt.
 
+        Runs per request, on the request's own coroutine — unlike
+        ``VisionEncoderBackend.forward_batch``, a failure here is scoped to the
+        one caller.
+
         Args:
             token_ids: Tokenized prompt containing the image placeholders.
             artifacts: Opaque values returned by the encoder backend, in image
                 order. Each adapter defines and validates its concrete artifact
                 contract.
+
+        Raises:
+            ValueError: the artifacts do not satisfy this adapter's contract, or
+                do not line up with the placeholders in ``token_ids`` — a
+                request-level fault the caller can act on. Dynamo maps this to
+                ``Backend(InvalidArgument)``, answering **HTTP 400 with the
+                message forwarded to the client verbatim**, so write it for that
+                audience: state the mismatch in terms of the request and leave
+                file paths, tracebacks, tensor dumps and weight identifiers out.
+                Anything the caller cannot act on belongs in a log line.
+            TypeError: an artifact is the wrong type entirely. Treated
+                identically to ``ValueError``; the same message rules apply.
+
+        Any other exception type is read as an engine fault rather than a bad
+        request: the caller gets a sanitized 5xx and the message stays in the
+        server log. Raise those freely — and prefer them whenever the request is
+        not actually at fault, since a 400 tells the caller not to retry.
         """

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
@@ -54,6 +54,39 @@ Attributes read **once at setup** (never per-request):
 Batching is **one-dimensional**: Dynamo packs by scalar ``cost`` up to
 ``max_batch_cost`` and never inspects item shape — the author owns any
 shape/padding concerns inside ``forward_batch``.
+
+Raising errors
+--------------
+
+An exception raised anywhere in this contract reaches the HTTP client, and its
+**type** — not its message — decides how:
+
+- ``ValueError`` / ``TypeError`` ⇒ the caller's input is at fault. Dynamo maps
+  these to ``Backend(InvalidArgument)``, answering **HTTP 400 with the message
+  forwarded to the client verbatim**.
+- **any other type** (``RuntimeError``, ``TimeoutError``, ``torch`` errors, …)
+  ⇒ the engine is at fault. The caller gets a sanitized 5xx and the message
+  survives in the server log only.
+
+Pick the type deliberately. Reporting an out-of-memory or a driver fault as
+``ValueError`` tells the caller its request was malformed and suppresses the
+retry that would have succeeded; reporting a genuinely bad image as
+``RuntimeError`` costs the caller the one message that would let them fix it.
+
+.. warning::
+   **A ``ValueError``/``TypeError`` message is published to the client.** Do not
+   interpolate file paths, tracebacks, tensor dumps, model or weight
+   identifiers, or any other server-internal state into one. Describe the fault
+   in terms of the request ("image 2 is 1-D; expected a 2-D embedding"), and
+   keep the diagnosis in a log line. Non-validation exception types are
+   sanitized before they leave the process, so they may say anything.
+
+Note the blast radius differs by method. A ``preprocess`` failure is scoped to
+the one image that caused it, but ``forward_batch`` runs a batch coalesced
+across *concurrent, unrelated requests*, and an exception there is delivered to
+**every request in that batch**. A per-item fault therefore belongs in
+``preprocess`` — raised from ``forward_batch`` it would tell unrelated callers
+their requests were invalid.
 """
 
 from __future__ import annotations
@@ -140,6 +173,12 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT, ArtifactT]):
         Raise to reject a bad input — it fails only that image, before submit.
         With ``preprocess_concurrency == 0`` this method is **never called**;
         overriding it without raising the concurrency fails fast at startup.
+
+        This is the right place to reject a malformed image: the failure is
+        scoped to the one raw that caused it, so a ``ValueError``/``TypeError``
+        here reaches exactly the caller who sent it, as an HTTP 400 carrying the
+        message. Keep that message free of server-internal detail (see
+        *Raising errors* in the module docstring).
         """
         return Preprocessed(item=raw)  # type: ignore[arg-type]  # ItemT == RawT
 
@@ -157,6 +196,18 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT, ArtifactT]):
         so results are safe to consume from another thread. ``target_bucket`` is
         reserved for CUDA-graph batching, once supported (the ladder rung to pad
         to), and is ``None`` until then.
+
+        Raises:
+            Exception: fails **every request in the batch**, not just the item
+                that caused it — ``items`` is coalesced across concurrent,
+                unrelated requests, and the exception is delivered to all of
+                them. So prefer a non-validation type here (the engine, not any
+                one caller, is what failed), and push per-item rejection up into
+                ``preprocess`` where it is scoped to a single image. A
+                ``ValueError``/``TypeError`` raised here answers HTTP 400 with
+                its message forwarded verbatim to callers who may have sent
+                perfectly valid input. See *Raising errors* in the module
+                docstring.
         """
         ...
 

--- a/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
@@ -86,31 +86,48 @@ async def test_custom_encoder_handler_returns_adapter_prepared_prompt():
     assert prompt["prompt_token_ids"] == [1, 99, 99, 2]
 
 
-async def test_custom_encoder_handler_rejects_encoder_failure_with_message():
-    """An encoder failure must reach the caller as a typed rejection.
-
-    `InvalidArgument` is what the bindings translate into a backend error the
-    frontend answers with HTTP 400, forwarding the message verbatim. Reporting
-    the same condition through `finish_reason` strips the message.
-    """
+async def _assemble_with_encoder_error(exc: Exception):
     handler = object.__new__(DecodeWorkerHandler)
     handler._custom_encoder_adapter = _adapter()
-    handler._custom_encoder = SimpleNamespace(
-        encode=AsyncMock(side_effect=RuntimeError("encoder failed"))
+    handler._custom_encoder = SimpleNamespace(encode=AsyncMock(side_effect=exc))
+    return await handler._assemble_custom_encoder_prompt(
+        {
+            "token_ids": [99],
+            "multi_modal_data": {
+                "image_url": [{"Url": "data:image/png;base64,unused"}]
+            },
+        },
+        "request-id",
     )
 
-    with pytest.raises(InvalidArgument) as excinfo:
-        await handler._assemble_custom_encoder_prompt(
-            {
-                "token_ids": [99],
-                "multi_modal_data": {
-                    "image_url": [{"Url": "data:image/png;base64,unused"}]
-                },
-            },
-            "request-id",
-        )
 
-    assert str(excinfo.value) == "CustomEncoder failed: encoder failed"
+async def test_custom_encoder_input_fault_propagates_as_value_error():
+    """An input fault stays a `ValueError`, which the bindings already map to
+    `Backend(InvalidArgument)` — HTTP 400 carrying the message. The adapters
+    raise `ValueError`/`TypeError` for every validation failure, so the
+    actionable case needs no conversion here."""
+    with pytest.raises(ValueError) as excinfo:
+        await _assemble_with_encoder_error(ValueError("placeholder tokens (0) != 1"))
+
+    assert "placeholder tokens (0) != 1" in str(excinfo.value)
+
+
+async def test_custom_encoder_engine_fault_keeps_its_own_type():
+    """The complement, and the point of not converting: an engine fault must
+    not be relabelled a client error. Doing so would answer 400 and suppress
+    retries for timeouts, CUDA faults and batcher shutdown — and since
+    `encode()` is co-batched, could blame a caller for another request's
+    failure."""
+    with pytest.raises(RuntimeError) as excinfo:
+        await _assemble_with_encoder_error(RuntimeError("CUDA error: out of memory"))
+
+    assert not isinstance(excinfo.value, InvalidArgument)
+    assert "out of memory" in str(excinfo.value)
+
+
+async def test_custom_encoder_timeout_keeps_its_own_type():
+    with pytest.raises(TimeoutError):
+        await _assemble_with_encoder_error(TimeoutError("encoder timed out"))
 
 
 async def test_custom_encoder_handler_rejects_unsupported_modality():

--- a/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 import torch
 
+from dynamo.llm.exceptions import InvalidArgument
 from dynamo.vllm.handlers import DecodeWorkerHandler
 from dynamo.vllm.multimodal_utils.custom_encoder import (
     Qwen3VLImageEncoding,
@@ -70,7 +71,7 @@ async def test_custom_encoder_handler_returns_adapter_prepared_prompt():
         encode=AsyncMock(return_value=[torch.ones((2, 4), dtype=torch.bfloat16)])
     )
 
-    prompt, error = await handler._assemble_custom_encoder_prompt(
+    prompt = await handler._assemble_custom_encoder_prompt(
         {
             "token_ids": [1, 99, 2],
             "multi_modal_data": {
@@ -80,32 +81,78 @@ async def test_custom_encoder_handler_returns_adapter_prepared_prompt():
         "request-id",
     )
 
-    assert error is None
     assert prompt is not None
     assert tuple(prompt["prompt_embeds"].shape) == (4, 4)
     assert prompt["prompt_token_ids"] == [1, 99, 99, 2]
 
 
-async def test_custom_encoder_handler_preserves_string_error_contract():
+async def test_custom_encoder_handler_rejects_encoder_failure_with_message():
+    """An encoder failure must reach the caller as a typed rejection.
+
+    `InvalidArgument` is what the bindings translate into a backend error the
+    frontend answers with HTTP 400, forwarding the message verbatim. Reporting
+    the same condition through `finish_reason` strips the message.
+    """
     handler = object.__new__(DecodeWorkerHandler)
     handler._custom_encoder_adapter = _adapter()
     handler._custom_encoder = SimpleNamespace(
         encode=AsyncMock(side_effect=RuntimeError("encoder failed"))
     )
 
-    prompt, error = await handler._assemble_custom_encoder_prompt(
-        {
-            "token_ids": [99],
-            "multi_modal_data": {
-                "image_url": [{"Url": "data:image/png;base64,unused"}]
+    with pytest.raises(InvalidArgument) as excinfo:
+        await handler._assemble_custom_encoder_prompt(
+            {
+                "token_ids": [99],
+                "multi_modal_data": {
+                    "image_url": [{"Url": "data:image/png;base64,unused"}]
+                },
             },
-        },
+            "request-id",
+        )
+
+    assert str(excinfo.value) == "CustomEncoder failed: encoder failed"
+
+
+async def test_custom_encoder_handler_rejects_unsupported_modality():
+    handler = object.__new__(DecodeWorkerHandler)
+    handler._custom_encoder_adapter = _adapter()
+    handler._custom_encoder = SimpleNamespace(encode=AsyncMock())
+
+    with pytest.raises(InvalidArgument) as excinfo:
+        await handler._assemble_custom_encoder_prompt(
+            {"token_ids": [1], "multi_modal_data": {"video_url": [{"Url": "v"}]}},
+            "request-id",
+        )
+
+    assert "image inputs only" in str(excinfo.value)
+    assert "video_url" in str(excinfo.value)
+
+
+async def test_custom_encoder_handler_rejects_image_item_without_url():
+    handler = object.__new__(DecodeWorkerHandler)
+    handler._custom_encoder_adapter = _adapter()
+    handler._custom_encoder = SimpleNamespace(encode=AsyncMock())
+
+    with pytest.raises(InvalidArgument) as excinfo:
+        await handler._assemble_custom_encoder_prompt(
+            {"token_ids": [1], "multi_modal_data": {"image_url": [{"Decoded": "x"}]}},
+            "request-id",
+        )
+
+    assert "'Url'" in str(excinfo.value)
+
+
+async def test_custom_encoder_handler_returns_none_for_text_only_request():
+    handler = object.__new__(DecodeWorkerHandler)
+    handler._custom_encoder_adapter = _adapter()
+    handler._custom_encoder = SimpleNamespace(encode=AsyncMock())
+
+    prompt = await handler._assemble_custom_encoder_prompt(
+        {"token_ids": [1, 2], "multi_modal_data": {}},
         "request-id",
     )
 
     assert prompt is None
-    assert error is not None
-    assert error["finish_reason"] == "error: CustomEncoder failed: encoder failed"
 
 
 async def test_custom_encoder_handler_returns_native_qwen3_vl_prompt():
@@ -121,7 +168,7 @@ async def test_custom_encoder_handler_returns_native_qwen3_vl_prompt():
         )
     )
 
-    prompt, error = await handler._assemble_custom_encoder_prompt(
+    prompt = await handler._assemble_custom_encoder_prompt(
         {
             "token_ids": [100, 101, 102],
             "multi_modal_data": {
@@ -131,7 +178,6 @@ async def test_custom_encoder_handler_returns_native_qwen3_vl_prompt():
         "request-id",
     )
 
-    assert error is None
     assert prompt is not None
     assert prompt["prompt_token_ids"] == [100, 101, 102]
     image = prompt["multi_modal_data"]["image"]


### PR DESCRIPTION
## Overview:

A request-level failure in the vLLM custom-encoder path was reported by returning `{"finish_reason": f"error: {msg}"}`. The caller received `{"message":"Internal server error","code":500}` naming nothing, while the message that said exactly what was wrong stayed in the worker's logs. This stops using `finish_reason` as an error channel, so failures reach the caller through the one that works — with the exception type deciding the status.

## Details:

`finish_reason` is not an error channel. OpenAI's `finish_reason` has no `error` value — errors are out of band, an HTTP status plus `{"error": {...}}`. Dynamo's own OpenAI-facing `CompletionFinishReason` agrees: it has only Stop/Length/ContentFilter, and `From<FinishReason>` maps `Error(_) => Stop`. Anything written into `finish_reason` has no route to the caller.

The channel that does reach the caller already exists: an exception raised out of the handler is mapped by the bindings to a typed `BackendError`, which the frontend turns into a status. So `_assemble_custom_encoder_prompt` now raises instead of returning an error dict, and with errors out of band it no longer needs a two-slot `(prompt, error)` return — it yields the prompt directly and the caller drops its error branch.

**The exception type is left alone deliberately.** An earlier revision converted every encoder/adapter failure to `InvalidArgument`; @jthomson04 and Devin Review both flagged it, correctly. Auditing the tree showed the split is already clean without any conversion:

| raised by | type | count | becomes |
|---|---|---|---|
| adapters (`linear.py`, `qwen3_vl.py`, `factory.py`) — input/artifact validation | `ValueError` / `TypeError` | 31 | `Backend(InvalidArgument)` → **400 + message** |
| `batcher.py`, `async_encoder.py` — lifecycle ("shut down during start()", "called before load()") | `RuntimeError` | 7 | `Backend(Unknown)` → sanitized 5xx |

The reported placeholder-mismatch failure is a `ValueError` ([linear.py:81](https://github.com/ai-dynamo/dynamo/blob/46d7253e0b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/linear.py#L81)), so it answers 400 carrying its message with no conversion here. Converting the rest would have relabelled timeouts, CUDA faults, batcher shutdown and cancellations as client errors — suppressing retries — and since `encode()` coalesces concurrent requests, `_run_batch` hands the same exception object to every request in the batch, so it could have answered "your request is invalid" to a caller whose input was fine.

Three sites change, all in `_assemble_custom_encoder_prompt`:

| condition | before | after |
|---|---|---|
| non-image modality sent to an image-only encoder | 500, no message | `InvalidArgument` → 400 + message |
| image item without a usable `'Url'` | 500, no message | `InvalidArgument` → 400 + message |
| encoder/adapter raised | 500, no message | re-raised unchanged → 400 + message for input faults, retryable 5xx otherwise |

The two validation branches keep raising `InvalidArgument`: their messages are constructed here from the request's own shape, which is what the verbatim-forwarding contract in [`errors.rs:139-141`](https://github.com/ai-dynamo/dynamo/blob/46d7253e0b/lib/bindings/python/rust/errors.rs#L139-L141) requires of a 4xx message.

### Documentation

That contract governed encoder-author code but lived only in the Rust bindings. 46d7253e0b records it where an author will see it: a *Raising errors* section on `VisionEncoderBackend` and a `Raises:` block on `CustomEncoderAdapter.prepare_prompt`, covering which type produces which status, that a `ValueError`/`TypeError` message is published to the client verbatim (no paths, tracebacks, tensor dumps, weight identifiers), and that a `forward_batch` failure is batch-wide while `preprocess` is scoped to one image.

### Relationship to #13118

Independent; either alone fixes this path. #13118 makes the Rust reader accept the `"error: <message>"` form workers already emit, for workers deployed inside the N-2 window. This stops the vLLM custom-encoder path from using `finish_reason` for errors at all, which is the direction the protocol should go — `FinishReason::Error(String)` is an error channel smuggled into a status enum. The remaining producers (sglang, trtllm, and the other `finish_reason: "error: ..."` sites in `handlers.py`) are follow-ups.

## Where should the reviewer start?

`components/src/dynamo/vllm/handlers.py` — `_assemble_custom_encoder_prompt`: its `Raises:` docstring, the two `raise InvalidArgument(...)` validation branches, and the `except Exception: ... raise` block explaining why nothing is converted.

## Validation

- `test_custom_encoder_input_fault_propagates_as_value_error` — a `ValueError` stays a `ValueError` (the bindings then map it to 400 + message).
- `test_custom_encoder_engine_fault_keeps_its_own_type` / `..._timeout_keeps_its_own_type` — a `RuntimeError` and a `TimeoutError` keep their types and are asserted *not* to be `InvalidArgument`, so they stay retryable 5xx.
- New cases for the unsupported-modality and missing-`'Url'` rejections, and the text-only passthrough.
- Lint clean: `isort`, `black`, `flake8`, `ruff`, `codespell`, `pytest-marker-report` via `pre-commit run --files`.
- **Not run locally:** the Python unit tests — no environment on this machine has `torch`, so `test_vllm_custom_encoder_handler.py` cannot be collected. Needs CI. `py_compile` passes on every changed file.

### Verified end to end

Measured on a live frontend + worker over the real request plane (etcd + NATS, `Qwen/Qwen3-0.6B` tokenizer, no GPU). The probe worker registers through the raw `endpoint.serve_endpoint()` route — the same path `dynamo.vllm` uses, where yielded dicts transcode straight to the wire with no worker-side typing. A Backend SDK worker is *not* a valid control: it validates chunk shape in-process and rejects the malformed `finish_reason` before the wire.

| scenario | status | body |
|---|---|---|
| worker writes `finish_reason: "error: <msg>"` (pre-fix) | **500** | `{"message":"Internal server error",...}` |
| same, plus the #13118 reader fix | **500** | `{"message":"Internal server error",...}` |
| worker raises, non-streaming | **400** | full message |
| worker raises, `stream: true`, default config | 200 + SSE | `Internal server error` |
| worker raises, `stream: true`, `DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS=2000` | **400** | full message |

The pre-fix row reproduces the reported failure exactly, including its log lines:

```
WARN  addressed_router: failed deserializing request-plane response
      err=unknown variant `error: CustomEncoder failed: placeholder tokens (0) != image tensors (1)...`
ERROR openai: Internal server error: unknown variant `error: CustomEncoder failed: ...`
```

Scope note on that measurement: it exercised `raise InvalidArgument(...)`, confirming `Backend(InvalidArgument)` → 400 with the message forwarded verbatim. The remaining link for the reported case — `ValueError` → `Backend(InvalidArgument)` — is the two-line mapping in `py_err_to_dynamo`/`map_python_exception` and is covered by unit tests, not by that run.

### Known gap: streaming

With `stream: true` and default config the caller still gets HTTP 200 followed by a sanitized SSE frame, because the error is classified *after* the 200 is committed: `annotated_to_sse_event` discards the typed `DynamoError`, and `openai_stream_error` then hardcodes `SanitizedError::Internal`. Setting `DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS` sidesteps it by catching the error before commit. Pre-existing and affects every backend error on the streaming path; tracked in #13139.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)