### PR TITLE
feat(snapshot): checkpoint POSIX CUDA VMM sharing

### DIFF
--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -132,6 +132,15 @@ WORKDIR /workspace
 
 COPY cmd/cuda-checkpoint-helper/main.c ./cmd/cuda-checkpoint-helper/main.c
 COPY cmd/ns-bind-mount/main.c ./cmd/ns-bind-mount/main.c
+COPY cmd/cuda-vmm-interpose/interpose.c ./cmd/cuda-vmm-interpose/interpose.c
+COPY cmd/cuda-vmm-interpose/coordinator.c ./cmd/cuda-vmm-interpose/coordinator.c
+COPY cmd/cuda-vmm-interpose/posix.c ./cmd/cuda-vmm-interpose/posix.c
+COPY cmd/cuda-vmm-interpose/posix.h ./cmd/cuda-vmm-interpose/posix.h
+COPY cmd/cuda-vmm-interpose/protocol.h ./cmd/cuda-vmm-interpose/protocol.h
+COPY cmd/cuda-vmm-interpose/util.c ./cmd/cuda-vmm-interpose/util.c
+COPY cmd/cuda-vmm-interpose/util.h ./cmd/cuda-vmm-interpose/util.h
+COPY cmd/cuda-vmm-interpose/Makefile ./cmd/cuda-vmm-interpose/Makefile
+COPY cmd/cuda-vmm-interpose/launch.sh ./cmd/cuda-vmm-interpose/launch.sh
 
 RUN gcc -O2 -Wall -Wextra -o /cuda-checkpoint-helper \
     ./cmd/cuda-checkpoint-helper/main.c \
@@ -140,6 +149,10 @@ RUN gcc -O2 -Wall -Wextra -o /cuda-checkpoint-helper \
     -lcuda
 
 RUN gcc -O2 -Wall -Wextra -o /ns-bind-mount ./cmd/ns-bind-mount/main.c
+
+RUN make -C ./cmd/cuda-vmm-interpose BUILD_DIR=/cuda-vmm-build \
+    && cp /cuda-vmm-build/libsnapshot_cuda_vmm.so /libsnapshot_cuda_vmm.so \
+    && cp /cuda-vmm-build/snapshot-cuda-vmm /snapshot-cuda-vmm
 
 # =============================================================================
 # Stage: CRIU Builder - Build CRIU with CUDA plugin
@@ -230,8 +243,9 @@ COPY --from=criu-builder /tmp/cuda-checkpoint/bin/x86_64_Linux/cuda-checkpoint /
 COPY --from=criu-builder /tmp/cuda-checkpoint/LICENSE /legal/cuda-checkpoint/LICENSE
 COPY --from=cuda-helper-builder /cuda-checkpoint-helper /usr/local/bin/cuda-checkpoint-helper
 COPY --from=cuda-helper-builder /ns-bind-mount /usr/local/sbin/ns-bind-mount
+COPY --from=cuda-helper-builder /snapshot-cuda-vmm /usr/local/bin/snapshot-cuda-vmm
 RUN chmod +x /usr/local/sbin/cuda-checkpoint /usr/local/bin/cuda-checkpoint-helper \
-             /usr/local/sbin/ns-bind-mount
+             /usr/local/sbin/ns-bind-mount /usr/local/bin/snapshot-cuda-vmm
 
 # Copy the built binaries
 COPY --from=builder /snapshot-agent /usr/local/bin/snapshot-agent
@@ -448,6 +462,10 @@ ENTRYPOINT ["/usr/local/bin/snapshot-agent"]
 #     EROFS. An emptyDir at /tmp (either medium) makes it work again, since
 #     volume mounts stay writable independently of the root filesystem.
 #
+# CUDA VMM interposition artifacts are installed below because they must exist
+# before the workload creates shared allocations. The remaining restore
+# toolchain is still injected from the agent bundle.
+#
 # cuda-checkpoint wrapping is opt-in (--cuda-checkpoint-wrap in snapshotctl).
 # When used, the source workload image must have cuda-checkpoint at the same
 # path as it runs from — CRIU restores file-backed mappings by path, not via
@@ -472,3 +490,10 @@ RUN if [ "${TARGETARCH}" != "amd64" ]; then \
 # Checkpoint volume mount point. This is a storage concern — no restore tooling
 # is provisioned here; see the stage comment above.
 RUN mkdir -p /checkpoints
+
+COPY --from=cuda-helper-builder /snapshot-cuda-vmm /usr/local/bin/snapshot-cuda-vmm
+COPY --from=cuda-helper-builder /libsnapshot_cuda_vmm.so /usr/local/lib/snapshot/libsnapshot_cuda_vmm.so
+COPY --from=cuda-helper-builder /workspace/cmd/cuda-vmm-interpose/launch.sh /usr/local/bin/snapshot-cuda-vmm-launch
+RUN chmod 0755 /usr/local/bin/snapshot-cuda-vmm \
+    /usr/local/bin/snapshot-cuda-vmm-launch \
+    && chmod 0644 /usr/local/lib/snapshot/libsnapshot_cuda_vmm.so

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/Makefile
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/Makefile
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+CC ?= cc
+CUDA_HOME ?= /usr/local/cuda
+BUILD_DIR ?= build
+
+INTERPOSER := $(BUILD_DIR)/libsnapshot_cuda_vmm.so
+COORDINATOR := $(BUILD_DIR)/snapshot-cuda-vmm
+INTERPOSER_SOURCES := interpose.c posix.c util.c
+INTERPOSER_HEADERS := posix.h protocol.h util.h
+COORDINATOR_SOURCES := coordinator.c util.c
+COORDINATOR_HEADERS := protocol.h util.h
+COMMON_FLAGS := -std=gnu11 -O2 -Wall -Wextra -Werror
+
+.PHONY: all clean
+
+all: $(INTERPOSER) $(COORDINATOR)
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+$(INTERPOSER): $(INTERPOSER_SOURCES) $(INTERPOSER_HEADERS) | $(BUILD_DIR)
+	$(CC) $(COMMON_FLAGS) -fPIC -shared -Wno-deprecated-declarations \
+		-I$(CUDA_HOME)/include -o $@.tmp $(INTERPOSER_SOURCES) \
+		-Wl,-Bsymbolic-functions -ldl -pthread
+	readelf -d $@.tmp >/dev/null
+	! readelf -d $@.tmp | grep -Eq 'NEEDED.*(libcuda|libcudart)'
+	mv $@.tmp $@
+
+$(COORDINATOR): $(COORDINATOR_SOURCES) $(COORDINATOR_HEADERS) | $(BUILD_DIR)
+	$(CC) $(COMMON_FLAGS) -o $@ $(COORDINATOR_SOURCES)
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
@@ -1,0 +1,196 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Same-node POSIX CUDA VMM checkpoint and restore
+
+This interposer implements checkpoint and restore for CUDA VMM allocations
+shared between processes on one node with
+`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`.
+
+## Contract
+
+Launch every participating CUDA process with:
+
+```bash
+snapshot-cuda-vmm-launch COMMAND [ARG...]
+```
+
+Every workload image used for checkpoint and restore must provide the launcher
+at `/usr/local/bin/snapshot-cuda-vmm-launch` and the readable interposer library
+at `/usr/local/lib/snapshot/libsnapshot_cuda_vmm.so`. `snapshotctl` uses these
+common paths but does not inject either file into the workload image.
+
+For checkpoint jobs created by `snapshotctl`, enable this wrapper with:
+
+```bash
+snapshotctl checkpoint --cuda-vmm-interpose [OTHER FLAGS]
+```
+
+This experimental flag is an explicit launch-time opt-in because the shim
+must be preloaded before the application creates CUDA VMM allocations.
+`snapshotctl` injects the interpose launcher. Single-GPU POSIX VMM
+checkpointing does not require a CUDA launch-job file. Multi-GPU
+checkpointing must also launch through the existing
+`cuda-checkpoint --launch-job` path; manual `snapshotctl` users must pass both
+`--cuda-checkpoint-wrap` and `--cuda-vmm-interpose`. The launch-job wrapper is
+outermost and `snapshot-cuda-vmm-launch` remains the inner wrapper.
+Operator-created multi-GPU checkpoint jobs enable the launch-job wrapper
+automatically; VMM interposition remains a separate opt-in.
+
+Legacy CUDA IPC remains driver-owned and is unsupported by this shim.
+
+`DYN_SNAPSHOT_PARTICIPANT_ID` may provide a stable 32-character lowercase
+hex participant ID. Otherwise, the shim creates one when the process starts.
+
+The orchestrator must externally quiesce the application at the checkpoint
+boundary. Allocation sharing, import, mapping, access updates, kernel work,
+communication-library setup, and teardown must not be in flight.
+
+During ordinary execution:
+
+- CUDA generic allocation handles for POSIX-capable allocations tracked by the
+  shim are tagged logical tokens; the corresponding real driver handles remain
+  internal.
+- Untracked CUDA generic allocation handles remain real driver handles.
+- A POSIX-capable allocation becomes checkpoint-managed when its shim
+  capability is exported.
+- POSIX exports return sealed capability FDs containing the creator,
+  allocation, endpoint, and authorization identities.
+- A shim capability import resolves through the creator's local Unix
+  endpoint. A transient raw CUDA FD is passed with `SCM_RIGHTS`, imported,
+  closed immediately, and never returned to the application.
+- A raw external POSIX import is passed directly to CUDA and is not tracked by
+  the shim.
+
+Handle ownership is explicit:
+
+| Source | Application receives | Managed table | Driver-handle owner |
+| --- | --- | --- | --- |
+| POSIX-capable create, tracked retain, or capability import | Tagged logical token | Logical token to driver handle | Shim |
+| Raw external import or other pass-through | Real driver handle | None | Application |
+| Checkpoint carrier | Nothing | No separate entry | Shim |
+
+`posix.c` owns the sealed capability format and remote creator exchange.
+`interpose.c` owns CUDA interception, allocation state, and local raw exports.
+
+Before native CUDA checkpoint, the snapshot agent asks the native coordinator
+to validate the complete participant topology. The original `cuMemCreate`
+participant is always the saver and must still have a live creator handle or
+mapping (the creator-anchor invariant). The shim then puts every allocation
+managed by the shim in checkpoint normal form: one unmapped creator-local
+carrier remains, managed mappings are removed without freeing VA reservations,
+and importer handles are released. Native CUDA alone saves and restores
+allocation bytes.
+
+On restore, native CUDA first restores creator allocations. CUDA processes are
+then unlocked so the shim can replay VMM topology while the application stays
+behind the restore-complete sentinel. Creators are reconstructed before
+importers; importers resolve fresh creator exports. The shim remaps every
+allocation at its saved VA, restores effective access and required handle
+translations, and performs final topology validation. Any failed validation
+fails closed. There is no rollback after checkpoint preparation mutates CUDA
+state.
+
+The native coordinator atomically writes `cuda-vmm.state`, its opaque durable
+topology sidecar, in the checkpoint directory. Go only orders native VMM
+prepare and restore; it does not serialize or inspect the topology. The
+sidecar contains no raw FDs or allocation contents.
+
+## Interception and symbol resolution
+
+The shim covers direct Driver API symbols and these resolver paths:
+
+- explicit `dlsym()` lookups from `libcuda.so` and `libcudart.so`;
+- `cuGetProcAddress`, `cuGetProcAddress_v2`, and `_ptsz`;
+- `cudaGetDriverEntryPoint` and `cudaGetDriverEntryPointByVersion`, including
+  the `_ptsz` exports present in CUDA 13.
+
+CUDA resolvers must first return success, a valid entry, and a successful query
+status when present. The shim then substitutes only symbols in its existing
+replacement table, using the requested CUDA version to select the ABI.
+Chaining with another `dlsym()` interposer and preserving original-caller
+`RTLD_NEXT` lookup scope are unsupported.
+
+## Testing
+
+Run the native interposer integration test from the repository root:
+
+```bash
+uv run --project deploy/snapshot/cmd/cuda-vmm-interpose/tests \
+  pytest deploy/snapshot/cmd/cuda-vmm-interpose/tests/test_cucheckpoint.py -v
+```
+
+## Qualification
+
+Disjoint GPU qualification is limited to source GPUs 0/1 restored onto
+destination GPUs 4/5 with user-mode `libcuda` 615.65 and kernel RM 595.58.03.
+
+## Limitations and future extensions
+
+> [!WARNING]
+> Raw external POSIX imports are passed through and are not tracked or
+> reconstructed. Every mapping and handle from such an import must be unmapped
+> and released before checkpoint prepare, as the GMS saver/sleep flow does. If
+> retained, native checkpoint may fail, or restore may later see stale or
+> incomplete sharing; the shim cannot validate this.
+
+The shim reserves generic handles whose top 16 bits are `0xd94d` for logical
+tokens. If CUDA returns a raw pass-through handle in that range, the shim
+releases it and returns `CUDA_ERROR_INVALID_HANDLE`.
+
+### Potentially silent gaps
+
+The following gaps can bypass bookkeeping or silently preserve stale state:
+
+- An un-interposed raw export or import call bypasses bookkeeping.
+- Raw FD aliases created with `dup` or `fcntl` are invisible.
+- Raw FDs cached, queued, or transferred with `SCM_RIGHTS` outside the adapter
+  can later import stale pre-restore state.
+- An unshimmed broker or helper makes the sharing topology incomplete.
+- An uncovered CUDA runtime symbol-resolution path can bypass wrappers.
+- An old generic handle retained by an uncovered consumer can be stale.
+- NVIDIA-specific `ioctl`, `fstat`, or `poll` semantics on a capability FD are
+  unsupported.
+- Checkpoint during sharing or communicator construction is unsupported.
+
+Applications must finish setup and externally quiesce the complete process
+group first.
+
+Children created with `fork()` and no subsequent `exec()` lazily receive a fresh
+random process-local participant identity, a child-PID control socket and thread,
+and empty allocation, handle, and mapping bookkeeping on their first intercepted
+VMM operation. This supports the fork-before-CUDA-initialization lifecycle used
+by vLLM. An explicitly configured parent participant ID is never reused by a
+forked child.
+
+Forking after the shim has tracked VMM allocations, handles, or mappings is
+unsupported. The child deliberately discards its inherited copies without
+freeing them or calling CUDA; inherited tracked CUDA state is not reconciled or
+preserved.
+
+### Fail-closed limitations
+
+The coordinator fails closed for a missing creator anchor, incomplete
+participants or topology, more than eight access descriptors, access updates
+that do not exactly match a tracked mapping range, and reconstruction or final
+validation failures. There is no rollback after checkpoint preparation mutates
+CUDA state.
+
+Multicast objects are not checkpointable yet. While interposition is enabled,
+all `cuMulticast*` entry points return `CUDA_ERROR_NOT_SUPPORTED`, including
+calls resolved through `dlsym()` or `cuGetProcAddress()`. NCCL workloads must set
+`NCCL_NVLS_ENABLE=0`; otherwise NCCL initialization fails intentionally rather
+than creating multicast state that cannot be restored.
+
+### Future compatibility
+
+FABRIC/IMEX handles, multicast checkpointing, raw-FD compatibility, and
+multi-node rendezvous are not implemented. The durable sidecar preserves
+allocation type, location, requested-handle type, mapping, access, and creator
+topology needed for those future compatibility seams. Creator endpoints and
+authorization tokens remain transient live/capability data and are not sidecar
+fields. The sidecar intentionally contains neither raw FDs nor allocation
+bytes.

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/coordinator.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/coordinator.c
@@ -1,0 +1,669 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "protocol.h"
+#include "util.h"
+
+#define TIMEOUT_SECONDS 30
+#define STATE_FILENAME "cuda-vmm.state"
+
+struct participant {
+  char* endpoint;
+  char id[SNAPSHOT_VMM_ID_SIZE];
+  struct snapshot_vmm_record* records;
+  uint32_t count;
+};
+
+struct allocation {
+  uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  char creator[SNAPSHOT_VMM_ID_SIZE];
+  uint64_t size;
+  bool creator_handle;
+  bool creator_mapping;
+  struct allocation* next;
+};
+
+static int
+connect_endpoint(const char* endpoint)
+{
+  struct sockaddr_un address = {.sun_family = AF_UNIX};
+  int fd;
+
+  if (strlen(endpoint) >= sizeof(address.sun_path))
+    return -1;
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", endpoint);
+  fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0 || snapshot_vmm_set_socket_timeouts(fd, TIMEOUT_SECONDS) != 0 ||
+      connect(fd, (const struct sockaddr*)&address, sizeof(address)) != 0) {
+    if (fd >= 0)
+      close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+static int
+exchange(struct participant* participant, uint16_t operation, struct snapshot_vmm_record** records, uint32_t* count)
+{
+  struct snapshot_vmm_header request;
+  struct snapshot_vmm_header response;
+  uint64_t payload_size;
+  int fd = -1;
+  int result = -1;
+  bool strings_terminated;
+
+  memset(&request, 0, sizeof(request));
+  request.magic = SNAPSHOT_VMM_MAGIC;
+  request.version = SNAPSHOT_VMM_VERSION;
+  request.operation = operation;
+  if (operation != SNAPSHOT_VMM_IDENTIFY)
+    snprintf(request.participant_id, sizeof(request.participant_id), "%s", participant->id);
+  fd = connect_endpoint(participant->endpoint);
+  if (fd < 0 || snapshot_vmm_write_all(fd, &request, sizeof(request)) != 0 ||
+      snapshot_vmm_read_all(fd, &response, sizeof(response)) != 0)
+    goto done;
+  strings_terminated = snapshot_vmm_header_strings_terminated(&response);
+  if (!strings_terminated || response.magic != SNAPSHOT_VMM_MAGIC || response.version != SNAPSHOT_VMM_VERSION ||
+      response.operation != operation || response.status != 0 || response.count > SNAPSHOT_VMM_MAX_RECORDS ||
+      response.payload_size != (uint64_t)response.count * sizeof(struct snapshot_vmm_record)) {
+    if (strings_terminated && response.message[0] != '\0')
+      fprintf(stderr, "%s: %s\n", participant->endpoint, response.message);
+    goto done;
+  }
+  if (operation == SNAPSHOT_VMM_IDENTIFY) {
+    snprintf(participant->id, sizeof(participant->id), "%s", response.participant_id);
+  } else if (strcmp(response.participant_id, participant->id) != 0) {
+    goto done;
+  }
+  payload_size = response.payload_size;
+  if (payload_size != 0) {
+    *records = calloc(response.count, sizeof(**records));
+    if (*records == NULL || snapshot_vmm_read_all(fd, *records, (size_t)payload_size) != 0)
+      goto done;
+  }
+  *count = response.count;
+  result = 0;
+done:
+  if (fd >= 0)
+    close(fd);
+  if (result != 0) {
+    free(*records);
+    *records = NULL;
+    *count = 0;
+  }
+  return result;
+}
+
+static struct allocation*
+find_allocation(struct allocation* allocations, const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE])
+{
+  struct allocation* allocation;
+
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (memcmp(allocation->id, id, SNAPSHOT_VMM_ALLOCATION_ID_SIZE) == 0)
+      return allocation;
+  }
+  return NULL;
+}
+
+static int
+validate_topology(struct participant* participants, size_t participant_count, struct allocation** output)
+{
+  struct allocation* allocations = NULL;
+  const char* reason = NULL;
+  uint64_t value = UINT64_MAX;
+  size_t participant_index;
+  uint32_t record_index = UINT32_MAX;
+
+  if (participant_count == 0) {
+    fprintf(stderr, "topology validate failed: no participants\n");
+    return -1;
+  }
+  for (participant_index = 0; participant_index < participant_count; participant_index++) {
+    struct participant* participant = &participants[participant_index];
+    size_t previous;
+
+    record_index = UINT32_MAX;
+    if (!snapshot_vmm_is_lower_hex_id(participant->id)) {
+      reason = "invalid participant identity";
+      goto failed;
+    }
+    for (previous = 0; previous < participant_index; previous++) {
+      if (strcmp(participants[previous].id, participant->id) == 0) {
+        reason = "duplicate participant identity";
+        goto failed;
+      }
+    }
+    for (record_index = 0; record_index < participant->count; record_index++) {
+      const struct snapshot_vmm_record* record = &participant->records[record_index];
+      struct allocation* allocation = find_allocation(allocations, record->allocation_id);
+
+      if (record->kind == SNAPSHOT_VMM_ALLOCATION) {
+        if (allocation == NULL) {
+          allocation = calloc(1, sizeof(*allocation));
+          if (allocation == NULL) {
+            reason = "allocation metadata allocation failed";
+            goto failed;
+          }
+          memcpy(allocation->id, record->allocation_id, sizeof(allocation->id));
+          allocation->next = allocations;
+          allocations = allocation;
+        }
+        if ((record->flags & SNAPSHOT_VMM_CREATOR) != 0) {
+          if (record->requested_handle_types != SNAPSHOT_VMM_POSIX_HANDLE_TYPE) {
+            reason = "non-POSIX requested handle type";
+            value = record->requested_handle_types;
+            goto failed;
+          }
+          if (record->allocation_size == 0) {
+            reason = "zero creator allocation size";
+            goto failed;
+          }
+          if (allocation->creator[0] != '\0' && strcmp(allocation->creator, participant->id) != 0) {
+            reason = "conflicting creators";
+            goto failed;
+          }
+          snprintf(allocation->creator, sizeof(allocation->creator), "%s", participant->id);
+          allocation->size = record->allocation_size;
+          allocation->creator_handle = (record->flags & SNAPSHOT_VMM_APPLICATION_HANDLE_LIVE) != 0;
+        }
+      } else if (record->kind == SNAPSHOT_VMM_MAPPING) {
+        if (record->address == 0) {
+          reason = "zero mapping address";
+          goto failed;
+        }
+        if (record->size == 0) {
+          reason = "zero mapping size";
+          goto failed;
+        }
+        if (record->access_count > SNAPSHOT_VMM_MAX_ACCESS) {
+          reason = "mapping access count exceeds limit";
+          value = record->access_count;
+          goto failed;
+        }
+        if (allocation == NULL) {
+          allocation = calloc(1, sizeof(*allocation));
+          if (allocation == NULL) {
+            reason = "allocation metadata allocation failed";
+            goto failed;
+          }
+          memcpy(allocation->id, record->allocation_id, sizeof(allocation->id));
+          allocation->next = allocations;
+          allocations = allocation;
+        }
+        if ((record->flags & SNAPSHOT_VMM_CREATOR) != 0)
+          allocation->creator_mapping = true;
+      } else {
+        reason = "unknown record kind";
+        value = record->kind;
+        goto failed;
+      }
+    }
+  }
+  {
+    struct allocation* allocation;
+    for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+      struct participant* participant;
+
+      if (allocation->creator[0] == '\0') {
+        reason = "missing creator";
+        goto failed;
+      }
+      if (allocation->size == 0) {
+        reason = "missing allocation size";
+        goto failed;
+      }
+      if (!allocation->creator_handle && !allocation->creator_mapping) {
+        reason = "missing creator anchor";
+        goto failed;
+      }
+      for (participant_index = 0; participant_index < participant_count; participant_index++) {
+        participant = &participants[participant_index];
+        for (record_index = 0; record_index < participant->count; record_index++) {
+          const struct snapshot_vmm_record* record = &participant->records[record_index];
+          if (record->kind == SNAPSHOT_VMM_MAPPING &&
+              memcmp(record->allocation_id, allocation->id, sizeof(allocation->id)) == 0 &&
+              (record->offset > allocation->size || record->size > allocation->size - record->offset)) {
+            reason = "mapping out of bounds";
+            goto failed;
+          }
+        }
+      }
+    }
+  }
+  *output = allocations;
+  return 0;
+failed:
+  if (value != UINT64_MAX)
+    fprintf(
+        stderr, "topology validate failed: %s (value %llu, participant index %zu, record index %u)\n", reason,
+        (unsigned long long)value, participant_index, (unsigned)record_index);
+  else if (participant_index < participant_count && record_index != UINT32_MAX)
+    fprintf(
+        stderr, "topology validate failed: %s (participant index %zu, record index %u)\n", reason, participant_index,
+        (unsigned)record_index);
+  else if (participant_index < participant_count)
+    fprintf(stderr, "topology validate failed: %s (participant index %zu)\n", reason, participant_index);
+  else
+    fprintf(stderr, "topology validate failed: %s\n", reason);
+  while (allocations != NULL) {
+    struct allocation* next = allocations->next;
+    free(allocations);
+    allocations = next;
+  }
+  return -1;
+}
+
+static int write_state(struct participant* participants, size_t count, FILE* output);
+
+static int
+write_state_atomic(const char* path, struct participant* participants, size_t count)
+{
+  char temporary[PATH_MAX];
+  FILE* output = NULL;
+  int fd;
+  int length;
+  int result = -1;
+
+  length = snprintf(temporary, sizeof(temporary), "%s.tmp.XXXXXX", path);
+  if (length < 0 || (size_t)length >= sizeof(temporary))
+    return -1;
+  fd = mkstemp(temporary);
+  if (fd < 0)
+    return -1;
+  output = fdopen(fd, "w");
+  if (output == NULL) {
+    close(fd);
+    unlink(temporary);
+    return -1;
+  }
+  if (write_state(participants, count, output) != 0 || fsync(fileno(output)) != 0)
+    goto done;
+  if (fclose(output) != 0) {
+    output = NULL;
+    goto done;
+  }
+  output = NULL;
+  if (rename(temporary, path) != 0)
+    goto done;
+  result = 0;
+done:
+  if (output != NULL)
+    fclose(output);
+  if (result != 0)
+    unlink(temporary);
+  return result;
+}
+
+static int
+record_compare(const void* left, const void* right)
+{
+  return memcmp(left, right, sizeof(struct snapshot_vmm_record));
+}
+
+static int
+participant_compare(const void* left, const void* right)
+{
+  const struct participant* a = left;
+  const struct participant* b = right;
+  return strcmp(a->id, b->id);
+}
+
+static int
+write_state(struct participant* participants, size_t count, FILE* output)
+{
+  size_t index;
+
+  qsort(participants, count, sizeof(*participants), participant_compare);
+  if (fprintf(output, "snapshot-cuda-posix-v1\n") < 0)
+    return -1;
+  for (index = 0; index < count; index++) {
+    struct participant* participant = &participants[index];
+    uint32_t record_index;
+
+    qsort(participant->records, participant->count, sizeof(*participant->records), record_compare);
+    if (fprintf(output, "participant %s %u\n", participant->id, participant->count) < 0)
+      return -1;
+    for (record_index = 0; record_index < participant->count; record_index++) {
+      const uint8_t* bytes = (const uint8_t*)&participant->records[record_index];
+      size_t byte_index;
+      for (byte_index = 0; byte_index < sizeof(struct snapshot_vmm_record); byte_index++) {
+        if (fprintf(output, "%02x", bytes[byte_index]) < 0)
+          return -1;
+      }
+      if (fputc('\n', output) == EOF)
+        return -1;
+    }
+  }
+  return fflush(output);
+}
+
+static int
+hex_digit(int value)
+{
+  if (value >= '0' && value <= '9')
+    return value - '0';
+  if (value >= 'a' && value <= 'f')
+    return value - 'a' + 10;
+  return -1;
+}
+
+static int
+read_record(FILE* input, struct snapshot_vmm_record* record)
+{
+  uint8_t* bytes = (uint8_t*)record;
+  size_t index;
+
+  for (index = 0; index < sizeof(*record); index++) {
+    int high = hex_digit(fgetc(input));
+    int low = hex_digit(fgetc(input));
+    if (high < 0 || low < 0)
+      return -1;
+    bytes[index] = (uint8_t)((high << 4) | low);
+  }
+  return fgetc(input) == '\n' ? 0 : -1;
+}
+
+static int
+read_state(FILE* input, struct participant** output, size_t* output_count)
+{
+  char line[128];
+  struct participant* participants = NULL;
+  size_t count = 0;
+
+  if (fgets(line, sizeof(line), input) == NULL || strcmp(line, "snapshot-cuda-posix-v1\n") != 0)
+    return -1;
+  while (fgets(line, sizeof(line), input) != NULL) {
+    struct participant* participant;
+    struct participant* expanded;
+    char id[SNAPSHOT_VMM_ID_SIZE];
+    unsigned int record_count;
+    unsigned int index;
+
+    if (sscanf(line, "participant %32s %u", id, &record_count) != 2 || !snapshot_vmm_is_lower_hex_id(id) ||
+        record_count > SNAPSHOT_VMM_MAX_RECORDS)
+      goto failed;
+    expanded = realloc(participants, (count + 1) * sizeof(*participants));
+    if (expanded == NULL)
+      goto failed;
+    participants = expanded;
+    participant = &participants[count++];
+    memset(participant, 0, sizeof(*participant));
+    snprintf(participant->id, sizeof(participant->id), "%s", id);
+    participant->records = calloc(record_count == 0 ? 1 : record_count, sizeof(*participant->records));
+    if (participant->records == NULL)
+      goto failed;
+    participant->count = record_count;
+    for (index = 0; index < record_count; index++) {
+      if (read_record(input, &participant->records[index]) != 0)
+        goto failed;
+    }
+  }
+  *output = participants;
+  *output_count = count;
+  return count == 0 ? -1 : 0;
+failed:
+  if (participants != NULL) {
+    size_t index;
+    for (index = 0; index < count; index++) free(participants[index].records);
+  }
+  free(participants);
+  return -1;
+}
+
+static int
+identify(struct participant* participants, size_t count)
+{
+  size_t index;
+
+  for (index = 0; index < count; index++) {
+    struct snapshot_vmm_record* records = NULL;
+    uint32_t record_count = 0;
+    if (exchange(&participants[index], SNAPSHOT_VMM_IDENTIFY, &records, &record_count) != 0)
+      return -1;
+    free(records);
+  }
+  return 0;
+}
+
+static int
+inspect(struct participant* participants, size_t count)
+{
+  size_t index;
+
+  if (identify(participants, count) != 0)
+    return -1;
+  for (index = 0; index < count; index++) {
+    if (exchange(
+            &participants[index], SNAPSHOT_VMM_INSPECT, &participants[index].records, &participants[index].count) != 0)
+      return -1;
+  }
+  return 0;
+}
+
+static void
+free_participants(struct participant* participants, size_t count)
+{
+  size_t index;
+
+  if (participants == NULL)
+    return;
+  for (index = 0; index < count; index++) {
+    free(participants[index].endpoint);
+    free(participants[index].records);
+  }
+  free(participants);
+}
+
+static void
+free_allocations(struct allocation* allocations)
+{
+  while (allocations != NULL) {
+    struct allocation* next = allocations->next;
+    free(allocations);
+    allocations = next;
+  }
+}
+
+static int
+command_all(struct participant* participants, size_t count, uint16_t operation)
+{
+  size_t index;
+
+  for (index = 0; index < count; index++) {
+    struct snapshot_vmm_record* records = NULL;
+    uint32_t record_count = 0;
+    if (exchange(&participants[index], operation, &records, &record_count) != 0)
+      return -1;
+    free(records);
+  }
+  return 0;
+}
+
+static int
+same_participants(struct participant* expected, size_t expected_count, struct participant* actual, size_t actual_count)
+{
+  size_t index;
+
+  if (expected_count != actual_count)
+    return -1;
+  qsort(expected, expected_count, sizeof(*expected), participant_compare);
+  qsort(actual, actual_count, sizeof(*actual), participant_compare);
+  for (index = 0; index < expected_count; index++) {
+    if (strcmp(expected[index].id, actual[index].id) != 0)
+      return -1;
+  }
+  return 0;
+}
+
+static int
+same_topology(struct participant* expected, size_t expected_count, struct participant* actual, size_t actual_count)
+{
+  size_t index;
+
+  if (same_participants(expected, expected_count, actual, actual_count) != 0)
+    return -1;
+  for (index = 0; index < expected_count; index++) {
+    if (expected[index].count != actual[index].count)
+      return -1;
+    qsort(expected[index].records, expected[index].count, sizeof(*expected[index].records), record_compare);
+    qsort(actual[index].records, actual[index].count, sizeof(*actual[index].records), record_compare);
+    if (memcmp(
+            expected[index].records, actual[index].records,
+            (size_t)expected[index].count * sizeof(*expected[index].records)) != 0)
+      return -1;
+  }
+  return 0;
+}
+
+int
+main(int argc, char** argv)
+{
+  struct participant* participants = NULL;
+  struct participant* expected = NULL;
+  struct allocation* allocations = NULL;
+  size_t participant_count = 0;
+  size_t expected_count = 0;
+  size_t index;
+  bool prepare;
+  int result = EXIT_FAILURE;
+  FILE* state = NULL;
+
+  char state_path[PATH_MAX];
+  const char* proc_root;
+  const char* checkpoint_dir;
+  const char* control_dir = "/snapshot-control";
+  int length;
+
+  if (argc < 9 || (argc - 6) % 3 != 0 || (strcmp(argv[1], "--prepare") != 0 && strcmp(argv[1], "--restore") != 0)) {
+    fprintf(
+        stderr,
+        "usage: %s (--prepare|--restore) --proc-root PATH "
+        "--checkpoint-dir PATH --process OBSERVED_PID NAMESPACE_PID...\n",
+        argv[0]);
+    return EXIT_FAILURE;
+  }
+  prepare = strcmp(argv[1], "--prepare") == 0;
+  if (strcmp(argv[2], "--proc-root") != 0 || strcmp(argv[4], "--checkpoint-dir") != 0)
+    return EXIT_FAILURE;
+  proc_root = argv[3];
+  checkpoint_dir = argv[5];
+  length = snprintf(state_path, sizeof(state_path), "%s/%s", checkpoint_dir, STATE_FILENAME);
+  if (length < 0 || (size_t)length >= sizeof(state_path))
+    return EXIT_FAILURE;
+  if (!prepare) {
+    state = fopen(state_path, "r");
+    if (state == NULL)
+      return errno == ENOENT ? EXIT_SUCCESS : EXIT_FAILURE;
+  }
+  if (proc_root[0] == '\0') {
+    const char* control = getenv("DYN_SNAPSHOT_CONTROL_DIR");
+    if (control != NULL && control[0] != '\0')
+      control_dir = control;
+  }
+  participant_count = (size_t)(argc - 6) / 3;
+  participants = calloc(participant_count, sizeof(*participants));
+  if (participants == NULL)
+    goto done;
+  for (index = 0; index < participant_count; index++) {
+    char endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+    char* end;
+    long observed;
+    long namespace;
+    int length;
+
+    if (strcmp(argv[6 + index * 3], "--process") != 0)
+      goto done;
+    errno = 0;
+    observed = strtol(argv[7 + index * 3], &end, 10);
+    if (errno != 0 || *end != '\0' || observed <= 0 || observed > INT_MAX)
+      goto done;
+    errno = 0;
+    namespace = strtol(argv[8 + index * 3], &end, 10);
+    if (errno != 0 || *end != '\0' || namespace <= 0 || namespace > INT_MAX)
+      goto done;
+    if (proc_root[0] == '\0')
+      length =
+          snprintf(endpoint, sizeof(endpoint), "%s/%s%ld.sock", control_dir, SNAPSHOT_VMM_SOCKET_PREFIX, namespace);
+    else
+      length = snprintf(
+          endpoint, sizeof(endpoint), "%s/%ld/root%s/%s%ld.sock", proc_root, observed, control_dir,
+          SNAPSHOT_VMM_SOCKET_PREFIX, namespace);
+    if (length < 0 || (size_t)length >= sizeof(endpoint))
+      goto done;
+    participants[index].endpoint = strdup(endpoint);
+    if (participants[index].endpoint == NULL)
+      goto done;
+  }
+  if (prepare) {
+    if (inspect(participants, participant_count) != 0) {
+      fprintf(stderr, "prepare failed: participant inspect\n");
+      goto done;
+    }
+    if (validate_topology(participants, participant_count, &allocations) != 0) {
+      fprintf(stderr, "prepare failed: topology validate\n");
+      goto done;
+    }
+    if (command_all(participants, participant_count, SNAPSHOT_VMM_CREATE_CARRIERS) != 0) {
+      fprintf(stderr, "prepare failed: checkpoint carrier creation\n");
+      goto done;
+    }
+    if (command_all(participants, participant_count, SNAPSHOT_VMM_PREPARE) != 0) {
+      fprintf(stderr, "prepare failed: participant prepare\n");
+      goto done;
+    }
+    if (write_state_atomic(state_path, participants, participant_count) != 0) {
+      fprintf(stderr, "prepare failed: atomic state write\n");
+      goto done;
+    }
+  } else {
+    if (read_state(state, &expected, &expected_count) != 0)
+      goto done;
+    if (fclose(state) != 0) {
+      state = NULL;
+      goto done;
+    }
+    state = NULL;
+    if (identify(participants, participant_count) != 0 ||
+        same_participants(expected, expected_count, participants, participant_count) != 0)
+      goto done;
+    if (command_all(participants, participant_count, SNAPSHOT_VMM_RESTORE_CREATORS) != 0 ||
+        command_all(participants, participant_count, SNAPSHOT_VMM_RESTORE_IMPORTERS) != 0) {
+      goto done;
+    }
+    for (index = 0; index < participant_count; index++) {
+      free(participants[index].records);
+      participants[index].records = NULL;
+      participants[index].count = 0;
+    }
+    if (inspect(participants, participant_count) != 0 ||
+        validate_topology(participants, participant_count, &allocations) != 0 ||
+        same_topology(expected, expected_count, participants, participant_count) != 0)
+      goto done;
+  }
+  result = EXIT_SUCCESS;
+done:
+  if (state != NULL)
+    fclose(state);
+  free_allocations(allocations);
+  free_participants(expected, expected_count);
+  free_participants(participants, participant_count);
+  return result;
+}

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
@@ -1,0 +1,1779 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <link.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/random.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "posix.h"
+#include "protocol.h"
+#include "util.h"
+
+#undef cuGetProcAddress
+#undef cuMulticastBindAddr
+#undef cuMulticastBindMem
+#undef cudaGetDriverEntryPoint
+#undef cudaGetDriverEntryPointByVersion
+
+#define CONTROL_DIR "/snapshot-control"
+#define CONTROL_TIMEOUT_SECONDS 30
+#define LOGICAL_HANDLE_TAG UINT64_C(0xd94d000000000000)
+#define LOGICAL_HANDLE_TAG_MASK UINT64_C(0xffff000000000000)
+#define LOGICAL_HANDLE_VALUE_MASK UINT64_C(0x0000ffffffffffff)
+
+CUresult CUDAAPI cuGetProcAddress(const char*, void**, int, cuuint64_t);
+CUresult CUDAAPI cuGetProcAddress_v2(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+CUresult CUDAAPI cuGetProcAddress_v2_ptsz(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+CUresult CUDAAPI cuMemRetainAllocationHandle(CUmemGenericAllocationHandle*, void*);
+CUresult CUDAAPI cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint(const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPointByVersion(
+    const char*, void**, unsigned int, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint_ptsz(const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+cudaError_t CUDARTAPI cudaGetDriverEntryPointByVersion_ptsz(
+    const char*, void**, unsigned int, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+
+typedef CUresult(CUDAAPI* create_fn)(
+    CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+typedef CUresult(CUDAAPI* release_fn)(CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* retain_fn)(CUmemGenericAllocationHandle*, void*);
+typedef CUresult(CUDAAPI* map_fn)(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+typedef CUresult(CUDAAPI* unmap_fn)(CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* access_fn)(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+typedef CUresult(CUDAAPI* export_fn)(
+    void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
+typedef CUresult(CUDAAPI* import_fn)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
+typedef CUresult(CUDAAPI* properties_fn)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* context_get_fn)(CUcontext*);
+typedef CUresult(CUDAAPI* context_set_fn)(CUcontext);
+
+struct allocation;
+
+struct handle {
+  CUmemGenericAllocationHandle logical;
+  CUmemGenericAllocationHandle driver;
+  bool live;
+  struct allocation* allocation;
+  struct handle* next;
+};
+
+struct mapping {
+  CUdeviceptr address;
+  size_t size;
+  size_t offset;
+  CUmemAccessDesc access[SNAPSHOT_VMM_MAX_ACCESS];
+  size_t access_count;
+  bool mapped;
+  bool checkpointed;
+  struct allocation* allocation;
+  struct mapping* next;
+};
+
+struct allocation {
+  uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  uint8_t authorization[SNAPSHOT_VMM_TOKEN_SIZE];
+  char creator_participant[SNAPSHOT_VMM_ID_SIZE];
+  char creator_endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+  size_t size;
+  CUmemAllocationProp properties;
+  CUcontext context;
+  CUmemGenericAllocationHandle carrier;
+  bool creator;
+  bool shared;
+  struct allocation* next;
+};
+
+enum phase {
+  PHASE_ACTIVE,
+  PHASE_CARRIERS,
+  PHASE_PREPARED,
+  PHASE_CREATORS_RESTORED,
+  PHASE_FAILED,
+};
+
+struct context_scope {
+  CUcontext previous;
+  bool changed;
+};
+
+static pthread_mutex_t state_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct allocation* allocations;
+static struct handle* handles;
+static struct mapping* mappings;
+static enum phase current_phase = PHASE_ACTIVE;
+static bool enabled;
+static char failure[96];
+static char participant_id[SNAPSHOT_VMM_ID_SIZE];
+static char control_directory[sizeof(((struct sockaddr_un*)0)->sun_path)];
+static char socket_path[sizeof(((struct sockaddr_un*)0)->sun_path)];
+static int listener = -1;
+static bool endpoint_needs_initialization;
+static uint64_t next_logical_handle = 1;
+static pthread_once_t real_dlsym_once = PTHREAD_ONCE_INIT;
+static void* (*real_dlsym_function)(void*, const char*);
+static _Atomic(uintptr_t) explicit_libcuda_handle;
+static _Atomic(uintptr_t) explicit_libcudart_handle;
+static _Atomic(uintptr_t) explicit_cu_get_proc_address;
+static _Atomic(uintptr_t) explicit_cu_get_proc_address_v2;
+
+static void* replacement(const char*, int);
+
+static void
+set_failure(const char* message)
+{
+  current_phase = PHASE_FAILED;
+  snprintf(failure, sizeof(failure), "%s", message);
+}
+
+static void
+set_importer_failure(const char* operation, CUresult result)
+{
+  current_phase = PHASE_FAILED;
+  if (result == CUDA_SUCCESS)
+    snprintf(failure, sizeof(failure), "importer restore: %s", operation);
+  else
+    snprintf(failure, sizeof(failure), "importer restore: %s failed: CUresult=%d", operation, (int)result);
+}
+
+static CUresult
+unavailable(void)
+{
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+static void
+initialize_real_dlsym(void)
+{
+  /*
+   * A dlsym interposer cannot call dlsym(RTLD_NEXT, ...) without recursing,
+   * and POSIX provides no alternate next-definition lookup. dlvsym is the
+   * simplest public glibc interface; the symbol version varies by architecture.
+   */
+  static const char* versions[] = {"GLIBC_2.2.5", "GLIBC_2.17", "GLIBC_2.34"};
+  size_t index;
+
+  for (index = 0; index < sizeof(versions) / sizeof(versions[0]); index++) {
+    real_dlsym_function = (void* (*)(void*, const char*))dlvsym(RTLD_NEXT, "dlsym", versions[index]);
+    if (real_dlsym_function != NULL)
+      return;
+  }
+}
+
+static void*
+real_dlsym(void* handle, const char* name)
+{
+  if (pthread_once(&real_dlsym_once, initialize_real_dlsym) != 0 || real_dlsym_function == NULL)
+    return NULL;
+  return real_dlsym_function(handle, name);
+}
+
+static void*
+real_symbol(const char* name)
+{
+  void* symbol = real_dlsym(RTLD_NEXT, name);
+  void* handle;
+
+  if (symbol != NULL)
+    return symbol;
+  handle = (void*)atomic_load(&explicit_libcuda_handle);
+  if (handle != NULL && (symbol = real_dlsym(handle, name)) != NULL)
+    return symbol;
+  handle = (void*)atomic_load(&explicit_libcudart_handle);
+  return handle == NULL ? NULL : real_dlsym(handle, name);
+}
+
+static bool
+is_cuda_library(void* handle, void* symbol, const char** library)
+{
+  struct link_map* map;
+  Dl_info info;
+  const char* provider;
+  const char* requested;
+
+  if (dladdr(symbol, &info) == 0)
+    return false;
+  provider = strrchr(info.dli_fname, '/');
+  provider = provider == NULL ? info.dli_fname : provider + 1;
+  if (strncmp(provider, "libcuda.so", 10) != 0 && strncmp(provider, "libcudart.so", 12) != 0)
+    return false;
+  *library = provider;
+  if (handle == NULL || handle == RTLD_NEXT)
+    return true;
+  if (dlinfo(handle, RTLD_DI_LINKMAP, &map) != 0 || map == NULL)
+    return false;
+  requested = strrchr(map->l_name, '/');
+  requested = requested == NULL ? map->l_name : requested + 1;
+  return (strncmp(requested, "libcuda.so", 10) == 0 && strncmp(provider, "libcuda.so", 10) == 0) ||
+         (strncmp(requested, "libcudart.so", 12) == 0 && strncmp(provider, "libcudart.so", 12) == 0);
+}
+
+void*
+dlsym(void* handle, const char* name)
+{
+  void* symbol = real_dlsym(handle, name);
+  void* entry;
+  const char* library;
+
+  if (!enabled || symbol == NULL || !is_cuda_library(handle, symbol, &library))
+    return symbol;
+  if (strncmp(library, "libcuda.so", 10) == 0) {
+    if (handle != NULL && handle != RTLD_NEXT)
+      atomic_store(&explicit_libcuda_handle, (uintptr_t)handle);
+    if (strcmp(name, "cuGetProcAddress") == 0)
+      atomic_store(&explicit_cu_get_proc_address, (uintptr_t)symbol);
+    if (strcmp(name, "cuGetProcAddress_v2") == 0)
+      atomic_store(&explicit_cu_get_proc_address_v2, (uintptr_t)symbol);
+  } else if (handle != NULL && handle != RTLD_NEXT)
+    atomic_store(&explicit_libcudart_handle, (uintptr_t)handle);
+  entry = replacement(name, 0);
+  return entry == NULL || entry == symbol ? symbol : entry;
+}
+
+static int
+random_bytes(void* output, size_t size)
+{
+  unsigned char* current = output;
+
+  while (size != 0) {
+    ssize_t count = getrandom(current, size, 0);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+static int
+random_id(char output[SNAPSHOT_VMM_ID_SIZE])
+{
+  uint8_t value[16];
+  size_t index;
+
+  if (random_bytes(value, sizeof(value)) != 0)
+    return -1;
+  for (index = 0; index < sizeof(value); index++)
+    snprintf(output + index * 2, SNAPSHOT_VMM_ID_SIZE - index * 2, "%02x", value[index]);
+  return 0;
+}
+
+static struct allocation*
+find_allocation(const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE])
+{
+  struct allocation* allocation;
+
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (memcmp(allocation->id, id, SNAPSHOT_VMM_ALLOCATION_ID_SIZE) == 0)
+      return allocation;
+  }
+  return NULL;
+}
+
+static bool
+is_logical_handle(CUmemGenericAllocationHandle handle)
+{
+  return ((uint64_t)handle & LOGICAL_HANDLE_TAG_MASK) == LOGICAL_HANDLE_TAG;
+}
+
+static struct handle*
+resolve_managed_handle(CUmemGenericAllocationHandle logical)
+{
+  struct handle* handle;
+
+  if (!is_logical_handle(logical))
+    return NULL;
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->live && handle->logical == logical)
+      return handle;
+  }
+  return NULL;
+}
+
+static int
+allocate_logical_handle(CUmemGenericAllocationHandle* output)
+{
+  if (next_logical_handle == 0 || next_logical_handle > LOGICAL_HANDLE_VALUE_MASK)
+    return -1;
+  *output = (CUmemGenericAllocationHandle)(LOGICAL_HANDLE_TAG | next_logical_handle++);
+  return 0;
+}
+
+static CUresult
+transfer_passthrough_handle(CUresult result, CUmemGenericAllocationHandle driver, CUmemGenericAllocationHandle* output)
+{
+  release_fn release;
+
+  if (result != CUDA_SUCCESS)
+    return result;
+  if (output == NULL || is_logical_handle(driver)) {
+    release = (release_fn)real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(driver);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  *output = driver;
+  return CUDA_SUCCESS;
+}
+
+static struct mapping*
+find_mapping(CUdeviceptr address, size_t size)
+{
+  struct mapping* mapping;
+
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (mapping->mapped && mapping->address == address && mapping->size == size)
+      return mapping;
+  }
+  return NULL;
+}
+
+static struct mapping*
+find_mapping_at(CUdeviceptr address)
+{
+  struct mapping* mapping;
+
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (mapping->mapped && address >= mapping->address && address < mapping->address + mapping->size)
+      return mapping;
+  }
+  return NULL;
+}
+
+static size_t
+live_handle_count(const struct allocation* allocation)
+{
+  const struct handle* handle;
+  size_t count = 0;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->live && handle->allocation == allocation)
+      count++;
+  }
+  return count;
+}
+
+static struct mapping*
+first_mapping(const struct allocation* allocation)
+{
+  struct mapping* mapping;
+
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (mapping->allocation == allocation && mapping->mapped)
+      return mapping;
+  }
+  return NULL;
+}
+
+static struct handle*
+first_live_handle(const struct allocation* allocation)
+{
+  struct handle* handle;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->allocation == allocation && handle->live)
+      return handle;
+  }
+  return NULL;
+}
+
+static int
+add_managed_handle(
+    struct allocation* allocation, CUmemGenericAllocationHandle driver, CUmemGenericAllocationHandle* logical)
+{
+  struct handle* handle = calloc(1, sizeof(*handle));
+
+  if (handle == NULL || allocate_logical_handle(logical) != 0) {
+    free(handle);
+    return -1;
+  }
+  handle->logical = *logical;
+  handle->driver = driver;
+  handle->live = true;
+  handle->allocation = allocation;
+  handle->next = handles;
+  handles = handle;
+  return 0;
+}
+
+static int
+enter_context(CUcontext context, struct context_scope* scope)
+{
+  context_get_fn get_current = (context_get_fn)real_symbol("cuCtxGetCurrent");
+  context_set_fn set_current = (context_set_fn)real_symbol("cuCtxSetCurrent");
+
+  memset(scope, 0, sizeof(*scope));
+  if (get_current == NULL || set_current == NULL || get_current(&scope->previous) != CUDA_SUCCESS)
+    return -1;
+  if (scope->previous != context) {
+    if (set_current(context) != CUDA_SUCCESS)
+      return -1;
+    scope->changed = true;
+  }
+  return 0;
+}
+
+static int
+leave_context(const struct context_scope* scope)
+{
+  context_set_fn set_current = (context_set_fn)real_symbol("cuCtxSetCurrent");
+
+  return !scope->changed || (set_current != NULL && set_current(scope->previous) == CUDA_SUCCESS) ? 0 : -1;
+}
+
+static int
+current_context(CUcontext* context)
+{
+  context_get_fn get_current = (context_get_fn)real_symbol("cuCtxGetCurrent");
+
+  return get_current != NULL && get_current(context) == CUDA_SUCCESS && *context != NULL ? 0 : -1;
+}
+
+static int
+create_posix_capability(const struct allocation* allocation, int* output)
+{
+  struct snapshot_vmm_posix_capability capability;
+
+  memset(&capability, 0, sizeof(capability));
+  capability.magic = SNAPSHOT_VMM_POSIX_CAPABILITY_MAGIC;
+  capability.version = SNAPSHOT_VMM_POSIX_CAPABILITY_VERSION;
+  snprintf(
+      capability.creator_participant, sizeof(capability.creator_participant), "%s", allocation->creator_participant);
+  memcpy(capability.allocation_id, allocation->id, sizeof(capability.allocation_id));
+  snprintf(capability.creator_endpoint, sizeof(capability.creator_endpoint), "%s", allocation->creator_endpoint);
+  memcpy(capability.authorization, allocation->authorization, sizeof(capability.authorization));
+  return snapshot_vmm_posix_create_capability(&capability, output);
+}
+
+static CUresult
+export_raw(struct allocation* allocation, int* output)
+{
+  export_fn export_handle = (export_fn)real_symbol("cuMemExportToShareableHandle");
+  retain_fn retain = (retain_fn)real_symbol("cuMemRetainAllocationHandle");
+  release_fn release = (release_fn)real_symbol("cuMemRelease");
+  struct context_scope scope;
+  struct handle* handle;
+  struct mapping* mapping;
+  CUmemGenericAllocationHandle temporary = 0;
+  CUresult result;
+
+  *output = -1;
+  if (!allocation->creator || export_handle == NULL || enter_context(allocation->context, &scope) != 0)
+    return CUDA_ERROR_INVALID_HANDLE;
+  handle = first_live_handle(allocation);
+  if (allocation->carrier != 0)
+    temporary = allocation->carrier;
+  else if (handle != NULL)
+    temporary = handle->driver;
+  else if ((mapping = first_mapping(allocation)) != NULL && retain != NULL) {
+    result = retain(&temporary, (void*)(uintptr_t)mapping->address);
+    if (result != CUDA_SUCCESS)
+      goto done;
+  } else {
+    result = CUDA_ERROR_INVALID_HANDLE;
+    goto done;
+  }
+  result = export_handle(output, temporary, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+  if (temporary != allocation->carrier && (handle == NULL || temporary != handle->driver) && release != NULL)
+    (void)release(temporary);
+done:
+  if (leave_context(&scope) != 0) {
+    if (*output >= 0) {
+      close(*output);
+      *output = -1;
+    }
+    return CUDA_ERROR_UNKNOWN;
+  }
+  return result;
+}
+
+static void*
+runtime_replacement(const char* symbol, unsigned int version)
+{
+  return replacement(symbol, version == 0 ? CUDA_VERSION : (int)version);
+}
+
+static cudaError_t
+runtime_driver_entry_point(
+    const char* resolver, const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  cudaError_t result;
+  void* entry;
+
+  if (strcmp(resolver, "cudaGetDriverEntryPoint") == 0 || strcmp(resolver, "cudaGetDriverEntryPoint_ptsz") == 0) {
+    typedef cudaError_t(CUDARTAPI * legacy_type)(
+        const char*, void**, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+    legacy_type legacy = (legacy_type)real_symbol(resolver);
+    result = legacy != NULL ? legacy(symbol, output, flags, status) : cudaErrorInitializationError;
+  } else {
+    typedef cudaError_t(CUDARTAPI * function_type)(
+        const char*, void**, unsigned int, unsigned long long, enum cudaDriverEntryPointQueryResult*);
+    function_type function = (function_type)real_symbol(resolver);
+    result = function != NULL ? function(symbol, output, version, flags, status) : cudaErrorInitializationError;
+  }
+  if (enabled && result == cudaSuccess && output != NULL && *output != NULL &&
+      (status == NULL || *status == cudaDriverEntryPointSuccess) &&
+      (entry = runtime_replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint(
+    const char* symbol, void** output, unsigned long long flags, enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPoint", symbol, output, 0, flags, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPoint_ptsz(
+    const char* symbol, void** output, unsigned long long flags, enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPoint_ptsz", symbol, output, 0, flags, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPointByVersion", symbol, output, version, flags, status);
+}
+
+cudaError_t CUDARTAPI
+cudaGetDriverEntryPointByVersion_ptsz(
+    const char* symbol, void** output, unsigned int version, unsigned long long flags,
+    enum cudaDriverEntryPointQueryResult* status)
+{
+  return runtime_driver_entry_point("cudaGetDriverEntryPointByVersion_ptsz", symbol, output, version, flags, status);
+}
+
+static int
+request_export(const struct snapshot_vmm_posix_capability* capability, int* output, char* error, size_t error_size)
+{
+  int result = -1;
+
+  *output = -1;
+  if (error != NULL && error_size != 0)
+    error[0] = '\0';
+  if (strcmp(capability->creator_participant, participant_id) == 0) {
+    struct allocation* allocation;
+    CUresult export_result;
+
+    pthread_mutex_lock(&state_lock);
+    allocation = find_allocation(capability->allocation_id);
+    if (allocation == NULL ||
+        memcmp(allocation->authorization, capability->authorization, sizeof(allocation->authorization)) != 0) {
+      if (error != NULL && error_size != 0)
+        snprintf(error, error_size, "%s", "creator allocation is unavailable");
+    } else if ((export_result = export_raw(allocation, output)) != CUDA_SUCCESS) {
+      if (error != NULL && error_size != 0)
+        snprintf(error, error_size, "creator export failed: CUresult=%d", (int)export_result);
+    } else {
+      result = 0;
+    }
+    pthread_mutex_unlock(&state_lock);
+    return result;
+  }
+  return snapshot_vmm_posix_request_export(capability, output, error, error_size);
+}
+
+static void
+fill_header(struct snapshot_vmm_header* header, uint16_t operation)
+{
+  memset(header, 0, sizeof(*header));
+  header->magic = SNAPSHOT_VMM_MAGIC;
+  header->version = SNAPSHOT_VMM_VERSION;
+  header->operation = operation;
+  snprintf(header->participant_id, sizeof(header->participant_id), "%s", participant_id);
+}
+
+static void
+response_error(struct snapshot_vmm_header* response, const char* message)
+{
+  response->status = -1;
+  snprintf(response->message, sizeof(response->message), "%s", message);
+}
+
+static struct snapshot_vmm_record*
+inspect_records(uint32_t* count)
+{
+  struct snapshot_vmm_record* records;
+  struct snapshot_vmm_record* record;
+  struct allocation* allocation;
+  struct mapping* mapping;
+  size_t total = 0;
+  size_t index;
+
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (allocation->shared && (live_handle_count(allocation) != 0 || first_mapping(allocation) != NULL))
+      total++;
+  }
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (mapping->allocation->shared && mapping->mapped)
+      total++;
+  }
+  if (total > SNAPSHOT_VMM_MAX_RECORDS)
+    return NULL;
+  records = calloc(total == 0 ? 1 : total, sizeof(*records));
+  if (records == NULL)
+    return NULL;
+  record = records;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    size_t handles_count = live_handle_count(allocation);
+    if (!allocation->shared || (handles_count == 0 && first_mapping(allocation) == NULL))
+      continue;
+    record->kind = SNAPSHOT_VMM_ALLOCATION;
+    record->flags = allocation->creator ? SNAPSHOT_VMM_CREATOR : 0;
+    if (handles_count != 0)
+      record->flags |= SNAPSHOT_VMM_APPLICATION_HANDLE_LIVE;
+    memcpy(record->allocation_id, allocation->id, sizeof(record->allocation_id));
+    record->allocation_size = allocation->size;
+    record->allocation_type = allocation->properties.type;
+    record->requested_handle_types = allocation->properties.requestedHandleTypes;
+    record->allocation_location_type = allocation->properties.location.type;
+    record->allocation_location_id = allocation->properties.location.id;
+    record->application_handle_count = (uint32_t)handles_count;
+    record++;
+  }
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (!mapping->allocation->shared || !mapping->mapped)
+      continue;
+    record->kind = SNAPSHOT_VMM_MAPPING;
+    record->flags = mapping->allocation->creator ? SNAPSHOT_VMM_CREATOR : 0;
+    memcpy(record->allocation_id, mapping->allocation->id, sizeof(record->allocation_id));
+    record->address = mapping->address;
+    record->size = mapping->size;
+    record->offset = mapping->offset;
+    record->access_count = (uint32_t)mapping->access_count;
+    for (index = 0; index < mapping->access_count; index++) {
+      record->access[index].location_type = mapping->access[index].location.type;
+      record->access[index].location_id = mapping->access[index].location.id;
+      record->access[index].flags = mapping->access[index].flags;
+    }
+    record++;
+  }
+  *count = (uint32_t)total;
+  return records;
+}
+
+static bool
+driver_handle_used(const struct handle* except, CUmemGenericAllocationHandle driver)
+{
+  const struct handle* handle;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle != except && handle->live && handle->driver == driver)
+      return true;
+  }
+  return false;
+}
+
+static int
+create_checkpoint_carriers(void)
+{
+  retain_fn retain = (retain_fn)real_symbol("cuMemRetainAllocationHandle");
+  struct allocation* allocation;
+  struct context_scope scope;
+
+  if (current_phase != PHASE_ACTIVE || retain == NULL)
+    return -1;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    struct handle* carrier_handle;
+    struct mapping* carrier_mapping;
+    CUresult result;
+
+    if (!allocation->shared || !allocation->creator ||
+        (live_handle_count(allocation) == 0 && first_mapping(allocation) == NULL))
+      continue;
+    carrier_handle = first_live_handle(allocation);
+    carrier_mapping = first_mapping(allocation);
+    if (carrier_handle != NULL) {
+      allocation->carrier = carrier_handle->driver;
+      continue;
+    }
+    if (carrier_mapping == NULL || enter_context(allocation->context, &scope) != 0)
+      goto failed;
+    result = retain(&allocation->carrier, (void*)(uintptr_t)carrier_mapping->address);
+    if (leave_context(&scope) != 0 || result != CUDA_SUCCESS)
+      goto failed;
+  }
+  current_phase = PHASE_CARRIERS;
+  return 0;
+failed:
+  set_failure("cannot create CUDA VMM checkpoint carrier");
+  return -1;
+}
+
+static int
+prepare_topology(void)
+{
+  release_fn release = (release_fn)real_symbol("cuMemRelease");
+  unmap_fn unmap = (unmap_fn)real_symbol("cuMemUnmap");
+  struct allocation* allocation;
+  struct context_scope scope;
+  struct handle* handle;
+  struct mapping* mapping;
+
+  if (current_phase != PHASE_CARRIERS || release == NULL || unmap == NULL)
+    return -1;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (allocation->shared && allocation->creator &&
+        (live_handle_count(allocation) != 0 || first_mapping(allocation) != NULL) && allocation->carrier == 0)
+      goto failed;
+  }
+  current_phase = PHASE_PREPARED;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (!allocation->shared ||
+        (live_handle_count(allocation) == 0 && first_mapping(allocation) == NULL && allocation->carrier == 0))
+      continue;
+    if (enter_context(allocation->context, &scope) != 0)
+      goto failed;
+    for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+      if (mapping->allocation == allocation && mapping->mapped) {
+        if (unmap(mapping->address, mapping->size) != CUDA_SUCCESS) {
+          (void)leave_context(&scope);
+          goto failed;
+        }
+        mapping->mapped = false;
+        mapping->checkpointed = true;
+      }
+    }
+    for (handle = handles; handle != NULL; handle = handle->next) {
+      CUmemGenericAllocationHandle old;
+
+      if (!handle->live || handle->allocation != allocation)
+        continue;
+      old = handle->driver;
+      if (allocation->creator && old == allocation->carrier) {
+        handle->driver = allocation->carrier;
+        continue;
+      }
+      if (!driver_handle_used(handle, old) && release(old) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        goto failed;
+      }
+      handle->driver = allocation->creator ? allocation->carrier : 0;
+    }
+    if (leave_context(&scope) != 0)
+      goto failed;
+  }
+  return 0;
+failed:
+  set_failure("cannot prepare CUDA VMM topology");
+  return -1;
+}
+
+static CUresult
+restore_mappings(struct allocation* allocation, CUmemGenericAllocationHandle handle, const char** operation)
+{
+  map_fn map = (map_fn)real_symbol("cuMemMap");
+  access_fn set_access = (access_fn)real_symbol("cuMemSetAccess");
+  struct mapping* mapping;
+  CUresult result;
+
+  if (map == NULL || set_access == NULL) {
+    *operation = "mapping symbols are unavailable";
+    return CUDA_ERROR_NOT_INITIALIZED;
+  }
+  for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+    if (!mapping->allocation->shared || mapping->allocation != allocation || !mapping->checkpointed)
+      continue;
+    result = map(mapping->address, mapping->size, mapping->offset, handle, 0);
+    if (result != CUDA_SUCCESS) {
+      *operation = "cuMemMap";
+      return result;
+    }
+    mapping->mapped = true;
+    if (mapping->access_count != 0) {
+      result = set_access(mapping->address, mapping->size, mapping->access, mapping->access_count);
+      if (result != CUDA_SUCCESS) {
+        *operation = "cuMemSetAccess";
+        return result;
+      }
+    }
+    mapping->checkpointed = false;
+  }
+  return CUDA_SUCCESS;
+}
+
+static int
+restore_creators(void)
+{
+  release_fn release = (release_fn)real_symbol("cuMemRelease");
+  struct allocation* allocation;
+  struct context_scope scope;
+  struct handle* handle;
+  const char* mapping_operation;
+
+  if ((current_phase != PHASE_PREPARED && current_phase != PHASE_FAILED) || release == NULL)
+    return -1;
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    if (!allocation->shared || !allocation->creator || allocation->carrier == 0)
+      continue;
+    if (enter_context(allocation->context, &scope) != 0)
+      goto failed;
+    if (restore_mappings(allocation, allocation->carrier, &mapping_operation) != CUDA_SUCCESS) {
+      (void)leave_context(&scope);
+      goto failed;
+    }
+    for (handle = handles; handle != NULL; handle = handle->next) {
+      if (handle->live && handle->allocation == allocation)
+        handle->driver = allocation->carrier;
+    }
+    if (live_handle_count(allocation) == 0) {
+      if (release(allocation->carrier) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        goto failed;
+      }
+      allocation->carrier = 0;
+    }
+    if (leave_context(&scope) != 0)
+      goto failed;
+  }
+  current_phase = PHASE_CREATORS_RESTORED;
+  failure[0] = '\0';
+  return 0;
+failed:
+  set_failure("cannot restore creator CUDA VMM topology");
+  return -1;
+}
+
+static int
+restore_importers(void)
+{
+  import_fn import_handle = (import_fn)real_symbol("cuMemImportFromShareableHandle");
+  release_fn release = (release_fn)real_symbol("cuMemRelease");
+  struct allocation* allocation;
+  struct context_scope scope;
+  struct handle* handle;
+
+  if (current_phase != PHASE_CREATORS_RESTORED || import_handle == NULL || release == NULL) {
+    snprintf(failure, sizeof(failure), "%s", "importer restore: phase or symbols are not ready");
+    return -1;
+  }
+  for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
+    struct snapshot_vmm_posix_capability capability;
+    CUmemGenericAllocationHandle imported = 0;
+    CUresult cuda_result;
+    char export_error[sizeof(failure)];
+    int export_result;
+    int raw_fd = -1;
+    bool needed = false;
+    const char* mapping_operation;
+
+    if (!allocation->shared || allocation->creator)
+      continue;
+    for (handle = handles; handle != NULL; handle = handle->next) {
+      if (handle->live && handle->allocation == allocation) {
+        needed = true;
+        break;
+      }
+    }
+    if (!needed) {
+      struct mapping* mapping;
+      for (mapping = mappings; mapping != NULL; mapping = mapping->next) {
+        if (mapping->allocation == allocation && mapping->checkpointed) {
+          needed = true;
+          break;
+        }
+      }
+    }
+    if (!needed)
+      continue;
+    memset(&capability, 0, sizeof(capability));
+    capability.magic = SNAPSHOT_VMM_POSIX_CAPABILITY_MAGIC;
+    capability.version = SNAPSHOT_VMM_POSIX_CAPABILITY_VERSION;
+    snprintf(
+        capability.creator_participant, sizeof(capability.creator_participant), "%s", allocation->creator_participant);
+    memcpy(capability.allocation_id, allocation->id, sizeof(capability.allocation_id));
+    snprintf(capability.creator_endpoint, sizeof(capability.creator_endpoint), "%s", allocation->creator_endpoint);
+    memcpy(capability.authorization, allocation->authorization, sizeof(capability.authorization));
+    if (enter_context(allocation->context, &scope) != 0) {
+      set_importer_failure("enter context", CUDA_SUCCESS);
+      return -1;
+    }
+    pthread_mutex_unlock(&state_lock);
+    export_result = request_export(&capability, &raw_fd, export_error, sizeof(export_error));
+    pthread_mutex_lock(&state_lock);
+    if (export_result != 0) {
+      (void)leave_context(&scope);
+      current_phase = PHASE_FAILED;
+      snprintf(
+          failure, sizeof(failure), "importer restore: creator export: %.61s",
+          export_error[0] != '\0' ? export_error : "request failed");
+      return -1;
+    }
+    cuda_result = import_handle(&imported, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+    if (cuda_result != CUDA_SUCCESS) {
+      close(raw_fd);
+      (void)leave_context(&scope);
+      set_importer_failure("cuMemImportFromShareableHandle", cuda_result);
+      return -1;
+    }
+    if (close(raw_fd) != 0) {
+      (void)release(imported);
+      (void)leave_context(&scope);
+      set_importer_failure("raw FD close", CUDA_SUCCESS);
+      return -1;
+    }
+    cuda_result = restore_mappings(allocation, imported, &mapping_operation);
+    if (cuda_result != CUDA_SUCCESS) {
+      (void)release(imported);
+      (void)leave_context(&scope);
+      set_importer_failure(mapping_operation, cuda_result);
+      return -1;
+    }
+    for (handle = handles; handle != NULL; handle = handle->next) {
+      if (handle->live && handle->allocation == allocation)
+        handle->driver = imported;
+    }
+    if (live_handle_count(allocation) == 0) {
+      cuda_result = release(imported);
+      if (cuda_result != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        set_importer_failure("cuMemRelease imported handle", cuda_result);
+        return -1;
+      }
+    }
+    if (leave_context(&scope) != 0) {
+      set_importer_failure("leave context", CUDA_SUCCESS);
+      return -1;
+    }
+  }
+  current_phase = PHASE_ACTIVE;
+  failure[0] = '\0';
+  return 0;
+}
+
+static bool
+valid_control_request(const struct snapshot_vmm_header* request)
+{
+  return snapshot_vmm_header_strings_terminated(request) && request->magic == SNAPSHOT_VMM_MAGIC &&
+         request->version == SNAPSHOT_VMM_VERSION && request->status == 0 && request->count == 0 &&
+         request->payload_size == 0 &&
+         ((request->operation == SNAPSHOT_VMM_IDENTIFY && request->participant_id[0] == '\0') ||
+          strcmp(request->participant_id, participant_id) == 0);
+}
+
+static void
+serve(int client)
+{
+  struct snapshot_vmm_header request;
+  struct snapshot_vmm_header response;
+  struct snapshot_vmm_record* records = NULL;
+  int passed_fd = -1;
+  int exported_fd = -1;
+
+  if (snapshot_vmm_receive_header(client, &request, &passed_fd) != 0)
+    goto done;
+  fill_header(&response, request.operation);
+  if (passed_fd >= 0 || !valid_control_request(&request)) {
+    response_error(&response, "invalid CUDA VMM control request");
+    (void)snapshot_vmm_send_header(client, &response, -1);
+    goto done;
+  }
+  pthread_mutex_lock(&state_lock);
+  switch (request.operation) {
+    case SNAPSHOT_VMM_IDENTIFY:
+      if (current_phase == PHASE_FAILED)
+        response_error(&response, failure);
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
+    case SNAPSHOT_VMM_INSPECT:
+      if (current_phase != PHASE_ACTIVE) {
+        response_error(&response, "CUDA VMM topology is not active");
+        (void)snapshot_vmm_send_header(client, &response, -1);
+        break;
+      }
+      records = inspect_records(&response.count);
+      if (records == NULL) {
+        response_error(&response, "cannot inspect CUDA VMM topology");
+        (void)snapshot_vmm_send_header(client, &response, -1);
+        break;
+      }
+      response.payload_size = (uint64_t)response.count * sizeof(struct snapshot_vmm_record);
+      if (snapshot_vmm_send_header(client, &response, -1) == 0 && response.payload_size != 0)
+        (void)snapshot_vmm_write_all(client, records, (size_t)response.payload_size);
+      break;
+    case SNAPSHOT_VMM_PREPARE:
+      if (prepare_topology() != 0)
+        response_error(&response, failure);
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
+    case SNAPSHOT_VMM_CREATE_CARRIERS:
+      if (create_checkpoint_carriers() != 0)
+        response_error(&response, failure);
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
+    case SNAPSHOT_VMM_RESTORE_CREATORS:
+      if (restore_creators() != 0)
+        response_error(&response, failure);
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
+    case SNAPSHOT_VMM_RESTORE_IMPORTERS:
+      if (restore_importers() != 0)
+        response_error(&response, failure);
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
+    case SNAPSHOT_VMM_EXPORT: {
+      struct allocation* allocation = find_allocation(request.allocation_id);
+      CUresult export_result;
+      if (strcmp(request.participant_id, participant_id) != 0 || allocation == NULL || !allocation->creator ||
+          memcmp(allocation->authorization, request.authorization, sizeof(request.authorization)) != 0 ||
+          (current_phase != PHASE_ACTIVE && current_phase != PHASE_CREATORS_RESTORED)) {
+        response_error(&response, "creator allocation is unavailable");
+        (void)snapshot_vmm_send_header(client, &response, -1);
+        break;
+      }
+      export_result = export_raw(allocation, &exported_fd);
+      if (export_result != CUDA_SUCCESS) {
+        char message[sizeof(response.message)];
+        snprintf(message, sizeof(message), "creator export failed: CUresult=%d", (int)export_result);
+        response_error(&response, message);
+        (void)snapshot_vmm_send_header(client, &response, -1);
+        break;
+      }
+      memcpy(response.allocation_id, allocation->id, sizeof(response.allocation_id));
+      (void)snapshot_vmm_send_header(client, &response, exported_fd);
+      break;
+    }
+    default:
+      response_error(&response, "unknown CUDA VMM control operation");
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
+  }
+  pthread_mutex_unlock(&state_lock);
+done:
+  if (passed_fd >= 0)
+    close(passed_fd);
+  if (exported_fd >= 0)
+    close(exported_fd);
+  free(records);
+}
+
+static void*
+control_agent(void* unused)
+{
+  (void)unused;
+  for (;;) {
+    int client = accept4(listener, NULL, NULL, SOCK_CLOEXEC);
+    if (client < 0) {
+      if (errno == EINTR)
+        continue;
+      return NULL;
+    }
+    if (snapshot_vmm_set_socket_timeouts(client, CONTROL_TIMEOUT_SECONDS) == 0)
+      serve(client);
+    close(client);
+  }
+}
+
+static int
+format_socket_path(char* output, size_t size)
+{
+  int count = snprintf(output, size, "%s/%s%ld.sock", control_directory, SNAPSHOT_VMM_SOCKET_PREFIX, (long)getpid());
+  return count >= 0 && (size_t)count < size ? 0 : -1;
+}
+
+static int
+start_control_endpoint(void)
+{
+  struct sockaddr_un address = {.sun_family = AF_UNIX};
+  pthread_t thread;
+
+  if (format_socket_path(socket_path, sizeof(socket_path)) != 0) {
+    socket_path[0] = '\0';
+    return -1;
+  }
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", socket_path);
+  listener = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (listener >= 0)
+    unlink(socket_path);
+  if (listener < 0 || bind(listener, (const struct sockaddr*)&address, sizeof(address)) != 0 ||
+      listen(listener, 8) != 0 || pthread_create(&thread, NULL, control_agent, NULL) != 0) {
+    if (listener >= 0)
+      close(listener);
+    listener = -1;
+    unlink(socket_path);
+    socket_path[0] = '\0';
+    return -1;
+  }
+  pthread_detach(thread);
+  return 0;
+}
+
+static void
+fork_prepare(void)
+{
+  pthread_mutex_lock(&state_lock);
+}
+
+static void
+fork_parent(void)
+{
+  pthread_mutex_unlock(&state_lock);
+}
+
+static void
+fork_child(void)
+{
+  if (listener >= 0)
+    close(listener);
+  listener = -1;
+  participant_id[0] = '\0';
+  socket_path[0] = '\0';
+  endpoint_needs_initialization = true;
+  allocations = NULL;
+  handles = NULL;
+  mappings = NULL;
+  next_logical_handle = 1;
+  current_phase = PHASE_ACTIVE;
+  failure[0] = '\0';
+  pthread_mutex_unlock(&state_lock);
+}
+
+static CUresult
+ensure_process_endpoint(void)
+{
+  CUresult result = CUDA_SUCCESS;
+
+  pthread_mutex_lock(&state_lock);
+  if (endpoint_needs_initialization) {
+    if (current_phase == PHASE_FAILED) {
+      result = CUDA_ERROR_NOT_INITIALIZED;
+    } else if (random_id(participant_id) != 0 || start_control_endpoint() != 0) {
+      set_failure("cannot start forked CUDA VMM control endpoint");
+      result = CUDA_ERROR_NOT_INITIALIZED;
+    } else {
+      endpoint_needs_initialization = false;
+    }
+  }
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+__attribute__((constructor)) static void
+initialize(void)
+{
+  const char* control;
+  const char* configured_participant;
+
+  enabled = getenv("DYN_SNAPSHOT_CUDA_VMM_INTERPOSE") != NULL;
+  if (!enabled)
+    return;
+  configured_participant = getenv("DYN_SNAPSHOT_PARTICIPANT_ID");
+  if (configured_participant != NULL && !snapshot_vmm_is_lower_hex_id(configured_participant)) {
+    set_failure("invalid CUDA VMM participant identity");
+    return;
+  }
+  if (configured_participant != NULL)
+    snprintf(participant_id, sizeof(participant_id), "%s", configured_participant);
+  else if (random_id(participant_id) != 0) {
+    set_failure("cannot create CUDA VMM participant identity");
+    return;
+  }
+  control = getenv("DYN_SNAPSHOT_CONTROL_DIR");
+  if (control == NULL || control[0] == '\0')
+    control = CONTROL_DIR;
+  if (control[0] != '/' || strlen(control) >= sizeof(control_directory) ||
+      snprintf(control_directory, sizeof(control_directory), "%s", control) >= (int)sizeof(control_directory)) {
+    set_failure("invalid CUDA VMM control directory");
+    return;
+  }
+  if (pthread_atfork(fork_prepare, fork_parent, fork_child) != 0) {
+    set_failure("cannot register CUDA VMM fork handlers");
+    return;
+  }
+  if (start_control_endpoint() != 0) {
+    set_failure("cannot start CUDA VMM control endpoint");
+    return;
+  }
+}
+
+__attribute__((destructor)) static void
+finalize(void)
+{
+  if (listener >= 0)
+    close(listener);
+  if (socket_path[0] != '\0')
+    unlink(socket_path);
+}
+
+CUresult CUDAAPI
+cuMemCreate(
+    CUmemGenericAllocationHandle* output, size_t size, const CUmemAllocationProp* properties, unsigned long long flags)
+{
+  create_fn function = (create_fn)real_symbol("cuMemCreate");
+  struct allocation* allocation;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
+
+  if (!enabled)
+    return function != NULL ? function(output, size, properties, flags) : unavailable();
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (properties == NULL || properties->requestedHandleTypes == 0) {
+    result = function != NULL ? function(&driver, size, properties, flags) : unavailable();
+    return transfer_passthrough_handle(result, driver, output);
+  }
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (properties->requestedHandleTypes != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  if (function == NULL)
+    return unavailable();
+  result = function(&driver, size, properties, flags);
+  if (result != CUDA_SUCCESS)
+    return result;
+  allocation = calloc(1, sizeof(*allocation));
+  pthread_mutex_lock(&state_lock);
+  if (allocation == NULL || current_phase != PHASE_ACTIVE ||
+      random_bytes(allocation->id, sizeof(allocation->id)) != 0 ||
+      random_bytes(allocation->authorization, sizeof(allocation->authorization)) != 0 ||
+      add_managed_handle(allocation, driver, &logical) != 0) {
+    release_fn release = (release_fn)real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(driver);
+    free(allocation);
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  allocation->size = size;
+  allocation->properties = *properties;
+  allocation->creator = true;
+  snprintf(allocation->creator_participant, sizeof(allocation->creator_participant), "%s", participant_id);
+  snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", socket_path);
+  allocation->next = allocations;
+  allocations = allocation;
+  *output = logical;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemRelease(CUmemGenericAllocationHandle application)
+{
+  release_fn function = (release_fn)real_symbol("cuMemRelease");
+  struct handle* handle;
+  CUresult result;
+
+  if (!enabled)
+    return function != NULL ? function(application) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = resolve_managed_handle(application);
+  if (handle == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    if (is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function != NULL ? function(application) : unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE || handle->driver == 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  result = CUDA_SUCCESS;
+  if (!driver_handle_used(handle, handle->driver))
+    result = function != NULL ? function(handle->driver) : unavailable();
+  if (result == CUDA_SUCCESS)
+    handle->live = false;
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+CUresult CUDAAPI
+cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
+{
+  retain_fn function = (retain_fn)real_symbol("cuMemRetainAllocationHandle");
+  struct mapping* mapping;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
+
+  if (enabled && (result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (function == NULL)
+    return unavailable();
+  if (!enabled)
+    return function(output, address);
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  result = function(&driver, address);
+  if (result != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  mapping = find_mapping_at((CUdeviceptr)(uintptr_t)address);
+  if (mapping == NULL) {
+    result = transfer_passthrough_handle(result, driver, output);
+  } else if (add_managed_handle(mapping->allocation, driver, &logical) != 0) {
+    release_fn release = (release_fn)real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(driver);
+    result = CUDA_ERROR_OUT_OF_MEMORY;
+  } else {
+    *output = logical;
+  }
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+CUresult CUDAAPI
+cuMemMap(
+    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle application, unsigned long long flags)
+{
+  map_fn function = (map_fn)real_symbol("cuMemMap");
+  struct mapping* mapping;
+  struct handle* handle;
+  CUresult result;
+
+  if (!enabled)
+    return function != NULL ? function(address, size, offset, application, flags) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = resolve_managed_handle(application);
+  if (handle == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    if (is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function != NULL ? function(address, size, offset, application, flags) : unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE || handle->driver == 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  result = function != NULL ? function(address, size, offset, handle->driver, flags) : unavailable();
+  if (result == CUDA_SUCCESS) {
+    mapping = calloc(1, sizeof(*mapping));
+    if (mapping == NULL) {
+      unmap_fn unmap = (unmap_fn)real_symbol("cuMemUnmap");
+      if (unmap != NULL)
+        (void)unmap(address, size);
+      result = CUDA_ERROR_OUT_OF_MEMORY;
+    } else {
+      mapping->address = address;
+      mapping->size = size;
+      mapping->offset = offset;
+      mapping->mapped = true;
+      mapping->allocation = handle->allocation;
+      mapping->next = mappings;
+      mappings = mapping;
+    }
+  }
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+CUresult CUDAAPI
+cuMemUnmap(CUdeviceptr address, size_t size)
+{
+  unmap_fn function = (unmap_fn)real_symbol("cuMemUnmap");
+  struct mapping* mapping;
+  CUresult result;
+
+  if (!enabled)
+    return function != NULL ? function(address, size) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  mapping = find_mapping(address, size);
+  if (mapping == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    return function != NULL ? function(address, size) : unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_READY;
+  }
+  result = function != NULL ? function(address, size) : unavailable();
+  if (result == CUDA_SUCCESS)
+    mapping->mapped = false;
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+CUresult CUDAAPI
+cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
+{
+  access_fn function = (access_fn)real_symbol("cuMemSetAccess");
+  struct mapping* mapping;
+  CUresult result;
+
+  if (!enabled)
+    return function != NULL ? function(address, size, descriptors, count) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  mapping = find_mapping(address, size);
+  if (mapping == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    return function != NULL ? function(address, size, descriptors, count) : unavailable();
+  }
+  if (current_phase != PHASE_ACTIVE || count > SNAPSHOT_VMM_MAX_ACCESS) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_NOT_SUPPORTED;
+  }
+  result = function != NULL ? function(address, size, descriptors, count) : unavailable();
+  if (result == CUDA_SUCCESS) {
+    memcpy(mapping->access, descriptors, count * sizeof(*descriptors));
+    mapping->access_count = count;
+  }
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+CUresult CUDAAPI
+cuMemExportToShareableHandle(
+    void* shareable, CUmemGenericAllocationHandle application, CUmemAllocationHandleType type, unsigned long long flags)
+{
+  export_fn function = (export_fn)real_symbol("cuMemExportToShareableHandle");
+  struct handle* handle;
+  CUcontext context;
+  CUresult result;
+  int capability = -1;
+
+  if (!enabled)
+    return function != NULL ? function(shareable, application, type, flags) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  pthread_mutex_lock(&state_lock);
+  handle = resolve_managed_handle(application);
+  if (handle == NULL) {
+    pthread_mutex_unlock(&state_lock);
+    if (is_logical_handle(application))
+      return CUDA_ERROR_INVALID_HANDLE;
+    return function != NULL ? function(shareable, application, type, flags) : unavailable();
+  }
+  if (!handle->allocation->creator || current_phase != PHASE_ACTIVE || current_context(&context) != 0 ||
+      create_posix_capability(handle->allocation, &capability) != 0) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  handle->allocation->context = context;
+  handle->allocation->shared = true;
+  *(int*)shareable = capability;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_handle, CUmemAllocationHandleType type)
+{
+  import_fn function = (import_fn)real_symbol("cuMemImportFromShareableHandle");
+  properties_fn get_properties;
+  struct snapshot_vmm_posix_capability capability;
+  struct allocation* allocation;
+  CUmemGenericAllocationHandle logical;
+  CUmemGenericAllocationHandle imported = 0;
+  int raw_fd = -1;
+  int capability_fd = (int)(uintptr_t)os_handle;
+  CUresult result;
+
+  if (!enabled)
+    return function != NULL ? function(output, os_handle, type) : unavailable();
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (snapshot_vmm_posix_read_capability(capability_fd, &capability) != 0) {
+    result = function != NULL ? function(&imported, os_handle, type) : unavailable();
+    return transfer_passthrough_handle(result, imported, output);
+  }
+  get_properties = (properties_fn)real_symbol("cuMemGetAllocationPropertiesFromHandle");
+  if (function == NULL || get_properties == NULL)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  if (current_phase != PHASE_ACTIVE) {
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  pthread_mutex_unlock(&state_lock);
+  if (request_export(&capability, &raw_fd, NULL, 0) != 0)
+    return CUDA_ERROR_INVALID_HANDLE;
+  result = function(&imported, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+  if (close(raw_fd) != 0 && result == CUDA_SUCCESS) {
+    release_fn release = (release_fn)real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(imported);
+    return CUDA_ERROR_UNKNOWN;
+  }
+  if (result != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  if (current_phase != PHASE_ACTIVE) {
+    release_fn release = (release_fn)real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(imported);
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  allocation = find_allocation(capability.allocation_id);
+  if (allocation == NULL) {
+    allocation = calloc(1, sizeof(*allocation));
+    if (allocation != NULL) {
+      memcpy(allocation->id, capability.allocation_id, sizeof(allocation->id));
+      memcpy(allocation->authorization, capability.authorization, sizeof(allocation->authorization));
+      snprintf(
+          allocation->creator_participant, sizeof(allocation->creator_participant), "%s",
+          capability.creator_participant);
+      snprintf(allocation->creator_endpoint, sizeof(allocation->creator_endpoint), "%s", capability.creator_endpoint);
+      allocation->creator = false;
+      allocation->next = allocations;
+      allocations = allocation;
+    }
+  }
+  if (allocation != NULL)
+    allocation->shared = true;
+  if (allocation == NULL || current_context(&allocation->context) != 0 ||
+      get_properties(&allocation->properties, imported) != CUDA_SUCCESS ||
+      add_managed_handle(allocation, imported, &logical) != 0) {
+    release_fn release = (release_fn)real_symbol("cuMemRelease");
+    if (release != NULL)
+      (void)release(imported);
+    pthread_mutex_unlock(&state_lock);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *output = logical;
+  pthread_mutex_unlock(&state_lock);
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI
+cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGenericAllocationHandle application)
+{
+  properties_fn function = (properties_fn)real_symbol("cuMemGetAllocationPropertiesFromHandle");
+  struct handle* handle;
+  CUresult result;
+
+  if (!enabled)
+    return function != NULL ? function(properties, application) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  handle = resolve_managed_handle(application);
+  if (handle == NULL)
+    result = is_logical_handle(application) ? CUDA_ERROR_INVALID_HANDLE
+                                            : (function != NULL ? function(properties, application) : unavailable());
+  else
+    result = current_phase == PHASE_ACTIVE && handle->driver != 0 ? function(properties, handle->driver)
+                                                                  : CUDA_ERROR_NOT_READY;
+  pthread_mutex_unlock(&state_lock);
+  return result;
+}
+
+CUresult CUDAAPI
+cuMulticastCreate(CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+  function_type function = (function_type)real_symbol("cuMulticastCreate");
+
+  return enabled ? CUDA_ERROR_NOT_SUPPORTED : (function != NULL ? function(output, properties) : unavailable());
+}
+
+CUresult CUDAAPI
+cuMulticastAddDevice(CUmemGenericAllocationHandle multicast, CUdevice device)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle, CUdevice);
+  function_type function = (function_type)real_symbol("cuMulticastAddDevice");
+
+  return enabled ? CUDA_ERROR_NOT_SUPPORTED : (function != NULL ? function(multicast, device) : unavailable());
+}
+
+CUresult CUDAAPI
+cuMulticastBindMem(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUmemGenericAllocationHandle memory,
+    size_t memory_offset, size_t size, unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+  function_type function = (function_type)real_symbol("cuMulticastBindMem");
+
+  return enabled ? CUDA_ERROR_NOT_SUPPORTED
+                 : (function != NULL ? function(multicast, multicast_offset, memory, memory_offset, size, flags)
+                                     : unavailable());
+}
+
+CUresult CUDAAPI
+cuMulticastBindMem_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size, unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+  function_type function = (function_type)real_symbol("cuMulticastBindMem_v2");
+
+  return enabled ? CUDA_ERROR_NOT_SUPPORTED
+                 : (function != NULL ? function(multicast, device, multicast_offset, memory, memory_offset, size, flags)
+                                     : unavailable());
+}
+
+CUresult CUDAAPI
+cuMulticastBindAddr(
+    CUmemGenericAllocationHandle multicast, size_t multicast_offset, CUdeviceptr memory, size_t size,
+    unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t, unsigned long long);
+  function_type function = (function_type)real_symbol("cuMulticastBindAddr");
+
+  return enabled ? CUDA_ERROR_NOT_SUPPORTED
+                 : (function != NULL ? function(multicast, multicast_offset, memory, size, flags) : unavailable());
+}
+
+CUresult CUDAAPI
+cuMulticastBindAddr_v2(
+    CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset, CUdeviceptr memory, size_t size,
+    unsigned long long flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(
+      CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t, unsigned long long);
+  function_type function = (function_type)real_symbol("cuMulticastBindAddr_v2");
+
+  return enabled
+             ? CUDA_ERROR_NOT_SUPPORTED
+             : (function != NULL ? function(multicast, device, multicast_offset, memory, size, flags) : unavailable());
+}
+
+CUresult CUDAAPI
+cuMulticastGetGranularity(
+    size_t* granularity, const CUmulticastObjectProp* properties, CUmulticastGranularity_flags option)
+{
+  typedef CUresult(CUDAAPI * function_type)(size_t*, const CUmulticastObjectProp*, CUmulticastGranularity_flags);
+  function_type function = (function_type)real_symbol("cuMulticastGetGranularity");
+
+  return enabled ? CUDA_ERROR_NOT_SUPPORTED
+                 : (function != NULL ? function(granularity, properties, option) : unavailable());
+}
+
+CUresult CUDAAPI
+cuMulticastUnbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_t offset, size_t size)
+{
+  typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
+  function_type function = (function_type)real_symbol("cuMulticastUnbind");
+
+  return enabled ? CUDA_ERROR_NOT_SUPPORTED
+                 : (function != NULL ? function(multicast, device, offset, size) : unavailable());
+}
+
+static void*
+replacement(const char* symbol, int version)
+{
+#define ENTRY(name)               \
+  if (strcmp(symbol, #name) == 0) \
+  return (void*)&name
+  if (symbol == NULL)
+    return NULL;
+  ENTRY(cuMemCreate);
+  ENTRY(cuMemRelease);
+  ENTRY(cuMemRetainAllocationHandle);
+  ENTRY(cuMemMap);
+  ENTRY(cuMemUnmap);
+  ENTRY(cuMemSetAccess);
+  ENTRY(cuMemExportToShareableHandle);
+  ENTRY(cuMemImportFromShareableHandle);
+  ENTRY(cuMemGetAllocationPropertiesFromHandle);
+  ENTRY(cuMulticastCreate);
+  ENTRY(cuMulticastAddDevice);
+  ENTRY(cuMulticastBindMem);
+  ENTRY(cuMulticastBindMem_v2);
+  ENTRY(cuMulticastBindAddr);
+  ENTRY(cuMulticastBindAddr_v2);
+  ENTRY(cuMulticastGetGranularity);
+  ENTRY(cuMulticastUnbind);
+  ENTRY(cuGetProcAddress_v2);
+  ENTRY(cuGetProcAddress_v2_ptsz);
+  ENTRY(cudaGetDriverEntryPoint);
+  ENTRY(cudaGetDriverEntryPoint_ptsz);
+  ENTRY(cudaGetDriverEntryPointByVersion);
+  ENTRY(cudaGetDriverEntryPointByVersion_ptsz);
+#undef ENTRY
+  if (strcmp(symbol, "cuGetProcAddress") == 0)
+    return version >= 12000 ? (void*)&cuGetProcAddress_v2 : (void*)&cuGetProcAddress;
+  return NULL;
+}
+
+CUresult CUDAAPI
+cuGetProcAddress(const char* symbol, void** output, int version, cuuint64_t flags)
+{
+  typedef CUresult(CUDAAPI * function_type)(const char*, void**, int, cuuint64_t);
+  function_type function = (function_type)atomic_load(&explicit_cu_get_proc_address);
+  CUresult result;
+  void* entry;
+
+  if (function == NULL)
+    function = (function_type)real_symbol("cuGetProcAddress");
+  result = function != NULL ? function(symbol, output, version, flags) : unavailable();
+  if (enabled && result == CUDA_SUCCESS && output != NULL && *output != NULL &&
+      (entry = replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}
+
+CUresult CUDAAPI
+cuGetProcAddress_v2(
+    const char* symbol, void** output, int version, cuuint64_t flags, CUdriverProcAddressQueryResult* status)
+{
+  typedef CUresult(CUDAAPI * function_type)(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+  function_type function = (function_type)atomic_load(&explicit_cu_get_proc_address_v2);
+  CUresult result;
+  void* entry;
+
+  if (function == NULL)
+    function = (function_type)real_symbol("cuGetProcAddress_v2");
+  result = function != NULL ? function(symbol, output, version, flags, status) : unavailable();
+  if (enabled && result == CUDA_SUCCESS && output != NULL && *output != NULL &&
+      (status == NULL || *status == CU_GET_PROC_ADDRESS_SUCCESS) && (entry = replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}
+
+CUresult CUDAAPI
+cuGetProcAddress_v2_ptsz(
+    const char* symbol, void** output, int version, cuuint64_t flags, CUdriverProcAddressQueryResult* status)
+{
+  typedef CUresult(CUDAAPI * function_type)(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*);
+  function_type function = (function_type)atomic_load(&explicit_cu_get_proc_address_v2);
+  cuuint64_t stream_flags = CU_GET_PROC_ADDRESS_LEGACY_STREAM | CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM;
+  CUresult result;
+  void* entry;
+
+  if (function == NULL)
+    function = (function_type)real_symbol("cuGetProcAddress_v2");
+  if ((flags & stream_flags) == 0)
+    flags |= CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM;
+  result = function != NULL ? function(symbol, output, version, flags, status) : unavailable();
+  if (enabled && result == CUDA_SUCCESS && output != NULL && *output != NULL &&
+      (status == NULL || *status == CU_GET_PROC_ADDRESS_SUCCESS) && (entry = replacement(symbol, version)) != NULL)
+    *output = entry;
+  return result;
+}

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/launch.sh
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/launch.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: snapshot-cuda-vmm-launch COMMAND [ARG...]" >&2
+  exit 2
+fi
+
+shim=/usr/local/lib/snapshot/libsnapshot_cuda_vmm.so
+if [ ! -r "$shim" ]; then
+  echo "CUDA VMM snapshot shim not found: $shim" >&2
+  exit 1
+fi
+
+export DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1
+export LD_PRELOAD="$shim${LD_PRELOAD:+:$LD_PRELOAD}"
+exec "$@"

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/posix.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/posix.c
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "posix.h"
+
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "util.h"
+
+#define EXPORT_TIMEOUT_SECONDS 30
+
+static bool
+zero_bytes(const void* value, size_t size)
+{
+  const uint8_t* bytes = value;
+  size_t index;
+
+  for (index = 0; index < size; index++) {
+    if (bytes[index] != 0)
+      return false;
+  }
+  return true;
+}
+
+int
+snapshot_vmm_posix_create_capability(const struct snapshot_vmm_posix_capability* capability, int* output)
+{
+  const int seals = F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL;
+  int fd;
+
+  fd = memfd_create("snapshot-cuda-vmm-capability", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  if (fd < 0 || snapshot_vmm_write_all(fd, capability, sizeof(*capability)) != 0 ||
+      fcntl(fd, F_ADD_SEALS, seals) != 0) {
+    if (fd >= 0)
+      close(fd);
+    return -1;
+  }
+  *output = fd;
+  return 0;
+}
+
+int
+snapshot_vmm_posix_read_capability(int fd, struct snapshot_vmm_posix_capability* capability)
+{
+  const int seals = F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL;
+  struct stat status;
+
+  memset(capability, 0, sizeof(*capability));
+  if (fd < 0 || fcntl(fd, F_GET_SEALS) != seals || fstat(fd, &status) != 0 ||
+      status.st_size != (off_t)sizeof(*capability) ||
+      snapshot_vmm_pread_all(fd, capability, sizeof(*capability)) != 0 ||
+      capability->magic != SNAPSHOT_VMM_POSIX_CAPABILITY_MAGIC ||
+      capability->version != SNAPSHOT_VMM_POSIX_CAPABILITY_VERSION ||
+      !zero_bytes(capability->reserved, sizeof(capability->reserved)) ||
+      !snapshot_vmm_is_lower_hex_id(capability->creator_participant) ||
+      zero_bytes(capability->allocation_id, sizeof(capability->allocation_id)) ||
+      capability->creator_endpoint[0] != '/' ||
+      memchr(capability->creator_endpoint, '\0', sizeof(capability->creator_endpoint)) == NULL ||
+      zero_bytes(capability->authorization, sizeof(capability->authorization)) ||
+      !zero_bytes(capability->reserved_identity, sizeof(capability->reserved_identity)))
+    return -1;
+  return 0;
+}
+
+int
+snapshot_vmm_posix_request_export(
+    const struct snapshot_vmm_posix_capability* capability, int* output, char* error, size_t error_size)
+{
+  struct sockaddr_un address = {.sun_family = AF_UNIX};
+  struct snapshot_vmm_header request;
+  struct snapshot_vmm_header response;
+  int client = -1;
+  int result = -1;
+
+  *output = -1;
+  if (error != NULL && error_size != 0)
+    error[0] = '\0';
+  memset(&request, 0, sizeof(request));
+  request.magic = SNAPSHOT_VMM_MAGIC;
+  request.version = SNAPSHOT_VMM_VERSION;
+  request.operation = SNAPSHOT_VMM_EXPORT;
+  snprintf(request.participant_id, sizeof(request.participant_id), "%s", capability->creator_participant);
+  memcpy(request.authorization, capability->authorization, sizeof(request.authorization));
+  memcpy(request.allocation_id, capability->allocation_id, sizeof(request.allocation_id));
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", capability->creator_endpoint);
+  client = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (client < 0 || snapshot_vmm_set_socket_timeouts(client, EXPORT_TIMEOUT_SECONDS) != 0 ||
+      connect(client, (const struct sockaddr*)&address, sizeof(address)) != 0 ||
+      snapshot_vmm_send_header(client, &request, -1) != 0 ||
+      snapshot_vmm_receive_header(client, &response, output) != 0) {
+    if (error != NULL && error_size != 0)
+      snprintf(error, error_size, "%s", "cannot contact creator endpoint");
+    goto done;
+  }
+  if (!snapshot_vmm_header_strings_terminated(&response) || response.magic != SNAPSHOT_VMM_MAGIC ||
+      response.version != SNAPSHOT_VMM_VERSION || response.operation != SNAPSHOT_VMM_EXPORT || response.count != 0 ||
+      response.payload_size != 0 || strcmp(response.participant_id, capability->creator_participant) != 0) {
+    if (error != NULL && error_size != 0)
+      snprintf(error, error_size, "%s", "invalid creator export response");
+    if (*output >= 0) {
+      close(*output);
+      *output = -1;
+    }
+    goto done;
+  }
+  if (response.status != 0) {
+    if (error != NULL && error_size != 0) {
+      if (response.message[0] != '\0')
+        snprintf(error, error_size, "%.*s", (int)sizeof(response.message), response.message);
+      else
+        snprintf(error, error_size, "%s", "creator export request failed");
+    }
+    if (*output >= 0) {
+      close(*output);
+      *output = -1;
+    }
+    goto done;
+  }
+  if (memcmp(response.allocation_id, capability->allocation_id, sizeof(response.allocation_id)) != 0 || *output < 0) {
+    if (error != NULL && error_size != 0)
+      snprintf(error, error_size, "%s", "invalid creator export response");
+    if (*output >= 0) {
+      close(*output);
+      *output = -1;
+    }
+    goto done;
+  }
+  result = 0;
+done:
+  if (client >= 0)
+    close(client);
+  return result;
+}

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/posix.h
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/posix.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SNAPSHOT_CUDA_VMM_POSIX_H
+#define SNAPSHOT_CUDA_VMM_POSIX_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/un.h>
+
+#include "protocol.h"
+
+#define SNAPSHOT_VMM_POSIX_CAPABILITY_MAGIC 0x44564d43U
+#define SNAPSHOT_VMM_POSIX_CAPABILITY_VERSION 1U
+
+struct snapshot_vmm_posix_capability {
+  uint32_t magic;
+  uint16_t version;
+  uint8_t reserved[35];
+  char creator_participant[SNAPSHOT_VMM_ID_SIZE];
+  uint8_t allocation_id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  char creator_endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+  uint8_t authorization[SNAPSHOT_VMM_TOKEN_SIZE];
+  uint8_t reserved_identity[42];
+};
+
+_Static_assert(sizeof(struct snapshot_vmm_posix_capability) == 256, "VMM POSIX capability layout changed");
+
+/* On success, output receives a capability FD owned by the caller. */
+int snapshot_vmm_posix_create_capability(const struct snapshot_vmm_posix_capability* capability, int* output);
+/* Reads without taking ownership of fd. */
+int snapshot_vmm_posix_read_capability(int fd, struct snapshot_vmm_posix_capability* capability);
+/* On success, output receives a raw export FD owned by the caller. */
+int snapshot_vmm_posix_request_export(
+    const struct snapshot_vmm_posix_capability* capability, int* output, char* error, size_t error_size);
+
+#endif

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SNAPSHOT_CUDA_VMM_PROTOCOL_H
+#define SNAPSHOT_CUDA_VMM_PROTOCOL_H
+
+#include <stdint.h>
+
+#define SNAPSHOT_VMM_MAGIC 0x44564d4dU
+#define SNAPSHOT_VMM_VERSION 1U
+#define SNAPSHOT_VMM_SOCKET_PREFIX "cuda-vmm-"
+#define SNAPSHOT_VMM_ID_SIZE 33U
+#define SNAPSHOT_VMM_ALLOCATION_ID_SIZE 16U
+#define SNAPSHOT_VMM_TOKEN_SIZE 16U
+#define SNAPSHOT_VMM_MAX_ACCESS 8U
+#define SNAPSHOT_VMM_MAX_RECORDS 4096U
+#define SNAPSHOT_VMM_POSIX_HANDLE_TYPE 1U
+
+enum snapshot_vmm_operation {
+  SNAPSHOT_VMM_IDENTIFY = 1,
+  SNAPSHOT_VMM_INSPECT = 2,
+  SNAPSHOT_VMM_CREATE_CARRIERS = 3,
+  SNAPSHOT_VMM_PREPARE = 4,
+  SNAPSHOT_VMM_RESTORE_CREATORS = 5,
+  SNAPSHOT_VMM_RESTORE_IMPORTERS = 6,
+  SNAPSHOT_VMM_EXPORT = 7,
+};
+
+enum snapshot_vmm_record_kind {
+  SNAPSHOT_VMM_ALLOCATION = 1,
+  SNAPSHOT_VMM_MAPPING = 2,
+};
+
+enum snapshot_vmm_record_flags {
+  SNAPSHOT_VMM_CREATOR = 1U << 0,
+  SNAPSHOT_VMM_APPLICATION_HANDLE_LIVE = 1U << 1,
+};
+
+struct snapshot_vmm_header {
+  uint32_t magic;
+  uint16_t version;
+  uint16_t operation;
+  int32_t status;
+  uint32_t count;
+  uint64_t payload_size;
+  char participant_id[SNAPSHOT_VMM_ID_SIZE];
+  char message[96];
+  uint8_t authorization[SNAPSHOT_VMM_TOKEN_SIZE];
+  uint8_t allocation_id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  uint8_t reserved[71];
+};
+
+struct snapshot_vmm_access {
+  int32_t location_type;
+  int32_t location_id;
+  uint64_t flags;
+};
+
+struct snapshot_vmm_record {
+  uint32_t kind;
+  uint32_t flags;
+  uint8_t allocation_id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  uint64_t address;
+  uint64_t size;
+  uint64_t offset;
+  uint64_t allocation_size;
+  int32_t allocation_type;
+  uint32_t requested_handle_types;
+  int32_t allocation_location_type;
+  int32_t allocation_location_id;
+  uint32_t access_count;
+  uint32_t application_handle_count;
+  struct snapshot_vmm_access access[SNAPSHOT_VMM_MAX_ACCESS];
+};
+
+_Static_assert(sizeof(struct snapshot_vmm_header) == 256, "VMM header layout changed");
+_Static_assert(sizeof(struct snapshot_vmm_access) == 16, "VMM access layout changed");
+_Static_assert(sizeof(struct snapshot_vmm_record) == 208, "VMM record layout changed");
+
+#endif

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/tests/pyproject.toml
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/tests/pyproject.toml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[project]
+name = "snapshot-cuda-vmm-interposer-tests"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = [
+  "cuda-bindings>=13.0.3,<14",
+  "pytest",
+  "torch>=2.11,<2.12",
+]
+
+[tool.uv]
+package = false
+
+[tool.pytest.ini_options]
+testpaths = ["."]

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/tests/test_cucheckpoint.py
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/tests/test_cucheckpoint.py
@@ -1,0 +1,773 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ctypes
+import os
+import queue
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import traceback
+from multiprocessing.reduction import recv_handle, send_handle
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from cuda.bindings import driver
+
+WORLD_SIZE = 2
+NUMEL = 2048
+COMMAND_TIMEOUT_SECONDS = 60
+CHECKPOINT_TIMEOUT_SECONDS = 120
+WORKER_TIMEOUT_SECONDS = 240
+PARENT_PARTICIPANT_ID = "a" * 32
+LOGICAL_HANDLE_TAG = 0xD94D000000000000
+LOGICAL_HANDLE_TAG_MASK = 0xFFFF000000000000
+POSIX_FD_HANDLE_TYPE = (
+    driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+)
+
+
+class _ExternalAllocation(NamedTuple):
+    device: driver.CUdevice
+    context: driver.CUcontext
+    address: int
+    size: int
+    handle: driver.CUmemGenericAllocationHandle
+    fd: int
+
+
+def _cuda_call(function, *arguments):
+    status, *outputs = function(*arguments)
+    if status != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"{function.__name__} failed: {status.name} ({int(status)})")
+    if not outputs:
+        return None
+    if len(outputs) == 1:
+        return outputs[0]
+    return tuple(outputs)
+
+
+def _assert_no_current_context(process: str) -> None:
+    status, context = driver.cuCtxGetCurrent()
+    if status == driver.CUresult.CUDA_ERROR_NOT_INITIALIZED:
+        return
+    if status != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuCtxGetCurrent failed: {status.name} ({int(status)})")
+    if int(context) != 0:
+        raise AssertionError(f"{process} has a current CUDA context")
+
+
+def _allocation_properties(device) -> driver.CUmemAllocationProp:
+    properties = driver.CUmemAllocationProp()
+    properties.type = driver.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+    properties.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    properties.location.id = int(device)
+    properties.requestedHandleTypes = POSIX_FD_HANDLE_TYPE
+    return properties
+
+
+def _allocation_size(properties: driver.CUmemAllocationProp) -> int:
+    return int(
+        _cuda_call(
+            driver.cuMemGetAllocationGranularity,
+            properties,
+            driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_MINIMUM,
+        )
+    )
+
+
+def _assert_handle_namespace(handle, logical: bool, stage: str) -> None:
+    tagged = int(handle) & LOGICAL_HANDLE_TAG_MASK == LOGICAL_HANDLE_TAG
+    if tagged != logical:
+        expected = "logical" if logical else "raw"
+        raise AssertionError(f"{stage}: handle {int(handle):#x} is not {expected}")
+
+
+def _map_allocation(handle, size: int, device) -> int:
+    address = int(_cuda_call(driver.cuMemAddressReserve, size, size, 0, 0))
+    mapped = False
+    try:
+        _cuda_call(driver.cuMemMap, address, size, 0, handle, 0)
+        mapped = True
+        access = driver.CUmemAccessDesc()
+        access.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+        access.location.id = int(device)
+        access.flags = driver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+        _cuda_call(driver.cuMemSetAccess, address, size, [access], 1)
+    except Exception:
+        if mapped:
+            _cuda_call(driver.cuMemUnmap, address, size)
+        _cuda_call(driver.cuMemAddressFree, address, size)
+        raise
+    return address
+
+
+def _write_bytes(address: int, expected: bytes) -> None:
+    source = ctypes.create_string_buffer(expected)
+    _cuda_call(driver.cuMemcpyHtoD, address, ctypes.addressof(source), len(expected))
+
+
+def _assert_bytes(address: int, expected: bytes, stage: str) -> None:
+    actual = ctypes.create_string_buffer(len(expected))
+    _cuda_call(driver.cuMemcpyDtoH, ctypes.addressof(actual), address, len(expected))
+    if actual.raw != expected:
+        raise AssertionError(f"{stage}: got {actual.raw!r}, expected {expected!r}")
+
+
+def _destroy_mapped_allocation(address: int, size: int, handle) -> None:
+    _cuda_call(driver.cuMemUnmap, address, size)
+    _cuda_call(driver.cuMemAddressFree, address, size)
+    _cuda_call(driver.cuMemRelease, handle)
+
+
+def _worker(
+    rank: int,
+    raw_fds: tuple[int, int],
+    restore_fds: tuple[int, int],
+    sync_dir: Path,
+    store_path: Path,
+) -> None:
+    _cuda_call(driver.cuInit, 0)
+    device = _cuda_call(driver.cuDeviceGet, rank)
+    properties = _allocation_properties(device)
+    private_size = _allocation_size(properties)
+    _assert_no_current_context("worker before private cuMemCreate")
+    private_handle = _cuda_call(driver.cuMemCreate, private_size, properties, 0)
+    _assert_handle_namespace(private_handle, True, "managed cuMemCreate")
+
+    torch.cuda.set_device(rank)
+    for other_rank, fd in enumerate(raw_fds):
+        if other_rank != rank:
+            os.close(fd)
+    for other_rank, fd in enumerate(restore_fds):
+        if other_rank != rank:
+            os.close(fd)
+    restore_socket = socket.socket(fileno=restore_fds[rank])
+    raw_fd = raw_fds[rank]
+    external_handle = None
+    external_address = 0
+    try:
+        external_handle = _cuda_call(
+            driver.cuMemImportFromShareableHandle,
+            raw_fd,
+            POSIX_FD_HANDLE_TYPE,
+        )
+        _assert_handle_namespace(external_handle, False, "raw external import")
+    finally:
+        os.close(raw_fd)
+    try:
+        external_address = _map_allocation(external_handle, private_size, device)
+        _assert_bytes(
+            external_address,
+            bytes([rank + 1]) * 32,
+            "raw external allocation",
+        )
+    finally:
+        if external_address:
+            _destroy_mapped_allocation(
+                external_address,
+                private_size,
+                external_handle,
+            )
+        elif external_handle is not None:
+            _cuda_call(driver.cuMemRelease, external_handle)
+
+    private_address = _map_allocation(private_handle, private_size, device)
+    retained_handle = _cuda_call(
+        driver.cuMemRetainAllocationHandle,
+        private_address,
+    )
+    _assert_handle_namespace(retained_handle, True, "managed retain")
+    _cuda_call(driver.cuMemRelease, retained_handle)
+    private_expected = bytes([0xA0 + rank]) * 32
+    _write_bytes(private_address, private_expected)
+
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{store_path}",
+        rank=rank,
+        world_size=WORLD_SIZE,
+    )
+    group_name = dist.group.WORLD.group_name
+    input_tensor = symm_mem.empty(NUMEL, dtype=torch.float32, device="cuda")
+    input_tensor.fill_(rank + 1)
+    symm_handle = symm_mem.rendezvous(input_tensor, group=group_name)
+    output = torch.empty_like(input_tensor)
+
+    torch.ops.symm_mem.one_shot_all_reduce_out(input_tensor, "sum", group_name, output)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        torch.ops.symm_mem.one_shot_all_reduce_out(
+            input_tensor, "sum", group_name, output
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_exact_result(output, "before checkpoint")
+    (sync_dir / f"ready-{rank}").touch()
+
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    while not (sync_dir / "continue").exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for restore")
+        time.sleep(0.05)
+
+    fresh_fd = recv_handle(restore_socket)
+    restore_socket.close()
+    fresh_handle = None
+    fresh_address = 0
+    try:
+        fresh_handle = _cuda_call(
+            driver.cuMemImportFromShareableHandle,
+            fresh_fd,
+            POSIX_FD_HANDLE_TYPE,
+        )
+        _assert_handle_namespace(fresh_handle, False, "fresh raw import after restore")
+    finally:
+        os.close(fresh_fd)
+    try:
+        fresh_address = _map_allocation(fresh_handle, private_size, device)
+        _assert_bytes(
+            fresh_address,
+            bytes([0x40 + rank]) * 32,
+            "fresh raw allocation after restore",
+        )
+    finally:
+        if fresh_address:
+            _destroy_mapped_allocation(
+                fresh_address,
+                private_size,
+                fresh_handle,
+            )
+        elif fresh_handle is not None:
+            _cuda_call(driver.cuMemRelease, fresh_handle)
+
+    _assert_bytes(private_address, private_expected, "private allocation after restore")
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_exact_result(output, "after restore")
+    (sync_dir / f"done-{rank}").touch()
+
+    dist.barrier()
+    del graph, output, symm_handle, input_tensor
+    torch.cuda.empty_cache()
+    dist.destroy_process_group()
+    _destroy_mapped_allocation(private_address, private_size, private_handle)
+
+
+def _assert_exact_result(output: torch.Tensor, stage: str) -> None:
+    expected = torch.full((NUMEL,), 3.0, dtype=torch.float32)
+    actual = output.cpu()
+    if not torch.equal(actual, expected):
+        mismatch = torch.nonzero(actual != expected)[0].item()
+        raise AssertionError(
+            f"{stage}: output[{mismatch}] is {actual[mismatch].item()}, expected 3.0"
+        )
+
+
+def _visible_gpus() -> tuple[str, str]:
+    configured = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if configured is None:
+        return "0", "1"
+    devices = [entry.strip() for entry in configured.split(",") if entry.strip()]
+    if len(devices) < WORLD_SIZE:
+        raise RuntimeError("CUDA_VISIBLE_DEVICES must contain two GPUs")
+    if devices[0] == devices[1]:
+        raise RuntimeError("the first two CUDA_VISIBLE_DEVICES entries must differ")
+    return devices[0], devices[1]
+
+
+def _create_external_allocations(byte_base: int) -> list[_ExternalAllocation]:
+    _cuda_call(driver.cuInit, 0)
+    allocations = []
+    try:
+        for rank in range(WORLD_SIZE):
+            allocations.append(_create_external_allocation(rank, byte_base))
+    except Exception:
+        _destroy_external_allocations(allocations)
+        raise
+    return allocations
+
+
+def _create_external_allocation(rank: int, byte_base: int) -> _ExternalAllocation:
+    device = _cuda_call(driver.cuDeviceGet, rank)
+    context = _cuda_call(driver.cuDevicePrimaryCtxRetain, device)
+    handle = None
+    address = 0
+    try:
+        _cuda_call(driver.cuCtxPushCurrent, context)
+        try:
+            properties = _allocation_properties(device)
+            size = _allocation_size(properties)
+            handle = _cuda_call(driver.cuMemCreate, size, properties, 0)
+            address = _map_allocation(handle, size, device)
+            _write_bytes(address, bytes([byte_base + rank]) * 32)
+            fd = int(
+                _cuda_call(
+                    driver.cuMemExportToShareableHandle,
+                    handle,
+                    POSIX_FD_HANDLE_TYPE,
+                    0,
+                )
+            )
+        except Exception:
+            if address:
+                _destroy_mapped_allocation(address, size, handle)
+            elif handle is not None:
+                _cuda_call(driver.cuMemRelease, handle)
+            raise
+        finally:
+            _cuda_call(driver.cuCtxPopCurrent)
+    except Exception:
+        _cuda_call(driver.cuDevicePrimaryCtxRelease, device)
+        raise
+    return _ExternalAllocation(device, context, address, size, handle, fd)
+
+
+def _destroy_external_allocations(allocations: list[_ExternalAllocation]) -> None:
+    while allocations:
+        allocation = allocations.pop()
+        os.close(allocation.fd)
+        _cuda_call(driver.cuCtxPushCurrent, allocation.context)
+        try:
+            _destroy_mapped_allocation(
+                allocation.address,
+                allocation.size,
+                allocation.handle,
+            )
+        finally:
+            _cuda_call(driver.cuCtxPopCurrent)
+            _cuda_call(driver.cuDevicePrimaryCtxRelease, allocation.device)
+
+
+def _build_native_tools(tmp_path: Path) -> tuple[Path, Path]:
+    interposer_dir = Path(__file__).resolve().parents[1]
+    cuda_home = Path(os.environ.get("CUDA_HOME", "/usr/local/cuda"))
+    compiler = os.environ.get("CC", "cc")
+    missing = []
+    if shutil.which("make") is None:
+        missing.append("make on PATH")
+    if shutil.which("readelf") is None:
+        missing.append("readelf on PATH")
+    if shutil.which(compiler) is None:
+        missing.append(f"{compiler} on PATH")
+    cuda_header = cuda_home / "include" / "cuda.h"
+    if not cuda_header.is_file():
+        missing.append(str(cuda_header))
+    if missing:
+        pytest.fail(
+            "missing native build prerequisites: "
+            f"{', '.join(missing)}; provide make, readelf, a C compiler, and "
+            "CUDA headers, or set CUDA_HOME to the CUDA toolkit root"
+        )
+    build_dir = tmp_path / "native"
+    result = subprocess.run(
+        [
+            "make",
+            "-C",
+            str(interposer_dir),
+            f"BUILD_DIR={build_dir}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"native build failed ({result.returncode}):\n"
+            f"{result.stdout}{result.stderr}"
+        )
+    interposer = (build_dir / "libsnapshot_cuda_vmm.so").resolve()
+    coordinator = (build_dir / "snapshot-cuda-vmm").resolve()
+    if not interposer.is_file() or not coordinator.is_file():
+        pytest.fail("native build did not produce the interposer and coordinator")
+    return interposer, coordinator
+
+
+def _fork_workers(
+    raw_fds: tuple[int, int],
+    restore_fds: tuple[int, int],
+    sync_dir: Path,
+    store_path: Path,
+) -> None:
+    if torch.cuda.is_initialized():
+        raise RuntimeError("parent initialized CUDA before forking workers")
+    _assert_no_current_context("parent before forking workers")
+
+    children = []
+    for rank in range(WORLD_SIZE):
+        child = os.fork()
+        if child == 0:
+            try:
+                _worker(rank, raw_fds, restore_fds, sync_dir, store_path)
+            except BaseException:  # noqa: BLE001 -- report child failures to parent
+                traceback.print_exc()
+                os._exit(1)
+            os._exit(0)
+        children.append((rank, child))
+        (sync_dir / f"pid-{rank}").write_text(f"{child}\n")
+
+    for fd in raw_fds:
+        os.close(fd)
+    for fd in restore_fds:
+        os.close(fd)
+
+    remaining = dict(children)
+    while remaining:
+        failures = []
+        for rank, child in tuple(remaining.items()):
+            waited, status = os.waitpid(child, os.WNOHANG)
+            if waited == 0:
+                continue
+            del remaining[rank]
+            exit_code = os.waitstatus_to_exitcode(status)
+            if not os.WIFEXITED(status) or exit_code != 0:
+                failures.append(f"rank {rank} PID {child}: {exit_code}")
+        if failures:
+            for child in remaining.values():
+                try:
+                    os.kill(child, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            for child in remaining.values():
+                os.waitpid(child, 0)
+            raise RuntimeError(f"forked workers failed: {', '.join(failures)}")
+        time.sleep(0.05)
+
+
+def _start_parent(
+    gpus: tuple[str, str],
+    interposer: Path,
+    control_dir: Path,
+    sync_dir: Path,
+    store_path: Path,
+    raw_fds: tuple[int, int],
+    restore_fds: tuple[int, int],
+) -> subprocess.Popen[str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CUDA_VISIBLE_DEVICES": ",".join(gpus),
+            "DYN_SNAPSHOT_CUDA_VMM_INTERPOSE": "1",
+            "DYN_SNAPSHOT_PARTICIPANT_ID": PARENT_PARTICIPANT_ID,
+            "DYN_SNAPSHOT_CONTROL_DIR": str(control_dir),
+            "LD_PRELOAD": str(interposer),
+            "PYTHONFAULTHANDLER": "1",
+            "PYTHONUNBUFFERED": "1",
+            "TORCH_SYMMEM_IMPLICIT_POOL": "0",
+            "TORCH_SYMM_MEM_DISABLE_MULTICAST": "1",
+        }
+    )
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-X",
+            "faulthandler",
+            "-u",
+            str(Path(__file__).resolve()),
+            "--parent",
+            *(str(fd) for fd in raw_fds),
+            *(str(fd) for fd in restore_fds),
+            str(sync_dir),
+            str(store_path),
+        ],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+        pass_fds=raw_fds + restore_fds,
+    )
+
+
+def _wait_for_child_pids(
+    parent: subprocess.Popen[str], sync_dir: Path
+) -> tuple[int, int]:
+    paths = [sync_dir / f"pid-{rank}" for rank in range(WORLD_SIZE)]
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    while True:
+        try:
+            pids = tuple(int(path.read_text()) for path in paths)
+        except (FileNotFoundError, ValueError):
+            pids = ()
+        if len(pids) == WORLD_SIZE:
+            if len(set(pids)) != WORLD_SIZE:
+                raise AssertionError(f"forked worker PIDs are not unique: {pids}")
+            return pids
+        if parent.poll() is not None:
+            raise RuntimeError(
+                f"parent {parent.pid} exited before publishing child PIDs "
+                f"with {parent.returncode}"
+            )
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for forked worker PIDs")
+        time.sleep(0.05)
+
+
+def _wait_for_workers(
+    parent: subprocess.Popen[str],
+    sync_dir: Path,
+    marker: str,
+) -> None:
+    expected = [sync_dir / f"{marker}-{rank}" for rank in range(WORLD_SIZE)]
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    while not all(path.exists() for path in expected):
+        if parent.poll() is not None:
+            raise RuntimeError(
+                f"parent {parent.pid} exited before workers reached {marker} "
+                f"with {parent.returncode}"
+            )
+        if time.monotonic() >= deadline:
+            missing = [str(path) for path in expected if not path.exists()]
+            raise TimeoutError(f"timed out waiting for {marker}: {', '.join(missing)}")
+        time.sleep(0.05)
+
+
+def _assert_worker_runtime(
+    process_id: int, interposer: Path, control_dir: Path
+) -> None:
+    maps = Path(f"/proc/{process_id}/maps").read_text().splitlines()
+    mapped_paths = {
+        fields[5] for line in maps if len(fields := line.split(maxsplit=5)) == 6
+    }
+    if str(interposer) not in mapped_paths:
+        raise AssertionError(f"{interposer} is not loaded in process {process_id}")
+    endpoint = control_dir / f"cuda-vmm-{process_id}.sock"
+    if not endpoint.is_socket():
+        raise AssertionError(f"interposer endpoint does not exist: {endpoint}")
+
+
+def _run_coordinator(
+    coordinator: Path,
+    operation: str,
+    checkpoint_dir: Path,
+    control_dir: Path,
+    process_ids: tuple[int, int],
+) -> None:
+    command = [
+        str(coordinator),
+        operation,
+        "--proc-root",
+        "",
+        "--checkpoint-dir",
+        str(checkpoint_dir),
+    ]
+    for process_id in process_ids:
+        command.extend(["--process", str(process_id), str(process_id)])
+    environment = os.environ.copy()
+    environment.pop("LD_PRELOAD", None)
+    environment.pop("DYN_SNAPSHOT_CUDA_VMM_INTERPOSE", None)
+    environment["DYN_SNAPSHOT_CONTROL_DIR"] = str(control_dir)
+    result = subprocess.run(
+        command,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"coordinator {operation} failed ({result.returncode}):\n"
+            f"{result.stdout}{result.stderr}"
+        )
+
+
+def _expect_state(process_id: int, expected) -> None:
+    actual = _cuda_call(driver.cuCheckpointProcessGetState, process_id)
+    if actual != expected:
+        raise AssertionError(
+            f"CUDA process {process_id} is {actual.name}, expected {expected.name}"
+        )
+
+
+def _native_checkpoint(process_ids: tuple[int, int]) -> None:
+    _cuda_call(driver.cuInit, 0)
+    running = driver.CUprocessState.CU_PROCESS_STATE_RUNNING
+    locked = driver.CUprocessState.CU_PROCESS_STATE_LOCKED
+    checkpointed = driver.CUprocessState.CU_PROCESS_STATE_CHECKPOINTED
+    for process_id in process_ids:
+        _expect_state(process_id, running)
+
+    lock_arguments = driver.CUcheckpointLockArgs()
+    lock_arguments.timeoutMs = COMMAND_TIMEOUT_SECONDS * 1000
+    for process_id in process_ids:
+        _cuda_call(driver.cuCheckpointProcessLock, process_id, lock_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, locked)
+
+    checkpoint_arguments = driver.CUcheckpointCheckpointArgs()
+    for process_id in process_ids:
+        _cuda_call(
+            driver.cuCheckpointProcessCheckpoint,
+            process_id,
+            checkpoint_arguments,
+        )
+    for process_id in process_ids:
+        _expect_state(process_id, checkpointed)
+
+    restore_arguments = driver.CUcheckpointRestoreArgs()
+    for process_id in process_ids:
+        _cuda_call(driver.cuCheckpointProcessRestore, process_id, restore_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, locked)
+
+    unlock_arguments = driver.CUcheckpointUnlockArgs()
+    for process_id in process_ids:
+        _cuda_call(driver.cuCheckpointProcessUnlock, process_id, unlock_arguments)
+    for process_id in process_ids:
+        _expect_state(process_id, running)
+
+
+def _native_checkpoint_with_timeout(
+    process_ids: tuple[int, int],
+) -> None:
+    outcomes: queue.Queue[Exception | None] = queue.Queue(maxsize=1)
+
+    def run() -> None:
+        try:
+            _native_checkpoint(process_ids)
+        except Exception as error:  # noqa: BLE001
+            outcomes.put(error)
+        else:
+            outcomes.put(None)
+
+    threading.Thread(target=run, daemon=True).start()
+    try:
+        outcome = outcomes.get(timeout=CHECKPOINT_TIMEOUT_SECONDS)
+    except queue.Empty as error:
+        raise TimeoutError(
+            f"native CUDA checkpoint exceeded {CHECKPOINT_TIMEOUT_SECONDS} seconds"
+        ) from error
+    if outcome is not None:
+        raise outcome
+
+
+def test_cucheckpoint_preserves_symmetric_memory_cuda_graph(tmp_path: Path) -> None:
+    interposer, coordinator = _build_native_tools(tmp_path)
+    gpus = _visible_gpus()
+    control_dir = tmp_path / "control"
+    checkpoint_dir = tmp_path / "checkpoint"
+    sync_dir = tmp_path / "sync"
+    control_dir.mkdir()
+    checkpoint_dir.mkdir()
+    sync_dir.mkdir()
+    store_path = tmp_path / "torch-distributed-store"
+
+    parent: subprocess.Popen[str] | None = None
+    child_pids: tuple[int, int] = ()
+    output = ("", "")
+    output_collected = False
+    failure: Exception | None = None
+    external_allocations: list[_ExternalAllocation] = []
+    restore_channels = [socket.socketpair() for _ in range(WORLD_SIZE)]
+
+    try:
+        external_allocations = _create_external_allocations(1)
+        parent = _start_parent(
+            gpus,
+            interposer,
+            control_dir,
+            sync_dir,
+            store_path,
+            tuple(allocation.fd for allocation in external_allocations),
+            tuple(receiver.fileno() for _, receiver in restore_channels),
+        )
+        for _, receiver in restore_channels:
+            receiver.close()
+        child_pids = _wait_for_child_pids(parent, sync_dir)
+        _wait_for_workers(parent, sync_dir, "ready")
+        _destroy_external_allocations(external_allocations)
+        _assert_worker_runtime(parent.pid, interposer, control_dir)
+        for child_pid in child_pids:
+            _assert_worker_runtime(child_pid, interposer, control_dir)
+
+        _run_coordinator(
+            coordinator,
+            "--prepare",
+            checkpoint_dir,
+            control_dir,
+            child_pids,
+        )
+        state = checkpoint_dir / "cuda-vmm.state"
+        if not state.is_file() or state.stat().st_size == 0:
+            raise AssertionError("coordinator did not write nonempty cuda-vmm.state")
+
+        _native_checkpoint_with_timeout(child_pids)
+        _run_coordinator(
+            coordinator,
+            "--restore",
+            checkpoint_dir,
+            control_dir,
+            child_pids,
+        )
+        external_allocations = _create_external_allocations(0x40)
+        for rank, (sender, _) in enumerate(restore_channels):
+            send_handle(sender, external_allocations[rank].fd, child_pids[rank])
+        (sync_dir / "continue").touch()
+        _wait_for_workers(parent, sync_dir, "done")
+
+        output = parent.communicate(timeout=COMMAND_TIMEOUT_SECONDS)
+        output_collected = True
+        if parent.returncode != 0:
+            raise RuntimeError(f"parent {parent.pid} exited with {parent.returncode}")
+    except Exception as error:  # noqa: BLE001
+        failure = error
+    finally:
+        if parent is not None and (failure is not None or parent.poll() is None):
+            try:
+                os.killpg(parent.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+        if parent is not None and not output_collected:
+            try:
+                output = parent.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(parent.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                output = parent.communicate(timeout=10)
+        _destroy_external_allocations(external_allocations)
+        for sender, receiver in restore_channels:
+            sender.close()
+            receiver.close()
+
+    if failure is not None:
+        parent_pid = parent.pid if parent is not None else "not started"
+        parent_returncode = parent.returncode if parent is not None else "not started"
+        sockets = sorted(path.name for path in control_dir.glob("*.sock"))
+        raise AssertionError(
+            f"{failure}\n"
+            f"parent PID/return code: {parent_pid}/{parent_returncode}\n"
+            f"forked child PIDs: {child_pids}\n"
+            f"control sockets: {sockets}\n"
+            f"parent and worker stdout:\n{output[0]}\n"
+            f"parent and worker stderr:\n{output[1]}"
+        ) from failure
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 8 or sys.argv[1] != "--parent":
+        raise SystemExit(
+            "usage: test_cucheckpoint.py --parent RAW_FD_0 RAW_FD_1 "
+            "RESTORE_FD_0 RESTORE_FD_1 SYNC_DIR STORE_PATH"
+        )
+    _fork_workers(
+        (int(sys.argv[2]), int(sys.argv[3])),
+        (int(sys.argv[4]), int(sys.argv[5])),
+        Path(sys.argv[6]),
+        Path(sys.argv[7]),
+    )

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/util.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/util.c
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "util.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+int
+snapshot_vmm_write_all(int fd, const void* value, size_t size)
+{
+  const uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = write(fd, current, size);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+snapshot_vmm_read_all(int fd, void* value, size_t size)
+{
+  uint8_t* current = value;
+
+  while (size != 0) {
+    ssize_t count = read(fd, current, size);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+int
+snapshot_vmm_pread_all(int fd, void* value, size_t size)
+{
+  uint8_t* current = value;
+  off_t offset = 0;
+
+  while (size != 0) {
+    ssize_t count = pread(fd, current, size, offset);
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count <= 0)
+      return -1;
+    current += count;
+    offset += count;
+    size -= (size_t)count;
+  }
+  return 0;
+}
+
+bool
+snapshot_vmm_is_lower_hex_id(const char value[SNAPSHOT_VMM_ID_SIZE])
+{
+  size_t index;
+
+  if (value == NULL)
+    return false;
+  for (index = 0; index < SNAPSHOT_VMM_ID_SIZE - 1; index++) {
+    if (!((value[index] >= '0' && value[index] <= '9') || (value[index] >= 'a' && value[index] <= 'f')))
+      return false;
+  }
+  return value[SNAPSHOT_VMM_ID_SIZE - 1] == '\0';
+}
+
+bool
+snapshot_vmm_header_strings_terminated(const struct snapshot_vmm_header* header)
+{
+  return memchr(header->participant_id, '\0', sizeof(header->participant_id)) != NULL &&
+         memchr(header->message, '\0', sizeof(header->message)) != NULL;
+}
+
+int
+snapshot_vmm_set_socket_timeouts(int fd, int seconds)
+{
+  struct timeval timeout = {.tv_sec = seconds};
+
+  return setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) == 0 &&
+                 setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) == 0
+             ? 0
+             : -1;
+}
+
+int
+snapshot_vmm_send_header(int fd, const struct snapshot_vmm_header* header, int passed_fd)
+{
+  char control[CMSG_SPACE(sizeof(int))] = {0};
+  struct iovec vector = {.iov_base = (void*)header, .iov_len = sizeof(*header)};
+  struct msghdr message = {.msg_iov = &vector, .msg_iovlen = 1};
+  ssize_t count;
+
+  if (passed_fd >= 0) {
+    struct cmsghdr* item;
+    message.msg_control = control;
+    message.msg_controllen = sizeof(control);
+    item = CMSG_FIRSTHDR(&message);
+    item->cmsg_level = SOL_SOCKET;
+    item->cmsg_type = SCM_RIGHTS;
+    item->cmsg_len = CMSG_LEN(sizeof(int));
+    memcpy(CMSG_DATA(item), &passed_fd, sizeof(passed_fd));
+  }
+  do {
+    count = sendmsg(fd, &message, MSG_NOSIGNAL);
+  } while (count < 0 && errno == EINTR);
+  return count == (ssize_t)sizeof(*header) ? 0 : -1;
+}
+
+int
+snapshot_vmm_receive_header(int fd, struct snapshot_vmm_header* header, int* passed_fd)
+{
+  char control[CMSG_SPACE(sizeof(int))] = {0};
+  struct iovec vector = {.iov_base = header, .iov_len = sizeof(*header)};
+  struct msghdr message = {
+      .msg_iov = &vector,
+      .msg_iovlen = 1,
+      .msg_control = control,
+      .msg_controllen = sizeof(control),
+  };
+  struct cmsghdr* item;
+  ssize_t count;
+
+  *passed_fd = -1;
+  do {
+    count = recvmsg(fd, &message, MSG_WAITALL | MSG_CMSG_CLOEXEC);
+  } while (count < 0 && errno == EINTR);
+  if (count != (ssize_t)sizeof(*header) || (message.msg_flags & (MSG_TRUNC | MSG_CTRUNC)) != 0)
+    return -1;
+  item = CMSG_FIRSTHDR(&message);
+  if (item != NULL && item->cmsg_level == SOL_SOCKET && item->cmsg_type == SCM_RIGHTS &&
+      item->cmsg_len == CMSG_LEN(sizeof(int)))
+    memcpy(passed_fd, CMSG_DATA(item), sizeof(*passed_fd));
+  return item == NULL || CMSG_NXTHDR(&message, item) == NULL ? 0 : -1;
+}

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/util.h
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/util.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SNAPSHOT_CUDA_VMM_UTIL_H
+#define SNAPSHOT_CUDA_VMM_UTIL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "protocol.h"
+
+int snapshot_vmm_write_all(int fd, const void* value, size_t size);
+int snapshot_vmm_read_all(int fd, void* value, size_t size);
+int snapshot_vmm_pread_all(int fd, void* value, size_t size);
+bool snapshot_vmm_is_lower_hex_id(const char value[SNAPSHOT_VMM_ID_SIZE]);
+bool snapshot_vmm_header_strings_terminated(const struct snapshot_vmm_header* header);
+int snapshot_vmm_set_socket_timeouts(int fd, int seconds);
+int snapshot_vmm_send_header(int fd, const struct snapshot_vmm_header* header, int passed_fd);
+int snapshot_vmm_receive_header(int fd, struct snapshot_vmm_header* header, int* passed_fd);
+
+#endif

--- a/deploy/snapshot/cmd/snapshotctl/checkpoint.go
+++ b/deploy/snapshot/cmd/snapshotctl/checkpoint.go
@@ -16,13 +16,14 @@ import (
 const defaultGeneratedCheckpointIDPrefix = "manual-snapshot"
 
 type checkpointOptions struct {
-	ManifestPath       string
-	Namespace          string
-	KubeContext        string
-	CheckpointID       string
-	Container          string
-	CudaCheckpointWrap bool
-	Timeout            time.Duration
+	ManifestPath           string
+	Namespace              string
+	KubeContext            string
+	CheckpointID           string
+	Container              string
+	CudaCheckpointWrap     bool
+	EnableCUDAVMMInterpose bool
+	Timeout                time.Duration
 }
 
 type result struct {
@@ -69,13 +70,27 @@ func runCheckpointFlow(ctx context.Context, opts checkpointOptions) (_ *result, 
 	}
 
 	checkpointJobName := pod.Name + "-checkpoint"
-	job, err := snapshotprotocol.NewCheckpointJob(&corev1.PodTemplateSpec{
+	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      pod.Labels,
 			Annotations: pod.Annotations,
 		},
 		Spec: *pod.Spec.DeepCopy(),
-	}, snapshotprotocol.CheckpointJobOptions{
+	}
+	if opts.EnableCUDAVMMInterpose {
+		targetContainer := containerByName(podTemplate.Spec.Containers, containers[0])
+		if targetContainer == nil {
+			return nil, fmt.Errorf("checkpoint job pod template has no container named %q", containers[0])
+		}
+		if len(targetContainer.Command) == 0 {
+			return nil, fmt.Errorf("checkpoint job requires container.command when CUDA VMM interposition is enabled")
+		}
+		targetContainer.Command, targetContainer.Args = wrapWithCUDAVMMInterposeLauncher(
+			targetContainer.Command,
+			targetContainer.Args,
+		)
+	}
+	job, err := snapshotprotocol.NewCheckpointJob(podTemplate, snapshotprotocol.CheckpointJobOptions{
 		Namespace:       namespace,
 		TargetContainer: containers[0],
 		CheckpointID:    checkpointID,
@@ -135,4 +150,20 @@ func runCheckpointFlow(ctx context.Context, opts checkpointOptions) (_ *result, 
 		res.BoundContent = *snap.Status.BoundPodSnapshotContentName
 	}
 	return res, nil
+}
+
+func containerByName(containers []corev1.Container, name string) *corev1.Container {
+	for index := range containers {
+		if containers[index].Name == name {
+			return &containers[index]
+		}
+	}
+	return nil
+}
+
+func wrapWithCUDAVMMInterposeLauncher(command, args []string) ([]string, []string) {
+	wrappedArgs := make([]string, 0, len(command)+len(args))
+	wrappedArgs = append(wrappedArgs, command...)
+	wrappedArgs = append(wrappedArgs, args...)
+	return []string{"snapshot-cuda-vmm-launch"}, wrappedArgs
 }

--- a/deploy/snapshot/cmd/snapshotctl/main.go
+++ b/deploy/snapshot/cmd/snapshotctl/main.go
@@ -48,6 +48,7 @@ func runCheckpoint(args []string) error {
 	checkpointID := flags.String("checkpoint-id", "", "Explicit checkpoint ID; defaults to a generated value")
 	container := flags.String("container", "", "Required. Name of the workload container inside the manifest to checkpoint. May be omitted if the manifest already sets the nvidia.com/snapshot-target-containers annotation")
 	cudaCheckpointWrap := flags.Bool("cuda-checkpoint-wrap", false, "Wrap the container command with cuda-checkpoint --launch-job (required for multi-GPU checkpoints; the placeholder image must have cuda-checkpoint at the same path as the source container)")
+	enableCUDAVMMInterpose := flags.Bool("cuda-vmm-interpose", false, "Experimental: launch the target through the CUDA VMM checkpoint interposer; must be enabled before CUDA VMM allocations are created")
 	timeout := flags.Duration("timeout", 45*time.Minute, "Maximum time to wait for checkpoint completion")
 
 	if err := flags.Parse(args); err != nil {
@@ -62,13 +63,14 @@ func runCheckpoint(args []string) error {
 
 	snapshotctlLog.Info("Running checkpoint", "manifest", *manifest, "namespace", *namespace)
 	result, err := runCheckpointFlow(context.Background(), checkpointOptions{
-		ManifestPath:       *manifest,
-		Namespace:          *namespace,
-		KubeContext:        *kubeContext,
-		CheckpointID:       *checkpointID,
-		Container:          *container,
-		CudaCheckpointWrap: *cudaCheckpointWrap,
-		Timeout:            *timeout,
+		ManifestPath:           *manifest,
+		Namespace:              *namespace,
+		KubeContext:            *kubeContext,
+		CheckpointID:           *checkpointID,
+		Container:              *container,
+		CudaCheckpointWrap:     *cudaCheckpointWrap,
+		EnableCUDAVMMInterpose: *enableCUDAVMMInterpose,
+		Timeout:                *timeout,
 	})
 	if err != nil {
 		return err

--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -354,10 +354,10 @@ func CheckpointProcessTree(ctx context.Context, cudaPIDs []int, jobFile, checkpo
 	return timings, nil
 }
 
-// RestoreAndUnlockProcessTree restores and unlocks CUDA state for the given PIDs.
+// RestoreProcessTree restores CUDA state for the given PIDs while keeping them locked.
 // helperBinaryPath must be the absolute path to cuda-checkpoint-helper: DefaultHelperBinaryPath
 // on the agent, or filepath.Join(bundleDir, HelperBinaryName) inside the placeholder namespace.
-func RestoreAndUnlockProcessTree(ctx context.Context, cudaPIDs []int, deviceMap, helperBinaryPath string, log logr.Logger) (RestorePhaseTimings, error) {
+func RestoreProcessTree(ctx context.Context, cudaPIDs []int, deviceMap, helperBinaryPath string, log logr.Logger) (RestorePhaseTimings, error) {
 	var timings RestorePhaseTimings
 
 	start := time.Now()
@@ -367,19 +367,22 @@ func RestoreAndUnlockProcessTree(ctx context.Context, cudaPIDs []int, deviceMap,
 			return timings, err
 		}
 	}
+	timings.TotalDuration = time.Since(start)
 
+	return timings, nil
+}
+
+// UnlockProcessTree resumes restored CUDA processes.
+func UnlockProcessTree(ctx context.Context, cudaPIDs []int, helperBinaryPath string, log logr.Logger) error {
 	for _, pid := range cudaPIDs {
 		if err := unlock(ctx, pid, helperBinaryPath, log); err != nil {
-			timings.TotalDuration = time.Since(start)
 			state, stateErr := getState(ctx, pid, helperBinaryPath)
 			if stateErr == nil && state == "running" {
 				log.Info("cuda-checkpoint-helper unlock returned error but process is already running", "pid", pid)
 				continue
 			}
-			return timings, err
+			return err
 		}
 	}
-	timings.TotalDuration = time.Since(start)
-
-	return timings, nil
+	return nil
 }

--- a/deploy/snapshot/internal/cuda/vmm_interpose.go
+++ b/deploy/snapshot/internal/cuda/vmm_interpose.go
@@ -1,0 +1,135 @@
+package cuda
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	vmmInterposeEnv = "DYN_SNAPSHOT_CUDA_VMM_INTERPOSE"
+	vmmCoordinator  = "/usr/local/bin/snapshot-cuda-vmm"
+)
+
+func DetectVMMInterpose(procRoot string, observedPIDs, namespacePIDs []int) (bool, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return false, fmt.Errorf(
+			"CUDA VMM PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	markers := 0
+	endpoints := 0
+	validEndpoints := 0
+	for index, observedPID := range observedPIDs {
+		content, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(observedPID), "environ"))
+		if err != nil {
+			return false, fmt.Errorf("read CUDA process %d environment: %w", observedPID, err)
+		}
+		for _, entry := range strings.Split(string(content), "\x00") {
+			if entry == vmmInterposeEnv+"=1" {
+				markers++
+				break
+			}
+		}
+		endpoint := filepath.Join(
+			procRoot,
+			strconv.Itoa(observedPID),
+			"root",
+			"snapshot-control",
+			fmt.Sprintf("cuda-vmm-%d.sock", namespacePIDs[index]),
+		)
+		info, err := os.Lstat(endpoint)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("stat CUDA VMM endpoint %q: %w", endpoint, err)
+		}
+		endpoints++
+		if info.Mode()&os.ModeSocket != 0 {
+			validEndpoints++
+		}
+	}
+	if markers == 0 && endpoints == 0 {
+		return false, nil
+	}
+	if validEndpoints != len(observedPIDs) {
+		return false, fmt.Errorf(
+			"CUDA VMM interposer endpoint missing or invalid for %d of %d CUDA processes",
+			len(observedPIDs)-validEndpoints,
+			len(observedPIDs),
+		)
+	}
+	return true, nil
+}
+
+func PrepareVMM(
+	ctx context.Context,
+	checkpointDir string,
+	procRoot string,
+	observedPIDs []int,
+	namespacePIDs []int,
+	log logr.Logger,
+) error {
+	args, err := vmmArgs("prepare", checkpointDir, procRoot, observedPIDs, namespacePIDs)
+	if err != nil {
+		return err
+	}
+	output, err := exec.CommandContext(ctx, vmmCoordinator, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s failed: %w (output: %s)", vmmCoordinator, err, strings.TrimSpace(string(output)))
+	}
+	log.Info("Prepared CUDA VMM interpose state")
+	return nil
+}
+
+func RestoreVMM(
+	ctx context.Context,
+	checkpointDir string,
+	observedPIDs []int,
+	namespacePIDs []int,
+) error {
+	args, err := vmmArgs("restore", checkpointDir, "", observedPIDs, namespacePIDs)
+	if err != nil {
+		return err
+	}
+	output, err := exec.CommandContext(ctx, vmmCoordinator, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s failed: %w (output: %s)", vmmCoordinator, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func vmmArgs(operation, checkpointDir, procRoot string, observedPIDs, namespacePIDs []int) ([]string, error) {
+	if len(observedPIDs) != len(namespacePIDs) {
+		return nil, fmt.Errorf(
+			"CUDA VMM PID mapping count mismatch: observed=%d namespace=%d",
+			len(observedPIDs),
+			len(namespacePIDs),
+		)
+	}
+	args := []string{
+		"--" + operation,
+		"--proc-root",
+		procRoot,
+		"--checkpoint-dir",
+		checkpointDir,
+	}
+	for index, observedPID := range observedPIDs {
+		args = append(
+			args,
+			"--process",
+			strconv.Itoa(observedPID),
+			strconv.Itoa(namespacePIDs[index]),
+		)
+	}
+	return args, nil
+}

--- a/deploy/snapshot/internal/executor/checkpoint.go
+++ b/deploy/snapshot/internal/executor/checkpoint.go
@@ -196,6 +196,14 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 	if len(cudaHostPIDs) > 0 {
 		log.V(1).Info("Resolved checkpoint CUDA PID mapping", "host_pids", cudaHostPIDs, "namespace_pids", cudaNamespacePIDs)
 	}
+	cudaVMMInterpose, err := cuda.DetectVMMInterpose(
+		snapshotruntime.HostProcPath,
+		cudaHostPIDs,
+		cudaNamespacePIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("detect CUDA VMM interposer: %w", err)
+	}
 	var gpuUUIDs []string
 	if len(cudaHostPIDs) > 0 {
 		gpuUUIDs, err = cuda.DiscoverGPUUUIDs(
@@ -214,17 +222,18 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 	}
 
 	return &types.CheckpointContainerSnapshot{
-		PID:            pid,
-		RootFS:         rootFS,
-		UpperDir:       upperDir,
-		OCISpec:        ociSpec,
-		Mounts:         mounts,
-		NetNSInode:     netNSInode,
-		StdioFDs:       stdioFDs,
-		HostCgroupPath: hostCgroupPath,
-		CUDAHostPIDs:   cudaHostPIDs,
-		CUDANSPIDs:     cudaNamespacePIDs,
-		GPUUUIDs:       gpuUUIDs,
+		PID:              pid,
+		RootFS:           rootFS,
+		UpperDir:         upperDir,
+		OCISpec:          ociSpec,
+		Mounts:           mounts,
+		NetNSInode:       netNSInode,
+		StdioFDs:         stdioFDs,
+		HostCgroupPath:   hostCgroupPath,
+		CUDAHostPIDs:     cudaHostPIDs,
+		CUDANSPIDs:       cudaNamespacePIDs,
+		GPUUUIDs:         gpuUUIDs,
+		CUDAVMMInterpose: cudaVMMInterpose,
 	}, nil
 }
 
@@ -262,6 +271,18 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 
 	// CUDA lock+checkpoint must happen before CRIU dump
 	if len(state.CUDAHostPIDs) > 0 {
+		if state.CUDAVMMInterpose {
+			if err := cuda.PrepareVMM(
+				ctx,
+				checkpointDir,
+				snapshotruntime.HostProcPath,
+				state.CUDAHostPIDs,
+				state.CUDANSPIDs,
+				log,
+			); err != nil {
+				return nil, fmt.Errorf("prepare CUDA VMM checkpoint: %w", err)
+			}
+		}
 		cudaTimings, err := cuda.CheckpointProcessTree(ctx, state.CUDAHostPIDs, cudaJobFile, checkpointDir, log)
 		if err != nil {
 			return nil, fmt.Errorf("CUDA checkpoint failed: %w", err)

--- a/deploy/snapshot/internal/executor/nsrestore.go
+++ b/deploy/snapshot/internal/executor/nsrestore.go
@@ -222,9 +222,22 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 			"restored_cuda_pids", restorePIDs,
 			"criu_callback_pid", restoredPID,
 		)
-		_, err = cuda.RestoreAndUnlockProcessTree(ctx, restorePIDs, opts.CUDADeviceMap, cudaHelperFdPath, log)
+		_, err = cuda.RestoreProcessTree(ctx, restorePIDs, opts.CUDADeviceMap, cudaHelperFdPath, log)
 		if err != nil {
 			return nil, 0, fmt.Errorf("CUDA restore failed: %w", err)
+		}
+		// CUDA APIs must be available for VMM replay. Application progress
+		// remains gated by the restore-complete sentinel.
+		if err := cuda.UnlockProcessTree(ctx, restorePIDs, cudaHelperFdPath, log); err != nil {
+			return nil, 0, fmt.Errorf("CUDA unlock failed: %w", err)
+		}
+		if err := cuda.RestoreVMM(
+			ctx,
+			opts.CheckpointPath,
+			restorePIDs,
+			m.CUDA.PIDs,
+		); err != nil {
+			return nil, 0, fmt.Errorf("restore CUDA VMM interpose state: %w", err)
 		}
 	}
 	timings.cudaDuration = time.Since(cudaStart)

--- a/deploy/snapshot/internal/types/inspect.go
+++ b/deploy/snapshot/internal/types/inspect.go
@@ -17,17 +17,18 @@ type MountInfo struct {
 
 // CheckpointContainerSnapshot holds runtime container state collected during checkpoint inspection.
 type CheckpointContainerSnapshot struct {
-	PID            int
-	RootFS         string
-	UpperDir       string
-	OCISpec        *specs.Spec
-	Mounts         []MountInfo
-	NetNSInode     uint64
-	StdioFDs       []string // readlink targets for FDs 0, 1, 2 (e.g. "pipe:[12345]")
-	HostCgroupPath string   // host filesystem path for CRIU's --freeze-cgroup
-	CUDAHostPIDs   []int    // host-visible PIDs used for checkpoint-side CUDA actions
-	CUDANSPIDs     []int    // namespace-relative PIDs stored in the checkpoint manifest
-	GPUUUIDs       []string // source GPU UUIDs from kubelet PodResources API
+	PID              int
+	RootFS           string
+	UpperDir         string
+	OCISpec          *specs.Spec
+	Mounts           []MountInfo
+	NetNSInode       uint64
+	StdioFDs         []string // readlink targets for FDs 0, 1, 2 (e.g. "pipe:[12345]")
+	HostCgroupPath   string   // host filesystem path for CRIU's --freeze-cgroup
+	CUDAHostPIDs     []int    // host-visible PIDs used for checkpoint-side CUDA actions
+	CUDANSPIDs       []int    // namespace-relative PIDs stored in the checkpoint manifest
+	GPUUUIDs         []string // source GPU UUIDs from kubelet PodResources API
+	CUDAVMMInterpose bool
 }
 
 // RestoreContainerSnapshot holds inspected state for the restore target.


### PR DESCRIPTION
## Summary

Add opt-in checkpoint and restore for same-node CUDA VMM allocations shared
between processes with `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`.

The implementation follows one rule:

> Before native CUDA checkpoint, reduce each shared allocation to one
> unmapped allocation in the process that originally called `cuMemCreate`.
> Let native CUDA checkpoint save and restore the allocation bytes. After
> native restore, rebuild sharing and mappings around that restored creator
> allocation.

This preserves application virtual addresses, CUDA graph pointers, allocation
contents, importer mappings, effective access, and application-visible generic
handle identity without copying GPU memory in the interposer.

This milestone deliberately targets one launch tree in one container on one
node. The interposer has no job-ID concept or rendezvous dependency. Snapshot
discovers the participating processes from the checkpoint target and coordinates
their fixed PID-local sockets. The Dynamo operator has no CUDA VMM interposition
API, field, environment injection, launcher detection, or wrapping behavior.

## Launch contract

The interposer must be present before the workload creates CUDA VMM allocations:

```bash
snapshot-cuda-vmm-launch APPLICATION [ARG...]
```

The launcher only:

1. verifies that a command was supplied;
2. verifies that
   `/usr/local/lib/snapshot/libsnapshot_cuda_vmm.so` is readable;
3. exports `DYN_SNAPSHOT_CUDA_VMM_INTERPOSE=1`;
4. prepends the library to `LD_PRELOAD`; and
5. `exec`s the original command.

For a manually created checkpoint Job, `snapshotctl` provides the explicit
opt-in:

```bash
snapshotctl checkpoint --cuda-vmm-interpose [OTHER FLAGS]
```

The wrapping is owned locally by `snapshotctl` before it calls the shared
`NewCheckpointJob` helper. When both multi-GPU launch-job wrapping and VMM
interposition are selected, the resulting order is:

```text
cuda-checkpoint --launch-job
└── snapshot-cuda-vmm-launch
    └── application
```

The shared checkpoint protocol retains only its existing
`cuda-checkpoint --launch-job` support. VMM interposition is not an operator or
shared protocol feature.

The snapshot image continues to package:

- `/usr/local/lib/snapshot/libsnapshot_cuda_vmm.so`
- `/usr/local/bin/snapshot-cuda-vmm`
- `/usr/local/bin/snapshot-cuda-vmm-launch`

The placeholder image keeps its base image's entrypoint and command. Packaging
these files does not opt a workload in; explicit manifest or `snapshotctl`
launch wrapping is required.

## Supported contract

| Area | Contract in this PR |
|---|---|
| Scope | One container launch tree on one node |
| Sharing transport | POSIX-FD CUDA VMM sharing between processes |
| Allocation saver | Always the original `cuMemCreate` participant |
| Allocation bytes | Saved and restored only by native CUDA checkpoint |
| Application pointers | VA reservations remain allocated; mappings return to the same VA, size, and allocation offset |
| Application POSIX handle | Sealed, self-describing capability FD |
| Raw CUDA export FD | Created only inside the interposer, transferred with `SCM_RIGHTS`, imported, and closed immediately |
| Participant discovery | Explicit observed PID and namespace PID pairs from Snapshot |
| Participant endpoint | Fixed PID-local Unix-domain socket |
| Runtime identities | Random participant ID, random allocation ID, creator endpoint, and random authorization token |
| Durable topology | Versioned native `cuda-vmm.state` sidecar containing no allocation bytes, raw FDs, authorization token, creator endpoint, or job identity |
| Quiescence | Supplied externally before checkpoint preparation |
| Worker creation | `fork()` without `exec()` is supported when children initialize CUDA/VMM after the fork |
| Failure after mutation | Fail closed; no rollback machinery is added |
| Multicast | Every `cuMulticast*` entry point returns `CUDA_ERROR_NOT_SUPPORTED` while interposition is enabled |
| Restore placement | Same GPU set, or a disjoint compatible GPU set with a user-mode driver that supports the flow |

FABRIC/IMEX sharing, multicast checkpointing, multi-container or multi-node
rendezvous, raw CUDA FD compatibility, legacy CUDA IPC, and partial
process-group restore are not implemented here. NCCL workloads must set
`NCCL_NVLS_ENABLE=0` until multicast checkpointing is implemented; otherwise
NCCL initialization fails intentionally instead of creating unrestorable
multicast state.

## Architecture and ownership

```mermaid
flowchart LR
    S[Snapshot agent] -->|observed PID + namespace PID| C[Native coordinator]
    C -->|fixed PID-local sockets| P1[Creator shim]
    C -->|fixed PID-local sockets| P2[Importer shim]
    P1 -->|sealed capability| A[Application CPU transport]
    A --> P2
    P2 -->|authorized request| P1
    P1 -->|transient raw CUDA FD via SCM_RIGHTS| P2
    N[native cuCheckpoint] -->|allocation bytes| P1
```

Native code is separated by responsibility:

| File | Responsibility |
|---|---|
| `interpose.c` | CUDA symbol interception and process-local allocation, handle, and mapping state |
| `posix.c` | POSIX capability creation/read and creator FD exchange |
| `coordinator.c` | Cross-process prepare/restore ordering, validation, and native sidecar |
| `protocol.h` | Fixed native wire and topology records |
| `util.c` | Exact I/O, socket timeouts, and `SCM_RIGHTS` helpers |

Go remains intentionally thin:

- detect that every CUDA process in the selected process group is interposed;
- invoke native prepare before native CUDA checkpoint;
- transport `cuda-vmm.state` as opaque checkpoint data;
- order native CUDA restore, unlock, native VMM reconstruction, and final
  application release; and
- keep the opaque VMM sidecar independent from the driver-owned multi-GPU
  launch-job artifact.

Go does not interpret allocation ownership, mapping topology, authorization,
or CUDA handles.

## Runtime capability flow

1. The creator application calls
   `cuMemExportToShareableHandle(..., CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)`.
2. The creator interposer returns a sealed capability FD containing creator
   participant, allocation, creator endpoint, and authorization identity.
3. The application may cache, duplicate, or transfer that capability through
   its normal CPU-side transport.
4. The importer passes the capability to the interposed
   `cuMemImportFromShareableHandle`.
5. The importer asks the creator's Unix-domain endpoint for a current export of
   that allocation.
6. The creator validates participant, allocation, and authorization identity,
   exports a temporary raw CUDA FD, and transfers it with `SCM_RIGHTS`.
7. The importer calls the real CUDA import and immediately closes the raw FD.

The capability is a checkpointable CPU object and does not retain a CUDA
allocation. A cached capability can resolve a fresh creator export after
restore. Redis or another metadata service is not involved.

## Checkpoint and restore lifecycle

The external orchestrator first quiesces application work and communication
libraries. Allocation exchange, import, mapping, communicator construction,
registration, kernels using the shared allocations, and teardown must not be
pending or in flight.

Checkpoint preparation:

1. Discover every interposed CUDA participant in the process tree.
2. Inspect each participant's allocation, handle, mapping, and access records.
3. Validate unique random participant identities and the complete topology.
4. Validate one original creator, creator-anchor liveness, mapping bounds,
   allocation offsets, importer ownership, and supported access shape.
5. Create one creator-local checkpoint carrier per allocation.
6. Unmap managed creator and importer mappings while preserving every VA
   reservation.
7. Release importer generic handles and verify checkpoint normal form.
8. Atomically write the native `cuda-vmm.state` topology sidecar.
9. Run the existing native CUDA lock/checkpoint path.

Restore:

1. Native CUDA restore recreates creator-local allocations and their bytes.
2. CUDA processes are unlocked while application progress remains behind the
   existing restore-complete sentinel.
3. Creator mappings are reconstructed first.
4. Importers request fresh transient POSIX exports from restored creators.
5. Every mapping is restored at its original VA, size, allocation offset, and
   effective access.
6. Application-visible generic handles are translated to current real handles.
7. The coordinator validates the reconstructed topology against the sidecar.
8. Snapshot releases the application only after VMM replay succeeds.

## CUDA API interposition

The preload library tracks and translates:

- `cuMemCreate`
- `cuMemRelease`
- `cuMemRetainAllocationHandle`
- `cuMemMap`
- `cuMemUnmap`
- `cuMemSetAccess`
- `cuMemExportToShareableHandle`
- `cuMemImportFromShareableHandle`
- `cuMemGetAllocationPropertiesFromHandle`

It also covers `dlsym`, `cuGetProcAddress`, `cuGetProcAddress_v2`, the supported
`_ptsz` variants, `cudaGetDriverEntryPoint`, and
`cudaGetDriverEntryPointByVersion`, so dynamically resolved Driver API calls
still reach the wrappers. Real driver symbols are resolved without recursing
through the interposer.

The interposer is not involved in kernel execution, CUDA graph replay, or
ordinary GPU loads and stores.

## Meaningful CUDA test surface

`tests/test_cucheckpoint.py` is a real two-GPU native `cuCheckpoint` component
test, not a protocol-only unit test. It:

- builds the checked-out interposer and coordinator;
- starts an interposed parent and two PyTorch ranks created with `fork()` and no
  subsequent `exec()`;
- verifies the parent and children have distinct PID-derived control endpoints;
- exercises external raw POSIX imports that are fully released before prepare;
- creates private POSIX-capable allocations whose bytes remain live through
  checkpoint and restore;
- creates two-rank POSIX-FD PyTorch symmetric memory with multicast disabled;
- runs an eager all-reduce, captures it in a CUDA graph, and validates exact
  pre-checkpoint replay;
- runs coordinator prepare, native
  `RUNNING -> LOCKED -> CHECKPOINTED -> LOCKED -> RUNNING`, and coordinator
  restore; and
- replays the same pre-checkpoint graph and validates exact post-restore values
  and private-allocation bytes.

Earlier GPU qualification of this test passed on two B200 GPUs. The same POSIX
milestone was also exercised on disjoint B200 GPU sets and in a DeepSeek V4
Flash TP4 deployment with multicast intentionally disabled. Those GPU campaigns
were not rerun for this rebase and identity simplification.

## Failure semantics and limitations

Admission fails before mutation when participant identity, creator ownership,
creator anchor, mapping bounds, access shape, or topology completeness is
invalid. After preparation mutates CUDA state, any failure fails the operation;
this PR does not add rollback.

The following remain unsupported:

- a CUDA export/import call that bypasses interposition;
- raw CUDA/RM export FDs exposed outside the capability path;
- aliases of raw CUDA FDs created through `dup` or `fcntl`;
- raw FDs cached, queued, or transferred outside the adapter;
- an unshimmed helper or broker in the allocation graph;
- an uncovered CUDA symbol-resolution path;
- a stale generic allocation handle retained by an uncovered consumer;
- NVIDIA-specific `ioctl`, `fstat`, or `poll` behavior on a capability FD;
- forking after the parent has tracked CUDA allocations, handles, or mappings;
- a creator with no remaining local handle or mapping;
- checkpoint during sharing setup, communicator construction, active work,
  resume, or teardown;
- more than eight access descriptors or an access update that does not exactly
  match a tracked mapping range;
- partial participant groups; and
- rollback after destructive preparation.

The implementation does not scan `/proc/self/fd` and does not interpose libc
`dup`, `close`, `fcntl`, `sendmsg`, or `recvmsg`.

## Validation

Validated on the final rebased tree:

```bash
make -C deploy/snapshot/cmd/cuda-vmm-interpose clean
make -C deploy/snapshot/cmd/cuda-vmm-interpose \
  CUDA_HOME="$PWD/../.cuda13/nvidia/cu13"

cd deploy/snapshot
go test ./...
```

Additional passing checks:

- native compilation with `-std=gnu11 -O2 -Wall -Wextra -Werror`;
- ELF inspection confirming no direct `libcuda` or `libcudart` dependency;
- all applicable pre-commit hooks on the changed files;
- shell syntax for `snapshot-cuda-vmm-launch`;
- Ruff format and lint;
- Python compilation and `pyproject.toml` parsing;
- `git diff --check`;
- no changes under `lib/gpu_memory_service/`, `deploy/operator/`, `.github/`,
  `examples/`, or `recipes/`; and
- repository-wide removal of `DYN_SNAPSHOT_JOB_ID`.


### Live composed-stack acceptance

Build on Demand run [`31908730437`](https://github.com/ai-dynamo/dynamo/actions/runs/31908730437) produced the exact composed SHA
`ad5d5ebc6f4f30da9bc65ac7355a836702622328`. That composition passed two
declarative end-to-end restore campaigns that exercise this PR's POSIX-FD VMM
base in the composed stack:

- DeepSeek V4 Flash TP4 restored from pinned GPUs 0-3 to the disjoint pinned
  GPUs 4-7 on `s2877` and returned exactly `DSV4_RESTORE_OK` three times.
- GLM 5.2 vLLM TP8/DP1/EP8 restored on the same ordered eight-GPU set on
  `s2877` (not a migration test) and returned three deterministic, coherent
  HTTP 200 responses ending in `GLM52_RESTORE_OK`.

Together these campaigns cover interposer detection and VMM preparation through
automatic checkpoint, CRIU/native CUDA restore, GMS load, wake, and frontend
readiness. DeepSeek V4 also exercised the multicast layer stacked in #13249.
The GLM runtime used the accepted snapshot policy with NCCL NVLS disabled, so
GLM supplies broader POSIX-base coverage and does not claim raw NVLS multicast.

No container image was built locally. GPU tests were not rerun during this
rebase.


