### PR TITLE
test(nvdec): isolate CUDA context from GMS checks

### DIFF
--- a/components/src/dynamo/common/tests/multimodal/test_nvdec_decoder_gpu.py
+++ b/components/src/dynamo/common/tests/multimodal/test_nvdec_decoder_gpu.py
@@ -29,6 +29,7 @@ pytestmark = [
     pytest.mark.post_merge,
     pytest.mark.gpu_1,
     pytest.mark.vllm,
+    pytest.mark.forked,
 ]
 
 


### PR DESCRIPTION
## Overview

Prevent the direct NVDEC integration test's process-lifetime CUDA context from causing false GPU Memory Service leak failures later in nightly CI.

## Summary

- Run both real NVDEC codec parameters in fork-isolated pytest children.
- Destroy each NVDEC CUDA context before the long-lived sequential pytest parent continues.
- Keep the GMS device-wide 100 MiB leak assertion unchanged.
- Add no sleeps, polling delays, or framework-specific memory exceptions.

## Details

The direct NVDEC test initializes PyNvVideoCodec and Torch CUDA in the nightly's sequential pytest process. On an RTX 6000 Ada, that parent retained 428 MiB and raised device usage from a 38 MiB idle baseline to 474 MiB.

The subsequent vLLM GMS tests completed their functional assertions and cleaned up their own processes, but their module-scoped device-wide guard still observed the earlier NVDEC context and failed at teardown.

Adding the existing `pytest.mark.forked` marker runs each codec case in a child process. CUDA teardown then follows process exit, while the GMS leak guard remains strict enough to catch actual GMS leaks.

### Shadow failover failure

This also fixes `tests/gpu_memory_service/test_shadow_failover.py::test_gms_shadow_engine_failover_vllm`. In the [August 10 scheduled nightly](https://github.com/ai-dynamo/dynamo/actions/runs/31370499179), the shadow-failover test body passed—including the primary crash, Shadow A's resume, and successful post-failover inference—but its teardown guard reported 531 MiB in the [H100 job](https://github.com/ai-dynamo/dynamo/actions/runs/31370499179/job/93405016479) and 196 MiB in the [standard CUDA job](https://github.com/ai-dynamo/dynamo/actions/runs/31370499179/job/93405016499).

This is the same cross-test contamination, not a separate demonstrated shadow-engine leak: the shadow test runs later in the same sequential pytest parent, and its identical device-wide guard observes the NVDEC CUDA context retained by that parent. Forking the earlier NVDEC cases destroys the context before either GMS module runs. The shadow failover assertions and the strict GMS leak guard remain unchanged.

## User and developer impact

Nightly GMS results no longer depend on whether a direct NVDEC test ran earlier in the same pytest process. Genuine GMS memory leaks remain visible because neither the threshold nor the assertion was weakened.

## Where should the reviewer start?

`components/src/dynamo/common/tests/multimodal/test_nvdec_decoder_gpu.py`

The complete code change is the module-level `pytest.mark.forked` marker.

## Validation

- Pre-fix control: NVDEC and the basic vLLM GMS test bodies passed, then GMS teardown failed at 474 MiB; usage returned to 38 MiB only when the parent pytest process exited.
- Nightly confirmation: `test_gms_shadow_engine_failover_vllm` passed its functional body in both CUDA jobs, then hit the same device-wide teardown failure described above.
- Post-fix nightly-equivalent sequence:
  - both H.264 and HEVC NVDEC parameters
  - `test_gms_basic_pause_resume_vllm`
  - `test_gms_shadow_engine_failover_vllm`
  - result: `4 passed, 5 deselected in 279.07s`
- Live post-NVDEC inspection found no CUDA compute owner while the parent pytest process was still running.
- Focused decoder module: `2 passed in 5.05s`.
- `pre-commit run --files components/src/dynamo/common/tests/multimodal/test_nvdec_decoder_gpu.py`
- `git diff --check origin/main...HEAD`

## Related Issues

**🚫 This PR is NOT linked to a public GitHub issue:**

- [x] Confirmed — no related public issue
- Internal tracking: [DYN-3876](https://linear.app/nvidia/issue/DYN-3876/isolate-nvdec-test-cuda-context-from-gms-nightly-leak-checks)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the GPU video-decoding integration tests to run with forked test isolation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->