### PR TITLE
docs: prevent footer from covering sidebar navigation

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -198,13 +198,15 @@ jobs:
             cp source-checkout/docs/fern/.gitignore docs-checkout/fern/.gitignore
           fi
 
-          # Sync the callout converter under fern/scripts/ and remove its old
-          # root-level location from docs-website after the source-tree move.
+          # Sync hosted-build transforms under fern/scripts/ and remove the
+          # callout converter's old root-level location after the source-tree move.
           rm -f docs-checkout/fern/convert_callouts.py
-          if [ -f source-checkout/docs/fern/scripts/convert_callouts.py ]; then
-            mkdir -p docs-checkout/fern/scripts
-            cp source-checkout/docs/fern/scripts/convert_callouts.py docs-checkout/fern/scripts/convert_callouts.py
-          fi
+          mkdir -p docs-checkout/fern/scripts
+          for script in convert_callouts.py inject_site_styles.py; do
+            if [ -f "source-checkout/docs/fern/scripts/$script" ]; then
+              cp "source-checkout/docs/fern/scripts/$script" "docs-checkout/fern/scripts/$script"
+            fi
+          done
 
           # Sync components/ directory (e.g., CustomFooter.tsx)
           if [ -d source-checkout/docs/fern/components ]; then
@@ -438,6 +440,14 @@ jobs:
       # PREVIEW - Generate a preview URL for docs changes
       ##########################################################################
 
+      # The NVIDIA global theme replaces project css/footer fields. Inject the
+      # registered SiteStyles component into the disposable composed pages so
+      # its page-level <style> survives the theme merge. Do this after change
+      # detection so generated tags never enter the docs-website commit.
+      - name: Inject hosted site styles for preview
+        if: steps.ctx.outputs.is_main != 'true' && steps.changes.outputs.has_changes == 'true'
+        run: python3 source-checkout/docs/fern/scripts/inject_site_styles.py docs-checkout/fern
+
       - name: Generate docs preview
         if: steps.ctx.outputs.is_main != 'true' && steps.changes.outputs.has_changes == 'true'
         id: preview
@@ -497,6 +507,10 @@ jobs:
           git push origin docs-website
 
           echo "Successfully synced dev docs to docs-website branch"
+
+      - name: Inject hosted site styles for publish
+        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
+        run: python3 docs-checkout/fern/scripts/inject_site_styles.py docs-checkout/fern
 
       - name: Publish Docs
         if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
@@ -916,6 +930,14 @@ jobs:
           git push origin docs-website
 
           echo "Successfully released documentation for $TAG on docs-website branch"
+
+      - name: Inject hosted site styles for release publish
+        run: |
+          if [ -f docs-checkout/fern/scripts/inject_site_styles.py ]; then
+            python3 docs-checkout/fern/scripts/inject_site_styles.py docs-checkout/fern
+          else
+            echo "::warning::inject_site_styles.py is absent from docs-website; publishing without hosted site corrections"
+          fi
 
       - name: Publish Docs
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,12 @@ repos:
       language: system
       files: ^docs/fern/(main\.css|components/CustomFooter\.tsx|scripts/sync_site_css\.py)$
       pass_filenames: false
+    - id: test-inject-site-styles
+      name: Test hosted SiteStyles injection
+      entry: pytest -c docs/fern/scripts/pytest.ini docs/fern/scripts/test_inject_site_styles.py
+      language: system
+      files: ^(docs/fern/(components/SiteStyles\.tsx|scripts/(inject_site_styles|test_inject_site_styles)\.py)|\.github/workflows/fern-docs\.yml)$
+      pass_filenames: false
     - id: check-asset-paths
       name: Check docs asset paths are ones Fern rewrites
       entry: python3 docs/fern/scripts/check_asset_paths.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,9 +95,11 @@ repos:
     - id: test-inject-site-styles
       name: Test hosted SiteStyles injection
       entry: pytest -c docs/fern/scripts/pytest.ini docs/fern/scripts/test_inject_site_styles.py
-      language: system
+      language: python
       files: ^(docs/fern/(components/SiteStyles\.tsx|scripts/(inject_site_styles|test_inject_site_styles)\.py)|\.github/workflows/fern-docs\.yml)$
       pass_filenames: false
+      additional_dependencies:
+        - pytest
     - id: check-asset-paths
       name: Check docs asset paths are ones Fern rewrites
       entry: python3 docs/fern/scripts/check_asset_paths.py

--- a/docs/fern/components/CustomFooter.tsx
+++ b/docs/fern/components/CustomFooter.tsx
@@ -6,17 +6,18 @@
 /**
  * Custom footer for Dynamo docs (Fern native header/footer).
  *
- * Site chrome CSS is delivered below as a page-level <style> block (NOT via
- * the docs.yml `css:` field) so it survives the shared NVIDIA global theme,
- * which replaces project `css` at publish (same fix as #11952; re-applied
- * after the docs restructure moved styles back to main.css and production
- * rendered unstyled). Inlined rather than imported because Fern custom
- * footer components cannot import local modules.
+ * SITE_CSS mirrors docs/fern/main.css, which stays canonical and is served via
+ * docs.yml `css:` for local and unthemed builds. The inline copy keeps those
+ * styles available whenever Fern renders this project footer; it cannot cover
+ * hosted builds where the shared NVIDIA global theme replaces both project CSS
+ * and the footer. Hosted theme-chrome corrections instead live in SiteStyles
+ * and are injected into the disposable composed pages before Fern generates
+ * them. Inlined rather than imported because Fern custom footer components
+ * cannot import local modules.
  *
- * SITE_CSS mirrors docs/fern/main.css, which stays canonical and served via
- * docs.yml `css:` (the server-rendered / no-JS baseline). Do not edit the
- * block by hand: run `python3 docs/fern/scripts/sync_site_css.py` after
- * changing main.css. Pre-commit enforces the mirror with `--check`.
+ * Do not edit the block by hand: run
+ * `python3 docs/fern/scripts/sync_site_css.py` after changing main.css.
+ * Pre-commit enforces the mirror with `--check`.
  */
 // sync-site-css:begin (generated from ../main.css)
 const SITE_CSS = `

--- a/docs/fern/components/CustomFooter.tsx
+++ b/docs/fern/components/CustomFooter.tsx
@@ -187,7 +187,6 @@ html.dark,
 /* Sidebar styling */
 #fern-sidebar {
     border-right: 1px solid var(--border, var(--grayscale-a5)) !important;
-    height: 100vh !important;
 }
 .fern-sidebar-link:not(:hover) {
     background-color: transparent !important;

--- a/docs/fern/components/RecipeStyles.tsx
+++ b/docs/fern/components/RecipeStyles.tsx
@@ -68,14 +68,11 @@ main.fern-main:not(:has(> .fern-layout-content-wrapper ~ aside)) .fern-layout-gu
 }
 
 /* Product switcher: hide the FontAwesome "code" glyph (</>) placeholder.
-   This rule also lives in SiteStyles, but SiteStyles is injected from the
-   footer and is NOT in the server-rendered HTML (it only applies once the
-   footer hydrates client-side). On this long page that leaves the header
-   product switcher showing the </> placeholder above the fold. RecipeStyles
-   IS server-rendered, so re-declaring the rule here hides the placeholder
-   immediately on recipe/benchmark pages. Scoped to the code glyph via :has()
-   so the version selector keeps its own (Lucide "tag") icon. Same
-   compensate-for-client-only-SiteStyles pattern as the .dark re-bind above. */
+   This rule also lives in main.css and its CustomFooter mirror, but the hosted
+   NVIDIA theme can replace both delivery paths. RecipeStyles is rendered with
+   every recipe and benchmark page, so re-declaring the rule here keeps those
+   pages independent of site-wide theme behavior. Scoped to the code glyph via
+   :has() so the version selector keeps its own (Lucide "tag") icon. */
 .fern-selection-item-icon:has(svg[icon="code"]) {
     display: none !important;
 }
@@ -474,13 +471,11 @@ main.fern-main:not(:has(> .fern-layout-content-wrapper ~ aside)) .fern-layout-gu
     padding: 10px;
     border: 1px solid var(--border, var(--grayscale-a5));
     border-radius: 8px;
-    /* Literal fallbacks: the --nv-* palette lives in SiteStyles, which is
-       injected from the footer and therefore not applied until the footer
-       renders. Above the fold on this (long) page the card would otherwise
-       resolve to a transparent background, letting the empty-state message
-       painted behind the grid (.dynamo-model-grid::before) bleed through the
-       card text. The fallback keeps the tile opaque regardless of SiteStyles
-       load order. */
+    /* Literal fallbacks: the --nv-* palette comes from main.css or its
+       CustomFooter mirror, both of which the hosted theme can replace. Without
+       a fallback the card can resolve to a transparent background, letting the
+       empty-state message painted behind the grid
+       (.dynamo-model-grid::before) bleed through the card text. */
     background: var(--nv-color-bg-default, #ffffff);
     color: var(--pst-color-text-base);
     text-decoration: none;
@@ -489,7 +484,8 @@ main.fern-main:not(:has(> .fern-layout-content-wrapper ~ aside)) .fern-layout-gu
 /* --nv-color-bg-default does not flip in the dark theme (stays #FFFFFF), so
    in dark mode the card would be a white tile with light text. Flip the
    surface to match the other dark-aware components (chip, search box, etc.).
-   Same fallback rationale as above (SiteStyles may not be loaded yet). */
+   Same fallback rationale as above (site-level palette delivery varies by
+   build and theme). */
 .dark .dynamo-model-card {
     background: var(--nv-dark-grey-2, #1a1a1a);
 }

--- a/docs/fern/components/SiteStyles.tsx
+++ b/docs/fern/components/SiteStyles.tsx
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Hosted-site layout corrections that must survive the NVIDIA global theme.
+ *
+ * The global theme replaces docs.yml `css:` and owns the custom footer, so
+ * main.css cannot override theme chrome in hosted previews or production.
+ * The publishing workflow renders this component once on every page; React
+ * hoists the style element into the document head.
+ */
+const SITE_CSS = `
+/* Preserve Fern's footer-aware sticky-sidebar sizing. The NVIDIA theme carries
+   an older !important height that ignores --custom-footer-visible-height. The
+   state/viewport attributes make this rule more specific than both the theme's
+   default and preview-banner sidebar rules. */
+#fern-sidebar[data-viewport="desktop"][data-state="sticky"] {
+  height: calc(
+    100dvh - var(--header-height) - var(--custom-footer-visible-height, 0px)
+  ) !important;
+}
+`;
+
+export function SiteStyles() {
+  return <style>{SITE_CSS}</style>;
+}

--- a/docs/fern/components/SiteStyles.tsx
+++ b/docs/fern/components/SiteStyles.tsx
@@ -10,10 +10,13 @@
  * hoists the style element into the document head.
  */
 const SITE_CSS = `
-/* Preserve Fern's footer-aware sticky-sidebar sizing. The NVIDIA theme carries
-   an older !important height that ignores --custom-footer-visible-height. The
-   state/viewport attributes make this rule more specific than both the theme's
-   default and preview-banner sidebar rules. */
+/* Preserve Fern's footer-aware sticky-sidebar sizing. Fern's
+   FooterHeightTracker writes --custom-footer-visible-height on the root element
+   as the footer enters the viewport; the fallback covers SSR and pre-hydration.
+   The NVIDIA theme carries an older !important height that ignores that value.
+   Scope the override to the desktop sticky state so mobile and fixed sidebars
+   retain Fern's native sizing, while still outranking the theme's default and
+   preview-banner sidebar rules. */
 #fern-sidebar[data-viewport="desktop"][data-state="sticky"] {
   height: calc(
     100dvh - var(--header-height) - var(--custom-footer-visible-height, 0px)

--- a/docs/fern/main.css
+++ b/docs/fern/main.css
@@ -165,7 +165,6 @@ html.dark,
 /* Sidebar styling */
 #fern-sidebar {
     border-right: 1px solid var(--border, var(--grayscale-a5)) !important;
-    height: 100vh !important;
 }
 .fern-sidebar-link:not(:hover) {
     background-color: transparent !important;

--- a/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
+++ b/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
@@ -321,6 +321,12 @@ markdown files:
 React components in `docs/fern/components/` can be used in markdown via MDX. The
 `CustomFooter.tsx` renders the NVIDIA footer with legal links and branding.
 
+Hosted builds apply the NVIDIA global theme, which replaces project-level CSS and
+footer configuration. Immediately before Fern generates a preview or production
+site, `inject_site_styles.py` adds the page-level `SiteStyles` component to the
+disposable composed pages. This keeps site-wide compatibility corrections active
+without modifying authored pages or frozen release snapshots.
+
 ---
 
 ## Callout Conversion

--- a/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
+++ b/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
@@ -325,7 +325,10 @@ Hosted builds apply the NVIDIA global theme, which replaces project-level CSS an
 footer configuration. Immediately before Fern generates a preview or production
 site, `inject_site_styles.py` adds the page-level `SiteStyles` component to the
 disposable composed pages. This keeps site-wide compatibility corrections active
-without modifying authored pages or frozen release snapshots.
+without modifying authored pages or frozen release snapshots. Fern's hosted
+runtime publishes the visible footer height as
+`--custom-footer-visible-height`; `SiteStyles` can consume that native value while
+overriding older theme CSS that ignores it.
 
 ---
 

--- a/docs/fern/scripts/check_published_styles.py
+++ b/docs/fern/scripts/check_published_styles.py
@@ -19,8 +19,8 @@ Production sets `global-theme: nvidia`, which overrides the project `css:` and
 `js:` entries and the custom `footer:` (Fern's docs.yml schema documents the
 override). Components that deliver their CSS through a page-level <style>
 block survive it; anything relying on main.css does not. That failure is
-invisible before merge -- PR previews delete the theme -- so this runs against
-the published site after publish.
+also checked in themed PR previews; this post-publish probe remains the CDN
+backstop for the site people actually read.
 
 Each check asserts a selector appears as a CSS *rule* (followed by `{` or `,`),
 not merely as a class name in markup. A page can be full of `class="foo"` while
@@ -44,6 +44,7 @@ Usage:
 
 Exits 1 with the failing page/selector pairs listed.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -63,6 +64,11 @@ ALLOWED_ORIGINS: frozenset[str] = frozenset({"https://docs.nvidia.com"})
 
 # (page path, selector that must exist as a CSS rule, component that owns it)
 CHECKS: list[tuple[str, str, str]] = [
+    (
+        "",
+        '#fern-sidebar[data-viewport="desktop"][data-state="sticky"]',
+        "SiteStyles",
+    ),
     ("", ".dynamo-story-windowbar", "LandingStyles"),
     ("", ".dynamo-welcome__terminal", "LandingStyles"),
     ("community", ".dynamo-community-page", "LandingStyles"),

--- a/docs/fern/scripts/inject_site_styles.py
+++ b/docs/fern/scripts/inject_site_styles.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Render SiteStyles on every hosted Fern page before preview or publish.
+
+The private NVIDIA global theme replaces the project's ``css:`` and custom
+footer fields. Page-level MDX components survive that merge, so the docs
+workflow runs this script against its disposable composed tree immediately
+before ``fern generate``. Source pages and release snapshots remain unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+IMPORT = 'import { SiteStyles } from "@/components/SiteStyles";'
+COMPONENT = "<SiteStyles />"
+INJECTION = f"\n\n{IMPORT}\n\n{COMPONENT}\n"
+PAGE_SUFFIXES = {".md", ".mdx"}
+ROOT_PATTERNS = (
+    "pages",
+    "pages-*",
+    "digest",
+    "blogs",
+    "translations/*/pages*",
+)
+
+
+def discover_pages(fern_root: Path) -> list[Path]:
+    """Return every publishable Markdown page in a composed Fern tree."""
+    pages: set[Path] = set()
+    index = fern_root / "index.mdx"
+    if index.is_file():
+        pages.add(index)
+
+    for pattern in ROOT_PATTERNS:
+        for root in fern_root.glob(pattern):
+            if root.is_file() and root.suffix in PAGE_SUFFIXES:
+                pages.add(root)
+            elif root.is_dir():
+                pages.update(
+                    path
+                    for path in root.rglob("*")
+                    if (
+                        path.is_file()
+                        and path.suffix in PAGE_SUFFIXES
+                        and path.name.lower() != "readme.md"
+                    )
+                )
+    return sorted(pages)
+
+
+def inject(path: Path) -> bool:
+    """Insert the import and component after frontmatter; return whether changed."""
+    text = path.read_text(encoding="utf-8")
+    if COMPONENT in text:
+        return False
+    if text.startswith("---\n"):
+        closing = text.find("\n---\n", 4)
+        if closing < 0:
+            raise ValueError(f"{path}: Fern page has no closing frontmatter delimiter")
+        insert_at = closing + len("\n---")
+        rendered = text[:insert_at] + INJECTION + text[insert_at + 1 :]
+    else:
+        # Legacy snapshots include generated Markdown without frontmatter. MDX
+        # imports are valid at the document start, so keep those pages covered.
+        rendered = f"{IMPORT}\n\n{COMPONENT}\n\n{text}"
+    path.write_text(rendered, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fern_root", type=Path, help="Composed Fern directory")
+    args = parser.parse_args()
+
+    pages = discover_pages(args.fern_root)
+    if not pages:
+        parser.error(f"no publishable pages found under {args.fern_root}")
+
+    changed = sum(inject(path) for path in pages)
+    print(f"inject_site_styles: updated {changed}/{len(pages)} pages")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/fern/scripts/test_inject_site_styles.py
+++ b/docs/fern/scripts/test_inject_site_styles.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for hosted-page SiteStyles injection."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import inject_site_styles as site_styles  # noqa: E402
+
+pytestmark = [pytest.mark.pre_merge, pytest.mark.gpu_0, pytest.mark.unit]
+
+
+def page(path: Path, body: str = "## Heading\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\ntitle: Test\n---\n\n{body}", encoding="utf-8")
+    return path
+
+
+def test_discovers_all_published_page_roots(tmp_path: Path):
+    expected = {
+        page(tmp_path / "index.mdx"),
+        page(tmp_path / "pages-dev" / "guide.md"),
+        page(tmp_path / "pages-v1.0.0" / "reference.mdx"),
+        page(tmp_path / "pages" / "legacy.md"),
+        page(tmp_path / "digest" / "post.mdx"),
+        page(tmp_path / "blogs" / "archive.md"),
+        page(tmp_path / "translations" / "zh-CN" / "pages-dev" / "guide.md"),
+    }
+    page(tmp_path / "blogs" / "README.md")
+    page(tmp_path / "components" / "README.md")
+
+    assert set(site_styles.discover_pages(tmp_path)) == expected
+
+
+def test_injects_after_frontmatter_and_is_idempotent(tmp_path: Path):
+    target = page(tmp_path / "pages-dev" / "guide.md")
+
+    assert site_styles.inject(target)
+    rendered = target.read_text(encoding="utf-8")
+    assert rendered.startswith("---\ntitle: Test\n---\n\nimport { SiteStyles }")
+    assert rendered.count(site_styles.IMPORT) == 1
+    assert rendered.count(site_styles.COMPONENT) == 1
+    assert not site_styles.inject(target)
+
+
+def test_injects_before_legacy_content_without_frontmatter(tmp_path: Path):
+    target = tmp_path / "pages-v0.8.0" / "generated.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("## Generated reference\n", encoding="utf-8")
+
+    assert site_styles.inject(target)
+    rendered = target.read_text(encoding="utf-8")
+    assert rendered.startswith(f"{site_styles.IMPORT}\n\n{site_styles.COMPONENT}")
+    assert rendered.endswith("## Generated reference\n")


### PR DESCRIPTION
## Summary

- remove Dynamo's `height: 100vh` sidebar override so Fern's native footer-aware sizing can apply in local builds
- add a focused page-level `SiteStyles` correction that overrides the older sidebar height bundled by the private NVIDIA global theme
- inject `SiteStyles` into the disposable composed pages immediately before hosted preview, production, and release generation; authored pages and frozen snapshots remain unchanged
- verify the correction reaches published pages and unit-test the hosted-page injection transform

## Validation

- `fern check` (0 errors; 11 existing warnings)
- `bash docs/fern/scripts/simulate_docs_website.sh` (all assertions passed)
- composed `docs-website` tree injection: 2,424 pages updated; `fern check` returned 0 errors
- `pytest -c docs/fern/scripts/pytest.ini docs/fern/scripts/test_inject_site_styles.py` (3 passed)
- `python3 docs/fern/scripts/check_published_styles.py --test` (7 passed)
- `python3 docs/fern/scripts/sync_site_css.py --check`
- `ruff check` and `ruff format --check` for the changed Python scripts
- Playwright against the themed hosted preview at 1440x500, 1280x500, and 1440x350 with the proposed page-level rule; the sidebar and table of contents stop at the footer boundary and the final sidebar entry remains reachable

`pre-commit` is not installed in the local environment, so the equivalent focused checks above were run directly.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar sizing to account for both the header and visible footer.
  * Prevented sidebar content from extending beyond the available viewport height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
