### PR TITLE
fix(recipes): parameterize DeepSeek-V4 model download so H200 recipes get the FP8 checkpoint

### DIFF
--- a/docs/fern/pages/recipes/model-recipes/deepseek-v4-flash.mdx
+++ b/docs/fern/pages/recipes/model-recipes/deepseek-v4-flash.mdx
@@ -125,6 +125,17 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the Job did not download. Downloading the checkpoint for the other SKU leaves the worker unable to start.
 </Warning>
 
+If the wrong checkpoint was already downloaded, reset before applying the other one. A Job's pod template is immutable, so re-applying `model-download.yaml` with a different `MODEL_NAME` is rejected rather than starting a second download, and the PVC holds one checkpoint:
+
+```bash
+# With no workers running (they hold the PVC open):
+kubectl delete job model-download -n ${NAMESPACE}
+kubectl delete pvc model-cache -n ${NAMESPACE}          # frees the ~160 GB already downloaded
+kubectl apply -f recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+Then apply the download Job for the checkpoint your variant serves, as above.
+
 <div data-sku="b200" data-variant="agg">
 
 ```bash

--- a/docs/fern/pages/recipes/model-recipes/deepseek-v4-flash.mdx
+++ b/docs/fern/pages/recipes/model-recipes/deepseek-v4-flash.mdx
@@ -95,9 +95,35 @@ Create storage, download the checkpoint into the PVC, then apply the target's `d
 
 ```bash
 kubectl apply -f recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+The download Job takes a single `MODEL_NAME`. Its default is the public checkpoint; B200 overrides it with the NVFP4 one.
+
+<div data-sku="b200">
+
+```bash
+sed 's|value: deepseek-ai/DeepSeek-V4-Flash$|value: nvidia/DeepSeek-V4-Flash-NVFP4|' \
+  recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download.yaml \
+  | kubectl apply -f - -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="h200">
+
+```bash
 kubectl apply -f recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download.yaml -n ${NAMESPACE}
+```
+
+</div>
+
+```bash
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=7200s
 ```
+
+<Warning>
+The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the Job did not download. Downloading the checkpoint for the other SKU leaves the worker unable to start.
+</Warning>
 
 <div data-sku="b200" data-variant="agg">
 

--- a/docs/fern/pages/recipes/model-recipes/deepseek-v4-pro.mdx
+++ b/docs/fern/pages/recipes/model-recipes/deepseek-v4-pro.mdx
@@ -129,6 +129,17 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the Job did not download. Downloading the checkpoint for the other SKU leaves the worker unable to start.
 </Warning>
 
+If the wrong checkpoint was already downloaded, reset before applying the other one. A Job's pod template is immutable, so re-applying `model-download.yaml` with a different `MODEL_NAME` is rejected rather than starting a second download, and the PVC holds one checkpoint:
+
+```bash
+# With no workers running (they hold the PVC open):
+kubectl delete job model-download -n ${NAMESPACE}
+kubectl delete pvc model-cache -n ${NAMESPACE}          # frees the ~865 GB already downloaded
+kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+Then apply the download Job for the checkpoint your variant serves, as above.
+
 <div data-sku="b200" data-variant="agg">
 
 ```bash

--- a/docs/fern/pages/recipes/model-recipes/deepseek-v4-pro.mdx
+++ b/docs/fern/pages/recipes/model-recipes/deepseek-v4-pro.mdx
@@ -99,9 +99,35 @@ Create storage, download the checkpoint (~865 GB, 1.5–3 h first apply), then a
 
 ```bash
 kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+The download Job takes a single `MODEL_NAME`, because each checkpoint is ~865 GB and the PVC holds one, not both. Its default is the public FP8 checkpoint; B200 overrides it with the NVFP4 one.
+
+<div data-sku="b200">
+
+```bash
+sed 's|value: deepseek-ai/DeepSeek-V4-Pro$|value: nvidia/DeepSeek-V4-Pro-NVFP4|' \
+  recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download.yaml \
+  | kubectl apply -f - -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="h200">
+
+```bash
 kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download.yaml -n ${NAMESPACE}
+```
+
+</div>
+
+```bash
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=14400s
 ```
+
+<Warning>
+The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the Job did not download. Downloading the checkpoint for the other SKU leaves the worker unable to start.
+</Warning>
 
 <div data-sku="b200" data-variant="agg">
 

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -124,6 +124,19 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 > The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the
 > Job did not download. Downloading the wrong one leaves the worker unable to start.
 
+If the wrong checkpoint was already downloaded, reset before applying the other one. A Job's pod
+template is immutable, so re-applying `model-download.yaml` with a different `MODEL_NAME` is
+rejected rather than starting a second download, and the PVC holds one checkpoint:
+
+```bash
+# With no workers running (they hold the PVC open):
+kubectl delete job model-download -n ${NAMESPACE}
+kubectl delete pvc model-cache -n ${NAMESPACE}          # frees the ~160 GB already downloaded
+kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+Then apply the download Job for the checkpoint your variant serves, as above.
+
 ### Deploy
 
 Same flow for **every** variant (Agentic and Day-0): apply its `deploy.yaml`, then wait on its DGD.

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -80,7 +80,7 @@ Floor-picks (max system tok/s/GPU at user_p50 ≥ 50), default temperature. Agen
    - **DisAgg B200** (`disagg-b200-agentic`, 2P1D): **12 B200** — (2 prefill + 1 decode) pods × 4 GPUs, across **multiple nodes**; needs the [per-rank NIC mapping](../README.md#per-rank-nic-mapping-b200--h200-disaggregated).
    - **DisAgg H200** (`disagg-h200-agentic`, 4P3D): **28 H200** — (4 prefill + 3 decode) pods × 4 GPUs, across **multiple nodes**; same NIC mapping.
    - **GB200 Day-0 variants**: 4 GB200 GPUs (single NVL4 tray, arm64). Nodes must be labeled `nvidia.com/gpu.product=NVIDIA-GB200` and tainted `kubernetes.io/arch=arm64:NoSchedule` (the manifests carry the matching `nodeSelector` + `toleration`).
-3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V4-Flash`.
+3. **HuggingFace token** with access to the checkpoint your variant serves — `deepseek-ai/DeepSeek-V4-Flash` (public) for the H200, GB200, Day-0 B200, and SGLang variants, or `nvidia/DeepSeek-V4-Flash-NVFP4` for the two agentic B200 variants (`vllm/agg-b200-agentic`, `vllm/disagg-b200-agentic`).
 
 ## Quick Start
 
@@ -95,14 +95,34 @@ kubectl create secret generic hf-token-secret \
   --from-literal=HF_TOKEN="your-token-here" \
   -n ${NAMESPACE}
 
-# Download model into the model-cache PVC.
+# Storage for the checkpoint.
 # Edit model-cache/model-cache.yaml and set storageClassName to a RWX class in your cluster.
 # The PVC requests 400Gi; DeepSeek-V4-Flash is ~160GB on disk (46 safetensors shards,
 # FP4+FP8 mixed) and typically takes 30-60 min to download on first apply.
 kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+Then download **the checkpoint your variant serves**. The download Job takes a single `MODEL_NAME`;
+its default is the public checkpoint, which 6 of the 8 variants request:
+
+```bash
+# H200 agentic, GB200, Day-0 B200, and all SGLang variants — public checkpoint (the Job default):
 kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
+```
+
+```bash
+# vllm/agg-b200-agentic and vllm/disagg-b200-agentic only — NVFP4:
+sed 's|value: deepseek-ai/DeepSeek-V4-Flash$|value: nvidia/DeepSeek-V4-Flash-NVFP4|' \
+  model-cache/model-download.yaml | kubectl apply -f - -n ${NAMESPACE}
+```
+
+```bash
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=7200s
 ```
+
+> [!IMPORTANT]
+> The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the
+> Job did not download. Downloading the wrong one leaves the worker unable to start.
 
 ### Deploy
 

--- a/recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download.yaml
@@ -22,6 +22,11 @@ spec:
             - secretRef:
                 name: hf-token-secret
           env:
+            # One checkpoint per PVC. The default serves the 6 variants that ask for the public
+            # checkpoint. Override with "nvidia/DeepSeek-V4-Flash-NVFP4" for the two NVFP4
+            # variants, vllm/agg-b200-agentic and vllm/disagg-b200-agentic.
+            - name: MODEL_NAME
+              value: deepseek-ai/DeepSeek-V4-Flash
             - name: HF_HOME
               value: /model-store
             # Default "1" = fast: XET buffers use up to ~64 GB RAM, so the Job requests "64Gi" below
@@ -33,11 +38,7 @@ spec:
             - |
               set -eux
               pip install --no-cache-dir huggingface_hub==1.16.4
-              # Downloads ONE checkpoint per your SKU (the PVC in the README holds one, not both).
-              # B200 (NVFP4) is active by default; for H200, comment the NVFP4 line and uncomment
-              # the public checkpoint line instead.
-              hf download --max-workers 4 nvidia/DeepSeek-V4-Flash-NVFP4   # B200 recipes: NVFP4 experts + FP8 - default
-              # hf download --max-workers 4 deepseek-ai/DeepSeek-V4-Flash  # H200 recipes: public checkpoint
+              hf download --max-workers 4 "$MODEL_NAME"
           resources:
             requests:
               cpu: "2"

--- a/recipes/deepseek-v4/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/README.md
@@ -76,7 +76,7 @@ Bold = recommended pick per SKU: B200 disagg wins (+6.2%); H200 AGG wins (1P3D d
    - **B200 variants** (agentic + `vllm-agg-b200`, `sglang-agg`, `sglang-disagg-b200`): **8 B200 GPUs per worker** (TP=8 fills the box, x86_64). Totals: **AGG `agg-b200-agentic` = 8** (1 node); **DisAgg `disagg-b200-agentic` (1P1D) = 16** (1 prefill + 1 decode pod, across 2 nodes).
    - **H200 variants**: **8 H200 GPUs per worker** (public FP8 checkpoint, `max_model_len=86016`). Totals: **AGG `agg-h200-agentic` = 8** (1 node — the recommended H200 pick); **DisAgg `disagg-h200-agentic` (1P3D) = 32** (1 prefill + 3 decode pods, across 4 nodes).
    - **GB200 variants** (`vllm-agg-gb200`, `vllm-disagg-gb200`, `sglang-agg-gb200`, `sglang-disagg-gb200`): **2 GB200 nodes per worker**, each 4 GPUs (one NVL4 tray), on the **same NVLink72 clique**. Label `nvidia.com/gpu.product=NVIDIA-GB200`, taint `kubernetes.io/arch=arm64:NoSchedule`, and install the **DRA / ComputeDomain controller** (`kubectl get crd | grep computedomain`) — each manifest's `ComputeDomain` CR + `resourceClaims` co-locate the pod set on one NVLink72 fabric.
-3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V4-Pro`.
+3. **HuggingFace token** with access to the checkpoint your variant serves — `deepseek-ai/DeepSeek-V4-Pro` (public FP8) for the H200, GB200, Day-0 B200, and SGLang variants, or `nvidia/DeepSeek-V4-Pro-NVFP4` for the two agentic B200 variants (`vllm/agg-b200-agentic`, `vllm/disagg-b200-agentic`).
 
 ## Quick Start
 
@@ -91,14 +91,35 @@ kubectl create secret generic hf-token-secret \
   --from-literal=HF_TOKEN="your-token-here" \
   -n ${NAMESPACE}
 
-# Download model into the model-cache PVC.
+# Storage for the checkpoint.
 # Edit model-cache/model-cache.yaml and set storageClassName to a RWX class in your cluster.
 # The PVC requests 1500Gi; DeepSeek-V4-Pro is ~865 GB on disk (64 safetensors shards,
 # FP4+FP8 mixed) and typically takes 1.5-3 hours to download on first apply.
 kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+Then download **the checkpoint your variant serves**. Each checkpoint is ~865 GB and the PVC holds
+one, not both, so the download Job takes a single `MODEL_NAME`. Its default is the public FP8
+checkpoint, which 9 of the 11 variants request:
+
+```bash
+# H200 agentic, GB200, Day-0 B200, and all SGLang variants — public FP8 (the Job default):
 kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
+```
+
+```bash
+# vllm/agg-b200-agentic and vllm/disagg-b200-agentic only — NVFP4:
+sed 's|value: deepseek-ai/DeepSeek-V4-Pro$|value: nvidia/DeepSeek-V4-Pro-NVFP4|' \
+  model-cache/model-download.yaml | kubectl apply -f - -n ${NAMESPACE}
+```
+
+```bash
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=14400s
 ```
+
+> [!IMPORTANT]
+> The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the
+> Job did not download. Downloading the wrong one leaves the worker unable to start.
 
 ### Deploy
 

--- a/recipes/deepseek-v4/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/README.md
@@ -121,6 +121,19 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 > The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the
 > Job did not download. Downloading the wrong one leaves the worker unable to start.
 
+If the wrong checkpoint was already downloaded, reset before applying the other one. A Job's pod
+template is immutable, so re-applying `model-download.yaml` with a different `MODEL_NAME` is
+rejected rather than starting a second download, and the PVC holds one checkpoint:
+
+```bash
+# With no workers running (they hold the PVC open):
+kubectl delete job model-download -n ${NAMESPACE}
+kubectl delete pvc model-cache -n ${NAMESPACE}          # frees the ~865 GB already downloaded
+kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+Then apply the download Job for the checkpoint your variant serves, as above.
+
 ### Deploy
 
 Same flow for **every** variant (Agentic and Day-0): apply its `deploy.yaml`, then wait on its DGD.

--- a/recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download.yaml
@@ -22,6 +22,12 @@ spec:
             - secretRef:
                 name: hf-token-secret
           env:
+            # One checkpoint per PVC: each is ~865 GB and the PVC in the README requests 1500Gi,
+            # so both do not fit. The default serves the 9 variants that ask for the public FP8
+            # checkpoint. Override with "nvidia/DeepSeek-V4-Pro-NVFP4" for the two NVFP4 variants,
+            # vllm/agg-b200-agentic and vllm/disagg-b200-agentic.
+            - name: MODEL_NAME
+              value: deepseek-ai/DeepSeek-V4-Pro
             - name: HF_HOME
               value: /model-store
             # Default "1" = fast: XET buffers use up to ~64 GB RAM, so the Job requests "64Gi" below
@@ -33,11 +39,7 @@ spec:
             - |
               set -eux
               pip install --no-cache-dir huggingface_hub==1.16.4
-              # Downloads ONE checkpoint per your SKU (each is ~865 GB; the PVC in the README
-              # holds one, not both). B200 (NVFP4) is active by default; for H200, comment the
-              # NVFP4 line and uncomment the public FP8 line instead.
-              hf download --max-workers 4 nvidia/DeepSeek-V4-Pro-NVFP4   # B200 recipes (NVFP4) - default
-              # hf download --max-workers 4 deepseek-ai/DeepSeek-V4-Pro  # H200 recipes (public FP8)
+              hf download --max-workers 4 "$MODEL_NAME"
           resources:
             requests:
               cpu: "2"

--- a/tests/basic/test_recipe_model_download_consistency.py
+++ b/tests/basic/test_recipe_model_download_consistency.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Repo-consistency test for the DeepSeek-V4 recipe families.
+
+Each family ships one shared ``model-cache/model-download.yaml`` Job and several
+``deploy.yaml`` variants. The workers mount the resulting PVC read-only with
+``HF_HUB_OFFLINE=1``, so a checkpoint the Job never downloaded is a hard startup
+failure rather than a slow first launch. This test asserts the cross-file
+invariant that makes that impossible to introduce silently: every checkpoint
+repo id a ``deploy.yaml`` asks for must be obtainable from the family's download
+Job -- as its default ``MODEL_NAME``, as a repo id in an active ``hf download``
+line, or as a documented override value named in a comment.
+
+Scope is the two DeepSeek-V4 families deliberately. Other recipe families use
+different download mechanisms (inline ``snapshot_download`` calls, for example)
+and some carry pre-existing mismatches of their own; widening this test is a
+separate change.
+"""
+
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Set
+
+import pytest
+import yaml
+
+# Reads files only, so it is cheap enough to gate every merge.
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.post_merge,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RECIPE_FAMILIES = [
+    "recipes/deepseek-v4/deepseek-v4-pro",
+    "recipes/deepseek-v4/deepseek-v4-flash",
+]
+
+# A HuggingFace repo id: exactly one "/" separating an org from a model name.
+# Anchored, so shell fragments and absolute paths do not match.
+REPO_ID_RE = re.compile(r"^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$")
+
+# Repo ids written inside a comment, e.g.: Override with "nvidia/Foo-NVFP4".
+# Quoting is required so a commented-out shell command does not read as a
+# documented override.
+QUOTED_REPO_ID_RE = re.compile(r"[\"']([A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*)[\"']")
+
+# Flags whose argument names the checkpoint, in either vLLM or SGLang spelling.
+MODEL_FLAGS = ("--model", "--model-path", "--served-model-name")
+
+# Env vars the deploy.yaml files interpolate into those flags.
+MODEL_ENV_VARS = ("MODEL_PATH", "SERVED_MODEL_NAME")
+
+
+def _iter_nodes(node: Any) -> Iterable[Any]:
+    """Yield every mapping and sequence in a loaded YAML document."""
+    yield node
+    if isinstance(node, dict):
+        for value in node.values():
+            yield from _iter_nodes(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_nodes(item)
+
+
+def _load_documents(path: Path) -> List[Any]:
+    return [doc for doc in yaml.safe_load_all(path.read_text()) if doc is not None]
+
+
+def _repo_ids_from_flags(text: str) -> Set[str]:
+    """Extract checkpoint ids from ``--model <id>`` style flags in a script."""
+    found: Set[str] = set()
+    for line in text.splitlines():
+        tokens = line.replace("\\", " ").split()
+        for flag, value in zip(tokens, tokens[1:]):
+            if flag.split("=")[0] in MODEL_FLAGS:
+                candidate = value.strip("\"'")
+                if REPO_ID_RE.match(candidate):
+                    found.add(candidate)
+    return found
+
+
+def _repo_ids_from_arg_list(items: List[Any]) -> Set[str]:
+    """Extract checkpoint ids from an args list of alternating flag/value items."""
+    found: Set[str] = set()
+    strings = [item for item in items if isinstance(item, str)]
+    for flag, value in zip(strings, strings[1:]):
+        if flag in MODEL_FLAGS and REPO_ID_RE.match(value.strip("\"'")):
+            found.add(value.strip("\"'"))
+    return found
+
+
+def _repo_ids_from_env(node: Dict[str, Any], names: Iterable[str]) -> Set[str]:
+    """Extract checkpoint ids from ``env:`` entries with the given names."""
+    found: Set[str] = set()
+    env = node.get("env")
+    if not isinstance(env, list):
+        return found
+    wanted = set(names)
+    for entry in env:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") in wanted and isinstance(entry.get("value"), str):
+            value = entry["value"].strip()
+            if REPO_ID_RE.match(value):
+                found.add(value)
+    return found
+
+
+def _referenced_checkpoints(deploy_path: Path) -> Set[str]:
+    """Every checkpoint repo id a deploy manifest asks a worker to serve."""
+    found: Set[str] = set()
+    for document in _load_documents(deploy_path):
+        for node in _iter_nodes(document):
+            if isinstance(node, str):
+                if any(flag in node for flag in MODEL_FLAGS):
+                    found |= _repo_ids_from_flags(node)
+            elif isinstance(node, list):
+                found |= _repo_ids_from_arg_list(node)
+            elif isinstance(node, dict):
+                found |= _repo_ids_from_env(node, MODEL_ENV_VARS)
+    return found
+
+
+def _obtainable_checkpoints(download_path: Path) -> Set[str]:
+    """Every checkpoint the download Job can be made to fetch.
+
+    The default ``MODEL_NAME`` and any repo id passed to an active ``hf
+    download`` come from the parsed document; documented overrides come from the
+    raw text, since YAML parsing discards comments.
+    """
+    found: Set[str] = set()
+
+    for document in _load_documents(download_path):
+        for node in _iter_nodes(document):
+            if isinstance(node, dict):
+                found |= _repo_ids_from_env(node, ["MODEL_NAME"])
+
+    for raw_line in download_path.read_text().splitlines():
+        code, _, comment = raw_line.partition("#")
+        if "hf download" in code:
+            for token in code.split():
+                candidate = token.strip("\"'")
+                if REPO_ID_RE.match(candidate):
+                    found.add(candidate)
+        if comment:
+            found |= set(QUOTED_REPO_ID_RE.findall(comment))
+
+    return found
+
+
+@pytest.mark.parametrize("family", RECIPE_FAMILIES)
+def test_every_deployed_checkpoint_is_downloadable(family: str) -> None:
+    family_dir = REPO_ROOT / family
+    download_path = family_dir / "model-cache" / "model-download.yaml"
+    assert download_path.is_file(), f"missing download Job: {download_path}"
+
+    deploy_paths = sorted(family_dir.rglob("deploy.yaml"))
+    assert deploy_paths, f"no deploy.yaml found under {family_dir}"
+
+    obtainable = _obtainable_checkpoints(download_path)
+    assert obtainable, f"no checkpoint repo id found in {download_path}"
+
+    problems = []
+    for deploy_path in deploy_paths:
+        referenced = _referenced_checkpoints(deploy_path)
+        assert referenced, f"no checkpoint repo id found in {deploy_path}"
+        for checkpoint in sorted(referenced - obtainable):
+            problems.append(f"{deploy_path.relative_to(REPO_ROOT)} serves {checkpoint}")
+
+    assert not problems, (
+        f"{download_path.relative_to(REPO_ROOT)} can only supply "
+        f"{sorted(obtainable)}, but these variants ask for a checkpoint it "
+        f"neither downloads by default nor documents as an override:\n  "
+        + "\n  ".join(problems)
+    )

--- a/tests/basic/test_recipe_model_download_consistency.py
+++ b/tests/basic/test_recipe_model_download_consistency.py
@@ -12,6 +12,11 @@ repo id a ``deploy.yaml`` asks for must be obtainable from the family's download
 Job -- as its default ``MODEL_NAME``, as a repo id in an active ``hf download``
 line, or as a documented override value named in a comment.
 
+Obtainability alone would still pass a Job whose default is the checkpoint only
+a minority of variants serve, since the majority's checkpoint would remain
+obtainable as a documented override. So the default itself is checked too: no
+checkpoint may be requested by more variants than the default ``MODEL_NAME``.
+
 Scope is the two DeepSeek-V4 families deliberately. Other recipe families use
 different download mechanisms (inline ``snapshot_download`` calls, for example)
 and some carry pre-existing mismatches of their own; widening this test is a
@@ -19,8 +24,9 @@ separate change.
 """
 
 import re
+from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Set
+from typing import Any, Dict, Iterable, List, Sequence, Set
 
 import pytest
 import yaml
@@ -67,31 +73,49 @@ def _iter_nodes(node: Any) -> Iterable[Any]:
             yield from _iter_nodes(item)
 
 
+def _read_text(path: Path) -> str:
+    with path.open(encoding="utf-8") as manifest_file:
+        return manifest_file.read()
+
+
 def _load_documents(path: Path) -> List[Any]:
-    return [doc for doc in yaml.safe_load_all(path.read_text()) if doc is not None]
+    return [doc for doc in yaml.safe_load_all(_read_text(path)) if doc is not None]
+
+
+def _repo_ids_from_tokens(tokens: Sequence[str]) -> Set[str]:
+    """Extract checkpoint ids from model flags in a token sequence.
+
+    Both spellings occur in these recipes: ``--model <id>`` as two tokens and
+    ``--model=<id>`` as one.
+    """
+    found: Set[str] = set()
+    for index, token in enumerate(tokens):
+        name, separator, inline_value = token.partition("=")
+        if name not in MODEL_FLAGS:
+            continue
+        if separator:
+            value = inline_value
+        elif index + 1 < len(tokens):
+            value = tokens[index + 1]
+        else:
+            continue
+        candidate = value.strip("\"'")
+        if REPO_ID_RE.match(candidate):
+            found.add(candidate)
+    return found
 
 
 def _repo_ids_from_flags(text: str) -> Set[str]:
     """Extract checkpoint ids from ``--model <id>`` style flags in a script."""
     found: Set[str] = set()
     for line in text.splitlines():
-        tokens = line.replace("\\", " ").split()
-        for flag, value in zip(tokens, tokens[1:]):
-            if flag.split("=")[0] in MODEL_FLAGS:
-                candidate = value.strip("\"'")
-                if REPO_ID_RE.match(candidate):
-                    found.add(candidate)
+        found |= _repo_ids_from_tokens(line.replace("\\", " ").split())
     return found
 
 
 def _repo_ids_from_arg_list(items: List[Any]) -> Set[str]:
-    """Extract checkpoint ids from an args list of alternating flag/value items."""
-    found: Set[str] = set()
-    strings = [item for item in items if isinstance(item, str)]
-    for flag, value in zip(strings, strings[1:]):
-        if flag in MODEL_FLAGS and REPO_ID_RE.match(value.strip("\"'")):
-            found.add(value.strip("\"'"))
-    return found
+    """Extract checkpoint ids from an args list of flag and value items."""
+    return _repo_ids_from_tokens([item for item in items if isinstance(item, str)])
 
 
 def _repo_ids_from_env(node: Dict[str, Any], names: Iterable[str]) -> Set[str]:
@@ -126,6 +150,16 @@ def _referenced_checkpoints(deploy_path: Path) -> Set[str]:
     return found
 
 
+def _default_checkpoints(download_path: Path) -> Set[str]:
+    """The checkpoints the download Job fetches when applied unmodified."""
+    found: Set[str] = set()
+    for document in _load_documents(download_path):
+        for node in _iter_nodes(document):
+            if isinstance(node, dict):
+                found |= _repo_ids_from_env(node, ["MODEL_NAME"])
+    return found
+
+
 def _obtainable_checkpoints(download_path: Path) -> Set[str]:
     """Every checkpoint the download Job can be made to fetch.
 
@@ -133,14 +167,9 @@ def _obtainable_checkpoints(download_path: Path) -> Set[str]:
     download`` come from the parsed document; documented overrides come from the
     raw text, since YAML parsing discards comments.
     """
-    found: Set[str] = set()
+    found: Set[str] = _default_checkpoints(download_path)
 
-    for document in _load_documents(download_path):
-        for node in _iter_nodes(document):
-            if isinstance(node, dict):
-                found |= _repo_ids_from_env(node, ["MODEL_NAME"])
-
-    for raw_line in download_path.read_text().splitlines():
+    for raw_line in _read_text(download_path).splitlines():
         code, _, comment = raw_line.partition("#")
         if "hf download" in code:
             for token in code.split():
@@ -166,9 +195,11 @@ def test_every_deployed_checkpoint_is_downloadable(family: str) -> None:
     assert obtainable, f"no checkpoint repo id found in {download_path}"
 
     problems = []
+    demand: Counter = Counter()
     for deploy_path in deploy_paths:
         referenced = _referenced_checkpoints(deploy_path)
         assert referenced, f"no checkpoint repo id found in {deploy_path}"
+        demand.update(referenced)
         for checkpoint in sorted(referenced - obtainable):
             problems.append(f"{deploy_path.relative_to(REPO_ROOT)} serves {checkpoint}")
 
@@ -177,4 +208,18 @@ def test_every_deployed_checkpoint_is_downloadable(family: str) -> None:
         f"{sorted(obtainable)}, but these variants ask for a checkpoint it "
         f"neither downloads by default nor documents as an override:\n  "
         + "\n  ".join(problems)
+    )
+
+    # Obtainability is satisfied by a documented override, so it would also pass a
+    # Job whose default serves the minority of variants. Check the default too.
+    defaults = _default_checkpoints(download_path)
+    assert defaults, f"no default MODEL_NAME found in {download_path}"
+    best = max(demand.values())
+    assert all(demand[checkpoint] == best for checkpoint in defaults), (
+        f"{download_path.relative_to(REPO_ROOT)} defaults to {sorted(defaults)}, "
+        f"which fewer variants serve than "
+        f"{sorted(c for c, n in demand.items() if n == best)}. The default should "
+        f"be the checkpoint most variants ask for, so that the documented "
+        f"override is the exception rather than the rule. Variant demand: "
+        f"{dict(sorted(demand.items()))}."
     )


### PR DESCRIPTION
## Overview:

The two DeepSeek-V4 recipe families (`deepseek-v4-pro`, `deepseek-v4-flash`) each ship a single shared `model-cache/model-download.yaml` Job, and that Job hard-coded the B200 NVFP4 checkpoint with the public FP8 checkpoint sitting commented out beneath it. The H200 agentic variants (`vllm/agg-h200-agentic`, `vllm/disagg-h200-agentic`) serve `deepseek-ai/DeepSeek-V4-Pro` / `-Flash`, mount the model PVC read-only with `HF_HUB_OFFLINE=1`, and so cannot start against a PVC that only holds the NVFP4 weights — a user following the Quick Start gets workers that fail on a missing checkpoint with no way to recover in place.

This replaces the comment toggle with a real `MODEL_NAME` environment variable defaulted to the public checkpoint, documents the `sed` override the two NVFP4 B200 variants need, and adds a repo-consistency test so the mismatch cannot silently return.

This commit is a `git cherry-pick -x` of `aabfca15`, the substantive commit of #13034, onto current `main`; it carries the same seven files with no edits on top.

## Details:

- `recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download.yaml` and `recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download.yaml` — replace the active NVFP4 `hf download` line plus commented-out FP8 line with a `MODEL_NAME` env var defaulted to `deepseek-ai/DeepSeek-V4-Pro` / `deepseek-ai/DeepSeek-V4-Flash`, consumed as `hf download --max-workers 4 "$MODEL_NAME"`. The retained comment explains the one-checkpoint-per-PVC constraint and names the B200 agentic variants that need the override.
- `recipes/deepseek-v4/deepseek-v4-pro/README.md` and `recipes/deepseek-v4/deepseek-v4-flash/README.md` — split the Quick Start download step by SKU, document the `sed` override for the NVFP4 variants, widen the Hugging Face token prerequisite to name both checkpoints, and add an `[!IMPORTANT]` note that workers mount the PVC read-only with `HF_HUB_OFFLINE=1`.
- `docs/fern/pages/recipes/model-recipes/deepseek-v4-pro.mdx` and `docs/fern/pages/recipes/model-recipes/deepseek-v4-flash.mdx` — mirror the SKU-branched download step onto the docs site inside the existing `data-sku` switcher, plus a `<Warning>`. Both components are already in use on these pages.
- `tests/basic/test_recipe_model_download_consistency.py` (new) — a pure-PyYAML unit test asserting that every checkpoint any `recipes/deepseek-v4/**/deploy.yaml` asks for is obtainable from that family's download Job: as the default `MODEL_NAME`, as a repo id in an active `hf download` line, or as a documented override.

## Where should the reviewer start?

1. `recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download.yaml` — the parameterization itself; `deepseek-v4-flash` is the identical change.
2. `tests/basic/test_recipe_model_download_consistency.py` — the guard, and the scope it deliberately covers (the two DeepSeek-V4 families only).
3. The two README Quick Start sections — the `sed` override is the step a B200 user must not miss.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #13034 — this PR carries that PR's commit against `main`. If #13034 is preferred, close this one in its favour rather than reviewing both.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified checkpoint requirements for DeepSeek-V4 Flash and Pro across supported GPU configurations.
  * Added guidance for selecting the correct checkpoint, configuring downloads, and running workers offline.
  * Updated quick-start instructions to separate storage setup from model download steps.

* **Improvements**
  * Model downloads now support a configurable checkpoint selection, including public and NVFP4 variants.
  * Added validation to ensure deployment configurations reference checkpoints available through the documented download process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->