### PR TITLE
fix(profiler): clamp vLLM length to model context

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_model_info.py
+++ b/components/src/dynamo/profiler/tests/unit/test_model_info.py
@@ -4,6 +4,7 @@
 """Unit tests for profiler model-info helpers."""
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -15,7 +16,10 @@ pytestmark = [
 ]
 
 try:
-    from dynamo.profiler.utils.model_info import get_mamba_cache_align_block_size
+    from dynamo.profiler.utils.model_info import (
+        get_mamba_cache_align_block_size,
+        get_model_context_length,
+    )
 except ImportError as e:
     pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
 
@@ -33,3 +37,69 @@ def test_mamba_cache_align_block_size_from_local_config(tmp_path) -> None:
     )
 
     assert get_mamba_cache_align_block_size(tmp_path) == 8320
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        ({"max_position_embeddings": 2048}, 2048),
+        ({"n_positions": 1024}, 1024),
+        ({"text_config": {"max_sequence_length": 4096}}, 4096),
+        (
+            {
+                "max_position_embeddings": 2048,
+                "model_type": "llama",
+                "rope_scaling": {"type": "linear", "factor": 4.0},
+            },
+            8192,
+        ),
+        (
+            {
+                "max_position_embeddings": 8192,
+                "model_type": "llama",
+                "rope_scaling": {"rope_type": "llama3", "factor": 8.0},
+            },
+            8192,
+        ),
+    ],
+)
+def test_model_context_length_from_local_config(
+    tmp_path, config: dict, expected: int
+) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(config))
+
+    assert get_model_context_length(tmp_path) == expected
+
+
+def test_model_context_length_prefers_nested_object_config(monkeypatch) -> None:
+    config = SimpleNamespace(
+        max_position_embeddings=8192,
+        decoder=SimpleNamespace(max_position_embeddings=2048),
+    )
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.model_info._load_model_config",
+        lambda *args, **kwargs: config,
+    )
+
+    assert get_model_context_length("test/model") == 2048
+
+
+def test_model_config_falls_back_when_aic_download_fails(monkeypatch) -> None:
+    class DownloadError(Exception):
+        pass
+
+    expected = SimpleNamespace(max_position_embeddings=4096)
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.model_info.HuggingFaceDownloadError",
+        DownloadError,
+    )
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.model_info._load_model_config_from_model_path",
+        lambda *args, **kwargs: (_ for _ in ()).throw(DownloadError()),
+    )
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.model_info.AutoConfig.from_pretrained",
+        lambda *args, **kwargs: expected,
+    )
+
+    assert get_model_context_length("test/model") == 4096

--- a/components/src/dynamo/profiler/tests/unit/test_model_info.py
+++ b/components/src/dynamo/profiler/tests/unit/test_model_info.py
@@ -46,6 +46,10 @@ def test_mamba_cache_align_block_size_from_local_config(tmp_path) -> None:
         ({"n_positions": 1024}, 1024),
         ({"text_config": {"max_sequence_length": 4096}}, 4096),
         (
+            {"max_position_embeddings": 8192, "model_max_length": 131072},
+            131072,
+        ),
+        (
             {
                 "max_position_embeddings": 2048,
                 "model_type": "llama",
@@ -71,6 +75,15 @@ def test_model_context_length_from_local_config(
     assert get_model_context_length(tmp_path) == expected
 
 
+def test_model_context_length_uses_tokenizer_ceiling(tmp_path) -> None:
+    (tmp_path / "config.json").write_text(json.dumps({"max_position_embeddings": 8192}))
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps({"model_max_length": 2048})
+    )
+
+    assert get_model_context_length(tmp_path) == 2048
+
+
 def test_model_context_length_prefers_nested_object_config(monkeypatch) -> None:
     config = SimpleNamespace(
         max_position_embeddings=8192,
@@ -79,6 +92,10 @@ def test_model_context_length_prefers_nested_object_config(monkeypatch) -> None:
     monkeypatch.setattr(
         "dynamo.profiler.utils.model_info._load_model_config",
         lambda *args, **kwargs: config,
+    )
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.model_info._load_tokenizer_config",
+        lambda *args, **kwargs: None,
     )
 
     assert get_model_context_length("test/model") == 2048
@@ -100,6 +117,10 @@ def test_model_config_falls_back_when_aic_download_fails(monkeypatch) -> None:
     monkeypatch.setattr(
         "dynamo.profiler.utils.model_info.AutoConfig.from_pretrained",
         lambda *args, **kwargs: expected,
+    )
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.model_info._load_tokenizer_config",
+        lambda *args, **kwargs: None,
     )
 
     assert get_model_context_length("test/model") == 4096

--- a/components/src/dynamo/profiler/tests/unit/test_model_info.py
+++ b/components/src/dynamo/profiler/tests/unit/test_model_info.py
@@ -53,6 +53,14 @@ def test_mamba_cache_align_block_size_from_local_config(tmp_path) -> None:
             2048,
         ),
         (
+            {
+                "model_type": "llama",
+                "rope_scaling": {"type": "linear", "factor": 4.0},
+                "text_config": {"max_position_embeddings": 2048},
+            },
+            8192,
+        ),
+        (
             {"max_position_embeddings": 8192, "model_max_length": 131072},
             131072,
         ),

--- a/components/src/dynamo/profiler/tests/unit/test_model_info.py
+++ b/components/src/dynamo/profiler/tests/unit/test_model_info.py
@@ -46,6 +46,13 @@ def test_mamba_cache_align_block_size_from_local_config(tmp_path) -> None:
         ({"n_positions": 1024}, 1024),
         ({"text_config": {"max_sequence_length": 4096}}, 4096),
         (
+            {
+                "max_position_embeddings": 8192,
+                "thinker_config": {"text_config": {"max_position_embeddings": 2048}},
+            },
+            2048,
+        ),
+        (
             {"max_position_embeddings": 8192, "model_max_length": 131072},
             131072,
         ),
@@ -88,6 +95,24 @@ def test_model_context_length_prefers_nested_object_config(monkeypatch) -> None:
     config = SimpleNamespace(
         max_position_embeddings=8192,
         decoder=SimpleNamespace(max_position_embeddings=2048),
+    )
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.model_info._load_model_config",
+        lambda *args, **kwargs: config,
+    )
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.model_info._load_tokenizer_config",
+        lambda *args, **kwargs: None,
+    )
+
+    assert get_model_context_length("test/model") == 2048
+
+
+def test_model_context_length_prefers_get_text_config(monkeypatch) -> None:
+    text_config = SimpleNamespace(max_position_embeddings=2048)
+    config = SimpleNamespace(
+        max_position_embeddings=8192,
+        get_text_config=lambda: text_config,
     )
     monkeypatch.setattr(
         "dynamo.profiler.utils.model_info._load_model_config",

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -453,8 +453,45 @@ def test_vllm_mamba_align_skips_without_explicit_align_mode() -> None:
     assert result == args
 
 
-def test_vllm_model_runtime_constraints_update_decode_config() -> None:
-    """Candidate-level vLLM postprocessing fixes generated decode worker args."""
+@pytest.mark.parametrize(
+    "args, context_length, expected",
+    [
+        (["--max-model-len", "6500"], 2048, ["--max-model-len", "2048"]),
+        (["--max-model-len=6500"], 4096, ["--max-model-len", "4096"]),
+        (["--max-model-len", "2048"], 4096, ["--max-model-len", "2048"]),
+        (
+            ["--max-model-len", "2000", "--max-model-len=6500"],
+            4096,
+            ["--max-model-len", "4096"],
+        ),
+        (
+            ["--max-model-len", "6500", "--max-model-len=2000"],
+            4096,
+            ["--max-model-len", "2000"],
+        ),
+        (
+            ["--max-num-batched-tokens", "6012"],
+            2048,
+            ["--max-num-batched-tokens", "6012"],
+        ),
+    ],
+)
+def test_vllm_model_context_window_ceiling(
+    args: list[str], context_length: int, expected: list[str]
+) -> None:
+    modifier = CONFIG_MODIFIERS["vllm"]
+
+    with patch(
+        "dynamo.profiler.utils.config_modifiers.vllm.get_model_context_length",
+        return_value=context_length,
+    ):
+        result = modifier._apply_model_context_window_ceiling(args, "test/model")
+
+    assert result == expected
+
+
+def test_vllm_model_runtime_constraints_update_worker_configs() -> None:
+    """Candidate-level vLLM postprocessing fixes generated worker args."""
     modifier = CONFIG_MODIFIERS["vllm"]
     config = {
         "apiVersion": "nvidia.com/v1beta1",
@@ -464,9 +501,16 @@ def test_vllm_model_runtime_constraints_update_decode_config() -> None:
             "components": [
                 _make_component("Frontend", "frontend"),
                 _make_component(
+                    "VllmPrefillWorker",
+                    "prefill",
+                    args=["--max-model-len=6500"],
+                ),
+                _make_component(
                     "VllmDecodeWorker",
                     "decode",
                     args=[
+                        "--max-model-len",
+                        "6500",
                         "--mamba-cache-mode",
                         "align",
                         "--max-num-batched-tokens",
@@ -477,13 +521,23 @@ def test_vllm_model_runtime_constraints_update_decode_config() -> None:
         },
     }
 
-    with patch(
-        "dynamo.profiler.utils.config_modifiers.vllm.get_mamba_cache_align_block_size",
-        return_value=8320,
+    with (
+        patch(
+            "dynamo.profiler.utils.config_modifiers.vllm.get_model_context_length",
+            return_value=2048,
+        ),
+        patch(
+            "dynamo.profiler.utils.config_modifiers.vllm.get_mamba_cache_align_block_size",
+            return_value=8320,
+        ),
     ):
         result = modifier.apply_model_runtime_constraints(config, "nemotron")
 
-    args = _main_container(_components_by_name(result)["VllmDecodeWorker"])["args"]
+    components = _components_by_name(result)
+    prefill_args = _main_container(components["VllmPrefillWorker"])["args"]
+    args = _main_container(components["VllmDecodeWorker"])["args"]
+    assert prefill_args == ["--max-model-len", "2048"]
+    assert args[args.index("--max-model-len") + 1] == "2048"
     assert args[args.index("--max-num-batched-tokens") + 1] == "8320"
 
 

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -435,6 +435,30 @@ def test_vllm_mamba_align_raises_max_num_batched_tokens() -> None:
     assert result[result.index("--max-num-batched-tokens") + 1] == "8320"
 
 
+def test_vllm_mamba_align_normalizes_duplicate_token_caps() -> None:
+    modifier = CONFIG_MODIFIERS["vllm"]
+    args = [
+        "--mamba-cache-mode",
+        "align",
+        "--max-num-batched-tokens",
+        "20000",
+        "--max-num-batched-tokens=1024",
+    ]
+
+    with patch(
+        "dynamo.profiler.utils.config_modifiers.vllm.get_mamba_cache_align_block_size",
+        return_value=8320,
+    ):
+        result = modifier._apply_mamba_cache_align_token_floor(args, "nemotron")
+
+    assert result == [
+        "--mamba-cache-mode",
+        "align",
+        "--max-num-batched-tokens",
+        "8320",
+    ]
+
+
 def test_vllm_mamba_align_skips_without_explicit_align_mode() -> None:
     """Do not probe model metadata for ordinary prefix-caching decode workers."""
     modifier = CONFIG_MODIFIERS["vllm"]
@@ -458,6 +482,9 @@ def test_vllm_mamba_align_skips_without_explicit_align_mode() -> None:
     [
         (["--max-model-len", "6500"], 2048, ["--max-model-len", "2048"]),
         (["--max-model-len=6500"], 4096, ["--max-model-len", "4096"]),
+        (["--max-model-len", "6k"], 4096, ["--max-model-len", "4096"]),
+        (["--max-model-len=6K"], 4096, ["--max-model-len", "4096"]),
+        (["--max-model-len", "6.5k"], 4096, ["--max-model-len", "4096"]),
         (["--max-model-len", "2048"], 4096, ["--max-model-len", "2048"]),
         (
             ["--max-model-len", "2000", "--max-model-len=6500"],
@@ -503,7 +530,13 @@ def test_vllm_model_runtime_constraints_update_worker_configs() -> None:
                 _make_component(
                     "VllmPrefillWorker",
                     "prefill",
-                    args=["--max-model-len=6500"],
+                    args=[
+                        "--max-model-len=6500",
+                        "--mamba-cache-mode",
+                        "align",
+                        "--max-num-batched-tokens",
+                        "1024",
+                    ],
                 ),
                 _make_component(
                     "VllmDecodeWorker",
@@ -536,7 +569,8 @@ def test_vllm_model_runtime_constraints_update_worker_configs() -> None:
     components = _components_by_name(result)
     prefill_args = _main_container(components["VllmPrefillWorker"])["args"]
     args = _main_container(components["VllmDecodeWorker"])["args"]
-    assert prefill_args == ["--max-model-len", "2048"]
+    assert prefill_args[prefill_args.index("--max-model-len") + 1] == "2048"
+    assert prefill_args[prefill_args.index("--max-num-batched-tokens") + 1] == "8320"
     assert args[args.index("--max-model-len") + 1] == "2048"
     assert args[args.index("--max-num-batched-tokens") + 1] == "8320"
 

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -27,7 +27,10 @@ from dynamo.profiler.utils.config import (
 from dynamo.profiler.utils.config_modifiers.protocol import BaseConfigModifier
 from dynamo.profiler.utils.defaults import DYNAMO_RUN_DEFAULT_PORT, EngineType
 from dynamo.profiler.utils.dgd_template import load_dgd_template
-from dynamo.profiler.utils.model_info import get_mamba_cache_align_block_size
+from dynamo.profiler.utils.model_info import (
+    get_mamba_cache_align_block_size,
+    get_model_context_length,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -43,12 +46,13 @@ DEFAULT_VLLM_KV_TRANSFER_CONFIG = '{"kv_connector":"NixlConnector","kv_role":"kv
 
 
 def _get_valued_arg(args: list[str], key: str) -> str | None:
+    value = None
     for i, arg in enumerate(args):
         if arg == key and i + 1 < len(args):
-            return args[i + 1]
+            value = args[i + 1]
         if isinstance(arg, str) and arg.startswith(f"{key}="):
-            return arg.split("=", 1)[1]
-    return None
+            value = arg.split("=", 1)[1]
+    return value
 
 
 def _set_valued_arg(args: list[str], key: str, value: str) -> list[str]:
@@ -284,6 +288,50 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         return _set_valued_arg(args, "--max-num-batched-tokens", str(mamba_align_floor))
 
     @classmethod
+    def _apply_model_context_window_ceiling(
+        cls, args: list[str], model_name_or_path: str | None
+    ) -> list[str]:
+        """Keep generated ``--max-model-len`` within the model's context window."""
+        if not model_name_or_path:
+            return args
+
+        current = _get_valued_arg(args, "--max-model-len")
+        if current is None:
+            return args
+        try:
+            current_value = int(current)
+        except ValueError:
+            logger.warning(
+                "Cannot validate non-integer vLLM --max-model-len value %r",
+                current,
+            )
+            return args
+
+        try:
+            context_length = get_model_context_length(model_name_or_path)
+        except (OSError, RuntimeError, TypeError, ValueError):
+            logger.warning(
+                "Could not derive the model context window for %s; leaving "
+                "--max-model-len=%s unchanged.",
+                model_name_or_path,
+                current,
+                exc_info=True,
+            )
+            return args
+        if context_length is None:
+            return args
+
+        target_value = min(current_value, context_length)
+        if target_value < current_value:
+            logger.warning(
+                "Clamping vLLM --max-model-len from %d to model context window %d for %s.",
+                current_value,
+                context_length,
+                model_name_or_path,
+            )
+        return set_unique_argument_value(args, "--max-model-len", str(target_value))
+
+    @classmethod
     def apply_model_runtime_constraints(
         cls, config: dict, model_name_or_path: str | None
     ) -> dict:
@@ -295,7 +343,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
                 exc_info=True,
             )
             return config
-        for component_type in (SubComponentType.DECODE,):
+        for component_type in (SubComponentType.PREFILL, SubComponentType.DECODE):
             try:
                 worker_service = get_worker_component_from_config(
                     cfg, backend="vllm", sub_component_type=component_type
@@ -322,7 +370,11 @@ class VllmV1ConfigModifier(BaseConfigModifier):
                     exc_info=True,
                 )
                 continue
-            args = cls._apply_mamba_cache_align_token_floor(args, model_name_or_path)
+            args = cls._apply_model_context_window_ceiling(args, model_name_or_path)
+            if component_type == SubComponentType.DECODE:
+                args = cls._apply_mamba_cache_align_token_floor(
+                    args, model_name_or_path
+                )
             main_container.args = args
         return cfg.model_dump()
 

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import re
 from typing import Tuple
 from uuid import uuid4
 
@@ -56,14 +57,33 @@ def _get_valued_arg(args: list[str], key: str) -> str | None:
 
 
 def _set_valued_arg(args: list[str], key: str, value: str) -> list[str]:
-    for i, arg in enumerate(args):
-        if arg == key and i + 1 < len(args):
-            args[i + 1] = value
-            return args
-        if isinstance(arg, str) and arg.startswith(f"{key}="):
-            args[i] = f"{key}={value}"
-            return args
-    return set_argument_value(args, key, value)
+    return set_unique_argument_value(args, key, value)
+
+
+def _parse_human_readable_int(value: str) -> int:
+    """Match vLLM's decimal lowercase and binary uppercase size suffixes."""
+    value = value.strip()
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)([kKmMgGtT])", value)
+    if match is None:
+        return int(value)
+
+    number, suffix = match.groups()
+    if suffix.islower():
+        multiplier = {
+            "k": 10**3,
+            "m": 10**6,
+            "g": 10**9,
+            "t": 10**12,
+        }[suffix]
+        return int(float(number) * multiplier)
+
+    multiplier = {
+        "K": 2**10,
+        "M": 2**20,
+        "G": 2**30,
+        "T": 2**40,
+    }[suffix]
+    return int(number) * multiplier
 
 
 def _finalize_disagg_cli_args(args: list[str], role: SubComponentType) -> list[str]:
@@ -299,7 +319,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         if current is None:
             return args
         try:
-            current_value = int(current)
+            current_value = _parse_human_readable_int(current)
         except ValueError:
             logger.warning(
                 "Cannot validate non-integer vLLM --max-model-len value %r",
@@ -371,10 +391,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
                 )
                 continue
             args = cls._apply_model_context_window_ceiling(args, model_name_or_path)
-            if component_type == SubComponentType.DECODE:
-                args = cls._apply_mamba_cache_align_token_floor(
-                    args, model_name_or_path
-                )
+            args = cls._apply_mamba_cache_align_token_floor(args, model_name_or_path)
             main_container.args = args
         return cfg.model_dump()
 

--- a/components/src/dynamo/profiler/utils/model_info.py
+++ b/components/src/dynamo/profiler/utils/model_info.py
@@ -11,9 +11,16 @@ from pydantic import BaseModel
 from transformers import AutoConfig
 
 try:
-    from aiconfigurator_core.sdk.utils import get_model_config_from_model_path
+    from aiconfigurator_core.sdk.utils import (
+        HuggingFaceDownloadError,
+        _load_model_config_from_model_path,
+    )
 except ImportError:
-    get_model_config_from_model_path = None
+
+    class HuggingFaceDownloadError(Exception):
+        pass
+
+    _load_model_config_from_model_path = None
 logger = logging.getLogger(__name__)
 
 DTYPE_BYTES_MAP = {
@@ -30,8 +37,12 @@ DTYPE_BYTES_MAP = {
 CONTEXT_LENGTH_ATTRS = [
     "max_position_embeddings",  # Most common (BERT, GPT, LLaMA, etc.)
     "n_positions",  # GPT-2, GPT-Neo
+    "max_seq_len",  # MPT
     "max_sequence_length",  # Some models
+    "max_seq_length",  # Some encoder configs
     "seq_length",  # Some older models
+    "seq_len",  # Alternative spelling
+    "max_target_positions",  # Encoder-decoder models
     "model_max_length",  # Some tokenizer configs
     "sliding_window",  # Mistral with sliding window attention
 ]
@@ -225,7 +236,7 @@ def _positive_int_config_value(config: object, attr: str) -> Optional[int]:
     return parsed if parsed > 0 else None
 
 
-def _load_model_config_for_mamba(
+def _load_model_config(
     model_name_or_path: Union[str, Path],
     trust_remote_code: bool = False,
 ) -> object:
@@ -235,16 +246,83 @@ def _load_model_config_for_mamba(
         with open(config_path) as f:
             return json.load(f)
 
-    if get_model_config_from_model_path is not None:
-        model_config = get_model_config_from_model_path(str(model_name_or_path))
-        raw_config = model_config.get("raw_config")
-        if raw_config is not None:
-            return raw_config
+    if _load_model_config_from_model_path is not None:
+        try:
+            return _load_model_config_from_model_path(str(model_name_or_path))
+        except HuggingFaceDownloadError:
+            logger.debug(
+                "AIConfigurator could not load model config for %s; falling back "
+                "to Transformers",
+                model_name_or_path,
+                exc_info=True,
+            )
 
     return AutoConfig.from_pretrained(
         model_name_or_path,
         trust_remote_code=trust_remote_code,
     )
+
+
+def get_model_context_length(
+    model_name_or_path: Union[str, Path],
+    trust_remote_code: bool = False,
+) -> Optional[int]:
+    """Return vLLM's config-derived context-window ceiling when available."""
+    config = _load_model_config(model_name_or_path, trust_remote_code)
+    candidates = []
+    for key in ("text_config", "language_config", "decoder", "generator"):
+        nested = _get_config_value(config, key)
+        if nested is not None:
+            candidates.append(nested)
+    candidates.append(config)
+
+    for candidate in candidates:
+        lengths = []
+        for attr in CONTEXT_LENGTH_ATTRS:
+            if attr in ("model_max_length", "sliding_window"):
+                continue
+            value = _positive_int_config_value(candidate, attr)
+            if value is not None:
+                lengths.append(value)
+
+        context_length = min(lengths) if lengths else None
+        model_max_length = _positive_int_config_value(candidate, "model_max_length")
+        if model_max_length is not None:
+            context_length = model_max_length
+        if context_length is None:
+            continue
+
+        rope_params = _get_config_value(candidate, "rope_parameters")
+        if rope_params is None:
+            rope_params = _get_config_value(candidate, "rope_scaling")
+        model_type = str(_get_config_value(candidate, "model_type") or "")
+        if isinstance(rope_params, dict) and "gemma3" not in model_type:
+            if any(isinstance(value, dict) for value in rope_params.values()):
+                rope_configs = [
+                    value for value in rope_params.values() if isinstance(value, dict)
+                ]
+            else:
+                rope_configs = [rope_params]
+
+            scaling_factor = 1.0
+            for rope_config in rope_configs:
+                rope_type = rope_config.get("rope_type") or rope_config.get("type")
+                if rope_type not in ("su", "longrope", "llama3"):
+                    try:
+                        scaling_factor = float(
+                            rope_config.get("factor", scaling_factor) or 1.0
+                        )
+                    except (TypeError, ValueError):
+                        scaling_factor = 1.0
+                    if rope_type == "yarn":
+                        original = rope_config.get("original_max_position_embeddings")
+                        try:
+                            context_length = int(original)
+                        except (TypeError, ValueError):
+                            pass
+            context_length = int(context_length * scaling_factor)
+        return context_length
+    return None
 
 
 def get_mamba_cache_align_block_size(
@@ -257,7 +335,7 @@ def get_mamba_cache_align_block_size(
     when Mamba cache mode is ``align``. Nemotron-H configs expose the fields
     needed to compute it directly.
     """
-    config = _load_model_config_for_mamba(model_name_or_path, trust_remote_code)
+    config = _load_model_config(model_name_or_path, trust_remote_code)
     mamba_num_heads = _positive_int_config_value(config, "mamba_num_heads")
     mamba_head_dim = _positive_int_config_value(config, "mamba_head_dim")
     ssm_state_size = _positive_int_config_value(config, "ssm_state_size")

--- a/components/src/dynamo/profiler/utils/model_info.py
+++ b/components/src/dynamo/profiler/utils/model_info.py
@@ -355,7 +355,15 @@ def get_model_context_length(
         rope_params = _get_config_value(candidate, "rope_parameters")
         if rope_params is None:
             rope_params = _get_config_value(candidate, "rope_scaling")
-        model_type = str(_get_config_value(candidate, "model_type") or "")
+        if rope_params is None and candidate is not config:
+            rope_params = _get_config_value(config, "rope_parameters")
+            if rope_params is None:
+                rope_params = _get_config_value(config, "rope_scaling")
+        model_type = str(
+            _get_config_value(candidate, "model_type")
+            or _get_config_value(config, "model_type")
+            or ""
+        )
         if isinstance(rope_params, dict) and "gemma3" not in model_type:
             if any(isinstance(value, dict) for value in rope_params.values()):
                 rope_configs = [

--- a/components/src/dynamo/profiler/utils/model_info.py
+++ b/components/src/dynamo/profiler/utils/model_info.py
@@ -312,11 +312,23 @@ def get_model_context_length(
         tokenizer_config, "model_max_length"
     )
     candidates = []
+    candidate_ids = set()
+
+    def add_candidate(candidate: object) -> None:
+        if candidate is None or id(candidate) in candidate_ids:
+            return
+        candidate_ids.add(id(candidate))
+        candidates.append(candidate)
+
+    thinker_config = _get_config_value(config, "thinker_config")
+    add_candidate(_get_config_value(thinker_config, "text_config"))
+    if not isinstance(config, dict):
+        get_text_config = getattr(config, "get_text_config", None)
+        if callable(get_text_config):
+            add_candidate(get_text_config())
     for key in ("text_config", "language_config", "decoder", "generator"):
-        nested = _get_config_value(config, key)
-        if nested is not None:
-            candidates.append(nested)
-    candidates.append(config)
+        add_candidate(_get_config_value(config, key))
+    add_candidate(config)
 
     for candidate in candidates:
         lengths = []

--- a/components/src/dynamo/profiler/utils/model_info.py
+++ b/components/src/dynamo/profiler/utils/model_info.py
@@ -231,9 +231,47 @@ def _positive_int_config_value(config: object, attr: str) -> Optional[int]:
     value = _get_config_value(config, attr)
     try:
         parsed = int(value)
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return None
     return parsed if parsed > 0 else None
+
+
+def _load_tokenizer_config(
+    model_name_or_path: Union[str, Path],
+) -> Optional[dict]:
+    """Load optional tokenizer metadata without making context lookup fail."""
+    path = Path(model_name_or_path)
+    if path.is_dir():
+        config_path = path / "tokenizer_config.json"
+        if not config_path.is_file():
+            return None
+    else:
+        try:
+            config_path = Path(
+                hf_hub_download(
+                    repo_id=str(model_name_or_path),
+                    filename="tokenizer_config.json",
+                )
+            )
+        except Exception:
+            logger.debug(
+                "Could not load tokenizer config for %s",
+                model_name_or_path,
+                exc_info=True,
+            )
+            return None
+
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        logger.debug(
+            "Could not read tokenizer config for %s",
+            model_name_or_path,
+            exc_info=True,
+        )
+        return None
+    return config if isinstance(config, dict) else None
 
 
 def _load_model_config(
@@ -269,6 +307,10 @@ def get_model_context_length(
 ) -> Optional[int]:
     """Return vLLM's config-derived context-window ceiling when available."""
     config = _load_model_config(model_name_or_path, trust_remote_code)
+    tokenizer_config = _load_tokenizer_config(model_name_or_path)
+    tokenizer_context_length = _positive_int_config_value(
+        tokenizer_config, "model_max_length"
+    )
     candidates = []
     for key in ("text_config", "language_config", "decoder", "generator"):
         nested = _get_config_value(config, key)
@@ -289,6 +331,12 @@ def get_model_context_length(
         model_max_length = _positive_int_config_value(candidate, "model_max_length")
         if model_max_length is not None:
             context_length = model_max_length
+        if tokenizer_context_length is not None:
+            context_length = (
+                min(context_length, tokenizer_context_length)
+                if context_length is not None
+                else tokenizer_context_length
+            )
         if context_length is None:
             continue
 


### PR DESCRIPTION
## Summary

- Clamp generated vLLM `--max-model-len` to the model's config-derived context window during final DGD materialization.
- Apply the constraint to aggregated and disaggregated prefill/decode workers, on both normal AIC and naive fallback paths.
- Preserve smaller user values, normalize duplicate CLI arguments using vLLM's last-value semantics, and account for nested configs and RoPE scaling.

## Root cause

The generated vLLM length comes from workload ISL + OSL + a fixed margin (6500 with the defaults) and was never checked against the selected model. vLLM rejects that value at startup for models such as Llama-2 (4096) and TinyLlama (2048), leaving the worker in CrashLoopBackOff.

Addresses NVBug 6596670.

## Validation

- `152 passed`: profiler model-info, protocol, materialization, and profile-SLA unit tests on `main`
- `ruff check` on all changed Python files
- `ruff format --check` on changed source files and the new model-info tests
- Independent agentic code review completed with no blocking findings

Note: the AIConfigurator dependency pin is intentionally unchanged; the release update is handled separately.
