### PR TITLE
fix(frontend): classify backend errors on the streaming path

### DIFF
--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -199,32 +199,30 @@ fn stream_error_frame(message: &str, type_slug: &str, code: u16) -> String {
 /// Build the inline SSE error frame for a stream that already committed its
 /// HTTP status.
 ///
-/// Classification mirrors the pre-commit path in `backend_error_response`: a
-/// request the backend rejected as invalid forwards its message verbatim, and
-/// everything else stays sanitized so internals never reach the caller. The
-/// `code` field is advisory here — the real status went out with the 200 — but
-/// `message` and `type` are what a streaming client actually reads, and
-/// reporting `Internal server error` for every failure made a caller's own bad
-/// request indistinguishable from an engine fault.
+/// Every frame stays sanitized. That is deliberate and predates this
+/// classification: the body used to be `err.to_string()` until it was replaced
+/// with a static message to stop backend internals reaching clients. Nothing
+/// here reintroduces that — only the *category* is recovered, never the text.
+///
+/// Note the asymmetry with the pre-commit path, which does forward a rejection's
+/// message on a 400. It can afford to; a streamed frame cannot, because
+/// `Backend(InvalidArgument)` also covers any Python `ValueError`/`TypeError` an
+/// engine raises, whose text may name paths or tensor shapes.
+///
+/// `code` is advisory here — the real status went out with the 200 — but `type`
+/// is what a streaming client reads to tell its own bad request apart from an
+/// engine fault, and reporting `internal_server_error` for every failure erased
+/// that distinction.
 fn openai_stream_error(error: &(dyn std::error::Error + 'static)) -> (ErrorType, String) {
     use crate::http::service::metrics::{
         request_was_cancelled, request_was_rejected, request_was_unavailable,
     };
     use crate::http::service::openai::find_invalid_argument_in_chain;
 
-    if let Some(invalid_argument) = find_invalid_argument_in_chain(error) {
-        return (
-            ErrorType::Validation,
-            stream_error_frame(
-                invalid_argument.message(),
-                "invalid_request_error",
-                axum::http::StatusCode::BAD_REQUEST.as_u16(),
-            ),
-        );
-    }
-
     // Same precedence as `ErrorMessage::from_anyhow`.
-    let (sanitized, error_type) = if request_was_rejected(error) {
+    let (sanitized, error_type) = if find_invalid_argument_in_chain(error).is_some() {
+        (SanitizedError::InvalidRequest, ErrorType::Validation)
+    } else if request_was_rejected(error) {
         (SanitizedError::Overloaded, ErrorType::Overload)
     } else if request_was_unavailable(error) {
         (SanitizedError::Unavailable, ErrorType::Unavailable)
@@ -890,19 +888,20 @@ mod tests {
         }
     }
 
-    /// A rejection names something the caller can fix, so — unlike an internal
-    /// fault — its message must reach a streaming client, matching what the
-    /// pre-commit path returns for the same error.
+    /// A rejection is reported as a rejection — the caller can tell the fault
+    /// was theirs — but the backend's text never rides along. `InvalidArgument`
+    /// covers engine-raised `ValueError`s too, so the message is not safe to
+    /// forward on a path that cannot inspect where it came from.
     #[tokio::test]
-    async fn test_mid_stream_invalid_argument_forwards_backend_message() {
+    async fn test_mid_stream_invalid_argument_reports_category_without_message() {
         use dynamo_runtime::error::{BackendError, DynamoError, ErrorType as RuntimeErrorType};
 
         let (_metrics, guard, ctx, handle) = setup_test("invalid-arg-model", "req-invalid");
-        let message = "CustomEncoder failed: placeholder tokens (0) != image tensors (1)";
+        let backend_detail = "ValueError: shape mismatch at /opt/dynamo/engine/worker.py:512";
         let stream = typed_error_stream(
             DynamoError::builder()
                 .error_type(RuntimeErrorType::Backend(BackendError::InvalidArgument))
-                .message(message)
+                .message(backend_detail)
                 .build(),
         );
 
@@ -910,9 +909,17 @@ mod tests {
         let body = collect_sse_body(monitored).await;
         let frame = error_frame(&body);
 
-        assert_eq!(frame["message"], message);
+        assert_eq!(frame["message"], "Invalid request");
         assert_eq!(frame["type"], "invalid_request_error");
         assert_eq!(frame["code"], 400);
+        assert!(
+            !body.contains("worker.py"),
+            "leaked backend detail. Body:\n{body}"
+        );
+        assert!(
+            !body.contains("shape mismatch"),
+            "leaked backend detail. Body:\n{body}"
+        );
         assert!(
             body.contains("data: [DONE]"),
             "stream must still terminate. Body:\n{body}"

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -185,17 +185,63 @@ async fn connection_monitor(
 
 type StreamErrorFormatter = fn(&(dyn std::error::Error + 'static)) -> (ErrorType, String);
 
-fn openai_stream_error(_error: &(dyn std::error::Error + 'static)) -> (ErrorType, String) {
-    let error = SanitizedError::Internal;
-    let body = serde_json::json!({
+fn stream_error_frame(message: &str, type_slug: &str, code: u16) -> String {
+    serde_json::json!({
         "error": {
-            "message": error.to_string(),
-            "type": error.openai_type_slug(),
-            "code": error.status().as_u16(),
+            "message": message,
+            "type": type_slug,
+            "code": code,
         }
     })
-    .to_string();
-    (ErrorType::Internal, body)
+    .to_string()
+}
+
+/// Build the inline SSE error frame for a stream that already committed its
+/// HTTP status.
+///
+/// Classification mirrors the pre-commit path in `backend_error_response`: a
+/// request the backend rejected as invalid forwards its message verbatim, and
+/// everything else stays sanitized so internals never reach the caller. The
+/// `code` field is advisory here — the real status went out with the 200 — but
+/// `message` and `type` are what a streaming client actually reads, and
+/// reporting `Internal server error` for every failure made a caller's own bad
+/// request indistinguishable from an engine fault.
+fn openai_stream_error(error: &(dyn std::error::Error + 'static)) -> (ErrorType, String) {
+    use crate::http::service::metrics::{
+        request_was_cancelled, request_was_rejected, request_was_unavailable,
+    };
+    use crate::http::service::openai::find_invalid_argument_in_chain;
+
+    if let Some(invalid_argument) = find_invalid_argument_in_chain(error) {
+        return (
+            ErrorType::Validation,
+            stream_error_frame(
+                invalid_argument.message(),
+                "invalid_request_error",
+                axum::http::StatusCode::BAD_REQUEST.as_u16(),
+            ),
+        );
+    }
+
+    // Same precedence as `ErrorMessage::from_anyhow`.
+    let (sanitized, error_type) = if request_was_rejected(error) {
+        (SanitizedError::Overloaded, ErrorType::Overload)
+    } else if request_was_unavailable(error) {
+        (SanitizedError::Unavailable, ErrorType::Unavailable)
+    } else if request_was_cancelled(error) {
+        (SanitizedError::Cancelled, ErrorType::Cancelled)
+    } else {
+        (SanitizedError::Internal, ErrorType::Internal)
+    };
+
+    (
+        error_type,
+        stream_error_frame(
+            &sanitized.to_string(),
+            sanitized.openai_type_slug(),
+            sanitized.status().as_u16(),
+        ),
+    )
 }
 
 /// This method will consume a stream of SSE events and monitor for disconnects or context cancellation.
@@ -820,5 +866,85 @@ mod tests {
         assert!(!body.contains("site-packages"), "leaked a filesystem path");
         assert!(!body.contains("panicked at"), "leaked panic text");
         assert!(!body.contains("ValueError"), "leaked exception type");
+    }
+
+    /// Pull the structured `{"error": {...}}` frame out of an SSE body.
+    fn error_frame(text: &str) -> serde_json::Value {
+        text.lines()
+            .find_map(|line| {
+                let payload = line.strip_prefix("data: ")?;
+                serde_json::from_str::<serde_json::Value>(payload)
+                    .ok()?
+                    .get("error")
+                    .cloned()
+            })
+            .unwrap_or_else(|| panic!("body missing structured error frame. Body:\n{text}"))
+    }
+
+    fn typed_error_stream(
+        error: dynamo_runtime::error::DynamoError,
+    ) -> impl futures::Stream<Item = Result<Event, axum::Error>> {
+        async_stream::try_stream! {
+            yield Event::default().data("chunk-0");
+            Err(axum::Error::new(error))?;
+        }
+    }
+
+    /// A rejection names something the caller can fix, so — unlike an internal
+    /// fault — its message must reach a streaming client, matching what the
+    /// pre-commit path returns for the same error.
+    #[tokio::test]
+    async fn test_mid_stream_invalid_argument_forwards_backend_message() {
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType as RuntimeErrorType};
+
+        let (_metrics, guard, ctx, handle) = setup_test("invalid-arg-model", "req-invalid");
+        let message = "CustomEncoder failed: placeholder tokens (0) != image tensors (1)";
+        let stream = typed_error_stream(
+            DynamoError::builder()
+                .error_type(RuntimeErrorType::Backend(BackendError::InvalidArgument))
+                .message(message)
+                .build(),
+        );
+
+        let monitored = monitor_for_disconnects_with_timeout(stream, ctx, guard, handle, None);
+        let body = collect_sse_body(monitored).await;
+        let frame = error_frame(&body);
+
+        assert_eq!(frame["message"], message);
+        assert_eq!(frame["type"], "invalid_request_error");
+        assert_eq!(frame["code"], 400);
+        assert!(
+            body.contains("data: [DONE]"),
+            "stream must still terminate. Body:\n{body}"
+        );
+    }
+
+    /// The complement: an untyped backend fault stays sanitized. Forwarding
+    /// messages is gated on the rejection classification, not on the error
+    /// merely being typed.
+    #[tokio::test]
+    async fn test_mid_stream_unknown_backend_error_stays_sanitized() {
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType as RuntimeErrorType};
+
+        let (_metrics, guard, ctx, handle) = setup_test("unknown-model", "req-unknown");
+        let secret = "assertion failed at engine/worker.py:512";
+        let stream = typed_error_stream(
+            DynamoError::builder()
+                .error_type(RuntimeErrorType::Backend(BackendError::Unknown))
+                .message(secret)
+                .build(),
+        );
+
+        let monitored = monitor_for_disconnects_with_timeout(stream, ctx, guard, handle, None);
+        let body = collect_sse_body(monitored).await;
+        let frame = error_frame(&body);
+
+        assert_eq!(frame["message"], "Internal server error");
+        assert_eq!(frame["type"], "internal_server_error");
+        assert_eq!(frame["code"], 500);
+        assert!(
+            !body.contains(secret),
+            "leaked internal detail. Body:\n{body}"
+        );
     }
 }

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -57,6 +57,14 @@ pub(crate) fn invalid_argument(message: impl Into<String>) -> DynamoError {
 /// chain, file path, or panic stack.
 #[derive(Debug, Clone, Copy)]
 pub enum SanitizedError {
+    /// 400 Bad Request, body sanitized.
+    ///
+    /// For paths that must report *that* a request was rejected without
+    /// repeating why. The unary path forwards a backend rejection's message
+    /// verbatim; a streamed frame cannot, because `Backend(InvalidArgument)`
+    /// also covers any Python `ValueError`/`TypeError` an engine raises, whose
+    /// text may be internal.
+    InvalidRequest,
     /// 499 Client Closed Request.
     Cancelled,
     /// 529 Site Is Overloaded.
@@ -100,6 +108,7 @@ impl SanitizedError {
 
     pub fn status(self) -> StatusCode {
         match self {
+            SanitizedError::InvalidRequest => StatusCode::BAD_REQUEST,
             // 499 is not IANA-registered but is widely used (nginx).
             SanitizedError::Cancelled => StatusCode::from_u16(499).unwrap(),
             SanitizedError::Overloaded => overload_status_code(),
@@ -121,6 +130,7 @@ impl SanitizedError {
     /// generic `api_error`.
     pub fn anthropic_type(self) -> &'static str {
         match self {
+            SanitizedError::InvalidRequest => "invalid_request_error",
             SanitizedError::Cancelled => "request_cancelled",
             SanitizedError::Overloaded => "overloaded_error",
             SanitizedError::Unavailable => "overloaded_error",
@@ -135,6 +145,7 @@ impl SanitizedError {
     /// OpenAI-style snake_case `type` field used in inline error frames.
     pub fn openai_type_slug(self) -> &'static str {
         match self {
+            SanitizedError::InvalidRequest => "invalid_request_error",
             SanitizedError::Cancelled => "request_cancelled",
             SanitizedError::Overloaded => "service_unavailable",
             SanitizedError::Unavailable => "service_unavailable",
@@ -157,6 +168,7 @@ impl SanitizedError {
 impl std::fmt::Display for SanitizedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            SanitizedError::InvalidRequest => f.write_str("Invalid request"),
             SanitizedError::Cancelled => f.write_str("Request cancelled"),
             SanitizedError::Overloaded => f.write_str("Service temporarily overloaded"),
             SanitizedError::Unavailable => f.write_str("Service temporarily unavailable"),

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -2056,11 +2056,16 @@ fn annotated_to_sse_event<T: Serialize>(
 
     if let Some(ref msg) = annotated.event {
         if msg == "error" {
-            let error_message = if let Some(ref dynamo_err) = annotated.error
-                && !dynamo_err.message().is_empty()
-            {
-                dynamo_err.message().to_string()
-            } else if let Some(ref comments) = annotated.comment {
+            // Hand the typed error onward when the producer supplied one. The
+            // SSE error formatter classifies on it to pick the status and
+            // decide whether the message may be forwarded; collapsing to a
+            // `String` here erases `error_type` and left every streamed backend
+            // failure — invalid argument, overload, engine fault — looking
+            // identical to the caller.
+            if let Some(dynamo_err) = annotated.error.filter(|err| !err.message().is_empty()) {
+                return Err(axum::Error::new(dynamo_err));
+            }
+            let error_message = if let Some(ref comments) = annotated.comment {
                 let joined = comments.join(" -- ");
                 if joined.trim().is_empty() {
                     "unspecified error".to_string()
@@ -2239,6 +2244,48 @@ async fn handler_metrics(State(state): State<Arc<MetricsHandlerState>>) -> impl 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The SSE error formatter classifies on `error_type`, so the typed error
+    /// has to survive this conversion. Flattening it to its message here is
+    /// what made every streamed backend failure look internal downstream.
+    #[test]
+    fn test_annotated_error_event_preserves_typed_error() {
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType as RuntimeErrorType};
+
+        let annotated = crate::types::Annotated::<serde_json::Value> {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: None,
+            error: Some(
+                DynamoError::builder()
+                    .error_type(RuntimeErrorType::Backend(BackendError::InvalidArgument))
+                    .message("bad image payload")
+                    .build(),
+            ),
+        };
+
+        let err = annotated_to_sse_event(annotated).expect_err("error event must become Err");
+        let found = crate::http::service::openai::find_invalid_argument_in_chain(&err)
+            .expect("typed InvalidArgument must survive into the axum error chain");
+        assert_eq!(found.message(), "bad image payload");
+    }
+
+    /// Without a typed error the comment fallback still applies, untyped.
+    #[test]
+    fn test_annotated_error_event_falls_back_to_comment() {
+        let annotated = crate::types::Annotated::<serde_json::Value> {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: Some(vec!["worker exploded".to_string()]),
+            error: None,
+        };
+
+        let err = annotated_to_sse_event(annotated).expect_err("error event must become Err");
+        assert!(err.to_string().contains("worker exploded"));
+        assert!(crate::http::service::openai::find_invalid_argument_in_chain(&err).is_none());
+    }
 
     #[test]
     fn test_round_to_sig_figs() {


### PR DESCRIPTION
## Overview:

Once a streaming response commits HTTP 200, every backend error reaches the client as the same frame:

```json
{"error":{"message":"Internal server error","type":"internal_server_error","code":500}}
```

regardless of what actually failed. A caller's own invalid request is indistinguishable from an engine fault, an overload, or a cancellation. This recovers the *category* — and only the category.

## Details:

Two layers drop the classification:

1. `annotated_to_sse_event` (`metrics.rs`) wraps only `dynamo_err.message()` — a `String` — into `axum::Error`, discarding the typed `DynamoError` and with it `error_type`.
2. `openai_stream_error` (`disconnect.rs`) has no type left to read, so it hardcodes `SanitizedError::Internal`.

This preserves the `DynamoError` through the SSE conversion and classifies on it, using the same precedence as `ErrorMessage::from_anyhow`:

| error | before | after |
|---|---|---|
| `InvalidArgument` / `Backend(InvalidArgument)` | `Internal server error` / `internal_server_error` / 500 | `Invalid request` / `invalid_request_error` / **400** |
| queue rejection / overload | same generic frame | `Service temporarily overloaded` / `service_unavailable` / 529 |
| unavailable | same generic frame | `Service temporarily unavailable` / `service_unavailable` / 503 |
| cancelled | same generic frame | `Request cancelled` / `request_cancelled` / 499 |
| anything else | generic frame | unchanged |

### Every message stays sanitized — deliberately

An earlier revision of this PR forwarded the rejection's message, reasoning that `openai_stream_error` ignored its argument only because nothing typed reached it. **That was wrong about the history.** 97a28ac3f6 (`fix(http): sanitize HTTP error responses to avoid leaking internals`, #10151) deliberately replaced `err.to_string()` with a static frame and rewrote `assert_fault_contract` to assert the raw detail appears nowhere in the body; #11640 only moved that behaviour into a pluggable formatter. Nothing here reintroduces it.

Forwarding would also be wider than it sounds: `py_err_to_dynamo` (`backend.rs:1654`) maps **any** Python `ValueError`/`TypeError` to `Backend(InvalidArgument)`, so an engine-internal `ValueError` naming a path or tensor shape would ride out to the client. This path cannot distinguish an authored rejection from an incidental one, so it forwards neither.

Hence `SanitizedError::InvalidRequest`: a fixed `("Invalid request", invalid_request_error, 400)` triple. A streaming client learns the fault was its own — the actual gap — with no backend text crossing the boundary.

The unary path still forwards a rejection's message on 400. It can afford to; that is the established protocol contract there and predates this change. The asymmetry is now stated in the code rather than implied.

`code` in the frame is advisory — the real status went out with the 200 and cannot be revised.

## Where should the reviewer start?

`lib/llm/src/http/service/disconnect.rs` — `openai_stream_error` and the doc comment stating why nothing is forwarded. Then `SanitizedError::InvalidRequest` in `error.rs`, and the one substantive line in `annotated_to_sse_event` (`metrics.rs`) that keeps the typed error reachable.

## Validation

- `test_mid_stream_invalid_argument_reports_category_without_message` — a `Backend(InvalidArgument)` fault whose message is `ValueError: shape mismatch at /opt/dynamo/engine/worker.py:512` yields `Invalid request` / `invalid_request_error` / 400, and asserts neither `worker.py` nor `shape mismatch` appears anywhere in the body.
- `test_mid_stream_unknown_backend_error_stays_sanitized` — `Backend(Unknown)` stays `Internal server error` / 500 with its detail absent.
- `test_annotated_error_event_preserves_typed_error` / `..._falls_back_to_comment` — the conversion keeps the typed error; the untyped comment fallback is unchanged.
- `test_mid_stream_error_does_not_leak_internal_details` passes **unmodified** — the guard that this does not widen what reaches a client.
- `cargo test -p dynamo-llm --lib` — 2057 passed, 0 failed. `cargo fmt --all` and `cargo clippy -p dynamo-llm --no-deps --all-targets -- -D warnings` clean.

### Verified end to end

Live frontend + worker over the real request plane (etcd + NATS, no GPU), `stream: true`, no `DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS`:

```
before:  data: {"error":{"message":"Internal server error","type":"internal_server_error","code":500}}
after:   data: {"error":{"message":"Invalid request","type":"invalid_request_error","code":400}}
```

Non-streaming re-checked on the same build and unchanged — still 400 carrying the backend's full message — confirming the pre-commit path is untouched.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)