### PR TITLE
fix(mocker): retain SGLang cache-hit observations [DYN-3700] [cherry-pick #12954]

### DIFF
--- a/lib/mocker/src/live/tests.rs
+++ b/lib/mocker/src/live/tests.rs
@@ -53,6 +53,49 @@ async fn wait_for_idle(engine: &LiveEngine) {
     .expect("live request state should return to idle");
 }
 
+async fn submit_and_finish(engine: &LiveEngine, tokens: Vec<u32>, uuid: Uuid) {
+    let mut request = engine
+        .submit(DirectRequest {
+            tokens,
+            max_output_tokens: 4,
+            uuid: Some(uuid),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while let Some(signal) = request.recv().await {
+            if signal.completed {
+                return;
+            }
+        }
+        panic!("request output closed before completion");
+    })
+    .await
+    .expect("request should complete");
+    wait_for_idle(engine).await;
+}
+
+#[tokio::test]
+async fn sglang_live_metrics_retain_the_last_prefill_cache_observation() {
+    let engine = LiveEngine::start(args(EngineType::Sglang), 0).unwrap();
+    let repeated_prompt = (1..=8).collect::<Vec<_>>();
+
+    submit_and_finish(&engine, repeated_prompt.clone(), Uuid::from_u128(30)).await;
+    submit_and_finish(&engine, repeated_prompt, Uuid::from_u128(31)).await;
+
+    let hit = engine.metrics_receiver().borrow().clone();
+    assert!(hit.sglang_cache_hit_tokens > 0);
+    assert!(hit.sglang_cache_total_tokens >= hit.sglang_cache_hit_tokens);
+
+    submit_and_finish(&engine, (101..=108).collect(), Uuid::from_u128(32)).await;
+
+    let miss = engine.metrics_receiver().borrow().clone();
+    assert_eq!(miss.sglang_cache_hit_tokens, 0);
+    assert!(miss.sglang_cache_total_tokens > 0);
+    engine.shutdown().await.unwrap();
+}
+
 #[tokio::test]
 async fn streams_planned_tokens_to_the_owning_request() {
     for engine_type in [EngineType::Vllm, EngineType::Sglang] {

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -443,8 +443,7 @@ impl LiveEffectsPublisher {
         self.publish_router_effects(self.captured_kv_events.drain(), None);
         self.publish_lifecycle(pending.pass.lifecycle_events).await;
         let metrics = core.pass_boundary_metrics(pending.pass.mocker_metrics);
-        self.record(PublishedEffect::Metrics);
-        let _ = self.metrics_tx.send(metrics);
+        self.publish_metrics(metrics);
         Ok(())
     }
 
@@ -475,6 +474,26 @@ impl LiveEffectsPublisher {
         .await
     }
 
+    fn publish_live_metrics<C: LiveBoundaryCore>(&self, core: &C) {
+        self.publish_metrics(core.live_metrics());
+    }
+
+    fn publish_metrics(&self, mut metrics: MockerMetrics) {
+        self.record(PublishedEffect::Metrics);
+        self.metrics_tx.send_modify(|current| {
+            // NOTE: This is a semantic latch, not optional smoothing. SGLang's cache fields are
+            // per-prefill observations, while `watch` retains only the latest value. DO NOT let a
+            // decode or idle snapshot with no prefill tokens erase a meaningful observation before
+            // consumers can read it. A real miss has a nonzero total and must replace the latch.
+            // This latch is specific to SGLang's aggregate cache observation; do not generalize it.
+            if metrics.sglang_cache_total_tokens == 0 {
+                metrics.sglang_cache_hit_tokens = current.sglang_cache_hit_tokens;
+                metrics.sglang_cache_total_tokens = current.sglang_cache_total_tokens;
+            }
+            *current = metrics;
+        });
+    }
+
     async fn apply_command_inner<C: LiveBoundaryCore>(
         &self,
         core: &mut C,
@@ -500,8 +519,7 @@ impl LiveEffectsPublisher {
                 let _ = reply.send(Ok(effects));
                 if allow_destination_admission {
                     self.publish_lifecycle(lifecycle_events).await;
-                    self.record(PublishedEffect::Metrics);
-                    let _ = self.metrics_tx.send(core.live_metrics());
+                    self.publish_live_metrics(core);
                 }
                 Some(command_result)
             }
@@ -523,8 +541,7 @@ impl LiveEffectsPublisher {
         let made_progress = !lifecycle_events.is_empty() || !kv_events.is_empty();
         self.publish_router_effects(kv_events, None);
         self.publish_lifecycle(lifecycle_events).await;
-        self.record(PublishedEffect::Metrics);
-        let _ = self.metrics_tx.send(core.live_metrics());
+        self.publish_live_metrics(core);
         made_progress
     }
 
@@ -550,8 +567,7 @@ impl LiveEffectsPublisher {
         let made_progress = !kv_events.is_empty() || !effects.lifecycle_events.is_empty();
         self.publish_router_effects(kv_events, None);
         self.publish_lifecycle(effects.lifecycle_events).await;
-        self.record(PublishedEffect::Metrics);
-        let _ = self.metrics_tx.send(core.live_metrics());
+        self.publish_live_metrics(core);
         made_progress
     }
 


### PR DESCRIPTION
## Summary

- Cherry-pick of #12954 to `release/1.4.0`.
- Retain the last meaningful SGLang per-prefill cache-hit observation so decode and idle snapshots cannot erase it before the metrics consumer reads it.
- Preserve genuine cache misses as authoritative observations.

Fixes DYN-3700
Fixes https://nvbugs/6542610

## Original PR

- Main PR: #12954
- Merge commit: `77bc33483f20af6af585ea5f60bffadc8f25b451`

## Validation

- `cargo test -p dynamo-mocker sglang_live_metrics_retain_the_last_prefill_cache_observation -- --nocapture`
- `cargo fmt --manifest-path lib/mocker/Cargo.toml -- --check`
- `cargo clippy --manifest-path lib/mocker/Cargo.toml --no-deps --all-targets -- -D warnings`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->