### PR TITLE
fix(runtime): bound TCP accept failures under file-descriptor pressure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,6 +2943,7 @@ dependencies = [
  "jsonschema",
  "k8s-openapi",
  "kube",
+ "libc",
  "local-ip-address",
  "log",
  "lru 0.16.4",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "humantime",
  "k8s-openapi",
  "kube",
+ "libc",
  "local-ip-address",
  "log",
  "lru",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2611,6 +2611,7 @@ dependencies = [
  "humantime",
  "k8s-openapi",
  "kube",
+ "libc",
  "local-ip-address",
  "log",
  "lru 0.16.4",

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -51,6 +51,7 @@ fastrand = "2"
 futures = { workspace = true }
 fs4 = { workspace = true }
 humantime = { workspace = true }
+libc = { workspace = true }
 parking_lot = { workspace = true }
 prometheus = { workspace = true }
 rand = { workspace = true }

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -819,6 +819,7 @@ dependencies = [
  "humantime",
  "k8s-openapi",
  "kube",
+ "libc",
  "local-ip-address",
  "log",
  "lru",

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -749,6 +749,9 @@ pub mod transport {
         pub const BYTES_RECEIVED_TOTAL: &str = "tcp_bytes_received_total";
         pub const ERRORS_TOTAL: &str = "tcp_errors_total";
         pub const SERVER_QUEUE_DEPTH: &str = "tcp_server_queue_depth";
+        /// Response-server accept failures that triggered a file-descriptor-exhaustion
+        /// backoff sleep; counts per failed accept, not per backoff episode
+        pub const ACCEPT_BACKOFF_TOTAL: &str = "tcp_accept_backoff_total";
     }
     pub mod nats {
         pub const ERRORS_TOTAL: &str = "nats_errors_total";

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -749,7 +749,7 @@ pub mod transport {
         pub const BYTES_RECEIVED_TOTAL: &str = "tcp_bytes_received_total";
         pub const ERRORS_TOTAL: &str = "tcp_errors_total";
         pub const SERVER_QUEUE_DEPTH: &str = "tcp_server_queue_depth";
-        /// Response-server accept failures that triggered a file-descriptor-exhaustion
+        /// Response-server accept failures that triggered a descriptor- or memory-exhaustion
         /// backoff sleep; counts per failed accept, not per backoff episode
         pub const ACCEPT_BACKOFF_TOTAL: &str = "tcp_accept_backoff_total";
     }

--- a/lib/runtime/src/metrics/transport_metrics.rs
+++ b/lib/runtime/src/metrics/transport_metrics.rs
@@ -39,6 +39,19 @@ pub static TCP_ERRORS_TOTAL: Lazy<Counter> = Lazy::new(|| {
     .expect("tcp_errors_total counter")
 });
 
+/// Incremented once per `listener.accept()` failure with `EMFILE`/`ENFILE` — that is,
+/// per failed accept while the process is at its file-descriptor ceiling, not once per
+/// backoff episode. A single episode of exhaustion therefore advances this counter many
+/// times, which is what makes it usable as a rate. Alertable signal for the condition
+/// described in <https://github.com/ai-dynamo/dynamo/issues/11822>.
+pub static TCP_ACCEPT_BACKOFF_TOTAL: Lazy<Counter> = Lazy::new(|| {
+    Counter::new(
+        transport_metric_name(transport::tcp::ACCEPT_BACKOFF_TOTAL),
+        "Total TCP response-server accept failures caused by file-descriptor exhaustion",
+    )
+    .expect("tcp_accept_backoff_total counter")
+});
+
 // --- NATS counters ---
 
 /// `error_type` label values: "request_failed"
@@ -66,6 +79,7 @@ pub fn ensure_transport_metrics_registered_prometheus(
                 registry.register(Box::new(TCP_BYTES_SENT_TOTAL.clone()))?;
                 registry.register(Box::new(TCP_BYTES_RECEIVED_TOTAL.clone()))?;
                 registry.register(Box::new(TCP_ERRORS_TOTAL.clone()))?;
+                registry.register(Box::new(TCP_ACCEPT_BACKOFF_TOTAL.clone()))?;
                 registry.register(Box::new(NATS_ERRORS_TOTAL.clone()))?;
                 Ok(())
             })()

--- a/lib/runtime/src/metrics/transport_metrics.rs
+++ b/lib/runtime/src/metrics/transport_metrics.rs
@@ -39,15 +39,16 @@ pub static TCP_ERRORS_TOTAL: Lazy<Counter> = Lazy::new(|| {
     .expect("tcp_errors_total counter")
 });
 
-/// Incremented once per `listener.accept()` failure with `EMFILE`/`ENFILE` — that is,
-/// per failed accept while the process is at its file-descriptor ceiling, not once per
-/// backoff episode. A single episode of exhaustion therefore advances this counter many
-/// times, which is what makes it usable as a rate. Alertable signal for the condition
-/// described in <https://github.com/ai-dynamo/dynamo/issues/11822>.
+/// Incremented once per `listener.accept()` failure with `EMFILE`, `ENFILE`, `ENOBUFS`, or
+/// `ENOMEM` — that is, per failed accept while the process or kernel is out of file
+/// descriptors or memory, not once per backoff episode. A single episode of exhaustion
+/// therefore advances this counter many times, which is what makes it usable as a rate.
+/// Alertable signal for the condition described in
+/// <https://github.com/ai-dynamo/dynamo/issues/11822>.
 pub static TCP_ACCEPT_BACKOFF_TOTAL: Lazy<Counter> = Lazy::new(|| {
     Counter::new(
         transport_metric_name(transport::tcp::ACCEPT_BACKOFF_TOTAL),
-        "Total TCP response-server accept failures caused by file-descriptor exhaustion",
+        "Total TCP response-server accept failures caused by descriptor or memory exhaustion",
     )
     .expect("tcp_accept_backoff_total counter")
 });

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -752,7 +752,7 @@ async fn handle_accept_error(err: &std::io::Error, backoff: &mut AcceptBackoff) 
     match AcceptBackoff::classify(err) {
         AcceptFailure::Ordinary => {
             // the client should retry, so we don't need to abort
-            tracing::warn!("failed to accept tcp connection: {err}");
+            tracing::warn!(error = %err, "failed to accept tcp connection");
             // Gated like the sibling in `handle_connection`: an unconditional
             // stderr write here doubles the log volume of any accept-error storm.
             #[cfg(debug_assertions)]
@@ -828,7 +828,7 @@ async fn tcp_listener(
                 if let Some(suppressed) = accept_backoff.record_success(std::time::Instant::now) {
                     tracing::warn!(
                         suppressed_failures = suppressed,
-                        "tcp accept recovered from file-descriptor exhaustion"
+                        "tcp accept recovered from resource exhaustion"
                     );
                 }
                 (stream, _addr)
@@ -2498,19 +2498,13 @@ mod tests {
         );
     }
 
-    // ---- accept-loop backoff under file-descriptor exhaustion (issue #11822) ----
+    // ---- accept-loop backoff under resource exhaustion (issue #11822) ----
 
-    /// Synthetic `EMFILE` — what `accept()` returns once the process is at its
-    /// descriptor ceiling. Building it here is what lets these tests prove the
-    /// retry schedule without touching the host's `RLIMIT_NOFILE`.
     #[cfg(unix)]
     fn emfile_error() -> std::io::Error {
         std::io::Error::from_raw_os_error(libc::EMFILE)
     }
 
-    /// All four exhaustion errnos — `EMFILE`, `ENFILE`, `ENOBUFS`, `ENOMEM` —
-    /// must classify as `Exhaustion`. Missing any one sends that error down the
-    /// immediate-retry path, reinstating the busy loop for that failure mode.
     #[cfg(unix)]
     #[test]
     fn accept_backoff_classifies_all_exhaustion_errnos() {
@@ -2522,242 +2516,78 @@ mod tests {
                 "errno {errno} must classify as exhaustion"
             );
         }
-    }
-
-    /// Consecutive exhaustion failures must produce a strictly growing delay
-    /// that saturates at the configured ceiling — never an unbounded delay and,
-    /// critically, never the zero delay that made the loop spin. Reverting to
-    /// the old immediate `continue` yields all-zero delays and fails the first
-    /// assertion.
-    #[cfg(unix)]
-    #[test]
-    fn accept_backoff_delay_grows_and_saturates() {
-        let mut backoff = AcceptBackoff::default();
-        let now = std::time::Instant::now();
-
-        let delays: Vec<Duration> = (0..12)
-            .map(|_| backoff.record_exhaustion(now).delay)
-            .collect();
-
-        assert!(
-            delays[0] > Duration::ZERO,
-            "the first exhaustion failure must introduce a real delay, got {:?}",
-            delays[0]
-        );
-
-        // Growth phase: each delay at least doubles until the ceiling is hit.
-        let saturation_index = delays
-            .iter()
-            .position(|d| *d == ACCEPT_BACKOFF_MAX_DELAY)
-            .expect("delay sequence should reach the ceiling within 12 failures");
-        assert!(
-            saturation_index > 0,
-            "delay should grow before saturating, but saturated immediately"
-        );
-        for pair in delays[..=saturation_index].windows(2) {
-            assert!(
-                pair[1] > pair[0],
-                "delay must strictly grow before saturation: {:?} -> {:?}",
-                pair[0],
-                pair[1]
-            );
-        }
-
-        // Bounded phase: it stays pinned at the ceiling and never exceeds it.
-        for d in &delays[saturation_index..] {
-            assert_eq!(
-                *d, ACCEPT_BACKOFF_MAX_DELAY,
-                "delay must stay pinned at the ceiling once saturated"
-            );
-        }
-        assert!(
-            delays.iter().all(|d| *d <= ACCEPT_BACKOFF_MAX_DELAY),
-            "no delay may exceed the configured maximum"
-        );
-    }
-
-    /// A successful accept ends the episode: the next exhaustion failure starts
-    /// over at the initial delay rather than resuming from the grown one.
-    /// Deleting the reset inside `record_success` makes this fail.
-    #[cfg(unix)]
-    #[test]
-    fn accept_backoff_resets_after_successful_accept() {
-        let mut backoff = AcceptBackoff::default();
-        let now = std::time::Instant::now();
-
-        let first = backoff.record_exhaustion(now).delay;
-        for _ in 0..6 {
-            backoff.record_exhaustion(now);
-        }
-        let grown = backoff.record_exhaustion(now).delay;
-        assert!(
-            grown > first,
-            "precondition: delay should have grown, {grown:?} vs {first:?}"
-        );
-
-        backoff.record_success(|| now);
-
-        let after_recovery = backoff.record_exhaustion(now).delay;
-        assert_eq!(
-            after_recovery, first,
-            "a successful accept must reset the schedule to its initial delay"
-        );
-    }
-
-    /// A flapping listener (success -> `EMFILE` -> success) must not emit an
-    /// unbounded stream of recovery lines, so the recovery notice shares its
-    /// rate-limit window with the failure summary.
-    #[cfg(unix)]
-    #[test]
-    fn accept_backoff_rate_limits_recovery_notice() {
-        let mut backoff = AcceptBackoff::default();
-        let t0 = std::time::Instant::now();
-
-        // The first failure opens the window and emits.
-        assert_eq!(
-            backoff.record_exhaustion(t0).log_suppressed,
-            Some(0),
-            "precondition: the first failure emits and opens the log window"
-        );
-
-        // Two more failures inside the window are suppressed, not emitted.
-        backoff.record_exhaustion(t0);
-        backoff.record_exhaustion(t0);
-
-        // The recovery lands inside that same window, so it must stay silent.
-        assert_eq!(
-            backoff.record_success(|| t0),
-            None,
-            "a recovery inside the log window must not emit"
-        );
-
-        // Flap back into the episode; still inside the window, still silent.
-        backoff.record_exhaustion(t0);
-        assert_eq!(
-            backoff.record_success(|| t0),
-            None,
-            "a flapping listener must not emit a recovery line per accept"
-        );
-
-        // Once the window elapses the recovery does emit -- and carries every
-        // failure suppressed meanwhile, rather than having discarded them.
-        backoff.record_exhaustion(t0);
-        assert_eq!(
-            backoff.record_success(|| t0 + ACCEPT_BACKOFF_LOG_INTERVAL),
-            Some(4),
-            "after the window elapses the recovery emits with the rolled-forward count"
-        );
-
-        // A success outside an episode is silent and leaves the schedule at its
-        // initial delay. That invariant is what lets the steady-state accept
-        // return before reading a clock: there is provably nothing to reset.
-        let t1 = t0 + ACCEPT_BACKOFF_LOG_INTERVAL * 2;
-        assert_eq!(
-            backoff.record_success(|| t1),
-            None,
-            "steady-state accepts must never emit a recovery line"
-        );
-        assert_eq!(
-            backoff.record_exhaustion(t1).delay,
-            ACCEPT_BACKOFF_INITIAL_DELAY,
-            "a success outside an episode must leave the schedule at its initial delay"
-        );
-    }
-
-    /// The summary is rate-limited against a caller-supplied clock: exactly one
-    /// emission per interval, carrying the count of failures suppressed since
-    /// the previous one, and a fresh emission once the interval elapses.
-    /// Removing the rate limit makes every failure emit and fails the count.
-    #[cfg(unix)]
-    #[test]
-    fn accept_backoff_rate_limits_summary_and_reports_suppressed_count() {
-        let mut backoff = AcceptBackoff::default();
-        let t0 = std::time::Instant::now();
-
-        // 50 failures inside one interval: only the first is authorized.
-        let authorized: Vec<Option<u64>> = (0..50)
-            .map(|_| backoff.record_exhaustion(t0).log_suppressed)
-            .collect();
-
-        assert_eq!(
-            authorized.iter().filter(|a| a.is_some()).count(),
-            1,
-            "exactly one summary may be emitted within a single interval"
-        );
-        assert_eq!(
-            authorized[0],
-            Some(0),
-            "the first emission has nothing suppressed behind it yet"
-        );
-
-        // Advance past the interval: the next failure is authorized again and
-        // reports the 49 it swallowed in between.
-        let t1 = t0 + ACCEPT_BACKOFF_LOG_INTERVAL + Duration::from_millis(1);
-        assert_eq!(
-            backoff.record_exhaustion(t1).log_suppressed,
-            Some(49),
-            "the next emission must report every failure suppressed since the last one"
-        );
-
-        // And the counter starts over from that emission.
-        let t2 = t1 + ACCEPT_BACKOFF_LOG_INTERVAL + Duration::from_millis(1);
-        backoff.record_exhaustion(t1);
-        backoff.record_exhaustion(t1);
-        assert_eq!(
-            backoff.record_exhaustion(t2).log_suppressed,
-            Some(2),
-            "the suppressed count must reset after each emission"
-        );
-    }
-
-    /// Negative control: an ordinary accept error keeps the pre-existing
-    /// warn-and-retry-immediately path. It must not be delayed and must not
-    /// perturb an in-progress backoff schedule — otherwise the fix would have
-    /// silently slowed or hidden every unexpected accept failure.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn accept_backoff_leaves_ordinary_errors_undelayed_and_stateless() {
+        // Ordinary errors stay on the immediate-retry path.
         let ordinary = std::io::Error::from(std::io::ErrorKind::ConnectionAborted);
         assert_eq!(
             AcceptBackoff::classify(&ordinary),
             AcceptFailure::Ordinary,
-            "ConnectionAborted is not descriptor exhaustion"
-        );
-
-        let mut backoff = AcceptBackoff::default();
-
-        // Drive the schedule partway up.
-        let now = std::time::Instant::now();
-        backoff.record_exhaustion(now);
-        let next_if_untouched = backoff.record_exhaustion(now).delay;
-        backoff.record_exhaustion(now);
-
-        // An ordinary error in the middle of an episode sleeps for nothing.
-        // `handle_accept_error` returns the duration it actually slept, so that
-        // return value is the whole property; a wall-clock bound on the
-        // surrounding call would only add flakiness, because the measured path
-        // also emits a `tracing::warn!` and, under `debug_assertions`, an
-        // `eprintln!`.
-        let slept = handle_accept_error(&ordinary, &mut backoff).await;
-        assert_eq!(
-            slept,
-            Duration::ZERO,
-            "ordinary accept errors must retry immediately"
-        );
-
-        // ...and leaves the exhaustion schedule exactly where it was: the next
-        // exhaustion failure continues the sequence rather than restarting it.
-        let resumed = backoff.record_exhaustion(now).delay;
-        assert_eq!(
-            resumed,
-            next_if_untouched * 4,
-            "an ordinary error must neither reset nor advance the backoff schedule"
         );
     }
 
-    /// End-to-end: a real listener still accepts a client after an injected
-    /// exhaustion episode (no real `EMFILE` provoked), the loop actually
-    /// slept rather than spun, and the Prometheus counter advanced.
+    #[cfg(unix)]
+    #[test]
+    fn accept_backoff_grows_resets_and_rate_limits() {
+        let mut backoff = AcceptBackoff::default();
+        let now = std::time::Instant::now();
+
+        // Delay doubles per consecutive failure and saturates at the ceiling.
+        let delays: Vec<Duration> = (0..12)
+            .map(|_| backoff.record_exhaustion(now).delay)
+            .collect();
+        assert!(delays[0] > Duration::ZERO);
+        let sat = delays
+            .iter()
+            .position(|d| *d == ACCEPT_BACKOFF_MAX_DELAY)
+            .expect("delay reaches the ceiling");
+        for pair in delays[..=sat].windows(2) {
+            assert!(pair[1] > pair[0], "delay must grow: {:?} -> {:?}", pair[0], pair[1]);
+        }
+        assert!(delays[sat..].iter().all(|d| *d == ACCEPT_BACKOFF_MAX_DELAY));
+
+        // A successful accept resets the schedule to the initial delay.
+        backoff.record_success(|| now);
+        assert_eq!(
+            backoff.record_exhaustion(now).delay,
+            ACCEPT_BACKOFF_INITIAL_DELAY,
+        );
+
+        // The summary is rate-limited: one emission per interval, carrying the
+        // count of failures suppressed since the previous one.
+        let t0 = std::time::Instant::now();
+        let mut backoff = AcceptBackoff::default();
+        let emitted: Vec<Option<u64>> = (0..50)
+            .map(|_| backoff.record_exhaustion(t0).log_suppressed)
+            .collect();
+        assert_eq!(emitted.iter().filter(|e| e.is_some()).count(), 1);
+        assert_eq!(emitted[0], Some(0));
+
+        let t1 = t0 + ACCEPT_BACKOFF_LOG_INTERVAL + Duration::from_millis(1);
+        assert_eq!(
+            backoff.record_exhaustion(t1).log_suppressed,
+            Some(49),
+            "next emission reports every failure suppressed since the last one",
+        );
+
+        // Recovery shares the rate-limit window with the failure summary, so a
+        // flapping listener cannot emit a recovery line per accept.
+        let mut backoff = AcceptBackoff::default();
+        let t0 = std::time::Instant::now();
+        assert_eq!(backoff.record_exhaustion(t0).log_suppressed, Some(0));
+        backoff.record_exhaustion(t0);
+        backoff.record_exhaustion(t0);
+        assert_eq!(
+            backoff.record_success(|| t0),
+            None,
+            "recovery inside the log window must not emit",
+        );
+        backoff.record_exhaustion(t0);
+        assert_eq!(
+            backoff.record_success(|| t0 + ACCEPT_BACKOFF_LOG_INTERVAL),
+            Some(4),
+            "after the window elapses the recovery emits with the rolled-forward count",
+        );
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn accept_backoff_socket_recovers_after_injected_exhaustion() {
@@ -2771,29 +2601,19 @@ mod tests {
         let mut backoff = AcceptBackoff::default();
         let counter_before = TCP_ACCEPT_BACKOFF_TOTAL.get();
 
-        // Three injected exhaustion failures, exactly as the loop would handle
-        // them. The elapsed wall time proves the loop yielded instead of
-        // spinning: with the sleep removed this collapses to ~0.
         let started = std::time::Instant::now();
         let mut expected_total = Duration::ZERO;
         for _ in 0..3 {
             expected_total += handle_accept_error(&emfile_error(), &mut backoff).await;
         }
-        assert!(
-            expected_total >= ACCEPT_BACKOFF_INITIAL_DELAY * 3,
-            "three exhaustion failures should have requested a growing delay, got {expected_total:?}"
-        );
+        assert!(expected_total >= ACCEPT_BACKOFF_INITIAL_DELAY * 3);
         assert!(
             started.elapsed() >= expected_total,
-            "the accept loop must actually sleep for the requested delay, spun for {:?}",
-            started.elapsed()
+            "the accept loop must sleep, not spin; elapsed {:?}",
+            started.elapsed(),
         );
-        assert!(
-            TCP_ACCEPT_BACKOFF_TOTAL.get() >= counter_before + 3.0,
-            "each exhaustion failure must advance the backoff counter"
-        );
+        assert!(TCP_ACCEPT_BACKOFF_TOTAL.get() >= counter_before + 3.0);
 
-        // The listener survived the episode: a real client still connects.
         let client = tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await });
         let (accepted, _peer) = tokio::time::timeout(Duration::from_secs(5), listener.accept())
             .await
@@ -2802,12 +2622,10 @@ mod tests {
         let _client = client.await.expect("client task").expect("client connect");
         drop(accepted);
 
-        // Recovery resets the schedule, as the loop's Ok(..) arm does.
         backoff.record_success(std::time::Instant::now);
         assert_eq!(
             backoff.record_exhaustion(std::time::Instant::now()).delay,
             ACCEPT_BACKOFF_INITIAL_DELAY,
-            "after a real accept the schedule must be back at its initial delay"
         );
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -2585,7 +2585,7 @@ mod tests {
         backoff.record_exhaustion(t0);
         assert_eq!(
             backoff.record_success(|| t0 + ACCEPT_BACKOFF_LOG_INTERVAL),
-            Some(4),
+            Some(3),
             "after the window elapses the recovery emits with the rolled-forward count",
         );
     }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -598,8 +598,7 @@ impl ResponseService for TcpStreamServer {
     }
 }
 
-/// First retry delay applied after a descriptor- or memory-exhaustion accept
-/// failure (`EMFILE`, `ENFILE`, `ENOBUFS`, `ENOMEM`).
+/// First retry delay applied after an `AcceptFailure::Exhaustion`.
 const ACCEPT_BACKOFF_INITIAL_DELAY: Duration = Duration::from_millis(5);
 /// Ceiling the retry delay saturates at, so the listener keeps polling often
 /// enough to notice recovery while no longer spinning.
@@ -611,8 +610,8 @@ const ACCEPT_BACKOFF_LOG_INTERVAL: Duration = Duration::from_secs(5);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AcceptFailure {
     /// The process or the host is out of file descriptors or kernel memory
-    /// (`EMFILE`, `ENFILE`, `ENOBUFS`, `ENOMEM`). Retrying immediately cannot
-    /// succeed, so the loop must back off.
+    /// — see `AcceptBackoff::classify` for the exact errno set. Retrying
+    /// immediately cannot succeed, so the loop must back off.
     Exhaustion,
     /// Anything else — a per-connection error that the client is expected to
     /// retry. Keeps the historical warn-and-retry-immediately behavior.
@@ -641,13 +640,12 @@ struct AcceptBackoff {
     initial_delay: Duration,
     max_delay: Duration,
     log_interval: Duration,
-    /// Delay the *next* exhaustion failure will be told to sleep.
     current_delay: Duration,
-    /// Failures observed since the last emitted summary.
     suppressed: u64,
-    /// When the last summary was emitted, in the caller's clock.
     last_log_at: Option<std::time::Instant>,
-    /// Whether the loop is currently inside an exhaustion episode.
+    /// Whether the loop is currently inside an exhaustion episode — the flag
+    /// `record_success` checks to tell a real recovery from an ordinary
+    /// steady-state accept.
     in_backoff: bool,
 }
 
@@ -672,14 +670,11 @@ impl AcceptBackoff {
     fn classify(err: &std::io::Error) -> AcceptFailure {
         #[cfg(unix)]
         {
-            // `std::io::ErrorKind` has no stable variant for any of these
-            // errnos, so the raw value is the portable-with-cfg way to
-            // recognize them.
-            //
-            // `EMFILE`/`ENFILE`: the process or host is out of file descriptors.
-            // `ENOBUFS`/`ENOMEM`: the kernel is out of network buffers or
-            // memory for the socket. All four make an immediate retry
-            // deterministic, so they get the backoff path.
+            // `std::io::ErrorKind` has no stable variant for these errnos, so
+            // the raw value is the portable-with-cfg way to recognize them.
+            // `EMFILE`/`ENFILE` are descriptor exhaustion; `ENOBUFS`/`ENOMEM`
+            // are kernel out-of-memory for the socket. All four make an
+            // immediate retry deterministic, so they get the backoff path.
             if matches!(
                 err.raw_os_error(),
                 Some(libc::EMFILE) | Some(libc::ENFILE) | Some(libc::ENOBUFS) | Some(libc::ENOMEM)
@@ -722,24 +717,16 @@ impl AcceptBackoff {
         }
     }
 
-    /// Record a successful accept. Returns `Some(suppressed)` when this success
-    /// ended an exhaustion episode *and* the shared log-rate window allows a
-    /// line, so a listener flapping at the descriptor ceiling cannot emit an
-    /// unbounded stream of recovery warnings; `None` during ordinary
-    /// steady-state accepts, or when the window has not yet elapsed. The
-    /// schedule is reset either way. A suppressed recovery keeps its count
-    /// rather than discarding it, so the next emitted summary — on either
-    /// path — still accounts for every failure observed.
-    ///
-    /// The clock arrives as a closure rather than an `Instant` so that the
-    /// steady-state accept — every ordinary connection, and this listener opens
-    /// one per request — takes the early return below without reading a clock
-    /// at all.
+    /// Record a successful accept. `Some(suppressed)` only when this success
+    /// both ended an exhaustion episode and the shared log-rate window allows
+    /// a line — so a listener flapping at the descriptor ceiling cannot emit
+    /// an unbounded stream of recovery lines, and a suppressed recovery keeps
+    /// its count for the next emission rather than discarding it. The clock
+    /// arrives as a closure, not an `Instant`, so the steady-state accept
+    /// (every ordinary connection) hits the early return below without
+    /// reading a clock at all.
     fn record_success(&mut self, now: impl FnOnce() -> std::time::Instant) -> Option<u64> {
         if !self.in_backoff {
-            // Outside an episode `current_delay` already equals `initial_delay`,
-            // because the `record_success` that closed the previous episode set
-            // it. There is nothing to reset and nothing to log.
             return None;
         }
         self.current_delay = self.initial_delay;
@@ -2617,13 +2604,9 @@ mod tests {
         );
     }
 
-    /// Regression guard for the recovery notice. A listener flapping at the
-    /// descriptor ceiling alternates success -> `EMFILE` -> success, so every
-    /// accepted connection ends an episode. If the recovery line were not held
-    /// to the same window as the failure summary, that alternation would emit
-    /// an unbounded stream of `warn!`s -- reinstating the exact log storm this
-    /// policy exists to bound. Deleting the window check inside `record_success`
-    /// makes the third assertion fail.
+    /// A flapping listener (success -> `EMFILE` -> success) must not emit an
+    /// unbounded stream of recovery lines, so the recovery notice shares its
+    /// rate-limit window with the failure summary.
     #[cfg(unix)]
     #[test]
     fn accept_backoff_rate_limits_recovery_notice() {
@@ -2772,12 +2755,9 @@ mod tests {
         );
     }
 
-    /// Deterministic socket recovery: a real listener that has just been through
-    /// an injected exhaustion episode still accepts a real client connection,
-    /// and the policy is back at its initial delay afterwards. Proves recovery
-    /// end-to-end without manipulating the host's descriptor limit — no real
-    /// `EMFILE` is ever provoked. Also asserts the loop actually sleeps (the
-    /// anti-spin property) and that the Prometheus counter advances.
+    /// End-to-end: a real listener still accepts a client after an injected
+    /// exhaustion episode (no real `EMFILE` provoked), the loop actually
+    /// slept rather than spun, and the Prometheus counter advanced.
     #[cfg(unix)]
     #[tokio::test]
     async fn accept_backoff_socket_recovers_after_injected_exhaustion() {

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -598,6 +598,186 @@ impl ResponseService for TcpStreamServer {
     }
 }
 
+/// First retry delay applied after an `EMFILE`/`ENFILE` accept failure.
+const ACCEPT_BACKOFF_INITIAL_DELAY: Duration = Duration::from_millis(5);
+/// Ceiling the retry delay saturates at, so the listener keeps polling often
+/// enough to notice recovery while no longer spinning.
+const ACCEPT_BACKOFF_MAX_DELAY: Duration = Duration::from_secs(1);
+/// Minimum wall-clock interval between two emitted exhaustion summaries.
+const ACCEPT_BACKOFF_LOG_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How the listener loop must treat a failed `accept()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AcceptFailure {
+    /// The process or the host is out of file descriptors (`EMFILE`/`ENFILE`).
+    /// Retrying immediately cannot succeed, so the loop must back off.
+    Exhaustion,
+    /// Anything else — a per-connection error that the client is expected to
+    /// retry. Keeps the historical warn-and-retry-immediately behavior.
+    Ordinary,
+}
+
+/// What the caller should do about one exhaustion failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AcceptBackoffAction {
+    /// How long to sleep before calling `accept()` again.
+    delay: Duration,
+    /// `Some(n)` when the caller should emit one summary line, where `n` is the
+    /// number of failures suppressed since the previous emission. `None` means
+    /// this failure is inside the current rate-limit window and must stay silent.
+    log_suppressed: Option<u64>,
+}
+
+/// Bounded exponential retry policy for the accept loop, kept deliberately pure:
+/// it reads no clock, performs no I/O and never sleeps. The caller supplies the
+/// current `Instant` and performs the sleep, which is what lets the retry
+/// schedule and the log-rate decision be unit-tested without reproducing the
+/// host's file-descriptor limit. Vocabulary mirrors `transports::etcd::connector`'s
+/// `BackoffState`.
+#[derive(Debug)]
+struct AcceptBackoff {
+    initial_delay: Duration,
+    max_delay: Duration,
+    log_interval: Duration,
+    /// Delay the *next* exhaustion failure will be told to sleep.
+    current_delay: Duration,
+    /// Failures observed since the last emitted summary.
+    suppressed: u64,
+    /// When the last summary was emitted, in the caller's clock.
+    last_log_at: Option<std::time::Instant>,
+    /// Whether the loop is currently inside an exhaustion episode.
+    in_backoff: bool,
+}
+
+impl Default for AcceptBackoff {
+    fn default() -> Self {
+        Self {
+            initial_delay: ACCEPT_BACKOFF_INITIAL_DELAY,
+            max_delay: ACCEPT_BACKOFF_MAX_DELAY,
+            log_interval: ACCEPT_BACKOFF_LOG_INTERVAL,
+            current_delay: ACCEPT_BACKOFF_INITIAL_DELAY,
+            suppressed: 0,
+            last_log_at: None,
+            in_backoff: false,
+        }
+    }
+}
+
+impl AcceptBackoff {
+    /// Classify an `accept()` error. Only file-descriptor exhaustion gets the
+    /// backoff treatment; everything else stays on the pre-existing path so
+    /// genuinely unexpected failures are not hidden or slowed down.
+    fn classify(err: &std::io::Error) -> AcceptFailure {
+        #[cfg(unix)]
+        {
+            // `std::io::ErrorKind` has no stable variant for either errno, so the
+            // raw value is the portable-with-cfg way to recognize them.
+            if matches!(err.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE)) {
+                return AcceptFailure::Exhaustion;
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = err;
+        }
+        AcceptFailure::Ordinary
+    }
+
+    /// Record one exhaustion failure and return the delay to sleep plus the
+    /// rate-limited logging decision. The delay doubles per consecutive failure
+    /// and saturates at `max_delay`.
+    fn record_exhaustion(&mut self, now: std::time::Instant) -> AcceptBackoffAction {
+        self.in_backoff = true;
+
+        let delay = self.current_delay;
+        self.current_delay = self.current_delay.saturating_mul(2).min(self.max_delay);
+
+        let due = match self.last_log_at {
+            None => true,
+            Some(prev) => now.saturating_duration_since(prev) >= self.log_interval,
+        };
+
+        let log_suppressed = if due {
+            self.last_log_at = Some(now);
+            Some(std::mem::take(&mut self.suppressed))
+        } else {
+            self.suppressed += 1;
+            None
+        };
+
+        AcceptBackoffAction {
+            delay,
+            log_suppressed,
+        }
+    }
+
+    /// Record a successful accept. Returns `Some(suppressed)` when this success
+    /// ended an exhaustion episode *and* the shared log-rate window allows a
+    /// line, so a listener flapping at the descriptor ceiling cannot emit an
+    /// unbounded stream of recovery warnings; `None` during ordinary
+    /// steady-state accepts, or when the window has not yet elapsed. The
+    /// schedule is reset either way. A suppressed recovery keeps its count
+    /// rather than discarding it, so the next emitted summary — on either
+    /// path — still accounts for every failure observed.
+    ///
+    /// The clock arrives as a closure rather than an `Instant` so that the
+    /// steady-state accept — every ordinary connection, and this listener opens
+    /// one per request — takes the early return below without reading a clock
+    /// at all.
+    fn record_success(&mut self, now: impl FnOnce() -> std::time::Instant) -> Option<u64> {
+        if !self.in_backoff {
+            // Outside an episode `current_delay` already equals `initial_delay`,
+            // because the `record_success` that closed the previous episode set
+            // it. There is nothing to reset and nothing to log.
+            return None;
+        }
+        self.current_delay = self.initial_delay;
+        self.in_backoff = false;
+        let now = now();
+
+        let due = match self.last_log_at {
+            None => true,
+            Some(prev) => now.saturating_duration_since(prev) >= self.log_interval,
+        };
+        if !due {
+            return None;
+        }
+        self.last_log_at = Some(now);
+        Some(std::mem::take(&mut self.suppressed))
+    }
+}
+
+/// Apply the accept-loop error policy to one failed `accept()`. Returns the
+/// delay that was actually slept — `Duration::ZERO` for ordinary errors, which
+/// keep the historical immediate-retry behavior.
+async fn handle_accept_error(err: &std::io::Error, backoff: &mut AcceptBackoff) -> Duration {
+    match AcceptBackoff::classify(err) {
+        AcceptFailure::Ordinary => {
+            // the client should retry, so we don't need to abort
+            tracing::warn!("failed to accept tcp connection: {err}");
+            // Gated like the sibling in `handle_connection`: an unconditional
+            // stderr write here doubles the log volume of any accept-error storm.
+            #[cfg(debug_assertions)]
+            eprintln!("failed to accept tcp connection: {}", err);
+            Duration::ZERO
+        }
+        AcceptFailure::Exhaustion => {
+            crate::metrics::transport_metrics::TCP_ACCEPT_BACKOFF_TOTAL.inc();
+            let action = backoff.record_exhaustion(std::time::Instant::now());
+            if let Some(suppressed) = action.log_suppressed {
+                tracing::warn!(
+                    error = %err,
+                    retry_delay_ms = action.delay.as_millis() as u64,
+                    suppressed_failures = suppressed,
+                    "tcp accept failed: out of file descriptors; backing off before retry"
+                );
+            }
+            time::sleep(action.delay).await;
+            action.delay
+        }
+    }
+}
+
 // Type aliases for boxed split halves used throughout the nested handlers below.
 type BoxRead = Box<dyn tokio::io::AsyncRead + Unpin + Send>;
 type BoxWrite = Box<dyn tokio::io::AsyncWrite + Unpin + Send>;
@@ -637,6 +817,8 @@ async fn tcp_listener(
         }
     };
 
+    let mut accept_backoff = AcceptBackoff::default();
+
     loop {
         // todo - add instrumentation
         // todo - add counter for all accepted connections
@@ -644,11 +826,17 @@ async fn tcp_listener(
         // todo - add counter for incoming bytes
         // todo - add counter for outgoing bytes
         let (stream, _addr) = match listener.accept().await {
-            Ok((stream, _addr)) => (stream, _addr),
+            Ok((stream, _addr)) => {
+                if let Some(suppressed) = accept_backoff.record_success(std::time::Instant::now) {
+                    tracing::warn!(
+                        suppressed_failures = suppressed,
+                        "tcp accept recovered from file-descriptor exhaustion"
+                    );
+                }
+                (stream, _addr)
+            }
             Err(e) => {
-                // the client should retry, so we don't need to abort
-                tracing::warn!("failed to accept tcp connection: {e}");
-                eprintln!("failed to accept tcp connection: {}", e);
+                handle_accept_error(&e, &mut accept_backoff).await;
                 continue;
             }
         };
@@ -2309,6 +2497,310 @@ mod tests {
         assert!(
             matches!(ctrl, ControlMessage::Stop),
             "context.stop() should emit Stop, got {ctrl:?}"
+        );
+    }
+
+    // ---- accept-loop backoff under file-descriptor exhaustion (issue #11822) ----
+
+    /// Synthetic `EMFILE` — what `accept()` returns once the process is at its
+    /// descriptor ceiling. Building it here is what lets these tests prove the
+    /// retry schedule without touching the host's `RLIMIT_NOFILE`.
+    #[cfg(unix)]
+    fn emfile_error() -> std::io::Error {
+        std::io::Error::from_raw_os_error(libc::EMFILE)
+    }
+
+    /// Consecutive exhaustion failures must produce a strictly growing delay
+    /// that saturates at the configured ceiling — never an unbounded delay and,
+    /// critically, never the zero delay that made the loop spin. Reverting to
+    /// the old immediate `continue` yields all-zero delays and fails the first
+    /// assertion.
+    #[cfg(unix)]
+    #[test]
+    fn accept_backoff_delay_grows_and_saturates() {
+        let mut backoff = AcceptBackoff::default();
+        let now = std::time::Instant::now();
+
+        let delays: Vec<Duration> = (0..12)
+            .map(|_| backoff.record_exhaustion(now).delay)
+            .collect();
+
+        assert!(
+            delays[0] > Duration::ZERO,
+            "the first exhaustion failure must introduce a real delay, got {:?}",
+            delays[0]
+        );
+
+        // Growth phase: each delay at least doubles until the ceiling is hit.
+        let saturation_index = delays
+            .iter()
+            .position(|d| *d == ACCEPT_BACKOFF_MAX_DELAY)
+            .expect("delay sequence should reach the ceiling within 12 failures");
+        assert!(
+            saturation_index > 0,
+            "delay should grow before saturating, but saturated immediately"
+        );
+        for pair in delays[..=saturation_index].windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "delay must strictly grow before saturation: {:?} -> {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
+
+        // Bounded phase: it stays pinned at the ceiling and never exceeds it.
+        for d in &delays[saturation_index..] {
+            assert_eq!(
+                *d, ACCEPT_BACKOFF_MAX_DELAY,
+                "delay must stay pinned at the ceiling once saturated"
+            );
+        }
+        assert!(
+            delays.iter().all(|d| *d <= ACCEPT_BACKOFF_MAX_DELAY),
+            "no delay may exceed the configured maximum"
+        );
+    }
+
+    /// A successful accept ends the episode: the next exhaustion failure starts
+    /// over at the initial delay rather than resuming from the grown one.
+    /// Deleting the reset inside `record_success` makes this fail.
+    #[cfg(unix)]
+    #[test]
+    fn accept_backoff_resets_after_successful_accept() {
+        let mut backoff = AcceptBackoff::default();
+        let now = std::time::Instant::now();
+
+        let first = backoff.record_exhaustion(now).delay;
+        for _ in 0..6 {
+            backoff.record_exhaustion(now);
+        }
+        let grown = backoff.record_exhaustion(now).delay;
+        assert!(
+            grown > first,
+            "precondition: delay should have grown, {grown:?} vs {first:?}"
+        );
+
+        backoff.record_success(|| now);
+
+        let after_recovery = backoff.record_exhaustion(now).delay;
+        assert_eq!(
+            after_recovery, first,
+            "a successful accept must reset the schedule to its initial delay"
+        );
+    }
+
+    /// Regression guard for the recovery notice. A listener flapping at the
+    /// descriptor ceiling alternates success -> `EMFILE` -> success, so every
+    /// accepted connection ends an episode. If the recovery line were not held
+    /// to the same window as the failure summary, that alternation would emit
+    /// an unbounded stream of `warn!`s -- reinstating the exact log storm this
+    /// policy exists to bound. Deleting the window check inside `record_success`
+    /// makes the third assertion fail.
+    #[cfg(unix)]
+    #[test]
+    fn accept_backoff_rate_limits_recovery_notice() {
+        let mut backoff = AcceptBackoff::default();
+        let t0 = std::time::Instant::now();
+
+        // The first failure opens the window and emits.
+        assert_eq!(
+            backoff.record_exhaustion(t0).log_suppressed,
+            Some(0),
+            "precondition: the first failure emits and opens the log window"
+        );
+
+        // Two more failures inside the window are suppressed, not emitted.
+        backoff.record_exhaustion(t0);
+        backoff.record_exhaustion(t0);
+
+        // The recovery lands inside that same window, so it must stay silent.
+        assert_eq!(
+            backoff.record_success(|| t0),
+            None,
+            "a recovery inside the log window must not emit"
+        );
+
+        // Flap back into the episode; still inside the window, still silent.
+        backoff.record_exhaustion(t0);
+        assert_eq!(
+            backoff.record_success(|| t0),
+            None,
+            "a flapping listener must not emit a recovery line per accept"
+        );
+
+        // Once the window elapses the recovery does emit -- and carries every
+        // failure suppressed meanwhile, rather than having discarded them.
+        backoff.record_exhaustion(t0);
+        assert_eq!(
+            backoff.record_success(|| t0 + ACCEPT_BACKOFF_LOG_INTERVAL),
+            Some(4),
+            "after the window elapses the recovery emits with the rolled-forward count"
+        );
+
+        // A success outside an episode is silent and leaves the schedule at its
+        // initial delay. That invariant is what lets the steady-state accept
+        // return before reading a clock: there is provably nothing to reset.
+        let t1 = t0 + ACCEPT_BACKOFF_LOG_INTERVAL * 2;
+        assert_eq!(
+            backoff.record_success(|| t1),
+            None,
+            "steady-state accepts must never emit a recovery line"
+        );
+        assert_eq!(
+            backoff.record_exhaustion(t1).delay,
+            ACCEPT_BACKOFF_INITIAL_DELAY,
+            "a success outside an episode must leave the schedule at its initial delay"
+        );
+    }
+
+    /// The summary is rate-limited against a caller-supplied clock: exactly one
+    /// emission per interval, carrying the count of failures suppressed since
+    /// the previous one, and a fresh emission once the interval elapses.
+    /// Removing the rate limit makes every failure emit and fails the count.
+    #[cfg(unix)]
+    #[test]
+    fn accept_backoff_rate_limits_summary_and_reports_suppressed_count() {
+        let mut backoff = AcceptBackoff::default();
+        let t0 = std::time::Instant::now();
+
+        // 50 failures inside one interval: only the first is authorized.
+        let authorized: Vec<Option<u64>> = (0..50)
+            .map(|_| backoff.record_exhaustion(t0).log_suppressed)
+            .collect();
+
+        assert_eq!(
+            authorized.iter().filter(|a| a.is_some()).count(),
+            1,
+            "exactly one summary may be emitted within a single interval"
+        );
+        assert_eq!(
+            authorized[0],
+            Some(0),
+            "the first emission has nothing suppressed behind it yet"
+        );
+
+        // Advance past the interval: the next failure is authorized again and
+        // reports the 49 it swallowed in between.
+        let t1 = t0 + ACCEPT_BACKOFF_LOG_INTERVAL + Duration::from_millis(1);
+        assert_eq!(
+            backoff.record_exhaustion(t1).log_suppressed,
+            Some(49),
+            "the next emission must report every failure suppressed since the last one"
+        );
+
+        // And the counter starts over from that emission.
+        let t2 = t1 + ACCEPT_BACKOFF_LOG_INTERVAL + Duration::from_millis(1);
+        backoff.record_exhaustion(t1);
+        backoff.record_exhaustion(t1);
+        assert_eq!(
+            backoff.record_exhaustion(t2).log_suppressed,
+            Some(2),
+            "the suppressed count must reset after each emission"
+        );
+    }
+
+    /// Negative control: an ordinary accept error keeps the pre-existing
+    /// warn-and-retry-immediately path. It must not be delayed and must not
+    /// perturb an in-progress backoff schedule — otherwise the fix would have
+    /// silently slowed or hidden every unexpected accept failure.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn accept_backoff_leaves_ordinary_errors_undelayed_and_stateless() {
+        let ordinary = std::io::Error::from(std::io::ErrorKind::ConnectionAborted);
+        assert_eq!(
+            AcceptBackoff::classify(&ordinary),
+            AcceptFailure::Ordinary,
+            "ConnectionAborted is not descriptor exhaustion"
+        );
+
+        let mut backoff = AcceptBackoff::default();
+
+        // Drive the schedule partway up.
+        let now = std::time::Instant::now();
+        backoff.record_exhaustion(now);
+        let next_if_untouched = backoff.record_exhaustion(now).delay;
+        backoff.record_exhaustion(now);
+
+        // An ordinary error in the middle of an episode sleeps for nothing.
+        // `handle_accept_error` returns the duration it actually slept, so that
+        // return value is the whole property; a wall-clock bound on the
+        // surrounding call would only add flakiness, because the measured path
+        // also emits a `tracing::warn!` and, under `debug_assertions`, an
+        // `eprintln!`.
+        let slept = handle_accept_error(&ordinary, &mut backoff).await;
+        assert_eq!(
+            slept,
+            Duration::ZERO,
+            "ordinary accept errors must retry immediately"
+        );
+
+        // ...and leaves the exhaustion schedule exactly where it was: the next
+        // exhaustion failure continues the sequence rather than restarting it.
+        let resumed = backoff.record_exhaustion(now).delay;
+        assert_eq!(
+            resumed,
+            next_if_untouched * 4,
+            "an ordinary error must neither reset nor advance the backoff schedule"
+        );
+    }
+
+    /// Deterministic socket recovery: a real listener that has just been through
+    /// an injected exhaustion episode still accepts a real client connection,
+    /// and the policy is back at its initial delay afterwards. Proves recovery
+    /// end-to-end without manipulating the host's descriptor limit — no real
+    /// `EMFILE` is ever provoked. Also asserts the loop actually sleeps (the
+    /// anti-spin property) and that the Prometheus counter advances.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn accept_backoff_socket_recovers_after_injected_exhaustion() {
+        use crate::metrics::transport_metrics::TCP_ACCEPT_BACKOFF_TOTAL;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral listener");
+        let addr = listener.local_addr().expect("local_addr");
+
+        let mut backoff = AcceptBackoff::default();
+        let counter_before = TCP_ACCEPT_BACKOFF_TOTAL.get();
+
+        // Three injected exhaustion failures, exactly as the loop would handle
+        // them. The elapsed wall time proves the loop yielded instead of
+        // spinning: with the sleep removed this collapses to ~0.
+        let started = std::time::Instant::now();
+        let mut expected_total = Duration::ZERO;
+        for _ in 0..3 {
+            expected_total += handle_accept_error(&emfile_error(), &mut backoff).await;
+        }
+        assert!(
+            expected_total >= ACCEPT_BACKOFF_INITIAL_DELAY * 3,
+            "three exhaustion failures should have requested a growing delay, got {expected_total:?}"
+        );
+        assert!(
+            started.elapsed() >= expected_total,
+            "the accept loop must actually sleep for the requested delay, spun for {:?}",
+            started.elapsed()
+        );
+        assert!(
+            TCP_ACCEPT_BACKOFF_TOTAL.get() >= counter_before + 3.0,
+            "each exhaustion failure must advance the backoff counter"
+        );
+
+        // The listener survived the episode: a real client still connects.
+        let client = tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await });
+        let (accepted, _peer) = tokio::time::timeout(Duration::from_secs(5), listener.accept())
+            .await
+            .expect("listener should still accept after backing off")
+            .expect("accept should succeed");
+        let _client = client.await.expect("client task").expect("client connect");
+        drop(accepted);
+
+        // Recovery resets the schedule, as the loop's Ok(..) arm does.
+        backoff.record_success(std::time::Instant::now);
+        assert_eq!(
+            backoff.record_exhaustion(std::time::Instant::now()).delay,
+            ACCEPT_BACKOFF_INITIAL_DELAY,
+            "after a real accept the schedule must be back at its initial delay"
         );
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -2518,10 +2518,7 @@ mod tests {
         }
         // Ordinary errors stay on the immediate-retry path.
         let ordinary = std::io::Error::from(std::io::ErrorKind::ConnectionAborted);
-        assert_eq!(
-            AcceptBackoff::classify(&ordinary),
-            AcceptFailure::Ordinary,
-        );
+        assert_eq!(AcceptBackoff::classify(&ordinary), AcceptFailure::Ordinary,);
     }
 
     #[cfg(unix)]
@@ -2540,7 +2537,12 @@ mod tests {
             .position(|d| *d == ACCEPT_BACKOFF_MAX_DELAY)
             .expect("delay reaches the ceiling");
         for pair in delays[..=sat].windows(2) {
-            assert!(pair[1] > pair[0], "delay must grow: {:?} -> {:?}", pair[0], pair[1]);
+            assert!(
+                pair[1] > pair[0],
+                "delay must grow: {:?} -> {:?}",
+                pair[0],
+                pair[1]
+            );
         }
         assert!(delays[sat..].iter().all(|d| *d == ACCEPT_BACKOFF_MAX_DELAY));
 

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -598,7 +598,8 @@ impl ResponseService for TcpStreamServer {
     }
 }
 
-/// First retry delay applied after an `EMFILE`/`ENFILE` accept failure.
+/// First retry delay applied after a descriptor- or memory-exhaustion accept
+/// failure (`EMFILE`, `ENFILE`, `ENOBUFS`, `ENOMEM`).
 const ACCEPT_BACKOFF_INITIAL_DELAY: Duration = Duration::from_millis(5);
 /// Ceiling the retry delay saturates at, so the listener keeps polling often
 /// enough to notice recovery while no longer spinning.
@@ -609,8 +610,9 @@ const ACCEPT_BACKOFF_LOG_INTERVAL: Duration = Duration::from_secs(5);
 /// How the listener loop must treat a failed `accept()`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AcceptFailure {
-    /// The process or the host is out of file descriptors (`EMFILE`/`ENFILE`).
-    /// Retrying immediately cannot succeed, so the loop must back off.
+    /// The process or the host is out of file descriptors or kernel memory
+    /// (`EMFILE`, `ENFILE`, `ENOBUFS`, `ENOMEM`). Retrying immediately cannot
+    /// succeed, so the loop must back off.
     Exhaustion,
     /// Anything else — a per-connection error that the client is expected to
     /// retry. Keeps the historical warn-and-retry-immediately behavior.
@@ -664,15 +666,24 @@ impl Default for AcceptBackoff {
 }
 
 impl AcceptBackoff {
-    /// Classify an `accept()` error. Only file-descriptor exhaustion gets the
-    /// backoff treatment; everything else stays on the pre-existing path so
-    /// genuinely unexpected failures are not hidden or slowed down.
+    /// Classify an `accept()` error. Only descriptor or kernel-memory exhaustion
+    /// gets the backoff treatment; everything else stays on the pre-existing
+    /// path so genuinely unexpected failures are not hidden or slowed down.
     fn classify(err: &std::io::Error) -> AcceptFailure {
         #[cfg(unix)]
         {
-            // `std::io::ErrorKind` has no stable variant for either errno, so the
-            // raw value is the portable-with-cfg way to recognize them.
-            if matches!(err.raw_os_error(), Some(libc::EMFILE) | Some(libc::ENFILE)) {
+            // `std::io::ErrorKind` has no stable variant for any of these
+            // errnos, so the raw value is the portable-with-cfg way to
+            // recognize them.
+            //
+            // `EMFILE`/`ENFILE`: the process or host is out of file descriptors.
+            // `ENOBUFS`/`ENOMEM`: the kernel is out of network buffers or
+            // memory for the socket. All four make an immediate retry
+            // deterministic, so they get the backoff path.
+            if matches!(
+                err.raw_os_error(),
+                Some(libc::EMFILE) | Some(libc::ENFILE) | Some(libc::ENOBUFS) | Some(libc::ENOMEM)
+            ) {
                 return AcceptFailure::Exhaustion;
             }
         }
@@ -769,7 +780,7 @@ async fn handle_accept_error(err: &std::io::Error, backoff: &mut AcceptBackoff) 
                     error = %err,
                     retry_delay_ms = action.delay.as_millis() as u64,
                     suppressed_failures = suppressed,
-                    "tcp accept failed: out of file descriptors; backing off before retry"
+                    "tcp accept failed: out of file descriptors or kernel memory; backing off before retry"
                 );
             }
             time::sleep(action.delay).await;
@@ -2508,6 +2519,22 @@ mod tests {
     #[cfg(unix)]
     fn emfile_error() -> std::io::Error {
         std::io::Error::from_raw_os_error(libc::EMFILE)
+    }
+
+    /// All four exhaustion errnos — `EMFILE`, `ENFILE`, `ENOBUFS`, `ENOMEM` —
+    /// must classify as `Exhaustion`. Missing any one sends that error down the
+    /// immediate-retry path, reinstating the busy loop for that failure mode.
+    #[cfg(unix)]
+    #[test]
+    fn accept_backoff_classifies_all_exhaustion_errnos() {
+        for errno in [libc::EMFILE, libc::ENFILE, libc::ENOBUFS, libc::ENOMEM] {
+            let err = std::io::Error::from_raw_os_error(errno);
+            assert_eq!(
+                AcceptBackoff::classify(&err),
+                AcceptFailure::Exhaustion,
+                "errno {errno} must classify as exhaustion"
+            );
+        }
     }
 
     /// Consecutive exhaustion failures must produce a strictly growing delay


### PR DESCRIPTION
## Summary

The TCP response server retried `listener.accept()` immediately after any error. Once the
process reached its file-descriptor ceiling (`EMFILE`/`ENFILE`), that became a busy loop:
`accept()` fails deterministically while the descriptor table is full, so the loop spun at
microsecond cadence, accepted nothing, and wrote the same warning on every iteration. The
error arm also logged twice — `tracing::warn!` plus an unconditional `eprintln!` — so
rate-limiting only the tracing sink would have left half the flood in place.

`AcceptBackoff` is a private, pure, synchronous policy in
`lib/runtime/src/pipeline/network/tcp/server.rs`. It classifies an `accept()` error via
`raw_os_error()`, computes a bounded exponential delay (5 ms doubling to a 1 s ceiling),
decides whether a summary is due against a caller-supplied `Instant`, and resets on a
successful accept. It reads no clock, performs no I/O, and never sleeps — the caller does
both. That is what makes the retry schedule and the log-rate decision testable without
reproducing the host's file-descriptor limit.

Only exhaustion errors take the new path. Every other accept error keeps the pre-existing
warn-and-retry-immediately behaviour, so genuinely unexpected failures are neither hidden
nor slowed. The `eprintln!` is now gated behind `#[cfg(debug_assertions)]`, matching its
sibling in `handle_connection`.

The recovery notice shares the failure summary's rate-limit window. At the descriptor
ceiling the loop does not fail in one long run — it alternates failure and success as
descriptors are freed and reclaimed — so an unthrottled recovery line would reinstate the
storm this policy exists to bound. A suppressed recovery keeps its count rather than
discarding it, so the next emitted summary still accounts for every failure observed.
`record_success` takes the clock as a closure, so the steady-state accept returns without
reading a clock at all; that path runs once per request, because `create_response_stream`
dials a fresh `TcpStream::connect` rather than pooling.

Operator visibility: at most one structured summary per 5 s, carrying the error, the
current delay, and the number of failures suppressed since the last emission; one line on
recovery; and a new `dynamo_transport_tcp_accept_backoff_total` counter registered in
`ensure_transport_metrics_registered_prometheus`.

## Exhaustion classification

`AcceptBackoff::classify` treats four `accept()` errnos as `AcceptFailure::Exhaustion`:
`EMFILE` and `ENFILE` (file-descriptor exhaustion), and `ENOBUFS` and `ENOMEM` (kernel
network-buffer or memory exhaustion). All four are deterministic failures where an
immediate retry just re-enters the same error, so they all take the bounded backoff path.
Every other accept error keeps the warn-and-retry-immediately behaviour. The doc comments
on the policy constants, the `Exhaustion` variant, the metric help strings, and the warning
text all describe "file descriptors or kernel memory" rather than descriptors alone.

## Where should the reviewer start?

* `lib/runtime/src/pipeline/network/tcp/server.rs` — the `AcceptBackoff` policy, its
  integration into the accept loop, and the tests. The policy type and its classification
  of `raw_os_error()` are worth the closest reading.
* `lib/runtime/Cargo.toml` — one line. `libc` was a `dynamo-runtime` dependency until
  https://github.com/ai-dynamo/dynamo/pull/12620 dropped it; `AcceptBackoff::classify`
  matches on `libc::EMFILE`/`libc::ENFILE`/`libc::ENOBUFS`/`libc::ENOMEM`, so this adds it
  back as a workspace dependency.
* `lib/runtime/src/metrics/transport_metrics.rs` and
  `lib/runtime/src/metrics/prometheus_names.rs` — registration and naming of the counter.

## Validation

CI on this PR is green. All four `rust-clippy` jobs and all four `rust-tests` jobs pass
(root workspace, `lib/bindings/kvbm`, `lib/bindings/python`, `lib/runtime/examples`).
The Rust workspace is not built on my laptop, so CI is the verification path.

What I verified by reading:

* Both metric doc comments describe per-failed-accept semantics, matching the `.inc()`
  site in `handle_accept_error` and the counter's own help text.
* `prometheus_names.py` needs no regeneration. The codegen emits one Python class per
  top-level `pub mod` and does not descend into nested modules — `frontend_service`'s five
  nested mods produce no classes either, and the generated `class transport` is empty.
  `ACCEPT_BACKOFF_TOTAL` is nested inside `transport::tcp`, so the generated file is
  unchanged.
* `Instant` in this file resolves to `tokio::time::Instant`, so every `Instant` in the
  policy and its tests is written as `std::time::Instant` explicitly.

## Scope

Two things this PR deliberately does not do:

* A parallel instance of the same tight-retry pattern remains in
  `lib/runtime/src/pipeline/network/tcp/shared_tcp_endpoint.rs`. Out of scope here.
* `cargo test -p dynamo-runtime --lib` is known to hang in
  `pipeline::network::egress::push_router::tests::transport_resolution_falls_back_when_selected_instance_disappears`,
  and it hangs on a clean `main` too. Unrelated to this change, but a reviewer running the
  full suite locally will hit it.

## History

This supersedes https://github.com/ai-dynamo/dynamo/pull/12282, which carried the same
change but was opened from a fork. That routed it through copy-pr-bot, and the full
NVIDIA-runner CI never ran on it — it saw 25 checks where an in-repo PR sees 76. In the
meantime https://github.com/ai-dynamo/dynamo/pull/10921 rewrote the same accept loop to
spawn per-connection for the TLS handshake, so the old branch conflicts. This is a fresh
branch off `main` with the policy re-integrated against the new loop, rather than a
conflict resolution. It also folds in a review fix that was written on the old PR but
never landed there.

Review feedback already incorporated from https://github.com/ai-dynamo/dynamo/pull/12282:
three CodeRabbit findings (unbounded recovery log, incorrect metric doc comments, a flaky
wall-clock assertion) and @richardhuo-nv's question about per-request cost, which is what
the closure-based clock answers.

## Related Issues

Closes https://github.com/ai-dynamo/dynamo/issues/11822

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP server recovery when the system runs out of file descriptors or kernel memory.
  * Added bounded retry delays and clearer recovery logging to reduce excessive retry activity.
  * Preserved immediate retries for ordinary connection-accept errors.

* **Monitoring**
  * Added a metric to track TCP connection-accept failures caused by file-descriptor or memory exhaustion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->