### PR TITLE
docs(observability): mark the CKF counter as registered but never incremented

### DIFF
--- a/docs/fern/reference/observability/metric-labels.mdx
+++ b/docs/fern/reference/observability/metric-labels.mdx
@@ -112,7 +112,7 @@ Added by an individual metric family. Each label appears only on the metrics not
 </ParamField>
 
 <ParamField path="outcome" type="string">
-  `[Shared]` On `dynamo_kvrouter_ckf_mutation_total` — the block-level CKF mutation outcome, finer-grained than the event `status` above.
+  `[Shared]` On `dynamo_component_ckf_mutation_total`, and on `dynamo_kvrouter_ckf_mutation_total` from the standalone indexer — the block-level CKF mutation outcome. Both counters are registered but never incremented today, so no series carries this label in practice.
 
   <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>unknown_remove</Badge> <Badge intent="note" minimal>capacity_exhausted</Badge></span>
 </ParamField>

--- a/docs/fern/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/reference/observability/metrics-catalog.mdx
@@ -333,7 +333,7 @@ The frontend registers these metrics when queueing is enabled by `--router-queue
 </ParamField>
 
 <ParamField path="dynamo_component_ckf_mutation_total" type="counter">
-  CKF block-level mutation outcomes recorded by the router indexer, finer-grained than the event `status` on the counter above. Labeled by `outcome` — see [Metric-specific labels](metric-labels.mdx#metric-specific-labels).
+  CKF block-level mutation outcomes recorded by the router indexer, labeled by `outcome` — see [Metric-specific labels](metric-labels.mdx#metric-specific-labels). **Registered, always zero.** The series is created and exported, but no code path currently increments it, so it reads 0 in every deployment. Do not build alerts or dashboard panels on it. The standalone indexer exports the same counter as `dynamo_kvrouter_ckf_mutation_total`, with the same caveat.
 </ParamField>
 
 The standalone indexer exposes the device-tier-only counter `dynamo_kvrouter_kv_cache_events_applied` and the CKF counter as `dynamo_kvrouter_ckf_mutation_total`; see [Standalone KV Indexer](../../components/router/standalone-indexer.md).


### PR DESCRIPTION
Follow-up to #12983, which corrected the CKF counter name on this branch but not the more important fact.

## What #12983 got right, and what it missed

It renamed `dynamo_kvrouter_ckf_mutation_total` to `dynamo_component_ckf_mutation_total`. That was correct: the `kvrouter`-prefixed name comes only from `new_registered`, the standalone indexer path, while an embedded router registers through `from_component` and exports the component-scoped name. PromQL copied off this page returned no series on a normal Frontend+KV deployment.

**The rename was not sufficient.** `inc_ckf_mutation` has no call sites outside its own definition in `lib/kv-router/src/indexer/metrics.rs`, and `CkfMutationKind` is referenced nowhere else in the tree. The counter is created and exported, but nothing increments it under either name, so it reads 0 in every deployment.

Since #12983 already merged, the release branch currently documents a counter that will never move, and a reader scraping `/metrics` finds something called `..._mutation_total` and reasonably builds a panel on it.

## The fix

Uses the catalog's existing **Registered, always zero** category rather than deleting the entry. The series is exported whether or not it is documented, so removing the entry would remove the warning without removing the metric. The `metric-labels.mdx` entry for `outcome` gets the same treatment, since no series carries that label in practice.

## Notes

Docs only. The equivalent correction for `main` is in #12975. Whether the missing call sites are an oversight or a deliberately reserved series is a question out with the KV-router owner; the documentation should describe what ships either way.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->