### PR TITLE
fix(llm): clear nvext on the synthetic chunk from a response template

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -79,7 +79,10 @@ use crate::protocols::{
     },
     openai::{
         DeltaGeneratorExt,
-        chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
+        chat_completions::{
+            NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
+            scrub_synthetic_chunk_metadata,
+        },
         completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
         embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
     },
@@ -323,40 +326,6 @@ struct ChoiceReasoningState {
     // parser had already handed over. Draining again is fine; finalizing again
     // is not.
     parser_finished: bool,
-}
-
-/// Strip every per-chunk field from a response that is being reused as the
-/// envelope for a synthetic end-of-stream chunk.
-///
-/// Both end-of-stream flushes build their chunk by cloning the last chunk they
-/// saw, because that is the only way to carry the buffered bytes out on a
-/// correctly-shaped response. The clone is not a new generation: it produced no
-/// tokens and re-channels bytes the parser was already holding. So everything
-/// describing the *original* chunk's generation has to go, or it is reported
-/// twice:
-///
-/// - `event` / `comment` — the annotation channel carries per-chunk payloads
-///   such as generated `token_ids`.
-/// - `error` — an error annotation must not be replayed on a later chunk.
-/// - `usage` / `llm_metrics` — `metrics.rs` sums `chunk_tokens` and samples an
-///   ITL point per chunk carrying `llm_metrics`.
-/// - `nvext` — per-chunk NVIDIA extensions. `merge_response_nvext` append-merges
-///   `completion_token_ids`, so a repeat turns `[42]` into `[42, 42]`, and
-///   fields it does not append (such as `prompt_logprobs`) are overwritten.
-///
-/// Kept as one function so the two call sites cannot drift apart: they already
-/// did, which is how `nvext` survived on both.
-fn scrub_synthetic_chunk_metadata(
-    response: &mut Annotated<NvCreateChatCompletionStreamResponse>,
-) -> Option<()> {
-    response.event = None;
-    response.comment = None;
-    response.error = None;
-    let data = response.data.as_mut()?;
-    data.inner.usage = None;
-    data.llm_metrics = None;
-    data.nvext = None;
-    Some(())
 }
 
 /// Drain what a choice still holds on the `defer_reasoning_for_nonempty_content`
@@ -4018,12 +3987,14 @@ impl OpenAIPreprocessor {
                     );
                     let mut rec = nv_chunk.clone();
                     rec.id = None;
-                    rec.event = None;
-                    rec.comment = None;
-                    rec.error = None;
+                    // Same synthetic-clone contract as the end-of-stream flushes:
+                    // this chunk produced no tokens, it only re-channels the tail
+                    // the jail was already holding. `nvext` is already `None` on
+                    // every `nv_chunk` built above, so clearing it here is a
+                    // no-op today — routed through the shared scrub anyway so
+                    // this copy of the field list cannot drift from the others.
+                    scrub_synthetic_chunk_metadata(&mut rec)?;
                     let rd = rec.data.as_mut()?;
-                    rd.inner.usage = None;
-                    rd.llm_metrics = None;
                     rd.inner.choices.retain(|c| c.index == choice_idx);
                     for rc in &mut rd.inner.choices {
                         rc.delta.content = Some(ChatCompletionMessageContent::Text(tail.clone()));

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -246,6 +246,40 @@ pub struct NvCreateChatCompletionStreamResponse {
     pub llm_metrics: Option<crate::protocols::common::metrics::LLMMetricAnnotation>,
 }
 
+/// Clear everything that describes the *original* chunk's generation from a
+/// chunk that was cloned off it.
+///
+/// A synthetic chunk is built by cloning a real chunk, because that is the only
+/// way to carry buffered bytes out on a correctly-shaped response. The clone is
+/// not a new generation: it produced no tokens and re-channels bytes the parser
+/// was already holding. So everything describing the original chunk's
+/// generation has to go, or it is reported twice:
+///
+/// - `event` / `comment` — the annotation channel carries per-chunk payloads
+///   such as generated `token_ids`.
+/// - `error` — an error annotation must not be replayed on a later chunk.
+/// - `usage` / `llm_metrics` — `metrics.rs` sums `chunk_tokens` and samples an
+///   ITL point per chunk carrying `llm_metrics`.
+/// - `nvext` — per-chunk NVIDIA extensions. `merge_response_nvext` append-merges
+///   `completion_token_ids`, so a repeat turns `[42]` into `[42, 42]`, and
+///   fields it does not append (such as `prompt_logprobs`) are overwritten.
+///
+/// Kept as one function so the call sites — the two end-of-stream flushes in
+/// `preprocessor.rs` and [`stream_choice_chunk_from_template`] — cannot drift
+/// apart: they already did, which is how `nvext` survived on all three.
+pub(crate) fn scrub_synthetic_chunk_metadata(
+    response: &mut Annotated<NvCreateChatCompletionStreamResponse>,
+) -> Option<()> {
+    response.event = None;
+    response.comment = None;
+    response.error = None;
+    let data = response.data.as_mut()?;
+    data.inner.usage = None;
+    data.llm_metrics = None;
+    data.nvext = None;
+    Some(())
+}
+
 /// Build one synthetic stream choice from an existing response template.
 ///
 /// Both streaming tool-call paths use this constructor when an engine omits a
@@ -259,8 +293,6 @@ pub(super) fn stream_choice_chunk_from_template(
     finish_reason: Option<FinishReason>,
 ) -> Annotated<NvCreateChatCompletionStreamResponse> {
     let mut response = template.clone();
-    response.inner.usage = None;
-    response.llm_metrics = None;
     #[allow(deprecated)]
     let choice = ChatChoiceStream {
         index,
@@ -276,13 +308,15 @@ pub(super) fn stream_choice_chunk_from_template(
         logprobs: None,
     };
     response.inner.choices = vec![choice];
-    Annotated {
+    let mut annotated = Annotated {
         data: Some(response),
         id: None,
         event: None,
         comment: None,
         error: None,
-    }
+    };
+    scrub_synthetic_chunk_metadata(&mut annotated);
+    annotated
 }
 
 /// Implements `NvExtProvider` for `NvCreateChatCompletionRequest`,
@@ -1400,5 +1434,43 @@ mod tests {
                 serde_json::from_value(json_str).expect("Failed to deserialize request");
             assert!(request.normalize_reasoning_template_args().is_err());
         }
+    }
+
+    /// The synthetic chunk clones a real chunk, so every field describing that
+    /// chunk's own generation must be cleared — including `nvext`, which
+    /// `merge_response_nvext` append-merges (a repeat turns `[42]` into
+    /// `[42, 42]` during non-streaming aggregation).
+    #[test]
+    fn test_stream_choice_chunk_from_template_scrubs_per_chunk_metadata() {
+        let mut template: NvCreateChatCompletionStreamResponse = serde_json::from_value(json!({
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "test-model",
+            "choices": [],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+            "nvext": {"completion_token_ids": [42]}
+        }))
+        .expect("Failed to deserialize template");
+        template.llm_metrics = Some(crate::protocols::common::metrics::LLMMetricAnnotation {
+            chunk_tokens: 1,
+            ..Default::default()
+        });
+        assert!(template.nvext.is_some(), "template must carry nvext");
+
+        let chunk = stream_choice_chunk_from_template(
+            &template,
+            0,
+            Some(ChatCompletionMessageContent::Text("hi".to_string())),
+            None,
+            Some(FinishReason::Stop),
+        );
+
+        let data = chunk.data.expect("synthetic chunk must carry data");
+        assert_eq!(data.nvext, None, "nvext must not be replayed");
+        assert_eq!(data.inner.usage, None);
+        assert!(data.llm_metrics.is_none());
+        assert!(chunk.event.is_none() && chunk.comment.is_none() && chunk.error.is_none());
+        assert_eq!(data.inner.choices.len(), 1);
     }
 }


### PR DESCRIPTION
#### Overview:

This PR stops a streaming chat-completion chunk from reporting the same NVIDIA extension twice. When an engine omits a terminal choice, Dynamo synthesizes one by cloning the previous chunk; that clone kept the original's `nvext`. Affects all models on the streaming tool-call paths that hit the synthetic-choice constructor.

#### Example (before → after):

Input: a stream whose last real chunk carries `nvext = {"completion_token_ids": [42]}`, followed by a synthesized terminal choice.

```
before:  aggregated completion_token_ids = [42, 42]   <- merge_response_nvext append-merges, so the replay doubled it
after:   aggregated completion_token_ids = [42]
```

#### Details:

- `stream_choice_chunk_from_template` cleared `usage` and `llm_metrics` but not `nvext`; it now routes through the shared `scrub_synthetic_chunk_metadata`, which was moved from `preprocessor.rs` to `chat_completions.rs` so the field list lives in one place.
- Fields `merge_response_nvext` does not append (such as `prompt_logprobs`) were overwritten rather than doubled — same root cause.
- The glm47 truncation-recovery chunk kept a third copy of the same field list; it now uses the shared helper too. Not a live `nvext` leak there (the chunk it clones is always built with `nvext: None`) — it is the duplication that the helper exists to prevent.

#### Verification:

New unit test `test_stream_choice_chunk_from_template_scrubs_per_chunk_metadata` fails on the pre-fix code and passes after; `cargo test -p dynamo-llm` and `cargo clippy -p dynamo-llm` are otherwise unchanged (the only failures are pre-existing gated-model snapshot tests that fail identically on `main`).

#### Where should the reviewer start?

`lib/llm/src/protocols/openai/chat_completions.rs`, then `lib/llm/src/preprocessor.rs`

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->