### PR TITLE
fix(operator): post-#11392 correctness cleanup for DGDR profiler container conversion

### DIFF
--- a/deploy/operator/api/roundtrip_fuzz_test.go
+++ b/deploy/operator/api/roundtrip_fuzz_test.go
@@ -342,20 +342,20 @@ const (
 	fuzzDGDROutputCopierContainerName = "output-copier"
 )
 
+func fuzzDGDRProfilingExtraContainerNames(c randfill.Continue) []string {
+	names := make([]string, 1+c.Intn(3))
+	for i := range names {
+		names[i] = fmt.Sprintf("container-%d", i)
+	}
+	return names
+}
+
 func fuzzDGDRProfilingContainerNames(c randfill.Continue) []string {
 	switch c.Intn(10) {
 	case 0:
 		return nil
 	case 1:
 		return []string{}
-	}
-
-	extraNames := func() []string {
-		names := make([]string, 1+c.Intn(3))
-		for i := range names {
-			names[i] = fmt.Sprintf("container-%d", i)
-		}
-		return names
 	}
 
 	var names []string
@@ -365,17 +365,17 @@ func fuzzDGDRProfilingContainerNames(c randfill.Continue) []string {
 	case 1:
 		names = []string{fuzzDGDROutputCopierContainerName}
 	case 2:
-		names = extraNames()
+		names = fuzzDGDRProfilingExtraContainerNames(c)
 	case 3:
 		names = []string{fuzzDGDRProfilerContainerName, fuzzDGDROutputCopierContainerName}
 	case 4:
-		names = append([]string{fuzzDGDROutputCopierContainerName}, extraNames()...)
+		names = append([]string{fuzzDGDROutputCopierContainerName}, fuzzDGDRProfilingExtraContainerNames(c)...)
 	case 5:
-		names = append([]string{fuzzDGDRProfilerContainerName}, extraNames()...)
+		names = append([]string{fuzzDGDRProfilerContainerName}, fuzzDGDRProfilingExtraContainerNames(c)...)
 	default:
 		names = append(
 			[]string{fuzzDGDRProfilerContainerName, fuzzDGDROutputCopierContainerName},
-			extraNames()...,
+			fuzzDGDRProfilingExtraContainerNames(c)...,
 		)
 	}
 

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -233,7 +233,9 @@ func restoreDGDRHubSpec(raw string) (v1beta1.DynamoGraphDeploymentRequestSpec, b
 	if !ok {
 		return spec, false
 	}
-	migrateLegacyUnnamedProfilerInOverrides(spec.Overrides)
+	if spec.Overrides != nil && spec.Overrides.ProfilingJob != nil {
+		migrateLegacyUnnamedProfilerContainers(spec.Overrides.ProfilingJob.Template.Spec.Containers)
+	}
 	return spec, true
 }
 
@@ -788,20 +790,19 @@ func dgdrHubOnlyProfilingJob(src *batchv1.JobSpec) *batchv1.JobSpec {
 		return nil
 	}
 	save := src.DeepCopy()
+
+	// Canonicalize leftover name:"" profiler entries on the save copy only.
 	migrateLegacyUnnamedProfilerContainers(save.Template.Spec.Containers)
+
 	if idx := dgdrProfilerContainerIndex(save.Template.Spec.Containers); idx >= 0 {
-		hadProjectedResources := !apiequality.Semantic.DeepEqual(
-			save.Template.Spec.Containers[idx].Resources,
-			corev1.ResourceRequirements{},
-		)
-		save.Template.Spec.Containers[idx].Resources = corev1.ResourceRequirements{}
-		// Omit only when alpha alone reconstructs the same ordered list: a sole
-		// profiler whose only projected field was resources. An explicit
-		// name-only profiler (no resources) must remain in the annotation.
-		if hadProjectedResources &&
-			dgdrIsNameOnlyProfiler(save.Template.Spec.Containers[idx]) &&
-			len(save.Template.Spec.Containers) == 1 {
-			save.Template.Spec.Containers = slices.Delete(save.Template.Spec.Containers, idx, idx+1)
+		// A live name-only profiler is hub-only: v1alpha1 cannot represent the
+		// container name, so keep the entry. Drop the sole profiler only when
+		// every remaining field was alpha-representable and was stripped.
+		if !dgdrIsNameOnlyProfiler(save.Template.Spec.Containers[idx]) {
+			save.Template.Spec.Containers[idx].Resources = corev1.ResourceRequirements{}
+			if len(save.Template.Spec.Containers) == 1 && dgdrIsNameOnlyProfiler(save.Template.Spec.Containers[idx]) {
+				save.Template.Spec.Containers = slices.Delete(save.Template.Spec.Containers, idx, idx+1)
+			}
 		}
 	}
 	save.Template.Spec.Tolerations = nil
@@ -863,22 +864,29 @@ func dgdrProfilerContainerIndex(containers []corev1.Container) int {
 	return -1
 }
 
+// dgdrLiveProfilerContainerIndex reads a live v1beta1 profiling-job container
+// list. Prefer name:profiler. If none exists, treat a leftover name:"" entry as
+// the profiler. When both exist they are distinct map-list elements and only
+// name:profiler is the profiler. Does not mutate the list.
+func dgdrLiveProfilerContainerIndex(containers []corev1.Container) int {
+	if idx := dgdrProfilerContainerIndex(containers); idx >= 0 {
+		return idx
+	}
+	for i := range containers {
+		if containers[i].Name == "" {
+			return i
+		}
+	}
+	return -1
+}
+
 func dgdrIsNameOnlyProfiler(c corev1.Container) bool {
 	return apiequality.Semantic.DeepEqual(c, corev1.Container{Name: dgdrProfilerContainerName})
 }
 
-// migrateLegacyUnnamedProfilerInOverrides renames a legacy name:"" profiler
-// placeholder in restored hub annotations before map-list merging.
-func migrateLegacyUnnamedProfilerInOverrides(overrides *v1beta1.OverridesSpec) {
-	if overrides == nil || overrides.ProfilingJob == nil {
-		return
-	}
-	migrateLegacyUnnamedProfilerContainers(overrides.ProfilingJob.Template.Spec.Containers)
-}
-
-// migrateLegacyUnnamedProfilerContainers implements the narrow decode-time
-// migration for old nvidia.com/dgdr-spec payloads that used an unnamed
-// synthetic profiler entry:
+// migrateLegacyUnnamedProfilerContainers rewrites a leftover unnamed synthetic
+// profiler entry to name:profiler. Used when decoding sparse hub payloads and
+// when building the hub-only save copy from live hub source:
 //  1. If no name:profiler exists and a name:"" entry exists, rename that entry
 //     to profiler in place (preserve position and fields).
 //  2. If name:profiler already exists, leave any additional name:"" entry as a
@@ -998,13 +1006,8 @@ func projectProfilingJobToProfilingConfig(src *v1beta1.DynamoGraphDeploymentRequ
 		return
 	}
 	podSpec := &src.Overrides.ProfilingJob.Template.Spec
-
-	// Migrate leftover unnamed profiler entries on a copy so live hub storage
-	// is not mutated. Lookup after that is strict by name.
-	containers := slices.Clone(podSpec.Containers)
-	migrateLegacyUnnamedProfilerContainers(containers)
-	if idx := dgdrProfilerContainerIndex(containers); idx >= 0 {
-		res := containers[idx].Resources
+	if idx := dgdrLiveProfilerContainerIndex(podSpec.Containers); idx >= 0 {
+		res := podSpec.Containers[idx].Resources
 		if !apiequality.Semantic.DeepEqual(res, corev1.ResourceRequirements{}) {
 			dst.ProfilingConfig.Resources = &res
 		}

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -337,48 +337,67 @@ func TestBugDGDRProfilingJobResourcesFollowContainerName(t *testing.T) {
 	}
 }
 
-func TestBugDGDRProfilerFirstHubRoundTripPreservesOrder(t *testing.T) {
+func TestBugDGDRHubRoundTripPreservesContainerOrder(t *testing.T) {
 	profilerResources := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 	}
 	sidecarResources := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
 	}
-	wantContainers := []corev1.Container{
-		{Name: dgdrProfilerContainerName, Resources: profilerResources},
-		{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
-	}
-
-	t.Log("Start from a profiler-first v1beta1 override list")
-	hub := &v1beta1.DynamoGraphDeploymentRequest{
-		Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
-			Overrides: &v1beta1.OverridesSpec{
-				ProfilingJob: &batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{Containers: wantContainers},
-					},
-				},
+	tests := []struct {
+		name       string
+		containers []corev1.Container
+	}{
+		{
+			name: "profiler first",
+			containers: []corev1.Container{
+				{Name: dgdrProfilerContainerName, Resources: profilerResources},
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+			},
+		},
+		{
+			name: "sidecar first",
+			containers: []corev1.Container{
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+				{Name: dgdrProfilerContainerName, Resources: profilerResources},
 			},
 		},
 	}
 
-	t.Log("Convert hub → spoke → hub without changing alpha fields")
-	spoke := &DynamoGraphDeploymentRequest{}
-	if err := spoke.ConvertFrom(hub); err != nil {
-		t.Fatalf("ConvertFrom() error = %v", err)
-	}
-	restored := &v1beta1.DynamoGraphDeploymentRequest{}
-	if err := spoke.ConvertTo(restored); err != nil {
-		t.Fatalf("ConvertTo() error = %v", err)
-	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Log("Start from a named v1beta1 override list")
+			hub := &v1beta1.DynamoGraphDeploymentRequest{
+				Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+					Overrides: &v1beta1.OverridesSpec{
+						ProfilingJob: &batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{Containers: test.containers},
+							},
+						},
+					},
+				},
+			}
 
-	t.Log("Verify profiler-first ordering and resources survive the round trip")
-	if restored.Spec.Overrides == nil || restored.Spec.Overrides.ProfilingJob == nil {
-		t.Fatal("profilingJob override = nil, want profiler-first containers")
-	}
-	got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
-	if diff := cmp.Diff(wantContainers, got); diff != "" {
-		t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+			t.Log("Convert hub → spoke → hub without changing alpha fields")
+			spoke := &DynamoGraphDeploymentRequest{}
+			if err := spoke.ConvertFrom(hub); err != nil {
+				t.Fatalf("ConvertFrom() error = %v", err)
+			}
+			restored := &v1beta1.DynamoGraphDeploymentRequest{}
+			if err := spoke.ConvertTo(restored); err != nil {
+				t.Fatalf("ConvertTo() error = %v", err)
+			}
+
+			t.Log("Verify container ordering and resources survive the round trip")
+			if restored.Spec.Overrides == nil || restored.Spec.Overrides.ProfilingJob == nil {
+				t.Fatal("profilingJob override = nil, want restored named containers")
+			}
+			got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+			if diff := cmp.Diff(test.containers, got); diff != "" {
+				t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -430,48 +449,10 @@ func TestBugDGDRAlphaResourcesRoundTripOmitsPrivateAnnotation(t *testing.T) {
 	}
 }
 
-func TestBugDGDRSidecarFirstHubRoundTripPreservesOrder(t *testing.T) {
-	profilerResources := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
-	}
-	sidecarResources := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
-	}
-	wantContainers := []corev1.Container{
-		{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
-		{Name: dgdrProfilerContainerName, Resources: profilerResources},
-	}
-
-	hub := &v1beta1.DynamoGraphDeploymentRequest{
-		Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
-			Overrides: &v1beta1.OverridesSpec{
-				ProfilingJob: &batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{Containers: wantContainers},
-					},
-				},
-			},
-		},
-	}
-
-	spoke := &DynamoGraphDeploymentRequest{}
-	if err := spoke.ConvertFrom(hub); err != nil {
-		t.Fatalf("ConvertFrom() error = %v", err)
-	}
-	restored := &v1beta1.DynamoGraphDeploymentRequest{}
-	if err := spoke.ConvertTo(restored); err != nil {
-		t.Fatalf("ConvertTo() error = %v", err)
-	}
-
-	got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
-	if diff := cmp.Diff(wantContainers, got); diff != "" {
-		t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
-	}
-}
-
 func TestBugDGDRNameOnlyProfilerPreserved(t *testing.T) {
 	wantContainers := []corev1.Container{{Name: dgdrProfilerContainerName}}
 
+	t.Log("Start from a name-only v1beta1 profiler override")
 	hub := &v1beta1.DynamoGraphDeploymentRequest{
 		Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
 			Overrides: &v1beta1.OverridesSpec{
@@ -484,6 +465,7 @@ func TestBugDGDRNameOnlyProfilerPreserved(t *testing.T) {
 		},
 	}
 
+	t.Log("Convert hub → spoke and verify resources are not projected")
 	spoke := &DynamoGraphDeploymentRequest{}
 	if err := spoke.ConvertFrom(hub); err != nil {
 		t.Fatalf("ConvertFrom() error = %v", err)
@@ -491,6 +473,8 @@ func TestBugDGDRNameOnlyProfilerPreserved(t *testing.T) {
 	if spoke.Spec.ProfilingConfig.Resources != nil {
 		t.Fatalf("profilingConfig.resources = %#v, want nil for name-only profiler", spoke.Spec.ProfilingConfig.Resources)
 	}
+
+	t.Log("Convert spoke → hub and verify the name-only profiler is preserved")
 	restored := &v1beta1.DynamoGraphDeploymentRequest{}
 	if err := spoke.ConvertTo(restored); err != nil {
 		t.Fatalf("ConvertTo() error = %v", err)
@@ -622,6 +606,7 @@ func TestBugDGDRLiveHubUnnamedProfilerMigratesOnRoundTrip(t *testing.T) {
 }
 
 func TestBugDGDRLegacyUnnamedKeptDistinctWhenProfilerExists(t *testing.T) {
+	t.Log("Seed a spoke object with both a named profiler and a leftover unnamed annotation entry")
 	spoke := &DynamoGraphDeploymentRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -644,11 +629,13 @@ func TestBugDGDRLegacyUnnamedKeptDistinctWhenProfilerExists(t *testing.T) {
 		},
 	}
 
+	t.Log("Convert spoke → hub")
 	hub := &v1beta1.DynamoGraphDeploymentRequest{}
 	if err := spoke.ConvertTo(hub); err != nil {
 		t.Fatalf("ConvertTo() error = %v", err)
 	}
 
+	t.Log("Verify the unnamed entry stays distinct from the named profiler")
 	want := []corev1.Container{
 		{Name: dgdrProfilerContainerName, Image: "named-profiler:1"},
 		{Name: "", Image: "unnamed-extra:1"},

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -20,6 +20,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -372,7 +373,7 @@ func TestBugDGDRHubRoundTripPreservesContainerOrder(t *testing.T) {
 					Overrides: &v1beta1.OverridesSpec{
 						ProfilingJob: &batchv1.JobSpec{
 							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{Containers: test.containers},
+								Spec: corev1.PodSpec{Containers: slices.Clone(test.containers)},
 							},
 						},
 					},
@@ -458,7 +459,7 @@ func TestBugDGDRNameOnlyProfilerPreserved(t *testing.T) {
 			Overrides: &v1beta1.OverridesSpec{
 				ProfilingJob: &batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{Containers: wantContainers},
+						Spec: corev1.PodSpec{Containers: slices.Clone(wantContainers)},
 					},
 				},
 			},

--- a/deploy/operator/internal/controller/profiling_job_overrides.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides.go
@@ -402,18 +402,13 @@ func findContainerIndex(containers []corev1.Container, name string) int {
 }
 
 // profilerContainerOverride selects the override entry for the profiler container.
-// Prefers an entry named "profiler"; otherwise the first entry that is not the
-// output-copier sidecar (preserving backward compatibility for unnamed overrides).
+// Prefers name:profiler, then a leftover unnamed entry. Unknown names are not
+// aliases for the profiler.
 func profilerContainerOverride(overrides []corev1.Container) *corev1.Container {
 	if override := findContainerOverride(overrides, ContainerNameProfiler); override != nil {
 		return override
 	}
-	for i := range overrides {
-		if overrides[i].Name == "" || overrides[i].Name != ContainerNameOutputCopier {
-			return &overrides[i]
-		}
-	}
-	return nil
+	return findContainerOverride(overrides, "")
 }
 
 // applyContainerOverrides merges fields from the user's container override

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -1146,6 +1146,89 @@ func TestApplyProfilingJobOverrides_NamedProfilerAndOutputCopierOverrides(t *tes
 	}
 }
 
+func TestApplyProfilingJobOverrides_MergesByContainerNameNotIndex(t *testing.T) {
+	sidecarCPU := resource.MustParse("250m")
+	profilerCPU := resource.MustParse("2")
+	tests := []struct {
+		name      string
+		overrides []corev1.Container
+	}{
+		{
+			name: "sidecar-first named profiler",
+			overrides: []corev1.Container{
+				{
+					Name: ContainerNameOutputCopier,
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: sidecarCPU},
+					},
+				},
+				{
+					Name:  ContainerNameProfiler,
+					Image: "custom-profiler:v2",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: profilerCPU},
+					},
+				},
+			},
+		},
+		{
+			name: "sidecar-first unnamed profiler",
+			overrides: []corev1.Container{
+				{
+					Name: ContainerNameOutputCopier,
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: sidecarCPU},
+					},
+				},
+				{
+					Name:  "",
+					Image: "custom-profiler:v2",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: profilerCPU},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Log("Build a generated job whose profiler is not at index 0")
+			job := baseJob()
+			spec := &job.Spec.Template.Spec
+			spec.Containers[0], spec.Containers[1] = spec.Containers[1], spec.Containers[0]
+
+			t.Log("Apply sidecar-first container overrides")
+			applyProfilingJobOverrides(job, &batchv1.JobSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: test.overrides},
+				},
+			})
+
+			t.Log("Verify profiler got the named profiler override, not Containers[0]")
+			profiler := findContainer(job.Spec.Template.Spec.Containers, ContainerNameProfiler)
+			if profiler == nil {
+				t.Fatal("profiler container not found")
+			}
+			if profiler.Image != "custom-profiler:v2" {
+				t.Errorf("profiler image: want custom-profiler:v2, got %s", profiler.Image)
+			}
+			if profiler.Resources.Limits.Cpu().Cmp(profilerCPU) != 0 {
+				t.Errorf("profiler CPU: want %s, got %v", profilerCPU.String(), profiler.Resources.Limits)
+			}
+
+			t.Log("Verify output-copier received its own resources, not the profiler budget")
+			sidecar := findContainer(job.Spec.Template.Spec.Containers, ContainerNameOutputCopier)
+			if sidecar == nil {
+				t.Fatal("output-copier container not found")
+			}
+			if sidecar.Resources.Limits.Cpu().Cmp(sidecarCPU) != 0 {
+				t.Errorf("output-copier CPU: want %s, got %v", sidecarCPU.String(), sidecar.Resources.Limits)
+			}
+		})
+	}
+}
+
 func TestApplyProfilingJobOverrides_UnnamedOverrideTargetsProfiler(t *testing.T) {
 	t.Log("Apply a legacy unnamed container override")
 	job := baseJob()

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	profilerEntrypoint        = "python"
+	profilerOverrideImage     = "custom-profiler:v2"
 	outputCopierShell         = "/bin/sh"
 	outputCopierScriptStub    = "echo sidecar-script"
 	outputCopierOverrideImage = "internal-registry/kubectl:1.29"
@@ -766,13 +767,13 @@ func TestApplyProfilingJobOverrides_ContainerImage(t *testing.T) {
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
-					{Image: "custom-profiler:v2"},
+					{Image: profilerOverrideImage},
 				},
 			},
 		},
 	})
-	if job.Spec.Template.Spec.Containers[0].Image != "custom-profiler:v2" {
-		t.Errorf("expected image=custom-profiler:v2, got %s", job.Spec.Template.Spec.Containers[0].Image)
+	if job.Spec.Template.Spec.Containers[0].Image != profilerOverrideImage {
+		t.Errorf("expected image=%s, got %s", profilerOverrideImage, job.Spec.Template.Spec.Containers[0].Image)
 	}
 }
 
@@ -1164,7 +1165,7 @@ func TestApplyProfilingJobOverrides_MergesByContainerNameNotIndex(t *testing.T) 
 				},
 				{
 					Name:  ContainerNameProfiler,
-					Image: "custom-profiler:v2",
+					Image: profilerOverrideImage,
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{corev1.ResourceCPU: profilerCPU},
 					},
@@ -1182,7 +1183,7 @@ func TestApplyProfilingJobOverrides_MergesByContainerNameNotIndex(t *testing.T) 
 				},
 				{
 					Name:  "",
-					Image: "custom-profiler:v2",
+					Image: profilerOverrideImage,
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{corev1.ResourceCPU: profilerCPU},
 					},
@@ -1210,8 +1211,8 @@ func TestApplyProfilingJobOverrides_MergesByContainerNameNotIndex(t *testing.T) 
 			if profiler == nil {
 				t.Fatal("profiler container not found")
 			}
-			if profiler.Image != "custom-profiler:v2" {
-				t.Errorf("profiler image: want custom-profiler:v2, got %s", profiler.Image)
+			if profiler.Image != profilerOverrideImage {
+				t.Errorf("profiler image: want %s, got %s", profilerOverrideImage, profiler.Image)
 			}
 			if profiler.Resources.Limits.Cpu().Cmp(profilerCPU) != 0 {
 				t.Errorf("profiler CPU: want %s, got %v", profilerCPU.String(), profiler.Resources.Limits)
@@ -1236,7 +1237,7 @@ func TestApplyProfilingJobOverrides_UnnamedOverrideTargetsProfiler(t *testing.T)
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
-					{Name: "", Image: "custom-profiler:v2"},
+					{Name: "", Image: profilerOverrideImage},
 				},
 			},
 		},
@@ -1247,8 +1248,8 @@ func TestApplyProfilingJobOverrides_UnnamedOverrideTargetsProfiler(t *testing.T)
 	if profiler == nil {
 		t.Fatal("profiler container not found")
 	}
-	if profiler.Image != "custom-profiler:v2" {
-		t.Errorf("profiler image: want custom-profiler:v2, got %s", profiler.Image)
+	if profiler.Image != profilerOverrideImage {
+		t.Errorf("profiler image: want %s, got %s", profilerOverrideImage, profiler.Image)
 	}
 }
 
@@ -1261,7 +1262,7 @@ func TestApplyProfilingJobOverrides_UnknownNameDoesNotOverrideProfiler(t *testin
 				Containers: []corev1.Container{
 					{
 						Name:  "extra-tools",
-						Image: "custom-profiler:v2",
+						Image: profilerOverrideImage,
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
 						},

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -1146,6 +1146,61 @@ func TestApplyProfilingJobOverrides_NamedProfilerAndOutputCopierOverrides(t *tes
 	}
 }
 
+func TestApplyProfilingJobOverrides_UnnamedOverrideTargetsProfiler(t *testing.T) {
+	t.Log("Apply a legacy unnamed container override")
+	job := baseJob()
+	applyProfilingJobOverrides(job, &batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "", Image: "custom-profiler:v2"},
+				},
+			},
+		},
+	})
+
+	t.Log("Verify the unnamed override still targets the profiler")
+	profiler := findContainer(job.Spec.Template.Spec.Containers, ContainerNameProfiler)
+	if profiler == nil {
+		t.Fatal("profiler container not found")
+	}
+	if profiler.Image != "custom-profiler:v2" {
+		t.Errorf("profiler image: want custom-profiler:v2, got %s", profiler.Image)
+	}
+}
+
+func TestApplyProfilingJobOverrides_UnknownNameDoesNotOverrideProfiler(t *testing.T) {
+	t.Log("Apply an override whose only container has an unknown name")
+	job := baseJob()
+	applyProfilingJobOverrides(job, &batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "extra-tools",
+						Image: "custom-profiler:v2",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	t.Log("Verify the profiler image and resources are unchanged")
+	profiler := findContainer(job.Spec.Template.Spec.Containers, ContainerNameProfiler)
+	if profiler == nil {
+		t.Fatal("profiler container not found")
+	}
+	if profiler.Image != "profiler:latest" {
+		t.Errorf("profiler image should be unchanged, got %s", profiler.Image)
+	}
+	if len(profiler.Resources.Limits) != 0 || len(profiler.Resources.Requests) != 0 {
+		t.Errorf("profiler resources should be unchanged, got %+v", profiler.Resources)
+	}
+}
+
 func TestApplyProfilingJobOverrides_Combined(t *testing.T) {
 	job := baseJob()
 	applyProfilingJobOverrides(job, &batchv1.JobSpec{


### PR DESCRIPTION
**Overview**
This PR delivers a post-merge correctness cleanup for [#11392](https://github.com/ai-dynamo/dynamo/pull/11392) It fixes edge cases in `v1alpha1` $\leftrightarrow$ `v1beta1` conversion by properly binding `profilingConfig.resources` to the canonical `name: profiler` container map-list entry.

**Key Modifications & Fixes**

* **Canonical Container Binding**: Converts `v1alpha1 profilingConfig.resources` directly to `v1beta1 containers[name=profiler].resources` instead of relying on positional indexes (e.g., `containers[0]`), preventing resource budget cross-binding.
* **Order & Identity Preservation**: Retains container identity and ordering in the `[nvidia.com/dgdr-spec](https://nvidia.com/dgdr-spec)` annotation without synthesizing unnamed (`name: ""`) containers during conversion.
* **Legacy Migration on Restore**: Restores and migrates legacy unnamed profiler containers strictly at decode/restore time without mutating live objects in storage.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #11392
