### PR TITLE
refactor(aisimulate): flatten adapter search config

### DIFF
--- a/aisimulate/docs/sweeper/configuration.md
+++ b/aisimulate/docs/sweeper/configuration.md
@@ -23,8 +23,7 @@ search_space:
 
 adapters:
   example.policy:
-    search_space:
-      mode: [balanced, latency]
+    mode: [balanced, latency]
 
 workload:
   isl: 1024
@@ -41,9 +40,9 @@ sweep:
   parallel_evals: 4
 ```
 
-The adapter value is a search space, not one concrete runtime configuration. Its provider validates
-the whole mapping, contributes optimizer dimensions, and later materializes one concrete adapter
-configuration for each candidate.
+The mapping directly under each adapter name is its search space, not one concrete runtime
+configuration. Its provider validates that mapping, contributes optimizer dimensions, and later
+materializes one concrete adapter configuration for each candidate.
 
 ## Backend Fields
 
@@ -81,7 +80,7 @@ KV-feasible, and supported by at least one selected backend.
 
 ## Provider Selection
 
-Adapter names are provider entry-point names. A provider can be installed through the
+Adapter names select matching provider entry points. A provider can be installed through the
 `aisimulate.sweep_config_providers` entry-point group or injected into the `Sweeper` constructor:
 
 ```python

--- a/aisimulate/docs/sweeper/sweep-config-provider.md
+++ b/aisimulate/docs/sweeper/sweep-config-provider.md
@@ -31,9 +31,9 @@ class ExampleProvider:
         return AdapterReplaySpec(config={"mode": selection["mode"]})
 ```
 
-`generate_search_space` receives the complete adapter-owned search-space mapping plus an isolated
-`SweepContext`. It may validate composite settings, derive dimensions, and store JSON-compatible
-state in `AdapterSearchPlan`.
+`generate_search_space` receives the complete mapping configured directly under the adapter name,
+plus an isolated `SweepContext`. It may validate composite settings, derive dimensions, and store
+JSON-compatible state in `AdapterSearchPlan`.
 
 `materialize_replay` receives that plan, one concrete local selection, and an isolated
 `CandidateContext`. It returns the concrete adapter config and any versioned `RuntimeHookSpec`

--- a/aisimulate/docs/sweeper/tutorial.md
+++ b/aisimulate/docs/sweeper/tutorial.md
@@ -61,12 +61,11 @@ An installed or injected provider owns the schema below its adapter name:
 ```yaml
 adapters:
   example.policy:
-    search_space:
-      mode: [balanced, latency]
+    mode: [balanced, latency]
 ```
 
-The provider receives the complete `search_space` mapping. It does not receive a preselected
-concrete feature configuration.
+The provider receives the complete mapping directly under `example.policy`. It does not receive a
+preselected concrete feature configuration.
 
 ## 5. Run and Inspect
 

--- a/aisimulate/examples/sweeper/configs/smart_sweep.yaml
+++ b/aisimulate/examples/sweeper/configs/smart_sweep.yaml
@@ -10,12 +10,10 @@ search_space:
   backend: [vllm]
 adapters:
   dynamo.router:
-    search_space:
-      mode: [kv_router, round_robin]
+    mode: [kv_router, round_robin]
   dynamo.planner:
-    search_space:
-      scaling_policy: [disabled, throughput_180_5, hybrid_180_5]
-      # Other Planner search dimensions use adapter defaults.
+    scaling_policy: [disabled, throughput_180_5, hybrid_180_5]
+    # Other Planner search dimensions use adapter defaults.
 workload:
   trace_path: /data/replay/traffic.jsonl   # or omit and set a synthetic load (see below)
   trace_format: mooncake

--- a/aisimulate/src/aisimulate/sweeper/config.py
+++ b/aisimulate/src/aisimulate/sweeper/config.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import math
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -489,12 +489,8 @@ class SweepConfig(BaseModel):
     max_eval_seconds: float | None = Field(default=600.0, gt=0)
 
 
-class AdapterSearchConfig(BaseModel):
-    """One optional simulation adapter and the search space it owns."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    search_space: dict[str, Any] = Field(default_factory=dict)
+# The provider-owned search-space mapping for one adapter.
+AdapterSearchConfig: TypeAlias = dict[str, Any]
 
 
 class Candidate(BaseModel):
@@ -518,6 +514,7 @@ class SmartSearchConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     search_space: SearchSpace
+    # Each value is the provider-owned search-space mapping for that adapter.
     adapters: dict[str, AdapterSearchConfig] = Field(default_factory=dict)
     workload: Workload
     goal: OptimizationGoal = Field(default_factory=OptimizationGoal)
@@ -573,13 +570,13 @@ class SmartSearchConfig(BaseModel):
         if present_planner:
             raise ValueError(
                 "Planner search fields now belong to an adapter; move "
-                f"{present_planner} to adapters['dynamo.planner'].search_space"
+                f"{present_planner} to adapters['dynamo.planner']"
             )
         present_router = sorted(router_fields.intersection(search_space))
         if present_router:
             raise ValueError(
                 "Router search fields now belong to an adapter; move "
-                f"{present_router} to adapters['dynamo.router'].search_space"
+                f"{present_router} to adapters['dynamo.router']"
             )
         return data
 

--- a/aisimulate/src/aisimulate/sweeper/search.py
+++ b/aisimulate/src/aisimulate/sweeper/search.py
@@ -139,9 +139,7 @@ def _prepare_providers(
             goal=deepcopy(base_context.goal),
             show_progress=base_context.show_progress,
         )
-        plan = provider.generate_search_space(
-            deepcopy(config.adapters[name].search_space), context
-        )
+        plan = provider.generate_search_space(deepcopy(config.adapters[name]), context)
         _validate_search_plan(name, plan)
         # The adapter owns the object it returned and may reuse internal buffers
         # later. Take a complete core-owned snapshot at the ABI boundary.
@@ -672,10 +670,7 @@ class Sweeper:
         cache_context = _freeze(
             {
                 "search_space": config.search_space.model_dump(mode="python"),
-                "adapters": {
-                    name: request.model_dump(mode="python")
-                    for name, request in config.adapters.items()
-                },
+                "adapters": deepcopy(config.adapters),
                 "workload": config.workload.model_dump(mode="python"),
                 "goal": goal.model_dump(mode="python"),
                 "provider_plans": provider_plans,

--- a/aisimulate/tests/sweeper/test_config.py
+++ b/aisimulate/tests/sweeper/test_config.py
@@ -42,9 +42,8 @@ search_space:
   gpu_budget: 8
 adapters:
   dynamo.planner:
-    search_space:
-      scaling_interval: [5, 10]
-      load_predictor: [default, conservative]
+    scaling_interval: [5, 10]
+    load_predictor: [default, conservative]
 workload:
   isl: 128
   osl: 16
@@ -60,9 +59,15 @@ sweep:
 
     assert config.search_space.deployment_mode == ["agg"]
     assert config.search_space.backend == ["vllm"]
-    assert config.adapters["dynamo.planner"].search_space == {
+    assert config.adapters["dynamo.planner"] == {
         "scaling_interval": [5, 10],
         "load_predictor": ["default", "conservative"],
+    }
+    assert config.model_dump()["adapters"] == {
+        "dynamo.planner": {
+            "scaling_interval": [5, 10],
+            "load_predictor": ["default", "conservative"],
+        }
     }
     assert config.workload.request_rate == 2
     assert config.sweep.max_rounds == 2
@@ -96,7 +101,7 @@ def test_defaults_are_backend_only():
     )
 
 
-def test_extra_fields_are_forbidden_at_each_boundary():
+def test_extra_fields_are_forbidden_on_structured_models():
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         SmartSearchConfig(
             search_space=_search_space(bogus=1),
@@ -106,8 +111,20 @@ def test_extra_fields_are_forbidden_at_each_boundary():
         SmartSearchConfig(
             search_space=_search_space(),
             workload=_workload(),
-            adapters={"custom": {"search_space": {}, "bogus": 1}},
+            bogus=1,
         )
+
+
+def test_adapter_mapping_is_passed_through_for_provider_validation():
+    config = SmartSearchConfig(
+        search_space=_search_space(),
+        workload=_workload(),
+        adapters={"custom": {"mode": ["fast", "safe"], "weight": [0.0, 1.0]}},
+    )
+
+    assert config.adapters == {
+        "custom": {"mode": ["fast", "safe"], "weight": [0.0, 1.0]}
+    }
 
 
 @pytest.mark.parametrize(
@@ -125,7 +142,7 @@ def test_extra_fields_are_forbidden_at_each_boundary():
 def test_legacy_planner_fields_point_to_adapter_migration(field):
     with pytest.raises(
         ValidationError,
-        match=r"adapters\['dynamo\.planner'\]\.search_space",
+        match=r"adapters\['dynamo\.planner'\]",
     ):
         SmartSearchConfig(
             search_space=_search_space(**{field: 1}),
@@ -150,7 +167,7 @@ def test_legacy_planner_fields_point_to_adapter_migration(field):
 def test_legacy_router_fields_point_to_adapter_migration(field):
     with pytest.raises(
         ValidationError,
-        match=r"adapters\['dynamo\.router'\]\.search_space",
+        match=r"adapters\['dynamo\.router'\]",
     ):
         SmartSearchConfig(
             search_space=_search_space(**{field: 1}),

--- a/aisimulate/tests/sweeper/test_search_providers.py
+++ b/aisimulate/tests/sweeper/test_search_providers.py
@@ -37,9 +37,7 @@ def _config() -> SmartSearchConfig:
             "deployment_mode": ["agg"],
         },
         adapters={
-            "test.feature": {
-                "search_space": {"modes": ["fast"]},
-            }
+            "test.feature": {"modes": ["fast"]},
         },
         workload={"trace_path": TRACE},
         sweep={"max_rounds": 1, "candidates_per_round": 1, "parallel_evals": 1},
@@ -358,8 +356,8 @@ def test_adapter_reused_output_buffer_is_isolated_per_candidate(monkeypatch) -> 
 def test_adapter_search_contexts_are_isolated() -> None:
     config_data = _config().model_dump(mode="python")
     config_data["adapters"] = {
-        "mutator": {"search_space": {}},
-        "observer": {"search_space": {}},
+        "mutator": {},
+        "observer": {},
     }
     config = SmartSearchConfig.model_validate(config_data)
     observed_backends = []
@@ -466,7 +464,7 @@ def test_adapter_parameter_separator_collisions_are_rejected() -> None:
         search_module._merge_adapter_spaces([branch], {"test.feature": plan})
 
     config_data = _config().model_dump(mode="python")
-    config_data["adapters"] = {"ambiguous::adapter": {"search_space": {}}}
+    config_data["adapters"] = {"ambiguous::adapter": {}}
     config = SmartSearchConfig.model_validate(config_data)
     with pytest.raises(ValueError, match="adapter names.*reserved separator"):
         search_module._prepare_providers(

--- a/components/src/dynamo/replay/tests/test_simulation_integration.py
+++ b/components/src/dynamo/replay/tests/test_simulation_integration.py
@@ -54,22 +54,18 @@ def _config(
     # because it has complete coverage in the GB200 performance database.
     adapters = {
         "dynamo.planner": {
-            "search_space": {
-                "scaling_policy": [scaling_policy],
-                "fpm_sampling": ["default"],
-                "load_sensitivity": ["default"],
-                "load_predictor_candidates": ["constant_last"],
-            }
+            "scaling_policy": [scaling_policy],
+            "fpm_sampling": ["default"],
+            "load_sensitivity": ["default"],
+            "load_predictor_candidates": ["constant_last"],
         }
     }
     if include_router:
         adapters["dynamo.router"] = {
-            "search_space": {
-                "mode": ["kv_router"],
-                "overlap_score_credit": [0.5],
-                "prefill_load_scale": [1.0],
-                "temperature": [0.2],
-            }
+            "mode": ["kv_router"],
+            "overlap_score_credit": [0.5],
+            "prefill_load_scale": [1.0],
+            "temperature": [0.2],
         }
 
     return SmartSearchConfig(
@@ -158,7 +154,7 @@ def _run_one(policy: str):
 
     adapter = create_planner_provider()
     adapter_plan = adapter.generate_search_space(
-        config.adapters["dynamo.planner"].search_space,
+        config.adapters["dynamo.planner"],
         SweepContext(
             core_search_space=config.search_space.model_dump(mode="json"),
             workload=config.workload.model_dump(mode="json"),

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/configuration.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/configuration.md
@@ -28,8 +28,7 @@ search_space:
 
 adapters:
   example.policy:
-    search_space:
-      mode: [balanced, latency]
+    mode: [balanced, latency]
 
 workload:
   isl: 1024
@@ -46,9 +45,9 @@ sweep:
   parallel_evals: 4
 ```
 
-The adapter value is a search space, not one concrete runtime configuration. Its provider validates
-the whole mapping, contributes optimizer dimensions, and later materializes one concrete adapter
-configuration for each candidate.
+The mapping directly under each adapter name is its search space, not one concrete runtime
+configuration. Its provider validates that mapping, contributes optimizer dimensions, and later
+materializes one concrete adapter configuration for each candidate.
 
 ## Backend Fields
 
@@ -86,7 +85,7 @@ KV-feasible, and supported by at least one selected backend.
 
 ## Provider Selection
 
-Adapter names are provider entry-point names. A provider can be installed through the
+Adapter names select matching provider entry points. A provider can be installed through the
 `aisimulate.sweep_config_providers` entry-point group or injected into the `Sweeper` constructor:
 
 ```python

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/dynamo-integration.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/dynamo-integration.md
@@ -68,14 +68,12 @@ Each adapter value is a search space, not one concrete Planner or Router config:
 ```yaml
 adapters:
   dynamo.router:
-    search_space:
-      mode: [kv_router, round_robin]
-      overlap_score_credit: [0.0, 0.5, 1.0]
+    mode: [kv_router, round_robin]
+    overlap_score_credit: [0.0, 0.5, 1.0]
   dynamo.planner:
-    search_space:
-      scaling_policy: [disabled, load_180_5]
-      fpm_sampling: [default]
-      load_sensitivity: [default]
+    scaling_policy: [disabled, load_180_5]
+    fpm_sampling: [default]
+    load_sensitivity: [default]
 ```
 
 The Planner provider derives load-predictor parameters from all configured scaling intervals during

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/planner-goodput-per-gpu-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/planner-goodput-per-gpu-sweep.md
@@ -67,17 +67,15 @@ search_space:
   agg_max_num_seqs: [512]
 adapters:
   dynamo.router:
-    search_space:
-      mode: [kv_router]
-      overlap_score_credit: [1.0]
-      prefill_load_scale: [4.0]
-      temperature: [0.0]
+    mode: [kv_router]
+    overlap_score_credit: [1.0]
+    prefill_load_scale: [4.0]
+    temperature: [0.0]
   dynamo.planner:
-    search_space:
-      scaling_policy: [throughput_180_5, throughput_600_5, load_180_5,
-                       load_180_10, hybrid_180_5, hybrid_600_5]
-      load_sensitivity: [aggressive, default, conservative]
-      fpm_sampling: [small, default, large, fine]
+    scaling_policy: [throughput_180_5, throughput_600_5, load_180_5,
+                     load_180_10, hybrid_180_5, hybrid_600_5]
+    load_sensitivity: [aggressive, default, conservative]
+    fpm_sampling: [small, default, large, fine]
 workload:
   trace_path: <toolagent_trace.jsonl>            # open-loop: no replay_concurrency
   trace_format: mooncake

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/router-end-to-end-latency-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/router-end-to-end-latency-sweep.md
@@ -50,11 +50,10 @@ search_space:
   agg_max_num_seqs: [512]
 adapters:
   dynamo.router:
-    search_space:
-      mode: [kv_router, round_robin]
-      overlap_score_credit: [0.0, 0.5, 1.0]
-      prefill_load_scale: [0.0, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
-      temperature: [0.0, 0.2, 0.5, 1.0]
+    mode: [kv_router, round_robin]
+    overlap_score_credit: [0.0, 0.5, 1.0]
+    prefill_load_scale: [0.0, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
+    temperature: [0.0, 0.2, 0.5, 1.0]
 workload:
   trace_path: <toolagent_trace.jsonl>           # 2k subset for the search; full trace to validate
   trace_format: mooncake

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/sweep-config-provider.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/sweep-config-provider.md
@@ -36,9 +36,9 @@ class ExampleProvider:
         return AdapterReplaySpec(config={"mode": selection["mode"]})
 ```
 
-`generate_search_space` receives the complete adapter-owned search-space mapping plus an isolated
-`SweepContext`. It may validate composite settings, derive dimensions, and store JSON-compatible
-state in `AdapterSearchPlan`.
+`generate_search_space` receives the complete mapping configured directly under the adapter name,
+plus an isolated `SweepContext`. It may validate composite settings, derive dimensions, and store
+JSON-compatible state in `AdapterSearchPlan`.
 
 `materialize_replay` receives that plan, one concrete local selection, and an isolated
 `CandidateContext`. It returns the concrete adapter config and any versioned `RuntimeHookSpec`

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/tutorial.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/tutorial.md
@@ -66,12 +66,11 @@ An installed or injected provider owns the schema below its adapter name:
 ```yaml
 adapters:
   example.policy:
-    search_space:
-      mode: [balanced, latency]
+    mode: [balanced, latency]
 ```
 
-The provider receives the complete `search_space` mapping. It does not receive a preselected
-concrete feature configuration.
+The provider receives the complete mapping directly under `example.policy`. It does not receive a
+preselected concrete feature configuration.
 
 ## 5. Run and Inspect
 


### PR DESCRIPTION
## Summary

- flatten each `SmartSearchConfig.adapters` value so it is the provider-owned search mapping directly, removing the redundant `search_space` wrapper
- preserve `AdapterSearchConfig` as a public type alias and keep the provider ABI and config materialization behavior unchanged
- update migration errors, tests, example YAML, canonical AISimulate docs, generated Fern copies, and Dynamo integration examples

```yaml
adapters:
  dynamo.router:
    mode: [round_robin, kv_router]
```

## Compatibility

This intentionally changes the experimental Sweeper config shape. Existing nested adapter configs must remove one `search_space` level. Draft PR #13075 currently constructs the nested shape on its stacked CLI branch and will need the corresponding update when rebased.

## Validation

- `.venv/bin/python -m pytest -q --durations=10 aisimulate/tests/sweeper` (249 passed)
- `ruff check` on all changed Python files
- `python3 docs/fern/scripts/sync_aisimulate_docs.py --check`
- `git diff --check`
- changed Dynamo replay integration code compiles; local collection requires the full Kubernetes/runtime dependency stack and was not run

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simplified adapter sweep configuration by placing search-space parameters directly under each adapter.
  - Providers now receive and control the complete adapter configuration, including validation and materialization.

- **Documentation**
  - Updated configuration guides, tutorials, examples, and integration references to reflect the new format.
  - Clarified how adapter names select provider entry points and how search-space generation works.

- **Bug Fixes**
  - Improved migration guidance and error messages for legacy planner and router configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->