### PR TITLE
fix(gms): name V1 sockets by device ordinal

### DIFF
--- a/lib/gpu_memory_service/v1/device.py
+++ b/lib/gpu_memory_service/v1/device.py
@@ -66,7 +66,7 @@ def get_socket_path(device: int, tag: str = "weights") -> str:
     socket_dir = os.environ.get("GMS_SOCKET_DIR") or tempfile.gettempdir()
     path = os.path.join(
         socket_dir,
-        f"gms_{get_device_uuid(device)}_{tag}.sock",
+        f"gms_{device}_{tag}.sock",
     )
     path_bytes = len(os.fsencode(path))
     if path_bytes >= _AF_UNIX_PATH_LIMIT:


### PR DESCRIPTION
## Summary

- Name GMS V1 Unix-domain sockets by the CUDA-visible device ordinal and memory domain (`weights` or `kv`) instead of the physical GPU UUID.
- Keep the endpoint stable when a checkpointed worker migrates to a different physical GPU while retaining the same visible device ordinal.
- Preserve the existing physical-GPU UUID handshake and client-side identity validation; only endpoint discovery changes.
- Leave GMS V0 unchanged.

V1 servers and clients must use this change together because the socket naming convention changes.

## Validation

- `23 passed`:
  ```text
  cd lib/gpu_memory_service
  PYTHONPATH="$PWD/..:$PWD/tests" uv run --isolated --extra test \
    --with pytest-timeout --with cuda-python python -m pytest \
    -c /tmp/gms-v1-pytest.ini -o cache_dir=/tmp/gms-v1-pytest-cache -q \
    tests/test_cli_server.py \
    tests/test_v1_checkpoint.py \
    tests/test_v1_memory_manager.py::test_same_client_manager_preserves_weights_and_recreates_kv \
    tests/test_v1_memory_manager.py::test_identity_mismatch_wins_when_session_close_fails
  ```
- Ruff and Black checks passed for `lib/gpu_memory_service/v1/device.py`.
- Directly verified that socket-path generation no longer resolves a GPU UUID and produces ordinal paths such as `/gms/gms_3_weights.sock`.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated V1 GPU socket naming to use the CUDA-visible device number, improving consistency in multi-GPU environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->