### PR TITLE
fix(frontend): preserve cache salting when nvext is disabled

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -20,12 +20,13 @@ use dynamo_llm::kv_router::prefill_router::PrefillQueryOutcome;
 use dynamo_llm::kv_router::{KvRouter, PrefillRouter};
 use dynamo_llm::model_card::ModelDeploymentCard;
 use dynamo_llm::preprocessor::OpenAIPreprocessor;
-use dynamo_llm::protocols::common::extensions::{HEADER_TENANT_ID, request_cache_salt};
+use dynamo_llm::protocols::common::extensions::{
+    HEADER_TENANT_ID, last_non_empty_trimmed_value, request_cache_salt,
+};
 use dynamo_runtime::discovery::{DiscoveryInstance, DiscoveryQuery, hash_pod_name};
 use dynamo_runtime::pipeline::RouterMode;
 use dynamo_runtime::{DistributedRuntime, Runtime};
 
-use crate::envoy_helpers::find_header;
 use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo, ResponseUsage};
 
 const BOOKKEEPING_TIMEOUT: Duration = Duration::from_secs(5);
@@ -71,10 +72,14 @@ fn cache_namespace_with_header_override(
     headers: &[(String, String)],
     body_cache_namespace: Option<String>,
 ) -> Option<String> {
-    find_header(headers, HEADER_TENANT_ID)
-        .filter(|tenant_id| !tenant_id.is_empty())
-        .map(str::to_owned)
-        .or(body_cache_namespace)
+    last_non_empty_trimmed_value(
+        headers
+            .iter()
+            .filter(|(key, _)| key.eq_ignore_ascii_case(HEADER_TENANT_ID))
+            .map(|(_, value)| value.as_str()),
+    )
+    .map(str::to_owned)
+    .or(body_cache_namespace)
 }
 
 /// Name of the inference-serving HTTP port on a Dynamo worker pod.
@@ -1147,7 +1152,10 @@ mod tests {
 
     #[test]
     fn empty_tenant_header_falls_back_to_body_cache_namespace() {
-        let headers = vec![(HEADER_TENANT_ID.to_string(), String::new())];
+        let headers = vec![
+            (HEADER_TENANT_ID.to_string(), String::new()),
+            ("X-Tenant-ID".to_string(), "   ".to_string()),
+        ];
 
         assert_eq!(
             cache_namespace_with_header_override(&headers, Some("tenant-body".to_string()))
@@ -1159,6 +1167,21 @@ mod tests {
     #[test]
     fn absent_cache_namespace_stays_absent() {
         assert_eq!(cache_namespace_with_header_override(&[], None), None);
+    }
+
+    #[test]
+    fn last_non_empty_trimmed_tenant_header_wins() {
+        let headers = vec![
+            (HEADER_TENANT_ID.to_string(), "tenant-client".to_string()),
+            ("X-Tenant-ID".to_string(), "   ".to_string()),
+            (HEADER_TENANT_ID.to_string(), " tenant-gateway ".to_string()),
+        ];
+
+        assert_eq!(
+            cache_namespace_with_header_override(&headers, Some("tenant-body".to_string()))
+                .as_deref(),
+            Some("tenant-gateway")
+        );
     }
 
     /// Proves the core feature: `nvext.agent_hints.priority` lifts into a

--- a/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
+++ b/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
@@ -97,7 +97,7 @@ KV-cache entries:
 | TensorRT-LLM | Supported | Router matching and backend KV-cache reuse are isolated by salt. |
 | SGLang | Not supported end to end | Dynamo request hashes are namespaced, but the embedded SGLang engine does not receive the salt. SGLang KV events and radix-cache reuse remain unsalted. Do not rely on `cache_salt` for tenant cache isolation with SGLang. |
 
-Dynamo accepts three inputs, in descending precedence:
+Chat completion and completion requests accept three inputs, in descending precedence:
 
 1. The non-empty `x-tenant-id` HTTP header, intended for gateway-controlled tenant identity.
 2. The recommended `nvext.cache_salt` request field.
@@ -105,15 +105,19 @@ Dynamo accepts three inputs, in descending precedence:
 
 Empty strings are treated as absent. In particular, an empty `nvext.cache_salt` falls back to a
 non-empty top-level compatibility value. Requests without a salt retain the unsalted hashing and
-cache-reuse behavior.
+cache-reuse behavior. Responses and Anthropic Messages accept the first two inputs. Classify and
+pooling requests accept only their independent top-level `cache_salt` field. Embeddings requests do
+not accept a cache salt.
 
 `DYN_DISABLE_FRONTEND_NVEXT=true` disables non-salt NvExt fields, non-salt routing headers, and
-response `extra_fields`. Cache isolation is exempt. Dynamo continues to use `nvext.cache_salt` and
-`x-tenant-id` on chat completions, completions, Responses, and Anthropic Messages. The top-level
-compatibility field also remains active on chat and completion requests. The same precedence and
-empty-value rules apply when NvExt is disabled. Cache salt is an isolation key, not an
-authentication or authorization mechanism. Gateways must still authenticate the tenant identity
-they place in `x-tenant-id`.
+response `extra_fields` on endpoints that support those features. Cache isolation is exempt.
+Dynamo continues to use `nvext.cache_salt` and `x-tenant-id` on chat completions, completions,
+Responses, and Anthropic Messages. Top-level cache salts remain active on chat completions,
+completions, classify, and pooling. On embeddings, classify, and pooling, the switch only drops the
+legacy NvExt annotations; these endpoints do not use `x-tenant-id` or the `x-dynamo-*` routing
+headers in either mode. The same precedence and empty-value rules apply when NvExt is disabled.
+Cache salt is an isolation key, not an authentication or authorization mechanism. Gateways must
+still authenticate the tenant identity they place in `x-tenant-id`.
 
 Session identity is header-only. Use the coding-agent headers or Dynamo
 session headers described in [Session IDs](../../use-cases/agents/session-ids.mdx);

--- a/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
+++ b/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
@@ -107,10 +107,13 @@ Empty strings are treated as absent. In particular, an empty `nvext.cache_salt` 
 non-empty top-level compatibility value. Requests without a salt retain the unsalted hashing and
 cache-reuse behavior.
 
-`DYN_ENABLE_FRONTEND_NVEXT=false` disables both the `nvext` form and routing-header overrides,
-including `x-tenant-id`. The top-level backend-compatibility field is not part of the NvExt
-protocol. Cache salt is an isolation key, not an authentication or authorization mechanism;
-gateways must still authenticate the tenant identity they place in `x-tenant-id`.
+`DYN_DISABLE_FRONTEND_NVEXT=true` disables non-salt NvExt fields, non-salt routing headers, and
+response `extra_fields`. Cache isolation is exempt. Dynamo continues to use `nvext.cache_salt` and
+`x-tenant-id` on chat completions, completions, Responses, and Anthropic Messages. The top-level
+compatibility field also remains active on chat and completion requests. The same precedence and
+empty-value rules apply when NvExt is disabled. Cache salt is an isolation key, not an
+authentication or authorization mechanism. Gateways must still authenticate the tenant identity
+they place in `x-tenant-id`.
 
 Session identity is header-only. Use the coding-agent headers or Dynamo
 session headers described in [Session IDs](../../use-cases/agents/session-ids.mdx);

--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -686,12 +686,17 @@ Environment variables controlling frontend extensions. Extensions are enabled by
 truthy value (`1`, `true`, `yes`, or `on`, case-insensitive) to disable the corresponding surface.
 
 <ParamField path="DYN_DISABLE_FRONTEND_NVEXT" type="boolean" default="false">
-  When truthy, the frontend drops `request.nvext` on `/v1/chat/completions`, `/v1/completions`,
-  `/v1/responses`, `/v1/embeddings`, and `/v1/messages`; ignores the
+  When truthy, the frontend drops all request NvExt fields except a supported `cache_salt` on
+  `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/embeddings`, `/v1/messages`,
+  `/v1/classify`, and `/v1/pooling`; ignores the
   `x-dynamo-worker-instance-id`, `x-dynamo-prefill-instance-id`, `x-dynamo-dp-rank`,
   `x-dynamo-prefill-dp-rank`, `x-dynamo-request-priority`, and
   `x-dynamo-request-strict-priority` routing headers and their compatibility aliases; and ignores
-  the response-side `nvext.extra_fields` opt-in.
+  the response-side `nvext.extra_fields` opt-in. Cache isolation remains active. The frontend
+  continues to use non-empty `nvext.cache_salt` values where accepted. Top-level compatibility
+  fields on chat and completion requests are unaffected. The frontend also continues to use
+  non-empty `x-tenant-id` values on chat completions, completions, Responses, and Anthropic
+  Messages. The switch does not add `x-tenant-id` support to embeddings, classify, or pooling.
 </ParamField>
 
 <ParamField path="DYN_DISABLE_FRONTEND_ADMIN_API" type="boolean" default="false">

--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -686,17 +686,16 @@ Environment variables controlling frontend extensions. Extensions are enabled by
 truthy value (`1`, `true`, `yes`, or `on`, case-insensitive) to disable the corresponding surface.
 
 <ParamField path="DYN_DISABLE_FRONTEND_NVEXT" type="boolean" default="false">
-  When truthy, the frontend drops all request NvExt fields except a supported `cache_salt` on
-  `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/embeddings`, `/v1/messages`,
-  `/v1/classify`, and `/v1/pooling`; ignores the
+  When truthy, the frontend drops all request NvExt fields except `cache_salt` on
+  `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, and `/v1/messages`; ignores the
   `x-dynamo-worker-instance-id`, `x-dynamo-prefill-instance-id`, `x-dynamo-dp-rank`,
   `x-dynamo-prefill-dp-rank`, `x-dynamo-request-priority`, and
   `x-dynamo-request-strict-priority` routing headers and their compatibility aliases; and ignores
   the response-side `nvext.extra_fields` opt-in. Cache isolation remains active. The frontend
-  continues to use non-empty `nvext.cache_salt` values where accepted. Top-level compatibility
-  fields on chat and completion requests are unaffected. The frontend also continues to use
-  non-empty `x-tenant-id` values on chat completions, completions, Responses, and Anthropic
-  Messages. The switch does not add `x-tenant-id` support to embeddings, classify, or pooling.
+  continues to use non-empty `nvext.cache_salt` and `x-tenant-id` values on these four endpoint
+  groups. Top-level cache salts remain active on chat completions, completions, classify, and
+  pooling. On embeddings, classify, and pooling, the switch only drops legacy NvExt annotations;
+  these endpoints do not use `x-tenant-id` or `x-dynamo-*` routing headers in either mode.
 </ParamField>
 
 <ParamField path="DYN_DISABLE_FRONTEND_ADMIN_API" type="boolean" default="false">

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -48,7 +48,8 @@ use crate::protocols::anthropic::types::{
 };
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
-    apply_frontend_nvext_policy, has_non_cache_salt_routing_headers, session_affinity_from_headers,
+    apply_cache_salt_header_override, apply_header_routing_overrides,
+    has_non_cache_salt_routing_headers, session_affinity_from_headers,
 };
 use crate::protocols::common::input_trigger::classify_anthropic_request;
 use crate::protocols::openai::chat_completions::{
@@ -62,7 +63,7 @@ use crate::types::Annotated;
 // Re-use helpers from the openai module (sibling under service/)
 use super::error::{SanitizedError, invalid_argument};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
-use super::openai::{get_body_limit, get_or_create_request_id};
+use super::openai::{get_body_limit, get_or_create_request_id, warn_nvext_disabled};
 
 // ---------------------------------------------------------------------------
 // Router
@@ -467,7 +468,7 @@ async fn anthropic_messages(
     // etc.) that the stream converter needs for faithful response reconstruction.
     let anthropic_ctx = unified_request.anthropic_context().cloned();
     let mut chat_request = unified_request.into_inner();
-    apply_anthropic_header_routing_overrides(&mut chat_request, &headers, state.nvext_enabled());
+    apply_anthropic_nvext_policy(&mut chat_request, &headers, state.nvext_enabled());
     if let Err(error) = chat_request.validate() {
         inflight_guard.mark_error(ErrorType::Validation);
         let error = invalid_argument(error.to_string());
@@ -1049,50 +1050,40 @@ fn gate_anthropic_nvext(
     }
 
     let mut discarded = has_non_cache_salt_routing_headers(headers);
-    let Some(raw_nvext) = request.nvext.take() else {
-        if discarded {
-            tracing::warn!(
-                endpoint = "anthropic_messages",
-                "request carried disabled routing headers; dropping them"
-            );
-        }
-        return Ok(());
-    };
-    let serde_json::Value::Object(mut fields) = raw_nvext else {
-        tracing::warn!(
-            endpoint = "anthropic_messages",
-            "request carried disabled nvext data or routing headers; dropping them"
-        );
-        return Ok(());
-    };
+    if let Some(raw_nvext) = request.nvext.take() {
+        if let serde_json::Value::Object(mut fields) = raw_nvext {
+            if fields.keys().any(|field| field != "cache_salt") {
+                discarded = true;
+            }
 
-    if fields.keys().any(|field| field != "cache_salt") {
-        discarded = true;
+            request.nvext = match fields.remove("cache_salt") {
+                None | Some(serde_json::Value::Null) => None,
+                Some(serde_json::Value::String(cache_salt)) if cache_salt.is_empty() => None,
+                Some(serde_json::Value::String(cache_salt)) => {
+                    Some(serde_json::json!({ "cache_salt": cache_salt }))
+                }
+                Some(_) => anyhow::bail!("invalid nvext.cache_salt: expected a string or null"),
+            };
+        } else {
+            discarded = true;
+        }
     }
 
-    request.nvext = match fields.remove("cache_salt") {
-        None | Some(serde_json::Value::Null) => None,
-        Some(serde_json::Value::String(cache_salt)) if cache_salt.is_empty() => None,
-        Some(serde_json::Value::String(cache_salt)) => {
-            Some(serde_json::json!({ "cache_salt": cache_salt }))
-        }
-        Some(_) => anyhow::bail!("invalid nvext.cache_salt: expected a string or null"),
-    };
-    if discarded {
-        tracing::warn!(
-            endpoint = "anthropic_messages",
-            "request carried disabled nvext fields or routing headers; dropping them"
-        );
-    }
+    warn_nvext_disabled("anthropic_messages", discarded);
     Ok(())
 }
 
-fn apply_anthropic_header_routing_overrides(
+fn apply_anthropic_nvext_policy(
     request: &mut NvCreateChatCompletionRequest,
     headers: &HeaderMap,
     nvext_enabled: bool,
 ) {
-    request.nvext = apply_frontend_nvext_policy(request.nvext.take(), headers, nvext_enabled);
+    let nvext = apply_cache_salt_header_override(request.nvext.take(), headers);
+    request.nvext = if nvext_enabled {
+        apply_header_routing_overrides(nvext, headers)
+    } else {
+        nvext
+    };
 }
 
 /// Build an Anthropic-formatted error response from a canonical
@@ -1242,6 +1233,21 @@ mod tests {
     }
 
     #[test]
+    fn anthropic_nvext_gate_ignores_malformed_non_salt_data_when_disabled() {
+        for raw_nvext in [
+            serde_json::json!(42),
+            serde_json::json!({"agent_hints": 42}),
+            serde_json::json!({"unsupported_future_field": true}),
+        ] {
+            let mut request = request_with_nvext();
+            request.nvext = Some(raw_nvext);
+
+            gate_anthropic_nvext(&mut request, &HeaderMap::new(), false).unwrap();
+            assert!(request.nvext.is_none());
+        }
+    }
+
+    #[test]
     fn anthropic_nvext_rejects_agent_context() {
         let err = parse_nvext(Some(serde_json::json!({
             "agent_context": {
@@ -1254,7 +1260,7 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_header_routing_overrides_apply_when_enabled() {
+    fn anthropic_nvext_policy_applies_routing_when_enabled() {
         let request = request_with_nvext();
         let mut chat_request: NvCreateChatCompletionRequest = request.try_into().unwrap();
         let mut headers = HeaderMap::new();
@@ -1262,7 +1268,7 @@ mod tests {
         headers.insert("x-dynamo-prefill-instance-id", "7".parse().unwrap());
         headers.insert("x-dynamo-dp-rank", "3".parse().unwrap());
 
-        apply_anthropic_header_routing_overrides(&mut chat_request, &headers, true);
+        apply_anthropic_nvext_policy(&mut chat_request, &headers, true);
         let nvext = chat_request.nvext.unwrap();
 
         assert_eq!(nvext.backend_instance_id, Some(42));
@@ -1272,20 +1278,22 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_header_routing_overrides_keep_only_tenant_salt_when_disabled() {
+    fn anthropic_nvext_policy_applies_only_tenant_when_disabled() {
         let mut request = request_with_nvext();
         let mut headers = HeaderMap::new();
         headers.insert("x-dynamo-worker-instance-id", "42".parse().unwrap());
         headers.insert("x-dynamo-dp-rank", "3".parse().unwrap());
         headers.insert("x-dynamo-request-priority", "7".parse().unwrap());
-        headers.insert("x-tenant-id", "tenant-header".parse().unwrap());
+        headers.insert("x-tenant-id", "tenant-client".parse().unwrap());
+        headers.append("x-tenant-id", "   ".parse().unwrap());
+        headers.append("x-tenant-id", " tenant-gateway ".parse().unwrap());
         gate_anthropic_nvext(&mut request, &headers, false).unwrap();
         let mut chat_request: NvCreateChatCompletionRequest = request.try_into().unwrap();
 
-        apply_anthropic_header_routing_overrides(&mut chat_request, &headers, false);
+        apply_anthropic_nvext_policy(&mut chat_request, &headers, false);
         let nvext = chat_request.nvext.unwrap();
 
-        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-header"));
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-gateway"));
         assert_eq!(nvext.backend_instance_id, None);
         assert_eq!(nvext.decode_worker_id, None);
         assert_eq!(nvext.dp_rank, None);
@@ -1296,11 +1304,11 @@ mod tests {
     fn anthropic_empty_tenant_header_falls_back_to_body_salt_when_disabled() {
         let mut request = request_with_nvext();
         let mut headers = HeaderMap::new();
-        headers.insert("x-tenant-id", "".parse().unwrap());
+        headers.insert("x-tenant-id", "   ".parse().unwrap());
         gate_anthropic_nvext(&mut request, &headers, false).unwrap();
         let mut chat_request: NvCreateChatCompletionRequest = request.try_into().unwrap();
 
-        apply_anthropic_header_routing_overrides(&mut chat_request, &headers, false);
+        apply_anthropic_nvext_policy(&mut chat_request, &headers, false);
 
         assert_eq!(
             chat_request

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -48,7 +48,7 @@ use crate::protocols::anthropic::types::{
 };
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
-    apply_header_routing_overrides, session_affinity_from_headers,
+    apply_frontend_nvext_policy, has_non_cache_salt_routing_headers, session_affinity_from_headers,
 };
 use crate::protocols::common::input_trigger::classify_anthropic_request;
 use crate::protocols::openai::chat_completions::{
@@ -289,7 +289,14 @@ async fn handler_anthropic_messages(
             "max_tokens: must be greater than 0",
         ));
     }
-    gate_anthropic_nvext(&mut request, state.nvext_enabled());
+    if let Err(error) = gate_anthropic_nvext(&mut request, &headers, state.nvext_enabled()) {
+        inflight_guard.mark_error(ErrorType::Validation);
+        return Err(anthropic_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            &error.to_string(),
+        ));
+    }
 
     // Create request context
     let cancellation_labels = CancellationLabels {
@@ -1032,18 +1039,52 @@ fn estimate_input_tokens(req: &AnthropicCreateMessageRequest) -> u32 {
     .estimate_tokens()
 }
 
-fn gate_anthropic_nvext(request: &mut AnthropicCreateMessageRequest, nvext_enabled: bool) {
+fn gate_anthropic_nvext(
+    request: &mut AnthropicCreateMessageRequest,
+    headers: &HeaderMap,
+    nvext_enabled: bool,
+) -> anyhow::Result<()> {
     if nvext_enabled {
-        return;
+        return Ok(());
     }
 
-    if request.nvext.is_some() {
+    let mut discarded = has_non_cache_salt_routing_headers(headers);
+    let Some(raw_nvext) = request.nvext.take() else {
+        if discarded {
+            tracing::warn!(
+                endpoint = "anthropic_messages",
+                "request carried disabled routing headers; dropping them"
+            );
+        }
+        return Ok(());
+    };
+    let serde_json::Value::Object(mut fields) = raw_nvext else {
         tracing::warn!(
             endpoint = "anthropic_messages",
-            "request carried nvext data but the nvext extension is disabled on this frontend; dropping it"
+            "request carried disabled nvext data or routing headers; dropping them"
+        );
+        return Ok(());
+    };
+
+    if fields.keys().any(|field| field != "cache_salt") {
+        discarded = true;
+    }
+
+    request.nvext = match fields.remove("cache_salt") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(cache_salt)) if cache_salt.is_empty() => None,
+        Some(serde_json::Value::String(cache_salt)) => {
+            Some(serde_json::json!({ "cache_salt": cache_salt }))
+        }
+        Some(_) => anyhow::bail!("invalid nvext.cache_salt: expected a string or null"),
+    };
+    if discarded {
+        tracing::warn!(
+            endpoint = "anthropic_messages",
+            "request carried disabled nvext fields or routing headers; dropping them"
         );
     }
-    request.nvext = None;
+    Ok(())
 }
 
 fn apply_anthropic_header_routing_overrides(
@@ -1051,9 +1092,7 @@ fn apply_anthropic_header_routing_overrides(
     headers: &HeaderMap,
     nvext_enabled: bool,
 ) {
-    if nvext_enabled {
-        request.nvext = apply_header_routing_overrides(request.nvext.take(), headers);
-    }
+    request.nvext = apply_frontend_nvext_policy(request.nvext.take(), headers, nvext_enabled);
 }
 
 /// Build an Anthropic-formatted error response from a canonical
@@ -1156,6 +1195,7 @@ mod tests {
             "max_tokens": 16,
             "messages": [{"role": "user", "content": "hi"}],
             "nvext": {
+                "cache_salt": "tenant-body",
                 "agent_hints": {
                     "priority": 5
                 }
@@ -1167,7 +1207,7 @@ mod tests {
     #[test]
     fn anthropic_nvext_gate_preserves_when_enabled() {
         let mut request = request_with_nvext();
-        gate_anthropic_nvext(&mut request, true);
+        gate_anthropic_nvext(&mut request, &HeaderMap::new(), true).unwrap();
         let nvext = parse_nvext(request.nvext).unwrap();
 
         assert_eq!(
@@ -1177,11 +1217,28 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_nvext_gate_strips_when_disabled() {
+    fn anthropic_nvext_gate_retains_only_cache_salt_when_disabled() {
         let mut request = request_with_nvext();
-        gate_anthropic_nvext(&mut request, false);
+        gate_anthropic_nvext(&mut request, &HeaderMap::new(), false).unwrap();
+        let nvext = parse_nvext(request.nvext).unwrap().unwrap();
 
-        assert!(request.nvext.is_none());
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-body"));
+        assert!(!nvext.has_non_cache_salt_fields());
+    }
+
+    #[test]
+    fn anthropic_nvext_gate_rejects_invalid_cache_salt_when_disabled() {
+        let mut request = request_with_nvext();
+        request.nvext = Some(serde_json::json!({
+            "cache_salt": 42,
+            "ignored_field": true
+        }));
+
+        let error = gate_anthropic_nvext(&mut request, &HeaderMap::new(), false).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "invalid nvext.cache_salt: expected a string or null"
+        );
     }
 
     #[test]
@@ -1215,17 +1272,43 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_header_routing_overrides_skip_when_disabled() {
-        let request = request_with_nvext();
-        let mut chat_request: NvCreateChatCompletionRequest = request.try_into().unwrap();
+    fn anthropic_header_routing_overrides_keep_only_tenant_salt_when_disabled() {
+        let mut request = request_with_nvext();
         let mut headers = HeaderMap::new();
         headers.insert("x-dynamo-worker-instance-id", "42".parse().unwrap());
+        headers.insert("x-dynamo-dp-rank", "3".parse().unwrap());
+        headers.insert("x-dynamo-request-priority", "7".parse().unwrap());
+        headers.insert("x-tenant-id", "tenant-header".parse().unwrap());
+        gate_anthropic_nvext(&mut request, &headers, false).unwrap();
+        let mut chat_request: NvCreateChatCompletionRequest = request.try_into().unwrap();
 
         apply_anthropic_header_routing_overrides(&mut chat_request, &headers, false);
         let nvext = chat_request.nvext.unwrap();
 
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-header"));
         assert_eq!(nvext.backend_instance_id, None);
         assert_eq!(nvext.decode_worker_id, None);
+        assert_eq!(nvext.dp_rank, None);
+        assert_eq!(nvext.agent_hints, None);
+    }
+
+    #[test]
+    fn anthropic_empty_tenant_header_falls_back_to_body_salt_when_disabled() {
+        let mut request = request_with_nvext();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-tenant-id", "".parse().unwrap());
+        gate_anthropic_nvext(&mut request, &headers, false).unwrap();
+        let mut chat_request: NvCreateChatCompletionRequest = request.try_into().unwrap();
+
+        apply_anthropic_header_routing_overrides(&mut chat_request, &headers, false);
+
+        assert_eq!(
+            chat_request
+                .nvext
+                .and_then(|nvext| nvext.cache_salt)
+                .as_deref(),
+            Some("tenant-body")
+        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -52,8 +52,9 @@ use super::{
 use crate::engines::ValidateRequest;
 use crate::preprocessor::PRESERVE_OMITTED_MAX_TOKENS_CONTEXT_KEY;
 use crate::protocols::common::extensions::{
-    AGENT_CONTEXT_CONTEXT_KEY, AgentContext, InputTrigger, SESSION_AFFINITY_CONTEXT_KEY,
-    SessionAffinityId, agent_context_from_headers, apply_header_routing_overrides,
+    AGENT_CONTEXT_CONTEXT_KEY, AgentContext, InputTrigger, NvExt as CommonNvExt,
+    SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId, agent_context_from_headers,
+    apply_frontend_nvext_policy, has_non_cache_salt_routing_headers, retain_cache_salt,
     session_affinity_from_headers,
 };
 use crate::protocols::common::input_trigger::{
@@ -661,35 +662,22 @@ fn copy_context_metadata<T: Send + Sync + 'static, U: Send + Sync + 'static>(
     }
 }
 
-/// Warn (once per request) when nvext data is dropped because the extension is
-/// disabled. Only called from the disabled branch, so the default path is free.
-fn warn_nvext_disabled(endpoint: &str, nvext_present: bool, headers: &HeaderMap) {
-    use crate::protocols::common::extensions::{
-        HEADER_DATA_PARALLEL_RANK_ALIAS, HEADER_DP_RANK, HEADER_DP_RANK_ALIAS,
-        HEADER_PREFILL_DP_RANK, HEADER_PREFILL_DP_RANK_ALIAS, HEADER_PREFILL_INSTANCE_ID,
-        HEADER_PREFILL_INSTANCE_ID_ALIAS, HEADER_REQUEST_PRIORITY, HEADER_REQUEST_STRICT_PRIORITY,
-        HEADER_WORKER_INSTANCE_ID, HEADER_WORKER_INSTANCE_ID_ALIAS,
-    };
-    let header_present = [
-        HEADER_WORKER_INSTANCE_ID,
-        HEADER_WORKER_INSTANCE_ID_ALIAS,
-        HEADER_PREFILL_INSTANCE_ID,
-        HEADER_PREFILL_INSTANCE_ID_ALIAS,
-        HEADER_DP_RANK,
-        HEADER_DP_RANK_ALIAS,
-        HEADER_DATA_PARALLEL_RANK_ALIAS,
-        HEADER_PREFILL_DP_RANK,
-        HEADER_PREFILL_DP_RANK_ALIAS,
-        HEADER_REQUEST_PRIORITY,
-        HEADER_REQUEST_STRICT_PRIORITY,
-    ]
-    .iter()
-    .any(|h| headers.contains_key(*h));
+/// Warn once when the disabled NvExt policy discards a field or routing header.
+/// Honored cache salts and `x-tenant-id` headers do not cause this warning.
+fn warn_nvext_disabled(
+    endpoint: &str,
+    discarded_nvext: bool,
+    headers: &HeaderMap,
+    tenant_header_supported: bool,
+) {
+    use crate::protocols::common::extensions::HEADER_TENANT_ID;
+    let header_present = has_non_cache_salt_routing_headers(headers)
+        || (!tenant_header_supported && headers.contains_key(HEADER_TENANT_ID));
 
-    if nvext_present || header_present {
+    if discarded_nvext || header_present {
         tracing::warn!(
             endpoint,
-            "request carried nvext data but the nvext extension is disabled on this frontend; dropping it"
+            "request carried disabled nvext fields or routing headers; dropping them"
         );
     }
 }
@@ -717,12 +705,19 @@ async fn handler_completions(
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.inner.model)?;
 
-    request.nvext = if state.nvext_enabled() {
-        apply_header_routing_overrides(request.nvext.take(), &headers)
-    } else {
-        warn_nvext_disabled("completions", request.nvext.is_some(), &headers);
-        None
-    };
+    if !state.nvext_enabled() {
+        warn_nvext_disabled(
+            "completions",
+            request
+                .nvext
+                .as_ref()
+                .is_some_and(CommonNvExt::has_non_cache_salt_fields),
+            &headers,
+            true,
+        );
+    }
+    request.nvext =
+        apply_frontend_nvext_policy(request.nvext.take(), &headers, state.nvext_enabled());
 
     // create the context for the request
     let request_id = get_or_create_request_id(&headers);
@@ -1298,8 +1293,16 @@ async fn embeddings(
     check_model_serving_ready(&state, &request.inner.model)?;
 
     if !state.nvext_enabled() {
-        warn_nvext_disabled("embeddings", request.nvext.is_some(), &headers);
-        request.nvext = None;
+        warn_nvext_disabled(
+            "embeddings",
+            request
+                .nvext
+                .as_ref()
+                .is_some_and(|nvext| nvext.annotations.is_some()),
+            &headers,
+            false,
+        );
+        request.nvext = retain_cache_salt(request.nvext.take());
     }
 
     // Resolve alias → primary served name before wrapping the request, so
@@ -1470,8 +1473,16 @@ async fn classify(
     check_model_serving_ready(&state, &request.model)?;
 
     if !state.nvext_enabled() {
-        warn_nvext_disabled("classify", request.nvext.is_some(), &headers);
-        request.nvext = None;
+        warn_nvext_disabled(
+            "classify",
+            request
+                .nvext
+                .as_ref()
+                .is_some_and(|nvext| nvext.annotations.is_some()),
+            &headers,
+            false,
+        );
+        request.nvext = retain_cache_salt(request.nvext.take());
     }
 
     // Resolve alias → primary served name before wrapping the request, so
@@ -1741,8 +1752,16 @@ async fn pooling(
     check_model_serving_ready(&state, &request.model)?;
 
     if !state.nvext_enabled() {
-        warn_nvext_disabled("pooling", request.nvext.is_some(), &headers);
-        request.nvext = None;
+        warn_nvext_disabled(
+            "pooling",
+            request
+                .nvext
+                .as_ref()
+                .is_some_and(|nvext| nvext.annotations.is_some()),
+            &headers,
+            false,
+        );
+        request.nvext = retain_cache_salt(request.nvext.take());
     }
     let response_encoding = request.encoding_format;
     let response_dtype = request.embed_dtype.unwrap_or_default();
@@ -1885,12 +1904,19 @@ async fn handler_chat_completions(
         check_model_serving_ready(&state, resolved_model)?;
     }
 
-    request.nvext = if state.nvext_enabled() {
-        apply_header_routing_overrides(request.nvext.take(), &headers)
-    } else {
-        warn_nvext_disabled("chat_completions", request.nvext.is_some(), &headers);
-        None
-    };
+    if !state.nvext_enabled() {
+        warn_nvext_disabled(
+            "chat_completions",
+            request
+                .nvext
+                .as_ref()
+                .is_some_and(CommonNvExt::has_non_cache_salt_fields),
+            &headers,
+            true,
+        );
+    }
+    request.nvext =
+        apply_frontend_nvext_policy(request.nvext.take(), &headers, state.nvext_enabled());
 
     // create the context for the request
     let request_id = get_or_create_request_id(&headers);
@@ -3128,12 +3154,19 @@ async fn handler_responses(
         check_model_serving_ready(&state, resolved_model)?;
     }
 
-    request.nvext = if state.nvext_enabled() {
-        apply_header_routing_overrides(request.nvext.take(), &headers)
-    } else {
-        warn_nvext_disabled("responses", request.nvext.is_some(), &headers);
-        None
-    };
+    if !state.nvext_enabled() {
+        warn_nvext_disabled(
+            "responses",
+            request
+                .nvext
+                .as_ref()
+                .is_some_and(CommonNvExt::has_non_cache_salt_fields),
+            &headers,
+            true,
+        );
+    }
+    request.nvext =
+        apply_frontend_nvext_policy(request.nvext.take(), &headers, state.nvext_enabled());
 
     // create the context for the request
     let request_id = get_or_create_request_id(&headers);

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -54,8 +54,7 @@ use crate::preprocessor::PRESERVE_OMITTED_MAX_TOKENS_CONTEXT_KEY;
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, AgentContext, InputTrigger, NvExt as CommonNvExt,
     SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId, agent_context_from_headers,
-    apply_frontend_nvext_policy, has_non_cache_salt_routing_headers, retain_cache_salt,
-    session_affinity_from_headers,
+    apply_frontend_nvext_policy, has_non_cache_salt_routing_headers, session_affinity_from_headers,
 };
 use crate::protocols::common::input_trigger::{
     classify_chat_request, classify_completion_request, classify_response_request,
@@ -664,17 +663,8 @@ fn copy_context_metadata<T: Send + Sync + 'static, U: Send + Sync + 'static>(
 
 /// Warn once when the disabled NvExt policy discards a field or routing header.
 /// Honored cache salts and `x-tenant-id` headers do not cause this warning.
-fn warn_nvext_disabled(
-    endpoint: &str,
-    discarded_nvext: bool,
-    headers: &HeaderMap,
-    tenant_header_supported: bool,
-) {
-    use crate::protocols::common::extensions::HEADER_TENANT_ID;
-    let header_present = has_non_cache_salt_routing_headers(headers)
-        || (!tenant_header_supported && headers.contains_key(HEADER_TENANT_ID));
-
-    if discarded_nvext || header_present {
+pub(super) fn warn_nvext_disabled(endpoint: &str, discarded: bool) {
+    if discarded {
         tracing::warn!(
             endpoint,
             "request carried disabled nvext fields or routing headers; dropping them"
@@ -711,9 +701,8 @@ async fn handler_completions(
             request
                 .nvext
                 .as_ref()
-                .is_some_and(CommonNvExt::has_non_cache_salt_fields),
-            &headers,
-            true,
+                .is_some_and(CommonNvExt::has_non_cache_salt_fields)
+                || has_non_cache_salt_routing_headers(&headers),
         );
     }
     request.nvext =
@@ -1299,10 +1288,8 @@ async fn embeddings(
                 .nvext
                 .as_ref()
                 .is_some_and(|nvext| nvext.annotations.is_some()),
-            &headers,
-            false,
         );
-        request.nvext = retain_cache_salt(request.nvext.take());
+        request.nvext = None;
     }
 
     // Resolve alias → primary served name before wrapping the request, so
@@ -1479,10 +1466,8 @@ async fn classify(
                 .nvext
                 .as_ref()
                 .is_some_and(|nvext| nvext.annotations.is_some()),
-            &headers,
-            false,
         );
-        request.nvext = retain_cache_salt(request.nvext.take());
+        request.nvext = None;
     }
 
     // Resolve alias → primary served name before wrapping the request, so
@@ -1758,10 +1743,8 @@ async fn pooling(
                 .nvext
                 .as_ref()
                 .is_some_and(|nvext| nvext.annotations.is_some()),
-            &headers,
-            false,
         );
-        request.nvext = retain_cache_salt(request.nvext.take());
+        request.nvext = None;
     }
     let response_encoding = request.encoding_format;
     let response_dtype = request.embed_dtype.unwrap_or_default();
@@ -1910,9 +1893,8 @@ async fn handler_chat_completions(
             request
                 .nvext
                 .as_ref()
-                .is_some_and(CommonNvExt::has_non_cache_salt_fields),
-            &headers,
-            true,
+                .is_some_and(CommonNvExt::has_non_cache_salt_fields)
+                || has_non_cache_salt_routing_headers(&headers),
         );
     }
     request.nvext =
@@ -3160,9 +3142,8 @@ async fn handler_responses(
             request
                 .nvext
                 .as_ref()
-                .is_some_and(CommonNvExt::has_non_cache_salt_fields),
-            &headers,
-            true,
+                .is_some_and(CommonNvExt::has_non_cache_salt_fields)
+                || has_non_cache_salt_routing_headers(&headers),
         );
     }
     request.nvext =

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -269,6 +269,13 @@ impl NvExt {
                 .any(|annotation| annotation.starts_with("query_instance_id:"))
         })
     }
+
+    /// Return true when this envelope contains any field other than `cache_salt`.
+    pub fn has_non_cache_salt_fields(&self) -> bool {
+        let mut non_salt = self.clone();
+        non_salt.cache_salt = None;
+        non_salt != Self::default()
+    }
 }
 
 impl NvExtBuilder {
@@ -303,6 +310,25 @@ pub const HEADER_DP_RANK_ALIAS: &str = "x-dp-rank";
 pub const HEADER_DATA_PARALLEL_RANK_ALIAS: &str = "x-data-parallel-rank";
 pub const HEADER_PREFILL_DP_RANK_ALIAS: &str = "x-prefill-dp-rank";
 const UNSET_DP_RANK_SENTINEL: u32 = u32::MAX;
+
+/// Return true when the request contains a routing header disabled by the NvExt switch.
+pub fn has_non_cache_salt_routing_headers(headers: &HeaderMap) -> bool {
+    [
+        HEADER_WORKER_INSTANCE_ID,
+        HEADER_WORKER_INSTANCE_ID_ALIAS,
+        HEADER_PREFILL_INSTANCE_ID,
+        HEADER_PREFILL_INSTANCE_ID_ALIAS,
+        HEADER_DP_RANK,
+        HEADER_DP_RANK_ALIAS,
+        HEADER_DATA_PARALLEL_RANK_ALIAS,
+        HEADER_PREFILL_DP_RANK,
+        HEADER_PREFILL_DP_RANK_ALIAS,
+        HEADER_REQUEST_PRIORITY,
+        HEADER_REQUEST_STRICT_PRIORITY,
+    ]
+    .iter()
+    .any(|header| headers.contains_key(*header))
+}
 
 impl From<AgentContextHeaderValues> for AgentContext {
     fn from(values: AgentContextHeaderValues) -> Self {
@@ -354,7 +380,6 @@ pub fn session_affinity_from_headers(headers: &HeaderMap) -> Option<SessionAffin
 /// - `x-dynamo-prefill-dp-rank` -> `prefill_dp_rank`
 /// - `x-dynamo-request-priority` -> `agent_hints.priority`
 /// - `x-dynamo-request-strict-priority` -> `agent_hints.strict_priority`
-/// - `x-tenant-id` -> `cache_salt`
 ///
 /// Routing headers take priority over existing nvext values when present.
 /// If no headers are present, returns the original nvext unchanged.
@@ -395,19 +420,12 @@ pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap)
     // `resolve_request_priority`.
     let priority = priority_header.and_then(|s| s.trim().parse::<i32>().ok());
     let strict_priority = strict_priority_header.and_then(|s| s.trim().parse::<u32>().ok());
-    let tenant_id = headers
-        .get(HEADER_TENANT_ID)
-        .and_then(|v| v.to_str().ok())
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
-
     if worker_id.is_none()
         && prefill_id.is_none()
         && dp_rank.is_none()
         && prefill_dp_rank.is_none()
         && priority.is_none()
         && strict_priority.is_none()
-        && tenant_id.is_none()
     {
         return nvext;
     }
@@ -437,10 +455,68 @@ pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap)
         hints.priority = resolved.priority;
         hints.strict_priority = resolved.strict_priority;
     }
-    if let Some(salt) = tenant_id {
-        ext.cache_salt = Some(salt);
-    }
     Some(ext)
+}
+
+/// Apply the `x-tenant-id` cache-salt override independently of other NvExt features.
+///
+/// A non-empty header takes priority over a body salt. An empty or invalid header is
+/// treated as absent and leaves the body unchanged.
+pub fn apply_cache_salt_header_override(
+    nvext: Option<NvExt>,
+    headers: &HeaderMap,
+) -> Option<NvExt> {
+    let Some(cache_salt) = headers
+        .get(HEADER_TENANT_ID)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    else {
+        return nvext;
+    };
+
+    let mut nvext = nvext.unwrap_or_default();
+    nvext.cache_salt = Some(cache_salt);
+    Some(nvext)
+}
+
+/// Policy used by the disabled-NvExt filter across OpenAI request envelopes.
+pub trait CacheSaltNvExt: Sized {
+    /// Consume the envelope and return only a non-empty cache salt, if supported.
+    fn into_cache_salt_only(self) -> Option<Self>;
+}
+
+impl CacheSaltNvExt for NvExt {
+    fn into_cache_salt_only(self) -> Option<Self> {
+        self.cache_salt
+            .filter(|cache_salt| !cache_salt.is_empty())
+            .map(|cache_salt| NvExt {
+                cache_salt: Some(cache_salt),
+                ..Default::default()
+            })
+    }
+}
+
+/// Remove all NvExt fields except a non-empty cache salt.
+pub fn retain_cache_salt<T: CacheSaltNvExt>(nvext: Option<T>) -> Option<T> {
+    nvext.and_then(CacheSaltNvExt::into_cache_salt_only)
+}
+
+/// Apply the frontend NvExt policy for endpoints that support routing headers.
+///
+/// Cache-salt resolution always runs. Other body fields and routing headers run only
+/// when NvExt is enabled.
+pub fn apply_frontend_nvext_policy(
+    nvext: Option<NvExt>,
+    headers: &HeaderMap,
+    nvext_enabled: bool,
+) -> Option<NvExt> {
+    let nvext = apply_cache_salt_header_override(nvext, headers);
+    if nvext_enabled {
+        apply_header_routing_overrides(nvext, headers)
+    } else {
+        retain_cache_salt(nvext)
+    }
 }
 
 /// Priority resolved with header-over-body precedence, per field: a well-formed
@@ -999,11 +1075,11 @@ mod tests {
     }
 
     #[test]
-    fn apply_header_routing_overrides_sets_cache_salt_from_tenant_header() {
+    fn cache_salt_header_override_has_precedence() {
         let mut headers = HeaderMap::new();
         headers.insert(HEADER_TENANT_ID, "tenant-a".parse().unwrap());
 
-        let nvext = apply_header_routing_overrides(None, &headers).unwrap();
+        let nvext = apply_cache_salt_header_override(None, &headers).unwrap();
         assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-a"));
 
         let mut headers = HeaderMap::new();
@@ -1013,8 +1089,74 @@ mod tests {
             ..Default::default()
         };
 
-        let nvext = apply_header_routing_overrides(Some(nvext), &headers).unwrap();
+        let nvext = apply_cache_salt_header_override(Some(nvext), &headers).unwrap();
         assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-header"));
+    }
+
+    #[test]
+    fn frontend_nvext_policy_preserves_cache_salt_when_disabled() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_WORKER_INSTANCE_ID, "42".parse().unwrap());
+        headers.insert(HEADER_REQUEST_PRIORITY, "7".parse().unwrap());
+        let body = NvExt {
+            cache_salt: Some("tenant-body".to_string()),
+            backend_instance_id: Some(99),
+            extra_fields: Some(vec!["worker_id".to_string()]),
+            ..Default::default()
+        };
+
+        let nvext = apply_frontend_nvext_policy(Some(body), &headers, false).unwrap();
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-body"));
+        assert!(!nvext.has_non_cache_salt_fields());
+    }
+
+    #[test]
+    fn frontend_nvext_policy_resolves_header_body_and_empty_values() {
+        let body = || NvExt {
+            cache_salt: Some("tenant-body".to_string()),
+            ..Default::default()
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_TENANT_ID, "tenant-header".parse().unwrap());
+        let nvext = apply_frontend_nvext_policy(Some(body()), &headers, false).unwrap();
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-header"));
+
+        headers.insert(HEADER_TENANT_ID, "".parse().unwrap());
+        let nvext = apply_frontend_nvext_policy(Some(body()), &headers, false).unwrap();
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-body"));
+
+        let empty_body = NvExt {
+            cache_salt: Some(String::new()),
+            ..Default::default()
+        };
+        let mut request = CacheSaltRequest {
+            nvext: apply_frontend_nvext_policy(Some(empty_body), &headers, false),
+            ..Default::default()
+        };
+        request
+            .unsupported_fields
+            .insert("cache_salt".to_string(), serde_json::json!("tenant-legacy"));
+        assert_eq!(request_cache_salt(&request), Some("tenant-legacy"));
+        assert!(apply_frontend_nvext_policy(None, &HeaderMap::new(), false).is_none());
+    }
+
+    #[test]
+    fn frontend_nvext_policy_keeps_full_enabled_behavior() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_TENANT_ID, "tenant-header".parse().unwrap());
+        headers.insert(HEADER_WORKER_INSTANCE_ID, "42".parse().unwrap());
+        let body = NvExt {
+            cache_salt: Some("tenant-body".to_string()),
+            extra_fields: Some(vec!["worker_id".to_string()]),
+            ..Default::default()
+        };
+
+        let nvext = apply_frontend_nvext_policy(Some(body), &headers, true).unwrap();
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-header"));
+        assert_eq!(nvext.backend_instance_id, Some(42));
+        assert_eq!(nvext.decode_worker_id, Some(42));
+        assert_eq!(nvext.extra_fields, Some(vec!["worker_id".to_string()]));
     }
 
     #[test]

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -272,9 +272,42 @@ impl NvExt {
 
     /// Return true when this envelope contains any field other than `cache_salt`.
     pub fn has_non_cache_salt_fields(&self) -> bool {
-        let mut non_salt = self.clone();
-        non_salt.cache_salt = None;
-        non_salt != Self::default()
+        let Self {
+            greed_sampling,
+            use_raw_prompt,
+            annotations,
+            backend_instance_id,
+            token_data,
+            max_thinking_tokens,
+            cache_salt: _,
+            extra_fields,
+            metadata_upload,
+            prefill_worker_id,
+            decode_worker_id,
+            dp_rank,
+            prefill_dp_rank,
+            agent_hints,
+            request_timestamp_ms,
+            routing_constraints,
+            router,
+        } = self;
+
+        greed_sampling.is_some()
+            || use_raw_prompt.is_some()
+            || annotations.is_some()
+            || backend_instance_id.is_some()
+            || token_data.is_some()
+            || max_thinking_tokens.is_some()
+            || extra_fields.is_some()
+            || metadata_upload.is_some()
+            || prefill_worker_id.is_some()
+            || decode_worker_id.is_some()
+            || dp_rank.is_some()
+            || prefill_dp_rank.is_some()
+            || agent_hints.is_some()
+            || request_timestamp_ms.is_some()
+            || routing_constraints.is_some()
+            || router.is_some()
     }
 }
 
@@ -310,6 +343,16 @@ pub const HEADER_DP_RANK_ALIAS: &str = "x-dp-rank";
 pub const HEADER_DATA_PARALLEL_RANK_ALIAS: &str = "x-data-parallel-rank";
 pub const HEADER_PREFILL_DP_RANK_ALIAS: &str = "x-prefill-dp-rank";
 const UNSET_DP_RANK_SENTINEL: u32 = u32::MAX;
+
+/// Return the last non-empty value after trimming surrounding whitespace.
+pub fn last_non_empty_trimmed_value<'a>(values: impl Iterator<Item = &'a str>) -> Option<&'a str> {
+    values
+        .filter_map(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then_some(value)
+        })
+        .last()
+}
 
 /// Return true when the request contains a routing header disabled by the NvExt switch.
 pub fn has_non_cache_salt_routing_headers(headers: &HeaderMap) -> bool {
@@ -460,18 +503,19 @@ pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap)
 
 /// Apply the `x-tenant-id` cache-salt override independently of other NvExt features.
 ///
-/// A non-empty header takes priority over a body salt. An empty or invalid header is
-/// treated as absent and leaves the body unchanged.
+/// The last non-empty, trimmed header takes priority over a body salt. Empty or
+/// invalid values are treated as absent and leave the body unchanged.
 pub fn apply_cache_salt_header_override(
     nvext: Option<NvExt>,
     headers: &HeaderMap,
 ) -> Option<NvExt> {
-    let Some(cache_salt) = headers
-        .get(HEADER_TENANT_ID)
-        .and_then(|value| value.to_str().ok())
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned)
-    else {
+    let Some(cache_salt) = last_non_empty_trimmed_value(
+        headers
+            .get_all(HEADER_TENANT_ID)
+            .iter()
+            .filter_map(|value| value.to_str().ok()),
+    )
+    .map(str::to_owned) else {
         return nvext;
     };
 
@@ -480,26 +524,17 @@ pub fn apply_cache_salt_header_override(
     Some(nvext)
 }
 
-/// Policy used by the disabled-NvExt filter across OpenAI request envelopes.
-pub trait CacheSaltNvExt: Sized {
-    /// Consume the envelope and return only a non-empty cache salt, if supported.
-    fn into_cache_salt_only(self) -> Option<Self>;
-}
-
-impl CacheSaltNvExt for NvExt {
-    fn into_cache_salt_only(self) -> Option<Self> {
-        self.cache_salt
+/// Remove all NvExt fields except a non-empty cache salt.
+pub fn retain_cache_salt(nvext: Option<NvExt>) -> Option<NvExt> {
+    nvext.and_then(|nvext| {
+        nvext
+            .cache_salt
             .filter(|cache_salt| !cache_salt.is_empty())
             .map(|cache_salt| NvExt {
                 cache_salt: Some(cache_salt),
                 ..Default::default()
             })
-    }
-}
-
-/// Remove all NvExt fields except a non-empty cache salt.
-pub fn retain_cache_salt<T: CacheSaltNvExt>(nvext: Option<T>) -> Option<T> {
-    nvext.and_then(CacheSaltNvExt::into_cache_salt_only)
+    })
 }
 
 /// Apply the frontend NvExt policy for endpoints that support routing headers.
@@ -1091,6 +1126,25 @@ mod tests {
 
         let nvext = apply_cache_salt_header_override(Some(nvext), &headers).unwrap();
         assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-header"));
+
+        headers.append(HEADER_TENANT_ID, "   ".parse().unwrap());
+        headers.append(HEADER_TENANT_ID, " tenant-gateway ".parse().unwrap());
+        let nvext = apply_cache_salt_header_override(Some(nvext), &headers).unwrap();
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-gateway"));
+    }
+
+    #[test]
+    fn cache_salt_header_override_ignores_only_empty_values() {
+        let mut headers = HeaderMap::new();
+        headers.append(HEADER_TENANT_ID, "".parse().unwrap());
+        headers.append(HEADER_TENANT_ID, "   ".parse().unwrap());
+        let nvext = NvExt {
+            cache_salt: Some("tenant-body".to_string()),
+            ..Default::default()
+        };
+
+        let nvext = apply_cache_salt_header_override(Some(nvext), &headers).unwrap();
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-body"));
     }
 
     #[test]
@@ -1183,6 +1237,19 @@ mod tests {
                 .dp_rank,
             Some(4)
         );
+    }
+
+    #[test]
+    fn routing_overrides_do_not_apply_tenant_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_TENANT_ID, "tenant-header".parse().unwrap());
+        let nvext = NvExt {
+            cache_salt: Some("tenant-body".to_string()),
+            ..Default::default()
+        };
+
+        let nvext = apply_header_routing_overrides(Some(nvext), &headers).unwrap();
+        assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-body"));
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/embeddings/nvext.rs
+++ b/lib/llm/src/protocols/openai/embeddings/nvext.rs
@@ -6,8 +6,6 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::{Validate, ValidationError};
 
-use crate::protocols::common::extensions::CacheSaltNvExt;
-
 pub trait NvExtProvider {
     fn nvext(&self) -> Option<&NvExt>;
 }
@@ -33,14 +31,6 @@ impl Default for NvExt {
 impl NvExt {
     pub fn builder() -> NvExtBuilder {
         NvExtBuilder::default()
-    }
-}
-
-impl CacheSaltNvExt for NvExt {
-    fn into_cache_salt_only(self) -> Option<Self> {
-        // This legacy envelope has annotations only. Cache salt is a top-level
-        // field on the pooling request types, so there is nothing to retain here.
-        None
     }
 }
 

--- a/lib/llm/src/protocols/openai/embeddings/nvext.rs
+++ b/lib/llm/src/protocols/openai/embeddings/nvext.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::{Validate, ValidationError};
 
+use crate::protocols::common::extensions::CacheSaltNvExt;
+
 pub trait NvExtProvider {
     fn nvext(&self) -> Option<&NvExt>;
 }
@@ -31,6 +33,14 @@ impl Default for NvExt {
 impl NvExt {
     pub fn builder() -> NvExtBuilder {
         NvExtBuilder::default()
+    }
+}
+
+impl CacheSaltNvExt for NvExt {
+    fn into_cache_salt_only(self) -> Option<Self> {
+        // This legacy envelope has annotations only. Cache salt is a top-level
+        // field on the pooling request types, so there is nothing to retain here.
+        None
     }
 }
 

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -28,12 +28,11 @@ const BASE_ENV: [(&str, Option<&str>); 3] = [
     (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
 ];
 
-const NVEXT_DISABLED_ENV: [(&str, Option<&str>); 4] = [
-    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
-    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
-    (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
-    (DYN_DISABLE_FRONTEND_NVEXT, Some("1")),
-];
+fn nvext_disabled_env() -> Vec<(&'static str, Option<&'static str>)> {
+    let mut env = BASE_ENV.to_vec();
+    env.push((DYN_DISABLE_FRONTEND_NVEXT, Some("1")));
+    env
+}
 
 async fn post_json(svc: &HarnessService, path: &str, body: Value) -> reqwest::Response {
     svc.client
@@ -99,7 +98,7 @@ async fn assert_anthropic_error(
 #[tokio::test]
 #[serial]
 async fn invalid_anthropic_cache_salt_is_rejected_when_nvext_is_disabled() {
-    temp_env::async_with_vars(NVEXT_DISABLED_ENV, async {
+    temp_env::async_with_vars(nvext_disabled_env(), async {
         let svc = HarnessService::start(Vec::new()).await;
         let response = post_json(
             &svc,

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -5,7 +5,7 @@
 
 use dynamo_llm::http::service::metrics::{Endpoint, ErrorType, RequestType, Status};
 use dynamo_runtime::config::environment_names::llm::{
-    DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
+    DYN_DISABLE_FRONTEND_NVEXT, DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
     DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS,
 };
 use serde_json::{Value, json};
@@ -26,6 +26,13 @@ const BASE_ENV: [(&str, Option<&str>); 3] = [
     (DYN_ENABLE_ANTHROPIC_API, Some("1")),
     (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
     (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
+];
+
+const NVEXT_DISABLED_ENV: [(&str, Option<&str>); 4] = [
+    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+    (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
+    (DYN_DISABLE_FRONTEND_NVEXT, Some("1")),
 ];
 
 async fn post_json(svc: &HarnessService, path: &str, body: Value) -> reqwest::Response {
@@ -87,6 +94,38 @@ async fn assert_anthropic_error(
             .is_some_and(|actual| actual.contains(message)),
         "unexpected Anthropic error body: {body}"
     );
+}
+
+#[tokio::test]
+#[serial]
+async fn invalid_anthropic_cache_salt_is_rejected_when_nvext_is_disabled() {
+    temp_env::async_with_vars(NVEXT_DISABLED_ENV, async {
+        let svc = HarnessService::start(Vec::new()).await;
+        let response = post_json(
+            &svc,
+            "/v1/messages",
+            json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+                "nvext": {
+                    "cache_salt": 42,
+                    "agent_hints": {"priority": 5}
+                }
+            }),
+        )
+        .await;
+
+        assert_anthropic_error(
+            response,
+            ExpectedError::Validation,
+            "invalid nvext.cache_salt: expected a string or null",
+        )
+        .await;
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
 }
 
 fn assert_error_metrics(

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -6,6 +6,7 @@ use async_stream::stream;
 use dynamo_llm::protocols::{
     Annotated,
     codec::SseLineCodec,
+    common::extensions::NvExt,
     convert_sse_stream,
     openai::{
         chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
@@ -50,16 +51,17 @@ use ports::bind_random_port;
 struct CounterEngine {}
 
 #[derive(Default)]
-struct NvextProbeEngine {
-    called: AtomicBool,
-    received_nvext: AtomicBool,
+struct NvExtCaptureEngine {
+    nvext: std::sync::Mutex<Option<Option<NvExt>>>,
 }
 
-impl NvextProbeEngine {
-    fn observed_nvext(&self) -> Option<bool> {
-        self.called
-            .load(Ordering::Acquire)
-            .then(|| self.received_nvext.load(Ordering::Acquire))
+impl NvExtCaptureEngine {
+    fn take_nvext(&self) -> Option<NvExt> {
+        self.nvext
+            .lock()
+            .unwrap()
+            .take()
+            .expect("engine did not receive a request")
     }
 }
 
@@ -161,34 +163,6 @@ impl
         SingleIn<NvCreateChatCompletionRequest>,
         ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
         Error,
-    > for NvextProbeEngine
-{
-    async fn generate(
-        &self,
-        request: SingleIn<NvCreateChatCompletionRequest>,
-    ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
-        let (request, context) = request.transfer(());
-        let ctx = context.context();
-        self.received_nvext
-            .store(request.nvext.is_some(), Ordering::Release);
-        self.called.store(true, Ordering::Release);
-        let mut generator = request.response_generator(ctx.id().to_string());
-
-        let stream = stream! {
-            let output = generator.create_choice(0, Some("choice 0".to_string()), None, None);
-            yield Annotated::from_data(output);
-        };
-
-        Ok(ResponseStream::new(Box::pin(stream), ctx))
-    }
-}
-
-#[async_trait]
-impl
-    AsyncEngine<
-        SingleIn<NvCreateChatCompletionRequest>,
-        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
-        Error,
     > for CounterEngine
 {
     async fn generate(
@@ -222,6 +196,23 @@ impl
         };
 
         Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateChatCompletionRequest>,
+        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
+        Error,
+    > for NvExtCaptureEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateChatCompletionRequest>,
+    ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
+        self.nvext.lock().unwrap().replace(request.nvext.clone());
+        CounterEngine {}.generate(request).await
     }
 }
 
@@ -1502,8 +1493,8 @@ async fn test_model_ready_endpoint_non_displayable_shadow() {
     task.await.unwrap().unwrap();
 }
 
-/// With nvext disabled, a request asking for response `extra_fields` must not
-/// produce any `nvext` field in the response.
+/// With nvext disabled, cache salting reaches the engine while all other NvExt
+/// behavior stays disabled, including response `extra_fields`.
 #[tokio::test]
 async fn test_nvext_disabled_strips_request_and_response() {
     dynamo_runtime::logging::init();
@@ -1524,20 +1515,24 @@ async fn test_nvext_disabled_strips_request_and_response() {
     wait_for_service_ready(port).await;
 
     let card = ModelDeploymentCard::with_name_only("test-model");
-    let probe_engine = Arc::new(NvextProbeEngine::default());
+    let engine = Arc::new(NvExtCaptureEngine::default());
     manager
-        .add_chat_completions_model("test-model", card.mdcsum(), probe_engine.clone())
+        .add_chat_completions_model("test-model", card.mdcsum(), engine.clone())
         .unwrap();
 
     let response = reqwest::Client::new()
         .post(format!("http://localhost:{port}/v1/chat/completions"))
         .header("x-dynamo-worker-instance-id", "42")
+        .header("x-dynamo-dp-rank", "3")
+        .header("x-dynamo-request-priority", "7")
+        .header("x-tenant-id", "tenant-header")
         .json(&serde_json::json!({
             "model": "test-model",
             "messages": [{"role": "user", "content": "hi"}],
             "stream": true,
             "max_tokens": 1,
             "nvext": {
+                "cache_salt": "tenant-body",
                 "extra_fields": ["worker_id", "timing", "engine_data"],
                 "backend_instance_id": 99
             }
@@ -1548,11 +1543,11 @@ async fn test_nvext_disabled_strips_request_and_response() {
     assert!(response.status().is_success());
 
     let body = response.text().await.expect("read body");
-    assert_eq!(
-        probe_engine.observed_nvext(),
-        Some(false),
-        "the disabled gate must strip nvext before dispatching to the engine"
-    );
+    let nvext = engine
+        .take_nvext()
+        .expect("cache salt must reach the engine");
+    assert_eq!(nvext.cache_salt.as_deref(), Some("tenant-header"));
+    assert!(!nvext.has_non_cache_salt_fields());
     assert!(
         !body.contains("\"nvext\""),
         "nvext gate off: response must not contain an `nvext` field, got: {body}"

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -339,11 +339,10 @@ pub mod llm {
     /// Master switch for the `nvext` extension protocol on the frontend.
     /// The protocol is **enabled by default**; this variable disables it.
     /// Truthy values (`1` / `true` / `yes` / `on`, case-insensitive) cause
-    /// the frontend to drop `request.nvext` at handler entry, ignore the
-    /// routing-override headers (`x-dynamo-worker-instance-id`,
-    /// `x-dynamo-prefill-instance-id`, `x-dynamo-dp-rank`,
-    /// `x-dynamo-prefill-dp-rank`), and silently ignore the response-side
-    /// `extra_fields` opt-in.
+    /// the frontend to drop all request NvExt fields except `cache_salt`,
+    /// ignore non-salt routing-override headers, and silently ignore the
+    /// response-side `extra_fields` opt-in. Cache isolation is exempt:
+    /// `cache_salt` and supported `x-tenant-id` headers remain active.
     pub const DYN_DISABLE_FRONTEND_NVEXT: &str = "DYN_DISABLE_FRONTEND_NVEXT";
 
     /// Ignore unknown OpenAI frontend request fields. Unknown fields are dropped,

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -339,10 +339,10 @@ pub mod llm {
     /// Master switch for the `nvext` extension protocol on the frontend.
     /// The protocol is **enabled by default**; this variable disables it.
     /// Truthy values (`1` / `true` / `yes` / `on`, case-insensitive) cause
-    /// the frontend to drop all request NvExt fields except `cache_salt`,
-    /// ignore non-salt routing-override headers, and silently ignore the
-    /// response-side `extra_fields` opt-in. Cache isolation is exempt:
-    /// `cache_salt` and supported `x-tenant-id` headers remain active.
+    /// the frontend to drop non-salt request NvExt fields, ignore supported
+    /// routing-override headers, and silently ignore the response-side
+    /// `extra_fields` opt-in. Cache isolation is exempt: supported
+    /// `cache_salt` and `x-tenant-id` inputs remain active.
     pub const DYN_DISABLE_FRONTEND_NVEXT: &str = "DYN_DISABLE_FRONTEND_NVEXT";
 
     /// Ignore unknown OpenAI frontend request fields. Unknown fields are dropped,


### PR DESCRIPTION
## Summary

- keep cache isolation active when `DYN_DISABLE_FRONTEND_NVEXT` disables other NvExt behavior
- continue to honor non-empty `x-tenant-id` on chat completions, completions, Responses, and Anthropic Messages
- use the last non-empty, trimmed tenant header in both the frontend and EPP so an appended gateway value wins
- retain only `nvext.cache_salt` when NvExt is disabled, while worker, rank, priority, routing, and response `extra_fields` stay disabled
- validate Anthropic `nvext.cache_salt` and return HTTP 400 for an invalid value while preserving disabled-mode leniency for other NvExt data
- update warnings and reference documentation to describe only discarded data and supported endpoint behavior

The root cause was that frontend handlers applied cache-salt header resolution inside the NvExt feature gate. The disabled path then removed the complete NvExt envelope, which could silently turn a salted request into an unsalted request. This change resolves cache salt before the gate and filters the disabled envelope down to the salt.

PR #12975 overlaps the two NvExt documentation hunks. This PR replaces the unsafe-behavior text with the corrected contract.

## Related Issues

N/A

## Where should the reviewer start?

- `lib/llm/src/protocols/common/extensions.rs` for tenant-header resolution, salt precedence, and the disabled-NvExt filter
- `lib/llm/src/http/service/anthropic.rs` for raw salt validation and the independent post-conversion tenant override
- `deploy/inference-gateway/ext-proc/src/epp.rs` for frontend/EPP cache-namespace parity

## Validation

- `cargo test -p dynamo-llm frontend_nvext_policy`
- `cargo test -p dynamo-llm cache_salt_header_override`
- `cargo test -p dynamo-llm routing_overrides_do_not_apply_tenant_header`
- `cargo test -p dynamo-llm http::service::anthropic::tests`
- `cargo test -p dynamo-llm --test http-service test_nvext_disabled_strips_request_and_response`
- `cargo test -p dynamo-llm --test frontend_protocol_validation_http invalid_anthropic_cache_salt_is_rejected_when_nvext_is_disabled`
- `cargo test -p dynamo-ext-proc tenant_header`
- `cargo fmt --all -- --check`
- changed-file `pre-commit` checks
- `fern check` (0 errors)
- `fern docs broken-links` (reports four existing errors in the unchanged Qwen 3.8 recipe page)
