### PR TITLE
feat(router): configure separate prefill and decode policies

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -46,6 +46,8 @@ _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "router_ttl_secs",
     "router_queue_threshold",
     "router_policy_config",
+    "router_prefill_policy",
+    "router_decode_policy",
     "router_event_threads",
     "router_queue_policy",
     "use_remote_indexer",
@@ -129,6 +131,8 @@ class KvRouterConfigBase(ConfigBase):
     router_ttl_secs: float
     router_queue_threshold: Optional[float]
     router_policy_config: Optional[str] = None
+    router_prefill_policy: Optional[str] = None
+    router_decode_policy: Optional[str] = None
     router_event_threads: int
     router_queue_policy: str
     use_remote_indexer: bool = False
@@ -421,6 +425,30 @@ class KvRouterArgGroup(ArgGroup):
                 "When omitted, router_queue_threshold and router_queue_policy define "
                 "one synthetic policy class; queueing remains disabled unless "
                 "router_queue_threshold is set."
+            ),
+            arg_type=str,
+        )
+        add_argument(
+            g,
+            flag_name="--router-prefill-policy",
+            env_var="DYN_ROUTER_PREFILL_POLICY",
+            default=None,
+            help=(
+                "KV Router: Named worker-selection instance for prefill workers. "
+                "Overrides worker_selection.prefill from --router-policy-config. "
+                "Use 'default' for Dynamo's built-in worker selector."
+            ),
+            arg_type=str,
+        )
+        add_argument(
+            g,
+            flag_name="--router-decode-policy",
+            env_var="DYN_ROUTER_DECODE_POLICY",
+            default=None,
+            help=(
+                "KV Router: Named worker-selection instance for decode workers. "
+                "Overrides worker_selection.decode from --router-policy-config. "
+                "Use 'default' for Dynamo's built-in worker selector."
             ),
             arg_type=str,
         )

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -319,6 +319,21 @@ def test_policy_config_cli_overrides_environment(
     assert config.kv_router_kwargs()["router_policy_config"] == explicit_policy_path
 
 
+def test_stage_policy_cli_and_environment_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DYN_ROUTER_PREFILL_POLICY", "env-prefill")
+    monkeypatch.setenv("DYN_ROUTER_DECODE_POLICY", "env-decode")
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(["--router-prefill-policy", "cli-prefill"])
+    kwargs = KvRouterConfigBase.from_cli_args(args).kv_router_kwargs()
+
+    assert kwargs["router_prefill_policy"] == "cli-prefill"
+    assert kwargs["router_decode_policy"] == "env-decode"
+
+
 def test_load_aware_clears_predicted_ttl() -> None:
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)

--- a/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
+++ b/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
@@ -272,14 +272,22 @@ Create `$POLICY_DIR/worker-selection.yaml`:
 ```yaml
 worker_selection:
   default: least-busy
+  prefill: prefill-least-busy
+  decode: least-busy
   instances:
     - name: least-busy
       type: least-busy
       parameters:
         min_device_overlap_blocks: 0
+    - name: prefill-least-busy
+      type: least-busy
+      parameters:
+        min_device_overlap_blocks: 1
 ```
 
-The `type` selects a registered provider. The `name` identifies one configured instance. `DYN_ROUTER_WORKER_SELECTION_POLICY` overrides `worker_selection.default` by instance name. Set the override to `default` to select Dynamo's built-in policy.
+The `type` selects a registered provider. The `name` identifies one configured instance. `worker_selection.prefill` and `worker_selection.decode` select separate instances for those worker pools. Both stage selections fall back to `worker_selection.default` when omitted.
+
+The selection order for each stage is the stage CLI flag, the matching `DYN_ROUTER_PREFILL_POLICY` or `DYN_ROUTER_DECODE_POLICY` environment variable, `DYN_ROUTER_WORKER_SELECTION_POLICY`, the YAML stage selection, the YAML default, and then Dynamo's built-in policy. Set any selection to `default` to use the built-in policy for that scope.
 
 ### Check the Policy and Catalog
 
@@ -381,7 +389,9 @@ uv pip install -e .
 # Start the frontend with the policy configuration.
 python3 -m dynamo.frontend \
   --router-mode kv \
-  --router-policy-config "$POLICY_DIR/worker-selection.yaml"
+  --router-policy-config "$POLICY_DIR/worker-selection.yaml" \
+  --router-prefill-policy prefill-least-busy \
+  --router-decode-policy least-busy
 ```
 
 </Tab>
@@ -427,7 +437,7 @@ cd "$POLICY_DIR/epp"
 DYN_EPP_MODE=standalone DYN_ROUTER_POLICY_CONFIG="$POLICY_DIR/worker-selection.yaml" cargo run --release
 ```
 
-Standalone EPP supplies `select` as `worker_type` because it selects from one worker pool. A policy that branches on `worker_type` must handle `select`.
+Standalone EPP supplies `select` as `worker_type` because it selects from one worker pool. It uses `worker_selection.default`; the prefill and decode selections apply only to the embedded frontend.
 
 </Tab>
 </Tabs>

--- a/examples/router/custom-policy-example/README.md
+++ b/examples/router/custom-policy-example/README.md
@@ -144,6 +144,8 @@ Create a YAML file outside the source tree:
 ```yaml
 worker_selection:
   default: simple-filter-score-pick
+  prefill: disagg-prefill
+  decode: disagg-decode
   instances:
     - name: simple-filter-score-pick
       type: simple-filter-score-pick
@@ -153,7 +155,11 @@ worker_selection:
       type: simple-filter-score-pick
       parameters:
         min_device_overlap_blocks: 8
-    - name: disagg-filter-score-pick
+    - name: disagg-prefill
+      type: disagg-filter-score-pick
+      parameters:
+        min_device_overlap_blocks: 0
+    - name: disagg-decode
       type: disagg-filter-score-pick
       parameters:
         min_device_overlap_blocks: 0
@@ -165,7 +171,10 @@ worker_selection:
 - `type` selects a registered provider.
 - `name` identifies one configured instance.
 - `worker_selection.default` selects an instance at startup.
-- `DYN_ROUTER_WORKER_SELECTION_POLICY` overrides the selected instance by name.
+- `worker_selection.prefill` and `worker_selection.decode` select separate instances for the embedded frontend's worker pools.
+- `--router-prefill-policy` and `--router-decode-policy` override the matching YAML selections.
+- `DYN_ROUTER_PREFILL_POLICY` and `DYN_ROUTER_DECODE_POLICY` provide stage-specific environment overrides.
+- `DYN_ROUTER_WORKER_SELECTION_POLICY` overrides the YAML selections for both stages.
 - The override value `default` selects Dynamo's built-in policy.
 
 Unknown policy types, duplicate registrations, and invalid parameters stop startup.
@@ -310,16 +319,19 @@ Send the same request. This time, `logit` is the sum of the active-request and u
 
 ### Disaggregated Policy
 
-Stop the frontend and Mocker processes. Start the frontend with the disaggregated policy:
+Stop the frontend and Mocker processes. Start the frontend with separate named prefill and decode policy instances:
 
 ```bash
-DYN_ROUTER_WORKER_SELECTION_POLICY=disagg-filter-score-pick \
 python -m dynamo.frontend \
   --router-mode kv \
   --router-policy-config /tmp/worker-selection.yaml \
+  --router-prefill-policy disagg-prefill \
+  --router-decode-policy disagg-decode \
   --discovery-backend file \
   --http-port 8000
 ```
+
+The two flags override `worker_selection.prefill` and `worker_selection.decode`. Omit the flags to use the YAML selections.
 
 In the second terminal, start two prefill Mocker workers:
 

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -239,7 +239,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, decode_active_request_weight=0.0, router_policy_config=None, router_tracking_hash="public-xxh3-v1", router_tracking_key_file=None, router_tracking_key_id=None))]
+    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, decode_active_request_weight=0.0, router_policy_config=None, router_prefill_policy=None, router_decode_policy=None, router_tracking_hash="public-xxh3-v1", router_tracking_key_file=None, router_tracking_key_id=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: Option<f64>,
@@ -267,6 +267,8 @@ impl KvRouterConfig {
         mut prefill_load_scale: f64,
         decode_active_request_weight: f64,
         router_policy_config: Option<String>,
+        router_prefill_policy: Option<String>,
+        router_decode_policy: Option<String>,
         router_tracking_hash: &str,
         router_tracking_key_file: Option<PathBuf>,
         router_tracking_key_id: Option<String>,
@@ -304,6 +306,8 @@ impl KvRouterConfig {
             router_ttl_secs,
             router_queue_threshold,
             router_policy_config,
+            router_prefill_policy,
+            router_decode_policy,
             policy_model_name: None,
             policy_config_cache: Default::default(),
             router_event_threads,

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -30,6 +30,19 @@ pub const DYN_ROUTER_MIN_INITIAL_WORKERS: &str = "DYN_ROUTER_MIN_INITIAL_WORKERS
 /// The reserved value `default` selects Dynamo's built-in worker selector.
 pub const DYN_ROUTER_WORKER_SELECTION_POLICY: &str = "DYN_ROUTER_WORKER_SELECTION_POLICY";
 
+/// Selects a configured custom worker-selection policy instance for prefill workers.
+pub const DYN_ROUTER_PREFILL_POLICY: &str = "DYN_ROUTER_PREFILL_POLICY";
+
+/// Selects a configured custom worker-selection policy instance for decode workers.
+pub const DYN_ROUTER_DECODE_POLICY: &str = "DYN_ROUTER_DECODE_POLICY";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkerSelectionPolicySelections {
+    pub(crate) fallback: Option<String>,
+    pub(crate) prefill: Option<String>,
+    pub(crate) decode: Option<String>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum WorkerSelectionPolicyConfigError {
     #[error("could not read {DYN_ROUTER_WORKER_SELECTION_POLICY}: {source}")]
@@ -163,6 +176,8 @@ fn log_env_config(config: &KvRouterConfig) {
         router_tracking_key_id = ?config.router_tracking_key_id,
         router_queue_threshold = ?config.router_queue_threshold,
         router_policy_config = ?config.router_policy_config,
+        router_prefill_policy = ?config.router_prefill_policy,
+        router_decode_policy = ?config.router_decode_policy,
         conditional_disagg_enabled = config.conditional_disagg_enabled,
         conditional_disagg_policy = ?config.conditional_disagg_policy,
         conditional_disagg_eff_isl_threshold = config.conditional_disagg_eff_isl_threshold,
@@ -253,6 +268,12 @@ fn kv_router_config_from_lookup(
     }
     if let Some(value) = get_env("DYN_ROUTER_POLICY_CONFIG") {
         config.router_policy_config = Some(value);
+    }
+    if let Some(value) = get_env(DYN_ROUTER_PREFILL_POLICY) {
+        config.router_prefill_policy = Some(value);
+    }
+    if let Some(value) = get_env(DYN_ROUTER_DECODE_POLICY) {
+        config.router_decode_policy = Some(value);
     }
     if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_CONDITIONAL_DISAGG") {
         config.conditional_disagg_enabled = value;
@@ -714,6 +735,18 @@ pub struct KvRouterConfig {
     #[serde(default)]
     pub router_policy_config: Option<String>,
 
+    /// Optional prefill worker-selection instance override.
+    ///
+    /// This frontend-only value is not serialized into worker model cards.
+    #[serde(skip)]
+    pub router_prefill_policy: Option<String>,
+
+    /// Optional decode worker-selection instance override.
+    ///
+    /// This frontend-only value is not serialized into worker model cards.
+    #[serde(skip)]
+    pub router_decode_policy: Option<String>,
+
     /// Run-level model selector used by offline and online replay.
     #[serde(skip)]
     #[doc(hidden)]
@@ -838,6 +871,8 @@ impl Default for KvRouterConfig {
             router_ttl_secs: 120.0,
             router_queue_threshold: None,
             router_policy_config: None,
+            router_prefill_policy: None,
+            router_decode_policy: None,
             policy_model_name: None,
             policy_config_cache: OnceLock::new(),
             router_event_threads: 4,
@@ -899,6 +934,8 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
             router_ttl_secs: compat.router_ttl_secs,
             router_queue_threshold: compat.router_queue_threshold,
             router_policy_config: compat.router_policy_config,
+            router_prefill_policy: None,
+            router_decode_policy: None,
             policy_model_name: None,
             policy_config_cache: OnceLock::new(),
             router_event_threads: compat.router_event_threads,
@@ -1040,10 +1077,12 @@ impl KvRouterConfig {
             .and_then(super::policy_config::RouterPolicyConfig::worker_selection))
     }
 
-    /// Return the configured custom worker-selection instance, if any.
+    /// Return one configured custom worker-selection instance, if any.
     ///
     /// `DYN_ROUTER_WORKER_SELECTION_POLICY` overrides the YAML default. The reserved value
-    /// `default`, and an absent selection, both use Dynamo's built-in worker selector.
+    /// `default`, and an absent selection, both use Dynamo's built-in worker selector. This method
+    /// also reports a stage-specific instance so stock builds can reject unsupported custom policy
+    /// configuration instead of silently ignoring it.
     pub fn selected_worker_selection_policy_instance(
         &self,
     ) -> Result<Option<String>, WorkerSelectionPolicyConfigError> {
@@ -1052,26 +1091,78 @@ impl KvRouterConfig {
             Err(VarError::NotPresent) => Ok(None),
             Err(source) => Err(source),
         };
-        self.selected_worker_selection_policy_instance_from(selected)
+        let selected = self.selected_worker_selection_policy_instances_from(selected)?;
+        Ok(selected.fallback.or(selected.prefill).or(selected.decode))
     }
 
+    #[cfg(test)]
     fn selected_worker_selection_policy_instance_from(
         &self,
         selected: Result<Option<String>, VarError>,
     ) -> Result<Option<String>, WorkerSelectionPolicyConfigError> {
+        let selected = self.selected_worker_selection_policy_instances_from(selected)?;
+        Ok(selected.fallback.or(selected.prefill).or(selected.decode))
+    }
+
+    #[cfg_attr(not(feature = "standalone-selection"), allow(dead_code))]
+    pub(crate) fn selected_worker_selection_policy_instances(
+        &self,
+    ) -> Result<WorkerSelectionPolicySelections, WorkerSelectionPolicyConfigError> {
+        let selected = match env::var(DYN_ROUTER_WORKER_SELECTION_POLICY) {
+            Ok(name) => Ok(Some(name)),
+            Err(VarError::NotPresent) => Ok(None),
+            Err(source) => Err(source),
+        };
+        self.selected_worker_selection_policy_instances_from(selected)
+    }
+
+    fn selected_worker_selection_policy_instances_from(
+        &self,
+        selected: Result<Option<String>, VarError>,
+    ) -> Result<WorkerSelectionPolicySelections, WorkerSelectionPolicyConfigError> {
+        fn normalized(value: Option<&str>) -> Option<String> {
+            value
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(str::to_owned)
+        }
+
+        fn custom_only(selected: Option<String>) -> Option<String> {
+            selected.filter(|name| name != "default")
+        }
+
         let policy_config = self
             .worker_selection_config()
             .map_err(|source| WorkerSelectionPolicyConfigError::Config { source })?;
-        let selected = selected
+        let global = selected
             .map_err(|source| WorkerSelectionPolicyConfigError::Environment { source })?
-            .map(|name| name.trim().to_owned())
-            .filter(|name| !name.is_empty())
+            .and_then(|name| normalized(Some(&name)));
+        let yaml_default = policy_config
+            .and_then(|config| config.default_instance())
+            .map(str::to_owned);
+        let fallback = global.clone().or_else(|| yaml_default.clone());
+        let prefill = normalized(self.router_prefill_policy.as_deref())
+            .or_else(|| global.clone())
             .or_else(|| {
                 policy_config
-                    .and_then(|config| config.default_instance())
+                    .and_then(|config| config.prefill_instance())
                     .map(str::to_owned)
-            });
-        Ok(selected.filter(|name| name != "default"))
+            })
+            .or_else(|| yaml_default.clone());
+        let decode = normalized(self.router_decode_policy.as_deref())
+            .or(global)
+            .or_else(|| {
+                policy_config
+                    .and_then(|config| config.decode_instance())
+                    .map(str::to_owned)
+            })
+            .or(yaml_default);
+
+        Ok(WorkerSelectionPolicySelections {
+            fallback: custom_only(fallback),
+            prefill: custom_only(prefill),
+            decode: custom_only(decode),
+        })
     }
 
     pub fn with_policy_model_name(mut self, model_name: Option<String>) -> Self {
@@ -1348,11 +1439,15 @@ mod tests {
             ),
             ("DYN_ROUTER_TRACKING_KEY_ID", "2026-01"),
             ("DYN_ROUTER_QUEUE_THRESHOLD", "4.5"),
+            (DYN_ROUTER_PREFILL_POLICY, "prefill-cli"),
+            (DYN_ROUTER_DECODE_POLICY, "decode-cli"),
         ]);
 
         assert_eq!(config.overlap_score_credit, 0.25);
         assert_eq!(config.overlap_score_credit_decay, 0.75);
         assert_eq!(config.prefill_load_scale, 2.5);
+        assert_eq!(config.router_prefill_policy.as_deref(), Some("prefill-cli"));
+        assert_eq!(config.router_decode_policy.as_deref(), Some("decode-cli"));
         assert_eq!(config.decode_active_request_weight, 32.0);
         assert_eq!(config.router_temperature, 0.7);
         assert!(!config.use_kv_events);
@@ -1668,6 +1763,60 @@ worker_selection:
     }
 
     #[test]
+    fn selected_worker_selection_policy_instances_apply_stage_precedence() {
+        let policy_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            policy_file.path(),
+            r#"
+worker_selection:
+  default: yaml-default
+  prefill: yaml-prefill
+  decode: yaml-decode
+  instances:
+    - name: yaml-default
+      type: acme
+    - name: yaml-prefill
+      type: acme
+    - name: yaml-decode
+      type: acme
+    - name: global
+      type: acme
+    - name: cli-prefill
+      type: acme
+"#,
+        )
+        .unwrap();
+        let mut config = KvRouterConfig {
+            router_policy_config: Some(policy_file.path().display().to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config
+                .selected_worker_selection_policy_instances_from(Ok(None))
+                .unwrap(),
+            WorkerSelectionPolicySelections {
+                fallback: Some("yaml-default".to_string()),
+                prefill: Some("yaml-prefill".to_string()),
+                decode: Some("yaml-decode".to_string()),
+            }
+        );
+
+        config.router_prefill_policy = Some("cli-prefill".to_string());
+        config.router_decode_policy = Some("default".to_string());
+        assert_eq!(
+            config
+                .selected_worker_selection_policy_instances_from(Ok(Some("global".to_string())))
+                .unwrap(),
+            WorkerSelectionPolicySelections {
+                fallback: Some("global".to_string()),
+                prefill: Some("cli-prefill".to_string()),
+                decode: None,
+            }
+        );
+    }
+
+    #[test]
     fn removed_missing_isl_queue_config_is_rejected_as_unknown() {
         for value in [
             serde_json::json!(null),
@@ -1714,6 +1863,15 @@ worker_selection:
         ] {
             assert!(value.get(post_v1_3_field).is_none(), "{post_v1_3_field}");
         }
+
+        let frontend_config = KvRouterConfig {
+            router_prefill_policy: Some("prefill-policy".to_string()),
+            router_decode_policy: Some("decode-policy".to_string()),
+            ..Default::default()
+        };
+        let value = serde_json::to_value(frontend_config).unwrap();
+        assert!(value.get("router_prefill_policy").is_none());
+        assert!(value.get("router_decode_policy").is_none());
 
         let error = serde_json::from_value::<KvRouterConfig>(serde_json::json!({
             "durable_kv_events": true,

--- a/lib/kv-router/src/scheduling/policy_config.rs
+++ b/lib/kv-router/src/scheduling/policy_config.rs
@@ -631,6 +631,27 @@ worker_selection:
     }
 
     #[test]
+    fn worker_selection_accepts_separate_prefill_and_decode_instances() {
+        let config = RouterPolicyConfig::from_yaml(
+            r#"
+worker_selection:
+  prefill: prefill-policy
+  decode: default
+  instances:
+    - name: prefill-policy
+      type: cache-aware
+      parameters: {}
+"#,
+        )
+        .unwrap();
+
+        let selection = config.worker_selection().unwrap();
+        assert_eq!(selection.default_instance(), None);
+        assert_eq!(selection.prefill_instance(), Some("prefill-policy"));
+        assert_eq!(selection.decode_instance(), Some("default"));
+    }
+
+    #[test]
     fn rejects_invalid_worker_selection_config() {
         for yaml in [
             r#"
@@ -639,6 +660,20 @@ worker_selection: {}
             r#"
 worker_selection:
   default: missing
+  instances:
+    - name: present
+      type: alpha
+"#,
+            r#"
+worker_selection:
+  prefill: missing
+  instances:
+    - name: present
+      type: alpha
+"#,
+            r#"
+worker_selection:
+  decode: missing
   instances:
     - name: present
       type: alpha

--- a/lib/kv-router/src/scheduling/worker_selection_config.rs
+++ b/lib/kv-router/src/scheduling/worker_selection_config.rs
@@ -13,6 +13,8 @@ use super::policy_config::{RouterPolicyConfigError, validate_identifier};
 #[derive(Debug, Clone, PartialEq)]
 pub struct WorkerSelectionConfig {
     default: Option<String>,
+    prefill: Option<String>,
+    decode: Option<String>,
     instances: HashMap<String, WorkerSelectionInstance>,
 }
 
@@ -20,6 +22,14 @@ impl WorkerSelectionConfig {
     /// The selected instance when no environment override is provided.
     pub fn default_instance(&self) -> Option<&str> {
         self.default.as_deref()
+    }
+
+    pub(crate) fn prefill_instance(&self) -> Option<&str> {
+        self.prefill.as_deref()
+    }
+
+    pub(crate) fn decode_instance(&self) -> Option<&str> {
+        self.decode.as_deref()
     }
 
     /// Look up one named instance.
@@ -60,14 +70,23 @@ pub(super) struct RawWorkerSelectionConfig {
     #[serde(default)]
     default: Option<String>,
     #[serde(default)]
+    prefill: Option<String>,
+    #[serde(default)]
+    decode: Option<String>,
+    #[serde(default)]
     instances: Vec<RawWorkerSelectionInstance>,
 }
 
 impl RawWorkerSelectionConfig {
     pub(super) fn resolve(self) -> Result<WorkerSelectionConfig, RouterPolicyConfigError> {
-        if self.instances.is_empty() && self.default.is_none() {
+        if self.instances.is_empty()
+            && self.default.is_none()
+            && self.prefill.is_none()
+            && self.decode.is_none()
+        {
             return Err(RouterPolicyConfigError::Validation(
-                "worker_selection must define an instance or default: default".to_string(),
+                "worker_selection must define an instance or a default, prefill, or decode selection"
+                    .to_string(),
             ));
         }
 
@@ -98,18 +117,25 @@ impl RawWorkerSelectionConfig {
             }
         }
 
-        if let Some(default) = self.default.as_deref()
-            && default != "default"
-            && !instances.contains_key(default)
-        {
-            return Err(RouterPolicyConfigError::Validation(format!(
-                "worker_selection default {:?} does not name a configured instance",
-                default
-            )));
+        for (stage, selected) in [
+            ("default", self.default.as_deref()),
+            ("prefill", self.prefill.as_deref()),
+            ("decode", self.decode.as_deref()),
+        ] {
+            if let Some(selected) = selected
+                && selected != "default"
+                && !instances.contains_key(selected)
+            {
+                return Err(RouterPolicyConfigError::Validation(format!(
+                    "worker_selection {stage} {selected:?} does not name a configured instance"
+                )));
+            }
         }
 
         Ok(WorkerSelectionConfig {
             default: self.default,
+            prefill: self.prefill,
+            decode: self.decode,
             instances,
         })
     }

--- a/lib/kv-router/src/services/selection/mod.rs
+++ b/lib/kv-router/src/services/selection/mod.rs
@@ -26,9 +26,10 @@ pub use error::SelectionError;
 pub use input::PromptRequest;
 pub use pending::SelectionCacheConfig;
 pub use policy_registry::{
-    DYN_ROUTER_WORKER_SELECTION_POLICY, WorkerSelectionPolicyParameters,
-    WorkerSelectionPolicyProvider, WorkerSelectionPolicyProviderError,
-    WorkerSelectionPolicyRegistry, WorkerSelectionPolicyRegistryError,
+    DYN_ROUTER_DECODE_POLICY, DYN_ROUTER_PREFILL_POLICY, DYN_ROUTER_WORKER_SELECTION_POLICY,
+    WorkerSelectionPolicyParameters, WorkerSelectionPolicyProvider,
+    WorkerSelectionPolicyProviderError, WorkerSelectionPolicyRegistry,
+    WorkerSelectionPolicyRegistryError,
 };
 pub use server::{AppState, run_server, run_server_with_service};
 pub use service::{SelectionService, SelectionServiceBuilder};

--- a/lib/kv-router/src/services/selection/policy_registry.rs
+++ b/lib/kv-router/src/services/selection/policy_registry.rs
@@ -11,7 +11,14 @@ use thiserror::Error;
 
 use crate::WorkerSelectionPolicyFactory;
 use crate::config::KvRouterConfig;
-pub use crate::scheduling::config::DYN_ROUTER_WORKER_SELECTION_POLICY;
+use crate::scheduling::config::WorkerSelectionPolicySelections;
+pub use crate::scheduling::config::{
+    DYN_ROUTER_DECODE_POLICY, DYN_ROUTER_PREFILL_POLICY, DYN_ROUTER_WORKER_SELECTION_POLICY,
+};
+use crate::scheduling::selector::WorkerSelectionPolicy;
+
+const PREFILL_WORKER_TYPE: &str = "prefill";
+const DECODE_WORKER_TYPE: &str = "decode";
 
 /// Parses one policy instance's YAML parameters and creates its partition factory.
 pub type WorkerSelectionPolicyProvider = Arc<
@@ -105,19 +112,76 @@ impl WorkerSelectionPolicyRegistry {
         Ok(())
     }
 
-    /// Resolve the configured policy instance once at process startup.
+    /// Resolve the configured policy instances once at process startup.
     ///
-    /// `DYN_ROUTER_WORKER_SELECTION_POLICY`, when set, overrides the YAML default and names an
-    /// instance. The reserved value `default` uses Dynamo's built-in selector.
+    /// Prefill and decode can select separate instances. The returned factory dispatches by the
+    /// worker type that the host supplies when it constructs each worker pool.
     pub fn resolve(
         &self,
         config: &KvRouterConfig,
     ) -> Result<Option<WorkerSelectionPolicyFactory>, WorkerSelectionPolicyRegistryError> {
-        let selected = config.selected_worker_selection_policy_instance()?;
+        let selected = config.selected_worker_selection_policy_instances()?;
         let policy_config = config.worker_selection_config().map_err(|source| {
             crate::scheduling::config::WorkerSelectionPolicyConfigError::Config { source }
         })?;
-        self.resolve_selected(policy_config, selected.as_deref())
+        self.resolve_selections(policy_config, selected)
+    }
+
+    fn resolve_selections(
+        &self,
+        policy_config: Option<&crate::scheduling::WorkerSelectionConfig>,
+        selected: WorkerSelectionPolicySelections,
+    ) -> Result<Option<WorkerSelectionPolicyFactory>, WorkerSelectionPolicyRegistryError> {
+        let mut resolved = HashMap::new();
+        let fallback = self.resolve_selected_cached(
+            policy_config,
+            selected.fallback.as_deref(),
+            &mut resolved,
+        )?;
+        let prefill = self.resolve_selected_cached(
+            policy_config,
+            selected.prefill.as_deref(),
+            &mut resolved,
+        )?;
+        let decode =
+            self.resolve_selected_cached(policy_config, selected.decode.as_deref(), &mut resolved)?;
+
+        if fallback.is_none() && prefill.is_none() && decode.is_none() {
+            return Ok(None);
+        }
+
+        Ok(Some(Arc::new(move |config, worker_type, partition| {
+            let selected = match worker_type {
+                PREFILL_WORKER_TYPE => prefill.as_ref(),
+                DECODE_WORKER_TYPE => decode.as_ref(),
+                _ => fallback.as_ref(),
+            };
+            match selected {
+                Some(factory) => factory(config, worker_type, partition),
+                None => WorkerSelectionPolicy::default(config.clone(), worker_type),
+            }
+        })))
+    }
+
+    fn resolve_selected_cached(
+        &self,
+        config: Option<&crate::scheduling::WorkerSelectionConfig>,
+        selected: Option<&str>,
+        resolved: &mut HashMap<String, WorkerSelectionPolicyFactory>,
+    ) -> Result<Option<WorkerSelectionPolicyFactory>, WorkerSelectionPolicyRegistryError> {
+        let Some(selected) = selected else {
+            return Ok(None);
+        };
+        if let Some(factory) = resolved.get(selected) {
+            return Ok(Some(factory.clone()));
+        }
+        let factory = self.resolve_selected(config, Some(selected))?;
+        if let Some(factory) = factory {
+            resolved.insert(selected.to_owned(), factory.clone());
+            Ok(Some(factory))
+        } else {
+            Ok(None)
+        }
     }
 
     fn resolve_selected(
@@ -171,8 +235,13 @@ impl WorkerSelectionPolicyRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::WorkerSelectionPolicyError;
     use crate::identity::RoutingPartitionRef;
-    use crate::scheduling::selector::WorkerSelectionPolicy;
+    use crate::scheduling::selector::{
+        WorkerInputView, WorkerPicker, WorkerSelectionContext, WorkerSelectionPolicy,
+    };
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(serde::Deserialize)]
     #[serde(deny_unknown_fields)]
@@ -198,6 +267,41 @@ mod tests {
             ));
         }
         Ok(Arc::new(policy))
+    }
+
+    struct NeverPicker;
+
+    impl WorkerPicker for NeverPicker {
+        fn pick(
+            &mut self,
+            _context: &WorkerSelectionContext<'_>,
+            _input: WorkerInputView<'_>,
+        ) -> Result<usize, WorkerSelectionPolicyError> {
+            unreachable!("registry tests only construct policies")
+        }
+    }
+
+    fn recording_provider(
+        provider_calls: Arc<AtomicUsize>,
+        factory_calls: Arc<Mutex<Vec<(usize, String)>>>,
+    ) -> WorkerSelectionPolicyProvider {
+        Arc::new(move |parameters| {
+            let parameters: Parameters = parameters.deserialize()?;
+            provider_calls.fetch_add(1, Ordering::Relaxed);
+            let factory_calls = factory_calls.clone();
+            Ok(Arc::new(move |config, worker_type, _partition| {
+                factory_calls
+                    .lock()
+                    .unwrap()
+                    .push((parameters.threshold, worker_type.to_string()));
+                WorkerSelectionPolicy::new(
+                    config.clone(),
+                    worker_type,
+                    Vec::new(),
+                    Box::new(NeverPicker),
+                )
+            }))
+        })
     }
 
     fn config() -> crate::scheduling::WorkerSelectionConfig {
@@ -246,6 +350,53 @@ worker_selection:
                 .resolve_selected(Some(&config), Some("second"))
                 .unwrap()
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn resolved_factory_dispatches_prefill_and_decode_instances() {
+        let provider_calls = Arc::new(AtomicUsize::new(0));
+        let factory_calls = Arc::new(Mutex::new(Vec::new()));
+        let mut registry = WorkerSelectionPolicyRegistry::default();
+        registry
+            .register(
+                "alpha",
+                recording_provider(provider_calls.clone(), factory_calls.clone()),
+            )
+            .unwrap();
+        registry
+            .register(
+                "beta",
+                recording_provider(provider_calls.clone(), factory_calls.clone()),
+            )
+            .unwrap();
+        let config = config();
+        let factory = registry
+            .resolve_selections(
+                Some(&config),
+                WorkerSelectionPolicySelections {
+                    fallback: Some("first".to_string()),
+                    prefill: Some("first".to_string()),
+                    decode: Some("second".to_string()),
+                },
+            )
+            .unwrap()
+            .unwrap();
+        let router_config = KvRouterConfig::default();
+        let partition = RoutingPartitionRef::new("model", "default");
+
+        factory(&router_config, PREFILL_WORKER_TYPE, partition);
+        factory(&router_config, DECODE_WORKER_TYPE, partition);
+        factory(&router_config, "select", partition);
+
+        assert_eq!(provider_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            *factory_calls.lock().unwrap(),
+            vec![
+                (1, "prefill".to_string()),
+                (2, "decode".to_string()),
+                (1, "select".to_string()),
+            ]
         );
     }
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Adds separate prefill and decode worker-selection policy choices to the embedded Dynamo frontend through YAML, environment variables, and CLI flags. This makes disaggregated routing policies independently configurable without changing worker discovery or per-request scheduling.

### How This Was Implemented
- Add `worker_selection.prefill` and `worker_selection.decode` selectors with validation and fallback to the existing YAML default.
- Add `--router-prefill-policy` and `--router-decode-policy`, their stage-specific environment variables, and Python-to-Rust configuration wiring.
- Resolve named policy instances once at startup, reuse duplicate instance factories, and dispatch the resolved factory when each prefill or decode worker pool is constructed.
- Preserve the built-in selector, the existing global override, stock-build rejection of unsupported custom instances, and standalone EPP `select` behavior.

<details>
<summary>Walkthrough</summary>

#### Mental model

The YAML file defines named policy instances. The frontend resolves one choice for each worker role at startup, then the existing discovery path supplies `prefill` or `decode` when it constructs that role's worker pool.

```mermaid
flowchart LR
    Config["YAML / env / CLI"] --> Resolve["Resolve stage selections at startup"]
    Resolve --> Factory["Role-dispatching policy factory"]
    Discovery["Worker discovery"] -->|"prefill or decode"| Factory
    Factory --> Prefill["Prefill policy instance"]
    Factory --> Decode["Decode policy instance"]
    Prefill --> Scheduler["Existing scheduler and accounting"]
    Decode --> Scheduler
```

#### State and ordering

Each stage uses this precedence, from highest to lowest: stage CLI flag, matching stage environment variable, `DYN_ROUTER_WORKER_SELECTION_POLICY`, YAML stage selection, YAML default, and the built-in selector. The reserved value `default` selects the built-in policy for that scope.

Named instances are parsed and validated with the existing startup policy configuration. When prefill, decode, and fallback select the same instance, the registry resolves its provider once and shares the resulting factory.

#### Request lifecycle

The Python frontend passes the two optional stage selections into `KvRouterConfig`. The linked policy registry resolves the fallback, prefill, and decode factories before the HTTP frontend starts. Discovery later constructs each routing partition with its existing `worker_type`; the wrapper selects the matching factory once for that partition, after which filtering, scoring, picking, scheduling, and accounting follow the existing paths.

Invalid instance names and policy types continue to fail during startup. A stock build without a linked custom-policy catalog rejects any custom stage selection instead of silently ignoring it.

#### Boundaries and limitations

This change does not alter how workers are classified, discovered, or selected per request. The role dispatch and all new allocation occur during startup or worker-pool construction, not on the request hot path.

Standalone EPP still supplies `select` because it has one worker pool and therefore uses `worker_selection.default`; the prefill and decode selectors apply to the embedded frontend. Existing configurations that only use `worker_selection.default` or `DYN_ROUTER_WORKER_SELECTION_POLICY` retain their previous behavior.

</details>

### Validation
- `cargo test -p dynamo-kv-router` (867 passed, 2 ignored)
- `cargo test -p dynamo-kv-router --features standalone-selection` (960 passed, 2 ignored; 6 integration tests passed)
- `cargo test -p dynamo-custom-policy-example-catalog -p dynamo-custom-policy-example-disagg-filter-score-pick` (5 passed)
- `.venv/bin/python -m pytest -q components/src/dynamo/common/tests/configuration/test_kv_router_args.py` (49 passed)
- `cargo clippy -p dynamo-kv-router --features standalone-selection --all-targets` (passed with one pre-existing dead-code warning)
- `cargo check --manifest-path lib/bindings/python/Cargo.toml --features custom-policy` and a custom-policy `maturin develop` build
- Live Mocker smoke test with 2 prefill workers, 2 decode workers, different policy types for each stage, and an HTTP 200 chat-completions response
<!-- codex-pr-description:end -->
