### PR TITLE
feat(frontend): cap Anthropic streaming responses with a wall-clock deadline

### DIFF
--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -65,11 +65,18 @@ The Rust HTTP server also reads these environment variables, which are not expos
 <ParamField path="DYN_HTTP_STREAM_MAX_DURATION_MS" type="integer" default="0">
   Hard wall-clock cap, in milliseconds, on a single streaming response. On expiry the
   frontend stops generation and closes the stream with a spec-valid terminal event
-  (`message_delta` with `stop_reason` plus `message_stop` on `/v1/messages`) rather than
-  severing it. Intended for deployments behind an egress proxy that caps total request
-  duration; set it below that cap with enough margin for the terminal events to flush.
-  Unlike `DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS` this is not an inactivity timer and does
-  not reset when tokens arrive. Unset, `0`, or invalid values disable the cap.
+  (`message_delta` with `stop_reason` plus `message_stop`) rather than severing it.
+  Intended for deployments behind an egress proxy that caps total request duration; set
+  it below that cap with enough margin for the terminal events to flush. Unlike
+  `DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS` this is not an inactivity timer and does not
+  reset when tokens arrive. Unset, `0`, or invalid values disable the cap.
+
+  <Note>
+    This cap is currently honored only by the Anthropic Messages endpoint
+    (`/v1/messages`). The OpenAI-compatible streaming endpoints
+    (`/v1/chat/completions`, `/v1/responses`) ignore it, so setting it does not protect
+    those paths.
+  </Note>
 </ParamField>
 
 ## Router

--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -62,6 +62,16 @@ The Rust HTTP server also reads these environment variables, which are not expos
   Unset, `0`, invalid, or unrepresentable values disable keep-alive comments.
 </ParamField>
 
+<ParamField path="DYN_HTTP_STREAM_MAX_DURATION_MS" type="integer" default="0">
+  Hard wall-clock cap, in milliseconds, on a single streaming response. On expiry the
+  frontend stops generation and closes the stream with a spec-valid terminal event
+  (`message_delta` with `stop_reason` plus `message_stop` on `/v1/messages`) rather than
+  severing it. Intended for deployments behind an egress proxy that caps total request
+  duration; set it below that cap with enough margin for the terminal events to flush.
+  Unlike `DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS` this is not an inactivity timer and does
+  not reset when tokens arrive. Unset, `0`, or invalid values disable the cap.
+</ParamField>
+
 ## Router
 
 This section is the canonical CLI and environment-variable reference for the frontend's embedded

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -162,6 +162,9 @@ class frontend_service:
     MODEL_CANCELLATION_TOTAL = "model_cancellation_total"
     # Total number of requests rejected due to resource exhaustion
     MODEL_REJECTION_TOTAL = "model_rejection_total"
+    # Total number of streaming responses the frontend truncated because the
+    # wall-clock deadline (`DYN_HTTP_STREAM_MAX_DURATION_MS`) expired
+    STREAM_TRUNCATED_TOTAL = "stream_truncated_total"
     # Active decode blocks (KV cache blocks) per worker
     # Gauge metric tracking current KV cache block utilization for each worker
     WORKER_ACTIVE_DECODE_BLOCKS = "worker_active_decode_blocks"

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -659,6 +659,16 @@ async fn anthropic_messages(
             tokio::pin!(budget);
 
             loop {
+                // Enforce the wall-clock budget before draining another chunk.
+                // The select below is `biased`, so a backend whose `next()` is
+                // always immediately ready wins every poll and the `budget` arm
+                // would never be reached — the cap would silently never fire
+                // under exactly the fast-backend load it exists to bound.
+                if stream_deadline.is_some_and(|at| Instant::now() >= at) {
+                    truncated = true;
+                    break;
+                }
+
                 tokio::select! {
                     // Prefer draining a ready backend chunk before honoring a
                     // cancel so no already-generated token is dropped.
@@ -695,21 +705,25 @@ async fn anthropic_messages(
                         break;
                     }
                     _ = &mut budget => {
-                        // Wall-clock deadline reached. Stop the GPU: tokens produced
-                        // after this point can never reach the client. stop_generating
-                        // (not kill) so usage accounting and disagg RDMA teardown still
-                        // run — see ai-dynamo/dynamo#12292 and #10923.
-                        tracing::warn!(
-                            env = DYN_HTTP_STREAM_MAX_DURATION_MS,
-                            budget_ms = stream_budget.map(|d| d.as_millis() as u64).unwrap_or_default(),
-                            output_tokens = converter.output_tokens(),
-                            "stream deadline reached; truncating with a spec-valid terminal event"
-                        );
-                        cancel_ctx.stop_generating();
+                        // Wall-clock deadline reached while the backend was idle.
                         truncated = true;
                         break;
                     }
                 }
+            }
+
+            if truncated {
+                // Stop the GPU: tokens produced after this point can never reach
+                // the client. stop_generating (not kill) so usage accounting and
+                // disagg RDMA teardown still run — see ai-dynamo/dynamo#12292
+                // and #10923. Shared by both truncation exits above.
+                tracing::warn!(
+                    env = DYN_HTTP_STREAM_MAX_DURATION_MS,
+                    budget_ms = stream_budget.map(|d| d.as_millis() as u64).unwrap_or_default(),
+                    output_tokens = converter.output_tokens(),
+                    "stream deadline reached; truncating with a spec-valid terminal event"
+                );
+                cancel_ctx.stop_generating();
             }
 
             if saw_error {
@@ -722,7 +736,9 @@ async fn anthropic_messages(
                     // MaxTokens is the only stop reason the client already knows how
                     // to continue from. Stop would assert the turn finished; an error
                     // event after visible output is not retried by Claude Code at all.
-                    converter.force_stop_reason(AnthropicStopReason::MaxTokens);
+                    // Only applied if the backend has not already reported a real
+                    // finish reason — see set_stop_reason_if_unset.
+                    converter.set_stop_reason_if_unset(AnthropicStopReason::MaxTokens);
                     if let Some((metrics, model)) = &truncation_ctx {
                         metrics.inc_stream_truncated(model, Endpoint::AnthropicMessages);
                     }

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -24,14 +24,17 @@ use axum::{
     },
     routing::{get, post},
 };
+use dynamo_runtime::config::environment_names::llm::DYN_HTTP_STREAM_MAX_DURATION_MS;
 use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
 use futures::StreamExt;
+use tokio::time::Instant;
 use tracing::Instrument;
 
 use super::{
     RouteDoc,
     disconnect::{
         ConnectionHandle, create_connection_monitor, monitor_for_disconnects_with_activity,
+        stream_max_duration,
     },
     metrics::{
         CancellationLabels, Endpoint, ErrorType, InflightGuard,
@@ -44,7 +47,8 @@ use crate::protocols::anthropic::stream_converter::AnthropicStreamConverter;
 use crate::protocols::anthropic::types::{
     AnthropicContentBlock, AnthropicCountTokensRequest, AnthropicCountTokensResponse,
     AnthropicCreateMessageRequest, AnthropicErrorBody, AnthropicErrorResponse, AnthropicMessage,
-    AnthropicMessageContent, AnthropicTool, SystemContent, chat_completion_to_anthropic_response,
+    AnthropicMessageContent, AnthropicStopReason, AnthropicTool, SystemContent,
+    chat_completion_to_anthropic_response,
 };
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
@@ -613,6 +617,21 @@ async fn anthropic_messages(
         let cancel_ctx = ctx.clone();
 
         let (activity_tx, activity_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        // Wall-clock budget for one streaming response. An egress proxy that caps
+        // total request duration severs the connection long after the `200` has
+        // been committed, so the client can never receive an HTTP status — it just
+        // hangs. Truncate ourselves first, as a spec-valid short turn. Captured at
+        // entry (not as a relative sleep inside the stream body) so it is bounded in
+        // total, matching the pre-commit error peek in openai.rs — an
+        // `async_stream::stream!` body only starts on first poll, so a relative
+        // sleep would start counting late under load.
+        let stream_budget = stream_max_duration();
+        let stream_deadline = stream_budget.map(|d| Instant::now() + d);
+        // Only capture what the truncation path needs, and only when the deadline
+        // is enabled — the default (disabled) path must not allocate per request.
+        let truncation_ctx = stream_deadline.map(|_| (state.metrics_clone(), model.clone()));
+
         let full_stream = async_stream::stream! {
             let mut events = Vec::with_capacity(4);
             converter.append_start_events(&mut events);
@@ -622,11 +641,22 @@ async fn anthropic_messages(
 
             let mut saw_error = false;
             let mut cancelled = false;
+            let mut truncated = false;
 
             // Keep a single cancellation future alive across chunks — recreating
             // it per token churns the underlying Notify (see disconnect.rs).
             let stopped = cancel_ctx.stopped();
             tokio::pin!(stopped);
+
+            // Unset -> a future that never resolves, matching the opt-in shape of
+            // backend_stream_timeout() in disconnect.rs. No behaviour change by default.
+            let budget = async move {
+                match stream_deadline {
+                    Some(at) => tokio::time::sleep_until(at).await,
+                    None => std::future::pending::<()>().await,
+                }
+            };
+            tokio::pin!(budget);
 
             loop {
                 tokio::select! {
@@ -664,12 +694,45 @@ async fn anthropic_messages(
                         cancelled = true;
                         break;
                     }
+                    _ = &mut budget => {
+                        // Wall-clock deadline reached. Stop the GPU: tokens produced
+                        // after this point can never reach the client. stop_generating
+                        // (not kill) so usage accounting and disagg RDMA teardown still
+                        // run — see ai-dynamo/dynamo#12292 and #10923.
+                        tracing::warn!(
+                            env = DYN_HTTP_STREAM_MAX_DURATION_MS,
+                            budget_ms = stream_budget.map(|d| d.as_millis() as u64).unwrap_or_default(),
+                            output_tokens = converter.output_tokens(),
+                            "stream deadline reached; truncating with a spec-valid terminal event"
+                        );
+                        cancel_ctx.stop_generating();
+                        truncated = true;
+                        break;
+                    }
                 }
             }
 
             if saw_error {
                 converter.append_error_events(&mut events);
             } else {
+                if truncated {
+                    // Drop any tool block still mid-JSON so we never flush a
+                    // malformed `tool_use` the client would replay as HTTP 400.
+                    let dropped = converter.drop_incomplete_tool_blocks();
+                    // MaxTokens is the only stop reason the client already knows how
+                    // to continue from. Stop would assert the turn finished; an error
+                    // event after visible output is not retried by Claude Code at all.
+                    converter.force_stop_reason(AnthropicStopReason::MaxTokens);
+                    if let Some((metrics, model)) = &truncation_ctx {
+                        metrics.inc_stream_truncated(model, Endpoint::AnthropicMessages);
+                    }
+                    if dropped > 0 {
+                        tracing::warn!(
+                            dropped_tool_blocks = dropped,
+                            "dropped tool blocks with incomplete JSON args on truncation"
+                        );
+                    }
+                }
                 converter.append_end_events(&mut events);
             }
             for event in events.drain(..) {

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -57,7 +57,7 @@ pub fn backend_stream_timeout() -> Option<Duration> {
 }
 
 /// Read the hard wall-clock cap for a single streaming response.
-/// Returns `None` if unset or zero (disabled).
+/// Returns `None` if unset, zero, or unrepresentable (disabled).
 ///
 /// Unlike [`backend_stream_timeout`], this is **not** an inactivity timer: it does
 /// not reset when tokens arrive, and it applies **no** 2x multiplier. It exists for
@@ -70,6 +70,13 @@ pub fn stream_max_duration() -> Option<Duration> {
         .and_then(|s| s.parse::<u64>().ok())
         .filter(|&ms| ms > 0)
         .map(Duration::from_millis)
+        // The caller forms the deadline as `Instant::now() + d`, which panics if the
+        // sum is unrepresentable. Whether any `u64` millisecond value can overflow
+        // depends on how the platform represents `Instant` — a `timespec` absorbs the
+        // whole range, a tick counter need not — so validate instead of relying on
+        // that. A value this large is a misconfiguration; disable the cap rather than
+        // turn it into a request-time panic.
+        .filter(|d| std::time::Instant::now().checked_add(*d).is_some())
 }
 
 #[derive(Clone, Copy)]
@@ -536,6 +543,18 @@ mod tests {
         // Valid -> parsed as milliseconds, with no 2x multiplier.
         temp_env::with_var(STREAM_MAX_DURATION_ENV, Some("265000"), || {
             assert_eq!(stream_max_duration(), Some(Duration::from_millis(265000)));
+        });
+        // Parses as u64 but cannot be turned into a deadline -> disabled, never a
+        // panic. On platforms whose `Instant` absorbs the whole millisecond range
+        // this still yields a duration; either way the handler must not panic.
+        temp_env::with_var(STREAM_MAX_DURATION_ENV, Some(&u64::MAX.to_string()), || {
+            match stream_max_duration() {
+                None => {}
+                Some(d) => assert!(
+                    std::time::Instant::now().checked_add(d).is_some(),
+                    "returned a duration that cannot be added to Instant::now()"
+                ),
+            }
         });
     }
 

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -39,6 +39,7 @@ use crate::http::service::error::SanitizedError;
 use crate::http::service::metrics::{CancellationLabels, ErrorType, InflightGuard, Metrics};
 
 use dynamo_runtime::config::environment_names::llm::DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS as BACKEND_STREAM_TIMEOUT_ENV;
+use dynamo_runtime::config::environment_names::llm::DYN_HTTP_STREAM_MAX_DURATION_MS as STREAM_MAX_DURATION_ENV;
 
 /// Read the backend stream inactivity timeout from the environment.
 /// Returns `None` if unset or zero (timeout disabled).
@@ -53,6 +54,22 @@ pub fn backend_stream_timeout() -> Option<Duration> {
         .and_then(|s| s.parse::<u64>().ok())
         .filter(|&secs| secs > 0)
         .map(|secs| Duration::from_secs(secs.saturating_mul(2)))
+}
+
+/// Read the hard wall-clock cap for a single streaming response.
+/// Returns `None` if unset or zero (disabled).
+///
+/// Unlike [`backend_stream_timeout`], this is **not** an inactivity timer: it does
+/// not reset when tokens arrive, and it applies **no** 2x multiplier. It exists for
+/// egress proxies that cap total request duration — those sever the connection long
+/// after the `200` has been committed, so the client cannot receive an HTTP status
+/// and simply hangs.
+pub fn stream_max_duration() -> Option<Duration> {
+    std::env::var(STREAM_MAX_DURATION_ENV)
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&ms| ms > 0)
+        .map(Duration::from_millis)
 }
 
 #[derive(Clone, Copy)]
@@ -499,6 +516,27 @@ mod tests {
         let (tx, _rx) = tokio::sync::oneshot::channel();
         let handle = ConnectionHandle::create_disabled(tx);
         (metrics, guard, context, handle)
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_stream_max_duration_parsing() {
+        // Unset -> disabled (opt-in default).
+        temp_env::with_var_unset(STREAM_MAX_DURATION_ENV, || {
+            assert_eq!(stream_max_duration(), None);
+        });
+        // Zero -> disabled.
+        temp_env::with_var(STREAM_MAX_DURATION_ENV, Some("0"), || {
+            assert_eq!(stream_max_duration(), None);
+        });
+        // Invalid -> disabled (no panic).
+        temp_env::with_var(STREAM_MAX_DURATION_ENV, Some("not-a-number"), || {
+            assert_eq!(stream_max_duration(), None);
+        });
+        // Valid -> parsed as milliseconds, with no 2x multiplier.
+        temp_env::with_var(STREAM_MAX_DURATION_ENV, Some("265000"), || {
+            assert_eq!(stream_max_duration(), Some(Duration::from_millis(265000)));
+        });
     }
 
     #[tokio::test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -421,6 +421,7 @@ pub struct Metrics {
     model_migration_max_seq_len_exceeded_total: IntCounterVec,
     model_cancellation_total: IntCounterVec,
     model_rejection_total: IntCounterVec,
+    stream_truncated_total: IntCounterVec,
 }
 
 // Inflight tracks requests from HTTP handler start until complete response is finished.
@@ -999,6 +1000,15 @@ impl Metrics {
         )
         .unwrap();
 
+        let stream_truncated_total = IntCounterVec::new(
+            Opts::new(
+                frontend_metric_name(frontend_service::STREAM_TRUNCATED_TOTAL),
+                "Total number of streaming responses truncated by the wall-clock deadline",
+            ),
+            &["model", "endpoint"],
+        )
+        .unwrap();
+
         Metrics {
             request_started_counter,
             request_counter,
@@ -1029,6 +1039,7 @@ impl Metrics {
             model_migration_max_seq_len_exceeded_total,
             model_cancellation_total,
             model_rejection_total,
+            stream_truncated_total,
         }
     }
 
@@ -1191,6 +1202,7 @@ impl Metrics {
         ))?;
         registry.register(Box::new(self.model_cancellation_total.clone()))?;
         registry.register(Box::new(self.model_rejection_total.clone()))?;
+        registry.register(Box::new(self.stream_truncated_total.clone()))?;
 
         Ok(())
     }
@@ -1312,6 +1324,23 @@ impl Metrics {
     /// Get the current rejection count for a model and endpoint
     pub fn get_rejection_count(&self, model: &str, endpoint: Endpoint) -> u64 {
         self.model_rejection_total
+            .with_label_values(&[model, &endpoint.to_string()])
+            .get()
+    }
+
+    /// Increment the stream-truncation counter for a model and endpoint. Emitted
+    /// when the wall-clock deadline (`DYN_HTTP_STREAM_MAX_DURATION_MS`) truncates a
+    /// streaming response, so a deadline truncation is distinguishable from a
+    /// genuine `max_tokens` turn.
+    pub fn inc_stream_truncated(&self, model: &str, endpoint: Endpoint) {
+        self.stream_truncated_total
+            .with_label_values(&[model, &endpoint.to_string()])
+            .inc();
+    }
+
+    /// Get the current stream-truncation count for a model and endpoint
+    pub fn get_stream_truncated_count(&self, model: &str, endpoint: Endpoint) -> u64 {
+        self.stream_truncated_total
             .with_label_values(&[model, &endpoint.to_string()])
             .get()
     }

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -527,12 +527,19 @@ impl AnthropicStreamConverter {
         }
     }
 
-    /// Force the terminal `stop_reason` when the frontend truncates a stream the
+    /// Set the terminal `stop_reason` when the frontend truncates a stream the
     /// backend has not finished. `append_end_events` then closes any open blocks
     /// and emits a spec-valid `message_delta` + `message_stop`, so the client sees a
     /// short-but-complete turn rather than a severed stream.
-    pub fn force_stop_reason(&mut self, reason: AnthropicStopReason) {
-        self.stop_reason = Some(reason);
+    ///
+    /// A reason already recorded from the backend's `finish_reason` wins: the
+    /// deadline can fire after the finish chunk was consumed but before the engine
+    /// stream ends (a trailing usage-only chunk, or stream teardown). Overwriting
+    /// there would report a completed turn as cut short — the client would continue
+    /// a turn that already ended, or discard a genuine `tool_use` because it looks
+    /// like `max_tokens`.
+    pub fn set_stop_reason_if_unset(&mut self, reason: AnthropicStopReason) {
+        self.stop_reason.get_or_insert(reason);
     }
 
     /// Output tokens observed so far (authoritative if the backend reported usage,

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -527,6 +527,39 @@ impl AnthropicStreamConverter {
         }
     }
 
+    /// Force the terminal `stop_reason` when the frontend truncates a stream the
+    /// backend has not finished. `append_end_events` then closes any open blocks
+    /// and emits a spec-valid `message_delta` + `message_stop`, so the client sees a
+    /// short-but-complete turn rather than a severed stream.
+    pub fn force_stop_reason(&mut self, reason: AnthropicStopReason) {
+        self.stop_reason = Some(reason);
+    }
+
+    /// Output tokens observed so far (authoritative if the backend reported usage,
+    /// otherwise the per-delta fallback count). For truncation logging/metrics.
+    pub fn output_tokens(&self) -> u32 {
+        self.usage.output_tokens
+    }
+
+    /// Drop buffered tool-call blocks whose concatenated argument fragments are not
+    /// yet complete JSON. Only called on truncation: emitting a `tool_use` with a
+    /// half-streamed `input` object makes the client replay a malformed block
+    /// (HTTP 400 next turn). A tool call with no arguments streamed yet is still a
+    /// valid empty-input block, so only partial-but-non-empty JSON is dropped.
+    /// Returns the number of blocks dropped.
+    pub fn drop_incomplete_tool_blocks(&mut self) -> usize {
+        let before = self.tool_call_states.len();
+        self.tool_call_states.retain(|state| {
+            let args: String = state
+                .argument_fragments
+                .iter()
+                .map(|(frag, _)| frag.as_str())
+                .collect();
+            args.trim().is_empty() || serde_json::from_str::<serde_json::Value>(&args).is_ok()
+        });
+        before - self.tool_call_states.len()
+    }
+
     /// Emit the final events when the stream ends.
     pub fn emit_end_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::new();

--- a/lib/llm/tests/anthropic_http_replay.rs
+++ b/lib/llm/tests/anthropic_http_replay.rs
@@ -674,6 +674,116 @@ async fn client_disconnect_is_not_misclassified_as_truncation_when_deadline_conf
     .await;
 }
 
+/// Regression: the deadline must not relabel a turn the backend already finished.
+///
+/// `text.sse` chunk 2 carries `finish_reason:"stop"`, so by the time the gated
+/// usage-only tail (chunk 3) is still in flight the converter already holds a real
+/// terminal reason (`end_turn`). If the deadline fires in that window the handler
+/// still takes the truncation path — but overwriting the recorded reason with
+/// `max_tokens` tells the client a complete answer was cut short, and a client such
+/// as Claude Code will continue a turn that already ended. Truncation bookkeeping
+/// (metric, warn) is still correct here; only the client-visible label must be
+/// preserved.
+#[tokio::test]
+#[serial]
+async fn stream_deadline_preserves_finish_reason_already_reported_by_backend() {
+    temp_env::async_with_vars(DEADLINE_ENV, async {
+        let script = load_agent_fixture("text.sse").await.unwrap();
+        // Head = role + content + finish_reason chunks; only the usage-only chunk
+        // is gated, so the deadline fires *after* a genuine finish was recorded.
+        let (svc, _gate) = HarnessService::start_with_gated_tail(script, 3).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "messages": [{"role": "user", "content": "Ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let raw = tokio::time::timeout(Duration::from_secs(10), response.text())
+            .await
+            .expect("stream did not terminate at the wall-clock deadline")
+            .expect("failed to read SSE body");
+
+        let events = parse_json_sse(&raw).await.unwrap();
+        let deltas: Vec<_> = events
+            .iter()
+            .filter(|event| event.event == "message_delta")
+            .collect();
+        assert_eq!(deltas.len(), 1, "expected one message_delta: {raw}");
+        assert_eq!(
+            deltas[0].data["delta"]["stop_reason"], "end_turn",
+            "a turn the backend already finished must not be relabelled max_tokens: {raw}"
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+/// Regression: a backend that is always ready must not starve the deadline.
+///
+/// The select loop is `biased`, so the backend-chunk arm is polled first by design
+/// (an already-generated token must never be dropped in favour of a cancel). With a
+/// backend whose `next()` is *always* immediately ready, that ordering means the
+/// budget arm is never reached and `DYN_HTTP_STREAM_MAX_DURATION_MS` is never
+/// enforced — exactly the fast-backend load the cap exists to bound. Multi-threaded
+/// so the client side can still make progress while the server task spins.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn stream_deadline_fires_against_a_continuously_ready_backend() {
+    temp_env::async_with_vars(DEADLINE_ENV, async {
+        // Reuse the fixture's first chunk (a role-only delta) as filler: it keeps
+        // the select loop permanently fed without accumulating output, so this test
+        // isolates scheduling starvation.
+        let script = load_agent_fixture("text.sse").await.unwrap();
+        let filler = script
+            .into_iter()
+            .next()
+            .expect("text.sse must contain at least one chunk");
+        let svc = HarnessService::start_endless(filler).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "messages": [{"role": "user", "content": "Ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        // The deadline is 300ms. Without enforcement ahead of chunk processing the
+        // backend arm wins every poll and this never returns.
+        let raw = tokio::time::timeout(Duration::from_secs(10), response.text())
+            .await
+            .expect("deadline was starved by a continuously-ready backend")
+            .expect("failed to read truncated SSE body");
+
+        let events = parse_json_sse(&raw).await.unwrap();
+        let deltas: Vec<_> = events
+            .iter()
+            .filter(|event| event.event == "message_delta")
+            .collect();
+        assert_eq!(deltas.len(), 1, "expected one message_delta: {raw}");
+        assert_eq!(deltas[0].data["delta"]["stop_reason"], "max_tokens");
+        assert_eq!(
+            svc.metrics
+                .get_stream_truncated_count(MODEL, Endpoint::AnthropicMessages),
+            1,
+            "deadline truncation must be recorded"
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
 #[tokio::test]
 #[serial]
 async fn parallel_tools_preserve_identity_and_arguments() {

--- a/lib/llm/tests/anthropic_http_replay.rs
+++ b/lib/llm/tests/anthropic_http_replay.rs
@@ -6,12 +6,14 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use dynamo_llm::http::service::metrics::{Endpoint, ErrorType, RequestType, Status};
 use dynamo_protocols::types::{
     ChatCompletionRequestAssistantMessageContent, ChatCompletionRequestMessage,
     ChatCompletionRequestToolMessageContent, ChatCompletionRequestUserMessageContent,
 };
 use dynamo_runtime::config::environment_names::llm::{
     DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
+    DYN_HTTP_STREAM_MAX_DURATION_MS,
 };
 use futures::StreamExt;
 use serde_json::{Value, json};
@@ -262,6 +264,409 @@ async fn finish_signal_publishes_tool_block_before_usage_tail() {
                 .filter(|event| event.event == "message_delta")
                 .count(),
             1
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+/// Vars for the wall-clock-deadline tests: base Anthropic env plus a short
+/// `DYN_HTTP_STREAM_MAX_DURATION_MS` so the frontend deadline fires well before
+/// any real timeout while the backend stream is gated (and never released).
+const DEADLINE_ENV: [(&str, Option<&str>); 3] = [
+    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+    (DYN_HTTP_STREAM_MAX_DURATION_MS, Some("300")),
+];
+
+/// When the wall-clock deadline expires mid-stream (backend still open), the
+/// frontend must close the response as a spec-valid short turn:
+/// `content_block_stop` for the open text block, `message_delta` with
+/// `stop_reason:"max_tokens"`, then `message_stop` + `[DONE]` — and NOT an
+/// `event: error`. The `text.sse` head (`role`, `"Pong."`) streams immediately;
+/// the finish/usage tail is gated and never released, so only the deadline can
+/// terminate the stream.
+#[tokio::test]
+#[serial]
+async fn stream_deadline_truncates_open_text_block_with_max_tokens() {
+    temp_env::async_with_vars(DEADLINE_ENV, async {
+        let script = load_agent_fixture("text.sse").await.unwrap();
+        // Split after the two content chunks (role + "Pong.") so the finish and
+        // usage chunks are gated; the text block is left open.
+        let split_at = 2;
+        let (svc, _gate) = HarnessService::start_with_gated_tail(script, split_at).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "messages": [{"role": "user", "content": "Ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        // The deadline is 300ms; give it generous slack. Without the fix this
+        // would hang until the test timeout.
+        let raw = tokio::time::timeout(Duration::from_secs(10), response.text())
+            .await
+            .expect("stream did not terminate at the wall-clock deadline")
+            .expect("failed to read truncated SSE body");
+
+        let events = parse_json_sse(&raw).await.unwrap();
+
+        // Exactly one terminal message_delta, carrying max_tokens.
+        let deltas: Vec<_> = events
+            .iter()
+            .filter(|event| event.event == "message_delta")
+            .collect();
+        assert_eq!(deltas.len(), 1, "expected one message_delta: {raw}");
+        assert_eq!(deltas[0].data["delta"]["stop_reason"], "max_tokens");
+
+        // A spec-valid terminal turn: message_stop + [DONE], no error frame.
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.event == "message_stop")
+                .count(),
+            1
+        );
+        assert_eq!(raw.matches("data: [DONE]").count(), 1);
+        assert!(
+            !events.iter().any(|event| event.event == "error"),
+            "truncation must not surface an error event: {raw}"
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+/// Opt-in guarantee: with `DYN_HTTP_STREAM_MAX_DURATION_MS` unset, a gated stream
+/// does NOT self-terminate — no `message_delta` arrives within a window that is
+/// comfortably longer than the deadline used above. This proves the deadline is
+/// what produced the terminal turn in the test above, not some other timer.
+#[tokio::test]
+#[serial]
+async fn stream_without_deadline_does_not_self_truncate() {
+    // Base ENV only: no DYN_HTTP_STREAM_MAX_DURATION_MS.
+    temp_env::async_with_vars(ENV, async {
+        let script = load_agent_fixture("text.sse").await.unwrap();
+        let (svc, gate) = HarnessService::start_with_gated_tail(script, 2).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "messages": [{"role": "user", "content": "Ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let mut body = response.bytes_stream();
+        let mut parser = IncrementalSseParser::default();
+        let mut saw_message_delta = false;
+        // Read for well past the 300ms deadline used above; nothing should
+        // finalize because no deadline is configured.
+        let _ = tokio::time::timeout(Duration::from_millis(800), async {
+            while let Some(bytes) = body.next().await {
+                let bytes = bytes.expect("failed to read SSE bytes");
+                for event in parser.push(&bytes).expect("failed to parse SSE") {
+                    saw_message_delta |= event == "message_delta";
+                }
+            }
+        })
+        .await;
+        assert!(
+            !saw_message_delta,
+            "stream self-truncated without a configured deadline"
+        );
+
+        gate.release();
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+/// A deadline that fires while a tool call's arguments are still mid-JSON must not
+/// flush a malformed `tool_use` (which the client would replay as HTTP 400). The
+/// `fragmented-tool.sse` head streams the tool id/name and the first arg fragment
+/// (`{"path"` — incomplete JSON); the fragment that closes the JSON is gated. On
+/// truncation the incomplete block is dropped: no `tool_use` content block is
+/// emitted, only the spec-valid `max_tokens` terminal turn.
+#[tokio::test]
+#[serial]
+async fn stream_deadline_drops_incomplete_tool_use() {
+    temp_env::async_with_vars(DEADLINE_ENV, async {
+        let script = load_agent_fixture("fragmented-tool.sse").await.unwrap();
+        // Immediate: role, tool id/name, and the first arg fragment leaving args
+        // at `{"path"` (incomplete JSON). Gated: the fragment that completes the
+        // JSON, plus finish/usage. So at the deadline the buffered tool args do
+        // not parse and the block must be dropped.
+        let split_at = 3;
+        let (svc, _gate) = HarnessService::start_with_gated_tail(script, split_at).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "tools": [tool("list_directory")],
+                "messages": [{"role": "user", "content": "List /tmp"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let raw = tokio::time::timeout(Duration::from_secs(10), response.text())
+            .await
+            .expect("stream did not terminate at the wall-clock deadline")
+            .expect("failed to read truncated SSE body");
+        let events = parse_json_sse(&raw).await.unwrap();
+
+        // No tool_use content block was flushed (the args JSON was incomplete).
+        assert!(
+            !events.iter().any(|event| {
+                event.event == "content_block_start"
+                    && event.data["content_block"]["type"] == "tool_use"
+            }),
+            "an incomplete tool_use must not be emitted on truncation: {raw}"
+        );
+        // Still a spec-valid truncated turn.
+        let deltas: Vec<_> = events
+            .iter()
+            .filter(|event| event.event == "message_delta")
+            .collect();
+        assert_eq!(deltas.len(), 1, "expected one message_delta: {raw}");
+        assert_eq!(deltas[0].data["delta"]["stop_reason"], "max_tokens");
+        assert_eq!(raw.matches("data: [DONE]").count(), 1);
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+/// A deadline that fires before the backend has ever produced a single chunk must
+/// still close the response as a spec-valid, non-empty turn: `message_start` (which
+/// is emitted unconditionally before the backend is first polled) followed directly
+/// by the terminal `message_delta{stop_reason:"max_tokens"}` + `message_stop`. No
+/// content block was ever opened, so none should appear closed either. This is the
+/// edge case the upstream contribution plan (docs/issues §10.5) calls out as
+/// required in addition to the mid-block case: the finalizer must not assume at
+/// least one block was ever started.
+#[tokio::test]
+#[serial]
+async fn stream_deadline_before_any_backend_chunk_still_emits_valid_terminal_turn() {
+    temp_env::async_with_vars(DEADLINE_ENV, async {
+        let script = load_agent_fixture("text.sse").await.unwrap();
+        // Gate everything: not even the role/text head chunk is released, so the
+        // deadline must fire while the converter has emitted nothing but the
+        // unconditional message_start.
+        let (svc, _gate) = HarnessService::start_with_gated_tail(script, 0).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "messages": [{"role": "user", "content": "Ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let raw = tokio::time::timeout(Duration::from_secs(10), response.text())
+            .await
+            .expect("stream did not terminate at the wall-clock deadline")
+            .expect("failed to read truncated SSE body");
+        let events = parse_json_sse(&raw).await.unwrap();
+
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.event == "message_start")
+                .count(),
+            1,
+            "message_start must still be emitted when the deadline fires before any backend chunk: {raw}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|event| event.event.starts_with("content_block")),
+            "no content block was ever opened, so none should appear in the truncated turn: {raw}"
+        );
+        let deltas: Vec<_> = events
+            .iter()
+            .filter(|event| event.event == "message_delta")
+            .collect();
+        assert_eq!(deltas.len(), 1, "expected one message_delta: {raw}");
+        assert_eq!(deltas[0].data["delta"]["stop_reason"], "max_tokens");
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.event == "message_stop")
+                .count(),
+            1
+        );
+        assert_eq!(raw.matches("data: [DONE]").count(), 1);
+        assert!(
+            !events.iter().any(|event| event.event == "error"),
+            "truncation must not surface an error event: {raw}"
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+/// Truncation must be observable through `stream_truncated_total`, not just through
+/// the SSE body — otherwise a deployment cannot distinguish a proxy-deadline
+/// truncation from a genuine `max_tokens` turn (docs/issues §7 "Observability nên
+/// thêm").
+#[tokio::test]
+#[serial]
+async fn stream_deadline_increments_truncation_metric() {
+    temp_env::async_with_vars(DEADLINE_ENV, async {
+        let script = load_agent_fixture("text.sse").await.unwrap();
+        let (svc, _gate) = HarnessService::start_with_gated_tail(script, 2).await;
+        assert_eq!(
+            svc.metrics
+                .get_stream_truncated_count(MODEL, Endpoint::AnthropicMessages),
+            0
+        );
+
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "messages": [{"role": "user", "content": "Ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let _raw = tokio::time::timeout(Duration::from_secs(10), response.text())
+            .await
+            .expect("stream did not terminate at the wall-clock deadline")
+            .expect("failed to read truncated SSE body");
+
+        assert_eq!(
+            svc.metrics
+                .get_stream_truncated_count(MODEL, Endpoint::AnthropicMessages),
+            1,
+            "wall-clock truncation must increment stream_truncated_total"
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+/// The whole point of truncating server-side is to stop the backend from wasting
+/// GPU cycles decoding tokens the client can never receive (docs/issues TL;DR: "vẫn
+/// decode — GPU cháy vô ích"). Assert `stop_generating()` actually reaches the
+/// backend's engine context, not just that the client-visible SSE looks correct.
+#[tokio::test]
+#[serial]
+async fn stream_deadline_calls_stop_generating_on_backend_context() {
+    temp_env::async_with_vars(DEADLINE_ENV, async {
+        let script = load_agent_fixture("text.sse").await.unwrap();
+        let (svc, _gate) = HarnessService::start_with_gated_tail(script, 2).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "messages": [{"role": "user", "content": "Ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let _raw = tokio::time::timeout(Duration::from_secs(10), response.text())
+            .await
+            .expect("stream did not terminate at the wall-clock deadline")
+            .expect("failed to read truncated SSE body");
+
+        assert!(
+            svc.engine.last_context_stopped().await,
+            "wall-clock deadline must call stop_generating() on the backend context \
+             so the worker stops producing tokens the client can never receive"
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+/// A genuine client disconnect must still be recorded as `cancelled`, never folded
+/// into the `truncated` path, even when a wall-clock deadline is configured and has
+/// not yet expired. This pins the invariant the implementation comment calls out
+/// directly: "cancelled" parks on `pending()` so the outer `monitor_for_disconnects`
+/// records the request as cancelled, while "truncated" ends normally and is recorded
+/// OK — the two must never be conflated (docs/issues §6.3(d)).
+#[tokio::test]
+#[serial]
+async fn client_disconnect_is_not_misclassified_as_truncation_when_deadline_configured() {
+    // A deadline generous enough that it cannot fire before this test's assertions
+    // run, so any termination we observe must come from the disconnect path.
+    const GENEROUS_DEADLINE_ENV: [(&str, Option<&str>); 3] = [
+        (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+        (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+        (DYN_HTTP_STREAM_MAX_DURATION_MS, Some("60000")),
+    ];
+    temp_env::async_with_vars(GENEROUS_DEADLINE_ENV, async {
+        let script = load_agent_fixture("text.sse").await.unwrap();
+        let (svc, _gate) = HarnessService::start_with_gated_tail(script, 2).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "messages": [{"role": "user", "content": "Ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        // Read the immediately-available head chunk, then drop the response body to
+        // simulate a client disconnect (same technique as the existing
+        // client-disconnect coverage in tests/http-service.rs).
+        let mut body = response.bytes_stream();
+        let _ = body.next().await;
+        drop(body);
+
+        // Give the connection monitor time to detect the drop and record it.
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if svc.metrics.get_request_counter(
+                    MODEL,
+                    &Endpoint::AnthropicMessages,
+                    &RequestType::Stream,
+                    &Status::Error,
+                    &ErrorType::Cancelled,
+                ) == 1
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("client disconnect was not recorded as cancelled");
+
+        assert_eq!(
+            svc.metrics
+                .get_stream_truncated_count(MODEL, Endpoint::AnthropicMessages),
+            0,
+            "a client disconnect must never be recorded as a wall-clock truncation"
         );
 
         svc.shutdown().await;

--- a/lib/llm/tests/common/http_harness.rs
+++ b/lib/llm/tests/common/http_harness.rs
@@ -53,6 +53,15 @@ impl HarnessService {
         (Self::start_with_engine(Arc::new(engine)).await, gate)
     }
 
+    /// Backend that never stops producing and never awaits — see
+    /// [`ScriptedChatEngine::with_endless_repeat`].
+    #[allow(dead_code)]
+    pub async fn start_endless(
+        chunk: dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse,
+    ) -> Self {
+        Self::start_with_engine(Arc::new(ScriptedChatEngine::with_endless_repeat(chunk))).await
+    }
+
     async fn start_with_engine(engine: Arc<ScriptedChatEngine>) -> Self {
         let client = reqwest::Client::builder()
             .no_proxy()

--- a/lib/llm/tests/common/scripted_chat_engine.rs
+++ b/lib/llm/tests/common/scripted_chat_engine.rs
@@ -30,8 +30,12 @@ enum QueuedScript {
     /// Yields `chunk` forever without ever awaiting, so `next()` is *always*
     /// immediately ready. Models a backend fast enough to keep the frontend's
     /// select loop permanently fed.
+    ///
+    /// Boxed: the response type is far larger than the other variants' payloads,
+    /// and an inline copy would bloat every `QueuedScript` (clippy
+    /// `large_enum_variant`).
     Endless {
-        chunk: NvCreateChatCompletionStreamResponse,
+        chunk: Box<NvCreateChatCompletionStreamResponse>,
     },
 }
 
@@ -90,7 +94,9 @@ impl ScriptedChatEngine {
     #[allow(dead_code)]
     pub fn with_endless_repeat(chunk: NvCreateChatCompletionStreamResponse) -> Self {
         Self {
-            scripts: Mutex::new(VecDeque::from([QueuedScript::Endless { chunk }])),
+            scripts: Mutex::new(VecDeque::from([QueuedScript::Endless {
+                chunk: Box::new(chunk),
+            }])),
             requests: Mutex::new(Vec::new()),
             contexts: Mutex::new(Vec::new()),
         }
@@ -176,7 +182,7 @@ impl
                     // first will never reach a later arm unless the consumer
                     // explicitly checks it.
                     loop {
-                        yield Annotated::from_data(chunk.clone());
+                        yield Annotated::from_data(chunk.as_ref().clone());
                     }
                 }
             }

--- a/lib/llm/tests/common/scripted_chat_engine.rs
+++ b/lib/llm/tests/common/scripted_chat_engine.rs
@@ -27,6 +27,12 @@ enum QueuedScript {
         split_at: usize,
         release: std::sync::Arc<Semaphore>,
     },
+    /// Yields `chunk` forever without ever awaiting, so `next()` is *always*
+    /// immediately ready. Models a backend fast enough to keep the frontend's
+    /// select loop permanently fed.
+    Endless {
+        chunk: NvCreateChatCompletionStreamResponse,
+    },
 }
 
 pub struct ScriptGate {
@@ -73,6 +79,21 @@ impl ScriptedChatEngine {
             },
             ScriptGate { release },
         )
+    }
+
+    /// An engine whose stream is *always* immediately ready: it repeats `chunk`
+    /// forever and never awaits. Used to prove the frontend cannot be starved out
+    /// of enforcing its wall-clock deadline by a backend that never stops
+    /// producing.
+    // This module is shared by several test binaries; only the Anthropic one
+    // exercises deadline starvation.
+    #[allow(dead_code)]
+    pub fn with_endless_repeat(chunk: NvCreateChatCompletionStreamResponse) -> Self {
+        Self {
+            scripts: Mutex::new(VecDeque::from([QueuedScript::Endless { chunk }])),
+            requests: Mutex::new(Vec::new()),
+            contexts: Mutex::new(Vec::new()),
+        }
     }
 
     /// Remove and return all requests observed so far, in arrival order.
@@ -147,6 +168,15 @@ impl
                     permit.forget();
                     for chunk in chunks {
                         yield Annotated::from_data(chunk);
+                    }
+                }
+                QueuedScript::Endless { chunk } => {
+                    // No `.await` anywhere in this arm: every poll resolves
+                    // immediately, so a `biased` select that polls this stream
+                    // first will never reach a later arm unless the consumer
+                    // explicitly checks it.
+                    loop {
+                        yield Annotated::from_data(chunk.clone());
                     }
                 }
             }

--- a/lib/llm/tests/common/scripted_chat_engine.rs
+++ b/lib/llm/tests/common/scripted_chat_engine.rs
@@ -13,7 +13,8 @@ use dynamo_llm::protocols::{
     },
 };
 use dynamo_runtime::pipeline::{
-    AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn, async_trait,
+    AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn,
+    async_trait,
 };
 use tokio::sync::{Mutex, Semaphore};
 
@@ -42,6 +43,7 @@ impl ScriptGate {
 pub struct ScriptedChatEngine {
     scripts: Mutex<VecDeque<QueuedScript>>,
     requests: Mutex<Vec<NvCreateChatCompletionRequest>>,
+    contexts: Mutex<Vec<std::sync::Arc<dyn AsyncEngineContext>>>,
 }
 
 impl ScriptedChatEngine {
@@ -49,6 +51,7 @@ impl ScriptedChatEngine {
         Self {
             scripts: Mutex::new(scripts.into_iter().map(QueuedScript::Immediate).collect()),
             requests: Mutex::new(Vec::new()),
+            contexts: Mutex::new(Vec::new()),
         }
     }
 
@@ -66,6 +69,7 @@ impl ScriptedChatEngine {
                     release: release.clone(),
                 }])),
                 requests: Mutex::new(Vec::new()),
+                contexts: Mutex::new(Vec::new()),
             },
             ScriptGate { release },
         )
@@ -78,6 +82,21 @@ impl ScriptedChatEngine {
 
     pub async fn remaining_scripts(&self) -> usize {
         self.scripts.lock().await.len()
+    }
+
+    /// Whether the most recent request's backend context has been stopped, i.e.
+    /// `stop_generating()` (or `kill()`/`stop()`) was called on it. Lets a test
+    /// confirm that a frontend-side truncation actually signals the backend to
+    /// stop producing tokens, not just that the client-visible SSE looks right.
+    // This module is shared by several test binaries; not all of them assert on
+    // backend cancellation.
+    #[allow(dead_code)]
+    pub async fn last_context_stopped(&self) -> bool {
+        self.contexts
+            .lock()
+            .await
+            .last()
+            .is_some_and(|ctx| ctx.is_stopped())
     }
 }
 
@@ -97,6 +116,7 @@ impl
         let ctx = context.context();
 
         self.requests.lock().await.push(request);
+        self.contexts.lock().await.push(ctx.clone());
         let script = self
             .scripts
             .lock()

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -316,11 +316,14 @@ pub mod llm {
     /// disabled.
     pub const DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS: &str = "DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS";
 
-    /// Hard wall-clock cap, in milliseconds, on a single streaming response. On
-    /// expiry the frontend stops generation and closes the stream with a spec-valid
-    /// terminal event rather than severing it. Unlike
-    /// `DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS` this is not an inactivity timer and does
-    /// not reset when tokens arrive. Unset, `0`, or invalid values disable it.
+    /// Hard wall-clock cap, in milliseconds, on a single streaming response.
+    ///
+    /// Currently honored only by the Anthropic Messages endpoint (`/v1/messages`);
+    /// `/v1/chat/completions` and `/v1/responses` ignore it. On expiry the frontend
+    /// stops generation and closes the stream with a spec-valid terminal event
+    /// rather than severing it. Unlike `DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS` this
+    /// is not an inactivity timer and does not reset when tokens arrive. Unset,
+    /// `0`, or invalid values disable it.
     pub const DYN_HTTP_STREAM_MAX_DURATION_MS: &str = "DYN_HTTP_STREAM_MAX_DURATION_MS";
 
     /// Enable LoRA adapter support (set to "true" to enable)

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -316,6 +316,13 @@ pub mod llm {
     /// disabled.
     pub const DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS: &str = "DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS";
 
+    /// Hard wall-clock cap, in milliseconds, on a single streaming response. On
+    /// expiry the frontend stops generation and closes the stream with a spec-valid
+    /// terminal event rather than severing it. Unlike
+    /// `DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS` this is not an inactivity timer and does
+    /// not reset when tokens arrive. Unset, `0`, or invalid values disable it.
+    pub const DYN_HTTP_STREAM_MAX_DURATION_MS: &str = "DYN_HTTP_STREAM_MAX_DURATION_MS";
+
     /// Enable LoRA adapter support (set to "true" to enable)
     pub const DYN_LORA_ENABLED: &str = "DYN_LORA_ENABLED";
 
@@ -916,6 +923,7 @@ mod tests {
             llm::DYN_LORA_ALLOCATION_EMA_ALPHA,
             llm::DYN_LORA_MCF_CONFIG,
             llm::DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS,
+            llm::DYN_HTTP_STREAM_MAX_DURATION_MS,
             llm::metrics::DYN_METRICS_PREFIX,
             llm::audit::DYN_AUDIT_SINKS,
             llm::audit::DYN_AUDIT_FORCE_LOGGING,

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -286,6 +286,10 @@ pub mod frontend_service {
     /// Total number of requests rejected due to resource exhaustion
     pub const MODEL_REJECTION_TOTAL: &str = "model_rejection_total";
 
+    /// Total number of streaming responses the frontend truncated because the
+    /// wall-clock deadline (`DYN_HTTP_STREAM_MAX_DURATION_MS`) expired
+    pub const STREAM_TRUNCATED_TOTAL: &str = "stream_truncated_total";
+
     /// Active decode blocks (KV cache blocks) per worker
     /// Gauge metric tracking current KV cache block utilization for each worker
     pub const WORKER_ACTIVE_DECODE_BLOCKS: &str = "worker_active_decode_blocks";


### PR DESCRIPTION
## Overview:

An egress proxy that caps total request duration severs a streaming connection long after the `200` has been committed. By that point the client can never receive an HTTP status — it just hangs until its own timeout, with no way to distinguish the failure from a slow model.

This adds `DYN_HTTP_STREAM_MAX_DURATION_MS`, an opt-in hard wall-clock budget for a single streaming response on `/v1/messages`. When it expires the frontend truncates the turn itself, closing the stream with a spec-valid terminal event (`message_delta` carrying `stop_reason: max_tokens`, then `message_stop`) instead of letting the proxy cut it. The client sees a short-but-complete turn it knows how to continue from.

Disabled by default: unset, `0`, or unparseable values leave behaviour exactly as it is today.

## Details:

**Configuration** — `stream_max_duration()` in `disconnect.rs` reads the budget in milliseconds. Unlike the neighbouring `DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS` this is deliberately **not** an inactivity timer: it does not reset when tokens arrive, and it applies no 2x multiplier. The two solve different problems — one detects a stalled backend, this one bounds total wall-clock so a proxy never wins the race. Unset, `0`, unparseable, or unrepresentable values disable it.

**Deadline capture** — the deadline is computed at handler entry rather than as a relative sleep inside the `async_stream::stream!` body. That body only starts on first poll, so a relative sleep would begin counting late under load and the budget would not actually be bounded in total. This mirrors the pre-commit error peek in `openai.rs`.

**Backend teardown** — on expiry the handler calls `stop_generating()` rather than `kill()`, so usage accounting and disaggregated RDMA teardown still run. Tokens produced after this point can never reach the client, so continuing to generate them only burns GPU.

**Incomplete tool calls** — `drop_incomplete_tool_blocks()` discards any `tool_use` block whose streamed argument fragments are not yet parseable JSON. Flushing a half-streamed `input` object would make the client replay a malformed block and take an HTTP 400 on the next turn. A tool call with no arguments streamed yet is still a valid empty-input block, so only partial-but-non-empty JSON is dropped.

**Choice of stop reason** — `max_tokens` is the only terminal reason the client already knows how to continue from. `stop` would assert the turn genuinely finished, and an error event emitted after visible output is not retried by clients at all.

**Backend already finished** — if the deadline fires after the backend reported a `finish_reason` but before the engine stream ends (a trailing usage-only chunk, or teardown), the recorded reason wins. Relabelling a completed turn `max_tokens` would make the client continue a turn that already ended, or discard a genuine `tool_use` as "do not execute". Truncation bookkeeping still fires in that window.

**Scope** — the cap is honored only by `/v1/messages`. `/v1/chat/completions` and `/v1/responses` ignore it; the env-var doc comment and the docs page say so explicitly, so an operator does not assume global protection.

**Observability** — a new `stream_truncated_total{model,endpoint}` counter makes a deadline truncation distinguishable from a genuine `max_tokens` turn, which is otherwise invisible downstream. A `warn!` on the truncation path records the configured budget and the output-token count. `lib/bindings/python/src/dynamo/prometheus_names.py`, the generated mirror of `prometheus_names.rs`, is regenerated so Python consumers can reference the constant.

**Cost when disabled** — the per-request state the truncation path needs (metrics handle, model name) is only captured when the deadline is enabled, so the default path allocates nothing extra. When unset, the budget future is `std::future::pending()`, matching the opt-in shape already used by `backend_stream_timeout()`.

## Where should the reviewer start?

1. **`lib/llm/src/http/service/anthropic.rs`** — the core change. Two things enforce the budget: an explicit expiry check at the top of the loop, and a `select!` arm on the budget future. Both are needed. The `select!` is `biased` with the backend-chunk arm first, so an already-generated token is never dropped in favour of a cancel — but that ordering also means a backend that is always ready would starve the budget arm, so the pre-loop check is what actually guarantees the cap. The arm still covers the idle-backend case. Also worth reading: the truncation block that drops incomplete tool blocks and sets the stop reason before `append_end_events`.
2. **`lib/llm/src/protocols/anthropic/stream_converter.rs`** — `drop_incomplete_tool_blocks()` and `force_stop_reason()`. The JSON-completeness check is the part most worth scrutinising.
3. **`lib/llm/src/http/service/disconnect.rs`** — `stream_max_duration()` and its parsing test; worth confirming the semantics really are distinct from `backend_stream_timeout()` above it.
4. **`lib/llm/tests/anthropic_http_replay.rs`** — the seven new integration tests, particularly `client_disconnect_is_not_misclassified_as_truncation_when_deadline_configured`.

## Validation

All runs below are against this branch's commit, rebased on current `main`.

| Check | Result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy --no-deps --all-targets -- -D warnings` | exit 0, no warnings (same invocation as pre-merge) |
| `cargo test -p dynamo-llm` | 2477 passed, 0 failed, 22 ignored (36 targets) |
| `cargo test -p dynamo-llm --test anthropic_http_replay` | 16 passed, 0 failed |

### New test coverage

Nine integration tests in `lib/llm/tests/anthropic_http_replay.rs`, driven end-to-end over real HTTP against a scripted chat engine:

| Test | Asserts |
|---|---|
| `stream_deadline_truncates_open_text_block_with_max_tokens` | an open text block is closed and the turn ends `stop_reason: max_tokens` |
| `stream_without_deadline_does_not_self_truncate` | default (unset) path is byte-for-byte unchanged |
| `stream_deadline_drops_incomplete_tool_use` | a `tool_use` with half-streamed JSON args never reaches the client |
| `stream_deadline_before_any_backend_chunk_still_emits_valid_terminal_turn` | expiry before the first token still yields a well-formed turn |
| `stream_deadline_increments_truncation_metric` | `stream_truncated_total` is incremented |
| `stream_deadline_calls_stop_generating_on_backend_context` | the backend is actually told to stop, not just the SSE closed |
| `client_disconnect_is_not_misclassified_as_truncation_when_deadline_configured` | a genuine client disconnect is not counted as a deadline truncation |
| `stream_deadline_preserves_finish_reason_already_reported_by_backend` | a turn the backend already finished is not relabelled `max_tokens` |
| `stream_deadline_fires_against_a_continuously_ready_backend` | an always-ready backend cannot starve the deadline |

Plus one unit test, `test_stream_max_duration_parsing` in `disconnect.rs`, covering unset / `0` / unparseable / valid / unrepresentable, confirming no 2x multiplier is applied and that any returned duration can always be added to `Instant::now()`.

### Review fixes

Two defects were found in review and fixed in `fix(frontend): enforce the stream deadline and keep real finish reasons`. Both were reproduced by a failing test before being fixed — the last two rows above are those regression tests.

- **A completed turn could be reported as cut short.** The truncation path set `stop_reason` to `max_tokens` unconditionally, even when the backend had already reported `end_turn` or `tool_use`. `force_stop_reason` is now `set_stop_reason_if_unset`. Before the fix the regression test asserted `end_turn` and got `max_tokens`.
- **The deadline could never fire at all.** Because the `select!` is `biased`, a backend whose `next()` is always immediately ready won every poll and the budget arm was never reached — the cap was silently unenforced under exactly the fast-backend load it exists to bound. The budget is now checked at the top of each iteration, before the select, preserving the `biased` guarantee. Before the fix the regression test hung well past its timeout.

Thanks to the Devin and CodeRabbit reviews for both.

A third commit, `fix(frontend): box the endless test script variant to satisfy clippy`, clears the `large_enum_variant` failure the first pre-merge run reported: the `QueuedScript::Endless` variant added for the starvation test held an inline `NvCreateChatCompletionStreamResponse`, which is much larger than the other variants' payloads. The payload is boxed; `with_endless_repeat` keeps its unboxed signature, so no caller changed and no behavior is affected. `rust-clippy (.)` was the only job that genuinely failed in that run — `pre-merge-status-check` is the aggregate gate, and `rust-clippy (lib/bindings/python)` was cancelled by matrix fail-fast.

A fourth commit, `fix(frontend): reject a stream deadline that cannot form an Instant`, addresses a further review finding: `stream_max_duration()` accepted any non-zero `u64` and the caller turns it into `Instant::now() + d`, which panics if the sum is unrepresentable. In practice this is unreachable on Linux — the env var caps at `u64` milliseconds, and `Duration::from_millis(u64::MAX)` (~5.8e8 years) added to `Instant::now()` still returns `Some` on an `i64`-seconds `timespec` — but a tick-counter `Instant` need not absorb that range, so the value is now validated with `checked_add` rather than left to platform internals. An unrepresentable value disables the cap instead of risking a request-time panic.

### Commits

| Commit | What |
|---|---|
| `e914832883` | the feature |
| `9b1bc5d3e7` | deadline starvation + finish-reason overwrite, with regression tests; Python metric mirror; endpoint-scope docs |
| `65368ee0ed` | `large_enum_variant` from the new test helper (pre-merge clippy) |
| `48d6413c9d` | reject a deadline value that cannot form an `Instant` |

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #12292
- Relates to #10923
