### PR TITLE
fix(snapshot): allow runtime storage directory override

### DIFF
--- a/deploy/helm/charts/snapshot/templates/_helpers.tpl
+++ b/deploy/helm/charts/snapshot/templates/_helpers.tpl
@@ -102,7 +102,9 @@ Host directory holding per-container storage (overlay upperdirs the agent
 reads for rootfs-diff capture, and CRI-O config.json fallback).
 */}}
 {{- define "snapshot.runtimeStorageDir" -}}
-{{- if eq .Values.runtime.type "crio" -}}/var/lib/containers{{- else -}}/var/lib/containerd{{- end -}}
+{{- if .Values.runtime.storageDir -}}
+{{- .Values.runtime.storageDir -}}
+{{- else if eq .Values.runtime.type "crio" -}}/var/lib/containers{{- else -}}/var/lib/containerd{{- end -}}
 {{- end }}
 
 {{- define "snapshot.pageBrokerControlPath" -}}/pagebroker/control{{- end -}}

--- a/deploy/helm/charts/snapshot/values.yaml
+++ b/deploy/helm/charts/snapshot/values.yaml
@@ -22,6 +22,9 @@
 runtime:
   type: containerd  # containerd | crio
   socketPath: ""
+  # Host directory containing container runtime snapshots and overlay upperdirs.
+  # Leave empty to use /var/lib/containerd (or /var/lib/containers for CRI-O).
+  storageDir: ""
 
 # Gates the OCP RBAC template and the DS required-scc annotation. Keep false
 # on vanilla Kubernetes (it references an OCP-only built-in SCC).


### PR DESCRIPTION
Allows the Snapshot DaemonSet runtime storage path to be overridden.

Validation: Helm lint and render.