### PR TITLE
feat(snapshot): package PageBroker with Snapshot agent

### DIFF
--- a/deploy/helm/charts/snapshot/templates/daemonset.yaml
+++ b/deploy/helm/charts/snapshot/templates/daemonset.yaml
@@ -101,9 +101,11 @@ spec:
         - name: pagebroker
           image: "{{ .Values.pageBroker.image.repository }}:{{ .Values.pageBroker.image.tag }}"
           imagePullPolicy: {{ .Values.pageBroker.image.pullPolicy }}
-          {{- with .Values.pageBroker.command }}
           command:
+          {{- with .Values.pageBroker.command }}
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+            - /usr/local/bin/pagebroker
           {{- end }}
           args:
             {{- with .Values.pageBroker.args }}
@@ -115,8 +117,10 @@ spec:
           volumeMounts:
             - name: pagebroker
               mountPath: /pagebroker
+            {{- if and (eq .Values.storage.type "pvc") (eq .Values.storage.accessMode "agentMount") }}
             - name: checkpoints
               mountPath: {{ .Values.storage.pvc.basePath }}
+            {{- end }}
         {{- end }}
         - name: agent
           image: "{{ .Values.daemonset.image.repository }}:{{ .Values.daemonset.image.tag }}"

--- a/deploy/helm/charts/snapshot/templates/daemonset.yaml
+++ b/deploy/helm/charts/snapshot/templates/daemonset.yaml
@@ -101,9 +101,17 @@ spec:
         - name: pagebroker
           image: "{{ .Values.pageBroker.image.repository }}:{{ .Values.pageBroker.image.tag }}"
           imagePullPolicy: {{ .Values.pageBroker.image.pullPolicy }}
+          {{- with .Values.pageBroker.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
+            {{- with .Values.pageBroker.args }}
+            {{- toYaml . | nindent 12 }}
+            {{- else }}
             - {{ printf "%s/pagebroker.sock" $pageBrokerControlPath | quote }}
             - {{ $pageBrokerStagingPath | quote }}
+            {{- end }}
           volumeMounts:
             - name: pagebroker
               mountPath: /pagebroker

--- a/deploy/helm/charts/snapshot/values.yaml
+++ b/deploy/helm/charts/snapshot/values.yaml
@@ -80,6 +80,10 @@ storage:
 
 pageBroker:
   enabled: false
+  # Optional entrypoint override for a shared snapshot-agent/PageBroker image.
+  command: []
+  # Optional arguments override. Defaults to the PageBroker socket and staging path.
+  args: []
   # Optional maximum size for tmpfs staging, for example "100Gi".
   stagingSizeLimit: ""
   image:

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -258,6 +258,7 @@ RUN chmod +x /usr/local/sbin/cuda-checkpoint /usr/local/bin/cuda-checkpoint-help
 # Copy the built binaries
 COPY --from=builder /snapshot-agent /usr/local/bin/snapshot-agent
 COPY --from=pagebroker-builder /workspace/pagebroker/pagebroker /usr/local/bin/pagebroker
+RUN /usr/local/bin/pagebroker 2>&1 | grep -q '^usage:'
 
 # Assemble the injection bundle: bind-mounted read-only into the placeholder's
 # mount namespace at /tmp/snapshot-binaries during restore (internal/nsmount).

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -78,6 +78,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN go test ./... -v && make -C pagebroker test
 
 # =============================================================================
+# Stage: PageBroker Builder
+# =============================================================================
+FROM go-base AS pagebroker-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libprotobuf-dev \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN make -C pagebroker daemon
+
+# =============================================================================
 # Stage: Builder - Build Go binaries
 # =============================================================================
 FROM go-base AS builder
@@ -216,6 +229,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libnet1 \
     libnl-3-200 \
     libnl-route-3-200 \
+    libprotobuf32 \
     libprotobuf-c1 \
     libgnutls30t64 \
     libnftables1 \
@@ -243,6 +257,7 @@ RUN chmod +x /usr/local/sbin/cuda-checkpoint /usr/local/bin/cuda-checkpoint-help
 
 # Copy the built binaries
 COPY --from=builder /snapshot-agent /usr/local/bin/snapshot-agent
+COPY --from=pagebroker-builder /workspace/pagebroker/pagebroker /usr/local/bin/pagebroker
 
 # Assemble the injection bundle: bind-mounted read-only into the placeholder's
 # mount namespace at /tmp/snapshot-binaries during restore (internal/nsmount).


### PR DESCRIPTION
Builds PageBroker into the Snapshot agent image so the PageBroker sidecar can use the same image with its own entrypoint.

The downstream concurrent checkpoint/restore run is recorded in #13172.