### PR TITLE
build: bump etcd v3.5.30 -> v3.5.33

### DIFF
--- a/container/compliance/native_packages.yaml
+++ b/container/compliance/native_packages.yaml
@@ -118,7 +118,7 @@ packages:
   # etcd — coordination store, downloaded as a release binary in dynamo_base and
   # placed at /usr/local/bin (no apt metadata).
   - name: etcd
-    version: v3.5.30
+    version: v3.5.33
     license: Apache-2.0
     source: https://github.com/etcd-io/etcd
     images:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -39,7 +39,7 @@ dynamo:
   uv_version: "0.12.0"
 
   nats_version: v2.12.12
-  etcd_version: v3.5.30
+  etcd_version: v3.5.33
 
   nixl_ref: v1.0.1
   nixl_ucx_ref: v1.21.0


### PR DESCRIPTION
## Overview:

Bump the etcd release binary shipped in the runtime images from v3.5.30 to v3.5.33.

## Details:

Routine currency bump to the latest 3.5 patch release (2026-07-23), which is built on the current Go toolchain. Scope:

- `container/context.yaml`: `etcd_version` v3.5.30 -> v3.5.33
- `container/compliance/native_packages.yaml`: keep the compliance manifest in sync

Risk notes:
- Patch-line bump on the 3.5 release train. The upstream changelog for 3.5.31-3.5.33 contains server fixes and dependency updates only; no flag or default changes.
- The gRPC v3 API consumed by the `etcd-client` crate is unchanged across 3.5.x patch releases.
- Release tarballs verified present for linux-amd64 and linux-arm64.

## Where should the reviewer start?

`container/context.yaml` (single pinned version; `dynamo_base.Dockerfile` fetches the tarball by this ARG and every runtime image copies the bundle from `dynamo_base`).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `etcd` component to version `v3.5.33`.
  * Synchronized the configured `etcd` version across deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->