### PR TITLE
feat: allow forcing the KVBM device layout to FullyContiguous on the vLLM connector

### DIFF
--- a/docs/fern/pages/reference/components/kvbm-configuration.mdx
+++ b/docs/fern/pages/reference/components/kvbm-configuration.mdx
@@ -62,6 +62,12 @@ KVBM offloads KV blocks GPU (G1) → host/CPU (G2) → disk (G3) → object stor
   Maximum number of block transfers in flight at once.
 </ParamField>
 
+<ParamField path="DYN_KVBM_DEVICE_LAYOUT_TYPE" type="string" default="unset">
+  Override the device (G1) layout of the vLLM connector instead of detecting it from the KV cache tensor shapes. Accepts `fully_contiguous` or `layer_separate`.
+
+  A `layer_separate` device tier splits every host or disk transfer into `num_layers * outer_dim` NIXL descriptors per block, which costs throughput on network storage where the cost is per request rather than per byte. Set this to `fully_contiguous` only when the engine allocates a single cross-layer contiguous KV cache; otherwise layout creation fails at startup.
+</ParamField>
+
 <ParamField path="DYN_KVBM_DISABLE_WRITE_COMBINED" type="boolean" default="false">
   Disable write-combined memory for transfers.
 </ParamField>

--- a/docs/fern/pages/reference/components/kvbm-configuration.mdx
+++ b/docs/fern/pages/reference/components/kvbm-configuration.mdx
@@ -63,9 +63,18 @@ KVBM offloads KV blocks GPU (G1) → host/CPU (G2) → disk (G3) → object stor
 </ParamField>
 
 <ParamField path="DYN_KVBM_DEVICE_LAYOUT_TYPE" type="string" default="unset">
-  Override the device (G1) layout of the vLLM connector instead of detecting it from the KV cache tensor shapes. Accepts `fully_contiguous` or `layer_separate`.
+  Override the device (G1) layout of the vLLM connector instead of detecting it from the KV cache tensor shapes. Accepted values:
 
-  A `layer_separate` device tier splits every host or disk transfer into `num_layers * outer_dim` NIXL descriptors per block, which costs throughput on network storage where the cost is per request rather than per byte. Set this to `fully_contiguous` only when the engine allocates a single cross-layer contiguous KV cache; otherwise layout creation fails at startup.
+  - `fully_contiguous`: one storage region spanning all layers, transferred as one NIXL descriptor per block.
+  - `layer_separate`: one storage region per layer. This selects the layout family only; `outer_contiguous` is still detected from the tensor shapes.
+  - `layer_separate_outer_contiguous`: one region per layer, laid out as `[outer_dim, n_blocks, ...]`.
+  - `layer_separate_block_contiguous`: one region per layer, laid out as `[n_blocks, outer_dim, ...]`.
+
+  A `layer_separate` device tier splits every host or disk transfer into `num_layers * outer_dim` NIXL descriptors per block, which costs throughput on network storage where the cost is per request rather than per byte.
+
+  Set this to `fully_contiguous` only when the engine hands KVBM a single cross-layer contiguous KV cache. vLLM registers one tensor per layer by default, and on that path forcing `fully_contiguous` aborts KV cache registration at startup.
+
+  Prefer plain `layer_separate` over the two explicit variants. Pinning a variant that contradicts the tensor shapes is rejected at startup, because honouring it would swap the block and outer strides and read the wrong K/V regions.
 </ParamField>
 
 <ParamField path="DYN_KVBM_DISABLE_WRITE_COMBINED" type="boolean" default="false">

--- a/lib/bindings/kvbm/python/kvbm/__init__.py
+++ b/lib/bindings/kvbm/python/kvbm/__init__.py
@@ -14,3 +14,4 @@ logger.info(f"Loaded nixl API module: {nixl._api}")
 from kvbm._core import BlockManager as BlockManager
 from kvbm._core import KvbmLeader as KvbmLeader
 from kvbm._core import KvbmWorker as KvbmWorker
+from kvbm._core import PyLayoutType as PyLayoutType

--- a/lib/bindings/kvbm/python/kvbm/_core.pyi
+++ b/lib/bindings/kvbm/python/kvbm/_core.pyi
@@ -11,6 +11,10 @@ class PyLayoutType:
     is emitted as num_layers * outer_dim descriptors per block. FullyContiguous
     describes a single cross-layer contiguous region and is transferred as one
     descriptor per block.
+
+    LayerSeparate names the layout family only. Where the KV cache tensors are
+    available, as on the vLLM connector, whether the outer dimension or the block
+    dimension comes first is still detected from their shapes.
     """
 
     FullyContiguous: ClassVar["PyLayoutType"]
@@ -167,7 +171,7 @@ class KvbmWorker:
         layout_blocking: bool
             Whether to block on layout initialization, defaults to False
         device_layout_type: Optional[PyLayoutType]
-            Layout type for device blocks; auto-detected from the tensor shapes when None
+            Layout type for device blocks, defaults to FullyContiguous
         host_layout_type: Optional[PyLayoutType]
             Layout type for host blocks, defaults to FullyContiguous
         disk_layout_type: Optional[PyLayoutType]

--- a/lib/bindings/kvbm/python/kvbm/_core.pyi
+++ b/lib/bindings/kvbm/python/kvbm/_core.pyi
@@ -1,7 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, List, Optional
+from typing import Any, ClassVar, List, Optional
+
+class PyLayoutType:
+    """
+    How the blocks of a KVBM tier are laid out in memory.
+
+    LayerSeparate describes one storage region per layer, so every NIXL transfer
+    is emitted as num_layers * outer_dim descriptors per block. FullyContiguous
+    describes a single cross-layer contiguous region and is transferred as one
+    descriptor per block.
+    """
+
+    FullyContiguous: ClassVar["PyLayoutType"]
+    LayerSeparate: ClassVar["PyLayoutType"]
 
 class NcclBootstrap:
     """
@@ -127,9 +140,9 @@ class KvbmWorker:
         dtype_width_bytes: int = 2,
         drt: Optional[Any] = None,
         layout_blocking: bool = False,
-        device_layout_type: Optional[Any] = None,
-        host_layout_type: Optional[Any] = None,
-        disk_layout_type: Optional[Any] = None,
+        device_layout_type: Optional[PyLayoutType] = None,
+        host_layout_type: Optional[PyLayoutType] = None,
+        disk_layout_type: Optional[PyLayoutType] = None,
         rank: Optional[int] = None,
         world_size: Optional[int] = None,
         nccl_comm_ref: Optional["NcclCommRef"] = None,
@@ -153,12 +166,12 @@ class KvbmWorker:
             Distributed runtime, if applicable
         layout_blocking: bool
             Whether to block on layout initialization, defaults to False
-        device_layout_type: Optional[Any]
-            Layout type for device blocks
-        host_layout_type: Optional[Any]
-            Layout type for host blocks
-        disk_layout_type: Optional[Any]
-            Layout type for disk blocks
+        device_layout_type: Optional[PyLayoutType]
+            Layout type for device blocks; auto-detected from the tensor shapes when None
+        host_layout_type: Optional[PyLayoutType]
+            Layout type for host blocks, defaults to FullyContiguous
+        disk_layout_type: Optional[PyLayoutType]
+            Layout type for disk blocks, defaults to FullyContiguous
         rank: Optional[int]
             Rank for replicated mode (None = sharded mode)
         world_size: Optional[int]

--- a/lib/bindings/kvbm/src/block_manager.rs
+++ b/lib/bindings/kvbm/src/block_manager.rs
@@ -30,6 +30,7 @@ pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<controller::BlockPoolStatus>()?;
     m.add_class::<controller::ResetBlocksResponse>()?;
 
+    m.add_class::<distributed::PyLayoutType>()?;
     m.add_class::<distributed::PyNcclBootstrap>()?;
     m.add_class::<distributed::PyNcclCommRef>()?;
 

--- a/lib/bindings/kvbm/src/block_manager/distributed/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/distributed/worker.rs
@@ -12,7 +12,7 @@ use llm_rs::block_manager::distributed::{
 };
 #[cfg(feature = "nccl")]
 use llm_rs::block_manager::distributed::{NcclBootstrap, NcclCommOwned};
-use llm_rs::block_manager::layout::LayoutType;
+use llm_rs::block_manager::layout::{LayoutType, LayoutTypeRequest};
 use llm_rs::block_manager::storage::torch::{TorchDevice, TorchTensor};
 
 /// Build NcclConfig from Python parameters.
@@ -97,6 +97,17 @@ impl From<PyLayoutType> for LayoutType {
             PyLayoutType::FullyContiguous => LayoutType::FullyContiguous,
             // Layout (outer_contiguous vs block_contiguous) is auto-detected from tensor shapes
             PyLayoutType::LayerSeparate => LayoutType::layer_separate_auto_default(),
+        }
+    }
+}
+
+impl From<PyLayoutType> for LayoutTypeRequest {
+    fn from(py_layout: PyLayoutType) -> Self {
+        match py_layout {
+            PyLayoutType::FullyContiguous => LayoutTypeRequest::Pinned(LayoutType::FullyContiguous),
+            // `LayerSeparate` names the family only; on paths that see the KV cache
+            // tensors, `outer_contiguous` still comes from their shapes.
+            PyLayoutType::LayerSeparate => LayoutTypeRequest::LayerSeparateAuto,
         }
     }
 }

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use anyhow;
 use dynamo_llm::block_manager::distributed::{KvbmWorker, KvbmWorkerConfig};
-use dynamo_llm::block_manager::layout::LayoutType;
+use dynamo_llm::block_manager::layout::{LayoutType, LayoutTypeRequest};
 use dynamo_llm::block_manager::storage::torch::TorchTensor;
 use dynamo_runtime::DistributedRuntime;
 use dynamo_runtime::config::environment_names::kvbm as env_kvbm;
@@ -27,17 +27,28 @@ use dynamo_runtime::utils::task::CriticalTaskExecutionHandle;
 
 /// Reads the device layout override from [`env_kvbm::DYN_KVBM_DEVICE_LAYOUT_TYPE`].
 ///
-/// Returns `None` when the variable is unset, empty, or holds an unparsable value, in
+/// Returns `None` when the variable is unset, empty, or holds an unusable value, in
 /// which case the caller keeps its shape-based auto-detection.
-fn device_layout_type_from_env() -> Option<LayoutType> {
-    let raw = std::env::var(env_kvbm::DYN_KVBM_DEVICE_LAYOUT_TYPE).ok()?;
+fn device_layout_type_from_env() -> Option<LayoutTypeRequest> {
+    let raw = match std::env::var(env_kvbm::DYN_KVBM_DEVICE_LAYOUT_TYPE) {
+        Ok(raw) => raw,
+        Err(std::env::VarError::NotPresent) => return None,
+        Err(std::env::VarError::NotUnicode(raw)) => {
+            tracing::warn!(
+                "Ignoring {}={raw:?}: value is not valid unicode",
+                env_kvbm::DYN_KVBM_DEVICE_LAYOUT_TYPE
+            );
+            return None;
+        }
+    };
+
     let raw = raw.trim();
     if raw.is_empty() {
         return None;
     }
 
-    match raw.parse::<LayoutType>() {
-        Ok(layout) => Some(layout),
+    match raw.parse::<LayoutTypeRequest>() {
+        Ok(request) => Some(request),
         Err(e) => {
             tracing::warn!(
                 "Ignoring {}={raw}: {e}",
@@ -58,7 +69,7 @@ pub trait Worker: Send + Sync {
         dtype_width_bytes: usize,
         kv_caches: Vec<(String, Arc<VllmTensor>)>,
         raw_event_handles: Vec<u64>,
-        device_layout_type: Option<LayoutType>,
+        device_layout_type: Option<LayoutTypeRequest>,
         host_layout_type: Option<LayoutType>,
         disk_layout_type: Option<LayoutType>,
         outer_dim: Option<usize>,
@@ -155,7 +166,7 @@ impl Worker for KvConnectorWorker {
         dtype_width_bytes: usize,
         kv_caches: Vec<(String, Arc<VllmTensor>)>,
         raw_event_handles: Vec<u64>,
-        device_layout_type: Option<LayoutType>,
+        device_layout_type: Option<LayoutTypeRequest>,
         host_layout_type: Option<LayoutType>,
         disk_layout_type: Option<LayoutType>,
         outer_dim: Option<usize>,
@@ -193,42 +204,17 @@ impl Worker for KvConnectorWorker {
 
         self.layer_events = raw_event_handles;
 
-        // Auto-detect device layout type if neither the caller nor the environment set it.
         // A LayerSeparate device tier fragments every disk/host transfer into
         // `num_layers * outer_dim` NIXL descriptors per block, so operators whose engine
         // allocates a cross-layer contiguous KV cache can force FullyContiguous instead.
-        let requested_device_layout_type = device_layout_type.or_else(device_layout_type_from_env);
+        // Precedence is caller argument, then environment, then shape-based detection;
+        // a request for LayerSeparate still leaves `outer_contiguous` to the shapes.
+        let requested_device_layout_type = device_layout_type
+            .or_else(device_layout_type_from_env)
+            .unwrap_or(LayoutTypeRequest::LayerSeparateAuto);
 
-        let detected_device_layout_type = match requested_device_layout_type {
-            Some(layout) => {
-                tracing::info!("Using explicit device layout: {:?}", layout);
-                layout
-            }
-            None => {
-                if let Some(ref shape) = first_tensor_shape {
-                    match LayoutType::layer_separate_auto(shape, num_device_blocks) {
-                        Ok(detected) => {
-                            tracing::info!(
-                                "Auto-detected device layout from tensor shape: {:?}",
-                                detected
-                            );
-                            detected
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to auto-detect layout from shape {:?}: {}. Using default.",
-                                shape,
-                                e
-                            );
-                            LayoutType::layer_separate_auto_default()
-                        }
-                    }
-                } else {
-                    tracing::warn!("No tensors available for layout detection. Using default.");
-                    LayoutType::layer_separate_auto_default()
-                }
-            }
-        };
+        let detected_device_layout_type = requested_device_layout_type
+            .resolve(first_tensor_shape.as_deref(), num_device_blocks)?;
 
         let mut config_builder = KvbmWorkerConfig::builder()
             .cancel_token(get_current_cancel_token())

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
@@ -22,7 +22,31 @@ use dynamo_llm::block_manager::distributed::{KvbmWorker, KvbmWorkerConfig};
 use dynamo_llm::block_manager::layout::LayoutType;
 use dynamo_llm::block_manager::storage::torch::TorchTensor;
 use dynamo_runtime::DistributedRuntime;
+use dynamo_runtime::config::environment_names::kvbm as env_kvbm;
 use dynamo_runtime::utils::task::CriticalTaskExecutionHandle;
+
+/// Reads the device layout override from [`env_kvbm::DYN_KVBM_DEVICE_LAYOUT_TYPE`].
+///
+/// Returns `None` when the variable is unset, empty, or holds an unparsable value, in
+/// which case the caller keeps its shape-based auto-detection.
+fn device_layout_type_from_env() -> Option<LayoutType> {
+    let raw = std::env::var(env_kvbm::DYN_KVBM_DEVICE_LAYOUT_TYPE).ok()?;
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    match raw.parse::<LayoutType>() {
+        Ok(layout) => Some(layout),
+        Err(e) => {
+            tracing::warn!(
+                "Ignoring {}={raw}: {e}",
+                env_kvbm::DYN_KVBM_DEVICE_LAYOUT_TYPE
+            );
+            None
+        }
+    }
+}
 
 pub trait Worker: Send + Sync {
     #[allow(clippy::too_many_arguments)]
@@ -169,9 +193,17 @@ impl Worker for KvConnectorWorker {
 
         self.layer_events = raw_event_handles;
 
-        // Auto-detect device layout type if not explicitly provided
-        let detected_device_layout_type = match device_layout_type {
-            Some(layout) => layout,
+        // Auto-detect device layout type if neither the caller nor the environment set it.
+        // A LayerSeparate device tier fragments every disk/host transfer into
+        // `num_layers * outer_dim` NIXL descriptors per block, so operators whose engine
+        // allocates a cross-layer contiguous KV cache can force FullyContiguous instead.
+        let requested_device_layout_type = device_layout_type.or_else(device_layout_type_from_env);
+
+        let detected_device_layout_type = match requested_device_layout_type {
+            Some(layout) => {
+                tracing::info!("Using explicit device layout: {:?}", layout);
+                layout
+            }
             None => {
                 if let Some(ref shape) = first_tensor_shape {
                     match LayoutType::layer_separate_auto(shape, num_device_blocks) {

--- a/lib/llm/src/block_manager/layout.rs
+++ b/lib/llm/src/block_manager/layout.rs
@@ -189,36 +189,154 @@ impl LayoutType {
     }
 }
 
+/// Lower-case a user-supplied layout name and drop the separators, so that
+/// `layer_separate`, `LayerSeparate` and `LAYER-SEPARATE` all name the same thing.
+fn normalize_layout_name(s: &str) -> String {
+    s.chars()
+        .filter(|c| *c != '_' && *c != '-')
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
 impl std::str::FromStr for LayoutType {
     type Err = LayoutError;
 
-    /// Parse a layout type from a user-supplied string, e.g. an environment variable.
+    /// Parse a fully specified layout type from a user-supplied string.
     ///
     /// Accepted values are case-insensitive and ignore `_` and `-`:
     /// - `fully_contiguous`
-    /// - `layer_separate` (equivalent to [`LayoutType::layer_separate_auto_default`];
-    ///   use `layer_separate_block_contiguous` to select `outer_contiguous = false`)
     /// - `layer_separate_outer_contiguous`
     /// - `layer_separate_block_contiguous`
+    ///
+    /// Plain `layer_separate` is deliberately not accepted: it names the layout family
+    /// without fixing `outer_contiguous`, which has to come from the KV cache tensor
+    /// shapes. Parse it through [`LayoutTypeRequest`] instead.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let normalized = s
-            .chars()
-            .filter(|c| *c != '_' && *c != '-')
-            .flat_map(char::to_lowercase)
-            .collect::<String>();
-
-        match normalized.as_str() {
+        match normalize_layout_name(s).as_str() {
             "fullycontiguous" => Ok(LayoutType::FullyContiguous),
-            "layerseparate" | "layerseparateoutercontiguous" => {
-                Ok(LayoutType::layer_separate(true))
-            }
+            "layerseparateoutercontiguous" => Ok(LayoutType::layer_separate(true)),
             "layerseparateblockcontiguous" => Ok(LayoutType::layer_separate(false)),
             _ => Err(LayoutError::InvalidConfig(format!(
-                "unknown layout type '{s}'; expected one of \
-                 'fully_contiguous', 'layer_separate', \
+                "unknown layout type '{s}'; expected one of 'fully_contiguous', \
                  'layer_separate_outer_contiguous', 'layer_separate_block_contiguous'"
             ))),
         }
+    }
+}
+
+/// A layout selection as supplied by an operator, before the KV cache tensor shapes are
+/// known.
+///
+/// This is kept distinct from [`LayoutType`] because `layer_separate` names a family, not
+/// a memory layout: `outer_contiguous` still has to be derived from the tensor shapes.
+/// Collapsing the two loses that distinction, and the mistake is silent — a
+/// `[n_blocks, outer_dim, ...]` cache pinned to `outer_contiguous = true` needs exactly
+/// the same storage size, so [`LayerSeparate::new`] validates it happily and
+/// [`LayerSeparate::memory_region`] then swaps the block and outer strides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutTypeRequest {
+    /// Use this layout as given and skip shape-based detection.
+    Pinned(LayoutType),
+
+    /// Use `LayerSeparate`, with `outer_contiguous` detected from the tensor shapes.
+    LayerSeparateAuto,
+}
+
+impl LayoutTypeRequest {
+    /// Resolve the request against the shape of the first registered KV cache tensor.
+    ///
+    /// `shape` is `None` when no tensor is available for detection; the request then
+    /// falls back to [`LayoutType::layer_separate_auto_default`].
+    ///
+    /// A pinned `LayerSeparate` variant that contradicts the shape is rejected rather
+    /// than honoured, because both interpretations pass layout validation: the mistake
+    /// would otherwise surface as transfers reading the wrong K/V regions instead of as
+    /// a startup error.
+    pub fn resolve(
+        &self,
+        shape: Option<&[usize]>,
+        num_device_blocks: usize,
+    ) -> anyhow::Result<LayoutType> {
+        // Detection only ever yields a LayerSeparate variant. `None` means the shape was
+        // unavailable or inconclusive, in which case a pinned request stands on its own.
+        let detected = match shape {
+            Some(shape) => match LayoutType::layer_separate_auto(shape, num_device_blocks) {
+                Ok(detected) => Some(detected),
+                Err(e) => {
+                    tracing::warn!("Failed to detect layout from shape {shape:?}: {e}");
+                    None
+                }
+            },
+            None => {
+                tracing::warn!("No tensors available for layout detection");
+                None
+            }
+        };
+
+        match (*self, detected) {
+            (Self::Pinned(pinned @ LayoutType::FullyContiguous), _) => {
+                tracing::info!("Using explicit device layout: {pinned:?}");
+                Ok(pinned)
+            }
+            (Self::Pinned(pinned), Some(detected))
+                if pinned != detected && !layer_separate_modes_equivalent(shape) =>
+            {
+                Err(anyhow::anyhow!(
+                    "requested device layout {pinned:?} contradicts the KV cache tensor shape \
+                     {:?}, which describes {detected:?}; honouring the request would read the \
+                     wrong K/V regions, so drop the override to use shape-based detection",
+                    shape.unwrap_or_default(),
+                ))
+            }
+            (Self::Pinned(pinned), _) => {
+                tracing::info!("Using explicit device layout: {pinned:?}");
+                Ok(pinned)
+            }
+            (Self::LayerSeparateAuto, Some(detected)) => {
+                tracing::info!("Auto-detected device layout from tensor shape: {detected:?}");
+                Ok(detected)
+            }
+            (Self::LayerSeparateAuto, None) => {
+                let fallback = LayoutType::layer_separate_auto_default();
+                tracing::warn!("Using default device layout: {fallback:?}");
+                Ok(fallback)
+            }
+        }
+    }
+}
+
+/// True when the tensor has an outer dimension of 1, in which case the outer-contiguous
+/// and block-contiguous interpretations describe the same memory and a pinned variant
+/// cannot contradict the shape. Fused-MLA caches registered as `[1, n_blocks, ...]` or
+/// `[n_blocks, 1, ...]` land here.
+fn layer_separate_modes_equivalent(shape: Option<&[usize]>) -> bool {
+    matches!(shape, Some(shape) if shape.len() >= 2 && (shape[0] == 1 || shape[1] == 1))
+}
+
+impl std::str::FromStr for LayoutTypeRequest {
+    type Err = LayoutError;
+
+    /// Parse a layout request from a user-supplied string, e.g. an environment variable.
+    ///
+    /// Accepted values are case-insensitive and ignore `_` and `-`:
+    /// - `fully_contiguous`
+    /// - `layer_separate` — the family, with `outer_contiguous` left to detection
+    /// - `layer_separate_outer_contiguous`
+    /// - `layer_separate_block_contiguous`
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if normalize_layout_name(s) == "layerseparate" {
+            return Ok(LayoutTypeRequest::LayerSeparateAuto);
+        }
+
+        s.parse::<LayoutType>()
+            .map(LayoutTypeRequest::Pinned)
+            .map_err(|_| {
+                LayoutError::InvalidConfig(format!(
+                    "unknown layout type '{s}'; expected one of 'fully_contiguous', \
+                     'layer_separate', 'layer_separate_outer_contiguous', \
+                     'layer_separate_block_contiguous'"
+                ))
+            })
     }
 }
 
@@ -1099,21 +1217,126 @@ pub mod tests {
             );
         }
 
-        for input in ["layer_separate", "layer_separate_outer_contiguous"] {
-            assert_eq!(
-                LayoutType::from_str(input).unwrap(),
-                LayoutType::layer_separate(true),
-                "failed to parse {input}"
-            );
-        }
-
+        assert_eq!(
+            LayoutType::from_str("layer_separate_outer_contiguous").unwrap(),
+            LayoutType::layer_separate(true)
+        );
         assert_eq!(
             LayoutType::from_str("layer_separate_block_contiguous").unwrap(),
             LayoutType::layer_separate(false)
         );
 
+        // `layer_separate` alone does not name a memory layout; only the request type
+        // accepts it, so that `outer_contiguous` keeps coming from the tensor shapes.
+        assert!(LayoutType::from_str("layer_separate").is_err());
         assert!(LayoutType::from_str("").is_err());
         assert!(LayoutType::from_str("contiguous").is_err());
+    }
+
+    #[test]
+    fn test_layout_type_request_from_str() {
+        use std::str::FromStr;
+
+        for input in ["layer_separate", "LayerSeparate", "LAYER-SEPARATE"] {
+            assert_eq!(
+                LayoutTypeRequest::from_str(input).unwrap(),
+                LayoutTypeRequest::LayerSeparateAuto,
+                "failed to parse {input}"
+            );
+        }
+
+        assert_eq!(
+            LayoutTypeRequest::from_str("fully_contiguous").unwrap(),
+            LayoutTypeRequest::Pinned(LayoutType::FullyContiguous)
+        );
+        assert_eq!(
+            LayoutTypeRequest::from_str("layer_separate_outer_contiguous").unwrap(),
+            LayoutTypeRequest::Pinned(LayoutType::layer_separate(true))
+        );
+        assert_eq!(
+            LayoutTypeRequest::from_str("layer_separate_block_contiguous").unwrap(),
+            LayoutTypeRequest::Pinned(LayoutType::layer_separate(false))
+        );
+
+        assert!(LayoutTypeRequest::from_str("").is_err());
+        assert!(LayoutTypeRequest::from_str("contiguous").is_err());
+    }
+
+    #[test]
+    fn test_layout_type_request_resolve() {
+        const NUM_BLOCKS: usize = 100;
+        // [n_blocks, outer_dim, page_size, inner_dim] and its outer-contiguous mirror.
+        const BLOCK_CONTIGUOUS: &[usize] = &[NUM_BLOCKS, 2, 16, 64];
+        const OUTER_CONTIGUOUS: &[usize] = &[2, NUM_BLOCKS, 16, 64];
+
+        let resolve = |request: LayoutTypeRequest, shape: Option<&[usize]>| {
+            request.resolve(shape, NUM_BLOCKS)
+        };
+
+        // Auto follows the shape in both directions, and falls back to the default when
+        // there is nothing to detect from.
+        assert_eq!(
+            resolve(LayoutTypeRequest::LayerSeparateAuto, Some(BLOCK_CONTIGUOUS)).unwrap(),
+            LayoutType::layer_separate(false)
+        );
+        assert_eq!(
+            resolve(LayoutTypeRequest::LayerSeparateAuto, Some(OUTER_CONTIGUOUS)).unwrap(),
+            LayoutType::layer_separate(true)
+        );
+        assert_eq!(
+            resolve(LayoutTypeRequest::LayerSeparateAuto, None).unwrap(),
+            LayoutType::layer_separate_auto_default()
+        );
+
+        // FullyContiguous is the point of the override: it is never second-guessed by
+        // shape detection, and fails later in LayoutConfig if the engine cannot supply it.
+        assert_eq!(
+            resolve(
+                LayoutTypeRequest::Pinned(LayoutType::FullyContiguous),
+                Some(BLOCK_CONTIGUOUS)
+            )
+            .unwrap(),
+            LayoutType::FullyContiguous
+        );
+
+        // A pinned LayerSeparate variant is honoured when it agrees with the shape...
+        assert_eq!(
+            resolve(
+                LayoutTypeRequest::Pinned(LayoutType::layer_separate(false)),
+                Some(BLOCK_CONTIGUOUS)
+            )
+            .unwrap(),
+            LayoutType::layer_separate(false)
+        );
+        // ...and rejected when it does not, instead of silently swapping the strides.
+        assert!(
+            resolve(
+                LayoutTypeRequest::Pinned(LayoutType::layer_separate(true)),
+                Some(BLOCK_CONTIGUOUS)
+            )
+            .is_err()
+        );
+
+        // With outer_dim = 1 the two modes describe the same memory, so a pinned variant
+        // is not a contradiction.
+        assert_eq!(
+            resolve(
+                LayoutTypeRequest::Pinned(LayoutType::layer_separate(true)),
+                Some(&[NUM_BLOCKS, 1, 16, 64])
+            )
+            .unwrap(),
+            LayoutType::layer_separate(true)
+        );
+
+        // An inconclusive shape leaves the pinned value as the only available answer.
+        assert_eq!(
+            resolve(
+                LayoutTypeRequest::Pinned(LayoutType::layer_separate(true)),
+                Some(&[4, 4, 16, 64])
+            )
+            .unwrap(),
+            LayoutType::layer_separate(true)
+        );
     }
 
     #[test]

--- a/lib/llm/src/block_manager/layout.rs
+++ b/lib/llm/src/block_manager/layout.rs
@@ -189,6 +189,39 @@ impl LayoutType {
     }
 }
 
+impl std::str::FromStr for LayoutType {
+    type Err = LayoutError;
+
+    /// Parse a layout type from a user-supplied string, e.g. an environment variable.
+    ///
+    /// Accepted values are case-insensitive and ignore `_` and `-`:
+    /// - `fully_contiguous`
+    /// - `layer_separate` (equivalent to [`LayoutType::layer_separate_auto_default`];
+    ///   use `layer_separate_block_contiguous` to select `outer_contiguous = false`)
+    /// - `layer_separate_outer_contiguous`
+    /// - `layer_separate_block_contiguous`
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let normalized = s
+            .chars()
+            .filter(|c| *c != '_' && *c != '-')
+            .flat_map(char::to_lowercase)
+            .collect::<String>();
+
+        match normalized.as_str() {
+            "fullycontiguous" => Ok(LayoutType::FullyContiguous),
+            "layerseparate" | "layerseparateoutercontiguous" => {
+                Ok(LayoutType::layer_separate(true))
+            }
+            "layerseparateblockcontiguous" => Ok(LayoutType::layer_separate(false)),
+            _ => Err(LayoutError::InvalidConfig(format!(
+                "unknown layout type '{s}'; expected one of \
+                 'fully_contiguous', 'layer_separate', \
+                 'layer_separate_outer_contiguous', 'layer_separate_block_contiguous'"
+            ))),
+        }
+    }
+}
+
 /// Local Memory Region
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Getters)]
 pub struct LocalMemoryRegion {
@@ -1049,6 +1082,38 @@ pub mod tests {
         };
 
         FullyContiguous::allocate(config, &NullDeviceAllocator)
+    }
+
+    #[test]
+    fn test_layout_type_from_str() {
+        use std::str::FromStr;
+
+        // A disk (FullyContiguous) -> device (LayerSeparate) onboard is emitted as
+        // `num_layers * outer_dim` NIXL descriptors per block, so operators need a way
+        // to force the device tier to FullyContiguous when the engine allows it.
+        for input in ["fully_contiguous", "FullyContiguous", "FULLY-CONTIGUOUS"] {
+            assert_eq!(
+                LayoutType::from_str(input).unwrap(),
+                LayoutType::FullyContiguous,
+                "failed to parse {input}"
+            );
+        }
+
+        for input in ["layer_separate", "layer_separate_outer_contiguous"] {
+            assert_eq!(
+                LayoutType::from_str(input).unwrap(),
+                LayoutType::layer_separate(true),
+                "failed to parse {input}"
+            );
+        }
+
+        assert_eq!(
+            LayoutType::from_str("layer_separate_block_contiguous").unwrap(),
+            LayoutType::layer_separate(false)
+        );
+
+        assert!(LayoutType::from_str("").is_err());
+        assert!(LayoutType::from_str("contiguous").is_err());
     }
 
     #[test]

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -219,11 +219,20 @@ pub mod kvbm {
     /// Disable disk offload filter
     pub const DYN_KVBM_DISABLE_DISK_OFFLOAD_FILTER: &str = "DYN_KVBM_DISABLE_DISK_OFFLOAD_FILTER";
 
-    /// Override the device (G1) layout type instead of detecting it from the KV cache
-    /// tensor shapes. Accepts `fully_contiguous` or `layer_separate`.
+    /// Override the device (G1) layout type of the vLLM connector instead of detecting it
+    /// from the KV cache tensor shapes. Accepts:
+    ///
+    /// - `fully_contiguous`
+    /// - `layer_separate` (family only; `outer_contiguous` still comes from the shapes)
+    /// - `layer_separate_outer_contiguous`
+    /// - `layer_separate_block_contiguous`
     ///
     /// A `layer_separate` device tier forces every NIXL transfer to be split into
     /// `num_layers * outer_dim` descriptors per block, which is costly on network storage.
+    /// `fully_contiguous` is only valid when the engine hands KVBM a single cross-layer
+    /// KV cache buffer; on vLLM's usual per-layer registration it fails at startup.
+    /// A `layer_separate_*` variant that contradicts the tensor shapes is also rejected
+    /// at startup rather than applied.
     pub const DYN_KVBM_DEVICE_LAYOUT_TYPE: &str = "DYN_KVBM_DEVICE_LAYOUT_TYPE";
 
     /// CPU cache configuration

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -219,6 +219,13 @@ pub mod kvbm {
     /// Disable disk offload filter
     pub const DYN_KVBM_DISABLE_DISK_OFFLOAD_FILTER: &str = "DYN_KVBM_DISABLE_DISK_OFFLOAD_FILTER";
 
+    /// Override the device (G1) layout type instead of detecting it from the KV cache
+    /// tensor shapes. Accepts `fully_contiguous` or `layer_separate`.
+    ///
+    /// A `layer_separate` device tier forces every NIXL transfer to be split into
+    /// `num_layers * outer_dim` descriptors per block, which is costly on network storage.
+    pub const DYN_KVBM_DEVICE_LAYOUT_TYPE: &str = "DYN_KVBM_DEVICE_LAYOUT_TYPE";
+
     /// CPU cache configuration
     pub mod cpu_cache {
         /// CPU cache size in GB

--- a/tests/dependencies/test_kvbm_imports.py
+++ b/tests/dependencies/test_kvbm_imports.py
@@ -43,12 +43,17 @@ def _check_kvbm_imports():
     """Helper to verify KVBM package and core classes can be imported."""
     try:
         import kvbm
-        from kvbm import BlockManager, KvbmLeader, KvbmWorker
+        from kvbm import BlockManager, KvbmLeader, KvbmWorker, PyLayoutType
 
         assert kvbm is not None, "kvbm module is None"
         assert BlockManager is not None, "BlockManager class not available"
         assert KvbmLeader is not None, "KvbmLeader class not available"
         assert KvbmWorker is not None, "KvbmWorker class not available"
+
+        # PyLayoutType is the only way to supply the `*_layout_type` arguments of
+        # KvbmWorker/register_kv_caches, so it has to be registered on the module.
+        assert PyLayoutType is not None, "PyLayoutType class not available"
+        assert PyLayoutType.FullyContiguous != PyLayoutType.LayerSeparate
     except ImportError as e:
         pytest.fail(f"Failed to import KVBM package or core classes: {e}")
 

--- a/tests/dependencies/test_kvbm_imports.py
+++ b/tests/dependencies/test_kvbm_imports.py
@@ -51,7 +51,8 @@ def _check_kvbm_imports():
         assert KvbmWorker is not None, "KvbmWorker class not available"
 
         # PyLayoutType is the only way to supply the `*_layout_type` arguments of
-        # KvbmWorker/register_kv_caches, so it has to be registered on the module.
+        # KvbmWorker.__init__ and of PyKvConnectorWorker.register_kv_caches, so it
+        # has to be registered on the module.
         assert PyLayoutType is not None, "PyLayoutType class not available"
         assert PyLayoutType.FullyContiguous != PyLayoutType.LayerSeparate
     except ImportError as e:


### PR DESCRIPTION
# Issue #12750 — KVBM disk→device onboarding fragments into per-layer NIXL descriptors

## 1. Root cause

`append_xfer_request` (`lib/llm/src/block_manager/block/transfer/nixl.rs:25`) emits a single
NIXL descriptor per block only when **both** sides of the transfer are fully contiguous.
Otherwise it falls back to one descriptor per `(layer, outer_dim)` region:

```rust
if src_data.is_fully_contiguous() && dst_data.is_fully_contiguous() { /* one desc */ }
else { for layer_idx { for outer_idx { /* one desc each */ } } }
```

For the vLLM connector the disk (G3) and host (G2) tiers default to `FullyContiguous`
(`vllm/connector/worker.rs:210-211`), but the device (G1) tier never can be:

- `KvConnectorWorker::register_kv_caches` only ever resolves the device layout through
  `LayoutType::layer_separate_auto` (`worker.rs:173`), and that function has no branch that
  returns `FullyContiguous` (`layout.rs:163-176`).
- `device_layout_type` *is* in the pyo3 signature of `PyKvConnectorWorker::register_kv_caches`
  and of `KvbmWorker::__init__`, but `PyLayoutType` was never passed to `add_class` in
  `block_manager::add_to_module`. The class therefore did not exist on the Python module, so
  no caller could construct a value for those arguments and they were always `None`.
- No environment variable overrode it either.

So on vLLM the device tier is unconditionally `LayerSeparate`, and every disk→device onboard
is split into `num_layers * outer_dim` descriptors per block (96 for the reporter's
48-layer model — 16.1 kB per read against a 1 MB-rsize NFS mount). The offload path does not
show this because it stages G1→G2→G3, and the G2→G3 leg is `FullyContiguous`→`FullyContiguous`,
hence one 768 kB descriptor per block. The TRT-LLM connector hardcodes all three tiers to
`FullyContiguous` (`trtllm_worker.rs:257-259`) and is likewise unaffected.

## 2. The fix and why

This change implements the first of the two fixes the reporter proposed: make the device
layout configurable so the fragmentation can be avoided where the engine supports it.

- Register `PyLayoutType` on the `kvbm._core` module and re-export it from the `kvbm`
  package. This is the concrete binding bug: three pyo3 arguments were unreachable from
  Python. Everything needed to honour them already existed on the Rust side.
- Add `LayoutType: FromStr` so a layout can be named in configuration, and honour
  `DYN_KVBM_DEVICE_LAYOUT_TYPE` in the vLLM connector worker when the caller does not pass
  `device_layout_type` explicitly. The connector is constructed by vLLM, not by Dynamo, so an
  environment variable is the only override reachable in a normal deployment; it follows the
  existing `DYN_KVBM_*` convention and is registered in `environment_names.rs` like the rest.

Precedence is caller argument → environment → existing shape-based auto-detection, so the
default behaviour is unchanged. An unparsable value logs a warning and falls back to
auto-detection rather than failing startup.

I deliberately did **not** attempt the reporter's second fix (descriptor aggregation and
layout conversion on the transfer path). See "Risk / uncertainty" for why that is not a
smaller change than it looks.

## 3. Files changed

| File | Change |
|------|--------|
| `lib/bindings/kvbm/src/block_manager.rs` | Register `PyLayoutType` in `add_to_module` |
| `lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs` | `device_layout_type_from_env()`; use it before falling back to auto-detection |
| `lib/llm/src/block_manager/layout.rs` | `impl FromStr for LayoutType` + unit test |
| `lib/runtime/src/config/environment_names.rs` | `DYN_KVBM_DEVICE_LAYOUT_TYPE` |
| `lib/bindings/kvbm/python/kvbm/__init__.py` | Re-export `PyLayoutType` |
| `lib/bindings/kvbm/python/kvbm/_core.pyi` | `PyLayoutType` stub; type the three `*_layout_type` arguments |
| `tests/dependencies/test_kvbm_imports.py` | Assert `PyLayoutType` is importable and its variants are distinct |
| `docs/fern/pages/reference/components/kvbm-configuration.mdx` | Document the new variable |

## 4. Risk / uncertainty

- **This unblocks the workaround; it is not a complete fix for every model.** Setting
  `fully_contiguous` only works where the engine hands KVBM a single cross-layer contiguous
  KV cache buffer (vLLM 0.23's cross-layer KV blocks, vllm-project/vllm#27743).
  `FullyContiguous::new` requires exactly one storage region and returns
  `InvalidConfig("FullyContiguous layout requires exactly one storage region")` otherwise, so
  a wrong setting fails loudly at registration rather than corrupting data. Models with mixed
  attention types, where vLLM cannot use the uniform layout, still fragment. Opting the
  connector into vLLM's cross-layer layout automatically is a follow-up and needs a vLLM
  version gate.
- **Descriptor aggregation would not help this report on its own.** vLLM's standard per-layer
  tensors are `[2, num_blocks, ...]`, so `layer_separate_auto` picks `outer_contiguous = true`
  and a block's K and V regions are far apart on the device. Merging adjacent descriptors would
  find no adjacent pairs on the device side, and NIXL requires the source and destination
  descriptor lists to correspond element-for-element, so the contiguous disk-side regions
  cannot be merged alone. The real model-agnostic fix is layout conversion on the transfer
  path (staging through a contiguous bounce buffer), which is a substantially larger change.
- The same contiguity condition exists in the v2 transfer path
  (`lib/kvbm-physical/src/transfer/executor/nixl.rs`, via `can_use_whole_block_transfer`).
  It is untouched here; the issue reproduces against the v1 path that 1.3.0/1.4.0 ship.
- Reading the override from the environment means it applies per worker process. That matches
  the other `DYN_KVBM_*` variables but is worth noting for heterogeneous deployments.

## 5. How I verified it

- `cargo test -p dynamo-llm --lib block_manager::layout::` — 50 passed, 0 failed, including the
  new `test_layout_type_from_str`.
- `cargo check --manifest-path lib/bindings/kvbm/Cargo.toml` — clean.
- `cargo clippy --manifest-path lib/bindings/kvbm/Cargo.toml` and
  `cargo clippy -p dynamo-llm -p dynamo-runtime --all-targets` — no new warnings.
- `cargo fmt --all -- --check` — clean.
- `black`, `isort`, `flake8` (with the repo's pre-commit arguments) and `ruff check` on the
  touched Python files — clean. `black` still reports pre-existing formatting drift elsewhere
  in `_core.pyi`; the diff hunks do not overlap the added lines and I left them alone.

Not verified: the end-to-end NFS throughput improvement. That needs the reporter's setup
(2x B200, TP=2, an NFS-backed G3 tier and a vLLM build with cross-layer KV blocks), which is
not available here. The claim this change supports is that `device_layout_type` is now
reachable and honoured, which the unit and import tests cover.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #12750

`Relates to` rather than `Closes`: this adds the override and registers `PyLayoutType` so
the device tier can be set at all, which resolves the reported fragmentation for engines
that allocate a single cross-layer contiguous KV cache. Making `FullyContiguous` reachable
without operator opt-in is a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting KVBM device layouts explicitly as `fully_contiguous` or `layer_separate`.
  - Added a public Python layout type with `FullyContiguous` and `LayerSeparate` options.
  - Layout selection now supports flexible capitalization, underscores, and hyphens.
  - Explicit settings take priority; otherwise, layouts are detected automatically.

- **Bug Fixes**
  - Invalid layout values now fall back safely to automatic detection with a warning.

- **Documentation**
  - Documented the new configuration option, supported values, descriptor behavior, and startup failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
