### PR TITLE
chore: Bump nixl to v1.3.2 for vllm (#12882)

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -89,7 +89,7 @@ vllm:
     # baseline_sbom: not yet captured for cpu — runtime build runs without subtraction
   flashinf_ref: v0.6.14
   vllm_omni_ref: "v0.26.0rc1"
-  nixl_ref: v1.3.1
+  nixl_ref: v1.3.2
   max_jobs: "10"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"

--- a/docs/fern/assets/releases.json
+++ b/docs/fern/assets/releases.json
@@ -15,7 +15,7 @@
     "vllm": "0.26.0",
     "nixlSglang": "1.3.0",
     "nixlTrtllm": "1.0.1",
-    "nixlVllm": "1.3.1"
+    "nixlVllm": "1.3.2"
   },
   "releases": [
     {

--- a/docs/fern/components/releases.data.ts
+++ b/docs/fern/components/releases.data.ts
@@ -73,7 +73,7 @@ export const MAIN_TOT: BackendPins = {
   vllm: "0.26.0",
   nixlSglang: "1.3.0",
   nixlTrtllm: "1.0.1",
-  nixlVllm: "1.3.1",
+  nixlVllm: "1.3.2",
 };
 
 const GH = "https://github.com/ai-dynamo/dynamo/releases/tag/";

--- a/docs/fern/reference/compatibility.mdx
+++ b/docs/fern/reference/compatibility.mdx
@@ -204,7 +204,7 @@ Current stable release: v1.3.0 (container tag `1.3.0`, wheel version `1.3.0.post
 
 | Dynamo | Type | SGLang | TensorRT-LLM | vLLM | NIXL (SGL / TRT / vLLM) | UCX |
 | --- | --- | --- | --- | --- | --- | --- |
-| main (ToT) | development head | 0.5.16 | 1.3.0rc22 | 0.26.0 | 1.3.0 / 1.0.1 / 1.3.1 | - |
+| main (ToT) | development head | 0.5.16 | 1.3.0rc22 | 0.26.0 | 1.3.0 / 1.0.1 / 1.3.2 | - |
 | v1.3.0 | stable | 0.5.14 | 1.3.0rc19 | 0.23.0 | 1.3.0 / 1.0.1 / 1.1.0 | 1.20.x |
 | v1.3.0-dev.1 | platform-preview | 0.5.12.post1 | 1.3.0rc17 | 0.22.0 | 1.0.1 / 0.10.1 / 1.1.0 | - |
 | v1.2.1 | patch | 0.5.11 | 1.3.0rc14 | 0.20.1 | 1.0.1 / 0.10.1 / 0.10.1 | - |

--- a/docs/fern/reference/releases-data.mdx
+++ b/docs/fern/reference/releases-data.mdx
@@ -15,7 +15,7 @@ Current stable release: v1.3.0 (Jul 20, 2026; container tag `1.3.0`, wheel versi
 
 | Version | Kind | Date | SGLang | TensorRT-LLM | vLLM | NIXL (SGL / TRT / vLLM) | UCX | Notes | Delta |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| main (ToT) | development head | - | 0.5.16 | 1.3.0rc22 | 0.26.0 | 1.3.0 / 1.0.1 / 1.3.1 | - | - | - |
+| main (ToT) | development head | - | 0.5.16 | 1.3.0rc22 | 0.26.0 | 1.3.0 / 1.0.1 / 1.3.2 | - | - | - |
 | v1.3.0 | stable | Jul 20, 2026 | 0.5.14 | 1.3.0rc19 | 0.23.0 | 1.3.0 / 1.0.1 / 1.1.0 | 1.20.x | [release notes](https://docs.nvidia.com/dynamo/dev/reference/releases/v1-3-0) | CUDA 12 container images discontinued; EFA variants go multi-arch as -efa; GA wheels published as 1.3.0.post1 (containers stay :1.3.0); UCX 1.20.x. |
 | v1.3.0-dev.1 | platform-preview | Jun 9, 2026 | 0.5.12.post1 | 1.3.0rc17 | 0.22.0 | 1.0.1 / 0.10.1 / 1.1.0 | - | [release notes](https://github.com/ai-dynamo/dynamo/releases/tag/v1.3.0-dev.1) | Full-platform preview of v1.3.0: complete runtime matrix, wheels on pypi.nvidia.com, crates, and Helm charts. Superseded by v1.3.0 GA. |
 | v1.2.1 | patch | Jun 13, 2026 | 0.5.11 | 1.3.0rc14 | 0.20.1 | 1.0.1 / 0.10.1 / 0.10.1 | - | [release notes](https://docs.nvidia.com/dynamo/dev/reference/releases/v1-2-0) | Patch release. Same backend pins as v1.2.0. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ trtllm =[
 
 vllm = [
     "uvloop",
-    "nixl[cu13]==1.3.1",
+    "nixl[cu13]==1.3.2",
     "vllm[flashinfer,runai,otel]==0.26.0",
     # vllm-omni is not part of ai-dynamo[vllm]: container builds inherit the
     # framework stack from vllm/vllm-openai, and pip/uv dependency resolution


### PR DESCRIPTION
## Overview:

This PR is a port of #12882 to the `release/1.4.0` branch

## Details:

This PR is meant to update NIXL to the latest release for the vllm build, to fix the issue observed with using v1.3.1 in https://github.com/ai-dynamo/dynamo/issues/12952 (nixl got updated to v.1.3.1 as part of the update to vllm v0.26.0)

## Where should the reviewer start?

container/context.yaml

Other files touched make the versions listed in docs consistent with this change.

## Related Issues

- Related to #12952 

- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->