### PR TITLE
fix(operator): preserve topology spread across rollouts

### DIFF
--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -88,6 +88,10 @@ const (
 	// so v1-compatible releases continue to generate new DCDs with the v1 value.
 	KubeLabelDynamoWorkerHash = "nvidia.com/dynamo-worker-hash"
 
+	// KubeAnnotationDynamoWorkerTopologySpreadScoped is a controller-owned marker
+	// for workload resources whose topology selectors are scoped by worker generation.
+	KubeAnnotationDynamoWorkerTopologySpreadScoped = "nvidia.com/dynamo-worker-topology-spread-scoped"
+
 	// CheckpointAutoAnnotation marks operator-created checkpoints whose
 	// lifecycle is tied to an owning DGD generation.
 	CheckpointAutoAnnotation = "nvidia.com/dynamo-auto-checkpoint"

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -554,6 +554,22 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 	kubeNs := opt.dynamoComponentDeployment.Namespace
 	labels := dynamo.GetDCDKubeLabels(opt.dynamoComponentDeployment)
 
+	// Scope new worker generations while preserving an existing workload's upgrade-compatible template.
+	existing := &leaderworkersetv1.LeaderWorkerSet{}
+	getErr := r.Get(ctx, client.ObjectKey{Name: kubeName, Namespace: kubeNs}, existing)
+	switch {
+	case k8serrors.IsNotFound(getErr):
+		scopeWorkerTopologySpreadConstraints(leaderPodTemplateSpec)
+		scopeWorkerTopologySpreadConstraints(workerPodTemplateSpec)
+	case getErr != nil:
+		return nil, false, errors.Wrap(getErr, "get existing LeaderWorkerSet before topology spread rendering")
+	case existing.Spec.LeaderWorkerTemplate.LeaderTemplate != nil &&
+		workerTopologySpreadConstraintsWereScoped(existing.Spec.LeaderWorkerTemplate.LeaderTemplate, leaderPodTemplateSpec) &&
+		workerTopologySpreadConstraintsWereScoped(&existing.Spec.LeaderWorkerTemplate.WorkerTemplate, workerPodTemplateSpec):
+		scopeWorkerTopologySpreadConstraints(leaderPodTemplateSpec)
+		scopeWorkerTopologySpreadConstraints(workerPodTemplateSpec)
+	}
+
 	if labels == nil {
 		labels = make(map[string]string)
 	}
@@ -822,6 +838,19 @@ func (r *DynamoComponentDeploymentReconciler) generateDeployment(ctx context.Con
 	podTemplateSpec, err := renderer.generatePodTemplateSpec(ctx, opt.dynamoComponentDeployment, dynamo.RoleMain, containerGPUs)
 	if err != nil {
 		return
+	}
+
+	// Scope new worker generations while preserving an existing workload's upgrade-compatible template.
+	existing := &appsv1.Deployment{}
+	getErr := r.Get(ctx, client.ObjectKey{Name: kubeName, Namespace: kubeNs}, existing)
+	switch {
+	case k8serrors.IsNotFound(getErr):
+		scopeWorkerTopologySpreadConstraints(podTemplateSpec)
+	case getErr != nil:
+		err = errors.Wrap(getErr, "get existing Deployment before topology spread rendering")
+		return
+	case workerTopologySpreadConstraintsWereScoped(&existing.Spec.Template, podTemplateSpec):
+		scopeWorkerTopologySpreadConstraints(podTemplateSpec)
 	}
 
 	maxSurge, maxUnavailable := getDeploymentRollingUpdateMaxSurgeAndMaxUnavailable(annotations)

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -554,22 +554,6 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 	kubeNs := opt.dynamoComponentDeployment.Namespace
 	labels := dynamo.GetDCDKubeLabels(opt.dynamoComponentDeployment)
 
-	// Scope new worker generations while preserving an existing workload's upgrade-compatible template.
-	existing := &leaderworkersetv1.LeaderWorkerSet{}
-	getErr := r.Get(ctx, client.ObjectKey{Name: kubeName, Namespace: kubeNs}, existing)
-	switch {
-	case k8serrors.IsNotFound(getErr):
-		scopeWorkerTopologySpreadConstraints(leaderPodTemplateSpec)
-		scopeWorkerTopologySpreadConstraints(workerPodTemplateSpec)
-	case getErr != nil:
-		return nil, false, errors.Wrap(getErr, "get existing LeaderWorkerSet before topology spread rendering")
-	case existing.Spec.LeaderWorkerTemplate.LeaderTemplate != nil &&
-		workerTopologySpreadConstraintsWereScoped(existing.Spec.LeaderWorkerTemplate.LeaderTemplate, leaderPodTemplateSpec) &&
-		workerTopologySpreadConstraintsWereScoped(&existing.Spec.LeaderWorkerTemplate.WorkerTemplate, workerPodTemplateSpec):
-		scopeWorkerTopologySpreadConstraints(leaderPodTemplateSpec)
-		scopeWorkerTopologySpreadConstraints(workerPodTemplateSpec)
-	}
-
 	if labels == nil {
 		labels = make(map[string]string)
 	}
@@ -580,6 +564,20 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 			Namespace: kubeNs,
 			Labels:    labels,
 		},
+	}
+
+	// Scope new worker generations while preserving an existing workload's upgrade-compatible template.
+	if isHashVersionedWorkerTemplate(leaderPodTemplateSpec) || isHashVersionedWorkerTemplate(workerPodTemplateSpec) {
+		existing := &leaderworkersetv1.LeaderWorkerSet{}
+		getErr := r.Get(ctx, client.ObjectKey{Name: kubeName, Namespace: kubeNs}, existing)
+		switch {
+		case k8serrors.IsNotFound(getErr):
+			scopeWorkerTopologySpreadWorkload(leaderWorkerSet, leaderPodTemplateSpec, workerPodTemplateSpec)
+		case getErr != nil:
+			return nil, false, errors.Wrap(getErr, "get existing LeaderWorkerSet before topology spread rendering")
+		case existing.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped] == commonconsts.KubeLabelValueTrue:
+			scopeWorkerTopologySpreadWorkload(leaderWorkerSet, leaderPodTemplateSpec, workerPodTemplateSpec)
+		}
 	}
 
 	desiredReplicas := int32(1)
@@ -841,16 +839,18 @@ func (r *DynamoComponentDeploymentReconciler) generateDeployment(ctx context.Con
 	}
 
 	// Scope new worker generations while preserving an existing workload's upgrade-compatible template.
-	existing := &appsv1.Deployment{}
-	getErr := r.Get(ctx, client.ObjectKey{Name: kubeName, Namespace: kubeNs}, existing)
-	switch {
-	case k8serrors.IsNotFound(getErr):
-		scopeWorkerTopologySpreadConstraints(podTemplateSpec)
-	case getErr != nil:
-		err = errors.Wrap(getErr, "get existing Deployment before topology spread rendering")
-		return
-	case workerTopologySpreadConstraintsWereScoped(&existing.Spec.Template, podTemplateSpec):
-		scopeWorkerTopologySpreadConstraints(podTemplateSpec)
+	if isHashVersionedWorkerTemplate(podTemplateSpec) {
+		existing := &appsv1.Deployment{}
+		getErr := r.Get(ctx, client.ObjectKey{Name: kubeName, Namespace: kubeNs}, existing)
+		switch {
+		case k8serrors.IsNotFound(getErr):
+			scopeWorkerTopologySpreadWorkload(kubeDeployment, podTemplateSpec)
+		case getErr != nil:
+			err = errors.Wrap(getErr, "get existing Deployment before topology spread rendering")
+			return
+		case existing.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped] == commonconsts.KubeLabelValueTrue:
+			scopeWorkerTopologySpreadWorkload(kubeDeployment, podTemplateSpec)
+		}
 	}
 
 	maxSurge, maxUnavailable := getDeploymentRollingUpdateMaxSurgeAndMaxUnavailable(annotations)

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -910,39 +910,164 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t 
 	require.Equal(t, commonconsts.ComponentTypeWorker, service.Spec.Selector[commonconsts.KubeLabelDynamoComponentType])
 }
 
-func TestScopeWorkerTopologySpreadConstraints(t *testing.T) {
-	podTemplate := &corev1.PodTemplateSpec{
-		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-			commonconsts.KubeLabelDynamoComponentType: commonconsts.ComponentTypeWorker,
-			commonconsts.KubeLabelDynamoWorkerHash:    "db6b6891",
-		}},
-		Spec: corev1.PodSpec{TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
-			{
-				MaxSkew:           1,
-				TopologyKey:       corev1.LabelHostname,
-				WhenUnsatisfiable: corev1.DoNotSchedule,
-				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-					commonconsts.KubeLabelDynamoComponentType: commonconsts.ComponentTypeWorker,
+func TestGenerateDeploymentScopesTopologySpreadToWorkerGeneration(t *testing.T) {
+	t.Log("Create a standalone worker with matching, unrelated, and namespace-wide spread selectors")
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-db6b6891",
+			Namespace: "default",
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoWorkerHash: "db6b6891",
+			},
+		},
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "worker",
+				ComponentType: v1beta1.ComponentTypeWorker,
+				PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew:           1,
+							TopologyKey:       corev1.LabelHostname,
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+								commonconsts.KubeLabelDynamoComponentType: commonconsts.ComponentTypeWorker,
+							}},
+						},
+						{
+							MaxSkew:           1,
+							TopologyKey:       corev1.LabelTopologyZone,
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+								"app.kubernetes.io/name": "another-workload",
+							}},
+						},
+						{
+							MaxSkew:           1,
+							TopologyKey:       "topology.kubernetes.io/region",
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector:     &metav1.LabelSelector{},
+						},
+					},
+					Containers: []corev1.Container{{
+						Name:  commonconsts.MainContainerName,
+						Image: "test-image:latest",
+					}},
 				}},
 			},
-			{
-				MaxSkew:           1,
-				TopologyKey:       corev1.LabelTopologyZone,
-				WhenUnsatisfiable: corev1.DoNotSchedule,
-				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-					"app.kubernetes.io/name": "another-workload",
-				}},
-			},
+		},
+	}
+	reconciler := &DynamoComponentDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(dcd).Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{},
+		DockerSecretRetriever: &mockDockerSecretRetriever{GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+			return nil, nil
 		}},
 	}
 
-	scopeWorkerTopologySpreadConstraints(podTemplate)
+	t.Log("Render the Kubernetes Deployment")
+	deployment, toDelete, err := reconciler.generateDeployment(t.Context(), generateResourceOption{
+		dynamoComponentDeployment: dcd,
+	})
+	require.NoError(t, err)
+	require.False(t, toDelete)
 
+	t.Log("Verify only the explicit matching selector gains the worker hash")
 	require.Equal(t,
-		[]string{commonconsts.KubeLabelDynamoWorkerHash},
-		podTemplate.Spec.TopologySpreadConstraints[0].MatchLabelKeys,
+		"db6b6891",
+		deployment.Spec.Template.Spec.TopologySpreadConstraints[0].LabelSelector.MatchLabels[commonconsts.KubeLabelDynamoWorkerHash],
 	)
-	require.Empty(t, podTemplate.Spec.TopologySpreadConstraints[1].MatchLabelKeys)
+	require.NotContains(t,
+		deployment.Spec.Template.Spec.TopologySpreadConstraints[1].LabelSelector.MatchLabels,
+		commonconsts.KubeLabelDynamoWorkerHash,
+	)
+	require.Empty(t, deployment.Spec.Template.Spec.TopologySpreadConstraints[2].LabelSelector.MatchLabels)
+}
+
+func TestRenderMultinodeTopologySpreadConstraintsUsesFinalRoleLabels(t *testing.T) {
+	t.Log("Create a legacy-compatible decode worker with role-specific topology selectors")
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "decode-db6b6891",
+			Namespace: "default",
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoGraphDeploymentName: "qwen",
+				commonconsts.KubeLabelDynamoComponentType:       commonconsts.ComponentTypeWorker,
+				commonconsts.KubeLabelDynamoWorkerHash:          "db6b6891",
+			},
+		},
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "decode",
+				ComponentType: v1beta1.ComponentTypeDecode,
+				Multinode:     &v1beta1.MultinodeSpec{NodeCount: 2},
+				PodTemplate: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+							{
+								MaxSkew:           1,
+								TopologyKey:       corev1.LabelHostname,
+								WhenUnsatisfiable: corev1.DoNotSchedule,
+								LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+									commonconsts.KubeLabelDynamoSubComponentType: commonconsts.ComponentTypeDecode,
+									dcdWorkloadRoleLabel:                         string(dynamo.RoleWorker),
+								}},
+							},
+							{
+								MaxSkew:           1,
+								TopologyKey:       corev1.LabelTopologyZone,
+								WhenUnsatisfiable: corev1.DoNotSchedule,
+								LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+									commonconsts.KubeLabelDynamoSubComponentType: commonconsts.ComponentTypeDecode,
+									dcdWorkloadRoleLabel:                         string(dynamo.RoleLeader),
+								}},
+							},
+						},
+						Containers: []corev1.Container{{
+							Name:    commonconsts.MainContainerName,
+							Image:   "test-image:latest",
+							Command: []string{"python3"},
+							Args:    []string{"-m", "dynamo.vllm"},
+						}},
+					},
+				},
+			},
+		},
+	}
+	renderer := newDCDWorkloadRenderer(
+		fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(dcd).Build(),
+		&configv1alpha1.OperatorConfiguration{},
+		&controller_common.RuntimeConfig{},
+		&mockDockerSecretRetriever{GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+			return nil, nil
+		}},
+	)
+
+	t.Log("Render the final leader and worker templates")
+	leaderTemplate, workerTemplate, err := renderer.renderMultinodePodTemplateSpecs(t.Context(), dcd)
+	require.NoError(t, err)
+
+	t.Log("Verify each role scopes only the selector that matches its final labels")
+	require.Equal(t, commonconsts.ComponentTypeDecode, leaderTemplate.Labels[commonconsts.KubeLabelDynamoSubComponentType])
+	require.Equal(t, commonconsts.ComponentTypeDecode, workerTemplate.Labels[commonconsts.KubeLabelDynamoSubComponentType])
+	require.NotContains(t,
+		leaderTemplate.Spec.TopologySpreadConstraints[0].LabelSelector.MatchLabels,
+		commonconsts.KubeLabelDynamoWorkerHash,
+	)
+	require.Equal(t,
+		"db6b6891",
+		leaderTemplate.Spec.TopologySpreadConstraints[1].LabelSelector.MatchLabels[commonconsts.KubeLabelDynamoWorkerHash],
+	)
+	require.Equal(t,
+		"db6b6891",
+		workerTemplate.Spec.TopologySpreadConstraints[0].LabelSelector.MatchLabels[commonconsts.KubeLabelDynamoWorkerHash],
+	)
+	require.NotContains(t,
+		workerTemplate.Spec.TopologySpreadConstraints[1].LabelSelector.MatchLabels,
+		commonconsts.KubeLabelDynamoWorkerHash,
+	)
 }
 
 func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentTypeWithoutWorkerHash(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -972,6 +972,10 @@ func TestGenerateDeploymentScopesTopologySpreadToWorkerGeneration(t *testing.T) 
 	})
 	require.NoError(t, err)
 	require.False(t, toDelete)
+	require.Equal(t,
+		commonconsts.KubeLabelValueTrue,
+		deployment.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped],
+	)
 
 	t.Log("Verify only the explicit matching selector gains the worker hash")
 	require.Equal(t,
@@ -992,6 +996,47 @@ func TestGenerateDeploymentScopesTopologySpreadToWorkerGeneration(t *testing.T) 
 	require.NoError(t, err)
 	require.False(t, toDelete)
 	require.Equal(t, deployment.Spec.Template, rerendered.Spec.Template)
+	require.Equal(t,
+		commonconsts.KubeLabelValueTrue,
+		rerendered.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped],
+	)
+
+	t.Log("Change a user-owned field on the already-scoped topology constraint")
+	updatedDCD := dcd.DeepCopy()
+	updatedDCD.Spec.PodTemplate.Spec.TopologySpreadConstraints[0].MaxSkew = 2
+	updated, toDelete, err := reconciler.generateDeployment(t.Context(), generateResourceOption{
+		dynamoComponentDeployment: updatedDCD,
+	})
+	require.NoError(t, err)
+	require.False(t, toDelete)
+	require.Equal(t, int32(2), updated.Spec.Template.Spec.TopologySpreadConstraints[0].MaxSkew)
+	require.Equal(t,
+		commonconsts.KubeLabelValueTrue,
+		updated.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped],
+	)
+	require.Equal(t,
+		"db6b6891",
+		updated.Spec.Template.Spec.TopologySpreadConstraints[0].LabelSelector.MatchLabels[commonconsts.KubeLabelDynamoWorkerHash],
+	)
+
+	t.Log("Persist the topology edit and verify generation scoping remains stable")
+	stored := &appsv1.Deployment{}
+	require.NoError(t, reconciler.Get(t.Context(), client.ObjectKeyFromObject(deployment), stored))
+	updated.ResourceVersion = stored.ResourceVersion
+	require.NoError(t, reconciler.Update(t.Context(), updated))
+	rerendered, toDelete, err = reconciler.generateDeployment(t.Context(), generateResourceOption{
+		dynamoComponentDeployment: updatedDCD,
+	})
+	require.NoError(t, err)
+	require.False(t, toDelete)
+	require.Equal(t,
+		updated.Spec.Template.Spec.TopologySpreadConstraints,
+		rerendered.Spec.Template.Spec.TopologySpreadConstraints,
+	)
+	require.Equal(t,
+		commonconsts.KubeLabelValueTrue,
+		rerendered.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped],
+	)
 }
 
 func TestRenderMultinodeTopologySpreadConstraintsUsesFinalRoleLabels(t *testing.T) {
@@ -1061,6 +1106,10 @@ func TestRenderMultinodeTopologySpreadConstraintsUsesFinalRoleLabels(t *testing.
 	})
 	require.NoError(t, err)
 	require.False(t, toDelete)
+	require.Equal(t,
+		commonconsts.KubeLabelValueTrue,
+		lws.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped],
+	)
 	leaderTemplate := lws.Spec.LeaderWorkerTemplate.LeaderTemplate
 	workerTemplate := &lws.Spec.LeaderWorkerTemplate.WorkerTemplate
 
@@ -1092,6 +1141,57 @@ func TestRenderMultinodeTopologySpreadConstraintsUsesFinalRoleLabels(t *testing.
 	require.NoError(t, err)
 	require.False(t, toDelete)
 	require.Equal(t, lws.Spec.LeaderWorkerTemplate, rerendered.Spec.LeaderWorkerTemplate)
+	require.Equal(t,
+		commonconsts.KubeLabelValueTrue,
+		rerendered.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped],
+	)
+
+	t.Log("Change a user-owned field on the already-scoped topology constraints")
+	updatedDCD := dcd.DeepCopy()
+	updatedDCD.Spec.PodTemplate.Spec.TopologySpreadConstraints[0].MaxSkew = 2
+	updated, toDelete, err := reconciler.generateLeaderWorkerSet(t.Context(), generateResourceOption{
+		dynamoComponentDeployment: updatedDCD,
+	})
+	require.NoError(t, err)
+	require.False(t, toDelete)
+	require.Equal(t,
+		commonconsts.KubeLabelValueTrue,
+		updated.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped],
+	)
+	updatedLeaderTemplate := updated.Spec.LeaderWorkerTemplate.LeaderTemplate
+	updatedWorkerTemplate := &updated.Spec.LeaderWorkerTemplate.WorkerTemplate
+	require.Equal(t, int32(2), updatedWorkerTemplate.Spec.TopologySpreadConstraints[0].MaxSkew)
+	require.Equal(t,
+		"db6b6891",
+		updatedWorkerTemplate.Spec.TopologySpreadConstraints[0].LabelSelector.MatchLabels[commonconsts.KubeLabelDynamoWorkerHash],
+	)
+	require.Equal(t,
+		"db6b6891",
+		updatedLeaderTemplate.Spec.TopologySpreadConstraints[1].LabelSelector.MatchLabels[commonconsts.KubeLabelDynamoWorkerHash],
+	)
+
+	t.Log("Persist the topology edit and verify both role templates remain stable")
+	stored := &leaderworkersetv1.LeaderWorkerSet{}
+	require.NoError(t, reconciler.Get(t.Context(), client.ObjectKeyFromObject(lws), stored))
+	updated.ResourceVersion = stored.ResourceVersion
+	require.NoError(t, reconciler.Update(t.Context(), updated))
+	rerendered, toDelete, err = reconciler.generateLeaderWorkerSet(t.Context(), generateResourceOption{
+		dynamoComponentDeployment: updatedDCD,
+	})
+	require.NoError(t, err)
+	require.False(t, toDelete)
+	require.Equal(t,
+		updated.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.TopologySpreadConstraints,
+		rerendered.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.TopologySpreadConstraints,
+	)
+	require.Equal(t,
+		updated.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.TopologySpreadConstraints,
+		rerendered.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.TopologySpreadConstraints,
+	)
+	require.Equal(t,
+		commonconsts.KubeLabelValueTrue,
+		rerendered.Annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped],
+	)
 }
 
 func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentTypeWithoutWorkerHash(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -910,6 +910,41 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t 
 	require.Equal(t, commonconsts.ComponentTypeWorker, service.Spec.Selector[commonconsts.KubeLabelDynamoComponentType])
 }
 
+func TestScopeWorkerTopologySpreadConstraints(t *testing.T) {
+	podTemplate := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+			commonconsts.KubeLabelDynamoComponentType: commonconsts.ComponentTypeWorker,
+			commonconsts.KubeLabelDynamoWorkerHash:    "db6b6891",
+		}},
+		Spec: corev1.PodSpec{TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+			{
+				MaxSkew:           1,
+				TopologyKey:       corev1.LabelHostname,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+					commonconsts.KubeLabelDynamoComponentType: commonconsts.ComponentTypeWorker,
+				}},
+			},
+			{
+				MaxSkew:           1,
+				TopologyKey:       corev1.LabelTopologyZone,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+					"app.kubernetes.io/name": "another-workload",
+				}},
+			},
+		}},
+	}
+
+	scopeWorkerTopologySpreadConstraints(podTemplate)
+
+	require.Equal(t,
+		[]string{commonconsts.KubeLabelDynamoWorkerHash},
+		podTemplate.Spec.TopologySpreadConstraints[0].MatchLabelKeys,
+	)
+	require.Empty(t, podTemplate.Spec.TopologySpreadConstraints[1].MatchLabelKeys)
+}
+
 func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentTypeWithoutWorkerHash(t *testing.T) {
 	s := scheme.Scheme
 	require.NoError(t, v1beta1.AddToScheme(s))

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -983,10 +983,20 @@ func TestGenerateDeploymentScopesTopologySpreadToWorkerGeneration(t *testing.T) 
 		commonconsts.KubeLabelDynamoWorkerHash,
 	)
 	require.Empty(t, deployment.Spec.Template.Spec.TopologySpreadConstraints[2].LabelSelector.MatchLabels)
+
+	t.Log("Persist the scoped Deployment and verify a later render preserves the same pod template")
+	require.NoError(t, reconciler.Create(t.Context(), deployment))
+	rerendered, toDelete, err := reconciler.generateDeployment(t.Context(), generateResourceOption{
+		dynamoComponentDeployment: dcd,
+	})
+	require.NoError(t, err)
+	require.False(t, toDelete)
+	require.Equal(t, deployment.Spec.Template, rerendered.Spec.Template)
 }
 
 func TestRenderMultinodeTopologySpreadConstraintsUsesFinalRoleLabels(t *testing.T) {
 	t.Log("Create a legacy-compatible decode worker with role-specific topology selectors")
+	require.NoError(t, leaderworkersetv1.AddToScheme(scheme.Scheme))
 	dcd := &v1beta1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "decode-db6b6891",
@@ -1036,18 +1046,23 @@ func TestRenderMultinodeTopologySpreadConstraintsUsesFinalRoleLabels(t *testing.
 			},
 		},
 	}
-	renderer := newDCDWorkloadRenderer(
-		fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(dcd).Build(),
-		&configv1alpha1.OperatorConfiguration{},
-		&controller_common.RuntimeConfig{},
-		&mockDockerSecretRetriever{GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+	reconciler := &DynamoComponentDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(dcd).Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{},
+		DockerSecretRetriever: &mockDockerSecretRetriever{GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
 			return nil, nil
 		}},
-	)
+	}
 
-	t.Log("Render the final leader and worker templates")
-	leaderTemplate, workerTemplate, err := renderer.renderMultinodePodTemplateSpecs(t.Context(), dcd)
+	t.Log("Render the new LeaderWorkerSet generation")
+	lws, toDelete, err := reconciler.generateLeaderWorkerSet(t.Context(), generateResourceOption{
+		dynamoComponentDeployment: dcd,
+	})
 	require.NoError(t, err)
+	require.False(t, toDelete)
+	leaderTemplate := lws.Spec.LeaderWorkerTemplate.LeaderTemplate
+	workerTemplate := &lws.Spec.LeaderWorkerTemplate.WorkerTemplate
 
 	t.Log("Verify each role scopes only the selector that matches its final labels")
 	require.Equal(t, commonconsts.ComponentTypeDecode, leaderTemplate.Labels[commonconsts.KubeLabelDynamoSubComponentType])
@@ -1068,6 +1083,15 @@ func TestRenderMultinodeTopologySpreadConstraintsUsesFinalRoleLabels(t *testing.
 		workerTemplate.Spec.TopologySpreadConstraints[1].LabelSelector.MatchLabels,
 		commonconsts.KubeLabelDynamoWorkerHash,
 	)
+
+	t.Log("Persist the scoped LeaderWorkerSet and verify a later render preserves both templates")
+	require.NoError(t, reconciler.Create(t.Context(), lws))
+	rerendered, toDelete, err := reconciler.generateLeaderWorkerSet(t.Context(), generateResourceOption{
+		dynamoComponentDeployment: dcd,
+	})
+	require.NoError(t, err)
+	require.False(t, toDelete)
+	require.Equal(t, lws.Spec.LeaderWorkerTemplate, rerendered.Spec.LeaderWorkerTemplate)
 }
 
 func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentTypeWithoutWorkerHash(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
@@ -311,14 +310,12 @@ func (r *dcdWorkloadRenderer) generatePodTemplateSpec(
 // scopeWorkerTopologySpreadConstraints mutates eligible constraints to select the template's exact worker generation.
 // podTemplate must be non-nil and carry its finalized workload labels.
 func scopeWorkerTopologySpreadConstraints(podTemplate *corev1.PodTemplateSpec) {
-	podLabels := podTemplate.Labels
-	workerHash := podLabels[commonconsts.KubeLabelDynamoWorkerHash]
-
 	// Skip templates that are not hash-versioned worker components.
-	if !dynamo.IsWorkerComponent(podLabels[commonconsts.KubeLabelDynamoComponentType]) ||
-		workerHash == "" {
+	if !isHashVersionedWorkerTemplate(podTemplate) {
 		return
 	}
+	podLabels := podTemplate.Labels
+	workerHash := podLabels[commonconsts.KubeLabelDynamoWorkerHash]
 
 	// Scope only constraints whose explicit selectors match the finalized pod labels.
 	for i := range podTemplate.Spec.TopologySpreadConstraints {
@@ -346,16 +343,37 @@ func scopeWorkerTopologySpreadConstraints(podTemplate *corev1.PodTemplateSpec) {
 	}
 }
 
-// workerTopologySpreadConstraintsWereScoped reports whether existing retains the scoped form of desired.
-// Both templates must be non-nil and carry their finalized workload labels.
-func workerTopologySpreadConstraintsWereScoped(existing, desired *corev1.PodTemplateSpec) bool {
-	scopedDesired := desired.DeepCopy()
-	scopeWorkerTopologySpreadConstraints(scopedDesired)
+// scopeWorkerTopologySpreadWorkload marks a new-style workload and scopes each finalized worker template.
+// workload must be non-nil; nil pod templates are ignored.
+func scopeWorkerTopologySpreadWorkload(workload metav1.Object, podTemplates ...*corev1.PodTemplateSpec) {
+	hasWorkerTemplate := false
 
-	return equality.Semantic.DeepEqual(
-		existing.Spec.TopologySpreadConstraints,
-		scopedDesired.Spec.TopologySpreadConstraints,
-	)
+	// Scope every hash-versioned template that belongs to the workload.
+	for _, podTemplate := range podTemplates {
+		if !isHashVersionedWorkerTemplate(podTemplate) {
+			continue
+		}
+		hasWorkerTemplate = true
+		scopeWorkerTopologySpreadConstraints(podTemplate)
+	}
+
+	// Mark only worker workloads so later reconciles can retain the scoped mode durably.
+	if !hasWorkerTemplate {
+		return
+	}
+	annotations := workload.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped] = commonconsts.KubeLabelValueTrue
+	workload.SetAnnotations(annotations)
+}
+
+// isHashVersionedWorkerTemplate reports whether a finalized pod template belongs to a worker generation.
+func isHashVersionedWorkerTemplate(podTemplate *corev1.PodTemplateSpec) bool {
+	return podTemplate != nil &&
+		dynamo.IsWorkerComponent(podTemplate.Labels[commonconsts.KubeLabelDynamoComponentType]) &&
+		podTemplate.Labels[commonconsts.KubeLabelDynamoWorkerHash] != ""
 }
 
 func labelSelectorReferencesKey(selector *metav1.LabelSelector, key string) bool {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
 	"sync"
 
 	"emperror.dev/errors"
@@ -36,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -296,13 +298,52 @@ func (r *dcdWorkloadRenderer) generatePodTemplateSpec(
 		}
 	}
 
-	return &corev1.PodTemplateSpec{
+	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      podLabels,
 			Annotations: podAnnotations,
 		},
 		Spec: *podSpec,
-	}, nil
+	}
+	scopeWorkerTopologySpreadConstraints(podTemplate)
+	return podTemplate, nil
+}
+
+func scopeWorkerTopologySpreadConstraints(podTemplate *corev1.PodTemplateSpec) {
+	podLabels := podTemplate.Labels
+	if !dynamo.IsWorkerComponent(podLabels[commonconsts.KubeLabelDynamoComponentType]) ||
+		podLabels[commonconsts.KubeLabelDynamoWorkerHash] == "" {
+		return
+	}
+
+	for i := range podTemplate.Spec.TopologySpreadConstraints {
+		constraint := &podTemplate.Spec.TopologySpreadConstraints[i]
+		if constraint.LabelSelector == nil {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(constraint.LabelSelector)
+		if err != nil || !selector.Matches(k8slabels.Set(podLabels)) ||
+			labelSelectorReferencesKey(constraint.LabelSelector, commonconsts.KubeLabelDynamoWorkerHash) ||
+			slices.Contains(constraint.MatchLabelKeys, commonconsts.KubeLabelDynamoWorkerHash) {
+			continue
+		}
+
+		// Old and new DCDs coexist during a rollout. Scope spread calculations
+		// to the incoming pod's generation so old pods cannot mask final skew.
+		constraint.MatchLabelKeys = append(constraint.MatchLabelKeys, commonconsts.KubeLabelDynamoWorkerHash)
+	}
+}
+
+func labelSelectorReferencesKey(selector *metav1.LabelSelector, key string) bool {
+	if _, exists := selector.MatchLabels[key]; exists {
+		return true
+	}
+	for _, expression := range selector.MatchExpressions {
+		if expression.Key == key {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *dcdWorkloadRenderer) generateService(

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
@@ -131,6 +131,7 @@ func (r *dcdWorkloadRenderer) generateLeaderPodTemplateSpec(
 	maps.Copy(leaderPodTemplateSpec.ObjectMeta.Labels, labels)
 	leaderPodTemplateSpec.ObjectMeta.Labels[dcdWorkloadRoleLabel] = string(dynamo.RoleLeader)
 	delete(leaderPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
+	scopeWorkerTopologySpreadConstraints(leaderPodTemplateSpec)
 
 	if err := checkMainContainer(&leaderPodTemplateSpec.Spec); err != nil {
 		return nil, errors.Wrap(err, "generateLeaderPodTemplateSpec: failed to check main container")
@@ -153,6 +154,7 @@ func (r *dcdWorkloadRenderer) generateWorkerPodTemplateSpec(
 	maps.Copy(workerPodTemplateSpec.ObjectMeta.Labels, labels)
 	workerPodTemplateSpec.ObjectMeta.Labels[dcdWorkloadRoleLabel] = string(dynamo.RoleWorker)
 	delete(workerPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
+	scopeWorkerTopologySpreadConstraints(workerPodTemplateSpec)
 
 	if err := checkMainContainer(&workerPodTemplateSpec.Spec); err != nil {
 		return nil, errors.Wrap(err, "generateWorkerPodTemplateSpec: failed to check LWS worker main container")
@@ -305,22 +307,35 @@ func (r *dcdWorkloadRenderer) generatePodTemplateSpec(
 		},
 		Spec: *podSpec,
 	}
-	scopeWorkerTopologySpreadConstraints(podTemplate)
+
+	// Finalize standalone templates here; multinode roles add their final labels in their role-specific renderers.
+	if role == dynamo.RoleMain {
+		scopeWorkerTopologySpreadConstraints(podTemplate)
+	}
 	return podTemplate, nil
 }
 
 func scopeWorkerTopologySpreadConstraints(podTemplate *corev1.PodTemplateSpec) {
 	podLabels := podTemplate.Labels
+	workerHash := podLabels[commonconsts.KubeLabelDynamoWorkerHash]
+
+	// Skip templates that are not hash-versioned worker components.
 	if !dynamo.IsWorkerComponent(podLabels[commonconsts.KubeLabelDynamoComponentType]) ||
-		podLabels[commonconsts.KubeLabelDynamoWorkerHash] == "" {
+		workerHash == "" {
 		return
 	}
 
+	// Scope only constraints whose explicit selectors match the finalized pod labels.
 	for i := range podTemplate.Spec.TopologySpreadConstraints {
 		constraint := &podTemplate.Spec.TopologySpreadConstraints[i]
-		if constraint.LabelSelector == nil {
+
+		// Preserve nil and namespace-wide selectors because they do not identify this workload specifically.
+		if constraint.LabelSelector == nil ||
+			(len(constraint.LabelSelector.MatchLabels) == 0 && len(constraint.LabelSelector.MatchExpressions) == 0) {
 			continue
 		}
+
+		// Leave invalid, unrelated, and user-scoped generation selectors unchanged.
 		selector, err := metav1.LabelSelectorAsSelector(constraint.LabelSelector)
 		if err != nil || !selector.Matches(k8slabels.Set(podLabels)) ||
 			labelSelectorReferencesKey(constraint.LabelSelector, commonconsts.KubeLabelDynamoWorkerHash) ||
@@ -328,16 +343,21 @@ func scopeWorkerTopologySpreadConstraints(podTemplate *corev1.PodTemplateSpec) {
 			continue
 		}
 
-		// Old and new DCDs coexist during a rollout. Scope spread calculations
-		// to the incoming pod's generation so old pods cannot mask final skew.
-		constraint.MatchLabelKeys = append(constraint.MatchLabelKeys, commonconsts.KubeLabelDynamoWorkerHash)
+		// Add the exact incoming generation so old pods cannot mask final skew during a rollout.
+		if constraint.LabelSelector.MatchLabels == nil {
+			constraint.LabelSelector.MatchLabels = map[string]string{}
+		}
+		constraint.LabelSelector.MatchLabels[commonconsts.KubeLabelDynamoWorkerHash] = workerHash
 	}
 }
 
 func labelSelectorReferencesKey(selector *metav1.LabelSelector, key string) bool {
+	// Check direct label matches before scanning expression requirements.
 	if _, exists := selector.MatchLabels[key]; exists {
 		return true
 	}
+
+	// Treat every expression on the key as user-owned selector behavior.
 	for _, expression := range selector.MatchExpressions {
 		if expression.Key == key {
 			return true

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
@@ -131,7 +132,6 @@ func (r *dcdWorkloadRenderer) generateLeaderPodTemplateSpec(
 	maps.Copy(leaderPodTemplateSpec.ObjectMeta.Labels, labels)
 	leaderPodTemplateSpec.ObjectMeta.Labels[dcdWorkloadRoleLabel] = string(dynamo.RoleLeader)
 	delete(leaderPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
-	scopeWorkerTopologySpreadConstraints(leaderPodTemplateSpec)
 
 	if err := checkMainContainer(&leaderPodTemplateSpec.Spec); err != nil {
 		return nil, errors.Wrap(err, "generateLeaderPodTemplateSpec: failed to check main container")
@@ -154,7 +154,6 @@ func (r *dcdWorkloadRenderer) generateWorkerPodTemplateSpec(
 	maps.Copy(workerPodTemplateSpec.ObjectMeta.Labels, labels)
 	workerPodTemplateSpec.ObjectMeta.Labels[dcdWorkloadRoleLabel] = string(dynamo.RoleWorker)
 	delete(workerPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
-	scopeWorkerTopologySpreadConstraints(workerPodTemplateSpec)
 
 	if err := checkMainContainer(&workerPodTemplateSpec.Spec); err != nil {
 		return nil, errors.Wrap(err, "generateWorkerPodTemplateSpec: failed to check LWS worker main container")
@@ -300,21 +299,17 @@ func (r *dcdWorkloadRenderer) generatePodTemplateSpec(
 		}
 	}
 
-	podTemplate := &corev1.PodTemplateSpec{
+	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      podLabels,
 			Annotations: podAnnotations,
 		},
 		Spec: *podSpec,
-	}
-
-	// Finalize standalone templates here; multinode roles add their final labels in their role-specific renderers.
-	if role == dynamo.RoleMain {
-		scopeWorkerTopologySpreadConstraints(podTemplate)
-	}
-	return podTemplate, nil
+	}, nil
 }
 
+// scopeWorkerTopologySpreadConstraints mutates eligible constraints to select the template's exact worker generation.
+// podTemplate must be non-nil and carry its finalized workload labels.
 func scopeWorkerTopologySpreadConstraints(podTemplate *corev1.PodTemplateSpec) {
 	podLabels := podTemplate.Labels
 	workerHash := podLabels[commonconsts.KubeLabelDynamoWorkerHash]
@@ -349,6 +344,18 @@ func scopeWorkerTopologySpreadConstraints(podTemplate *corev1.PodTemplateSpec) {
 		}
 		constraint.LabelSelector.MatchLabels[commonconsts.KubeLabelDynamoWorkerHash] = workerHash
 	}
+}
+
+// workerTopologySpreadConstraintsWereScoped reports whether existing retains the scoped form of desired.
+// Both templates must be non-nil and carry their finalized workload labels.
+func workerTopologySpreadConstraintsWereScoped(existing, desired *corev1.PodTemplateSpec) bool {
+	scopedDesired := desired.DeepCopy()
+	scopeWorkerTopologySpreadConstraints(scopedDesired)
+
+	return equality.Semantic.DeepEqual(
+		existing.Spec.TopologySpreadConstraints,
+		scopedDesired.Spec.TopologySpreadConstraints,
+	)
 }
 
 func labelSelectorReferencesKey(selector *metav1.LabelSelector, key string) bool {

--- a/deploy/operator/internal/controller/upgrade_test.go
+++ b/deploy/operator/internal/controller/upgrade_test.go
@@ -98,6 +98,16 @@ func TestLegacyWorkerIdentityUpgradeDoesNotTriggerRollout(t *testing.T) {
 						SubComponentType: commonconsts.ComponentTypeDecode,
 						DynamoNamespace:  &dynamoNamespace,
 						ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+							PodSpec: &corev1.PodSpec{
+								TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+									MaxSkew:           1,
+									TopologyKey:       corev1.LabelHostname,
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+										commonconsts.KubeLabelDynamoComponentType: commonconsts.ComponentTypeWorker,
+									}},
+								}},
+							},
 							MainContainer: &corev1.Container{
 								Name:    commonconsts.MainContainerName,
 								Image:   "test-image:latest",
@@ -137,6 +147,13 @@ spec:
         nvidia.com/metrics-enabled: "true"
         nvidia.com/selector: qwen-decode-db6b6891
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            nvidia.com/dynamo-component-type: worker
       volumes:
       - name: shared-memory
         emptyDir:
@@ -293,6 +310,16 @@ spec:
 						SubComponentType: commonconsts.ComponentTypeDecode,
 						DynamoNamespace:  &dynamoNamespace,
 						ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+							PodSpec: &corev1.PodSpec{
+								TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+									MaxSkew:           1,
+									TopologyKey:       corev1.LabelHostname,
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+										commonconsts.KubeLabelDynamoComponentType: commonconsts.ComponentTypeWorker,
+									}},
+								}},
+							},
 							MainContainer: &corev1.Container{
 								Name:    commonconsts.MainContainerName,
 								Image:   "test-image:latest",
@@ -332,6 +359,13 @@ spec:
           nvidia.com/metrics-enabled: "true"
           role: leader
       spec:
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              nvidia.com/dynamo-component-type: worker
         volumes:
         - name: shared-memory
           emptyDir:
@@ -439,6 +473,13 @@ spec:
           nvidia.com/metrics-enabled: "true"
           role: worker
       spec:
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              nvidia.com/dynamo-component-type: worker
         volumes:
         - name: shared-memory
           emptyDir:

--- a/deploy/operator/internal/controller/upgrade_test.go
+++ b/deploy/operator/internal/controller/upgrade_test.go
@@ -912,6 +912,9 @@ spec:
 			t.Log("compare old and new child specs; a change here would trigger a rollout")
 			require.Equal(t, specHash(t, oldChild), specHash(t, newChild), "upgrade should not change the child spec hash")
 
+			t.Log("confirm the legacy child is not enrolled in generation-scoped topology management")
+			require.NotContains(t, newChild.GetAnnotations(), commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped)
+
 			t.Log("assert worker pod labels keep the legacy worker identity")
 			for site, subComponentType := range tt.expectedWorkerSites {
 				oldLabels, ok := oldPodLabels[site]

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -141,7 +141,10 @@ func GetDCDKubeAnnotations(dcd *v1beta1.DynamoComponentDeployment) map[string]st
 	maps.Copy(annotations, GetDCDPreservedAlphaAnnotations(dcd))
 	maps.Copy(annotations, GetPodTemplateAnnotations(&dcd.Spec.DynamoComponentDeploymentSharedSpec))
 	AddBaseModelAnnotation(annotations, dcd.Spec.ModelRef)
+
+	// Keep controller-owned resource annotations out of generated pod metadata.
 	delete(annotations, commonconsts.KubeAnnotationDynamoOperatorOriginVersion)
+	delete(annotations, commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped)
 	for _, annotationKey := range commonconsts.KubeTopologySourceAnnotationKeys() {
 		delete(annotations, annotationKey)
 	}

--- a/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
@@ -144,6 +144,31 @@ func TestDCDAlphaCompatibilityHelpersReadThroughAPIConversion(t *testing.T) {
 	}
 }
 
+func TestGetDCDKubeAnnotationsExcludesWorkerTopologySpreadMarker(t *testing.T) {
+	t.Log("Create a DCD with a user annotation and the controller-owned topology marker")
+	dcd := &v1beta1.DynamoComponentDeployment{
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				PodTemplate: &corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					"example.com/user": "kept",
+					commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped: "spoofed",
+				}}},
+			},
+		},
+	}
+
+	t.Log("Render workload annotations")
+	annotations := GetDCDKubeAnnotations(dcd)
+
+	t.Log("Keep user metadata but reserve the controller-owned marker")
+	if got := annotations["example.com/user"]; got != "kept" {
+		t.Fatalf("user annotation = %q, want kept", got)
+	}
+	if _, exists := annotations[commonconsts.KubeAnnotationDynamoWorkerTopologySpreadScoped]; exists {
+		t.Fatalf("controller-owned topology marker was propagated: %#v", annotations)
+	}
+}
+
 func TestComponentRuntimeNamespace(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Overview:

Preserve worker topology spreading across operator-managed DGD rolling updates without rolling pre-existing workloads during an operator-only upgrade.

Old and new worker DCDs coexist during a rollout. A topology spread selector that matches both generations can be satisfied while replacement pods are scheduled, then become skewed after the old generation is removed. The DGD can consequently report `Ready=True` and a completed rollout while all current workers are concentrated on one node.

## Details:

- Add the incoming `nvidia.com/dynamo-worker-hash` value to eligible topology spread label selectors so old worker generations cannot mask final skew.
- Apply the transformation to finalized standalone Deployment templates and finalized multinode leader/worker templates.
- Match against final component, subcomponent, and role labels before deciding whether a constraint belongs to the rendered pod.
- Preserve nil and empty namespace-wide selectors, unrelated workload selectors, and selectors already managed by the user.
- Use an explicit worker-hash selector rather than `matchLabelKeys`, avoiding dependence on the optional `MatchLabelKeysInPodTopologySpread` feature gate.
- Enroll only newly created hash-versioned worker workloads. Pre-existing unmarked Deployment and LeaderWorkerSet resources retain their current pod templates during an operator-only upgrade.
- Store the enrolled mode in a controller-owned workload annotation so later topology edits, including `maxSkew` changes, retain generation scoping.
- Keep the controller-owned marker out of DCD-provided workload and pod annotations.

## Validation:

- `go test ./internal/... -count=1`
- `go test ./api/... ./cmd/... ./config/... ./test/utils -count=1`
- `make envtest ENVTEST_PACKAGES=./internal/controller`
- `go test -race ./internal/controller ./internal/dynamo -count=1`
- `go vet ./internal/...`
- Repository pre-commit hooks on all changed files
- AKS A/B validation on two A100 nodes:
  - Baseline rollouts finished collocated in 2 of 6 runs; generation-scoped controls remained spread in 6 of 6 runs.
  - The behavior was also reproduced with two Qwen3.5-4B vLLM workers.
  - A Deployment created by the stock v1.3.0 operator remained at generation 1, unmarked and unscoped, when reconciled by the patched controller.
  - A newly created worker Deployment received the durable marker and worker-hash selector, initially placed one replica on each A100 node, retained both after a `maxSkew` edit, and stayed unchanged on later reconciles.

## Where should the reviewer start?

`deploy/operator/internal/controller/dynamocomponentdeployment_controller.go`, where new and previously enrolled workloads are selected, followed by `scopeWorkerTopologySpreadWorkload` and `scopeWorkerTopologySpreadConstraints` in `dynamocomponentdeployment_renderer.go`.

## Related Issues

**This PR is linked to an issue:**

- Closes #13186
