### PR TITLE
refactor(router): unify LLM routing attempts

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -67,6 +67,7 @@ areas:
   - tests/router/
   - tests/router/configs/
   - lib/router-plugins/
+  - lib/router-policy/
   - examples/router/policy-class-queues.yaml
   - examples/router/custom-policy-example/
 - label: backend-vllm

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -65,6 +65,7 @@
 
 # === router  (@ai-dynamo/dynamo-router-codeowners) ===
 /lib/kv-router/                                                              @ai-dynamo/dynamo-router-codeowners
+/lib/router-policy/                                                          @ai-dynamo/dynamo-router-codeowners
 /lib/router-plugins/                                                         @ai-dynamo/dynamo-router-codeowners
 /lib/kv-router/tests/                                                        @ai-dynamo/dynamo-router-codeowners
 /lib/kv-router/src/indexer/                                                  @ai-dynamo/dynamo-router-codeowners

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,7 +2943,6 @@ dependencies = [
  "educe",
  "either",
  "etcd-client",
- "fastrand",
  "figment",
  "fs4",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,6 +2592,7 @@ dependencies = [
  "dashmap",
  "derive_builder",
  "dynamo-kv-hashing",
+ "dynamo-router-policy",
  "dynamo-runtime",
  "dynamo-tokens",
  "dynamo-truthy",
@@ -2909,6 +2910,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-router-policy"
+version = "1.4.0"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "dynamo-runtime"
 version = "1.4.0"
 dependencies = [
@@ -2930,6 +2938,7 @@ dependencies = [
  "dashmap",
  "derive-getters",
  "derive_builder",
+ "dynamo-router-policy",
  "dynamo-truthy",
  "educe",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "lib/kv-hashing",
     "lib/mocker",
     "lib/kv-router",
+    "lib/router-policy",
     "lib/router-plugins/catalog",
     "examples/router/custom-policy-example/simple-filter-score-pick",
     "examples/router/custom-policy-example/catalog",
@@ -65,6 +66,7 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.4.0" }
 dynamo-memory = { path = "lib/memory", version = "1.4.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.4.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.4.0" }
+dynamo-router-policy = { path = "lib/router-policy", version = "1.4.0" }
 dynamo-protocols = { version = "=5.3.1" }
 dynamo-parsers = { version = "7.0.1" }
 

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1664,6 +1664,7 @@ dependencies = [
  "dashmap",
  "derive_builder",
  "dynamo-kv-hashing",
+ "dynamo-router-policy",
  "dynamo-runtime",
  "dynamo-tokens",
  "dynamo-truthy",
@@ -1924,6 +1925,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-router-policy"
+version = "1.4.0"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "dynamo-runtime"
 version = "1.4.0"
 dependencies = [
@@ -1942,6 +1950,7 @@ dependencies = [
  "dashmap",
  "derive-getters",
  "derive_builder",
+ "dynamo-router-policy",
  "dynamo-truthy",
  "educe",
  "either",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1955,7 +1955,6 @@ dependencies = [
  "educe",
  "either",
  "etcd-client",
- "fastrand",
  "figment",
  "fs4",
  "futures",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2264,6 +2264,7 @@ dependencies = [
  "dashmap",
  "derive_builder",
  "dynamo-kv-hashing",
+ "dynamo-router-policy",
  "dynamo-runtime",
  "dynamo-tokens",
  "dynamo-truthy",
@@ -2580,6 +2581,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-router-policy"
+version = "1.4.0"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "dynamo-runtime"
 version = "1.4.0"
 dependencies = [
@@ -2599,6 +2607,7 @@ dependencies = [
  "dashmap",
  "derive-getters",
  "derive_builder",
+ "dynamo-router-policy",
  "dynamo-truthy",
  "educe",
  "either",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2612,7 +2612,6 @@ dependencies = [
  "educe",
  "either",
  "etcd-client",
- "fastrand",
  "figment",
  "fs4",
  "futures",

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -28,6 +28,7 @@ dynamo-runtime = { workspace = true, optional = true }
 dynamo-kv-hashing = { workspace = true }
 dynamo-tokens = { workspace = true }
 dynamo-truthy = { workspace = true }
+dynamo-router-policy = { workspace = true }
 
 # workspace
 anyhow = { workspace = true }

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -75,8 +75,9 @@ pub use scheduling::{
     WorkerSelectionInputTrigger, WorkerSelectionKvHints, WorkerSelectionPolicyError,
 };
 pub use selector::{
-    DefaultWorkerSelector, ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerFilter,
-    WorkerInputView, WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
+    DefaultWorkerSelector, ScoredWorkerCandidate, SimpleRoutingPolicy, SimpleWorkerPicker,
+    SimpleWorkerScorer, WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView,
+    WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
     WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelector,
 };
 pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -12,10 +12,10 @@ pub use default::DefaultWorkerSelector;
 
 use default::{DefaultWorkerPicker, DefaultWorkerScorer};
 pub use policy::{
-    CacheUnawareRequestContext, CacheUnawareWorkerSelectionPolicy, ScoredWorkerCandidate,
-    WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView, WorkerInputs,
-    WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer, WorkerSelectionContext,
-    WorkerSelectionPolicy,
+    CacheUnawarePolicyDecision, CacheUnawareRequestContext, CacheUnawareWorkerSelectionPolicy,
+    ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView,
+    WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
+    WorkerSelectionContext, WorkerSelectionPolicy,
 };
 pub use simple::{SimpleRoutingPolicy, SimpleWorkerPicker, SimpleWorkerScorer};
 

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -415,7 +415,11 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
                         .contains(WorkerInputs::ROUTING)
                         .then_some(routing_inputs.as_slice()),
                 };
-                let row = picker.pick(&input.context, picker_input)?;
+                let row = if input.context.advisory {
+                    picker.peek(&input.context, picker_input)?
+                } else {
+                    picker.pick(&input.context, picker_input)?
+                };
                 let Some(candidate) = candidates.get(row) else {
                     return Err(WorkerSelectionPolicyError::InvalidPickerRow {
                         row,

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 mod default;
 mod policy;
+mod simple;
 
 pub use default::DefaultWorkerSelector;
 
@@ -15,6 +16,7 @@ pub use policy::{
     WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
     WorkerSelectionContext, WorkerSelectionPolicy,
 };
+pub use simple::{SimpleRoutingPolicy, SimpleWorkerPicker, SimpleWorkerScorer};
 
 use default::{pick_default_worker, selection_weights};
 use policy::{

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -12,9 +12,10 @@ pub use default::DefaultWorkerSelector;
 
 use default::{DefaultWorkerPicker, DefaultWorkerScorer};
 pub use policy::{
-    ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView,
-    WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
-    WorkerSelectionContext, WorkerSelectionPolicy,
+    CacheUnawareRequestContext, CacheUnawareWorkerSelectionPolicy, ScoredWorkerCandidate,
+    WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView, WorkerInputs,
+    WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer, WorkerSelectionContext,
+    WorkerSelectionPolicy,
 };
 pub use simple::{SimpleRoutingPolicy, SimpleWorkerPicker, SimpleWorkerScorer};
 
@@ -87,7 +88,6 @@ impl<'a> WorkerSelectionInput<'a> {
             has_tier_overlap_blocks,
             use_default_cache_fallbacks: inputs.contains(WorkerInputs::DEFAULT_POLICY_CACHE),
             context: WorkerSelectionContext {
-                request,
                 request_id: request.mode.request_id().unwrap_or("-"),
                 request_blocks: request.request_blocks(block_size),
                 block_size,
@@ -98,6 +98,11 @@ impl<'a> WorkerSelectionInput<'a> {
                     .router_config_override
                     .as_ref()
                     .and_then(|config| config.router_temperature),
+                session_context: request.session_context.as_ref(),
+                expected_output_tokens: request.expected_output_tokens,
+                priority_jump: request.priority_jump,
+                strict_priority: request.strict_priority,
+                advisory: !request.mode.is_tracked(),
             },
         }
     }

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -839,6 +839,14 @@ mod tests {
     use super::*;
     use crate::scheduling::{WorkerSelectionInputTrigger, WorkerSelectionKvHints};
 
+    fn committed_request(isl_tokens: usize) -> SchedulingRequest {
+        let mut request = base_request(isl_tokens);
+        request.mode = crate::scheduling::ScheduleMode::Tracked {
+            request_id: "test".to_string(),
+        };
+        request
+    }
+
     #[test]
     fn default_policy_components_match_default_selector() {
         let worker0 = WorkerWithDpRank::from_worker_id(0);
@@ -847,7 +855,7 @@ mod tests {
             (0, TaintedWorkerConfig::default()),
             (1, TaintedWorkerConfig::default()),
         ]);
-        let mut request = base_request(16);
+        let mut request = committed_request(16);
         request.worker_loads =
             worker_loads_with_active_decode(FxHashMap::from_iter([(worker0, 8), (worker1, 1)]));
         let config = KvRouterConfig {
@@ -915,7 +923,7 @@ mod tests {
             (0, TaintedWorkerConfig::default()),
             (1, TaintedWorkerConfig::default()),
         ]);
-        let mut request = base_request(16);
+        let mut request = committed_request(16);
         request.overlap.tier_overlap_blocks.device =
             FxHashMap::from_iter([(worker0, 1), (worker1, 3)]);
         let policy = WorkerSelectionPolicy::new(
@@ -955,7 +963,7 @@ mod tests {
 
         let worker = WorkerWithDpRank::from_worker_id(0);
         let workers = HashMap::from([(worker.worker_id, TaintedWorkerConfig::default())]);
-        let mut request = base_request(16);
+        let mut request = committed_request(16);
         request.overlap.effective_overlap_blocks.insert(worker, 3.5);
         let policy = WorkerSelectionPolicy::new(
             KvRouterConfig::default(),
@@ -996,7 +1004,7 @@ mod tests {
         }
 
         let workers = HashMap::from([(0, TaintedWorkerConfig::default())]);
-        let mut request = base_request(16);
+        let mut request = committed_request(16);
         request.session_context = Some(SessionContext::new(
             "session-1".into(),
             Some("root".into()),
@@ -1053,7 +1061,7 @@ mod tests {
         }
 
         let workers = HashMap::from([(0, TaintedWorkerConfig::default())]);
-        let request = base_request(16);
+        let request = committed_request(16);
         let policy = WorkerSelectionPolicy::new_with_filters(
             KvRouterConfig::default(),
             "test",
@@ -1105,7 +1113,7 @@ mod tests {
             (0, TaintedWorkerConfig::default()),
             (1, TaintedWorkerConfig::default()),
         ]);
-        let mut request = base_request(16);
+        let mut request = committed_request(16);
         request.track_prefill_tokens = true;
         request.worker_loads.insert(
             worker0,
@@ -1153,7 +1161,7 @@ mod tests {
         }
 
         let workers = HashMap::from([(0, TaintedWorkerConfig::default())]);
-        let mut request = base_request(16);
+        let mut request = committed_request(16);
         request.track_prefill_tokens = true;
 
         let no_filter_config = KvRouterConfig {
@@ -1252,5 +1260,46 @@ mod tests {
         assert_eq!(policy.pick_worker(&advisory, &rows, worker_id).unwrap(), 7);
         assert_eq!(policy.pick_worker(&committed, &rows, worker_id).unwrap(), 7);
         assert_eq!(policy.pick_worker(&committed, &rows, worker_id).unwrap(), 8);
+    }
+
+    #[test]
+    fn kv_advisory_does_not_advance_custom_picker_state() {
+        use crate::scheduling::selector::{SimpleRoutingPolicy, SimpleWorkerPicker};
+
+        let workers = HashMap::from([
+            (0, TaintedWorkerConfig::default()),
+            (1, TaintedWorkerConfig::default()),
+        ]);
+        let mut request = base_request(16);
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(SimpleWorkerPicker::new(SimpleRoutingPolicy::RoundRobin)),
+        );
+
+        let first_advisory = policy
+            .select_worker(&workers, &request, request.eligibility(), 16)
+            .unwrap()
+            .worker;
+        let second_advisory = policy
+            .select_worker(&workers, &request, request.eligibility(), 16)
+            .unwrap()
+            .worker;
+        assert_eq!(second_advisory, first_advisory);
+
+        request.mode = crate::scheduling::ScheduleMode::Tracked {
+            request_id: "committed".to_string(),
+        };
+        let first_committed = policy
+            .select_worker(&workers, &request, request.eligibility(), 16)
+            .unwrap()
+            .worker;
+        let second_committed = policy
+            .select_worker(&workers, &request, request.eligibility(), 16)
+            .unwrap()
+            .worker;
+        assert_eq!(first_committed, first_advisory);
+        assert_ne!(second_committed, first_committed);
     }
 }

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::BitOr;
 
 use dynamo_router_policy::RouteCandidates;
@@ -415,7 +415,19 @@ impl<'a> CacheUnawareRequestContext<'a> {
 /// Thread-safe host adapter for custom filters, scorers, and pickers in
 /// cache-unaware routing modes.
 pub struct CacheUnawareWorkerSelectionPolicy {
-    state: Mutex<CustomWorkerSelectionState>,
+    state: Mutex<CacheUnawareWorkerSelectionState>,
+}
+
+struct CacheUnawareWorkerSelectionState {
+    policy: CustomWorkerSelectionState,
+    source_indices: Vec<usize>,
+}
+
+/// One custom cache-unaware policy decision and the complete post-filter worker set.
+#[derive(Debug)]
+pub struct CacheUnawarePolicyDecision {
+    pub index: usize,
+    pub allowed_worker_ids: HashSet<u64>,
 }
 
 impl WorkerSelectionPolicy {
@@ -477,7 +489,10 @@ impl WorkerSelectionPolicy {
     ) -> Result<CacheUnawareWorkerSelectionPolicy, WorkerSelectionPolicyError> {
         match self.state {
             WorkerSelectionPolicyState::Custom(state) => Ok(CacheUnawareWorkerSelectionPolicy {
-                state: Mutex::new(state.into_inner()),
+                state: Mutex::new(CacheUnawareWorkerSelectionState {
+                    policy: state.into_inner(),
+                    source_indices: Vec::new(),
+                }),
             }),
             WorkerSelectionPolicyState::Default(_) => Err(WorkerSelectionPolicyError::failed(
                 "only custom filter/scorer/picker policies can be adapted to cache-unaware routing",
@@ -491,18 +506,18 @@ impl CacheUnawareWorkerSelectionPolicy {
     ///
     /// Cache-unaware routing supplies worker identity and active-request load.
     /// Policies requesting KV-cache or routing-taint columns are rejected.
-    pub fn pick_worker<C, F>(
+    pub fn select<C, F>(
         &self,
         request: &CacheUnawareRequestContext<'_>,
         candidates_source: &C,
         worker_id: F,
-    ) -> Result<u64, WorkerSelectionPolicyError>
+    ) -> Result<CacheUnawarePolicyDecision, WorkerSelectionPolicyError>
     where
         C: RouteCandidates + ?Sized,
         F: Fn(usize) -> u64,
     {
         let mut state = self.state.lock();
-        let required_inputs = state.filter_inputs | state.scorer_picker_inputs;
+        let required_inputs = state.policy.filter_inputs | state.policy.scorer_picker_inputs;
         if required_inputs.without(WorkerInputs::LOAD) != WorkerInputs::NONE {
             return Err(WorkerSelectionPolicyError::failed(
                 "cache-unaware routing supports only worker identity and active-request load inputs",
@@ -527,6 +542,10 @@ impl CacheUnawareWorkerSelectionPolicy {
             strict_priority: request.strict_priority,
             advisory: request.advisory,
         };
+        let CacheUnawareWorkerSelectionState {
+            policy,
+            source_indices,
+        } = &mut *state;
         let CustomWorkerSelectionState {
             filters,
             scorers,
@@ -539,9 +558,10 @@ impl CacheUnawareWorkerSelectionPolicy {
             cache_inputs,
             load_inputs,
             routing_inputs,
-        } = &mut *state;
+        } = policy;
         unscored_candidates.clear();
         candidates.clear();
+        source_indices.clear();
         cache_inputs.clear();
         load_inputs.clear();
         routing_inputs.clear();
@@ -567,6 +587,7 @@ impl CacheUnawareWorkerSelectionPolicy {
             }
             if keep {
                 unscored_candidates.push(candidate_for(*scorer_picker_inputs));
+                source_indices.push(index);
             }
         }
 
@@ -591,9 +612,12 @@ impl CacheUnawareWorkerSelectionPolicy {
             }
         }
         if candidates.is_empty() {
-            return Err(WorkerSelectionPolicyError::failed(
-                "all eligible workers were rejected by policy filters",
-            ));
+            let message = if candidates_source.is_empty() {
+                "no eligible workers"
+            } else {
+                "all eligible workers were rejected by policy filters"
+            };
+            return Err(WorkerSelectionPolicyError::failed(message));
         }
         let input = WorkerInputView {
             candidates,
@@ -608,13 +632,19 @@ impl CacheUnawareWorkerSelectionPolicy {
         } else {
             picker.pick(&context, input)?
         };
-        candidates
-            .get(row)
-            .map(|candidate| candidate.worker.worker_id)
-            .ok_or(WorkerSelectionPolicyError::InvalidPickerRow {
+        let source_index = source_indices.get(row).copied().ok_or(
+            WorkerSelectionPolicyError::InvalidPickerRow {
                 row,
                 candidate_count: candidates.len(),
-            })
+            },
+        )?;
+        Ok(CacheUnawarePolicyDecision {
+            index: source_index,
+            allowed_worker_ids: candidates
+                .iter()
+                .map(|candidate| candidate.worker.worker_id)
+                .collect(),
+        })
     }
 }
 
@@ -1234,9 +1264,64 @@ mod tests {
         let request = CacheUnawareRequestContext::new("request", 32, false);
 
         let selected = policy
-            .pick_worker(&request, &rows, |index| [41, 42, 43][index])
+            .select(&request, &rows, |index| [41, 42, 43][index])
             .unwrap();
-        assert_eq!(selected, 42);
+        assert_eq!([41, 42, 43][selected.index], 42);
+        assert_eq!(selected.allowed_worker_ids, HashSet::from([41, 42, 43]));
+    }
+
+    #[test]
+    fn cache_unaware_adapter_returns_source_index_and_filtered_set() {
+        use crate::scheduling::selector::{SimpleRoutingPolicy, SimpleWorkerPicker};
+
+        struct RejectWorker(u64);
+
+        impl WorkerFilter for RejectWorker {
+            fn keep(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                candidate: &WorkerCandidate,
+            ) -> Result<bool, WorkerSelectionPolicyError> {
+                Ok(candidate.worker().worker_id != self.0)
+            }
+        }
+
+        let policy = WorkerSelectionPolicy::new_with_filters(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(RejectWorker(41))],
+            Vec::new(),
+            Box::new(SimpleWorkerPicker::new(SimpleRoutingPolicy::RoundRobin)),
+        )
+        .into_cache_unaware()
+        .unwrap();
+        let rows = CacheUnawareRows(vec![0, 0, 0]);
+        let request = CacheUnawareRequestContext::new("request", 32, false);
+
+        let selected = policy
+            .select(&request, &rows, |index| [41, 42, 43][index])
+            .unwrap();
+        assert_eq!(selected.index, 1);
+        assert_eq!(selected.allowed_worker_ids, HashSet::from([42, 43]));
+    }
+
+    #[test]
+    fn cache_unaware_adapter_distinguishes_empty_input() {
+        use crate::scheduling::selector::{SimpleRoutingPolicy, SimpleWorkerPicker};
+
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(SimpleWorkerPicker::new(SimpleRoutingPolicy::RoundRobin)),
+        )
+        .into_cache_unaware()
+        .unwrap();
+        let rows = CacheUnawareRows(Vec::new());
+        let request = CacheUnawareRequestContext::new("request", 32, false);
+
+        let error = policy.select(&request, &rows, |_| 0).unwrap_err();
+        assert!(error.to_string().contains("no eligible workers"));
     }
 
     #[test]
@@ -1256,10 +1341,16 @@ mod tests {
         let committed = CacheUnawareRequestContext::new("request", 8, false);
         let worker_id = |index| [7, 8][index];
 
-        assert_eq!(policy.pick_worker(&advisory, &rows, worker_id).unwrap(), 7);
-        assert_eq!(policy.pick_worker(&advisory, &rows, worker_id).unwrap(), 7);
-        assert_eq!(policy.pick_worker(&committed, &rows, worker_id).unwrap(), 7);
-        assert_eq!(policy.pick_worker(&committed, &rows, worker_id).unwrap(), 8);
+        assert_eq!(policy.select(&advisory, &rows, worker_id).unwrap().index, 0);
+        assert_eq!(policy.select(&advisory, &rows, worker_id).unwrap().index, 0);
+        assert_eq!(
+            policy.select(&committed, &rows, worker_id).unwrap().index,
+            0
+        );
+        assert_eq!(
+            policy.select(&committed, &rows, worker_id).unwrap().index,
+            1
+        );
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -5,6 +5,9 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ops::BitOr;
 
+use dynamo_router_policy::RouteCandidates;
+use parking_lot::Mutex;
+
 use super::{
     DefaultWorkerPicker, LogitWeights, WorkerSelectionInput, WorkerSelector,
     select_worker_with_policy,
@@ -17,7 +20,6 @@ use crate::scheduling::types::{
 };
 
 pub struct WorkerSelectionContext<'a> {
-    pub(super) request: &'a SchedulingRequest,
     pub(super) request_id: &'a str,
     pub(super) request_blocks: u64,
     pub(super) block_size: u32,
@@ -25,6 +27,11 @@ pub struct WorkerSelectionContext<'a> {
     pub(super) weights: LogitWeights,
     pub(super) min_active_prefill_tokens: usize,
     pub(super) router_temperature_override: Option<f64>,
+    pub(super) session_context: Option<&'a SessionContext>,
+    pub(super) expected_output_tokens: Option<u32>,
+    pub(super) priority_jump: f64,
+    pub(super) strict_priority: u32,
+    pub(super) advisory: bool,
 }
 
 pub struct WorkerCandidate {
@@ -148,6 +155,19 @@ pub trait WorkerPicker: Send {
         context: &WorkerSelectionContext<'_>,
         input: WorkerInputView<'_>,
     ) -> Result<usize, WorkerSelectionPolicyError>;
+
+    /// Return one row without committing picker-local state.
+    ///
+    /// Custom policies used by advisory routing must implement this method.
+    fn peek(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        _input: WorkerInputView<'_>,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        Err(WorkerSelectionPolicyError::failed(
+            "this picker does not support advisory selection",
+        ))
+    }
 }
 
 impl WorkerSelectionContext<'_> {
@@ -165,23 +185,28 @@ impl WorkerSelectionContext<'_> {
 
     /// Return the session metadata available to worker selection.
     pub fn session_context(&self) -> Option<&SessionContext> {
-        self.request.session_context.as_ref()
+        self.session_context
     }
 
     pub fn expected_output_tokens(&self) -> Option<u32> {
-        self.request.expected_output_tokens
+        self.expected_output_tokens
     }
 
     pub fn priority_jump(&self) -> f64 {
-        self.request.priority_jump
+        self.priority_jump
     }
 
     pub fn strict_priority(&self) -> u32 {
-        self.request.strict_priority
+        self.strict_priority
     }
 
     pub fn router_temperature_override(&self) -> Option<f64> {
         self.router_temperature_override
+    }
+
+    /// Return whether this is a read-only advisory selection.
+    pub fn is_advisory(&self) -> bool {
+        self.advisory
     }
 }
 
@@ -346,6 +371,53 @@ pub struct WorkerSelectionPolicy {
     state: WorkerSelectionPolicyState,
 }
 
+/// Request metadata exposed to a custom cache-unaware worker policy.
+pub struct CacheUnawareRequestContext<'a> {
+    request_id: &'a str,
+    request_tokens: usize,
+    session_context: Option<&'a SessionContext>,
+    expected_output_tokens: Option<u32>,
+    priority_jump: f64,
+    strict_priority: u32,
+    advisory: bool,
+}
+
+impl<'a> CacheUnawareRequestContext<'a> {
+    pub fn new(request_id: &'a str, request_tokens: usize, advisory: bool) -> Self {
+        Self {
+            request_id,
+            request_tokens,
+            session_context: None,
+            expected_output_tokens: None,
+            priority_jump: 0.0,
+            strict_priority: 0,
+            advisory,
+        }
+    }
+
+    pub fn with_session_context(mut self, session_context: Option<&'a SessionContext>) -> Self {
+        self.session_context = session_context;
+        self
+    }
+
+    pub fn with_expected_output_tokens(mut self, expected_output_tokens: Option<u32>) -> Self {
+        self.expected_output_tokens = expected_output_tokens;
+        self
+    }
+
+    pub fn with_priority(mut self, priority_jump: f64, strict_priority: u32) -> Self {
+        self.priority_jump = priority_jump;
+        self.strict_priority = strict_priority;
+        self
+    }
+}
+
+/// Thread-safe host adapter for custom filters, scorers, and pickers in
+/// cache-unaware routing modes.
+pub struct CacheUnawareWorkerSelectionPolicy {
+    state: Mutex<CustomWorkerSelectionState>,
+}
+
 impl WorkerSelectionPolicy {
     pub fn new(
         kv_router_config: KvRouterConfig,
@@ -397,6 +469,152 @@ impl WorkerSelectionPolicy {
             worker_type,
             state: WorkerSelectionPolicyState::Default(picker),
         }
+    }
+
+    /// Consume a custom KV policy and host it in a cache-unaware router.
+    pub fn into_cache_unaware(
+        self,
+    ) -> Result<CacheUnawareWorkerSelectionPolicy, WorkerSelectionPolicyError> {
+        match self.state {
+            WorkerSelectionPolicyState::Custom(state) => Ok(CacheUnawareWorkerSelectionPolicy {
+                state: Mutex::new(state.into_inner()),
+            }),
+            WorkerSelectionPolicyState::Default(_) => Err(WorkerSelectionPolicyError::failed(
+                "only custom filter/scorer/picker policies can be adapted to cache-unaware routing",
+            )),
+        }
+    }
+}
+
+impl CacheUnawareWorkerSelectionPolicy {
+    /// Run the custom policy over a borrowed runtime candidate table.
+    ///
+    /// Cache-unaware routing supplies worker identity and active-request load.
+    /// Policies requesting KV-cache or routing-taint columns are rejected.
+    pub fn pick_worker<C, F>(
+        &self,
+        request: &CacheUnawareRequestContext<'_>,
+        candidates_source: &C,
+        worker_id: F,
+    ) -> Result<u64, WorkerSelectionPolicyError>
+    where
+        C: RouteCandidates + ?Sized,
+        F: Fn(usize) -> u64,
+    {
+        let mut state = self.state.lock();
+        let required_inputs = state.filter_inputs | state.scorer_picker_inputs;
+        if required_inputs.without(WorkerInputs::LOAD) != WorkerInputs::NONE {
+            return Err(WorkerSelectionPolicyError::failed(
+                "cache-unaware routing supports only worker identity and active-request load inputs",
+            ));
+        }
+        let context = WorkerSelectionContext {
+            request_id: request.request_id,
+            request_blocks: request.request_tokens as u64,
+            block_size: 1,
+            track_prefill_tokens: false,
+            weights: LogitWeights {
+                overlap_score_credit: 0.0,
+                overlap_score_credit_decay: 0.0,
+                prefill_load_scale: 0.0,
+                shared_cache_multiplier: 0.0,
+            },
+            min_active_prefill_tokens: 0,
+            router_temperature_override: None,
+            session_context: request.session_context,
+            expected_output_tokens: request.expected_output_tokens,
+            priority_jump: request.priority_jump,
+            strict_priority: request.strict_priority,
+            advisory: request.advisory,
+        };
+        let CustomWorkerSelectionState {
+            filters,
+            scorers,
+            picker,
+            filter_inputs,
+            scorer_picker_inputs,
+            picker_inputs,
+            unscored_candidates,
+            candidates,
+            cache_inputs,
+            load_inputs,
+            routing_inputs,
+        } = &mut *state;
+        unscored_candidates.clear();
+        candidates.clear();
+        cache_inputs.clear();
+        load_inputs.clear();
+        routing_inputs.clear();
+
+        for index in 0..candidates_source.len() {
+            let candidate_for = |inputs| WorkerCandidate {
+                worker: WorkerWithDpRank::new(worker_id(index), 0),
+                inputs,
+                cache: WorkerCacheInput::default(),
+                load: WorkerLoadInput {
+                    active_requests: candidates_source.load(index) as usize,
+                    ..Default::default()
+                },
+                routing: WorkerRoutingInput::default(),
+            };
+            let filter_candidate = candidate_for(*filter_inputs);
+            let mut keep = true;
+            for filter in filters.iter_mut() {
+                if !filter.keep(&context, &filter_candidate)? {
+                    keep = false;
+                    break;
+                }
+            }
+            if keep {
+                unscored_candidates.push(candidate_for(*scorer_picker_inputs));
+            }
+        }
+
+        for candidate in unscored_candidates.iter() {
+            let mut cost = 0.0;
+            for (scorer_index, scorer) in scorers.iter_mut().enumerate() {
+                let contribution = scorer.score(&context, candidate)?;
+                cost += contribution;
+                if !contribution.is_finite() || !cost.is_finite() {
+                    return Err(WorkerSelectionPolicyError::NonFiniteCost {
+                        scorer_index,
+                        row: candidates.len(),
+                    });
+                }
+            }
+            candidates.push(ScoredWorkerCandidate {
+                worker: candidate.worker,
+                cost,
+            });
+            if picker_inputs.contains(WorkerInputs::LOAD) {
+                load_inputs.push(candidate.load);
+            }
+        }
+        if candidates.is_empty() {
+            return Err(WorkerSelectionPolicyError::failed(
+                "all eligible workers were rejected by policy filters",
+            ));
+        }
+        let input = WorkerInputView {
+            candidates,
+            cache: None,
+            load: picker_inputs
+                .contains(WorkerInputs::LOAD)
+                .then_some(load_inputs.as_slice()),
+            routing: None,
+        };
+        let row = if request.advisory {
+            picker.peek(&context, input)?
+        } else {
+            picker.pick(&context, input)?
+        };
+        candidates
+            .get(row)
+            .map(|candidate| candidate.worker.worker_id)
+            .ok_or(WorkerSelectionPolicyError::InvalidPickerRow {
+                row,
+                candidate_count: candidates.len(),
+            })
     }
 }
 
@@ -974,5 +1192,65 @@ mod tests {
             panic!("expected custom policy state");
         };
         assert!(state.borrow().unscored_candidates.is_empty());
+    }
+
+    struct CacheUnawareRows(Vec<u64>);
+
+    impl RouteCandidates for CacheUnawareRows {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        fn load(&self, index: usize) -> u64 {
+            self.0[index]
+        }
+    }
+
+    #[test]
+    fn cache_unaware_adapter_runs_custom_scorer_and_picker() {
+        use crate::scheduling::selector::{
+            SimpleRoutingPolicy, SimpleWorkerPicker, SimpleWorkerScorer,
+        };
+
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(SimpleWorkerScorer::new(
+                SimpleRoutingPolicy::LeastLoaded,
+            ))],
+            Box::new(SimpleWorkerPicker::new(SimpleRoutingPolicy::LeastLoaded)),
+        )
+        .into_cache_unaware()
+        .unwrap();
+        let rows = CacheUnawareRows(vec![9, 2, 6]);
+        let request = CacheUnawareRequestContext::new("request", 32, false);
+
+        let selected = policy
+            .pick_worker(&request, &rows, |index| [41, 42, 43][index])
+            .unwrap();
+        assert_eq!(selected, 42);
+    }
+
+    #[test]
+    fn cache_unaware_advisory_does_not_advance_picker_state() {
+        use crate::scheduling::selector::{SimpleRoutingPolicy, SimpleWorkerPicker};
+
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(SimpleWorkerPicker::new(SimpleRoutingPolicy::RoundRobin)),
+        )
+        .into_cache_unaware()
+        .unwrap();
+        let rows = CacheUnawareRows(vec![0, 0]);
+        let advisory = CacheUnawareRequestContext::new("query", 8, true);
+        let committed = CacheUnawareRequestContext::new("request", 8, false);
+        let worker_id = |index| [7, 8][index];
+
+        assert_eq!(policy.pick_worker(&advisory, &rows, worker_id).unwrap(), 7);
+        assert_eq!(policy.pick_worker(&advisory, &rows, worker_id).unwrap(), 7);
+        assert_eq!(policy.pick_worker(&committed, &rows, worker_id).unwrap(), 7);
+        assert_eq!(policy.pick_worker(&committed, &rows, worker_id).unwrap(), 8);
     }
 }

--- a/lib/kv-router/src/scheduling/selector/simple.rs
+++ b/lib/kv-router/src/scheduling/selector/simple.rs
@@ -167,6 +167,22 @@ impl WorkerPicker for SimpleWorkerPicker {
             .map(|decision| decision.index)
             .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible workers"))
     }
+
+    fn peek(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        input: WorkerInputView<'_>,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        if self.policy() == RoutingPolicy::DeviceAwareWeighted {
+            return Err(WorkerSelectionPolicyError::failed(
+                "device-aware routing requires runtime-owned device and embedding-cache inputs",
+            ));
+        }
+        self.inner
+            .peek(&NativeRows { input }, RouteContext::default())
+            .map(|decision| decision.index)
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible workers"))
+    }
 }
 
 #[cfg(test)]

--- a/lib/kv-router/src/scheduling/selector/simple.rs
+++ b/lib/kv-router/src/scheduling/selector/simple.rs
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_router_policy::{
+    PolicyDecision, RouteCandidates, RouteContext, RoutePicker, RoutingPolicy,
+};
+
+use super::{
+    WorkerCandidate, WorkerInputView, WorkerInputs, WorkerPicker, WorkerScorer,
+    WorkerSelectionContext,
+};
+use crate::scheduling::types::WorkerSelectionPolicyError;
+
+pub use dynamo_router_policy::RoutingPolicy as SimpleRoutingPolicy;
+
+/// Native scorer for cache-unaware routing presets.
+///
+/// Static policies contribute a constant cost and do not request load inputs. Load-aware
+/// policies project the host's active-request count into the picker's lower-is-better cost.
+#[derive(Clone, Copy, Debug)]
+pub struct SimpleWorkerScorer {
+    policy: SimpleRoutingPolicy,
+}
+
+impl SimpleWorkerScorer {
+    pub const fn new(policy: SimpleRoutingPolicy) -> Self {
+        Self { policy }
+    }
+
+    pub const fn policy(&self) -> SimpleRoutingPolicy {
+        self.policy
+    }
+
+    #[inline(always)]
+    fn score_load(&self, load: u64) -> u64 {
+        match self.policy {
+            RoutingPolicy::RoundRobin | RoutingPolicy::Random => 0,
+            RoutingPolicy::PowerOfTwoChoices
+            | RoutingPolicy::LeastLoaded
+            | RoutingPolicy::DeviceAwareWeighted => load,
+        }
+    }
+}
+
+impl WorkerScorer for SimpleWorkerScorer {
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        match self.policy {
+            RoutingPolicy::RoundRobin | RoutingPolicy::Random => WorkerInputs::NONE,
+            RoutingPolicy::PowerOfTwoChoices
+            | RoutingPolicy::LeastLoaded
+            | RoutingPolicy::DeviceAwareWeighted => WorkerInputs::LOAD,
+        }
+    }
+
+    fn score(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        candidate: &WorkerCandidate,
+    ) -> Result<f64, WorkerSelectionPolicyError> {
+        let active_requests = candidate
+            .load()
+            .map(|load| load.active_requests() as u64)
+            .unwrap_or(0);
+        Ok(self.score_load(active_requests) as f64)
+    }
+}
+
+/// Native picker for cache-unaware routing presets.
+///
+/// The same dependency-neutral kernel backs runtime's compatibility APIs and this native
+/// `WorkerPicker`. LLM orchestration calls the inherent borrowed-candidate methods so static
+/// round-robin and random selection remain allocation-free and candidate-count independent.
+#[derive(Debug)]
+pub struct SimpleWorkerPicker {
+    inner: RoutePicker,
+}
+
+impl SimpleWorkerPicker {
+    pub const fn new(policy: SimpleRoutingPolicy) -> Self {
+        Self {
+            inner: RoutePicker::new(policy),
+        }
+    }
+
+    pub const fn policy(&self) -> SimpleRoutingPolicy {
+        self.inner.policy()
+    }
+
+    #[inline(always)]
+    pub fn peek<C: RouteCandidates + ?Sized>(
+        &self,
+        scorer: &SimpleWorkerScorer,
+        candidates: &C,
+        context: RouteContext,
+    ) -> Option<PolicyDecision> {
+        debug_assert_eq!(self.policy(), scorer.policy());
+        self.inner.peek(&ScoredRows { candidates, scorer }, context)
+    }
+
+    #[inline(always)]
+    pub fn select<C: RouteCandidates + ?Sized>(
+        &self,
+        scorer: &SimpleWorkerScorer,
+        candidates: &C,
+        context: RouteContext,
+    ) -> Option<PolicyDecision> {
+        debug_assert_eq!(self.policy(), scorer.policy());
+        self.inner
+            .select(&ScoredRows { candidates, scorer }, context)
+    }
+}
+
+struct ScoredRows<'a, C: ?Sized> {
+    candidates: &'a C,
+    scorer: &'a SimpleWorkerScorer,
+}
+
+impl<C: RouteCandidates + ?Sized> RouteCandidates for ScoredRows<'_, C> {
+    fn len(&self) -> usize {
+        self.candidates.len()
+    }
+
+    fn load(&self, index: usize) -> u64 {
+        self.scorer.score_load(self.candidates.load(index))
+    }
+
+    fn device(&self, index: usize) -> dynamo_router_policy::RouteDevice {
+        self.candidates.device(index)
+    }
+
+    fn cache_hits(&self, index: usize) -> usize {
+        self.candidates.cache_hits(index)
+    }
+}
+
+struct NativeRows<'a> {
+    input: WorkerInputView<'a>,
+}
+
+impl RouteCandidates for NativeRows<'_> {
+    fn len(&self) -> usize {
+        self.input.candidates.len()
+    }
+
+    fn load(&self, index: usize) -> u64 {
+        self.input.candidates()[index].cost() as u64
+    }
+}
+
+impl WorkerPicker for SimpleWorkerPicker {
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        WorkerInputs::NONE
+    }
+
+    fn pick(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        input: WorkerInputView<'_>,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        if self.policy() == RoutingPolicy::DeviceAwareWeighted {
+            return Err(WorkerSelectionPolicyError::failed(
+                "device-aware routing requires runtime-owned device and embedding-cache inputs",
+            ));
+        }
+        self.inner
+            .select(&NativeRows { input }, RouteContext::default())
+            .map(|decision| decision.index)
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible workers"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Loads<'a>(&'a [u64]);
+
+    impl RouteCandidates for Loads<'_> {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        fn load(&self, index: usize) -> u64 {
+            self.0[index]
+        }
+    }
+
+    #[test]
+    fn native_round_robin_advisory_does_not_advance() {
+        let scorer = SimpleWorkerScorer::new(SimpleRoutingPolicy::RoundRobin);
+        let picker = SimpleWorkerPicker::new(SimpleRoutingPolicy::RoundRobin);
+        let rows = Loads(&[0, 0]);
+        assert_eq!(
+            picker
+                .peek(&scorer, &rows, RouteContext::default())
+                .unwrap()
+                .index,
+            0
+        );
+        assert_eq!(
+            picker
+                .peek(&scorer, &rows, RouteContext::default())
+                .unwrap()
+                .index,
+            0
+        );
+        assert_eq!(
+            picker
+                .select(&scorer, &rows, RouteContext::default())
+                .unwrap()
+                .index,
+            0
+        );
+        assert_eq!(
+            picker
+                .select(&scorer, &rows, RouteContext::default())
+                .unwrap()
+                .index,
+            1
+        );
+    }
+
+    #[test]
+    fn native_least_loaded_reads_host_load_column() {
+        let scorer = SimpleWorkerScorer::new(SimpleRoutingPolicy::LeastLoaded);
+        let picker = SimpleWorkerPicker::new(SimpleRoutingPolicy::LeastLoaded);
+        let rows = Loads(&[8, 1, 6]);
+        assert_eq!(
+            picker
+                .select(&scorer, &rows, RouteContext::default())
+                .unwrap()
+                .index,
+            1
+        );
+    }
+
+    #[test]
+    fn static_scorer_does_not_request_load() {
+        let scorer = SimpleWorkerScorer::new(SimpleRoutingPolicy::RoundRobin);
+        assert_eq!(scorer.required_worker_inputs(), WorkerInputs::NONE);
+        assert_eq!(scorer.score_load(19), 0);
+    }
+
+    #[test]
+    fn load_scorer_projects_active_requests() {
+        let scorer = SimpleWorkerScorer::new(SimpleRoutingPolicy::PowerOfTwoChoices);
+        assert_eq!(scorer.required_worker_inputs(), WorkerInputs::LOAD);
+        assert_eq!(scorer.score_load(19), 19);
+    }
+}

--- a/lib/kv-router/src/scheduling/selector/simple.rs
+++ b/lib/kv-router/src/scheduling/selector/simple.rs
@@ -143,7 +143,19 @@ impl RouteCandidates for NativeRows<'_> {
     }
 
     fn load(&self, index: usize) -> u64 {
-        self.input.candidates()[index].cost() as u64
+        ordered_cost(self.input.candidates()[index].cost())
+    }
+}
+
+/// Map a finite `f64` onto an integer key with the same total ordering.
+#[inline(always)]
+fn ordered_cost(cost: f64) -> u64 {
+    debug_assert!(cost.is_finite());
+    let bits = cost.to_bits();
+    if bits & (1 << 63) == 0 {
+        bits ^ (1 << 63)
+    } else {
+        !bits
     }
 }
 
@@ -187,7 +199,41 @@ impl WorkerPicker for SimpleWorkerPicker {
 
 #[cfg(test)]
 mod tests {
+    use super::super::ScoredWorkerCandidate;
     use super::*;
+
+    fn scored_candidates(costs: &[f64]) -> Vec<ScoredWorkerCandidate> {
+        costs
+            .iter()
+            .enumerate()
+            .map(|(worker_id, &cost)| ScoredWorkerCandidate {
+                worker: crate::protocols::WorkerWithDpRank::from_worker_id(worker_id as u64),
+                cost,
+            })
+            .collect()
+    }
+
+    fn selection_context() -> WorkerSelectionContext<'static> {
+        WorkerSelectionContext {
+            request_id: "test",
+            request_blocks: 1,
+            block_size: 1,
+            track_prefill_tokens: false,
+            weights: super::super::LogitWeights {
+                overlap_score_credit: 0.0,
+                overlap_score_credit_decay: 0.0,
+                prefill_load_scale: 0.0,
+                shared_cache_multiplier: 0.0,
+            },
+            min_active_prefill_tokens: 0,
+            router_temperature_override: None,
+            session_context: None,
+            expected_output_tokens: None,
+            priority_jump: 0.0,
+            strict_priority: 0,
+            advisory: false,
+        }
+    }
 
     struct Loads<'a>(&'a [u64]);
 
@@ -262,5 +308,33 @@ mod tests {
         let scorer = SimpleWorkerScorer::new(SimpleRoutingPolicy::PowerOfTwoChoices);
         assert_eq!(scorer.required_worker_inputs(), WorkerInputs::LOAD);
         assert_eq!(scorer.score_load(19), 19);
+    }
+
+    #[test]
+    fn worker_picker_preserves_fractional_cost_ordering() {
+        let mut picker = SimpleWorkerPicker::new(SimpleRoutingPolicy::LeastLoaded);
+        let candidates = scored_candidates(&[0.9, 0.4]);
+        let input = WorkerInputView {
+            candidates: &candidates,
+            cache: None,
+            load: None,
+            routing: None,
+        };
+
+        assert_eq!(picker.pick(&selection_context(), input).unwrap(), 1);
+    }
+
+    #[test]
+    fn worker_picker_preserves_negative_cost_ordering_for_p2c() {
+        let mut picker = SimpleWorkerPicker::new(SimpleRoutingPolicy::PowerOfTwoChoices);
+        let candidates = scored_candidates(&[-1.0, -5.0]);
+        let input = WorkerInputView {
+            candidates: &candidates,
+            cache: None,
+            load: None,
+            routing: None,
+        };
+
+        assert_eq!(picker.pick(&selection_context(), input).unwrap(), 1);
     }
 }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -30,7 +30,7 @@ use crate::{
     discovery::{KvWorkerMonitor, WORKER_TYPE_DECODE, WorkerSet},
     entrypoint::{self, ChatEngineFactoryCallback, RouterConfig},
     http::service::metrics::Metrics,
-    kv_router::{EncoderRouter, PrefillRouter, WorkerSelectorFactory},
+    kv_router::{CacheUnawarePolicyFactory, EncoderRouter, PrefillRouter, WorkerSelectorFactory},
     local_model::runtime_config::{
         ModelRuntimeConfig, TokenizerBackend, VLLM_INFERENCE_V1_GENERATE_CAPABILITY,
     },
@@ -230,6 +230,7 @@ where
     /// Keep raw pipelines out of default-off and backend-mismatched paths.
     generate_engine_capabilities: Vec<&'static str>,
     worker_selector_factory: WorkerSelectorFactory<Sel>,
+    cache_unaware_policy_factory: Option<CacheUnawarePolicyFactory>,
 }
 
 pub(crate) struct PreparedWorkerSet {
@@ -321,6 +322,7 @@ impl ModelWatcher<DefaultWorkerSelector> {
             Arc::new(|config, worker_type, _partition| {
                 DefaultWorkerSelector::new(Some(config.clone()), worker_type)
             }),
+            None,
         )
     }
 }
@@ -340,6 +342,7 @@ where
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
         metrics: Arc<Metrics>,
         worker_selector_factory: WorkerSelectorFactory<Sel>,
+        cache_unaware_policy_factory: Option<CacheUnawarePolicyFactory>,
     ) -> Self {
         Self {
             manager: model_manager,
@@ -358,6 +361,7 @@ where
             tokenizer_fallback_enabled: None,
             generate_engine_capabilities: Vec::new(),
             worker_selector_factory,
+            cache_unaware_policy_factory,
         }
     }
 
@@ -672,6 +676,34 @@ where
             worker_set.encoder_router = encoder_chooser.clone();
 
             let preprocessed_routing = if needs_preprocessed_routing {
+                let simple_policy = if router_config.router_mode == RouterMode::KV {
+                    None
+                } else {
+                    self.cache_unaware_policy_factory
+                        .as_ref()
+                        .map(|factory| {
+                            factory(
+                                &router_config.kv_router_config,
+                                WORKER_TYPE_DECODE,
+                                RoutingPartitionRef::new(&card.display_name, DEFAULT_ROUTING_GROUP),
+                            )
+                        })
+                        .transpose()?
+                };
+                let lora_simple_policy = if simple_policy.is_some() && self.manager.lora_enabled() {
+                    self.cache_unaware_policy_factory
+                        .as_ref()
+                        .map(|factory| {
+                            factory(
+                                &router_config.kv_router_config,
+                                WORKER_TYPE_DECODE,
+                                RoutingPartitionRef::new(&card.display_name, DEFAULT_ROUTING_GROUP),
+                            )
+                        })
+                        .transpose()?
+                } else {
+                    None
+                };
                 Some(
                     entrypoint::input::build_preprocessed_routing_with_selector(
                         &client,
@@ -683,6 +715,8 @@ where
                         encoder_chooser.clone(),
                         uses_multimodal_cache_routing(card),
                         router_config.session_affinity_ttl_secs,
+                        simple_policy,
+                        lora_simple_policy,
                     )
                     .await
                     .context("build_preprocessed_routing")?,

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -16,7 +16,6 @@ use crate::{
     kv_router::{
         EncoderRouter, KvPushRouter, KvRouter, PrefillRouter, metrics::RouterRequestMetrics,
     },
-    lora::LoraFilteredRouter,
     migration::Migration,
     model_card::ModelDeploymentCard,
     namespace::NamespaceFilter,
@@ -181,37 +180,28 @@ where
     )?;
 
     let engine: ServiceEngine<_, _> = match router_mode {
-        RouterMode::Direct => Arc::new(SessionAffinityPushRouter::new_with_coordinator(
-            router, affinity, true,
-        )),
-        RouterMode::Random | RouterMode::RoundRobin => {
-            match model_manager.lora_filter_for(endpoint_id) {
-                Some(lora_filter) => Arc::new(LoraFilteredRouter::new(
-                    router,
-                    lora_filter,
-                    model_manager.lora_load_estimator_for(endpoint_id),
-                    router_mode,
-                )),
-                None => Arc::new(SessionAffinityPushRouter::new_with_coordinator(
-                    router, affinity, false,
-                )),
-            }
-        }
-        RouterMode::PowerOfTwoChoices
-        | RouterMode::LeastLoaded
-        | RouterMode::DeviceAwareWeighted => {
-            Arc::new(SessionAffinityPushRouter::new_with_coordinator(
-                router,
-                affinity,
-                router_mode.is_direct_routing(),
-            ))
-        }
         RouterMode::KV => {
             let Some(chooser) = chooser else {
                 anyhow::bail!("RouterMode::KV requires KVRouter to not be null");
             };
             Arc::new(KvPushRouter::new_with_coordinator(
                 router, chooser, affinity,
+            ))
+        }
+        RouterMode::Direct
+        | RouterMode::Random
+        | RouterMode::RoundRobin
+        | RouterMode::PowerOfTwoChoices
+        | RouterMode::LeastLoaded
+        | RouterMode::DeviceAwareWeighted => {
+            let lora = model_manager
+                .lora_filter_for(endpoint_id)
+                .map(|filter| (filter, model_manager.lora_load_estimator_for(endpoint_id)));
+            Arc::new(SessionAffinityPushRouter::new_with_coordinator_and_lora(
+                router,
+                affinity,
+                router_mode.is_direct_routing(),
+                lora,
             ))
         }
     };

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -36,7 +36,7 @@ use crate::{
 
 use dynamo_kv_router::{
     config::min_initial_workers_from_env,
-    selector::{DefaultWorkerSelector, WorkerSelector},
+    selector::{CacheUnawareWorkerSelectionPolicy, DefaultWorkerSelector, WorkerSelector},
 };
 use dynamo_runtime::{
     DistributedRuntime,
@@ -159,6 +159,7 @@ fn validate_router_mode_for_lora(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn preprocessed_backend_engine<Sel>(
     router: LlmPushRouter,
     router_mode: RouterMode,
@@ -166,6 +167,8 @@ fn preprocessed_backend_engine<Sel>(
     model_manager: &Arc<crate::discovery::ModelManager>,
     endpoint_id: &dynamo_runtime::protocols::EndpointId,
     affinity: Option<AffinityCoordinator>,
+    simple_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
+    lora_simple_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
 ) -> anyhow::Result<ServiceEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>>
 where
     Sel: WorkerSelector<crate::local_model::runtime_config::ModelRuntimeConfig> + Send + 'static,
@@ -202,6 +205,8 @@ where
                 affinity,
                 router_mode.is_direct_routing(),
                 lora,
+                simple_policy,
+                lora_simple_policy,
             ))
         }
     };
@@ -231,6 +236,8 @@ pub async fn build_preprocessed_routing(
         encoder_chooser,
         enable_multimodal_cache_indexer,
         session_affinity_ttl_secs,
+        None,
+        None,
     )
     .await
 }
@@ -246,6 +253,8 @@ pub(crate) async fn build_preprocessed_routing_with_selector<Sel>(
     encoder_chooser: Option<Arc<EncoderRouter>>,
     enable_multimodal_cache_indexer: bool,
     session_affinity_ttl_secs: Option<u64>,
+    simple_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
+    lora_simple_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
 ) -> anyhow::Result<PreprocessedRouting<Sel>>
 where
     Sel: WorkerSelector<crate::local_model::runtime_config::ModelRuntimeConfig> + Send + 'static,
@@ -285,7 +294,7 @@ where
     let monitor_arc =
         worker_monitor.map(|m| Arc::new(m) as Arc<dyn dynamo_runtime::pipeline::WorkerLoadMonitor>);
 
-    let router = LlmPushRouter::from_client_with_state(
+    let mut router = LlmPushRouter::from_client_with_state(
         router_client,
         router_mode,
         monitor_arc,
@@ -293,6 +302,9 @@ where
         cache_key_extractor,
     )
     .await?;
+    if simple_policy.is_some() {
+        router.enable_policy_occupancy().await;
+    }
 
     // Eagerly register router request metrics so they appear as zeros even in
     // non-KV modes (Direct, Random, RoundRobin) where KvPushRouter is never created.
@@ -319,6 +331,8 @@ where
         &model_manager,
         &endpoint_id,
         affinity,
+        simple_policy,
+        lora_simple_policy,
     )?;
     Ok(PreprocessedRouting {
         backend_engine,

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -207,7 +207,7 @@ where
                 lora,
                 simple_policy,
                 lora_simple_policy,
-            ))
+            )?)
         }
     };
 

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -13,7 +13,7 @@ use crate::{
         FrontendRouteExtension,
         service_v2::{self, HttpService},
     },
-    kv_router::WorkerSelectorFactory,
+    kv_router::{CacheUnawarePolicyFactory, WorkerSelectorFactory},
     local_model::runtime_config::{ModelRuntimeConfig, TokenizerBackend},
     namespace::NamespaceFilter,
     types::openai::{
@@ -83,11 +83,18 @@ impl HttpFrontend {
 
         match self.worker_selection_policy_factory {
             Some(factory) => {
+                let cache_unaware_source = factory.clone();
+                let cache_unaware_factory: CacheUnawarePolicyFactory =
+                    Arc::new(move |config, worker_type, partition| {
+                        let policy = cache_unaware_source(config, worker_type, partition);
+                        Ok(Arc::new(policy.into_cache_unaware()?))
+                    });
                 run_with_worker_selector_factory(
                     distributed_runtime,
                     engine_config,
                     self.frontend_route_extensions,
                     factory,
+                    Some(cache_unaware_factory),
                 )
                 .await
             }
@@ -99,6 +106,7 @@ impl HttpFrontend {
                     Arc::new(|config, worker_type, _partition| {
                         DefaultWorkerSelector::new(Some(config.clone()), worker_type)
                     }),
+                    None,
                 )
                 .await
             }
@@ -133,6 +141,7 @@ async fn run_with_worker_selector_factory<Sel>(
     engine_config: EngineConfig,
     frontend_route_extensions: Vec<FrontendRouteExtension>,
     worker_selector_factory: WorkerSelectorFactory<Sel>,
+    cache_unaware_policy_factory: Option<CacheUnawarePolicyFactory>,
 ) -> anyhow::Result<()>
 where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
@@ -224,6 +233,7 @@ where
                 model.runtime_config().tokenizer_fallback_enabled,
                 generate_engine_capabilities,
                 worker_selector_factory.clone(),
+                cache_unaware_policy_factory,
             )
             .await?;
             http_service
@@ -311,6 +321,7 @@ async fn run_watcher<Sel>(
     tokenizer_fallback_enabled: Option<bool>,
     generate_engine_capabilities: Vec<&'static str>,
     worker_selector_factory: WorkerSelectorFactory<Sel>,
+    cache_unaware_policy_factory: Option<CacheUnawarePolicyFactory>,
 ) -> anyhow::Result<()>
 where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
@@ -333,6 +344,7 @@ where
         prefill_load_estimator,
         metrics.clone(),
         worker_selector_factory,
+        cache_unaware_policy_factory,
     );
     watch_obj.set_local_model_path(local_model_path);
     watch_obj.set_tokenizer_backend(tokenizer_backend);

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -21,6 +21,7 @@ use dynamo_kv_router::{
         ScheduleRequest, TieredOverlapRefresher, WorkerAvailabilityProvider,
         effective_prefill_tokens, overlap::cache_hit_estimates_from_tiered_matches,
     },
+    selector::CacheUnawareWorkerSelectionPolicy,
 };
 use dynamo_runtime::{
     CancellationToken,
@@ -78,6 +79,16 @@ use route_lookup::{
 
 pub(crate) type WorkerSelectorFactory<Sel> = Arc<
     dyn for<'a> Fn(&KvRouterConfig, &'static str, RoutingPartitionRef<'a>) -> Sel + Send + Sync,
+>;
+
+pub(crate) type CacheUnawarePolicyFactory = Arc<
+    dyn for<'a> Fn(
+            &KvRouterConfig,
+            &'static str,
+            RoutingPartitionRef<'a>,
+        ) -> anyhow::Result<Arc<CacheUnawareWorkerSelectionPolicy>>
+        + Send
+        + Sync,
 >;
 
 pub(crate) fn to_worker_selection_session_context(

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -292,7 +292,7 @@ where
                     push_router,
                     affinity,
                     context.router_mode.is_direct_routing(),
-                ),
+                )?,
             ))
         };
 

--- a/lib/llm/src/kv_router/prefill_router/admission.rs
+++ b/lib/llm/src/kv_router/prefill_router/admission.rs
@@ -44,7 +44,8 @@ where
         prepare: F,
     ) -> Result<(M, ManyOut<Annotated<LLMEngineOutput>>)>
     where
-        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M>,
+        M: Send,
+        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M> + Send,
     {
         match self {
             InnerPrefillRouter::KvRouter(router) => {

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -163,7 +163,8 @@ pub(crate) const BYPASS_REMOTE_PREFILL_ANNOTATION: &str = "x-bypass-remote-prefi
 /// from the prefill response and injecting them into the decode request.
 ///
 /// Modes:
-/// - Query-only: `query_instance_id` annotation present → returns worker IDs without execution
+/// - Worker query: `query_instance_id` keeps decode selection advisory, while an enabled prefill
+///   hop still executes its one-token KV handoff with committed scheduler accounting
 /// - Pre-routed: `prefill_worker_id`/`decode_worker_id` set → routes to specified workers
 /// - Normal: Worker IDs determined by router based on KV cache state
 ///

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -7,18 +7,23 @@ use dynamo_kv_router::{
     protocols::{TokensWithHashes, WorkerWithDpRank},
     selector::WorkerSelector,
 };
+#[cfg(test)]
+use dynamo_runtime::error::{ErrorType, match_error_chain};
 use dynamo_runtime::{
-    error::{DynamoError, ErrorType, match_error_chain},
-    metrics::frontend_perf::{STAGE_ROUTE, StageGuard},
+    error::DynamoError,
     pipeline::{
         AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
         ResponseStream, SingleIn, async_trait,
     },
     protocols::annotated::Annotated,
 };
-use futures::stream::{self, StreamExt};
+use futures::StreamExt;
+#[cfg(test)]
+use futures::stream;
 use tracing::Instrument;
 
+#[cfg(test)]
+use crate::session_affinity::AffinityAcquire;
 use crate::{
     kv_router::{
         KvRouter, metrics::RouterRequestMetrics, scheduler::DefaultWorkerSelector,
@@ -26,14 +31,9 @@ use crate::{
     },
     local_model::runtime_config::ModelRuntimeConfig,
     preprocessor::PreprocessedRequest,
-    protocols::common::{
-        FinishReason,
-        llm_backend::LLMEngineOutput,
-        timing::{RequestPhase, RoutingData},
-    },
-    session_affinity::{
-        AffinityAcquire, AffinityCoordinator, AffinityTarget, affinity_id, explicit_target,
-    },
+    protocols::common::{FinishReason, llm_backend::LLMEngineOutput, timing::RequestPhase},
+    routing_attempt::{AttemptBackend, AttemptKind, SelectionIntent},
+    session_affinity::{AffinityCoordinator, AffinityTarget, affinity_id, explicit_target},
 };
 
 mod cancellation;
@@ -47,10 +47,12 @@ use selection::{RoutingRequestParts, SelectionOptions, WorkerSelection};
 const OUTPUT_REPLAY_ID_ANNOTATION_KEY: &str = "output_replay_id";
 const OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY: &str = "output_replay_consumer";
 
+#[cfg(test)]
 fn is_cancelled(error: &Error) -> bool {
     match_error_chain(error.as_ref(), &[ErrorType::Cancelled], &[])
 }
 
+#[cfg(test)]
 fn invalidate_on_non_cancellation(operation: &mut Option<AffinityAcquire>, error: &Error) {
     if is_cancelled(error) {
         return;
@@ -123,6 +125,15 @@ where
     pub chooser: Arc<KvRouter<Sel>>,
     request_metrics: Arc<RouterRequestMetrics>,
     affinity: Option<AffinityCoordinator>,
+}
+
+pub(crate) struct KvAttempt<Sel = DefaultWorkerSelector>
+where
+    Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
+{
+    selection: WorkerSelection,
+    guard: Option<RequestGuard<Sel>>,
+    exact: bool,
 }
 
 impl<Sel> KvPushRouter<Sel>
@@ -209,6 +220,7 @@ where
         cancel_on_stop(request_context.as_ref(), selection_future).await?
     }
 
+    #[cfg(test)]
     async fn select_with_affinity(
         &self,
         request: &SingleIn<PreprocessedRequest>,
@@ -360,13 +372,18 @@ where
         Ok(guard)
     }
 
-    async fn dispatch_selection(
+    async fn dispatch_selection<M, F>(
         &self,
-        request: SingleIn<PreprocessedRequest>,
+        mut request: SingleIn<PreprocessedRequest>,
         selection: WorkerSelection,
         mut guard: RequestGuard<Sel>,
         exact: bool,
-    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+        prepare: F,
+    ) -> Result<(M, AffinityTarget, ManyOut<Annotated<LLMEngineOutput>>), Error>
+    where
+        M: Send,
+        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
+    {
         let context_id = request.context().id().to_string();
         let request_context = request.context().clone();
         let phase = request
@@ -378,9 +395,8 @@ where
         guard.start_dispatch(&phase_label);
         self.warn_if_output_replay_annotation_ignored(&request, &selection);
 
-        let (mut backend_input, context) = request.into_parts();
-        backend_input.routing_mut().dp_rank = Some(selection.worker.dp_rank);
-        let _ = backend_input
+        request.routing_mut().dp_rank = Some(selection.worker.dp_rank);
+        let _ = request
             .extra_args
             .as_mut()
             .and_then(serde_json::Value::as_object_mut)
@@ -388,7 +404,7 @@ where
             .and_then(serde_json::Value::as_object_mut)
             .and_then(|params| params.remove("router_hint"));
         if let Some(router_hint) = selection.router_hint.as_ref()
-            && let Err(error) = backend_input.attach_router_hint(router_hint)
+            && let Err(error) = request.attach_router_hint(router_hint)
         {
             tracing::warn!(
                 request_id = %context_id,
@@ -397,6 +413,15 @@ where
                 "Failed to attach router_hint to backend request"
             );
         }
+        let selected_target = route_target(selection.worker);
+        let metadata = match prepare(&mut request, selected_target) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                guard.abort().await;
+                return Err(error);
+            }
+        };
+        let (backend_input, context) = request.into_parts();
         let updated_request = context.map(|_| backend_input);
         guard.record_prefill_start();
 
@@ -405,9 +430,20 @@ where
                 self.inner
                     .dispatch_exact(updated_request, selection.worker.worker_id)
                     .await
+                    .map(|stream| (selection.worker.worker_id, stream))
             } else {
                 self.inner
-                    .direct(updated_request, selection.worker.worker_id)
+                    .direct_within_prepared(
+                        updated_request,
+                        selection.worker.worker_id,
+                        selection.fallback_worker_ids.as_ref(),
+                        |request, worker_id| {
+                            if worker_id != selection.worker.worker_id {
+                                request.routing_mut().dp_rank = None;
+                            }
+                            Ok(worker_id)
+                        },
+                    )
                     .await
             }
         };
@@ -424,8 +460,8 @@ where
         )
         .await
         .and_then(|result| result);
-        let response_stream = match dispatch_result {
-            Ok(stream) => stream,
+        let (resolved_worker_id, response_stream) = match dispatch_result {
+            Ok(result) => result,
             Err(error) => {
                 let typed_error = error
                     .chain()
@@ -436,6 +472,13 @@ where
             }
         };
 
+        let resolved_target = if resolved_worker_id == selection.worker.worker_id {
+            route_target(selection.worker)
+        } else {
+            guard.record_resolved_worker(resolved_worker_id, None);
+            AffinityTarget::new(resolved_worker_id, None)
+        };
+
         guard.mark_dispatched();
         let stream_context = response_stream.context();
         let wrapped_stream = Box::pin(monitor_response_stream(
@@ -443,7 +486,11 @@ where
             stream_context.clone(),
             guard,
         ));
-        Ok(ResponseStream::new(wrapped_stream, stream_context))
+        Ok((
+            metadata,
+            resolved_target,
+            ResponseStream::new(wrapped_stream, stream_context),
+        ))
     }
 
     fn warn_if_output_replay_annotation_ignored(
@@ -480,53 +527,149 @@ where
 
     pub(crate) async fn select_and_dispatch_prefill<M, F>(
         &self,
-        mut request: SingleIn<PreprocessedRequest>,
+        request: SingleIn<PreprocessedRequest>,
         prepare: F,
     ) -> Result<(M, ManyOut<Annotated<LLMEngineOutput>>), Error>
     where
-        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error>,
+        M: Send,
+        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
     {
-        let phase = RequestPhase::Prefill;
-        let phase_label = phase.to_string();
-        let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
-        let is_query_only = request.get_annotation_value("query_instance_id").is_some();
-        let (mut selection, mut operation) = self
-            .select_with_affinity(&request, phase, is_query_only)
+        crate::routing_attempt::select_and_dispatch_prefill(self, request, prepare).await
+    }
+}
+
+impl<Sel> AttemptBackend for KvPushRouter<Sel>
+where
+    Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
+{
+    type Attempt = KvAttempt<Sel>;
+
+    fn affinity(&self) -> Option<&AffinityCoordinator> {
+        self.affinity.as_ref()
+    }
+
+    fn direct(&self) -> bool {
+        false
+    }
+
+    async fn select(
+        &self,
+        request: &SingleIn<PreprocessedRequest>,
+        phase: RequestPhase,
+        intent: SelectionIntent,
+        pinned_target: Option<AffinityTarget>,
+    ) -> Result<Self::Attempt, Error> {
+        let is_query_only = intent == SelectionIntent::Advisory;
+        let affinity_worker = pinned_target.and_then(affinity_worker);
+        let mut selection = self
+            .select_request(request, phase, is_query_only, affinity_worker)
             .await?;
-        let mut guard = match self
-            .track_selection(&request, &mut selection, is_query_only)
-            .await
-        {
-            Ok(guard) => guard,
-            Err(error) => {
-                invalidate_on_non_cancellation(&mut operation, &error);
-                return Err(error);
+        let guard = if is_query_only {
+            None
+        } else {
+            Some(self.track_selection(request, &mut selection, false).await?)
+        };
+        Ok(KvAttempt {
+            selection,
+            guard,
+            exact: pinned_target.is_some(),
+        })
+    }
+
+    fn observe_advisory(&self, request: &SingleIn<PreprocessedRequest>, attempt: &Self::Attempt) {
+        let routing_parts = RoutingRequestParts::new(request);
+        if let Some(ref tracker) = request.tracker {
+            let isl_blocks = routing_parts
+                .token_ids
+                .len()
+                .div_ceil(self.chooser.block_size() as usize);
+            tracker.record_kv_hit(attempt.selection.effective_overlap_blocks, isl_blocks);
+            tracker.record_isl(
+                routing_parts.token_ids.len(),
+                Some(attempt.selection.cached_tokens),
+            );
+            tracker.record_worker(
+                attempt.selection.worker.worker_id,
+                Some(attempt.selection.worker.dp_rank),
+                self.chooser.worker_type(),
+            );
+            tracker.record_router_queue_depth(self.chooser.pending_count());
+        }
+        self.request_metrics
+            .input_sequence_tokens
+            .observe(request.token_ids.len() as f64);
+    }
+
+    async fn dispatch<M, F>(
+        &self,
+        mut request: SingleIn<PreprocessedRequest>,
+        attempt: Self::Attempt,
+        kind: AttemptKind,
+        prepare: F,
+    ) -> Result<(M, AffinityTarget, ManyOut<Annotated<LLMEngineOutput>>), Error>
+    where
+        M: Send,
+        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
+    {
+        let mut attempt = attempt;
+        let exact = kind == AttemptKind::Prefill || attempt.exact;
+        // Migration-disabled requests keep the original single transport lookup at dispatch.
+        // Prevalidation exists only to atomically acquire a replacement booking before a
+        // migration attempt releases the failed one.
+        if !exact && request.migration_state.is_some() {
+            loop {
+                let selected_worker = attempt.selection.worker.worker_id;
+                debug_assert!(
+                    attempt
+                        .selection
+                        .fallback_worker_ids
+                        .as_ref()
+                        .is_none_or(|workers| workers.contains(&selected_worker))
+                );
+                let Err(error) = self
+                    .inner
+                    .validate_exact_target(route_target(attempt.selection.worker))
+                else {
+                    break;
+                };
+
+                let typed_error = error
+                    .chain()
+                    .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned());
+                request
+                    .migration_state
+                    .get_or_insert_with(Default::default)
+                    .record_failure(selected_worker, typed_error);
+                let phase = request
+                    .tracker
+                    .as_ref()
+                    .map(|tracker| tracker.phase())
+                    .unwrap_or(RequestPhase::Aggregated);
+                let replacement = self
+                    .select(&request, phase, SelectionIntent::Committed, None)
+                    .await;
+                // The scheduler owns both bookings. Acquire the replacement before
+                // conditionally freeing the old worker so there is no unbooked gap.
+                attempt
+                    .guard
+                    .as_mut()
+                    .expect("committed KV attempt has a request guard")
+                    .abort()
+                    .await;
+                attempt = replacement?;
             }
-        };
-        let selected_target = route_target(selection.worker);
-        let metadata = match prepare(&mut request, selected_target) {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                guard.abort().await;
-                invalidate_on_non_cancellation(&mut operation, &error);
-                return Err(error);
-            }
-        };
-        drop(route_guard);
-        let stream = match self
-            .dispatch_selection(request, selection, guard, true)
-            .await
-        {
-            Ok(stream) => stream,
-            Err(error) => {
-                invalidate_on_non_cancellation(&mut operation, &error);
-                return Err(error);
-            }
-        };
-        let Some(operation) = operation else {
-            return Ok((metadata, stream));
-        };
-        Ok((metadata, operation.into_stream(selected_target, stream)?))
+        }
+
+        let KvAttempt {
+            selection,
+            guard,
+            exact: _,
+        } = attempt;
+        let guard = guard.expect("committed KV attempt has a request guard");
+        let (metadata, target, stream) = self
+            .dispatch_selection(request, selection, guard, true, prepare)
+            .await?;
+        Ok((metadata, target, stream))
     }
 }
 
@@ -559,85 +702,7 @@ where
         &self,
         request: SingleIn<PreprocessedRequest>,
     ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
-        let is_query_only = request.get_annotation_value("query_instance_id").is_some();
-        let phase = request
-            .tracker
-            .as_ref()
-            .map(|tracker| tracker.phase())
-            .unwrap_or(RequestPhase::Aggregated);
-        let phase_label = phase.to_string();
-        let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
-        let (mut selection, mut operation) = self
-            .select_with_affinity(&request, phase, is_query_only)
-            .await?;
-        if is_query_only {
-            let routing_parts = RoutingRequestParts::new(&request);
-            if let Some(ref tracker) = request.tracker {
-                let isl_blocks = routing_parts
-                    .token_ids
-                    .len()
-                    .div_ceil(self.chooser.block_size() as usize);
-                tracker.record_kv_hit(selection.effective_overlap_blocks, isl_blocks);
-                tracker.record_isl(routing_parts.token_ids.len(), Some(selection.cached_tokens));
-                tracker.record_worker(
-                    selection.worker.worker_id,
-                    Some(selection.worker.dp_rank),
-                    self.chooser.worker_type(),
-                );
-                tracker.record_router_queue_depth(self.chooser.pending_count());
-            }
-            self.request_metrics
-                .input_sequence_tokens
-                .observe(request.token_ids.len() as f64);
-            let stream_context = request.context().clone();
-            let worker_id_info = request
-                .tracker
-                .as_ref()
-                .and_then(|tracker| tracker.get_worker_info());
-
-            tracing::trace!(
-                ?phase,
-                worker_id = selection.worker.worker_id,
-                ?worker_id_info,
-                "Returning worker selection (query-only mode)"
-            );
-
-            let output = LLMEngineOutput {
-                routing_data: Some(RoutingData {
-                    worker_id: worker_id_info,
-                    token_ids: Some(request.token_ids.clone()),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            };
-            let response = Annotated::from_data(output);
-            let stream = stream::iter(vec![response]);
-            return Ok(ResponseStream::new(Box::pin(stream), stream_context));
-        }
-
-        let guard = match self.track_selection(&request, &mut selection, false).await {
-            Ok(guard) => guard,
-            Err(error) => {
-                invalidate_on_non_cancellation(&mut operation, &error);
-                return Err(error);
-            }
-        };
-        drop(route_guard);
-        let selected_target = route_target(selection.worker);
-        let stream = match self
-            .dispatch_selection(request, selection, guard, operation.is_some())
-            .await
-        {
-            Ok(stream) => stream,
-            Err(error) => {
-                invalidate_on_non_cancellation(&mut operation, &error);
-                return Err(error);
-            }
-        };
-        match operation {
-            Some(operation) => operation.into_stream(selected_target, stream),
-            None => Ok(stream),
-        }
+        crate::routing_attempt::generate(self, request).await
     }
 }
 
@@ -1011,7 +1076,8 @@ mod tests {
                     failed_request,
                     failed_selection,
                     failed_dispatch_guard,
-                    true,
+                    false,
+                    |_, _| Ok(()),
                 )
                 .await
                 .is_err()
@@ -1226,6 +1292,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(selection.worker.worker_id, 8);
+        assert_eq!(
+            selection.fallback_worker_ids,
+            Some(HashSet::from([8])),
+            "transport fallback must stay inside the post-migration candidate set"
+        );
         router.chooser.free(retry_request.id()).await.unwrap();
         drop(operation);
 

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -1572,11 +1572,14 @@ mod tests {
         // This attempt exercises the pre-dispatch worker-loss path: the old scheduler booking
         // must be released before the same request ID is admitted on its replacement.
         dispatch.reject_next.store(false, Ordering::Release);
+        let mut no_affinity = None;
         let ((), replacement, replacement_stream) = crate::routing_attempt::dispatch_attempt(
             kv_router.as_ref(),
             stale_request,
             stale_attempt,
+            RequestPhase::Aggregated,
             AttemptKind::Generate,
+            &mut no_affinity,
             |_, _| Ok(()),
         )
         .await

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -289,6 +289,7 @@ where
         request: &SingleIn<PreprocessedRequest>,
         selection: &mut WorkerSelection,
         is_query_only: bool,
+        count_started: bool,
     ) -> Result<RequestGuard<Sel>, Error> {
         let context_id = request.context().id().to_string();
         let request_context = request.context().clone();
@@ -302,6 +303,7 @@ where
             selected_worker,
             request,
             !is_query_only,
+            count_started,
         );
 
         let record_result: Result<(), Error> = async {
@@ -373,6 +375,35 @@ where
         Ok(guard)
     }
 
+    async fn select_attempt(
+        &self,
+        request: &SingleIn<PreprocessedRequest>,
+        phase: RequestPhase,
+        intent: SelectionIntent,
+        pinned_target: Option<AffinityTarget>,
+        count_started: bool,
+    ) -> Result<KvAttempt<Sel>, Error> {
+        let is_query_only = intent == SelectionIntent::Advisory;
+        let affinity_worker = pinned_target.and_then(affinity_worker);
+        let mut selection = self
+            .select_request(request, phase, is_query_only, affinity_worker)
+            .await?;
+        let guard = if is_query_only {
+            None
+        } else {
+            Some(
+                self.track_selection(request, &mut selection, false, count_started)
+                    .await?,
+            )
+        };
+        Ok(KvAttempt {
+            selection,
+            guard,
+            exact: pinned_target.is_some(),
+            route: None,
+        })
+    }
+
     fn warn_if_output_replay_annotation_ignored(
         &self,
         request: &SingleIn<PreprocessedRequest>,
@@ -424,6 +455,10 @@ where
 {
     type Attempt = KvAttempt<Sel>;
 
+    fn supports_advisory(&self) -> bool {
+        true
+    }
+
     fn affinity(&self) -> Option<&AffinityCoordinator> {
         self.affinity.as_ref()
     }
@@ -439,22 +474,8 @@ where
         intent: SelectionIntent,
         pinned_target: Option<AffinityTarget>,
     ) -> Result<Self::Attempt, Error> {
-        let is_query_only = intent == SelectionIntent::Advisory;
-        let affinity_worker = pinned_target.and_then(affinity_worker);
-        let mut selection = self
-            .select_request(request, phase, is_query_only, affinity_worker)
-            .await?;
-        let guard = if is_query_only {
-            None
-        } else {
-            Some(self.track_selection(request, &mut selection, false).await?)
-        };
-        Ok(KvAttempt {
-            selection,
-            guard,
-            exact: pinned_target.is_some(),
-            route: None,
-        })
+        self.select_attempt(request, phase, intent, pinned_target, true)
+            .await
     }
 
     fn observe_advisory(&self, request: &SingleIn<PreprocessedRequest>, attempt: &Self::Attempt) {
@@ -513,7 +534,7 @@ where
                         guard.abort().await;
                     }
                     *attempt = self
-                        .select(request, phase, SelectionIntent::Committed, None)
+                        .select_attempt(request, phase, SelectionIntent::Committed, None, false)
                         .await?;
                 }
             }
@@ -828,6 +849,7 @@ mod tests {
             WorkerWithDpRank::from_worker_id(0),
             &request(),
             false,
+            false,
         );
         let monitored = monitor_response_stream(source, context, guard);
         tokio::pin!(monitored);
@@ -853,7 +875,7 @@ mod tests {
             .unwrap();
         let failed_worker = failed_selection.worker;
         let failed_guard = router
-            .track_selection(&failed_request, &mut failed_selection, false)
+            .track_selection(&failed_request, &mut failed_selection, false, true)
             .await
             .unwrap();
         let failure = Annotated {
@@ -890,7 +912,7 @@ mod tests {
             .unwrap();
         assert_eq!(retry_selection.worker, failed_worker);
         let mut retry_guard = router
-            .track_selection(&retry_request, &mut retry_selection, false)
+            .track_selection(&retry_request, &mut retry_selection, false, true)
             .await
             .expect("same-worker booking must be released before yielding the error");
         retry_guard.abort().await;
@@ -972,7 +994,7 @@ mod tests {
             .await
             .unwrap();
         let guard = router
-            .track_selection(&request, &mut selection, is_query_only)
+            .track_selection(&request, &mut selection, is_query_only, true)
             .await
             .unwrap();
         (request, selection, guard)
@@ -1042,6 +1064,26 @@ mod tests {
         drop(completed_guard);
         assert_eq!(metrics.requests_started_total().get(), started_before + 3);
         assert_eq!(metrics.requests_total.get(), completed_before + 1);
+
+        drop(router);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn predispatch_reselection_counts_one_logical_request_start() {
+        let (router, runtime) = router_with_workers(None, &[7, 8]).await;
+        let started_before = router.request_metrics.requests_started_total().get();
+
+        assert!(
+            crate::routing_attempt::generate(&router, Context::new(request()))
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            router.request_metrics.requests_started_total().get(),
+            started_before + 1
+        );
 
         drop(router);
         runtime.shutdown();
@@ -1241,11 +1283,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(selection.worker.worker_id, 8);
-        assert_eq!(
-            selection.fallback_worker_ids,
-            Some(HashSet::from([8])),
-            "transport fallback must stay inside the post-migration candidate set"
-        );
         router.chooser.free(retry_request.id()).await.unwrap();
         drop(operation);
 

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -13,7 +13,7 @@ use dynamo_runtime::{
     error::DynamoError,
     pipeline::{
         AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
-        ResponseStream, SingleIn, async_trait,
+        ResolvedRoute, ResponseStream, RouteFallback, SingleIn, async_trait,
     },
     protocols::annotated::Annotated,
 };
@@ -134,6 +134,7 @@ where
     selection: WorkerSelection,
     guard: Option<RequestGuard<Sel>>,
     exact: bool,
+    route: Option<ResolvedRoute>,
 }
 
 impl<Sel> KvPushRouter<Sel>
@@ -372,127 +373,6 @@ where
         Ok(guard)
     }
 
-    async fn dispatch_selection<M, F>(
-        &self,
-        mut request: SingleIn<PreprocessedRequest>,
-        selection: WorkerSelection,
-        mut guard: RequestGuard<Sel>,
-        exact: bool,
-        prepare: F,
-    ) -> Result<(M, AffinityTarget, ManyOut<Annotated<LLMEngineOutput>>), Error>
-    where
-        M: Send,
-        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
-    {
-        let context_id = request.context().id().to_string();
-        let request_context = request.context().clone();
-        let phase = request
-            .tracker
-            .as_ref()
-            .map(|tracker| tracker.phase())
-            .unwrap_or(RequestPhase::Aggregated);
-        let phase_label = phase.to_string();
-        guard.start_dispatch(&phase_label);
-        self.warn_if_output_replay_annotation_ignored(&request, &selection);
-
-        request.routing_mut().dp_rank = Some(selection.worker.dp_rank);
-        let _ = request
-            .extra_args
-            .as_mut()
-            .and_then(serde_json::Value::as_object_mut)
-            .and_then(|args| args.get_mut("kv_transfer_params"))
-            .and_then(serde_json::Value::as_object_mut)
-            .and_then(|params| params.remove("router_hint"));
-        if let Some(router_hint) = selection.router_hint.as_ref()
-            && let Err(error) = request.attach_router_hint(router_hint)
-        {
-            tracing::warn!(
-                request_id = %context_id,
-                worker_id = selection.worker.worker_id,
-                error = %error,
-                "Failed to attach router_hint to backend request"
-            );
-        }
-        let selected_target = route_target(selection.worker);
-        let metadata = match prepare(&mut request, selected_target) {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                guard.abort().await;
-                return Err(error);
-            }
-        };
-        let (backend_input, context) = request.into_parts();
-        let updated_request = context.map(|_| backend_input);
-        guard.record_prefill_start();
-
-        let dispatch = async {
-            if exact {
-                self.inner
-                    .dispatch_exact(updated_request, selection.worker.worker_id)
-                    .await
-                    .map(|stream| (selection.worker.worker_id, stream))
-            } else {
-                self.inner
-                    .direct_within_prepared(
-                        updated_request,
-                        selection.worker.worker_id,
-                        selection.fallback_worker_ids.as_ref(),
-                        |request, worker_id| {
-                            if worker_id != selection.worker.worker_id {
-                                request.routing_mut().dp_rank = None;
-                            }
-                            Ok(worker_id)
-                        },
-                    )
-                    .await
-            }
-        };
-        let dispatch_result = cancel_on_stop(
-            request_context.as_ref(),
-            dispatch.instrument(tracing::info_span!(
-                "kv_router.route_request",
-                request_id = %context_id,
-                worker_id = selection.worker.worker_id,
-                dp_rank = selection.worker.dp_rank,
-                overlap_blocks = selection.overlap_amount,
-                phase = ?phase,
-            )),
-        )
-        .await
-        .and_then(|result| result);
-        let (resolved_worker_id, response_stream) = match dispatch_result {
-            Ok(result) => result,
-            Err(error) => {
-                let typed_error = error
-                    .chain()
-                    .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned());
-                guard.record_migration_failure(typed_error);
-                guard.abort().await;
-                return Err(error);
-            }
-        };
-
-        let resolved_target = if resolved_worker_id == selection.worker.worker_id {
-            route_target(selection.worker)
-        } else {
-            guard.record_resolved_worker(resolved_worker_id, None);
-            AffinityTarget::new(resolved_worker_id, None)
-        };
-
-        guard.mark_dispatched();
-        let stream_context = response_stream.context();
-        let wrapped_stream = Box::pin(monitor_response_stream(
-            response_stream,
-            stream_context.clone(),
-            guard,
-        ));
-        Ok((
-            metadata,
-            resolved_target,
-            ResponseStream::new(wrapped_stream, stream_context),
-        ))
-    }
-
     fn warn_if_output_replay_annotation_ignored(
         &self,
         request: &SingleIn<PreprocessedRequest>,
@@ -573,6 +453,7 @@ where
             selection,
             guard,
             exact: pinned_target.is_some(),
+            route: None,
         })
     }
 
@@ -600,76 +481,160 @@ where
             .observe(request.token_ids.len() as f64);
     }
 
-    async fn dispatch<M, F>(
+    async fn begin_dispatch(
         &self,
-        mut request: SingleIn<PreprocessedRequest>,
-        attempt: Self::Attempt,
+        request: &mut SingleIn<PreprocessedRequest>,
+        attempt: &mut Self::Attempt,
         kind: AttemptKind,
-        prepare: F,
-    ) -> Result<(M, AffinityTarget, ManyOut<Annotated<LLMEngineOutput>>), Error>
-    where
-        M: Send,
-        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
-    {
-        let mut attempt = attempt;
+    ) -> Result<AffinityTarget, Error> {
         let exact = kind == AttemptKind::Prefill || attempt.exact;
-        // Migration-disabled requests keep the original single transport lookup at dispatch.
-        // Prevalidation exists only to atomically acquire a replacement booking before a
-        // migration attempt releases the failed one.
-        if !exact && request.migration_state.is_some() {
-            loop {
-                let selected_worker = attempt.selection.worker.worker_id;
-                debug_assert!(
-                    attempt
-                        .selection
-                        .fallback_worker_ids
-                        .as_ref()
-                        .is_none_or(|workers| workers.contains(&selected_worker))
-                );
-                let Err(error) = self
-                    .inner
-                    .validate_exact_target(route_target(attempt.selection.worker))
-                else {
-                    break;
-                };
+        let phase = request
+            .tracker
+            .as_ref()
+            .map(|tracker| tracker.phase())
+            .unwrap_or(RequestPhase::Aggregated);
+        let route = loop {
+            let selected_worker = attempt.selection.worker.worker_id;
+            match self
+                .inner
+                .resolve_route(selected_worker, RouteFallback::Deny)
+            {
+                Ok(route) => break route,
+                Err(error) if exact => return Err(error),
+                Err(error) => {
+                    let typed_error = error
+                        .chain()
+                        .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned());
+                    request
+                        .migration_state
+                        .get_or_insert_with(Default::default)
+                        .record_failure(selected_worker, typed_error);
+                    if let Some(mut guard) = attempt.guard.take() {
+                        guard.abort().await;
+                    }
+                    *attempt = self
+                        .select(request, phase, SelectionIntent::Committed, None)
+                        .await?;
+                }
+            }
+        };
 
+        let context_id = request.context().id().to_string();
+        let phase_label = phase.to_string();
+        attempt
+            .guard
+            .as_mut()
+            .expect("committed KV attempt has a request guard")
+            .start_dispatch(&phase_label);
+        self.warn_if_output_replay_annotation_ignored(request, &attempt.selection);
+        request.routing_mut().dp_rank = Some(attempt.selection.worker.dp_rank);
+        let _ = request
+            .extra_args
+            .as_mut()
+            .and_then(serde_json::Value::as_object_mut)
+            .and_then(|args| args.get_mut("kv_transfer_params"))
+            .and_then(serde_json::Value::as_object_mut)
+            .and_then(|params| params.remove("router_hint"));
+        if let Some(router_hint) = attempt.selection.router_hint.as_ref()
+            && let Err(error) = request.attach_router_hint(router_hint)
+        {
+            tracing::warn!(
+                request_id = %context_id,
+                worker_id = attempt.selection.worker.worker_id,
+                error = %error,
+                "Failed to attach router_hint to backend request"
+            );
+        }
+        let target = route_target(attempt.selection.worker);
+        attempt.route = Some(route);
+        Ok(target)
+    }
+
+    fn after_prepare(
+        &self,
+        _request: &mut SingleIn<PreprocessedRequest>,
+        attempt: &mut Self::Attempt,
+    ) {
+        attempt
+            .guard
+            .as_mut()
+            .expect("prepared KV attempt has a request guard")
+            .record_prefill_start();
+    }
+
+    async fn dispatch_prepared(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+        attempt: &mut Self::Attempt,
+        _kind: AttemptKind,
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+        let context_id = request.context().id().to_string();
+        let request_context = request.context().clone();
+        let phase = request
+            .tracker
+            .as_ref()
+            .map(|tracker| tracker.phase())
+            .unwrap_or(RequestPhase::Aggregated);
+        let worker = attempt.selection.worker;
+        let overlap_blocks = attempt.selection.overlap_amount;
+        let route = attempt
+            .route
+            .take()
+            .expect("prepared KV attempt has a resolved route");
+        let (backend_input, context) = request.into_parts();
+        let updated_request = context.map(|_| backend_input);
+        let dispatch = self.inner.dispatch_resolved(updated_request, route);
+        let result = cancel_on_stop(
+            request_context.as_ref(),
+            dispatch.instrument(tracing::info_span!(
+                "kv_router.route_request",
+                request_id = %context_id,
+                worker_id = worker.worker_id,
+                dp_rank = worker.dp_rank,
+                overlap_blocks,
+                phase = ?phase,
+            )),
+        )
+        .await
+        .and_then(|result| result);
+        match result {
+            Ok(stream) => Ok(stream),
+            Err(error) => {
                 let typed_error = error
                     .chain()
                     .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned());
-                request
-                    .migration_state
-                    .get_or_insert_with(Default::default)
-                    .record_failure(selected_worker, typed_error);
-                let phase = request
-                    .tracker
-                    .as_ref()
-                    .map(|tracker| tracker.phase())
-                    .unwrap_or(RequestPhase::Aggregated);
-                let replacement = self
-                    .select(&request, phase, SelectionIntent::Committed, None)
-                    .await;
-                // The scheduler owns both bookings. Acquire the replacement before
-                // conditionally freeing the old worker so there is no unbooked gap.
-                attempt
-                    .guard
-                    .as_mut()
-                    .expect("committed KV attempt has a request guard")
-                    .abort()
-                    .await;
-                attempt = replacement?;
+                if let Some(guard) = attempt.guard.as_mut() {
+                    guard.record_migration_failure(typed_error);
+                }
+                Err(error)
             }
         }
+    }
 
-        let KvAttempt {
-            selection,
+    async fn abort(&self, attempt: &mut Self::Attempt) {
+        if let Some(mut guard) = attempt.guard.take() {
+            guard.abort().await;
+        }
+    }
+
+    fn finish_dispatch(
+        &self,
+        mut attempt: Self::Attempt,
+        _target: AffinityTarget,
+        stream: ManyOut<Annotated<LLMEngineOutput>>,
+    ) -> ManyOut<Annotated<LLMEngineOutput>> {
+        let mut guard = attempt
+            .guard
+            .take()
+            .expect("dispatched KV attempt has a request guard");
+        guard.mark_dispatched();
+        let stream_context = stream.context();
+        let wrapped = Box::pin(monitor_response_stream(
+            stream,
+            stream_context.clone(),
             guard,
-            exact: _,
-        } = attempt;
-        let guard = guard.expect("committed KV attempt has a request guard");
-        let (metadata, target, stream) = self
-            .dispatch_selection(request, selection, guard, true, prepare)
-            .await?;
-        Ok((metadata, target, stream))
+        ));
+        ResponseStream::new(wrapped, stream_context)
     }
 }
 
@@ -1061,28 +1026,12 @@ mod tests {
         failed_input.migration_state = Some(Default::default());
         let migration_state = failed_input.migration_state.clone().unwrap();
         let failed_request = Context::new(failed_input);
-        let (mut failed_selection, _) = router
-            .select_with_affinity(&failed_request, RequestPhase::Aggregated, false)
-            .await
-            .unwrap();
-        let failed_worker = failed_selection.worker.worker_id;
-        let failed_dispatch_guard = router
-            .track_selection(&failed_request, &mut failed_selection, false)
-            .await
-            .unwrap();
         assert!(
-            router
-                .dispatch_selection(
-                    failed_request,
-                    failed_selection,
-                    failed_dispatch_guard,
-                    false,
-                    |_, _| Ok(()),
-                )
+            crate::routing_attempt::generate(&router, failed_request)
                 .await
                 .is_err()
         );
-        assert_eq!(migration_state.excluded_worker_ids(), vec![failed_worker]);
+        assert_eq!(migration_state.excluded_worker_ids().len(), 1);
         assert_eq!(metrics.requests_started_total().get(), started_before + 2);
         assert_eq!(metrics.requests_total.get(), completed_before);
 
@@ -1382,9 +1331,18 @@ mod tests {
         runtime.shutdown();
     }
 
-    #[derive(Default)]
     struct RejectFirstDispatch {
         attempts: Mutex<Vec<(u64, Vec<u64>)>>,
+        reject_next: AtomicBool,
+    }
+
+    impl Default for RejectFirstDispatch {
+        fn default() -> Self {
+            Self {
+                attempts: Mutex::new(Vec::new()),
+                reject_next: AtomicBool::new(true),
+            }
+        }
     }
 
     #[async_trait]
@@ -1401,13 +1359,12 @@ mod tests {
                 .as_ref()
                 .map(|state| state.excluded_worker_ids())
                 .unwrap_or_default();
-            let attempt = {
+            {
                 let mut attempts = self.attempts.lock().unwrap();
                 attempts.push((worker_id, excluded_worker_ids));
-                attempts.len()
-            };
+            }
 
-            if attempt == 1 {
+            if self.reject_next.swap(false, Ordering::AcqRel) {
                 let output = Annotated {
                     data: None,
                     id: None,
@@ -1546,6 +1503,67 @@ mod tests {
                 .unwrap();
         let chooser = Arc::new(chooser);
         let kv_router = Arc::new(KvPushRouter::new(push_router, chooser.clone(), None).unwrap());
+
+        let mut stale_input = request();
+        stale_input.migration_state = Some(Default::default());
+        let stale_request = Context::new(stale_input);
+        let stale_attempt = kv_router
+            .select(
+                &stale_request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Committed,
+                None,
+            )
+            .await
+            .unwrap();
+        let stale_worker = stale_attempt.selection.worker.worker_id;
+        let stale_endpoint = if first_worker_drt.connection_id() == stale_worker {
+            first_worker_endpoint.clone()
+        } else {
+            assert_eq!(second_worker_drt.connection_id(), stale_worker);
+            second_worker_endpoint.clone()
+        };
+        stale_endpoint.unregister_endpoint_instance().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while client.instance_ids().contains(&stale_worker) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("removed worker must leave discovery");
+
+        // This attempt exercises the pre-dispatch worker-loss path: the old scheduler booking
+        // must be released before the same request ID is admitted on its replacement.
+        dispatch.reject_next.store(false, Ordering::Release);
+        let ((), replacement, replacement_stream) = crate::routing_attempt::dispatch_attempt(
+            kv_router.as_ref(),
+            stale_request,
+            stale_attempt,
+            AttemptKind::Generate,
+            |_, _| Ok(()),
+        )
+        .await
+        .unwrap();
+        assert_ne!(replacement.worker_id, stale_worker);
+        let replacement_responses = replacement_stream.collect::<Vec<_>>().await;
+        assert_eq!(replacement_responses.len(), 1);
+        assert!(replacement_responses[0].error.is_none());
+        let prevalidation_attempts = dispatch.attempts.lock().unwrap().clone();
+        assert_eq!(prevalidation_attempts.len(), 1);
+        assert_eq!(prevalidation_attempts[0].0, replacement.worker_id);
+        assert_eq!(prevalidation_attempts[0].1, vec![stale_worker]);
+        dispatch.attempts.lock().unwrap().clear();
+        dispatch.reject_next.store(true, Ordering::Release);
+
+        stale_endpoint.register_endpoint_instance().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while client.instance_ids().len() != 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("restored worker must return to discovery");
+
         let next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
             kv_router;
         let migration = Migration::new(1, None, "test".to_string(), Arc::new(Metrics::new()));

--- a/lib/llm/src/kv_router/push_router/request_guard.rs
+++ b/lib/llm/src/kv_router/push_router/request_guard.rs
@@ -344,6 +344,12 @@ where
         self.observability.record_prefill_start();
     }
 
+    pub(super) fn record_resolved_worker(&self, worker_id: u64, dp_rank: Option<u32>) {
+        if let Some(tracker) = self.observability.tracker.as_ref() {
+            tracker.record_worker(worker_id, dp_rank, self.cleanup.chooser.worker_type());
+        }
+    }
+
     pub(super) fn mark_dispatched(&mut self) {
         self.observability.mark_dispatched();
     }

--- a/lib/llm/src/kv_router/push_router/request_guard.rs
+++ b/lib/llm/src/kv_router/push_router/request_guard.rs
@@ -297,6 +297,7 @@ where
         worker: WorkerWithDpRank,
         request: &PreprocessedRequest,
         scheduler_tracked: bool,
+        count_started: bool,
     ) -> Self {
         // Snapshot request-scoped inputs now so the guard can outlive the
         // PreprocessedRequest after it is moved into backend dispatch.
@@ -308,7 +309,7 @@ where
             .and_then(|routing| routing.expected_output_tokens);
         let track_output_blocks =
             scheduler_tracked && chooser.kv_router_config().router_track_output_blocks;
-        if scheduler_tracked {
+        if scheduler_tracked && count_started {
             request_metrics.requests_started_total().inc();
         }
 

--- a/lib/llm/src/kv_router/push_router/request_guard.rs
+++ b/lib/llm/src/kv_router/push_router/request_guard.rs
@@ -344,12 +344,6 @@ where
         self.observability.record_prefill_start();
     }
 
-    pub(super) fn record_resolved_worker(&self, worker_id: u64, dp_rank: Option<u32>) {
-        if let Some(tracker) = self.observability.tracker.as_ref() {
-            tracker.record_worker(worker_id, dp_rank, self.cleanup.chooser.worker_type());
-        }
-    }
-
     pub(super) fn mark_dispatched(&mut self) {
         self.observability.mark_dispatched();
     }

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -33,6 +33,7 @@ pub(super) struct WorkerSelection {
     pub(super) cached_tokens: usize,
     pub(super) routing_hashes: Option<RoutingDecisionHashes>,
     pub(super) router_hint: Option<RouterHint>,
+    pub(super) fallback_worker_ids: Option<HashSet<WorkerId>>,
 }
 
 #[derive(Clone, Copy)]
@@ -126,6 +127,7 @@ where
                 cached_tokens,
                 routing_hashes,
                 router_hint,
+                fallback_worker_ids: None,
             }),
             FindBestMatchOutcome::QueueRejected { rejection } => Err(rejection.into()),
         }
@@ -162,7 +164,11 @@ where
             .as_ref()
             .map(|state| state.excluded_worker_ids())
             .unwrap_or_default();
-        if explicit_pin.is_none() && !migration_excluded_worker_ids.is_empty() {
+        if explicit_pin.is_none()
+            && (allowed_worker_ids.is_some()
+                || !migration_excluded_worker_ids.is_empty()
+                || routing_constraints.has_hard_constraints())
+        {
             let workers = self.chooser.workers_with_configs.borrow();
             let eligible =
                 allowed_worker_ids.get_or_insert_with(|| workers.keys().copied().collect());
@@ -192,7 +198,8 @@ where
             merge_affinity_pin(explicit_pin, affinity_pin)
         else {
             let _nvtx_kv = dynamo_nvtx_range!("route.kv_match");
-            let selection = self
+            let fallback_worker_ids = allowed_worker_ids.clone();
+            let mut selection = self
                 .select_best_match(BestMatchArgs {
                     context_id,
                     routing_parts,
@@ -211,6 +218,7 @@ where
                     routing_constraints: routing_constraints.clone(),
                 })
                 .await?;
+            selection.fallback_worker_ids = fallback_worker_ids;
 
             if !is_query_only {
                 let total_blocks = routing_parts

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -33,7 +33,6 @@ pub(super) struct WorkerSelection {
     pub(super) cached_tokens: usize,
     pub(super) routing_hashes: Option<RoutingDecisionHashes>,
     pub(super) router_hint: Option<RouterHint>,
-    pub(super) fallback_worker_ids: Option<HashSet<WorkerId>>,
 }
 
 #[derive(Clone, Copy)]
@@ -127,7 +126,6 @@ where
                 cached_tokens,
                 routing_hashes,
                 router_hint,
-                fallback_worker_ids: None,
             }),
             FindBestMatchOutcome::QueueRejected { rejection } => Err(rejection.into()),
         }
@@ -198,8 +196,7 @@ where
             merge_affinity_pin(explicit_pin, affinity_pin)
         else {
             let _nvtx_kv = dynamo_nvtx_range!("route.kv_match");
-            let fallback_worker_ids = allowed_worker_ids.clone();
-            let mut selection = self
+            let selection = self
                 .select_best_match(BestMatchArgs {
                     context_id,
                     routing_parts,
@@ -218,8 +215,6 @@ where
                     routing_constraints: routing_constraints.clone(),
                 })
                 .await?;
-            selection.fallback_worker_ids = fallback_worker_ids;
-
             if !is_query_only {
                 let total_blocks = routing_parts
                     .token_ids

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -36,6 +36,7 @@ pub mod reasoning_field;
 pub mod recorder;
 pub mod request_template;
 pub mod request_trace;
+mod routing_attempt;
 pub mod session_affinity;
 pub mod telemetry;
 pub use dynamo_tokenizers as tokenizers;

--- a/lib/llm/src/lora/filtered_router.rs
+++ b/lib/llm/src/lora/filtered_router.rs
@@ -34,9 +34,19 @@ use crate::protocols::common::timing::{
 };
 
 /// Decrements the [`LoadEstimator`] counter for a LoRA when dropped.
-struct LoadGuard {
+pub(crate) struct LoadGuard {
     estimator: Arc<LoadEstimator>,
     lora_name: String,
+}
+
+impl LoadGuard {
+    pub(crate) fn new(estimator: Arc<LoadEstimator>, lora_name: String) -> Self {
+        estimator.increment_load(&lora_name);
+        Self {
+            estimator,
+            lora_name,
+        }
+    }
 }
 
 impl Drop for LoadGuard {
@@ -49,6 +59,16 @@ impl Drop for LoadGuard {
 struct LoadTrackingStream<S> {
     inner: S,
     _guard: LoadGuard,
+}
+
+pub(crate) fn track_response(
+    stream: ManyOut<Annotated<LLMEngineOutput>>,
+    guard: LoadGuard,
+) -> ManyOut<Annotated<LLMEngineOutput>> {
+    Box::pin(LoadTrackingStream {
+        inner: stream,
+        _guard: guard,
+    })
 }
 
 impl<S> std::fmt::Debug for LoadTrackingStream<S> {
@@ -189,11 +209,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             return Ok(stream);
         };
 
-        self.load_estimator.increment_load(&lora_name);
-        let guard = LoadGuard {
-            estimator: self.load_estimator.clone(),
-            lora_name: lora_name.clone(),
-        };
+        let guard = LoadGuard::new(self.load_estimator.clone(), lora_name.clone());
 
         // Stage 1: narrow to the LoRA's replica set against the FULL routable set, so the
         // intended replicas are always represented even when they are currently busy.
@@ -266,10 +282,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             )
             .await?;
         Self::record_worker(tracker.as_deref(), worker_id);
-        let tracking = LoadTrackingStream {
-            inner: response_stream,
-            _guard: guard,
-        };
-        Ok(Box::pin(tracking))
+        Ok(track_response(response_stream, guard))
     }
 }

--- a/lib/llm/src/lora/filtered_router.rs
+++ b/lib/llm/src/lora/filtered_router.rs
@@ -17,9 +17,7 @@ use futures::Stream;
 use rand::Rng;
 
 use dynamo_runtime::{
-    engine::{
-        AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, AsyncEngineStream, Data,
-    },
+    engine::{AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, AsyncEngineStream},
     error::{DynamoError, ErrorType},
     pipeline::{Error, ManyOut, RouterMode, SingleIn, network::egress::push_router::PushRouter},
     protocols::annotated::Annotated,
@@ -58,7 +56,7 @@ impl Drop for LoadGuard {
 /// Thin wrapper around the inner response stream that holds a [`LoadGuard`].
 struct LoadTrackingStream<S> {
     inner: S,
-    _guard: LoadGuard,
+    guard: Option<LoadGuard>,
 }
 
 pub(crate) fn track_response(
@@ -67,26 +65,35 @@ pub(crate) fn track_response(
 ) -> ManyOut<Annotated<LLMEngineOutput>> {
     Box::pin(LoadTrackingStream {
         inner: stream,
-        _guard: guard,
+        guard: Some(guard),
     })
 }
 
 impl<S> std::fmt::Debug for LoadTrackingStream<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LoadTrackingStream")
-            .field("lora", &self._guard.lora_name)
+            .field(
+                "lora",
+                &self.guard.as_ref().map(|guard| guard.lora_name.as_str()),
+            )
             .finish()
     }
 }
 
 impl<S> Stream for LoadTrackingStream<S>
 where
-    S: Stream + Unpin,
+    S: Stream<Item = Annotated<LLMEngineOutput>> + Unpin,
 {
-    type Item = S::Item;
+    type Item = Annotated<LLMEngineOutput>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.inner).poll_next(cx)
+        let poll = Pin::new(&mut self.inner).poll_next(cx);
+        if matches!(&poll, Poll::Ready(None))
+            || matches!(&poll, Poll::Ready(Some(item)) if item.error.is_some())
+        {
+            self.guard.take();
+        }
+        poll
     }
 }
 
@@ -99,8 +106,8 @@ where
     }
 }
 
-impl<T: Data, S> AsyncEngineStream<T> for LoadTrackingStream<S> where
-    S: Stream<Item = T> + AsyncEngineContextProvider + Send + Unpin
+impl<S> AsyncEngineStream<Annotated<LLMEngineOutput>> for LoadTrackingStream<S> where
+    S: Stream<Item = Annotated<LLMEngineOutput>> + AsyncEngineContextProvider + Send + Unpin
 {
 }
 
@@ -283,5 +290,30 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             .await?;
         Self::record_worker(tracker.as_deref(), worker_id);
         Ok(track_response(response_stream, guard))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use dynamo_runtime::pipeline::{ResponseStream, context::Controller};
+    use futures::{StreamExt, stream};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn lora_load_releases_before_stream_error_is_observable() {
+        let estimator = Arc::new(LoadEstimator::new());
+        let guard = LoadGuard::new(estimator.clone(), "adapter".to_string());
+        let source = ResponseStream::new(
+            Box::pin(stream::iter([Annotated::from_error("backend failed")])),
+            Arc::new(Controller::default()),
+        );
+        let mut tracked = track_response(source, guard);
+        assert_eq!(estimator.get_inflight_counts().get("adapter"), Some(&1));
+
+        assert!(tracked.next().await.unwrap().error.is_some());
+        assert!(estimator.get_inflight_counts().is_empty());
     }
 }

--- a/lib/llm/src/routing_attempt.rs
+++ b/lib/llm/src/routing_attempt.rs
@@ -208,7 +208,9 @@ pub(crate) async fn dispatch_attempt<B, M, F>(
     backend: &B,
     mut request: SingleIn<PreprocessedRequest>,
     mut attempt: B::Attempt,
+    phase: RequestPhase,
     kind: AttemptKind,
+    operation: &mut Option<AffinityAcquire>,
     prepare: F,
 ) -> Result<(M, AffinityTarget, ManyOut<LlmResponse>), Error>
 where
@@ -223,7 +225,54 @@ where
         Ok(target) => target,
         Err(error) => {
             backend.abort(&mut attempt).await;
-            return Err(error);
+            let retry_bound_affinity = !is_cancelled(&error)
+                && operation
+                    .as_ref()
+                    .and_then(AffinityAcquire::target)
+                    .is_some()
+                && explicit_target(&request, phase)?.is_none();
+            if !retry_bound_affinity {
+                return Err(error);
+            }
+
+            operation
+                .take()
+                .expect("bound affinity retry has an acquisition")
+                .invalidate();
+            let affinity = backend
+                .affinity()
+                .expect("bound affinity retry has a coordinator");
+            let session_id =
+                affinity_id(&request)?.expect("bound affinity retry has a validated session ID");
+            let request_context = request.context();
+            let retry = affinity
+                .acquire_with_context(&session_id, None, request_context.as_ref())
+                .await?;
+            let retry_target = retry.target();
+            attempt = match backend
+                .select(&request, phase, SelectionIntent::Committed, retry_target)
+                .await
+            {
+                Ok(attempt) => attempt,
+                Err(error) => {
+                    retry.invalidate();
+                    return Err(error);
+                }
+            };
+            match backend
+                .begin_dispatch(&mut request, &mut attempt, kind)
+                .await
+            {
+                Ok(target) => {
+                    *operation = Some(retry);
+                    target
+                }
+                Err(error) => {
+                    backend.abort(&mut attempt).await;
+                    retry.invalidate();
+                    return Err(error);
+                }
+            }
         }
     };
     let metadata = match prepare(&mut request, target) {
@@ -268,9 +317,15 @@ pub(crate) async fn generate<B: AttemptBackend>(
     }
 
     drop(route_guard);
-    let dispatch = dispatch_attempt(backend, request, attempt, AttemptKind::Generate, |_, _| {
-        Ok(())
-    })
+    let dispatch = dispatch_attempt(
+        backend,
+        request,
+        attempt,
+        phase,
+        AttemptKind::Generate,
+        &mut operation,
+        |_, _| Ok(()),
+    )
     .await;
     let ((), target, stream) = match dispatch {
         Ok(result) => result,
@@ -301,7 +356,16 @@ where
     let (attempt, mut operation) =
         select_with_affinity(backend, &request, phase, SelectionIntent::Committed).await?;
     drop(route_guard);
-    let dispatch = dispatch_attempt(backend, request, attempt, AttemptKind::Prefill, prepare).await;
+    let dispatch = dispatch_attempt(
+        backend,
+        request,
+        attempt,
+        phase,
+        AttemptKind::Prefill,
+        &mut operation,
+        prepare,
+    )
+    .await;
     let (metadata, target, stream) = match dispatch {
         Ok(result) => result,
         Err(error) => {
@@ -417,6 +481,87 @@ mod tests {
         }
     }
 
+    struct StaleAffinityBackend {
+        affinity: AffinityCoordinator,
+        selections: Mutex<Vec<AffinityTarget>>,
+    }
+
+    impl AttemptBackend for StaleAffinityBackend {
+        type Attempt = AffinityTarget;
+
+        fn affinity(&self) -> Option<&AffinityCoordinator> {
+            Some(&self.affinity)
+        }
+
+        fn direct(&self) -> bool {
+            false
+        }
+
+        async fn select(
+            &self,
+            _request: &SingleIn<PreprocessedRequest>,
+            _phase: RequestPhase,
+            _intent: SelectionIntent,
+            pinned_target: Option<AffinityTarget>,
+        ) -> Result<Self::Attempt, Error> {
+            let target = pinned_target.unwrap_or_else(|| AffinityTarget::new(2, None));
+            self.selections.lock().unwrap().push(target);
+            Ok(target)
+        }
+
+        fn observe_advisory(
+            &self,
+            _request: &SingleIn<PreprocessedRequest>,
+            _attempt: &Self::Attempt,
+        ) {
+        }
+
+        async fn begin_dispatch(
+            &self,
+            _request: &mut SingleIn<PreprocessedRequest>,
+            attempt: &mut Self::Attempt,
+            _kind: AttemptKind,
+        ) -> Result<AffinityTarget, Error> {
+            if attempt.worker_id == 1 {
+                anyhow::bail!("bound worker disappeared before dispatch");
+            }
+            Ok(*attempt)
+        }
+
+        fn after_prepare(
+            &self,
+            _request: &mut SingleIn<PreprocessedRequest>,
+            _attempt: &mut Self::Attempt,
+        ) {
+        }
+
+        async fn dispatch_prepared(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+            _attempt: &mut Self::Attempt,
+            _kind: AttemptKind,
+        ) -> Result<ManyOut<LlmResponse>, Error> {
+            let context = request.context().clone();
+            Ok(ResponseStream::new(
+                Box::pin(stream::iter([Annotated::from_data(
+                    LLMEngineOutput::default(),
+                )])),
+                context,
+            ))
+        }
+
+        async fn abort(&self, _attempt: &mut Self::Attempt) {}
+
+        fn finish_dispatch(
+            &self,
+            _attempt: Self::Attempt,
+            _target: AffinityTarget,
+            stream: ManyOut<LlmResponse>,
+        ) -> ManyOut<LlmResponse> {
+            stream
+        }
+    }
+
     fn query_request() -> SingleIn<PreprocessedRequest> {
         Context::new(
             PreprocessedRequest::builder()
@@ -456,6 +601,41 @@ mod tests {
         assert_eq!(
             backend.intents.into_inner().unwrap(),
             vec![SelectionIntent::Advisory]
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_bound_target_rebinds_before_request_preparation() {
+        use std::time::Duration;
+
+        use crate::protocols::common::extensions::{
+            SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId,
+        };
+
+        let affinity = AffinityCoordinator::new(Duration::from_secs(10)).unwrap();
+        let session_id = SessionAffinityId::new("stale-bound-target");
+        let AffinityAcquire::Initialize(initializer) =
+            affinity.acquire(&session_id, None).await.unwrap()
+        else {
+            panic!("first request must initialize affinity");
+        };
+        drop(initializer.commit(AffinityTarget::new(1, None)).unwrap());
+        let backend = StaleAffinityBackend {
+            affinity: affinity.clone(),
+            selections: Mutex::new(Vec::new()),
+        };
+        let mut request = query_request();
+        request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_id.clone());
+
+        let _response = generate(&backend, request).await.unwrap();
+
+        assert_eq!(
+            backend.selections.into_inner().unwrap(),
+            vec![AffinityTarget::new(1, None), AffinityTarget::new(2, None)]
+        );
+        assert_eq!(
+            affinity.query_target(&session_id, None).unwrap(),
+            Some(AffinityTarget::new(2, None))
         );
     }
 }

--- a/lib/llm/src/routing_attempt.rs
+++ b/lib/llm/src/routing_attempt.rs
@@ -45,6 +45,10 @@ pub(crate) trait AttemptBackend: Send + Sync {
         false
     }
 
+    /// Backend-owned state for one selection.
+    ///
+    /// Advisory attempts must not retain admission state because the advisory path drops them
+    /// without calling [`Self::abort`].
     type Attempt: Send;
 
     fn affinity(&self) -> Option<&AffinityCoordinator>;
@@ -636,6 +640,24 @@ mod tests {
         assert_eq!(
             affinity.query_target(&session_id, None).unwrap(),
             Some(AffinityTarget::new(2, None))
+        );
+    }
+
+    #[tokio::test]
+    async fn query_marked_prefill_uses_committed_admission() {
+        let backend = TestBackend::new(true);
+        let (_metadata, mut response) =
+            select_and_dispatch_prefill(&backend, query_request(), |_, _| Ok("prepared"))
+                .await
+                .unwrap();
+
+        assert_eq!(
+            response.next().await.unwrap().data.unwrap().token_ids,
+            vec![9]
+        );
+        assert_eq!(
+            backend.intents.into_inner().unwrap(),
+            vec![SelectionIntent::Committed]
         );
     }
 }

--- a/lib/llm/src/routing_attempt.rs
+++ b/lib/llm/src/routing_attempt.rs
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! One host-owned orchestration path for an LLM routing attempt.
+//!
+//! Worker choice remains backend-owned. This module owns the shared intent,
+//! affinity, dispatch, and error-observation sequence around that choice.
+
+use dynamo_runtime::{
+    engine::AsyncEngineContextProvider,
+    error::{ErrorType, match_error_chain},
+    metrics::frontend_perf::{STAGE_ROUTE, StageGuard},
+    pipeline::{Error, ManyOut, ResponseStream, SingleIn},
+    protocols::annotated::Annotated,
+};
+use futures::stream;
+
+use crate::{
+    preprocessor::PreprocessedRequest,
+    protocols::common::{
+        llm_backend::LLMEngineOutput,
+        timing::{RequestPhase, RoutingData},
+    },
+    session_affinity::{
+        AffinityAcquire, AffinityCoordinator, AffinityTarget, LlmResponse, affinity_id,
+        explicit_target, invalid_argument,
+    },
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SelectionIntent {
+    Advisory,
+    Committed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AttemptKind {
+    Generate,
+    Prefill,
+}
+
+pub(crate) trait AttemptBackend: Send + Sync {
+    type Attempt: Send;
+
+    fn affinity(&self) -> Option<&AffinityCoordinator>;
+
+    fn direct(&self) -> bool;
+
+    async fn select(
+        &self,
+        request: &SingleIn<PreprocessedRequest>,
+        phase: RequestPhase,
+        intent: SelectionIntent,
+        pinned_target: Option<AffinityTarget>,
+    ) -> Result<Self::Attempt, Error>;
+
+    fn observe_advisory(&self, request: &SingleIn<PreprocessedRequest>, attempt: &Self::Attempt);
+
+    async fn dispatch<M, F>(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+        attempt: Self::Attempt,
+        kind: AttemptKind,
+        prepare: F,
+    ) -> Result<(M, AffinityTarget, ManyOut<LlmResponse>), Error>
+    where
+        M: Send,
+        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send;
+}
+
+fn phase(request: &PreprocessedRequest) -> RequestPhase {
+    request
+        .tracker
+        .as_ref()
+        .map(|tracker| tracker.phase())
+        .unwrap_or(RequestPhase::Aggregated)
+}
+
+fn is_cancelled(error: &Error) -> bool {
+    match_error_chain(error.as_ref(), &[ErrorType::Cancelled], &[])
+}
+
+fn invalidate_on_non_cancellation(operation: &mut Option<AffinityAcquire>, error: &Error) {
+    if is_cancelled(error) {
+        return;
+    }
+    if let Some(operation) = operation.take() {
+        operation.invalidate();
+    }
+}
+
+fn direct_target<B: AttemptBackend>(
+    backend: &B,
+    explicit: Option<AffinityTarget>,
+    phase: RequestPhase,
+) -> Result<Option<AffinityTarget>, Error> {
+    if !backend.direct() {
+        return Ok(explicit);
+    }
+    explicit.map(Some).ok_or_else(|| {
+        invalid_argument(format!(
+            "worker ID required for {phase} request in Direct routing mode"
+        ))
+    })
+}
+
+async fn select_with_affinity<B: AttemptBackend>(
+    backend: &B,
+    request: &SingleIn<PreprocessedRequest>,
+    phase: RequestPhase,
+    intent: SelectionIntent,
+) -> Result<(B::Attempt, Option<AffinityAcquire>), Error> {
+    let explicit = direct_target(backend, explicit_target(request, phase)?, phase)?;
+    let Some(affinity) = backend.affinity() else {
+        return Ok((
+            backend.select(request, phase, intent, explicit).await?,
+            None,
+        ));
+    };
+    let Some(session_id) = affinity_id(request)? else {
+        return Ok((
+            backend.select(request, phase, intent, explicit).await?,
+            None,
+        ));
+    };
+
+    if intent == SelectionIntent::Advisory {
+        let target = affinity.query_target(&session_id, explicit)?.or(explicit);
+        return Ok((backend.select(request, phase, intent, target).await?, None));
+    }
+
+    let request_context = request.context();
+    let operation = affinity
+        .acquire_with_context(&session_id, explicit, request_context.as_ref())
+        .await?;
+    let target = operation.target().or(explicit);
+    match backend.select(request, phase, intent, target).await {
+        Ok(attempt) => Ok((attempt, Some(operation))),
+        Err(error) if is_cancelled(&error) => Err(error),
+        Err(_) if operation.target().is_some() && explicit.is_none() => {
+            operation.invalidate();
+            let retry = affinity
+                .acquire_with_context(&session_id, None, request_context.as_ref())
+                .await?;
+            let retry_target = retry.target();
+            match backend.select(request, phase, intent, retry_target).await {
+                Ok(attempt) => Ok((attempt, Some(retry))),
+                Err(error) => {
+                    retry.invalidate();
+                    Err(error)
+                }
+            }
+        }
+        Err(error) => {
+            operation.invalidate();
+            Err(error)
+        }
+    }
+}
+
+fn advisory_response<B: AttemptBackend>(
+    backend: &B,
+    request: SingleIn<PreprocessedRequest>,
+    attempt: &B::Attempt,
+) -> ManyOut<LlmResponse> {
+    backend.observe_advisory(&request, attempt);
+    let stream_context = request.context().clone();
+    let worker_id = request
+        .tracker
+        .as_ref()
+        .and_then(|tracker| tracker.get_worker_info());
+    let output = LLMEngineOutput {
+        routing_data: Some(RoutingData {
+            worker_id,
+            token_ids: Some(request.token_ids.clone()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let response = Annotated::from_data(output);
+    ResponseStream::new(Box::pin(stream::iter([response])), stream_context)
+}
+
+pub(crate) async fn generate<B: AttemptBackend>(
+    backend: &B,
+    request: SingleIn<PreprocessedRequest>,
+) -> Result<ManyOut<LlmResponse>, Error> {
+    let phase = phase(&request);
+    let intent = if request.get_annotation_value("query_instance_id").is_some() {
+        SelectionIntent::Advisory
+    } else {
+        SelectionIntent::Committed
+    };
+    let phase_label = phase.to_string();
+    let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
+    let (attempt, mut operation) = select_with_affinity(backend, &request, phase, intent).await?;
+    if intent == SelectionIntent::Advisory {
+        return Ok(advisory_response(backend, request, &attempt));
+    }
+
+    drop(route_guard);
+    let dispatch = backend
+        .dispatch(request, attempt, AttemptKind::Generate, |_, _| Ok(()))
+        .await;
+    let ((), target, stream) = match dispatch {
+        Ok(result) => result,
+        Err(error) => {
+            invalidate_on_non_cancellation(&mut operation, &error);
+            return Err(error);
+        }
+    };
+    match operation {
+        Some(operation) => operation.into_stream(target, stream),
+        None => Ok(stream),
+    }
+}
+
+pub(crate) async fn select_and_dispatch_prefill<B, M, F>(
+    backend: &B,
+    request: SingleIn<PreprocessedRequest>,
+    prepare: F,
+) -> Result<(M, ManyOut<LlmResponse>), Error>
+where
+    B: AttemptBackend,
+    M: Send,
+    F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
+{
+    let phase = RequestPhase::Prefill;
+    let phase_label = phase.to_string();
+    let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
+    let (attempt, mut operation) =
+        select_with_affinity(backend, &request, phase, SelectionIntent::Committed).await?;
+    drop(route_guard);
+    let dispatch = backend
+        .dispatch(request, attempt, AttemptKind::Prefill, prepare)
+        .await;
+    let (metadata, target, stream) = match dispatch {
+        Ok(result) => result,
+        Err(error) => {
+            invalidate_on_non_cancellation(&mut operation, &error);
+            return Err(error);
+        }
+    };
+    let stream = match operation {
+        Some(operation) => operation.into_stream(target, stream)?,
+        None => stream,
+    };
+    Ok((metadata, stream))
+}

--- a/lib/llm/src/routing_attempt.rs
+++ b/lib/llm/src/routing_attempt.rs
@@ -40,6 +40,11 @@ pub(crate) enum AttemptKind {
 }
 
 pub(crate) trait AttemptBackend: Send + Sync {
+    /// Return whether `query_instance_id` requests are advisory for this backend.
+    fn supports_advisory(&self) -> bool {
+        false
+    }
+
     type Attempt: Send;
 
     fn affinity(&self) -> Option<&AffinityCoordinator>;
@@ -248,7 +253,9 @@ pub(crate) async fn generate<B: AttemptBackend>(
     request: SingleIn<PreprocessedRequest>,
 ) -> Result<ManyOut<LlmResponse>, Error> {
     let phase = phase(&request);
-    let intent = if request.get_annotation_value("query_instance_id").is_some() {
+    let intent = if backend.supports_advisory()
+        && request.get_annotation_value("query_instance_id").is_some()
+    {
         SelectionIntent::Advisory
     } else {
         SelectionIntent::Committed
@@ -307,4 +314,148 @@ where
         None => stream,
     };
     Ok((metadata, stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use dynamo_runtime::pipeline::Context;
+    use futures::StreamExt;
+
+    use super::*;
+
+    struct TestBackend {
+        advisory: bool,
+        intents: Mutex<Vec<SelectionIntent>>,
+    }
+
+    impl TestBackend {
+        fn new(advisory: bool) -> Self {
+            Self {
+                advisory,
+                intents: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl AttemptBackend for TestBackend {
+        type Attempt = ();
+
+        fn supports_advisory(&self) -> bool {
+            self.advisory
+        }
+
+        fn affinity(&self) -> Option<&AffinityCoordinator> {
+            None
+        }
+
+        fn direct(&self) -> bool {
+            false
+        }
+
+        async fn select(
+            &self,
+            _request: &SingleIn<PreprocessedRequest>,
+            _phase: RequestPhase,
+            intent: SelectionIntent,
+            _pinned_target: Option<AffinityTarget>,
+        ) -> Result<Self::Attempt, Error> {
+            self.intents.lock().unwrap().push(intent);
+            Ok(())
+        }
+
+        fn observe_advisory(
+            &self,
+            _request: &SingleIn<PreprocessedRequest>,
+            _attempt: &Self::Attempt,
+        ) {
+        }
+
+        async fn begin_dispatch(
+            &self,
+            _request: &mut SingleIn<PreprocessedRequest>,
+            _attempt: &mut Self::Attempt,
+            _kind: AttemptKind,
+        ) -> Result<AffinityTarget, Error> {
+            Ok(AffinityTarget::new(1, None))
+        }
+
+        fn after_prepare(
+            &self,
+            _request: &mut SingleIn<PreprocessedRequest>,
+            _attempt: &mut Self::Attempt,
+        ) {
+        }
+
+        async fn dispatch_prepared(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+            _attempt: &mut Self::Attempt,
+            _kind: AttemptKind,
+        ) -> Result<ManyOut<LlmResponse>, Error> {
+            let context = request.context().clone();
+            let output = Annotated::from_data(LLMEngineOutput {
+                token_ids: vec![9],
+                ..Default::default()
+            });
+            Ok(ResponseStream::new(
+                Box::pin(stream::iter([output])),
+                context,
+            ))
+        }
+
+        async fn abort(&self, _attempt: &mut Self::Attempt) {}
+
+        fn finish_dispatch(
+            &self,
+            _attempt: Self::Attempt,
+            _target: AffinityTarget,
+            stream: ManyOut<LlmResponse>,
+        ) -> ManyOut<LlmResponse> {
+            stream
+        }
+    }
+
+    fn query_request() -> SingleIn<PreprocessedRequest> {
+        Context::new(
+            PreprocessedRequest::builder()
+                .model("test".to_string())
+                .token_ids(vec![1, 2, 3])
+                .stop_conditions(Default::default())
+                .sampling_options(Default::default())
+                .output_options(Default::default())
+                .annotations(vec!["query_instance_id:true".to_string()])
+                .build()
+                .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn query_annotation_dispatches_when_backend_does_not_support_advisory() {
+        let backend = TestBackend::new(false);
+        let mut response = generate(&backend, query_request()).await.unwrap();
+
+        assert_eq!(
+            response.next().await.unwrap().data.unwrap().token_ids,
+            vec![9]
+        );
+        assert_eq!(
+            backend.intents.into_inner().unwrap(),
+            vec![SelectionIntent::Committed]
+        );
+    }
+
+    #[tokio::test]
+    async fn query_annotation_remains_advisory_for_kv_style_backend() {
+        let backend = TestBackend::new(true);
+        let mut response = generate(&backend, query_request()).await.unwrap();
+
+        let output = response.next().await.unwrap().data.unwrap();
+        assert!(output.routing_data.is_some());
+        assert_eq!(
+            backend.intents.into_inner().unwrap(),
+            vec![SelectionIntent::Advisory]
+        );
+    }
 }

--- a/lib/llm/src/routing_attempt.rs
+++ b/lib/llm/src/routing_attempt.rs
@@ -56,16 +56,34 @@ pub(crate) trait AttemptBackend: Send + Sync {
 
     fn observe_advisory(&self, request: &SingleIn<PreprocessedRequest>, attempt: &Self::Attempt);
 
-    async fn dispatch<M, F>(
+    async fn begin_dispatch(
+        &self,
+        request: &mut SingleIn<PreprocessedRequest>,
+        attempt: &mut Self::Attempt,
+        kind: AttemptKind,
+    ) -> Result<AffinityTarget, Error>;
+
+    fn after_prepare(
+        &self,
+        request: &mut SingleIn<PreprocessedRequest>,
+        attempt: &mut Self::Attempt,
+    );
+
+    async fn dispatch_prepared(
         &self,
         request: SingleIn<PreprocessedRequest>,
-        attempt: Self::Attempt,
+        attempt: &mut Self::Attempt,
         kind: AttemptKind,
-        prepare: F,
-    ) -> Result<(M, AffinityTarget, ManyOut<LlmResponse>), Error>
-    where
-        M: Send,
-        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send;
+    ) -> Result<ManyOut<LlmResponse>, Error>;
+
+    async fn abort(&self, attempt: &mut Self::Attempt);
+
+    fn finish_dispatch(
+        &self,
+        attempt: Self::Attempt,
+        target: AffinityTarget,
+        stream: ManyOut<LlmResponse>,
+    ) -> ManyOut<LlmResponse>;
 }
 
 fn phase(request: &PreprocessedRequest) -> RequestPhase {
@@ -181,6 +199,50 @@ fn advisory_response<B: AttemptBackend>(
     ResponseStream::new(Box::pin(stream::iter([response])), stream_context)
 }
 
+pub(crate) async fn dispatch_attempt<B, M, F>(
+    backend: &B,
+    mut request: SingleIn<PreprocessedRequest>,
+    mut attempt: B::Attempt,
+    kind: AttemptKind,
+    prepare: F,
+) -> Result<(M, AffinityTarget, ManyOut<LlmResponse>), Error>
+where
+    B: AttemptBackend,
+    M: Send,
+    F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
+{
+    let target = match backend
+        .begin_dispatch(&mut request, &mut attempt, kind)
+        .await
+    {
+        Ok(target) => target,
+        Err(error) => {
+            backend.abort(&mut attempt).await;
+            return Err(error);
+        }
+    };
+    let metadata = match prepare(&mut request, target) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            backend.abort(&mut attempt).await;
+            return Err(error);
+        }
+    };
+    backend.after_prepare(&mut request, &mut attempt);
+    let stream = match backend.dispatch_prepared(request, &mut attempt, kind).await {
+        Ok(stream) => stream,
+        Err(error) => {
+            backend.abort(&mut attempt).await;
+            return Err(error);
+        }
+    };
+    Ok((
+        metadata,
+        target,
+        backend.finish_dispatch(attempt, target, stream),
+    ))
+}
+
 pub(crate) async fn generate<B: AttemptBackend>(
     backend: &B,
     request: SingleIn<PreprocessedRequest>,
@@ -199,9 +261,10 @@ pub(crate) async fn generate<B: AttemptBackend>(
     }
 
     drop(route_guard);
-    let dispatch = backend
-        .dispatch(request, attempt, AttemptKind::Generate, |_, _| Ok(()))
-        .await;
+    let dispatch = dispatch_attempt(backend, request, attempt, AttemptKind::Generate, |_, _| {
+        Ok(())
+    })
+    .await;
     let ((), target, stream) = match dispatch {
         Ok(result) => result,
         Err(error) => {
@@ -231,9 +294,7 @@ where
     let (attempt, mut operation) =
         select_with_affinity(backend, &request, phase, SelectionIntent::Committed).await?;
     drop(route_guard);
-    let dispatch = backend
-        .dispatch(request, attempt, AttemptKind::Prefill, prepare)
-        .await;
+    let dispatch = dispatch_attempt(backend, request, attempt, AttemptKind::Prefill, prepare).await;
     let (metadata, target, stream) = match dispatch {
         Ok(result) => result,
         Err(error) => {

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -730,7 +730,14 @@ impl Stream for AffinityTrackedStream {
                 drop(self.lease.take());
                 Poll::Ready(None)
             }
-            Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
+            Poll::Ready(Some(item)) => {
+                if item.error.is_some()
+                    && let Some(mut lease) = self.lease.take()
+                {
+                    lease.invalidate();
+                }
+                Poll::Ready(Some(item))
+            }
             poll => poll,
         }
     }

--- a/lib/llm/src/session_affinity/mod.rs
+++ b/lib/llm/src/session_affinity/mod.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use dynamo_runtime::{component::Client, pipeline::Error};
 
-pub(crate) use coordinator::{AffinityAcquire, affinity_id};
+pub(crate) use coordinator::{AffinityAcquire, affinity_id, invalid_argument};
 pub use coordinator::{AffinityCoordinator, AffinityTarget, explicit_target};
 pub use push_router::SessionAffinityPushRouter;
 

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -262,7 +262,7 @@ impl AttemptBackend for SessionAffinityPushRouter {
     async fn select(
         &self,
         request: &SingleIn<PreprocessedRequest>,
-        phase: RequestPhase,
+        _phase: RequestPhase,
         intent: SelectionIntent,
         pinned_target: Option<AffinityTarget>,
     ) -> Result<Self::Attempt, Error> {
@@ -393,7 +393,7 @@ impl AttemptBackend for SessionAffinityPushRouter {
         Ok(SimpleAttempt {
             target: AffinityTarget::new(selected.worker_id, dp_rank),
             reservation,
-            exact: crate::session_affinity::explicit_target(request, phase)?.is_some(),
+            exact: pinned_target.is_some(),
             allowed_fallback,
             load_guard,
             route: None,

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -1,32 +1,71 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
+use dynamo_kv_router::{SimpleRoutingPolicy, SimpleWorkerPicker, SimpleWorkerScorer};
+use dynamo_runtime::error::{DynamoError, ErrorType};
 use dynamo_runtime::pipeline::{
-    AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
-    SingleIn, async_trait as pipeline_async_trait,
+    AsyncEngine, Error, ManyOut, PushRouter, RouteFallback, RouteReservation, SingleIn,
+    async_trait as pipeline_async_trait,
 };
 
-use super::{
-    AffinityCoordinator, AffinityTarget, LlmResponse,
-    coordinator::{affinity_id, invalid_argument},
-    explicit_target,
-};
+use super::{AffinityCoordinator, AffinityTarget, LlmResponse};
 use crate::{
+    lora::{
+        LoraFilter,
+        filtered_router::{LoadGuard, track_response},
+        load_estimator::LoadEstimator,
+    },
     preprocessor::PreprocessedRequest,
     protocols::common::timing::{
         RequestPhase, RequestTracker, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL,
     },
+    routing_attempt::{AttemptBackend, AttemptKind, SelectionIntent},
 };
+
+pub(crate) struct SimpleAttempt {
+    target: AffinityTarget,
+    reservation: Option<RouteReservation>,
+    exact: bool,
+    allowed_fallback: Option<HashSet<u64>>,
+    load_guard: Option<LoadGuard>,
+}
+
+struct LoraConstraint {
+    filter: Arc<LoraFilter>,
+    load_estimator: Arc<LoadEstimator>,
+}
 
 pub struct SessionAffinityPushRouter {
     inner: PushRouter<PreprocessedRequest, LlmResponse>,
+    policy: Option<(SimpleWorkerScorer, SimpleWorkerPicker)>,
     affinity: Option<AffinityCoordinator>,
     direct: bool,
+    lora: Option<LoraConstraint>,
 }
 
 impl SessionAffinityPushRouter {
+    fn policy_for(
+        mode: dynamo_runtime::pipeline::RouterMode,
+    ) -> Option<(SimpleWorkerScorer, SimpleWorkerPicker)> {
+        use dynamo_runtime::pipeline::RouterMode;
+
+        let policy = match mode {
+            RouterMode::RoundRobin => SimpleRoutingPolicy::RoundRobin,
+            RouterMode::Random => SimpleRoutingPolicy::Random,
+            RouterMode::PowerOfTwoChoices => SimpleRoutingPolicy::PowerOfTwoChoices,
+            RouterMode::LeastLoaded => SimpleRoutingPolicy::LeastLoaded,
+            RouterMode::DeviceAwareWeighted => SimpleRoutingPolicy::DeviceAwareWeighted,
+            RouterMode::Direct => return None,
+            RouterMode::KV => panic!("KV routing must use KvPushRouter"),
+        };
+        Some((
+            SimpleWorkerScorer::new(policy),
+            SimpleWorkerPicker::new(policy),
+        ))
+    }
+
     pub fn new(
         inner: PushRouter<PreprocessedRequest, LlmResponse>,
         ttl: Option<Duration>,
@@ -41,19 +80,82 @@ impl SessionAffinityPushRouter {
         affinity: Option<AffinityCoordinator>,
         direct: bool,
     ) -> Self {
+        let policy = Self::policy_for(inner.router_mode());
         Self {
             inner,
+            policy,
             affinity,
             direct,
+            lora: None,
         }
     }
 
-    fn phase(request: &PreprocessedRequest) -> RequestPhase {
-        request
-            .tracker
+    pub(crate) fn new_with_coordinator_and_lora(
+        inner: PushRouter<PreprocessedRequest, LlmResponse>,
+        affinity: Option<AffinityCoordinator>,
+        direct: bool,
+        lora: Option<(Arc<LoraFilter>, Arc<LoadEstimator>)>,
+    ) -> Self {
+        let policy = Self::policy_for(inner.router_mode());
+        Self {
+            inner,
+            policy,
+            affinity,
+            direct,
+            lora: lora.map(|(filter, load_estimator)| LoraConstraint {
+                filter,
+                load_estimator,
+            }),
+        }
+    }
+
+    fn lora_candidates(
+        &self,
+        request: &PreprocessedRequest,
+        intent: SelectionIntent,
+    ) -> Result<(Option<HashSet<u64>>, Option<LoadGuard>), Error> {
+        let Some(lora) = self.lora.as_ref() else {
+            return Ok((None, None));
+        };
+        let Some(lora_name) = request
+            .routing
             .as_ref()
-            .map(|tracker| tracker.phase())
-            .unwrap_or(RequestPhase::Aggregated)
+            .and_then(|routing| routing.lora_name.as_deref())
+        else {
+            return Ok((None, None));
+        };
+
+        let routable = self.inner.client.instance_ids_avail();
+        let replicas = lora
+            .filter
+            .filter_worker_ids_for_lora(Some(lora_name), &routable);
+        if replicas.is_empty() {
+            anyhow::bail!("No workers available after LoRA filtering (lora={lora_name})");
+        }
+
+        let free = self
+            .inner
+            .client
+            .instance_ids_free()
+            .into_iter()
+            .collect::<HashSet<_>>();
+        let candidates = replicas
+            .into_iter()
+            .filter(|worker_id| free.contains(worker_id))
+            .collect::<HashSet<_>>();
+        if candidates.is_empty() {
+            return Err(DynamoError::builder()
+                .error_type(ErrorType::ResourceExhausted)
+                .message(format!(
+                    "All eligible LoRA workers are overloaded (lora={lora_name})"
+                ))
+                .build()
+                .into());
+        }
+
+        let guard = (intent == SelectionIntent::Committed)
+            .then(|| LoadGuard::new(lora.load_estimator.clone(), lora_name.to_string()));
+        Ok((Some(candidates), guard))
     }
 
     fn record_target(tracker: Option<&RequestTracker>, target: AffinityTarget) {
@@ -68,6 +170,7 @@ impl SessionAffinityPushRouter {
         tracker.record_worker(target.worker_id, target.dp_rank, worker_type);
     }
 
+    #[cfg(test)]
     fn prepare_resolved_target(
         request: &mut PreprocessedRequest,
         requested: AffinityTarget,
@@ -83,90 +186,21 @@ impl SessionAffinityPushRouter {
         )
     }
 
-    fn direct_target(
-        &self,
-        explicit: Option<AffinityTarget>,
-        phase: RequestPhase,
-    ) -> Result<Option<AffinityTarget>, Error> {
-        if !self.direct {
-            return Ok(explicit);
-        }
-        explicit.map(Some).ok_or_else(|| {
-            invalid_argument(format!(
-                "worker ID required for {phase} request in Direct routing mode"
-            ))
-        })
-    }
-
     pub fn peek_next_worker(&self) -> Option<u64> {
-        self.inner.peek_next_worker()
+        match self.policy.as_ref() {
+            Some((scorer, picker)) => {
+                self.inner
+                    .peek_next_worker_with_policy(|candidates, context| {
+                        picker.peek(scorer, candidates, context)
+                    })
+            }
+            None => self.inner.peek_next_worker(),
+        }
     }
 
     #[cfg(test)]
     pub(crate) fn occupancy_for_test(&self, worker_id: u64) -> u64 {
         self.inner.occupancy_for_test(worker_id)
-    }
-
-    async fn acquire_routable(
-        &self,
-        session_id: &crate::protocols::common::extensions::SessionAffinityId,
-        explicit: Option<AffinityTarget>,
-        request_context: &dyn AsyncEngineContext,
-    ) -> Result<super::AffinityAcquire, Error> {
-        let affinity = self
-            .affinity
-            .as_ref()
-            .expect("affinity acquisition requires an enabled coordinator");
-        let operation = affinity
-            .acquire_with_context(session_id, explicit, request_context)
-            .await?;
-        let Some(target) = operation.target() else {
-            return Ok(operation);
-        };
-        if self
-            .inner
-            .client
-            .instance_ids_avail()
-            .contains(&target.worker_id)
-        {
-            return Ok(operation);
-        }
-
-        operation.invalidate();
-        affinity
-            .acquire_with_context(session_id, explicit, request_context)
-            .await
-    }
-
-    /// Adapts the generic worker-only router while keeping a known rank attached
-    /// to its worker through preparation and exact dispatch.
-    async fn select_and_dispatch_exact_target<M, F>(
-        &self,
-        request: SingleIn<PreprocessedRequest>,
-        pinned_target: Option<AffinityTarget>,
-        prepare: F,
-    ) -> Result<(M, ManyOut<LlmResponse>), Error>
-    where
-        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error>,
-    {
-        let ((metadata, tracker, target), stream) = self
-            .inner
-            .select_and_dispatch_exact(
-                request,
-                pinned_target.map(|target| target.worker_id),
-                move |request, worker_id| {
-                    let target = pinned_target.unwrap_or(AffinityTarget {
-                        worker_id,
-                        dp_rank: None,
-                    });
-                    debug_assert_eq!(target.worker_id, worker_id);
-                    let metadata = prepare(request, target)?;
-                    Ok((metadata, request.tracker.take(), target))
-                },
-            )
-            .await?;
-        Self::record_target(tracker.as_deref(), target);
-        Ok((metadata, stream))
     }
 
     pub async fn select_and_dispatch_prefill<M, F>(
@@ -175,77 +209,139 @@ impl SessionAffinityPushRouter {
         prepare: F,
     ) -> Result<(M, ManyOut<LlmResponse>), Error>
     where
-        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error>,
+        M: Send,
+        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
     {
-        let session_id = if self.affinity.is_some() {
-            affinity_id(&request)?
+        crate::routing_attempt::select_and_dispatch_prefill(self, request, prepare).await
+    }
+}
+
+impl AttemptBackend for SessionAffinityPushRouter {
+    type Attempt = SimpleAttempt;
+
+    fn affinity(&self) -> Option<&AffinityCoordinator> {
+        self.affinity.as_ref()
+    }
+
+    fn direct(&self) -> bool {
+        self.direct
+    }
+
+    async fn select(
+        &self,
+        request: &SingleIn<PreprocessedRequest>,
+        _phase: RequestPhase,
+        intent: SelectionIntent,
+        pinned_target: Option<AffinityTarget>,
+    ) -> Result<Self::Attempt, Error> {
+        let pinned_worker = pinned_target.map(|target| target.worker_id);
+        let (allowed_fallback, load_guard) = self.lora_candidates(request.content(), intent)?;
+        let native_policy = if pinned_worker.is_none() {
+            self.policy.as_ref()
         } else {
             None
         };
-        if !self.direct && session_id.is_none() {
-            let explicit = explicit_target(&request, RequestPhase::Prefill)?;
-            return self
-                .select_and_dispatch_exact_target(request, explicit, prepare)
-                .await;
-        }
-        let explicit = self.direct_target(
-            explicit_target(&request, RequestPhase::Prefill)?,
-            RequestPhase::Prefill,
-        )?;
-        let Some(session_id) = session_id else {
-            let Some(target) = explicit else {
-                return Err(invalid_argument(
-                    "Direct routing requires an explicit prefill target",
-                ));
-            };
-            return self
-                .select_and_dispatch_exact_target(request, Some(target), prepare)
-                .await;
-        };
-        let is_query_only = request.get_annotation_value("query_instance_id").is_some();
-        if is_query_only {
-            let selected = self
-                .affinity
-                .as_ref()
-                .expect("affinity query requires an enabled coordinator")
-                .query_target(&session_id, explicit)?
-                .or(explicit);
-            return self
-                .select_and_dispatch_exact_target(request, selected, prepare)
-                .await;
-        }
-
-        let request_context = request.context();
-        let operation = self
-            .acquire_routable(&session_id, explicit, request_context.as_ref())
-            .await?;
-        let selected = operation.target().or(explicit);
-        let rank = selected.and_then(|target| target.dp_rank);
-        let dispatch = self
-            .inner
-            .select_and_dispatch_exact(
-                request,
-                selected.map(|target| target.worker_id),
-                move |request, worker_id| {
-                    let target = AffinityTarget {
-                        worker_id,
-                        dp_rank: rank,
-                    };
-                    let metadata = prepare(request, target)?;
-                    Ok((metadata, request.tracker.take(), target))
-                },
-            )
-            .await;
-        let ((metadata, tracker, target), stream) = match dispatch {
-            Ok(result) => result,
-            Err(error) => {
-                operation.invalidate();
-                return Err(error);
+        let (selected, reservation) = match (intent, native_policy) {
+            (SelectionIntent::Advisory, Some((scorer, picker))) => {
+                let target = self.inner.peek_within_policy(
+                    request.content(),
+                    None,
+                    allowed_fallback.as_ref(),
+                    |candidates, context| picker.peek(scorer, candidates, context),
+                )?;
+                (target, None)
+            }
+            (SelectionIntent::Committed, Some((scorer, picker))) => {
+                let reservation = self
+                    .inner
+                    .reserve_within_policy(
+                        request.content(),
+                        None,
+                        allowed_fallback.as_ref(),
+                        |candidates, context| picker.select(scorer, candidates, context),
+                    )
+                    .await?;
+                (reservation.target(), Some(reservation))
+            }
+            (SelectionIntent::Advisory, None) => {
+                let target = self.inner.peek_within(
+                    request.content(),
+                    pinned_worker,
+                    allowed_fallback.as_ref(),
+                )?;
+                (target, None)
+            }
+            (SelectionIntent::Committed, None) => {
+                let reservation = self
+                    .inner
+                    .reserve_within(request.content(), pinned_worker, allowed_fallback.as_ref())
+                    .await?;
+                (reservation.target(), Some(reservation))
             }
         };
-        let stream = operation.into_stream(target, stream)?;
-        Self::record_target(tracker.as_deref(), target);
-        Ok((metadata, stream))
+        let dp_rank = pinned_target
+            .filter(|target| target.worker_id == selected.worker_id)
+            .and_then(|target| target.dp_rank);
+        Ok(SimpleAttempt {
+            target: AffinityTarget::new(selected.worker_id, dp_rank),
+            reservation,
+            exact: pinned_target.is_some(),
+            allowed_fallback,
+            load_guard,
+        })
+    }
+
+    fn observe_advisory(&self, request: &SingleIn<PreprocessedRequest>, attempt: &Self::Attempt) {
+        Self::record_target(request.tracker.as_deref(), attempt.target);
+    }
+
+    async fn dispatch<M, F>(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+        attempt: Self::Attempt,
+        kind: AttemptKind,
+        prepare: F,
+    ) -> Result<(M, AffinityTarget, ManyOut<LlmResponse>), Error>
+    where
+        M: Send,
+        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
+    {
+        let SimpleAttempt {
+            target,
+            reservation,
+            exact,
+            allowed_fallback,
+            load_guard,
+        } = attempt;
+        let reservation = reservation.expect("committed simple attempt has a reservation");
+        let fallback = if exact || kind == AttemptKind::Prefill {
+            RouteFallback::Deny
+        } else if let Some(allowed) = allowed_fallback.as_ref() {
+            RouteFallback::Within(allowed)
+        } else {
+            RouteFallback::Allow
+        };
+        let ((metadata, tracker, actual_target), stream) = self
+            .inner
+            .dispatch_reserved_prepared(
+                request,
+                reservation,
+                fallback,
+                move |request, worker_id| {
+                    let dp_rank = target.dp_rank.filter(|_| worker_id == target.worker_id);
+                    request.routing_mut().dp_rank = dp_rank;
+                    let actual_target = AffinityTarget::new(worker_id, dp_rank);
+                    let metadata = prepare(request, actual_target)?;
+                    Ok((metadata, request.tracker.take(), actual_target))
+                },
+            )
+            .await?;
+        Self::record_target(tracker.as_deref(), actual_target);
+        let stream = match load_guard {
+            Some(guard) => track_response(stream, guard),
+            None => stream,
+        };
+        Ok((metadata, actual_target, stream))
     }
 }
 
@@ -257,117 +353,28 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
         &self,
         request: SingleIn<PreprocessedRequest>,
     ) -> Result<ManyOut<LlmResponse>, Error> {
-        let phase = Self::phase(&request);
-        let session_id = if self.affinity.is_some() {
-            affinity_id(&request)?
-        } else {
-            None
-        };
-        let explicit = self.direct_target(explicit_target(&request, phase)?, phase)?;
-        if !self.direct && session_id.is_none() {
-            let ((), stream) = self
-                .select_and_dispatch_exact_target(request, explicit, |_, _| Ok(()))
-                .await?;
-            return Ok(stream);
-        }
-        let Some(session_id) = session_id else {
-            let Some(target) = explicit else {
-                return Err(invalid_argument(format!(
-                    "Direct routing requires an explicit {phase} target"
-                )));
-            };
-            let ((tracker, target), stream) = self
-                .inner
-                .direct_within_prepared(
-                    request,
-                    target.worker_id,
-                    None,
-                    move |request, worker_id| {
-                        Ok(Self::prepare_resolved_target(request, target, worker_id))
-                    },
-                )
-                .await?;
-            Self::record_target(tracker.as_deref(), target);
-            return Ok(stream);
-        };
-
-        let is_query_only = request.get_annotation_value("query_instance_id").is_some();
-        if is_query_only {
-            let target = self
-                .affinity
-                .as_ref()
-                .expect("affinity query requires an enabled coordinator")
-                .query_target(&session_id, explicit)?
-                .or(explicit);
-            let rank = target.and_then(|target| target.dp_rank);
-            let ((tracker, target), stream) = self
-                .inner
-                .select_and_dispatch_exact(
-                    request,
-                    target.map(|target| target.worker_id),
-                    move |request, worker_id| {
-                        if rank.is_some() {
-                            request.routing_mut().dp_rank = rank;
-                        }
-                        Ok((
-                            request.tracker.take(),
-                            AffinityTarget {
-                                worker_id,
-                                dp_rank: rank,
-                            },
-                        ))
-                    },
-                )
-                .await?;
-            Self::record_target(tracker.as_deref(), target);
-            return Ok(stream);
-        }
-
-        let request_context = request.context();
-        let operation = self
-            .acquire_routable(&session_id, explicit, request_context.as_ref())
-            .await?;
-        let selected = operation.target().or(explicit);
-        let rank = selected.and_then(|target| target.dp_rank);
-        let dispatch = self
-            .inner
-            .select_and_dispatch_exact(
-                request,
-                selected.map(|target| target.worker_id),
-                move |request, worker_id| {
-                    if rank.is_some() {
-                        request.routing_mut().dp_rank = rank;
-                    }
-                    let target = AffinityTarget {
-                        worker_id,
-                        dp_rank: rank,
-                    };
-                    Ok((request.tracker.take(), target))
-                },
-            )
-            .await;
-        let ((tracker, target), stream) = match dispatch {
-            Ok(result) => result,
-            Err(error) => {
-                operation.invalidate();
-                return Err(error);
-            }
-        };
-        let stream = operation.into_stream(target, stream)?;
-        Self::record_target(tracker.as_deref(), target);
-        Ok(stream)
+        crate::routing_attempt::generate(self, request).await
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
+    use dynamo_kv_router::protocols::WorkerWithDpRank;
     use dynamo_runtime::{
         DistributedRuntime, Runtime,
-        distributed::DistributedConfig,
+        discovery::EventTransportKind,
+        distributed::{DiscoveryBackend, DistributedConfig, RequestPlaneMode},
         pipeline::{Context, RouterMode},
+        storage::kv::Selector,
     };
+    use futures::StreamExt;
 
     use super::*;
+    use crate::lora::{
+        LoadEstimator, LoraFilter, LoraReplicaConfig, LoraRoutingTable, LoraStateTracker,
+    };
     use crate::protocols::common::{
         extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
         preprocessor::RoutingHints,
@@ -459,6 +466,260 @@ mod tests {
         assert!(router.affinity.is_none());
 
         drop(router);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn advisory_query_uses_common_path_without_admission_or_dispatch() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("simple_advisory_attempt".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate");
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+        let inner = PushRouter::from_client(client, RouterMode::LeastLoaded)
+            .await
+            .unwrap();
+        let router = SessionAffinityPushRouter::new(inner, None, false).unwrap();
+        let tracker = Arc::new(RequestTracker::new());
+        let mut content = request(None, true);
+        content.tracker = Some(tracker.clone());
+
+        let mut stream = router.generate(Context::new(content)).await.unwrap();
+        let output = stream.next().await.unwrap().data.unwrap();
+
+        assert_eq!(tracker.decode_worker_id(), Some(worker_id));
+        assert_eq!(router.occupancy_for_test(worker_id), 0);
+        assert!(output.routing_data.is_some());
+        assert!(stream.next().await.is_none());
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn simple_round_robin_uses_native_picker_state() {
+        async fn shared_drt(runtime: Runtime, store: &std::path::Path) -> DistributedRuntime {
+            DistributedRuntime::new(
+                runtime,
+                DistributedConfig {
+                    discovery_backend: DiscoveryBackend::KvStore(Selector::File(store.to_owned())),
+                    nats_config: None,
+                    request_plane: RequestPlaneMode::Tcp,
+                    event_transport_kind: EventTransportKind::Zmq,
+                },
+            )
+            .await
+            .unwrap()
+        }
+
+        let runtime = Runtime::from_current().unwrap();
+        let store = tempfile::tempdir().unwrap();
+        let router_drt = shared_drt(runtime.clone(), store.path()).await;
+        let first_worker_drt = shared_drt(runtime.clone(), store.path()).await;
+        let second_worker_drt = shared_drt(runtime.clone(), store.path()).await;
+        let endpoint_for = |drt: &DistributedRuntime| {
+            drt.namespace("simple_native_round_robin".to_string())
+                .unwrap()
+                .component("workers".to_string())
+                .unwrap()
+                .endpoint("generate")
+        };
+        endpoint_for(&first_worker_drt)
+            .register_endpoint_instance()
+            .await
+            .unwrap();
+        endpoint_for(&second_worker_drt)
+            .register_endpoint_instance()
+            .await
+            .unwrap();
+        let endpoint = endpoint_for(&router_drt);
+        let client = endpoint.client().await.unwrap();
+        let workers = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let workers = client.instance_ids();
+                if workers.len() == 2 {
+                    return workers;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("both workers must be discovered");
+        assert_eq!(workers.len(), 2);
+        let inner = PushRouter::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+        let router = SessionAffinityPushRouter::new(inner, None, false).unwrap();
+        let request = Context::new(request(None, false));
+
+        let advisory = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Advisory,
+                None,
+            )
+            .await
+            .unwrap();
+        let first = advisory.target.worker_id;
+        drop(advisory);
+
+        let committed = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Committed,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(committed.target.worker_id, first);
+        drop(committed);
+
+        assert_eq!(
+            router.inner.peek_next_worker(),
+            Some(first),
+            "the compatibility runtime picker must not own normal LLM cursor state"
+        );
+        let second = router
+            .peek_next_worker()
+            .expect("native picker must expose the next worker");
+        assert_ne!(second, first);
+
+        let committed = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Committed,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(committed.target.worker_id, second);
+        drop(committed);
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn native_load_picker_reservation_owns_occupancy() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("simple_native_occupancy".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate");
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+        let inner = PushRouter::from_client(client, RouterMode::LeastLoaded)
+            .await
+            .unwrap();
+        let router = SessionAffinityPushRouter::new(inner, None, false).unwrap();
+        let request = Context::new(request(None, false));
+
+        let committed = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Committed,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(committed.target.worker_id, worker_id);
+        assert_eq!(router.occupancy_for_test(worker_id), 1);
+        drop(committed);
+        assert_eq!(router.occupancy_for_test(worker_id), 0);
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn lora_constraint_uses_common_advisory_and_reservation_lifecycle() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("lora_attempt_lifecycle".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate");
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let workers = client.wait_for_instances().await.unwrap();
+        let allowed_worker = workers[0].id();
+
+        let table = LoraRoutingTable::new();
+        table.update_allocation(
+            "adapter".to_string(),
+            LoraReplicaConfig {
+                lora_name: "adapter".to_string(),
+                replica_factor: 1,
+                replica_set: vec![WorkerWithDpRank::new(allowed_worker, 0)],
+                updated_at: Instant::now(),
+                is_active: true,
+            },
+        );
+        let filter = Arc::new(LoraFilter::new(table, LoraStateTracker::new()));
+        let estimator = Arc::new(LoadEstimator::new());
+        let inner = PushRouter::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+        let router = SessionAffinityPushRouter::new_with_coordinator_and_lora(
+            inner,
+            None,
+            false,
+            Some((filter, estimator.clone())),
+        );
+        let mut content = request(None, false);
+        content.routing_mut().lora_name = Some("adapter".to_string());
+        let request = Context::new(content);
+
+        let advisory = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Advisory,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(advisory.target.worker_id, allowed_worker);
+        assert!(estimator.get_inflight_counts().is_empty());
+        drop(advisory);
+
+        let committed = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Committed,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(committed.target.worker_id, allowed_worker);
+        assert_eq!(estimator.get_inflight_counts().get("adapter"), Some(&1));
+        drop(committed);
+        assert!(estimator.get_inflight_counts().is_empty());
+
         runtime.shutdown();
     }
 

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -58,7 +58,7 @@ pub struct SessionAffinityPushRouter {
 impl SessionAffinityPushRouter {
     fn policy_for(
         mode: dynamo_runtime::pipeline::RouterMode,
-    ) -> Option<(SimpleWorkerScorer, SimpleWorkerPicker)> {
+    ) -> Result<Option<(SimpleWorkerScorer, SimpleWorkerPicker)>, Error> {
         use dynamo_runtime::pipeline::RouterMode;
 
         let policy = match mode {
@@ -67,13 +67,13 @@ impl SessionAffinityPushRouter {
             RouterMode::PowerOfTwoChoices => SimpleRoutingPolicy::PowerOfTwoChoices,
             RouterMode::LeastLoaded => SimpleRoutingPolicy::LeastLoaded,
             RouterMode::DeviceAwareWeighted => SimpleRoutingPolicy::DeviceAwareWeighted,
-            RouterMode::Direct => return None,
-            RouterMode::KV => panic!("KV routing must use KvPushRouter"),
+            RouterMode::Direct => return Ok(None),
+            RouterMode::KV => anyhow::bail!("KV routing must use KvPushRouter"),
         };
-        Some((
+        Ok(Some((
             SimpleWorkerScorer::new(policy),
             SimpleWorkerPicker::new(policy),
-        ))
+        )))
     }
 
     pub fn new(
@@ -82,23 +82,23 @@ impl SessionAffinityPushRouter {
         direct: bool,
     ) -> Result<Self, Error> {
         let affinity = ttl.map(AffinityCoordinator::new).transpose()?;
-        Ok(Self::new_with_coordinator(inner, affinity, direct))
+        Self::new_with_coordinator(inner, affinity, direct)
     }
 
     pub(crate) fn new_with_coordinator(
         inner: PushRouter<PreprocessedRequest, LlmResponse>,
         affinity: Option<AffinityCoordinator>,
         direct: bool,
-    ) -> Self {
-        let policy = Self::policy_for(inner.router_mode());
-        Self {
+    ) -> Result<Self, Error> {
+        let policy = Self::policy_for(inner.router_mode())?;
+        Ok(Self {
             inner,
             policy,
             custom_policy: None,
             affinity,
             direct,
             lora: None,
-        }
+        })
     }
 
     pub(crate) fn new_with_coordinator_and_lora(
@@ -108,10 +108,11 @@ impl SessionAffinityPushRouter {
         lora: Option<(Arc<LoraFilter>, Arc<LoadEstimator>)>,
         custom_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
         lora_custom_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         let mode = inner.router_mode();
-        let policy = Self::policy_for(mode);
-        Self {
+        let policy = Self::policy_for(mode)?;
+        let lora_policy = Self::policy_for(mode)?;
+        Ok(Self {
             inner,
             policy,
             custom_policy,
@@ -120,10 +121,10 @@ impl SessionAffinityPushRouter {
             lora: lora.map(|(filter, load_estimator)| LoraConstraint {
                 filter,
                 load_estimator,
-                policy: Self::policy_for(mode),
+                policy: lora_policy,
                 custom_policy: lora_custom_policy,
             }),
-        }
+        })
     }
 
     fn lora_candidates(
@@ -557,6 +558,35 @@ mod tests {
             .expect("test router must enable affinity")
     }
 
+    #[tokio::test]
+    async fn constructor_rejects_kv_mode_without_panicking() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("simple_router_rejects_kv".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate");
+        let inner = PushRouter::from_client(endpoint.client().await.unwrap(), RouterMode::KV)
+            .await
+            .unwrap();
+
+        let error = SessionAffinityPushRouter::new(inner, None, false)
+            .err()
+            .expect("KV mode must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("KV routing must use KvPushRouter")
+        );
+
+        runtime.shutdown();
+    }
+
     #[test]
     fn direct_fallback_clears_stale_dp_rank() {
         let tracker = Arc::new(RequestTracker::new());
@@ -848,7 +878,8 @@ mod tests {
             None,
             Some(Arc::new(policy)),
             None,
-        );
+        )
+        .unwrap();
         let request = Context::new(request(None, false));
 
         let committed = router
@@ -910,7 +941,8 @@ mod tests {
             Some((filter, estimator.clone())),
             None,
             None,
-        );
+        )
+        .unwrap();
         let mut content = request(None, false);
         content.routing_mut().lora_name = Some("adapter".to_string());
         let request = Context::new(content);
@@ -995,7 +1027,8 @@ mod tests {
             Some((filter, estimator)),
             None,
             None,
-        );
+        )
+        .unwrap();
         let base_request = Context::new(request(None, false));
         let mut lora_content = request(None, false);
         lora_content.routing_mut().lora_name = Some("adapter".to_string());

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -3,10 +3,15 @@
 
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
-use dynamo_kv_router::{SimpleRoutingPolicy, SimpleWorkerPicker, SimpleWorkerScorer};
+use dynamo_kv_router::{
+    SimpleRoutingPolicy, SimpleWorkerPicker, SimpleWorkerScorer,
+    selector::{CacheUnawareRequestContext, CacheUnawareWorkerSelectionPolicy},
+};
+use dynamo_runtime::engine::AsyncEngineContextProvider;
 use dynamo_runtime::error::{DynamoError, ErrorType};
 use dynamo_runtime::pipeline::{
-    AsyncEngine, Error, ManyOut, PushRouter, RouteFallback, RouteReservation, SingleIn,
+    AsyncEngine, Error, ManyOut, PushRouter, ResolvedRoute, RouteAdmissionKind, RouteFallback,
+    RoutePolicyCandidates, RoutePolicyDecision, RouteReservation, SingleIn,
     async_trait as pipeline_async_trait,
 };
 
@@ -30,16 +35,21 @@ pub(crate) struct SimpleAttempt {
     exact: bool,
     allowed_fallback: Option<HashSet<u64>>,
     load_guard: Option<LoadGuard>,
+    route: Option<ResolvedRoute>,
+    tracker: Option<Arc<RequestTracker>>,
 }
 
 struct LoraConstraint {
     filter: Arc<LoraFilter>,
     load_estimator: Arc<LoadEstimator>,
+    policy: Option<(SimpleWorkerScorer, SimpleWorkerPicker)>,
+    custom_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
 }
 
 pub struct SessionAffinityPushRouter {
     inner: PushRouter<PreprocessedRequest, LlmResponse>,
     policy: Option<(SimpleWorkerScorer, SimpleWorkerPicker)>,
+    custom_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
     affinity: Option<AffinityCoordinator>,
     direct: bool,
     lora: Option<LoraConstraint>,
@@ -84,6 +94,7 @@ impl SessionAffinityPushRouter {
         Self {
             inner,
             policy,
+            custom_policy: None,
             affinity,
             direct,
             lora: None,
@@ -95,16 +106,22 @@ impl SessionAffinityPushRouter {
         affinity: Option<AffinityCoordinator>,
         direct: bool,
         lora: Option<(Arc<LoraFilter>, Arc<LoadEstimator>)>,
+        custom_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
+        lora_custom_policy: Option<Arc<CacheUnawareWorkerSelectionPolicy>>,
     ) -> Self {
-        let policy = Self::policy_for(inner.router_mode());
+        let mode = inner.router_mode();
+        let policy = Self::policy_for(mode);
         Self {
             inner,
             policy,
+            custom_policy,
             affinity,
             direct,
             lora: lora.map(|(filter, load_estimator)| LoraConstraint {
                 filter,
                 load_estimator,
+                policy: Self::policy_for(mode),
+                custom_policy: lora_custom_policy,
             }),
         }
     }
@@ -168,6 +185,26 @@ impl SessionAffinityPushRouter {
             WORKER_TYPE_DECODE
         };
         tracker.record_worker(target.worker_id, target.dp_rank, worker_type);
+    }
+
+    fn custom_policy_decision(
+        policy: &CacheUnawareWorkerSelectionPolicy,
+        request: &CacheUnawareRequestContext<'_>,
+        candidates: &RoutePolicyCandidates<'_>,
+    ) -> Result<Option<RoutePolicyDecision>, Error> {
+        let worker_id =
+            policy.pick_worker(request, candidates, |index| candidates.worker_id(index))?;
+        let index = (0..candidates.len())
+            .find(|&index| candidates.worker_id(index) == worker_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "custom policy selected worker {worker_id} outside the host candidate table"
+                )
+            })?;
+        Ok(Some(RoutePolicyDecision {
+            index,
+            admission: RouteAdmissionKind::Occupancy,
+        }))
     }
 
     #[cfg(test)]
@@ -237,33 +274,101 @@ impl AttemptBackend for SessionAffinityPushRouter {
         let pinned_worker = pinned_target.map(|target| target.worker_id);
         let (allowed_fallback, load_guard) = self.lora_candidates(request.content(), intent)?;
         let native_policy = if pinned_worker.is_none() {
-            self.policy.as_ref()
+            if allowed_fallback.is_some() {
+                self.lora
+                    .as_ref()
+                    .and_then(|constraint| constraint.policy.as_ref())
+            } else {
+                self.policy.as_ref()
+            }
         } else {
             None
         };
-        let (selected, reservation) = match (intent, native_policy) {
-            (SelectionIntent::Advisory, Some((scorer, picker))) => {
+        let custom_policy = if pinned_worker.is_some() {
+            None
+        } else if allowed_fallback.is_some() {
+            self.lora
+                .as_ref()
+                .and_then(|constraint| constraint.custom_policy.as_deref())
+        } else {
+            self.custom_policy.as_deref()
+        };
+        let custom_selection = if let Some(policy) = custom_policy {
+            let session_context = request
+                .agent_context
+                .as_ref()
+                .map(crate::kv_router::to_worker_selection_session_context);
+            let routing = request.routing.as_ref();
+            let engine_context = request.context();
+            let custom_context = CacheUnawareRequestContext::new(
+                engine_context.id(),
+                request.token_ids.len(),
+                intent == SelectionIntent::Advisory,
+            )
+            .with_session_context(session_context.as_ref())
+            .with_expected_output_tokens(routing.and_then(|routing| routing.expected_output_tokens))
+            .with_priority(
+                routing
+                    .and_then(|routing| routing.priority_jump)
+                    .unwrap_or(0.0),
+                routing
+                    .and_then(|routing| routing.strict_priority)
+                    .unwrap_or(0),
+            );
+            Some(match intent {
+                SelectionIntent::Advisory => {
+                    let target = self.inner.peek_within_policy(
+                        request.content(),
+                        None,
+                        allowed_fallback.as_ref(),
+                        |candidates, _context| {
+                            Self::custom_policy_decision(policy, &custom_context, candidates)
+                        },
+                    )?;
+                    (target, None)
+                }
+                SelectionIntent::Committed => {
+                    let reservation = self
+                        .inner
+                        .reserve_within_policy(
+                            request.content(),
+                            None,
+                            allowed_fallback.as_ref(),
+                            |candidates, _context| {
+                                Self::custom_policy_decision(policy, &custom_context, candidates)
+                            },
+                        )
+                        .await?;
+                    (reservation.target(), Some(reservation))
+                }
+            })
+        } else {
+            None
+        };
+        let (selected, reservation) = match (custom_selection, intent, native_policy) {
+            (Some(selection), _, _) => selection,
+            (None, SelectionIntent::Advisory, Some((scorer, picker))) => {
                 let target = self.inner.peek_within_policy(
                     request.content(),
                     None,
                     allowed_fallback.as_ref(),
-                    |candidates, context| picker.peek(scorer, candidates, context),
+                    |candidates, context| Ok(picker.peek(scorer, candidates, context)),
                 )?;
                 (target, None)
             }
-            (SelectionIntent::Committed, Some((scorer, picker))) => {
+            (None, SelectionIntent::Committed, Some((scorer, picker))) => {
                 let reservation = self
                     .inner
                     .reserve_within_policy(
                         request.content(),
                         None,
                         allowed_fallback.as_ref(),
-                        |candidates, context| picker.select(scorer, candidates, context),
+                        |candidates, context| Ok(picker.select(scorer, candidates, context)),
                     )
                     .await?;
                 (reservation.target(), Some(reservation))
             }
-            (SelectionIntent::Advisory, None) => {
+            (None, SelectionIntent::Advisory, None) => {
                 let target = self.inner.peek_within(
                     request.content(),
                     pinned_worker,
@@ -271,7 +376,7 @@ impl AttemptBackend for SessionAffinityPushRouter {
                 )?;
                 (target, None)
             }
-            (SelectionIntent::Committed, None) => {
+            (None, SelectionIntent::Committed, None) => {
                 let reservation = self
                     .inner
                     .reserve_within(request.content(), pinned_worker, allowed_fallback.as_ref())
@@ -288,6 +393,8 @@ impl AttemptBackend for SessionAffinityPushRouter {
             exact: pinned_target.is_some(),
             allowed_fallback,
             load_guard,
+            route: None,
+            tracker: None,
         })
     }
 
@@ -295,53 +402,81 @@ impl AttemptBackend for SessionAffinityPushRouter {
         Self::record_target(request.tracker.as_deref(), attempt.target);
     }
 
-    async fn dispatch<M, F>(
+    async fn begin_dispatch(
         &self,
-        request: SingleIn<PreprocessedRequest>,
-        attempt: Self::Attempt,
+        request: &mut SingleIn<PreprocessedRequest>,
+        attempt: &mut Self::Attempt,
         kind: AttemptKind,
-        prepare: F,
-    ) -> Result<(M, AffinityTarget, ManyOut<LlmResponse>), Error>
-    where
-        M: Send,
-        F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error> + Send,
-    {
-        let SimpleAttempt {
-            target,
-            reservation,
-            exact,
-            allowed_fallback,
-            load_guard,
-        } = attempt;
-        let reservation = reservation.expect("committed simple attempt has a reservation");
-        let fallback = if exact || kind == AttemptKind::Prefill {
+    ) -> Result<AffinityTarget, Error> {
+        let fallback = if attempt.exact || kind == AttemptKind::Prefill {
             RouteFallback::Deny
-        } else if let Some(allowed) = allowed_fallback.as_ref() {
+        } else if let Some(allowed) = attempt.allowed_fallback.as_ref() {
             RouteFallback::Within(allowed)
         } else {
             RouteFallback::Allow
         };
-        let ((metadata, tracker, actual_target), stream) = self
+        let route = self
             .inner
-            .dispatch_reserved_prepared(
-                request,
-                reservation,
-                fallback,
-                move |request, worker_id| {
-                    let dp_rank = target.dp_rank.filter(|_| worker_id == target.worker_id);
-                    request.routing_mut().dp_rank = dp_rank;
-                    let actual_target = AffinityTarget::new(worker_id, dp_rank);
-                    let metadata = prepare(request, actual_target)?;
-                    Ok((metadata, request.tracker.take(), actual_target))
-                },
-            )
-            .await?;
-        Self::record_target(tracker.as_deref(), actual_target);
-        let stream = match load_guard {
+            .resolve_route(attempt.target.worker_id, fallback)?;
+        attempt
+            .reservation
+            .as_mut()
+            .expect("committed simple attempt has a reservation")
+            .retarget(route.target());
+        let worker_id = route.target().worker_id;
+        let dp_rank = attempt
+            .target
+            .dp_rank
+            .filter(|_| worker_id == attempt.target.worker_id);
+        request.routing_mut().dp_rank = dp_rank;
+        let target = AffinityTarget::new(worker_id, dp_rank);
+        attempt.target = target;
+        attempt.route = Some(route);
+        Ok(target)
+    }
+
+    fn after_prepare(
+        &self,
+        request: &mut SingleIn<PreprocessedRequest>,
+        attempt: &mut Self::Attempt,
+    ) {
+        attempt.tracker = request.tracker.take();
+    }
+
+    async fn dispatch_prepared(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+        attempt: &mut Self::Attempt,
+        _kind: AttemptKind,
+    ) -> Result<ManyOut<LlmResponse>, Error> {
+        let route = attempt
+            .route
+            .take()
+            .expect("prepared simple attempt has a resolved route");
+        self.inner.dispatch_resolved(request, route).await
+    }
+
+    async fn abort(&self, attempt: &mut Self::Attempt) {
+        attempt.reservation.take();
+        attempt.load_guard.take();
+    }
+
+    fn finish_dispatch(
+        &self,
+        mut attempt: Self::Attempt,
+        target: AffinityTarget,
+        stream: ManyOut<LlmResponse>,
+    ) -> ManyOut<LlmResponse> {
+        Self::record_target(attempt.tracker.as_deref(), target);
+        let stream = attempt
+            .reservation
+            .take()
+            .expect("dispatched simple attempt has a reservation")
+            .into_tracked_stream(stream);
+        match attempt.load_guard.take() {
             Some(guard) => track_response(stream, guard),
             None => stream,
-        };
-        Ok((metadata, actual_target, stream))
+        }
     }
 }
 
@@ -361,7 +496,11 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
 mod tests {
     use std::time::Instant;
 
-    use dynamo_kv_router::protocols::WorkerWithDpRank;
+    use dynamo_kv_router::{
+        KvRouterConfig, WorkerSelectionPolicyError,
+        protocols::WorkerWithDpRank,
+        selector::{WorkerInputView, WorkerPicker, WorkerSelectionContext, WorkerSelectionPolicy},
+    };
     use dynamo_runtime::{
         DistributedRuntime, Runtime,
         discovery::EventTransportKind,
@@ -649,6 +788,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn injected_policy_selects_non_kv_worker_and_owns_occupancy() {
+        struct HighestWorkerPicker;
+
+        impl WorkerPicker for HighestWorkerPicker {
+            fn pick(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                input: WorkerInputView<'_>,
+            ) -> Result<usize, WorkerSelectionPolicyError> {
+                Ok(input
+                    .candidates()
+                    .iter()
+                    .enumerate()
+                    .max_by_key(|(_, candidate)| candidate.worker().worker_id)
+                    .map(|(index, _)| index)
+                    .expect("candidate"))
+            }
+        }
+
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("custom_simple_policy".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate");
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let expected = client
+            .wait_for_instances()
+            .await
+            .unwrap()
+            .iter()
+            .map(|instance| instance.id())
+            .max()
+            .unwrap();
+        let mut inner = PushRouter::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+        inner.enable_policy_occupancy().await;
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(HighestWorkerPicker),
+        )
+        .into_cache_unaware()
+        .unwrap();
+        let router = SessionAffinityPushRouter::new_with_coordinator_and_lora(
+            inner,
+            None,
+            false,
+            None,
+            Some(Arc::new(policy)),
+            None,
+        );
+        let request = Context::new(request(None, false));
+
+        let committed = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Committed,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(committed.target.worker_id, expected);
+        assert_eq!(router.occupancy_for_test(expected), 1);
+        drop(committed);
+        assert_eq!(router.occupancy_for_test(expected), 0);
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
     async fn lora_constraint_uses_common_advisory_and_reservation_lifecycle() {
         let runtime = Runtime::from_current().unwrap();
         let distributed =
@@ -688,6 +908,8 @@ mod tests {
             None,
             false,
             Some((filter, estimator.clone())),
+            None,
+            None,
         );
         let mut content = request(None, false);
         content.routing_mut().lora_name = Some("adapter".to_string());
@@ -719,6 +941,96 @@ mod tests {
         assert_eq!(estimator.get_inflight_counts().get("adapter"), Some(&1));
         drop(committed);
         assert!(estimator.get_inflight_counts().is_empty());
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn lora_round_robin_cursor_is_independent_from_base_requests() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("lora_round_robin_cursor".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate");
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let real_worker = client.wait_for_instances().await.unwrap()[0].id();
+        let workers = vec![
+            real_worker,
+            real_worker.wrapping_add(1),
+            real_worker.wrapping_add(2),
+        ];
+        client.override_discovered_instances(workers.clone());
+        let lora_workers = &workers[..2];
+
+        let table = LoraRoutingTable::new();
+        table.update_allocation(
+            "adapter".to_string(),
+            LoraReplicaConfig {
+                lora_name: "adapter".to_string(),
+                replica_factor: 2,
+                replica_set: lora_workers
+                    .iter()
+                    .map(|worker_id| WorkerWithDpRank::new(*worker_id, 0))
+                    .collect(),
+                updated_at: Instant::now(),
+                is_active: true,
+            },
+        );
+        let filter = Arc::new(LoraFilter::new(table, LoraStateTracker::new()));
+        let estimator = Arc::new(LoadEstimator::new());
+        let inner = PushRouter::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+        let router = SessionAffinityPushRouter::new_with_coordinator_and_lora(
+            inner,
+            None,
+            false,
+            Some((filter, estimator)),
+            None,
+            None,
+        );
+        let base_request = Context::new(request(None, false));
+        let mut lora_content = request(None, false);
+        lora_content.routing_mut().lora_name = Some("adapter".to_string());
+        let lora_request = Context::new(lora_content);
+        let mut selected_lora_workers = Vec::new();
+
+        for _ in 0..2 {
+            let base = router
+                .select(
+                    &base_request,
+                    RequestPhase::Aggregated,
+                    SelectionIntent::Committed,
+                    None,
+                )
+                .await
+                .unwrap();
+            drop(base);
+
+            let lora = router
+                .select(
+                    &lora_request,
+                    RequestPhase::Aggregated,
+                    SelectionIntent::Committed,
+                    None,
+                )
+                .await
+                .unwrap();
+            selected_lora_workers.push(lora.target.worker_id);
+            drop(lora);
+        }
+
+        assert_ne!(
+            selected_lora_workers[0], selected_lora_workers[1],
+            "base requests must not pin the LoRA round-robin cursor to one replica"
+        );
 
         runtime.shutdown();
     }

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -499,6 +499,16 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
 mod tests {
     use std::time::Instant;
 
+    use super::*;
+    use crate::lora::{
+        LoadEstimator, LoraFilter, LoraReplicaConfig, LoraRoutingTable, LoraStateTracker,
+    };
+    use crate::protocols::common::{
+        extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
+        preprocessor::RoutingHints,
+        timing::RequestTracker,
+    };
+    use crate::session_affinity::AffinityAcquire;
     use dynamo_kv_router::{
         KvRouterConfig, WorkerSelectionPolicyError,
         protocols::WorkerWithDpRank,
@@ -514,18 +524,6 @@ mod tests {
         pipeline::{Context, RouterMode},
         storage::kv::Selector,
     };
-    use futures::StreamExt;
-
-    use super::*;
-    use crate::lora::{
-        LoadEstimator, LoraFilter, LoraReplicaConfig, LoraRoutingTable, LoraStateTracker,
-    };
-    use crate::protocols::common::{
-        extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
-        preprocessor::RoutingHints,
-        timing::RequestTracker,
-    };
-    use crate::session_affinity::AffinityAcquire;
 
     fn request(worker_id: Option<u64>, query_only: bool) -> PreprocessedRequest {
         PreprocessedRequest::builder()
@@ -644,7 +642,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn advisory_query_uses_common_path_without_admission_or_dispatch() {
+    async fn explicit_advisory_selection_does_not_admit() {
         let runtime = Runtime::from_current().unwrap();
         let distributed =
             DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
@@ -667,13 +665,20 @@ mod tests {
         let mut content = request(None, true);
         content.tracker = Some(tracker.clone());
 
-        let mut stream = router.generate(Context::new(content)).await.unwrap();
-        let output = stream.next().await.unwrap().data.unwrap();
+        let request = Context::new(content);
+        let advisory = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Advisory,
+                None,
+            )
+            .await
+            .unwrap();
+        router.observe_advisory(&request, &advisory);
 
         assert_eq!(tracker.decode_worker_id(), Some(worker_id));
         assert_eq!(router.occupancy_for_test(worker_id), 0);
-        assert!(output.routing_data.is_some());
-        assert!(stream.next().await.is_none());
 
         runtime.shutdown();
     }

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -192,18 +192,12 @@ impl SessionAffinityPushRouter {
         policy: &CacheUnawareWorkerSelectionPolicy,
         request: &CacheUnawareRequestContext<'_>,
         candidates: &RoutePolicyCandidates<'_>,
+        allowed_worker_ids: &mut Option<HashSet<u64>>,
     ) -> Result<Option<RoutePolicyDecision>, Error> {
-        let worker_id =
-            policy.pick_worker(request, candidates, |index| candidates.worker_id(index))?;
-        let index = (0..candidates.len())
-            .find(|&index| candidates.worker_id(index) == worker_id)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "custom policy selected worker {worker_id} outside the host candidate table"
-                )
-            })?;
+        let decision = policy.select(request, candidates, |index| candidates.worker_id(index))?;
+        *allowed_worker_ids = Some(decision.allowed_worker_ids);
         Ok(Some(RoutePolicyDecision {
-            index,
+            index: decision.index,
             admission: RouteAdmissionKind::Occupancy,
         }))
     }
@@ -268,32 +262,27 @@ impl AttemptBackend for SessionAffinityPushRouter {
     async fn select(
         &self,
         request: &SingleIn<PreprocessedRequest>,
-        _phase: RequestPhase,
+        phase: RequestPhase,
         intent: SelectionIntent,
         pinned_target: Option<AffinityTarget>,
     ) -> Result<Self::Attempt, Error> {
         let pinned_worker = pinned_target.map(|target| target.worker_id);
-        let (allowed_fallback, load_guard) = self.lora_candidates(request.content(), intent)?;
-        let native_policy = if pinned_worker.is_none() {
-            if allowed_fallback.is_some() {
-                self.lora
-                    .as_ref()
-                    .and_then(|constraint| constraint.policy.as_ref())
-            } else {
-                self.policy.as_ref()
-            }
+        let (mut allowed_fallback, load_guard) = self.lora_candidates(request.content(), intent)?;
+        let native_policy = if allowed_fallback.is_some() {
+            self.lora
+                .as_ref()
+                .and_then(|constraint| constraint.policy.as_ref())
         } else {
-            None
+            self.policy.as_ref()
         };
-        let custom_policy = if pinned_worker.is_some() {
-            None
-        } else if allowed_fallback.is_some() {
+        let custom_policy = if allowed_fallback.is_some() {
             self.lora
                 .as_ref()
                 .and_then(|constraint| constraint.custom_policy.as_deref())
         } else {
             self.custom_policy.as_deref()
         };
+        let mut policy_allowed_workers = None;
         let custom_selection = if let Some(policy) = custom_policy {
             let session_context = request
                 .agent_context
@@ -320,10 +309,15 @@ impl AttemptBackend for SessionAffinityPushRouter {
                 SelectionIntent::Advisory => {
                     let target = self.inner.peek_within_policy(
                         request.content(),
-                        None,
+                        pinned_worker,
                         allowed_fallback.as_ref(),
                         |candidates, _context| {
-                            Self::custom_policy_decision(policy, &custom_context, candidates)
+                            Self::custom_policy_decision(
+                                policy,
+                                &custom_context,
+                                candidates,
+                                &mut policy_allowed_workers,
+                            )
                         },
                     )?;
                     (target, None)
@@ -333,10 +327,15 @@ impl AttemptBackend for SessionAffinityPushRouter {
                         .inner
                         .reserve_within_policy(
                             request.content(),
-                            None,
+                            pinned_worker,
                             allowed_fallback.as_ref(),
                             |candidates, _context| {
-                                Self::custom_policy_decision(policy, &custom_context, candidates)
+                                Self::custom_policy_decision(
+                                    policy,
+                                    &custom_context,
+                                    candidates,
+                                    &mut policy_allowed_workers,
+                                )
                             },
                         )
                         .await?;
@@ -351,7 +350,7 @@ impl AttemptBackend for SessionAffinityPushRouter {
             (None, SelectionIntent::Advisory, Some((scorer, picker))) => {
                 let target = self.inner.peek_within_policy(
                     request.content(),
-                    None,
+                    pinned_worker,
                     allowed_fallback.as_ref(),
                     |candidates, context| Ok(picker.peek(scorer, candidates, context)),
                 )?;
@@ -362,7 +361,7 @@ impl AttemptBackend for SessionAffinityPushRouter {
                     .inner
                     .reserve_within_policy(
                         request.content(),
-                        None,
+                        pinned_worker,
                         allowed_fallback.as_ref(),
                         |candidates, context| Ok(picker.select(scorer, candidates, context)),
                     )
@@ -385,13 +384,16 @@ impl AttemptBackend for SessionAffinityPushRouter {
                 (reservation.target(), Some(reservation))
             }
         };
+        if policy_allowed_workers.is_some() {
+            allowed_fallback = policy_allowed_workers;
+        }
         let dp_rank = pinned_target
             .filter(|target| target.worker_id == selected.worker_id)
             .and_then(|target| target.dp_rank);
         Ok(SimpleAttempt {
             target: AffinityTarget::new(selected.worker_id, dp_rank),
             reservation,
-            exact: pinned_target.is_some(),
+            exact: crate::session_affinity::explicit_target(request, phase)?.is_some(),
             allowed_fallback,
             load_guard,
             route: None,
@@ -500,7 +502,10 @@ mod tests {
     use dynamo_kv_router::{
         KvRouterConfig, WorkerSelectionPolicyError,
         protocols::WorkerWithDpRank,
-        selector::{WorkerInputView, WorkerPicker, WorkerSelectionContext, WorkerSelectionPolicy},
+        selector::{
+            WorkerCandidate, WorkerFilter, WorkerInputView, WorkerPicker, WorkerSelectionContext,
+            WorkerSelectionPolicy,
+        },
     };
     use dynamo_runtime::{
         DistributedRuntime, Runtime,
@@ -895,6 +900,140 @@ mod tests {
         assert_eq!(router.occupancy_for_test(expected), 1);
         drop(committed);
         assert_eq!(router.occupancy_for_test(expected), 0);
+
+        let pinned = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Committed,
+                Some(AffinityTarget::new(expected, None)),
+            )
+            .await
+            .unwrap();
+        assert_eq!(pinned.target.worker_id, expected);
+        assert_eq!(router.occupancy_for_test(expected), 1);
+        drop(pinned);
+        assert_eq!(router.occupancy_for_test(expected), 0);
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn custom_policy_validates_pins_and_constrains_transport_fallback() {
+        struct RejectWorker(u64);
+
+        impl WorkerFilter for RejectWorker {
+            fn keep(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                candidate: &WorkerCandidate,
+            ) -> Result<bool, WorkerSelectionPolicyError> {
+                Ok(candidate.worker().worker_id != self.0)
+            }
+        }
+
+        struct HighestWorkerPicker;
+
+        impl WorkerPicker for HighestWorkerPicker {
+            fn pick(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                input: WorkerInputView<'_>,
+            ) -> Result<usize, WorkerSelectionPolicyError> {
+                Ok(input
+                    .candidates()
+                    .iter()
+                    .enumerate()
+                    .max_by_key(|(_, candidate)| candidate.worker().worker_id)
+                    .map(|(index, _)| index)
+                    .expect("candidate"))
+            }
+        }
+
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("custom_policy_fallback".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate");
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let real_worker = client.wait_for_instances().await.unwrap()[0].id();
+        let stale_worker = real_worker.wrapping_add(1);
+        let rejected_worker = real_worker.wrapping_add(2);
+        client.override_instance_avail(vec![real_worker, stale_worker, rejected_worker]);
+
+        let mut inner = PushRouter::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+        inner.enable_policy_occupancy().await;
+        let policy = WorkerSelectionPolicy::new_with_filters(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(RejectWorker(rejected_worker))],
+            Vec::new(),
+            Box::new(HighestWorkerPicker),
+        )
+        .into_cache_unaware()
+        .unwrap();
+        let router = SessionAffinityPushRouter::new_with_coordinator_and_lora(
+            inner,
+            None,
+            false,
+            None,
+            Some(Arc::new(policy)),
+            None,
+        )
+        .unwrap();
+        let mut request = Context::new(request(None, false));
+
+        assert!(
+            router
+                .select(
+                    &request,
+                    RequestPhase::Aggregated,
+                    SelectionIntent::Committed,
+                    Some(AffinityTarget::new(rejected_worker, None)),
+                )
+                .await
+                .is_err(),
+            "custom filters must reject an ineligible pinned target"
+        );
+
+        let mut pinned = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Committed,
+                Some(AffinityTarget::new(real_worker, None)),
+            )
+            .await
+            .unwrap();
+        assert_eq!(router.occupancy_for_test(real_worker), 1);
+        router.abort(&mut pinned).await;
+        assert_eq!(router.occupancy_for_test(real_worker), 0);
+
+        let mut attempt = router
+            .select(
+                &request,
+                RequestPhase::Aggregated,
+                SelectionIntent::Committed,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(attempt.target.worker_id, stale_worker);
+        let target = router
+            .begin_dispatch(&mut request, &mut attempt, AttemptKind::Generate)
+            .await
+            .unwrap();
+        assert_eq!(target.worker_id, real_worker);
+        router.abort(&mut attempt).await;
 
         runtime.shutdown();
     }

--- a/lib/llm/src/session_affinity/tests.rs
+++ b/lib/llm/src/session_affinity/tests.rs
@@ -340,7 +340,7 @@ async fn session_affinity_committed_binding_survives_cancelled_stream_until_ttl(
 }
 
 #[tokio::test(start_paused = true)]
-async fn session_affinity_error_stream_refreshes_idle_ttl() {
+async fn session_affinity_error_stream_invalidates_before_yielding_error() {
     let coordinator = coordinator();
     let AffinityAcquire::Initialize(initializer) =
         coordinator.acquire(&session_id(), None).await.unwrap()
@@ -348,12 +348,14 @@ async fn session_affinity_error_stream_refreshes_idle_ttl() {
         panic!("first request must initialize");
     };
     let lease = initializer.commit(target(7, Some(0))).unwrap();
-    tokio::time::advance(Duration::from_secs(9)).await;
     let mut stream = lease.into_stream(error_response_stream());
     assert!(stream.next().await.unwrap().is_err());
-    assert!(stream.next().await.is_none());
-
-    assert_binding_expires_after_refreshed_ttl(&coordinator).await;
+    assert_eq!(coordinator.query_target(&session_id(), None).unwrap(), None);
+    assert_eq!(coordinator.entry_count(), 0);
+    assert!(matches!(
+        coordinator.acquire(&session_id(), None).await.unwrap(),
+        AffinityAcquire::Initialize(_)
+    ));
 }
 
 #[tokio::test(start_paused = true)]

--- a/lib/router-policy/Cargo.toml
+++ b/lib/router-policy/Cargo.toml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-router-policy"
+description = "Dependency-neutral routing policy kernel for Dynamo"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+fastrand = "2"

--- a/lib/router-policy/src/lib.rs
+++ b/lib/router-policy/src/lib.rs
@@ -1,0 +1,455 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dependency-neutral worker-picking policies.
+//!
+//! Hosts retain ownership of discovery, eligibility, load, and admission. This crate owns only
+//! the allocation-free picking algorithms and their policy-local state.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RoutingPolicy {
+    RoundRobin,
+    Random,
+    PowerOfTwoChoices,
+    LeastLoaded,
+    DeviceAwareWeighted,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RouteDevice {
+    Cpu,
+    #[default]
+    Accelerator,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RouteContext {
+    pub required_cache_hits: usize,
+    pub non_cpu_to_cpu_ratio: usize,
+}
+
+impl Default for RouteContext {
+    fn default() -> Self {
+        Self {
+            required_cache_hits: 0,
+            non_cpu_to_cpu_ratio: 8,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdmissionKind {
+    None,
+    Occupancy,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PolicyDecision {
+    pub index: usize,
+    pub admission: AdmissionKind,
+}
+
+/// Host-owned, borrowed candidate table consumed by a picker.
+///
+/// Static policies only call [`Self::len`]. Load-aware policies additionally call
+/// [`Self::load`], and the device-aware policy reads the device and cache columns. A host can
+/// therefore wrap its native discovery snapshot without constructing policy-owned rows.
+pub trait RouteCandidates {
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn load(&self, index: usize) -> u64;
+
+    fn device(&self, _index: usize) -> RouteDevice {
+        RouteDevice::Accelerator
+    }
+
+    fn cache_hits(&self, _index: usize) -> usize {
+        0
+    }
+}
+
+#[derive(Debug)]
+pub struct RoutePicker {
+    policy: RoutingPolicy,
+    round_robin_cursor: AtomicU64,
+}
+
+impl RoutePicker {
+    pub const fn new(policy: RoutingPolicy) -> Self {
+        Self {
+            policy,
+            round_robin_cursor: AtomicU64::new(0),
+        }
+    }
+
+    pub const fn policy(&self) -> RoutingPolicy {
+        self.policy
+    }
+
+    #[inline(always)]
+    pub fn peek<C: RouteCandidates + ?Sized>(
+        &self,
+        candidates: &C,
+        context: RouteContext,
+    ) -> Option<PolicyDecision> {
+        if self.policy == RoutingPolicy::Random {
+            return random_decision(candidates);
+        }
+        let mut samples = RandomSamples;
+        self.choose_with_samples(candidates, context, false, &mut samples)
+    }
+
+    #[inline(always)]
+    pub fn select<C: RouteCandidates + ?Sized>(
+        &self,
+        candidates: &C,
+        context: RouteContext,
+    ) -> Option<PolicyDecision> {
+        if self.policy == RoutingPolicy::Random {
+            return random_decision(candidates);
+        }
+        let mut samples = RandomSamples;
+        self.choose_with_samples(candidates, context, true, &mut samples)
+    }
+
+    #[inline(always)]
+    fn choose_with_samples<C: RouteCandidates + ?Sized>(
+        &self,
+        candidates: &C,
+        context: RouteContext,
+        commit: bool,
+        samples: &mut impl SampleSource,
+    ) -> Option<PolicyDecision> {
+        if candidates.is_empty() {
+            return None;
+        }
+
+        let (index, admission) = match self.policy {
+            RoutingPolicy::RoundRobin => {
+                let cursor = if commit {
+                    self.round_robin_cursor.fetch_add(1, Ordering::Relaxed)
+                } else {
+                    self.round_robin_cursor.load(Ordering::Relaxed)
+                };
+                (cursor as usize % candidates.len(), AdmissionKind::None)
+            }
+            RoutingPolicy::Random => (samples.index(candidates.len()), AdmissionKind::None),
+            RoutingPolicy::PowerOfTwoChoices => {
+                let first = samples.index(candidates.len());
+                if candidates.len() == 1 {
+                    return Some(PolicyDecision {
+                        index: first,
+                        admission: AdmissionKind::Occupancy,
+                    });
+                }
+                let second_offset = 1 + samples.index(candidates.len() - 1);
+                let second = (first + second_offset) % candidates.len();
+                let index = if candidates.load(first) <= candidates.load(second) {
+                    first
+                } else {
+                    second
+                };
+                (index, AdmissionKind::Occupancy)
+            }
+            RoutingPolicy::LeastLoaded => {
+                (lowest_load(candidates, samples)?, AdmissionKind::Occupancy)
+            }
+            RoutingPolicy::DeviceAwareWeighted => {
+                return device_aware(candidates, context, samples);
+            }
+        };
+        Some(PolicyDecision { index, admission })
+    }
+}
+
+trait SampleSource {
+    fn index(&mut self, upper: usize) -> usize;
+}
+
+struct RandomSamples;
+
+impl SampleSource for RandomSamples {
+    #[inline(always)]
+    fn index(&mut self, upper: usize) -> usize {
+        fastrand::usize(..upper)
+    }
+}
+
+#[inline(always)]
+fn random_decision<C: RouteCandidates + ?Sized>(candidates: &C) -> Option<PolicyDecision> {
+    (!candidates.is_empty()).then(|| PolicyDecision {
+        index: fastrand::usize(..candidates.len()),
+        admission: AdmissionKind::None,
+    })
+}
+
+#[inline(always)]
+fn lowest_load<C: RouteCandidates + ?Sized>(
+    candidates: &C,
+    samples: &mut impl SampleSource,
+) -> Option<usize> {
+    let mut best = None;
+    let mut best_load = u64::MAX;
+    let mut ties = 0usize;
+    for index in 0..candidates.len() {
+        let load = candidates.load(index);
+        if load < best_load {
+            best = Some(index);
+            best_load = load;
+            ties = 1;
+        } else if load == best_load {
+            ties += 1;
+            if samples.index(ties) == 0 {
+                best = Some(index);
+            }
+        }
+    }
+    best
+}
+
+#[derive(Default)]
+struct DeviceGroup {
+    count: u64,
+    total_load: u64,
+    best: Option<usize>,
+    best_load: u64,
+    best_ties: usize,
+}
+
+impl DeviceGroup {
+    #[inline(always)]
+    fn consider(&mut self, index: usize, load: u64, samples: &mut impl SampleSource) {
+        self.count += 1;
+        self.total_load = self.total_load.saturating_add(load);
+        if self.best.is_none() || load < self.best_load {
+            self.best = Some(index);
+            self.best_load = load;
+            self.best_ties = 1;
+        } else if load == self.best_load {
+            self.best_ties += 1;
+            if samples.index(self.best_ties) == 0 {
+                self.best = Some(index);
+            }
+        }
+    }
+}
+
+#[inline(always)]
+fn device_aware<C: RouteCandidates + ?Sized>(
+    candidates: &C,
+    context: RouteContext,
+    samples: &mut impl SampleSource,
+) -> Option<PolicyDecision> {
+    let mut cpu = DeviceGroup {
+        best_load: u64::MAX,
+        ..Default::default()
+    };
+    let mut accelerator = DeviceGroup {
+        best_load: u64::MAX,
+        ..Default::default()
+    };
+    let mut full_cache = DeviceGroup {
+        best_load: u64::MAX,
+        ..Default::default()
+    };
+
+    for index in 0..candidates.len() {
+        let load = candidates.load(index);
+        match candidates.device(index) {
+            RouteDevice::Cpu => cpu.consider(index, load, samples),
+            RouteDevice::Accelerator => accelerator.consider(index, load, samples),
+        }
+        if context.required_cache_hits > 0
+            && candidates.cache_hits(index) >= context.required_cache_hits
+        {
+            full_cache.consider(index, load, samples);
+        }
+    }
+
+    if let Some(index) = full_cache.best {
+        return Some(PolicyDecision {
+            index,
+            admission: AdmissionKind::None,
+        });
+    }
+
+    let index = match (cpu.best, accelerator.best) {
+        (None, None) => return None,
+        (Some(index), None) | (None, Some(index)) => index,
+        (Some(cpu_index), Some(accelerator_index)) => {
+            let ratio = context.non_cpu_to_cpu_ratio.max(1) as u64;
+            let allowed_cpu = accelerator.total_load.saturating_mul(cpu.count)
+                / ratio.saturating_mul(accelerator.count);
+            if cpu.total_load < allowed_cpu {
+                cpu_index
+            } else {
+                accelerator_index
+            }
+        }
+    };
+    Some(PolicyDecision {
+        index,
+        admission: AdmissionKind::Occupancy,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    struct Rows<'a> {
+        loads: &'a [u64],
+    }
+
+    impl RouteCandidates for Rows<'_> {
+        fn len(&self) -> usize {
+            self.loads.len()
+        }
+
+        fn load(&self, index: usize) -> u64 {
+            self.loads[index]
+        }
+    }
+
+    struct ScriptedSamples {
+        values: Vec<usize>,
+        consumed: usize,
+    }
+
+    impl ScriptedSamples {
+        fn new(values: impl Into<Vec<usize>>) -> Self {
+            Self {
+                values: values.into(),
+                consumed: 0,
+            }
+        }
+    }
+
+    impl SampleSource for ScriptedSamples {
+        fn index(&mut self, upper: usize) -> usize {
+            let value = self.values[self.consumed];
+            self.consumed += 1;
+            value % upper
+        }
+    }
+
+    #[test]
+    fn round_robin_peek_does_not_advance_committed_cursor() {
+        let picker = RoutePicker::new(RoutingPolicy::RoundRobin);
+        let rows = Rows { loads: &[0, 0] };
+        assert_eq!(
+            picker.peek(&rows, RouteContext::default()).unwrap().index,
+            0
+        );
+        assert_eq!(
+            picker.peek(&rows, RouteContext::default()).unwrap().index,
+            0
+        );
+        assert_eq!(
+            picker.select(&rows, RouteContext::default()).unwrap().index,
+            0
+        );
+        assert_eq!(
+            picker.select(&rows, RouteContext::default()).unwrap().index,
+            1
+        );
+    }
+
+    #[test]
+    fn least_loaded_uses_host_loads() {
+        let picker = RoutePicker::new(RoutingPolicy::LeastLoaded);
+        let rows = Rows { loads: &[7, 2, 9] };
+        let decision = picker.select(&rows, RouteContext::default()).unwrap();
+        assert_eq!(decision.index, 1);
+        assert_eq!(decision.admission, AdmissionKind::Occupancy);
+    }
+
+    #[test]
+    fn p2c_uses_two_samples_and_two_load_reads() {
+        struct CountingRows<'a> {
+            loads: &'a [u64],
+            reads: Cell<usize>,
+        }
+
+        impl RouteCandidates for CountingRows<'_> {
+            fn len(&self) -> usize {
+                self.loads.len()
+            }
+
+            fn load(&self, index: usize) -> u64 {
+                self.reads.set(self.reads.get() + 1);
+                self.loads[index]
+            }
+        }
+
+        let picker = RoutePicker::new(RoutingPolicy::PowerOfTwoChoices);
+        let rows = CountingRows {
+            loads: &[0, 5, 0, 1],
+            reads: Cell::new(0),
+        };
+        let mut samples = ScriptedSamples::new(vec![1, 1]);
+        let decision = picker
+            .choose_with_samples(&rows, RouteContext::default(), true, &mut samples)
+            .unwrap();
+        assert_eq!(decision.index, 3);
+        assert_eq!(samples.consumed, 2);
+        assert_eq!(rows.reads.get(), 2);
+    }
+
+    #[test]
+    fn full_device_cache_hit_skips_occupancy_admission() {
+        struct DeviceRows {
+            loads: [u64; 3],
+            devices: [RouteDevice; 3],
+            cache_hits: [usize; 3],
+        }
+
+        impl RouteCandidates for DeviceRows {
+            fn len(&self) -> usize {
+                self.loads.len()
+            }
+
+            fn load(&self, index: usize) -> u64 {
+                self.loads[index]
+            }
+
+            fn device(&self, index: usize) -> RouteDevice {
+                self.devices[index]
+            }
+
+            fn cache_hits(&self, index: usize) -> usize {
+                self.cache_hits[index]
+            }
+        }
+
+        let picker = RoutePicker::new(RoutingPolicy::DeviceAwareWeighted);
+        let rows = DeviceRows {
+            loads: [0, 20, 1],
+            devices: [
+                RouteDevice::Cpu,
+                RouteDevice::Accelerator,
+                RouteDevice::Accelerator,
+            ],
+            cache_hits: [0, 2, 1],
+        };
+        let decision = picker
+            .peek(
+                &rows,
+                RouteContext {
+                    required_cache_hits: 2,
+                    non_cpu_to_cpu_ratio: 8,
+                },
+            )
+            .unwrap();
+        assert_eq!(decision.index, 1);
+        assert_eq!(decision.admission, AdmissionKind::None);
+    }
+}

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -30,6 +30,7 @@ nvtx = ["dep:cudarc"]
 [dependencies]
 # repo
 dynamo-truthy = { workspace = true }
+dynamo-router-policy = { workspace = true }
 
 # Use workspace dependencies where available
 anyhow = { workspace = true }

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -48,7 +48,6 @@ derive_builder = { workspace = true }
 derive-getters = { workspace = true }
 either = { workspace = true }
 etcd-client = { workspace = true }
-fastrand = "2"
 futures = { workspace = true }
 fs4 = { workspace = true }
 humantime = { workspace = true }

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -790,6 +790,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynamo-router-policy"
+version = "1.4.0"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "dynamo-runtime"
 version = "1.4.0"
 dependencies = [
@@ -808,6 +815,7 @@ dependencies = [
  "dashmap",
  "derive-getters",
  "derive_builder",
+ "dynamo-router-policy",
  "dynamo-truthy",
  "educe",
  "either",

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -820,7 +820,6 @@ dependencies = [
  "educe",
  "either",
  "etcd-client",
- "fastrand",
  "figment",
  "fs4",
  "futures",

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -87,13 +87,19 @@ impl RoutingOccupancyState {
         candidates: CandidateView<'_>,
         context: RouteContext,
     ) -> Option<(RouteDecision, Option<Arc<AtomicU64>>)> {
+        self.with_selection_lock(|| {
+            let decision = picker.select(candidates, context, |id| self.load(id))?;
+            let counter = match decision.admission {
+                AdmissionKind::None => None,
+                AdmissionKind::Occupancy => Some(self.increment(decision.target.worker_id)),
+            };
+            Some((decision, counter))
+        })
+    }
+
+    pub(crate) fn with_selection_lock<R>(&self, select: impl FnOnce() -> R) -> R {
         let _guard = self.exact_selection_lock.lock();
-        let decision = picker.select(candidates, context, |id| self.load(id))?;
-        let counter = match decision.admission {
-            AdmissionKind::None => None,
-            AdmissionKind::Occupancy => Some(self.increment(decision.target.worker_id)),
-        };
-        Some((decision, counter))
+        select()
     }
 
     pub(crate) fn decrement_counter(counter: &AtomicU64) {

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -590,6 +590,23 @@ impl Client {
         self.instance_source.borrow().clone()
     }
 
+    /// Clone one discovered instance without cloning the full discovery snapshot.
+    pub fn find_instance(&self, instance_id: u64) -> Option<Instance> {
+        self.instance_source
+            .borrow()
+            .iter()
+            .find(|instance| instance.id() == instance_id)
+            .cloned()
+    }
+
+    /// Check the current discovery snapshot without cloning it.
+    pub fn has_instance(&self, instance_id: u64) -> bool {
+        self.instance_source
+            .borrow()
+            .iter()
+            .any(|instance| instance.id() == instance_id)
+    }
+
     pub fn instance_ids(&self) -> Vec<u64> {
         self.instances().into_iter().map(|ep| ep.id()).collect()
     }

--- a/lib/runtime/src/pipeline.rs
+++ b/lib/runtime/src/pipeline.rs
@@ -19,7 +19,9 @@ pub use network::egress::addressed_router::{
     AddressedPushRouter, AddressedRequest, StreamingDispatch,
 };
 pub use network::egress::push_router::{
-    MultimodalCacheIndex, MultimodalCacheKeyExtractor, PushRouter, RouterMode, WorkerLoadMonitor,
+    MultimodalCacheIndex, MultimodalCacheKeyExtractor, PushRouter, RouteFallback,
+    RoutePolicyCandidates, RoutePolicyContext, RoutePolicyDecision, RouteReservation, RouterMode,
+    WorkerLoadMonitor,
 };
 pub mod registry;
 

--- a/lib/runtime/src/pipeline.rs
+++ b/lib/runtime/src/pipeline.rs
@@ -19,9 +19,9 @@ pub use network::egress::addressed_router::{
     AddressedPushRouter, AddressedRequest, StreamingDispatch,
 };
 pub use network::egress::push_router::{
-    MultimodalCacheIndex, MultimodalCacheKeyExtractor, PushRouter, RouteFallback,
-    RoutePolicyCandidates, RoutePolicyContext, RoutePolicyDecision, RouteReservation, RouterMode,
-    WorkerLoadMonitor,
+    MultimodalCacheIndex, MultimodalCacheKeyExtractor, PushRouter, ResolvedRoute,
+    RouteAdmissionKind, RouteFallback, RoutePolicyCandidates, RoutePolicyContext,
+    RoutePolicyDecision, RouteReservation, RouterMode, WorkerLoadMonitor,
 };
 pub mod registry;
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -41,7 +41,8 @@ use tokio_stream::StreamExt;
 use tracing::Instrument;
 
 pub use dynamo_router_policy::{
-    PolicyDecision as RoutePolicyDecision, RouteContext as RoutePolicyContext,
+    AdmissionKind as RouteAdmissionKind, PolicyDecision as RoutePolicyDecision,
+    RouteContext as RoutePolicyContext,
 };
 
 /// Check if an error chain indicates the worker should be reported as down.
@@ -102,18 +103,36 @@ impl RouteReservation {
         self.target
     }
 
-    fn retarget(&mut self, target: RouteTarget) {
+    /// Transfer this reservation to a target resolved before request preparation.
+    pub fn retarget(&mut self, target: RouteTarget) {
         if let Some(permit) = self.permit.as_mut() {
             permit.retarget(target.worker_id);
         }
         self.target = target;
     }
 
-    fn into_tracked_stream<U: Data + MaybeError>(self, stream: ManyOut<U>) -> ManyOut<U> {
+    /// Transfer the reservation lifetime to the dispatched response stream.
+    pub fn into_tracked_stream<U: Data + MaybeError>(self, stream: ManyOut<U>) -> ManyOut<U> {
         match self.permit {
             Some(permit) => permit.into_tracked_stream(stream),
             None => stream,
         }
+    }
+}
+
+/// A worker target fixed before target-specific request preparation.
+///
+/// Dispatch re-resolves the latest transport for this same worker. It never
+/// falls back after request preparation has begun.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResolvedRoute {
+    target: RouteTarget,
+}
+
+impl ResolvedRoute {
+    /// Return the worker selected for this route.
+    pub fn target(self) -> RouteTarget {
+        self.target
     }
 }
 
@@ -272,6 +291,26 @@ pub enum RouteFallback<'a> {
 pub struct RoutePolicyCandidates<'a> {
     candidates: CandidateView<'a>,
     occupancy: Option<&'a RoutingOccupancyState>,
+}
+
+impl RoutePolicyCandidates<'_> {
+    /// Return the number of host-validated candidates.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.candidates.len()
+    }
+
+    /// Return whether the host candidate table is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.candidates.is_empty()
+    }
+
+    /// Return the stable worker ID at `index`.
+    #[inline(always)]
+    pub fn worker_id(&self, index: usize) -> u64 {
+        self.candidates.target(index).worker_id
+    }
 }
 
 impl dynamo_router_policy::RouteCandidates for RoutePolicyCandidates<'_> {
@@ -727,6 +766,17 @@ where
         Ok(router)
     }
 
+    /// Enable frontend-local occupancy for an injected cache-unaware policy.
+    ///
+    /// Built-in static policies leave this disabled and retain their
+    /// allocation-free, lock-free selection path.
+    pub async fn enable_policy_occupancy(&mut self) {
+        if self.occupancy_state.is_none() {
+            self.occupancy_state =
+                Some(get_or_create_routing_occupancy_state(&self.client.endpoint).await);
+        }
+    }
+
     /// Like the other constructors but with a caller-supplied [`StreamingDispatch`]
     /// as the final hop. Fault detection is on, so the dispatch's `ErrorType`
     /// mapping drives report-down / overload / migration as usual.
@@ -1009,8 +1059,87 @@ where
     /// Callers that own admission can use this before request preparation to
     /// rebook under that owner before conditionally releasing the old target.
     pub fn validate_exact_target(&self, target: RouteTarget) -> anyhow::Result<()> {
-        self.resolve_transport(target.worker_id, RouteFallback::Deny)?;
-        Ok(())
+        if self.client.has_instance(target.worker_id) {
+            return Ok(());
+        }
+        Err(self.missing_instance_error(target.worker_id))
+    }
+
+    /// Resolve the worker that will own target-specific request preparation.
+    ///
+    /// Transport fallback is allowed only here, before the caller mutates the
+    /// request for a worker. [`Self::dispatch_resolved`] later refreshes the
+    /// transport for this same worker and fails if it disappeared.
+    pub fn resolve_route(
+        &self,
+        instance_id: u64,
+        fallback: RouteFallback<'_>,
+    ) -> anyhow::Result<ResolvedRoute> {
+        let resolved_id = if self.client.has_instance(instance_id) {
+            instance_id
+        } else {
+            let allowed = match fallback {
+                RouteFallback::Allow => None,
+                RouteFallback::Deny => return Err(self.missing_instance_error(instance_id)),
+                RouteFallback::Within(allowed) => Some(allowed),
+            };
+            let routing_instances = self.client.routing_instances();
+            let replacement = routing_instances.free_ids().iter().copied().find(|&id| {
+                id != instance_id && allowed.is_none_or(|allowed| allowed.contains(&id))
+            });
+            replacement.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Instance {} not found and no other instances available for endpoint {}",
+                    instance_id,
+                    self.client.endpoint.id()
+                )
+            })?
+        };
+        self.check_workers_available(resolved_id, "")?;
+        Ok(ResolvedRoute {
+            target: RouteTarget::worker(resolved_id),
+        })
+    }
+
+    /// Dispatch a request prepared for one fixed worker.
+    ///
+    /// The transport snapshot is refreshed after preparation, but the worker
+    /// ID cannot change at this boundary.
+    pub async fn dispatch_resolved(
+        &self,
+        request: SingleIn<T>,
+        route: ResolvedRoute,
+    ) -> anyhow::Result<ManyOut<U>> {
+        let route_start = Instant::now();
+        let request_id = request.id().to_string();
+        let instance_id = route.target.worker_id;
+        let route_span = if matches!(self.router_mode, RouterMode::KV) {
+            tracing::Span::none()
+        } else {
+            tracing::info_span!(
+                "router.route_request",
+                request_id = %request_id,
+                worker_id = instance_id,
+                router_mode = ?self.router_mode,
+            )
+        };
+        let (resolved_id, address, transport_kind, instance) =
+            self.resolve_transport(instance_id, RouteFallback::Deny)?;
+        debug_assert_eq!(resolved_id, instance_id);
+        self.check_workers_available(instance_id, &request_id)?;
+        let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
+
+        STAGE_DURATION_SECONDS
+            .with_label_values(&[STAGE_ROUTE])
+            .observe(route_start.elapsed().as_secs_f64());
+
+        let _nvtx_transport = dynamo_nvtx_range!(transport_kind);
+        let stream = self
+            .addressed
+            .generate(request)
+            .instrument(route_span)
+            .await;
+        self.wrap_with_fault_detection(stream, instance_id)
     }
 
     /// Select and book one worker, prepare the request for that exact worker,
@@ -1035,7 +1164,7 @@ where
     /// occupancy to the replacement before it releases the original charge.
     pub async fn dispatch_reserved_prepared<M, F>(
         &self,
-        request: SingleIn<T>,
+        mut request: SingleIn<T>,
         mut reservation: RouteReservation,
         fallback: RouteFallback<'_>,
         prepare: F,
@@ -1043,18 +1172,10 @@ where
     where
         F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
     {
-        let instance_id = reservation.target.worker_id;
-        let (metadata, stream) = self
-            .generate_with_fault_detection_prepared(
-                instance_id,
-                request,
-                fallback,
-                |request, resolved_instance_id| {
-                    reservation.retarget(RouteTarget::worker(resolved_instance_id));
-                    prepare(request, resolved_instance_id)
-                },
-            )
-            .await?;
+        let route = self.resolve_route(reservation.target.worker_id, fallback)?;
+        reservation.retarget(route.target());
+        let metadata = prepare(&mut request, route.target.worker_id)?;
+        let stream = self.dispatch_resolved(request, route).await?;
         Ok((metadata, reservation.into_tracked_stream(stream)))
     }
 
@@ -1595,7 +1716,10 @@ where
         select: F,
     ) -> anyhow::Result<RouteReservation>
     where
-        F: FnOnce(&RoutePolicyCandidates<'_>, RoutePolicyContext) -> Option<RoutePolicyDecision>,
+        F: FnOnce(
+            &RoutePolicyCandidates<'_>,
+            RoutePolicyContext,
+        ) -> anyhow::Result<Option<RoutePolicyDecision>>,
     {
         if let Some(instance_id) = pinned_worker {
             return self
@@ -1622,7 +1746,11 @@ where
         }
 
         let occupancy = self.occupancy_state.as_deref();
-        let choose = || self.select_policy_candidate(request, instance_ids, occupancy, select);
+        let device = (self.router_mode == RouterMode::DeviceAwareWeighted)
+            .then(|| self.device_aware_candidates(request, instance_ids));
+        let choose = || {
+            self.select_policy_candidate_prepared(instance_ids, occupancy, device.as_ref(), select)
+        };
         let (decision, counter) = match occupancy {
             Some(state) => state.with_selection_lock(|| {
                 let decision = choose()?;
@@ -1746,7 +1874,10 @@ where
         select: F,
     ) -> anyhow::Result<RouteTarget>
     where
-        F: FnOnce(&RoutePolicyCandidates<'_>, RoutePolicyContext) -> Option<RoutePolicyDecision>,
+        F: FnOnce(
+            &RoutePolicyCandidates<'_>,
+            RoutePolicyContext,
+        ) -> anyhow::Result<Option<RoutePolicyDecision>>,
     {
         if let Some(instance_id) = pinned_worker {
             return self.peek_within(request, Some(instance_id), allowed);
@@ -1786,21 +1917,41 @@ where
         select: F,
     ) -> anyhow::Result<RouteDecision>
     where
-        F: FnOnce(&RoutePolicyCandidates<'_>, RoutePolicyContext) -> Option<RoutePolicyDecision>,
+        F: FnOnce(
+            &RoutePolicyCandidates<'_>,
+            RoutePolicyContext,
+        ) -> anyhow::Result<Option<RoutePolicyDecision>>,
     {
-        let policy_decision = if self.router_mode == RouterMode::DeviceAwareWeighted {
-            let device = self.device_aware_candidates(request, instance_ids);
+        let device = (self.router_mode == RouterMode::DeviceAwareWeighted)
+            .then(|| self.device_aware_candidates(request, instance_ids));
+        self.select_policy_candidate_prepared(instance_ids, occupancy, device.as_ref(), select)
+    }
+
+    fn select_policy_candidate_prepared<F>(
+        &self,
+        instance_ids: &[u64],
+        occupancy: Option<&RoutingOccupancyState>,
+        device: Option<&DeviceAwareCandidates>,
+        select: F,
+    ) -> anyhow::Result<RouteDecision>
+    where
+        F: FnOnce(
+            &RoutePolicyCandidates<'_>,
+            RoutePolicyContext,
+        ) -> anyhow::Result<Option<RoutePolicyDecision>>,
+    {
+        let policy_decision = if let Some(device) = device {
             let candidates = RoutePolicyCandidates {
                 candidates: CandidateView::DeviceAware(&device.candidates),
                 occupancy,
             };
-            select(&candidates, device.context)
+            select(&candidates, device.context)?
         } else {
             let candidates = RoutePolicyCandidates {
                 candidates: CandidateView::Workers(instance_ids),
                 occupancy,
             };
-            select(&candidates, RoutePolicyContext::default())
+            select(&candidates, RoutePolicyContext::default())?
         }
         .ok_or_else(|| anyhow::anyhow!("routing policy returned no worker"))?;
 
@@ -1874,14 +2025,29 @@ where
             )
         };
 
-        let (instance_id, address, transport_kind, instance) =
-            self.resolve_transport(instance_id, fallback)?;
-        self.check_workers_available(instance_id, &request_id)?;
-
-        let metadata = prepare(&mut request, instance_id)?;
-        // Preparation can await or update routing-visible state. Revalidate the
-        // committed target at the final dispatch boundary.
-        self.check_workers_available(instance_id, &request_id)?;
+        let (instance_id, address, transport_kind, instance, metadata) = match fallback {
+            RouteFallback::Deny => {
+                // Preserve transport-error precedence without cloning the transport snapshot.
+                self.validate_exact_target(RouteTarget::worker(instance_id))?;
+                self.check_workers_available(instance_id, &request_id)?;
+                let metadata = prepare(&mut request, instance_id)?;
+                // Exact dispatch resolves discovery after preparation. This keeps request
+                // metadata and the captured transport on the same worker incarnation.
+                let (resolved_id, address, transport_kind, instance) =
+                    self.resolve_transport(instance_id, RouteFallback::Deny)?;
+                debug_assert_eq!(resolved_id, instance_id);
+                self.check_workers_available(resolved_id, &request_id)?;
+                (resolved_id, address, transport_kind, instance, metadata)
+            }
+            fallback => {
+                let (resolved_id, address, transport_kind, instance) =
+                    self.resolve_transport(instance_id, fallback)?;
+                self.check_workers_available(resolved_id, &request_id)?;
+                let metadata = prepare(&mut request, resolved_id)?;
+                self.check_workers_available(resolved_id, &request_id)?;
+                (resolved_id, address, transport_kind, instance, metadata)
+            }
+        };
         let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
 
         STAGE_DURATION_SECONDS
@@ -1954,19 +2120,15 @@ where
         use crate::component::TransportType;
 
         let lookup = |id: u64| {
-            self.client
-                .instances()
-                .iter()
-                .find(|i| i.instance_id == id)
-                .map(|instance| {
-                    let (addr, kind) = match &instance.transport {
-                        TransportType::Tcp(tcp_endpoint) => {
-                            (tcp_endpoint.clone(), "transport.tcp.request")
-                        }
-                        TransportType::Nats(subject) => (subject.clone(), "transport.nats.request"),
-                    };
-                    (addr, kind, instance.clone())
-                })
+            self.client.find_instance(id).map(|instance| {
+                let (addr, kind) = match &instance.transport {
+                    TransportType::Tcp(tcp_endpoint) => {
+                        (tcp_endpoint.clone(), "transport.tcp.request")
+                    }
+                    TransportType::Nats(subject) => (subject.clone(), "transport.nats.request"),
+                };
+                (addr, kind, instance)
+            })
         };
 
         if let Some((addr, kind, inst)) = lookup(instance_id) {
@@ -1975,14 +2137,7 @@ where
         let allowed_fallback = match fallback {
             RouteFallback::Allow => None,
             RouteFallback::Deny => {
-                return Err(DynamoError::builder()
-                    .error_type(ErrorType::CannotConnect)
-                    .message(format!(
-                        "instance_id={instance_id} not found for endpoint {}",
-                        self.client.endpoint.id()
-                    ))
-                    .build()
-                    .into());
+                return Err(self.missing_instance_error(instance_id));
             }
             RouteFallback::Within(allowed) => Some(allowed),
         };
@@ -2019,6 +2174,17 @@ where
                 self.client.endpoint.id()
             )),
         }
+    }
+
+    fn missing_instance_error(&self, instance_id: u64) -> anyhow::Error {
+        DynamoError::builder()
+            .error_type(ErrorType::CannotConnect)
+            .message(format!(
+                "instance_id={instance_id} not found for endpoint {}",
+                self.client.endpoint.id()
+            ))
+            .build()
+            .into()
     }
 
     /// Wrap a dispatched stream with fault detection + inactivity timeout.
@@ -2931,6 +3097,59 @@ mod tests {
             0,
             "validation failure must release the selected worker"
         );
+        rt.shutdown();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn exact_dispatch_resolves_transport_after_preparation() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("test_exact_transport_revalidation".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+
+        let router =
+            PushRouter::<u64, TestResponse>::from_client(client.clone(), RouterMode::LeastLoaded)
+                .await
+                .unwrap();
+        let state = router.occupancy_state.clone().unwrap();
+        let endpoint_for_prepare = endpoint.clone();
+        let client_for_prepare = client.clone();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            router.select_and_dispatch_exact(SingleIn::new(42), Some(worker_id), move |_, _| {
+                tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(async move {
+                        endpoint_for_prepare
+                            .unregister_endpoint_instance()
+                            .await
+                            .unwrap();
+                        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                            while client_for_prepare.instance_ids().contains(&worker_id) {
+                                tokio::task::yield_now().await;
+                            }
+                        })
+                        .await
+                        .expect("discovery removal must reach the client");
+                    });
+                });
+                Ok(())
+            }),
+        )
+        .await
+        .expect("exact dispatch must not use the removed transport")
+        .unwrap_err();
+
+        assert_cannot_connect(&result);
+        assert_eq!(state.load(worker_id), 0);
         rt.shutdown();
     }
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -73,6 +73,14 @@ fn response_inactivity_timeout() -> Option<std::time::Duration> {
         .map(std::time::Duration::from_secs)
 }
 
+fn device_aware_non_cpu_to_cpu_ratio() -> usize {
+    std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value >= 1)
+        .unwrap_or(8)
+}
+
 /// RAII handle for one in-flight unit of work charged against
 /// [`RoutingOccupancyState`]. The counter is incremented at construction; the
 /// matching decrement is emitted on drop (or by [`Self::into_tracked_stream`]).
@@ -245,6 +253,10 @@ where
     /// Cached response inactivity timeout. Read once at construction from
     /// [`environment_names::llm::DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS`](crate::config::environment_names::llm::DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS) to avoid a syscall per request.
     response_timeout: Option<std::time::Duration>,
+
+    /// Cached device-aware routing weight. Environment configuration is immutable after router
+    /// construction, so request paths do not need to read and parse it repeatedly.
+    device_aware_non_cpu_to_cpu_ratio: usize,
 
     /// Shared request occupancy state for tracked routing modes.
     occupancy_state: Option<Arc<RoutingOccupancyState>>,
@@ -683,6 +695,7 @@ where
             random_picker,
             fault_detection_enabled: false,
             response_timeout: response_inactivity_timeout(),
+            device_aware_non_cpu_to_cpu_ratio: device_aware_non_cpu_to_cpu_ratio(),
             occupancy_state,
             multimodal_cache_indexer: None,
             multimodal_cache_key_extractor: None,
@@ -757,6 +770,7 @@ where
             random_picker,
             fault_detection_enabled: true,
             response_timeout: response_inactivity_timeout(),
+            device_aware_non_cpu_to_cpu_ratio: device_aware_non_cpu_to_cpu_ratio(),
             occupancy_state,
             multimodal_cache_indexer,
             multimodal_cache_key_extractor,
@@ -816,6 +830,7 @@ where
             random_picker,
             fault_detection_enabled: true,
             response_timeout: response_inactivity_timeout(),
+            device_aware_non_cpu_to_cpu_ratio: device_aware_non_cpu_to_cpu_ratio(),
             occupancy_state,
             multimodal_cache_indexer: None,
             multimodal_cache_key_extractor: None,
@@ -1301,12 +1316,6 @@ where
                 (instance.instance_id, device)
             })
             .collect::<HashMap<_, _>>();
-        let cuda_to_cpu_ratio = std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
-            .ok()
-            .and_then(|value| value.parse::<usize>().ok())
-            .filter(|value| *value >= 1)
-            .unwrap_or(8);
-
         let (request_cache_keys, cache_matched_candidates) =
             if let (Some(indexer), Some(extractor)) = (
                 self.multimodal_cache_indexer.as_ref(),
@@ -1346,7 +1355,7 @@ where
             candidates,
             context: RouteContext {
                 required_cache_hits: request_cache_key_count,
-                non_cpu_to_cpu_ratio: cuda_to_cpu_ratio,
+                non_cpu_to_cpu_ratio: self.device_aware_non_cpu_to_cpu_ratio,
             },
             embedding_cache_hit,
             request_cache_keys: request_cache_keys.len(),
@@ -1465,11 +1474,6 @@ where
                     .iter()
                     .map(|instance| (instance.instance_id, instance.device_type.clone()))
                     .collect();
-                let cuda_to_cpu_ratio = std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
-                    .ok()
-                    .and_then(|value| value.parse::<usize>().ok())
-                    .filter(|value| *value >= 1)
-                    .unwrap_or(8);
                 let candidates = instance_ids
                     .iter()
                     .map(|worker_id| RouteCandidate {
@@ -1491,7 +1495,7 @@ where
                         CandidateView::DeviceAware(&candidates),
                         RouteContext {
                             required_cache_hits: 0,
-                            non_cpu_to_cpu_ratio: cuda_to_cpu_ratio,
+                            non_cpu_to_cpu_ratio: self.device_aware_non_cpu_to_cpu_ratio,
                         },
                     )
                     .map(|decision| decision.target.worker_id)
@@ -1552,11 +1556,7 @@ where
                 &rows,
                 RoutePolicyContext {
                     required_cache_hits: 0,
-                    non_cpu_to_cpu_ratio: std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
-                        .ok()
-                        .and_then(|value| value.parse::<usize>().ok())
-                        .filter(|value| *value >= 1)
-                        .unwrap_or(8),
+                    non_cpu_to_cpu_ratio: self.device_aware_non_cpu_to_cpu_ratio,
                 },
             )
         } else {

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -1610,18 +1610,10 @@ where
                     self.client.endpoint.id()
                 ));
             }
-            let permit = match self.router_mode {
-                RouterMode::LeastLoaded
-                | RouterMode::PowerOfTwoChoices
-                | RouterMode::DeviceAwareWeighted => {
-                    let state = self.occupancy_state()?;
-                    Some(OccupancyPermit::acquire(state, instance_id))
-                }
-                RouterMode::RoundRobin
-                | RouterMode::Random
-                | RouterMode::Direct
-                | RouterMode::KV => None,
-            };
+            let permit = self
+                .occupancy_state
+                .clone()
+                .map(|state| OccupancyPermit::acquire(state, instance_id));
             return Ok(RouteReservation::new(
                 RouteTarget::worker(instance_id),
                 permit,
@@ -1721,25 +1713,34 @@ where
             RoutePolicyContext,
         ) -> anyhow::Result<Option<RoutePolicyDecision>>,
     {
-        if let Some(instance_id) = pinned_worker {
-            return self
-                .reserve_within(request, Some(instance_id), allowed)
-                .await;
-        }
-
         let routing_instances = self.client.routing_instances();
+        let pinned;
         let constrained;
-        let instance_ids = match allowed {
-            Some(allowed) => {
-                constrained = routing_instances
-                    .free_ids()
-                    .iter()
-                    .copied()
-                    .filter(|instance_id| allowed.contains(instance_id))
-                    .collect::<Vec<_>>();
-                constrained.as_slice()
+        let instance_ids = match pinned_worker {
+            Some(instance_id) => {
+                if !routing_instances.routable_ids().contains(&instance_id)
+                    || allowed.is_some_and(|allowed| !allowed.contains(&instance_id))
+                {
+                    return Err(anyhow::anyhow!(
+                        "instance_id={instance_id} not found for endpoint {}",
+                        self.client.endpoint.id()
+                    ));
+                }
+                pinned = [instance_id];
+                pinned.as_slice()
             }
-            None => routing_instances.free_ids(),
+            None => match allowed {
+                Some(allowed) => {
+                    constrained = routing_instances
+                        .free_ids()
+                        .iter()
+                        .copied()
+                        .filter(|instance_id| allowed.contains(instance_id))
+                        .collect::<Vec<_>>();
+                    constrained.as_slice()
+                }
+                None => routing_instances.free_ids(),
+            },
         };
         if instance_ids.is_empty() {
             return Err(self.empty_free_pool_error(&routing_instances));
@@ -1879,23 +1880,34 @@ where
             RoutePolicyContext,
         ) -> anyhow::Result<Option<RoutePolicyDecision>>,
     {
-        if let Some(instance_id) = pinned_worker {
-            return self.peek_within(request, Some(instance_id), allowed);
-        }
-
         let routing_instances = self.client.routing_instances();
+        let pinned;
         let constrained;
-        let instance_ids = match allowed {
-            Some(allowed) => {
-                constrained = routing_instances
-                    .free_ids()
-                    .iter()
-                    .copied()
-                    .filter(|instance_id| allowed.contains(instance_id))
-                    .collect::<Vec<_>>();
-                constrained.as_slice()
+        let instance_ids = match pinned_worker {
+            Some(instance_id) => {
+                if !routing_instances.routable_ids().contains(&instance_id)
+                    || allowed.is_some_and(|allowed| !allowed.contains(&instance_id))
+                {
+                    return Err(anyhow::anyhow!(
+                        "instance_id={instance_id} not found for endpoint {}",
+                        self.client.endpoint.id()
+                    ));
+                }
+                pinned = [instance_id];
+                pinned.as_slice()
             }
-            None => routing_instances.free_ids(),
+            None => match allowed {
+                Some(allowed) => {
+                    constrained = routing_instances
+                        .free_ids()
+                        .iter()
+                        .copied()
+                        .filter(|instance_id| allowed.contains(instance_id))
+                        .collect::<Vec<_>>();
+                    constrained.as_slice()
+                }
+                None => routing_instances.free_ids(),
+            },
         };
         if instance_ids.is_empty() {
             return Err(self.empty_free_pool_error(&routing_instances));

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -18,8 +18,8 @@ use crate::{
     },
     protocols::{EndpointId, maybe_error::MaybeError},
     routing_policy::{
-        CandidateView, RouteCandidate, RouteContext, RouteDevice, RoutePicker, RoutePolicy,
-        RouteTarget,
+        AdmissionKind, CandidateView, RouteCandidate, RouteContext, RouteDecision, RouteDevice,
+        RoutePicker, RoutePolicy, RouteTarget,
     },
     traits::DistributedRuntimeProvider,
 };
@@ -39,6 +39,10 @@ use std::{
 };
 use tokio_stream::StreamExt;
 use tracing::Instrument;
+
+pub use dynamo_router_policy::{
+    PolicyDecision as RoutePolicyDecision, RouteContext as RoutePolicyContext,
+};
 
 /// Check if an error chain indicates the worker should be reported as down.
 fn is_inhibited(err: &(dyn std::error::Error + 'static)) -> bool {
@@ -76,6 +80,41 @@ struct OccupancyPermit {
     instance_id: u64,
     counter: Arc<AtomicU64>,
     armed: bool,
+}
+
+/// One committed routing decision and its optional admission state.
+///
+/// The reservation owns any frontend-local occupancy charge from selection until
+/// dispatch transfers that charge to the response stream. Dropping an undispatched
+/// reservation releases the charge.
+pub struct RouteReservation {
+    target: RouteTarget,
+    permit: Option<OccupancyPermit>,
+}
+
+impl RouteReservation {
+    fn new(target: RouteTarget, permit: Option<OccupancyPermit>) -> Self {
+        Self { target, permit }
+    }
+
+    /// Return the stable target selected for this attempt.
+    pub fn target(&self) -> RouteTarget {
+        self.target
+    }
+
+    fn retarget(&mut self, target: RouteTarget) {
+        if let Some(permit) = self.permit.as_mut() {
+            permit.retarget(target.worker_id);
+        }
+        self.target = target;
+    }
+
+    fn into_tracked_stream<U: Data + MaybeError>(self, stream: ManyOut<U>) -> ManyOut<U> {
+        match self.permit {
+            Some(permit) => permit.into_tracked_stream(stream),
+            None => stream,
+        }
+    }
 }
 
 impl OccupancyPermit {
@@ -219,10 +258,50 @@ pub enum RouterMode {
 }
 
 #[derive(Clone, Copy)]
-enum TransportFallback<'a> {
+pub enum RouteFallback<'a> {
     Allow,
     Deny,
     Within(&'a HashSet<u64>),
+}
+
+/// Borrowed, host-owned candidates exposed to an LLM policy picker.
+///
+/// The wrapper retains runtime ownership of discovery and occupancy. Static pickers can select by
+/// index without allocating or walking the candidate slice; load-aware pickers read occupancy
+/// through the common dependency-neutral policy contract.
+pub struct RoutePolicyCandidates<'a> {
+    candidates: CandidateView<'a>,
+    occupancy: Option<&'a RoutingOccupancyState>,
+}
+
+impl dynamo_router_policy::RouteCandidates for RoutePolicyCandidates<'_> {
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.candidates.len()
+    }
+
+    #[inline(always)]
+    fn load(&self, index: usize) -> u64 {
+        self.occupancy
+            .map(|state| state.load(self.candidates.target(index).worker_id))
+            .unwrap_or(0)
+    }
+
+    #[inline(always)]
+    fn device(&self, index: usize) -> dynamo_router_policy::RouteDevice {
+        match self.candidates {
+            CandidateView::Workers(_) => dynamo_router_policy::RouteDevice::Accelerator,
+            CandidateView::DeviceAware(candidates) => candidates[index].device,
+        }
+    }
+
+    #[inline(always)]
+    fn cache_hits(&self, index: usize) -> usize {
+        match self.candidates {
+            CandidateView::Workers(_) => 0,
+            CandidateView::DeviceAware(candidates) => candidates[index].cache_hits,
+        }
+    }
 }
 
 struct DeviceAwareCandidates {
@@ -515,6 +594,11 @@ where
     T: Data + Serialize,
     U: Data + for<'de> Deserialize<'de> + MaybeError,
 {
+    /// Return the construction-time routing mode.
+    pub const fn router_mode(&self) -> RouterMode {
+        self.router_mode
+    }
+
     /// Create a new PushRouter without a worker load monitor (no overload detection)
     pub async fn from_client(client: Client, router_mode: RouterMode) -> anyhow::Result<Self> {
         Self::from_client_with_monitor(client, router_mode, None).await
@@ -847,7 +931,7 @@ where
             worker_id = instance_id,
             "Selected worker"
         );
-        self.generate_with_fault_detection(instance_id, request, TransportFallback::Deny)
+        self.generate_with_fault_detection(instance_id, request, RouteFallback::Deny)
             .await
     }
 
@@ -901,8 +985,8 @@ where
         );
 
         let fallback = allowed_fallback
-            .map(TransportFallback::Within)
-            .unwrap_or(TransportFallback::Allow);
+            .map(RouteFallback::Within)
+            .unwrap_or(RouteFallback::Allow);
         self.generate_with_fault_detection_prepared(instance_id, request, fallback, prepare)
             .await
     }
@@ -916,31 +1000,62 @@ where
         request: SingleIn<T>,
         instance_id: u64,
     ) -> anyhow::Result<ManyOut<U>> {
-        self.generate_with_fault_detection(instance_id, request, TransportFallback::Deny)
+        self.generate_with_fault_detection(instance_id, request, RouteFallback::Deny)
             .await
+    }
+
+    /// Validate that an exact target still has a routable transport.
+    ///
+    /// Callers that own admission can use this before request preparation to
+    /// rebook under that owner before conditionally releasing the old target.
+    pub fn validate_exact_target(&self, target: RouteTarget) -> anyhow::Result<()> {
+        self.resolve_transport(target.worker_id, RouteFallback::Deny)?;
+        Ok(())
     }
 
     /// Select and book one worker, prepare the request for that exact worker,
     /// then dispatch without reselection or transport fallback.
     pub async fn select_and_dispatch_exact<M, F>(
         &self,
-        mut request: SingleIn<T>,
+        request: SingleIn<T>,
         pinned_worker: Option<u64>,
         prepare: F,
     ) -> anyhow::Result<(M, ManyOut<U>)>
     where
         F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
     {
-        let (instance_id, permit) = self
-            .select_exact_target(request.content(), pinned_worker)
+        let reservation = self.reserve(request.content(), pinned_worker).await?;
+        self.dispatch_reserved_prepared(request, reservation, RouteFallback::Deny, prepare)
+            .await
+    }
+
+    /// Prepare and dispatch one committed reservation.
+    ///
+    /// If transport fallback changes the target, this method transfers local
+    /// occupancy to the replacement before it releases the original charge.
+    pub async fn dispatch_reserved_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        mut reservation: RouteReservation,
+        fallback: RouteFallback<'_>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
+        let instance_id = reservation.target.worker_id;
+        let (metadata, stream) = self
+            .generate_with_fault_detection_prepared(
+                instance_id,
+                request,
+                fallback,
+                |request, resolved_instance_id| {
+                    reservation.retarget(RouteTarget::worker(resolved_instance_id));
+                    prepare(request, resolved_instance_id)
+                },
+            )
             .await?;
-        let metadata = prepare(&mut request, instance_id)?;
-        let stream = self.dispatch_exact(request, instance_id).await?;
-        let stream = match permit {
-            Some(permit) => permit.into_tracked_stream(stream),
-            None => stream,
-        };
-        Ok((metadata, stream))
+        Ok((metadata, reservation.into_tracked_stream(stream)))
     }
 
     /// Select a worker using the configured routing mode, prepare the request with the worker
@@ -974,30 +1089,15 @@ where
         &self,
         instance_id: u64,
         request: SingleIn<T>,
-        mut permit: Option<OccupancyPermit>,
+        permit: Option<OccupancyPermit>,
         prepare: F,
     ) -> anyhow::Result<(M, ManyOut<U>)>
     where
         F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
     {
-        let (metadata, stream) = self
-            .generate_with_fault_detection_prepared(
-                instance_id,
-                request,
-                TransportFallback::Allow,
-                |request, resolved_instance_id| {
-                    if let Some(permit) = permit.as_mut() {
-                        permit.retarget(resolved_instance_id);
-                    }
-                    prepare(request, resolved_instance_id)
-                },
-            )
-            .await?;
-        let stream = match permit {
-            Some(permit) => permit.into_tracked_stream(stream),
-            None => stream,
-        };
-        Ok((metadata, stream))
+        let reservation = RouteReservation::new(RouteTarget::worker(instance_id), permit);
+        self.dispatch_reserved_prepared(request, reservation, RouteFallback::Allow, prepare)
+            .await
     }
 
     /// Issue a request using device-aware weighted routing.
@@ -1285,6 +1385,69 @@ where
         }
     }
 
+    /// Advisory sibling of [`Self::peek_next_worker`] for an LLM-owned native picker.
+    pub fn peek_next_worker_with_policy<F>(&self, select: F) -> Option<u64>
+    where
+        F: FnOnce(&RoutePolicyCandidates<'_>, RoutePolicyContext) -> Option<RoutePolicyDecision>,
+    {
+        let routing_instances = self.client.routing_instances();
+        let instance_ids = routing_instances.free_ids();
+        if instance_ids.is_empty() {
+            return None;
+        }
+        match self.router_mode {
+            RouterMode::Direct => return None,
+            RouterMode::KV => {
+                panic!("peek_next_worker_with_policy should not be called for KV routing mode")
+            }
+            _ => {}
+        }
+
+        let decision = if self.router_mode == RouterMode::DeviceAwareWeighted {
+            let device_type_map: HashMap<u64, Option<DeviceType>> = self
+                .client
+                .instances()
+                .iter()
+                .map(|instance| (instance.instance_id, instance.device_type.clone()))
+                .collect();
+            let candidates = instance_ids
+                .iter()
+                .map(|worker_id| RouteCandidate {
+                    target: RouteTarget::worker(*worker_id),
+                    device: if matches!(device_type_map.get(worker_id), Some(Some(DeviceType::Cpu)))
+                    {
+                        RouteDevice::Cpu
+                    } else {
+                        RouteDevice::Accelerator
+                    },
+                    cache_hits: 0,
+                })
+                .collect::<Vec<_>>();
+            let rows = RoutePolicyCandidates {
+                candidates: CandidateView::DeviceAware(&candidates),
+                occupancy: self.occupancy_state.as_deref(),
+            };
+            select(
+                &rows,
+                RoutePolicyContext {
+                    required_cache_hits: 0,
+                    non_cpu_to_cpu_ratio: std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
+                        .ok()
+                        .and_then(|value| value.parse::<usize>().ok())
+                        .filter(|value| *value >= 1)
+                        .unwrap_or(8),
+                },
+            )
+        } else {
+            let rows = RoutePolicyCandidates {
+                candidates: CandidateView::Workers(instance_ids),
+                occupancy: self.occupancy_state.as_deref(),
+            };
+            select(&rows, RoutePolicyContext::default())
+        }?;
+        instance_ids.get(decision.index).copied()
+    }
+
     #[cfg(any(test, feature = "testing"))]
     #[doc(hidden)]
     pub fn occupancy_for_test(&self, worker_id: u64) -> u64 {
@@ -1294,14 +1457,33 @@ where
             .unwrap_or(0)
     }
 
-    async fn select_exact_target(
+    /// Commit one worker selection and retain any local admission state.
+    ///
+    /// Selection and occupancy admission stay atomic under the occupancy owner.
+    /// This method does not dispatch the request.
+    pub async fn reserve(
         &self,
         request: &T,
         pinned_worker: Option<u64>,
-    ) -> anyhow::Result<(u64, Option<OccupancyPermit>)> {
+    ) -> anyhow::Result<RouteReservation> {
+        self.reserve_within(request, pinned_worker, None).await
+    }
+
+    /// Commit one worker selection within an optional host-validated candidate set.
+    ///
+    /// The unconstrained path does not allocate a candidate collection. Constrained
+    /// selection intersects the supplied set with the current free worker snapshot.
+    pub async fn reserve_within(
+        &self,
+        request: &T,
+        pinned_worker: Option<u64>,
+        allowed: Option<&HashSet<u64>>,
+    ) -> anyhow::Result<RouteReservation> {
         if let Some(instance_id) = pinned_worker {
             let routing_instances = self.client.routing_instances();
-            if !routing_instances.routable_ids().contains(&instance_id) {
+            if !routing_instances.routable_ids().contains(&instance_id)
+                || allowed.is_some_and(|allowed| !allowed.contains(&instance_id))
+            {
                 return Err(anyhow::anyhow!(
                     "instance_id={instance_id} not found for endpoint {}",
                     self.client.endpoint.id()
@@ -1319,7 +1501,28 @@ where
                 | RouterMode::Direct
                 | RouterMode::KV => None,
             };
-            return Ok((instance_id, permit));
+            return Ok(RouteReservation::new(
+                RouteTarget::worker(instance_id),
+                permit,
+            ));
+        }
+
+        let routing_instances = self.client.routing_instances();
+        let constrained;
+        let instance_ids = match allowed {
+            Some(allowed) => {
+                constrained = routing_instances
+                    .free_ids()
+                    .iter()
+                    .copied()
+                    .filter(|instance_id| allowed.contains(instance_id))
+                    .collect::<Vec<_>>();
+                constrained.as_slice()
+            }
+            None => routing_instances.free_ids(),
+        };
+        if instance_ids.is_empty() {
+            return Err(self.empty_free_pool_error(&routing_instances));
         }
 
         match self.router_mode {
@@ -1327,12 +1530,6 @@ where
             | RouterMode::PowerOfTwoChoices
             | RouterMode::DeviceAwareWeighted => {
                 let state = self.occupancy_state()?;
-                let routing_instances = self.client.routing_instances();
-                let instance_ids = routing_instances.free_ids();
-                if instance_ids.is_empty() {
-                    return Err(self.empty_free_pool_error(&routing_instances));
-                }
-
                 let (decision, counter) = match self.router_mode {
                     RouterMode::LeastLoaded | RouterMode::PowerOfTwoChoices => state
                         .select_and_admit(
@@ -1356,14 +1553,26 @@ where
                 let instance_id = decision.target.worker_id;
                 let permit = counter
                     .map(|counter| OccupancyPermit::from_counter(state, instance_id, counter));
-                Ok((instance_id, permit))
+                Ok(RouteReservation::new(
+                    RouteTarget::worker(instance_id),
+                    permit,
+                ))
             }
-            RouterMode::RoundRobin => self
-                .select_untracked_worker(self.round_robin_picker.as_ref())
-                .map(|(instance_id, _)| (instance_id, None)),
-            RouterMode::Random => self
-                .select_untracked_worker(self.random_picker.as_ref())
-                .map(|(instance_id, _)| (instance_id, None)),
+            RouterMode::RoundRobin | RouterMode::Random => {
+                let picker = if self.router_mode == RouterMode::RoundRobin {
+                    self.round_robin_picker.as_ref()
+                } else {
+                    self.random_picker.as_ref()
+                };
+                let decision = picker
+                    .select(
+                        CandidateView::Workers(instance_ids),
+                        RouteContext::default(),
+                        |_| 0,
+                    )
+                    .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
+                Ok(RouteReservation::new(decision.target, None))
+            }
             RouterMode::Direct => Err(anyhow::anyhow!(
                 "Worker ID required for exact dispatch in Direct routing mode"
             )),
@@ -1371,6 +1580,245 @@ where
                 "select_and_dispatch_exact cannot select workers in KV routing mode"
             )),
         }
+    }
+
+    /// Commit a selection made by an LLM-owned native picker.
+    ///
+    /// Runtime still owns candidate discovery, validation, and atomic occupancy admission. The
+    /// picker returns an index into the borrowed host table plus its admission capability. The
+    /// unconstrained static path constructs no candidate collection.
+    pub async fn reserve_within_policy<F>(
+        &self,
+        request: &T,
+        pinned_worker: Option<u64>,
+        allowed: Option<&HashSet<u64>>,
+        select: F,
+    ) -> anyhow::Result<RouteReservation>
+    where
+        F: FnOnce(&RoutePolicyCandidates<'_>, RoutePolicyContext) -> Option<RoutePolicyDecision>,
+    {
+        if let Some(instance_id) = pinned_worker {
+            return self
+                .reserve_within(request, Some(instance_id), allowed)
+                .await;
+        }
+
+        let routing_instances = self.client.routing_instances();
+        let constrained;
+        let instance_ids = match allowed {
+            Some(allowed) => {
+                constrained = routing_instances
+                    .free_ids()
+                    .iter()
+                    .copied()
+                    .filter(|instance_id| allowed.contains(instance_id))
+                    .collect::<Vec<_>>();
+                constrained.as_slice()
+            }
+            None => routing_instances.free_ids(),
+        };
+        if instance_ids.is_empty() {
+            return Err(self.empty_free_pool_error(&routing_instances));
+        }
+
+        let occupancy = self.occupancy_state.as_deref();
+        let choose = || self.select_policy_candidate(request, instance_ids, occupancy, select);
+        let (decision, counter) = match occupancy {
+            Some(state) => state.with_selection_lock(|| {
+                let decision = choose()?;
+                let counter = match decision.admission {
+                    AdmissionKind::None => None,
+                    AdmissionKind::Occupancy => Some(state.increment(decision.target.worker_id)),
+                };
+                Ok::<_, anyhow::Error>((decision, counter))
+            })?,
+            None => {
+                let decision = choose()?;
+                if decision.admission != AdmissionKind::None {
+                    anyhow::bail!(
+                        "routing policy requested occupancy admission for {:?} mode without occupancy state",
+                        self.router_mode
+                    );
+                }
+                (decision, None)
+            }
+        };
+        let permit = counter.map(|counter| {
+            OccupancyPermit::from_counter(
+                self.occupancy_state
+                    .clone()
+                    .expect("admitted policy decision has occupancy state"),
+                decision.target.worker_id,
+                counter,
+            )
+        });
+        Ok(RouteReservation::new(decision.target, permit))
+    }
+
+    /// Select one worker without advancing state or retaining admission.
+    pub fn peek(&self, request: &T, pinned_worker: Option<u64>) -> anyhow::Result<RouteTarget> {
+        self.peek_within(request, pinned_worker, None)
+    }
+
+    /// Select one worker within an optional candidate set without retaining admission.
+    pub fn peek_within(
+        &self,
+        request: &T,
+        pinned_worker: Option<u64>,
+        allowed: Option<&HashSet<u64>>,
+    ) -> anyhow::Result<RouteTarget> {
+        if let Some(instance_id) = pinned_worker {
+            let routing_instances = self.client.routing_instances();
+            if !routing_instances.routable_ids().contains(&instance_id)
+                || allowed.is_some_and(|allowed| !allowed.contains(&instance_id))
+            {
+                return Err(anyhow::anyhow!(
+                    "instance_id={instance_id} not found for endpoint {}",
+                    self.client.endpoint.id()
+                ));
+            }
+            return Ok(RouteTarget::worker(instance_id));
+        }
+
+        let routing_instances = self.client.routing_instances();
+        let constrained;
+        let instance_ids = match allowed {
+            Some(allowed) => {
+                constrained = routing_instances
+                    .free_ids()
+                    .iter()
+                    .copied()
+                    .filter(|instance_id| allowed.contains(instance_id))
+                    .collect::<Vec<_>>();
+                constrained.as_slice()
+            }
+            None => routing_instances.free_ids(),
+        };
+        if instance_ids.is_empty() {
+            return Err(self.empty_free_pool_error(&routing_instances));
+        }
+
+        let decision = match self.router_mode {
+            RouterMode::RoundRobin => self.round_robin_picker.peek(
+                CandidateView::Workers(instance_ids),
+                RouteContext::default(),
+                |_| 0,
+            ),
+            RouterMode::Random => self.random_picker.peek(
+                CandidateView::Workers(instance_ids),
+                RouteContext::default(),
+                |_| 0,
+            ),
+            RouterMode::PowerOfTwoChoices | RouterMode::LeastLoaded => {
+                let state = self.occupancy_state()?;
+                state.peek(
+                    self.picker()?,
+                    CandidateView::Workers(instance_ids),
+                    RouteContext::default(),
+                )
+            }
+            RouterMode::DeviceAwareWeighted => {
+                let state = self.occupancy_state()?;
+                let selection = self.device_aware_candidates(request, instance_ids);
+                state.peek(
+                    self.picker()?,
+                    CandidateView::DeviceAware(&selection.candidates),
+                    selection.context,
+                )
+            }
+            RouterMode::Direct => {
+                anyhow::bail!("Worker ID required for advisory Direct routing")
+            }
+            RouterMode::KV => anyhow::bail!("KV routing does not use the runtime route picker"),
+        };
+        decision
+            .map(|decision| decision.target)
+            .ok_or_else(|| self.empty_free_pool_error(&routing_instances))
+    }
+
+    /// Select through an LLM-owned native picker without advancing policy state or retaining
+    /// admission.
+    pub fn peek_within_policy<F>(
+        &self,
+        request: &T,
+        pinned_worker: Option<u64>,
+        allowed: Option<&HashSet<u64>>,
+        select: F,
+    ) -> anyhow::Result<RouteTarget>
+    where
+        F: FnOnce(&RoutePolicyCandidates<'_>, RoutePolicyContext) -> Option<RoutePolicyDecision>,
+    {
+        if let Some(instance_id) = pinned_worker {
+            return self.peek_within(request, Some(instance_id), allowed);
+        }
+
+        let routing_instances = self.client.routing_instances();
+        let constrained;
+        let instance_ids = match allowed {
+            Some(allowed) => {
+                constrained = routing_instances
+                    .free_ids()
+                    .iter()
+                    .copied()
+                    .filter(|instance_id| allowed.contains(instance_id))
+                    .collect::<Vec<_>>();
+                constrained.as_slice()
+            }
+            None => routing_instances.free_ids(),
+        };
+        if instance_ids.is_empty() {
+            return Err(self.empty_free_pool_error(&routing_instances));
+        }
+        self.select_policy_candidate(
+            request,
+            instance_ids,
+            self.occupancy_state.as_deref(),
+            select,
+        )
+        .map(|decision| decision.target)
+    }
+
+    fn select_policy_candidate<F>(
+        &self,
+        request: &T,
+        instance_ids: &[u64],
+        occupancy: Option<&RoutingOccupancyState>,
+        select: F,
+    ) -> anyhow::Result<RouteDecision>
+    where
+        F: FnOnce(&RoutePolicyCandidates<'_>, RoutePolicyContext) -> Option<RoutePolicyDecision>,
+    {
+        let policy_decision = if self.router_mode == RouterMode::DeviceAwareWeighted {
+            let device = self.device_aware_candidates(request, instance_ids);
+            let candidates = RoutePolicyCandidates {
+                candidates: CandidateView::DeviceAware(&device.candidates),
+                occupancy,
+            };
+            select(&candidates, device.context)
+        } else {
+            let candidates = RoutePolicyCandidates {
+                candidates: CandidateView::Workers(instance_ids),
+                occupancy,
+            };
+            select(&candidates, RoutePolicyContext::default())
+        }
+        .ok_or_else(|| anyhow::anyhow!("routing policy returned no worker"))?;
+
+        let target = instance_ids
+            .get(policy_decision.index)
+            .copied()
+            .map(RouteTarget::worker)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "routing policy returned candidate index {}, but the host table contains {} workers",
+                    policy_decision.index,
+                    instance_ids.len()
+                )
+            })?;
+        Ok(RouteDecision {
+            target,
+            admission: policy_decision.admission,
+        })
     }
 
     fn occupancy_state(&self) -> anyhow::Result<Arc<RoutingOccupancyState>> {
@@ -1396,7 +1844,7 @@ where
         &self,
         instance_id: u64,
         request: SingleIn<T>,
-        fallback: TransportFallback<'_>,
+        fallback: RouteFallback<'_>,
     ) -> anyhow::Result<ManyOut<U>> {
         self.generate_with_fault_detection_prepared(instance_id, request, fallback, |_, _| Ok(()))
             .await
@@ -1407,7 +1855,7 @@ where
         &self,
         instance_id: u64,
         mut request: SingleIn<T>,
-        fallback: TransportFallback<'_>,
+        fallback: RouteFallback<'_>,
         prepare: F,
     ) -> anyhow::Result<(M, ManyOut<U>)>
     where
@@ -1431,6 +1879,9 @@ where
         self.check_workers_available(instance_id, &request_id)?;
 
         let metadata = prepare(&mut request, instance_id)?;
+        // Preparation can await or update routing-visible state. Revalidate the
+        // committed target at the final dispatch boundary.
+        self.check_workers_available(instance_id, &request_id)?;
         let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
 
         STAGE_DURATION_SECONDS
@@ -1498,7 +1949,7 @@ where
     fn resolve_transport(
         &self,
         instance_id: u64,
-        fallback: TransportFallback<'_>,
+        fallback: RouteFallback<'_>,
     ) -> anyhow::Result<(u64, String, &'static str, Instance)> {
         use crate::component::TransportType;
 
@@ -1522,8 +1973,8 @@ where
             return Ok((instance_id, addr, kind, inst));
         }
         let allowed_fallback = match fallback {
-            TransportFallback::Allow => None,
-            TransportFallback::Deny => {
+            RouteFallback::Allow => None,
+            RouteFallback::Deny => {
                 return Err(DynamoError::builder()
                     .error_type(ErrorType::CannotConnect)
                     .message(format!(
@@ -1533,7 +1984,7 @@ where
                     .build()
                     .into());
             }
-            TransportFallback::Within(allowed) => Some(allowed),
+            RouteFallback::Within(allowed) => Some(allowed),
         };
 
         let routing_instances = self.client.routing_instances();
@@ -1708,7 +2159,7 @@ where
         );
 
         let (instance_id, address, transport_kind, instance) =
-            self.resolve_transport(instance_id, TransportFallback::Allow)?;
+            self.resolve_transport(instance_id, RouteFallback::Allow)?;
         self.check_workers_available(instance_id, &request_id)?;
 
         STAGE_DURATION_SECONDS
@@ -2311,6 +2762,109 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn round_robin_advisory_peek_does_not_advance_cursor() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("test_round_robin_advisory".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let real_worker = client.wait_for_instances().await.unwrap()[0].id();
+        client.override_instance_avail(vec![real_worker, real_worker.wrapping_add(1)]);
+
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+        let first_peek = router.peek(&42, None).unwrap();
+        assert_eq!(router.peek(&42, None).unwrap(), first_peek);
+
+        let first = router.reserve(&42, None).await.unwrap();
+        assert_eq!(first.target(), first_peek);
+        let second = router.reserve(&42, None).await.unwrap();
+        assert_ne!(second.target(), first.target());
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn dropping_undispatched_reservation_releases_occupancy() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("test_reservation_drop".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::LeastLoaded)
+            .await
+            .unwrap();
+        let reservation = router.reserve(&42, None).await.unwrap();
+        assert_eq!(reservation.target().worker_id, worker_id);
+        assert_eq!(router.occupancy_for_test(worker_id), 1);
+        drop(reservation);
+        assert_eq!(router.occupancy_for_test(worker_id), 0);
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn constrained_selection_stays_within_allowed_workers() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("test_constrained_selection".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let allowed_worker = client.wait_for_instances().await.unwrap()[0].id();
+        let denied_worker = allowed_worker.wrapping_add(1);
+        client.override_instance_avail(vec![allowed_worker, denied_worker]);
+        let allowed = HashSet::from([allowed_worker]);
+
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+        assert_eq!(
+            router.peek_within(&42, None, Some(&allowed)).unwrap(),
+            RouteTarget::worker(allowed_worker)
+        );
+        assert_eq!(
+            router
+                .reserve_within(&42, None, Some(&allowed))
+                .await
+                .unwrap()
+                .target(),
+            RouteTarget::worker(allowed_worker)
+        );
+        assert!(
+            router
+                .reserve_within(&42, Some(denied_worker), Some(&allowed))
+                .await
+                .is_err()
+        );
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
     async fn exact_selection_releases_occupancy_when_preparation_fails() {
         let rt = Runtime::from_current().unwrap();
         let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
@@ -2669,10 +3223,11 @@ mod tests {
         .await
         .unwrap();
 
-        let (worker_id, permit) = router.select_exact_target(&42, None).await.unwrap();
-        assert_eq!(worker_id, cache_worker);
-        assert!(
-            permit.is_none(),
+        let reservation = router.reserve(&42, None).await.unwrap();
+        assert_eq!(reservation.target().worker_id, cache_worker);
+        assert_eq!(
+            router.occupancy_for_test(cache_worker),
+            0,
             "full cache hits bypass occupancy charging"
         );
 
@@ -2780,7 +3335,7 @@ mod tests {
         // registration would wait forever because the test intentionally has
         // no worker handler.
         let (resolved_id, _, _, _) = router
-            .resolve_transport(stale_id, TransportFallback::Allow)
+            .resolve_transport(stale_id, RouteFallback::Allow)
             .expect("normal routing should fall back from a stale worker");
         assert_eq!(resolved_id, real_id);
 
@@ -2899,32 +3454,32 @@ mod tests {
 
         assert!(
             router
-                .resolve_transport(stale_id, TransportFallback::Allow)
+                .resolve_transport(stale_id, RouteFallback::Allow)
                 .is_ok(),
             "normal dispatch should preserve transport fallback"
         );
         let allowed = HashSet::from([real_id]);
         assert!(
             router
-                .resolve_transport(stale_id, TransportFallback::Within(&allowed))
+                .resolve_transport(stale_id, RouteFallback::Within(&allowed))
                 .is_ok(),
             "constrained dispatch should fall back within the allowed worker set"
         );
         let disallowed = HashSet::new();
         let disallowed_error = router
-            .resolve_transport(stale_id, TransportFallback::Within(&disallowed))
+            .resolve_transport(stale_id, RouteFallback::Within(&disallowed))
             .unwrap_err();
         assert_not_cannot_connect(&disallowed_error);
 
         let exact_error = router
-            .resolve_transport(stale_id, TransportFallback::Deny)
+            .resolve_transport(stale_id, RouteFallback::Deny)
             .unwrap_err();
         assert_cannot_connect(&exact_error);
 
         let second_stale_id = stale_id.wrapping_add(1);
         client.override_instance_avail(vec![stale_id, second_stale_id]);
         let stale_fallback_error = router
-            .resolve_transport(stale_id, TransportFallback::Allow)
+            .resolve_transport(stale_id, RouteFallback::Allow)
             .unwrap_err();
         assert_cannot_connect(&stale_fallback_error);
         assert!(

--- a/lib/runtime/src/routing_policy/mod.rs
+++ b/lib/runtime/src/routing_policy/mod.rs
@@ -4,9 +4,9 @@
 mod picker;
 mod types;
 
+pub(crate) use dynamo_router_policy::{
+    AdmissionKind, RouteContext, RouteDevice, RoutingPolicy as RoutePolicy,
+};
 pub(crate) use picker::RoutePicker;
 pub use types::RouteTarget;
-pub(crate) use types::{
-    AdmissionKind, CandidateView, RouteCandidate, RouteContext, RouteDecision, RouteDevice,
-    RoutePolicy,
-};
+pub(crate) use types::{CandidateView, RouteCandidate, RouteDecision};

--- a/lib/runtime/src/routing_policy/picker.rs
+++ b/lib/runtime/src/routing_policy/picker.rs
@@ -1,29 +1,60 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use dynamo_router_policy::RoutePicker as PolicyPicker;
 
-use super::{
-    AdmissionKind, CandidateView, RouteCandidate, RouteContext, RouteDecision, RouteDevice,
-    RoutePolicy, RouteTarget,
-};
+use super::{CandidateView, RouteContext, RouteDecision, RoutePolicy};
+
+struct RuntimeCandidates<'a, F> {
+    candidates: CandidateView<'a>,
+    load: &'a F,
+}
+
+impl<F> dynamo_router_policy::RouteCandidates for RuntimeCandidates<'_, F>
+where
+    F: Fn(u64) -> u64,
+{
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.candidates.len()
+    }
+
+    #[inline(always)]
+    fn load(&self, index: usize) -> u64 {
+        (self.load)(self.candidates.target(index).worker_id)
+    }
+
+    #[inline(always)]
+    fn device(&self, index: usize) -> dynamo_router_policy::RouteDevice {
+        match self.candidates {
+            CandidateView::Workers(_) => dynamo_router_policy::RouteDevice::Accelerator,
+            CandidateView::DeviceAware(candidates) => candidates[index].device,
+        }
+    }
+
+    #[inline(always)]
+    fn cache_hits(&self, index: usize) -> usize {
+        match self.candidates {
+            CandidateView::Workers(_) => 0,
+            CandidateView::DeviceAware(candidates) => candidates[index].cache_hits,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct RoutePicker {
-    policy: RoutePolicy,
-    round_robin_cursor: AtomicU64,
+    inner: PolicyPicker,
 }
 
 impl RoutePicker {
     pub(crate) const fn new(policy: RoutePolicy) -> Self {
         Self {
-            policy,
-            round_robin_cursor: AtomicU64::new(0),
+            inner: PolicyPicker::new(policy),
         }
     }
 
     pub(crate) const fn policy(&self) -> RoutePolicy {
-        self.policy
+        self.inner.policy()
     }
 
     #[inline(always)]
@@ -33,11 +64,16 @@ impl RoutePicker {
         context: RouteContext,
         load: impl Fn(u64) -> u64,
     ) -> Option<RouteDecision> {
-        if self.policy == RoutePolicy::Random {
-            return random_decision(candidates);
-        }
-        let mut samples = RandomSamples;
-        self.choose_with_samples(candidates, context, &load, false, &mut samples)
+        let rows = RuntimeCandidates {
+            candidates,
+            load: &load,
+        };
+        self.inner
+            .peek(&rows, context)
+            .map(|decision| RouteDecision {
+                target: candidates.target(decision.index),
+                admission: decision.admission,
+            })
     }
 
     #[inline(always)]
@@ -47,396 +83,15 @@ impl RoutePicker {
         context: RouteContext,
         load: impl Fn(u64) -> u64,
     ) -> Option<RouteDecision> {
-        if self.policy == RoutePolicy::Random {
-            return random_decision(candidates);
-        }
-        let mut samples = RandomSamples;
-        self.choose_with_samples(candidates, context, &load, true, &mut samples)
-    }
-
-    #[inline(always)]
-    fn choose_with_samples(
-        &self,
-        candidates: CandidateView<'_>,
-        context: RouteContext,
-        load: &impl Fn(u64) -> u64,
-        commit: bool,
-        samples: &mut impl SampleSource,
-    ) -> Option<RouteDecision> {
-        if candidates.is_empty() {
-            return None;
-        }
-
-        match self.policy {
-            RoutePolicy::RoundRobin => {
-                let cursor = if commit {
-                    self.round_robin_cursor.fetch_add(1, Ordering::Relaxed)
-                } else {
-                    self.round_robin_cursor.load(Ordering::Relaxed)
-                };
-                Some(RouteDecision {
-                    target: candidates.target(cursor as usize % candidates.len()),
-                    admission: AdmissionKind::None,
-                })
-            }
-            RoutePolicy::Random => Some(RouteDecision {
-                target: candidates.target(samples.index(candidates.len())),
-                admission: AdmissionKind::None,
-            }),
-            RoutePolicy::PowerOfTwoChoices => {
-                let first = samples.index(candidates.len());
-                if candidates.len() == 1 {
-                    return Some(RouteDecision {
-                        target: candidates.target(first),
-                        admission: AdmissionKind::Occupancy,
-                    });
-                }
-                let second_offset = 1 + samples.index(candidates.len() - 1);
-                let second = (first + second_offset) % candidates.len();
-                let first_target = candidates.target(first);
-                let second_target = candidates.target(second);
-                let target = if load(first_target.worker_id) <= load(second_target.worker_id) {
-                    first_target
-                } else {
-                    second_target
-                };
-                Some(RouteDecision {
-                    target,
-                    admission: AdmissionKind::Occupancy,
-                })
-            }
-            RoutePolicy::LeastLoaded => {
-                lowest_load(candidates, load, samples).map(|target| RouteDecision {
-                    target,
-                    admission: AdmissionKind::Occupancy,
-                })
-            }
-            RoutePolicy::DeviceAwareWeighted => {
-                let CandidateView::DeviceAware(candidates) = candidates else {
-                    return None;
-                };
-                device_aware(candidates, context, load, samples)
-            }
-        }
-    }
-}
-
-trait SampleSource {
-    fn index(&mut self, upper: usize) -> usize;
-}
-
-struct RandomSamples;
-
-impl SampleSource for RandomSamples {
-    #[inline(always)]
-    fn index(&mut self, upper: usize) -> usize {
-        fastrand::usize(..upper)
-    }
-}
-
-#[inline(always)]
-fn random_decision(candidates: CandidateView<'_>) -> Option<RouteDecision> {
-    let upper = candidates.len();
-    if upper == 0 {
-        return None;
-    }
-    let index = fastrand::usize(..upper);
-    let target = match candidates {
-        CandidateView::Workers(workers) => RouteTarget::worker(workers[index]),
-        CandidateView::DeviceAware(candidates) => candidates[index].target,
-    };
-    Some(RouteDecision {
-        target,
-        admission: AdmissionKind::None,
-    })
-}
-
-#[inline(always)]
-fn lowest_load(
-    candidates: CandidateView<'_>,
-    load: &impl Fn(u64) -> u64,
-    samples: &mut impl SampleSource,
-) -> Option<RouteTarget> {
-    match candidates {
-        CandidateView::Workers(workers) => {
-            let mut best = None;
-            let mut best_load = u64::MAX;
-            let mut ties = 0usize;
-            for &worker_id in workers {
-                let target_load = load(worker_id);
-                if target_load < best_load {
-                    best = Some(RouteTarget::worker(worker_id));
-                    best_load = target_load;
-                    ties = 1;
-                } else if target_load == best_load {
-                    ties += 1;
-                    if samples.index(ties) == 0 {
-                        best = Some(RouteTarget::worker(worker_id));
-                    }
-                }
-            }
-            best
-        }
-        CandidateView::DeviceAware(candidates) => {
-            let mut best = None;
-            let mut best_load = u64::MAX;
-            let mut ties = 0usize;
-            for candidate in candidates {
-                let target_load = load(candidate.target.worker_id);
-                if target_load < best_load {
-                    best = Some(candidate.target);
-                    best_load = target_load;
-                    ties = 1;
-                } else if target_load == best_load {
-                    ties += 1;
-                    if samples.index(ties) == 0 {
-                        best = Some(candidate.target);
-                    }
-                }
-            }
-            best
-        }
-    }
-}
-
-#[derive(Default)]
-struct DeviceGroup {
-    count: u64,
-    total_load: u64,
-    best: Option<RouteTarget>,
-    best_load: u64,
-    best_ties: usize,
-}
-
-impl DeviceGroup {
-    #[inline(always)]
-    fn consider(&mut self, target: RouteTarget, target_load: u64, samples: &mut impl SampleSource) {
-        self.count += 1;
-        self.total_load = self.total_load.saturating_add(target_load);
-        if self.best.is_none() || target_load < self.best_load {
-            self.best = Some(target);
-            self.best_load = target_load;
-            self.best_ties = 1;
-        } else if target_load == self.best_load {
-            self.best_ties += 1;
-            if samples.index(self.best_ties) == 0 {
-                self.best = Some(target);
-            }
-        }
-    }
-}
-
-#[inline(always)]
-fn device_aware(
-    candidates: &[RouteCandidate],
-    context: RouteContext,
-    load: &impl Fn(u64) -> u64,
-    samples: &mut impl SampleSource,
-) -> Option<RouteDecision> {
-    let mut cpu = DeviceGroup {
-        best_load: u64::MAX,
-        ..Default::default()
-    };
-    let mut accelerator = DeviceGroup {
-        best_load: u64::MAX,
-        ..Default::default()
-    };
-    let mut full_cache = DeviceGroup {
-        best_load: u64::MAX,
-        ..Default::default()
-    };
-
-    for candidate in candidates {
-        let target_load = load(candidate.target.worker_id);
-        match candidate.device {
-            RouteDevice::Cpu => cpu.consider(candidate.target, target_load, samples),
-            RouteDevice::Accelerator => {
-                accelerator.consider(candidate.target, target_load, samples)
-            }
-        }
-        if context.required_cache_hits > 0 && candidate.cache_hits >= context.required_cache_hits {
-            full_cache.consider(candidate.target, target_load, samples);
-        }
-    }
-
-    if let Some(target) = full_cache.best {
-        return Some(RouteDecision {
-            target,
-            admission: AdmissionKind::None,
-        });
-    }
-
-    let target = match (cpu.best, accelerator.best) {
-        (None, None) => return None,
-        (Some(target), None) => target,
-        (None, Some(target)) => target,
-        (Some(cpu_target), Some(accelerator_target)) => {
-            let ratio = context.non_cpu_to_cpu_ratio.max(1) as u64;
-            let allowed_cpu = accelerator.total_load.saturating_mul(cpu.count)
-                / ratio.saturating_mul(accelerator.count);
-            if cpu.total_load < allowed_cpu {
-                cpu_target
-            } else {
-                accelerator_target
-            }
-        }
-    };
-
-    Some(RouteDecision {
-        target,
-        admission: AdmissionKind::Occupancy,
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use std::cell::Cell;
-
-    use super::*;
-
-    struct ScriptedSamples {
-        values: Vec<usize>,
-        consumed: usize,
-    }
-
-    impl ScriptedSamples {
-        fn new(values: impl Into<Vec<usize>>) -> Self {
-            Self {
-                values: values.into(),
-                consumed: 0,
-            }
-        }
-    }
-
-    impl SampleSource for ScriptedSamples {
-        fn index(&mut self, upper: usize) -> usize {
-            let value = self.values[self.consumed];
-            self.consumed += 1;
-            value % upper
-        }
-    }
-
-    #[test]
-    fn round_robin_peek_does_not_advance_selection() {
-        let picker = RoutePicker::new(RoutePolicy::RoundRobin);
-        let candidates = CandidateView::Workers(&[10, 20, 30, 40]);
-        for _ in 0..16 {
-            assert_eq!(
-                picker
-                    .peek(candidates, RouteContext::default(), |_| 0)
-                    .unwrap()
-                    .target
-                    .worker_id,
-                10
-            );
-        }
-        let selected = (0..4)
-            .map(|_| {
-                picker
-                    .select(candidates, RouteContext::default(), |_| 0)
-                    .unwrap()
-                    .target
-                    .worker_id
+        let rows = RuntimeCandidates {
+            candidates,
+            load: &load,
+        };
+        self.inner
+            .select(&rows, context)
+            .map(|decision| RouteDecision {
+                target: candidates.target(decision.index),
+                admission: decision.admission,
             })
-            .collect::<Vec<_>>();
-        assert_eq!(selected, [10, 20, 30, 40]);
-    }
-
-    #[test]
-    fn random_peek_uses_one_independent_sample() {
-        let picker = RoutePicker::new(RoutePolicy::Random);
-        let candidates = CandidateView::Workers(&[10, 20, 30, 40]);
-        let mut samples = ScriptedSamples::new(vec![2]);
-        let decision = picker
-            .choose_with_samples(
-                candidates,
-                RouteContext::default(),
-                &|_| 0,
-                false,
-                &mut samples,
-            )
-            .unwrap();
-        assert_eq!(decision.target.worker_id, 30);
-        assert_eq!(samples.consumed, 1);
-    }
-
-    #[test]
-    fn p2c_uses_exactly_two_samples_and_two_load_reads() {
-        let picker = RoutePicker::new(RoutePolicy::PowerOfTwoChoices);
-        let candidates = CandidateView::Workers(&[10, 20, 30, 40]);
-        let mut samples = ScriptedSamples::new(vec![1, 1]);
-        let reads = Cell::new(0);
-        let decision = picker
-            .choose_with_samples(
-                candidates,
-                RouteContext::default(),
-                &|worker| {
-                    reads.set(reads.get() + 1);
-                    if worker == 20 { 5 } else { 1 }
-                },
-                true,
-                &mut samples,
-            )
-            .unwrap();
-        assert_eq!(decision.target.worker_id, 40);
-        assert_eq!(samples.consumed, 2);
-        assert_eq!(reads.get(), 2);
-    }
-
-    #[test]
-    fn least_loaded_ties_follow_scripted_reservoir_samples() {
-        let picker = RoutePicker::new(RoutePolicy::LeastLoaded);
-        let candidates = CandidateView::Workers(&[10, 20, 30]);
-        let mut samples = ScriptedSamples::new(vec![1, 0]);
-        let decision = picker
-            .choose_with_samples(
-                candidates,
-                RouteContext::default(),
-                &|_| 3,
-                true,
-                &mut samples,
-            )
-            .unwrap();
-        assert_eq!(decision.target.worker_id, 30);
-        assert_eq!(samples.consumed, 2);
-    }
-
-    #[test]
-    fn device_aware_scans_each_candidate_once_and_full_hits_skip_admission() {
-        let picker = RoutePicker::new(RoutePolicy::DeviceAwareWeighted);
-        let candidates = [
-            RouteCandidate {
-                target: RouteTarget::worker(10),
-                device: RouteDevice::Cpu,
-                cache_hits: 0,
-            },
-            RouteCandidate {
-                target: RouteTarget::worker(20),
-                device: RouteDevice::Accelerator,
-                cache_hits: 2,
-            },
-            RouteCandidate {
-                target: RouteTarget::worker(30),
-                device: RouteDevice::Accelerator,
-                cache_hits: 1,
-            },
-        ];
-        let reads = Cell::new(0);
-        let decision = picker
-            .peek(
-                CandidateView::DeviceAware(&candidates),
-                RouteContext {
-                    required_cache_hits: 2,
-                    non_cpu_to_cpu_ratio: 8,
-                },
-                |worker| {
-                    reads.set(reads.get() + 1);
-                    worker
-                },
-            )
-            .unwrap();
-        assert_eq!(decision.target.worker_id, 20);
-        assert_eq!(decision.admission, AdmissionKind::None);
-        assert_eq!(reads.get(), candidates.len());
     }
 }

--- a/lib/runtime/src/routing_policy/types.rs
+++ b/lib/runtime/src/routing_policy/types.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use dynamo_router_policy::{AdmissionKind, RouteDevice};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RouteTarget {
     pub worker_id: u64,
@@ -18,22 +20,6 @@ impl RouteTarget {
     pub const fn new(worker_id: u64, dp_rank: Option<u32>) -> Self {
         Self { worker_id, dp_rank }
     }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum RoutePolicy {
-    RoundRobin,
-    Random,
-    PowerOfTwoChoices,
-    LeastLoaded,
-    DeviceAwareWeighted,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(crate) enum RouteDevice {
-    Cpu,
-    #[default]
-    Accelerator,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -61,7 +47,7 @@ pub(crate) enum CandidateView<'a> {
 
 impl CandidateView<'_> {
     #[inline(always)]
-    pub(super) fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         match self {
             Self::Workers(workers) => workers.len(),
             Self::DeviceAware(candidates) => candidates.len(),
@@ -69,38 +55,17 @@ impl CandidateView<'_> {
     }
 
     #[inline(always)]
-    pub(super) fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     #[inline(always)]
-    pub(super) fn target(&self, index: usize) -> RouteTarget {
+    pub(crate) fn target(&self, index: usize) -> RouteTarget {
         match self {
             Self::Workers(workers) => RouteTarget::worker(workers[index]),
             Self::DeviceAware(candidates) => candidates[index].target,
         }
     }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct RouteContext {
-    pub(crate) required_cache_hits: usize,
-    pub(crate) non_cpu_to_cpu_ratio: usize,
-}
-
-impl Default for RouteContext {
-    fn default() -> Self {
-        Self {
-            required_cache_hits: 0,
-            non_cpu_to_cpu_ratio: 8,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum AdmissionKind {
-    None,
-    Occupancy,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This PR routes every LLM mode through one host-owned request-attempt engine while each backend retains its native selection and admission state. It removes parallel lifecycle paths without making simple routing construct KV-only services or making runtime depend on KV-router.

Closes #12998

### How This Was Implemented

- Add one `dynamo-llm` attempt executor for target resolution, preparation, abort, raw dispatch, and lease transfer.
- Adapt simple, direct, affinity, and LoRA modes to native scorer/picker contracts with runtime-owned atomic occupancy.
- Keep KV routing on its existing `WorkerSelector`, queue, rejection, booking, migration, and `RequestGuard` machinery.
- Move shared simple picker algorithms into dependency-neutral `dynamo-router-policy`; default round-robin and random paths remain allocation-free.
- Connect the existing worker-selection policy factory to non-KV routing without adding overhead to built-in policies.
- Route KV mode to `KvPushRouter` and every other LLM mode to `SessionAffinityPushRouter` at the composition root.

<details>
<summary>Walkthrough</summary>

#### Ownership model

```mermaid
flowchart LR
    Request["Preprocessed request"] --> Attempt["Common attempt executor"]
    Attempt --> Runtime["Simple / affinity / LoRA adapter"]
    Attempt --> KV["KV adapter"]
    Runtime --> Policy["Native or injected scorer + picker"]
    Policy --> Occupancy["Runtime occupancy reservation"]
    KV --> Selector["KV WorkerSelector"]
    Selector --> Booking["Scheduler RequestGuard"]
    Occupancy --> Dispatch["Prepare + exact-worker dispatch"]
    Booking --> Dispatch
    Dispatch --> Stream["Tracked stream or released error"]
```

`dispatch_attempt` owns begin, prepare, abort-on-error, raw dispatch, and lease-transfer ordering. Backends expose narrow hooks and remain the owners of their selection state.

Runtime owns discovery, transport validation, affinity, and local occupancy. The KV scheduler remains the owner of cache-aware selection, queueing, rejection, request bookings, and migration state.

#### Target and failure semantics

An advisory selection does not advance a round-robin cursor or retain occupancy or a KV booking. A committed selection reserves admission atomically and returns a stable worker target.

The worker is fixed before target-specific preparation. Dispatch then refreshes the latest transport for that same worker, so endpoint churn cannot silently move a prepared request to another worker.

Exact direct targets and KV prefill bookings deny fallback. Ordinary unpinned KV worker loss aborts the stale booking, records the failed worker, and reselects through the KV scheduler so the replacement transport always has matching scheduler accounting.

Base and LoRA routing domains have independent native picker state and independent injected policy instances. Device-aware candidate preparation happens before the occupancy mutex; the lock covers only selection and admission.

#### Custom policy boundary

The existing `HttpFrontend.worker_selection_policy_factory` now works in non-KV modes through a cache-unaware adapter. Custom filters, scorers, and pickers run over runtime-owned candidates and pay the plugin synchronization/allocation cost; built-in simple routing does not construct plugin context or take the plugin mutex.

The adapter supports worker identity and active-request load. Cache-derived or routing-input policy requirements fail explicitly because non-KV modes do not construct KV indexers, subscriptions, slot trackers, or scheduler bookings.

`dynamo-runtime` depends only on the neutral policy crate and has no `dynamo-kv-router` dependency.

</details>

### Validation

- Focused suites passed: 41 runtime push-router tests, 13 session-affinity tests, 11 KV push-router tests, 36 KV selector/policy tests, and 4 neutral router-policy tests.
- Adversarial coverage includes stale-worker reselection without duplicate booking, worker removal during preparation, mixed base/LoRA traffic, custom non-KV policy injection, atomic custom-policy admission, and device-aware lock scope.
- `cargo clippy -p dynamo-router-policy -p dynamo-kv-router -p dynamo-runtime -p dynamo-llm --lib -- -D warnings`
- Locked/offline Cargo metadata passed in the root, Python bindings, KVBM bindings, and runtime-examples workspaces.
- `cargo fmt --all -- --check`, `git diff --check`, strict CODEOWNERS generation/coverage, and all applicable `prek` hooks passed.
- Teleport Kubernetes A/B benchmark passed all 21 routing-mode/scale cells after a full raw-record audit.

### Main vs PR Mocker Performance

Baseline `main` was fixed at `3fdaec3a`. The PR candidate was a clean synthetic merge (`b55b90ac`, tree `94f4eab9`) of exact PR head `bcee48c5` onto that baseline, so both revisions contain the same current-main changes.

Each table cell is median baseline → PR throughput in req/s, followed by the PR delta. Every arm used a fresh topology, Qwen3-0.6B Mockers, concurrency 128, 4,096 warmup requests, and 32,768 measured requests; cells used three interleaved runs per revision unless marked `†`, where two balanced extension runs brought the total to five.

| Routing mode | 64 mockers | 256 mockers | 1,024 mockers |
| --- | ---: | ---: | ---: |
| `round-robin` | 2,925.8 → 2,921.3 (-0.15%) | 2,939.5 → 2,898.3 (-1.40%) `†` | 2,896.3 → 2,928.4 (+1.11%) |
| `random` | 2,922.1 → 2,925.5 (+0.12%) | 2,929.9 → 2,935.2 (+0.18%) `†` | 2,643.9 → 2,660.8 (+0.64%) |
| `power-of-two` | 2,927.1 → 2,924.7 (-0.08%) | 2,934.4 → 2,890.6 (-1.49%) `†` | 2,629.0 → 2,639.6 (+0.40%) |
| `least-loaded` | 2,921.3 → 2,918.7 (-0.09%) | 2,942.5 → 2,937.5 (-0.17%) | 2,643.7 → 2,639.2 (-0.17%) |
| `device-aware-weighted` | 2,922.4 → 2,922.3 (0.00%) | 2,931.5 → 2,926.0 (-0.19%) | 2,626.9 → 2,633.1 (+0.23%) |
| `direct` | 2,926.2 → 2,922.1 (-0.14%) | 2,922.9 → 2,927.8 (+0.17%) | 2,910.2 → 2,929.1 (+0.65%) |
| `kv` | 2,910.4 → 2,914.3 (+0.13%) | 2,942.6 → 2,867.8 (-2.54%) `†` | 2,709.5 → 2,765.7 (+2.07%) |

All 21 cells passed the predeclared -3% practical non-regression floor. Across 4,653,056 accepted measured requests, the full JSONL audit found zero errors; the geometric-mean PR/main throughput delta was -0.04%, and the worst cell was -2.54%. Error or incomplete attempts were retained in the append-only ledger, rejected by the same gate for both revisions, and rerun from fresh topologies.

All seven expected routing strategies therefore work at 64, 256, and 1,024 registered Mockers without a material throughput regression. Direct mode intentionally targets one explicit live worker, while the text-only `device-aware-weighted` workload exercises its expected least-loaded fallback because it contains no multimodal device-cache affinity signal.
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable worker-routing policies, including round-robin, random, least-loaded, power-of-two, and device-aware selection.
  * Added advisory route previews and cache-aware worker selection.
  * Added occupancy-based admission and reservation tracking for safer dispatch.
  * Added support for separate routing policies for standard and LoRA traffic.
* **Improvements**
  * Improved fallback handling, worker migration, and exact-target dispatch.
  * Enhanced routing reliability when workers become unavailable.
  * Added instance lookup capabilities for runtime discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

