### PR TITLE
test(sglang): cover routed experts string passthrough

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1021,6 +1021,33 @@ async def test_process_token_stream_accepts_incremental_logprob_arrays():
 
 
 @pytest.mark.asyncio
+async def test_process_token_stream_passes_through_encoded_routed_experts():
+    """Preserve SGLang's base64 routed-experts payload without re-encoding."""
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": None,
+                            "routed_experts": "AQIDBA==",
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+        )
+    )
+
+    assert chunks[0]["engine_data"]["routed_experts"] == "AQIDBA=="
+
+
+@pytest.mark.asyncio
 async def test_process_token_stream_uploads_large_metadata(tmp_path):
     handler = _new_decode_handler()
     uploader = MetadataUploader(
@@ -1254,6 +1281,33 @@ async def test_process_text_stream_stop_reason_requires_nvext_extra_field():
 
     assert "stop_reason" not in chunks[0]["choices"][0]
     assert "nvext" not in chunks[0]
+
+
+@pytest.mark.asyncio
+async def test_process_text_stream_passes_through_encoded_routed_experts():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_text_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "text": "Hello",
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": None,
+                            "routed_experts": "AQIDBA==",
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            request={"nvext": {"extra_fields": ["routed_experts"]}},
+        )
+    )
+
+    assert chunks[0]["nvext"]["routed_experts"] == "AQIDBA=="
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add regression coverage for NVBug 6179574 / OPS-7057
- exercise both SGLang token and text streaming paths with `routed_experts` supplied as a base64 string
- verify the encoded value is forwarded unchanged, preventing tensor conversion or double encoding

## Context

SGLang 0.5.11+ returns `meta_info["routed_experts"]` as a base64 UTF-8 string. The v1.2.0 handler previously attempted `.numpy().tobytes()` on that value, causing an `AttributeError` and HTTP 500 during MoE token streaming. The production fix shipped without direct regression coverage.

## Validation

- `components/src/dynamo/sglang/tests/test_sglang_decode_handler.py`: **82 passed**
- `git diff --check`

This is a test-only change.

## Related Issues

Closes [OPS-7057](https://linear.app/nvidia/issue/OPS-7057/unit-test-frontend-regression-coverage-for-nvbug-6179574-sglang-moe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for token and text streaming responses.
  * Verified that routed-expert metadata is preserved and forwarded correctly in response data and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->