### PR TITLE
feat(skills): add skill to open PR or issue against upstream

### DIFF
--- a/.agents/skills/issue-create/SKILL.md
+++ b/.agents/skills/issue-create/SKILL.md
@@ -142,8 +142,16 @@ cat >"$body_file" <<'EOF'
 <reviewed issue body>
 EOF
 
-title='<template prefix><concise title>'
-labels=('<template label>')
+IFS= read -r title <<'EOF'
+<template prefix><concise title>
+EOF
+
+labels=()
+while IFS= read -r label; do
+  labels+=("$label")
+done <<'EOF'
+<template label>
+EOF
 
 args=(--repo ai-dynamo/dynamo --title "$title" --body-file "$body_file")
 for label in "${labels[@]}"; do
@@ -153,8 +161,8 @@ done
 gh issue create "${args[@]}"
 ```
 
-Quoting the title this way keeps values such as `Fix user's cache` intact, and the array supports any
-number of labels.
+The quoted heredoc preserves title text such as `Fix user's cache` without evaluating it as shell
+syntax, and the array supports any number of repository-defined labels.
 
 For a DEP, add the selected area label to `labels`. Prefer explicit title, labels, and body over
 `--template` so the submitted issue is deterministic and can be reviewed before the external write.

--- a/.agents/skills/issue-create/SKILL.md
+++ b/.agents/skills/issue-create/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: issue-create
+description: Opens an issue against ai-dynamo/dynamo using the repository's current GitHub issue forms, including bug reports, feature requests, contribution requests, full DEPs, and lightweight DEPs. Use when the user asks to file, create, submit, or draft an upstream Dynamo issue and the title, labels, and body must align with .github/ISSUE_TEMPLATE.
+license: Apache-2.0
+metadata:
+  author: NVIDIA
+  tags:
+    - dynamo
+    - github
+    - issue
+    - contribution
+---
+
+# Create an Upstream Issue
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+Create a public issue in `ai-dynamo/dynamo` that matches a current repository issue form. Do not use
+a blank issue when `.github/ISSUE_TEMPLATE/config.yml` disables blank issues.
+
+## 1. Read the Current Forms
+
+Treat the repository files as the source of truth; do not rely on remembered fields:
+
+```bash
+find .github/ISSUE_TEMPLATE -maxdepth 1 -type f -print
+sed -n '1,240p' .github/ISSUE_TEMPLATE/config.yml
+sed -n '1,260p' .github/ISSUE_TEMPLATE/*.yml
+```
+
+For each form, extract:
+
+- `name`, `description`, title prefix, and automatic labels;
+- every field label in body order;
+- dropdown options; and
+- which fields are required.
+
+If the local checkout might be stale, fetch the templates from upstream before creating the issue:
+
+```bash
+git fetch upstream main
+git show upstream/main:.github/ISSUE_TEMPLATE/<template>.yml
+```
+
+## 2. Select One Template
+
+Choose the form whose stated purpose matches the user's request:
+
+- **Bug Report** for reproducible incorrect behavior.
+- **Feature Request** for a desired capability when the user is not proposing to implement it.
+- **Contribution Request** when the user intends to implement a bug fix, feature, refactor, or
+  performance improvement and wants maintainer agreement.
+- **Lightweight DEP** for a smaller design or process proposal that needs Summary, Motivation, and
+  Proposal.
+- **Dynamo Enhancement Proposal (DEP)** for a substantial feature, architecture change, public API
+  change, integration contract, or cross-component design.
+
+If two forms are genuinely plausible and choosing incorrectly would change the review workflow, ask
+the user which intent applies. Otherwise choose the best match and state it.
+
+## 3. Build the Issue Exactly From the Form
+
+Use the form's title prefix verbatim and replace any placeholder suffix with a concise description.
+Apply all labels declared by the selected template. Do not invent labels or omit automatic labels
+when creating the issue through `gh`.
+
+Render every required field as a Markdown `##` heading using the form's visible `label`, in the same
+order as the YAML. Include optional fields only when useful. For dropdowns, copy exactly one listed
+option.
+
+For example, a bug body follows the current visible labels rather than its internal YAML IDs:
+
+```markdown
+## Describe the Bug
+
+<description>
+
+## Steps to Reproduce
+
+1. <step>
+
+## Expected Behavior
+
+<expected result>
+
+## Actual Behavior
+
+<actual result>
+
+## Environment
+
+<environment details>
+```
+
+Never submit placeholders such as `TBD`, `Enter bug title`, or `XXXX`. Do not fabricate reproduction
+steps, environment data, alternatives, PR size, or affected components. Ask for missing required
+facts when they cannot be established from the conversation or repository.
+
+Every issue created by this skill is public, so review the body of any template before submission.
+Inspect the title, body, and any referenced artifact for credentials, tokens, private URLs, personal
+data, non-public organization or customer names, and sensitive portions of logs, stack traces, or
+environment output. Redact only the sensitive portions and keep the remaining diagnostics, because
+logs and environment details are required fields on several forms. Include an intentionally public
+name only when the user explicitly confirms it is already public and should appear.
+
+For DEPs, use an area exactly from the DEP form's dropdown and apply it as a label in addition to the
+form's DEP labels.
+
+Before submission, show or internally review the final template choice, title, labels, and body for
+completeness and sensitive information.
+
+## 4. Check for Duplicates
+
+Search open and closed issues using distinctive terms from the proposed title:
+
+```bash
+gh issue list --repo ai-dynamo/dynamo --state all --search '<distinctive terms>' --limit 20
+gh search issues --repo ai-dynamo/dynamo --match title,body '<distinctive terms>'
+```
+
+If a likely duplicate exists, report it and do not create another issue unless the user explicitly
+asks to proceed.
+
+## 5. Create the Issue
+
+Write the reviewed body to a unique private temporary file and use non-interactive arguments. Keep
+user-derived values in quoted shell variables and build the label list as an array; never pass them
+through `eval` or embed them directly in the command:
+
+```bash
+gh auth status
+
+body_file="$(mktemp "${TMPDIR:-/tmp}/dynamo-issue-body.XXXXXX")"
+chmod 600 "$body_file"
+trap 'rm -f "$body_file"' EXIT
+
+# Write the reviewed issue body, then set the reviewed title and template labels.
+cat >"$body_file" <<'EOF'
+<reviewed issue body>
+EOF
+
+title='<template prefix><concise title>'
+labels=('<template label>')
+
+args=(--repo ai-dynamo/dynamo --title "$title" --body-file "$body_file")
+for label in "${labels[@]}"; do
+  args+=(--label "$label")
+done
+
+gh issue create "${args[@]}"
+```
+
+Quoting the title this way keeps values such as `Fix user's cache` intact, and the array supports any
+number of labels.
+
+For a DEP, add the selected area label to `labels`. Prefer explicit title, labels, and body over
+`--template` so the submitted issue is deterministic and can be reviewed before the external write.
+
+Create the issue only when the user has asked to file or open it. If the user asked only for a draft,
+return the proposed title, labels, and body without calling `gh issue create`.
+
+## 6. Report
+
+Return the issue number and URL, selected template, title, and labels. For Contribution Requests,
+mention that implementation should wait for maintainer approval. For DEPs, mention the initial DEP
+lifecycle labels applied by the template.

--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -170,21 +170,23 @@ than from the current directory's default repository:
 ```bash
 gh auth status
 
-origin_repo="$(gh repo view "$(git remote get-url origin)" \
-  --json nameWithOwner,isFork,parent \
-  --jq '.nameWithOwner')"
+origin_url="$(git remote get-url origin)"
+origin_repo="$(gh repo view "$origin_url" --json nameWithOwner --jq '.nameWithOwner')"
 origin_owner="${origin_repo%%/*}"
+origin_source="$(gh api "repos/$origin_repo" --jq '.source.full_name // empty')"
 ```
 
 `origin` is a valid head repository when it is `ai-dynamo/dynamo` itself — a feature branch pushed
-directly to upstream is legitimate — or a fork whose parent is `ai-dynamo/dynamo`. Stop when it is
-neither:
+directly to upstream is legitimate — or a fork whose source is `ai-dynamo/dynamo`. The REST `source`
+field is used after resolving the remote URL because `gh repo view <git-url> --json parent` can omit
+the parent repository. Stop when `origin` is neither upstream nor part of its fork network:
 
 ```bash
-gh repo view "$(git remote get-url origin)" --json nameWithOwner,isFork,parent \
-  --jq 'select(.nameWithOwner == "ai-dynamo/dynamo"
-    or (.isFork and .parent.nameWithOwner == "ai-dynamo/dynamo"))
-    | .nameWithOwner'
+if [ "$origin_repo" != 'ai-dynamo/dynamo' ] && \
+   [ "$origin_source" != 'ai-dynamo/dynamo' ]; then
+  echo "origin resolves to $origin_repo, not ai-dynamo/dynamo or one of its forks." >&2
+  exit 1
+fi
 ```
 
 Push the captured branch to `origin` without force:
@@ -203,7 +205,9 @@ Open the pull request explicitly against upstream `main`, reusing the same deriv
 branch, and quoted title and body file:
 
 ```bash
-title='<type(scope): summary>'
+IFS= read -r title <<'EOF'
+<type(scope): summary>
+EOF
 
 gh pr create \
   --repo ai-dynamo/dynamo \

--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: pr-create
+description: Opens a pull request from the current branch against ai-dynamo/dynamo, including branch and remote checks, DCO verification, a repository-compliant Conventional Commit title, a complete PR body, push, and gh pr create. Use when a Dynamo change is committed on a branch and the user asks to open, create, submit, or draft the upstream pull request.
+license: Apache-2.0
+metadata:
+  author: NVIDIA
+  tags:
+    - dynamo
+    - github
+    - pull-request
+    - contribution
+---
+
+# Create an Upstream Pull Request
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+Open a pull request from the current branch to `ai-dynamo/dynamo`. Do not implement unrelated
+changes or create an issue as part of this workflow.
+
+## 1. Inspect the Branch
+
+Run from the repository root:
+
+```bash
+git status --short --branch
+
+branch="$(git branch --show-current)"
+if [ -z "$branch" ]; then
+  echo 'Detached HEAD: check out a named branch before opening a pull request.' >&2
+  exit 1
+fi
+if [ "$branch" = 'main' ]; then
+  echo 'Open the pull request from a non-main branch.' >&2
+  exit 1
+fi
+
+git remote -v
+git fetch upstream main
+git log --oneline upstream/main..HEAD
+git diff --stat upstream/main...HEAD
+git diff --check upstream/main...HEAD
+```
+
+Reuse `$branch` for every later step instead of re-reading the current branch.
+
+Stop and explain the problem when:
+
+- the branch has no commits beyond `upstream/main`;
+- tracked changes are uncommitted;
+- the branch contains changes unrelated to the requested pull request; or
+- `upstream` does not resolve to `ai-dynamo/dynamo`.
+
+Ignore unrelated untracked files. Never add, commit, delete, or include them.
+
+## 2. Verify Every Commit
+
+Dynamo requires a Developer Certificate of Origin trailer on every commit. Verify each branch commit
+carries a `Signed-off-by:` trailer matching that commit's author identity:
+
+```bash
+while read -r commit; do
+  author="$(git show -s --format='%an <%ae>' "$commit")"
+  signoffs="$(git show -s --format='%(trailers:key=Signed-off-by,valueonly,unfold)' "$commit")"
+
+  if ! printf '%s\n' "$signoffs" | grep -Fxqi -- "$author"; then
+    echo "$commit is missing a Signed-off-by trailer matching $author" >&2
+    exit 1
+  fi
+done < <(git rev-list upstream/main..HEAD)
+```
+
+The repository's `scripts/dco_check.py` commit-msg hook only enforces that a `Signed-off-by:` line is
+present, so the loop above is the stricter local check; report a mismatch rather than treating hook
+success as sufficient. A cryptographic GPG or SSH signature is optional and does not replace DCO
+sign-off.
+
+When sign-off is missing, stop and show the appropriate repair command, such as
+`git commit --amend --no-edit -s` for the last commit or
+`git rebase --signoff upstream/main` for a range; do not rewrite published history without explicit
+approval.
+
+Review the actual patch before drafting the pull request:
+
+```bash
+git diff upstream/main...HEAD
+```
+
+Use the validation results already produced for the branch. Do not claim a check was run unless its
+result is known.
+
+## 3. Draft the Title
+
+Read the current rules in `AGENTS.md` and `.github/workflows/lint-pr-title.yaml`. Use:
+
+```text
+type(scope): imperative summary
+```
+
+Choose one allowed type from the workflow. Typical choices are `docs`, `fix`, `feat`, `test`,
+`refactor`, `perf`, `ci`, `build`, or `chore`. Choose a short scope that names the affected area,
+such as `skills`, `router`, `frontend`, `vllm`, or `operator`.
+
+The title must describe the whole PR, not merely the last commit. Keep it concise, lowercase after
+the colon, and omit a trailing period. Example:
+
+```text
+feat(skills): add upstream submission workflows
+```
+
+## 4. Draft the Body
+
+Read `.github/pull_request_template.md` before drafting because it can change. The current template
+requires these sections:
+
+```markdown
+## Overview:
+
+<what changed and why>
+
+## Details:
+
+<implementation details, including validation such as `<command>` and its result>
+
+## Where should the reviewer start?
+
+<the files or entry points to read first>
+
+## Related Issues
+
+- Closes #<issue>
+```
+
+Report validation inside `## Details:` rather than adding a separate `Validation` heading, so the
+body stays template-compatible while still recording which checks ran.
+
+`## Related Issues` takes exactly one path. Use `Closes #<issue>` when the pull request should close
+the issue, `Relates to #<issue>` when it references, depends on, or partially addresses one, or the
+template's no-issue confirmation when there is none. Delete the paths that do not apply:
+
+```markdown
+## Related Issues
+
+- [x] Confirmed — no related issue
+```
+
+Use `Not run (<reason>)` for relevant checks that were not run. Do not include placeholder text such
+as `#XXXX`.
+
+Write the final body to a unique private temporary file so quoting and Markdown remain intact:
+
+```bash
+pr_body_file="$(mktemp "${TMPDIR:-/tmp}/dynamo-pr-body.XXXXXX")"
+chmod 600 "$pr_body_file"
+trap 'rm -f "$pr_body_file"' EXIT
+
+cat >"$pr_body_file" <<'EOF'
+<final pull request body>
+EOF
+```
+
+## 5. Push and Open
+
+Confirm GitHub authentication and derive the head repository from the exact `origin` remote rather
+than from the current directory's default repository:
+
+```bash
+gh auth status
+
+origin_repo="$(gh repo view "$(git remote get-url origin)" \
+  --json nameWithOwner,isFork,parent \
+  --jq '.nameWithOwner')"
+origin_owner="${origin_repo%%/*}"
+```
+
+`origin` is a valid head repository when it is `ai-dynamo/dynamo` itself — a feature branch pushed
+directly to upstream is legitimate — or a fork whose parent is `ai-dynamo/dynamo`. Stop when it is
+neither:
+
+```bash
+gh repo view "$(git remote get-url origin)" --json nameWithOwner,isFork,parent \
+  --jq 'select(.nameWithOwner == "ai-dynamo/dynamo"
+    or (.isFork and .parent.nameWithOwner == "ai-dynamo/dynamo"))
+    | .nameWithOwner'
+```
+
+Push the captured branch to `origin` without force:
+
+```bash
+git push -u origin "$branch"
+```
+
+If an open pull request already exists for the branch, report it instead of creating a duplicate:
+
+```bash
+gh pr list --repo ai-dynamo/dynamo --head "$origin_owner:$branch" --state open
+```
+
+Open the pull request explicitly against upstream `main`, reusing the same derived owner, captured
+branch, and quoted title and body file:
+
+```bash
+title='<type(scope): summary>'
+
+gh pr create \
+  --repo ai-dynamo/dynamo \
+  --base main \
+  --head "$origin_owner:$branch" \
+  --title "$title" \
+  --body-file "$pr_body_file"
+```
+
+Add `--draft` only when the user requested a draft or the change is intentionally not ready for
+review. Leave maintainer edits enabled by default.
+
+## 6. Report
+
+Return the pull request number and URL, title, head/base branches, and validation performed. Remind
+the user that full CI may require a maintainer comment of `/ok to test <short-sha>` when applicable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ to it — edit only the canonical copy. Reach for the right group first:
 - `dynamo-kv-replay-parity` — validate offline KV replay parity and performance
 - `dynamo-agent-harness` — drive persistent Claude Code, Codex, or OpenCode sessions through Dynamo over ACP
 - `graham-code-review` — strict Rust/systems review in Graham King's style
+- `issue-create` — open upstream issues using the repository's GitHub issue forms
+- `pr-create` — open an upstream pull request with compliant title, body, and DCO checks
 - `pr-monitor` — CI health check, failure root-cause, and skip analysis
 - `visual-review` — interactive HTML code-review dashboards with diagrams and annotated diffs
 


### PR DESCRIPTION
## Summary

- add a `pr-create` skill for opening upstream pull requests from an existing branch with compliant titles, PR bodies, remote checks, and DCO verification
- add an `issue-create` skill that reads and follows the current GitHub issue forms for bugs, features, contribution requests, and DEPs
- register both skills in the root `AGENTS.md` skill index

## Details

The PR workflow intentionally starts from an already-implemented branch and does not require deciding whether to open an issue first. The issue workflow treats `.github/ISSUE_TEMPLATE` as the source of truth so title prefixes, labels, required fields, and dropdown values remain aligned as templates evolve.

## Validation

- `python3 scripts/validate_skills.py .`
- `python3 /home/jonathan/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/pr-create`
- `python3 /home/jonathan/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/issue-create`
- `uvx pre-commit run --files AGENTS.md .agents/skills/pr-create/SKILL.md .agents/skills/issue-create/SKILL.md`
- `git diff --check upstream/main...HEAD`

## Where should the reviewer start?

- `.agents/skills/pr-create/SKILL.md`
- `.agents/skills/issue-create/SKILL.md`

## Related Issues

- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating and drafting issues using current GitHub issue forms.
  * Added a documented workflow for opening compliant pull requests, including validation and duplicate checks.
  * Updated the development skills list to include the new issue and pull request creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->