### PR TITLE
test(operator): cover discovered DGDR GPU budget handoff

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -21,7 +21,9 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -2301,6 +2304,102 @@ spec:
 	})
 
 	Context("GPU Discovery Integration Tests", func() {
+		It("Should pass the discovered total GPU budget to the profiler", func() {
+			ctx := context.Background()
+			dgdrName := "test-dgdr-discovered-total-gpus"
+			namespace := envtestNamespace
+			request := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			}
+
+			By("creating a DGDR without a total GPU budget")
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dgdrName,
+					Namespace: namespace,
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:   "Qwen/Qwen3-32B",
+					Backend: nvidiacomv1beta1.BackendTypeAuto,
+					Image:   "test-profiler:1.1.0",
+					Hardware: &nvidiacomv1beta1.HardwareSpec{
+						GPUSKU:         nvidiacomv1beta1.GPUSKUTypeH200SXM,
+						VRAMMB:         ptr.To(141312.0),
+						NumGPUsPerNode: ptr.To[int32](8),
+					},
+					SLA: &nvidiacomv1beta1.SLASpec{
+						TTFT: ptr.To(2000.0),
+						ITL:  ptr.To(30.0),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+
+			By("creating two eight-GPU nodes for node-label discovery")
+			gpuNodes := make([]*corev1.Node, 0, 2)
+			for _, nodeName := range []string{"gpu-worker-budget-1", "gpu-worker-budget-2"} {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+						Labels: map[string]string{
+							gpu.LabelGPUCount:   "8",
+							gpu.LabelGPUProduct: "H200-SXM5-141GB",
+							gpu.LabelGPUMemory:  "141312",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, node)).Should(Succeed())
+				gpuNodes = append(gpuNodes, node)
+			}
+			defer func() {
+				for _, node := range gpuNodes {
+					_ = k8sClient.Delete(ctx, node)
+				}
+			}()
+
+			reconciler.RuntimeConfig.Gate = features.Defaults()
+			reconciler.GPUDiscovery = nil
+			reconciler.APIReader = k8sClient
+
+			By("validating the request and persisting discovered hardware")
+			_, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			var persisted nvidiacomv1beta1.DynamoGraphDeploymentRequest
+			Expect(k8sClient.Get(ctx, request.NamespacedName, &persisted)).Should(Succeed())
+			Expect(persisted.Spec.Hardware).NotTo(BeNil())
+			Expect(persisted.Spec.Hardware.TotalGPUs).NotTo(BeNil())
+			Expect(*persisted.Spec.Hardware.TotalGPUs).To(Equal(int32(16)))
+
+			By("creating the profiling Job from the persisted DGDR")
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			job := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: getProfilingJobName(&persisted), Namespace: namespace,
+			}, job)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, job) }()
+
+			By("verifying the profiler receives the discovered budget in its inline config")
+			profiler := findContainer(job.Spec.Template.Spec.Containers, ContainerNameProfiler)
+			Expect(profiler).NotTo(BeNil())
+
+			configFlagIndex := slices.Index(profiler.Args, "--config")
+			Expect(configFlagIndex).To(BeNumerically(">=", 0))
+			configArgIndex := configFlagIndex + 1
+			Expect(configArgIndex).To(BeNumerically("<", len(profiler.Args)))
+
+			var profilerConfig nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec
+			Expect(json.Unmarshal([]byte(profiler.Args[configArgIndex]), &profilerConfig)).To(Succeed())
+			Expect(profilerConfig.Hardware).NotTo(BeNil())
+			Expect(profilerConfig.Hardware.TotalGPUs).NotTo(BeNil())
+			Expect(*profilerConfig.Hardware.TotalGPUs).To(Equal(*persisted.Spec.Hardware.TotalGPUs))
+		})
+
 		It("Should use GPU discovery when nodes have GPU labels", func() {
 			ctx := context.Background()
 			dgdrName := "test-dgdr-gpu-discovery"

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -2312,7 +2312,7 @@ spec:
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			}
 
-			By("creating a DGDR without a total GPU budget")
+			GinkgoT().Log("creating a DGDR without a total GPU budget")
 			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dgdrName,
@@ -2336,7 +2336,7 @@ spec:
 			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
 
-			By("creating two eight-GPU nodes for node-label discovery")
+			GinkgoT().Log("creating two eight-GPU nodes for node-label discovery")
 			gpuNodes := make([]*corev1.Node, 0, 2)
 			for _, nodeName := range []string{"gpu-worker-budget-1", "gpu-worker-budget-2"} {
 				node := &corev1.Node{
@@ -2358,11 +2358,12 @@ spec:
 				}
 			}()
 
+			GinkgoT().Log("enabling node-label GPU discovery on the reconciler")
 			reconciler.RuntimeConfig.Gate = features.Defaults()
 			reconciler.GPUDiscovery = nil
 			reconciler.APIReader = k8sClient
 
-			By("validating the request and persisting discovered hardware")
+			GinkgoT().Log("validating the request and persisting discovered hardware")
 			_, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = reconciler.Reconcile(ctx, request)
@@ -2374,7 +2375,7 @@ spec:
 			Expect(persisted.Spec.Hardware.TotalGPUs).NotTo(BeNil())
 			Expect(*persisted.Spec.Hardware.TotalGPUs).To(Equal(int32(16)))
 
-			By("creating the profiling Job from the persisted DGDR")
+			GinkgoT().Log("creating the profiling Job from the persisted DGDR")
 			_, err = reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -2384,7 +2385,7 @@ spec:
 			}, job)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, job) }()
 
-			By("verifying the profiler receives the discovered budget in its inline config")
+			GinkgoT().Log("verifying the profiler receives the discovered budget in its inline config")
 			profiler := findContainer(job.Spec.Template.Spec.Containers, ContainerNameProfiler)
 			Expect(profiler).NotTo(BeNil())
 


### PR DESCRIPTION
## Overview:

Adds a DGDR v1beta1 envtest verifying that an auto-discovered DGDR GPU budget is persisted and passed to the profiler.

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for deployments that omit a total GPU count.
  * Verified GPU capacity is discovered from labeled H200 nodes and persisted correctly.
  * Confirmed profiling jobs receive the calculated GPU budget in their configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->