### PR TITLE
fix(frontend): release resources after LoRA unload - #12743

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,6 +2624,7 @@ dependencies = [
  "ipnet",
  "json-five",
  "lazy_static",
+ "libc",
  "llm-multimodal",
  "llm-tokenizer",
  "lru 0.16.4",

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -182,6 +182,8 @@ impl Router {
             // ext-proc constructs no KvWorkerMonitor; overload publishing is
             // unused on this path (matches the prior namespace-lookup miss).
             None,
+            // This standalone router is not owned by a frontend WorkerSet.
+            None,
         );
 
         spawn_prefill_discovery_watcher(drt.clone(), actual_namespace.to_string(), prefill_tx);

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -864,6 +864,8 @@ pub unsafe extern "C" fn create_routers(
             // C bindings construct no KvWorkerMonitor; overload publishing is
             // unused on this path (matches the prior namespace-lookup miss).
             None,
+            // This standalone router is not owned by a frontend WorkerSet.
+            None,
         );
 
         // Spawn background discovery watcher for prefill workers.

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1711,6 +1711,7 @@ dependencies = [
  "image",
  "ipnet",
  "json-five",
+ "libc",
  "lru",
  "minijinja",
  "modelexpress-client",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2315,6 +2315,7 @@ dependencies = [
  "image",
  "ipnet",
  "json-five",
+ "libc",
  "llm-multimodal",
  "llm-tokenizer",
  "lru 0.16.4",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -88,6 +88,7 @@ futures = { workspace = true }
 futures-util = { workspace = true }
 hf-hub = { workspace = true, features = ["tokio", "rustls-tls", "ureq"] }
 ipnet = { workspace = true }
+libc = { workspace = true }
 lru = { workspace = true }
 moka = { workspace = true }
 oneshot = { workspace = true }

--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -18,6 +18,7 @@ pub use kv_source_watch::KvSourceMembershipWatch;
 mod model_manager;
 pub use model_manager::{ModelManager, ModelManagerError, UNKNOWN_METRIC_MODEL};
 
+mod allocator;
 mod worker_set;
 pub use worker_set::WorkerSet;
 

--- a/lib/llm/src/discovery/allocator.rs
+++ b/lib/llm/src/discovery/allocator.rs
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+use std::sync::{Arc, LazyLock, mpsc};
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+use std::time::Duration;
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+struct AllocatorTrimScheduler {
+    sender: mpsc::SyncSender<()>,
+}
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+impl AllocatorTrimScheduler {
+    fn new(quiet_period: Duration, trim: Arc<dyn Fn() + Send + Sync>) -> Self {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            while receiver.recv().is_ok() {
+                loop {
+                    match receiver.recv_timeout(quiet_period) {
+                        Ok(()) => {}
+                        Err(mpsc::RecvTimeoutError::Timeout) => {
+                            trim();
+                            break;
+                        }
+                        Err(mpsc::RecvTimeoutError::Disconnected) => {
+                            trim();
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+        Self { sender }
+    }
+
+    fn schedule(&self) {
+        match self.sender.try_send(()) {
+            Ok(()) | Err(mpsc::TrySendError::Full(())) => {}
+            Err(mpsc::TrySendError::Disconnected(())) => {
+                tracing::warn!("Allocator trim worker stopped unexpectedly");
+            }
+        }
+    }
+}
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+static ALLOCATOR_TRIM_SCHEDULER: LazyLock<Arc<AllocatorTrimScheduler>> = LazyLock::new(|| {
+    Arc::new(AllocatorTrimScheduler::new(
+        Duration::from_millis(100),
+        Arc::new(|| {
+            // SAFETY: malloc_trim is process-wide and internally synchronizes glibc arenas.
+            let released_pages = unsafe { libc::malloc_trim(0) != 0 };
+            tracing::debug!(released_pages, "Trimmed allocator after model teardown");
+        }),
+    ))
+});
+
+/// Schedules allocator trimming after the last WorkerSet, active request, and teardown task exits.
+pub(crate) struct AllocatorTrimOnDrop {
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    scheduler: Arc<AllocatorTrimScheduler>,
+}
+
+impl AllocatorTrimOnDrop {
+    pub(crate) fn new() -> Self {
+        Self {
+            #[cfg(all(target_os = "linux", target_env = "gnu"))]
+            scheduler: ALLOCATOR_TRIM_SCHEDULER.clone(),
+        }
+    }
+}
+
+impl Drop for AllocatorTrimOnDrop {
+    fn drop(&mut self) {
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        self.scheduler.schedule();
+    }
+}
+
+#[cfg(all(test, target_os = "linux", target_env = "gnu"))]
+mod tests {
+    use super::*;
+    use dynamo_runtime::{
+        engine::{AsyncEngineContext, EngineContextGuard},
+        pipeline::Context,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn trim_waits_for_request_teardown_and_runs_off_async_worker() {
+        let async_thread = std::thread::current().id();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let trim_thread = Arc::new(std::sync::Mutex::new(None));
+        let scheduler = Arc::new(AllocatorTrimScheduler::new(
+            Duration::from_millis(10),
+            Arc::new({
+                let calls = calls.clone();
+                let trim_thread = trim_thread.clone();
+                move || {
+                    *trim_thread.lock().unwrap() = Some(std::thread::current().id());
+                    calls.fetch_add(1, Ordering::SeqCst);
+                }
+            }),
+        ));
+        let teardown: EngineContextGuard = Arc::new(AllocatorTrimOnDrop { scheduler });
+        let context = Context::new(());
+        context.controller().retain(teardown.clone());
+        drop(teardown);
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        std::thread::spawn(move || drop(context)).join().unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while calls.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("allocator trim did not run after request teardown");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_ne!(trim_thread.lock().unwrap().unwrap(), async_thread);
+    }
+
+    #[tokio::test]
+    async fn trim_waits_for_background_teardown_task() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let scheduler = Arc::new(AllocatorTrimScheduler::new(
+            Duration::from_millis(10),
+            Arc::new({
+                let calls = calls.clone();
+                move || {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                }
+            }),
+        ));
+        let teardown = Arc::new(AllocatorTrimOnDrop { scheduler });
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn({
+            let teardown = teardown.clone();
+            async move {
+                let _teardown = teardown;
+                let _ = release_rx.await;
+            }
+        });
+
+        drop(teardown);
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        release_tx.send(()).unwrap();
+        task.await.unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while calls.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("allocator trim did not run after task teardown");
+    }
+}

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -307,6 +307,54 @@ impl ModelManager {
         true
     }
 
+    /// Register a LoRA model as a lightweight view of an existing base WorkerSet.
+    pub(crate) fn add_adapter_view(
+        &self,
+        card_key: &str,
+        base_model_name: &str,
+        worker_set_key: &str,
+        adapter_card: ModelDeploymentCard,
+    ) -> anyhow::Result<()> {
+        let _reservation = self.reservation_lock.lock();
+        let adapter_name = adapter_card.name().to_string();
+        anyhow::ensure!(
+            adapter_card.lora.is_some(),
+            "adapter view requires LoRA metadata"
+        );
+        anyhow::ensure!(
+            adapter_name != base_model_name,
+            "LoRA adapter name collides with its base model"
+        );
+        anyhow::ensure!(
+            !self.alias_to_primary.contains_key(&adapter_name),
+            "LoRA adapter name is reserved as a model alias"
+        );
+        if let Some(existing) = self.models.get(&adapter_name) {
+            anyhow::ensure!(
+                existing
+                    .worker_sets()
+                    .iter()
+                    .all(|worker_set| worker_set.card().lora.is_some()),
+                "LoRA adapter name collides with a registered base model"
+            );
+        }
+
+        let base_worker_set = self
+            .models
+            .get(base_model_name)
+            .and_then(|model| model.get_worker_set(worker_set_key))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "base WorkerSet for LoRA adapter {adapter_name:?} is not registered"
+                )
+            })?;
+        let adapter_view = Arc::new(base_worker_set.adapter_view(adapter_card.clone()));
+        self.cards.insert(card_key.to_string(), adapter_card);
+        self.get_or_create_model(&adapter_name)
+            .add_worker_set(worker_set_key.to_string(), adapter_view);
+        Ok(())
+    }
+
     /// Record that `alias` is an alternate name for `primary`. Used to normalize metrics labels.
     ///
     /// The claim is taken atomically through the map entry so two concurrent
@@ -1091,8 +1139,8 @@ impl ModelManager {
         let lora_domain = self.lora_domain(&endpoint.id());
 
         // Register router via discovery mechanism.
-        let discovery = endpoint.component().drt().discovery();
-        let instance_id = discovery.instance_id();
+        let drt = endpoint.component().drt();
+        let instance_id = drt.discovery().instance_id();
 
         // Build transport for router endpoint based on request plane mode
         // Use the worker's component name so each target pool gets its own router discovery group
@@ -1109,7 +1157,7 @@ impl ModelManager {
             request_plane_codec: Some(RequestPlanePayloadCodec::configured()),
         };
 
-        discovery.register(discovery_spec).await?;
+        let registration = drt.register_endpoint_lease(discovery_spec).await?;
 
         // Get of create runtime config watcher for this endpoint
         let workers_with_configs = self.get_or_create_runtime_config_watcher(endpoint).await?;
@@ -1148,7 +1196,7 @@ impl ModelManager {
                 None
             };
 
-        let chooser = KvRouter::new_with_worker_role(
+        let mut chooser = KvRouter::new_with_worker_role(
             endpoint.clone(),
             client,
             workers_with_configs,
@@ -1165,6 +1213,7 @@ impl ModelManager {
             self.lora_enabled.then(|| lora_domain.filter.clone()),
         )
         .await?;
+        chooser.set_endpoint_registration(registration);
 
         // F2: feed the LoRA LoadEstimator in KV mode. Start exactly one active-sequence
         // subscription per decode endpoint. WORKER_TYPE_DECODE is the routing path for BOTH
@@ -2038,7 +2087,7 @@ mod tests {
     use dynamo_kv_router::protocols::{KV_EVENT_SUBJECT, WorkerWithDpRank};
     use dynamo_runtime::{
         DistributedRuntime, Runtime,
-        discovery::{Discovery, DiscoverySpec, MockDiscovery, SharedMockRegistry},
+        discovery::{Discovery, MockDiscovery, SharedMockRegistry},
         distributed::DistributedConfig,
         transports::event_plane::EventScope,
     };

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1235,6 +1235,44 @@ impl ModelWatcher {
             return Ok(());
         }
 
+        // Adapter cards describe another view of the same worker endpoint. Reuse the base
+        // WorkerSet so adapter churn does not rebuild tokenizers, routers, or network clients.
+        if card.lora.is_some() {
+            let mut base_mcid = mcid.clone();
+            base_mcid.model_suffix = None;
+            let base_card = self
+                .manager
+                .get_model_card(&base_mcid.to_path())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "base model card for LoRA adapter {:?} is not registered",
+                        card.name()
+                    )
+                })?;
+            anyhow::ensure!(
+                base_card.lora.is_none(),
+                "base model card for LoRA adapter contains LoRA metadata"
+            );
+            let base_ws_key = worker_set_key(
+                &model_card_endpoint_id(&base_mcid),
+                base_card.model_type,
+                base_card.worker_type,
+            );
+            self.manager.add_adapter_view(
+                &mcid.to_path(),
+                base_card.name(),
+                &base_ws_key,
+                card.clone(),
+            )?;
+            tracing::debug!(
+                model_name = card.name(),
+                base_model_name = base_card.name(),
+                namespace,
+                "Registered LoRA adapter view over base WorkerSet"
+            );
+            return Ok(());
+        }
+
         // Guard against concurrent pipeline construction for the same (model, namespace, type)
         let registration_key = ModelManager::model_namespace_key(&model_name, &ws_key);
         if !self
@@ -1435,6 +1473,7 @@ impl ModelWatcher {
         // Build the WorkerSet with all applicable engines
         let mut worker_set = WorkerSet::new(namespace.clone(), checksum.to_string(), card.clone());
         worker_set.set_endpoint_id(endpoint.id());
+        let allocator_trim = worker_set.initialize_allocator_trim_on_teardown();
         worker_set.set_instance_watcher(instance_watcher);
 
         // A surface-less Encode worker is reached only through EncoderRouter.
@@ -1449,6 +1488,7 @@ impl ModelWatcher {
                     card.model_input.as_str()
                 );
             }
+            worker_set.enable_allocator_trim_on_teardown();
             self.manager
                 .add_worker_set(card.name(), &ws_key, worker_set);
 
@@ -1502,6 +1542,7 @@ impl ModelWatcher {
             // No engine on the worker set — just lifecycle tracking so the
             // prefill router can be activated/deactivated as workers come
             // and go.
+            worker_set.enable_allocator_trim_on_teardown();
             if !self
                 .manager
                 .add_worker_set(card.name(), &ws_key, worker_set)
@@ -1589,20 +1630,23 @@ impl ModelWatcher {
             // need the shared chooser in KV mode.
             let kv_chooser =
                 if router_config.router_mode == RouterMode::KV && needs_preprocessed_routing {
-                    Some(
-                        self.manager
-                            .kv_chooser_for_with_worker_role(
-                                &endpoint,
-                                card.kv_cache_block_size,
-                                Some(router_config.kv_router_config.clone()),
-                                self.prefill_load_estimator.clone(),
-                                card.worker_type,
-                                WORKER_TYPE_DECODE, // This is the decode router
-                                Some(card.display_name.clone()),
-                                card.runtime_config.enable_eagle,
-                            )
-                            .await?,
-                    )
+                    let mut chooser = self
+                        .manager
+                        .kv_chooser_for_with_worker_role(
+                            &endpoint,
+                            card.kv_cache_block_size,
+                            Some(router_config.kv_router_config.clone()),
+                            self.prefill_load_estimator.clone(),
+                            card.worker_type,
+                            WORKER_TYPE_DECODE, // This is the decode router
+                            Some(card.display_name.clone()),
+                            card.runtime_config.enable_eagle,
+                        )
+                        .await?;
+                    Arc::get_mut(&mut chooser)
+                        .expect("new KV chooser must have one owner")
+                        .set_teardown_task_guard(allocator_trim.clone());
+                    Some(chooser)
                 } else {
                     None
                 };
@@ -1624,9 +1668,10 @@ impl ModelWatcher {
                     .as_ref()
                     .map(|chooser| chooser.client().clone())
                     .unwrap_or_else(|| client.clone());
-                Some(KvWorkerMonitor::new(
+                Some(KvWorkerMonitor::new_with_task_guard(
                     monitor_client,
                     router_config.load_threshold_config.clone(),
+                    allocator_trim.clone(),
                 ))
             } else {
                 None
@@ -1680,6 +1725,7 @@ impl ModelWatcher {
                     // Hand the monitor directly so the prefill Client can be attached
                     // to it on activation (no namespace lookup).
                     worker_monitor.clone(),
+                    Some(allocator_trim.clone()),
                 )
             });
 
@@ -1689,7 +1735,14 @@ impl ModelWatcher {
                 }
                 self.manager
                     .register_encoder_router(&model_name, &namespace)
-                    .map(|rx| EncoderRouter::new(rx, model_name.clone(), namespace.clone()))
+                    .map(|rx| {
+                        EncoderRouter::new_with_task_guard(
+                            rx,
+                            model_name.clone(),
+                            namespace.clone(),
+                            allocator_trim.clone(),
+                        )
+                    })
             } else {
                 None
             };
@@ -1948,7 +2001,7 @@ impl ModelWatcher {
                 .link(service_backend)?
                 .link(backend.backward_edge())?
                 .link(preprocessor.backward_edge())?
-                .link(frontend)?;
+                .link_terminal(frontend)?;
 
             worker_set.embeddings_engine = Some(embedding_engine);
         } else if card.model_input == ModelInput::Tensor && card.model_type.supports_tensor() {
@@ -2001,6 +2054,7 @@ impl ModelWatcher {
         // Add the completed WorkerSet to the Model, then mirror it under any
         // configured aliases so alias names resolve, list, and report readiness
         // exactly like the primary.
+        worker_set.enable_allocator_trim_on_teardown();
         if !self
             .manager
             .add_worker_set(card.name(), &ws_key, worker_set)
@@ -2218,6 +2272,134 @@ mod tests {
         assert!(!supports_encoder_result_handoff(&card));
     }
 
+    #[tokio::test]
+    async fn repeated_lora_registration_reuses_and_releases_base_chat_pipeline() {
+        use dynamo_runtime::{Runtime, distributed::DistributedConfig};
+
+        let runtime = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let manager = Arc::new(ModelManager::new());
+        let watcher = ModelWatcher::new(
+            drt,
+            manager.clone(),
+            RouterConfig::default(),
+            0,
+            None,
+            None,
+            None,
+            Arc::new(Metrics::new_with_prefix(Some(
+                "watcher_lora_lifecycle_test".to_string(),
+            ))),
+        );
+        let base_mcid = ModelCardInstanceId {
+            namespace: "lora-lifecycle-ns".to_string(),
+            component: "workers".to_string(),
+            endpoint: "generate".to_string(),
+            instance_id: 1,
+            model_suffix: None,
+        };
+        let adapter_mcid = ModelCardInstanceId {
+            model_suffix: Some("adapter".to_string()),
+            ..base_mcid.clone()
+        };
+        let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
+        let mut base_card = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
+        base_card.set_name("lora-lifecycle-base");
+        base_card.model_input = ModelInput::Tokens;
+        base_card.model_type = ModelType::Chat;
+        base_card.worker_type = Some(WorkerType::Aggregated);
+        let mut adapter_card = base_card.clone();
+        adapter_card.set_name("lora-lifecycle-adapter");
+        adapter_card.lora = Some(crate::model_card::LoraInfo {
+            name: adapter_card.name().to_string(),
+            max_gpu_lora_count: Some(1),
+        });
+        let ws_key = worker_set_key(
+            &model_card_endpoint_id(&base_mcid),
+            base_card.model_type,
+            base_card.worker_type,
+        );
+
+        watcher
+            .handle_put(&base_mcid, &mut base_card)
+            .await
+            .unwrap();
+        let base_engine = manager
+            .get_model(base_card.name())
+            .and_then(|model| model.get_worker_set(&ws_key))
+            .and_then(|worker_set| worker_set.chat_engine.clone())
+            .expect("base chat pipeline was not registered");
+        let released_base_engine = Arc::downgrade(&base_engine);
+        drop(base_engine);
+        let base_engine_owner_count = released_base_engine.strong_count();
+
+        for _ in 0..3 {
+            watcher
+                .handle_put(&adapter_mcid, &mut adapter_card)
+                .await
+                .unwrap();
+            let adapter_view = manager
+                .get_model(adapter_card.name())
+                .and_then(|model| model.get_worker_set(&ws_key))
+                .expect("LoRA adapter view was not registered");
+            assert!(
+                released_base_engine.strong_count() > base_engine_owner_count,
+                "LoRA adapter must retain the shared base chat pipeline"
+            );
+            let engine = adapter_view.chat_engine.clone().unwrap();
+            let messages: Vec<dynamo_protocols::types::ChatCompletionRequestMessage> =
+                serde_json::from_str(r#"[{"role":"user","content":"populate tokenizer cache"}]"#)
+                    .unwrap();
+            let request = NvCreateChatCompletionRequest {
+                inner: dynamo_protocols::types::CreateChatCompletionRequestArgs::default()
+                    .model(adapter_card.name())
+                    .messages(messages)
+                    .build()
+                    .unwrap(),
+                common: Default::default(),
+                nvext: None,
+                chat_template_args: None,
+                thinking: None,
+                media_io_kwargs: None,
+                return_tokens_as_token_ids: None,
+                unsupported_fields: Default::default(),
+            };
+            assert!(engine.generate(SingleIn::new(request)).await.is_err());
+            let released_adapter_view = Arc::downgrade(&adapter_view);
+            let released_adapter_engine = Arc::downgrade(&engine);
+            drop(engine);
+            drop(adapter_view);
+
+            watcher
+                .handle_delete_serialized(
+                    &adapter_mcid,
+                    &NamespaceFilter::Exact(adapter_mcid.namespace.clone()),
+                )
+                .await
+                .unwrap();
+            assert!(manager.get_model(adapter_card.name()).is_none());
+            assert_eq!(released_adapter_view.strong_count(), 0);
+            assert_eq!(released_adapter_engine.strong_count(), 0);
+            assert_eq!(
+                released_base_engine.strong_count(),
+                base_engine_owner_count,
+                "removed LoRA adapter retained the shared base chat pipeline"
+            );
+        }
+
+        watcher
+            .handle_delete_serialized(
+                &base_mcid,
+                &NamespaceFilter::Exact(base_mcid.namespace.clone()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(released_base_engine.strong_count(), 0);
+        runtime.shutdown();
+    }
     #[test]
     fn base_card_with_capacity_seeds_idle_lora_capable_worker() {
         // jh-nv (watcher base-card seeding): a base worker card (lora=None) carrying

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -7,6 +7,7 @@ use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 
 use dashmap::DashMap;
 use dynamo_kv_router::protocols::ActiveLoad;
@@ -533,6 +534,19 @@ pub struct KvWorkerMonitor {
     thresholds: Arc<RwLock<LoadThresholdConfig>>,
     /// Guard to ensure start_monitoring() only runs once across clones
     started: Arc<AtomicBool>,
+    start_lock: Arc<tokio::sync::Mutex<()>>,
+    lifecycle: Arc<MonitorLifecycle>,
+}
+
+struct MonitorLifecycle {
+    cancellation_token: CancellationToken,
+    task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
+}
+
+impl Drop for MonitorLifecycle {
+    fn drop(&mut self) {
+        self.cancellation_token.cancel();
+    }
 }
 
 impl KvWorkerMonitor {
@@ -551,6 +565,23 @@ impl KvWorkerMonitor {
     /// prefill-pool overload publishing and TTFT metric cleanup when prefill workers
     /// are removed.
     pub fn new(client: Client, config: LoadThresholdConfig) -> Self {
+        Self::new_inner(client, config, None)
+    }
+
+    pub(crate) fn new_with_task_guard(
+        client: Client,
+        config: LoadThresholdConfig,
+        task_guard: dynamo_runtime::engine::EngineContextGuard,
+    ) -> Self {
+        Self::new_inner(client, config, Some(task_guard))
+    }
+
+    fn new_inner(
+        client: Client,
+        config: LoadThresholdConfig,
+        task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
+    ) -> Self {
+        let cancellation_token = client.endpoint.drt().child_token();
         Self {
             client,
             prefill_client: Arc::new(RwLock::new(None)),
@@ -558,6 +589,11 @@ impl KvWorkerMonitor {
             worker_load_states: Arc::new(DashMap::new()),
             thresholds: Arc::new(RwLock::new(config)),
             started: Arc::new(AtomicBool::new(false)),
+            start_lock: Arc::new(tokio::sync::Mutex::new(())),
+            lifecycle: Arc::new(MonitorLifecycle {
+                cancellation_token,
+                task_guard,
+            }),
         }
     }
 
@@ -676,16 +712,14 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
     /// This is safe to call multiple times (e.g., from cloned monitors shared across
     /// pipelines) - only the first call spawns the background task.
     async fn start_monitoring(&self) -> anyhow::Result<()> {
-        // Guard: only start once across all clones
-        if self.started.swap(true, Ordering::SeqCst) {
+        let _start_guard = self.start_lock.lock().await;
+        if self.started.load(Ordering::Acquire) {
             tracing::debug!("Worker monitoring already started, skipping");
             return Ok(());
         }
 
         let endpoint = &self.client.endpoint;
-        let component = endpoint.component();
-
-        let cancellation_token = component.drt().child_token();
+        let cancellation_token = self.lifecycle.cancellation_token.child_token();
 
         let decode_configs_rx = match runtime_config_watch(endpoint).await {
             Ok(rx) => rx,
@@ -695,7 +729,6 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                     %error,
                     "KvWorkerMonitor: failed to watch endpoint runtime configs"
                 );
-                self.started.store(false, Ordering::SeqCst);
                 return Err(error);
             }
         };
@@ -722,9 +755,22 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
         let prefill_client_holder = self.prefill_client.clone();
         let prefill_client_notify = self.prefill_client_notify.clone();
         let thresholds = self.thresholds.clone();
+        let started = self.started.clone();
+        let task_guard = self.lifecycle.task_guard.clone();
 
         // Spawn background monitoring task
+        self.started.store(true, Ordering::Release);
         tokio::spawn(async move {
+            let _task_guard = task_guard;
+            struct StartedGuard(Arc<AtomicBool>);
+
+            impl Drop for StartedGuard {
+                fn drop(&mut self) {
+                    self.0.store(false, Ordering::Release);
+                }
+            }
+
+            let _started_guard = StartedGuard(started);
             let mut kv_metrics_rx = kv_metrics_rx;
             let mut prefill_metrics_rx: Option<TypedEventSubscriber<ActiveLoad>> = None;
             let mut prefill_configs_rx: Option<RuntimeConfigWatch> = None;
@@ -1106,12 +1152,14 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                             known_prefill_workers = rx.borrow().iter().copied().collect();
                             prefill_instances_rx = Some(rx);
 
-                            prefill_metrics_rx = match EventSubscriber::for_endpoint(
-                                &prefill_endpoint,
-                                KV_METRICS_SUBJECT,
-                            )
-                            .await
-                            {
+                            let metrics_result = tokio::select! {
+                                _ = cancellation_token.cancelled() => break,
+                                result = EventSubscriber::for_endpoint(
+                                    &prefill_endpoint,
+                                    KV_METRICS_SUBJECT,
+                                ) => result,
+                            };
+                            prefill_metrics_rx = match metrics_result {
                                 Ok(subscriber) => Some(subscriber.typed::<ActiveLoad>()),
                                 Err(error) => {
                                     tracing::warn!(
@@ -1122,7 +1170,11 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                                     None
                                 }
                             };
-                            prefill_configs_rx = match runtime_config_watch(&prefill_endpoint).await {
+                            let config_result = tokio::select! {
+                                _ = cancellation_token.cancelled() => break,
+                                result = runtime_config_watch(&prefill_endpoint) => result,
+                            };
+                            prefill_configs_rx = match config_result {
                                 Ok(rx) => Some(rx),
                                 Err(error) => {
                                     tracing::warn!(
@@ -1702,6 +1754,53 @@ mod tests {
             Some(HashSet::from([7])),
             "attach must seed the prefill client with the current overloaded set"
         );
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn dropping_last_monitor_releases_task_state() {
+        use super::KvWorkerMonitor;
+        use dynamo_runtime::pipeline::WorkerLoadMonitor;
+        use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
+        use std::sync::Arc;
+
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let client = drt
+            .namespace("test_monitor_lifecycle".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("decode".to_string())
+            .client()
+            .await
+            .unwrap();
+        let monitor = KvWorkerMonitor::new(client, LoadThresholdConfig::default());
+        let monitor_clone = monitor.clone();
+        let worker_load_states = Arc::downgrade(&monitor.worker_load_states);
+
+        let (first_start, second_start) =
+            tokio::join!(monitor.start_monitoring(), monitor_clone.start_monitoring());
+        first_start.unwrap();
+        second_start.unwrap();
+        drop(monitor);
+        assert!(
+            !monitor_clone.lifecycle.cancellation_token.is_cancelled()
+                && worker_load_states.upgrade().is_some(),
+            "dropping one clone must not stop a shared monitor"
+        );
+        drop(monitor_clone);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while worker_load_states.strong_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("monitor task retained state after its last owner was dropped");
 
         rt.shutdown();
     }

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -7,11 +7,14 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContextProvider, Data};
+use dynamo_runtime::pipeline::{Error, ManyOut, SingleIn};
 use dynamo_runtime::protocols::EndpointId;
 use tokio::sync::watch;
 
 use crate::{
-    discovery::KvWorkerMonitor,
+    discovery::{KvWorkerMonitor, allocator::AllocatorTrimOnDrop},
     kv_router::{EncoderRouter, KvRouter, PrefillRouter},
     model_card::ModelDeploymentCard,
     types::{
@@ -26,6 +29,102 @@ use crate::{
         },
     },
 };
+
+type StreamingEngine<Req, Resp> = Arc<dyn AsyncEngine<SingleIn<Req>, ManyOut<Resp>, Error>>;
+
+struct RequestLifetimeEngine<Req, Resp>
+where
+    Req: AsyncEngineContextProvider + Send + 'static,
+    Resp: AsyncEngineContextProvider + 'static,
+{
+    inner: Arc<dyn AsyncEngine<Req, Resp, Error>>,
+    teardown: Arc<AllocatorTrimOnDrop>,
+}
+
+#[async_trait]
+impl<Req, Resp> AsyncEngine<Req, Resp, Error> for RequestLifetimeEngine<Req, Resp>
+where
+    Req: AsyncEngineContextProvider + Send + 'static,
+    Resp: AsyncEngineContextProvider + 'static,
+{
+    async fn generate(&self, request: Req) -> Result<Resp, Error> {
+        request.context().retain(self.teardown.clone());
+        let response = self.inner.generate(request).await?;
+        response.context().retain(self.teardown.clone());
+        Ok(response)
+    }
+}
+
+fn retain_teardown_until_requests_finish<Req, Resp>(
+    engine: Option<Arc<dyn AsyncEngine<Req, Resp, Error>>>,
+    teardown: &Arc<AllocatorTrimOnDrop>,
+) -> Option<Arc<dyn AsyncEngine<Req, Resp, Error>>>
+where
+    Req: AsyncEngineContextProvider + Send + 'static,
+    Resp: AsyncEngineContextProvider + 'static,
+{
+    engine.map(|inner| {
+        Arc::new(RequestLifetimeEngine {
+            inner,
+            teardown: teardown.clone(),
+        }) as Arc<dyn AsyncEngine<Req, Resp, Error>>
+    })
+}
+
+struct LoraContextEngine<Req: Data, Resp: Data> {
+    inner: StreamingEngine<Req, Resp>,
+    lora_name: String,
+}
+
+#[async_trait]
+impl<Req: Data, Resp: Data> AsyncEngine<SingleIn<Req>, ManyOut<Resp>, Error>
+    for LoraContextEngine<Req, Resp>
+{
+    async fn generate(&self, mut request: SingleIn<Req>) -> Result<ManyOut<Resp>, Error> {
+        request.insert(
+            crate::preprocessor::LORA_NAME_CONTEXT_KEY,
+            self.lora_name.clone(),
+        );
+        self.inner.generate(request).await
+    }
+}
+
+struct LoraGenerateEngine {
+    inner: GenerateStreamingEngine,
+    lora_name: String,
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<crate::protocols::common::preprocessor::PreprocessedRequest>,
+        ManyOut<crate::types::Annotated<crate::protocols::common::llm_backend::LLMEngineOutput>>,
+        Error,
+    > for LoraGenerateEngine
+{
+    async fn generate(
+        &self,
+        mut request: SingleIn<crate::protocols::common::preprocessor::PreprocessedRequest>,
+    ) -> Result<
+        ManyOut<crate::types::Annotated<crate::protocols::common::llm_backend::LLMEngineOutput>>,
+        Error,
+    > {
+        request.routing.get_or_insert_default().lora_name = Some(self.lora_name.clone());
+        self.inner.generate(request).await
+    }
+}
+
+fn lora_context_engine<Req: Data, Resp: Data>(
+    engine: &Option<StreamingEngine<Req, Resp>>,
+    lora_name: &str,
+) -> Option<StreamingEngine<Req, Resp>> {
+    engine.as_ref().map(|inner| {
+        Arc::new(LoraContextEngine {
+            inner: inner.clone(),
+            lora_name: lora_name.to_string(),
+        }) as Arc<dyn AsyncEngine<SingleIn<Req>, ManyOut<Resp>, Error>>
+    })
+}
 
 /// A set of workers from the same namespace/configuration with their own pipeline.
 pub struct WorkerSet {
@@ -70,6 +169,10 @@ pub struct WorkerSet {
     /// Watcher for available instance IDs (from the Client's discovery watch).
     /// None for in-process models (http/grpc) which don't have a discovery client.
     instance_count_rx: Option<watch::Receiver<Vec<u64>>>,
+
+    /// Drops after engine fields and after every active request context releases it.
+    allocator_trim: Option<Arc<AllocatorTrimOnDrop>>,
+    allocator_trim_wrapped: bool,
 }
 
 impl WorkerSet {
@@ -93,6 +196,8 @@ impl WorkerSet {
             prefill_router: None,
             encoder_router: None,
             instance_count_rx: None,
+            allocator_trim: None,
+            allocator_trim_wrapped: false,
         }
     }
 
@@ -223,6 +328,78 @@ impl WorkerSet {
     pub fn set_instance_watcher(&mut self, rx: watch::Receiver<Vec<u64>>) {
         self.instance_count_rx = Some(rx);
     }
+
+    pub(crate) fn initialize_allocator_trim_on_teardown(&mut self) -> Arc<AllocatorTrimOnDrop> {
+        self.allocator_trim
+            .get_or_insert_with(|| Arc::new(AllocatorTrimOnDrop::new()))
+            .clone()
+    }
+
+    pub(crate) fn enable_allocator_trim_on_teardown(&mut self) {
+        if self.allocator_trim_wrapped {
+            return;
+        }
+        let teardown = self.initialize_allocator_trim_on_teardown();
+        macro_rules! retain_for_requests {
+            ($field:ident) => {
+                self.$field = retain_teardown_until_requests_finish(self.$field.take(), &teardown);
+            };
+        }
+        retain_for_requests!(chat_engine);
+        retain_for_requests!(completions_engine);
+        retain_for_requests!(embeddings_engine);
+        retain_for_requests!(images_engine);
+        retain_for_requests!(videos_engine);
+        retain_for_requests!(audios_engine);
+        retain_for_requests!(tensor_engine);
+        retain_for_requests!(realtime_engine);
+        retain_for_requests!(generate_engine);
+        self.allocator_trim_wrapped = true;
+    }
+
+    pub(crate) fn adapter_view(&self, card: ModelDeploymentCard) -> Self {
+        let lora_name = card
+            .lora
+            .as_ref()
+            .expect("adapter views require LoRA metadata")
+            .name
+            .clone();
+        let mdcsum = card.mdcsum().to_string();
+        let generate_engine = self.generate_engine.as_ref().map(|inner| {
+            Arc::new(LoraGenerateEngine {
+                inner: inner.clone(),
+                lora_name: lora_name.clone(),
+            }) as GenerateStreamingEngine
+        });
+        let mut view = Self {
+            namespace: self.namespace.clone(),
+            endpoint_id: self.endpoint_id.clone(),
+            mdcsum,
+            card,
+            chat_engine: lora_context_engine(&self.chat_engine, &lora_name),
+            completions_engine: lora_context_engine(&self.completions_engine, &lora_name),
+            embeddings_engine: lora_context_engine(&self.embeddings_engine, &lora_name),
+            images_engine: lora_context_engine(&self.images_engine, &lora_name),
+            videos_engine: lora_context_engine(&self.videos_engine, &lora_name),
+            audios_engine: lora_context_engine(&self.audios_engine, &lora_name),
+            tensor_engine: lora_context_engine(&self.tensor_engine, &lora_name),
+            // The bidirectional realtime engine cannot carry the server-streaming context
+            // wrapper. Do not expose the base weights through an adapter model name.
+            realtime_engine: None,
+            generate_engine,
+            kv_router: self.kv_router.clone(),
+            worker_monitor: self.worker_monitor.clone(),
+            prefill_router: self.prefill_router.clone(),
+            encoder_router: self.encoder_router.clone(),
+            instance_count_rx: self.instance_count_rx.clone(),
+            allocator_trim: None,
+            allocator_trim_wrapped: false,
+        };
+        if self.allocator_trim.is_some() {
+            view.enable_allocator_trim_on_teardown();
+        }
+        view
+    }
 }
 
 #[cfg(test)]
@@ -246,7 +423,7 @@ mod tests {
     use async_trait::async_trait;
     use dynamo_runtime::engine::AsyncEngine;
     use dynamo_runtime::pipeline::{Error, ManyOut, SingleIn};
-    use std::marker::PhantomData;
+    use std::{marker::PhantomData, sync::Mutex};
 
     fn make_worker_set(namespace: &str, mdcsum: &str) -> WorkerSet {
         WorkerSet::new(
@@ -280,11 +457,67 @@ mod tests {
         }
     }
 
+    struct CaptureGenerateEngine {
+        observed_lora: Arc<Mutex<Option<String>>>,
+    }
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for CaptureGenerateEngine
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            *self.observed_lora.lock().unwrap() = request
+                .routing
+                .as_ref()
+                .and_then(|routing| routing.lora_name.clone());
+            Err(anyhow::anyhow!("captured request"))
+        }
+    }
+
     #[test]
     fn test_worker_set_basics() {
         let ws = make_worker_set("ns1", "abc123");
         assert_eq!(ws.namespace(), "ns1");
         assert_eq!(ws.mdcsum(), "abc123");
+    }
+
+    #[tokio::test]
+    async fn adapter_view_routes_generate_requests_with_adapter_identity() {
+        let observed_lora = Arc::new(Mutex::new(None));
+        let mut base = make_worker_set("ns1", "abc123");
+        base.generate_engine = Some(Arc::new(CaptureGenerateEngine {
+            observed_lora: observed_lora.clone(),
+        }));
+        let mut adapter_card = ModelDeploymentCard::with_name_only("adapter-model");
+        adapter_card.lora = Some(crate::model_card::LoraInfo {
+            name: "adapter-model".to_string(),
+            max_gpu_lora_count: Some(4),
+        });
+        let adapter = base.adapter_view(adapter_card);
+        let request = PreprocessedRequest::builder()
+            .model("adapter-model".to_string())
+            .token_ids(vec![1])
+            .stop_conditions(Default::default())
+            .sampling_options(Default::default())
+            .output_options(Default::default())
+            .build()
+            .unwrap();
+
+        let result = adapter
+            .generate_engine
+            .as_ref()
+            .unwrap()
+            .generate(SingleIn::new(request))
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            observed_lora.lock().unwrap().as_deref(),
+            Some("adapter-model")
+        );
     }
 
     #[test]

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -471,7 +471,7 @@ where
         .link(engine)?
         .link(backend.backward_edge())?
         .link(preprocessor.backward_edge())?
-        .link(frontend)?)
+        .link_terminal(frontend)?)
 }
 
 impl PreprocessedRouting {
@@ -516,7 +516,7 @@ impl PreprocessedRouting {
             .link(token_backend.backward_edge())?
             .link(migration.backward_edge())?
             .link(preprocessor_op.backward_edge())?
-            .link(frontend)?;
+            .link_terminal(frontend)?;
 
         Ok(engine)
     }
@@ -550,7 +550,7 @@ impl PreprocessedRouting {
             .link(prefill_op.backward_edge())?
             .link(encoder_op.backward_edge())?
             .link(migration.backward_edge())?
-            .link(frontend)?;
+            .link_terminal(frontend)?;
 
         Ok(engine)
     }

--- a/lib/llm/src/entrypoint/input/endpoint.rs
+++ b/lib/llm/src/entrypoint/input/endpoint.rs
@@ -78,7 +78,7 @@ pub async fn run(
                 .link(backend.forward_edge())?
                 .link(engine)?
                 .link(backend.backward_edge())?
-                .link(frontend)?;
+                .link_terminal(frontend)?;
             let ingress = Ingress::for_pipeline(pipeline)?;
 
             // The disaggregation role is carried by `worker_type`, not

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -279,6 +279,8 @@ where
     /// narrowed to the LoRA's allocated/loaded replicas inside `find_best_match_details`,
     /// covering both the decode and prefill routers (both built via `kv_chooser_for`).
     lora_filter: Option<Arc<crate::lora::LoraFilter>>,
+    endpoint_registration: Option<dynamo_runtime::discovery::EndpointRegistrationLease>,
+    teardown_task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
 }
 
 fn resolve_tracking_model_name(
@@ -482,7 +484,26 @@ where
             _served_indexer_handle: served_indexer_handle,
             shared_cache,
             lora_filter,
+            endpoint_registration: None,
+            teardown_task_guard: None,
         })
+    }
+
+    pub(crate) fn set_endpoint_registration(
+        &mut self,
+        registration: dynamo_runtime::discovery::EndpointRegistrationLease,
+    ) {
+        self.endpoint_registration = Some(registration);
+    }
+
+    pub(crate) fn set_teardown_task_guard(
+        &mut self,
+        task_guard: dynamo_runtime::engine::EngineContextGuard,
+    ) {
+        if let Some(subscription) = self.kv_event_subscription.as_mut() {
+            subscription.set_task_guard(task_guard.clone());
+        }
+        self.teardown_task_guard = Some(task_guard);
     }
 
     /// Get a reference to the client used by this KvRouter

--- a/lib/llm/src/kv_router/encoder_router.rs
+++ b/lib/llm/src/kv_router/encoder_router.rs
@@ -85,6 +85,24 @@ impl EncoderRouter {
         model_name: String,
         namespace: String,
     ) -> Arc<Self> {
+        Self::new_inner(activation_rx, model_name, namespace, None)
+    }
+
+    pub(crate) fn new_with_task_guard(
+        activation_rx: oneshot::Receiver<Endpoint>,
+        model_name: String,
+        namespace: String,
+        task_guard: dynamo_runtime::engine::EngineContextGuard,
+    ) -> Arc<Self> {
+        Self::new_inner(activation_rx, model_name, namespace, Some(task_guard))
+    }
+
+    fn new_inner(
+        activation_rx: oneshot::Receiver<Endpoint>,
+        model_name: String,
+        namespace: String,
+        task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
+    ) -> Arc<Self> {
         let cancel_token = CancellationToken::new();
         let router = Arc::new(Self {
             router: OnceLock::new(),
@@ -96,6 +114,7 @@ impl EncoderRouter {
 
         let router_weak = Arc::downgrade(&router);
         tokio::spawn(async move {
+            let _task_guard = task_guard;
             tokio::select! {
                 result = activation_rx => {
                     let Ok(endpoint) = result else {

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -365,9 +365,18 @@ pub(super) fn clear_mismatch_metric_on_cancellation(
 pub(crate) struct KvEventSubscriptionHandle {
     cancel: CancellationToken,
     completions: Vec<oneshot::Receiver<()>>,
+    runtime: tokio::runtime::Handle,
+    task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
 }
 
 impl KvEventSubscriptionHandle {
+    pub(crate) fn set_task_guard(
+        &mut self,
+        task_guard: dynamo_runtime::engine::EngineContextGuard,
+    ) {
+        self.task_guard = Some(task_guard);
+    }
+
     pub(crate) async fn shutdown(mut self) {
         self.cancel.cancel();
         for completion in self.completions.drain(..) {
@@ -379,6 +388,16 @@ impl KvEventSubscriptionHandle {
 impl Drop for KvEventSubscriptionHandle {
     fn drop(&mut self) {
         self.cancel.cancel();
+        let Some(task_guard) = self.task_guard.take() else {
+            return;
+        };
+        let completions = std::mem::take(&mut self.completions);
+        self.runtime.spawn(async move {
+            let _task_guard = task_guard;
+            for completion in completions {
+                let _ = completion.await;
+            }
+        });
     }
 }
 
@@ -393,6 +412,7 @@ pub async fn start_subscriber(
     worker_type: &'static str,
     cancellation_token: CancellationToken,
 ) -> Result<KvEventSubscriptionHandle> {
+    let runtime = endpoint.component().drt().runtime().secondary();
     let transport_kind = endpoint.component().drt().default_event_transport_kind();
     let direct_zmq = uses_direct_zmq(transport_kind);
     let cancel = cancellation_token.child_token();
@@ -445,6 +465,8 @@ pub async fn start_subscriber(
         return Ok(KvEventSubscriptionHandle {
             cancel,
             completions: vec![completion_rx, health_completion],
+            runtime,
+            task_guard: None,
         });
     }
 
@@ -478,6 +500,8 @@ pub async fn start_subscriber(
     Ok(KvEventSubscriptionHandle {
         cancel,
         completions: vec![completion_rx, health_completion],
+        runtime,
+        task_guard: None,
     })
 }
 
@@ -640,10 +664,44 @@ mod tests {
         let handle = KvEventSubscriptionHandle {
             cancel,
             completions,
+            runtime: tokio::runtime::Handle::current(),
+            task_guard: None,
         };
 
         tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
             .await
             .expect("subscription shutdown should complete");
+    }
+
+    #[tokio::test]
+    async fn dropped_subscription_retains_task_guard_until_owned_tasks_finish() {
+        let cancel = CancellationToken::new();
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let _ = release_rx.await;
+            let _ = completion_tx.send(());
+        });
+        let teardown = Arc::new(());
+        let teardown_weak = Arc::downgrade(&teardown);
+        let mut handle = KvEventSubscriptionHandle {
+            cancel,
+            completions: vec![completion_rx],
+            runtime: tokio::runtime::Handle::current(),
+            task_guard: None,
+        };
+        handle.set_task_guard(teardown.clone());
+        drop(teardown);
+
+        drop(handle);
+        assert!(teardown_weak.upgrade().is_some());
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while teardown_weak.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("subscription task guard was not released after task completion");
     }
 }

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -13,7 +13,7 @@ use dynamo_runtime::{
     discovery::DiscoveryQuery,
     pipeline::{PushRouter, RouterMode},
     prelude::DistributedRuntimeProvider,
-    protocols::annotated::Annotated,
+    protocols::{EndpointId, annotated::Annotated},
 };
 
 use super::{InnerPrefillRouter, PrefillLifecycleState, PrefillRouter};
@@ -27,6 +27,18 @@ use crate::{
     },
     session_affinity::create_affinity_coordinator,
 };
+
+struct ActivationConfig {
+    endpoint: Endpoint,
+    model_manager: Arc<ModelManager>,
+    router_mode: RouterMode,
+    kv_cache_block_size: u32,
+    kv_router_config: Option<KvRouterConfig>,
+    prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
+    session_affinity_ttl: Option<std::time::Duration>,
+    configured_is_eagle: bool,
+    model_name: String,
+}
 
 impl PrefillRouter {
     /// Create a disabled prefill router that will never activate (passthrough only)
@@ -46,7 +58,10 @@ impl PrefillRouter {
             model_name: String::new(), // Not used for disabled router
             namespace: String::new(),  // Not used for disabled router
             is_eagle: false,
+            task_guard: None,
             lifecycle: std::sync::atomic::AtomicU8::new(PrefillLifecycleState::Pending as u8),
+            #[cfg(test)]
+            activation_task_state: Arc::new(()),
         })
     }
 
@@ -63,6 +78,7 @@ impl PrefillRouter {
         namespace: String,
         is_eagle: bool,
         worker_monitor: Option<crate::discovery::KvWorkerMonitor>,
+        task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
     ) -> Arc<Self> {
         let prefill_router = std::sync::OnceLock::new();
         let cancel_token = tokio_util::sync::CancellationToken::new();
@@ -78,28 +94,68 @@ impl PrefillRouter {
             model_name,
             namespace,
             is_eagle,
+            task_guard: task_guard.clone(),
             lifecycle: std::sync::atomic::AtomicU8::new(PrefillLifecycleState::Pending as u8),
+            #[cfg(test)]
+            activation_task_state: Arc::new(()),
         });
 
         // Spawn background task to wait for activation
-        let router_clone = router.clone();
+        let router_weak = Arc::downgrade(&router);
+        #[cfg(test)]
+        let activation_task_state = router.activation_task_state.clone();
         tokio::spawn(async move {
+            let _activation_task_guard = task_guard;
+            #[cfg(test)]
+            let _activation_task_state = activation_task_state;
             tokio::select! {
                 result = activation_rx => {
                     let Ok(endpoint) = result else {
                         tracing::debug!("Prefill router activation channel closed without receiving endpoint");
                         return;
                     };
+                    let Some(router) = router_weak.upgrade() else {
+                        return;
+                    };
+                    let router_mode = router.router_mode;
+                    let session_affinity_ttl = router.session_affinity_ttl;
+                    let configured_is_eagle = router.is_eagle;
+                    let model_name = router.model_name.clone();
+                    let prefill_load_estimator = router.prefill_load_estimator.clone();
+                    drop(router);
 
-                    if let Err(e) = router_clone.activate(
+                    let activation_config = ActivationConfig {
                         endpoint,
                         model_manager,
+                        router_mode,
                         kv_cache_block_size,
                         kv_router_config,
-                        router_clone.prefill_load_estimator.clone(),
-                        worker_monitor.as_ref(),
-                    ).await {
-                        tracing::error!(error = %e, "Failed to activate prefill router");
+                        prefill_load_estimator,
+                        session_affinity_ttl,
+                        configured_is_eagle,
+                        model_name,
+                    };
+                    let activation = Self::build_activation(activation_config);
+                    let activation = tokio::select! {
+                        result = activation => result,
+                        _ = cancel_token.cancelled() => {
+                            tracing::debug!("Prefill router activation cancelled");
+                            return;
+                        }
+                    };
+                    match activation {
+                        Ok((endpoint_id, inner_router, prefill_client)) => {
+                            if let Some(router) = router_weak.upgrade() {
+                                Self::attach_prefill_client(
+                                    worker_monitor.as_ref(),
+                                    &prefill_client,
+                                );
+                                router.finish_activation(endpoint_id, inner_router);
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "Failed to activate prefill router");
+                        }
                     }
                 }
                 _ = cancel_token.cancelled() => {
@@ -111,23 +167,23 @@ impl PrefillRouter {
         router
     }
 
-    /// Activate the prefill router with the provided endpoint
-    async fn activate(
-        &self,
-        endpoint: Endpoint,
-        model_manager: Arc<ModelManager>,
-        kv_cache_block_size: u32,
-        kv_router_config: Option<KvRouterConfig>,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        worker_monitor: Option<&crate::discovery::KvWorkerMonitor>,
-    ) -> Result<()> {
-        tracing::info!(
-            router_mode = ?self.router_mode,
-            "Activating prefill router"
-        );
+    async fn build_activation(
+        config: ActivationConfig,
+    ) -> Result<(EndpointId, InnerPrefillRouter, Client)> {
+        let ActivationConfig {
+            endpoint,
+            model_manager,
+            router_mode,
+            kv_cache_block_size,
+            kv_router_config,
+            prefill_load_estimator,
+            session_affinity_ttl,
+            configured_is_eagle,
+            model_name,
+        } = config;
+        tracing::info!(?router_mode, "Activating prefill router");
 
-        // Store endpoint metadata for bootstrap and topology preparation.
-        let _ = self.endpoint_id.set(endpoint.id());
+        let endpoint_id = endpoint.id();
 
         // Start runtime config watcher for this endpoint (needed for get_disaggregated_endpoint)
         // This must be done before creating the router so bootstrap info is available
@@ -135,7 +191,7 @@ impl PrefillRouter {
             .get_or_create_runtime_config_watcher(&endpoint)
             .await?;
 
-        let inner_router = if self.router_mode.is_kv_routing() {
+        let inner_router = if router_mode.is_kv_routing() {
             let endpoint_id = endpoint.id();
             let discovered_cards = endpoint
                 .component()
@@ -151,10 +207,10 @@ impl PrefillRouter {
                 Ok(instances) => instances
                     .into_iter()
                     .find_map(|instance| instance.deserialize_model::<ModelDeploymentCard>().ok())
-                    .map_or(self.is_eagle, |card| card.runtime_config.enable_eagle),
+                    .map_or(configured_is_eagle, |card| card.runtime_config.enable_eagle),
                 Err(error) => {
                     tracing::warn!(%error, "Failed to read prefill model card; using configured EAGLE mode");
-                    self.is_eagle
+                    configured_is_eagle
                 }
             };
 
@@ -167,16 +223,16 @@ impl PrefillRouter {
                     prefill_load_estimator,
                     Some(crate::worker_type::WorkerType::Prefill),
                     WORKER_TYPE_PREFILL,
-                    Some(self.model_name.clone()),
+                    Some(model_name),
                     is_eagle,
                 )
                 .await?;
 
             // Extract client from kv_chooser to ensure shared state
             let client = kv_chooser.client().clone();
-            Self::attach_prefill_client(worker_monitor, &client);
             let affinity =
-                create_affinity_coordinator(self.session_affinity_ttl, client.clone()).await?;
+                create_affinity_coordinator(session_affinity_ttl, client.clone()).await?;
+            let prefill_client = client.clone();
 
             // Build the PushRouter for prefill with KV mode using the shared client
             let push_router = PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client_with_monitor(
@@ -187,38 +243,48 @@ impl PrefillRouter {
             .await?;
 
             // Wrap it in KvPushRouter
-            InnerPrefillRouter::KvRouter(Arc::new(KvPushRouter::new_with_coordinator(
-                push_router,
-                kv_chooser,
-                affinity,
-            )))
+            (
+                InnerPrefillRouter::KvRouter(Arc::new(KvPushRouter::new_with_coordinator(
+                    push_router,
+                    kv_chooser,
+                    affinity,
+                ))),
+                prefill_client,
+            )
         } else {
             // Create client for simple router
             let client = endpoint.client().await?;
-            Self::attach_prefill_client(worker_monitor, &client);
             let affinity =
-                create_affinity_coordinator(self.session_affinity_ttl, client.clone()).await?;
+                create_affinity_coordinator(session_affinity_ttl, client.clone()).await?;
+            let prefill_client = client.clone();
 
             // Create simple push router with the frontend's router mode
             // Note: Per-worker metrics (active_prefill_tokens, active_decode_blocks) are only
             // available in KV routing mode where the router has actual bookkeeping.
             let push_router = PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client_with_monitor(
                 client,
-                self.router_mode,
+                router_mode,
                 None, // worker_monitor
             )
             .await?;
 
-            InnerPrefillRouter::SimpleRouter(Arc::new(
-                crate::session_affinity::SessionAffinityPushRouter::new_with_coordinator(
-                    push_router,
-                    affinity,
-                    self.router_mode.is_direct_routing(),
-                ),
-            ))
+            (
+                InnerPrefillRouter::SimpleRouter(Arc::new(
+                    crate::session_affinity::SessionAffinityPushRouter::new_with_coordinator(
+                        push_router,
+                        affinity,
+                        router_mode.is_direct_routing(),
+                    ),
+                )),
+                prefill_client,
+            )
         };
 
-        // Set the router (ignore error if already set).
+        Ok((endpoint_id, inner_router.0, inner_router.1))
+    }
+
+    fn finish_activation(&self, endpoint_id: EndpointId, inner_router: InnerPrefillRouter) {
+        let _ = self.endpoint_id.set(endpoint_id);
         let _ = self.prefill_router.set(inner_router);
         match self.complete_activation() {
             PrefillLifecycleState::Active => {
@@ -235,8 +301,6 @@ impl PrefillRouter {
             }
             PrefillLifecycleState::Pending => unreachable!("activation must leave pending state"),
         }
-
-        Ok(())
     }
 
     pub(super) fn complete_activation(&self) -> PrefillLifecycleState {

--- a/lib/llm/src/kv_router/prefill_router/admission.rs
+++ b/lib/llm/src/kv_router/prefill_router/admission.rs
@@ -52,6 +52,7 @@ impl PrefillRouter {
     pub(super) async fn consume_prefill_stream(
         mut prefill_response: ManyOut<Annotated<LLMEngineOutput>>,
         tracker: Option<Arc<RequestTracker>>,
+        task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
     ) -> Result<PrefillCompletion, PrefillError> {
         let Some(first_output) = prefill_response.next().await else {
             return Err(PrefillError::PrefillError(
@@ -107,7 +108,10 @@ impl PrefillRouter {
                 }
             }
         } else {
-            tokio::spawn(async move { while prefill_response.next().await.is_some() {} });
+            tokio::spawn(async move {
+                let _task_guard = task_guard;
+                while prefill_response.next().await.is_some() {}
+            });
         }
 
         // A CTX request that reaches EOS/stop during its one-token prefill step
@@ -173,10 +177,11 @@ impl PrefillRouter {
         phase_transition_permit: OwnedSemaphorePermit,
     ) {
         let span = tracing::Span::current();
+        let task_guard = self.task_guard.clone();
         tokio::spawn(
             async move {
                 drop(phase_transition_permit);
-                match Self::consume_prefill_stream(prefill_stream, tracker).await {
+                match Self::consume_prefill_stream(prefill_stream, tracker, task_guard).await {
                     Ok(_) => tracing::debug!("Prefill background task completed"),
                     Err(error) => tracing::warn!("Prefill background task error: {error:?}"),
                 }
@@ -212,11 +217,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bootstrap_drain_retains_teardown_guard_until_stream_finishes() {
+        let first = Annotated::from_data(LLMEngineOutput {
+            disaggregated_params: Some(json!({
+                "bootstrap_host": "127.0.0.1",
+                "bootstrap_port": 1,
+                "bootstrap_room": "test",
+                "ctx_request_id": 42,
+            })),
+            ..Default::default()
+        });
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let stream = stream::iter([first]).chain(stream::once(async move {
+            let _ = release_rx.await;
+            Annotated::from_data(LLMEngineOutput::default())
+        }));
+        let response = ResponseStream::new(Box::pin(stream), Arc::new(Controller::default()));
+        let teardown = Arc::new(());
+        let teardown_weak = Arc::downgrade(&teardown);
+        let task_guard: dynamo_runtime::engine::EngineContextGuard = teardown.clone();
+        drop(teardown);
+
+        PrefillRouter::consume_prefill_stream(response, None, Some(task_guard))
+            .await
+            .unwrap();
+        assert!(teardown_weak.upgrade().is_some());
+
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while teardown_weak.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("bootstrap drain did not release its teardown guard");
+    }
+
+    #[tokio::test]
     async fn first_output_error_does_not_record_prefill_complete() {
         let tracker = Arc::new(RequestTracker::new());
         let result = PrefillRouter::consume_prefill_stream(
             prefill_stream(vec![Annotated::from_error("prefill failed")]),
             Some(tracker.clone()),
+            None,
         )
         .await;
 
@@ -233,6 +276,7 @@ mod tests {
                 Annotated::from_error("prefill stream failed"),
             ]),
             Some(tracker.clone()),
+            None,
         )
         .await;
 
@@ -256,6 +300,7 @@ mod tests {
             };
             let result = PrefillRouter::consume_prefill_stream(
                 prefill_stream(vec![Annotated::from_data(output)]),
+                None,
                 None,
             )
             .await
@@ -282,6 +327,7 @@ mod tests {
         let result = PrefillRouter::consume_prefill_stream(
             prefill_stream(vec![Annotated::from_data(output)]),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -301,6 +347,7 @@ mod tests {
         };
         let result = PrefillRouter::consume_prefill_stream(
             prefill_stream(vec![Annotated::from_data(output)]),
+            None,
             None,
         )
         .await
@@ -325,6 +372,7 @@ mod tests {
             };
             let result = PrefillRouter::consume_prefill_stream(
                 prefill_stream(vec![Annotated::from_data(output)]),
+                None,
                 None,
             )
             .await;

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -165,8 +165,11 @@ pub struct PrefillRouter {
     /// Namespace (used for logging / lifecycle messages).
     namespace: String,
     is_eagle: bool,
+    task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
     /// Initialization and worker availability state.
     lifecycle: AtomicU8,
+    #[cfg(test)]
+    activation_task_state: Arc<()>,
 }
 
 impl Drop for PrefillRouter {
@@ -264,7 +267,9 @@ impl
                 }
             } else {
                 drop(prefill_phase_barrier);
-                let completion = Self::consume_prefill_stream(prefill_stream, tracker).await?;
+                let completion =
+                    Self::consume_prefill_stream(prefill_stream, tracker, self.task_guard.clone())
+                        .await?;
 
                 match completion {
                     PrefillCompletion::Handoff {
@@ -631,6 +636,37 @@ mod tests {
             RouterMode::RoundRobin,
             None,
         )
+    }
+
+    #[tokio::test]
+    async fn dropping_pending_router_releases_activation_task() {
+        let (_activation_tx, activation_rx) = tokio::sync::oneshot::channel();
+        let router = PrefillRouter::new(
+            activation_rx,
+            Arc::new(crate::discovery::ModelManager::new()),
+            RouterMode::RoundRobin,
+            16,
+            None,
+            None,
+            None,
+            "test-model".to_string(),
+            "test-namespace".to_string(),
+            false,
+            None,
+            None,
+        );
+        let task_state = Arc::downgrade(&router.activation_task_state);
+        let weak = Arc::downgrade(&router);
+
+        drop(router);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while weak.strong_count() != 0 || task_state.strong_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pending activation task retained its PrefillRouter");
     }
 
     #[test]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -460,6 +460,8 @@ pub struct OpenAIPreprocessor {
     routing_prepend_bos: Option<crate::protocols::TokenIdType>,
 }
 
+pub(crate) const LORA_NAME_CONTEXT_KEY: &str = "discovery.lora_name";
+
 impl OpenAIPreprocessor {
     fn omitted_max_tokens_default(
         prompt_len: usize,
@@ -1055,7 +1057,12 @@ impl OpenAIPreprocessor {
         tracker: Option<&RequestTracker>,
     ) -> Result<(PreprocessedRequest, HashMap<String, String>, bool)> {
         let (request, annotations, prompt_injected_reasoning, _image_tokens) = self
-            .preprocess_request_with_options(request, tracker, PreprocessRequestOptions::default())
+            .preprocess_request_with_options(
+                request,
+                tracker,
+                PreprocessRequestOptions::default(),
+                None,
+            )
             .await?;
         Ok((request, annotations, prompt_injected_reasoning))
     }
@@ -1073,6 +1080,7 @@ impl OpenAIPreprocessor {
         request: &R,
         tracker: Option<&RequestTracker>,
         options: PreprocessRequestOptions,
+        lora_name: Option<String>,
     ) -> Result<(
         PreprocessedRequest,
         HashMap<String, String>,
@@ -1081,7 +1089,7 @@ impl OpenAIPreprocessor {
     )> {
         let _stage_guard = StageGuard::new(STAGE_PREPROCESS, "");
         let preprocess_start = Instant::now();
-        let mut builder = self.builder(request)?;
+        let mut builder = self.builder_with_lora(request, lora_name)?;
 
         let template_start = Instant::now();
         let formatted_prompt = {
@@ -1200,6 +1208,21 @@ impl OpenAIPreprocessor {
         &self,
         request: &R,
     ) -> Result<PreprocessedRequestBuilder> {
+        self.builder_with_lora(request, None)
+    }
+
+    fn builder_with_lora<
+        R: OAIChatLikeRequest
+            + AnnotationsProvider
+            + SamplingOptionsProvider
+            + StopConditionsProvider
+            + OutputOptionsProvider
+            + NvExtProvider,
+    >(
+        &self,
+        request: &R,
+        lora_name_override: Option<String>,
+    ) -> Result<PreprocessedRequestBuilder> {
         let mut builder = PreprocessedRequest::builder();
         builder.model(request.model());
 
@@ -1284,7 +1307,7 @@ impl OpenAIPreprocessor {
         builder.output_options(output_options);
         builder.annotations(request.annotations().unwrap_or_default());
         builder.mdc_sum(Some(self.mdcsum.clone()));
-        let lora_name = self.lora_name.clone();
+        let lora_name = self.lora_name.clone().or(lora_name_override);
         let cache_namespace = request_cache_salt(request).map(str::to_owned);
 
         // Extract routing hints from nvext if present
@@ -3713,7 +3736,16 @@ impl
 
         // convert the chat completion request to a common completion request
         let (mut common_request, annotations, prompt_injected_reasoning, image_tokens) = self
-            .preprocess_request_with_options(&request, tracker.as_deref(), preprocess_options)
+            .preprocess_request_with_options(
+                &request,
+                tracker.as_deref(),
+                preprocess_options,
+                context
+                    .get_optional::<String>(LORA_NAME_CONTEXT_KEY)
+                    .ok()
+                    .flatten()
+                    .map(|name| name.as_ref().clone()),
+            )
             .await?;
         attach_agent_context_from_context(&mut common_request, &context);
 
@@ -3877,7 +3909,14 @@ impl
         let mut response_generator = Box::new(response_generator);
         let tracker = Some(response_generator.tracker());
         // convert the chat completion request to a common completion request
-        let mut builder = self.builder(&request)?;
+        let mut builder = self.builder_with_lora(
+            &request,
+            context
+                .get_optional::<String>(LORA_NAME_CONTEXT_KEY)
+                .ok()
+                .flatten()
+                .map(|name| name.as_ref().clone()),
+        )?;
 
         // Check if embeddings are provided - skip tokenization path
         let annotations = if let Some(ref prompt_embeds) = request.inner.prompt_embeds {

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -182,6 +182,25 @@ pub(crate) struct EndpointDiscoverySource {
     event_subscribers: StdMutex<Vec<tokio::sync::mpsc::UnboundedSender<DiscoveryEvent>>>,
 }
 
+pub(crate) struct DiscoveryEventReceiver {
+    receiver: tokio::sync::mpsc::UnboundedReceiver<DiscoveryEvent>,
+    _source: Arc<EndpointDiscoverySource>,
+}
+
+impl std::ops::Deref for DiscoveryEventReceiver {
+    type Target = tokio::sync::mpsc::UnboundedReceiver<DiscoveryEvent>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.receiver
+    }
+}
+
+impl std::ops::DerefMut for DiscoveryEventReceiver {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.receiver
+    }
+}
+
 impl EndpointDiscoverySource {
     fn new(instance_source: tokio::sync::watch::Receiver<Vec<Instance>>) -> Self {
         Self {
@@ -360,20 +379,21 @@ struct RoutingInstancesState {
     snapshot: ArcSwap<RoutingInstances>,
     update_lock: StdMutex<()>,
     instance_avail_tx: tokio::sync::watch::Sender<Vec<u64>>,
-    instance_avail_rx: tokio::sync::watch::Receiver<Vec<u64>>,
 }
 
 impl RoutingInstancesState {
-    fn new(discovered_ids: Vec<u64>) -> Self {
+    fn new(discovered_ids: Vec<u64>) -> (Self, tokio::sync::watch::Receiver<Vec<u64>>) {
         let snapshot = RoutingInstances::new(discovered_ids);
         let (instance_avail_tx, instance_avail_rx) =
             tokio::sync::watch::channel(snapshot.routable_ids().to_vec());
-        Self {
-            snapshot: ArcSwap::from_pointee(snapshot),
-            update_lock: StdMutex::new(()),
-            instance_avail_tx,
+        (
+            Self {
+                snapshot: ArcSwap::from_pointee(snapshot),
+                update_lock: StdMutex::new(()),
+                instance_avail_tx,
+            },
             instance_avail_rx,
-        }
+        )
     }
 
     fn snapshot(&self) -> arc_swap::Guard<Arc<RoutingInstances>> {
@@ -415,10 +435,6 @@ impl RoutingInstancesState {
 
     fn overloaded_ids(&self) -> Option<HashSet<u64>> {
         self.snapshot().overloaded_ids()
-    }
-
-    fn instance_avail_watcher(&self) -> tokio::sync::watch::Receiver<Vec<u64>> {
-        self.instance_avail_rx.clone()
     }
 
     fn report_instance_down(&self, instance_id: u64) {
@@ -485,6 +501,8 @@ pub struct Client {
     pub instance_source: Arc<tokio::sync::watch::Receiver<Vec<Instance>>>,
     // Immutable routing snapshot. Free IDs are derived from discovered IDs and overloaded IDs.
     routing_instances: Arc<RoutingInstancesState>,
+    // Client clones and standalone watchers jointly own the reconciliation task.
+    instance_avail_owner: Arc<tokio::sync::watch::Receiver<Vec<u64>>>,
     /// Interval for periodic reconciliation of instance_avail with instance_source.
     /// This ensures instances removed via `report_instance_down` are eventually restored.
     /// A zero value disables local worker inhibition.
@@ -521,11 +539,13 @@ impl Client {
             .iter()
             .map(|instance| instance.id())
             .collect();
+        let (routing_instances, instance_avail_owner) = RoutingInstancesState::new(initial_ids);
         let client = Client {
             endpoint: endpoint.clone(),
             endpoint_discovery_source,
             instance_source: instance_source.clone(),
-            routing_instances: Arc::new(RoutingInstancesState::new(initial_ids)),
+            routing_instances: Arc::new(routing_instances),
+            instance_avail_owner: Arc::new(instance_avail_owner),
             reconcile_interval,
         };
         client.monitor_instance_source();
@@ -561,17 +581,18 @@ impl Client {
 
     /// Get a watcher for available instance IDs
     pub fn instance_avail_watcher(&self) -> tokio::sync::watch::Receiver<Vec<u64>> {
-        self.routing_instances.instance_avail_watcher()
+        self.instance_avail_owner.as_ref().clone()
     }
 
     /// Subscribe to raw discovery events for this endpoint.
     ///
     /// Unlike `instance_source`, this feed does not coalesce remove→add pairs,
     /// so consumers can react to every removal event exactly once.
-    pub(crate) fn subscribe_discovery_events(
-        &self,
-    ) -> tokio::sync::mpsc::UnboundedReceiver<DiscoveryEvent> {
-        self.endpoint_discovery_source.subscribe_events()
+    pub(crate) fn subscribe_discovery_events(&self) -> DiscoveryEventReceiver {
+        DiscoveryEventReceiver {
+            receiver: self.endpoint_discovery_source.subscribe_events(),
+            _source: self.endpoint_discovery_source.clone(),
+        }
     }
 
     /// Wait for at least one Instance to be available for this Endpoint
@@ -651,10 +672,13 @@ impl Client {
     fn monitor_instance_source(&self) {
         let reconcile_interval = self.reconcile_interval;
         let cancel_token = self.endpoint.drt().primary_token();
-        let client = self.clone();
+        let endpoint = self.endpoint.clone();
+        let endpoint_discovery_source = self.endpoint_discovery_source.clone();
+        let routing_instances = self.routing_instances.clone();
+        let instance_source = self.instance_source.clone();
         let endpoint_id = self.endpoint.id();
         tokio::task::spawn(async move {
-            let mut rx = client.instance_source.as_ref().clone();
+            let mut rx = instance_source.as_ref().clone();
             while !cancel_token.is_cancelled() {
                 let instance_ids: Vec<u64> = rx
                     .borrow_and_update()
@@ -662,19 +686,20 @@ impl Client {
                     .map(|instance| instance.id())
                     .collect();
 
-                let routing_instances = client.reconcile_discovered_instances(instance_ids);
+                let snapshot = routing_instances.reconcile_discovered(instance_ids);
 
                 // Clean up stale occupancy counters for instances that no longer exist.
-                let registry = client.endpoint.drt().routing_occupancy_states();
+                let registry = endpoint.drt().routing_occupancy_states();
                 if let Ok(registry) = registry.try_lock()
-                    && let Some(weak) = registry.get(&client.endpoint)
+                    && let Some(weak) = registry.get(&endpoint)
                     && let Some(state) = weak.upgrade()
                 {
-                    state.retain(routing_instances.discovered_ids());
+                    state.retain(snapshot.discovered_ids());
                 }
 
                 tokio::select! {
                     _ = cancel_token.cancelled() => break,
+                    _ = routing_instances.instance_avail_tx.closed() => break,
                     result = rx.changed() => {
                         if let Err(err) = result {
                             tracing::error!(
@@ -690,6 +715,7 @@ impl Client {
                     }
                 }
             }
+            drop(endpoint_discovery_source);
         });
     }
 
@@ -698,10 +724,6 @@ impl Client {
     #[cfg(test)]
     pub(crate) fn override_instance_avail(&self, ids: Vec<u64>) {
         self.routing_instances.override_routable_ids(ids);
-    }
-
-    fn reconcile_discovered_instances(&self, discovered_ids: Vec<u64>) -> Arc<RoutingInstances> {
-        self.routing_instances.reconcile_discovered(discovered_ids)
     }
 
     async fn get_or_create_dynamic_discovery_source(
@@ -733,7 +755,7 @@ impl Client {
         let discovery_source = Arc::new(EndpointDiscoverySource::new(watch_rx));
 
         let secondary = endpoint.component.drt.runtime().secondary().clone();
-        let discovery_source_task = discovery_source.clone();
+        let discovery_source_task = Arc::downgrade(&discovery_source);
 
         secondary.spawn(async move {
             tracing::trace!("endpoint_watcher: Starting for discovery query: {:?}", discovery_query);
@@ -760,7 +782,9 @@ impl Client {
                     }
                 };
 
-                discovery_source_task.broadcast_event(&discovery_event);
+                if let Some(discovery_source) = discovery_source_task.upgrade() {
+                    discovery_source.broadcast_event(&discovery_event);
+                }
 
                 match discovery_event {
                     DiscoveryEvent::Added(DiscoveryInstance::Endpoint(instance)) => {
@@ -792,6 +816,41 @@ mod tests {
     use super::*;
     use crate::{DistributedRuntime, Runtime, distributed::DistributedConfig};
 
+    async fn wait_for_discovery_event(
+        receiver: &mut DiscoveryEventReceiver,
+        predicate: impl Fn(&DiscoveryEvent) -> bool,
+    ) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let event = receiver.recv().await.expect("discovery event feed closed");
+                if predicate(&event) {
+                    return;
+                }
+            }
+        })
+        .await
+        .expect("expected discovery event was not received");
+    }
+
+    async fn wait_for_watch_state<T>(
+        receiver: &mut tokio::sync::watch::Receiver<Vec<T>>,
+        predicate: impl Fn(&[T]) -> bool,
+    ) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if predicate(receiver.borrow_and_update().as_slice()) {
+                    return;
+                }
+                receiver
+                    .changed()
+                    .await
+                    .expect("instance availability feed closed");
+            }
+        })
+        .await
+        .expect("expected instance availability state was not observed");
+    }
+
     #[test]
     fn test_inhibited_duration_from_env() {
         assert_eq!(
@@ -810,6 +869,82 @@ mod tests {
             inhibited_duration_from_env(|_| Some("invalid".to_string())),
             Duration::from_secs(DEFAULT_INHIBITED_DURATION_SECS)
         );
+    }
+
+    #[tokio::test]
+    async fn dropping_last_client_releases_routing_state() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("test_client_lifecycle".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("decode".to_string());
+        let client = endpoint.client().await.unwrap();
+        let routing_instances = Arc::downgrade(&client.routing_instances);
+        let discovery_source = Arc::downgrade(&client.endpoint_discovery_source);
+        let mut raw_watcher = client.instance_source.as_ref().clone();
+        let mut watcher = client.instance_avail_watcher();
+        let mut event_watcher = client.subscribe_discovery_events();
+        raw_watcher.borrow_and_update();
+        watcher.borrow_and_update();
+
+        drop(client);
+        assert!(routing_instances.upgrade().is_some());
+        assert!(discovery_source.upgrade().is_some());
+
+        endpoint.register_endpoint_instance().await.unwrap();
+        wait_for_watch_state(&mut watcher, |instances| instances.len() == 1).await;
+        wait_for_discovery_event(&mut event_watcher, |event| {
+            matches!(event, DiscoveryEvent::Added(DiscoveryInstance::Endpoint(_)))
+        })
+        .await;
+
+        endpoint.unregister_endpoint_instance().await.unwrap();
+        wait_for_watch_state(&mut watcher, |instances| instances.is_empty()).await;
+        assert!(raw_watcher.borrow_and_update().is_empty());
+        wait_for_discovery_event(&mut event_watcher, |event| {
+            matches!(event, DiscoveryEvent::Removed(_))
+        })
+        .await;
+
+        drop(watcher);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while routing_instances.strong_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("client monitor retained state after its last observer was dropped");
+        assert!(discovery_source.upgrade().is_some());
+
+        endpoint.register_endpoint_instance().await.unwrap();
+        wait_for_watch_state(&mut raw_watcher, |instances| instances.len() == 1).await;
+        wait_for_discovery_event(&mut event_watcher, |event| {
+            matches!(event, DiscoveryEvent::Added(DiscoveryInstance::Endpoint(_)))
+        })
+        .await;
+        endpoint.unregister_endpoint_instance().await.unwrap();
+        wait_for_watch_state(&mut raw_watcher, |instances| instances.is_empty()).await;
+        wait_for_discovery_event(&mut event_watcher, |event| {
+            matches!(event, DiscoveryEvent::Removed(_))
+        })
+        .await;
+
+        drop(event_watcher);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while discovery_source.strong_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("discovery event receiver retained its source after being dropped");
+
+        rt.shutdown();
     }
 
     /// Test that instances removed via report_instance_down are restored after

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -13,6 +13,10 @@ use tokio_util::sync::CancellationToken;
 mod metadata;
 pub use metadata::{DiscoveryMetadata, MetadataSnapshot};
 
+mod registration;
+pub use registration::EndpointRegistrationLease;
+pub(crate) use registration::EndpointRegistrationManager;
+
 mod mock;
 pub use mock::{MockDiscovery, SharedMockRegistry};
 mod kv_store;

--- a/lib/runtime/src/discovery/registration.rs
+++ b/lib/runtime/src/discovery/registration.rs
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{sync::Arc, time::Duration};
+
+use anyhow::{Context, Result};
+use dashmap::{DashMap, mapref::entry::Entry as DashEntry};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    Discovery, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery, DiscoverySpec,
+    EndpointInstanceId,
+};
+
+struct RegistrationEntry {
+    instance: DiscoveryInstance,
+    leases: usize,
+    owned: bool,
+}
+
+type RegistrationSlot = Arc<Mutex<Option<RegistrationEntry>>>;
+
+/// Coordinates endpoint registration ownership across all users of one distributed runtime.
+pub(crate) struct EndpointRegistrationManager {
+    discovery: Arc<dyn Discovery>,
+    slots: DashMap<EndpointInstanceId, RegistrationSlot>,
+    runtime: tokio::runtime::Handle,
+    cancellation: CancellationToken,
+}
+
+impl EndpointRegistrationManager {
+    pub(crate) fn new(
+        discovery: Arc<dyn Discovery>,
+        runtime: tokio::runtime::Handle,
+        cancellation: CancellationToken,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            discovery,
+            slots: DashMap::new(),
+            runtime,
+            cancellation,
+        })
+    }
+
+    pub(crate) async fn register(
+        self: &Arc<Self>,
+        spec: DiscoverySpec,
+    ) -> Result<EndpointRegistrationLease> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        let manager = self.clone();
+        self.runtime.spawn(async move {
+            let result = manager.acquire(spec).await;
+            let _ = result_tx.send(result);
+        });
+        result_rx
+            .await
+            .context("endpoint discovery registration task ended without a result")?
+    }
+
+    async fn acquire(self: &Arc<Self>, spec: DiscoverySpec) -> Result<EndpointRegistrationLease> {
+        let candidate = spec.clone().into_instance(self.discovery.instance_id());
+        let DiscoveryInstanceId::Endpoint(id) = candidate.id() else {
+            anyhow::bail!("endpoint registration leases require an endpoint specification");
+        };
+        let slot = self
+            .slots
+            .entry(id.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(None)))
+            .clone();
+        let mut entry = slot.lock().await;
+        if let Some(entry) = entry.as_mut() {
+            anyhow::ensure!(
+                entry.instance == candidate,
+                "endpoint registration lease conflicts with the existing specification"
+            );
+            entry.leases += 1;
+            return Ok(EndpointRegistrationLease::new(self.clone(), id));
+        }
+
+        let registration = async {
+            let existing = self
+                .discovery
+                .list(DiscoveryQuery::Endpoint {
+                    namespace: id.namespace.clone(),
+                    component: id.component.clone(),
+                    endpoint: id.endpoint.clone(),
+                })
+                .await?
+                .into_iter()
+                .find(|instance| instance.id() == DiscoveryInstanceId::Endpoint(id.clone()));
+            match existing {
+                Some(existing) => {
+                    anyhow::ensure!(
+                        existing == candidate,
+                        "endpoint registration lease conflicts with a pre-existing specification"
+                    );
+                    Ok((existing, false))
+                }
+                None => Ok((self.discovery.register(spec).await?, true)),
+            }
+        }
+        .await;
+        let (instance, owned) = match registration {
+            Ok(registration) => registration,
+            Err(error) => {
+                drop(entry);
+                self.remove_unused_slot(&id, &slot);
+                return Err(error);
+            }
+        };
+        *entry = Some(RegistrationEntry {
+            instance,
+            leases: 1,
+            owned,
+        });
+        Ok(EndpointRegistrationLease::new(self.clone(), id))
+    }
+
+    async fn release(self: Arc<Self>, id: EndpointInstanceId) {
+        let Some(slot) = self.slots.get(&id).map(|slot| slot.clone()) else {
+            return;
+        };
+        let mut entry = slot.lock().await;
+        let Some(registration) = entry.as_mut() else {
+            return;
+        };
+        registration.leases = registration.leases.saturating_sub(1);
+        if registration.leases != 0 {
+            return;
+        }
+        if registration.owned {
+            let mut retry_delay = Duration::from_millis(50);
+            loop {
+                match self
+                    .discovery
+                    .unregister(registration.instance.clone())
+                    .await
+                {
+                    Ok(()) => break,
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            instance = ?registration.instance.id(),
+                            "Failed to release endpoint discovery registration; retrying"
+                        );
+                    }
+                }
+                tokio::select! {
+                    _ = self.cancellation.cancelled() => return,
+                    _ = tokio::time::sleep(retry_delay) => {}
+                }
+                retry_delay = (retry_delay * 2).min(Duration::from_secs(5));
+            }
+        }
+        *entry = None;
+        drop(entry);
+        self.remove_unused_slot(&id, &slot);
+    }
+
+    fn remove_unused_slot(&self, id: &EndpointInstanceId, slot: &RegistrationSlot) {
+        if let DashEntry::Occupied(entry) = self.slots.entry(id.clone())
+            && Arc::ptr_eq(entry.get(), slot)
+            && Arc::strong_count(slot) == 2
+        {
+            entry.remove();
+        }
+    }
+}
+
+/// Keeps a discovery endpoint registered until the last lease is dropped.
+pub struct EndpointRegistrationLease {
+    manager: Arc<EndpointRegistrationManager>,
+    id: Option<EndpointInstanceId>,
+}
+
+impl EndpointRegistrationLease {
+    fn new(manager: Arc<EndpointRegistrationManager>, id: EndpointInstanceId) -> Self {
+        Self {
+            manager,
+            id: Some(id),
+        }
+    }
+}
+
+impl std::fmt::Debug for EndpointRegistrationLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EndpointRegistrationLease")
+            .field("id", &self.id)
+            .finish()
+    }
+}
+
+impl Drop for EndpointRegistrationLease {
+    fn drop(&mut self) {
+        let Some(id) = self.id.take() else {
+            return;
+        };
+        let manager = self.manager.clone();
+        self.manager.runtime.spawn(async move {
+            manager.release(id).await;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        component::TransportType,
+        discovery::{DiscoveryStream, MockDiscovery, SharedMockRegistry},
+    };
+    use async_trait::async_trait;
+
+    struct BlockingRegistrationDiscovery {
+        inner: MockDiscovery,
+        registered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl Discovery for BlockingRegistrationDiscovery {
+        fn instance_id(&self) -> u64 {
+            self.inner.instance_id()
+        }
+
+        async fn register_internal(&self, spec: DiscoverySpec) -> Result<DiscoveryInstance> {
+            let instance = self.inner.register_internal(spec).await?;
+            self.registered.notify_one();
+            self.release.notified().await;
+            Ok(instance)
+        }
+
+        async fn unregister(&self, instance: DiscoveryInstance) -> Result<()> {
+            self.inner.unregister(instance).await
+        }
+
+        async fn list(&self, query: DiscoveryQuery) -> Result<Vec<DiscoveryInstance>> {
+            self.inner.list(query).await
+        }
+
+        async fn list_and_watch(
+            &self,
+            query: DiscoveryQuery,
+            cancel_token: Option<CancellationToken>,
+        ) -> Result<DiscoveryStream> {
+            self.inner.list_and_watch(query, cancel_token).await
+        }
+    }
+
+    fn endpoint_spec() -> DiscoverySpec {
+        DiscoverySpec::Endpoint {
+            namespace: "ns".to_string(),
+            component: "frontend".to_string(),
+            endpoint: "router".to_string(),
+            transport: TransportType::Tcp("127.0.0.1:1/7/router".to_string()),
+            device_type: None,
+            request_plane_codec: None,
+        }
+    }
+
+    async fn wait_for_endpoint_count(discovery: &dyn Discovery, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let instances = discovery.list(DiscoveryQuery::AllEndpoints).await.unwrap();
+                if instances.len() == expected {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("endpoint registration count did not converge");
+    }
+
+    #[tokio::test]
+    async fn cancelled_registration_releases_endpoint_after_register_completes() {
+        let registered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let discovery: Arc<dyn Discovery> = Arc::new(BlockingRegistrationDiscovery {
+            inner: MockDiscovery::new(Some(7), SharedMockRegistry::new()),
+            registered: registered.clone(),
+            release: release.clone(),
+        });
+        let manager = EndpointRegistrationManager::new(
+            discovery.clone(),
+            tokio::runtime::Handle::current(),
+            CancellationToken::new(),
+        );
+        let caller = tokio::spawn({
+            let manager = manager.clone();
+            async move { manager.register(endpoint_spec()).await }
+        });
+
+        registered.notified().await;
+        caller.abort();
+        let _ = caller.await;
+        wait_for_endpoint_count(discovery.as_ref(), 1).await;
+        release.notify_one();
+        wait_for_endpoint_count(discovery.as_ref(), 0).await;
+    }
+
+    #[tokio::test]
+    async fn endpoint_remains_registered_until_last_lease_drops() {
+        let discovery: Arc<dyn Discovery> =
+            Arc::new(MockDiscovery::new(Some(7), SharedMockRegistry::new()));
+        let manager = EndpointRegistrationManager::new(
+            discovery.clone(),
+            tokio::runtime::Handle::current(),
+            CancellationToken::new(),
+        );
+        let first = manager.register(endpoint_spec()).await.unwrap();
+        let second = manager.register(endpoint_spec()).await.unwrap();
+        wait_for_endpoint_count(discovery.as_ref(), 1).await;
+
+        drop(first);
+        tokio::task::yield_now().await;
+        wait_for_endpoint_count(discovery.as_ref(), 1).await;
+        drop(second);
+        wait_for_endpoint_count(discovery.as_ref(), 0).await;
+    }
+}

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -12,7 +12,7 @@ use crate::service::{ServiceClient, ServiceSet};
 use crate::storage::kv;
 use crate::{discovery, system_status_server, transports};
 use crate::{
-    discovery::Discovery,
+    discovery::{Discovery, DiscoverySpec, EndpointRegistrationLease, EndpointRegistrationManager},
     metrics::PrometheusUpdateCallback,
     metrics::{MetricsHierarchy, MetricsRegistry},
     transports::{etcd, nats, tcp},
@@ -62,6 +62,7 @@ pub struct DistributedRuntime {
 
     // Service discovery client
     discovery_client: Arc<dyn discovery::Discovery>,
+    endpoint_registrations: Arc<EndpointRegistrationManager>,
 
     // Discovery metadata (only used for Kubernetes backend)
     // Shared with system status server to expose via /metadata endpoint
@@ -200,6 +201,11 @@ impl DistributedRuntime {
             request_plane,
         );
 
+        let endpoint_registrations = EndpointRegistrationManager::new(
+            discovery_client.clone(),
+            runtime.secondary(),
+            runtime.primary_token(),
+        );
         let distributed_runtime = Self {
             runtime,
             network_manager: Arc::new(network_manager),
@@ -207,6 +213,7 @@ impl DistributedRuntime {
             tcp_server: Arc::new(OnceCell::new()),
             system_status_server: Arc::new(OnceLock::new()),
             discovery_client,
+            endpoint_registrations,
             discovery_metadata,
             component_registry,
             endpoint_discovery_sources: Arc::new(Mutex::new(HashMap::new())),
@@ -370,6 +377,14 @@ impl DistributedRuntime {
     /// Returns the discovery interface for service registration and discovery
     pub fn discovery(&self) -> Arc<dyn Discovery> {
         self.discovery_client.clone()
+    }
+
+    /// Register an endpoint until the last runtime-wide owner drops its lease.
+    pub async fn register_endpoint_lease(
+        &self,
+        spec: DiscoverySpec,
+    ) -> Result<EndpointRegistrationLease> {
+        self.endpoint_registrations.register(spec).await
     }
 
     pub async fn tcp_server(&self) -> Result<Arc<tcp::server::TcpStreamServer>> {

--- a/lib/runtime/src/engine.rs
+++ b/lib/runtime/src/engine.rs
@@ -91,6 +91,7 @@ pub type EngineUnary<Resp> = Pin<Box<dyn AsyncEngineUnary<Resp>>>;
 /// at the [`crate::pipeline`] alias layer for documentary clarity at use sites.
 pub type EngineStream<T> = Pin<Box<dyn AsyncEngineStream<T>>>;
 pub type Context = Arc<dyn AsyncEngineContext>;
+pub type EngineContextGuard = Arc<dyn Any + Send + Sync>;
 
 impl<T: Data> From<EngineStream<T>> for DataStream<T> {
     fn from(stream: EngineStream<T>) -> Self {
@@ -157,6 +158,11 @@ pub trait AsyncEngineContext: Send + Sync + Debug {
     /// child AsyncEngineContext, in the order they are linked, and then the method on this
     /// AsyncEngineContext continues.
     fn link_child(&self, child: Arc<dyn AsyncEngineContext>);
+
+    /// Retain request-scoped state until the engine context is dropped.
+    fn retain(&self, guard: EngineContextGuard) {
+        drop(guard);
+    }
 }
 
 /// Provides access to the [`AsyncEngineContext`] associated with an engine operation.

--- a/lib/runtime/src/pipeline/context.rs
+++ b/lib/runtime/src/pipeline/context.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex};
 
 use super::{AsyncEngineContext, AsyncEngineContextProvider, Data};
-use crate::engine::AsyncEngineController;
+use crate::engine::{AsyncEngineController, EngineContextGuard};
 use async_trait::async_trait;
 
 use super::registry::Registry;
@@ -329,6 +329,10 @@ impl AsyncEngineContext for StreamContext {
     fn link_child(&self, child: Arc<dyn AsyncEngineContext>) {
         self.controller.link_child(child);
     }
+
+    fn retain(&self, guard: EngineContextGuard) {
+        self.controller.retain(guard);
+    }
 }
 
 impl AsyncEngineContextProvider for StreamContext {
@@ -361,6 +365,17 @@ pub struct Controller {
     tx: Sender<State>,
     rx: Receiver<State>,
     child_context: Mutex<Vec<Arc<dyn AsyncEngineContext>>>,
+    retained: Mutex<Vec<RetainedGuard>>,
+}
+
+struct RetainedGuard {
+    _guard: EngineContextGuard,
+}
+
+impl std::fmt::Debug for RetainedGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RetainedGuard")
+    }
 }
 
 impl Controller {
@@ -371,6 +386,7 @@ impl Controller {
             tx,
             rx,
             child_context: Mutex::new(Vec::new()),
+            retained: Mutex::new(Vec::new()),
         }
     }
 
@@ -472,6 +488,13 @@ impl AsyncEngineContext for Controller {
             .lock()
             .expect("Failed to lock child context")
             .push(child);
+    }
+
+    fn retain(&self, guard: EngineContextGuard) {
+        self.retained
+            .lock()
+            .expect("Failed to lock retained engine state")
+            .push(RetainedGuard { _guard: guard });
     }
 }
 

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -827,7 +827,7 @@ where
         let backend = ServiceBackend::from_engine(engine);
 
         // create the pipeline
-        let pipeline = frontend.link(backend)?.link(frontend)?;
+        let pipeline = frontend.link(backend)?.link_terminal(frontend)?;
 
         let ingress = Ingress::new_with_adapter(payload_adapter);
         ingress.attach(pipeline)?;

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -376,6 +376,17 @@ struct TcpConnection {
     post_enqueue_barrier: Option<Arc<tokio::sync::Barrier>>,
 }
 
+impl Drop for TcpConnection {
+    fn drop(&mut self) {
+        self.healthy.store(false, Ordering::Relaxed);
+        self.closed.store(true, Ordering::Release);
+        self.admission.close();
+        self.writer_notify.notify_one();
+        self.writer_handle.abort();
+        self.reader_handle.abort();
+    }
+}
+
 impl TcpConnection {
     /// Create a new connection with lock-free submit and batched write/read tasks
     async fn connect(addr: SocketAddr, timeout: Duration, channel_buffer: usize) -> Result<Self> {
@@ -1588,7 +1599,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::task::{Context, Poll};
     use tokio::io::{AsyncReadExt, AsyncWrite};
-    use tokio::net::TcpListener;
+    use tokio::net::{TcpListener, TcpStream};
 
     #[test]
     fn test_tcp_config_default() {
@@ -1645,6 +1656,49 @@ mod tests {
         assert!(client.is_healthy());
     }
 
+    async fn echo_requests(stream: TcpStream) {
+        let (mut read_half, mut write_half) = tokio::io::split(stream);
+        loop {
+            let mut len_buf = [0u8; 2];
+            if read_half.read_exact(&mut len_buf).await.is_err() {
+                break;
+            }
+            let path_len = u16::from_be_bytes(len_buf) as usize;
+            let mut path_buf = vec![0u8; path_len];
+            if read_half.read_exact(&mut path_buf).await.is_err() {
+                break;
+            }
+
+            let mut headers_len_buf = [0u8; 2];
+            if read_half.read_exact(&mut headers_len_buf).await.is_err() {
+                break;
+            }
+            let headers_len = u16::from_be_bytes(headers_len_buf) as usize;
+            let mut headers_buf = vec![0u8; headers_len];
+            if read_half.read_exact(&mut headers_buf).await.is_err() {
+                break;
+            }
+
+            let mut payload_len_buf = [0u8; 4];
+            if read_half.read_exact(&mut payload_len_buf).await.is_err() {
+                break;
+            }
+            let payload_len = u32::from_be_bytes(payload_len_buf) as usize;
+            let mut payload = vec![0u8; payload_len];
+            if read_half.read_exact(&mut payload).await.is_err() {
+                break;
+            }
+
+            use crate::pipeline::network::codec::TcpResponseMessage;
+            let encoded = TcpResponseMessage::new(Bytes::from(payload))
+                .encode()
+                .unwrap();
+            if write_half.write_all(&encoded).await.is_err() {
+                break;
+            }
+        }
+    }
+
     /// Helper: spawn a mock TCP server that echoes requests.
     /// Returns (listener_addr, connection_count_tracker).
     async fn spawn_echo_server() -> (SocketAddr, Arc<AtomicUsize>) {
@@ -1662,55 +1716,69 @@ mod tests {
                 let (stream, _) = result.unwrap();
                 conn_count_clone.fetch_add(1, Ordering::SeqCst);
 
-                tokio::spawn(async move {
-                    let (mut read_half, mut write_half) = tokio::io::split(stream);
-                    loop {
-                        // Read path length
-                        let mut len_buf = [0u8; 2];
-                        if read_half.read_exact(&mut len_buf).await.is_err() {
-                            break;
-                        }
-                        let path_len = u16::from_be_bytes(len_buf) as usize;
-                        let mut path_buf = vec![0u8; path_len];
-                        if read_half.read_exact(&mut path_buf).await.is_err() {
-                            break;
-                        }
-
-                        // Read headers length
-                        let mut headers_len_buf = [0u8; 2];
-                        if read_half.read_exact(&mut headers_len_buf).await.is_err() {
-                            break;
-                        }
-                        let headers_len = u16::from_be_bytes(headers_len_buf) as usize;
-                        let mut headers_buf = vec![0u8; headers_len];
-                        if read_half.read_exact(&mut headers_buf).await.is_err() {
-                            break;
-                        }
-
-                        // Read payload length + payload
-                        let mut len_buf = [0u8; 4];
-                        if read_half.read_exact(&mut len_buf).await.is_err() {
-                            break;
-                        }
-                        let payload_len = u32::from_be_bytes(len_buf) as usize;
-                        let mut payload_buf = vec![0u8; payload_len];
-                        if read_half.read_exact(&mut payload_buf).await.is_err() {
-                            break;
-                        }
-
-                        // Send response
-                        use crate::pipeline::network::codec::TcpResponseMessage;
-                        let response = TcpResponseMessage::new(Bytes::from(payload_buf));
-                        let encoded = response.encode().unwrap();
-                        if write_half.write_all(&encoded).await.is_err() {
-                            break;
-                        }
-                    }
-                });
+                tokio::spawn(echo_requests(stream));
             }
         });
 
         (addr, conn_count)
+    }
+
+    async fn spawn_active_echo_server() -> (SocketAddr, Arc<AtomicUsize>) {
+        struct ActiveConnection(Arc<AtomicUsize>);
+
+        impl Drop for ActiveConnection {
+            fn drop(&mut self) {
+                self.0.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let active_connections = Arc::new(AtomicUsize::new(0));
+        let tracker = active_connections.clone();
+
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tracker.fetch_add(1, Ordering::SeqCst);
+                let active = ActiveConnection(tracker.clone());
+                tokio::spawn(async move {
+                    let _active = active;
+                    echo_requests(stream).await;
+                });
+            }
+        });
+
+        (addr, active_connections)
+    }
+
+    #[tokio::test]
+    async fn dropping_client_closes_pooled_connections() {
+        let (addr, active_connections) = spawn_active_echo_server().await;
+        let client = TcpRequestClient::with_config(TcpRequestConfig {
+            request_timeout: Duration::from_secs(5),
+            connect_timeout: Duration::from_secs(5),
+            pool_size: 1,
+            channel_buffer: 1,
+        })
+        .unwrap();
+        let mut headers = Headers::new();
+        headers.insert("x-endpoint-path".to_string(), "test".to_string());
+
+        client
+            .send_request(addr.to_string(), Bytes::from_static(b"test"), headers)
+            .await
+            .unwrap();
+        assert_eq!(active_connections.load(Ordering::SeqCst), 1);
+
+        drop(client);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while active_connections.load(Ordering::SeqCst) != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropping the TCP client left its pooled connection open");
     }
 
     struct RecordingWriter {

--- a/lib/runtime/src/pipeline/nodes.rs
+++ b/lib/runtime/src/pipeline/nodes.rs
@@ -33,10 +33,10 @@
 //!
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Arc, Mutex, OnceLock, Weak},
 };
 
-use super::AsyncEngine;
+use super::{AsyncEngine, AsyncEngineContextProvider};
 use async_trait::async_trait;
 use tokio::sync::oneshot;
 
@@ -67,6 +67,15 @@ pub trait Source<T: PipelineIO>: Data {
         self.set_edge(edge, private::Token)?;
         Ok(sink)
     }
+
+    /// Close a pipeline response path without creating an ownership cycle.
+    ///
+    /// The returned sink is the pipeline's ownership root and must be retained by the caller.
+    fn link_terminal<S: Sink<T> + 'static>(&self, sink: Arc<S>) -> Result<Arc<S>, PipelineError> {
+        let edge = Edge::new_weak(sink.clone());
+        self.set_edge(edge, private::Token)?;
+        Ok(sink)
+    }
 }
 
 /// A [`Sink`] trait defines how data is received from a source and processed.
@@ -77,16 +86,39 @@ pub trait Sink<T: PipelineIO>: Data {
 
 /// An [`Edge`] is a connection between a [`Source`] and a [`Sink`].
 pub struct Edge<T: PipelineIO> {
-    downstream: Arc<dyn Sink<T>>,
+    downstream: EdgeTarget<T>,
+}
+
+enum EdgeTarget<T: PipelineIO> {
+    Strong(Arc<dyn Sink<T>>),
+    Weak(Weak<dyn Sink<T>>),
 }
 
 impl<T: PipelineIO> Edge<T> {
     fn new(downstream: Arc<dyn Sink<T>>) -> Self {
-        Edge { downstream }
+        Edge {
+            downstream: EdgeTarget::Strong(downstream),
+        }
+    }
+
+    fn new_weak<S: Sink<T> + 'static>(downstream: Arc<S>) -> Self {
+        let downstream: Arc<dyn Sink<T>> = downstream;
+        Edge {
+            downstream: EdgeTarget::Weak(Arc::downgrade(&downstream)),
+        }
     }
 
     async fn write(&self, data: T) -> Result<(), Error> {
-        self.downstream.on_data(data, private::Token).await
+        match &self.downstream {
+            EdgeTarget::Strong(downstream) => downstream.on_data(data, private::Token).await,
+            EdgeTarget::Weak(downstream) => {
+                let Some(downstream) = downstream.upgrade() else {
+                    data.context().stop_generating();
+                    return Err(PipelineError::DetachedStreamReceiver.into());
+                };
+                downstream.on_data(data, private::Token).await
+            }
+        }
     }
 }
 
@@ -146,7 +178,7 @@ pub struct PipelineOperatorBackwardEdge<
     DownIn: PipelineIO,
     DownOut: PipelineIO,
 > {
-    parent: Arc<PipelineOperator<UpIn, UpOut, DownIn, DownOut>>,
+    parent: Weak<PipelineOperator<UpIn, UpOut, DownIn, DownOut>>,
 }
 
 /// A [`PipelineOperator`] is a node that can transform both the forward and backward paths using the logic defined
@@ -199,7 +231,7 @@ where
         self: &Arc<Self>,
     ) -> Arc<PipelineOperatorBackwardEdge<UpIn, UpOut, DownIn, DownOut>> {
         Arc::new(PipelineOperatorBackwardEdge {
-            parent: self.clone(),
+            parent: Arc::downgrade(self),
         })
     }
 }
@@ -262,7 +294,11 @@ where
     UpOut: PipelineIO,
 {
     async fn on_data(&self, data: DownOut, token: private::Token) -> Result<(), Error> {
-        self.parent.downstream.on_data(data, token).await
+        let Some(parent) = self.parent.upgrade() else {
+            data.context().stop_generating();
+            return Err(PipelineError::DetachedStreamReceiver.into());
+        };
+        parent.downstream.on_data(data, token).await
     }
 }
 
@@ -276,11 +312,19 @@ where
     UpOut: PipelineIO,
 {
     async fn on_next(&self, data: UpOut, token: private::Token) -> Result<(), Error> {
-        self.parent.upstream.on_next(data, token).await
+        let Some(parent) = self.parent.upgrade() else {
+            data.context().stop_generating();
+            return Err(PipelineError::DetachedStreamReceiver.into());
+        };
+        parent.upstream.on_next(data, token).await
     }
 
     fn set_edge(&self, edge: Edge<UpOut>, token: private::Token) -> Result<(), PipelineError> {
-        self.parent.upstream.set_edge(edge, token)
+        self.parent
+            .upgrade()
+            .ok_or(PipelineError::DetachedStreamReceiver)?
+            .upstream
+            .set_edge(edge, token)
     }
 }
 

--- a/lib/runtime/src/pipeline/nodes/sources.rs
+++ b/lib/runtime/src/pipeline/nodes/sources.rs
@@ -15,10 +15,12 @@ pub struct Frontend<In: PipelineIO, Out: PipelineIO> {
 /// A [`ServiceFrontend`] is the interface for an [`AsyncEngine<SingleIn<Context<In>>, ManyOut<Annotated<Out>>, Error>`]
 pub struct ServiceFrontend<In: PipelineIO, Out: PipelineIO> {
     inner: Frontend<In, Out>,
+    self_weak: Weak<Self>,
 }
 
 pub struct SegmentSource<In: PipelineIO, Out: PipelineIO> {
     inner: Frontend<In, Out>,
+    self_weak: Weak<Self>,
 }
 
 // impl<In: DataType, Out: PipelineIO> Frontend<In, Out> {

--- a/lib/runtime/src/pipeline/nodes/sources/common.rs
+++ b/lib/runtime/src/pipeline/nodes/sources/common.rs
@@ -9,8 +9,9 @@ macro_rules! impl_frontend {
     ($type:ident) => {
         impl<In: PipelineIO, Out: PipelineIO> $type<In, Out> {
             pub fn new() -> Arc<Self> {
-                Arc::new(Self {
+                Arc::new_cyclic(|self_weak| Self {
                     inner: Frontend::default(),
+                    self_weak: self_weak.clone(),
                 })
             }
         }
@@ -40,7 +41,14 @@ macro_rules! impl_frontend {
             for $type<In, Out>
         {
             async fn generate(&self, request: In) -> Result<Out, Error> {
-                self.inner.generate(request).await
+                if let Some(root) = self.self_weak.upgrade() {
+                    request.context().retain(root.clone());
+                    let response = self.inner.generate(request).await?;
+                    response.context().retain(root);
+                    Ok(response)
+                } else {
+                    self.inner.generate(request).await
+                }
             }
         }
     };

--- a/lib/runtime/tests/pipeline.rs
+++ b/lib/runtime/tests/pipeline.rs
@@ -107,12 +107,31 @@ fn make_backend_engine() -> ServiceEngine<SingleIn<String>, ManyOut<Annotated<St
     ))
 }
 
+struct DistinctResponseContextBackend;
+
+#[async_trait::async_trait]
+impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error>
+    for DistinctResponseContextBackend
+{
+    async fn generate(
+        &self,
+        request: SingleIn<String>,
+    ) -> Result<ManyOut<Annotated<String>>, Error> {
+        let response_context =
+            Context::with_id_and_metadata((), request.id().to_string(), Default::default());
+        Ok(ResponseStream::new(
+            Box::pin(stream::iter([Annotated::Data("response".to_string())])),
+            response_context.context(),
+        ))
+    }
+}
+
 #[tokio::test]
 async fn test_service_source_sink() {
     let source = ServiceFrontend::<SingleIn<String>, ManyOut<Annotated<String>>>::new();
     let sink = ServiceBackend::from_engine(make_backend_engine());
 
-    let service = source.link(sink).unwrap().link(source).unwrap();
+    let service = source.link(sink).unwrap().link_terminal(source).unwrap();
 
     let mut stream = service.generate("test".to_string().into()).await.unwrap();
 
@@ -168,7 +187,7 @@ fn make_service()
         .link(preprocess)?
         .link(backend)?
         .link(postprocess)?
-        .link(frontend)?;
+        .link_terminal(frontend)?;
 
     Ok(service)
 }
@@ -210,7 +229,7 @@ async fn test_disaggregated_service() {
         .unwrap()
         .link(postprocessor)
         .unwrap()
-        .link(frontend)
+        .link_terminal(frontend)
         .unwrap();
 
     // Node 1
@@ -222,7 +241,7 @@ async fn test_disaggregated_service() {
         .unwrap()
         .link(backend)
         .unwrap()
-        .link(start_node1.clone())
+        .link_terminal(start_node1.clone())
         .unwrap();
 
     let opts = mock::MockNetworkOptions::default();
@@ -280,7 +299,7 @@ fn make_service_with_operator()
         .link(backend)?
         .link(postprocess)?
         .link(operator.backward_edge())?
-        .link(frontend)?;
+        .link_terminal(frontend)?;
 
     Ok(service)
 }
@@ -303,4 +322,98 @@ async fn test_service_source_node_sink_with_operator() {
 
     assert_eq!(annotations_counter, 1);
     assert_eq!(counter, 48);
+}
+
+#[test]
+fn dropping_service_releases_operator_graph() {
+    let frontend = ServiceFrontend::<SingleIn<String>, ManyOut<Annotated<String>>>::new();
+    let backend = ServiceBackend::from_engine(make_backend_engine());
+    let operator = PipelineOperator::new(Arc::new(PreprocesOperator {}));
+    let frontend_weak = Arc::downgrade(&frontend);
+    let backend_weak = Arc::downgrade(&backend);
+    let operator_weak = Arc::downgrade(&operator);
+
+    let service = frontend
+        .link(operator.forward_edge())
+        .unwrap()
+        .link(backend)
+        .unwrap()
+        .link(operator.backward_edge())
+        .unwrap()
+        .link_terminal(frontend.clone())
+        .unwrap();
+
+    drop(operator);
+    drop(service);
+    drop(frontend);
+
+    assert!(frontend_weak.upgrade().is_none());
+    assert!(backend_weak.upgrade().is_none());
+    assert!(operator_weak.upgrade().is_none());
+}
+
+#[tokio::test]
+async fn active_response_stream_retains_operator_graph() {
+    let frontend = ServiceFrontend::<SingleIn<String>, ManyOut<Annotated<String>>>::new();
+    let backend = ServiceBackend::from_engine(make_backend_engine());
+    let operator = PipelineOperator::new(Arc::new(PreprocesOperator {}));
+    let frontend_weak = Arc::downgrade(&frontend);
+    let backend_weak = Arc::downgrade(&backend);
+    let operator_weak = Arc::downgrade(&operator);
+
+    let service = frontend
+        .link(operator.forward_edge())
+        .unwrap()
+        .link(backend)
+        .unwrap()
+        .link(operator.backward_edge())
+        .unwrap()
+        .link_terminal(frontend.clone())
+        .unwrap();
+    drop(operator);
+    drop(frontend);
+
+    let mut stream = service.generate("test".to_string().into()).await.unwrap();
+    drop(service);
+
+    assert!(frontend_weak.upgrade().is_some());
+    assert!(backend_weak.upgrade().is_some());
+    assert!(operator_weak.upgrade().is_some());
+    while stream.next().await.is_some() {}
+    drop(stream);
+
+    assert!(frontend_weak.upgrade().is_none());
+    assert!(backend_weak.upgrade().is_none());
+    assert!(operator_weak.upgrade().is_none());
+}
+
+#[tokio::test]
+async fn distinct_response_context_retains_operator_graph() {
+    let frontend = ServiceFrontend::<SingleIn<String>, ManyOut<Annotated<String>>>::new();
+    let backend = ServiceBackend::from_engine(Arc::new(DistinctResponseContextBackend));
+    let operator = PipelineOperator::new(Arc::new(PreprocesOperator {}));
+    let frontend_weak = Arc::downgrade(&frontend);
+    let backend_weak = Arc::downgrade(&backend);
+    let operator_weak = Arc::downgrade(&operator);
+    let service = frontend
+        .link(operator.forward_edge())
+        .unwrap()
+        .link(backend)
+        .unwrap()
+        .link(operator.backward_edge())
+        .unwrap()
+        .link_terminal(frontend.clone())
+        .unwrap();
+    drop(operator);
+    drop(frontend);
+
+    let stream = service.generate("test".to_string().into()).await.unwrap();
+    drop(service);
+    assert!(frontend_weak.upgrade().is_some());
+    assert!(backend_weak.upgrade().is_some());
+    assert!(operator_weak.upgrade().is_some());
+    drop(stream);
+    assert!(frontend_weak.upgrade().is_none());
+    assert!(backend_weak.upgrade().is_none());
+    assert!(operator_weak.upgrade().is_none());
 }


### PR DESCRIPTION
## Summary

- Backport the merged LoRA frontend resource-lifecycle fix from #12743 to `release/1.4.0`.
- Close pooled TCP tasks when their final owner drops, reuse base pipelines for LoRA adapter views, and retain pipeline roots through active response streams.
- Make endpoint discovery registration cancellation-safe and keep teardown guards alive through prefill, encoder, KV subscription, and request lifecycles.
- Schedule coalesced glibc allocator trimming on a dedicated thread after teardown completes.
- Include the release-only LoRA identity propagation prerequisite that is already present on `main` but absent from `release/1.4.0`.

## Why

On unpatched `release/1.4.0`, repeated LoRA load/use/unload cycles retain frontend pipelines, transport tasks, sockets, file descriptors, and allocator pages. A local 30-cycle reproduction grew frontend RSS from 187,900 KiB to 2,574,836 KiB, total FDs from 42 to 162, and socket FDs from 20 to 140, with no recovery after 60 seconds idle.

## Backport notes

PR #12743 was squash-merged to `main` as `5ac50127f6a6d664c037579c8d358853240823e0`. The first commit is its semantic cherry-pick onto the latest `release/1.4.0` tip. Conflict resolution preserves the release branch's older one-shot prefill/encoder discovery APIs. The second commit supplies LoRA identity propagation that `main` already had before the squash merge, but the release branch did not.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p dynamo-runtime -p dynamo-llm --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --locked --no-run`
- 12 focused lifecycle/resource regression tests covering cancellation-safe endpoint registration, active response-stream pipeline retention, client transport cleanup, allocator teardown ordering, prefill drains and activation, KV recovery subscription ownership, and repeated LoRA adapter-view reuse/release.
- Fresh bare-machine 100-cycle LoRA load / three chat / unload run against exact PR head `d7dfbd8ed07dfa73a54beb85b3823282e6aafbed`, followed by 60 seconds idle.

| Frontend resource | Baseline | Cycle 100 | Settled after 60s | Result |
| --- | ---: | ---: | ---: | --- |
| RSS | 178,304 KiB | 155,440 KiB | 155,092 KiB | -13.02% settled; overall slope -6.52 KiB/cycle |
| Total FDs | 42 | 42 | 42 | No growth |
| Socket FDs | 20 | 20 | 20 | No growth |
| Established TCP | 3 | 3 | 3 | No growth |
| Connected Unix streams | 15 | 15 | 15 | No growth |

All 100 loads, 300 chats, and 100 unloads completed successfully. One-second sampling saw only transient in-flight request connections, and every descriptor/socket metric returned to baseline.

Lychee currently reports two pre-existing `release/1.4.0` documentation links that hardcode a recipe path on `main` which was renamed there. This PR changes no docs or recipes, and the linked recipe file remains present on `release/1.4.0`.

Signed-off-by: Biswa Panda <biswa.panda@gmail.com>
