### PR TITLE
chore: update Aiconfigurator release source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.11.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=c80c1875e1e623dc89bbe150d9d763a3a8d232df#c80c1875e1e623dc89bbe150d9d763a3a8d232df"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=614b9c8c8725332533616786e2eb049df48935f0#614b9c8c8725332533616786e2eb049df48935f0"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rustls-pemfile = { version = "2" }
 
 [patch.crates-io]
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "c80c1875e1e623dc89bbe150d9d763a3a8d232df" }
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "614b9c8c8725332533616786e2eb049df48935f0" }
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/aisimulate/pyproject.toml
+++ b/aisimulate/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 ]
 dependencies = [
     "ai-dynamo>=1.3.0,<2.0.0",
-    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df",
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core",
+    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core",
     "chex==0.1.87",
     "filterpy==1.4.5",
     "flax==0.10.0",

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core",
     "aiperf==0.10.0",
     "matplotlib",
     "networkx",

--- a/container/deps/requirements.frontend.txt
+++ b/container/deps/requirements.frontend.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Required by experimental KV router --router-prefill-load-model=aic.
-aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core
+aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core
 
 # tritonclient<=2.62.0 requires grpcio<1.68 and protobuf<6.0dev; pin here so the
 # resolver picks compatible versions when installed alongside runtime deps.

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -4,9 +4,9 @@
 # Dependencies required by the planner, profiler, and global_planner services.
 
 # Keep both layers on the same immutable AIC source revision.
-aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df
+aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0
 
-aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core
+aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.11.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=c80c1875e1e623dc89bbe150d9d763a3a8d232df#c80c1875e1e623dc89bbe150d9d763a3a8d232df"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=614b9c8c8725332533616786e2eb049df48935f0#614b9c8c8725332533616786e2eb049df48935f0"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -120,7 +120,7 @@ opentelemetry_sdk = { version = "0.31.0", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [patch.crates-io]
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "c80c1875e1e623dc89bbe150d9d763a3a8d232df" }
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "614b9c8c8725332533616786e2eb049df48935f0" }
 
 [profile.profiling]
 inherits = "release"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ sglang = [
 ]
 
 mocker = [
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
## Summary

- update every Python and Rust source pin for `aiconfigurator` and `aiconfigurator-core` from `c80c1875e1e623dc89bbe150d9d763a3a8d232df` to `614b9c8c8725332533616786e2eb049df48935f0`
- keep the Dynamo `release/1.4.0` branch aligned with the current tip of Aiconfigurator `release/0.11.0`
- preserve the established nine-file source-pin and lockfile pattern from #12519

This branch was created from Dynamo `release/1.4.0` at `26cea2cff1355d4c478b67ad83a267dbaa2f41c2`, which was re-fetched and verified immediately before push.

## Validation

- verified `614b9c8c8725332533616786e2eb049df48935f0` is the live tip of Aiconfigurator `release/0.11.0`
- parsed all seven affected TOML files
- parsed all seven affected PEP 508 requirements
- verified both Cargo lockfiles resolve `aiconfigurator-core v0.11.0` from the requested revision
- ran feature-enabled inverse dependency checks for the root workspace and Python bindings
- `git diff --check`
