### PR TITLE
fix(recipes): parameterize DeepSeek-V4 model download so H200 recipes get the FP8 checkpoint (cherry-pick #13034)

### DIFF
--- a/docs/fern/recipes/deepseek-v4-flash.mdx
+++ b/docs/fern/recipes/deepseek-v4-flash.mdx
@@ -95,9 +95,35 @@ Create storage, download the checkpoint into the PVC, then apply the target's `d
 
 ```bash
 kubectl apply -f recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-cache.yaml -n ${NAMESPACE}
-kubectl apply -f recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download.yaml -n ${NAMESPACE}
-kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=7200s
 ```
+
+There is one download Job per checkpoint, because the PVC holds one, not both. B200 serves the NVFP4 checkpoint; every other variant serves the public one.
+
+<div data-sku="b200">
+
+```bash
+kubectl apply -f recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download-nvfp4.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download-nvfp4 -n ${NAMESPACE} --timeout=7200s
+```
+
+</div>
+
+<div data-sku="h200">
+
+```bash
+kubectl apply -f recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download-fp8.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download-fp8 -n ${NAMESPACE} --timeout=7200s
+```
+
+</div>
+
+<Warning>
+The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the Job did not download. Downloading the checkpoint for the other SKU leaves the worker unable to start.
+</Warning>
+
+<Note>
+To switch a populated PVC to the other checkpoint: stop the workers, delete the PVC, re-apply `model-cache.yaml`, then apply the other Job. The two Jobs have distinct names, so applying the second one does not collide with the first.
+</Note>
 
 <div data-sku="b200" data-variant="agg">
 

--- a/docs/fern/recipes/deepseek-v4-pro.mdx
+++ b/docs/fern/recipes/deepseek-v4-pro.mdx
@@ -99,9 +99,35 @@ Create storage, download the checkpoint (~865 GB, 1.5–3 h first apply), then a
 
 ```bash
 kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-cache.yaml -n ${NAMESPACE}
-kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download.yaml -n ${NAMESPACE}
-kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=14400s
 ```
+
+There is one download Job per checkpoint, because each checkpoint is ~865 GB and the PVC holds one, not both. B200 serves the NVFP4 checkpoint; every other variant serves the public FP8 one.
+
+<div data-sku="b200">
+
+```bash
+kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download-nvfp4.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download-nvfp4 -n ${NAMESPACE} --timeout=14400s
+```
+
+</div>
+
+<div data-sku="h200">
+
+```bash
+kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download-fp8.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download-fp8 -n ${NAMESPACE} --timeout=14400s
+```
+
+</div>
+
+<Warning>
+The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the Job did not download. Downloading the checkpoint for the other SKU leaves the worker unable to start.
+</Warning>
+
+<Note>
+To switch a populated PVC to the other checkpoint: stop the workers, delete the PVC, re-apply `model-cache.yaml`, then apply the other Job. The two Jobs have distinct names, so applying the second one does not collide with the first.
+</Note>
 
 <div data-sku="b200" data-variant="agg">
 

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # DeepSeek-V4-Flash Recipe
 
-Serving recipes for **DeepSeek-V4-Flash** on Dynamo — a MoE model (284B total / 13B active) with hybrid CSA + HCA attention and a Blackwell FP4 indexer cache. B200 recipes serve the `nvidia/DeepSeek-V4-Flash-NVFP4` checkpoint; H200 serves the public `deepseek-ai/DeepSeek-V4-Flash` (see [`model-cache/model-download.yaml`](model-cache/model-download.yaml)). Two families today — see [Recipes](#recipes):
+Serving recipes for **DeepSeek-V4-Flash** on Dynamo — a MoE model (284B total / 13B active) with hybrid CSA + HCA attention and a Blackwell FP4 indexer cache. B200 recipes serve the `nvidia/DeepSeek-V4-Flash-NVFP4` checkpoint; H200 serves the public `deepseek-ai/DeepSeek-V4-Flash` (see [`model-cache/`](model-cache/)). Two families today — see [Recipes](#recipes):
 
 - **Agentic (vLLM)** — the benchmarked, workload-tuned picks (B200 & H200, AGG + disaggregated); numbers in [Performance](#performance).
 - **Day-0** — the original single-node aggregated recipes (B200/GB200, vLLM + SGLang).
@@ -80,7 +80,7 @@ Floor-picks (max system tok/s/GPU at user_p50 ≥ 50), default temperature. Agen
    - **DisAgg B200** (`disagg-b200-agentic`, 2P1D): **12 B200** — (2 prefill + 1 decode) pods × 4 GPUs, across **multiple nodes**; needs the [per-rank NIC mapping](../README.md#per-rank-nic-mapping-b200--h200-disaggregated).
    - **DisAgg H200** (`disagg-h200-agentic`, 4P3D): **28 H200** — (4 prefill + 3 decode) pods × 4 GPUs, across **multiple nodes**; same NIC mapping.
    - **GB200 Day-0 variants**: 4 GB200 GPUs (single NVL4 tray, arm64). Nodes must be labeled `nvidia.com/gpu.product=NVIDIA-GB200` and tainted `kubernetes.io/arch=arm64:NoSchedule` (the manifests carry the matching `nodeSelector` + `toleration`).
-3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V4-Flash`.
+3. **HuggingFace token** with access to the checkpoint your variant serves — `deepseek-ai/DeepSeek-V4-Flash` (public) for the H200, GB200, Day-0 B200, and SGLang variants, or `nvidia/DeepSeek-V4-Flash-NVFP4` for the two agentic B200 variants (`vllm/agg-b200-agentic`, `vllm/disagg-b200-agentic`).
 
 ## Quick Start
 
@@ -95,14 +95,36 @@ kubectl create secret generic hf-token-secret \
   --from-literal=HF_TOKEN="your-token-here" \
   -n ${NAMESPACE}
 
-# Download model into the model-cache PVC.
+# Storage for the checkpoint.
 # Edit model-cache/model-cache.yaml and set storageClassName to a RWX class in your cluster.
 # The PVC requests 400Gi; DeepSeek-V4-Flash is ~160GB on disk (46 safetensors shards,
 # FP4+FP8 mixed) and typically takes 30-60 min to download on first apply.
 kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
-kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
-kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=7200s
 ```
+
+Then download **the checkpoint your variant serves**. The PVC holds one checkpoint, not both, so
+there is one download Job per checkpoint. Apply the one your target SKU needs:
+
+```bash
+# H200 agentic, GB200, Day-0 B200, and all SGLang variants — public checkpoint (6 of the 8 variants):
+kubectl apply -f model-cache/model-download-fp8.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download-fp8 -n ${NAMESPACE} --timeout=7200s
+```
+
+```bash
+# vllm/agg-b200-agentic and vllm/disagg-b200-agentic only — NVFP4:
+kubectl apply -f model-cache/model-download-nvfp4.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download-nvfp4 -n ${NAMESPACE} --timeout=7200s
+```
+
+> [!IMPORTANT]
+> The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the
+> Job did not download. Downloading the wrong one leaves the worker unable to start.
+
+> [!NOTE]
+> To switch a populated PVC to the other checkpoint: stop the workers, delete the PVC, re-apply
+> `model-cache/model-cache.yaml`, then apply the other Job. The two Jobs have distinct names, so
+> applying the second one does not collide with the first.
 
 ### Deploy
 

--- a/recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download-fp8.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download-fp8.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Downloads the public checkpoint (deepseek-ai/DeepSeek-V4-Flash) into the
+# model-cache PVC. This is what 6 of the 8 Flash variants serve:
+# vllm/agg-h200-agentic, vllm/disagg-h200-agentic, vllm/agg_b200,
+# vllm/agg_gb200, sglang/agg, and sglang/agg-gb200.
+#
+# The -fp8 suffix mirrors the Pro family's filenames so the two families read
+# the same way; the checkpoint itself is FP4+FP8 mixed, and the README calls it
+# the public checkpoint rather than an FP8 one.
+#
+# Sibling of model-download-nvfp4.yaml — that one is the NVFP4 checkpoint for
+# the two B200 agentic variants. Apply whichever your target SKU needs, not
+# both: the PVC requests 400Gi and holds one checkpoint, not the pair.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download-fp8
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download-fp8
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download-fp8
+          image: python:3.10-slim
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: deepseek-ai/DeepSeek-V4-Flash
+            - name: HF_HOME
+              value: /model-store
+            # Default "1" = fast: XET buffers use up to ~64 GB RAM, so the Job requests "64Gi" below
+            # and must land on a node with >=64Gi allocatable RAM. On memory-constrained clusters set
+            # "0" (buffers cap ~8 GB) and lower the memory to "8Gi"/"16Gi": https://huggingface.co/docs/hub/en/xet/using-xet-storage#download-buffers
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.16.4
+              hf download --max-workers 4 "$MODEL_NAME"
+          resources:
+            requests:
+              cpu: "2"
+              memory: "64Gi"
+            limits:
+              cpu: "8"
+              memory: "64Gi"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download-nvfp4.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download-nvfp4.yaml
@@ -1,9 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Downloads the NVFP4 checkpoint (nvidia/DeepSeek-V4-Flash-NVFP4) into the
+# model-cache PVC. This is what the two B200 agentic variants serve:
+# vllm/agg-b200-agentic and vllm/disagg-b200-agentic.
+#
+# Sibling of model-download-fp8.yaml — that one is the public checkpoint for the
+# other six variants. Apply whichever your target SKU needs, not both: the PVC
+# requests 400Gi and holds one checkpoint, not the pair.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: model-download
+  name: model-download-nvfp4
 spec:
   backoffLimit: 3
   completions: 1
@@ -11,17 +19,19 @@ spec:
   template:
     metadata:
       labels:
-        app: model-download
+        app: model-download-nvfp4
     spec:
       restartPolicy: Never
       containers:
-        - name: model-download
+        - name: model-download-nvfp4
           image: python:3.10-slim
           command: ["sh", "-c"]
           envFrom:
             - secretRef:
                 name: hf-token-secret
           env:
+            - name: MODEL_NAME
+              value: nvidia/DeepSeek-V4-Flash-NVFP4
             - name: HF_HOME
               value: /model-store
             # Default "1" = fast: XET buffers use up to ~64 GB RAM, so the Job requests "64Gi" below
@@ -33,11 +43,7 @@ spec:
             - |
               set -eux
               pip install --no-cache-dir huggingface_hub==1.16.4
-              # Downloads ONE checkpoint per your SKU (the PVC in the README holds one, not both).
-              # B200 (NVFP4) is active by default; for H200, comment the NVFP4 line and uncomment
-              # the public checkpoint line instead.
-              hf download --max-workers 4 nvidia/DeepSeek-V4-Flash-NVFP4   # B200 recipes: NVFP4 experts + FP8 - default
-              # hf download --max-workers 4 deepseek-ai/DeepSeek-V4-Flash  # H200 recipes: public checkpoint
+              hf download --max-workers 4 "$MODEL_NAME"
           resources:
             requests:
               cpu: "2"

--- a/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_b200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_b200/deploy.yaml
@@ -11,7 +11,7 @@
 #        Tested on 4 of 8 GPUs per B200 node.
 #
 # Weights: served from the `model-cache` PVC populated by
-#          `../../model-cache/model-download.yaml`.
+#          `../../model-cache/model-download-fp8.yaml`.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_gb200/deploy.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # DeepSeek-V4-Flash on vLLM, aggregated, GB200 (TP=4 + EP, single NVL4 tray).
-# Weights: pre-staged on the `model-cache` PVC by `../../model-cache/model-download.yaml`.
+# Weights: pre-staged on the `model-cache` PVC by `../../model-cache/model-download-fp8.yaml`.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/recipes/deepseek-v4/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # DeepSeek-V4-Pro Recipe
 
-Serving recipes for **DeepSeek-V4-Pro** on Dynamo — a MoE model (1.6T total / 49B active) with hybrid CSA + HCA attention, a Blackwell FP4 indexer cache, and mHC residual connections. B200 recipes serve the `nvidia/DeepSeek-V4-Pro-NVFP4` checkpoint at the full **1M** context; H200 serves the public `deepseek-ai/DeepSeek-V4-Pro` (FP8), capped at `max_model_len=86016` by HBM (see [`model-cache/model-download.yaml`](model-cache/model-download.yaml)). Two families today — see [Recipes](#recipes):
+Serving recipes for **DeepSeek-V4-Pro** on Dynamo — a MoE model (1.6T total / 49B active) with hybrid CSA + HCA attention, a Blackwell FP4 indexer cache, and mHC residual connections. B200 recipes serve the `nvidia/DeepSeek-V4-Pro-NVFP4` checkpoint at the full **1M** context; H200 serves the public `deepseek-ai/DeepSeek-V4-Pro` (FP8), capped at `max_model_len=86016` by HBM (see [`model-cache/`](model-cache/)). Two families today — see [Recipes](#recipes):
 
 - **Agentic (vLLM)** — the benchmarked, workload-tuned picks (B200 & H200, AGG + disaggregated); numbers in [Performance](#performance).
 - **Day-0** — the original single-node / cross-tray aggregated + disaggregated recipes (B200/GB200, vLLM + SGLang).
@@ -76,7 +76,7 @@ Bold = recommended pick per SKU: B200 disagg wins (+6.2%); H200 AGG wins (1P3D d
    - **B200 variants** (agentic + `vllm-agg-b200`, `sglang-agg`, `sglang-disagg-b200`): **8 B200 GPUs per worker** (TP=8 fills the box, x86_64). Totals: **AGG `agg-b200-agentic` = 8** (1 node); **DisAgg `disagg-b200-agentic` (1P1D) = 16** (1 prefill + 1 decode pod, across 2 nodes).
    - **H200 variants**: **8 H200 GPUs per worker** (public FP8 checkpoint, `max_model_len=86016`). Totals: **AGG `agg-h200-agentic` = 8** (1 node — the recommended H200 pick); **DisAgg `disagg-h200-agentic` (1P3D) = 32** (1 prefill + 3 decode pods, across 4 nodes).
    - **GB200 variants** (`vllm-agg-gb200`, `vllm-disagg-gb200`, `sglang-agg-gb200`, `sglang-disagg-gb200`): **2 GB200 nodes per worker**, each 4 GPUs (one NVL4 tray), on the **same NVLink72 clique**. Label `nvidia.com/gpu.product=NVIDIA-GB200`, taint `kubernetes.io/arch=arm64:NoSchedule`, and install the **DRA / ComputeDomain controller** (`kubectl get crd | grep computedomain`) — each manifest's `ComputeDomain` CR + `resourceClaims` co-locate the pod set on one NVLink72 fabric.
-3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V4-Pro`.
+3. **HuggingFace token** with access to the checkpoint your variant serves — `deepseek-ai/DeepSeek-V4-Pro` (public FP8) for the H200, GB200, Day-0 B200, and SGLang variants, or `nvidia/DeepSeek-V4-Pro-NVFP4` for the two agentic B200 variants (`vllm/agg-b200-agentic`, `vllm/disagg-b200-agentic`).
 
 ## Quick Start
 
@@ -91,14 +91,36 @@ kubectl create secret generic hf-token-secret \
   --from-literal=HF_TOKEN="your-token-here" \
   -n ${NAMESPACE}
 
-# Download model into the model-cache PVC.
+# Storage for the checkpoint.
 # Edit model-cache/model-cache.yaml and set storageClassName to a RWX class in your cluster.
 # The PVC requests 1500Gi; DeepSeek-V4-Pro is ~865 GB on disk (64 safetensors shards,
 # FP4+FP8 mixed) and typically takes 1.5-3 hours to download on first apply.
 kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
-kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
-kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=14400s
 ```
+
+Then download **the checkpoint your variant serves**. Each checkpoint is ~865 GB and the PVC holds
+one, not both, so there is one download Job per checkpoint. Apply the one your target SKU needs:
+
+```bash
+# H200 agentic, GB200, Day-0 B200, and all SGLang variants — public FP8 (9 of the 11 variants):
+kubectl apply -f model-cache/model-download-fp8.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download-fp8 -n ${NAMESPACE} --timeout=14400s
+```
+
+```bash
+# vllm/agg-b200-agentic and vllm/disagg-b200-agentic only — NVFP4:
+kubectl apply -f model-cache/model-download-nvfp4.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download-nvfp4 -n ${NAMESPACE} --timeout=14400s
+```
+
+> [!IMPORTANT]
+> The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetch a checkpoint the
+> Job did not download. Downloading the wrong one leaves the worker unable to start.
+
+> [!NOTE]
+> To switch a populated PVC to the other checkpoint: stop the workers, delete the PVC, re-apply
+> `model-cache/model-cache.yaml`, then apply the other Job. The two Jobs have distinct names, so
+> applying the second one does not collide with the first.
 
 ### Deploy
 

--- a/recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download-fp8.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download-fp8.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Downloads the public FP8 checkpoint (deepseek-ai/DeepSeek-V4-Pro) into the
+# model-cache PVC. This is what 9 of the 11 Pro variants serve:
+# vllm/agg-h200-agentic, vllm/disagg-h200-agentic, vllm/agg/b200,
+# vllm/agg/gb200, vllm/disagg/gb200, and all four SGLang variants.
+#
+# Sibling of model-download-nvfp4.yaml — that one is the NVFP4 checkpoint for
+# the two B200 agentic variants. Apply whichever your target SKU needs, not
+# both: each checkpoint is ~865 GB and the PVC requests 1500Gi, so the PVC holds
+# one of them, not the pair.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download-fp8
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download-fp8
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download-fp8
+          image: python:3.10-slim
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: deepseek-ai/DeepSeek-V4-Pro
+            - name: HF_HOME
+              value: /model-store
+            # Default "1" = fast: XET buffers use up to ~64 GB RAM, so the Job requests "64Gi" below
+            # and must land on a node with >=64Gi allocatable RAM. On memory-constrained clusters set
+            # "0" (buffers cap ~8 GB) and lower the memory to "8Gi"/"16Gi": https://huggingface.co/docs/hub/en/xet/using-xet-storage#download-buffers
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.16.4
+              hf download --max-workers 4 "$MODEL_NAME"
+          resources:
+            requests:
+              cpu: "2"
+              memory: "64Gi"
+            limits:
+              cpu: "8"
+              memory: "64Gi"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download-nvfp4.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download-nvfp4.yaml
@@ -1,9 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Downloads the NVFP4 checkpoint (nvidia/DeepSeek-V4-Pro-NVFP4) into the
+# model-cache PVC. This is what the two B200 agentic variants serve:
+# vllm/agg-b200-agentic and vllm/disagg-b200-agentic.
+#
+# Sibling of model-download-fp8.yaml — that one is the public FP8 checkpoint for
+# the other nine variants. Apply whichever your target SKU needs, not both: each
+# checkpoint is ~865 GB and the PVC requests 1500Gi, so the PVC holds one of
+# them, not the pair.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: model-download
+  name: model-download-nvfp4
 spec:
   backoffLimit: 3
   completions: 1
@@ -11,17 +20,19 @@ spec:
   template:
     metadata:
       labels:
-        app: model-download
+        app: model-download-nvfp4
     spec:
       restartPolicy: Never
       containers:
-        - name: model-download
+        - name: model-download-nvfp4
           image: python:3.10-slim
           command: ["sh", "-c"]
           envFrom:
             - secretRef:
                 name: hf-token-secret
           env:
+            - name: MODEL_NAME
+              value: nvidia/DeepSeek-V4-Pro-NVFP4
             - name: HF_HOME
               value: /model-store
             # Default "1" = fast: XET buffers use up to ~64 GB RAM, so the Job requests "64Gi" below
@@ -33,11 +44,7 @@ spec:
             - |
               set -eux
               pip install --no-cache-dir huggingface_hub==1.16.4
-              # Downloads ONE checkpoint per your SKU (each is ~865 GB; the PVC in the README
-              # holds one, not both). B200 (NVFP4) is active by default; for H200, comment the
-              # NVFP4 line and uncomment the public FP8 line instead.
-              hf download --max-workers 4 nvidia/DeepSeek-V4-Pro-NVFP4   # B200 recipes (NVFP4) - default
-              # hf download --max-workers 4 deepseek-ai/DeepSeek-V4-Pro  # H200 recipes (public FP8)
+              hf download --max-workers 4 "$MODEL_NAME"
           resources:
             requests:
               cpu: "2"

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml
@@ -17,7 +17,7 @@
 #
 # Shape: 1 replica x 8 GPUs, TP=8 + Expert Parallel. Fills a single 8-GPU node.
 # Weights: served from the `model-cache` PVC populated by
-#          `../../model-cache/model-download.yaml`.
+#          `../../model-cache/model-download-fp8.yaml`.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/gb200/deploy.yaml
@@ -11,7 +11,7 @@
 # NVLink72 (MNNVL) via ComputeDomain, not RoCE/IB.
 #
 # Prerequisites: DRA / ComputeDomain controller installed cluster-wide.
-# Weights: served from the `model-cache` PVC (see ../../model-cache/model-download.yaml).
+# Weights: served from the `model-cache` PVC (see ../../model-cache/model-download-fp8.yaml).
 ---
 apiVersion: resource.nvidia.com/v1beta1
 kind: ComputeDomain

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/deploy.yaml
@@ -11,7 +11,7 @@
 # control plane goes over TCP (eth0); bulk KV flows over MNNVL/cuda_ipc.
 #
 # Prerequisites: DRA / ComputeDomain controller installed cluster-wide.
-# Weights: served from the `model-cache` PVC (see ../../model-cache/model-download.yaml).
+# Weights: served from the `model-cache` PVC (see ../../model-cache/model-download-fp8.yaml).
 ---
 apiVersion: resource.nvidia.com/v1beta1
 kind: ComputeDomain


### PR DESCRIPTION
Cherry-pick of #13034 (merged to `main` as 1278ebe) onto `release/1.4.0`.

The DeepSeek-V4 recipes shared one model-download Job per family, so an H200 deployment pulled the B200 NVFP4 checkpoint. The download is now split into `model-download-fp8.yaml` and `model-download-nvfp4.yaml` and each deploy references the one it needs.

The content changes are byte-identical to the main-side diff. The two `.mdx` files land under `docs/fern/recipes/` here rather than `docs/fern/pages/recipes/model-recipes/`, because the release branch still carries the pre-restructure docs tree; git resolved the rename and the file contents match exactly.

Closes P0 6571929 for 1.4.0.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->