### PR TITLE
feat(recipes): add model-agnostic accuracy check example (cherry-pick #12495)

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -105,6 +105,11 @@ Each complete recipe follows this standard structure:
         └── perf.yaml (optional)  # AIPerf benchmark job
 ```
 
+In addition, [`accuracy/`](accuracy/) is a shared, model-agnostic accuracy
+check (deliberately outside the per-model structure above): point it at any
+deployed recipe to compare the served model's benchmark score against its
+model card. See [`accuracy/README.md`](accuracy/README.md).
+
 ## Quick Start
 
 ### Prerequisites

--- a/recipes/accuracy/README.md
+++ b/recipes/accuracy/README.md
@@ -1,0 +1,115 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Accuracy Check
+
+A model-agnostic accuracy check for any deployed recipe: `accuracy.yaml` runs a
+public benchmark against a live Dynamo endpoint with [AIPerf](https://github.com/ai-dynamo/aiperf)
+and grades the answers.
+
+AIPerf ships graders for a range of benchmarks, among them MMLU and MMLU-Pro,
+GSM8K, MATH-500, AIME, GPQA-Diamond, HellaSwag, BIG-Bench Hard, and
+LiveCodeBench. The example defaults to GPQA-Diamond; see
+[Accuracy Benchmarking](https://github.com/ai-dynamo/aiperf/blob/main/docs/accuracy/accuracy-benchmarking.md)
+for the full list, each one's dataset and default few-shot setting, and the
+benchmark-specific flags (chain-of-thought prompting, for instance).
+
+Accuracy is usually evaluated alongside throughput and latency when validating a
+deployment, to confirm the deployed configuration performs in line with the
+checkpoint's published results.
+
+Read the result as an **A/B test**, not an absolute capability claim: A is the
+score measured through your deployment, B is the checkpoint's published
+model-card number for the same benchmark.
+
+## How it works
+
+1. The Job waits for the target deployment to advertise the model on
+   `/v1/models`, then runs `aiperf profile --accuracy-benchmark <benchmark>`:
+   the benchmark's questions are sent as ordinary chat requests through the
+   full serving path.
+2. AIPerf grades each response against ground truth. Responses it cannot parse
+   an answer out of are counted wrong but reported separately as `unparsed`. A
+   nonzero unparsed count means formatting or truncation problems rather than
+   wrong answers, and should be investigated before trusting the score.
+3. The scored summary prints to the Job log and is written to
+   `/model-cache/accuracy/<epoch>_<job-name>/accuracy_results.csv` on the
+   model-cache PVC (the same layout the perf benchmarks use).
+
+## Run
+
+Point the Job at a deployed recipe by editing the `CONFIGURE` block at the top
+of its env list, then apply it:
+
+| Variable | Set it to |
+|---|---|
+| `ENDPOINT` | Frontend service of the deployed DGD, e.g. `<deployment>-frontend:8000` |
+| `TARGET_MODEL` | Model ID exactly as the deployment advertises it on `/v1/models`; it also fetches the tokenizer, so it must resolve on Hugging Face |
+| `BENCHMARK` | Benchmark to run. See [available benchmarks](https://github.com/ai-dynamo/aiperf/blob/main/docs/accuracy/accuracy-benchmarking.md#available-benchmarks) |
+| `NUM_REQUESTS` | The benchmark's full dataset size, so the score is comparable to a published number |
+| `TEMPERATURE`, `TOP_P`, `MAX_TOKENS` | Match the sampling of the model card being compared against |
+
+```bash
+# accuracy-check is a fixed-name Job; clear any prior run before re-applying
+# (for example when switching ENDPOINT to a different target).
+kubectl delete job accuracy-check -n $NAMESPACE --ignore-not-found
+kubectl apply -f accuracy.yaml -n $NAMESPACE
+kubectl logs -f job/accuracy-check -n $NAMESPACE
+```
+
+## Reading the result
+
+Compare the score to the checkpoint's model card, not to a fixed threshold, and
+compare the general range rather than exact decimals:
+
+- **Match the sampling.** Scores are only comparable when temperature, top_p,
+  and token limits match the methodology the baseline was measured under. If a
+  card publishes numbers for several quantizations, compare against the one the
+  recipe actually serves.
+- **Harnesses differ.** Different evaluation tools produce slightly different
+  scores for the same model on the same benchmark, so a small offset from a
+  published number is not by itself a defect.
+- **One run is not a measurement.** On a few-hundred-question benchmark at
+  nonzero temperature, two runs of the same deployment will differ by a few
+  answers, which is a few points of score. When a difference matters (comparing
+  two serving modes, or deciding whether a gap from the model card is real), run
+  it more than once and look at the spread rather than trusting a single number.
+- **Check `unparsed` first.** A nonzero unparsed count usually means responses
+  are being truncated. Raise `MAX_TOKENS` and re-run before reading anything
+  into the score.
+
+## Requirements and caveats
+
+- **Remove perf-only synthetic settings from the deployment first.** Some
+  recipes pin a simulated speculative-decode acceptance length for performance
+  benchmarking (on SGLang, the `SGLANG_SIMULATE_ACC_*` environment variables).
+  Those bypass real draft-token verification, so the outputs are not
+  representative. Accuracy must be measured with verification on.
+- The `hf-token-secret` is optional: the Job starts without it, and it is only
+  needed for gated models or datasets. For a gated benchmark (GPQA-Diamond, for
+  example) the token must have accepted the dataset's terms.
+- The Job mounts a `model-cache` PVC for the tokenizer, dataset, and results.
+  Most recipes create one under that name; if the recipe under test uses a
+  different one, update `claimName` in the manifest, or the pod sits `Pending`
+  with no other symptom.
+- **Give reasoning models generous `MAX_TOKENS`.** Reasoning chains can run to
+  tens of thousands of tokens; a low cap truncates them mid-thought and
+  deflates the score through unparsed answers.
+- **Check the time budget before a long run.** `activeDeadlineSeconds` bounds
+  the entire Job, including the readiness wait and any retry. Runtime scales
+  with the request count and per-request latency: a 198-question benchmark
+  against a large reasoning model takes hours, and a larger benchmark scales
+  from there. If the budget is exceeded the pod is killed mid-run and no score
+  is printed, which looks like a failure rather than a timeout. Raising
+  `CONCURRENCY` shortens the run — it sets how many requests are in flight, not
+  what is asked — so it is the first lever to reach for before extending the
+  deadline.
+- Replica counts do not affect accuracy (it is per-request), so a minimal
+  1-replica deployment is sufficient and cheapest.
+- AIPerf prints an advisory recommending temperature 0 for reproducibility.
+  Matching the model card's sampling takes precedence, since that is what makes
+  the comparison valid.
+- This is not a perf benchmark. Use the recipe's `perf.yaml` for
+  throughput and latency.

--- a/recipes/accuracy/accuracy.yaml
+++ b/recipes/accuracy/accuracy.yaml
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Model-agnostic AIPerf accuracy check for a deployed Dynamo recipe.
+#
+# NOT a perf benchmark: sends a public benchmark's questions as ordinary chat
+# requests through the deployment and grades the answers, so the score
+# reflects the whole serving path. Compare the result against the checkpoint's
+# published model-card number for the same benchmark — see README.md.
+#
+# To use this with a recipe, edit the CONFIGURE block below (ENDPOINT,
+# TARGET_MODEL, BENCHMARK, NUM_REQUESTS, and the sampling parameters).
+# Nothing else needs to change.
+#
+# Prerequisites:
+# - Target DGD is Ready; a 1-replica deployment suffices (accuracy is
+#   per-request and independent of replica count)
+# - The deployment carries no perf-only synthetic settings that bypass real
+#   speculative-decode verification (on SGLang, SGLANG_SIMULATE_ACC_*)
+# - hf-token-secret carries a token that has accepted the benchmark dataset's
+#   terms, if it is gated
+# - A model-cache PVC exists in the namespace for the tokenizer, dataset, and
+#   results. Most recipes create one named model-cache; if yours uses another
+#   name, update claimName at the bottom of this file
+#
+# Results: /model-cache/accuracy/<epoch>_<job-name>/
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: accuracy-check
+spec:
+  backoffLimit: 1
+  # Bounds the whole Job, including the readiness wait and any retry. Runtime
+  # scales with the request count and per-request latency, and falls as
+  # CONCURRENCY rises: a 198-question run against a large reasoning model at
+  # concurrency 10 took ~3.7h, while a full MMLU run is ~70x the requests.
+  # Raise this (or CONCURRENCY) for larger benchmarks and slower models, or the
+  # pod is killed mid-run with no results.
+  activeDeadlineSeconds: 28800
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: accuracy-check
+    spec:
+      # Optional: co-locate the eval pod with the target DGD frontend for
+      # network locality. Preferred, not required — frontends often land on
+      # busy shared CPU nodes with no headroom for the eval pod's requests.
+      # Uncomment and set the deployment name to match your ENDPOINT.
+      #
+      # affinity:
+      #   podAffinity:
+      #     preferredDuringSchedulingIgnoredDuringExecution:
+      #     - weight: 100
+      #       podAffinityTerm:
+      #         labelSelector:
+      #           matchExpressions:
+      #           - key: nvidia.com/dynamo-component-type
+      #             operator: In
+      #             values:
+      #             - frontend
+      #           - key: nvidia.com/dynamo-graph-deployment-name
+      #             operator: In
+      #             values:
+      #             - <your-dgd-name>
+      #         topologyKey: kubernetes.io/hostname
+      #
+      # tolerations: # Uncomment and populate for tainted frontend nodes.
+      containers:
+      - name: accuracy
+        # python + pip rather than the NGC aiperf image: the accuracy graders
+        # require the aiperf [accuracy] extras, which the runtime image does
+        # not ship.
+        image: python:3.12-slim
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          export COLUMNS=200
+          # aiperf depends on crick, which has no Linux aarch64 wheel. ARM
+          # benchmark pods need build tools to compile it from source.
+          apt-get update && apt-get install -y --no-install-recommends build-essential && apt-get clean
+          pip install --no-cache-dir "aiperf[accuracy]==0.12.0" > /dev/null
+          EPOCH=$(date +%s)
+
+          wait_for_model_ready() {
+            python3 - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.request
+
+          endpoint = os.environ["ENDPOINT"]
+          model = os.environ["TARGET_MODEL"]
+          max_attempts = int(os.environ.get("WAIT_FOR_MODEL_MAX_ATTEMPTS", "720"))
+          url = f"http://{endpoint}/v1/models"
+
+          print(f"Waiting for model '{model}' at {url} (max {max_attempts} attempts) ...")
+          for attempt in range(1, max_attempts + 1):
+              try:
+                  with urllib.request.urlopen(url, timeout=5) as response:
+                      payload = json.load(response)
+                  if any(item.get("id") == model for item in payload.get("data", [])):
+                      print(json.dumps(payload, indent=2))
+                      raise SystemExit(0)
+              except Exception:
+                  pass
+
+              if attempt == max_attempts:
+                  break
+              timestamp = time.strftime("%H:%M:%S")
+              print(f"[{timestamp}] not ready (attempt {attempt}/{max_attempts}), sleeping 5s")
+              time.sleep(5)
+
+          raise SystemExit(
+              f"model '{model}' did not become ready after {max_attempts} attempts"
+          )
+          PY
+          }
+
+          wait_for_model_ready
+          RUN_DIR="${ROOT_ARTIFACT_DIR}/${EPOCH}_${JOB_NAME}"
+          mkdir -p "$RUN_DIR"
+          echo "=============================================="
+          echo "Accuracy Check (aiperf): ${BENCHMARK}"
+          echo "=============================================="
+          echo "Endpoint:     http://${ENDPOINT}"
+          echo "Model:        ${TARGET_MODEL}"
+          echo "Sampling:     temperature=${TEMPERATURE} top_p=${TOP_P} max_tokens=${MAX_TOKENS}"
+          echo "Artifact dir: ${RUN_DIR}"
+          echo "=============================================="
+
+          # NOTE: --tokenizer-trust-remote-code executes tokenizer code from
+          # the TARGET_MODEL repo; some checkpoints require it to load. Only
+          # point TARGET_MODEL at repos you trust.
+          aiperf profile \
+            -m "$TARGET_MODEL" \
+            --tokenizer "$TARGET_MODEL" \
+            --tokenizer-trust-remote-code \
+            --url "http://$ENDPOINT" \
+            --endpoint-type chat \
+            --accuracy-benchmark "$BENCHMARK" \
+            --num-requests "$NUM_REQUESTS" \
+            --concurrency "$CONCURRENCY" \
+            --extra-inputs temperature:"$TEMPERATURE" \
+            --extra-inputs top_p:"$TOP_P" \
+            --extra-inputs max_tokens:"$MAX_TOKENS" \
+            --extra-inputs max_completion_tokens:"$MAX_TOKENS" \
+            --request-timeout-seconds 3600 \
+            --random-seed 42 \
+            --ui simple \
+            --artifact-dir "$RUN_DIR"
+          echo ""
+          echo "===== ACCURACY RESULTS ====="
+          cat "$RUN_DIR"/accuracy_results.csv
+          echo "Done. Artifacts: ${RUN_DIR}"
+        env:
+        # ---------------------------------------------------------------
+        # CONFIGURE — the only values that change per recipe / per run.
+        # ---------------------------------------------------------------
+        # Frontend service of the deployed DGD to evaluate.
+        - name: ENDPOINT
+          value: <your-frontend-service>:8000
+        # Model ID exactly as the deployment advertises it on /v1/models. It is
+        # also used to fetch the tokenizer, so it must resolve on Hugging Face.
+        - name: TARGET_MODEL
+          value: <org/model-id>
+        # Benchmark to run, by its CLI name: mmlu, mmlu_pro, gsm8k, math_500,
+        # gpqa_diamond, hellaswag, bigbench (BIG-Bench Hard), lcb_codegeneration
+        # (LiveCodeBench), or one of three AIME variants — aime (2024, 8-shot),
+        # aime24 (2024, 0-shot, matches most published trt-llm/lighteval
+        # numbers), aime25 (2025, 0-shot). Full list:
+        # https://github.com/ai-dynamo/aiperf/blob/main/docs/accuracy/accuracy-benchmarking.md
+        - name: BENCHMARK
+          value: gpqa_diamond
+        # Number of questions to send. Use the benchmark's full dataset size
+        # so the score is comparable to a published model-card number
+        # (GPQA-Diamond, for example, has 198 questions).
+        - name: NUM_REQUESTS
+          value: "198"
+        # Sampling must match the methodology of the model card being compared
+        # against — scores are only comparable under matched sampling. A
+        # generous MAX_TOKENS matters for reasoning models: truncated chains
+        # grade as unparsed and deflate the score.
+        - name: TEMPERATURE
+          value: "1.0"
+        - name: TOP_P
+          value: "0.95"
+        - name: MAX_TOKENS
+          value: "100000"
+        # ---------------------------------------------------------------
+        # The remainder rarely needs changing.
+        # ---------------------------------------------------------------
+        # In-flight requests. Unlike a perf benchmark, where concurrency is the
+        # variable under test, here it mainly sets how long the run takes:
+        # raise it to finish sooner, bounded by what the deployment can serve.
+        - name: CONCURRENCY
+          value: "10"
+        # Readiness poll: attempts x 5s sleep = max wait for the model to
+        # appear on /v1/models before the Job fails (720 = 1 hour).
+        - name: WAIT_FOR_MODEL_MAX_ATTEMPTS
+          value: "720"
+        - name: AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT
+          value: "3600"
+        - name: AIPERF_DATASET_CONFIGURATION_TIMEOUT
+          value: "3600"
+        - name: JOB_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['job-name']
+        - name: ROOT_ARTIFACT_DIR
+          value: /model-cache/accuracy
+        - name: HF_HOME
+          value: /model-cache
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        envFrom:
+        # Only needed for gated models/datasets; optional so the pod still
+        # starts when the secret is absent.
+        - secretRef:
+            name: hf-token-secret
+            optional: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: 8Gi
+          limits:
+            cpu: "16"
+            memory: 64Gi
+        volumeMounts:
+        - name: model-cache
+          mountPath: /model-cache
+      restartPolicy: Never
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache


### PR DESCRIPTION
Cherry-pick of #12495 (merged to `main` as baeec47) onto `release/1.4.0`.

Adds a model-agnostic accuracy check recipe: a Job that waits on `/v1/models`, then runs `aiperf profile --accuracy-benchmark` against a live endpoint.

Additive only, 373 insertions and no deletions across three files: `recipes/README.md`, `recipes/accuracy/README.md`, and `recipes/accuracy/accuracy.yaml`. It adds no code to any runtime path, so it cannot affect a shipping component.

Picked clean; the content changes are byte-identical to the main-side diff.

Requested for 1.4.0 by the author.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->