### PR TITLE
test(compliance): greedy decoding + larger output budget for the OpenResponses suite

### DIFF
--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -75,12 +75,13 @@ BUN_VERSION = "1.3.12"
 NODE_VERSION = "20.19.0"
 OPENRESPONSES_REPO = "https://github.com/openresponses/openresponses.git"
 OPENRESPONSES_SHA = "fa29df5"
-# 2048, not 512: the compliance worker runs a qwen3-style *reasoning* model,
-# and its <think> tokens count against max_output_tokens. At 512 the "System
-# Prompt" case can exhaust the budget mid-think and return
-# status=incomplete/{"reason": "max_output_tokens"} — an assertion failure
-# that has nothing to do with API compliance. 2048 keeps the worst-case
-# response under a minute while leaving thinking headroom.
+# 2048, not 512: when the small compliance model has a bad sampling day it
+# can ramble to whatever cap is set and come back status=incomplete /
+# {"reason": "max_output_tokens"} — an assertion failure that has nothing to
+# do with API compliance (observed on the "System Prompt" case). The real
+# de-flaking is the temperature=0 default injected below; the larger cap is
+# headroom so a long-but-terminating greedy answer still completes. Worst
+# case stays under a minute per response.
 OPENRESPONSES_MAX_OUTPUT_TOKENS = 2048
 CLAUDE_SUBAGENT_NAME = "dynamo-subagent-smoke"
 CLAUDE_SUBAGENT_TIMEOUT_S = 45
@@ -342,6 +343,11 @@ def _patch_openresponses_suite(install_dir: Path) -> None:
         "      ...body,\n"
         "      max_output_tokens: body.max_output_tokens ?? "
         f"{OPENRESPONSES_MAX_OUTPUT_TOKENS},\n"
+        # Greedy decoding unless a case asks otherwise: the suite asserts API
+        # behavior, not model creativity, and sampled runs of the small
+        # compliance model can degenerate into repetition loops that blow the
+        # token cap and fail completedStatus for reasons unrelated to the API.
+        "      temperature: body.temperature ?? 0,\n"
         "      stream: streaming,\n"
         "    }),"
     )

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -75,7 +75,13 @@ BUN_VERSION = "1.3.12"
 NODE_VERSION = "20.19.0"
 OPENRESPONSES_REPO = "https://github.com/openresponses/openresponses.git"
 OPENRESPONSES_SHA = "fa29df5"
-OPENRESPONSES_MAX_OUTPUT_TOKENS = 512
+# 2048, not 512: the compliance worker runs a qwen3-style *reasoning* model,
+# and its <think> tokens count against max_output_tokens. At 512 the "System
+# Prompt" case can exhaust the budget mid-think and return
+# status=incomplete/{"reason": "max_output_tokens"} — an assertion failure
+# that has nothing to do with API compliance. 2048 keeps the worst-case
+# response under a minute while leaving thinking headroom.
+OPENRESPONSES_MAX_OUTPUT_TOKENS = 2048
 CLAUDE_SUBAGENT_NAME = "dynamo-subagent-smoke"
 CLAUDE_SUBAGENT_TIMEOUT_S = 45
 OPENCODE_SUBTASK_COMMAND = "dynamo-subagent-smoke"


### PR DESCRIPTION
## What

Two changes to the OpenResponses suite patch in `tests/frontend/test_frontend_api_surface_compliance.py`:

1. Inject `temperature: body.temperature ?? 0` into every suite request — same `JSON.stringify` patch that already injects the `max_output_tokens` default. Cases that set their own temperature keep it.
2. `OPENRESPONSES_MAX_OUTPUT_TOKENS` 512 → 2048.

## Why

The compliance suite asserts **API behavior**, but with default sampling its verdicts depend on model mood. We captured the "System Prompt" case failing with:

```
"status": "incomplete",
"incomplete_details": { "reason": "max_output_tokens" }
```

The response text starts as a sane answer, decays into word salad, and ends in a literal repetition loop until it hits the token cap — a sampling-degeneration artifact of the small compliance model, nothing to do with API compliance. Raising the budget alone does not fix this class of failure: a degenerate generation rambles to whatever cap is set (we verified 2048 alone still fails the same way).

With `temperature: 0` the same request completes deterministically (3/3 replays, 71 output tokens). Greedy decoding makes the suite's verdicts reproducible on any hardware; the larger cap is headroom so a long-but-terminating answer still completes (worst case stays well inside the suite's per-step time budget).

## Verification

With both changes the full OpenResponses suite passes 6/6 in repeated runs, including the previously failing "System Prompt" case; the other five cases are unaffected by greedy decoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated OpenResponses compliance checks to support responses of up to 2,048 output tokens.
  * Standardized generated test requests to use a temperature of 0 when no value is provided.
  * Retained validation for streaming behavior and output-token settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->