### PR TITLE
docs(rust): fix rustdoc lint warnings surfaced by cargo doc --no-deps

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/envoy_helpers.rs
+++ b/deploy/inference-gateway/ext-proc/src/envoy_helpers.rs
@@ -16,7 +16,7 @@ use crate::proto::envoy::service::ext_proc::v3::{
 use crate::proto::envoy::r#type::v3::{HttpStatus, StatusCode};
 
 /// EPP protocol constants from proposal 004-endpoint-picker-protocol.
-/// These match both the full EPP and the LW-EPP from GAIE (issue #2834[https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2834]).
+/// These match both the full EPP and the LW-EPP from GAIE (issue #2834 <https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2834>).
 pub mod metadata {
     pub const SUBSET_FILTER_NAMESPACE: &str = "envoy.lb.subset_hint";
     pub const SUBSET_FILTER_KEY: &str = "x-gateway-destination-endpoint-subset";

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -531,10 +531,10 @@ pub struct MetricsCtx<'a> {
     pub metrics: &'a crate::metrics::EngineMetrics,
 }
 
-/// Invoked once with a freshly-built [`SnapshotPublisher`]; engine drives
+/// Invoked once with a freshly-built [`SnapshotPublisher`](crate::SnapshotPublisher); engine drives
 /// `publish(rank, snapshot)` from its own stat-logger threads thereafter.
 ///
-/// Mirror of [`OnPublisherReady`] for the KV-event Push flavor — same
+/// Mirror of `OnPublisherReady` for the KV-event Push flavor — same
 /// "framework constructs, engine writes" handoff pattern.
 pub type OnSnapshotPublisherReady = Box<
     dyn FnOnce(Arc<crate::snapshot_publisher::SnapshotPublisher>) -> Result<(), DynamoError>

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -534,7 +534,7 @@ pub struct MetricsCtx<'a> {
 /// Invoked once with a freshly-built [`SnapshotPublisher`](crate::SnapshotPublisher); engine drives
 /// `publish(rank, snapshot)` from its own stat-logger threads thereafter.
 ///
-/// Mirror of `OnPublisherReady` for the KV-event Push flavor — same
+/// Mirror of [`OnPublisherReady`] for the KV-event Push flavor — same
 /// "framework constructs, engine writes" handoff pattern.
 pub type OnSnapshotPublisherReady = Box<
     dyn FnOnce(Arc<crate::snapshot_publisher::SnapshotPublisher>) -> Result<(), DynamoError>

--- a/lib/backend-common/src/lib.rs
+++ b/lib/backend-common/src/lib.rs
@@ -4,7 +4,7 @@
 //! Shared runtime glue for Rust LLM backends.
 //!
 //! Two-type abstraction: [`LLMEngine`] (the engine trait an author implements)
-//! and [`Worker`] (the runtime lifecycle owner), plus a [`run`] helper called
+//! and [`Worker`] (the runtime lifecycle owner), plus a [`run()`] helper called
 //! from each backend's `main.rs`.
 //!
 //! Engines work directly with [`PreprocessedRequest`] and [`LLMEngineOutput`]

--- a/lib/backend-common/src/metrics.rs
+++ b/lib/backend-common/src/metrics.rs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! [`EngineMetrics`] — slim metrics-only handle for [`LLMEngine`] authors,
+//! [`EngineMetrics`] — slim metrics-only handle for `LLMEngine` authors,
 //! plus [`LifecycleGauges`] — framework-owned gauges emitted independently
 //! of engine opt-in (cleanup_time, drain_time, model_load_time).
 //!
 //! `Worker` constructs an `EngineMetrics` from the endpoint's
 //! [`MetricsHierarchy`] and hands it to the engine via
-//! [`LLMEngine::setup_metrics`]. Engines never see the full `Endpoint` —
+//! `LLMEngine::setup_metrics`. Engines never see the full `Endpoint` —
 //! only the surface needed to bridge a foreign registry into the runtime's
 //! `/metrics` output via [`EngineMetrics::add_expfmt_callback`].
 
@@ -21,7 +21,7 @@ use dynamo_runtime::metrics::{
 use crate::engine::EngineConfig;
 use crate::error::{BackendError, DynamoError, ErrorType};
 
-/// Metrics handle passed to [`LLMEngine::setup_metrics`].
+/// Metrics handle passed to `LLMEngine::setup_metrics`.
 /// Not `Clone` — engines should retain returned instruments, not this object.
 pub struct EngineMetrics {
     hierarchy: Arc<dyn MetricsHierarchy>,

--- a/lib/backend-common/src/metrics.rs
+++ b/lib/backend-common/src/metrics.rs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! [`EngineMetrics`] — slim metrics-only handle for `LLMEngine` authors,
+//! [`EngineMetrics`] — slim metrics-only handle for [`LLMEngine`](crate::LLMEngine) authors,
 //! plus [`LifecycleGauges`] — framework-owned gauges emitted independently
 //! of engine opt-in (cleanup_time, drain_time, model_load_time).
 //!
 //! `Worker` constructs an `EngineMetrics` from the endpoint's
 //! [`MetricsHierarchy`] and hands it to the engine via
-//! `LLMEngine::setup_metrics`. Engines never see the full `Endpoint` —
+//! [`LLMEngine::setup_metrics`](crate::LLMEngine::setup_metrics). Engines never see the full `Endpoint` —
 //! only the surface needed to bridge a foreign registry into the runtime's
 //! `/metrics` output via [`EngineMetrics::add_expfmt_callback`].
 
@@ -21,7 +21,7 @@ use dynamo_runtime::metrics::{
 use crate::engine::EngineConfig;
 use crate::error::{BackendError, DynamoError, ErrorType};
 
-/// Metrics handle passed to `LLMEngine::setup_metrics`.
+/// Metrics handle passed to [`LLMEngine::setup_metrics`](crate::LLMEngine::setup_metrics).
 /// Not `Clone` — engines should retain returned instruments, not this object.
 pub struct EngineMetrics {
     hierarchy: Arc<dyn MetricsHierarchy>,

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -68,7 +68,7 @@ const MODEL_TAINT_UPDATE_ROUTE: &str = "update/model_taints";
 /// distributed runtime is constructed.
 ///
 /// `dynamo-runtime` reads these from environment variables in
-/// [`DistributedConfig::from_settings`]. We mirror that by setting them
+/// `DistributedConfig::from_settings`. We mirror that by setting them
 /// here before [`Runtime::from_settings`] runs, so a programmatic caller
 /// can override per-process values without poking `std::env::set_var`
 /// from user code.

--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -100,7 +100,7 @@ struct StoreRouteDecision {
     skip_backend: bool,
 }
 
-/// Branch-sharded wrapper over N [`AsyncShardHandle`] shard backends.
+/// Branch-sharded wrapper over N `AsyncShardHandle` shard backends.
 ///
 /// For the common in-process case use `BranchShardedIndexer<ThreadPoolIndexer<T>>`
 /// (constructed via [`BranchShardedIndexer::new`]).  For the multi-process

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -795,7 +795,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
     /// will log a warning but not return an error (double free is allowed).
     ///
     /// This also performs the underlying prefill-complete cleanup via
-    /// [`ActiveSequences::free`], so callers do not need to call
+    /// `ActiveSequences::free`, so callers do not need to call
     /// [`Self::mark_prefill_completed`] before freeing a completed request.
     pub fn free(&self, request_id: &RequestId, decay_now: Instant) -> Result<(), SequenceError> {
         match self.mutate_request_worker_prompt_state(

--- a/lib/kv-router/src/services/indexer/mod.rs
+++ b/lib/kv-router/src/services/indexer/mod.rs
@@ -24,7 +24,7 @@
 //!   `disk`, per-`dp_rank` device counts, and `longest_matched`.
 //!
 //! The `instances` shape is intended to align with Mooncake's
-//! "[RFC]: KV-Store Indexer API Standardization"
+//! "\[RFC\]: KV-Store Indexer API Standardization"
 //! (<https://github.com/kvcache-ai/Mooncake/issues/1403>).
 //! Tier counts are CUMULATIVE through each tier's walk — see the doc on the
 //! response struct in [`server`] for the exact semantics.

--- a/lib/kvbm-consolidator/src/hash.rs
+++ b/lib/kvbm-consolidator/src/hash.rs
@@ -7,7 +7,7 @@
 //! The router expects a u64 per block-edge. The 128-bit PLH packs `(mode | position |
 //! parent_fragment | current_fragment)`. The u64 the router consumes is what a *child*
 //! at `position+1` would see as its `parent_hash_fragment` — produced by
-//! [`PositionalLineageHash::parent_fragment_for_child_position`], which handles the
+//! `PositionalLineageHash::parent_fragment_for_child_position`, which handles the
 //! 0→1 (pos 256) and 1→2 (pos 65536) mode-boundary alignments.
 
 use kvbm_logical::SequenceHash;

--- a/lib/kvbm-consolidator/src/tracker.rs
+++ b/lib/kvbm-consolidator/src/tracker.rs
@@ -17,7 +17,7 @@
 //!
 //! Hash synthesis for external (vLLM / TRT-LLM) sources delegates entirely to
 //! [`dynamo_kv_hashing`]: the consolidator builds a single-block [`Request`] for each
-//! event, gets the [`BlockHash`] via [`Request::block_hashes`], and chains via
+//! event, gets the `BlockHash` via [`Request::block_hashes`], and chains via
 //! [`PositionalLineageHash::extend`] from the parent's PLH. KVBM events arrive with a
 //! PLH already computed by the upstream registry.
 

--- a/lib/kvbm-logical/src/blocks/immutable.rs
+++ b/lib/kvbm-logical/src/blocks/immutable.rs
@@ -222,7 +222,7 @@ impl<T: BlockMetadata + Sync> ImmutableBlock<T> {
     ///   stash a heterogeneous list of pins (different `T`s) can still
     ///   address each slot unambiguously at runtime.
     ///
-    /// See [`crate::blocks::pin`] for the rationale.
+    /// See `crate::blocks::pin` for the rationale.
     pub fn pin(&self) -> LifecyclePinRef {
         LifecyclePinRef::new(self.inner.clone() as Arc<dyn LifecyclePin>)
     }

--- a/lib/kvbm-logical/src/blocks/mod.rs
+++ b/lib/kvbm-logical/src/blocks/mod.rs
@@ -28,9 +28,9 @@
 //! - [`ImmutableBlock`] — `Registered` state (cheap-to-clone strong handle).
 //! - [`WeakBlock`] — non-owning reference to a registered block.
 //!
-//! Slot bookkeeping lives in [`BlockStore<T>`](crate::pools::BlockStore);
+//! Slot bookkeeping lives in `BlockStore<T>` (`crate::pools::BlockStore`);
 //! `Primary` vs `Duplicate` is captured by an internal flag on
-//! [`ImmutableBlockInner`] and the corresponding slot state.
+//! `ImmutableBlockInner` and the corresponding slot state.
 
 mod complete;
 mod immutable;

--- a/lib/kvbm-logical/src/integrations/request.rs
+++ b/lib/kvbm-logical/src/integrations/request.rs
@@ -173,8 +173,8 @@ impl<T: BlockMetadata> RequestSequence<T> {
     /// Search for prefix cache hits and add matched blocks in one step.
     ///
     /// This is the standard entry point for prefix matching on a fresh
-    /// sequence. Combines [`match_prefix`](Self::match_prefix) and
-    /// [`add_matched_blocks`](Self::add_matched_blocks).
+    /// sequence. Combines `match_prefix` and
+    /// `add_matched_blocks`.
     ///
     /// # Panics
     ///

--- a/lib/kvbm-logical/src/manager/mod.rs
+++ b/lib/kvbm-logical/src/manager/mod.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Block lifecycle orchestration over the unified [`BlockStore`].
+//! Block lifecycle orchestration over the unified `BlockStore`.
 //!
-//! [`BlockManager`] owns a single [`BlockStore`] and the [`BlockRegistry`].
+//! [`BlockManager`] owns a single `BlockStore` and the [`BlockRegistry`].
 //! All pool transitions go through the store's single mutex; the manager
 //! adds the registry coordination, allocation eviction policy, and metrics.
 
@@ -25,7 +25,7 @@ use crate::metrics::BlockPoolMetrics;
 use crate::pools::{BlockDuplicationPolicy, BlockStore, SequenceHash};
 use crate::registry::BlockRegistry;
 
-/// Manages the full block lifecycle over the unified [`BlockStore`].
+/// Manages the full block lifecycle over the unified `BlockStore`.
 ///
 /// Construct via [`BlockManager::builder()`].
 pub struct BlockManager<T: BlockMetadata> {
@@ -44,7 +44,7 @@ impl<T: BlockMetadata + Sync> BlockManager<T> {
     }
 
     /// Stable, process-unique identifier for this manager's underlying
-    /// [`BlockStore`](crate::pools::BlockStore). See [`crate::ManagerId`].
+    /// `BlockStore`. See [`crate::ManagerId`].
     /// Cheap (one field load via the store).
     ///
     /// Together with a [`BlockId`](crate::BlockId) this names a specific
@@ -127,7 +127,7 @@ impl<T: BlockMetadata + Sync> BlockManager<T> {
     /// the first hash that hits neither the active nor the inactive pool.
     ///
     /// The whole active-or-inactive prefix is resolved under a **single**
-    /// store-mutex acquisition via [`BlockStore::match_prefix_locked_batch`]
+    /// store-mutex acquisition via `BlockStore::match_prefix_locked_batch`
     /// — no per-hash registry radix-tree lookup, no per-hash store lock.
     /// Frequency-tracker touches are batched and applied *after* the store
     /// lock is released: every returned block is touched exactly once

--- a/lib/kvbm-logical/src/pools/mod.rs
+++ b/lib/kvbm-logical/src/pools/mod.rs
@@ -3,9 +3,9 @@
 
 //! Block pool bookkeeping for thread-safe block management.
 //!
-//! - [`BlockStore<T>`]: unified single-mutex owner of reset and inactive
+//! - `BlockStore<T>`: unified single-mutex owner of reset and inactive
 //!   pool state.
-//! - [`InactiveIndex`]: pluggable T-free eviction-order trait for the
+//! - `InactiveIndex`: pluggable T-free eviction-order trait for the
 //!   inactive pool (crate-private).
 //! - Type-safe RAII guards (`MutableBlock`, `CompleteBlock`,
 //!   `ImmutableBlock`, `WeakBlock`) live in `crate::blocks` and return to

--- a/lib/kvbm-logical/src/registry/mod.rs
+++ b/lib/kvbm-logical/src/registry/mod.rs
@@ -199,7 +199,7 @@ impl BlockRegistry {
     /// Returns `Vec<(SequenceHash, bool)>` where `bool` is true if a block
     /// exists for at least one of the supplied tier `TypeId`s.
     ///
-    /// Same consistency caveats as [`check_presence`]: this is a
+    /// Same consistency caveats as `check_presence`: this is a
     /// refcounted shadow of authoritative store state, not a linearizable
     /// snapshot. May briefly disagree with the store mid-mutation.
     ///

--- a/lib/kvbm-physical/src/layout/mod.rs
+++ b/lib/kvbm-physical/src/layout/mod.rs
@@ -148,7 +148,7 @@ pub(crate) enum InnerShape {
 ///
 /// This trait enables direct access to entire blocks as contiguous memory,
 /// without requiring layer/outer indexing. It is implemented by
-/// [`FullyContiguousLayout`] but NOT by [`LayerSeparateLayout`] (which
+/// `FullyContiguousLayout` but NOT by `LayerSeparateLayout` (which
 /// stores each layer separately).
 ///
 /// Use this trait when you need to:

--- a/lib/kvbm-physical/src/transfer/mod.rs
+++ b/lib/kvbm-physical/src/transfer/mod.rs
@@ -10,7 +10,7 @@
 //! # Core Concepts
 //!
 //! - [`PhysicalLayout`]: Wraps a layout with its physical storage location and NIXL metadata
-//! - [`LayoutDescriptor`]: Serializable representation for cross-node communication
+//! - `LayoutDescriptor`: Serializable representation for cross-node communication
 //! - Transfer strategies: memcpy, CUDA, NIXL based on source/destination locations
 //! - Block-wise and layer-wise transfer operations
 //!

--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -89,7 +89,6 @@ pub trait BlockMetadata: Default + std::fmt::Debug + Clone + Ord + Send + Sync +
     fn on_returned(&mut self, tick: u64);
 
     /// Resets the metadata to the default value
-    /// If called, the `BlockMetadata::is_reset()` should return true
     fn reset_metadata(&mut self);
 
     /// The offload priority of the block. Higher priority blocks are offloaded first.

--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -89,7 +89,7 @@ pub trait BlockMetadata: Default + std::fmt::Debug + Clone + Ord + Send + Sync +
     fn on_returned(&mut self, tick: u64);
 
     /// Resets the metadata to the default value
-    /// If called, the [BlockMetadata::is_reset()] should return true
+    /// If called, the `BlockMetadata::is_reset()` should return true
     fn reset_metadata(&mut self);
 
     /// The offload priority of the block. Higher priority blocks are offloaded first.
@@ -114,7 +114,7 @@ pub trait MaybeReturnableBlock<S: Storage, L: LocalityProvider, M: BlockMetadata
     /// Try to take ownership of the block.
     ///
     /// This is an internal function guarded by the PrivateToken and is used to implement the public facing
-    /// [`super::pool::BlockPool::return_block`] and [`super::pool::BlockPool::return_block_blocking`] functions.
+    /// `super::pool::BlockPool::return_block` and `super::pool::BlockPool::return_block_blocking` functions.
     fn try_take_block(self, token: private::PrivateToken) -> Option<Vec<Block<S, L, M>>>;
 }
 
@@ -278,7 +278,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> Block<S, L, M> {
     /// Apply a [TokenBlock] to the block
     /// Requires the block to be in the [BlockState::Reset] state.
     ///
-    /// Additionally, the [TokenBlock] must match the [BlockLayout::page_size()]
+    /// Additionally, the [TokenBlock] must match the `BlockLayout::page_size()`
     /// Transitions the state to [BlockState::Complete]. Returns `Err` otherwise.
     pub fn apply_token_block(&mut self, token_block: TokenBlock) -> Result<()> {
         if self.page_size() != token_block.tokens().len() {
@@ -472,7 +472,7 @@ pub trait BlockExt {
     /// Apply a [TokenBlock] to the block
     /// Requires the block to be in the [BlockState::Reset] state.
     ///
-    /// Additionally, the [TokenBlock] must match the [BlockLayout::page_size()]
+    /// Additionally, the [TokenBlock] must match the `BlockLayout::page_size()`
     /// Transitions the state to [BlockState::Complete]. Returns `Err` otherwise.
     fn apply_token_block(&mut self, token_block: TokenBlock) -> Result<()>;
 
@@ -582,7 +582,7 @@ impl<L: BlockLayout + 'static, M: BlockMetadata> Blocks<L, M> {
         })
     }
 
-    /// Convert collection into Vec<Block> with default metadata/state
+    /// Convert collection into `Vec<Block>` with default metadata/state
     pub fn into_blocks(self) -> BlockResult<Vec<Block<L::StorageType, locality::Local, M>>> {
         // convert box to arc
         let layout: Arc<dyn BlockLayout<StorageType = L::StorageType>> = Arc::new(*self.layout);

--- a/lib/llm/src/block_manager/connector/protocol.rs
+++ b/lib/llm/src/block_manager/connector/protocol.rs
@@ -25,7 +25,7 @@
 //! - To transition to the [`SlotState::Prefilling`] state, the slot must be in either the [`SlotState::Initialized`]
 //!   [`SlotState::NotScheduled`], or [`SlotState::OnboardStaged`] state.
 //!   - When in the [`SlotState::Prefilling`] state, store/save operations are allowed.
-//!   - Store/Save operations are determined when processing the [`SchedulerOutput`].
+//!   - Store/Save operations are determined when processing the `SchedulerOutput`.
 //!   - If a store operation is issued, the following will happen:
 //!     - Leader will trigger a message to the TransferEngine with the use StoreRequest and a ConnectorStoreRequest
 //!     - The presence of the ConnectorStoreRequest will trigger the TransferEngine to request a SchedulerStoreRequest,
@@ -49,9 +49,9 @@
 //!       - When the completion event is received, the atomic completion counter will be incremented.
 //!
 //!
-//! All transfer requests are triggered by the leader based on the details in the [`SchedulerOutput`].
+//! All transfer requests are triggered by the leader based on the details in the `SchedulerOutput`.
 //!
-//! [`SchedulerOutput`] is transform
+//! `SchedulerOutput` is transform
 
 use super::scheduler::{DISCONNECTED_WARNING, SchedulingDecision};
 use super::*;
@@ -152,7 +152,7 @@ pub struct WorkerTransferRequest {
 }
 
 /// Sent by Worker to Scheduler.
-/// Combines [`WorkerTransferRequest`] and [`WorkerRequestState`] and issues a [`WorkerSchedulerRequest`]
+/// Combines [`WorkerTransferRequest`] and `WorkerRequestState` and issues a [`WorkerSchedulerRequest`]
 ///
 /// This object has all the links to the worker to track completion and observe any cancellation signals.
 pub struct WorkerSchedulerRequest {
@@ -162,7 +162,7 @@ pub struct WorkerSchedulerRequest {
     pub cancel_token: CancellationToken,
 }
 
-/// One-time use object returned from [`Scheduler::schedule_transfer`]
+/// One-time use object returned from `Scheduler::schedule_transfer`
 /// This object carries with it the [`SchedulingDecision`] and is used to mark the transfer as complete.
 #[async_trait::async_trait]
 pub trait TransferCompletionHandle: Send {

--- a/lib/llm/src/block_manager/connector/protocol.rs
+++ b/lib/llm/src/block_manager/connector/protocol.rs
@@ -162,7 +162,7 @@ pub struct WorkerSchedulerRequest {
     pub cancel_token: CancellationToken,
 }
 
-/// One-time use object returned from `Scheduler::schedule_transfer`
+/// One-time use object returned from `TransferSchedulerClient::schedule_transfer`
 /// This object carries with it the [`SchedulingDecision`] and is used to mark the transfer as complete.
 #[async_trait::async_trait]
 pub trait TransferCompletionHandle: Send {

--- a/lib/llm/src/block_manager/connector/protocol.rs
+++ b/lib/llm/src/block_manager/connector/protocol.rs
@@ -51,7 +51,7 @@
 //!
 //! All transfer requests are triggered by the leader based on the details in the `SchedulerOutput`.
 //!
-//! `SchedulerOutput` is transform
+//! `SchedulerOutput` is transformed into a [`LeaderTransferRequest`].
 
 use super::scheduler::{DISCONNECTED_WARNING, SchedulingDecision};
 use super::*;

--- a/lib/llm/src/block_manager/distributed/transfer.rs
+++ b/lib/llm/src/block_manager/distributed/transfer.rs
@@ -233,7 +233,7 @@ impl ConnectorTransferBatcher {
     }
 }
 
-/// A handler for all block transfers. Wraps a group of [`BlockTransferPoolManager`]s.
+/// A handler for all block transfers. Wraps a group of `BlockTransferPoolManager`s.
 #[derive(Clone)]
 pub struct BlockTransferHandler {
     device: Option<LocalBlockDataList<DeviceStorage>>,

--- a/lib/llm/src/block_manager/events.rs
+++ b/lib/llm/src/block_manager/events.rs
@@ -23,7 +23,7 @@ use crate::block_manager::kv_consolidator::KvEventConsolidator;
 ///   from the cache. This messasge will include enough information to identify the block within a
 ///   storage hierarchy; minmally, the sequence hash and the storage location/class.
 ///
-/// The [RegistrationHandle] associated from [EventManager::block_register] call is an RAII object
+/// The [RegistrationHandle] associated from `EventManager::block_register` call is an RAII object
 /// which will trigger a `Remove` event on being dropped.
 pub trait EventManager: EventPublisher + EventReleaseManager + Send + Sync {
     // fn register_block(&self, token_block: &TokenBlock) -> PublishHandle;

--- a/lib/llm/src/block_manager/layout.rs
+++ b/lib/llm/src/block_manager/layout.rs
@@ -19,7 +19,7 @@
 //!   associated [`StorageType`].
 //! - [`BlockLayoutConfig`]: Provides metadata about the layout, such as the number of blocks, layers, page size,
 //!   and data type.
-//! - [`BlockLayoutLookup`]: Offers methods to retrieve the memory address and size of a specific memory region
+//! - `BlockLayoutLookup`: Offers methods to retrieve the memory address and size of a specific memory region
 //!   (page) within the layout.
 //!
 //! ### 2. Layout Configuration
@@ -29,7 +29,7 @@
 //! - `page_size`: Size of each page (often corresponds to a dimension like sequence length or number of tokens).
 //! - `inner_dim`: The inner dimension of the data (e.g., hidden size).
 //! - `alignment`: Required memory alignment for certain operations or hardware. Must be a power of 2.
-//! - `dtype`: The data type ([`DType`]) of the elements stored.
+//! - `dtype`: The data type (`DType`) of the elements stored.
 //!
 //! This configuration is validated to ensure consistency and correctness (e.g., alignment must be a power of 2).
 //!
@@ -41,7 +41,7 @@
 //!   necessary.
 //!
 //! ### 4. Strides and Alignment
-//! The layout calculations meticulously handle strides between layers and blocks. For instance, in [`FullyContiguousConfig`]:
+//! The layout calculations meticulously handle strides between layers and blocks. For instance, in `FullyContiguousConfig`:
 //! - `layer_stride_in_bytes`: The size of one memory region (page).
 //! - `natural_block_stride`: The size of one block if there were no additional alignment padding between blocks.
 //! - `block_stride_in_bytes`: The actual stride between the start of consecutive blocks, potentially larger than
@@ -53,7 +53,7 @@
 //!
 //! ### 5. Storage Interaction
 //! Layouts are tightly coupled with the [`Storage`] trait from the `super::storage` module.
-//! The [`BlockLayout::allocate`] method uses a [`StorageAllocator`] to obtain the necessary memory,
+//! The `BlockLayout::allocate` method uses a [`StorageAllocator`] to obtain the necessary memory,
 //! calculating the required size including any padding for alignment.
 //!
 //! ### 6. Error Handling

--- a/lib/llm/src/block_manager/layout/nixl.rs
+++ b/lib/llm/src/block_manager/layout/nixl.rs
@@ -44,11 +44,11 @@
 //! ## Usage Flow
 //!
 //! 1.  **Create/Allocate Layout**: A block layout (e.g., [`FullyContiguous`]) is created or allocated,
-//!     ensuring its underlying storage is NIXL-compatible (e.g., using [`SystemStorage`] that implements
+//!     ensuring its underlying storage is NIXL-compatible (e.g., using `SystemStorage` that implements
 //!     [`NixlRegisterableStorage`]).
-//! 2.  **Register with NIXL**: The [`nixl_register`] method from the [`NixlLayout`] trait is called on the
+//! 2.  **Register with NIXL**: The `nixl_register` method from the [`NixlLayout`] trait is called on the
 //!     layout instance with a [`NixlAgent`].
-//! 3.  **Serialize**: The [`serialize`] method from [`ToSerializedNixlBlockLayout`] is used to get a
+//! 3.  **Serialize**: The `serialize` method from [`ToSerializedNixlBlockLayout`] is used to get a
 //!     [`SerializedNixlBlockLayout`].
 //! 4.  **Transmit**: The [`SerializedNixlBlockLayout`] (or its byte representation) is sent to another
 //!     process/node.

--- a/lib/llm/src/block_manager/layout/utils.rs
+++ b/lib/llm/src/block_manager/layout/utils.rs
@@ -197,7 +197,7 @@ impl WorkerLayoutVerifier {
     }
 }
 
-/// Validation function for Option<usize> to check if it's Some(power_of_2).
+/// Validation function for `Option<usize>` to check if it's Some(power_of_2).
 pub fn validate_power_of_2(alignment: usize) -> Result<(), ValidationError> {
     if !alignment.is_power_of_two() {
         // Return validation error if alignment is not a power of 2

--- a/lib/llm/src/block_manager/layout/utils.rs
+++ b/lib/llm/src/block_manager/layout/utils.rs
@@ -197,7 +197,7 @@ impl WorkerLayoutVerifier {
     }
 }
 
-/// Validation function for `Option<usize>` to check if it's Some(power_of_2).
+/// Validates that `alignment` is a power of 2, returning an error if it is not.
 pub fn validate_power_of_2(alignment: usize) -> Result<(), ValidationError> {
     if !alignment.is_power_of_two() {
         // Return validation error if alignment is not a power of 2

--- a/lib/llm/src/block_manager/offload.rs
+++ b/lib/llm/src/block_manager/offload.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Offloading
 //! Offloading is the process of moving blocks to a cache level further away from the device.
-//! When blocks are registered (via [`ManagedBlockPool::register_blocks`]), they are automatically sent to the offload manager.
+//! When blocks are registered (via `ManagedBlockPool::register_blocks`), they are automatically sent to the offload manager.
 //! Due to limited bandwidth, the offload manager must prioritize which offloads to perform.
 //! This is indicated by the `priority` parameter to [`OffloadManager::offload`].
 //! When a offload request is received, the offload manager will enqueue it into a priority queue.
@@ -20,17 +20,17 @@
 //! ## Transfer Managers
 //! The offload manager uses two transfer managers to handle the offloading and onboarding of blocks.
 //!
-//! The [`CudaTransferManager`] is responsible for transfers between the device and host.
-//! The [`DiskTransferManager`] is responsible for transfers from host to disk and disk to device.
+//! The `CudaTransferManager` is responsible for transfers between the device and host.
+//! The `DiskTransferManager` is responsible for transfers from host to disk and disk to device.
 //!
 //! ## Worker Threads
 //! The offload manager uses two kinds of worker threads to handle the offloading and onboarding of blocks.
 //!
-//! The [`OffloadManager::offload_worker`] is responsible for offloading blocks.
-//! The [`OffloadManager::onboard_worker`] is responsible for onboarding blocks.
+//! The `OffloadManager::offload_worker` is responsible for offloading blocks.
+//! The `OffloadManager::onboard_worker` is responsible for onboarding blocks.
 //!
 //! The kind of offloads/onboards they perform is dictated by the source and target arguments
-//! of the [`OffloadManager::offload_worker`] and [`OffloadManager::onboard_worker`] methods.
+//! of the `OffloadManager::offload_worker` and `OffloadManager::onboard_worker` methods.
 
 use super::block::{
     BlockError, BlockMetadata, BlockState, ImmutableBlock, MutableBlock,

--- a/lib/llm/src/block_manager/pool/managed.rs
+++ b/lib/llm/src/block_manager/pool/managed.rs
@@ -31,11 +31,11 @@
 //!     [`InactiveBlockPool`].
 //! 2.  Sequences request blocks via [`BlockPool::allocate_blocks`], which attempts to acquire them
 //!     from the [`InactiveBlockPool`]. This returns [`MutableBlock`]s.
-//! 3.  Once a [`MutableBlock`] is filled and ready, it's registered using [`BlockPool::register_block`].
+//! 3.  Once a [`MutableBlock`] is filled and ready, it's registered using `BlockPool::register_block`.
 //!     This process checks the both the [`ActiveBlockPool`] and the [`InactiveBlockPool`] for existing blocks
 //!     with the same content hash. It returns an [`ImmutableBlock`] representing the canonical block
 //!     (either the one provided or an existing one).
-//! 4.  Sequences can also try to reuse blocks directly using [`BlockPool::match_sequence_hash`], which
+//! 4.  Sequences can also try to reuse blocks directly using `BlockPool::match_sequence_hash`, which
 //!     checks both the active and inactive pools.
 //! 5.  When an [`ImmutableBlock`] is no longer needed by any sequence (its `Arc` count drops to zero),
 //!     the underlying [`MutableBlock`] (if it still exists via the weak reference in the active pool)
@@ -167,7 +167,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> ManagedBlockPool<S, L, M
 
     /// Creates a new [`ManagedBlockPool`] with the given [`EventManager`].
     ///
-    /// The pool starts empty and requires blocks to be added via [`add_blocks`].
+    /// The pool starts empty and requires blocks to be added via `add_blocks`.
     ///
     /// # Arguments
     ///

--- a/lib/llm/src/block_manager/pool/managed.rs
+++ b/lib/llm/src/block_manager/pool/managed.rs
@@ -32,7 +32,7 @@
 //! 2.  Sequences request blocks via [`BlockPool::allocate_blocks`], which attempts to acquire them
 //!     from the [`InactiveBlockPool`]. This returns [`MutableBlock`]s.
 //! 3.  Once a [`MutableBlock`] is filled and ready, it's registered using `BlockPool::register_block`.
-//!     This process checks the both the [`ActiveBlockPool`] and the [`InactiveBlockPool`] for existing blocks
+//!     This process checks both the [`ActiveBlockPool`] and the [`InactiveBlockPool`] for existing blocks
 //!     with the same content hash. It returns an [`ImmutableBlock`] representing the canonical block
 //!     (either the one provided or an existing one).
 //! 4.  Sequences can also try to reuse blocks directly using `BlockPool::match_sequence_hash`, which

--- a/lib/llm/src/block_manager/pool/managed/inactive.rs
+++ b/lib/llm/src/block_manager/pool/managed/inactive.rs
@@ -77,8 +77,8 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> InactiveBlockPool<S, L, 
 
     /// Returns the number of blocks currently available in the pool.
     ///
-    /// This is calculated dynamically based on the blocks in the [`uninitialized_set`]
-    /// and the [`lookup_map`].
+    /// This is calculated dynamically based on the blocks in the `uninitialized_set`
+    /// and the `lookup_map`.
     ///
     /// # Returns
     ///
@@ -305,7 +305,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> InactiveBlockPool<S, L, 
 
     /// Attempts to find and take multiple blocks matching a sequence of `TokenBlock`s.
     ///
-    /// Extracts sequence hashes from the [`TokenBlock`]s and calls [`take_with_sequence_hash`].
+    /// Extracts sequence hashes from the [`TokenBlock`]s and calls `take_with_sequence_hash`.
     /// Stops if a hash is not found.
     ///
     /// # Arguments
@@ -346,18 +346,18 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> InactiveBlockPool<S, L, 
 
     /// Acquires a single free block from the pool.
     ///
-    /// Prioritizes blocks from the [`uninitialized_set`] first, then takes the
-    /// lowest priority block from the [`priority_set`] (and [`lookup_map`]).
+    /// Prioritizes blocks from the `uninitialized_set` first, then takes the
+    /// lowest priority block from the `priority_set` (and `lookup_map`).
     /// If a block is taken from the priority set, it is reset.
     ///
     /// # Returns
     ///
-    /// An [`Option<Block<T, M>>`] containing a free block if available, otherwise `None`.
+    /// An `Option<Block<T, M>>` containing a free block if available, otherwise `None`.
     ///
     /// # Panics
     ///
-    /// This function can panic if there is an inconsistency between the [`priority_set`]
-    /// and [`lookup_map`] (i.e., a key exists in the set but not the map). This indicates
+    /// This function can panic if there is an inconsistency between the `priority_set`
+    /// and `lookup_map` (i.e., a key exists in the set but not the map). This indicates
     /// a bug in the pool's internal logic.
     #[instrument(level = "debug", skip(self))]
     pub fn acquire_free_block(&mut self) -> Option<Block<S, L, M>> {
@@ -397,7 +397,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> InactiveBlockPool<S, L, 
 
     /// Acquires a specified number of free blocks from the pool.
     ///
-    /// Checks if enough blocks are available and then calls [`acquire_free_block`] repeatedly.
+    /// Checks if enough blocks are available and then calls `acquire_free_block` repeatedly.
     ///
     /// # Arguments
     ///
@@ -412,7 +412,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> InactiveBlockPool<S, L, 
     ///
     /// # Panics
     ///
-    /// This function can panic if [`acquire_free_block`] panics due to internal inconsistencies.
+    /// This function can panic if `acquire_free_block` panics due to internal inconsistencies.
     #[instrument(level = "debug", skip(self))]
     pub fn acquire_free_blocks(
         &mut self,
@@ -515,7 +515,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> InactiveBlockPool<S, L, 
         Ok(())
     }
 
-    /// Returns the [`PoolStatus`] of the pool.
+    /// Returns the `PoolStatus` of the pool.
     pub fn status(&self) -> (usize, usize) {
         let inactive_blocks = self.priority_set.len();
         let empty_blocks = self.uninitialized_set.len();

--- a/lib/llm/src/block_manager/pool/managed/inactive.rs
+++ b/lib/llm/src/block_manager/pool/managed/inactive.rs
@@ -352,7 +352,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> InactiveBlockPool<S, L, 
     ///
     /// # Returns
     ///
-    /// An `Option<Block<T, M>>` containing a free block if available, otherwise `None`.
+    /// An `Option<Block<S, L, M>>` containing a free block if available, otherwise `None`.
     ///
     /// # Panics
     ///
@@ -515,7 +515,9 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> InactiveBlockPool<S, L, 
         Ok(())
     }
 
-    /// Returns the `PoolStatus` of the pool.
+    /// Returns `(inactive_blocks, empty_blocks)`: the number of blocks in the
+    /// priority set (previously-registered, reusable blocks) and the number of
+    /// blocks in the uninitialized set (never-registered, empty blocks), respectively.
     pub fn status(&self) -> (usize, usize) {
         let inactive_blocks = self.priority_set.len();
         let empty_blocks = self.uninitialized_set.len();

--- a/lib/llm/src/block_manager/storage.rs
+++ b/lib/llm/src/block_manager/storage.rs
@@ -255,14 +255,14 @@ pub trait RegistationHandle: std::any::Any + Send + Sync + 'static {
     /// This should be called when the external registration of this storage
     /// is no longer needed.
     ///
-    /// Note: All `RegistrationHandle`s should be explicitly released before
+    /// Note: All `RegistationHandle`s should be explicitly released before
     /// the [Storage] is dropped.
     fn release(&mut self);
 }
 
-/// A collection of `RegistrationHandle`s for a [RegisterableStorage].
+/// A collection of `RegistationHandle`s for a [RegisterableStorage].
 ///
-/// This is used to ensure that all `RegistrationHandle`s are explicitly released
+/// This is used to ensure that all `RegistationHandle`s are explicitly released
 /// before the [RegisterableStorage] is dropped.
 #[derive(Default)]
 pub struct RegistrationHandles {

--- a/lib/llm/src/block_manager/storage.rs
+++ b/lib/llm/src/block_manager/storage.rs
@@ -255,14 +255,14 @@ pub trait RegistationHandle: std::any::Any + Send + Sync + 'static {
     /// This should be called when the external registration of this storage
     /// is no longer needed.
     ///
-    /// Note: All [RegistrationHandle]s should be explicitly released before
+    /// Note: All `RegistrationHandle`s should be explicitly released before
     /// the [Storage] is dropped.
     fn release(&mut self);
 }
 
-/// A collection of [RegistrationHandle]s for a [RegisterableStorage].
+/// A collection of `RegistrationHandle`s for a [RegisterableStorage].
 ///
-/// This is used to ensure that all [RegistrationHandle]s are explicitly released
+/// This is used to ensure that all `RegistrationHandle`s are explicitly released
 /// before the [RegisterableStorage] is dropped.
 #[derive(Default)]
 pub struct RegistrationHandles {

--- a/lib/llm/src/block_manager/storage/cuda.rs
+++ b/lib/llm/src/block_manager/storage/cuda.rs
@@ -115,7 +115,7 @@ impl Cuda {
     /// If the context does not exist, it will be created or fail.
     ///
     /// This will lazily instantiate a context for a device. Use
-    /// `CudaContextManager::device` to get an existing context.
+    /// [`Cuda::device`] to get an existing context.
     pub fn device_or_create(device_id: usize) -> Result<Arc<CudaContext>, StorageError> {
         Cuda::instance().lock().unwrap().get_context(device_id)
     }

--- a/lib/llm/src/block_manager/storage/cuda.rs
+++ b/lib/llm/src/block_manager/storage/cuda.rs
@@ -115,7 +115,7 @@ impl Cuda {
     /// If the context does not exist, it will be created or fail.
     ///
     /// This will lazily instantiate a context for a device. Use
-    /// [CudaContextManager::device] to get an existing context.
+    /// `CudaContextManager::device` to get an existing context.
     pub fn device_or_create(device_id: usize) -> Result<Arc<CudaContext>, StorageError> {
         Cuda::instance().lock().unwrap().get_context(device_id)
     }

--- a/lib/llm/src/block_manager/v2/physical/transfer/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/mod.rs
@@ -10,7 +10,7 @@
 //! # Core Concepts
 //!
 //! - [`PhysicalLayout`]: Wraps a layout with its physical storage location and NIXL metadata
-//! - [`LayoutDescriptor`]: Serializable representation for cross-node communication
+//! - `LayoutDescriptor`: Serializable representation for cross-node communication
 //! - Transfer strategies: memcpy, CUDA, NIXL based on source/destination locations
 //! - Block-wise and layer-wise transfer operations
 //!

--- a/lib/llm/src/block_manager/v2/physical/transfer/nixl_agent/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/nixl_agent/mod.rs
@@ -107,9 +107,9 @@ impl NixlAgent {
     /// - Any backend fails to initialize
     ///
     /// # Example
-    /// ```text
+    /// ```ignore
     /// // In production: require both UCX and GDS, fail if either is missing
-    /// let agent = NixlAgent::require_backends("worker-0", &["UCX", "GDS_MT])?;
+    /// let agent = NixlAgent::require_backends("worker-0", &["UCX", "GDS_MT"])?;
     /// ```
     pub fn require_backends(name: &str, backends: &[&str]) -> Result<Self> {
         let agent = RawNixlAgent::new(name)?;
@@ -190,8 +190,8 @@ impl NixlAgent {
     /// Use this at the start of operations that need specific backends.
     ///
     /// # Example
-    /// ```text
-    /// agent.require_backend("GDS_MT)?;
+    /// ```ignore
+    /// agent.require_backend("GDS_MT")?;
     /// // Proceed with GDS-specific operations
     /// ```
     pub fn require_backend(&self, backend: &str) -> Result<()> {

--- a/lib/llm/src/block_manager/v2/physical/transfer/nixl_agent/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/nixl_agent/mod.rs
@@ -107,7 +107,7 @@ impl NixlAgent {
     /// - Any backend fails to initialize
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// // In production: require both UCX and GDS, fail if either is missing
     /// let agent = NixlAgent::require_backends("worker-0", &["UCX", "GDS_MT])?;
     /// ```
@@ -190,7 +190,7 @@ impl NixlAgent {
     /// Use this at the start of operations that need specific backends.
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// agent.require_backend("GDS_MT)?;
     /// // Proceed with GDS-specific operations
     /// ```

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -461,7 +461,7 @@ impl Model {
     /// Structured per-namespace worker readiness for this model — the data
     /// behind the `GET /v1/models/{model}/ready` observability endpoint.
     ///
-    /// Built on the same [`Self::evaluate_namespace`] facts the serving gate
+    /// Built on the same `Self::evaluate_namespace` facts the serving gate
     /// uses, so the reported `ready`/`missing` can never disagree with routing;
     /// this method only layers display data (per-type counts, reason strings).
     pub fn namespace_readiness(&self) -> ModelReadiness {
@@ -569,7 +569,7 @@ impl Model {
     /// where a `ModelDeploymentCard` is registered before its WorkerSet has
     /// been wired up.
     ///
-    /// Delegates to [`Self::select_worker_set_with`] so readiness reports
+    /// Delegates to `Self::select_worker_set_with` so readiness reports
     /// exactly what request routing would accept — including the namespace
     /// completeness gate. Without that, a live decode-only WorkerSet with a
     /// chat engine but no prefill peer would report ready while every request

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -464,7 +464,7 @@ impl ModelManager {
     /// reservation first-come and symmetric across namespaces. A later deployment
     /// re-using a name fails loudly rather than silently displacing the owner.
     ///
-    /// Holds [`Self::reservation_lock`] across the reserved-name check and the
+    /// Holds `Self::reservation_lock` across the reserved-name check and the
     /// insert so the claim is atomic against a concurrent `register_alias` for
     /// the same name (a name can never end up both a live primary and an alias).
     /// The lock is always taken before any map access, so it never inverts with a
@@ -536,7 +536,7 @@ impl ModelManager {
     /// refused and logged so operators find the collision in the logs rather
     /// than through silent metric re-attribution.
     ///
-    /// Holds [`Self::reservation_lock`] across the live-primary probe and the
+    /// Holds `Self::reservation_lock` across the live-primary probe and the
     /// entry insert so the claim is atomic against a concurrent `add_worker_set`
     /// for the same name. Within that section the `models` guard is dropped before
     /// touching `alias_to_primary` (via `is_some_and`), and the lock is taken

--- a/lib/llm/src/grpc/protos/model_config.proto
+++ b/lib/llm/src/grpc/protos/model_config.proto
@@ -193,7 +193,7 @@ message ModelInstanceGroup
   //@@  .. cpp:var:: string name
   //@@
   //@@     Optional name of this group of instances. If not specified the
-  //@@     name will be formed as <model name>_<group number>. The name of
+  //@@     name will be formed as {model name}_{group number}. The name of
   //@@     individual instances will be further formed by a unique instance
   //@@     number and GPU index:
   //@@
@@ -245,7 +245,7 @@ message ModelInstanceGroup
   //@@     parameter specifies a set of optimization profiles available to this
   //@@     instance group. The inference server will choose the optimal profile
   //@@     based on the shapes of the input tensors. This field should lie
-  //@@     between 0 and <TotalNumberOfOptimizationProfilesInPlanModel> - 1
+  //@@     between 0 and TotalNumberOfOptimizationProfilesInPlanModel - 1
   //@@     and be specified only for TensorRT backend, otherwise an error will
   //@@     be generated. If not specified, the server will select the first
   //@@     optimization profile by default.

--- a/lib/llm/src/grpc/service/openai.rs
+++ b/lib/llm/src/grpc/service/openai.rs
@@ -37,7 +37,7 @@ pub const ANNOTATION_REQUEST_ID: &str = "request_id";
 /// OpenAI Completions Request Handler
 ///
 /// This method will handle the incoming request for the `/v1/completions endpoint`. The endpoint is a "source"
-/// for an [`super::OpenAICompletionsStreamingEngine`] and will return a stream of
+/// for an `OpenAICompletionsStreamingEngine` and will return a stream of
 /// responses which will be forward to the client.
 ///
 /// Note: For all requests, streaming or non-streaming, we always call the engine with streaming enabled. For

--- a/lib/llm/src/grpc/service/tensor.rs
+++ b/lib/llm/src/grpc/service/tensor.rs
@@ -49,7 +49,7 @@ pub struct ExtendedNvCreateTensorResponse {
 /// Tensor Request Handler
 ///
 /// This method will handle the incoming request for model type tensor. The endpoint is a "source"
-/// for an [`super::OpenAICompletionsStreamingEngine`] and will return a stream of
+/// for an `OpenAICompletionsStreamingEngine` and will return a stream of
 /// responses which will be forward to the client.
 ///
 /// Note: For all requests, streaming or non-streaming, we always call the engine with streaming enabled. For

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -7,7 +7,7 @@
 //! is meant to be a gateway/ingress into the Dynamo LLM Distributed Runtime.
 //!
 //! In order to create a common pattern, the HttpService forwards the incoming OAI Chat Request or OAI Completion Request to the
-//! to a model-specific engines.  The engines can be attached and detached dynamically using the [`ModelManager`].
+//! to a model-specific engines.  The engines can be attached and detached dynamically using the [`ModelManager`](crate::discovery::ModelManager).
 //!
 //! Note: All requests, whether the client requests `stream=true` or `stream=false`, are propagated downstream as `stream=true`.
 //! This enables use to handle only 1 pattern of request-response in the downstream services. Non-streaming user requests are

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -25,7 +25,7 @@
 //! cancel the request or not.
 //!
 //! The [`ConnectionHandle`] is also used to signal to the client that the request has been cancelled. This is
-//! done by sending a [`axum::response::sse::Event`] with the event type "error" and the data "[DONE]".
+//! done by sending a [`axum::response::sse::Event`] with the event type "error" and the data "`[DONE]`".
 //!
 
 use axum::response::sse::Event;

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -16,10 +16,10 @@
 //! - The handler sends a `session.created` server event before any
 //!   engine events flow.
 //! - The handler loops over inbound client frames in
-//!   [`select_engine`] until a `session.update` arrives with a usable model
+//!   `select_engine` until a `session.update` arrives with a usable model
 //!   (`session.model` for realtime sessions or
 //!   `session.audio.input.transcription.model` for transcription sessions)
-//!   and [`ModelManager::get_realtime_engine`] returns Ok.
+//!   and `ModelManager::get_realtime_engine` returns Ok.
 //! - Non-conforming frames (wrong event type, missing model, unknown / unavailable
 //!   model, malformed JSON, binary frames) emit a spec-shaped
 //!   `RealtimeServerEvent::Error` while the loop continues so a well-behaved client

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -514,7 +514,7 @@ impl State {
     }
 
     /// Master switch for the `nvext` extension protocol (see
-    /// [`environment_names::llm::DYN_DISABLE_FRONTEND_NVEXT`]).
+    /// `environment_names::llm::DYN_DISABLE_FRONTEND_NVEXT`).
     #[inline]
     pub fn nvext_enabled(&self) -> bool {
         self.nvext_enabled

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -31,7 +31,7 @@
 //!   - Standalone router (`python -m dynamo.router`): available on `DYN_SYSTEM_PORT`
 //!     when set (default is `-1`, disabled), populated per-request
 //!
-//! - [`KvPublisherMetrics`]: Worker-local KV event publisher and ZMQ relay counters.
+//! - `KvPublisherMetrics`: Worker-local KV event publisher and ZMQ relay counters.
 //!   Registered on the DRT `MetricsRegistry` hierarchy via `Component::metrics()`.
 //!   Populated by `KvEventPublisher` and the ZMQ listener when engines publish KV
 //!   events.

--- a/lib/llm/src/lora/load_estimator.rs
+++ b/lib/llm/src/lora/load_estimator.rs
@@ -592,7 +592,7 @@ impl LoadEstimator {
     }
 
     /// Remove all tracking data for a LoRA. After this call the LoRA will no
-    /// longer appear in [`get_current_load`] results. Useful when a LoRA is
+    /// longer appear in `get_current_load` results. Useful when a LoRA is
     /// permanently unloaded and its stale rate-counter / predictor entries
     /// should be purged.
     pub fn remove_lora(&self, lora_name: &str) {

--- a/lib/llm/src/lora/routing/mod.rs
+++ b/lib/llm/src/lora/routing/mod.rs
@@ -42,7 +42,7 @@ pub trait LoraAllocator: Send + Sync {
         self.compute_replica_set(lora_name, workers, replica_factor)
     }
 
-    /// Stability-preserving slot-aware variant: like [`compute_replica_set_with_slots`],
+    /// Stability-preserving slot-aware variant: like [`Self::compute_replica_set_with_slots`],
     /// but retains workers from `prior` (the LoRA's current placement) when they are still
     /// present and not at capacity, before filling remaining slots from the ranked list.
     ///

--- a/lib/llm/src/lora/state_tracker.rs
+++ b/lib/llm/src/lora/state_tracker.rs
@@ -204,8 +204,8 @@ impl LoraStateTracker {
 
     /// Set a worker's LoRA slot capacity directly, without registering any adapter on it.
     ///
-    /// Capacity-only counterpart to [`handle_mdc_addition`] (which records a loaded adapter AND
-    /// sets capacity). Makes the worker appear in [`list_workers`] with the given capacity and no
+    /// Capacity-only counterpart to `handle_mdc_addition` (which records a loaded adapter AND
+    /// sets capacity). Makes the worker appear in `list_workers` with the given capacity and no
     /// loaded LoRAs, so callers can establish cluster topology / per-worker `max_gpu_lora_count`
     /// without consuming a slot with a phantom adapter.
     pub fn set_worker_capacity(&self, worker: WorkerWithDpRank, capacity: u32) {

--- a/lib/llm/src/perf.rs
+++ b/lib/llm/src/perf.rs
@@ -186,7 +186,7 @@ impl<R: Data + Clone> RecordingStream<R> {
         Self::from_stream_and_context(stream, ctx, mode, capacity, recorded_tx)
     }
 
-    /// Convert to Pin<Box<dyn AsyncEngineStream<R>>>
+    /// Convert to `Pin<Box<dyn AsyncEngineStream<R>>>`
     pub fn into_async_engine_stream(self) -> EngineStream<R> {
         Box::pin(self)
     }

--- a/lib/llm/src/perf/logprobs.rs
+++ b/lib/llm/src/perf/logprobs.rs
@@ -119,7 +119,7 @@ impl TokenLogProbs {
 /// Trait for extracting logprob information from various response types
 pub trait LogprobExtractor {
     /// Extract logprobs organized by choice index
-    /// Returns: HashMap<choice_index, Vec<TokenLogProbs>>
+    /// Returns: `HashMap<choice_index, Vec<TokenLogProbs>>`
     fn extract_logprobs_by_choice(&self) -> HashMap<u32, Vec<TokenLogProbs>>;
 }
 

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -630,7 +630,7 @@ pub struct OutputOptions {
     /// templates that are applied during the backend preprocessing.
     pub formatted_prompt: Option<bool>,
 
-    /// When true, logprob token fields are returned as "token_id:<id>"
+    /// When true, logprob token fields are returned as "token_id:`<id>`"
     /// instead of decoded text.
     pub return_tokens_as_token_ids: Option<bool>,
 }

--- a/lib/llm/src/protocols/common/llm_backend.rs
+++ b/lib/llm/src/protocols/common/llm_backend.rs
@@ -146,7 +146,7 @@ pub struct BackendOutput {
 
     /// Router-computed data handed back to the frontend (e.g. per-request timing from
     /// a standalone router) so it joins this request's trace/metrics. Dynamo-internal,
-    /// consumed by the frontend and not surfaced to clients. See `RoutingData`.
+    /// consumed by the frontend and not surfaced to clients. See [`RoutingData`](crate::protocols::common::timing::RoutingData).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing_data: Option<crate::protocols::common::timing::RoutingData>,
 }
@@ -232,7 +232,7 @@ pub struct LLMEngineOutput {
     pub engine_data: Option<serde_json::Value>,
 
     /// Router-computed data handed back to the frontend (e.g. standalone-router timing).
-    /// Dynamo-internal; consumed by the frontend. See `RoutingData`.
+    /// Dynamo-internal; consumed by the frontend. See [`RoutingData`](crate::protocols::common::timing::RoutingData).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing_data: Option<crate::protocols::common::timing::RoutingData>,
 }

--- a/lib/llm/src/protocols/common/llm_backend.rs
+++ b/lib/llm/src/protocols/common/llm_backend.rs
@@ -146,7 +146,7 @@ pub struct BackendOutput {
 
     /// Router-computed data handed back to the frontend (e.g. per-request timing from
     /// a standalone router) so it joins this request's trace/metrics. Dynamo-internal,
-    /// consumed by the frontend and not surfaced to clients. See [`RoutingData`].
+    /// consumed by the frontend and not surfaced to clients. See `RoutingData`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing_data: Option<crate::protocols::common::timing::RoutingData>,
 }
@@ -232,7 +232,7 @@ pub struct LLMEngineOutput {
     pub engine_data: Option<serde_json::Value>,
 
     /// Router-computed data handed back to the frontend (e.g. standalone-router timing).
-    /// Dynamo-internal; consumed by the frontend. See [`RoutingData`].
+    /// Dynamo-internal; consumed by the frontend. See `RoutingData`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing_data: Option<crate::protocols::common::timing::RoutingData>,
 }

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -237,7 +237,7 @@ pub type MultimodalDataMap = std::collections::HashMap<String, Vec<MultimodalDat
 /// Backend cache UUIDs aligned positionally with multimodal data slots.
 pub type MultimodalUuidMap = std::collections::HashMap<String, Vec<Option<String>>>;
 
-/// [`PreprocessedRequest`] is the internal representation of an LLM request. The [`dynamo.llm-preprocessor`]
+/// [`PreprocessedRequest`] is the internal representation of an LLM request. The `dynamo.llm-preprocessor`
 /// crate is responsible for converting request from the public APIs to this internal representation.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 pub struct PreprocessedRequest {

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -117,7 +117,7 @@ pub struct NvCreateChatCompletionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub media_io_kwargs: Option<MediaDecoder>,
 
-    /// When true, logprob token fields are returned as "token_id:<id>" instead
+    /// When true, logprob token fields are returned as "token_id:`<id>`" instead
     /// of decoded text.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub return_tokens_as_token_ids: Option<bool>,

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -197,7 +197,7 @@ impl DeltaGenerator {
     /// This should be sent after the last content chunk when stream_options.include_usage is true.
     ///
     /// # Returns
-    /// * A [`CreateChatCompletionStreamResponse`] with empty choices and usage stats.
+    /// * A `CreateChatCompletionStreamResponse` with empty choices and usage stats.
     pub fn create_usage_chunk(&self) -> NvCreateChatCompletionStreamResponse {
         let usage = self.get_usage();
 

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -5,9 +5,9 @@
 //!
 //! Gated behind
 //! [`DYN_ENABLE_EXPERIMENTAL_PARSERS_V2`](dynamo_runtime::config::environment_names::llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2).
-//! When enabled, the families in [`V2_FAMILIES`] (Qwen3-Coder, DeepSeek-V4) stream
+//! When enabled, the families in `V2_FAMILIES` (Qwen3-Coder, DeepSeek-V4) stream
 //! straight through their `dynamo_parsers_v2` parser instead of
-//! [`JailedStream`](super::jail::JailedStream): the v2 parser owns incremental
+//! `JailedStream`: the v2 parser owns incremental
 //! tool-call emission and drops a parameter value truncated at EOF rather than
 //! guessing it. The jail is never built for these families in either path
 //! (`apply_stream` for streaming, `parse_complete` for batch). Other families, and

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -43,7 +43,7 @@ pub struct NvCreateCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
 
-    /// When true, logprob token fields are returned as "token_id:<id>"
+    /// When true, logprob token fields are returned as `"token_id:<id>"`
     /// instead of the decoded text.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_tokens_as_token_ids: Option<bool>,

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -15,7 +15,7 @@ use crate::protocols::{
     openai::ParsingOptions,
 };
 
-/// Aggregates a stream of [`CompletionResponse`]s into a single [`CompletionResponse`].
+/// Aggregates a stream of `CompletionResponse`s into a single `CompletionResponse`.
 pub struct DeltaAggregator {
     id: String,
     model: String,
@@ -52,7 +52,7 @@ impl DeltaAggregator {
         }
     }
 
-    /// Aggregates a stream of [`Annotated<CompletionResponse>`]s into a single [`CompletionResponse`].
+    /// Aggregates a stream of `Annotated<CompletionResponse>`s into a single `CompletionResponse`.
     pub async fn apply(
         stream: impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
         parsing_options: ParsingOptions,

--- a/lib/llm/src/tokens.rs
+++ b/lib/llm/src/tokens.rs
@@ -177,7 +177,7 @@ pub enum TokenBlockError {
 /// Represents a partially filled block of tokens within a sequence.
 ///
 /// This structure accumulates tokens until it reaches the specified `block_size`,
-/// at which point it can be [`commit`](PartialTokenBlock::commit)ted into a full [`TokenBlock`].
+/// at which point it can be `commit`ted into a full [`TokenBlock`].
 #[derive(Debug, PartialEq)] // No Clone: intended to be unique within a sequence
 pub struct PartialTokenBlock {
     tokens: Tokens,
@@ -624,7 +624,7 @@ impl TokenBlockSequence {
     /// If adding this token completes the current partial block, the block is committed,
     /// and the index of the newly completed block is returned.
     ///
-    /// This method is equivalent to calling [`extend`] with a single-token [`Tokens`] object.
+    /// This method is equivalent to calling `extend` with a single-token [`Tokens`] object.
     ///
     /// # Arguments
     ///
@@ -745,7 +745,7 @@ impl TokenBlockSequence {
 
     /// Removes the last `count` tokens from the sequence.
     ///
-    /// This is a convenience method that calculates the required length and calls [`truncate`].
+    /// This is a convenience method that calculates the required length and calls `truncate`.
     ///
     /// # Arguments
     ///

--- a/lib/memory/src/actions.rs
+++ b/lib/memory/src/actions.rs
@@ -107,7 +107,7 @@ pub trait Slice: MemoryDescriptor + 'static {
     ///
     /// # Safety
     /// The caller must ensure:
-    /// - offset + (len * size_of::<T>()) <= self.size()
+    /// - offset + (len * `size_of::<T>()`) <= self.size()
     /// - offset is properly aligned for type T
     /// - The memory region is valid and initialized
     /// - No concurrent mutable access occurs while the slice is in use
@@ -212,7 +212,7 @@ pub trait SliceMut: MemoryDescriptor + 'static {
     ///
     /// # Safety
     /// The caller must ensure:
-    /// - offset + (len * size_of::<T>()) <= self.size()
+    /// - offset + (len * `size_of::<T>()`) <= self.size()
     /// - offset is properly aligned for type T
     /// - The memory region is valid
     /// - No other references (mutable or immutable) exist to this memory region

--- a/lib/memory/src/arena.rs
+++ b/lib/memory/src/arena.rs
@@ -215,7 +215,7 @@ where
 {
     /// Get the agent name from registered storage.
     ///
-    /// This is a convenience method when using ArenaAllocator with NixlRegistered<T> storage.
+    /// This is a convenience method when using ArenaAllocator with `NixlRegistered<T>` storage.
     pub fn agent_name(&self) -> &str {
         self.storage.agent_name()
     }

--- a/lib/memory/src/lib.rs
+++ b/lib/memory/src/lib.rs
@@ -209,7 +209,7 @@ pub fn create_buffer<S: MemoryDescriptor + 'static>(memory: S) -> Buffer {
 }
 
 impl Buffer {
-    /// Create a Buffer from an existing Arc<dyn MemoryDescriptor>.
+    /// Create a Buffer from an existing `Arc<dyn MemoryDescriptor>`.
     pub fn from_arc(arc: Arc<dyn MemoryDescriptor>) -> Self {
         Buffer(arc)
     }

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -80,7 +80,7 @@ pub struct TraceThroughputStats {
 /// Goodput: throughput restricted to the requests that satisfy the SLA. Present
 /// on the report only when an SLA was supplied to the collector (goodput is
 /// undefined without one). A completed request counts as "good" per
-/// [`SlaThresholds::is_good`].
+/// `SlaThresholds::is_good`.
 #[derive(Debug, Clone)]
 pub struct TraceGoodputStats {
     /// Completed requests that satisfied the SLA.

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -169,7 +169,7 @@ impl<Events: EngineEventBatch> EngineEffects<Events> {
     }
 }
 
-/// Accumulated traffic statistics returned by [`TrafficAccumulator::drain`].
+/// Accumulated traffic statistics returned by `TrafficAccumulator::drain`.
 ///
 /// IMPORTANT: When fields here are added or renamed, update the PyO3
 /// binding in ``lib/bindings/python/rust/llm/replay.rs`` (drain_traffic

--- a/lib/mocker/src/scheduler/vllm/mod.rs
+++ b/lib/mocker/src/scheduler/vllm/mod.rs
@@ -4,7 +4,7 @@
 //! Shared vLLM/TRT-LLM scheduler simulation around a unified request model.
 //!
 //! vLLM and TRT-LLM share the queue, allocation, and lifecycle core. Their
-//! admission and preemption differences live in [`policy`].
+//! admission and preemption differences live in `policy`.
 
 mod core;
 mod live;

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -64,7 +64,7 @@ pub mod logging {
         pub const OTEL_EXPORTER_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
 
         /// OTLP exporter endpoint URL for traces
-        /// Spec: https://opentelemetry.io/docs/specs/otel/protocol/exporter/
+        /// Spec: <https://opentelemetry.io/docs/specs/otel/protocol/exporter/>
         pub const OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
 
         /// OTLP exporter endpoint URL for logs. Falls back to OTEL_EXPORTER_OTLP_ENDPOINT or the protocol default when unset.
@@ -289,7 +289,7 @@ pub mod kvbm {
     /// NIXL backend configuration
     pub mod nixl {
         /// Prefix for NIXL backend environment variables
-        /// Pattern: DYN_KVBM_NIXL_BACKEND_<backend>=true/false
+        /// Pattern: `DYN_KVBM_NIXL_BACKEND_<backend>`=true/false
         /// Example: DYN_KVBM_NIXL_BACKEND_UCX=true
         pub const PREFIX: &str = "DYN_KVBM_NIXL_BACKEND_";
     }
@@ -435,7 +435,7 @@ pub mod llm {
         /// Custom metrics prefix (overrides default "dynamo_frontend")
         pub const DYN_METRICS_PREFIX: &str = "DYN_METRICS_PREFIX";
 
-        /// Histogram bucket configuration (pattern: <PREFIX>_MIN, <PREFIX>_MAX, <PREFIX>_COUNT)
+        /// Histogram bucket configuration (pattern: `<PREFIX>_MIN`, `<PREFIX>_MAX`, `<PREFIX>_COUNT`)
         /// Example: DYN_HISTOGRAM_TTFT_MIN, DYN_HISTOGRAM_TTFT_MAX, DYN_HISTOGRAM_TTFT_COUNT
         pub const HISTOGRAM_PREFIX: &str = "DYN_HISTOGRAM_";
     }
@@ -747,7 +747,7 @@ pub mod event_plane {
 /// ZMQ Broker environment variables
 pub mod zmq_broker {
     /// Explicit ZMQ broker URL (takes precedence over discovery)
-    /// Format: "xsub=<url1>[;<url2>...] , xpub=<url1>[;<url2>...]"
+    /// Format: `"xsub=<url1>[;<url2>...] , xpub=<url1>[;<url2>...]"`
     /// Example: "xsub=tcp://broker:5555 , xpub=tcp://broker:5556"
     pub const DYN_ZMQ_BROKER_URL: &str = "DYN_ZMQ_BROKER_URL";
 

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -56,7 +56,7 @@ impl EventTransportKind {
     /// Returns `Zmq` if the variable is not set or is empty: ZMQ is the default
     /// event plane for all backends. NATS remains available as an explicit opt-in
     /// (`DYN_EVENT_PLANE=nats`). When you have access to a runtime, prefer
-    /// [`DistributedRuntime::default_event_transport_kind`], which resolves the same
+    /// `DistributedRuntime::default_event_transport_kind`, which resolves the same
     /// default through the configured discovery backend.
     ///
     /// Returns an error for unrecognised values.

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -461,7 +461,7 @@ impl DistributedRuntime {
     /// The value is resolved once at construction time by `DiscoveryBackend::resolve_event_transport_kind`:
     /// if `DYN_EVENT_PLANE` is set explicitly that value wins; otherwise the default is ZMQ.
     ///
-    /// Use this instead of [`EventTransportKind::from_env_or_default`] wherever you have
+    /// Use this instead of `EventTransportKind::from_env_or_default` wherever you have
     /// access to a `DistributedRuntime`.
     pub fn default_event_transport_kind(&self) -> crate::discovery::EventTransportKind {
         self.event_transport_kind

--- a/lib/runtime/src/metrics/frontend_perf.rs
+++ b/lib/runtime/src/metrics/frontend_perf.rs
@@ -45,7 +45,7 @@ impl StageGuard {
     ///
     /// * `stage` — pipeline stage name; use `frontend_perf::STAGE_{PREPROCESS,ROUTE,DISPATCH}`
     ///   constants from [`crate::metrics::prometheus_names`].
-    /// * `phase` — request phase; use [`RequestPhase::to_string`] output
+    /// * `phase` — request phase; use `RequestPhase::to_string` output
     ///   (`"prefill"|"decode"|"aggregated"`), or `""` for stages without a phase.
     pub fn new(stage: &str, phase: &str) -> Self {
         let gauge = STAGE_REQUESTS.with_label_values(&[stage, phase]);

--- a/lib/runtime/src/nvtx.rs
+++ b/lib/runtime/src/nvtx.rs
@@ -3,7 +3,7 @@
 
 //! NVTX timeline-annotation helpers for Nsight Systems profiling.
 //!
-//! Delegates to [`cudarc::nvtx`] for the actual NVTX calls
+//! Delegates to `cudarc::nvtx` for the actual NVTX calls
 //!
 //! # Gating (two-level)
 //!

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -200,7 +200,7 @@ impl Drop for Cleanup {
 }
 
 /// Awaitable handle for a stream sender or receiver. Drop without calling
-/// [`into_parts()`] runs the optional cleanup closure, removing the
+/// `into_parts()` runs the optional cleanup closure, removing the
 /// registration from the stream server's maps.
 pub struct RegisteredStream<T> {
     pub connection_info: ConnectionInfo,

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -435,7 +435,7 @@ impl AddressedPushRouter {
 
     /// Bidirectional generation. Note that it doesn't implement the AsyncEngine trait directly
     /// because there is no trivial way to wrap (instance and address) into ManyIn style.
-    /// May wrap as SingleIn<AddressedStreamRequest<T>> and unwrap here but really just syntax
+    /// May wrap as `SingleIn<AddressedStreamRequest<T>>` and unwrap here but really just syntax
     /// sugar, so we just do it inline here. Will consider only if we do want to call this from
     /// typed erased AsyncEngine impls.
     pub async fn dispatch_bidirectional<T, U>(

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -1548,7 +1548,7 @@ impl TcpRequestClient {
     /// Start a background task that eagerly warms TCP connections for
     /// newly-discovered backends.
     ///
-    /// Delegates to [`TcpConnectionPool::start_warmup_watcher`].
+    /// Delegates to `TcpConnectionPool::start_warmup_watcher`.
     pub fn start_warmup(
         &self,
         instance_rx: tokio::sync::watch::Receiver<Vec<crate::component::Instance>>,

--- a/lib/runtime/src/service.rs
+++ b/lib/runtime/src/service.rs
@@ -42,15 +42,15 @@ impl ServiceClient {
 /// Tree structure:
 /// Structure:
 /// - ServiceSet
-///   - services: Vec<ServiceInfo>
+///   - services: `Vec<ServiceInfo>`
 ///     - name: String
 ///     - id: String
 ///     - version: String
 ///     - started: String
-///     - endpoints: Vec<EndpointInfo>
+///     - endpoints: `Vec<EndpointInfo>`
 ///       - name: String
 ///       - subject: String
-///       - data: Option<NatsStatsMetrics>
+///       - data: `Option<NatsStatsMetrics>`
 ///         - average_processing_time: f64
 ///         - last_error: String
 ///         - num_errors: u64
@@ -123,7 +123,7 @@ impl EndpointInfo {
 // for easy deserialization. Ideally, this type already exists or can
 // be exposed in the library somewhere.
 /// Stats structure returned from NATS service API
-/// https://github.com/nats-io/nats.rs/blob/main/async-nats/src/service/endpoint.rs
+/// <https://github.com/nats-io/nats.rs/blob/main/async-nats/src/service/endpoint.rs>
 #[derive(Debug, Clone, Serialize, Deserialize, Dissolve)]
 pub struct NatsStatsMetrics {
     // Standard NATS Stats Service API fields from $SRV.STATS.<service_name> requests

--- a/lib/runtime/src/tls_utils.rs
+++ b/lib/runtime/src/tls_utils.rs
@@ -32,7 +32,7 @@ pub fn handshake_timeout() -> std::time::Duration {
 
 /// Build a rustls `ServerConfig` from PEM certificate and key files.
 ///
-/// The certificate is served through a [`ReloadingCertifiedKey`], so a rotated
+/// The certificate is served through a `ReloadingCertifiedKey`, so a rotated
 /// cert/key on disk (in-place rewrite or an atomic symlink swap) is picked up
 /// automatically on the next handshake without restarting the process. The
 /// initial load is validated eagerly: an invalid cert/key path

--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -406,7 +406,7 @@ impl Default for NatsAuth {
 }
 
 /// Extract NATS bucket and key from a nats URL of the form:
-/// nats://host[:port]/bucket/key
+/// `nats://host[:port]/bucket/key`
 pub fn url_to_bucket_and_key(url: &Url) -> anyhow::Result<(String, String)> {
     let Some(mut path_segments) = url.path_segments() else {
         anyhow::bail!("No path in NATS URL: {url}");

--- a/lib/runtime/src/utils/tasks/critical.rs
+++ b/lib/runtime/src/utils/tasks/critical.rs
@@ -155,7 +155,7 @@ impl CriticalTaskExecutionHandle {
         })
     }
 
-    /// Check if the task awaiting on the [Server]s background event loop has finished.
+    /// Check if the task awaiting on the `Server`'s background event loop has finished.
     pub fn is_finished(&self) -> bool {
         self.monitor_task.is_finished()
     }

--- a/lib/runtime/src/utils/tasks/tracker.rs
+++ b/lib/runtime/src/utils/tasks/tracker.rs
@@ -546,7 +546,7 @@ pub trait Continuation: Send + Sync + std::fmt::Debug + std::any::Any {
     /// This method is called when a task fails and a continuation is provided.
     /// The implementation can perform retry logic, fallback operations,
     /// transformations, or any other follow-up action.
-    /// Returns the result in a type-erased Box<dyn Any> for flexibility.
+    /// Returns the result in a type-erased `Box<dyn Any>` for flexibility.
     async fn execute(
         &self,
         cancel_token: CancellationToken,
@@ -2136,7 +2136,7 @@ impl TaskTracker {
     ///
     /// The task will be wrapped with scheduling and error handling logic,
     /// then executed according to the configured policies. For tasks that
-    /// need to inspect cancellation tokens, use [`spawn_cancellable`] instead.
+    /// need to inspect cancellation tokens, use `spawn_cancellable` instead.
     ///
     /// # Arguments
     /// * `future` - The async task to execute

--- a/lib/runtime/src/worker.rs
+++ b/lib/runtime/src/worker.rs
@@ -13,10 +13,10 @@
 //! the signal handler used to trap `SIGINT` and `SIGTERM` signals and trigger a graceful shutdown.
 //!
 //! On termination, the user application is given a graceful shutdown period of controlled by
-//! the [DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT] environment variable. If the application does not
+//! the `DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT` environment variable. If the application does not
 //! shutdown in time, the worker will terminate the application with an exit code of 911.
 //!
-//! The default values of [DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT] differ between the development
+//! The default values of `DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT` differ between the development
 //! and release builds. In development, the default is [DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_DEBUG] and
 //! in release, the default is [DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_RELEASE].
 

--- a/lib/tokens/src/lib.rs
+++ b/lib/tokens/src/lib.rs
@@ -65,7 +65,7 @@ pub const CHAIN_XXH3_SEED: u64 = 1337;
 ///
 /// This is the single source of truth for the chain recurrence used by:
 /// - [`PositionalLineageHash::extend`]
-/// - [`TokenBlock::from_chunk`]
+/// - `TokenBlock::from_chunk`
 /// - `dynamo_kv_router::protocols::compute_next_seq_hash` (request side)
 /// - `dynamo_kv_router::indexer::PositionalIndexer` (chain re-validation)
 ///
@@ -1358,7 +1358,7 @@ impl TokenBlockSequence {
     /// If adding this token completes the current partial block, the block is committed,
     /// and the index of the newly completed block is returned.
     ///
-    /// This method is equivalent to calling [`extend`] with a single-token [`Tokens`] object.
+    /// This method is equivalent to calling `extend` with a single-token [`Tokens`] object.
     ///
     /// # Arguments
     ///
@@ -1471,7 +1471,7 @@ impl TokenBlockSequence {
 
     /// Removes the last `count` tokens from the sequence.
     ///
-    /// This is a convenience method that calculates the required length and calls [`truncate`].
+    /// This is a convenience method that calculates the required length and calls `truncate`.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
## Overview:

Cleans up all `cargo doc --no-deps` rustdoc lint warnings across the workspace (151 warnings, 77 files). Doc-comment-only changes — no logic touched.

## Details:

Fixes fall into a few categories:
- **Unclosed HTML tags** — unescaped generic syntax like `Vec<Block>`, `Option<usize>` misparsed as HTML tags; wrapped in backticks as inline code.
- **Unresolved intra-doc links** — `[X]` references rustdoc couldn't resolve; converted to plain code spans `` `X` ``, or fixed the path when the target genuinely existed and was public.
- **Links to private items** — public docs linking to private items; de-linked to code spans rather than making internals public.
- **Bare URLs** — wrapped in `<...>` autolink syntax.
- **Invalid ` ```ignore ` code blocks** — non-Rust snippets that failed to parse; changed the fence to ` ```text `.
- **Generated-code warnings** from `lib/llm/src/grpc/protos/model_config.proto` (embedded via prost-build into the generated gRPC bindings) — reworded `<model name>_<group number>` placeholder syntax to avoid literal angle brackets.

## Where should the reviewer start?

Any file is representative; `lib/llm/src/block_manager/pool/managed/inactive.rs` and `lib/runtime/src/config/environment_names.rs` had the most warnings fixed. `lib/llm/src/grpc/protos/model_config.proto` is the one non-`.rs` file touched.

## Validation

- `cargo doc --no-deps --workspace` produces zero rustdoc lint warnings (previously 151).
- `cargo build --workspace` succeeds.

## Related Issues
closes: DIS-2672
**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved and corrected documentation across runtime, memory, networking, routing, model serving, and token-processing components.
  * Standardized code formatting, cross-references, URLs, examples, and environment-variable references.
  * Clarified several workflow descriptions, API behaviors, safety notes, and configuration examples.
  * No runtime behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->