### PR TITLE
chore(container): bump etcd and NATS versions (cherry-pick #13016)

### DIFF
--- a/container/compliance/native_packages.yaml
+++ b/container/compliance/native_packages.yaml
@@ -118,7 +118,7 @@ packages:
   # etcd — coordination store, downloaded as a release binary in dynamo_base and
   # placed at /usr/local/bin (no apt metadata).
   - name: etcd
-    version: v3.5.30
+    version: v3.5.33
     license: Apache-2.0
     source: https://github.com/etcd-io/etcd
     images:
@@ -133,7 +133,7 @@ packages:
   # nats-server — messaging server, downloaded as a .deb in dynamo_base (dpkg -i
   # may not survive into the final runtime layer attribution reliably).
   - name: nats-server
-    version: v2.12.12
+    version: v2.12.14
     license: Apache-2.0
     source: https://github.com/nats-io/nats-server
     images:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -38,8 +38,8 @@ dynamo:
   # and uv rejects cache entries written by a newer version.
   uv_version: "0.12.0"
 
-  nats_version: v2.12.12
-  etcd_version: v3.5.30
+  nats_version: v2.12.14
+  etcd_version: v3.5.33
 
   nixl_ref: v1.0.1
   nixl_ucx_ref: v1.21.0

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -82,7 +82,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         "/opt/nvidia/nvda_nixl/lib64" \
         > /etc/ld.so.conf.d/00-dynamo-trtllm.conf && \
     ldconfig && \
-    rm -f /usr/local/bin/etcd && \
+    rm -f \
+        /usr/local/bin/etcd \
+        /usr/local/bin/etcdctl \
+        /usr/local/bin/etcdutl && \
     /usr/bin/python3 -m pip uninstall -y --break-system-packages wandb && \
     ! /usr/bin/python3 -c "import wandb" 2>/dev/null && \
     [ ! -e /usr/local/lib/python3.12/dist-packages/wandb ] && \
@@ -341,8 +344,8 @@ CMD ["/bin/bash"]
 # single layer. Only Dynamo-specific env needs redeclaring below.
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS pre_runtime
 # Whiteout paths runtime_full removed — COPY can't represent deletions, so
-# without this, upstream's /workspace, /home/ubuntu, single-file
-# /usr/local/bin/etcd, and preinstalled opencv (cv2/ + vendored
+# without this, upstream's /workspace, /home/ubuntu, standalone
+# /usr/local/bin/etcd* tools, and preinstalled opencv (cv2/ + vendored
 # opencv_python_headless.libs/ + dist-info) would leak alongside our content.
 # Keep this list in sync with any deletion RUNs in the stages above.
 #
@@ -364,7 +367,10 @@ FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS pre_runtime
 # has the same doubling problem. Dropping them here is free: the overlay restores
 # whatever runtime_full holds, so listing one that did not move costs nothing and
 # omitting one that did would leave stale metadata behind.
-RUN rm -rf /workspace /home/ubuntu /usr/local/bin/etcd \
+RUN rm -rf /workspace /home/ubuntu \
+    /usr/local/bin/etcd \
+    /usr/local/bin/etcdctl \
+    /usr/local/bin/etcdutl \
     /usr/local/bin/wandb \
     /usr/local/lib/python3.12/dist-packages/wandb \
     /usr/local/lib/python3.12/dist-packages/wandb-* \


### PR DESCRIPTION
Cherry-pick of #13016 (merged to `main` as 99a7976) onto `release/1.4.0`.

Brings the shared runtime pins to `etcd v3.5.33` and `NATS Server v2.12.14`, keeps `native_packages.yaml` attribution in step, and widens the TRT-LLM cleanup so `etcdctl` and `etcdutl` go with `etcd` rather than leaving the base image's older client tools in the final image.

Without this, 1.4.0 ships `etcd v3.5.30` and `NATS v2.12.12`. Both are upstream Go binaries, so a version bump is the only way to move them.

The `container/context.yaml` and `native_packages.yaml` hunks applied clean. In `trtllm_runtime.Dockerfile` the pick carries only what #13016 changes, the three client tools in place of the single `etcd` entry. The surrounding comment block on the main-side diff belongs to #13132 and reaches this branch through #13195 instead, so importing it here would have duplicated that work.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->