### PR TITLE
fix(vllm): use writable buffer for NIXL objects

### DIFF
--- a/components/src/dynamo/vllm/omni/connectors/nixl_connector.py
+++ b/components/src/dynamo/vllm/omni/connectors/nixl_connector.py
@@ -501,6 +501,7 @@ def _tensor_uint8_to_bytes(tensor: torch.Tensor) -> bytes:
 
 
 def _bytes_to_uint8_tensor(value: bytes, device: torch.device) -> torch.Tensor:
+    # Use writable storage because torch.frombuffer warns on immutable bytes.
     writable_value = bytearray(value)
     return (
         torch.frombuffer(writable_value, dtype=torch.uint8)

--- a/components/src/dynamo/vllm/omni/connectors/nixl_connector.py
+++ b/components/src/dynamo/vllm/omni/connectors/nixl_connector.py
@@ -501,9 +501,9 @@ def _tensor_uint8_to_bytes(tensor: torch.Tensor) -> bytes:
 
 
 def _bytes_to_uint8_tensor(value: bytes, device: torch.device) -> torch.Tensor:
+    writable_value = bytearray(value)
     return (
-        torch.frombuffer(value, dtype=torch.uint8)
-        .clone()
+        torch.frombuffer(writable_value, dtype=torch.uint8)
         .to(device=device)
         .contiguous()
     )


### PR DESCRIPTION
## Overview:

Fix the consistently failing vLLM-Omni NIXL object round-trip test in Nightly CI.

PyTorch warns when `torch.frombuffer` receives immutable `bytes`, even when the result is cloned immediately. Dynamo promotes warnings to errors in pytest, so serialized NIXL object transfers fail before the clone can make the tensor writable.

## Details:

- Copy serialized bytes into a writable `bytearray` before calling `torch.frombuffer`.
- Remove the now-redundant tensor clone.
- Keep the raw tensor transfer path unchanged.
- Do not suppress or filter any warnings.

This matches the existing writable-buffer pattern in `mm_kwargs_transfer.py`. The common small control-object path is slightly faster. Large generic serialized objects have a higher CPU copy cost, while large model tensors are unaffected because they use the raw tensor path.

### Validation

Tested on an NVIDIA RTX 6000 Ada 48 GB with the CUDA 13 vLLM test stack:

- Nightly-equivalent GPU scheduler invocation: 4 passed
- Full vLLM-Omni suite: 211 passed
- Real two-agent NIXL/UCX round trips:
  - structured serialized object
  - 1 MiB and 16 MiB serialized objects
  - 1 MiB CUDA tensor
- Explicit warning capture: zero warnings
- All repository pre-commit hooks passed
- Commit is OpenPGP-signed and DCO-compliant

No new test is added because `test_nixl_connector_object_roundtrip` already exercises the exact production conversion and fails under the repository's warning-as-error policy without this fix.

## Where should the reviewer start?

`components/src/dynamo/vllm/omni/connectors/nixl_connector.py`, in `_bytes_to_uint8_tensor`.

## Related Issues

- Linear: DYN-3971
- [x] Confirmed — no related GitHub issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when converting byte data for processing.
  * Avoided unnecessary copying during byte-buffer conversion, helping maintain efficient performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->