### PR TITLE
chore: clean up TRT-LLM runtime base-image leftovers (cherry-pick #13183)

### DIFF
--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -56,8 +56,11 @@ WORKDIR /workspace
 
 # Install packages missing from upstream, sanity-check libnixl, register
 # TRT-LLM lib paths with ldconfig (upstream's /etc/shinit_v2 only sets them
-# for shells, not K8s python3 launches), swap upstream's single-binary etcd
-# for dynamo_base's directory, and symlink system libstdc++ to a stable
+# for shells, not K8s python3 launches), swap upstream's standalone etcd
+# tooling (etcd, etcdctl, etcdutl) for dynamo_base's directory so the image
+# carries a single copy of each tool, drop the unused wandb developer tooling
+# the DLFW base carries (upstream removes it on main, Dockerfile.multi), and
+# symlink system libstdc++ to a stable
 # path for LD_PRELOAD — keeps PyInstaller-bundled tools (specifically `jet`,
 # NVIDIA's internal PyInstaller-packaged CI runner) from shadowing it with an
 # older copy.
@@ -80,6 +83,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         > /etc/ld.so.conf.d/00-dynamo-trtllm.conf && \
     ldconfig && \
     rm -f /usr/local/bin/etcd && \
+    /usr/bin/python3 -m pip uninstall -y --break-system-packages wandb && \
+    ! /usr/bin/python3 -c "import wandb" 2>/dev/null && \
+    [ ! -e /usr/local/lib/python3.12/dist-packages/wandb ] && \
     mkdir -p /opt/dynamo && \
     LIBSTDCPP=/usr/lib/${ARCH_ALT}-linux-gnu/libstdc++.so.6 && \
     test -f "$LIBSTDCPP" && ln -sf "$LIBSTDCPP" /opt/dynamo/libstdc++.so.6
@@ -338,6 +344,9 @@ FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS pre_runtime
 # whatever runtime_full holds, so listing one that did not move costs nothing and
 # omitting one that did would leave stale metadata behind.
 RUN rm -rf /workspace /home/ubuntu /usr/local/bin/etcd \
+    /usr/local/bin/wandb \
+    /usr/local/lib/python3.12/dist-packages/wandb \
+    /usr/local/lib/python3.12/dist-packages/wandb-* \
     /usr/local/lib/python3.12/dist-packages/cv2 \
     /usr/local/lib/python3.12/dist-packages/opencv_python_headless* \
     /usr/local/lib/python3.12/dist-packages/nvidia/dali \
@@ -359,7 +368,8 @@ RUN rm -rf /workspace /home/ubuntu /usr/local/bin/etcd \
     /usr/local/lib/python3.12/dist-packages/attr \
     /usr/local/lib/python3.12/dist-packages/attrs \
     /usr/local/lib/python3.12/dist-packages/attrs-* && \
-    ! /usr/bin/python3 -c "import cv2" 2>/dev/null
+    ! /usr/bin/python3 -c "import cv2" 2>/dev/null && \
+    ! /usr/bin/python3 -c "import wandb" 2>/dev/null
 COPY --from=runtime_full / /
 
 # Post-overlay guard for the DALI whiteout above. This is the only stage where


### PR DESCRIPTION
Cherry-pick of #13183 (merged to `main` as c3f85c9) onto `release/1.4.0`.

Removes wandb from the TRT-LLM runtime image. The uninstall runs against the system interpreter with `--break-system-packages`, because with `VIRTUAL_ENV` set a plain pip targets the venv and leaves the system-site copy in place where the image inventory reads it. Two build-time guards assert the removal took, and the whiteout is mirrored into the overlay stage so the squash `COPY` cannot re-add the tree.

## Scope

This carries only #13183's own contribution. On `main` its diff also shows `etcdctl` and `etcdutl` removals, but those came from #13016 and reach this branch through its own pick #13225. Importing them here would have duplicated that work and made the two picks fight over the same lines.

One consequence while both are in flight: the comment above the `rm -f` already names all three tools, because that wording is #13183's, while the command still removes only `etcd` until #13225 lands. #13225 is approved and makes the comment accurate.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->