### PR TITLE
docs(recipes): declare recipe-specific images

### DIFF
--- a/docs/fern/pages/recipes/_catalog/README.md
+++ b/docs/fern/pages/recipes/_catalog/README.md
@@ -82,8 +82,10 @@ python3 docs/fern/pages/recipes/_catalog/validate.py
 (The single script validates **both** catalogs.) It checks: index ↔ file
 correspondence (no orphans, no dangling entries), internal-`id`/filename match,
 no duplicate ids, schema conformance, that every `page:` resolves under `docs/fern/`,
-that every deploy/perf/benchmark asset path resolves in the repo, and
-cross-catalog referential integrity (recipe `related_benchmarks` ↔ benchmark
+that every deploy/perf/benchmark asset path resolves in the repo, that declared
+recipe-specific images are exact `image:` fields in their owning deploy assets
+and are not assigned to multiple recipes, and cross-catalog referential
+integrity (recipe `related_benchmarks` ↔ benchmark
 ids; benchmark `related_recipes` and `promotion_candidate.deferred_recipe_id` ↔
 recipe ids, including deferred). It exits non-zero on any failure.
 
@@ -92,10 +94,8 @@ The validator uses **stdlib only** and degrades gracefully: it prefers `pyyaml`
 parser and falls back to a required-keys check. It prints which mode it ran in.
 For full schema validation, `pip install pyyaml jsonschema`.
 
-> [!NOTE]
-> CI does not yet run this validator. **Follow-up:** wire
-> `python3 docs/fern/pages/recipes/_catalog/validate.py` into the docs CI job so catalog
-> changes are gated on it.
+The pre-merge recipe catalog tests run this validator, so catalog changes are
+gated on its path, attribution, and referential-integrity checks.
 
 ## Page blueprint
 

--- a/docs/fern/pages/recipes/_catalog/recipes/glm-5-2.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/glm-5-2.yaml
@@ -10,6 +10,9 @@ model:
   hf_id: nvidia/GLM-5.2-NVFP4 (B200) / zai-org/GLM-5.2-FP8 (H200)
   precision: NVFP4 + FP8 KV (B200) / FP8 + FP8 KV (H200)
 status: validated
+artifacts:
+  recipe_specific_images:
+  - nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
 targets:
 - id: sglang-agg-b200
   recommended: false

--- a/docs/fern/pages/recipes/_catalog/recipes/inkling.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/inkling.yaml
@@ -10,6 +10,9 @@ model:
   hf_id: thinkingmachines/Inkling-NVFP4
   precision: NVFP4
 status: experimental
+artifacts:
+  recipe_specific_images:
+  - nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-inkling-dev.1
 targets:
 - id: agg-b200
   recommended: true

--- a/docs/fern/pages/recipes/_catalog/recipes/kimi-k2-6.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/kimi-k2-6.yaml
@@ -10,6 +10,9 @@ model:
   hf_id: moonshotai/Kimi-K2.6
   precision: NVFP4 + FP8 KV (B200) / native INT4 (H200)
 status: validated
+artifacts:
+  recipe_specific_images:
+  - nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1
 targets:
 - id: agg-b200-chat
   recommended: true

--- a/docs/fern/pages/recipes/_catalog/recipes/kimi-k3.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/kimi-k3.yaml
@@ -10,6 +10,9 @@ model:
   hf_id: moonshotai/Kimi-K3
   precision: MXFP4 experts + BF16 dense, FP8 KV cache
 status: experimental  # Day-0
+artifacts:
+  recipe_specific_images:
+  - nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-kimi-k3-dev.1
 targets:
 - id: vllm-agg-gb200
   recommended: false

--- a/docs/fern/pages/recipes/_catalog/recipes/nemotron-3-5-lightning.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/nemotron-3-5-lightning.yaml
@@ -10,6 +10,10 @@ model:
   hf_id: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
   precision: NVFP4
 status: experimental
+artifacts:
+  recipe_specific_images:
+  - nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
+  - nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
 targets:
 - id: vllm-agg-b200-dspark
   recommended: true

--- a/docs/fern/pages/recipes/_catalog/recipes/nemotron-3-super.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/nemotron-3-super.yaml
@@ -10,6 +10,9 @@ model:
   hf_id: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 (B200) / -FP8 (H200)
   precision: NVFP4 (B200) / FP8 (H200), FP8 KV
 status: validated
+artifacts:
+  recipe_specific_images:
+  - nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1
 targets:
 - id: agg-b200-chat
   recommended: true

--- a/docs/fern/pages/recipes/_catalog/recipes/nemotron-3-ultra.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/nemotron-3-ultra.yaml
@@ -10,6 +10,9 @@ model:
   hf_id: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
   precision: NVFP4 + FP8
 status: experimental
+artifacts:
+  recipe_specific_images:
+  - nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
 targets:
 - id: agg-b200-chat-mtp
   recommended: true

--- a/docs/fern/pages/recipes/_catalog/recipes/qwen-3-8-2-4t-a95b-fp8.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/qwen-3-8-2-4t-a95b-fp8.yaml
@@ -10,6 +10,10 @@ model:
   hf_id: Qwen/Qwen3.8-2.4T-A95B-FP8
   precision: FP8 weights, FP8 KV cache
 status: experimental
+artifacts:
+  recipe_specific_images:
+  - nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-qwen-3.8-2.4t-dev.1
+  - nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-qwen-3.8-2.4t-dev.1
 targets:
 - id: vllm-agg-gb300-chat
   recommended: true

--- a/docs/fern/pages/recipes/_catalog/schema.json
+++ b/docs/fern/pages/recipes/_catalog/schema.json
@@ -47,6 +47,23 @@
       "type": "string",
       "enum": ["validated", "experimental"]
     },
+    "artifacts": {
+      "type": "object",
+      "description": "Recipe-owned published artifacts used for exact adoption attribution.",
+      "required": ["recipe_specific_images"],
+      "properties": {
+        "recipe_specific_images": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^nvcr\\.io/nvidia/ai-dynamo/[A-Za-z0-9._-]+:[^\\s@]+$"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "targets": {
       "type": "array",
       "minItems": 1,

--- a/docs/fern/pages/recipes/_catalog/schema.json
+++ b/docs/fern/pages/recipes/_catalog/schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\nSPDX-License-Identifier: Apache-2.0",
   "$id": "https://github.com/ai-dynamo/dynamo/docs/recipes/_catalog/schema.json",
   "title": "Dynamo recipe catalog entry",
   "description": "JSON Schema (draft 2020-12) for ONE recipe object, i.e. the contents of docs/recipes/_catalog/recipes/<id>.yaml. Derived from the data in the former recipes.yaml. Active recipes carry a rendered `page`; deferred recipes carry a `deferred_reason` and have no rendered page.",
@@ -58,7 +59,7 @@
           "uniqueItems": true,
           "items": {
             "type": "string",
-            "pattern": "^nvcr\\.io/nvidia/ai-dynamo/[A-Za-z0-9._-]+:[^\\s@]+$"
+            "pattern": "^nvcr\\.io/nvidia/ai-dynamo/[A-Za-z0-9._-]+:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$"
           }
         }
       },

--- a/docs/fern/pages/recipes/_catalog/validate.py
+++ b/docs/fern/pages/recipes/_catalog/validate.py
@@ -426,12 +426,14 @@ def check_page(obj, label):
 
 
 def check_assets_recipe(obj, label):
+    deploy_assets = []
     for t in obj.get("targets") or []:
         if not isinstance(t, dict):
             continue
         dep = t.get("deploy") or {}
         asset = dep.get("asset") if isinstance(dep, dict) else None
         if asset:
+            deploy_assets.append(asset)
             if not os.path.isfile(resolve_repo_path(asset)):
                 err(
                     "[%s] target %s deploy asset missing: %s"
@@ -445,6 +447,23 @@ def check_assets_recipe(obj, label):
                     "[%s] target %s benchmark asset missing: %s"
                     % (label, t.get("id"), basset)
                 )
+    check_recipe_specific_images(obj, deploy_assets, label)
+
+
+def check_recipe_specific_images(obj, deploy_assets, label):
+    configured_images = (obj.get("artifacts") or {}).get("recipe_specific_images") or []
+    deploy_documents = []
+    for asset in deploy_assets:
+        path = resolve_repo_path(asset)
+        if os.path.isfile(path):
+            with open(path, "r") as f:
+                deploy_documents.append(f.read())
+    for image in configured_images:
+        if not any(image in document for document in deploy_documents):
+            err(
+                "[%s] recipe-specific image is not referenced by a deploy asset: %s"
+                % (label, image)
+            )
 
 
 def check_assets_benchmark(obj, label):

--- a/docs/fern/pages/recipes/_catalog/validate.py
+++ b/docs/fern/pages/recipes/_catalog/validate.py
@@ -12,7 +12,9 @@ Checks, for BOTH catalogs:
   4. Each entry validates against schema.json (uses the `jsonschema` package
      if importable; otherwise falls back to a required-top-level-keys check).
   5. Every `page:` path resolves to a real file under docs/.
-  6. Every deploy / perf / benchmark asset path resolves in the repo tree.
+  6. Every deploy / perf / benchmark asset path resolves in the repo tree;
+     declared recipe-specific images are exact image fields in an owning
+     deploy asset and are not declared by another recipe.
   7. Cross-catalog referential integrity: recipe related_benchmarks ids exist
      in the benchmark index; benchmark related_recipes ids exist in the recipe
      index (active OR deferred); benchmark promotion_candidate.deferred_recipe_id
@@ -32,6 +34,7 @@ Runnable from the repo root as:
 
 import json
 import os
+import re
 import sys
 
 # --- Locate repo root relative to this script ---------------------------------
@@ -311,6 +314,10 @@ def load_yaml(path):
 ERRORS = []
 WARNINGS = []
 
+_IMAGE_FIELD_RE = re.compile(
+    r"""^\s*(?:-\s*)?image:\s*(?:"([^"]+)"|'([^']+)'|([^\s#]+))\s*(?:#.*)?$"""
+)
+
 
 def err(msg):
     ERRORS.append(msg)
@@ -450,19 +457,61 @@ def check_assets_recipe(obj, label):
     check_recipe_specific_images(obj, deploy_assets, label)
 
 
+def _deploy_images(path):
+    images = set()
+    with open(path, "r") as f:
+        for line in f:
+            match = _IMAGE_FIELD_RE.match(line)
+            if match:
+                images.add(next(value for value in match.groups() if value is not None))
+    return images
+
+
 def check_recipe_specific_images(obj, deploy_assets, label):
-    configured_images = (obj.get("artifacts") or {}).get("recipe_specific_images") or []
-    deploy_documents = []
+    artifacts = obj.get("artifacts")
+    if artifacts is None:
+        return
+    if not isinstance(artifacts, dict):
+        err("[%s] artifacts must be an object" % label)
+        return
+    configured_images = artifacts.get("recipe_specific_images")
+    if configured_images is None:
+        return
+    if not isinstance(configured_images, list):
+        err("[%s] artifacts.recipe_specific_images must be an array" % label)
+        return
+    deployed_images = set()
     for asset in deploy_assets:
         path = resolve_repo_path(asset)
         if os.path.isfile(path):
-            with open(path, "r") as f:
-                deploy_documents.append(f.read())
+            deployed_images.update(_deploy_images(path))
     for image in configured_images:
-        if not any(image in document for document in deploy_documents):
+        if image not in deployed_images:
             err(
                 "[%s] recipe-specific image is not referenced by a deploy asset: %s"
                 % (label, image)
+            )
+
+
+def check_recipe_specific_image_ownership(entries):
+    owners = {}
+    for recipe_id, obj in entries.items():
+        if not isinstance(obj, dict):
+            continue
+        artifacts = obj.get("artifacts")
+        if not isinstance(artifacts, dict):
+            continue
+        configured_images = artifacts.get("recipe_specific_images")
+        if not isinstance(configured_images, list):
+            continue
+        for image in configured_images:
+            if isinstance(image, str):
+                owners.setdefault(image, set()).add(recipe_id)
+    for image, recipe_ids in sorted(owners.items()):
+        if len(recipe_ids) > 1:
+            err(
+                "[recipes] recipe-specific image declared by multiple recipes: %s (%s)"
+                % (image, ", ".join(sorted(recipe_ids)))
             )
 
 
@@ -520,6 +569,7 @@ def main():
         validate_against_schema(obj, rec_schema, label)
         check_page(obj, label)
         check_assets_recipe(obj, label)
+    check_recipe_specific_image_ownership(rec_entries)
 
     for fid, obj in sorted(ben_entries.items()):
         if not isinstance(obj, dict):

--- a/tests/docs/test_recipe_catalog_artifacts.py
+++ b/tests/docs/test_recipe_catalog_artifacts.py
@@ -66,7 +66,7 @@ _SPEC.loader.exec_module(catalog_validate)
             ("nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1",),
         ),
         (
-            "qwen-3-8-2-4t-a95b",
+            "qwen-3-8-2-4t-a95b-fp8",
             (
                 "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-qwen-3.8-2.4t-dev.1",
                 "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-qwen-3.8-2.4t-dev.1",

--- a/tests/docs/test_recipe_catalog_artifacts.py
+++ b/tests/docs/test_recipe_catalog_artifacts.py
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib.util
+import json
+import re
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -8,20 +13,170 @@ import yaml
 
 pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
 
-CATALOG = Path("docs/fern/pages/recipes/_catalog")
-EXPECTED_RECIPE_IMAGES = {
-    "glm-5-2": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1",
-    "inkling": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-inkling-dev.1",
-    "kimi-k2-6": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1",
-    "kimi-k3": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-kimi-k3-dev.1",
-    "nemotron-3-super": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1",
-    "nemotron-3-ultra": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1",
-}
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CATALOG = REPO_ROOT / "docs/fern/pages/recipes/_catalog"
+VALIDATOR_PATH = CATALOG / "validate.py"
+
+_SPEC = importlib.util.spec_from_file_location(
+    "recipe_catalog_validate", VALIDATOR_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+catalog_validate = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(catalog_validate)
 
 
-def test_recipe_specific_images_are_catalog_owned() -> None:
-    for recipe_id, image in EXPECTED_RECIPE_IMAGES.items():
-        document = yaml.safe_load(
-            (CATALOG / "recipes" / f"{recipe_id}.yaml").read_text()
-        )
-        assert document["artifacts"]["recipe_specific_images"] == [image]
+@pytest.mark.parametrize(
+    ("recipe_id", "expected_images"),
+    (
+        (
+            "glm-5-2",
+            ("nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1",),
+        ),
+        (
+            "inkling",
+            ("nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-inkling-dev.1",),
+        ),
+        (
+            "kimi-k2-6",
+            ("nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1",),
+        ),
+        (
+            "kimi-k3",
+            ("nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-kimi-k3-dev.1",),
+        ),
+        (
+            "nemotron-3-5-lightning",
+            (
+                "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1",
+                "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1",
+            ),
+        ),
+        (
+            "nemotron-3-super",
+            ("nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1",),
+        ),
+        (
+            "nemotron-3-ultra",
+            ("nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1",),
+        ),
+        (
+            "qwen-3-8-2-4t-a95b",
+            (
+                "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-qwen-3.8-2.4t-dev.1",
+                "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-qwen-3.8-2.4t-dev.1",
+            ),
+        ),
+    ),
+)
+def test_recipe_specific_images_are_catalog_owned(
+    recipe_id: str,
+    expected_images: tuple[str, ...],
+) -> None:
+    document = yaml.safe_load((CATALOG / "recipes" / f"{recipe_id}.yaml").read_text())
+    assert tuple(document["artifacts"]["recipe_specific_images"]) == expected_images
+
+
+def test_recipe_catalog_schema_has_spdx_metadata() -> None:
+    schema = json.loads((CATALOG / "schema.json").read_text())
+
+    assert schema["$comment"] == (
+        "SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & "
+        "AFFILIATES. All rights reserved.\n"
+        "SPDX-License-Identifier: Apache-2.0"
+    )
+
+
+@pytest.mark.parametrize(
+    "image",
+    (
+        "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0/invalid",
+        "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0:invalid",
+    ),
+)
+def test_recipe_catalog_schema_rejects_malformed_image_tags(image: str) -> None:
+    schema = json.loads((CATALOG / "schema.json").read_text())
+    pattern = schema["properties"]["artifacts"]["properties"]["recipe_specific_images"][
+        "items"
+    ]["pattern"]
+
+    assert re.fullmatch(pattern, image) is None
+
+
+@pytest.mark.parametrize(
+    ("artifacts", "expected_error"),
+    (
+        ("not-an-object", "artifacts must be an object"),
+        (
+            {"recipe_specific_images": ""},
+            "artifacts.recipe_specific_images must be an array",
+        ),
+        (
+            {"recipe_specific_images": "not-an-array"},
+            "artifacts.recipe_specific_images must be an array",
+        ),
+    ),
+)
+def test_recipe_image_validation_reports_malformed_artifacts(
+    artifacts: object,
+    expected_error: str,
+) -> None:
+    catalog_validate.ERRORS.clear()
+
+    catalog_validate.check_recipe_specific_images(
+        {"artifacts": artifacts}, [], "recipe:malformed"
+    )
+
+    assert any(expected_error in error for error in catalog_validate.ERRORS)
+
+
+def test_recipe_image_validation_ignores_comment_only_references(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    declared = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-recipe-dev.1"
+    asset = tmp_path / "deploy.yaml"
+    asset.write_text(
+        "# image: " + declared + "\n"
+        "containers:\n"
+        "- image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0\n"
+    )
+    monkeypatch.setattr(catalog_validate, "REPO_ROOT", str(tmp_path))
+    catalog_validate.ERRORS.clear()
+
+    catalog_validate.check_recipe_specific_images(
+        {"artifacts": {"recipe_specific_images": [declared]}},
+        [asset.name],
+        "recipe:comment-only",
+    )
+
+    assert any(
+        "is not referenced by a deploy asset" in error
+        for error in catalog_validate.ERRORS
+    )
+
+
+def test_recipe_image_validation_rejects_duplicate_ownership() -> None:
+    image = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-shared-dev.1"
+    entries = {
+        "recipe-a": {"artifacts": {"recipe_specific_images": [image]}},
+        "recipe-b": {"artifacts": {"recipe_specific_images": [image]}},
+    }
+    catalog_validate.ERRORS.clear()
+
+    catalog_validate.check_recipe_specific_image_ownership(entries)
+
+    assert any(
+        "declared by multiple recipes" in error for error in catalog_validate.ERRORS
+    )
+
+
+def test_recipe_catalog_validator_runs_in_pre_merge(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR_PATH)],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/docs/test_recipe_catalog_artifacts.py
+++ b/tests/docs/test_recipe_catalog_artifacts.py
@@ -17,6 +17,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CATALOG = REPO_ROOT / "docs/fern/pages/recipes/_catalog"
 VALIDATOR_PATH = CATALOG / "validate.py"
 
+if not VALIDATOR_PATH.is_file():
+    pytest.skip(
+        "recipe catalog sources are not present in this runtime image",
+        allow_module_level=True,
+    )
+
 _SPEC = importlib.util.spec_from_file_location(
     "recipe_catalog_validate", VALIDATOR_PATH
 )

--- a/tests/docs/test_recipe_catalog_artifacts.py
+++ b/tests/docs/test_recipe_catalog_artifacts.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
+CATALOG = Path("docs/fern/pages/recipes/_catalog")
+EXPECTED_RECIPE_IMAGES = {
+    "glm-5-2": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1",
+    "inkling": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-inkling-dev.1",
+    "kimi-k2-6": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1",
+    "kimi-k3": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-kimi-k3-dev.1",
+    "nemotron-3-super": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1",
+    "nemotron-3-ultra": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1",
+}
+
+
+def test_recipe_specific_images_are_catalog_owned() -> None:
+    for recipe_id, image in EXPECTED_RECIPE_IMAGES.items():
+        document = yaml.safe_load(
+            (CATALOG / "recipes" / f"{recipe_id}.yaml").read_text()
+        )
+        assert document["artifacts"]["recipe_specific_images"] == [image]


### PR DESCRIPTION
Summary:
- add catalog-owned recipe_specific_images metadata for six recipes with exact published NGC tags
- extend the catalog schema and validator so declared images must exist in a referenced deploy asset
- add a pre-merge unit contract for the current mappings

Why:
The internal Recipes Adoption dashboard needs an upstream-owned attribution contract instead of hardcoded recipe-to-image mappings.

Validation:
- full catalog validator in JSON-schema mode: 21 recipes and 6 benchmarks passed
- focused catalog ownership test passed
- repository pre-commit and commit-msg hooks passed

Follow-up:
The dashboard MR will consume this metadata and will reject publication if no exact recipe-specific image mappings are present.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recipe-specific runtime image details for six recipes.
  * Recipe catalog entries now support validated container image artifact references.
* **Bug Fixes**
  * Added validation to detect recipe images that are not referenced by deployable assets.
* **Tests**
  * Added coverage confirming expected runtime images are configured across supported recipes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->