### PR TITLE
feat(vllm): consume workflow encoder results

### DIFF
--- a/components/src/dynamo/common/external_encoder.py
+++ b/components/src/dynamo/common/external_encoder.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned handoff from an external encoder to an LLM worker."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+EXTERNAL_ENCODER_RESULT_SCHEMA = "dynamo.external_encoder_result"
+EXTERNAL_ENCODER_RESULT_VERSION = 0
+LINEAR_EMBEDDINGS_FORMAT = "linear_embeddings"
+
+
+def _check_keys(data: Mapping[str, Any], required: set[str]) -> None:
+    missing = required - set(data)
+    unknown = set(data) - required
+    if missing:
+        raise ValueError(f"external encoder result missing fields: {sorted(missing)}")
+    if unknown:
+        raise ValueError(
+            f"external encoder result has unknown fields: {sorted(unknown)}"
+        )
+
+
+@dataclass(frozen=True)
+class ExternalEncoderResult:
+    """NIXL reference plus metadata for packed linear embeddings."""
+
+    features: Mapping[str, Any]
+    row_splits: tuple[int, ...]
+    image_token_id: int
+    format: str = LINEAR_EMBEDDINGS_FORMAT
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.features, Mapping) or not self.features:
+            raise ValueError("external encoder features must be a non-empty object")
+        if self.format != LINEAR_EMBEDDINGS_FORMAT:
+            raise ValueError(f"unsupported external encoder format {self.format!r}")
+        row_splits = tuple(self.row_splits)
+        if len(row_splits) < 2 or row_splits[0] != 0:
+            raise ValueError("external encoder row_splits must start at zero")
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in row_splits
+        ):
+            raise ValueError(
+                "external encoder row_splits must contain non-negative integers"
+            )
+        if any(left > right for left, right in zip(row_splits, row_splits[1:])):
+            raise ValueError("external encoder row_splits must be non-decreasing")
+        if isinstance(self.image_token_id, bool) or not isinstance(
+            self.image_token_id, int
+        ):
+            raise ValueError("external encoder image_token_id must be an integer")
+        if self.image_token_id < 0:
+            raise ValueError("external encoder image_token_id must be non-negative")
+
+        shape = self.features.get("shape")
+        if (
+            isinstance(shape, list)
+            and shape
+            and isinstance(shape[0], int)
+            and not isinstance(shape[0], bool)
+            and row_splits[-1] != shape[0]
+        ):
+            raise ValueError(
+                "external encoder row_splits do not cover the packed feature rows"
+            )
+        object.__setattr__(self, "features", MappingProxyType(dict(self.features)))
+        object.__setattr__(self, "row_splits", row_splits)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": EXTERNAL_ENCODER_RESULT_SCHEMA,
+            "version": EXTERNAL_ENCODER_RESULT_VERSION,
+            "format": self.format,
+            "features": dict(self.features),
+            "row_splits": list(self.row_splits),
+            "image_token_id": self.image_token_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ExternalEncoderResult":
+        if not isinstance(data, Mapping):
+            raise ValueError("external encoder result must be an object")
+        _check_keys(
+            data,
+            {
+                "schema",
+                "version",
+                "format",
+                "features",
+                "row_splits",
+                "image_token_id",
+            },
+        )
+        if data["schema"] != EXTERNAL_ENCODER_RESULT_SCHEMA:
+            raise ValueError(f"unsupported external encoder schema {data['schema']!r}")
+        version = data["version"]
+        if (
+            isinstance(version, bool)
+            or not isinstance(version, int)
+            or version != EXTERNAL_ENCODER_RESULT_VERSION
+        ):
+            raise ValueError(f"unsupported external encoder version {version!r}")
+        row_splits = data["row_splits"]
+        if not isinstance(row_splits, list):
+            raise ValueError("external encoder row_splits must be an array")
+        return cls(
+            features=data["features"],
+            row_splits=tuple(row_splits),
+            image_token_id=data["image_token_id"],
+            format=data["format"],
+        )
+
+    @classmethod
+    def from_parts(
+        cls, features: Mapping[str, Any], metadata: Mapping[str, Any]
+    ) -> "ExternalEncoderResult":
+        if not isinstance(metadata, Mapping):
+            raise ValueError("external encoder metadata must be an object")
+        _check_keys(metadata, {"row_splits", "image_token_id"})
+        row_splits = metadata["row_splits"]
+        if not isinstance(row_splits, list):
+            raise ValueError("external encoder row_splits must be an array")
+        return cls(
+            features=features,
+            row_splits=tuple(row_splits),
+            image_token_id=metadata["image_token_id"],
+        )

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -100,6 +100,7 @@ from .multimodal_utils.custom_encoder import (
     VisionEncoderBackend,
     create_custom_encoder_adapter,
 )
+from .multimodal_utils.external_encoder import ExternalEncoderPromptLoader
 from .multimodal_utils.prefill_worker_utils import MultiModalEmbeddingLoader
 from .multimodal_utils.request_processor import (
     IMAGE_URL_KEY,
@@ -3152,6 +3153,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             enable_frontend_decoding=enable_frontend_decoding,
             encode_worker_client=encode_worker_client,
         )
+        # This path is decoder-specific and the NIXL importer itself remains
+        # lazy until a request actually carries encoder_result.
+        self._external_encoder_prompt_loader: Optional[
+            ExternalEncoderPromptLoader
+        ] = None
 
     async def generate(self, request, context):
         # Use context ID for request tracking and correlation
@@ -3162,6 +3168,16 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         with time_and_log_code_section(
             f"[DECODE] request: {request_id} generate"
         ) as decode_timer:
+            if self.use_vllm_tokenizer and request.get("encoder_result") is not None:
+                yield {
+                    "finish_reason": (
+                        "error: external encoder results require token-in/token-out "
+                        "mode"
+                    ),
+                    "index": 0,
+                    "token_ids": [],
+                }
+                return
             if self.use_vllm_tokenizer:
                 # Text-in-text-out mode: use InputParamManager and OpenAI-compatible format
                 generator = self._generate_text_mode(request, context, request_id)
@@ -3276,6 +3292,63 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         )
         return prepared
 
+    async def _assemble_external_encoder_prompt(
+        self,
+        request: Dict[str, Any],
+        request_id: str,
+    ) -> tuple[EmbedsPrompt | None, Dict[str, Any] | None]:
+        """Import a workflow encoder result and prepare the vLLM prompt."""
+
+        conflicts = [
+            key
+            for key in (
+                "multi_modal_data",
+                "multi_modal_uuids",
+                "prompt_embeds",
+            )
+            if request.get(key) is not None
+        ]
+        extra_args = request.get("extra_args")
+        if isinstance(extra_args, Mapping):
+            conflicts.extend(
+                f"extra_args.{key}"
+                for key in ("mm_kwargs_shm", "mm_kwargs_nixl")
+                if extra_args.get(key) is not None
+            )
+
+        try:
+            if conflicts:
+                raise ValueError(
+                    "encoder_result is authoritative and cannot be combined with "
+                    f"raw multimodal or prompt embedding fields: {sorted(conflicts)}"
+                )
+            encoder_result = request.get("encoder_result")
+            if not isinstance(encoder_result, Mapping):
+                raise ValueError("encoder_result must be an object")
+            token_ids = request.get("token_ids")
+            if not isinstance(token_ids, list):
+                raise ValueError("external encoder results require token_ids")
+            if self._external_encoder_prompt_loader is None:
+                self._external_encoder_prompt_loader = ExternalEncoderPromptLoader(
+                    self.model_config,
+                    self.config.engine_args,
+                )
+            prompt = await self._external_encoder_prompt_loader.load(
+                encoder_result,
+                token_ids,
+            )
+        except Exception as exc:
+            msg = f"External encoder result failed: {exc}"
+            logger.exception("Request %s: %s", request_id, msg)
+            return None, {
+                "finish_reason": f"error: {msg}",
+                "index": 0,
+                "token_ids": [],
+            }
+
+        logger.debug("Request %s: prepared external encoder prompt", request_id)
+        return prompt, None
+
     async def _generate_token_mode(self, request, context, request_id):
         """Generate tokens using internal protocol format (token-in-token-out)."""
         # Firstly extract disaggregated params from prefill result if available
@@ -3291,6 +3364,17 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             kv_params = None
 
         mode = cast(DisaggregationMode, self.config.disaggregation_mode)
+        has_external_encoder_result = request.get("encoder_result") is not None
+        if has_external_encoder_result and mode != DisaggregationMode.AGGREGATED:
+            yield {
+                "finish_reason": (
+                    "error: external encoder results currently require an "
+                    "aggregated vLLM worker"
+                ),
+                "index": 0,
+                "token_ids": [],
+            }
+            return
         is_decode_only = mode == DisaggregationMode.DECODE
         if is_decode_only and BYPASS_REMOTE_PREFILL_ANNOTATION in (
             request.get("annotations") or []
@@ -3302,9 +3386,20 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             is_decode_only = False
             mode = DisaggregationMode.AGGREGATED
         has_mm_data = request.get("multi_modal_data") is not None
-        custom_prompt: EmbedsPrompt | TokensPrompt | None = None
+        assembled_prompt: EmbedsPrompt | TokensPrompt | None = None
 
-        if (
+        if has_external_encoder_result:
+            (
+                assembled_prompt,
+                assemble_error,
+            ) = await self._assemble_external_encoder_prompt(request, request_id)
+            if assemble_error is not None:
+                yield assemble_error
+                return
+            multi_modal_data = None
+            mm_processor_kwargs = None
+            pre_rendered = None
+        elif (
             mode == DisaggregationMode.AGGREGATED
             and self._custom_encoder is not None
             and has_mm_data
@@ -3315,7 +3410,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             # Failures propagate as exceptions; the bindings map the type to a
             # typed backend error, so an input fault answers 400 with its
             # message and an engine fault stays a retryable 5xx.
-            custom_prompt = await self._assemble_custom_encoder_prompt(
+            assembled_prompt = await self._assemble_custom_encoder_prompt(
                 request,
                 request_id,
             )
@@ -3350,8 +3445,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # branches without spelling out the full union.
         prompt: Any
         with _nvtx.annotate("mm_backend:build_prompt", color="yellow"):
-            if custom_prompt is not None:
-                prompt = custom_prompt
+            if assembled_prompt is not None:
+                prompt = assembled_prompt
             elif pre_rendered is not None:
                 # pre_rendered is a MultiModalInput dict with "type": "multimodal".
                 # The engine's InputProcessor.process_inputs() will see the "type"

--- a/components/src/dynamo/vllm/multimodal_utils/external_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/external_encoder.py
@@ -29,7 +29,7 @@ def _make_cpu_nixl_importer() -> TensorImporter:
     # Keep the workflow/NIXL dependency off the ordinary vLLM startup path.
     # The package (and its native connector) is loaded only when the first
     # request actually carries an external encoder result.
-    from dynamo.workflow.nixl import NixlTensorCarrier
+    from dynamo.experimental.workflow.nixl import NixlTensorCarrier
 
     return NixlTensorCarrier(receive_device="cpu")
 

--- a/components/src/dynamo/vllm/multimodal_utils/external_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/external_encoder.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Turn a workflow-produced external encoder result into a vLLM prompt."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol
+
+import torch
+from vllm.inputs import EmbedsPrompt
+
+from dynamo.common.external_encoder import ExternalEncoderResult
+from dynamo.vllm.multimodal_utils.custom_encoder.adapter.linear import (
+    build_mixed_embeds,
+)
+from dynamo.vllm.multimodal_utils.model_config import _hidden_size, _is_multimodal_model
+
+
+class TensorImporter(Protocol):
+    """Consumer-side subset of the workflow NIXL carrier."""
+
+    async def import_tensor(self, reference: Mapping[str, Any]) -> Any:
+        ...
+
+
+def _make_cpu_nixl_importer() -> TensorImporter:
+    # Keep the workflow/NIXL dependency off the ordinary vLLM startup path.
+    # The package (and its native connector) is loaded only when the first
+    # request actually carries an external encoder result.
+    from dynamo.workflow.nixl import NixlTensorCarrier
+
+    return NixlTensorCarrier(receive_device="cpu")
+
+
+class ExternalEncoderPromptLoader:
+    """Import packed visual features and build a mixed ``EmbedsPrompt``."""
+
+    def __init__(
+        self,
+        model_config: Any,
+        engine_args: Any,
+        *,
+        importer_factory: Callable[[], TensorImporter] = _make_cpu_nixl_importer,
+    ) -> None:
+        if model_config is None:
+            raise ValueError(
+                "external encoder results require the resolved vLLM ModelConfig"
+            )
+        if _is_multimodal_model(model_config):
+            raise ValueError(
+                "external linear embeddings currently require a text-only decoder"
+            )
+        if not getattr(engine_args, "enable_prompt_embeds", False):
+            raise ValueError(
+                "external linear embeddings require --enable-prompt-embeds"
+            )
+
+        self._hidden_size = _hidden_size(model_config)
+        model_dtype = getattr(model_config, "dtype", None)
+        self._dtype = model_dtype if isinstance(model_dtype, torch.dtype) else None
+        self._importer_factory = importer_factory
+        self._importer: TensorImporter | None = None
+
+    async def load(
+        self,
+        encoder_result: Mapping[str, Any],
+        token_ids: list[int],
+    ) -> EmbedsPrompt:
+        """Read one packed feature tensor and adapt it to vLLM's mixed mode."""
+
+        parsed = ExternalEncoderResult.from_dict(encoder_result)
+        if self._importer is None:
+            self._importer = self._importer_factory()
+        packed = await self._importer.import_tensor(parsed.features)
+        if not isinstance(packed, torch.Tensor):
+            raise TypeError(
+                "external encoder NIXL import must produce a torch.Tensor; "
+                f"got {type(packed).__name__}"
+            )
+        if packed.device.type != "cpu":
+            raise ValueError(
+                f"external encoder tensor is on {packed.device}; expected CPU"
+            )
+        if packed.dim() != 2 or packed.shape[1] != self._hidden_size:
+            raise ValueError(
+                f"external encoder tensor has shape {tuple(packed.shape)}; "
+                f"expected 2D with decoder hidden size {self._hidden_size}"
+            )
+        if self._dtype is not None and packed.dtype != self._dtype:
+            raise ValueError(
+                f"external encoder tensor has dtype {packed.dtype}; "
+                f"expected decoder dtype {self._dtype}"
+            )
+        if parsed.row_splits[-1] != packed.shape[0]:
+            raise ValueError(
+                "external encoder row_splits do not cover the imported tensor rows"
+            )
+
+        rows = [
+            packed[start:end]
+            for start, end in zip(parsed.row_splits, parsed.row_splits[1:])
+        ]
+        prompt_embeds, prompt_token_ids, prompt_is_token_ids = build_mixed_embeds(
+            token_ids,
+            rows,
+            parsed.image_token_id,
+        )
+        return EmbedsPrompt(
+            prompt_embeds=prompt_embeds,
+            prompt_token_ids=prompt_token_ids,
+            prompt_is_token_ids=prompt_is_token_ids,
+        )

--- a/components/src/dynamo/vllm/tests/test_vllm_external_encoder.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_external_encoder.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for workflow-produced encoder results consumed by stock vLLM."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import torch
+from vllm.inputs import EmbedsPrompt
+
+from dynamo.common.external_encoder import ExternalEncoderResult
+from dynamo.vllm.constants import DisaggregationMode
+from dynamo.vllm.handlers import DecodeWorkerHandler
+from dynamo.vllm.multimodal_utils.external_encoder import ExternalEncoderPromptLoader
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+_HIDDEN = 4
+_IMAGE_TOKEN_ID = 99
+
+
+def _model_config(
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    multimodal: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        dtype=dtype,
+        get_hidden_size=lambda: _HIDDEN,
+        is_multimodal_model=multimodal,
+    )
+
+
+def _engine_args(*, enable_prompt_embeds: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(enable_prompt_embeds=enable_prompt_embeds)
+
+
+def _encoder_result(
+    *,
+    row_splits: tuple[int, ...] = (0, 2, 3),
+) -> dict:
+    return ExternalEncoderResult(
+        features={"opaque": "nixl-reference"},
+        row_splits=row_splits,
+        image_token_id=_IMAGE_TOKEN_ID,
+    ).to_dict()
+
+
+def _handler(mode: DisaggregationMode = DisaggregationMode.AGGREGATED):
+    handler = object.__new__(DecodeWorkerHandler)
+    handler.config = SimpleNamespace(
+        disaggregation_mode=mode,
+        engine_args=_engine_args(),
+    )
+    handler.model_config = _model_config()
+    handler._external_encoder_prompt_loader = None
+    handler._custom_encoder = None
+    return handler
+
+
+async def test_loader_imports_packed_features_and_builds_mixed_prompt():
+    packed = torch.arange(12, dtype=torch.bfloat16).reshape(3, _HIDDEN)
+    importer = SimpleNamespace(import_tensor=AsyncMock(return_value=packed))
+    factory = MagicMock(return_value=importer)
+    loader = ExternalEncoderPromptLoader(
+        _model_config(),
+        _engine_args(),
+        importer_factory=factory,
+    )
+
+    prompt = await loader.load(
+        _encoder_result(),
+        [1, _IMAGE_TOKEN_ID, 2, _IMAGE_TOKEN_ID, 3],
+    )
+
+    assert prompt["prompt_token_ids"] == [1, 99, 99, 2, 99, 3]
+    assert prompt["prompt_is_token_ids"] == [True, False, False, True, False, True]
+    torch.testing.assert_close(prompt["prompt_embeds"][1:3], packed[:2])
+    torch.testing.assert_close(prompt["prompt_embeds"][4], packed[2])
+    factory.assert_called_once_with()
+    importer.import_tensor.assert_awaited_once_with(_encoder_result()["features"])
+
+
+async def test_loader_reuses_lazy_importer():
+    packed = torch.ones((1, _HIDDEN), dtype=torch.bfloat16)
+    importer = SimpleNamespace(import_tensor=AsyncMock(return_value=packed))
+    factory = MagicMock(return_value=importer)
+    loader = ExternalEncoderPromptLoader(
+        _model_config(),
+        _engine_args(),
+        importer_factory=factory,
+    )
+
+    assert factory.call_count == 0
+    result = _encoder_result(row_splits=(0, 1))
+    await loader.load(result, [_IMAGE_TOKEN_ID])
+    await loader.load(result, [_IMAGE_TOKEN_ID])
+
+    factory.assert_called_once_with()
+    assert importer.import_tensor.await_count == 2
+
+
+@pytest.mark.parametrize(
+    "model_config,engine_args,match",
+    [
+        (_model_config(multimodal=True), _engine_args(), "text-only decoder"),
+        (_model_config(), _engine_args(enable_prompt_embeds=False), "prompt-embeds"),
+    ],
+)
+def test_loader_rejects_incompatible_decoder_configuration(
+    model_config, engine_args, match
+):
+    with pytest.raises(ValueError, match=match):
+        ExternalEncoderPromptLoader(model_config, engine_args)
+
+
+@pytest.mark.parametrize(
+    "packed,row_splits,match",
+    [
+        (
+            torch.ones((3, _HIDDEN + 1), dtype=torch.bfloat16),
+            (0, 3),
+            "hidden size",
+        ),
+        (
+            torch.ones((3, _HIDDEN), dtype=torch.float32),
+            (0, 3),
+            "decoder dtype",
+        ),
+        (
+            torch.ones((2, _HIDDEN), dtype=torch.bfloat16),
+            (0, 3),
+            "cover the imported tensor rows",
+        ),
+        (
+            torch.ones((2, _HIDDEN), dtype=torch.bfloat16),
+            (0, 0, 2),
+            "0 rows",
+        ),
+    ],
+)
+async def test_loader_rejects_invalid_imported_tensor(packed, row_splits, match):
+    importer = SimpleNamespace(import_tensor=AsyncMock(return_value=packed))
+    loader = ExternalEncoderPromptLoader(
+        _model_config(),
+        _engine_args(),
+        importer_factory=lambda: importer,
+    )
+    token_ids = [_IMAGE_TOKEN_ID] * (len(row_splits) - 1)
+
+    with pytest.raises(ValueError, match=match):
+        await loader.load(_encoder_result(row_splits=row_splits), token_ids)
+
+
+async def test_handler_assembles_external_prompt_through_shared_loader():
+    handler = _handler()
+    expected = EmbedsPrompt(
+        prompt_embeds=torch.ones((1, _HIDDEN), dtype=torch.bfloat16),
+        prompt_token_ids=[_IMAGE_TOKEN_ID],
+        prompt_is_token_ids=[False],
+    )
+    loader = SimpleNamespace(load=AsyncMock(return_value=expected))
+    handler._external_encoder_prompt_loader = loader
+    request = {
+        "token_ids": [_IMAGE_TOKEN_ID],
+        "encoder_result": _encoder_result(row_splits=(0, 1)),
+    }
+
+    prompt, error = await handler._assemble_external_encoder_prompt(request, "req-1")
+
+    assert error is None
+    assert prompt is expected
+    loader.load.assert_awaited_once_with(
+        request["encoder_result"],
+        request["token_ids"],
+    )
+
+
+async def test_handler_rejects_competing_raw_media():
+    handler = _handler()
+    request = {
+        "token_ids": [_IMAGE_TOKEN_ID],
+        "encoder_result": _encoder_result(row_splits=(0, 1)),
+        "multi_modal_data": {"image_url": [{"Url": "unused"}]},
+    }
+
+    prompt, error = await handler._assemble_external_encoder_prompt(request, "req-1")
+
+    assert prompt is None
+    assert error is not None
+    assert "authoritative" in error["finish_reason"]
+
+
+async def test_handler_rejects_external_result_on_disaggregated_vllm_worker():
+    handler = _handler(DisaggregationMode.DECODE)
+
+    chunks = [
+        chunk
+        async for chunk in handler._generate_token_mode(
+            {"encoder_result": _encoder_result(row_splits=(0, 1))},
+            MagicMock(),
+            "req-1",
+        )
+    ]
+
+    assert len(chunks) == 1
+    assert "aggregated vLLM worker" in chunks[0]["finish_reason"]
+
+
+async def test_aggregated_token_path_selects_external_prompt_assembly():
+    handler = _handler()
+    handler._assemble_external_encoder_prompt = AsyncMock(
+        return_value=(
+            None,
+            {
+                "finish_reason": "error: stop after selection",
+                "index": 0,
+                "token_ids": [],
+            },
+        )
+    )
+    request = {"encoder_result": _encoder_result(row_splits=(0, 1))}
+
+    chunks = [
+        chunk
+        async for chunk in handler._generate_token_mode(
+            request,
+            MagicMock(),
+            "req-1",
+        )
+    ]
+
+    assert chunks[0]["finish_reason"] == "error: stop after selection"
+    handler._assemble_external_encoder_prompt.assert_awaited_once_with(
+        request,
+        "req-1",
+    )


### PR DESCRIPTION
_Based on #13085._

## Why

The stock vLLM worker needs one stable internal shape for externally produced encoder features. Keeping that schema in shared Dynamo code lets the workflow Generate adapter prepare the existing request without publishing vLLM runtime construction as a workflow API.

> Experimental: This workflow API is under active development and may evolve based on feedback. It is an optional orchestration layer over Dynamo's discoverable workers and endpoints; applications may compose those primitives directly when they prefer to own the orchestration logic.

## What Change

- Add the shared `ExternalEncoderResult` handoff schema.
- Preserve model, tensor reference, dtype, shape, and row metadata for stock vLLM's external-encoder path.
- Keep NIXL initialization lazy and isolated from request-only Generate bindings.

```mermaid
classDiagram
    GenerateEndpointInvoker ..> ExternalEncoderResult : prepares external result
    ExternalEncoderPromptLoader ..> ExternalEncoderResult : validates handoff
    ExternalEncoderPromptLoader ..> NixlTensorCarrier : imports tensor
    ExternalEncoderPromptLoader ..> EmbedsPrompt : builds mixed prompt

    note for ExternalEncoderResult "Shared internal handoff schema"
    note for ExternalEncoderPromptLoader "Owns strict prompt construction"
```

## Test Plan

- Generated Python API references pass the scoped freshness check.
- Applicable pre-commit hooks pass.
- Downstream #13087 covers the mocked producer-to-Generate handoff; runtime-specific vLLM qualification remains in the downstream example.
