### PR TITLE
feat(planner): configure Prometheus request timeout

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -64,6 +64,9 @@ class SLAPlannerDefaults(BasePlannerDefaults):
         "PROMETHEUS_EXTRA_QUERY_PARAMS"
     )
     metric_pulling_prometheus_ca_bundle = os.environ.get("PROMETHEUS_CA_BUNDLE")
+    metric_pulling_prometheus_request_timeout_seconds = float(
+        os.environ.get("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", "10")
+    )
     profile_results_dir = "profiling_results"
 
     isl = 3000  # in number of tokens

--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -64,9 +64,7 @@ class SLAPlannerDefaults(BasePlannerDefaults):
         "PROMETHEUS_EXTRA_QUERY_PARAMS"
     )
     metric_pulling_prometheus_ca_bundle = os.environ.get("PROMETHEUS_CA_BUNDLE")
-    metric_pulling_prometheus_request_timeout_seconds = float(
-        os.environ.get("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", "10")
-    )
+    metric_pulling_prometheus_request_timeout_seconds = 10.0
     profile_results_dir = "profiling_results"
 
     isl = 3000  # in number of tokens

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -583,13 +583,14 @@ class PlannerConfig(BaseModel):
         default_factory=lambda: float(
             os.environ.get("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", "10")
         ),
+        validate_default=True,
         gt=0,
         exclude=True,
         description=(
-            "Maximum time in seconds for each Prometheus API request. This bounds "
-            "metric collection when Prometheus is slow or unreachable so the planner "
-            "control loop can continue. Failed requests are not retried within the "
-            "same collection cycle."
+            "Connection and read inactivity timeout in seconds for each Prometheus "
+            "API request. This is not a total wall-clock deadline: a response that "
+            "continues delivering data can run longer. Failed requests are not "
+            "retried within the same collection cycle."
         ),
     )
 

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -582,7 +582,7 @@ class PlannerConfig(BaseModel):
     metric_pulling_prometheus_request_timeout_seconds: float = Field(
         default_factory=lambda: float(
             os.environ.get(
-                "PROMETHEUS_REQUEST_TIMEOUT_SECONDS",
+                "DYN_PLANNER_PROMETHEUS_REQUEST_TIMEOUT_SECONDS",
                 SLAPlannerDefaults.metric_pulling_prometheus_request_timeout_seconds,
             )
         ),

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -588,7 +588,8 @@ class PlannerConfig(BaseModel):
         description=(
             "Maximum time in seconds for each Prometheus API request. This bounds "
             "metric collection when Prometheus is slow or unreachable so the planner "
-            "control loop can continue."
+            "control loop can continue. Failed requests are not retried within the "
+            "same collection cycle."
         ),
     )
 

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -581,7 +581,10 @@ class PlannerConfig(BaseModel):
     )
     metric_pulling_prometheus_request_timeout_seconds: float = Field(
         default_factory=lambda: float(
-            os.environ.get("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", "10")
+            os.environ.get(
+                "PROMETHEUS_REQUEST_TIMEOUT_SECONDS",
+                SLAPlannerDefaults.metric_pulling_prometheus_request_timeout_seconds,
+            )
         ),
         validate_default=True,
         gt=0,

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -579,6 +579,18 @@ class PlannerConfig(BaseModel):
             "regardless of ssl_verify."
         ),
     )
+    metric_pulling_prometheus_request_timeout_seconds: float = Field(
+        default_factory=lambda: float(
+            os.environ.get("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", "10")
+        ),
+        gt=0,
+        exclude=True,
+        description=(
+            "Maximum time in seconds for each Prometheus API request. This bounds "
+            "metric collection when Prometheus is slow or unreachable so the planner "
+            "control loop can continue."
+        ),
+    )
 
     @field_validator("metric_pulling_prometheus_ca_bundle", mode="after")
     @classmethod

--- a/components/src/dynamo/planner/environment/metrics_provider/prometheus_traffic_provider.py
+++ b/components/src/dynamo/planner/environment/metrics_provider/prometheus_traffic_provider.py
@@ -40,6 +40,9 @@ class PrometheusTrafficProvider(TrafficMetricsProvider):
             ssl_verify=config.metric_pulling_prometheus_ssl_verify,
             extra_query_params=config.metric_pulling_prometheus_extra_query_params,
             ca_bundle=config.metric_pulling_prometheus_ca_bundle,
+            request_timeout_seconds=(
+                config.metric_pulling_prometheus_request_timeout_seconds
+            ),
         )
         if config.throughput_metrics_source == "router":
             self.prometheus_traffic_client.warn_if_router_not_scraped()

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -23,6 +23,7 @@ from prometheus_api_client import PrometheusApiClientException, PrometheusConnec
 from pydantic import BaseModel, ValidationError
 from requests import ConnectionError as RequestsConnectionError
 from requests import Timeout as RequestsTimeout
+from urllib3.util.retry import Retry
 
 from dynamo import prometheus_names
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -121,6 +122,7 @@ class PrometheusAPIClient:
         self.prom = PrometheusConnect(
             url=url,
             disable_ssl=not ssl_verify,
+            retry=Retry(total=0),
             timeout=request_timeout_seconds,
         )
         if bearer_token:

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -23,7 +23,6 @@ from prometheus_api_client import PrometheusApiClientException, PrometheusConnec
 from pydantic import BaseModel, ValidationError
 from requests import ConnectionError as RequestsConnectionError
 from requests import Timeout as RequestsTimeout
-from urllib3.util.retry import Retry
 
 from dynamo import prometheus_names
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -122,7 +121,7 @@ class PrometheusAPIClient:
         self.prom = PrometheusConnect(
             url=url,
             disable_ssl=not ssl_verify,
-            retry=Retry(total=0),
+            retry=0,
             timeout=request_timeout_seconds,
         )
         if bearer_token:

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -122,7 +122,9 @@ class PrometheusAPIClient:
             url=url,
             disable_ssl=not ssl_verify,
             retry=0,
-            timeout=request_timeout_seconds,
+            # prometheus-api-client annotates this as int but forwards it unchanged
+            # to Requests, which supports floating-point timeouts.
+            timeout=request_timeout_seconds,  # type: ignore[arg-type]
         )
         if bearer_token:
             self.prom._session.headers["Authorization"] = f"Bearer {bearer_token}"

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -116,8 +116,13 @@ class PrometheusAPIClient:
         ssl_verify: bool = False,
         extra_query_params: Optional[Dict[str, str]] = None,
         ca_bundle: Optional[str] = None,
+        request_timeout_seconds: float = 10.0,
     ):
-        self.prom = PrometheusConnect(url=url, disable_ssl=not ssl_verify)
+        self.prom = PrometheusConnect(
+            url=url,
+            disable_ssl=not ssl_verify,
+            timeout=request_timeout_seconds,
+        )
         if bearer_token:
             self.prom._session.headers["Authorization"] = f"Bearer {bearer_token}"
         if bearer_token_file:

--- a/components/src/dynamo/planner/tests/unit/test_planner_config.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_config.py
@@ -223,6 +223,29 @@ def test_throughput_metrics_source_invalid():
         PlannerConfig(namespace="test-ns", throughput_metrics_source="invalid")
 
 
+def test_prometheus_request_timeout_defaults_to_ten_seconds():
+    config = PlannerConfig(namespace="test-ns")
+
+    assert config.metric_pulling_prometheus_request_timeout_seconds == 10.0
+
+
+def test_prometheus_request_timeout_uses_environment_default(monkeypatch):
+    monkeypatch.setenv("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", "2.5")
+
+    config = PlannerConfig(namespace="test-ns")
+
+    assert config.metric_pulling_prometheus_request_timeout_seconds == 2.5
+
+
+@pytest.mark.parametrize("timeout", [0, -1])
+def test_prometheus_request_timeout_rejects_non_positive_values(timeout):
+    with pytest.raises(ValidationError):
+        PlannerConfig(
+            namespace="test-ns",
+            metric_pulling_prometheus_request_timeout_seconds=timeout,
+        )
+
+
 @pytest.mark.parametrize("bucket_size", [1, 4, 9, 16, 25])
 def test_fpm_sample_bucket_size_accepts_perfect_squares(bucket_size):
     """fpm_sample_bucket_size must be a perfect square (valid values)."""

--- a/components/src/dynamo/planner/tests/unit/test_planner_config.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_config.py
@@ -223,7 +223,8 @@ def test_throughput_metrics_source_invalid():
         PlannerConfig(namespace="test-ns", throughput_metrics_source="invalid")
 
 
-def test_prometheus_request_timeout_defaults_to_ten_seconds():
+def test_prometheus_request_timeout_defaults_to_ten_seconds(monkeypatch):
+    monkeypatch.delenv("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", raising=False)
     config = PlannerConfig(namespace="test-ns")
 
     assert config.metric_pulling_prometheus_request_timeout_seconds == 10.0
@@ -244,6 +245,16 @@ def test_prometheus_request_timeout_rejects_non_positive_values(timeout):
             namespace="test-ns",
             metric_pulling_prometheus_request_timeout_seconds=timeout,
         )
+
+
+@pytest.mark.parametrize("timeout", ["0", "-1"])
+def test_prometheus_request_timeout_rejects_non_positive_environment_values(
+    monkeypatch, timeout
+):
+    monkeypatch.setenv("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", timeout)
+
+    with pytest.raises(ValidationError):
+        PlannerConfig(namespace="test-ns")
 
 
 @pytest.mark.parametrize("bucket_size", [1, 4, 9, 16, 25])

--- a/components/src/dynamo/planner/tests/unit/test_planner_config.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_config.py
@@ -224,14 +224,14 @@ def test_throughput_metrics_source_invalid():
 
 
 def test_prometheus_request_timeout_defaults_to_ten_seconds(monkeypatch):
-    monkeypatch.delenv("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("DYN_PLANNER_PROMETHEUS_REQUEST_TIMEOUT_SECONDS", raising=False)
     config = PlannerConfig(namespace="test-ns")
 
     assert config.metric_pulling_prometheus_request_timeout_seconds == 10.0
 
 
 def test_prometheus_request_timeout_uses_environment_default(monkeypatch):
-    monkeypatch.setenv("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", "2.5")
+    monkeypatch.setenv("DYN_PLANNER_PROMETHEUS_REQUEST_TIMEOUT_SECONDS", "2.5")
 
     config = PlannerConfig(namespace="test-ns")
 
@@ -251,7 +251,7 @@ def test_prometheus_request_timeout_rejects_non_positive_values(timeout):
 def test_prometheus_request_timeout_rejects_non_positive_environment_values(
     monkeypatch, timeout
 ):
-    monkeypatch.setenv("PROMETHEUS_REQUEST_TIMEOUT_SECONDS", timeout)
+    monkeypatch.setenv("DYN_PLANNER_PROMETHEUS_REQUEST_TIMEOUT_SECONDS", timeout)
 
     with pytest.raises(ValidationError):
         PlannerConfig(namespace="test-ns")

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -16,7 +16,7 @@
 import logging
 import math
 from types import SimpleNamespace
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from prometheus_api_client import PrometheusApiClientException
@@ -224,10 +224,9 @@ def test_prometheus_client_configures_request_timeout(mock_prometheus_connect):
     mock_prometheus_connect.assert_called_once_with(
         url="http://localhost:9090",
         disable_ssl=True,
-        retry=ANY,
+        retry=0,
         timeout=2.5,
     )
-    assert mock_prometheus_connect.call_args.kwargs["retry"].total == 0
 
 
 def test_get_average_metric_none_result():

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -16,7 +16,7 @@
 import logging
 import math
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from prometheus_api_client import PrometheusApiClientException
@@ -224,8 +224,10 @@ def test_prometheus_client_configures_request_timeout(mock_prometheus_connect):
     mock_prometheus_connect.assert_called_once_with(
         url="http://localhost:9090",
         disable_ssl=True,
+        retry=ANY,
         timeout=2.5,
     )
+    assert mock_prometheus_connect.call_args.kwargs["retry"].total == 0
 
 
 def test_get_average_metric_none_result():

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -213,6 +213,21 @@ def test_frontend_metric_with_partial_data():
     assert metric.pod is None
 
 
+@patch("dynamo.planner.monitoring.traffic_metrics.PrometheusConnect")
+def test_prometheus_client_configures_request_timeout(mock_prometheus_connect):
+    PrometheusAPIClient(
+        "http://localhost:9090",
+        "test_namespace",
+        request_timeout_seconds=2.5,
+    )
+
+    mock_prometheus_connect.assert_called_once_with(
+        url="http://localhost:9090",
+        disable_ssl=True,
+        timeout=2.5,
+    )
+
+
 def test_get_average_metric_none_result():
     """Test _get_average_metric when prometheus returns None"""
     # TODO: Replace hardcoded port with allocate_port() from tests.utils.port_utils

--- a/components/src/dynamo/planner/tests/unit/test_prometheus_traffic_provider.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus_traffic_provider.py
@@ -77,6 +77,26 @@ def test_accept_length_uses_current_runtime_namespace():
     )
 
 
+def test_provider_passes_prometheus_request_timeout():
+    config = _config()
+    config.metric_pulling_prometheus_request_timeout_seconds = 3.5
+    client_patch = patch(
+        "dynamo.planner.environment.metrics_provider."
+        "prometheus_traffic_provider.PrometheusAPIClient"
+    )
+    client_class = client_patch.start()
+    try:
+        PrometheusTrafficProvider(
+            config=config,
+            state_source=_state_source(),
+            metrics_state=Metrics(),
+        )
+    finally:
+        client_patch.stop()
+
+    assert client_class.call_args.kwargs["request_timeout_seconds"] == 3.5
+
+
 def test_accept_length_falls_back_to_configured_namespace():
     provider, client, client_patch = _provider()
     client.get_avg_spec_decode_accept_length.return_value = 2.5

--- a/components/src/dynamo/planner/tests/unit/test_prometheus_traffic_provider.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus_traffic_provider.py
@@ -80,21 +80,17 @@ def test_accept_length_uses_current_runtime_namespace():
 def test_provider_passes_prometheus_request_timeout():
     config = _config()
     config.metric_pulling_prometheus_request_timeout_seconds = 3.5
-    client_patch = patch(
+    with patch(
         "dynamo.planner.environment.metrics_provider."
         "prometheus_traffic_provider.PrometheusAPIClient"
-    )
-    client_class = client_patch.start()
-    try:
+    ) as client_class:
         PrometheusTrafficProvider(
             config=config,
             state_source=_state_source(),
             metrics_state=Metrics(),
         )
-    finally:
-        client_patch.stop()
 
-    assert client_class.call_args.kwargs["request_timeout_seconds"] == 3.5
+        assert client_class.call_args.kwargs["request_timeout_seconds"] == 3.5
 
 
 def test_accept_length_falls_back_to_configured_namespace():

--- a/docs/fern/pages/reference/components/planner-configuration.mdx
+++ b/docs/fern/pages/reference/components/planner-configuration.mdx
@@ -312,7 +312,7 @@ These fields default from environment variables and are excluded from serialized
 </ParamField>
 
 <ParamField path="metric_pulling_prometheus_request_timeout_seconds" type="number" default="10.0">
-  Connection and read inactivity timeout in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. This is not a total wall-clock deadline: a response that continues delivering data can run longer. The Planner does not retry failed requests within the same collection cycle.
+  Connection and read inactivity timeout in seconds for each Prometheus API request. Defaults from `DYN_PLANNER_PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. This is not a total wall-clock deadline: a response that continues delivering data can run longer. The Planner does not retry failed requests within the same collection cycle.
 </ParamField>
 
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">
@@ -627,7 +627,7 @@ The Planner reads these environment variables. The Prometheus and namespace vari
 | `PROMETHEUS_SSL_VERIFY` | Default for `metric_pulling_prometheus_ssl_verify` (`1`/`true`/`yes`). | `false` |
 | `PROMETHEUS_EXTRA_QUERY_PARAMS` | Default for `metric_pulling_prometheus_extra_query_params` (URL query string). | unset |
 | `PROMETHEUS_CA_BUNDLE` | Default for `metric_pulling_prometheus_ca_bundle`. | unset |
-| `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` | Default for `metric_pulling_prometheus_request_timeout_seconds`. | `10.0` |
+| `DYN_PLANNER_PROMETHEUS_REQUEST_TIMEOUT_SECONDS` | Default for `metric_pulling_prometheus_request_timeout_seconds`. | `10.0` |
 | `PLANNER_PROMETHEUS_PORT` | Default for `metric_reporting_prometheus_port`. | `0` |
 | `DYN_PARENT_DGD_K8S_NAME` | Parent DGD name for the GlobalPlanner connector (`environment: global-planner`). | required |
 | `POD_NAMESPACE` | Kubernetes namespace for the GlobalPlanner connector. | required |

--- a/docs/fern/pages/reference/components/planner-configuration.mdx
+++ b/docs/fern/pages/reference/components/planner-configuration.mdx
@@ -311,6 +311,10 @@ These fields default from environment variables and are excluded from serialized
   Path to a CA bundle for verifying the upstream Prometheus TLS certificate. When set, the bundle is used for verification regardless of `metric_pulling_prometheus_ssl_verify`. Must point to an existing file.
 </ParamField>
 
+<ParamField path="metric_pulling_prometheus_request_timeout_seconds" type="number" default="10.0">
+  Maximum time in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`.
+</ParamField>
+
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">
   Port on which the Planner exposes its own `dynamo_planner_*` metrics. Defaults from `PLANNER_PROMETHEUS_PORT`. `0` disables.
 </ParamField>
@@ -623,6 +627,7 @@ The Planner reads these environment variables. The Prometheus and namespace vari
 | `PROMETHEUS_SSL_VERIFY` | Default for `metric_pulling_prometheus_ssl_verify` (`1`/`true`/`yes`). | `false` |
 | `PROMETHEUS_EXTRA_QUERY_PARAMS` | Default for `metric_pulling_prometheus_extra_query_params` (URL query string). | unset |
 | `PROMETHEUS_CA_BUNDLE` | Default for `metric_pulling_prometheus_ca_bundle`. | unset |
+| `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` | Default for `metric_pulling_prometheus_request_timeout_seconds`. | `10.0` |
 | `PLANNER_PROMETHEUS_PORT` | Default for `metric_reporting_prometheus_port`. | `0` |
 | `DYN_PARENT_DGD_K8S_NAME` | Parent DGD name for the GlobalPlanner connector (`environment: global-planner`). | required |
 | `POD_NAMESPACE` | Kubernetes namespace for the GlobalPlanner connector. | required |

--- a/docs/fern/pages/reference/components/planner-configuration.mdx
+++ b/docs/fern/pages/reference/components/planner-configuration.mdx
@@ -312,7 +312,7 @@ These fields default from environment variables and are excluded from serialized
 </ParamField>
 
 <ParamField path="metric_pulling_prometheus_request_timeout_seconds" type="number" default="10.0">
-  Maximum time in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. The Planner does not retry failed requests within the same collection cycle.
+  Connection and read inactivity timeout in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. This is not a total wall-clock deadline: a response that continues delivering data can run longer. The Planner does not retry failed requests within the same collection cycle.
 </ParamField>
 
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">

--- a/docs/fern/pages/reference/components/planner-configuration.mdx
+++ b/docs/fern/pages/reference/components/planner-configuration.mdx
@@ -312,7 +312,7 @@ These fields default from environment variables and are excluded from serialized
 </ParamField>
 
 <ParamField path="metric_pulling_prometheus_request_timeout_seconds" type="number" default="10.0">
-  Maximum time in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`.
+  Maximum time in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. The Planner does not retry failed requests within the same collection cycle.
 </ParamField>
 
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
@@ -477,7 +477,7 @@ These fields default from environment variables and are excluded from serialized
 </ParamField>
 
 <ParamField path="metric_pulling_prometheus_request_timeout_seconds" type="number" default="10.0">
-  Maximum time in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. The Planner does not retry failed requests within the same collection cycle.
+  Connection and read inactivity timeout in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. This is not a total wall-clock deadline: a response that continues delivering data can run longer. The Planner does not retry failed requests within the same collection cycle.
 </ParamField>
 
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
@@ -477,7 +477,7 @@ These fields default from environment variables and are excluded from serialized
 </ParamField>
 
 <ParamField path="metric_pulling_prometheus_request_timeout_seconds" type="number" default="10.0">
-  Maximum time in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`.
+  Maximum time in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. The Planner does not retry failed requests within the same collection cycle.
 </ParamField>
 
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
@@ -477,7 +477,7 @@ These fields default from environment variables and are excluded from serialized
 </ParamField>
 
 <ParamField path="metric_pulling_prometheus_request_timeout_seconds" type="number" default="10.0">
-  Connection and read inactivity timeout in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. This is not a total wall-clock deadline: a response that continues delivering data can run longer. The Planner does not retry failed requests within the same collection cycle.
+  Connection and read inactivity timeout in seconds for each Prometheus API request. Defaults from `DYN_PLANNER_PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`. This is not a total wall-clock deadline: a response that continues delivering data can run longer. The Planner does not retry failed requests within the same collection cycle.
 </ParamField>
 
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
@@ -476,6 +476,10 @@ These fields default from environment variables and are excluded from serialized
   Path to a CA bundle for verifying the upstream Prometheus TLS certificate. When set, the bundle is used for verification regardless of `metric_pulling_prometheus_ssl_verify`. Must point to an existing file.
 </ParamField>
 
+<ParamField path="metric_pulling_prometheus_request_timeout_seconds" type="number" default="10.0">
+  Maximum time in seconds for each Prometheus API request. Defaults from `PROMETHEUS_REQUEST_TIMEOUT_SECONDS` and must be greater than `0`.
+</ParamField>
+
 <ParamField path="metric_reporting_prometheus_port" type="integer" default="0">
   Port on which the Planner exposes its own `dynamo_planner_*` metrics. Defaults from `PLANNER_PROMETHEUS_PORT`. `0` disables.
 </ParamField>


### PR DESCRIPTION
## Summary

- add a configurable timeout for Planner Prometheus API requests, defaulting to 10 seconds
- wire the timeout from Planner configuration through the traffic provider to `PrometheusConnect`
- support `PROMETHEUS_REQUEST_TIMEOUT_SECONDS`, validate positive values, and document the new setting
- add focused coverage for the default, environment override, validation, client construction, and provider wiring

This prevents a slow or unreachable Prometheus endpoint from blocking the Planner control loop indefinitely.

## Validation

- `git diff --check`
- `uvx --from ruff==0.5.2 ruff check <changed Python files>`
- `uvx --from black==23.1.0 black --check <changed Python files>`
- `uvx --from isort==5.12.0 --with toml isort --check-only <changed Python files>`
- Targeted Planner pytest collection was attempted, but the local minimal environment does not include the built Dynamo runtime and Kubernetes test dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Prometheus request timeouts for metric collection.
  * Supports environment-based configuration through `PROMETHEUS_REQUEST_TIMEOUT_SECONDS`.
  * Defaults to 10 seconds and requires a positive value.

* **Documentation**
  * Updated planner configuration references with timeout behavior, validation, units, and environment-variable options.

* **Tests**
  * Added coverage for defaults, environment overrides, validation, and timeout propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->