### PR TITLE
chore(operator): remove unused identity defaults

### DIFF
--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -7,9 +7,6 @@ import (
 )
 
 const (
-	DefaultUserId = "default"
-	DefaultOrgId  = "default"
-
 	DynamoServicePort       = 8000
 	DynamoServicePortName   = "http"
 	DynamoContainerPortName = "http"


### PR DESCRIPTION
## Summary

- Remove the unused `DefaultUserId` and `DefaultOrgId` constants from the operator.
- These constants originally provided fallback identity headers for the CompoundAI/Yatai client when Kubernetes resources lacked `Nv-Ngc-Org` or `Nv-Actor-Id` labels.
- The constants entered this repository with the CompoundAI operator migration in a014b97129 (#10).
- The DynamoNimDeployment and NIM call sites were removed in 044e12e1c9 (#551).
- The final DynamoNimRequest call site was removed with the remaining Bento/Yatai integration in f11ea8f774 (#782), leaving both constants unreferenced.
- Repository-wide search confirms that only the declarations remained.

## Validation

- `git grep -n -E 'Default(User|Org)Id'` returns no matches after the change.
- `go test ./internal/consts/...`
- `go test ./internal/...`
- Commit-time pre-commit hooks, including DCO validation.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed obsolete default user and organization identifiers.
  * No user-visible functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->