### PR TITLE
feat(snapshot): checkpoint POSIX CUDA multicast

### DIFF
--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -134,6 +134,8 @@ COPY cmd/cuda-checkpoint-helper/main.c ./cmd/cuda-checkpoint-helper/main.c
 COPY cmd/ns-bind-mount/main.c ./cmd/ns-bind-mount/main.c
 COPY cmd/cuda-vmm-interpose/interpose.c ./cmd/cuda-vmm-interpose/interpose.c
 COPY cmd/cuda-vmm-interpose/coordinator.c ./cmd/cuda-vmm-interpose/coordinator.c
+COPY cmd/cuda-vmm-interpose/multicast.c ./cmd/cuda-vmm-interpose/multicast.c
+COPY cmd/cuda-vmm-interpose/multicast.h ./cmd/cuda-vmm-interpose/multicast.h
 COPY cmd/cuda-vmm-interpose/posix.c ./cmd/cuda-vmm-interpose/posix.c
 COPY cmd/cuda-vmm-interpose/posix.h ./cmd/cuda-vmm-interpose/posix.h
 COPY cmd/cuda-vmm-interpose/protocol.h ./cmd/cuda-vmm-interpose/protocol.h

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/Makefile
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/Makefile
@@ -7,8 +7,8 @@ BUILD_DIR ?= build
 
 INTERPOSER := $(BUILD_DIR)/libsnapshot_cuda_vmm.so
 COORDINATOR := $(BUILD_DIR)/snapshot-cuda-vmm
-INTERPOSER_SOURCES := interpose.c posix.c util.c
-INTERPOSER_HEADERS := posix.h protocol.h util.h
+INTERPOSER_SOURCES := interpose.c multicast.c posix.c util.c
+INTERPOSER_HEADERS := multicast.h posix.h protocol.h util.h
 COORDINATOR_SOURCES := coordinator.c util.c
 COORDINATOR_HEADERS := protocol.h util.h
 COMMON_FLAGS := -std=gnu11 -O2 -Wall -Wextra -Werror

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/README.md
@@ -4,10 +4,10 @@ All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Same-node POSIX CUDA VMM checkpoint and restore
+# Same-node POSIX CUDA VMM and multicast checkpoint and restore
 
 This interposer implements checkpoint and restore for CUDA VMM allocations
-shared between processes on one node with
+and complete CUDA multicast groups shared between processes on one node with
 `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`.
 
 ## Contract
@@ -46,58 +46,107 @@ Legacy CUDA IPC remains driver-owned and is unsupported by this shim.
 hex participant ID. Otherwise, the shim creates one when the process starts.
 
 The orchestrator must externally quiesce the application at the checkpoint
-boundary. Allocation sharing, import, mapping, access updates, kernel work,
-communication-library setup, and teardown must not be in flight.
+boundary. Allocation sharing, import, mapping, access updates, multicast
+setup/teardown, kernel work, and communication-library setup must not be in
+flight.
 
 During ordinary execution:
 
-- CUDA generic allocation handles for POSIX-capable allocations tracked by the
-  shim are tagged logical tokens; the corresponding real driver handles remain
-  internal.
-- Untracked CUDA generic allocation handles remain real driver handles.
-- A POSIX-capable allocation becomes checkpoint-managed when its shim
+- CUDA generic handles for tracked POSIX resources are tagged logical tokens.
+  The handle table distinguishes unicast allocations from multicast objects;
+  corresponding real driver handles remain internal.
+- Untracked CUDA generic handles remain real driver handles.
+- A POSIX-capable unicast allocation becomes checkpoint-managed when its shim
   capability is exported.
 - POSIX exports return sealed capability FDs containing the creator,
-  allocation, endpoint, and authorization identities.
-- A shim capability import resolves through the creator's local Unix
-  endpoint. A transient raw CUDA FD is passed with `SCM_RIGHTS`, imported,
-  closed immediately, and never returned to the application.
-- A raw external POSIX import is passed directly to CUDA and is not tracked by
-  the shim.
+  resource, endpoint, and authorization identities.
+- A capability import resolves through the creator's local Unix endpoint. A
+  transient raw CUDA FD is passed with `SCM_RIGHTS`, imported, closed
+  immediately, and never returned to the application.
+- A raw external POSIX import is passed directly to CUDA and is not tracked.
+- POSIX multicast create/export/import, device membership, `BindMem`,
+  `BindAddr`, unbind, generic mapping, and mapping access are passed to CUDA
+  and recorded. Device-explicit `_v2` bind variants are included when the
+  build headers expose them.
 
 Handle ownership is explicit:
 
 | Source | Application receives | Managed table | Driver-handle owner |
 | --- | --- | --- | --- |
-| POSIX-capable create, tracked retain, or capability import | Tagged logical token | Logical token to driver handle | Shim |
+| POSIX-capable create, tracked retain, or capability import | Tagged logical token | Logical token to UC or MC resource | Shim |
 | Raw external import or other pass-through | Real driver handle | None | Application |
-| Checkpoint carrier | Nothing | No separate entry | Shim |
+| UC checkpoint carrier | Nothing | No separate entry | Shim |
+| Transient MC teardown/restore handle | Nothing | No durable entry | Shim |
 
 `posix.c` owns the sealed capability format and remote creator exchange.
-`interpose.c` owns CUDA interception, allocation state, and local raw exports.
+`multicast.c` owns the complete multicast lifecycle: identities and handles,
+team membership, UC bindings, mappings and access, teardown, fresh same-node
+FD exchange, reconstruction, and validation. `interpose.c` owns generic CUDA
+interception and unicast allocation state.
 
-Before native CUDA checkpoint, the snapshot agent asks the native coordinator
-to validate the complete participant topology. The original `cuMemCreate`
-participant is always the saver and must still have a live creator handle or
-mapping (the creator-anchor invariant). The shim then puts every allocation
-managed by the shim in checkpoint normal form: one unmapped creator-local
-carrier remains, managed mappings are removed without freeing VA reservations,
-and importer handles are released. Native CUDA alone saves and restores
-allocation bytes.
+## Multicast is a topology overlay
+
+A multicast object is topology layered over restored unicast members. It does
+not own separately checkpointed bytes:
+
+```text
+multicast object -> UC member A -> creator A's native cuCheckpoint bytes
+                 -> UC member B -> creator B's native cuCheckpoint bytes
+```
+
+The recorded multicast creator is only the deterministic control-plane
+participant that creates and exports a fresh object during restore. It is not
+a byte saver or checkpoint anchor. No old multicast object or handle remains
+at the native checkpoint boundary. If the application released its multicast
+handle but retained a mapping, the shim derives only a short-lived teardown
+handle from that mapping and releases it before native checkpoint.
+
+## Checkpoint and restore ordering
+
+Before native CUDA checkpoint, the coordinator validates the complete
+participant topology. Every original `cuMemCreate` participant remains the
+saver for its unicast allocation and must still have a live creator handle or
+mapping (the creator-anchor invariant).
+
+Multicast teardown is the first destructive stage:
+
+1. unmap every multicast VA without freeing its reservation;
+2. unbind every recorded UC member;
+3. release every imported/creator multicast handle and old object;
+4. retain only stable logical identity and topology metadata.
+
+The coordinator waits for every participant to report multicast detached.
+Only after that barrier does the shim normalize unicast allocations. Each
+creator keeps one unmapped local carrier, all managed UC mappings are removed
+without freeing VA reservations, and importer handles are released. Native
+`cuCheckpoint` alone saves and restores unicast allocation bytes.
 
 On restore, native CUDA first restores creator allocations. CUDA processes are
-then unlocked so the shim can replay VMM topology while the application stays
-behind the restore-complete sentinel. Creators are reconstructed before
-importers; importers resolve fresh creator exports. The shim remaps every
-allocation at its saved VA, restores effective access and required handle
-translations, and performs final topology validation. Any failed validation
-fails closed. There is no rollback after checkpoint preparation mutates CUDA
-state.
+then unlocked so the shim can reconstruct topology while the application
+remains behind the restore-complete sentinel:
+
+1. restore UC creator handles and mappings;
+2. import current-generation UC handles and restore importer mappings;
+3. have the recorded MC metadata creator create a fresh POSIX object;
+4. import that fresh object in all other participants;
+5. add every recorded device to the complete team before replaying bindings;
+6. replay `BindMem` and `BindAddr` against restored UC handles or addresses;
+7. map each original multicast VA and restore access;
+8. install logical-to-current-handle translation and validate before resume.
+
+The coordinator rejects partial groups. All checkpoint participants must
+report the multicast object, exactly one metadata creator, the complete unique
+device set, and bindings for every device. Reconstruction and final
+validation fail closed. There is no rollback after checkpoint preparation
+mutates CUDA state.
 
 The native coordinator atomically writes `cuda-vmm.state`, its opaque durable
 topology sidecar, in the checkpoint directory. Go only orders native VMM
-prepare and restore; it does not serialize or inspect the topology. The
-sidecar contains no raw FDs or allocation contents.
+prepare and restore; it does not serialize or inspect CUDA topology. The
+sidecar contains no raw FDs or allocation contents. Its MC records contain
+only stable identity and creator, properties, devices and participants, UC
+member identities, binding offsets/sizes/flags/API variant, mapping
+VAs/offsets/flags/access, and logical-handle liveness.
 
 ## Interception and symbol resolution
 
@@ -114,14 +163,33 @@ replacement table, using the requested CUDA version to select the ABI.
 Chaining with another `dlsym()` interposer and preserving original-caller
 `RTLD_NEXT` lookup scope are unsupported.
 
+The multicast surface includes create, add-device, `BindMem`, `BindAddr`,
+unbind, granularity, generic export/import/release/retain/property consumers,
+and generic map/unmap/access consumers. Resolver requests at CUDA 13.1 or
+later are directed to the device-explicit bind ABI when the installed headers
+expose it.
+
 ## Testing
 
-Run the native interposer integration test from the repository root:
+Run the native interposer integration tests from the repository root:
 
 ```bash
-uv run --project deploy/snapshot/cmd/cuda-vmm-interpose/tests \
-  pytest deploy/snapshot/cmd/cuda-vmm-interpose/tests/test_cucheckpoint.py -v
+cuda-checkpoint --launch-job \
+  uv run --project deploy/snapshot/cmd/cuda-vmm-interpose/tests \
+    pytest deploy/snapshot/cmd/cuda-vmm-interpose/tests/test_cucheckpoint.py -v
 ```
+
+The project contains a non-multimem POSIX baseline and a two-GPU multicast
+case. The baseline sets `TORCH_SYMM_MEM_DISABLE_MULTICAST=1` and uses the
+non-multicast collective, although PyTorch 2.11 may still initialize dormant
+multicast topology during rendezvous. The multicast case requires PyTorch
+symmetric memory to select multicast, runs a real multimem collective,
+replaces its local UC member with a `cuMulticastBindAddr` binding, captures the
+collective in a CUDA graph, performs native `cuCheckpoint`, and replays the
+same graph after reconstruction. It fails rather than accepting PyTorch's
+non-multicast fallback. The test also requires and verifies the shared
+`CUDA_CHECKPOINT_JOB_FILE` established by `--launch-job`; the pytest controller
+and both CUDA workers use that same native checkpoint job.
 
 ## Qualification
 
@@ -133,9 +201,9 @@ destination GPUs 4/5 with user-mode `libcuda` 615.65 and kernel RM 595.58.03.
 > [!WARNING]
 > Raw external POSIX imports are passed through and are not tracked or
 > reconstructed. Every mapping and handle from such an import must be unmapped
-> and released before checkpoint prepare, as the GMS saver/sleep flow does. If
-> retained, native checkpoint may fail, or restore may later see stale or
-> incomplete sharing; the shim cannot validate this.
+> and released before checkpoint prepare, as the GMS saver/sleep flow does.
+> If retained, native checkpoint may fail or restore may later see stale or
+> incomplete sharing.
 
 The shim reserves generic handles whose top 16 bits are `0xd94d` for logical
 tokens. If CUDA returns a raw pass-through handle in that range, the shim
@@ -143,54 +211,52 @@ releases it and returns `CUDA_ERROR_INVALID_HANDLE`.
 
 ### Potentially silent gaps
 
-The following gaps can bypass bookkeeping or silently preserve stale state:
-
-- An un-interposed raw export or import call bypasses bookkeeping.
-- Raw FD aliases created with `dup` or `fcntl` are invisible.
-- Raw FDs cached, queued, or transferred with `SCM_RIGHTS` outside the adapter
-  can later import stale pre-restore state.
+- An un-interposed raw export or import bypasses bookkeeping.
+- Raw FD aliases made with `dup`, `fcntl`, or out-of-adapter `SCM_RIGHTS` are
+  invisible and can later import stale state.
 - An unshimmed broker or helper makes the sharing topology incomplete.
 - An uncovered CUDA runtime symbol-resolution path can bypass wrappers.
 - An old generic handle retained by an uncovered consumer can be stale.
 - NVIDIA-specific `ioctl`, `fstat`, or `poll` semantics on a capability FD are
   unsupported.
+- `BindAddr` ranges outside tracked VMM mappings rely on native
+  `cuCheckpoint` to restore their underlying allocation at the identical VA.
+- Access updates that do not exactly match a tracked mapping are passed
+  through but are not recorded for restore.
 - Checkpoint during sharing or communicator construction is unsupported.
 
 Applications must finish setup and externally quiesce the complete process
 group first.
 
-Children created with `fork()` and no subsequent `exec()` lazily receive a fresh
-random process-local participant identity, a child-PID control socket and thread,
-and empty allocation, handle, and mapping bookkeeping on their first intercepted
-VMM operation. This supports the fork-before-CUDA-initialization lifecycle used
-by vLLM. An explicitly configured parent participant ID is never reused by a
-forked child.
+Children made with `fork()` and no subsequent `exec()` lazily receive a fresh
+random process-local participant identity, child-PID control socket and
+thread, and empty allocation, handle, mapping, and multicast bookkeeping on
+their first intercepted VMM operation. This supports the fork-before-CUDA
+initialization lifecycle used by vLLM. An explicitly configured parent
+participant ID is never reused by a forked child.
 
-Forking after the shim has tracked VMM allocations, handles, or mappings is
-unsupported. The child deliberately discards its inherited copies without
-freeing them or calling CUDA; inherited tracked CUDA state is not reconciled or
-preserved.
+Forking after the shim has tracked CUDA state is unsupported. The child
+deliberately discards inherited bookkeeping without freeing resources or
+calling CUDA.
 
 ### Fail-closed limitations
 
-The coordinator fails closed for a missing creator anchor, incomplete
-participants or topology, more than eight access descriptors, access updates
-that do not exactly match a tracked mapping range, and reconstruction or final
-validation failures. There is no rollback after checkpoint preparation mutates
-CUDA state.
+The coordinator fails closed for a missing UC creator anchor, incomplete
+participants or topology, more than eight access descriptors, reconstruction
+failures, or final validation failures. Multicast additionally fails closed
+for non-POSIX handle types, cross-node or partial groups, duplicate or missing
+devices, missing member bindings, or more than one metadata creator.
 
-Multicast objects are not checkpointable yet. While interposition is enabled,
-all `cuMulticast*` entry points return `CUDA_ERROR_NOT_SUPPORTED`, including
-calls resolved through `dlsym()` or `cuGetProcAddress()`. NCCL workloads must set
-`NCCL_NVLS_ENABLE=0`; otherwise NCCL initialization fails intentionally rather
-than creating multicast state that cannot be restored.
+Only complete same-node POSIX multicast groups are supported. The shim does
+not coordinate a subset of an NCCL/PyTorch team or restore one participant
+independently. A multicast identity is tracked in one CUDA context per
+process.
 
 ### Future compatibility
 
-FABRIC/IMEX handles, multicast checkpointing, raw-FD compatibility, and
-multi-node rendezvous are not implemented. The durable sidecar preserves
-allocation type, location, requested-handle type, mapping, access, and creator
-topology needed for those future compatibility seams. Creator endpoints and
-authorization tokens remain transient live/capability data and are not sidecar
-fields. The sidecar intentionally contains neither raw FDs nor allocation
-bytes.
+FABRIC/MNNVL multicast belongs behind a future `fabric.c` boundary with IMEX
+authorization and a cross-node rendezvous service. FABRIC/IMEX handles,
+raw-FD compatibility, and multi-node rendezvous are not implemented here.
+Creator endpoints and authorization tokens remain transient live/capability
+data and are not sidecar fields. The sidecar intentionally contains neither
+raw FDs nor allocation bytes.

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/coordinator.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/coordinator.c
@@ -31,6 +31,26 @@ struct participant {
   uint32_t count;
 };
 
+struct multicast {
+  uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  char creator[SNAPSHOT_VMM_ID_SIZE];
+  uint64_t size;
+  uint64_t handle_types;
+  uint64_t flags;
+  uint32_t num_devices;
+  uint32_t creators;
+  uint32_t devices;
+  uint32_t bindings;
+  struct multicast_device* device_list;
+  struct multicast* next;
+};
+
+struct multicast_device {
+  int32_t device;
+  bool bound;
+  struct multicast_device* next;
+};
+
 struct allocation {
   uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
   char creator[SNAPSHOT_VMM_ID_SIZE];
@@ -57,6 +77,45 @@ connect_endpoint(const char* endpoint)
     return -1;
   }
   return fd;
+}
+
+static struct multicast*
+find_multicast(struct multicast* multicasts, const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE])
+{
+  struct multicast* multicast;
+
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    if (memcmp(multicast->id, id, SNAPSHOT_VMM_ALLOCATION_ID_SIZE) == 0)
+      return multicast;
+  }
+  return NULL;
+}
+
+static struct multicast_device*
+find_multicast_device(struct multicast* multicast, int32_t device)
+{
+  struct multicast_device* current;
+
+  for (current = multicast->device_list; current != NULL; current = current->next) {
+    if (current->device == device)
+      return current;
+  }
+  return NULL;
+}
+
+static void
+free_multicasts(struct multicast* multicasts)
+{
+  while (multicasts != NULL) {
+    struct multicast* next = multicasts->next;
+    while (multicasts->device_list != NULL) {
+      struct multicast_device* device_next = multicasts->device_list->next;
+      free(multicasts->device_list);
+      multicasts->device_list = device_next;
+    }
+    free(multicasts);
+    multicasts = next;
+  }
 }
 
 static int
@@ -127,6 +186,7 @@ static int
 validate_topology(struct participant* participants, size_t participant_count, struct allocation** output)
 {
   struct allocation* allocations = NULL;
+  struct multicast* multicasts = NULL;
   const char* reason = NULL;
   uint64_t value = UINT64_MAX;
   size_t participant_index;
@@ -154,6 +214,7 @@ validate_topology(struct participant* participants, size_t participant_count, st
     for (record_index = 0; record_index < participant->count; record_index++) {
       const struct snapshot_vmm_record* record = &participant->records[record_index];
       struct allocation* allocation = find_allocation(allocations, record->allocation_id);
+      struct multicast* multicast = find_multicast(multicasts, record->allocation_id);
 
       if (record->kind == SNAPSHOT_VMM_ALLOCATION) {
         if (allocation == NULL) {
@@ -210,6 +271,88 @@ validate_topology(struct participant* participants, size_t participant_count, st
         }
         if ((record->flags & SNAPSHOT_VMM_CREATOR) != 0)
           allocation->creator_mapping = true;
+      } else if (record->kind == SNAPSHOT_VMM_MULTICAST) {
+        if (record->handle_types != SNAPSHOT_VMM_POSIX_HANDLE_TYPE || record->num_devices == 0 ||
+            record->allocation_size == 0 || !snapshot_vmm_is_lower_hex_id(record->creator_participant)) {
+          reason = "invalid multicast properties";
+          goto failed;
+        }
+        if (multicast == NULL) {
+          multicast = calloc(1, sizeof(*multicast));
+          if (multicast == NULL) {
+            reason = "multicast metadata allocation failed";
+            goto failed;
+          }
+          memcpy(multicast->id, record->allocation_id, sizeof(multicast->id));
+          multicast->size = record->allocation_size;
+          multicast->handle_types = record->handle_types;
+          multicast->flags = record->object_flags;
+          multicast->num_devices = record->num_devices;
+          snprintf(multicast->creator, sizeof(multicast->creator), "%s", record->creator_participant);
+          multicast->next = multicasts;
+          multicasts = multicast;
+        } else if (
+            multicast->size != record->allocation_size || multicast->handle_types != record->handle_types ||
+            multicast->flags != record->object_flags || multicast->num_devices != record->num_devices ||
+            strcmp(multicast->creator, record->creator_participant) != 0) {
+          reason = "inconsistent multicast properties";
+          goto failed;
+        }
+        if ((record->flags & SNAPSHOT_VMM_CREATOR) != 0) {
+          if (strcmp(participant->id, multicast->creator) != 0) {
+            reason = "invalid multicast creator";
+            goto failed;
+          }
+          multicast->creators++;
+        }
+      } else if (record->kind == SNAPSHOT_VMM_MULTICAST_DEVICE) {
+        struct multicast_device* device;
+        if (multicast == NULL) {
+          reason = "multicast device precedes object";
+          goto failed;
+        }
+        if (find_multicast_device(multicast, record->device) != NULL) {
+          reason = "duplicate multicast device";
+          goto failed;
+        }
+        device = calloc(1, sizeof(*device));
+        if (device == NULL) {
+          reason = "multicast device metadata allocation failed";
+          goto failed;
+        }
+        device->device = record->device;
+        device->next = multicast->device_list;
+        multicast->device_list = device;
+        multicast->devices++;
+      } else if (record->kind == SNAPSHOT_VMM_MULTICAST_BINDING) {
+        struct allocation* member = find_allocation(allocations, record->member_id);
+        struct multicast_device* device;
+        if (multicast == NULL || record->size == 0 || record->offset > multicast->size ||
+            record->size > multicast->size - record->offset ||
+            (record->binding_kind != SNAPSHOT_VMM_MULTICAST_BIND_MEM &&
+             record->binding_kind != SNAPSHOT_VMM_MULTICAST_BIND_ADDR) ||
+            (record->api_version != 1 && record->api_version != 2)) {
+          reason = "invalid multicast binding";
+          goto failed;
+        }
+        if ((record->binding_kind == SNAPSHOT_VMM_MULTICAST_BIND_MEM && (member == NULL || record->address != 0)) ||
+            (record->binding_kind == SNAPSHOT_VMM_MULTICAST_BIND_ADDR && record->address == 0)) {
+          reason = "invalid multicast member";
+          goto failed;
+        }
+        device = find_multicast_device(multicast, record->device);
+        if (device == NULL) {
+          reason = "multicast binding device is absent";
+          goto failed;
+        }
+        device->bound = true;
+        multicast->bindings++;
+      } else if (record->kind == SNAPSHOT_VMM_MULTICAST_MAPPING) {
+        if (multicast == NULL || record->address == 0 || record->size == 0 || record->offset > multicast->size ||
+            record->size > multicast->size - record->offset || record->access_count > SNAPSHOT_VMM_MAX_ACCESS) {
+          reason = "invalid multicast mapping";
+          goto failed;
+        }
       } else {
         reason = "unknown record kind";
         value = record->kind;
@@ -248,7 +391,38 @@ validate_topology(struct participant* participants, size_t participant_count, st
       }
     }
   }
+  {
+    struct multicast* multicast;
+    for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+      if (multicast->creators != 1) {
+        reason = "multicast group must have exactly one creator";
+        value = multicast->creators;
+        goto failed;
+      }
+      if (multicast->devices != multicast->num_devices) {
+        reason = "incomplete multicast device group";
+        value = multicast->devices;
+        goto failed;
+      }
+      if (multicast->bindings < multicast->num_devices) {
+        reason = "incomplete multicast binding group";
+        value = multicast->bindings;
+        goto failed;
+      }
+      {
+        struct multicast_device* device;
+        for (device = multicast->device_list; device != NULL; device = device->next) {
+          if (!device->bound) {
+            reason = "multicast device has no binding";
+            value = (uint64_t)(uint32_t)device->device;
+            goto failed;
+          }
+        }
+      }
+    }
+  }
   *output = allocations;
+  free_multicasts(multicasts);
   return 0;
 failed:
   if (value != UINT64_MAX)
@@ -268,6 +442,7 @@ failed:
     free(allocations);
     allocations = next;
   }
+  free_multicasts(multicasts);
   return -1;
 }
 
@@ -332,7 +507,7 @@ write_state(struct participant* participants, size_t count, FILE* output)
   size_t index;
 
   qsort(participants, count, sizeof(*participants), participant_compare);
-  if (fprintf(output, "snapshot-cuda-posix-v1\n") < 0)
+  if (fprintf(output, "snapshot-cuda-posix-v2\n") < 0)
     return -1;
   for (index = 0; index < count; index++) {
     struct participant* participant = &participants[index];
@@ -388,7 +563,7 @@ read_state(FILE* input, struct participant** output, size_t* output_count)
   struct participant* participants = NULL;
   size_t count = 0;
 
-  if (fgets(line, sizeof(line), input) == NULL || strcmp(line, "snapshot-cuda-posix-v1\n") != 0)
+  if (fgets(line, sizeof(line), input) == NULL || strcmp(line, "snapshot-cuda-posix-v2\n") != 0)
     return -1;
   while (fgets(line, sizeof(line), input) != NULL) {
     struct participant* participant;
@@ -625,6 +800,10 @@ main(int argc, char** argv)
       fprintf(stderr, "prepare failed: checkpoint carrier creation\n");
       goto done;
     }
+    if (command_all(participants, participant_count, SNAPSHOT_VMM_PREPARE_MULTICAST) != 0) {
+      fprintf(stderr, "prepare failed: multicast teardown\n");
+      goto done;
+    }
     if (command_all(participants, participant_count, SNAPSHOT_VMM_PREPARE) != 0) {
       fprintf(stderr, "prepare failed: participant prepare\n");
       goto done;
@@ -645,7 +824,11 @@ main(int argc, char** argv)
         same_participants(expected, expected_count, participants, participant_count) != 0)
       goto done;
     if (command_all(participants, participant_count, SNAPSHOT_VMM_RESTORE_CREATORS) != 0 ||
-        command_all(participants, participant_count, SNAPSHOT_VMM_RESTORE_IMPORTERS) != 0) {
+        command_all(participants, participant_count, SNAPSHOT_VMM_RESTORE_IMPORTERS) != 0 ||
+        command_all(participants, participant_count, SNAPSHOT_VMM_RESTORE_MULTICAST_CREATORS) != 0 ||
+        command_all(participants, participant_count, SNAPSHOT_VMM_RESTORE_MULTICAST_IMPORTERS) != 0 ||
+        command_all(participants, participant_count, SNAPSHOT_VMM_RESTORE_MULTICAST_DEVICES) != 0 ||
+        command_all(participants, participant_count, SNAPSHOT_VMM_RESTORE_MULTICAST) != 0) {
       goto done;
     }
     for (index = 0; index < participant_count; index++) {

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/interpose.c
@@ -24,6 +24,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include "multicast.h"
 #include "posix.h"
 #include "protocol.h"
 #include "util.h"
@@ -107,8 +108,13 @@ struct allocation {
 enum phase {
   PHASE_ACTIVE,
   PHASE_CARRIERS,
+  PHASE_MULTICAST_DETACHED,
   PHASE_PREPARED,
   PHASE_CREATORS_RESTORED,
+  PHASE_UNICAST_RESTORED,
+  PHASE_MULTICAST_CREATED,
+  PHASE_MULTICAST_IMPORTED,
+  PHASE_MULTICAST_JOINED,
   PHASE_FAILED,
 };
 
@@ -138,6 +144,22 @@ static _Atomic(uintptr_t) explicit_cu_get_proc_address;
 static _Atomic(uintptr_t) explicit_cu_get_proc_address_v2;
 
 static void* replacement(const char*, int);
+static struct handle* resolve_managed_handle(CUmemGenericAllocationHandle logical);
+static struct mapping* find_mapping_at(CUdeviceptr address);
+static struct mapping* first_mapping(const struct allocation* allocation);
+static struct handle* first_live_handle(const struct allocation* allocation);
+
+static void
+release_state_lock(void)
+{
+  pthread_mutex_unlock(&state_lock);
+}
+
+static void
+acquire_state_lock(void)
+{
+  pthread_mutex_lock(&state_lock);
+}
 
 static void
 set_failure(const char* message)
@@ -189,7 +211,7 @@ real_dlsym(void* handle, const char* name)
 }
 
 static void*
-real_symbol(const char* name)
+lookup_real_symbol(const char* name)
 {
   void* symbol = real_dlsym(RTLD_NEXT, name);
   void* handle;
@@ -201,6 +223,12 @@ real_symbol(const char* name)
     return symbol;
   handle = (void*)atomic_load(&explicit_libcudart_handle);
   return handle == NULL ? NULL : real_dlsym(handle, name);
+}
+
+static void*
+real_symbol(const char* name)
+{
+  return lookup_real_symbol(name);
 }
 
 static bool
@@ -290,6 +318,66 @@ find_allocation(const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE])
       return allocation;
   }
   return NULL;
+}
+
+static int
+multicast_member_from_handle(CUmemGenericAllocationHandle logical, struct snapshot_multicast_member* member)
+{
+  struct handle* handle = resolve_managed_handle(logical);
+
+  if (handle == NULL || handle->driver == 0)
+    return -1;
+  memcpy(member->id, handle->allocation->id, sizeof(member->id));
+  member->handle = handle->driver;
+  member->device = handle->allocation->properties.location.id;
+  return 0;
+}
+
+static int
+multicast_member_from_address(CUdeviceptr address, size_t size, struct snapshot_multicast_member* member)
+{
+  struct mapping* mapping = find_mapping_at(address);
+
+  if (mapping == NULL || size > mapping->size || address - mapping->address > mapping->size - size)
+    return -1;
+  memcpy(member->id, mapping->allocation->id, sizeof(member->id));
+  member->address = address;
+  member->allocation_offset = mapping->offset + (size_t)(address - mapping->address);
+  member->device = mapping->allocation->properties.location.id;
+  return 0;
+}
+
+static void
+multicast_mark_member_shared(const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE])
+{
+  struct allocation* allocation = find_allocation(id);
+
+  if (allocation != NULL)
+    allocation->shared = true;
+}
+
+static int
+multicast_member_from_id(const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE], struct snapshot_multicast_member* member)
+{
+  retain_fn retain = (retain_fn)real_symbol("cuMemRetainAllocationHandle");
+  struct allocation* allocation = find_allocation(id);
+  struct handle* handle;
+  struct mapping* mapping;
+
+  if (allocation == NULL)
+    return -1;
+  memcpy(member->id, allocation->id, sizeof(member->id));
+  member->device = allocation->properties.location.id;
+  handle = first_live_handle(allocation);
+  if (handle != NULL && handle->driver != 0) {
+    member->handle = handle->driver;
+    return 0;
+  }
+  mapping = first_mapping(allocation);
+  if (mapping == NULL || retain == NULL || retain(&member->handle, (void*)(uintptr_t)mapping->address) != CUDA_SUCCESS)
+    return -1;
+  member->temporary_handle = true;
+  return 0;
 }
 
 static bool
@@ -459,6 +547,7 @@ create_posix_capability(const struct allocation* allocation, int* output)
   memset(&capability, 0, sizeof(capability));
   capability.magic = SNAPSHOT_VMM_POSIX_CAPABILITY_MAGIC;
   capability.version = SNAPSHOT_VMM_POSIX_CAPABILITY_VERSION;
+  capability.resource_kind = SNAPSHOT_VMM_RESOURCE_UNICAST;
   snprintf(
       capability.creator_participant, sizeof(capability.creator_participant), "%s", allocation->creator_participant);
   memcpy(capability.allocation_id, allocation->id, sizeof(capability.allocation_id));
@@ -580,16 +669,21 @@ request_export(const struct snapshot_vmm_posix_capability* capability, int* outp
   if (error != NULL && error_size != 0)
     error[0] = '\0';
   if (strcmp(capability->creator_participant, participant_id) == 0) {
-    struct allocation* allocation;
-    CUresult export_result;
+    CUresult export_result = CUDA_ERROR_INVALID_HANDLE;
 
     pthread_mutex_lock(&state_lock);
-    allocation = find_allocation(capability->allocation_id);
-    if (allocation == NULL ||
-        memcmp(allocation->authorization, capability->authorization, sizeof(allocation->authorization)) != 0) {
+    if (capability->resource_kind == SNAPSHOT_VMM_RESOURCE_MULTICAST) {
+      export_result = snapshot_multicast_export_raw(capability->allocation_id, capability->authorization, output);
+    } else {
+      struct allocation* allocation = find_allocation(capability->allocation_id);
+      if (allocation != NULL &&
+          memcmp(allocation->authorization, capability->authorization, sizeof(allocation->authorization)) == 0)
+        export_result = export_raw(allocation, output);
+    }
+    if (export_result == CUDA_ERROR_INVALID_HANDLE) {
       if (error != NULL && error_size != 0)
-        snprintf(error, error_size, "%s", "creator allocation is unavailable");
-    } else if ((export_result = export_raw(allocation, output)) != CUDA_SUCCESS) {
+        snprintf(error, error_size, "%s", "creator resource is unavailable");
+    } else if (export_result != CUDA_SUCCESS) {
       if (error != NULL && error_size != 0)
         snprintf(error, error_size, "creator export failed: CUresult=%d", (int)export_result);
     } else {
@@ -636,6 +730,7 @@ inspect_records(uint32_t* count)
     if (mapping->allocation->shared && mapping->mapped)
       total++;
   }
+  total += snapshot_multicast_record_count();
   if (total > SNAPSHOT_VMM_MAX_RECORDS)
     return NULL;
   records = calloc(total == 0 ? 1 : total, sizeof(*records));
@@ -675,6 +770,10 @@ inspect_records(uint32_t* count)
       record->access[index].flags = mapping->access[index].flags;
     }
     record++;
+  }
+  if (snapshot_multicast_write_records(record, total - (size_t)(record - records)) != 0) {
+    free(records);
+    return NULL;
   }
   *count = (uint32_t)total;
   return records;
@@ -729,6 +828,19 @@ failed:
 }
 
 static int
+prepare_multicast(void)
+{
+  if (current_phase != PHASE_CARRIERS)
+    return -1;
+  if (snapshot_multicast_prepare() != 0) {
+    set_failure(snapshot_multicast_error());
+    return -1;
+  }
+  current_phase = PHASE_MULTICAST_DETACHED;
+  return 0;
+}
+
+static int
 prepare_topology(void)
 {
   release_fn release = (release_fn)real_symbol("cuMemRelease");
@@ -738,14 +850,13 @@ prepare_topology(void)
   struct handle* handle;
   struct mapping* mapping;
 
-  if (current_phase != PHASE_CARRIERS || release == NULL || unmap == NULL)
+  if (current_phase != PHASE_MULTICAST_DETACHED || release == NULL || unmap == NULL)
     return -1;
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
     if (allocation->shared && allocation->creator &&
         (live_handle_count(allocation) != 0 || first_mapping(allocation) != NULL) && allocation->carrier == 0)
       goto failed;
   }
-  current_phase = PHASE_PREPARED;
   for (allocation = allocations; allocation != NULL; allocation = allocation->next) {
     if (!allocation->shared ||
         (live_handle_count(allocation) == 0 && first_mapping(allocation) == NULL && allocation->carrier == 0))
@@ -781,6 +892,7 @@ prepare_topology(void)
     if (leave_context(&scope) != 0)
       goto failed;
   }
+  current_phase = PHASE_PREPARED;
   return 0;
 failed:
   set_failure("cannot prepare CUDA VMM topology");
@@ -907,6 +1019,7 @@ restore_importers(void)
     memset(&capability, 0, sizeof(capability));
     capability.magic = SNAPSHOT_VMM_POSIX_CAPABILITY_MAGIC;
     capability.version = SNAPSHOT_VMM_POSIX_CAPABILITY_VERSION;
+    capability.resource_kind = SNAPSHOT_VMM_RESOURCE_UNICAST;
     snprintf(
         capability.creator_participant, sizeof(capability.creator_participant), "%s", allocation->creator_participant);
     memcpy(capability.allocation_id, allocation->id, sizeof(capability.allocation_id));
@@ -964,7 +1077,7 @@ restore_importers(void)
       return -1;
     }
   }
-  current_phase = PHASE_ACTIVE;
+  current_phase = PHASE_UNICAST_RESTORED;
   failure[0] = '\0';
   return 0;
 }
@@ -1024,6 +1137,11 @@ serve(int client)
         response_error(&response, failure);
       (void)snapshot_vmm_send_header(client, &response, -1);
       break;
+    case SNAPSHOT_VMM_PREPARE_MULTICAST:
+      if (prepare_multicast() != 0)
+        response_error(&response, failure);
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
     case SNAPSHOT_VMM_CREATE_CARRIERS:
       if (create_checkpoint_carriers() != 0)
         response_error(&response, failure);
@@ -1039,17 +1157,68 @@ serve(int client)
         response_error(&response, failure);
       (void)snapshot_vmm_send_header(client, &response, -1);
       break;
+    case SNAPSHOT_VMM_RESTORE_MULTICAST_CREATORS:
+      if (current_phase != PHASE_UNICAST_RESTORED || snapshot_multicast_restore_creators() != 0) {
+        set_failure(snapshot_multicast_error());
+        response_error(&response, failure);
+      } else {
+        current_phase = PHASE_MULTICAST_CREATED;
+      }
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
+    case SNAPSHOT_VMM_RESTORE_MULTICAST_IMPORTERS:
+      if (current_phase != PHASE_MULTICAST_CREATED || snapshot_multicast_restore_importers() != 0) {
+        set_failure(snapshot_multicast_error());
+        response_error(&response, failure);
+      } else {
+        current_phase = PHASE_MULTICAST_IMPORTED;
+      }
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
+    case SNAPSHOT_VMM_RESTORE_MULTICAST_DEVICES:
+      if (current_phase != PHASE_MULTICAST_IMPORTED || snapshot_multicast_restore_devices() != 0) {
+        set_failure(snapshot_multicast_error());
+        response_error(&response, failure);
+      } else {
+        current_phase = PHASE_MULTICAST_JOINED;
+      }
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
+    case SNAPSHOT_VMM_RESTORE_MULTICAST:
+      if (current_phase != PHASE_MULTICAST_JOINED || snapshot_multicast_restore_topology() != 0) {
+        set_failure(snapshot_multicast_error());
+        response_error(&response, failure);
+      } else {
+        current_phase = PHASE_ACTIVE;
+        failure[0] = '\0';
+      }
+      (void)snapshot_vmm_send_header(client, &response, -1);
+      break;
     case SNAPSHOT_VMM_EXPORT: {
-      struct allocation* allocation = find_allocation(request.allocation_id);
       CUresult export_result;
-      if (strcmp(request.participant_id, participant_id) != 0 || allocation == NULL || !allocation->creator ||
-          memcmp(allocation->authorization, request.authorization, sizeof(request.authorization)) != 0 ||
-          (current_phase != PHASE_ACTIVE && current_phase != PHASE_CREATORS_RESTORED)) {
-        response_error(&response, "creator allocation is unavailable");
+      if (strcmp(request.participant_id, participant_id) != 0 ||
+          (request.resource_kind != SNAPSHOT_VMM_RESOURCE_UNICAST &&
+           request.resource_kind != SNAPSHOT_VMM_RESOURCE_MULTICAST) ||
+          (current_phase != PHASE_ACTIVE && current_phase != PHASE_CREATORS_RESTORED &&
+           current_phase != PHASE_UNICAST_RESTORED && current_phase != PHASE_MULTICAST_CREATED &&
+           current_phase != PHASE_MULTICAST_IMPORTED && current_phase != PHASE_MULTICAST_JOINED)) {
+        response_error(&response, "creator resource is unavailable");
         (void)snapshot_vmm_send_header(client, &response, -1);
         break;
       }
-      export_result = export_raw(allocation, &exported_fd);
+      response.resource_kind = request.resource_kind;
+      if (request.resource_kind == SNAPSHOT_VMM_RESOURCE_MULTICAST) {
+        export_result = snapshot_multicast_export_raw(request.allocation_id, request.authorization, &exported_fd);
+      } else {
+        struct allocation* allocation = find_allocation(request.allocation_id);
+        if (allocation == NULL || !allocation->creator ||
+            memcmp(allocation->authorization, request.authorization, sizeof(request.authorization)) != 0) {
+          response_error(&response, "creator allocation is unavailable");
+          (void)snapshot_vmm_send_header(client, &response, -1);
+          break;
+        }
+        export_result = export_raw(allocation, &exported_fd);
+      }
       if (export_result != CUDA_SUCCESS) {
         char message[sizeof(response.message)];
         snprintf(message, sizeof(message), "creator export failed: CUresult=%d", (int)export_result);
@@ -1057,7 +1226,7 @@ serve(int client)
         (void)snapshot_vmm_send_header(client, &response, -1);
         break;
       }
-      memcpy(response.allocation_id, allocation->id, sizeof(response.allocation_id));
+      memcpy(response.allocation_id, request.allocation_id, sizeof(response.allocation_id));
       (void)snapshot_vmm_send_header(client, &response, exported_fd);
       break;
     }
@@ -1150,6 +1319,7 @@ fork_child(void)
   allocations = NULL;
   handles = NULL;
   mappings = NULL;
+  snapshot_multicast_reset();
   next_logical_handle = 1;
   current_phase = PHASE_ACTIVE;
   failure[0] = '\0';
@@ -1179,6 +1349,17 @@ ensure_process_endpoint(void)
 __attribute__((constructor)) static void
 initialize(void)
 {
+  const struct snapshot_multicast_callbacks multicast_callbacks = {
+      .real_symbol = lookup_real_symbol,
+      .allocate_logical_handle = allocate_logical_handle,
+      .random_bytes = random_bytes,
+      .member_from_handle = multicast_member_from_handle,
+      .member_from_address = multicast_member_from_address,
+      .member_from_id = multicast_member_from_id,
+      .mark_member_shared = multicast_mark_member_shared,
+      .release_state_lock = release_state_lock,
+      .acquire_state_lock = acquire_state_lock,
+  };
   const char* control;
   const char* configured_participant;
 
@@ -1212,6 +1393,7 @@ initialize(void)
     set_failure("cannot start CUDA VMM control endpoint");
     return;
   }
+  snapshot_multicast_initialize(&multicast_callbacks, participant_id, socket_path);
 }
 
 __attribute__((destructor)) static void
@@ -1289,6 +1471,11 @@ cuMemRelease(CUmemGenericAllocationHandle application)
   pthread_mutex_lock(&state_lock);
   handle = resolve_managed_handle(application);
   if (handle == NULL) {
+    if (snapshot_multicast_is_handle(application)) {
+      result = current_phase == PHASE_ACTIVE ? snapshot_multicast_release(application) : CUDA_ERROR_NOT_READY;
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     if (is_logical_handle(application))
       return CUDA_ERROR_INVALID_HANDLE;
@@ -1324,6 +1511,13 @@ cuMemRetainAllocationHandle(CUmemGenericAllocationHandle* output, void* address)
     return function(output, address);
   if (output == NULL)
     return CUDA_ERROR_INVALID_VALUE;
+  pthread_mutex_lock(&state_lock);
+  result = current_phase == PHASE_ACTIVE ? snapshot_multicast_retain(output, address) : CUDA_ERROR_NOT_READY;
+  if (result != CUDA_ERROR_INVALID_VALUE) {
+    pthread_mutex_unlock(&state_lock);
+    return result;
+  }
+  pthread_mutex_unlock(&state_lock);
   result = function(&driver, address);
   if (result != CUDA_SUCCESS)
     return result;
@@ -1359,6 +1553,12 @@ cuMemMap(
   pthread_mutex_lock(&state_lock);
   handle = resolve_managed_handle(application);
   if (handle == NULL) {
+    if (snapshot_multicast_is_handle(application)) {
+      result = current_phase == PHASE_ACTIVE ? snapshot_multicast_map(address, size, offset, application, flags)
+                                             : CUDA_ERROR_NOT_READY;
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     if (is_logical_handle(application))
       return CUDA_ERROR_INVALID_HANDLE;
@@ -1404,6 +1604,11 @@ cuMemUnmap(CUdeviceptr address, size_t size)
   pthread_mutex_lock(&state_lock);
   mapping = find_mapping(address, size);
   if (mapping == NULL) {
+    if (snapshot_multicast_has_mapping(address, size)) {
+      result = current_phase == PHASE_ACTIVE ? snapshot_multicast_unmap(address, size) : CUDA_ERROR_NOT_READY;
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     return function != NULL ? function(address, size) : unavailable();
   }
@@ -1432,6 +1637,12 @@ cuMemSetAccess(CUdeviceptr address, size_t size, const CUmemAccessDesc* descript
   pthread_mutex_lock(&state_lock);
   mapping = find_mapping(address, size);
   if (mapping == NULL) {
+    if (snapshot_multicast_has_mapping(address, size)) {
+      result = current_phase == PHASE_ACTIVE ? snapshot_multicast_set_access(address, size, descriptors, count)
+                                             : CUDA_ERROR_NOT_READY;
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     return function != NULL ? function(address, size, descriptors, count) : unavailable();
   }
@@ -1467,6 +1678,12 @@ cuMemExportToShareableHandle(
   pthread_mutex_lock(&state_lock);
   handle = resolve_managed_handle(application);
   if (handle == NULL) {
+    if (snapshot_multicast_is_handle(application)) {
+      result = current_phase == PHASE_ACTIVE ? snapshot_multicast_export(shareable, application, type, flags)
+                                             : CUDA_ERROR_NOT_READY;
+      pthread_mutex_unlock(&state_lock);
+      return result;
+    }
     pthread_mutex_unlock(&state_lock);
     if (is_logical_handle(application))
       return CUDA_ERROR_INVALID_HANDLE;
@@ -1512,6 +1729,19 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle* output, void* os_ha
     return CUDA_ERROR_INVALID_HANDLE;
   if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
     return result;
+  if (capability.resource_kind == SNAPSHOT_VMM_RESOURCE_MULTICAST) {
+    if (request_export(&capability, &raw_fd, NULL, 0) != 0)
+      return CUDA_ERROR_INVALID_HANDLE;
+    pthread_mutex_lock(&state_lock);
+    result = current_phase == PHASE_ACTIVE ? snapshot_multicast_import(output, &capability, raw_fd)
+                                           : CUDA_ERROR_INVALID_HANDLE;
+    pthread_mutex_unlock(&state_lock);
+    if (close(raw_fd) != 0 && result == CUDA_SUCCESS) {
+      (void)cuMemRelease(*output);
+      return CUDA_ERROR_UNKNOWN;
+    }
+    return result;
+  }
   pthread_mutex_lock(&state_lock);
   if (current_phase != PHASE_ACTIVE) {
     pthread_mutex_unlock(&state_lock);
@@ -1581,12 +1811,17 @@ cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* properties, CUmemGen
     return result;
   pthread_mutex_lock(&state_lock);
   handle = resolve_managed_handle(application);
-  if (handle == NULL)
-    result = is_logical_handle(application) ? CUDA_ERROR_INVALID_HANDLE
-                                            : (function != NULL ? function(properties, application) : unavailable());
-  else
+  if (handle == NULL) {
+    if (snapshot_multicast_is_handle(application))
+      result = current_phase == PHASE_ACTIVE ? snapshot_multicast_get_properties(properties, application)
+                                             : CUDA_ERROR_NOT_READY;
+    else
+      result = is_logical_handle(application) ? CUDA_ERROR_INVALID_HANDLE
+                                              : (function != NULL ? function(properties, application) : unavailable());
+  } else {
     result = current_phase == PHASE_ACTIVE && handle->driver != 0 ? function(properties, handle->driver)
                                                                   : CUDA_ERROR_NOT_READY;
+  }
   pthread_mutex_unlock(&state_lock);
   return result;
 }
@@ -1596,8 +1831,16 @@ cuMulticastCreate(CUmemGenericAllocationHandle* output, const CUmulticastObjectP
 {
   typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
   function_type function = (function_type)real_symbol("cuMulticastCreate");
+  CUresult result;
 
-  return enabled ? CUDA_ERROR_NOT_SUPPORTED : (function != NULL ? function(output, properties) : unavailable());
+  if (!enabled)
+    return function != NULL ? function(output, properties) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  result = current_phase == PHASE_ACTIVE ? snapshot_multicast_create(output, properties) : CUDA_ERROR_NOT_READY;
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
 CUresult CUDAAPI
@@ -1605,8 +1848,16 @@ cuMulticastAddDevice(CUmemGenericAllocationHandle multicast, CUdevice device)
 {
   typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle, CUdevice);
   function_type function = (function_type)real_symbol("cuMulticastAddDevice");
+  CUresult result;
 
-  return enabled ? CUDA_ERROR_NOT_SUPPORTED : (function != NULL ? function(multicast, device) : unavailable());
+  if (!enabled)
+    return function != NULL ? function(multicast, device) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  result = current_phase == PHASE_ACTIVE ? snapshot_multicast_add_device(multicast, device) : CUDA_ERROR_NOT_READY;
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
 CUresult CUDAAPI
@@ -1617,12 +1868,21 @@ cuMulticastBindMem(
   typedef CUresult(CUDAAPI * function_type)(
       CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
   function_type function = (function_type)real_symbol("cuMulticastBindMem");
+  CUresult result;
 
-  return enabled ? CUDA_ERROR_NOT_SUPPORTED
-                 : (function != NULL ? function(multicast, multicast_offset, memory, memory_offset, size, flags)
-                                     : unavailable());
+  if (!enabled)
+    return function != NULL ? function(multicast, multicast_offset, memory, memory_offset, size, flags) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  result = current_phase == PHASE_ACTIVE
+               ? snapshot_multicast_bind_mem(multicast, 0, false, multicast_offset, memory, memory_offset, size, flags)
+               : CUDA_ERROR_NOT_READY;
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
+#if CUDA_VERSION >= 13010
 CUresult CUDAAPI
 cuMulticastBindMem_v2(
     CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset,
@@ -1631,11 +1891,22 @@ cuMulticastBindMem_v2(
   typedef CUresult(CUDAAPI * function_type)(
       CUmemGenericAllocationHandle, CUdevice, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
   function_type function = (function_type)real_symbol("cuMulticastBindMem_v2");
+  CUresult result;
 
-  return enabled ? CUDA_ERROR_NOT_SUPPORTED
-                 : (function != NULL ? function(multicast, device, multicast_offset, memory, memory_offset, size, flags)
-                                     : unavailable());
+  if (!enabled)
+    return function != NULL ? function(multicast, device, multicast_offset, memory, memory_offset, size, flags)
+                            : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  result =
+      current_phase == PHASE_ACTIVE
+          ? snapshot_multicast_bind_mem(multicast, device, true, multicast_offset, memory, memory_offset, size, flags)
+          : CUDA_ERROR_NOT_READY;
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
+#endif
 
 CUresult CUDAAPI
 cuMulticastBindAddr(
@@ -1645,11 +1916,21 @@ cuMulticastBindAddr(
   typedef CUresult(CUDAAPI * function_type)(
       CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t, unsigned long long);
   function_type function = (function_type)real_symbol("cuMulticastBindAddr");
+  CUresult result;
 
-  return enabled ? CUDA_ERROR_NOT_SUPPORTED
-                 : (function != NULL ? function(multicast, multicast_offset, memory, size, flags) : unavailable());
+  if (!enabled)
+    return function != NULL ? function(multicast, multicast_offset, memory, size, flags) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  result = current_phase == PHASE_ACTIVE
+               ? snapshot_multicast_bind_address(multicast, 0, false, multicast_offset, memory, size, flags)
+               : CUDA_ERROR_NOT_READY;
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
+#if CUDA_VERSION >= 13010
 CUresult CUDAAPI
 cuMulticastBindAddr_v2(
     CUmemGenericAllocationHandle multicast, CUdevice device, size_t multicast_offset, CUdeviceptr memory, size_t size,
@@ -1658,11 +1939,20 @@ cuMulticastBindAddr_v2(
   typedef CUresult(CUDAAPI * function_type)(
       CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t, unsigned long long);
   function_type function = (function_type)real_symbol("cuMulticastBindAddr_v2");
+  CUresult result;
 
-  return enabled
-             ? CUDA_ERROR_NOT_SUPPORTED
-             : (function != NULL ? function(multicast, device, multicast_offset, memory, size, flags) : unavailable());
+  if (!enabled)
+    return function != NULL ? function(multicast, device, multicast_offset, memory, size, flags) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  result = current_phase == PHASE_ACTIVE
+               ? snapshot_multicast_bind_address(multicast, device, true, multicast_offset, memory, size, flags)
+               : CUDA_ERROR_NOT_READY;
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
+#endif
 
 CUresult CUDAAPI
 cuMulticastGetGranularity(
@@ -1671,8 +1961,7 @@ cuMulticastGetGranularity(
   typedef CUresult(CUDAAPI * function_type)(size_t*, const CUmulticastObjectProp*, CUmulticastGranularity_flags);
   function_type function = (function_type)real_symbol("cuMulticastGetGranularity");
 
-  return enabled ? CUDA_ERROR_NOT_SUPPORTED
-                 : (function != NULL ? function(granularity, properties, option) : unavailable());
+  return function != NULL ? function(granularity, properties, option) : unavailable();
 }
 
 CUresult CUDAAPI
@@ -1680,9 +1969,17 @@ cuMulticastUnbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_
 {
   typedef CUresult(CUDAAPI * function_type)(CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
   function_type function = (function_type)real_symbol("cuMulticastUnbind");
+  CUresult result;
 
-  return enabled ? CUDA_ERROR_NOT_SUPPORTED
-                 : (function != NULL ? function(multicast, device, offset, size) : unavailable());
+  if (!enabled)
+    return function != NULL ? function(multicast, device, offset, size) : unavailable();
+  if ((result = ensure_process_endpoint()) != CUDA_SUCCESS)
+    return result;
+  pthread_mutex_lock(&state_lock);
+  result =
+      current_phase == PHASE_ACTIVE ? snapshot_multicast_unbind(multicast, device, offset, size) : CUDA_ERROR_NOT_READY;
+  pthread_mutex_unlock(&state_lock);
+  return result;
 }
 
 static void*
@@ -1693,6 +1990,12 @@ replacement(const char* symbol, int version)
   return (void*)&name
   if (symbol == NULL)
     return NULL;
+#if CUDA_VERSION >= 13010
+  if (version >= 13010 && strcmp(symbol, "cuMulticastBindMem") == 0)
+    return (void*)&cuMulticastBindMem_v2;
+  if (version >= 13010 && strcmp(symbol, "cuMulticastBindAddr") == 0)
+    return (void*)&cuMulticastBindAddr_v2;
+#endif
   ENTRY(cuMemCreate);
   ENTRY(cuMemRelease);
   ENTRY(cuMemRetainAllocationHandle);
@@ -1705,9 +2008,13 @@ replacement(const char* symbol, int version)
   ENTRY(cuMulticastCreate);
   ENTRY(cuMulticastAddDevice);
   ENTRY(cuMulticastBindMem);
+#if CUDA_VERSION >= 13010
   ENTRY(cuMulticastBindMem_v2);
+#endif
   ENTRY(cuMulticastBindAddr);
+#if CUDA_VERSION >= 13010
   ENTRY(cuMulticastBindAddr_v2);
+#endif
   ENTRY(cuMulticastGetGranularity);
   ENTRY(cuMulticastUnbind);
   ENTRY(cuGetProcAddress_v2);

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/multicast.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/multicast.c
@@ -1,0 +1,1351 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+
+#include "multicast.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+typedef CUresult(CUDAAPI* release_fn)(CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* retain_fn)(CUmemGenericAllocationHandle*, void*);
+typedef CUresult(CUDAAPI* map_fn)(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+typedef CUresult(CUDAAPI* unmap_fn)(CUdeviceptr, size_t);
+typedef CUresult(CUDAAPI* access_fn)(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+typedef CUresult(CUDAAPI* export_fn)(
+    void*, CUmemGenericAllocationHandle, CUmemAllocationHandleType, unsigned long long);
+typedef CUresult(CUDAAPI* import_fn)(CUmemGenericAllocationHandle*, void*, CUmemAllocationHandleType);
+typedef CUresult(CUDAAPI* properties_fn)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+typedef CUresult(CUDAAPI* context_get_fn)(CUcontext*);
+typedef CUresult(CUDAAPI* context_set_fn)(CUcontext);
+typedef CUresult(CUDAAPI* context_device_fn)(CUdevice*);
+typedef CUresult(CUDAAPI* create_fn)(CUmemGenericAllocationHandle*, const CUmulticastObjectProp*);
+typedef CUresult(CUDAAPI* add_device_fn)(CUmemGenericAllocationHandle, CUdevice);
+typedef CUresult(CUDAAPI* bind_mem_fn)(
+    CUmemGenericAllocationHandle, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+typedef CUresult(CUDAAPI* bind_address_fn)(
+    CUmemGenericAllocationHandle, size_t, CUdeviceptr, size_t, unsigned long long);
+#if CUDA_VERSION >= 13010
+typedef CUresult(CUDAAPI* bind_mem_v2_fn)(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUmemGenericAllocationHandle, size_t, size_t, unsigned long long);
+typedef CUresult(CUDAAPI* bind_address_v2_fn)(
+    CUmemGenericAllocationHandle, CUdevice, size_t, CUdeviceptr, size_t, unsigned long long);
+#endif
+typedef CUresult(CUDAAPI* unbind_fn)(CUmemGenericAllocationHandle, CUdevice, size_t, size_t);
+
+struct multicast;
+
+struct multicast_handle {
+  CUmemGenericAllocationHandle logical;
+  CUmemGenericAllocationHandle driver;
+  bool live;
+  struct multicast* multicast;
+  struct multicast_handle* next;
+};
+
+struct multicast_device {
+  CUdevice device;
+  struct multicast_device* next;
+};
+
+struct multicast_binding {
+  uint8_t member_id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  CUdeviceptr member_address;
+  size_t multicast_offset;
+  size_t member_offset;
+  size_t size;
+  unsigned long long flags;
+  CUdevice device;
+  uint8_t kind;
+  uint8_t api_version;
+  bool bound;
+  bool checkpointed;
+  struct multicast_binding* next;
+};
+
+struct multicast_mapping {
+  CUdeviceptr address;
+  size_t size;
+  size_t offset;
+  unsigned long long flags;
+  CUmemAccessDesc access[SNAPSHOT_VMM_MAX_ACCESS];
+  size_t access_count;
+  bool mapped;
+  bool checkpointed;
+  struct multicast_mapping* next;
+};
+
+struct multicast {
+  uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  uint8_t authorization[SNAPSHOT_VMM_TOKEN_SIZE];
+  char creator_participant[SNAPSHOT_VMM_ID_SIZE];
+  char creator_endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
+  CUmulticastObjectProp properties;
+  CUcontext context;
+  CUmemGenericAllocationHandle restore_handle;
+  bool creator;
+  bool checkpointed;
+  struct multicast_device* devices;
+  struct multicast_binding* bindings;
+  struct multicast_mapping* mappings;
+  struct multicast* next;
+};
+
+struct context_scope {
+  CUcontext previous;
+  bool changed;
+};
+
+static struct snapshot_multicast_callbacks operations;
+static const char* current_participant;
+static const char* current_endpoint;
+static struct multicast* multicasts;
+static struct multicast_handle* handles;
+static char failure[128];
+
+static void*
+symbol(const char* name)
+{
+  return operations.real_symbol == NULL ? NULL : operations.real_symbol(name);
+}
+
+static CUresult
+unavailable(void)
+{
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+static int
+fail(const char* operation, CUresult result)
+{
+  if (result == CUDA_SUCCESS)
+    snprintf(failure, sizeof(failure), "%s", operation);
+  else
+    snprintf(failure, sizeof(failure), "%s failed: CUresult=%d", operation, (int)result);
+  return -1;
+}
+
+static struct multicast*
+find_multicast(const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE])
+{
+  struct multicast* multicast;
+
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    if (memcmp(multicast->id, id, SNAPSHOT_VMM_ALLOCATION_ID_SIZE) == 0)
+      return multicast;
+  }
+  return NULL;
+}
+
+static struct multicast_handle*
+find_handle(CUmemGenericAllocationHandle logical)
+{
+  struct multicast_handle* handle;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->logical == logical)
+      return handle;
+  }
+  return NULL;
+}
+
+static struct multicast_mapping*
+find_mapping(CUdeviceptr address, size_t size)
+{
+  struct multicast* multicast;
+
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    struct multicast_mapping* mapping;
+    for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+      if (mapping->mapped && mapping->address == address && mapping->size == size)
+        return mapping;
+    }
+  }
+  return NULL;
+}
+
+static struct multicast_mapping*
+find_mapping_at(CUdeviceptr address)
+{
+  struct multicast* multicast;
+
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    struct multicast_mapping* mapping;
+    for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+      if (mapping->mapped && address >= mapping->address && address < mapping->address + mapping->size)
+        return mapping;
+    }
+  }
+  return NULL;
+}
+
+static struct multicast*
+mapping_owner(const struct multicast_mapping* expected)
+{
+  struct multicast* multicast;
+
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    const struct multicast_mapping* mapping;
+    for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+      if (mapping == expected)
+        return multicast;
+    }
+  }
+  return NULL;
+}
+
+static size_t
+live_handle_count(const struct multicast* multicast)
+{
+  const struct multicast_handle* handle;
+  size_t count = 0;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->live && handle->multicast == multicast)
+      count++;
+  }
+  return count;
+}
+
+static CUmemGenericAllocationHandle
+current_driver(const struct multicast* multicast)
+{
+  const struct multicast_handle* handle;
+
+  if (multicast->restore_handle != 0)
+    return multicast->restore_handle;
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->live && handle->multicast == multicast && handle->driver != 0)
+      return handle->driver;
+  }
+  return 0;
+}
+
+static bool
+driver_used(const struct multicast_handle* except, CUmemGenericAllocationHandle driver)
+{
+  const struct multicast_handle* handle;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle != except && handle->live && handle->driver == driver)
+      return true;
+  }
+  return false;
+}
+
+static bool
+matches_capability(const struct multicast* multicast, const struct snapshot_vmm_posix_capability* capability)
+{
+  return memcmp(multicast->authorization, capability->authorization, sizeof(multicast->authorization)) == 0 &&
+         strcmp(multicast->creator_participant, capability->creator_participant) == 0 &&
+         strcmp(multicast->creator_endpoint, capability->creator_endpoint) == 0 &&
+         multicast->properties.numDevices == capability->num_devices &&
+         multicast->properties.size == capability->allocation_size &&
+         multicast->properties.handleTypes == capability->handle_types &&
+         multicast->properties.flags == capability->object_flags;
+}
+
+static bool
+active(const struct multicast* multicast)
+{
+  const struct multicast_binding* binding;
+  const struct multicast_mapping* mapping;
+
+  if (live_handle_count(multicast) != 0)
+    return true;
+  for (binding = multicast->bindings; binding != NULL; binding = binding->next) {
+    if (binding->bound)
+      return true;
+  }
+  for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+    if (mapping->mapped)
+      return true;
+  }
+  return false;
+}
+
+static int
+add_handle(struct multicast* multicast, CUmemGenericAllocationHandle driver, CUmemGenericAllocationHandle* logical)
+{
+  struct multicast_handle* handle = calloc(1, sizeof(*handle));
+
+  if (handle == NULL || operations.allocate_logical_handle == NULL ||
+      operations.allocate_logical_handle(logical) != 0) {
+    free(handle);
+    return -1;
+  }
+  handle->logical = *logical;
+  handle->driver = driver;
+  handle->live = true;
+  handle->multicast = multicast;
+  handle->next = handles;
+  handles = handle;
+  return 0;
+}
+
+static void
+install_driver(struct multicast* multicast, CUmemGenericAllocationHandle driver)
+{
+  struct multicast_handle* handle;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->live && handle->multicast == multicast)
+      handle->driver = driver;
+  }
+  multicast->restore_handle = driver;
+}
+
+static int
+enter_context(CUcontext context, struct context_scope* scope)
+{
+  context_get_fn get_current = (context_get_fn)symbol("cuCtxGetCurrent");
+  context_set_fn set_current = (context_set_fn)symbol("cuCtxSetCurrent");
+
+  memset(scope, 0, sizeof(*scope));
+  if (get_current == NULL || set_current == NULL || get_current(&scope->previous) != CUDA_SUCCESS)
+    return -1;
+  if (scope->previous != context) {
+    if (set_current(context) != CUDA_SUCCESS)
+      return -1;
+    scope->changed = true;
+  }
+  return 0;
+}
+
+static int
+leave_context(const struct context_scope* scope)
+{
+  context_set_fn set_current = (context_set_fn)symbol("cuCtxSetCurrent");
+
+  return !scope->changed || (set_current != NULL && set_current(scope->previous) == CUDA_SUCCESS) ? 0 : -1;
+}
+
+static int
+capture_context(CUcontext* context)
+{
+  context_get_fn get_current = (context_get_fn)symbol("cuCtxGetCurrent");
+
+  return get_current != NULL && get_current(context) == CUDA_SUCCESS && *context != NULL ? 0 : -1;
+}
+
+static int
+capture_device(CUdevice* device)
+{
+  context_device_fn get_device = (context_device_fn)symbol("cuCtxGetDevice");
+
+  return get_device != NULL && get_device(device) == CUDA_SUCCESS ? 0 : -1;
+}
+
+static int
+fill_capability(const struct multicast* multicast, struct snapshot_vmm_posix_capability* capability)
+{
+  memset(capability, 0, sizeof(*capability));
+  capability->magic = SNAPSHOT_VMM_POSIX_CAPABILITY_MAGIC;
+  capability->version = SNAPSHOT_VMM_POSIX_CAPABILITY_VERSION;
+  capability->resource_kind = SNAPSHOT_VMM_RESOURCE_MULTICAST;
+  snprintf(
+      capability->creator_participant, sizeof(capability->creator_participant), "%s", multicast->creator_participant);
+  memcpy(capability->allocation_id, multicast->id, sizeof(capability->allocation_id));
+  snprintf(capability->creator_endpoint, sizeof(capability->creator_endpoint), "%s", multicast->creator_endpoint);
+  memcpy(capability->authorization, multicast->authorization, sizeof(capability->authorization));
+  capability->allocation_size = multicast->properties.size;
+  capability->handle_types = multicast->properties.handleTypes;
+  capability->object_flags = multicast->properties.flags;
+  capability->num_devices = multicast->properties.numDevices;
+  return 0;
+}
+
+static CUresult
+bind_memory(
+    CUmemGenericAllocationHandle driver, const struct multicast_binding* binding, CUmemGenericAllocationHandle member)
+{
+  CUresult result;
+
+  /* Bind waits for the complete multicast team, so it must not block the creator endpoint under state_lock. */
+#if CUDA_VERSION >= 13010
+  if (binding->api_version == 2) {
+    bind_mem_v2_fn function = (bind_mem_v2_fn)symbol("cuMulticastBindMem_v2");
+    if (function == NULL)
+      return unavailable();
+    operations.release_state_lock();
+    result = function(
+        driver, binding->device, binding->multicast_offset, member, binding->member_offset, binding->size,
+        binding->flags);
+    operations.acquire_state_lock();
+    return result;
+  }
+#endif
+  {
+    bind_mem_fn function = (bind_mem_fn)symbol("cuMulticastBindMem");
+    if (function == NULL)
+      return unavailable();
+    operations.release_state_lock();
+    result = function(driver, binding->multicast_offset, member, binding->member_offset, binding->size, binding->flags);
+    operations.acquire_state_lock();
+    return result;
+  }
+}
+
+static CUresult
+bind_address(CUmemGenericAllocationHandle driver, const struct multicast_binding* binding)
+{
+  CUresult result;
+
+#if CUDA_VERSION >= 13010
+  if (binding->api_version == 2) {
+    bind_address_v2_fn function = (bind_address_v2_fn)symbol("cuMulticastBindAddr_v2");
+    if (function == NULL)
+      return unavailable();
+    operations.release_state_lock();
+    result = function(
+        driver, binding->device, binding->multicast_offset, binding->member_address, binding->size, binding->flags);
+    operations.acquire_state_lock();
+    return result;
+  }
+#endif
+  {
+    bind_address_fn function = (bind_address_fn)symbol("cuMulticastBindAddr");
+    if (function == NULL)
+      return unavailable();
+    operations.release_state_lock();
+    result = function(driver, binding->multicast_offset, binding->member_address, binding->size, binding->flags);
+    operations.acquire_state_lock();
+    return result;
+  }
+}
+
+void
+snapshot_multicast_initialize(
+    const struct snapshot_multicast_callbacks* callbacks, const char* participant_id, const char* endpoint)
+{
+  operations = *callbacks;
+  current_participant = participant_id;
+  current_endpoint = endpoint;
+}
+
+void
+snapshot_multicast_reset(void)
+{
+  multicasts = NULL;
+  handles = NULL;
+  failure[0] = '\0';
+}
+
+bool
+snapshot_multicast_is_handle(CUmemGenericAllocationHandle logical)
+{
+  return find_handle(logical) != NULL;
+}
+
+bool
+snapshot_multicast_has_mapping(CUdeviceptr address, size_t size)
+{
+  return find_mapping(address, size) != NULL;
+}
+
+CUresult
+snapshot_multicast_release(CUmemGenericAllocationHandle logical)
+{
+  release_fn release = (release_fn)symbol("cuMemRelease");
+  struct multicast_handle* handle = find_handle(logical);
+  CUresult result;
+
+  if (handle == NULL || !handle->live)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (handle->driver == 0)
+    return CUDA_ERROR_NOT_READY;
+  result = CUDA_SUCCESS;
+  if (!driver_used(handle, handle->driver))
+    result = release == NULL ? unavailable() : release(handle->driver);
+  if (result == CUDA_SUCCESS)
+    handle->live = false;
+  return result;
+}
+
+CUresult
+snapshot_multicast_retain(CUmemGenericAllocationHandle* output, void* address)
+{
+  retain_fn retain = (retain_fn)symbol("cuMemRetainAllocationHandle");
+  release_fn release = (release_fn)symbol("cuMemRelease");
+  struct multicast_mapping* mapping = find_mapping_at((CUdeviceptr)(uintptr_t)address);
+  struct multicast* multicast;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle existing;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
+
+  if (output == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (mapping == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  multicast = mapping_owner(mapping);
+  if (multicast == NULL || retain == NULL)
+    return unavailable();
+  existing = current_driver(multicast);
+  result = retain(&driver, address);
+  if (result != CUDA_SUCCESS)
+    return result;
+  if (existing != 0) {
+    result = release == NULL ? unavailable() : release(driver);
+    if (result != CUDA_SUCCESS)
+      return result;
+    driver = existing;
+  }
+  if (add_handle(multicast, driver, &logical) != 0) {
+    if (existing == 0 && release != NULL)
+      (void)release(driver);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  *output = logical;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+snapshot_multicast_map(
+    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle logical, unsigned long long flags)
+{
+  map_fn map = (map_fn)symbol("cuMemMap");
+  struct multicast_handle* handle = find_handle(logical);
+  struct multicast_mapping* mapping;
+  CUresult result;
+
+  if (handle == NULL || !handle->live)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (handle->driver == 0)
+    return CUDA_ERROR_NOT_READY;
+  mapping = calloc(1, sizeof(*mapping));
+  if (mapping == NULL)
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  result = map == NULL ? unavailable() : map(address, size, offset, handle->driver, flags);
+  if (result != CUDA_SUCCESS) {
+    free(mapping);
+    return result;
+  }
+  mapping->address = address;
+  mapping->size = size;
+  mapping->offset = offset;
+  mapping->flags = flags;
+  mapping->mapped = true;
+  mapping->next = handle->multicast->mappings;
+  handle->multicast->mappings = mapping;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+snapshot_multicast_unmap(CUdeviceptr address, size_t size)
+{
+  unmap_fn unmap = (unmap_fn)symbol("cuMemUnmap");
+  struct multicast_mapping* mapping = find_mapping(address, size);
+  CUresult result;
+
+  if (mapping == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  result = unmap == NULL ? unavailable() : unmap(address, size);
+  if (result == CUDA_SUCCESS)
+    mapping->mapped = false;
+  return result;
+}
+
+CUresult
+snapshot_multicast_set_access(CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count)
+{
+  access_fn set_access = (access_fn)symbol("cuMemSetAccess");
+  struct multicast_mapping* mapping = find_mapping(address, size);
+  CUresult result;
+
+  if (mapping == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (count > SNAPSHOT_VMM_MAX_ACCESS)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  result = set_access == NULL ? unavailable() : set_access(address, size, descriptors, count);
+  if (result == CUDA_SUCCESS) {
+    memcpy(mapping->access, descriptors, count * sizeof(*descriptors));
+    mapping->access_count = count;
+  }
+  return result;
+}
+
+CUresult
+snapshot_multicast_export(
+    void* shareable, CUmemGenericAllocationHandle logical, CUmemAllocationHandleType type, unsigned long long flags)
+{
+  struct snapshot_vmm_posix_capability capability;
+  struct multicast_handle* handle = find_handle(logical);
+  int capability_fd = -1;
+
+  if (shareable == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (type != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR || flags != 0)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  if (handle == NULL || !handle->live || handle->driver == 0)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (!handle->multicast->creator)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  fill_capability(handle->multicast, &capability);
+  if (snapshot_vmm_posix_create_capability(&capability, &capability_fd) != 0)
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  *(int*)shareable = capability_fd;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+snapshot_multicast_import(
+    CUmemGenericAllocationHandle* output, const struct snapshot_vmm_posix_capability* capability, int raw_fd)
+{
+  import_fn import_handle = (import_fn)symbol("cuMemImportFromShareableHandle");
+  release_fn release = (release_fn)symbol("cuMemRelease");
+  struct multicast* multicast;
+  CUcontext context;
+  bool created = false;
+  bool acquired = true;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
+
+  if (output == NULL || capability == NULL || raw_fd < 0)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (capability->resource_kind != SNAPSHOT_VMM_RESOURCE_MULTICAST ||
+      capability->handle_types != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_INVALID_HANDLE;
+  result = import_handle == NULL
+               ? unavailable()
+               : import_handle(&driver, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+  if (result != CUDA_SUCCESS)
+    return result;
+  multicast = find_multicast(capability->allocation_id);
+  if (multicast != NULL && !matches_capability(multicast, capability)) {
+    if (release != NULL)
+      (void)release(driver);
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  if (capture_context(&context) != 0 || (multicast != NULL && multicast->context != context)) {
+    if (release != NULL)
+      (void)release(driver);
+    return CUDA_ERROR_NOT_SUPPORTED;
+  }
+  if (multicast != NULL) {
+    CUmemGenericAllocationHandle existing = current_driver(multicast);
+    if (existing != 0) {
+      result = release == NULL ? unavailable() : release(driver);
+      if (result != CUDA_SUCCESS)
+        return result;
+      driver = existing;
+      acquired = false;
+    }
+  }
+  if (multicast == NULL) {
+    multicast = calloc(1, sizeof(*multicast));
+    if (multicast != NULL) {
+      memcpy(multicast->id, capability->allocation_id, sizeof(multicast->id));
+      memcpy(multicast->authorization, capability->authorization, sizeof(multicast->authorization));
+      snprintf(
+          multicast->creator_participant, sizeof(multicast->creator_participant), "%s",
+          capability->creator_participant);
+      snprintf(multicast->creator_endpoint, sizeof(multicast->creator_endpoint), "%s", capability->creator_endpoint);
+      multicast->properties.numDevices = capability->num_devices;
+      multicast->properties.size = capability->allocation_size;
+      multicast->properties.handleTypes = capability->handle_types;
+      multicast->properties.flags = capability->object_flags;
+      multicast->context = context;
+      multicast->creator = false;
+      created = true;
+    }
+  }
+  if (multicast == NULL || add_handle(multicast, driver, &logical) != 0) {
+    if (acquired && release != NULL)
+      (void)release(driver);
+    if (created)
+      free(multicast);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  if (created) {
+    multicast->next = multicasts;
+    multicasts = multicast;
+  }
+  *output = logical;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+snapshot_multicast_get_properties(CUmemAllocationProp* properties, CUmemGenericAllocationHandle logical)
+{
+  properties_fn get_properties = (properties_fn)symbol("cuMemGetAllocationPropertiesFromHandle");
+  struct multicast_handle* handle = find_handle(logical);
+
+  if (handle == NULL || !handle->live)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (handle->driver == 0)
+    return CUDA_ERROR_NOT_READY;
+  return get_properties == NULL ? unavailable() : get_properties(properties, handle->driver);
+}
+
+CUresult
+snapshot_multicast_create(CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties)
+{
+  create_fn create = (create_fn)symbol("cuMulticastCreate");
+  release_fn release = (release_fn)symbol("cuMemRelease");
+  struct multicast* multicast;
+  CUmemGenericAllocationHandle driver = 0;
+  CUmemGenericAllocationHandle logical;
+  CUresult result;
+
+  if (output == NULL || properties == NULL)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (properties->handleTypes != CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  result = create == NULL ? unavailable() : create(&driver, properties);
+  if (result != CUDA_SUCCESS)
+    return result;
+  multicast = calloc(1, sizeof(*multicast));
+  if (multicast == NULL || operations.random_bytes == NULL ||
+      operations.random_bytes(multicast->id, sizeof(multicast->id)) != 0 ||
+      operations.random_bytes(multicast->authorization, sizeof(multicast->authorization)) != 0 ||
+      capture_context(&multicast->context) != 0 || add_handle(multicast, driver, &logical) != 0) {
+    if (release != NULL)
+      (void)release(driver);
+    free(multicast);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  multicast->properties = *properties;
+  multicast->creator = true;
+  snprintf(multicast->creator_participant, sizeof(multicast->creator_participant), "%s", current_participant);
+  snprintf(multicast->creator_endpoint, sizeof(multicast->creator_endpoint), "%s", current_endpoint);
+  multicast->next = multicasts;
+  multicasts = multicast;
+  *output = logical;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+snapshot_multicast_add_device(CUmemGenericAllocationHandle logical, CUdevice device)
+{
+  add_device_fn add_device = (add_device_fn)symbol("cuMulticastAddDevice");
+  struct multicast_handle* handle = find_handle(logical);
+  struct multicast_device* added = calloc(1, sizeof(*added));
+  CUresult result;
+
+  if (handle == NULL || !handle->live)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (handle->driver == 0)
+    return CUDA_ERROR_NOT_READY;
+  if (added == NULL)
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  result = add_device == NULL ? unavailable() : add_device(handle->driver, device);
+  if (result != CUDA_SUCCESS) {
+    free(added);
+    return result;
+  }
+  added->device = device;
+  added->next = handle->multicast->devices;
+  handle->multicast->devices = added;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+snapshot_multicast_bind_mem(
+    CUmemGenericAllocationHandle multicast_logical, CUdevice device, bool device_explicit, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size, unsigned long long flags)
+{
+  struct multicast_handle* handle = find_handle(multicast_logical);
+  struct snapshot_multicast_member member;
+  struct multicast_binding* binding;
+  CUresult result;
+
+  if (handle == NULL || !handle->live)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (handle->driver == 0)
+    return CUDA_ERROR_NOT_READY;
+  memset(&member, 0, sizeof(member));
+  if (operations.member_from_handle == NULL || operations.member_from_handle(memory, &member) != 0)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  if (!device_explicit)
+    device = member.device;
+  binding = calloc(1, sizeof(*binding));
+  if (binding == NULL)
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  memcpy(binding->member_id, member.id, sizeof(binding->member_id));
+  binding->multicast_offset = multicast_offset;
+  binding->member_offset = memory_offset;
+  binding->size = size;
+  binding->flags = flags;
+  binding->device = device;
+  binding->kind = SNAPSHOT_VMM_MULTICAST_BIND_MEM;
+  binding->api_version = device_explicit ? 2 : 1;
+  result = bind_memory(handle->driver, binding, member.handle);
+  if (result != CUDA_SUCCESS) {
+    free(binding);
+    return result;
+  }
+  if (operations.mark_member_shared != NULL)
+    operations.mark_member_shared(member.id);
+  binding->bound = true;
+  binding->next = handle->multicast->bindings;
+  handle->multicast->bindings = binding;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+snapshot_multicast_bind_address(
+    CUmemGenericAllocationHandle multicast_logical, CUdevice device, bool device_explicit, size_t multicast_offset,
+    CUdeviceptr memory, size_t size, unsigned long long flags)
+{
+  struct multicast_handle* handle = find_handle(multicast_logical);
+  struct snapshot_multicast_member member;
+  struct multicast_binding* binding;
+  bool tracked_member = false;
+  CUresult result;
+
+  if (handle == NULL || !handle->live)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (handle->driver == 0)
+    return CUDA_ERROR_NOT_READY;
+  memset(&member, 0, sizeof(member));
+  if (operations.member_from_address == NULL || operations.member_from_address(memory, size, &member) != 0) {
+    if (operations.random_bytes == NULL || operations.random_bytes(member.id, sizeof(member.id)) != 0 ||
+        (!device_explicit && capture_device(&device) != 0))
+      return CUDA_ERROR_NOT_SUPPORTED;
+    member.address = memory;
+  } else {
+    tracked_member = true;
+    if (!device_explicit)
+      device = member.device;
+  }
+  binding = calloc(1, sizeof(*binding));
+  if (binding == NULL)
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  memcpy(binding->member_id, member.id, sizeof(binding->member_id));
+  binding->member_address = memory;
+  binding->multicast_offset = multicast_offset;
+  binding->member_offset = member.allocation_offset;
+  binding->size = size;
+  binding->flags = flags;
+  binding->device = device;
+  binding->kind = SNAPSHOT_VMM_MULTICAST_BIND_ADDR;
+  binding->api_version = device_explicit ? 2 : 1;
+  result = bind_address(handle->driver, binding);
+  if (result != CUDA_SUCCESS) {
+    free(binding);
+    return result;
+  }
+  if (tracked_member && operations.mark_member_shared != NULL)
+    operations.mark_member_shared(member.id);
+  binding->bound = true;
+  binding->next = handle->multicast->bindings;
+  handle->multicast->bindings = binding;
+  return CUDA_SUCCESS;
+}
+
+CUresult
+snapshot_multicast_unbind(CUmemGenericAllocationHandle logical, CUdevice device, size_t offset, size_t size)
+{
+  unbind_fn unbind = (unbind_fn)symbol("cuMulticastUnbind");
+  struct multicast_handle* handle = find_handle(logical);
+  struct multicast_binding* binding;
+  CUresult result;
+
+  if (handle == NULL || !handle->live)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (handle->driver == 0)
+    return CUDA_ERROR_NOT_READY;
+  for (binding = handle->multicast->bindings; binding != NULL; binding = binding->next) {
+    if (binding->bound && binding->device == device && binding->multicast_offset == offset && binding->size == size)
+      break;
+  }
+  if (binding == NULL)
+    return CUDA_ERROR_NOT_SUPPORTED;
+  result = unbind == NULL ? unavailable() : unbind(handle->driver, device, offset, size);
+  if (result != CUDA_SUCCESS)
+    return result;
+  binding->bound = false;
+  return CUDA_SUCCESS;
+}
+
+size_t
+snapshot_multicast_record_count(void)
+{
+  const struct multicast* multicast;
+  size_t count = 0;
+
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    const struct multicast_binding* binding;
+    const struct multicast_device* device;
+    const struct multicast_mapping* mapping;
+    if (!active(multicast))
+      continue;
+    count++;
+    for (device = multicast->devices; device != NULL; device = device->next) count++;
+    for (binding = multicast->bindings; binding != NULL; binding = binding->next) {
+      if (binding->bound)
+        count++;
+    }
+    for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+      if (mapping->mapped)
+        count++;
+    }
+  }
+  return count;
+}
+
+int
+snapshot_multicast_write_records(struct snapshot_vmm_record* records, size_t count)
+{
+  const struct multicast* multicast;
+  size_t written = 0;
+
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    const struct multicast_binding* binding;
+    const struct multicast_device* device;
+    const struct multicast_mapping* mapping;
+    struct snapshot_vmm_record* record;
+    size_t index;
+
+    if (!active(multicast))
+      continue;
+    if (written == count)
+      return -1;
+    record = &records[written++];
+    record->kind = SNAPSHOT_VMM_MULTICAST;
+    record->flags = multicast->creator ? SNAPSHOT_VMM_CREATOR : 0;
+    if (live_handle_count(multicast) != 0)
+      record->flags |= SNAPSHOT_VMM_APPLICATION_HANDLE_LIVE;
+    memcpy(record->allocation_id, multicast->id, sizeof(record->allocation_id));
+    record->allocation_size = multicast->properties.size;
+    record->application_handle_count = (uint32_t)live_handle_count(multicast);
+    record->handle_types = multicast->properties.handleTypes;
+    record->object_flags = multicast->properties.flags;
+    record->num_devices = multicast->properties.numDevices;
+    snprintf(record->creator_participant, sizeof(record->creator_participant), "%s", multicast->creator_participant);
+    for (device = multicast->devices; device != NULL; device = device->next) {
+      if (written == count)
+        return -1;
+      record = &records[written++];
+      record->kind = SNAPSHOT_VMM_MULTICAST_DEVICE;
+      memcpy(record->allocation_id, multicast->id, sizeof(record->allocation_id));
+      record->device = device->device;
+    }
+    for (binding = multicast->bindings; binding != NULL; binding = binding->next) {
+      if (!binding->bound)
+        continue;
+      if (written == count)
+        return -1;
+      record = &records[written++];
+      record->kind = SNAPSHOT_VMM_MULTICAST_BINDING;
+      memcpy(record->allocation_id, multicast->id, sizeof(record->allocation_id));
+      memcpy(record->member_id, binding->member_id, sizeof(record->member_id));
+      record->address = binding->member_address;
+      record->size = binding->size;
+      record->offset = binding->multicast_offset;
+      record->member_offset = binding->member_offset;
+      record->operation_flags = binding->flags;
+      record->binding_kind = binding->kind;
+      record->api_version = binding->api_version;
+      record->device = binding->device;
+    }
+    for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+      if (!mapping->mapped)
+        continue;
+      if (written == count)
+        return -1;
+      record = &records[written++];
+      record->kind = SNAPSHOT_VMM_MULTICAST_MAPPING;
+      memcpy(record->allocation_id, multicast->id, sizeof(record->allocation_id));
+      record->address = mapping->address;
+      record->size = mapping->size;
+      record->offset = mapping->offset;
+      record->operation_flags = mapping->flags;
+      record->access_count = (uint32_t)mapping->access_count;
+      for (index = 0; index < mapping->access_count; index++) {
+        record->access[index].location_type = mapping->access[index].location.type;
+        record->access[index].location_id = mapping->access[index].location.id;
+        record->access[index].flags = mapping->access[index].flags;
+      }
+    }
+  }
+  return written == count ? 0 : -1;
+}
+
+int
+snapshot_multicast_prepare(void)
+{
+  unmap_fn unmap = (unmap_fn)symbol("cuMemUnmap");
+  unbind_fn unbind = (unbind_fn)symbol("cuMulticastUnbind");
+  release_fn release = (release_fn)symbol("cuMemRelease");
+  struct multicast* multicast;
+
+  failure[0] = '\0';
+  if (unmap == NULL || unbind == NULL || release == NULL)
+    return fail("multicast teardown symbols are unavailable", CUDA_SUCCESS);
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    if (active(multicast) && current_driver(multicast) == 0) {
+      struct multicast_mapping* mapping;
+      bool retainable = false;
+      for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+        if (mapping->mapped) {
+          retainable = true;
+          break;
+        }
+      }
+      if (!retainable)
+        return fail("multicast object has no handle or mapping", CUDA_SUCCESS);
+    }
+  }
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    struct multicast_binding* binding;
+    struct multicast_handle* handle;
+    struct multicast_mapping* mapping;
+    struct context_scope scope;
+    CUmemGenericAllocationHandle driver;
+    bool temporary = false;
+
+    if (!active(multicast))
+      continue;
+    driver = current_driver(multicast);
+    if (enter_context(multicast->context, &scope) != 0)
+      return fail("cannot enter multicast context", CUDA_SUCCESS);
+    if (driver == 0) {
+      retain_fn retain = (retain_fn)symbol("cuMemRetainAllocationHandle");
+      for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+        if (mapping->mapped)
+          break;
+      }
+      if (retain == NULL || mapping == NULL || retain(&driver, (void*)(uintptr_t)mapping->address) != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        return fail("cannot retain multicast teardown handle", CUDA_SUCCESS);
+      }
+      temporary = true;
+    }
+    for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+      CUresult result;
+      if (!mapping->mapped)
+        continue;
+      result = unmap(mapping->address, mapping->size);
+      if (result != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        return fail("cuMemUnmap multicast mapping", result);
+      }
+      mapping->mapped = false;
+      mapping->checkpointed = true;
+    }
+    for (binding = multicast->bindings; binding != NULL; binding = binding->next) {
+      CUresult result;
+      if (!binding->bound)
+        continue;
+      result = unbind(driver, binding->device, binding->multicast_offset, binding->size);
+      if (result != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        return fail("cuMulticastUnbind", result);
+      }
+      binding->bound = false;
+      binding->checkpointed = true;
+    }
+    for (handle = handles; handle != NULL; handle = handle->next) {
+      CUmemGenericAllocationHandle old;
+      CUresult result;
+      if (!handle->live || handle->multicast != multicast)
+        continue;
+      old = handle->driver;
+      if (!driver_used(handle, old)) {
+        result = release(old);
+        if (result != CUDA_SUCCESS) {
+          (void)leave_context(&scope);
+          return fail("cuMemRelease multicast handle", result);
+        }
+      }
+      handle->driver = 0;
+    }
+    if (temporary) {
+      CUresult result = release(driver);
+      if (result != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        return fail("cuMemRelease multicast teardown handle", result);
+      }
+    }
+    multicast->checkpointed = true;
+    if (leave_context(&scope) != 0)
+      return fail("cannot leave multicast context", CUDA_SUCCESS);
+  }
+  return 0;
+}
+
+int
+snapshot_multicast_restore_creators(void)
+{
+  create_fn create = (create_fn)symbol("cuMulticastCreate");
+  struct multicast* multicast;
+
+  failure[0] = '\0';
+  if (create == NULL)
+    return fail("cuMulticastCreate is unavailable", CUDA_SUCCESS);
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    struct context_scope scope;
+    CUmemGenericAllocationHandle driver = 0;
+    CUresult result;
+    if (!multicast->checkpointed || !multicast->creator)
+      continue;
+    if (enter_context(multicast->context, &scope) != 0)
+      return fail("cannot enter multicast creator context", CUDA_SUCCESS);
+    result = create(&driver, &multicast->properties);
+    if (result == CUDA_SUCCESS)
+      install_driver(multicast, driver);
+    if (leave_context(&scope) != 0)
+      return fail("cannot leave multicast creator context", CUDA_SUCCESS);
+    if (result != CUDA_SUCCESS)
+      return fail("cuMulticastCreate", result);
+  }
+  return 0;
+}
+
+int
+snapshot_multicast_restore_importers(void)
+{
+  import_fn import_handle = (import_fn)symbol("cuMemImportFromShareableHandle");
+  release_fn release = (release_fn)symbol("cuMemRelease");
+  struct multicast* multicast;
+
+  failure[0] = '\0';
+  if (import_handle == NULL || release == NULL)
+    return fail("multicast import symbols are unavailable", CUDA_SUCCESS);
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    struct context_scope scope;
+    CUmemGenericAllocationHandle driver = current_driver(multicast);
+    CUresult result = CUDA_SUCCESS;
+
+    if (!multicast->checkpointed)
+      continue;
+    if (enter_context(multicast->context, &scope) != 0)
+      return fail("cannot enter multicast importer context", CUDA_SUCCESS);
+    if (!multicast->creator) {
+      struct snapshot_vmm_posix_capability capability;
+      char export_error[sizeof(failure)];
+      int raw_fd = -1;
+
+      fill_capability(multicast, &capability);
+      if (snapshot_vmm_posix_request_export(&capability, &raw_fd, export_error, sizeof(export_error)) != 0) {
+        (void)leave_context(&scope);
+        snprintf(
+            failure, sizeof(failure), "multicast creator export: %.96s",
+            export_error[0] == '\0' ? "request failed" : export_error);
+        return -1;
+      }
+      result = import_handle(&driver, (void*)(uintptr_t)raw_fd, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+      if (close(raw_fd) != 0 && result == CUDA_SUCCESS) {
+        (void)release(driver);
+        result = CUDA_ERROR_UNKNOWN;
+      }
+      if (result == CUDA_SUCCESS)
+        install_driver(multicast, driver);
+    }
+    if (leave_context(&scope) != 0)
+      return fail("cannot leave multicast importer context", CUDA_SUCCESS);
+    if (result != CUDA_SUCCESS)
+      return fail("multicast import", result);
+  }
+  return 0;
+}
+
+int
+snapshot_multicast_restore_devices(void)
+{
+  add_device_fn add_device = (add_device_fn)symbol("cuMulticastAddDevice");
+  struct multicast* multicast;
+
+  failure[0] = '\0';
+  if (add_device == NULL)
+    return fail("cuMulticastAddDevice is unavailable", CUDA_SUCCESS);
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    struct multicast_device* device;
+    struct context_scope scope;
+    CUmemGenericAllocationHandle driver;
+
+    if (!multicast->checkpointed)
+      continue;
+    driver = current_driver(multicast);
+    if (driver == 0)
+      return fail("imported multicast handle is unavailable", CUDA_SUCCESS);
+    if (enter_context(multicast->context, &scope) != 0)
+      return fail("cannot enter multicast device context", CUDA_SUCCESS);
+    for (device = multicast->devices; device != NULL; device = device->next) {
+      CUresult result = add_device(driver, device->device);
+      if (result != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        return fail("cuMulticastAddDevice", result);
+      }
+    }
+    if (leave_context(&scope) != 0)
+      return fail("cannot leave multicast device context", CUDA_SUCCESS);
+  }
+  return 0;
+}
+
+int
+snapshot_multicast_restore_topology(void)
+{
+  map_fn map = (map_fn)symbol("cuMemMap");
+  access_fn set_access = (access_fn)symbol("cuMemSetAccess");
+  release_fn release = (release_fn)symbol("cuMemRelease");
+  struct multicast* multicast;
+
+  failure[0] = '\0';
+  if (map == NULL || set_access == NULL || release == NULL)
+    return fail("multicast mapping symbols are unavailable", CUDA_SUCCESS);
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    struct multicast_binding* binding;
+    struct multicast_mapping* mapping;
+    struct context_scope scope;
+    CUmemGenericAllocationHandle driver;
+
+    if (!multicast->checkpointed)
+      continue;
+    driver = current_driver(multicast);
+    if (driver == 0)
+      return fail("restored multicast handle is unavailable", CUDA_SUCCESS);
+    if (enter_context(multicast->context, &scope) != 0)
+      return fail("cannot enter multicast restore context", CUDA_SUCCESS);
+    for (binding = multicast->bindings; binding != NULL; binding = binding->next) {
+      struct snapshot_multicast_member member;
+      CUresult result;
+
+      if (!binding->checkpointed)
+        continue;
+      if (binding->kind == SNAPSHOT_VMM_MULTICAST_BIND_MEM) {
+        memset(&member, 0, sizeof(member));
+        if (operations.member_from_id == NULL || operations.member_from_id(binding->member_id, &member) != 0) {
+          (void)leave_context(&scope);
+          return fail("restored multicast member is unavailable", CUDA_SUCCESS);
+        }
+        result = bind_memory(driver, binding, member.handle);
+        if (member.temporary_handle) {
+          CUresult release_result = release(member.handle);
+          if (result == CUDA_SUCCESS)
+            result = release_result;
+        }
+      } else {
+        result = bind_address(driver, binding);
+      }
+      if (result != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        return fail("restore multicast binding", result);
+      }
+      binding->bound = true;
+      binding->checkpointed = false;
+    }
+    for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+      CUresult result;
+      if (!mapping->checkpointed)
+        continue;
+      result = map(mapping->address, mapping->size, mapping->offset, driver, mapping->flags);
+      if (result == CUDA_SUCCESS && mapping->access_count != 0)
+        result = set_access(mapping->address, mapping->size, mapping->access, mapping->access_count);
+      if (result != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        return fail("restore multicast mapping or access", result);
+      }
+      mapping->mapped = true;
+      mapping->checkpointed = false;
+    }
+    multicast->checkpointed = false;
+    multicast->restore_handle = 0;
+    if (live_handle_count(multicast) == 0) {
+      CUresult result = release(driver);
+      if (result != CUDA_SUCCESS) {
+        (void)leave_context(&scope);
+        return fail("cuMemRelease restored multicast handle", result);
+      }
+    }
+    if (leave_context(&scope) != 0)
+      return fail("cannot leave multicast restore context", CUDA_SUCCESS);
+  }
+  return snapshot_multicast_validate_restored();
+}
+
+int
+snapshot_multicast_validate_restored(void)
+{
+  const struct multicast_handle* handle;
+  const struct multicast* multicast;
+
+  for (handle = handles; handle != NULL; handle = handle->next) {
+    if (handle->live && handle->driver == 0)
+      return fail("multicast logical handle was not restored", CUDA_SUCCESS);
+  }
+  for (multicast = multicasts; multicast != NULL; multicast = multicast->next) {
+    const struct multicast_binding* binding;
+    const struct multicast_mapping* mapping;
+    if (multicast->checkpointed)
+      return fail("multicast object remains checkpointed", CUDA_SUCCESS);
+    for (binding = multicast->bindings; binding != NULL; binding = binding->next) {
+      if (binding->checkpointed)
+        return fail("multicast binding remains checkpointed", CUDA_SUCCESS);
+    }
+    for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+      if (mapping->checkpointed)
+        return fail("multicast mapping remains checkpointed", CUDA_SUCCESS);
+    }
+  }
+  return 0;
+}
+
+CUresult
+snapshot_multicast_export_raw(
+    const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE], const uint8_t authorization[SNAPSHOT_VMM_TOKEN_SIZE],
+    int* output)
+{
+  export_fn export_handle = (export_fn)symbol("cuMemExportToShareableHandle");
+  retain_fn retain = (retain_fn)symbol("cuMemRetainAllocationHandle");
+  release_fn release = (release_fn)symbol("cuMemRelease");
+  struct multicast* multicast = find_multicast(id);
+  struct multicast_mapping* mapping;
+  struct context_scope scope;
+  CUmemGenericAllocationHandle driver;
+  bool temporary = false;
+  CUresult result;
+
+  *output = -1;
+  if (multicast == NULL || !multicast->creator ||
+      memcmp(multicast->authorization, authorization, sizeof(multicast->authorization)) != 0)
+    return CUDA_ERROR_INVALID_HANDLE;
+  driver = current_driver(multicast);
+  if (export_handle == NULL || enter_context(multicast->context, &scope) != 0)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (driver == 0) {
+    for (mapping = multicast->mappings; mapping != NULL; mapping = mapping->next) {
+      if (mapping->mapped)
+        break;
+    }
+    if (mapping == NULL || retain == NULL || retain(&driver, (void*)(uintptr_t)mapping->address) != CUDA_SUCCESS) {
+      (void)leave_context(&scope);
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    temporary = true;
+  }
+  result = export_handle(output, driver, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+  if (temporary) {
+    CUresult release_result = release == NULL ? CUDA_ERROR_NOT_INITIALIZED : release(driver);
+    if (result == CUDA_SUCCESS)
+      result = release_result;
+  }
+  if (result != CUDA_SUCCESS && *output >= 0) {
+    close(*output);
+    *output = -1;
+  }
+  if (leave_context(&scope) != 0) {
+    if (*output >= 0) {
+      close(*output);
+      *output = -1;
+    }
+    return CUDA_ERROR_UNKNOWN;
+  }
+  return result;
+}
+
+const char*
+snapshot_multicast_error(void)
+{
+  return failure[0] == '\0' ? "multicast operation failed" : failure;
+}

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/multicast.h
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/multicast.h
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SNAPSHOT_CUDA_VMM_MULTICAST_H
+#define SNAPSHOT_CUDA_VMM_MULTICAST_H
+
+#include <cuda.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "posix.h"
+#include "protocol.h"
+
+struct snapshot_multicast_member {
+  uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  CUmemGenericAllocationHandle handle;
+  CUdeviceptr address;
+  size_t allocation_offset;
+  CUdevice device;
+  bool temporary_handle;
+};
+
+struct snapshot_multicast_callbacks {
+  void* (*real_symbol)(const char* name);
+  int (*allocate_logical_handle)(CUmemGenericAllocationHandle* output);
+  int (*random_bytes)(void* output, size_t size);
+  int (*member_from_handle)(CUmemGenericAllocationHandle logical, struct snapshot_multicast_member* member);
+  int (*member_from_address)(CUdeviceptr address, size_t size, struct snapshot_multicast_member* member);
+  int (*member_from_id)(const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE], struct snapshot_multicast_member* member);
+  void (*mark_member_shared)(const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE]);
+  void (*release_state_lock)(void);
+  void (*acquire_state_lock)(void);
+};
+
+void snapshot_multicast_initialize(
+    const struct snapshot_multicast_callbacks* callbacks, const char* participant_id, const char* endpoint);
+void snapshot_multicast_reset(void);
+
+bool snapshot_multicast_is_handle(CUmemGenericAllocationHandle logical);
+bool snapshot_multicast_has_mapping(CUdeviceptr address, size_t size);
+CUresult snapshot_multicast_release(CUmemGenericAllocationHandle logical);
+CUresult snapshot_multicast_retain(CUmemGenericAllocationHandle* output, void* address);
+CUresult snapshot_multicast_map(
+    CUdeviceptr address, size_t size, size_t offset, CUmemGenericAllocationHandle logical, unsigned long long flags);
+CUresult snapshot_multicast_unmap(CUdeviceptr address, size_t size);
+CUresult snapshot_multicast_set_access(
+    CUdeviceptr address, size_t size, const CUmemAccessDesc* descriptors, size_t count);
+CUresult snapshot_multicast_export(
+    void* shareable, CUmemGenericAllocationHandle logical, CUmemAllocationHandleType type, unsigned long long flags);
+CUresult snapshot_multicast_import(
+    CUmemGenericAllocationHandle* output, const struct snapshot_vmm_posix_capability* capability, int raw_fd);
+CUresult snapshot_multicast_get_properties(CUmemAllocationProp* properties, CUmemGenericAllocationHandle logical);
+
+CUresult snapshot_multicast_create(CUmemGenericAllocationHandle* output, const CUmulticastObjectProp* properties);
+CUresult snapshot_multicast_add_device(CUmemGenericAllocationHandle logical, CUdevice device);
+CUresult snapshot_multicast_bind_mem(
+    CUmemGenericAllocationHandle multicast, CUdevice device, bool device_explicit, size_t multicast_offset,
+    CUmemGenericAllocationHandle memory, size_t memory_offset, size_t size, unsigned long long flags);
+CUresult snapshot_multicast_bind_address(
+    CUmemGenericAllocationHandle multicast, CUdevice device, bool device_explicit, size_t multicast_offset,
+    CUdeviceptr memory, size_t size, unsigned long long flags);
+CUresult snapshot_multicast_unbind(CUmemGenericAllocationHandle multicast, CUdevice device, size_t offset, size_t size);
+
+size_t snapshot_multicast_record_count(void);
+int snapshot_multicast_write_records(struct snapshot_vmm_record* records, size_t count);
+int snapshot_multicast_prepare(void);
+int snapshot_multicast_restore_creators(void);
+int snapshot_multicast_restore_importers(void);
+int snapshot_multicast_restore_devices(void);
+int snapshot_multicast_restore_topology(void);
+int snapshot_multicast_validate_restored(void);
+CUresult snapshot_multicast_export_raw(
+    const uint8_t id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE], const uint8_t authorization[SNAPSHOT_VMM_TOKEN_SIZE],
+    int* output);
+const char* snapshot_multicast_error(void);
+
+#endif

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/posix.c
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/posix.c
@@ -69,7 +69,18 @@ snapshot_vmm_posix_read_capability(int fd, struct snapshot_vmm_posix_capability*
       capability->creator_endpoint[0] != '/' ||
       memchr(capability->creator_endpoint, '\0', sizeof(capability->creator_endpoint)) == NULL ||
       zero_bytes(capability->authorization, sizeof(capability->authorization)) ||
+      !zero_bytes(capability->reserved_alignment, sizeof(capability->reserved_alignment)) ||
+      (capability->resource_kind != SNAPSHOT_VMM_RESOURCE_UNICAST &&
+       capability->resource_kind != SNAPSHOT_VMM_RESOURCE_MULTICAST) ||
       !zero_bytes(capability->reserved_identity, sizeof(capability->reserved_identity)))
+    return -1;
+  if (capability->resource_kind == SNAPSHOT_VMM_RESOURCE_UNICAST &&
+      (capability->num_devices != 0 || capability->allocation_size != 0 || capability->handle_types != 0 ||
+       capability->object_flags != 0))
+    return -1;
+  if (capability->resource_kind == SNAPSHOT_VMM_RESOURCE_MULTICAST &&
+      (capability->num_devices == 0 || capability->allocation_size == 0 ||
+       capability->handle_types != SNAPSHOT_VMM_POSIX_HANDLE_TYPE))
     return -1;
   return 0;
 }
@@ -91,6 +102,7 @@ snapshot_vmm_posix_request_export(
   request.magic = SNAPSHOT_VMM_MAGIC;
   request.version = SNAPSHOT_VMM_VERSION;
   request.operation = SNAPSHOT_VMM_EXPORT;
+  request.resource_kind = capability->resource_kind;
   snprintf(request.participant_id, sizeof(request.participant_id), "%s", capability->creator_participant);
   memcpy(request.authorization, capability->authorization, sizeof(request.authorization));
   memcpy(request.allocation_id, capability->allocation_id, sizeof(request.allocation_id));
@@ -106,7 +118,8 @@ snapshot_vmm_posix_request_export(
   }
   if (!snapshot_vmm_header_strings_terminated(&response) || response.magic != SNAPSHOT_VMM_MAGIC ||
       response.version != SNAPSHOT_VMM_VERSION || response.operation != SNAPSHOT_VMM_EXPORT || response.count != 0 ||
-      response.payload_size != 0 || strcmp(response.participant_id, capability->creator_participant) != 0) {
+      response.payload_size != 0 || strcmp(response.participant_id, capability->creator_participant) != 0 ||
+      response.resource_kind != capability->resource_kind) {
     if (error != NULL && error_size != 0)
       snprintf(error, error_size, "%s", "invalid creator export response");
     if (*output >= 0) {

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/posix.h
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/posix.h
@@ -14,7 +14,7 @@
 #include "protocol.h"
 
 #define SNAPSHOT_VMM_POSIX_CAPABILITY_MAGIC 0x44564d43U
-#define SNAPSHOT_VMM_POSIX_CAPABILITY_VERSION 1U
+#define SNAPSHOT_VMM_POSIX_CAPABILITY_VERSION 2U
 
 struct snapshot_vmm_posix_capability {
   uint32_t magic;
@@ -24,7 +24,13 @@ struct snapshot_vmm_posix_capability {
   uint8_t allocation_id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
   char creator_endpoint[sizeof(((struct sockaddr_un*)0)->sun_path)];
   uint8_t authorization[SNAPSHOT_VMM_TOKEN_SIZE];
-  uint8_t reserved_identity[42];
+  uint8_t reserved_alignment[2];
+  uint32_t resource_kind;
+  uint32_t num_devices;
+  uint64_t allocation_size;
+  uint64_t handle_types;
+  uint64_t object_flags;
+  uint8_t reserved_identity[8];
 };
 
 _Static_assert(sizeof(struct snapshot_vmm_posix_capability) == 256, "VMM POSIX capability layout changed");

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/protocol.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 
 #define SNAPSHOT_VMM_MAGIC 0x44564d4dU
-#define SNAPSHOT_VMM_VERSION 1U
+#define SNAPSHOT_VMM_VERSION 2U
 #define SNAPSHOT_VMM_SOCKET_PREFIX "cuda-vmm-"
 #define SNAPSHOT_VMM_ID_SIZE 33U
 #define SNAPSHOT_VMM_ALLOCATION_ID_SIZE 16U
@@ -27,16 +27,35 @@ enum snapshot_vmm_operation {
   SNAPSHOT_VMM_RESTORE_CREATORS = 5,
   SNAPSHOT_VMM_RESTORE_IMPORTERS = 6,
   SNAPSHOT_VMM_EXPORT = 7,
+  SNAPSHOT_VMM_RESTORE_MULTICAST_CREATORS = 8,
+  SNAPSHOT_VMM_RESTORE_MULTICAST_IMPORTERS = 9,
+  SNAPSHOT_VMM_RESTORE_MULTICAST_DEVICES = 10,
+  SNAPSHOT_VMM_RESTORE_MULTICAST = 11,
+  SNAPSHOT_VMM_PREPARE_MULTICAST = 12,
 };
 
 enum snapshot_vmm_record_kind {
   SNAPSHOT_VMM_ALLOCATION = 1,
   SNAPSHOT_VMM_MAPPING = 2,
+  SNAPSHOT_VMM_MULTICAST = 3,
+  SNAPSHOT_VMM_MULTICAST_DEVICE = 4,
+  SNAPSHOT_VMM_MULTICAST_BINDING = 5,
+  SNAPSHOT_VMM_MULTICAST_MAPPING = 6,
 };
 
 enum snapshot_vmm_record_flags {
   SNAPSHOT_VMM_CREATOR = 1U << 0,
   SNAPSHOT_VMM_APPLICATION_HANDLE_LIVE = 1U << 1,
+};
+
+enum snapshot_vmm_resource_kind {
+  SNAPSHOT_VMM_RESOURCE_UNICAST = 1,
+  SNAPSHOT_VMM_RESOURCE_MULTICAST = 2,
+};
+
+enum snapshot_vmm_multicast_binding_kind {
+  SNAPSHOT_VMM_MULTICAST_BIND_MEM = 1,
+  SNAPSHOT_VMM_MULTICAST_BIND_ADDR = 2,
 };
 
 struct snapshot_vmm_header {
@@ -50,7 +69,8 @@ struct snapshot_vmm_header {
   char message[96];
   uint8_t authorization[SNAPSHOT_VMM_TOKEN_SIZE];
   uint8_t allocation_id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
-  uint8_t reserved[71];
+  uint32_t resource_kind;
+  uint8_t reserved[64];
 };
 
 struct snapshot_vmm_access {
@@ -74,10 +94,30 @@ struct snapshot_vmm_record {
   uint32_t access_count;
   uint32_t application_handle_count;
   struct snapshot_vmm_access access[SNAPSHOT_VMM_MAX_ACCESS];
+  uint8_t member_id[SNAPSHOT_VMM_ALLOCATION_ID_SIZE];
+  char creator_participant[SNAPSHOT_VMM_ID_SIZE];
+  uint8_t binding_kind;
+  uint8_t api_version;
+  uint8_t reserved[5];
+  uint64_t member_offset;
+  uint64_t operation_flags;
+  uint64_t handle_types;
+  uint64_t object_flags;
+  uint32_t num_devices;
+  int32_t device;
 };
 
 _Static_assert(sizeof(struct snapshot_vmm_header) == 256, "VMM header layout changed");
 _Static_assert(sizeof(struct snapshot_vmm_access) == 16, "VMM access layout changed");
-_Static_assert(sizeof(struct snapshot_vmm_record) == 208, "VMM record layout changed");
+_Static_assert(sizeof(struct snapshot_vmm_record) == 304, "VMM record layout changed");
+_Static_assert(
+    SNAPSHOT_VMM_ALLOCATION < SNAPSHOT_VMM_MULTICAST_BINDING, "unicast members must sort before multicast bindings");
+_Static_assert(
+    SNAPSHOT_VMM_MULTICAST < SNAPSHOT_VMM_MULTICAST_DEVICE, "multicast objects must sort before their devices");
+_Static_assert(
+    SNAPSHOT_VMM_MULTICAST_DEVICE < SNAPSHOT_VMM_MULTICAST_BINDING,
+    "multicast devices must sort before their bindings");
+_Static_assert(
+    SNAPSHOT_VMM_MULTICAST < SNAPSHOT_VMM_MULTICAST_MAPPING, "multicast objects must sort before their mappings");
 
 #endif

--- a/deploy/snapshot/cmd/cuda-vmm-interpose/tests/test_cucheckpoint.py
+++ b/deploy/snapshot/cmd/cuda-vmm-interpose/tests/test_cucheckpoint.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import ctypes
 import os
 import queue
+import re
 import shutil
 import signal
 import socket
@@ -136,7 +137,9 @@ def _worker(
     restore_fds: tuple[int, int],
     sync_dir: Path,
     store_path: Path,
+    multicast: bool,
 ) -> None:
+    _require_launch_job()
     _cuda_call(driver.cuInit, 0)
     device = _cuda_call(driver.cuDeviceGet, rank)
     properties = _allocation_properties(device)
@@ -202,16 +205,26 @@ def _worker(
     input_tensor = symm_mem.empty(NUMEL, dtype=torch.float32, device="cuda")
     input_tensor.fill_(rank + 1)
     symm_handle = symm_mem.rendezvous(input_tensor, group=group_name)
+    if multicast:
+        if not symm_handle.has_multicast_support:
+            raise AssertionError("PyTorch silently fell back from CUDA multicast")
+        if int(symm_handle.multicast_ptr) == 0:
+            raise AssertionError("PyTorch selected multicast without a multicast VA")
+        _replace_local_binding_with_address(
+            rank,
+            input_tensor,
+            symm_handle,
+            properties,
+        )
+        dist.barrier()
     output = torch.empty_like(input_tensor)
 
-    torch.ops.symm_mem.one_shot_all_reduce_out(input_tensor, "sum", group_name, output)
+    _collective(input_tensor, group_name, output, multicast)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        torch.ops.symm_mem.one_shot_all_reduce_out(
-            input_tensor, "sum", group_name, output
-        )
+        _collective(input_tensor, group_name, output, multicast)
     graph.replay()
     torch.cuda.synchronize()
     _assert_exact_result(output, "before checkpoint")
@@ -264,6 +277,67 @@ def _worker(
     torch.cuda.empty_cache()
     dist.destroy_process_group()
     _destroy_mapped_allocation(private_address, private_size, private_handle)
+
+
+def _collective(
+    input_tensor: torch.Tensor,
+    group_name: str,
+    output: torch.Tensor,
+    multicast: bool,
+) -> None:
+    operation = (
+        torch.ops.symm_mem.multimem_one_shot_all_reduce_out
+        if multicast
+        else torch.ops.symm_mem.one_shot_all_reduce_out
+    )
+    operation(input_tensor, "sum", group_name, output)
+
+
+def _replace_local_binding_with_address(
+    rank: int,
+    input_tensor: torch.Tensor,
+    symm_handle,
+    properties: driver.CUmemAllocationProp,
+) -> None:
+    granularity = int(
+        _cuda_call(
+            driver.cuMemGetAllocationGranularity,
+            properties,
+            driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED,
+        )
+    )
+    buffer_size = input_tensor.numel() * input_tensor.element_size()
+    signal_offset = (buffer_size + 15) // 16 * 16
+    unrounded_size = signal_offset + symm_mem.get_signal_pad_size()
+    block_size = (unrounded_size + granularity - 1) // granularity * granularity
+    multicast_handle = _cuda_call(
+        driver.cuMemRetainAllocationHandle,
+        int(symm_handle.multicast_ptr),
+    )
+    _assert_handle_namespace(
+        multicast_handle,
+        True,
+        "retained multicast handle",
+    )
+    device = _cuda_call(driver.cuDeviceGet, rank)
+    try:
+        _cuda_call(
+            driver.cuMulticastUnbind,
+            multicast_handle,
+            device,
+            0,
+            block_size,
+        )
+        _cuda_call(
+            driver.cuMulticastBindAddr,
+            multicast_handle,
+            0,
+            int(symm_handle.buffer_ptrs[rank]),
+            block_size,
+            0,
+        )
+    finally:
+        _cuda_call(driver.cuMemRelease, multicast_handle)
 
 
 def _assert_exact_result(output: torch.Tensor, stage: str) -> None:
@@ -401,6 +475,7 @@ def _fork_workers(
     restore_fds: tuple[int, int],
     sync_dir: Path,
     store_path: Path,
+    multicast: bool,
 ) -> None:
     if torch.cuda.is_initialized():
         raise RuntimeError("parent initialized CUDA before forking workers")
@@ -411,7 +486,14 @@ def _fork_workers(
         child = os.fork()
         if child == 0:
             try:
-                _worker(rank, raw_fds, restore_fds, sync_dir, store_path)
+                _worker(
+                    rank,
+                    raw_fds,
+                    restore_fds,
+                    sync_dir,
+                    store_path,
+                    multicast,
+                )
             except BaseException:  # noqa: BLE001 -- report child failures to parent
                 traceback.print_exc()
                 os._exit(1)
@@ -455,8 +537,10 @@ def _start_parent(
     store_path: Path,
     raw_fds: tuple[int, int],
     restore_fds: tuple[int, int],
+    multicast: bool,
 ) -> subprocess.Popen[str]:
     environment = os.environ.copy()
+    launch_job_fds = _require_launch_job()
     environment.update(
         {
             "CUDA_VISIBLE_DEVICES": ",".join(gpus),
@@ -467,9 +551,12 @@ def _start_parent(
             "PYTHONFAULTHANDLER": "1",
             "PYTHONUNBUFFERED": "1",
             "TORCH_SYMMEM_IMPLICIT_POOL": "0",
-            "TORCH_SYMM_MEM_DISABLE_MULTICAST": "1",
         }
     )
+    if multicast:
+        environment.pop("TORCH_SYMM_MEM_DISABLE_MULTICAST", None)
+    else:
+        environment["TORCH_SYMM_MEM_DISABLE_MULTICAST"] = "1"
     return subprocess.Popen(
         [
             sys.executable,
@@ -482,14 +569,34 @@ def _start_parent(
             *(str(fd) for fd in restore_fds),
             str(sync_dir),
             str(store_path),
+            "multicast" if multicast else "unicast",
         ],
         env=environment,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         start_new_session=True,
-        pass_fds=raw_fds + restore_fds,
+        pass_fds=raw_fds + restore_fds + launch_job_fds,
     )
+
+
+def _require_launch_job() -> tuple[int, ...]:
+    job_file = os.environ.get("CUDA_CHECKPOINT_JOB_FILE")
+    if not job_file:
+        raise RuntimeError(
+            "CUDA_CHECKPOINT_JOB_FILE is missing; run this test through "
+            "cuda-checkpoint --launch-job"
+        )
+    if not Path(job_file).is_file():
+        raise RuntimeError(
+            f"CUDA checkpoint launch-job file is unavailable: {job_file}"
+        )
+    match = re.fullmatch(r"/proc/self/fd/([0-9]+)", job_file)
+    if match is None:
+        return ()
+    descriptor = int(match.group(1))
+    os.fstat(descriptor)
+    return (descriptor,)
 
 
 def _wait_for_child_pids(
@@ -656,6 +763,17 @@ def _native_checkpoint_with_timeout(
 
 
 def test_cucheckpoint_preserves_symmetric_memory_cuda_graph(tmp_path: Path) -> None:
+    _run_cucheckpoint_test(tmp_path, multicast=False)
+
+
+def test_cucheckpoint_preserves_multicast_symmetric_memory_cuda_graph(
+    tmp_path: Path,
+) -> None:
+    _run_cucheckpoint_test(tmp_path, multicast=True)
+
+
+def _run_cucheckpoint_test(tmp_path: Path, multicast: bool) -> None:
+    _require_launch_job()
     interposer, coordinator = _build_native_tools(tmp_path)
     gpus = _visible_gpus()
     control_dir = tmp_path / "control"
@@ -668,7 +786,7 @@ def test_cucheckpoint_preserves_symmetric_memory_cuda_graph(tmp_path: Path) -> N
 
     parent: subprocess.Popen[str] | None = None
     child_pids: tuple[int, int] = ()
-    output = ("", "")
+    output: tuple[str | None, str | None] = ("", "")
     output_collected = False
     failure: Exception | None = None
     external_allocations: list[_ExternalAllocation] = []
@@ -684,6 +802,7 @@ def test_cucheckpoint_preserves_symmetric_memory_cuda_graph(tmp_path: Path) -> N
             store_path,
             tuple(allocation.fd for allocation in external_allocations),
             tuple(receiver.fileno() for _, receiver in restore_channels),
+            multicast,
         )
         for _, receiver in restore_channels:
             receiver.close()
@@ -754,20 +873,24 @@ def test_cucheckpoint_preserves_symmetric_memory_cuda_graph(tmp_path: Path) -> N
             f"parent PID/return code: {parent_pid}/{parent_returncode}\n"
             f"forked child PIDs: {child_pids}\n"
             f"control sockets: {sockets}\n"
-            f"parent and worker stdout:\n{output[0]}\n"
-            f"parent and worker stderr:\n{output[1]}"
+            f"parent and worker stdout:\n{output[0] or ''}\n"
+            f"parent and worker stderr:\n{output[1] or ''}"
         ) from failure
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 8 or sys.argv[1] != "--parent":
+    if len(sys.argv) != 9 or sys.argv[1] != "--parent":
         raise SystemExit(
             "usage: test_cucheckpoint.py --parent RAW_FD_0 RAW_FD_1 "
-            "RESTORE_FD_0 RESTORE_FD_1 SYNC_DIR STORE_PATH"
+            "RESTORE_FD_0 RESTORE_FD_1 SYNC_DIR STORE_PATH "
+            "(unicast|multicast)"
         )
+    if sys.argv[8] not in {"unicast", "multicast"}:
+        raise SystemExit("worker mode must be unicast or multicast")
     _fork_workers(
         (int(sys.argv[2]), int(sys.argv[3])),
         (int(sys.argv[4]), int(sys.argv[5])),
         Path(sys.argv[6]),
         Path(sys.argv[7]),
+        sys.argv[8] == "multicast",
     )


### PR DESCRIPTION
## Summary

Add transparent checkpoint and restore for complete same-node CUDA multicast
groups backed by `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`, stacked on the
POSIX CUDA VMM interposer in #13129.

This PR covers the common PyTorch symmetric-memory and NCCL NVLS topology on one
node. It does not add FABRIC/IMEX/MNNVL, cross-node rendezvous, Redis, legacy
CUDA IPC wrappers, operator API, or Go-side CUDA topology knowledge.

## Design

### Resource model

- Treat multicast as a topology overlay over checkpoint-managed unicast
  allocations.
- Keep unicast and multicast identities distinct behind tagged logical CUDA
  handles.
- Keep real current-generation CUDA handles private to the shim.
- Record one deterministic multicast metadata creator, the complete device set,
  and each member process's local bindings, mappings, access, and logical-handle
  liveness.
- Allow each multicast object to be owned by a subset of the discovered
  processes. Processes outside that object are phase no-ops.
- Keep validation object-local and complete: creator, device, binding, and
  property validation covers every member and property of each multicast
  object without requiring unrelated processes to own it.
- Keep allocation bytes exclusively under native `cuCheckpoint`; multicast does
  not introduce another byte-saving path.

### Ownership boundaries

| File | Responsibility |
|---|---|
| `interpose.c` | LD_PRELOAD/API interception, CUDA resolver mediation, generic handle translation, and unicast state |
| `posix.c` | Sealed POSIX capability FDs and same-node creator exchange through Unix sockets plus `SCM_RIGHTS` |
| `multicast.c` | Multicast identities, handles, team membership, `BindMem`/`BindAddr`, mappings/access, detach, reconstruction, and validation |
| `coordinator.c` | Complete topology validation and ordered participant phases |

Go transports the opaque native sidecar and orders the existing native
checkpoint lifecycle. It does not enumerate or serialize CUDA multicast
topology.

### Interception surface

Track and translate:

- `cuMulticastCreate`
- `cuMulticastAddDevice`
- `cuMulticastBindMem` and CUDA 13.1 `_v2`
- `cuMulticastBindAddr` and CUDA 13.1 `_v2`
- `cuMulticastUnbind`
- `cuMulticastGetGranularity`
- generic VMM export/import, release/retain, allocation-property, map/unmap, and
  access consumers

Cover direct Driver API calls plus:

- explicit `dlsym()` lookups from `libcuda.so` and `libcudart.so`;
- `cuGetProcAddress`, `cuGetProcAddress_v2`, and `_ptsz`; and
- `cudaGetDriverEntryPoint` and `cudaGetDriverEntryPointByVersion`, including
  CUDA 13 `_ptsz` exports.

## Checkpoint topology teardown

The coordinator first validates the complete object-local participant topology
and the existing unicast creator-anchor invariant. Every discovered process
enters the ordered phases, but a process that is not a member of any multicast
object is a multicast phase no-op.

Multicast is detached before unicast normalization:

1. create any unicast checkpoint carriers needed by the existing base flow;
2. unmap each multicast VA while preserving its reservation;
3. unbind each recorded local unicast member;
4. release creator/imported multicast handles and destroy the old object;
5. wait for every participant to report multicast detached;
6. remove managed unicast mappings without freeing VA reservations and release
   importer handles; and
7. let native `cuCheckpoint` save unicast allocation bytes.

The shim commits each multicast record's detached/checkpointed bookkeeping only
after the corresponding CUDA call succeeds. A failed CUDA teardown therefore
does not falsely advance native state.

## Restore topology replay

After native CUDA restore and driver unlock, the application remains externally
quiesced while the shim reconstructs:

1. unicast creator handles and mappings;
2. current-generation unicast imports and importer mappings;
3. one fresh POSIX multicast object from the recorded metadata creator;
4. fresh imports of that object in its other member processes;
5. the complete device team;
6. each member process's own `BindMem` or `BindAddr` binding;
7. original multicast VAs and access;
8. logical-to-current handle translation; and
9. final object-local topology validation against the opaque sidecar.

Nonmember processes remain no-ops throughout multicast reconstruction. CUDA
multicast bind may block until the full object-local team joins. The shim
therefore releases its bookkeeping mutex only around the native bind call so
creator endpoints remain serviceable, then reacquires it before committing
local state.

The coordinator writes opaque `snapshot-cuda-posix-v2` state. It contains stable
participant/resource identities and topology only—no raw FDs, authorization
tokens, creator endpoints, or allocation bytes.

## Runtime contract

- VMM interposition remains explicit launch-time opt-in through
  `snapshot-cuda-vmm-launch` or `snapshotctl --cuda-vmm-interpose`.
- Single-GPU POSIX VMM checkpointing does not require a CUDA launch-job file.
- Multi-GPU workloads also use the existing driver-owned
  `cuda-checkpoint --launch-job` path. Manual `snapshotctl` users pass both
  `--cuda-checkpoint-wrap` and `--cuda-vmm-interpose`.
- Legacy CUDA IPC remains driver-owned and is not wrapped here.
- The complete process group must be externally quiesced before checkpoint
  preparation.
- A multicast object may belong to a subgroup of discovered processes;
  multicast detach, restore, and validation phases are no-ops in nonmembers.
- Creator, device, binding, and property validation remains complete within
  each multicast object.

## Meaningful CUDA tests

The colocated self-contained pytest project contains two real two-GPU
`cuCheckpoint` scenarios:

- a non-multimem POSIX symmetric-memory regression; and
- a required multicast symmetric-memory path with no unicast fallback.

The multicast case:

- requires PyTorch multicast support and a nonzero multicast pointer;
- exercises interposed `BindMem` during symmetric-memory setup;
- replaces the local binding through direct interposed `cuMulticastBindAddr`;
- performs a real multimem all-reduce;
- captures that collective in a CUDA graph;
- verifies exact results before checkpoint;
- executes coordinator prepare, native lock/checkpoint/restore/unlock, and
  coordinator restore;
- validates fresh post-restore sharing and private allocation bytes; and
- replays the same pre-checkpoint CUDA graph and verifies exact results after
  restore.

No CRIU or PodSnapshot is required for this component gate; the tests call the
native `cuCheckpoint` API directly and run under
`cuda-checkpoint --launch-job`.

Earlier two-B200 qualification passed both component scenarios:

```text
test_cucheckpoint_preserves_symmetric_memory_cuda_graph
# 1 passed in 8.02s

test_cucheckpoint_preserves_multicast_symmetric_memory_cuda_graph
# 1 passed in 9.75s
```

An earlier composed acceptance run also exercised DeepSeek V4 Flash TP4 with
multicast enabled, disjoint restore from GPUs 0-3 to GPUs 4-7, nonmember process
phase no-ops, three multicast objects, and coherent post-restore inference. That
campaign used independent composed-test fixes not included in this product PR.
GPU campaigns were not rerun for this restack.

## Supported scope and limitations

Supported:

- complete same-node multicast objects, including objects owned by a subset of
  discovered processes;
- POSIX-FD-backed CUDA VMM members;
- distributed member add/bind behavior used by PyTorch symmetric memory and
  NCCL NVLS;
- `BindMem` and `BindAddr` common paths; and
- one CUDA context per multicast identity per process.

Explicitly excluded:

- FABRIC/IMEX/MNNVL and cross-node groups;
- partial-team or independent-participant restore;
- raw external POSIX imports retained across checkpoint;
- legacy CUDA IPC reconstruction in this shim;
- checkpoint during sharing or communicator construction;
- fork after the shim has tracked CUDA state; and
- rollback after destructive checkpoint preparation.

Potentially silent raw-FD alias, unshimmed broker, uncovered resolver,
raw-handle collision, and pass-through `BindAddr` limitations are documented in
the interposer README.

## Validation

The multicast changes were replayed from only the two canonical commits:

```text
a63baafc84 feat(snapshot): checkpoint POSIX CUDA multicast
9bfee56a85 fix(snapshot): commit multicast state after CUDA success
```

`git range-diff` shows the second patch is unchanged. The first differs only
where it inherits #13129's simplified identity model and fixed-structure
reserved-byte layout.

Validated on the final restacked tree:

```bash
make -C deploy/snapshot/cmd/cuda-vmm-interpose clean
make -C deploy/snapshot/cmd/cuda-vmm-interpose \
  CUDA_HOME="$PWD/../.cuda13/nvidia/cu13"

cd deploy/snapshot
go test ./...
```

Additional passing checks:

- native compilation with `-std=gnu11 -O2 -Wall -Wextra -Werror`;
- ELF inspection confirming no direct `libcuda` or `libcudart` dependency;
- all applicable pre-commit hooks on the multicast range;
- shell syntax;
- Ruff format and lint;
- Python compilation and `pyproject.toml` parsing;
- `git diff --check`; and
- range-path audit confirming only the snapshot Dockerfile and
  `deploy/snapshot/cmd/cuda-vmm-interpose/` changed above #13129.


### Live composed-stack acceptance

Build on Demand run [`31908730437`](https://github.com/ai-dynamo/dynamo/actions/runs/31908730437) produced the exact composed SHA
`ad5d5ebc6f4f30da9bc65ac7355a836702622328`. That composition passed:

- the direct DeepSeek V4 Flash TP4 multicast/NCCL NVLS qualification, including
  three multicast objects, nonmember-process phase no-ops, restore from pinned
  GPUs 0-3 to disjoint pinned GPUs 4-7 on `s2877`, and three exact
  `DSV4_RESTORE_OK` responses; and
- broader GLM 5.2 vLLM TP8/DP1/EP8 composed-stack coverage on the same ordered
  eight-GPU set on `s2877` (not a migration test), with three deterministic,
  coherent HTTP 200 responses ending in `GLM52_RESTORE_OK` after restore.

DeepSeek V4 is the direct live qualification of raw CUDA multicast/NCCL NVLS
replay. GLM does not make that claim: its accepted snapshot lifecycle policy
runtime-injected `NCCL_CUMEM_ENABLE=0`, `NCCL_NVLS_ENABLE=0`, and
`NCCL_IB_DISABLE=1`. GLM instead validates the wider composed checkpoint,
restore, GMS, wake, and inference path around this stack.

No container image was built locally. GPU tests were not rerun during this
restack.

## Stack

- Base: #13129 (`rewrite/snapshot-cuda-vmm-posix-native`)
- This PR: one GPG-signed, DCO-signed commit above the rewritten #13129 tip


