### PR TITLE
fix(snapshot): resume direct PodSnapshot sources

### DIFF
--- a/deploy/snapshot/internal/controller/podsnapshotcontent.go
+++ b/deploy/snapshot/internal/controller/podsnapshotcontent.go
@@ -435,8 +435,9 @@ func (w *NodeController) setSnapshotContentFailed(ctx context.Context, content *
 
 // executorCheckpoint is the production checkpointFn. The reconciler has already resolved the
 // container ID and host PID. It runs executor.Checkpoint to the destination, verifies the
-// artifact directory, and writes the snapshot-complete sentinel. On dump or verification
-// failure it SIGKILLs the CUDA-locked process before returning the error.
+// artifact directory, and writes the snapshot-complete sentinel for cooperative checkpoint
+// Job sources. On dump, verification, or sentinel failure it SIGKILLs the source process
+// before returning the error.
 func (w *NodeController) executorCheckpoint(ctx context.Context, params CheckpointParams) error {
 	log := logr.FromContextOrDiscard(ctx)
 
@@ -466,14 +467,21 @@ func (w *NodeController) executorCheckpoint(ctx context.Context, params Checkpoi
 		return fmt.Errorf("verify checkpoint path %s: not a directory", params.HostPath)
 	}
 
-	if err := snapshotruntime.WriteControlSentinel(params.ContainerPID, snapshotprotocol.SnapshotCompleteFile); err != nil {
+	if err := writeSnapshotCompleteSentinel(params, snapshotruntime.WriteControlSentinel); err != nil {
 		w.killCheckpointProcess(log, params.ContainerPID, "checkpoint sentinel failed")
 		return fmt.Errorf("write snapshot-complete sentinel: %w", err)
 	}
 	return nil
 }
 
-// killCheckpointProcess signals the CUDA-locked process so it does not hang after a failed dump.
+func writeSnapshotCompleteSentinel(params CheckpointParams, writeSentinel func(int, string) error) error {
+	if params.Pod == nil || params.Pod.Labels[snapshotprotocol.CheckpointSourceLabel] != "true" {
+		return nil
+	}
+	return writeSentinel(params.ContainerPID, snapshotprotocol.SnapshotCompleteFile)
+}
+
+// killCheckpointProcess signals the source process so failed snapshots remain fail-closed.
 func (w *NodeController) killCheckpointProcess(log logr.Logger, pid int, reason string) {
 	if err := snapshotruntime.SendSignalToPID(log, pid, syscall.SIGKILL, reason); err != nil {
 		log.Error(err, "Failed to signal checkpoint process", "reason", reason)

--- a/deploy/snapshot/internal/controller/podsnapshotcontent_test.go
+++ b/deploy/snapshot/internal/controller/podsnapshotcontent_test.go
@@ -39,6 +39,39 @@ type fakeCheckpointer struct {
 	err    error
 }
 
+func TestWriteSnapshotCompleteSentinelForCheckpointJob(t *testing.T) {
+	pod := makeSourcePod("abc")
+	pod.Labels[snapshotprotocol.CheckpointSourceLabel] = "true"
+	var gotPID int
+	var gotName string
+
+	err := writeSnapshotCompleteSentinel(
+		CheckpointParams{Pod: pod, ContainerPID: 4242},
+		func(pid int, name string) error {
+			gotPID = pid
+			gotName = name
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 4242, gotPID)
+	assert.Equal(t, snapshotprotocol.SnapshotCompleteFile, gotName)
+}
+
+func TestWriteSnapshotCompleteSentinelSkipsDirectPodSnapshotSource(t *testing.T) {
+	pod := makeSourcePod("abc")
+
+	err := writeSnapshotCompleteSentinel(
+		CheckpointParams{Pod: pod, ContainerPID: 4242},
+		func(int, string) error {
+			return errors.New("sentinel writer must not be called")
+		},
+	)
+
+	require.NoError(t, err)
+}
+
 // fn is the checkpointFn seam the NodeController invokes for the dump.
 func (fc *fakeCheckpointer) fn(_ context.Context, params CheckpointParams) error {
 	fc.mu.Lock()

--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -326,11 +326,25 @@ func BuildDeviceMap(sourceUUIDs, targetUUIDs []string, log logr.Logger) (string,
 }
 
 // CheckpointProcessTree locks and checkpoints CUDA state for all given PIDs,
-// then persists the launch-job state needed to restore them.
-// On failure, the caller is expected to fail the operation and terminate the workload.
-func CheckpointProcessTree(ctx context.Context, cudaPIDs []int, jobFile, checkpointDir string, log logr.Logger) (CheckpointPhaseTimings, error) {
-	var timings CheckpointPhaseTimings
-
+// persists the launch-job state needed to restore the artifact, runs capture
+// while CUDA is checkpointed, then restores and unlocks the live source.
+//
+// Once every CUDA process is checkpointed, source recovery always runs with a
+// fresh bounded context. This keeps recovery possible when capture fails or
+// cancels ctx. Errors before every process reaches CHECKPOINTED remain
+// fail-closed for the caller to terminate the workload.
+func CheckpointProcessTree(
+	ctx context.Context,
+	cudaPIDs []int,
+	jobFile,
+	checkpointDir string,
+	recoveryTimeout time.Duration,
+	capture func() error,
+	log logr.Logger,
+) (timings CheckpointPhaseTimings, err error) {
+	if recoveryTimeout <= 0 {
+		return timings, fmt.Errorf("CUDA source recovery timeout must be greater than zero")
+	}
 	start := time.Now()
 	for _, pid := range cudaPIDs {
 		if err := lockWithJobFile(ctx, pid, jobFile, log); err != nil {
@@ -345,33 +359,56 @@ func CheckpointProcessTree(ctx context.Context, cudaPIDs []int, jobFile, checkpo
 			return timings, err
 		}
 	}
+
+	defer func() {
+		recoveryCtx, cancel := context.WithTimeout(context.Background(), recoveryTimeout)
+		defer cancel()
+		recoveryTimings, recoveryErr := restoreAndUnlockProcessTree(
+			recoveryCtx,
+			cudaPIDs,
+			"",
+			cudaCheckpointHelperBinary,
+			jobFile,
+			log,
+		)
+		timings.TotalDuration += recoveryTimings.TotalDuration
+		if recoveryErr != nil {
+			recoveryErr = fmt.Errorf("recover source CUDA process tree: %w", recoveryErr)
+			err = errors.Join(err, recoveryErr)
+		}
+	}()
+
 	if err := refreshJobFileArtifact(jobFile, checkpointDir); err != nil {
 		timings.TotalDuration = time.Since(start)
 		return timings, err
 	}
 	timings.TotalDuration = time.Since(start)
 
-	return timings, nil
+	return timings, capture()
 }
 
 // RestoreAndUnlockProcessTree restores and unlocks CUDA state for the given PIDs.
 // helperBinaryPath must be the absolute path to cuda-checkpoint-helper: DefaultHelperBinaryPath
 // on the agent, or filepath.Join(bundleDir, HelperBinaryName) inside the placeholder namespace.
 func RestoreAndUnlockProcessTree(ctx context.Context, cudaPIDs []int, deviceMap, helperBinaryPath string, log logr.Logger) (RestorePhaseTimings, error) {
+	return restoreAndUnlockProcessTree(ctx, cudaPIDs, deviceMap, helperBinaryPath, "", log)
+}
+
+func restoreAndUnlockProcessTree(ctx context.Context, cudaPIDs []int, deviceMap, helperBinaryPath, jobFile string, log logr.Logger) (RestorePhaseTimings, error) {
 	var timings RestorePhaseTimings
 
 	start := time.Now()
 	for _, pid := range cudaPIDs {
-		if err := restoreProcess(ctx, pid, deviceMap, helperBinaryPath, log); err != nil {
+		if err := restoreWithJobFile(ctx, pid, deviceMap, jobFile, helperBinaryPath, log); err != nil {
 			timings.TotalDuration = time.Since(start)
 			return timings, err
 		}
 	}
 
 	for _, pid := range cudaPIDs {
-		if err := unlock(ctx, pid, helperBinaryPath, log); err != nil {
+		if err := unlockWithJobFile(ctx, pid, jobFile, helperBinaryPath, log); err != nil {
 			timings.TotalDuration = time.Since(start)
-			state, stateErr := getState(ctx, pid, helperBinaryPath)
+			state, stateErr := getState(ctx, pid, jobFile, helperBinaryPath)
 			if stateErr == nil && state == "running" {
 				log.Info("cuda-checkpoint-helper unlock returned error but process is already running", "pid", pid)
 				continue

--- a/deploy/snapshot/internal/cuda/job_test.go
+++ b/deploy/snapshot/internal/cuda/job_test.go
@@ -5,10 +5,14 @@ package cuda
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sys/unix"
@@ -158,7 +162,7 @@ func TestStageJobFileRequiresLaunchJobStateForMultiGPU(t *testing.T) {
 	}
 }
 
-func TestCheckpointProcessTreePersistsStateAfterEveryProcessCheckpoint(t *testing.T) {
+func TestCheckpointProcessTreePersistsStateThenRecoversEveryProcess(t *testing.T) {
 	tempDir := t.TempDir()
 	trace := filepath.Join(tempDir, "trace")
 	helper := filepath.Join(tempDir, "cuda-checkpoint-helper")
@@ -180,6 +184,7 @@ if [ "$job_file" != "$DYNAMO_TEST_JOB_FILE" ]; then
 fi
 printf '%s %s\n' "$action" "$pid" >> "$DYNAMO_TEST_TRACE"
 if [ "$action" = checkpoint ]; then printf '|%s' "$pid" >> "$job_file"; fi
+if [ "$action" = restore ]; then printf '|restored-%s' "$pid" >> "$job_file"; fi
 `
 	if err := os.WriteFile(helper, []byte(script), 0700); err != nil {
 		t.Fatal(err)
@@ -202,14 +207,30 @@ if [ "$action" = checkpoint ]; then printf '|%s' "$pid" >> "$job_file"; fi
 	t.Setenv("DYNAMO_TEST_TRACE", trace)
 	t.Setenv("DYNAMO_TEST_JOB_FILE", liveJobFile)
 
-	if _, err := CheckpointProcessTree(context.Background(), []int{101, 202}, liveJobFile, checkpointDir, logr.Discard()); err != nil {
+	capture := func() error {
+		artifact, err := os.ReadFile(filepath.Join(checkpointDir, snapshotprotocol.CUDAJobFileName))
+		if err != nil {
+			return err
+		}
+		if got, want := string(artifact), "initial|101|202"; got != want {
+			return fmt.Errorf("persisted job state during capture = %q, want %q", got, want)
+		}
+		f, err := os.OpenFile(trace, os.O_APPEND|os.O_WRONLY, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = f.WriteString("persist artifact\n")
+		return err
+	}
+	if _, err := CheckpointProcessTree(context.Background(), []int{101, 202}, liveJobFile, checkpointDir, time.Second, capture, logr.Discard()); err != nil {
 		t.Fatalf("CheckpointProcessTree() error = %v", err)
 	}
 	traceContent, err := os.ReadFile(trace)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(traceContent), "lock 101\nlock 202\ncheckpoint 101\ncheckpoint 202\n"; got != want {
+	if got, want := string(traceContent), "lock 101\nlock 202\ncheckpoint 101\ncheckpoint 202\npersist artifact\nrestore 101\nrestore 202\nunlock 101\nunlock 202\n"; got != want {
 		t.Fatalf("helper call order = %q, want %q", got, want)
 	}
 	artifact, err := os.ReadFile(filepath.Join(checkpointDir, snapshotprotocol.CUDAJobFileName))
@@ -218,6 +239,232 @@ if [ "$action" = checkpoint ]; then printf '|%s' "$pid" >> "$job_file"; fi
 	}
 	if got, want := string(artifact), "initial|101|202"; got != want {
 		t.Fatalf("persisted job state = %q, want %q", got, want)
+	}
+	liveState, err := os.ReadFile(liveJobFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(liveState), "initial|101|202|restored-101|restored-202"; got != want {
+		t.Fatalf("live job state after recovery = %q, want %q", got, want)
+	}
+}
+
+func TestCheckpointProcessTreeRecoversWithFreshContextAfterCaptureCancellation(t *testing.T) {
+	tempDir := t.TempDir()
+	trace := filepath.Join(tempDir, "trace")
+	installFakeCUDAHelper(t, `
+action=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --action) action="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf '%s\n' "$action" >> "$DYNAMO_TEST_TRACE"
+`)
+	t.Setenv("DYNAMO_TEST_TRACE", trace)
+	ctx, cancel := context.WithCancel(context.Background())
+	liveJobFile := filepath.Join(tempDir, "live-job")
+	checkpointDir := filepath.Join(tempDir, "checkpoint")
+	if err := os.Mkdir(checkpointDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(liveJobFile, []byte("job-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, snapshotprotocol.CUDAJobFileName), []byte("validation-copy"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := CheckpointProcessTree(
+		ctx,
+		[]int{101},
+		liveJobFile,
+		checkpointDir,
+		time.Second,
+		func() error {
+			cancel()
+			return ctx.Err()
+		},
+		logr.Discard(),
+	)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("CheckpointProcessTree() error = %v, want context.Canceled", err)
+	}
+	traceContent, readErr := os.ReadFile(trace)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got, want := string(traceContent), "lock\ncheckpoint\nrestore\nunlock\n"; got != want {
+		t.Fatalf("helper call order = %q, want %q", got, want)
+	}
+}
+
+func TestCheckpointProcessTreeGetStateCancellationKillsChild(t *testing.T) {
+	const (
+		recoveryTimeout = 100 * time.Millisecond
+		returnTimeout   = time.Second
+	)
+	tempDir := t.TempDir()
+	childPIDFile := filepath.Join(tempDir, "child-pid")
+	installFakeCUDAHelper(t, `
+if [ "$1" = "--get-state" ]; then
+    sleep 300 &
+    printf '%s\n' "$!" > "$DYNAMO_TEST_CHILD_PID_FILE"
+    wait
+fi
+action=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --action) action="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+if [ "$action" = unlock ]; then exit 1; fi
+`)
+	t.Setenv("DYNAMO_TEST_CHILD_PID_FILE", childPIDFile)
+	liveJobFile := filepath.Join(tempDir, "live-job")
+	checkpointDir := filepath.Join(tempDir, "checkpoint")
+	if err := os.Mkdir(checkpointDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(liveJobFile, []byte("job-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, snapshotprotocol.CUDAJobFileName), []byte("validation-copy"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := CheckpointProcessTree(
+			context.Background(),
+			[]int{101},
+			liveJobFile,
+			checkpointDir,
+			recoveryTimeout,
+			func() error { return nil },
+			logr.Discard(),
+		)
+		result <- err
+	}()
+
+	cleanupChild := true
+	killChild := func() {
+		content, err := os.ReadFile(childPIDFile)
+		if err != nil {
+			return
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(content)))
+		if err == nil {
+			_ = unix.Kill(pid, unix.SIGKILL)
+		}
+	}
+	t.Cleanup(func() {
+		if cleanupChild {
+			killChild()
+		}
+	})
+
+	var err error
+	select {
+	case err = <-result:
+	case <-time.After(returnTimeout):
+		killChild()
+		select {
+		case <-result:
+		case <-time.After(time.Second):
+		}
+		t.Fatal("CheckpointProcessTree() did not return after recovery deadline")
+	}
+	if duration := time.Since(start); duration > returnTimeout {
+		t.Fatalf("CheckpointProcessTree() took %s after recovery cancellation", duration)
+	}
+	if err == nil || !strings.Contains(err.Error(), "recover source CUDA process tree") {
+		t.Fatalf("CheckpointProcessTree() error = %v, want recovery failure", err)
+	}
+
+	content, readErr := os.ReadFile(childPIDFile)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	childPID, parseErr := strconv.Atoi(strings.TrimSpace(string(content)))
+	if parseErr != nil {
+		t.Fatal(parseErr)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		processErr := unix.Kill(childPID, 0)
+		if errors.Is(processErr, unix.ESRCH) {
+			cleanupChild = false
+			break
+		}
+		if processErr != nil {
+			t.Fatalf("probe get-state child %d: %v", childPID, processErr)
+		}
+		if time.Now().After(deadline) {
+			killChild()
+			t.Fatalf("get-state child %d remains after recovery cancellation", childPID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestCheckpointProcessTreeJoinsCaptureAndRecoveryErrors(t *testing.T) {
+	tempDir := t.TempDir()
+	trace := filepath.Join(tempDir, "trace")
+	installFakeCUDAHelper(t, `
+action=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --action) action="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf '%s\n' "$action" >> "$DYNAMO_TEST_TRACE"
+if [ "$action" = restore ]; then
+    sleep 300 &
+    wait
+fi
+`)
+	t.Setenv("DYNAMO_TEST_TRACE", trace)
+	liveJobFile := filepath.Join(tempDir, "live-job")
+	checkpointDir := filepath.Join(tempDir, "checkpoint")
+	if err := os.Mkdir(checkpointDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(liveJobFile, []byte("job-state"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, snapshotprotocol.CUDAJobFileName), []byte("validation-copy"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	captureErr := errors.New("capture failed")
+	_, err := CheckpointProcessTree(
+		context.Background(),
+		[]int{101},
+		liveJobFile,
+		checkpointDir,
+		100*time.Millisecond,
+		func() error { return captureErr },
+		logr.Discard(),
+	)
+
+	if !errors.Is(err, captureErr) {
+		t.Fatalf("CheckpointProcessTree() error = %v, want capture error", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("CheckpointProcessTree() error = %v, want recovery deadline", err)
+	}
+	traceContent, readErr := os.ReadFile(trace)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got, want := string(traceContent), "lock\ncheckpoint\nrestore\n"; got != want {
+		t.Fatalf("helper call order = %q, want %q", got, want)
 	}
 }
 

--- a/deploy/snapshot/internal/cuda/shim.go
+++ b/deploy/snapshot/internal/cuda/shim.go
@@ -43,8 +43,12 @@ func unlock(ctx context.Context, pid int, helperBinaryPath string, log logr.Logg
 	return runAction(ctx, pid, actionUnlock, "", helperBinaryPath, log)
 }
 
-func getState(ctx context.Context, pid int, helperBinaryPath string) (string, error) {
-	cmd := exec.CommandContext(ctx, helperBinaryPath, "--get-state", "--pid", strconv.Itoa(pid))
+func getState(ctx context.Context, pid int, jobFile, helperBinaryPath string) (string, error) {
+	args := []string{"--get-state", "--pid", strconv.Itoa(pid)}
+	if jobFile != "" {
+		args = append(args, "--job-file", jobFile)
+	}
+	cmd := helperCommand(ctx, helperBinaryPath, args...)
 	output, err := cmd.CombinedOutput()
 	state := strings.TrimSpace(string(output))
 	if err != nil {
@@ -61,12 +65,7 @@ func runAction(ctx context.Context, pid int, action, deviceMap, helperBinaryPath
 	if action == actionRestore && deviceMap != "" {
 		args = append(args, "--device-map", deviceMap)
 	}
-	cmd := exec.CommandContext(ctx, helperBinaryPath, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		return normalizeProcessGroupKillError(syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL))
-	}
-	cmd.WaitDelay = helperWaitDelay
+	cmd := helperCommand(ctx, helperBinaryPath, args...)
 	details := snapshotruntime.ProcessDetails{
 		ObservedPID:   pid,
 		OutermostPID:  pid,
@@ -105,6 +104,16 @@ func runAction(ctx context.Context, pid int, action, deviceMap, helperBinaryPath
 		"output", out,
 	)
 	return nil
+}
+
+func helperCommand(ctx context.Context, helperBinaryPath string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, helperBinaryPath, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return normalizeProcessGroupKillError(syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL))
+	}
+	cmd.WaitDelay = helperWaitDelay
+	return cmd
 }
 
 func normalizeProcessGroupKillError(err error) error {

--- a/deploy/snapshot/internal/cuda/shim_job_file.go
+++ b/deploy/snapshot/internal/cuda/shim_job_file.go
@@ -6,10 +6,8 @@ package cuda
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -21,24 +19,36 @@ func lockWithJobFile(ctx context.Context, pid int, jobFile string, log logr.Logg
 	if jobFile == "" {
 		return lock(ctx, pid, log)
 	}
-	return runActionWithJobFile(ctx, pid, actionLock, jobFile, log)
+	return runActionWithJobFile(ctx, pid, actionLock, "", jobFile, cudaCheckpointHelperBinary, log)
 }
 
 func checkpointWithJobFile(ctx context.Context, pid int, jobFile string, log logr.Logger) error {
 	if jobFile == "" {
 		return checkpoint(ctx, pid, log)
 	}
-	return runActionWithJobFile(ctx, pid, actionCheckpoint, jobFile, log)
+	return runActionWithJobFile(ctx, pid, actionCheckpoint, "", jobFile, cudaCheckpointHelperBinary, log)
 }
 
-func runActionWithJobFile(ctx context.Context, pid int, action, jobFile string, log logr.Logger) error {
-	args := []string{"--action", action, "--pid", strconv.Itoa(pid), "--job-file", jobFile}
-	cmd := exec.CommandContext(ctx, cudaCheckpointHelperBinary, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		return normalizeProcessGroupKillError(syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL))
+func restoreWithJobFile(ctx context.Context, pid int, deviceMap, jobFile, helperBinaryPath string, log logr.Logger) error {
+	if jobFile == "" {
+		return restoreProcess(ctx, pid, deviceMap, helperBinaryPath, log)
 	}
-	cmd.WaitDelay = helperWaitDelay
+	return runActionWithJobFile(ctx, pid, actionRestore, deviceMap, jobFile, helperBinaryPath, log)
+}
+
+func unlockWithJobFile(ctx context.Context, pid int, jobFile, helperBinaryPath string, log logr.Logger) error {
+	if jobFile == "" {
+		return unlock(ctx, pid, helperBinaryPath, log)
+	}
+	return runActionWithJobFile(ctx, pid, actionUnlock, "", jobFile, helperBinaryPath, log)
+}
+
+func runActionWithJobFile(ctx context.Context, pid int, action, deviceMap, jobFile, helperBinaryPath string, log logr.Logger) error {
+	args := []string{"--action", action, "--pid", strconv.Itoa(pid), "--job-file", jobFile}
+	if action == actionRestore && deviceMap != "" {
+		args = append(args, "--device-map", deviceMap)
+	}
+	cmd := helperCommand(ctx, helperBinaryPath, args...)
 	details := snapshotruntime.ProcessDetails{
 		ObservedPID:   pid,
 		OutermostPID:  pid,

--- a/deploy/snapshot/internal/executor/checkpoint.go
+++ b/deploy/snapshot/internal/executor/checkpoint.go
@@ -90,8 +90,8 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	}
 	phaseTimings.PrepareDuration = time.Since(prepareStart)
 
-	// Phase 3: Capture — CRIU dump, rootfs diff
-	captureTimings, err := captureCheckpoint(ctx, criuOpts, &cfg.CRIU, data, state, tmpDir, cudaJobFile, log)
+	// Phase 3: Capture — CUDA state, CRIU dump, rootfs diff, then live CUDA recovery
+	captureTimings, err := captureCheckpoint(ctx, criuOpts, &cfg.CRIU, data, state, tmpDir, cudaJobFile, cfg.Restore.RestoreTimeout(), log)
 	if err != nil {
 		return err
 	}
@@ -254,37 +254,52 @@ func configureCheckpoint(
 	return criuOpts, m, nil
 }
 
-func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSettings *types.CRIUSettings, data *types.CheckpointManifest, state *types.CheckpointContainerSnapshot, checkpointDir, cudaJobFile string, log logr.Logger) (*checkpointPhaseTimings, error) {
+func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSettings *types.CRIUSettings, data *types.CheckpointManifest, state *types.CheckpointContainerSnapshot, checkpointDir, cudaJobFile string, cudaRecoveryTimeout time.Duration, log logr.Logger) (*checkpointPhaseTimings, error) {
 	timings := &checkpointPhaseTimings{}
 
-	// CUDA lock+checkpoint must happen before CRIU dump
-	if len(state.CUDAHostPIDs) > 0 {
-		cudaTimings, err := cuda.CheckpointProcessTree(ctx, state.CUDAHostPIDs, cudaJobFile, checkpointDir, log)
+	capture := func() error {
+		criuDumpDuration, err := criu.ExecuteDump(criuOpts, checkpointDir, criuSettings, log)
 		if err != nil {
-			return nil, fmt.Errorf("CUDA checkpoint failed: %w", err)
+			return err
 		}
-		timings.CUDADuration = cudaTimings.TotalDuration
+		timings.CRIUDumpDuration = criuDumpDuration
+
+		// Overlay rootfs diff capture is best-effort. Failures are logged but not
+		// propagated — a checkpoint without overlay diffs is still valid for restore
+		// (the base container image provides the filesystem).
+		if state.UpperDir != "" {
+			overlayCaptureStart := time.Now()
+			if _, err := snapshotruntime.CaptureRootfsDiff(state.UpperDir, checkpointDir, data.Overlay.Exclusions, data.Overlay.BindMountDests); err != nil {
+				log.Error(err, "Failed to capture rootfs diff")
+			}
+			if _, err := snapshotruntime.CaptureDeletedFiles(state.UpperDir, checkpointDir); err != nil {
+				log.Error(err, "Failed to capture deleted files")
+			}
+			timings.OverlayCaptureDuration = time.Since(overlayCaptureStart)
+		}
+		return nil
 	}
 
-	criuDumpDuration, err := criu.ExecuteDump(criuOpts, checkpointDir, criuSettings, log)
+	if len(state.CUDAHostPIDs) == 0 {
+		if err := capture(); err != nil {
+			return nil, err
+		}
+		return timings, nil
+	}
+
+	cudaTimings, err := cuda.CheckpointProcessTree(
+		ctx,
+		state.CUDAHostPIDs,
+		cudaJobFile,
+		checkpointDir,
+		cudaRecoveryTimeout,
+		capture,
+		log,
+	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CUDA checkpoint capture failed: %w", err)
 	}
-	timings.CRIUDumpDuration = criuDumpDuration
-
-	// Overlay rootfs diff capture is best-effort. Failures are logged but not
-	// propagated — a checkpoint without overlay diffs is still valid for restore
-	// (the base container image provides the filesystem).
-	if state.UpperDir != "" {
-		overlayCaptureStart := time.Now()
-		if _, err := snapshotruntime.CaptureRootfsDiff(state.UpperDir, checkpointDir, data.Overlay.Exclusions, data.Overlay.BindMountDests); err != nil {
-			log.Error(err, "Failed to capture rootfs diff")
-		}
-		if _, err := snapshotruntime.CaptureDeletedFiles(state.UpperDir, checkpointDir); err != nil {
-			log.Error(err, "Failed to capture deleted files")
-		}
-		timings.OverlayCaptureDuration = time.Since(overlayCaptureStart)
-	}
+	timings.CUDADuration = cudaTimings.TotalDuration
 
 	return timings, nil
 }

--- a/deploy/snapshot/protocol/control_volume.go
+++ b/deploy/snapshot/protocol/control_volume.go
@@ -27,8 +27,8 @@ const (
 	// mount path to the workload.
 	SnapshotControlDirEnv = "DYN_SNAPSHOT_CONTROL_DIR"
 
-	// SnapshotCompleteFile is written by the snapshot agent inside the
-	// control volume when a checkpoint has completed successfully.
+	// SnapshotCompleteFile is written by the snapshot agent inside a
+	// cooperative checkpoint Job's control volume when capture succeeds.
 	SnapshotCompleteFile = "snapshot-complete"
 
 	// RestoreCompleteFile is written by the snapshot agent inside the


### PR DESCRIPTION
## Summary

- restore and unlock source CUDA processes after a successful `PodSnapshot` capture
- use the source workload's live CUDA launch-job file for multi-GPU recovery while keeping the staged artifact immutable
- skip the cooperative `snapshot-complete` sentinel for direct, unlabeled `PodSnapshot` sources so workloads without `/snapshot-control` remain running
- preserve the existing sentinel/exit/`JobComplete` contract for labeled `DynamoCheckpoint` capture Jobs
- bound CUDA recovery and helper subprocess trees even when capture is cancelled

## Validation

- `cd deploy/snapshot && go test ./...`
- `cd deploy/snapshot && go test -race ./internal/cuda ./internal/executor ./internal/controller`
- `cd deploy/snapshot && go vet ./...`
- targeted `deploy/operator/internal/controller` DynamoCheckpoint lifecycle tests
- `gofmt` and `git diff --check`
- live `dynamo-aks-exp` validation with the exact commit image (`8edbe78a7d1907c00e5955d2d98c588fccae0bf8-snapshot-agent`):
  - started a DRA-backed, single-process Qwen3-0.6B CUDA inference server and confirmed baseline inference returned HTTP 200
  - captured a UID-pinned, direct/unlabeled `PodSnapshot`; status became `Ready=True`, reason `Captured`
  - agent logs show CUDA `lock` -> `checkpoint` -> CRIU dump -> CUDA `restore` -> `unlock`
  - after capture, the source retained the same Pod UID and container ID, remained Ready/Running with restart count 0, and returned HTTP 200 for both health and fresh GPU inference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved CUDA checkpoint handling to capture state, restore running processes, and preserve job state after checkpointing.
  - Added configurable recovery timing for CUDA workloads.
- **Bug Fixes**
  - Checkpoint completion markers are now created only for eligible checkpoint jobs.
  - Improved cancellation and recovery behavior, including cleanup of interrupted helper processes.
  - Errors from capture and recovery are now reported together for clearer diagnostics.
- **Documentation**
  - Clarified when the checkpoint completion marker is written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->