### PR TITLE
fix(snapshot): stage CUDA job file from fixed path

### DIFF
--- a/deploy/snapshot/internal/cuda/job.go
+++ b/deploy/snapshot/internal/cuda/job.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
@@ -21,57 +20,19 @@ const JobFileEnv = "CUDA_CHECKPOINT_JOB_FILE"
 // StageJobFile copies a launch-job file into the checkpoint artifact and
 // returns the host-visible path to the source pod's live job file. Capture
 // helpers must use that live file so they join the same CUDA job as the target
-// processes; the artifact copy is only a seed for later restore pods. A process
-// may only name the job file created for this checkpoint; the privileged agent
-// must not copy an arbitrary container path into shared storage.
-func StageJobFile(hostProcPath string, cudaPIDs []int, checkpointDir string, sourceGPUCount int) (string, error) {
-	if len(cudaPIDs) == 0 {
-		return "", nil
-	}
-
-	jobFile := ""
-	jobFilePID := 0
-	missingPIDs := make([]int, 0, len(cudaPIDs))
-	for _, pid := range cudaPIDs {
-		value, err := processEnvironmentValue(hostProcPath, pid, JobFileEnv)
-		if err != nil {
-			return "", err
-		}
-		if value == "" {
-			missingPIDs = append(missingPIDs, pid)
-			continue
-		}
-		if jobFile == "" {
-			jobFile = value
-			jobFilePID = pid
-			continue
-		}
-		if value != jobFile {
-			return "", fmt.Errorf("CUDA processes do not share one %s: %q != %q", JobFileEnv, jobFile, value)
-		}
-	}
-	if jobFile == "" {
-		if sourceGPUCount > 1 {
-			return "", fmt.Errorf("multi-GPU CUDA processes are missing %s", JobFileEnv)
-		}
-		return "", nil
-	}
-	if len(missingPIDs) > 0 {
-		return "", fmt.Errorf("CUDA processes %v are missing %s while other CUDA processes use it", missingPIDs, JobFileEnv)
-	}
-	if !filepath.IsAbs(jobFile) || filepath.Clean(jobFile) != jobFile {
-		return "", fmt.Errorf("%s must be an absolute, clean path, got %q", JobFileEnv, jobFile)
-	}
-	if jobFile == "/proc" || strings.HasPrefix(jobFile, "/proc/") {
-		return "", fmt.Errorf("%s must be persisted outside procfs before checkpoint, got %q", JobFileEnv, jobFile)
-	}
-	if jobFile != snapshotprotocol.CUDAJobFilePath {
-		return "", fmt.Errorf("%s is %q, want checkpoint job file %q", JobFileEnv, jobFile, snapshotprotocol.CUDAJobFilePath)
-	}
-
-	sourcePath := filepath.Join(hostProcPath, strconv.Itoa(jobFilePID), "root", strings.TrimPrefix(jobFile, string(os.PathSeparator)))
+// processes; the artifact copy is only a seed for later restore pods. The
+// launch wrapper persists the driver-created file at a fixed path before
+// starting the workload.
+func StageJobFile(sourceRootPath, checkpointDir string, sourceGPUCount int) (string, error) {
+	sourcePath := filepath.Join(sourceRootPath, strings.TrimPrefix(snapshotprotocol.CUDAJobFilePath, string(os.PathSeparator)))
 	destinationPath := filepath.Join(checkpointDir, snapshotprotocol.CUDAJobFileName)
 	if err := copyJobFile(sourcePath, destinationPath); err != nil {
+		if os.IsNotExist(err) {
+			if sourceGPUCount > 1 {
+				return "", fmt.Errorf("multi-GPU CUDA source is missing %s; source must be launched under cuda-checkpoint --launch-job", snapshotprotocol.CUDAJobFilePath)
+			}
+			return "", nil
+		}
 		return "", fmt.Errorf("stage CUDA checkpoint job file: %w", err)
 	}
 	return sourcePath, nil
@@ -92,7 +53,7 @@ func refreshJobFileArtifact(liveJobFile, checkpointDir string) error {
 }
 
 // PrepareLiveJobFile materializes the immutable capture-time launch-job state
-// at the stable path recorded in the checkpointed process environment. It runs
+// at the fixed launch-job path. It runs
 // inside the restore container's namespaces before CRIU recreates processes.
 // The returned path is the per-restore working copy that CUDA helpers must use;
 // the staged artifact remains immutable so it can seed later restores.
@@ -117,20 +78,6 @@ func JobFileFromCheckpoint(checkpointDir string) (string, error) {
 		return "", fmt.Errorf("CUDA checkpoint job file %q is not a regular file", jobFile)
 	}
 	return jobFile, nil
-}
-
-func processEnvironmentValue(hostProcPath string, pid int, name string) (string, error) {
-	content, err := os.ReadFile(filepath.Join(hostProcPath, strconv.Itoa(pid), "environ"))
-	if err != nil {
-		return "", fmt.Errorf("read environment for CUDA process %d: %w", pid, err)
-	}
-	prefix := name + "="
-	for _, entry := range strings.Split(string(content), "\x00") {
-		if strings.HasPrefix(entry, prefix) {
-			return strings.TrimPrefix(entry, prefix), nil
-		}
-	}
-	return "", nil
 }
 
 func copyJobFile(sourcePath, destinationPath string) error {

--- a/deploy/snapshot/internal/cuda/job_test.go
+++ b/deploy/snapshot/internal/cuda/job_test.go
@@ -17,28 +17,21 @@ import (
 )
 
 func TestStageJobFile(t *testing.T) {
-	procRoot := t.TempDir()
+	sourceRoot := t.TempDir()
 	checkpointDir := t.TempDir()
 	jobFile := snapshotprotocol.CUDAJobFilePath
-
-	for _, pid := range []string{"101", "202"} {
-		processRoot := filepath.Join(procRoot, pid, "root")
-		if err := os.MkdirAll(filepath.Join(processRoot, filepath.Dir(jobFile)), 0700); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(procRoot, pid, "environ"), []byte("OTHER=value\x00"+JobFileEnv+"="+jobFile+"\x00"), 0600); err != nil {
-			t.Fatal(err)
-		}
+	if err := os.MkdirAll(filepath.Join(sourceRoot, filepath.Dir(jobFile)), 0700); err != nil {
+		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(procRoot, "101", "root", jobFile), []byte("job-state"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(sourceRoot, jobFile), []byte("job-state"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
-	helperJobFile, err := StageJobFile(procRoot, []int{101, 202}, checkpointDir, 2)
+	helperJobFile, err := StageJobFile(sourceRoot, checkpointDir, 2)
 	if err != nil {
 		t.Fatalf("StageJobFile() error = %v", err)
 	}
-	wantHelperJobFile := filepath.Join(procRoot, "101", "root", jobFile)
+	wantHelperJobFile := filepath.Join(sourceRoot, jobFile)
 	if helperJobFile != wantHelperJobFile {
 		t.Fatalf("StageJobFile() = %q, want %q", helperJobFile, wantHelperJobFile)
 	}
@@ -52,57 +45,23 @@ func TestStageJobFile(t *testing.T) {
 	}
 }
 
-func TestStageJobFileRejectsTransientProcPath(t *testing.T) {
-	procRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(procRoot, "101"), 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(procRoot, "101", "environ"), []byte(JobFileEnv+"=/proc/1/fd/3\x00"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := StageJobFile(procRoot, []int{101}, t.TempDir(), 1)
-	if err == nil || !strings.Contains(err.Error(), "persisted outside procfs") {
-		t.Fatalf("expected transient procfs error, got %v", err)
-	}
-}
-
-func TestStageJobFileRejectsUnexpectedContainerPath(t *testing.T) {
-	procRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(procRoot, "101"), 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(procRoot, "101", "environ"), []byte(JobFileEnv+"=/etc/shadow\x00"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := StageJobFile(procRoot, []int{101}, t.TempDir(), 1)
-	if err == nil || !strings.Contains(err.Error(), "want checkpoint job file") {
-		t.Fatalf("expected unexpected-path error, got %v", err)
-	}
-}
-
 func TestStageJobFileRejectsSymlink(t *testing.T) {
-	procRoot := t.TempDir()
+	sourceRoot := t.TempDir()
 	checkpointDir := t.TempDir()
 	jobFile := snapshotprotocol.CUDAJobFilePath
-	processRoot := filepath.Join(procRoot, "101", "root")
-	if err := os.MkdirAll(filepath.Join(processRoot, filepath.Dir(jobFile)), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(sourceRoot, filepath.Dir(jobFile)), 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(procRoot, "101", "environ"), []byte(JobFileEnv+"="+jobFile+"\x00"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	secret := filepath.Join(processRoot, "secret")
+	secret := filepath.Join(sourceRoot, "secret")
 	if err := os.WriteFile(secret, []byte("must-not-copy"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	source := filepath.Join(processRoot, jobFile)
+	source := filepath.Join(sourceRoot, jobFile)
 	if err := os.Symlink(filepath.Join("..", "secret"), source); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err := StageJobFile(procRoot, []int{101}, checkpointDir, 1)
+	_, err := StageJobFile(sourceRoot, checkpointDir, 1)
 	if err == nil {
 		t.Fatal("expected symlink source to be rejected")
 	}
@@ -138,22 +97,14 @@ func TestRefreshJobFileArtifactCapturesPostCheckpointState(t *testing.T) {
 }
 
 func TestStageJobFileRequiresLaunchJobStateForMultiGPU(t *testing.T) {
-	procRoot := t.TempDir()
-	for _, pid := range []string{"101", "202"} {
-		if err := os.MkdirAll(filepath.Join(procRoot, pid), 0700); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(procRoot, pid, "environ"), []byte("OTHER=value\x00"), 0600); err != nil {
-			t.Fatal(err)
-		}
-	}
+	sourceRoot := t.TempDir()
 
-	jobFile, err := StageJobFile(procRoot, []int{101}, t.TempDir(), 1)
+	jobFile, err := StageJobFile(sourceRoot, t.TempDir(), 1)
 	if err != nil || jobFile != "" {
 		t.Fatalf("legacy single-GPU StageJobFile() = %q, %v", jobFile, err)
 	}
-	_, err = StageJobFile(procRoot, []int{101, 202}, t.TempDir(), 2)
-	if err == nil || !strings.Contains(err.Error(), "multi-GPU CUDA processes are missing") {
+	_, err = StageJobFile(sourceRoot, t.TempDir(), 2)
+	if err == nil || !strings.Contains(err.Error(), "source must be launched under cuda-checkpoint --launch-job") {
 		t.Fatalf("expected missing multi-GPU launch-job error, got %v", err)
 	}
 }

--- a/deploy/snapshot/internal/executor/checkpoint.go
+++ b/deploy/snapshot/internal/executor/checkpoint.go
@@ -78,9 +78,12 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	if err != nil {
 		return err
 	}
-	cudaJobFile, err := cuda.StageJobFile(snapshotruntime.HostProcPath, state.CUDAHostPIDs, tmpDir, len(state.GPUUUIDs))
-	if err != nil {
-		return err
+	cudaJobFile := ""
+	if len(state.CUDAHostPIDs) > 0 {
+		cudaJobFile, err = cuda.StageJobFile(state.RootFS, tmpDir, len(state.GPUUUIDs))
+		if err != nil {
+			return err
+		}
 	}
 
 	// Phase 2: Configure CRIU options and build checkpoint manifest


### PR DESCRIPTION
## Summary

- Standalone source workloads that need multi-GPU CUDA checkpointing must be launched under `cuda-checkpoint --launch-job` before creating a `PodSnapshot`. Dynamo's launch wrapper persists the driver's transient job file at the stable `/snapshot-control/cuda-checkpoint-job` path before it execs the workload; `PodSnapshot` cannot retroactively wrap an already-running source process.
- During checkpoint, the agent opens that exact fixed path through the source container's canonical resolved root filesystem (the source init PID's `/proc/<init-pid>/root`) instead of discovering or validating `CUDA_CHECKPOINT_JOB_FILE` through every CUDA process's `/proc/<pid>/environ`. The existing `O_NOFOLLOW` and regular-file checks remain in place.
- The agent passes the resulting host-visible path explicitly to `cuda-checkpoint-helper`, which sets `CUDA_CHECKPOINT_JOB_FILE` for each driver operation. After all CUDA processes reach the checkpointed state, the agent refreshes the opaque job-file contents into the checkpoint artifact. Restore behavior is unchanged: it materializes the staged artifact at the fixed path and passes that path explicitly.
- Sources with no CUDA processes do not stage a job file or invoke the CUDA helper. A single-GPU source may omit the launch-job file; a multi-GPU source fails closed with a clear instruction to launch under `cuda-checkpoint --launch-job` when the fixed file is missing.
- Remove the `SPT_NOENV` workaround and all dependence on procfs environment visibility or `setproctitle` behavior for checkpoint-side job-file discovery.

## Validation

- `cd deploy/snapshot && go test -count=1 ./internal/cuda ./internal/executor ./protocol` (pass)
- `git diff --check` (pass)
