### PR TITLE
test(kvbm): avoid ZMQ port allocation races

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5318,7 +5318,6 @@ dependencies = [
  "futures",
  "insta",
  "kvbm-logical",
- "portpicker",
  "pretty_assertions",
  "proptest",
  "rmp-serde",
@@ -7193,15 +7192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand 0.8.6",
 ]
 
 [[package]]

--- a/lib/kvbm-consolidator/Cargo.toml
+++ b/lib/kvbm-consolidator/Cargo.toml
@@ -30,7 +30,6 @@ testing = []
 
 [dev-dependencies]
 insta = { version = "1", features = ["yaml", "redactions"] }
-portpicker = "0.1"
 pretty_assertions = "1.4"
 proptest = "1.5"
 rstest = "0.26"

--- a/lib/kvbm-consolidator/tests/common/mod.rs
+++ b/lib/kvbm-consolidator/tests/common/mod.rs
@@ -70,14 +70,30 @@ pub enum EventMirror {
     AllBlocksCleared {},
 }
 
-// ─── Port allocation ─────────────────────────────────────────────────────────
+// ─── Endpoint allocation ─────────────────────────────────────────────────────
 
-pub fn pick_port() -> u16 {
-    portpicker::pick_unused_port().expect("no free port")
+/// Unique local endpoint for one test socket.
+///
+/// Using a tempfile-backed IPC endpoint avoids the select-then-bind race inherent in
+/// choosing an unused TCP port while integration tests run in parallel processes.
+pub struct IpcEndpoint {
+    endpoint: String,
+    _tempdir: tempfile::TempDir,
 }
 
-pub fn make_endpoint(port: u16) -> String {
-    format!("tcp://127.0.0.1:{port}")
+impl IpcEndpoint {
+    pub fn new() -> Self {
+        let tempdir = tempfile::tempdir().expect("create ZMQ IPC tempdir");
+        let socket_path = tempdir.path().join("socket");
+        Self {
+            endpoint: format!("ipc://{}", socket_path.display()),
+            _tempdir: tempdir,
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.endpoint
+    }
 }
 
 // ─── Tracing init ────────────────────────────────────────────────────────────
@@ -101,17 +117,22 @@ pub fn init_tracing() {
 pub struct ZmqPubHandle {
     socket: SharedPubSocket,
     pub endpoint: String,
+    _endpoint_guard: IpcEndpoint,
 }
 
 impl ZmqPubHandle {
-    /// Bind a PUB socket on a free port; simulates the vLLM publisher.
+    /// Bind a PUB socket on a unique local endpoint; simulates the vLLM publisher.
     pub async fn spawn() -> Self {
-        let port = pick_port();
-        let endpoint = make_endpoint(port);
+        let endpoint_guard = IpcEndpoint::new();
+        let endpoint = endpoint_guard.as_str().to_string();
         let socket = bind_pub_socket(&endpoint)
             .await
             .expect("bind_pub_socket failed");
-        Self { socket, endpoint }
+        Self {
+            socket,
+            endpoint,
+            _endpoint_guard: endpoint_guard,
+        }
     }
 
     /// Encode `batch` as msgpack and send as 3-frame multipart `[b"", seq, payload]`.

--- a/lib/kvbm-consolidator/tests/dedup.rs
+++ b/lib/kvbm-consolidator/tests/dedup.rs
@@ -83,10 +83,9 @@ async fn cross_source_dedup() {
     tokio::time::timeout(Duration::from_secs(5), async {
         let (tx, rx) = broadcast::channel::<KvCacheEvent>(64);
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .kvbm_events(
                 tokio_stream::wrappers::BroadcastStream::new(rx)
@@ -97,7 +96,7 @@ async fn cross_source_dedup() {
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse"
@@ -205,17 +204,16 @@ async fn parent_chain_resolution() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(20))
             .build()
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse"
@@ -307,17 +305,16 @@ async fn clear_all_propagates() {
 
     tokio::time::timeout(Duration::from_secs(15), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(20))
             .build()
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(10)).await,
             "sync_pulse"

--- a/lib/kvbm-consolidator/tests/e2e.rs
+++ b/lib/kvbm-consolidator/tests/e2e.rs
@@ -10,7 +10,7 @@ mod common;
 
 use std::time::Duration;
 
-use common::{TestBatch, ZmqPubHandle, ZmqSubHandle, init_tracing, pick_port, sync_pulse};
+use common::{IpcEndpoint, TestBatch, ZmqPubHandle, ZmqSubHandle, init_tracing, sync_pulse};
 use kvbm_consolidator::wire::vllm_in::{BlockHashValue, RawKvEvent};
 use kvbm_consolidator::{ConsolidatorBuilder, EventSource};
 use serde::{Deserialize, Serialize};
@@ -214,19 +214,20 @@ async fn run_replay(fixture_path: &str, engine_source: EventSource, snapshot_nam
     let raw = std::fs::read(fixture_path).expect("read fixture");
     let payload_blobs: Vec<Vec<u8>> = rmp_serde::from_slice(&raw).expect("deserialize fixture");
 
-    let egress_port = pick_port();
-    let zmq_out = format!("tcp://127.0.0.1:{egress_port}");
+    let zmq_out = IpcEndpoint::new();
 
     let pub_handle = ZmqPubHandle::spawn().await;
 
-    let consolidator = ConsolidatorBuilder::new(&zmq_out, engine_source)
+    let consolidator = ConsolidatorBuilder::new(zmq_out.as_str(), engine_source)
         .zmq_in(&pub_handle.endpoint)
         .poll_interval(Duration::from_millis(20))
         .build()
         .await
         .expect("build consolidator");
 
-    let mut sub = ZmqSubHandle::spawn(&zmq_out).await.expect("spawn sub");
+    let mut sub = ZmqSubHandle::spawn(zmq_out.as_str())
+        .await
+        .expect("spawn sub");
 
     assert!(
         sync_pulse(&pub_handle, &mut sub, Duration::from_secs(5)).await,

--- a/lib/kvbm-consolidator/tests/kvbm_bridge.rs
+++ b/lib/kvbm-consolidator/tests/kvbm_bridge.rs
@@ -88,10 +88,9 @@ async fn kvbm_bridge_plumbing() {
     tokio::time::timeout(Duration::from_secs(8), async {
         let (tx, rx) = broadcast::channel::<KvCacheEvent>(64);
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .kvbm_events(
                 tokio_stream::wrappers::BroadcastStream::new(rx)
@@ -102,7 +101,7 @@ async fn kvbm_bridge_plumbing() {
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse"
@@ -197,11 +196,10 @@ async fn registry_presence_after_kvbm_store() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let (tx, rx) = broadcast::channel::<KvCacheEvent>(64);
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
         let registry = BlockRegistry::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Kvbm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Kvbm)
             .kvbm_events(
                 tokio_stream::wrappers::BroadcastStream::new(rx)
                     .filter_map(|r| futures::future::ready(r.ok())),

--- a/lib/kvbm-consolidator/tests/lifecycle.rs
+++ b/lib/kvbm-consolidator/tests/lifecycle.rs
@@ -43,17 +43,16 @@ async fn backpressure_ingress() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(10))
             .build()
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse"
@@ -128,10 +127,9 @@ async fn shutdown_cancellation() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(50))
             .build()

--- a/lib/kvbm-consolidator/tests/output_contract.rs
+++ b/lib/kvbm-consolidator/tests/output_contract.rs
@@ -64,17 +64,16 @@ async fn sequence_counter_monotonic() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(20))
             .build()
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse"
@@ -146,10 +145,9 @@ async fn lora_name_passthrough() {
     tokio::time::timeout(Duration::from_secs(5), async {
         let (tx, rx) = broadcast::channel::<KvCacheEvent>(64);
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .kvbm_events(
                 tokio_stream::wrappers::BroadcastStream::new(rx)
@@ -160,7 +158,7 @@ async fn lora_name_passthrough() {
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse"
@@ -233,17 +231,16 @@ async fn different_dp_ranks_collapse_to_zero() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(20))
             .build()
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse"

--- a/lib/kvbm-consolidator/tests/zmq_ingress.rs
+++ b/lib/kvbm-consolidator/tests/zmq_ingress.rs
@@ -60,16 +60,17 @@ async fn zmq_cache_namespaces_remain_isolated() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(20))
             .build()
             .await
             .expect("build consolidator");
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("spawn sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str())
+            .await
+            .expect("spawn sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse timed out"
@@ -162,17 +163,18 @@ async fn zmq_ingress_roundtrip() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(20))
             .build()
             .await
             .expect("build consolidator");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("spawn sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str())
+            .await
+            .expect("spawn sub");
 
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
@@ -266,17 +268,18 @@ async fn zmq_multipart_parsing() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(20))
             .build()
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("spawn sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str())
+            .await
+            .expect("spawn sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse timed out"
@@ -352,17 +355,18 @@ async fn malformed_msgpack_is_logged_not_fatal() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(20))
             .build()
             .await
             .expect("build");
 
-        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("spawn sub");
+        let mut sub = ZmqSubHandle::spawn(egress_ep.as_str())
+            .await
+            .expect("spawn sub");
         assert!(
             sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await,
             "sync_pulse timed out"
@@ -405,18 +409,17 @@ async fn multiple_subscribers_receive_same_output() {
 
     tokio::time::timeout(Duration::from_secs(5), async {
         let pub_handle = ZmqPubHandle::spawn().await;
-        let egress_port = common::pick_port();
-        let egress_ep = common::make_endpoint(egress_port);
+        let egress_ep = common::IpcEndpoint::new();
 
-        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Vllm)
+        let consolidator = ConsolidatorBuilder::new(egress_ep.as_str(), EventSource::Vllm)
             .zmq_in(&pub_handle.endpoint)
             .poll_interval(Duration::from_millis(20))
             .build()
             .await
             .expect("build");
 
-        let mut sub1 = ZmqSubHandle::spawn(&egress_ep).await.expect("sub1");
-        let mut sub2 = ZmqSubHandle::spawn(&egress_ep).await.expect("sub2");
+        let mut sub1 = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub1");
+        let mut sub2 = ZmqSubHandle::spawn(egress_ep.as_str()).await.expect("sub2");
 
         // Use sync_pulse on sub1 only (PUB fanout means sub2 also receives it).
         // Then drain both subs so no stale messages affect assertions.


### PR DESCRIPTION
## Overview:

Stabilize the KVBM consolidator integration tests by replacing race-prone temporary TCP port selection with unique tempfile-backed ZMQ IPC endpoints.

This PR is independent of the vLLM RL-control stack and can be reviewed and merged in parallel.

## Details:

- Keep each IPC endpoint directory alive for the socket lifetime.
- Use the shared IPC endpoint helper across all KVBM consolidator integration tests.
- Remove the unused `portpicker` development dependency.
- Preserve the existing test behavior and assertions.

## Where should the reviewer start?

Start with `lib/kvbm-consolidator/tests/common/mod.rs`, then confirm the mechanical endpoint substitutions in the integration tests.

## Validation:

- `cargo test --locked -p kvbm-consolidator --all-targets` — 51 passed, 1 intentionally ignored

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue**:

- [x] Confirmed — no related GitHub issue