### PR TITLE
feat(vllm): sync RL control protocol

### DIFF
--- a/lib/mocker/servers/vllm/src/server.rs
+++ b/lib/mocker/servers/vllm/src/server.rs
@@ -415,7 +415,7 @@ impl pb::control_server::Control for VllmMockerService {
 }
 
 fn rl_control_unavailable() -> Status {
-    Status::failed_precondition("the vLLM mocker does not advertise RL control capabilities")
+    Status::unimplemented("the vLLM mocker does not implement RL control RPCs")
 }
 
 fn checked_token(signal: &OutputSignal) -> BoxedStatusResult<u32> {

--- a/lib/mocker/servers/vllm/src/server.rs
+++ b/lib/mocker/servers/vllm/src/server.rs
@@ -131,6 +131,7 @@ impl VllmMockerService {
                     anyhow::anyhow!("max_num_batched_tokens exceeds the Control API range")
                 })?
                 .unwrap_or_default(),
+            rl_capabilities: None,
         };
         Ok(Self {
             config: Arc::new(config),
@@ -320,6 +321,101 @@ impl pb::control_server::Control for VllmMockerService {
             sources: Vec::new(),
         }))
     }
+
+    async fn pause_generation(
+        &self,
+        _request: Request<pb::PauseGenerationRequest>,
+    ) -> Result<Response<pb::PauseGenerationResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn resume_generation(
+        &self,
+        _request: Request<pb::ResumeGenerationRequest>,
+    ) -> Result<Response<pb::ResumeGenerationResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn is_paused(
+        &self,
+        _request: Request<pb::IsPausedRequest>,
+    ) -> Result<Response<pb::IsPausedResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn sleep(
+        &self,
+        _request: Request<pb::SleepRequest>,
+    ) -> Result<Response<pb::SleepResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn wake_up(
+        &self,
+        _request: Request<pb::WakeUpRequest>,
+    ) -> Result<Response<pb::WakeUpResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn is_sleeping(
+        &self,
+        _request: Request<pb::IsSleepingRequest>,
+    ) -> Result<Response<pb::IsSleepingResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn init_weight_transfer_engine(
+        &self,
+        _request: Request<pb::InitWeightTransferEngineRequest>,
+    ) -> Result<Response<pb::InitWeightTransferEngineResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn start_weight_update(
+        &self,
+        _request: Request<pb::StartWeightUpdateRequest>,
+    ) -> Result<Response<pb::StartWeightUpdateResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn start_draft_weight_update(
+        &self,
+        _request: Request<pb::StartDraftWeightUpdateRequest>,
+    ) -> Result<Response<pb::StartDraftWeightUpdateResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn update_weights(
+        &self,
+        _request: Request<pb::UpdateWeightsRequest>,
+    ) -> Result<Response<pb::UpdateWeightsResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn finish_weight_update(
+        &self,
+        _request: Request<pb::FinishWeightUpdateRequest>,
+    ) -> Result<Response<pb::FinishWeightUpdateResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn update_weight_version(
+        &self,
+        _request: Request<pb::UpdateWeightVersionRequest>,
+    ) -> Result<Response<pb::UpdateWeightVersionResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn get_weight_version(
+        &self,
+        _request: Request<pb::GetWeightVersionRequest>,
+    ) -> Result<Response<pb::GetWeightVersionResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+}
+
+fn rl_control_unavailable() -> Status {
+    Status::failed_precondition("the vLLM mocker does not advertise RL control capabilities")
 }
 
 fn checked_token(signal: &OutputSignal) -> BoxedStatusResult<u32> {

--- a/lib/mocker/servers/vllm/src/server_tests.rs
+++ b/lib/mocker/servers/vllm/src/server_tests.rs
@@ -203,6 +203,34 @@ fn service_rejects_non_vllm_or_multi_rank_engines() {
     );
 }
 
+/// Regression: a mocker without RL capabilities could classify an unsupported
+/// RPC as a caller or runtime-state error, causing clients to mis-handle
+/// capability absence; this test catches it at the Control RPC boundary.
+#[tokio::test]
+async fn unsupported_rl_control_reports_unimplemented() {
+    let service =
+        VllmMockerService::new(MockerServerConfig::default(), MockEngineArgs::default()).unwrap();
+    let server_info = pb::control_server::Control::get_server_info(
+        &service,
+        Request::new(pb::GetServerInfoRequest {}),
+    )
+    .await
+    .unwrap()
+    .into_inner();
+    assert!(server_info.rl_capabilities.is_none());
+
+    let error = pb::control_server::Control::pause_generation(
+        &service,
+        Request::new(pb::PauseGenerationRequest {
+            mode: pb::PauseMode::Keep as i32,
+            clear_cache: Some(false),
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.code(), tonic::Code::Unimplemented);
+}
+
 #[tokio::test]
 async fn unary_generate_maps_capacity_rejection_to_resource_exhausted() {
     let args = MockEngineArgs::builder()

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Source: [`rust/proto/inference.proto`](https://github.com/vllm-project/vllm/blob/3d1f5cee1552b8208f3009c75f8bc856f27e0eff/rust/proto/inference.proto) and [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/3d1f5cee1552b8208f3009c75f8bc856f27e0eff/rust/proto/control.proto)
-- Commit: `3d1f5cee1552b8208f3009c75f8bc856f27e0eff`
+- Inference source: [`rust/proto/inference.proto`](https://github.com/vllm-project/vllm/blob/3d1f5cee1552b8208f3009c75f8bc856f27e0eff/rust/proto/inference.proto) at `3d1f5cee1552b8208f3009c75f8bc856f27e0eff`
+- RL Control source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/76ebe5a217d7536a5661272c680f0b1e3a62f5be/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) at `76ebe5a217d7536a5661272c680f0b1e3a62f5be`
 - `inference.proto` SHA-256: `6152c306583166ecd691c9c715cab950523e8d1ed2db3dc2bcb538f6ca90e56f`
-- `control.proto` SHA-256: `390c88e94f1b68421c54c6d9440f2088d2709a432549c7a0fe94d35ce7b37476`
+- `control.proto` SHA-256: `db72b0782142054293b07fd48247cc821c048213b9c95dbc37fb0d81dde8f46f`
 
 The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/control.proto
+++ b/lib/sidecar/vllm/proto/control.proto
@@ -9,6 +9,21 @@ service Control {
   rpc GetModelInfo (GetModelInfoRequest) returns (ModelInfo) {}
   rpc Abort (AbortRequest) returns (AbortResponse) {}
   rpc GetKvEventSources (GetKvEventSourcesRequest) returns (GetKvEventSourcesResponse) {}
+
+  // Reinforcement-learning lifecycle and weight updates.
+  rpc PauseGeneration (PauseGenerationRequest) returns (PauseGenerationResponse) {}
+  rpc ResumeGeneration (ResumeGenerationRequest) returns (ResumeGenerationResponse) {}
+  rpc IsPaused (IsPausedRequest) returns (IsPausedResponse) {}
+  rpc Sleep (SleepRequest) returns (SleepResponse) {}
+  rpc WakeUp (WakeUpRequest) returns (WakeUpResponse) {}
+  rpc IsSleeping (IsSleepingRequest) returns (IsSleepingResponse) {}
+  rpc InitWeightTransferEngine (InitWeightTransferEngineRequest) returns (InitWeightTransferEngineResponse) {}
+  rpc StartWeightUpdate (StartWeightUpdateRequest) returns (StartWeightUpdateResponse) {}
+  rpc StartDraftWeightUpdate (StartDraftWeightUpdateRequest) returns (StartDraftWeightUpdateResponse) {}
+  rpc UpdateWeights (UpdateWeightsRequest) returns (UpdateWeightsResponse) {}
+  rpc FinishWeightUpdate (FinishWeightUpdateRequest) returns (FinishWeightUpdateResponse) {}
+  rpc UpdateWeightVersion (UpdateWeightVersionRequest) returns (UpdateWeightVersionResponse) {}
+  rpc GetWeightVersion (GetWeightVersionRequest) returns (GetWeightVersionResponse) {}
 }
 
 message GetServerInfoRequest {}
@@ -23,6 +38,14 @@ message ServerInfo {
   uint64 total_kv_blocks = 7;
   uint64 max_running_requests = 8;
   uint64 max_batched_tokens = 9;
+  RlCapabilities rl_capabilities = 11;
+}
+
+message RlCapabilities {
+  bool weight_transfer_enabled = 1;
+  string weight_transfer_backend = 2;
+  bool sleep_mode_enabled = 3;
+  bool draft_weight_updates_enabled = 4;
 }
 
 message ParallelismInfo {
@@ -52,6 +75,64 @@ message AbortRequest {
 }
 
 message AbortResponse {}
+
+// ======================================================================================
+// Reinforcement-learning control
+// ======================================================================================
+
+enum PauseMode {
+  PAUSE_MODE_UNSPECIFIED = 0;
+  PAUSE_MODE_ABORT = 1;
+  PAUSE_MODE_WAIT = 2;
+  PAUSE_MODE_KEEP = 3;
+}
+
+message PauseGenerationRequest {
+  PauseMode mode = 1;
+  optional bool clear_cache = 2;
+}
+message PauseGenerationResponse {}
+
+message ResumeGenerationRequest {}
+message ResumeGenerationResponse {}
+
+message IsPausedRequest {}
+message IsPausedResponse { bool paused = 1; }
+
+message SleepRequest {
+  optional uint32 level = 1;
+  PauseMode mode = 2;
+}
+message SleepResponse {}
+
+message WakeUpRequest { repeated string tags = 1; }
+message WakeUpResponse {}
+
+message IsSleepingRequest {}
+message IsSleepingResponse { bool sleeping = 1; }
+
+// The payloads are backend-specific JSON objects. Tensor data remains on the
+// configured NCCL, IPC, or sparse-NCCL transport rather than crossing gRPC.
+message InitWeightTransferEngineRequest { bytes init_info_json = 1; }
+message InitWeightTransferEngineResponse {}
+
+message StartWeightUpdateRequest {}
+message StartWeightUpdateResponse {}
+
+message StartDraftWeightUpdateRequest {}
+message StartDraftWeightUpdateResponse {}
+
+message UpdateWeightsRequest { bytes update_info_json = 1; }
+message UpdateWeightsResponse {}
+
+message FinishWeightUpdateRequest { optional string weight_version = 1; }
+message FinishWeightUpdateResponse {}
+
+message UpdateWeightVersionRequest { string weight_version = 1; }
+message UpdateWeightVersionResponse {}
+
+message GetWeightVersionRequest {}
+message GetWeightVersionResponse { string weight_version = 1; }
 
 // ======================================================================================
 // KV discovery

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -256,6 +256,101 @@ impl pb::control_server::Control for FakeVllm {
                 .collect(),
         }))
     }
+
+    async fn pause_generation(
+        &self,
+        _request: Request<pb::PauseGenerationRequest>,
+    ) -> Result<Response<pb::PauseGenerationResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn resume_generation(
+        &self,
+        _request: Request<pb::ResumeGenerationRequest>,
+    ) -> Result<Response<pb::ResumeGenerationResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn is_paused(
+        &self,
+        _request: Request<pb::IsPausedRequest>,
+    ) -> Result<Response<pb::IsPausedResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn sleep(
+        &self,
+        _request: Request<pb::SleepRequest>,
+    ) -> Result<Response<pb::SleepResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn wake_up(
+        &self,
+        _request: Request<pb::WakeUpRequest>,
+    ) -> Result<Response<pb::WakeUpResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn is_sleeping(
+        &self,
+        _request: Request<pb::IsSleepingRequest>,
+    ) -> Result<Response<pb::IsSleepingResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn init_weight_transfer_engine(
+        &self,
+        _request: Request<pb::InitWeightTransferEngineRequest>,
+    ) -> Result<Response<pb::InitWeightTransferEngineResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn start_weight_update(
+        &self,
+        _request: Request<pb::StartWeightUpdateRequest>,
+    ) -> Result<Response<pb::StartWeightUpdateResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn start_draft_weight_update(
+        &self,
+        _request: Request<pb::StartDraftWeightUpdateRequest>,
+    ) -> Result<Response<pb::StartDraftWeightUpdateResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn update_weights(
+        &self,
+        _request: Request<pb::UpdateWeightsRequest>,
+    ) -> Result<Response<pb::UpdateWeightsResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn finish_weight_update(
+        &self,
+        _request: Request<pb::FinishWeightUpdateRequest>,
+    ) -> Result<Response<pb::FinishWeightUpdateResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn update_weight_version(
+        &self,
+        _request: Request<pb::UpdateWeightVersionRequest>,
+    ) -> Result<Response<pb::UpdateWeightVersionResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+
+    async fn get_weight_version(
+        &self,
+        _request: Request<pb::GetWeightVersionRequest>,
+    ) -> Result<Response<pb::GetWeightVersionResponse>, Status> {
+        Err(rl_control_unavailable())
+    }
+}
+
+fn rl_control_unavailable() -> Status {
+    Status::failed_precondition("RL controls are not enabled in this protocol-only test server")
 }
 
 fn model_info() -> pb::ModelInfo {
@@ -288,6 +383,7 @@ fn server_info() -> pb::ServerInfo {
         total_kv_blocks: 4096,
         max_running_requests: 128,
         max_batched_tokens: 2048,
+        rl_capabilities: None,
     }
 }
 

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -350,7 +350,7 @@ impl pb::control_server::Control for FakeVllm {
 }
 
 fn rl_control_unavailable() -> Status {
-    Status::failed_precondition("RL controls are not enabled in this protocol-only test server")
+    Status::unimplemented("RL control RPCs are not implemented in this protocol-only test server")
 }
 
 fn model_info() -> pb::ModelInfo {


### PR DESCRIPTION
## Overview:

Vendor the RL control protocol from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) and update Dynamo's vLLM mock servers to satisfy the expanded tonic contract.

This is PR 3 of 4 in the vLLM RL-control stack.

## Details:

- Sync `control.proto` from vLLM commit `76ebe5a217d7536a5661272c680f0b1e3a62f5be`.
- Record the exact source revision and SHA-256 in the vendored protocol README.
- Add `rl_capabilities` to server metadata construction.
- Return `UNIMPLEMENTED` for RL methods in the production mocker because it does not implement or advertise RL capabilities.
- Add protocol-only stubs to the sidecar test fake; semantic fake implementations and adapter tests remain in the next PR.

## Where should the reviewer start?

Start with `lib/sidecar/vllm/proto/control.proto`, then review the explicit unavailable responses in `lib/mocker/servers/vllm/src/server.rs`.

## Validation:

- `cargo fmt --all -- --check`
- `sha256sum lib/sidecar/vllm/proto/control.proto` — `db72b0782142054293b07fd48247cc821c048213b9c95dbc37fb0d81dde8f46f`
- `cargo test --locked -p dynamo-vllm-sidecar -p dynamo-vllm-mocker` — all package, integration, and executable tests passed

## Stack:

1. [#13259 — fix(backend): harden administrative route lifecycle](https://github.com/ai-dynamo/dynamo/pull/13259)
2. [#13260 — feat(backend): add RL route discovery endpoint](https://github.com/ai-dynamo/dynamo/pull/13260)
3. **[#13261 — feat(vllm): sync RL control protocol](https://github.com/ai-dynamo/dynamo/pull/13261) (this PR)**
4. [#13066 — feat(vllm): route RL controls through sidecar](https://github.com/ai-dynamo/dynamo/pull/13066)

Linear: [DIS-2671](https://linear.app/nvidia/issue/DIS-2671)

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue**:

- [x] Confirmed — no related GitHub issue
