### PR TITLE
fix(gms): retry V1 allocations on transient OOM

### DIFF
--- a/lib/gpu_memory_service/v1/server/allocations.py
+++ b/lib/gpu_memory_service/v1/server/allocations.py
@@ -5,9 +5,16 @@
 
 from __future__ import annotations
 
+import logging
 import threading
+import time
+from collections.abc import Callable
 
 from gpu_memory_service.common.vmm import VMMDevice
+
+logger = logging.getLogger(__name__)
+
+_ALLOCATION_RETRY_INTERVAL = 0.5
 
 
 class GMSAllocationManager:
@@ -23,7 +30,12 @@ class GMSAllocationManager:
         self._allocations: dict[str, int] = {}
         self._lock = threading.Lock()
 
-    def allocate(self, allocation_id: str, aligned_size: int) -> None:
+    def allocate(
+        self,
+        allocation_id: str,
+        aligned_size: int,
+        is_connected: Callable[[], bool] | None = None,
+    ) -> None:
         with self._lock:
             if not allocation_id:
                 raise RuntimeError("allocation ID must not be empty")
@@ -31,11 +43,24 @@ class GMSAllocationManager:
                 raise RuntimeError("allocation size is not aligned for this GPU")
             if allocation_id in self._allocations:
                 raise RuntimeError("allocation ID already exists")
-            allocated, handle = self._vmm.create_tolerate_oom(
-                aligned_size, self._device
-            )
-            if not allocated:
-                raise MemoryError(f"cannot allocate {aligned_size} GPU bytes")
+            while True:
+                if is_connected is not None and not is_connected():
+                    raise ConnectionAbortedError(
+                        "RW client disconnected during allocation retry"
+                    )
+                allocated, handle = self._vmm.create_tolerate_oom(
+                    aligned_size, self._device
+                )
+                if allocated:
+                    break
+                if is_connected is None:
+                    raise MemoryError(f"cannot allocate {aligned_size} GPU bytes")
+                logger.warning(
+                    "cuMemCreate OOM for aligned_size=%d; retrying in %.3fs",
+                    aligned_size,
+                    _ALLOCATION_RETRY_INTERVAL,
+                )
+                time.sleep(_ALLOCATION_RETRY_INTERVAL)
             self._allocations[allocation_id] = int(handle)
 
     def export(self, allocation_id: str) -> int:

--- a/lib/gpu_memory_service/v1/server/rpc.py
+++ b/lib/gpu_memory_service/v1/server/rpc.py
@@ -336,11 +336,18 @@ class GMSServerMemoryManager:
         return self._sessions.acquire(requested, is_cancelled=is_cancelled)
 
     def handle_request(
-        self, session: ServerSession, request: Request
+        self,
+        session: ServerSession,
+        request: Request,
+        is_connected: Callable[[], bool] | None = None,
     ) -> tuple[Response, int]:
         if isinstance(request, AllocateRequest):
             self._require_rw(session)
-            self._allocations.allocate(request.allocation_id, request.aligned_size)
+            self._allocations.allocate(
+                request.allocation_id,
+                request.aligned_size,
+                is_connected,
+            )
             self._allocation_sizes[request.allocation_id] = request.aligned_size
             return SuccessResponse(), -1
         if isinstance(request, ExportRequest):
@@ -449,7 +456,13 @@ class _GMSRequestHandler(socketserver.BaseRequestHandler):
                         raise RuntimeError(  # noqa: TRY004
                             "handshake is valid only as the first message"
                         )
-                    response, export_fd = manager.handle_request(session, request)
+                    response, export_fd = manager.handle_request(
+                        session,
+                        request,
+                        lambda: _socket_is_alive(self.request),
+                    )
+                except ConnectionAbortedError:
+                    return
                 except Exception as exc:
                     if isinstance(exc, (MemoryError, RuntimeError)):
                         logger.log(


### PR DESCRIPTION
## Summary

- retry GMS V1 `cuMemCreate` calls every 500 ms when GPU memory is temporarily unavailable
- keep the allocation RPC blocked while its RW client remains connected
- stop retrying when the client disconnects so normal RW epoch cleanup can run

This matches GMS V0's allocation-backpressure behavior without adding configuration or changing the wire protocol. V1's existing per-RPC client timeout remains unchanged.

## Validation

- `pre-commit run --files lib/gpu_memory_service/v1/server/allocations.py lib/gpu_memory_service/v1/server/rpc.py`
- `pytest -c /dev/null -q lib/gpu_memory_service/tests/test_v1_server.py` (5 passed; minimal config used because the package-only test environment does not install unrelated root pytest plugins)
- SGLang TP=1 snapshot/failover cluster diagnosis reproduced the transient allocation race: immediate shadow wake failed with `cannot allocate 1224736768 GPU bytes`, while delaying wake until the old cgroup's GPU memory was reclaimed succeeded

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GPU memory allocation now retries temporarily unavailable requests instead of failing immediately.
  * Requests are safely canceled when the client disconnects during allocation.
  * Disconnected clients no longer produce unnecessary server-side errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->