### PR TITLE
build(aisimulate): allow Python 3.13 wheels

### DIFF
--- a/aisimulate/pyproject.toml
+++ b/aisimulate/pyproject.toml
@@ -12,7 +12,7 @@ description = "Backend-neutral inference simulation and deployment configuration
 readme = "README.md"
 license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [


### PR DESCRIPTION
## Summary

- widen the AISimulate wheel's supported Python range from 3.10–3.12 to 3.10–3.13
- publish the Python 3.13 classifier
- stack the metadata change on `yongmingd/aisimulate-engine-replayer` / #12525

This is a draft because the published `aiconfigurator` and `aiconfigurator-core` wheels still declare `numpy~=1.26.4`. Python 3.13 needs NumPy 2.x, so a clean dependency-resolved install still needs an upstream AIC metadata release. This PR intentionally does not remove ai-dynamo's Python 3.13 exclusion marker yet.

## Validation

- built `aisimulate-0.1.0.dev1-cp310-abi3-linux_x86_64.whl` with Python 3.13.5
- verified wheel metadata contains `Requires-Python: >=3.10, <3.14` and the Python 3.13 classifier
- ran the default Vizier Sweeper on CPU under Python 3.13: 2 candidates on `TFRT_CPU_0`
- ran the default Vizier Sweeper on GPU under Python 3.13: 2 candidates on `cuda:0`, including an explicit JAX device computation
- ran the real Dynamo replay + Planner + KV Router spawned-worker integration test: `1 passed in 5.27s`
- ran `uvx pre-commit run --files aisimulate/pyproject.toml`

For the runtime tests, AIC/AIC-core were installed with their NumPy metadata overridden and NumPy 2.5.2.