### PR TITLE
feat(vllm): add disaggregated LMCache MP-mode launch script

### DIFF
--- a/examples/backends/vllm/launch/disagg_lmcache_mp.sh
+++ b/examples/backends/vllm/launch/disagg_lmcache_mp.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+# Explicitly unset PROMETHEUS_MULTIPROC_DIR to let Dynamo manage it internally
+unset PROMETHEUS_MULTIPROC_DIR
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+MODEL="Qwen/Qwen3-0.6B"
+
+# ---- Tunable (override via env vars) ----
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_CONCURRENT_SEQS="${MAX_CONCURRENT_SEQS:-2}"
+
+# KV cache cap for predictable launches; profiler/test framework overrides via
+# env. Applied per worker process (prefill and decode each get the same value,
+# on their own GPU).
+: "${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:=1119388000}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+LMCACHE_PORT="${LMCACHE_PORT:-5555}"
+LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+
+print_launch_banner "Launching Disaggregated Serving (2 GPUs) + LMCache" "$MODEL" "$HTTP_PORT"
+
+# Start the single LMCache mp server (out-of-process cache engine) shared by the
+# prefill and decode workers.
+lmcache server \
+  --l1-size-gb "${LMCACHE_L1_SIZE_GB:-16}" --eviction-policy LRU \
+  --port "$LMCACHE_PORT" --http-port "$LMCACHE_HTTP_PORT" &
+SERVER_PID=$!
+
+# Wait until the server's HTTP admin endpoint is healthy before launching workers.
+for _ in $(seq 1 60); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "LMCache server process died unexpectedly" >&2
+    exit 1
+  fi
+  curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 || {
+  echo "lmcache server failed to become healthy on :$LMCACHE_HTTP_PORT" >&2
+  exit 1
+}
+
+# run ingress
+# dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
+python3 -m dynamo.frontend &
+
+# run decode worker on GPU 0
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
+CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
+  --model "$MODEL" --enforce-eager \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --max-num-seqs "$MAX_CONCURRENT_SEQS" \
+  $GPU_MEM_ARGS \
+  --disaggregation-mode decode \
+  --disable-hybrid-kv-cache-manager \
+  --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT}}" &
+
+# run prefill worker on GPU 1
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
+CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
+  --model "$MODEL" --enforce-eager \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --max-num-seqs "$MAX_CONCURRENT_SEQS" \
+  $GPU_MEM_ARGS \
+  --disaggregation-mode prefill \
+  --disable-hybrid-kv-cache-manager \
+  --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT}}" &
+
+# Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
+wait_any_exit

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -300,6 +300,29 @@ vllm_configs = {
             metric_payload_default(min_num_requests=6, backend="vllm"),
         ],
     ),
+    "disaggregated_lmcache_mp": VLLMConfig(
+        name="disaggregated_lmcache_mp",
+        directory=vllm_dir,
+        script_name="disagg_lmcache_mp.sh",
+        marks=[
+            pytest.mark.core,
+            pytest.mark.lmcache,
+            pytest.mark.gpu_2,
+            pytest.mark.profiled_vram_gib(3.8),  # per worker, same cap as agg
+            pytest.mark.requested_vllm_kv_cache_bytes(
+                1_119_388_000
+            ),  # KV cache cap per worker (2x safety over min=559_693_824)
+            pytest.mark.timeout(900),  # two engines boot before serving
+            pytest.mark.pre_merge,
+        ],
+        model="Qwen/Qwen3-0.6B",
+        env={"LMCACHE_L1_SIZE_GB": "8"},
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+            metric_payload_default(min_num_requests=6, backend="vllm"),
+        ],
+    ),
     "agg-request-plane-tcp": VLLMConfig(
         name="agg-request-plane-tcp",
         directory=vllm_dir,

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -35,6 +35,7 @@ from tests.utils.payload_builder import (
     embedding_payload,
     embedding_payload_default,
     kv_events_metrics_payload,
+    lmcache_mp_hit_metrics_payload,
     metric_payload_default,
     pooling_payload,
     router_cached_tokens_chat_payload,
@@ -316,8 +317,26 @@ vllm_configs = {
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
-        env={"LMCACHE_L1_SIZE_GB": "8"},
+        # Distinct LMCache ports so this cannot collide with
+        # aggregated_lmcache_mp when both run on the same host.
+        env={
+            "LMCACHE_L1_SIZE_GB": "8",
+            "LMCACHE_PORT": "5556",
+            "LMCACHE_HTTP_PORT": "8180",
+        },
         request_payloads=[
+            # First request of a prompt no worker has seen: the prefill-side
+            # lookup must miss, so any pool hit recorded before the next
+            # payload can only be the decode worker loading prefill-stored KV.
+            chat_payload(
+                "Describe the water cycle in two short sentences.",
+                repeat_count=1,
+                expected_response=[],
+                max_tokens=32,
+            ),
+            # Cross-worker handoff proof: local recomputation never
+            # increments the MP server's hit counter.
+            lmcache_mp_hit_metrics_payload(port=8180),
             chat_payload_default(),
             completion_payload_default(),
             metric_payload_default(min_num_requests=6, backend="vllm"),

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -22,6 +22,7 @@ from tests.utils.payloads import (
     ImageTokenMetricsPayload,
     KvEventMetricsPayload,
     LMCacheMetricsPayload,
+    LMCacheMPMetricsPayload,
     MetricsPayload,
     PoolingPayload,
     ResponsesPayload,
@@ -349,6 +350,23 @@ def metric_payload_default(
     else:
         # Default to base MetricsPayload for unknown backends
         return MetricsPayload(**common_args)
+
+
+def lmcache_mp_hit_metrics_payload(port: int) -> LMCacheMPMetricsPayload:
+    """Assert the LMCache MP server recorded pool lookup hits.
+
+    Targets the MP server's own HTTP metrics endpoint (``port`` is the
+    script's ``LMCACHE_HTTP_PORT``), not a worker system port, so the
+    harness's DefaultPort remapping leaves it untouched.
+    """
+    return LMCacheMPMetricsPayload(
+        body={},
+        repeat_count=1,
+        expected_log=[],
+        expected_response=[],
+        min_num_requests=0,
+        port=port,
+    )
 
 
 def image_token_metrics_payload(

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -2074,6 +2074,37 @@ class LMCacheMetricsPayload(MetricsPayload):
 
 
 @dataclass
+class LMCacheMPMetricsPayload(MetricsPayload):
+    """Metrics validation against the LMCache MP server's own endpoint.
+
+    Asserts the shared pool served lookup hits. The hit counter is only
+    incremented by a lookup that found tokens in the pool, so a worker
+    that silently recomputes instead of loading can never satisfy it.
+    """
+
+    def _get_common_metric_checks(self) -> list[MetricCheck]:
+        # The MP server exposes lmcache_mp_* metrics only, none of the
+        # dynamo_component_* series the base class checks.
+        return []
+
+    def _get_backend_specific_checks(self) -> list[MetricCheck]:
+        def metric_pattern(name: str) -> str:
+            return rf"{name}(?:\{{[^}}]*\}})?\s+([\d.eE+-]+)"
+
+        return [
+            MetricCheck(
+                name="lmcache_mp_lookup_hit_tokens_total",
+                pattern=metric_pattern,
+                validator=lambda value: float(value) > 0,
+                error_msg=lambda name, value: (
+                    f"{name} should be > 0 after the KV handoff, but got {value}"
+                ),
+                success_msg=lambda name, value: f"SUCCESS: {name} = {value}",
+            ),
+        ]
+
+
+@dataclass
 class SGLangMetricsPayload(MetricsPayload):
     """Metrics validation for SGLang backend with auto-label checks"""
 


### PR DESCRIPTION
## Overview:

Adds `disagg_lmcache_mp.sh`, the disaggregated counterpart of the aggregated LMCache MP launch script added in #9982: separate prefill and decode workers (one GPU each) sharing a single LMCache MP server, with the KV handoff going through the shared pool instead of a NIXL side channel.

The script is the one already validated and merged in the LMCache repository (LMCache/LMCache#3935), following the plan to validate there first and then land it here.

## Details:

The script mirrors the structure of `agg_lmcache_mp.sh` (server startup with a health gate, KV cache byte cap via the profiler override, `--disable-hybrid-kv-cache-manager`) and of `disagg.sh` (two workers with `--disaggregation-mode` on separate GPUs). A serve test entry `disaggregated_lmcache_mp` is added mirroring the `aggregated_lmcache_mp` marks with `gpu_2`.

This depends on #13258: without LMCacheMPConnector registered for PD, the frontend rejects requests at the PD protocol check, so this should merge after it. Verified end to end on Kubernetes with Dynamo 1.3.0 and an LMCache v0.5.4 nightly MP server (the same disaggregated topology, with requests completing and the decode side hitting prefill stored KV).

## Where should the reviewer start?

`examples/backends/vllm/launch/disagg_lmcache_mp.sh`, then the new entry in `tests/serve/test_vllm.py`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a launch option for two-GPU disaggregated vLLM serving with shared LMCache support.
  - Added health checks and coordinated process management for serving components.
  - Added coverage for chat, completion, and metrics requests in the new serving configuration.

- **Tests**
  - Added an integration test configuration covering LMCache-enabled, multi-GPU vLLM deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->