### PR TITLE
fix(frontend): treat an absent Content-Type as JSON

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2003,14 +2003,17 @@ fn json_deserialize_error(error: serde_json::Error) -> ErrorResponse {
 }
 
 fn ensure_json_content_type(headers: &HeaderMap) -> Result<(), ErrorResponse> {
-    // FastAPI treats an absent Content-Type as JSON, so vLLM/SGLang accept these. A header
-    // that is present but not JSON still fails: the caller asserted a format we cannot parse.
-    let Some(content_type) = headers
-        .get(axum::http::header::CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-    else {
+    // FastAPI treats an absent or empty Content-Type as JSON, so vLLM/SGLang accept these.
+    // A header that is present and asserts some other format still fails.
+    let Some(content_type) = headers.get(axum::http::header::CONTENT_TYPE) else {
         return Ok(());
     };
+    let Ok(content_type) = content_type.to_str() else {
+        return Err(unsupported_media_type_error());
+    };
+    if content_type.trim().is_empty() {
+        return Ok(());
+    }
 
     if is_json_content_type(content_type) {
         Ok(())
@@ -4643,6 +4646,24 @@ mod tests {
     fn test_ensure_json_content_type_accepts_absent_header() {
         let headers = HeaderMap::new();
         assert!(ensure_json_content_type(&headers).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_json_content_type_accepts_empty_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(axum::http::header::CONTENT_TYPE, "".parse().unwrap());
+        assert!(ensure_json_content_type(&headers).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_json_content_type_rejects_undecodable_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+        );
+        let err = ensure_json_content_type(&headers).expect_err("undecodable must be rejected");
+        assert_eq!(err.0, StatusCode::UNSUPPORTED_MEDIA_TYPE);
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2003,11 +2003,13 @@ fn json_deserialize_error(error: serde_json::Error) -> ErrorResponse {
 }
 
 fn ensure_json_content_type(headers: &HeaderMap) -> Result<(), ErrorResponse> {
+    // FastAPI treats an absent Content-Type as JSON, so vLLM/SGLang accept these. A header
+    // that is present but not JSON still fails: the caller asserted a format we cannot parse.
     let Some(content_type) = headers
         .get(axum::http::header::CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
     else {
-        return Err(unsupported_media_type_error());
+        return Ok(());
     };
 
     if is_json_content_type(content_type) {
@@ -4638,10 +4640,18 @@ mod tests {
     }
 
     #[test]
-    fn test_ensure_json_content_type_rejects_missing_or_non_json() {
+    fn test_ensure_json_content_type_accepts_absent_header() {
         let headers = HeaderMap::new();
-        let err = ensure_json_content_type(&headers).expect_err("missing content type should fail");
-        assert_eq!(err.0, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert!(ensure_json_content_type(&headers).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_json_content_type_rejects_non_json() {
+        let headers = HeaderMap::new();
+        assert!(
+            ensure_json_content_type(&headers).is_ok(),
+            "an absent Content-Type is treated as JSON, matching FastAPI"
+        );
 
         let mut headers = HeaderMap::new();
         headers.insert(


### PR DESCRIPTION
## Problem

`ensure_json_content_type()` returns **415** for a request with no `Content-Type` header.

FastAPI — which backs the vLLM and SGLang HTTP frontends Dynamo stands in for — parses the body as JSON when the header is absent:

```python
content_type_value = request.headers.get("content-type")
if not content_type_value:
    if not actual_strict_content_type:
        json_body = await request.json()
```

(`fastapi/routing.py`; the strict variant is opt-in and defaults off.)

So a client that omits the header succeeds against `vllm serve` and gets 415 from Dynamo. It's a silent compatibility break on migration: same request shape, unmodified client, and it starts failing **100% of the time** rather than intermittently.

We hit this in production after moving an endpoint from vLLM to Dynamo — a measurable rise in 415s from clients that had worked for months. Reproduced against the live endpoint:

| `Content-Type` | before | after |
|---|---|---|
| `application/json` | 200 | 200 |
| `application/json; charset=utf-8` | 200 | 200 |
| `Application/JSON` | 200 | 200 |
| `application/vnd.x+json` | 200 | 200 |
| *(absent)* | **415** | **200** |
| `text/plain` | 415 | 415 |

## Change

Treat an absent `Content-Type` as JSON. A header that is *present but not JSON* is still rejected — that's a caller asserting a format we can't parse, rather than declining to assert one.

## Reviewer note — this inverts an existing assertion

`test_ensure_json_content_type_rejects_missing_or_non_json` explicitly required a missing header to fail, so the current behaviour looks deliberate rather than accidental. I could not find the rationale in the history available to me.

If that strictness was intentional, please say so and I'll rework this. An opt-in flag preserving the current default would also solve our case — I went with changing the default because Dynamo's value here is a drop-in OpenAI-compatible contract, and silently rejecting requests the replaced server accepted works against that. Happy to defer to maintainer preference.

## Testing

`cargo test -p dynamo-llm --lib --no-default-features` → **1878 passed, 0 failed**.

Test coverage: absent header accepted; JSON variants (charset, mixed case, `+json` suffix) accepted; `text/plain` still 415.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests without a `Content-Type` header are now accepted as JSON.
  * Requests with explicitly non-JSON media types continue to be rejected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->