### PR TITLE
build(ffmpeg): exclude the IAMF parser from the in-tree build

### DIFF
--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -323,6 +323,24 @@ ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
 # No H.264 parser/decoder/encoder is enabled — H.264 is not built at all. Image
 # decode does not use ffmpeg (it goes through the Rust `image` crate), so no
 # still-image decoders are enabled here.
+# IAMF is disabled explicitly because the allowlist above does not reach it.
+# CONFIG_IAMFDEC lives in configure's CONFIG_EXTRA rather than COMPONENT_LIST, so
+# --disable-demuxers leaves it alone, and configure sets
+# mov_demuxer_suggest="iamfdec zlib" -- enabling the mov demuxer we do want pulls
+# the IAMF parser back in behind it. That compiles libavformat/iamf_parse.o, and
+# mov.c reaches mix_presentation_obu() through the iacb box handler.
+#
+# Nothing in Dynamo demuxes untrusted input with this build: every in-tree ffmpeg
+# call site is an encode (imageio.get_writer -> libvpx_vp9), and video decode goes
+# through PyNvVideoCodec/NVDEC, a separate library. This is defence in depth, and
+# it keeps an image inventory from reporting IAMF parser advisories against a
+# parser we never feed.
+#
+# The two greps are the point of the change: --disable-<name> for a CONFIG_EXTRA
+# entry is not a documented user-facing option, so assert the configure result
+# rather than assume the flag took. If a future ffmpeg stops accepting these, the
+# build fails here instead of silently shipping the parser again.
+#
 # The `fd` protocol is enabled alongside `pipe`: `ffmpeg -i -` reads stdin via
 # the `fd:` protocol on ffmpeg 8.x (not `pipe:`), so omitting it breaks the
 # imageio encode path with "Protocol not found. Did you mean file:fd:?". Both
@@ -398,7 +416,11 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         --disable-parsers \
         --enable-parser=vp8,vp9 \
         --disable-protocols \
-        --enable-protocol=file,pipe,fd && \
+        --enable-protocol=file,pipe,fd \
+        --disable-iamfdec \
+        --disable-iamfenc && \
+    grep -q '^#define CONFIG_IAMFDEC 0$' config.h && \
+    grep -q '^#define CONFIG_IAMFENC 0$' config.h && \
     make -j$(nproc) && \
     make install && \
     # Compliance guard: fail the build if any royalty-bearing / HW codec surface


### PR DESCRIPTION
## What

The in-tree FFmpeg media allowlist does not reach IAMF. `CONFIG_IAMFDEC` lives in configure's `CONFIG_EXTRA` rather than `COMPONENT_LIST`, so `--disable-demuxers` leaves it alone, and configure sets `mov_demuxer_suggest="iamfdec zlib"` — enabling the `mov` demuxer the encode path needs pulls the IAMF parser back in behind it.

The effect is that `libavformat/iamf_parse.o` compiles and `mov.c` can reach `mix_presentation_obu()` via the `iacb` box handler, despite every other demuxer being excluded by construction.

## Why this is defence in depth, not a fix

Nothing in Dynamo demuxes untrusted input with this build:

- Every in-tree ffmpeg call site is an **encode** — `imageio.get_writer` to `libvpx_vp9` (`common/utils/video_utils.py`, `sglang/.../video_generation_handler.py`).
- There is no imageio/ffmpeg **read** path in shipped code — no `imread`, `get_reader`, or `imopen` outside tests.
- Video **decode** goes through `PyNvVideoCodec`/NVDEC (`common/multimodal/nvdec_decoder.py`), a separate library with its own bundled `libavformat`.

The value is that an image inventory stops reporting IAMF parser advisories against a parser we never feed.

## Assert, don't assume

`--disable-<name>` for a `CONFIG_EXTRA` entry is not a documented user-facing option, so the build greps `config.h` for `CONFIG_IAMFDEC 0` and `CONFIG_IAMFENC 0` and fails if either is still enabled.

Without that assertion a future ffmpeg could stop honouring the flag and ship the parser again with the change still looking applied — the same failure mode as a version floor that never reaches the image.

## Scope

One stage of `wheel_builder.Dockerfile`, shared by all frameworks. Renders clean for trtllm, vllm and sglang. No change to the encoder, decoder, muxer, demuxer, parser or protocol allowlists, and the existing royalty-bearing-codec guard is untouched.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->