### PR TITLE
feat(sglang): enable snapshot-backed failover

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+import os
 import sys
 
 import uvloop
@@ -35,6 +36,45 @@ configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
 
+async def _resume_snapshot_engine(snapshot_controller, runtime) -> object | None:
+    """Resume a restored engine, electing one active failover engine if needed."""
+    pause_controller = snapshot_controller.pause_controller
+    lock_path = os.environ.get("FAILOVER_LOCK_PATH")
+    if not lock_path:
+        await pause_controller.resume()
+        pause_controller.mark_resumed()
+        return None
+
+    if not pause_controller.is_paused:
+        raise RuntimeError("failover engine must be paused before election")
+
+    # A restored standby is healthy as a process, but it must not resume GPU
+    # memory or register with discovery until it owns the failover lock.
+    runtime.set_health_status(True)
+    logger.info("[Shadow] Engine sleeping, startup probe now passing, waiting for lock")
+
+    from gpu_memory_service.failover_lock.flock import FlockFailoverLock
+
+    engine_id = os.environ.get("ENGINE_ID", "0")
+    lock = FlockFailoverLock(lock_path)
+    await lock.acquire(engine_id=f"engine-{engine_id}")
+    logger.info("[Shadow] Lock acquired, waking SGLang engine")
+    try:
+        await pause_controller.resume()
+        pause_controller.mark_resumed()
+    except BaseException:
+        # resume() may have partially restored GPU state. Keep the lock until
+        # process exit rather than allowing two engines to become active.
+        logger.critical(
+            "[Shadow] Engine wake failed after lock acquisition; "
+            "terminating process while retaining the lock"
+        )
+        os._exit(1)
+
+    logger.info("[Shadow] Engine awake, registering with discovery")
+    return lock
+
+
 async def worker(argv: list[str] | None = None):
     if argv is None:
         argv = sys.argv[1:]
@@ -62,8 +102,6 @@ async def worker(argv: list[str] | None = None):
             dynamo_args,
             lambda: parse_snapshot_restore_runtime_config(argv),
         )
-        await snapshot_controller.pause_controller.resume()
-        snapshot_controller.pause_controller.mark_resumed()
 
     shutdown_event = asyncio.Event()
     shutdown_endpoints: list = []
@@ -72,6 +110,11 @@ async def worker(argv: list[str] | None = None):
         request_plane=dynamo_args.request_plane,
         event_plane=dynamo_args.event_plane,
     )
+
+    # Keep the flock object alive for the serving process lifetime. Linux
+    # releases it when this process exits, including SIGKILL/container failure.
+    if snapshot_controller is not None:
+        _failover_lock = await _resume_snapshot_engine(snapshot_controller, runtime)
 
     run_deferred_handlers = install_graceful_shutdown(
         loop, runtime, shutdown_endpoints, shutdown_event

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -266,7 +266,19 @@ func (r *dgdCheckpointsReconciler) createCheckpointCR(
 		return nil, err
 	}
 	if dynamo.IsIntraPodFailoverEnabled(component) {
-		if err := dynamo.PrepareVLLMAutomaticFailoverSnapshotSource(targetContainer); err != nil {
+		var err error
+		switch backendFramework {
+		case dynamo.BackendFrameworkVLLM:
+			err = dynamo.PrepareVLLMAutomaticFailoverSnapshotSource(targetContainer)
+		case dynamo.BackendFrameworkSGLang:
+			err = dynamo.PrepareSGLangAutomaticFailoverSnapshotSource(targetContainer)
+		default:
+			err = fmt.Errorf(
+				"automatic failover snapshot source does not support backend %q",
+				backendFramework,
+			)
+		}
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -436,7 +436,6 @@ func TestDGDCheckpointsReconciler_CreatePreservesGMSSaverClient(t *testing.T) {
 	sglangDGD.Name = "test-sglang-dgd"
 	sglangDGD.UID = types.UID("sglang-dgd-uid")
 	sglangComponent := component.DeepCopy()
-	sglangComponent.Failover = nil
 	sglangComponent.Checkpoint.Identity.BackendFramework = string(dynamo.BackendFrameworkSGLang)
 	sglangComponent.ExtraPodSpec.MainContainer.Args = []string{"-m", "dynamo.sglang", "--tp", "1"}
 

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -155,7 +155,7 @@ func TestDynamoGraphDeploymentReconcileLocksProviderBeforeRejectingStoredCheckpo
 	require.Equal(t, string(reasonFailedToReconcileResources), ready.Reason)
 	require.Equal(t,
 		"component \"prefill\": Snapshot with gpuMemoryService.mode=InterPod is unsupported\n"+
-			"component \"decode\": Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint: checkpointRef must be omitted so the DGD owns the automatic checkpoint",
+			"component \"decode\": Snapshot with active/passive failover requires an operator-managed automatic single-node Worker checkpoint: checkpointRef must be omitted so the DGD owns the automatic checkpoint",
 		ready.Message,
 	)
 	require.Zero(t, stored.Status.ObservedGeneration)

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -402,12 +402,13 @@ var intraPodFailoverLockFile = filepath.Join(gmsruntime.SharedMountPath, "failov
 const (
 	failoverEngineCount                    = 2
 	vllmModuleName                         = "dynamo.vllm"
+	sglangModuleName                       = "dynamo.sglang"
 	vllmLoadFormatFlag                     = "--load-format"
 	vllmWorkerClassFlag                    = "--worker-cls"
 	gmsV0VLLMWorkerClass                   = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
 	gmsV0VLLMWorkerClassAlt                = "gpu_memory_service.integrations.vllm.worker:GMSWorker"
 	gmsV1VLLMWorkerClass                   = "gpu_memory_service.v1.integrations.vllm.worker.GMSV1Worker"
-	checkpointFailoverCompatibilityMessage = "Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint"
+	checkpointFailoverCompatibilityMessage = "Snapshot with active/passive failover requires an operator-managed automatic single-node Worker checkpoint"
 )
 
 // IsDGDControlled reports whether a DCD has an exact DynamoGraphDeployment
@@ -489,8 +490,9 @@ func validateAutomaticFailoverCheckpointProfile(
 	if config.TargetContainerName != "" && config.TargetContainerName != commonconsts.MainContainerName {
 		violations = append(violations, errors.New("targetContainerName must be main"))
 	}
-	if BackendFramework(backendFramework) != BackendFrameworkVLLM {
-		violations = append(violations, errors.New("backendFramework must be vllm"))
+	backend := BackendFramework(backendFramework)
+	if backend != BackendFrameworkVLLM && backend != BackendFrameworkSGLang {
+		violations = append(violations, errors.New("backendFramework must be vllm or sglang"))
 	}
 	if component.ComponentType != v1beta1.ComponentTypeWorker {
 		violations = append(violations, errors.New("component type must be Worker"))
@@ -520,23 +522,36 @@ func validateAutomaticFailoverCheckpointProfile(
 	} else if gpuCount != 1 {
 		violations = append(violations, errors.New("main container must request exactly one GPU"))
 	}
-	if err := configureVLLMAutomaticSnapshotLoadProfile(main.DeepCopy()); err != nil {
-		violations = append(violations, err)
-		return violations
+	switch backend {
+	case BackendFrameworkVLLM:
+		if err := configureVLLMAutomaticSnapshotLoadProfile(main.DeepCopy()); err != nil {
+			violations = append(violations, err)
+			return violations
+		}
+		violations = append(violations, validateAutomaticSnapshotFlags(main.Args, []automaticSnapshotFlag{
+			{flag: "--disaggregation-mode", defaultValue: "agg", want: "agg", description: "disaggregation mode must be aggregated"},
+			{flag: "--request-plane", defaultValue: "tcp", want: "tcp", description: "request plane must be tcp"},
+			{flag: tensorParallelSizeFlag, defaultValue: "1", want: "1", description: "tensor parallel size must be 1"},
+			{flag: pipelineParallelSizeFlag, defaultValue: "1", want: "1", description: "pipeline parallel size must be 1"},
+			{flag: dataParallelSizeFlag, defaultValue: "1", want: "1", description: "data parallel size must be 1"},
+		})...)
+	case BackendFrameworkSGLang:
+		violations = append(violations, validateSGLangAutomaticSnapshotProfile(main)...)
 	}
-	for _, profile := range []struct {
-		flag         string
-		defaultValue string
-		want         string
-		description  string
-	}{
-		{flag: "--disaggregation-mode", defaultValue: "agg", want: "agg", description: "disaggregation mode must be aggregated"},
-		{flag: "--request-plane", defaultValue: "tcp", want: "tcp", description: "request plane must be tcp"},
-		{flag: tensorParallelSizeFlag, defaultValue: "1", want: "1", description: "tensor parallel size must be 1"},
-		{flag: pipelineParallelSizeFlag, defaultValue: "1", want: "1", description: "pipeline parallel size must be 1"},
-		{flag: dataParallelSizeFlag, defaultValue: "1", want: "1", description: "data parallel size must be 1"},
-	} {
-		value, _, _, found, err := tokenizedVLLMFlag(main.Args, profile.flag)
+	return violations
+}
+
+type automaticSnapshotFlag struct {
+	flag         string
+	defaultValue string
+	want         string
+	description  string
+}
+
+func validateAutomaticSnapshotFlags(args []string, profiles []automaticSnapshotFlag) []error {
+	var violations []error
+	for _, profile := range profiles {
+		value, _, _, found, err := tokenizedFlag(args, profile.flag)
 		if err != nil {
 			violations = append(violations, err)
 			continue
@@ -549,6 +564,24 @@ func validateAutomaticFailoverCheckpointProfile(
 		}
 	}
 	return violations
+}
+
+func validateSGLangAutomaticSnapshotProfile(container *corev1.Container) []error {
+	if !isDirectDynamoModuleCommand(container, sglangModuleName) {
+		return []error{fmt.Errorf(
+			"requires a direct python -m %s command with tokenized arguments (command=%q args=%q)",
+			sglangModuleName,
+			container.Command,
+			container.Args,
+		)}
+	}
+	return validateAutomaticSnapshotFlags(container.Args, []automaticSnapshotFlag{
+		{flag: "--disaggregation-mode", defaultValue: "agg", want: "agg", description: "disaggregation mode must be aggregated"},
+		{flag: "--request-plane", defaultValue: "tcp", want: "tcp", description: "request plane must be tcp"},
+		{flag: "--tp", defaultValue: "1", want: "1", description: "tensor parallel size must be 1"},
+		{flag: "--dp-size", defaultValue: "1", want: "1", description: "data parallel size must be 1"},
+		{flag: "--pp-size", defaultValue: "1", want: "1", description: "pipeline parallel size must be 1"},
+	})
 }
 
 func wrapFailoverCompatibilityViolations(violations []error) []error {
@@ -579,6 +612,24 @@ func PrepareVLLMAutomaticFailoverSnapshotSource(container *corev1.Container) err
 	return nil
 }
 
+// PrepareSGLangAutomaticFailoverSnapshotSource selects the GMS V1 snapshot
+// plugin without adding destination-only election state to the source process.
+func PrepareSGLangAutomaticFailoverSnapshotSource(container *corev1.Container) error {
+	if container == nil {
+		return fmt.Errorf("automatic failover snapshot source container is nil")
+	}
+	if violations := validateSGLangAutomaticSnapshotProfile(container); len(violations) > 0 {
+		return fmt.Errorf("automatic failover snapshot source: %w", errors.Join(violations...))
+	}
+	removeEnvVar(container, "DYN_FORWARDPASS_METRIC_PORT")
+	EnableSGLangGMSV1(container)
+	container.Env = MergeEnvs(container.Env, []corev1.EnvVar{{
+		Name:  "DYN_REQUEST_PLANE",
+		Value: "tcp",
+	}})
+	return nil
+}
+
 func configureVLLMAutomaticSnapshotLoadProfile(container *corev1.Container) error {
 	if !isDirectDynamoVLLMCommand(container) {
 		return fmt.Errorf(
@@ -592,13 +643,13 @@ func configureVLLMAutomaticSnapshotLoadProfile(container *corev1.Container) erro
 		return fmt.Errorf("arguments after -- are unsupported")
 	}
 
-	workerClass, _, _, _, err := tokenizedVLLMFlag(container.Args, vllmWorkerClassFlag)
+	workerClass, _, _, _, err := tokenizedFlag(container.Args, vllmWorkerClassFlag)
 	if err != nil {
 		return err
 	}
 	switch workerClass {
 	case gmsV1VLLMWorkerClass:
-		loadFormat, _, _, found, err := tokenizedVLLMFlag(container.Args, vllmLoadFormatFlag)
+		loadFormat, _, _, found, err := tokenizedFlag(container.Args, vllmLoadFormatFlag)
 		if err != nil {
 			return err
 		}
@@ -619,31 +670,35 @@ func configureVLLMAutomaticSnapshotLoadProfile(container *corev1.Container) erro
 }
 
 func isDirectDynamoVLLMCommand(container *corev1.Container) bool {
+	return isDirectDynamoModuleCommand(container, vllmModuleName)
+}
+
+func isDirectDynamoModuleCommand(container *corev1.Container, module string) bool {
 	args := container.Args
 	switch {
 	case len(container.Command) == 0 &&
 		len(args) >= 3 &&
 		isPythonCommand(args[0]) &&
 		args[1] == "-m" &&
-		args[2] == vllmModuleName:
+		args[2] == module:
 		return true
 	case len(container.Command) == 1 &&
 		isPythonCommand(container.Command[0]) &&
 		len(args) >= 2 &&
 		args[0] == "-m" &&
-		args[1] == vllmModuleName:
+		args[1] == module:
 		return true
 	case len(container.Command) == 3 &&
 		isPythonCommand(container.Command[0]) &&
 		container.Command[1] == "-m" &&
-		container.Command[2] == vllmModuleName:
+		container.Command[2] == module:
 		return true
 	default:
 		return false
 	}
 }
 
-func tokenizedVLLMFlag(args []string, flag string) (value string, index int, equalsForm, found bool, err error) {
+func tokenizedFlag(args []string, flag string) (value string, index int, equalsForm, found bool, err error) {
 	index = -1
 	for i, arg := range args {
 		switch {
@@ -670,7 +725,7 @@ func tokenizedVLLMFlag(args []string, flag string) (value string, index int, equ
 }
 
 func upsertTokenizedVLLMFlag(args []string, flag, value string) ([]string, error) {
-	_, index, equalsForm, found, err := tokenizedVLLMFlag(args, flag)
+	_, index, equalsForm, found, err := tokenizedFlag(args, flag)
 	if err != nil {
 		return nil, err
 	}
@@ -688,14 +743,16 @@ func upsertTokenizedVLLMFlag(args []string, flag, value string) ([]string, error
 func configureCheckpointFailoverEngines(
 	podSpec *corev1.PodSpec,
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+	backendFramework BackendFramework,
 ) {
 	engineNames := IntraPodFailoverEngineContainerNames(component)
 	for i := range podSpec.Containers {
 		if slices.Contains(engineNames, podSpec.Containers[i].Name) {
-			podSpec.Containers[i].Env = MergeEnvs(podSpec.Containers[i].Env, []corev1.EnvVar{
-				{Name: "DYN_VLLM_DISAGGREGATION_MODE", Value: "agg"},
-				{Name: "DYN_REQUEST_PLANE", Value: "tcp"},
-			})
+			env := []corev1.EnvVar{{Name: "DYN_REQUEST_PLANE", Value: "tcp"}}
+			if backendFramework == BackendFrameworkVLLM {
+				env = append(env, corev1.EnvVar{Name: "DYN_VLLM_DISAGGREGATION_MODE", Value: "agg"})
+			}
+			podSpec.Containers[i].Env = MergeEnvs(podSpec.Containers[i].Env, env)
 		}
 	}
 }
@@ -770,8 +827,11 @@ func buildFailoverPod(
 		if err := applyVLLMOverrides(updated, numberOfNodes); err != nil {
 			return err
 		}
+	case BackendFrameworkSGLang:
+		// SGLang only needs the backend-agnostic engine identity, health, and
+		// lock wiring added above. GMS V1 is selected before cloning.
 	default:
-		return fmt.Errorf("failover is currently supported only for vLLM (detected: %s)", backendFramework)
+		return fmt.Errorf("failover is currently supported only for vLLM and SGLang (detected: %s)", backendFramework)
 	}
 
 	*podSpec = *updated

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -617,11 +617,17 @@ func TestBuildFailoverPod_EmptyContainers(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least one container")
 }
 
-func TestBuildFailoverPod_RejectsNonVLLM(t *testing.T) {
+func TestBuildFailoverPod_SupportsSGLangAndRejectsUnknownBackend(t *testing.T) {
 	ps := intraPodFailoverPodSpec()
-	err := buildFailoverPod(&ps, 1, BackendFrameworkSGLang, failoverEngineCount)
+	require.NoError(t, buildFailoverPod(&ps, 1, BackendFrameworkSGLang, failoverEngineCount))
+	require.Len(t, ps.Containers, 3)
+	assert.Equal(t, "engine-0", ps.Containers[0].Name)
+	assert.Equal(t, "engine-1", ps.Containers[1].Name)
+
+	ps = intraPodFailoverPodSpec()
+	err := buildFailoverPod(&ps, 1, BackendFrameworkTRTLLM, failoverEngineCount)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "currently supported only for vLLM")
+	assert.Contains(t, err.Error(), "currently supported only for vLLM and SGLang")
 }
 
 func TestBuildFailoverPod_EngineEnvVars(t *testing.T) {
@@ -833,6 +839,17 @@ func TestValidateAutomaticFailoverCheckpoint(t *testing.T) {
 		require.Empty(t, ValidateAutomaticFailoverCheckpointSource(twoShadows, string(BackendFrameworkVLLM)))
 	})
 
+	t.Run("accepts SGLang TP1 snapshot failover", func(t *testing.T) {
+		sglang := component.DeepCopy()
+		sglang.PodTemplate.Spec.Containers[0].Args = []string{"-m", sglangModuleName, "--tp", "1"}
+
+		require.Empty(t, ValidateAutomaticFailoverCheckpointSource(sglang, string(BackendFrameworkSGLang)))
+
+		target := sglang.DeepCopy()
+		target.Experimental.Checkpoint.CheckpointRef = ptr.To("checkpoint-worker")
+		require.Empty(t, ValidateAutomaticFailoverCheckpointTarget(target, string(BackendFrameworkSGLang), true))
+	})
+
 	t.Run("rejects unsupported shadow counts", func(t *testing.T) {
 		for _, count := range []int32{-1, 3} {
 			invalid := component.DeepCopy()
@@ -919,6 +936,23 @@ func TestPrepareVLLMAutomaticFailoverSnapshotSource(t *testing.T) {
 	})
 }
 
+func TestPrepareSGLangAutomaticFailoverSnapshotSource(t *testing.T) {
+	container := validAutomaticFailoverComponent().PodTemplate.Spec.Containers[0]
+	container.Args = []string{"-m", sglangModuleName, "--tp", "1"}
+	container.Env = []corev1.EnvVar{
+		{Name: "DYN_FORWARDPASS_METRIC_PORT", Value: "9100"},
+		{Name: "KEEP_ME", Value: "yes"},
+	}
+
+	require.NoError(t, PrepareSGLangAutomaticFailoverSnapshotSource(&container))
+
+	env := envToMap(container.Env)
+	assert.NotContains(t, env, "DYN_FORWARDPASS_METRIC_PORT")
+	assert.Equal(t, "true", env[sglangGMSV1EnvVar])
+	assert.Equal(t, "tcp", env["DYN_REQUEST_PLANE"])
+	assert.Equal(t, "yes", env["KEEP_ME"])
+}
+
 func TestIsDGDControlled(t *testing.T) {
 	dgd := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "graph", UID: types.UID("graph-uid")},
@@ -998,7 +1032,7 @@ func validAutomaticFailoverComponent() *v1beta1.DynamoComponentDeploymentSharedS
 
 func vllmFlagValue(t *testing.T, args []string, flag string) string {
 	t.Helper()
-	value, _, _, found, err := tokenizedVLLMFlag(args, flag)
+	value, _, _, found, err := tokenizedFlag(args, flag)
 	require.NoError(t, err)
 	require.True(t, found)
 	return value

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1721,7 +1721,7 @@ func GenerateBasePodSpec(
 			return nil, fmt.Errorf("failed to build failover pod: %w", err)
 		}
 		if GetCheckpoint(component) != nil {
-			configureCheckpointFailoverEngines(&podSpec, component)
+			configureCheckpointFailoverEngines(&podSpec, component, backendFramework)
 		}
 	}
 

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -205,7 +205,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 			username: "system:serviceaccount:default:regular-user",
 			wantWebhookErrs: []string{
-				"spec.experimental.checkpoint: Forbidden: Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint: checkpoint failover is only supported for an operator-generated DCD",
+				"spec.experimental.checkpoint: Forbidden: Snapshot with active/passive failover requires an operator-managed automatic single-node Worker checkpoint: checkpoint failover is only supported for an operator-generated DCD",
 			},
 		},
 		{

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1227,7 +1227,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				}
 			}),
 			wantWebhookErrs: []string{
-				"spec.components[1].experimental.checkpoint: Forbidden: Snapshot with active/passive failover requires an operator-managed automatic single-node vLLM Worker checkpoint: checkpointRef must be omitted so the DGD owns the automatic checkpoint",
+				"spec.components[1].experimental.checkpoint: Forbidden: Snapshot with active/passive failover requires an operator-managed automatic single-node Worker checkpoint: checkpointRef must be omitted so the DGD owns the automatic checkpoint",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- elect one restored SGLang engine with the existing process-lifetime flock before resuming GPU memory or registering with discovery
- support SGLang in the operator-managed TP=PP=DP=1 Snapshot failover profile
- prepare SGLang checkpoint sources with GMS V1 and TCP request-plane settings instead of vLLM-specific mutations
- clone SGLang shadow containers using the existing backend-neutral failover wiring

## Dependencies

This draft PR is based on a temporary composition branch so its visible diff contains only SGLang failover support. The composition has two independent prerequisite legs rooted at `#13301`:

- `#13301 -> #12869 -> #12874` for snapshot-backed failover runtime and operator orchestration
- `#13301 -> #13218` for SGLang GMS V1 memory integration

The temporary base replays `#13218` over `#12874` and carries only the minimal test-fixture compatibility required by that composition. After the prerequisites merge, this PR can be rebased onto `main` without changing its intended patch.

## Validation

- `python3 -m compileall -q components/src/dynamo/sglang/main.py`
- `go test ./internal/gms ./internal/checkpoint ./internal/dynamo`
- `go test ./internal/controller -run '^TestDGDCheckpointsReconciler_CreatePreservesGMSSaverClient$' -count=1`
- `pre-commit run --files <changed files>`

