### PR TITLE
fix(sglang): drain prefill KV transfers before shutdown

### DIFF
--- a/components/src/dynamo/common/utils/tests/test_graceful_shutdown.py
+++ b/components/src/dynamo/common/utils/tests/test_graceful_shutdown.py
@@ -115,6 +115,47 @@ def test_drain_callback_called_before_shutdown():
     )
 
 
+def test_shutdown_order_unregister_grace_drain_signal_runtime(monkeypatch):
+    """Shutdown sequencing protects both routing and in-flight transfers."""
+    call_order = []
+
+    class RecordingEndpoint:
+        async def unregister_endpoint_instance(self):
+            call_order.append("unregister")
+
+    class RecordingEvent:
+        def set(self):
+            call_order.append("shutdown_event")
+
+    async def record_sleep(_seconds):
+        call_order.append("grace")
+
+    async def drain():
+        call_order.append("drain")
+
+    runtime = MagicMock()
+    runtime.shutdown.side_effect = lambda: call_order.append("runtime_shutdown")
+    monkeypatch.setattr(_gs.asyncio, "sleep", record_sleep)
+
+    asyncio.run(
+        graceful_shutdown_with_discovery(
+            runtime=runtime,
+            endpoints=[RecordingEndpoint()],
+            shutdown_event=RecordingEvent(),
+            grace_period_s=1,
+            drain_callback=drain,
+        )
+    )
+
+    assert call_order == [
+        "unregister",
+        "grace",
+        "drain",
+        "shutdown_event",
+        "runtime_shutdown",
+    ]
+
+
 def test_no_drain_callback_still_shuts_down():
     """Backward compatibility: shutdown still works without drain_callback."""
     mock_runtime = MagicMock()

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -204,6 +204,7 @@ async def init_prefill(
     shutdown_endpoints: list,
     run_deferred_handlers: Callable[[], Awaitable[None]] | None = None,
     snapshot_engine: Optional[sgl.Engine] = None,
+    drain_callbacks: list[Callable[[], Awaitable[None]]] | None = None,
 ) -> None:
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
@@ -276,6 +277,8 @@ async def init_prefill(
     handler = PrefillWorkerHandler(
         engine, config, publisher, generate_endpoint, shutdown_event
     )
+    if drain_callbacks is not None:
+        drain_callbacks.append(handler.drain)
     handler.register_engine_routes(runtime)
 
     health_check_payload = SglangPrefillHealthCheckPayload(engine).to_dict()

--- a/components/src/dynamo/sglang/init_multimodal.py
+++ b/components/src/dynamo/sglang/init_multimodal.py
@@ -210,6 +210,7 @@ async def init_multimodal_prefill_worker(
     shutdown_event: asyncio.Event,
     shutdown_endpoints: list,
     run_deferred_handlers: Callable[[], Awaitable[None]] | None = None,
+    drain_callbacks: list[Callable[[], Awaitable[None]]] | None = None,
 ) -> None:
     """Initialize multimodal prefill worker component"""
     server_args, dynamo_args = config.server_args, config.dynamo_args
@@ -221,6 +222,8 @@ async def init_multimodal_prefill_worker(
     )
 
     handler = MultimodalPrefillWorkerHandler(engine, config, shutdown_event)
+    if drain_callbacks is not None:
+        drain_callbacks.append(handler.drain)
 
     shutdown_endpoints[:] = [generate_endpoint]
 

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 import sys
+from collections.abc import Awaitable, Callable
 
 import uvloop
 
@@ -61,6 +62,9 @@ async def worker(argv: list[str] | None = None):
 
     shutdown_event = asyncio.Event()
     shutdown_endpoints: list = []
+    drain_callbacks: list[Callable[[], Awaitable[None]]] | None = (
+        [] if config.serving_mode == DisaggregationMode.PREFILL else None
+    )
     runtime, loop = create_runtime(
         discovery_backend=dynamo_args.discovery_backend,
         request_plane=dynamo_args.request_plane,
@@ -68,7 +72,11 @@ async def worker(argv: list[str] | None = None):
     )
 
     run_deferred_handlers = install_graceful_shutdown(
-        loop, runtime, shutdown_endpoints, shutdown_event
+        loop,
+        runtime,
+        shutdown_endpoints,
+        shutdown_event,
+        drain_callbacks=drain_callbacks,
     )
     logger.info(
         "Signal handlers set up for graceful shutdown "
@@ -115,6 +123,7 @@ async def worker(argv: list[str] | None = None):
                 shutdown_event,
                 shutdown_endpoints,
                 run_deferred_handlers,
+                drain_callbacks=drain_callbacks,
             )
     elif config.dynamo_args.diffusion_worker:
         await init_llm_diffusion(
@@ -141,6 +150,7 @@ async def worker(argv: list[str] | None = None):
             shutdown_endpoints,
             run_deferred_handlers,
             snapshot_engine=snapshot_engine,
+            drain_callbacks=drain_callbacks,
         )
 
 

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -24,6 +24,7 @@ from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
     build_disagg_mm_kwargs,
     raise_if_unextracted_multimodal,
 )
+from dynamo.sglang.request_handlers.prefill_drain import PrefillResultDrain
 
 # Sentinel value matching u32::MAX from the C/Go prefill-routing ABI.
 # This remains as a compatibility fallback for older callers that still encode
@@ -54,19 +55,14 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         self.engine = engine
         self.bootstrap_host, self.bootstrap_port = self._get_bootstrap_info(self.engine)
         super().__init__(engine, config, publisher, generate_endpoint, shutdown_event)
-        self._consume_tasks: set[asyncio.Task[Any]] = set()
+        self._result_drain = PrefillResultDrain()
         logging.info(
             f"Prefill worker handler initialized - bootstrap host: {self.bootstrap_host}, bootstrap port: {self.bootstrap_port}"
         )
 
     def cleanup(self) -> None:
         """Shutdown the prefill engine and cleanup resources."""
-        # Cancel all pending consume tasks
-        for task in self._consume_tasks:
-            if not task.done():
-                task.cancel()
-        self._consume_tasks.clear()
-
+        self._result_drain.cancel()
         super().cleanup()
         self.engine.shutdown()
         logging.info("Prefill engine shutdown")
@@ -207,6 +203,11 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 yield res
             return
 
+        # Register the result consumer before publishing bootstrap information.
+        # Once bootstrap is visible to the router, the request has been accepted
+        # and shutdown drain must account for its KV transfer.
+        task = self._result_drain.create_task(self._consume_results(results, context))
+
         # Yield bootstrap_info for PrefillRouter - required for async generator
         # contract and Rust-side expects disaggregated_params in first output.
         yield {
@@ -216,11 +217,13 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             "disaggregated_params": bootstrap_info,
         }
 
-        task = asyncio.create_task(self._consume_results(results, context))
-        self._consume_tasks.add(task)
-        task.add_done_callback(self._consume_tasks.discard)
+        # Shield the result consumer so cancellation of the RPC stream does not
+        # bypass the handler's cancellation monitor or the shutdown drain.
+        await asyncio.shield(task)
 
-        await task
+    async def drain(self) -> None:
+        """Wait until accepted prefill KV transfers reach a terminal state."""
+        await self._result_drain.drain()
 
     async def _consume_results(
         self, results: AsyncIterator[Any], context: Context

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -20,6 +20,7 @@ from dynamo.sglang.protocol import (
     SglangMultimodalRequest,
 )
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
+from dynamo.sglang.request_handlers.prefill_drain import PrefillResultDrain
 
 logger = logging.getLogger(__name__)
 
@@ -692,6 +693,7 @@ class MultimodalPrefillWorkerHandler(
 
         # Get bootstrap info using BootstrapManager
         self.bootstrap_host, self.bootstrap_port = self._get_bootstrap_info(engine)
+        self._result_drain = PrefillResultDrain()
 
         logger.info(
             f"Multimodal prefill worker handler initialized - bootstrap host: {self.bootstrap_host}, bootstrap port: {self.bootstrap_port}"
@@ -729,13 +731,19 @@ class MultimodalPrefillWorkerHandler(
                 "bootstrap_room": bootstrap_room,
             }
 
+            # Register all embedding and prefill work before publishing bootstrap.
+            # The tracked task reaches terminal only after the engine result stream,
+            # including the KV transfer status, has ended.
+            task = self._result_drain.create_task(
+                self._process_prefill_generation(
+                    disagg_request, bootstrap_room, context=context
+                )
+            )
+
             _end_bootstrap()
             yield json.dumps(bootstrap_info)
 
-            # Process prefill generation
-            await self._process_prefill_generation(
-                disagg_request, bootstrap_room, context=context
-            )
+            await asyncio.shield(task)
 
         except Exception as e:
             logger.error(f"Error in prefill generation: {e}", exc_info=True)
@@ -773,42 +781,51 @@ class MultimodalPrefillWorkerHandler(
         input_ids = request.request.token_ids
         sampling_params = disagg_request.sampling_params
         tensor_id: int | None = None
+        result_consumption_started = False
 
-        # Process embeddings from encode worker using our embeddings processor
-        with _nvtx.annotate("mm:prefill:load_multimodal", color="cyan"):
-            (
-                image_mm_items,
-                video_data,
-                _,
-                tensor_id,
-            ) = await _build_mm_items(request, self.embeddings_processor)
+        try:
+            # Process embeddings from encode worker using our embeddings processor
+            with _nvtx.annotate("mm:prefill:load_multimodal", color="cyan"):
+                (
+                    image_mm_items,
+                    video_data,
+                    _,
+                    tensor_id,
+                ) = await _build_mm_items(request, self.embeddings_processor)
 
-        trace_header = (
-            context.trace_headers() if context and self.enable_trace else None
-        )
+            trace_header = (
+                context.trace_headers() if context and self.enable_trace else None
+            )
 
-        # Start SGLang prefill generation (like regular SGLang)
-        with _nvtx.annotate("mm:prefill:engine_async_generate", color="blue"):
-            gen_params = {
-                "input_ids": input_ids,
-                "sampling_params": sampling_params,
-                "stream": True,
-                "bootstrap_host": self.bootstrap_host,
-                "bootstrap_port": self.bootstrap_port,
-                "bootstrap_room": bootstrap_room,
-                "external_trace_header": trace_header,
-                "rid": context.trace_id if context else None,
-            }
+            # Start SGLang prefill generation (like regular SGLang)
+            with _nvtx.annotate("mm:prefill:engine_async_generate", color="blue"):
+                gen_params = {
+                    "input_ids": input_ids,
+                    "sampling_params": sampling_params,
+                    "stream": True,
+                    "bootstrap_host": self.bootstrap_host,
+                    "bootstrap_port": self.bootstrap_port,
+                    "bootstrap_room": bootstrap_room,
+                    "external_trace_header": trace_header,
+                    "rid": context.trace_id if context else None,
+                }
 
-            if image_mm_items:
-                gen_params["image_data"] = image_mm_items
-            if video_data:
-                gen_params["video_data"] = video_data
+                if image_mm_items:
+                    gen_params["image_data"] = image_mm_items
+                if video_data:
+                    gen_params["video_data"] = video_data
 
-            results = await self.engine.async_generate(**gen_params)
+                results = await self.engine.async_generate(**gen_params)
 
-        # Consume results without yielding (prefill doesn't return text, just coordinates)
-        asyncio.create_task(self._consume_results(results, tensor_id))
+            # Consume through terminal state (prefill doesn't return text, but the
+            # stream owns the KV transfer lifecycle used by shutdown drain).
+            result_consumption_started = True
+            await self._consume_results(results, tensor_id)
+        finally:
+            # _consume_results owns release once entered. This fallback covers
+            # cancellation or engine failure before result consumption starts.
+            if tensor_id is not None and not result_consumption_started:
+                self.embeddings_processor.release_embeddings(tensor_id)
 
     async def _consume_results(self, results, tensor_id: Optional[int]):
         """Consume prefill results without returning them (like regular SGLang)"""
@@ -823,6 +840,11 @@ class MultimodalPrefillWorkerHandler(
                 self.embeddings_processor.release_embeddings(tensor_id)
 
     def cleanup(self):
+        self._result_drain.cancel()
         super().cleanup()
         self.engine.shutdown()
         logger.info("Multimodal prefill engine shutdown")
+
+    async def drain(self) -> None:
+        """Wait until accepted multimodal prefill transfers reach terminal state."""
+        await self._result_drain.drain()

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -773,7 +773,7 @@ class MultimodalPrefillWorkerHandler(
         self,
         disagg_request: DisaggSglangMultimodalRequest,
         bootstrap_room: int,
-        context=None,
+        context: Context,
     ):
         """Process multimodal input and start prefill generation"""
         # Get the SglangMultimodalRequest from the DisaggSglangMultimodalRequest
@@ -820,21 +820,33 @@ class MultimodalPrefillWorkerHandler(
             # Consume through terminal state (prefill doesn't return text, but the
             # stream owns the KV transfer lifecycle used by shutdown drain).
             result_consumption_started = True
-            await self._consume_results(results, tensor_id)
+            await self._consume_results(results, tensor_id, context)
         finally:
             # _consume_results owns release once entered. This fallback covers
             # cancellation or engine failure before result consumption starts.
             if tensor_id is not None and not result_consumption_started:
                 self.embeddings_processor.release_embeddings(tensor_id)
 
-    async def _consume_results(self, results, tensor_id: Optional[int]):
+    async def _consume_results(
+        self, results, tensor_id: Optional[int], context: Context
+    ) -> None:
         """Consume prefill results without returning them (like regular SGLang)"""
         released = False
+        request_id_future: asyncio.Future[str] = asyncio.Future()
         try:
-            async for _ in results:
-                if tensor_id is not None and not released:
-                    self.embeddings_processor.release_embeddings(tensor_id)
-                    released = True
+            async with self._cancellation_monitor(request_id_future, context):
+                async for result in results:
+                    if not request_id_future.done() and isinstance(result, dict):
+                        sglang_request_id = result.get("meta_info", {}).get("id")
+                        if sglang_request_id:
+                            request_id_future.set_result(sglang_request_id)
+                            logger.debug(
+                                "New multimodal prefill request ID: %s",
+                                sglang_request_id,
+                            )
+                    if tensor_id is not None and not released:
+                        self.embeddings_processor.release_embeddings(tensor_id)
+                        released = True
         finally:
             if tensor_id is not None and not released:
                 self.embeddings_processor.release_embeddings(tensor_id)

--- a/components/src/dynamo/sglang/request_handlers/prefill_drain.py
+++ b/components/src/dynamo/sglang/request_handlers/prefill_drain.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import logging
+from collections.abc import Coroutine
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class PrefillResultDrain:
+    """Track accepted prefill work until its result stream reaches terminal state."""
+
+    def __init__(self) -> None:
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._tasks)
+
+    def create_task(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._task_done)
+        return task
+
+    def _task_done(self, task: asyncio.Task[Any]) -> None:
+        self._tasks.discard(task)
+        if task.cancelled():
+            return
+        exception = task.exception()
+        if exception is not None:
+            logger.error(
+                "Prefill result consumer failed",
+                exc_info=(type(exception), exception, exception.__traceback__),
+            )
+
+    async def drain(self) -> None:
+        """Wait for all tracked work without letting waiter cancellation cancel it."""
+        while tasks := tuple(self._tasks):
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in tasks), return_exceptions=True
+            )
+
+    def cancel(self) -> None:
+        """Cancel tracked work as a final cleanup fallback after drain timeout."""
+        for task in tuple(self._tasks):
+            task.cancel()

--- a/components/src/dynamo/sglang/request_handlers/prefill_drain.py
+++ b/components/src/dynamo/sglang/request_handlers/prefill_drain.py
@@ -37,13 +37,25 @@ class PrefillResultDrain:
             )
 
     async def drain(self) -> None:
-        """Wait for all tracked work without letting waiter cancellation cancel it."""
-        while tasks := tuple(self._tasks):
-            await asyncio.gather(
-                *(asyncio.shield(task) for task in tasks), return_exceptions=True
-            )
+        """Wait for tracked work, cancelling it if the bounded drain is cancelled."""
+        try:
+            while tasks := tuple(self._tasks):
+                await asyncio.gather(
+                    *(asyncio.shield(task) for task in tasks), return_exceptions=True
+                )
+        except asyncio.CancelledError:
+            await self.cancel_and_wait()
+            raise
+
+    async def cancel_and_wait(self) -> None:
+        """Cancel tracked work and wait for its cancellation cleanup to finish."""
+        tasks = tuple(self._tasks)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def cancel(self) -> None:
-        """Cancel tracked work as a final cleanup fallback after drain timeout."""
+        """Request cancellation as a final synchronous cleanup fallback."""
         for task in tuple(self._tasks):
             task.cancel()

--- a/components/src/dynamo/sglang/shutdown.py
+++ b/components/src/dynamo/sglang/shutdown.py
@@ -43,8 +43,24 @@ def install_graceful_shutdown(
     deferred_handlers_ran = False
 
     async def _drain() -> None:
-        if drain_callbacks is not None:
-            await asyncio.gather(*(callback() for callback in drain_callbacks))
+        if drain_callbacks is None:
+            return
+
+        callbacks = tuple(drain_callbacks)
+        results = await asyncio.gather(
+            *(callback() for callback in callbacks), return_exceptions=True
+        )
+        for callback, result in zip(callbacks, results):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, Exception):
+                logging.error(
+                    "Drain callback failed: %r",
+                    callback,
+                    exc_info=(type(result), result, result.__traceback__),
+                )
+            elif isinstance(result, BaseException):
+                raise result
 
     async def run_deferred_handlers() -> None:
         nonlocal deferred_handlers_ran

--- a/components/src/dynamo/sglang/shutdown.py
+++ b/components/src/dynamo/sglang/shutdown.py
@@ -20,6 +20,7 @@ def install_graceful_shutdown(
     endpoints: list[str],
     shutdown_event: asyncio.Event,
     *,
+    drain_callbacks: list[Callable[[], Awaitable[None]]] | None = None,
     signals: tuple[int, ...] = (signal.SIGTERM, signal.SIGINT),
 ) -> Callable[[], Awaitable[None]]:
     """
@@ -40,6 +41,10 @@ def install_graceful_shutdown(
     shutdown_started = False
     shutdown_signum: int | None = None
     deferred_handlers_ran = False
+
+    async def _drain() -> None:
+        if drain_callbacks is not None:
+            await asyncio.gather(*(callback() for callback in drain_callbacks))
 
     async def run_deferred_handlers() -> None:
         nonlocal deferred_handlers_ran
@@ -74,6 +79,7 @@ def install_graceful_shutdown(
             endpoints,
             shutdown_event=shutdown_event,
             grace_period_s=None,
+            drain_callback=_drain if drain_callbacks is not None else None,
         )
 
     def _schedule_shutdown(signum: int, frame: Any | None) -> None:

--- a/components/src/dynamo/sglang/tests/test_sglang_prefill_drain.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_prefill_drain.py
@@ -46,24 +46,26 @@ async def test_prefill_result_drain_waits_for_pending_transfer():
 
 
 @pytest.mark.asyncio
-async def test_prefill_result_drain_timeout_does_not_cancel_transfer():
+async def test_prefill_result_drain_timeout_cancels_transfer():
     result_drain = PrefillResultDrain()
     transfer_terminal = asyncio.Event()
+    transfer_cleanup_complete = asyncio.Event()
 
     async def consume_until_terminal():
-        await transfer_terminal.wait()
+        try:
+            await transfer_terminal.wait()
+        finally:
+            transfer_cleanup_complete.set()
 
     transfer_task = result_drain.create_task(consume_until_terminal())
 
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(result_drain.drain(), timeout=0.01)
 
-    assert not transfer_task.done()
-    assert result_drain.pending_count == 1
-
-    result_drain.cancel()
+    assert transfer_cleanup_complete.is_set()
     with pytest.raises(asyncio.CancelledError):
         await transfer_task
+    assert result_drain.pending_count == 0
 
 
 @pytest.mark.asyncio
@@ -185,6 +187,17 @@ async def test_multimodal_prefill_work_reaches_engine_stream_terminal(monkeypatc
     handler.engine = SimpleNamespace(
         async_generate=AsyncMock(return_value=result_stream())
     )
+
+    class NoopCancellationMonitor:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    handler._cancellation_monitor = (
+        lambda request_id, context: NoopCancellationMonitor()
+    )
     monkeypatch.setattr(
         worker_handler,
         "_build_mm_items",
@@ -196,7 +209,7 @@ async def test_multimodal_prefill_work_reaches_engine_stream_terminal(monkeypatc
         sampling_params={},
     )
     work_task = asyncio.create_task(
-        handler._process_prefill_generation(request, 42, context=None)
+        handler._process_prefill_generation(request, 42, context=SimpleNamespace())
     )
     await asyncio.sleep(0)
 
@@ -233,7 +246,7 @@ async def test_multimodal_prefill_cancellation_releases_loaded_embeddings(monkey
         sampling_params={},
     )
     work_task = asyncio.create_task(
-        handler._process_prefill_generation(request, 42, context=None)
+        handler._process_prefill_generation(request, 42, context=SimpleNamespace())
     )
     await asyncio.wait_for(engine_started.wait(), timeout=1)
 
@@ -242,6 +255,63 @@ async def test_multimodal_prefill_cancellation_releases_loaded_embeddings(monkey
         await work_task
 
     embeddings_processor.release_embeddings.assert_called_once_with(7)
+
+
+@pytest.mark.asyncio
+async def test_multimodal_prefill_monitors_request_cancellation(monkeypatch):
+    from dynamo.sglang.request_handlers.multimodal import worker_handler
+
+    cancellation_requested = asyncio.Event()
+    stream_terminal = asyncio.Event()
+    request_id_published = asyncio.Event()
+
+    async def result_stream():
+        yield {"meta_info": {"id": "sglang-request-id"}}
+        request_id_published.set()
+        await stream_terminal.wait()
+
+    tokenizer_manager = SimpleNamespace(abort_request=MagicMock())
+    handler = MultimodalPrefillWorkerHandler.__new__(MultimodalPrefillWorkerHandler)
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 1234
+    handler.enable_trace = False
+    handler.embeddings_processor = object()
+    handler.engine = SimpleNamespace(
+        async_generate=AsyncMock(return_value=result_stream()),
+        tokenizer_manager=tokenizer_manager,
+    )
+    monkeypatch.setattr(
+        worker_handler,
+        "_build_mm_items",
+        AsyncMock(return_value=(None, None, None, None)),
+    )
+
+    context = SimpleNamespace(
+        id=lambda: "context-id",
+        trace_id="trace-id",
+        trace_headers=lambda: {},
+        async_killed_or_stopped=cancellation_requested.wait,
+    )
+    request = SimpleNamespace(
+        request=SimpleNamespace(request=SimpleNamespace(token_ids=[1, 2, 3])),
+        sampling_params={},
+    )
+    work_task = asyncio.create_task(
+        handler._process_prefill_generation(request, 42, context=context)
+    )
+    await asyncio.wait_for(request_id_published.wait(), timeout=1)
+
+    cancellation_requested.set()
+    for _ in range(10):
+        if tokenizer_manager.abort_request.called:
+            break
+        await asyncio.sleep(0)
+
+    tokenizer_manager.abort_request.assert_called_once_with(
+        rid="sglang-request-id", abort_all=False
+    )
+    stream_terminal.set()
+    await work_task
 
 
 @pytest.mark.asyncio
@@ -289,3 +359,52 @@ async def test_shutdown_uses_callback_registered_after_signal_install(monkeypatc
     await asyncio.wait_for(shutdown_complete.wait(), timeout=1)
 
     assert call_order == ["shutdown", "drain"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drain_callbacks_isolate_failures(monkeypatch, caplog):
+    from dynamo.sglang import shutdown as shutdown_module
+
+    captured_handlers = {}
+    shutdown_complete = asyncio.Event()
+    successful_callback_ran = False
+
+    loop = SimpleNamespace(
+        add_signal_handler=MagicMock(),
+        call_soon_threadsafe=lambda callback: callback(),
+    )
+    monkeypatch.setattr(
+        shutdown_module.signal,
+        "signal",
+        lambda sig, callback: captured_handlers.__setitem__(sig, callback),
+    )
+
+    async def graceful_shutdown(runtime, endpoints, **kwargs):
+        await kwargs["drain_callback"]()
+        shutdown_complete.set()
+
+    monkeypatch.setattr(
+        shutdown_module, "graceful_shutdown_with_discovery", graceful_shutdown
+    )
+
+    async def failing_drain():
+        raise RuntimeError("drain failed")
+
+    async def successful_drain():
+        nonlocal successful_callback_ran
+        successful_callback_ran = True
+
+    shutdown_module.install_graceful_shutdown(
+        loop,
+        object(),
+        [],
+        asyncio.Event(),
+        drain_callbacks=[failing_drain, successful_drain],
+        signals=(signal.SIGTERM,),
+    )
+
+    captured_handlers[signal.SIGTERM](signal.SIGTERM, None)
+    await asyncio.wait_for(shutdown_complete.wait(), timeout=1)
+
+    assert successful_callback_ran
+    assert "Drain callback failed" in caplog.text

--- a/components/src/dynamo/sglang/tests/test_sglang_prefill_drain.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_prefill_drain.py
@@ -69,6 +69,7 @@ async def test_prefill_result_drain_timeout_does_not_cancel_transfer():
 @pytest.mark.asyncio
 async def test_regular_prefill_registers_transfer_before_bootstrap_yield(monkeypatch):
     transfer_terminal = asyncio.Event()
+    consumer_cancelled = False
     result_drain = PrefillResultDrain()
     handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
     handler.bootstrap_host = "127.0.0.1"
@@ -82,7 +83,12 @@ async def test_regular_prefill_registers_transfer_before_bootstrap_yield(monkeyp
     handler.engine = SimpleNamespace(async_generate=AsyncMock(return_value=object()))
 
     async def consume_results(results, context):
-        await transfer_terminal.wait()
+        nonlocal consumer_cancelled
+        try:
+            await transfer_terminal.wait()
+        except asyncio.CancelledError:
+            consumer_cancelled = True
+            raise
 
     handler._consume_results = consume_results
     monkeypatch.setattr(
@@ -101,12 +107,25 @@ async def test_regular_prefill_registers_transfer_before_bootstrap_yield(monkeyp
     assert bootstrap["disaggregated_params"]["bootstrap_room"] == 42
     assert result_drain.pending_count == 1
 
+    # Simulate the outer RPC stream being cancelled after the router received
+    # bootstrap. The shielded result consumer must remain tracked and draining.
+    outer_rpc_task = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    outer_rpc_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await outer_rpc_task
+
+    assert not consumer_cancelled
+    assert result_drain.pending_count == 1
+
     drain_task = asyncio.create_task(handler.drain())
     await asyncio.sleep(0)
     assert not drain_task.done()
 
     transfer_terminal.set()
     await drain_task
+    assert not consumer_cancelled
+    assert result_drain.pending_count == 0
     with pytest.raises(StopAsyncIteration):
         await anext(stream)
 

--- a/components/src/dynamo/sglang/tests/test_sglang_prefill_drain.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_prefill_drain.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import signal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
+from dynamo.sglang.request_handlers.multimodal.worker_handler import (
+    MultimodalPrefillWorkerHandler,
+)
+from dynamo.sglang.request_handlers.prefill_drain import PrefillResultDrain
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.mark.asyncio
+async def test_prefill_result_drain_waits_for_pending_transfer():
+    result_drain = PrefillResultDrain()
+    transfer_terminal = asyncio.Event()
+
+    async def consume_until_terminal():
+        await transfer_terminal.wait()
+
+    result_drain.create_task(consume_until_terminal())
+    drain_task = asyncio.create_task(result_drain.drain())
+    await asyncio.sleep(0)
+
+    assert result_drain.pending_count == 1
+    assert not drain_task.done()
+
+    transfer_terminal.set()
+    await drain_task
+    assert result_drain.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_prefill_result_drain_timeout_does_not_cancel_transfer():
+    result_drain = PrefillResultDrain()
+    transfer_terminal = asyncio.Event()
+
+    async def consume_until_terminal():
+        await transfer_terminal.wait()
+
+    transfer_task = result_drain.create_task(consume_until_terminal())
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(result_drain.drain(), timeout=0.01)
+
+    assert not transfer_task.done()
+    assert result_drain.pending_count == 1
+
+    result_drain.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await transfer_task
+
+
+@pytest.mark.asyncio
+async def test_regular_prefill_registers_transfer_before_bootstrap_yield(monkeypatch):
+    transfer_terminal = asyncio.Event()
+    result_drain = PrefillResultDrain()
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 1234
+    handler._result_drain = result_drain
+    handler._generate_bootstrap_room = lambda: 42
+    handler._get_input_param = lambda request: {"input_ids": request["token_ids"]}
+    handler._resolve_lora = lambda request: None
+    handler._priority_kwargs = lambda priority: {}
+    handler.enable_trace = False
+    handler.engine = SimpleNamespace(async_generate=AsyncMock(return_value=object()))
+
+    async def consume_results(results, context):
+        await transfer_terminal.wait()
+
+    handler._consume_results = consume_results
+    monkeypatch.setattr(
+        "dynamo.sglang.request_handlers.llm.prefill_handler.require_reasoning_kwargs",
+        lambda engine, request: {},
+    )
+
+    context = SimpleNamespace(
+        id=lambda: "request-id",
+        trace_id="trace-id",
+        trace_headers=lambda: {},
+    )
+    stream = handler.generate({"request": {"token_ids": [1, 2, 3]}}, context)
+
+    bootstrap = await anext(stream)
+    assert bootstrap["disaggregated_params"]["bootstrap_room"] == 42
+    assert result_drain.pending_count == 1
+
+    drain_task = asyncio.create_task(handler.drain())
+    await asyncio.sleep(0)
+    assert not drain_task.done()
+
+    transfer_terminal.set()
+    await drain_task
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+
+
+@pytest.mark.asyncio
+async def test_multimodal_prefill_registers_work_before_bootstrap_yield(monkeypatch):
+    from dynamo.sglang.request_handlers.multimodal import worker_handler
+
+    transfer_terminal = asyncio.Event()
+    result_drain = PrefillResultDrain()
+    handler = MultimodalPrefillWorkerHandler.__new__(MultimodalPrefillWorkerHandler)
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 1234
+    handler._result_drain = result_drain
+    handler._generate_bootstrap_room = lambda: 42
+    handler._validate_and_parse_disagg_request = lambda request: request
+
+    async def process_prefill(disagg_request, bootstrap_room, context=None):
+        await transfer_terminal.wait()
+
+    handler._process_prefill_generation = process_prefill
+    monkeypatch.setattr(worker_handler._nvtx, "start_range", lambda *args, **kwargs: 1)
+    monkeypatch.setattr(worker_handler._nvtx, "end_range", lambda *args, **kwargs: None)
+
+    stream = handler.generate(object(), SimpleNamespace())
+    bootstrap = json.loads(await anext(stream))
+
+    assert bootstrap["bootstrap_room"] == 42
+    assert result_drain.pending_count == 1
+
+    drain_task = asyncio.create_task(handler.drain())
+    await asyncio.sleep(0)
+    assert not drain_task.done()
+
+    transfer_terminal.set()
+    await drain_task
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+
+
+@pytest.mark.asyncio
+async def test_multimodal_prefill_work_reaches_engine_stream_terminal(monkeypatch):
+    from dynamo.sglang.request_handlers.multimodal import worker_handler
+
+    transfer_terminal = asyncio.Event()
+
+    async def result_stream():
+        await transfer_terminal.wait()
+        if False:
+            yield None
+
+    handler = MultimodalPrefillWorkerHandler.__new__(MultimodalPrefillWorkerHandler)
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 1234
+    handler.enable_trace = False
+    handler.embeddings_processor = object()
+    handler.engine = SimpleNamespace(
+        async_generate=AsyncMock(return_value=result_stream())
+    )
+    monkeypatch.setattr(
+        worker_handler,
+        "_build_mm_items",
+        AsyncMock(return_value=(None, None, None, None)),
+    )
+
+    request = SimpleNamespace(
+        request=SimpleNamespace(request=SimpleNamespace(token_ids=[1, 2, 3])),
+        sampling_params={},
+    )
+    work_task = asyncio.create_task(
+        handler._process_prefill_generation(request, 42, context=None)
+    )
+    await asyncio.sleep(0)
+
+    assert not work_task.done()
+    transfer_terminal.set()
+    await work_task
+
+
+@pytest.mark.asyncio
+async def test_multimodal_prefill_cancellation_releases_loaded_embeddings(monkeypatch):
+    from dynamo.sglang.request_handlers.multimodal import worker_handler
+
+    engine_started = asyncio.Event()
+
+    async def start_generation(**kwargs):
+        engine_started.set()
+        await asyncio.Event().wait()
+
+    embeddings_processor = SimpleNamespace(release_embeddings=MagicMock())
+    handler = MultimodalPrefillWorkerHandler.__new__(MultimodalPrefillWorkerHandler)
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 1234
+    handler.enable_trace = False
+    handler.embeddings_processor = embeddings_processor
+    handler.engine = SimpleNamespace(async_generate=start_generation)
+    monkeypatch.setattr(
+        worker_handler,
+        "_build_mm_items",
+        AsyncMock(return_value=(None, None, None, 7)),
+    )
+
+    request = SimpleNamespace(
+        request=SimpleNamespace(request=SimpleNamespace(token_ids=[1, 2, 3])),
+        sampling_params={},
+    )
+    work_task = asyncio.create_task(
+        handler._process_prefill_generation(request, 42, context=None)
+    )
+    await asyncio.wait_for(engine_started.wait(), timeout=1)
+
+    work_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await work_task
+
+    embeddings_processor.release_embeddings.assert_called_once_with(7)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_uses_callback_registered_after_signal_install(monkeypatch):
+    from dynamo.sglang import shutdown as shutdown_module
+
+    captured_handlers = {}
+    shutdown_complete = asyncio.Event()
+    call_order = []
+    drain_callbacks = []
+
+    loop = SimpleNamespace(
+        add_signal_handler=MagicMock(),
+        call_soon_threadsafe=lambda callback: callback(),
+    )
+    monkeypatch.setattr(
+        shutdown_module.signal,
+        "signal",
+        lambda sig, callback: captured_handlers.__setitem__(sig, callback),
+    )
+
+    async def graceful_shutdown(runtime, endpoints, **kwargs):
+        call_order.append("shutdown")
+        await kwargs["drain_callback"]()
+        shutdown_complete.set()
+
+    monkeypatch.setattr(
+        shutdown_module, "graceful_shutdown_with_discovery", graceful_shutdown
+    )
+
+    shutdown_module.install_graceful_shutdown(
+        loop,
+        object(),
+        [],
+        asyncio.Event(),
+        drain_callbacks=drain_callbacks,
+        signals=(signal.SIGTERM,),
+    )
+
+    async def drain():
+        call_order.append("drain")
+
+    drain_callbacks.append(drain)
+    captured_handlers[signal.SIGTERM](signal.SIGTERM, None)
+    await asyncio.wait_for(shutdown_complete.wait(), timeout=1)
+
+    assert call_order == ["shutdown", "drain"]


### PR DESCRIPTION
## Summary

- track regular and multimodal SGLang prefill result streams before publishing bootstrap metadata
- wait for tracked KV-transfer work during graceful shutdown before setting the shutdown event
- shield transfer tasks from drain-waiter timeout cancellation while preserving bounded cleanup
- add focused tests for shutdown ordering, bootstrap registration, terminal-state drain, timeout behavior, and multimodal cleanup

## Why

SGLang prefill cleanup could cancel result-consumer tasks and shut down the engine before an in-flight KV transfer reached a terminal state. The common graceful-shutdown path already supports a drain callback; this change wires SGLang into that barrier and closes the bootstrap/task-registration race.

## Validation

- `ruff check` on changed Python files
- `python -m py_compile` on changed Python files
- `git diff --check`
- common graceful-shutdown unit tests: `7 passed`
- standalone async drain shield/terminal verification

SGLang-specific pytest collection was not run locally because the current environment does not include the SGLang dependency; CI provides the backend test environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful draining for standard and multimodal prefill transfers during shutdown.
  * Shutdown now waits for accepted in-progress transfers to complete before stopping services.
  * Added safer handling for interrupted multimodal processing, including resource cleanup.

* **Bug Fixes**
  * Improved transfer tracking to prevent work from being lost during shutdown or cancellation.

* **Tests**
  * Added coverage for graceful shutdown sequencing, pending transfers, timeouts, cancellation, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->