### PR TITLE
build: use published Aiconfigurator 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,8 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.11.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=614b9c8c8725332533616786e2eb049df48935f0#614b9c8c8725332533616786e2eb049df48935f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdf1c98afd417d5819b78ee6efe59bbe23ea44a246621e4a60ac7dff0a29e16"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,9 +185,6 @@ tokio-rustls = { version = "0.26" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = { version = "2" }
 
-[patch.crates-io]
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "614b9c8c8725332533616786e2eb049df48935f0" }
-
 [profile.dev.package]
 insta.opt-level = 3
 

--- a/aisimulate/pyproject.toml
+++ b/aisimulate/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 ]
 dependencies = [
     "ai-dynamo>=1.3.0,<2.0.0",
-    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0",
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core",
+    "aiconfigurator==0.11.0",
+    "aiconfigurator-core==0.11.0",
     "chex==0.1.87",
     "filterpy==1.4.5",
     "flax==0.10.0",
@@ -61,9 +61,6 @@ test = [
 [project.urls]
 Repository = "https://github.com/ai-dynamo/dynamo.git"
 Documentation = "https://github.com/ai-dynamo/dynamo/tree/main/docs/fern/components/aisimulate"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/aisimulate"]

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core",
+    "aiconfigurator-core==0.11.0",
     "aiperf==0.10.0",
     "matplotlib",
     "networkx",

--- a/container/deps/requirements.frontend.txt
+++ b/container/deps/requirements.frontend.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Required by experimental KV router --router-prefill-load-model=aic.
-aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core
+aiconfigurator-core==0.11.0
 
 # tritonclient<=2.62.0 requires grpcio<1.68 and protobuf<6.0dev; pin here so the
 # resolver picks compatible versions when installed alongside runtime deps.

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,10 +3,10 @@
 
 # Dependencies required by the planner, profiler, and global_planner services.
 
-# Keep both layers on the same immutable AIC source revision.
-aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0
+# Keep both layers on the same published AIC release.
+aiconfigurator==0.11.0
 
-aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core
+aiconfigurator-core==0.11.0
 aiofiles<=25.1.0
 aiohttp>=3.14.3,<4.0  # see overrides.planner.txt: aiperf pins aiohttp~=3.13.3
 filterpy==1.4.5

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -35,7 +35,8 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.11.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=614b9c8c8725332533616786e2eb049df48935f0#614b9c8c8725332533616786e2eb049df48935f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdf1c98afd417d5819b78ee6efe59bbe23ea44a246621e4a60ac7dff0a29e16"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -119,9 +119,6 @@ dynamo-llm = { path = "../../llm", default-features = false }
 opentelemetry_sdk = { version = "0.31.0", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["registry"] }
 
-[patch.crates-io]
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "614b9c8c8725332533616786e2eb049df48935f0" }
-
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ sglang = [
 ]
 
 mocker = [
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@614b9c8c8725332533616786e2eb049df48935f0#subdirectory=aic-core",
+    "aiconfigurator-core==0.11.0",
 ]
 
 [project.entry-points.pytest11]
@@ -117,9 +117,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.custom]
 path = "hatch_build.py"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = [


### PR DESCRIPTION
## Summary

- replace Aiconfigurator Git-SHA dependencies with the published `aiconfigurator==0.11.0` and `aiconfigurator-core==0.11.0` releases
- remove the Rust `[patch.crates-io]` overrides and refresh both Cargo lockfiles to the crates.io source and checksum
- remove Hatch's `allow-direct-references` opt-in now that the Python metadata no longer contains direct references
- leave nightly versioning and publication automation unchanged

## Validation

- `cargo tree --locked -p dynamo-mocker --features aic-forward-pass -i aiconfigurator-core`
- `cargo tree --locked --manifest-path lib/bindings/python/Cargo.toml --features aic-forward-pass -i aiconfigurator-core`
- parsed the five modified TOML manifests with Python 3.12
- parsed all 37 modified-project PEP 508 dependency declarations
- `git diff --check`
