### PR TITLE
feat(mocker): randomize synthetic replay lengths

### DIFF
--- a/components/src/dynamo/replay/api.py
+++ b/components/src/dynamo/replay/api.py
@@ -49,6 +49,8 @@ class _SyntheticReplayOptions(_CommonReplayOptions, total=False):
     request_rate: float | None
     arrival_interval_ms: float | None
     arrival_seed: int
+    random_range_ratio: float
+    random_seed: int
     turns_per_session: int
     shared_prefix_ratio: float
     num_prefix_groups: int
@@ -292,6 +294,8 @@ def run_synthetic_trace_replay(
     request_rate=None,
     arrival_interval_ms=None,
     arrival_seed=42,
+    random_range_ratio=1.0,
+    random_seed=0,
     turns_per_session=1,
     shared_prefix_ratio=0.0,
     num_prefix_groups=0,
@@ -305,7 +309,13 @@ def run_synthetic_trace_replay(
     capture_per_request=False,
     capture_planner_details=True,
 ) -> ReplayReport | dict[str, Any]:
-    """Run synthetic replay with the same timing boundary as trace replay."""
+    """Run synthetic replay with the same timing boundary as trace replay.
+
+    ``random_range_ratio`` uniformly samples ISL and OSL independently from
+    ``[int(ratio * configured_length), configured_length]``. The default 1.0
+    preserves fixed lengths; ``random_seed`` makes variable lengths repeatable.
+    Random lengths currently support single-turn synthetic workloads only.
+    """
     replay_kwargs = {
         "extra_engine_args": extra_engine_args,
         "prefill_engine_args": prefill_engine_args,
@@ -322,6 +332,8 @@ def run_synthetic_trace_replay(
         "request_rate": request_rate,
         "arrival_interval_ms": arrival_interval_ms,
         "arrival_seed": arrival_seed,
+        "random_range_ratio": random_range_ratio,
+        "random_seed": random_seed,
         "turns_per_session": turns_per_session,
         "shared_prefix_ratio": shared_prefix_ratio,
         "num_prefix_groups": num_prefix_groups,

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -732,6 +732,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=42,
         help="seed for synthetic open-loop arrival timestamps",
     )
+    parser.add_argument(
+        "--random-range-ratio",
+        type=float,
+        default=1.0,
+        help=(
+            "uniformly sample synthetic input and output lengths from "
+            "[int(ratio * configured_length), configured_length]; default 1.0 "
+            "keeps lengths fixed; currently supports single-turn workloads only"
+        ),
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=0,
+        help="seed for synthetic input/output length sampling",
+    )
     parser.add_argument("--turns-per-session", type=int, default=1)
     parser.add_argument("--shared-prefix-ratio", type=float, default=0.0)
     parser.add_argument("--num-prefix-groups", type=int, default=0)
@@ -977,6 +993,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             request_rate=args.request_rate,
             arrival_interval_ms=args.arrival_interval_ms,
             arrival_seed=args.arrival_seed,
+            random_range_ratio=args.random_range_ratio,
+            random_seed=args.random_seed,
             turns_per_session=args.turns_per_session,
             shared_prefix_ratio=args.shared_prefix_ratio,
             num_prefix_groups=args.num_prefix_groups,

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2533,6 +2533,7 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "pythonize",
+ "rand 0.9.4",
  "rmp",
  "rmpv",
  "serde",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -77,6 +77,7 @@ rmp = { version = "0.8" }
 rmpv = { version = "1", features = ["with-serde"] }
 once_cell = { version = "1.20.3" }
 parking_lot = { version = "0.12.4" }
+rand = "0.9.2"
 serde = { version = "1" }
 serde_json = { version = "1.0.138" }
 serde-transcode = "1.1"

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -22,6 +22,7 @@ use pyo3::{
     prelude::*,
 };
 use pythonize::pythonize;
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use serde::Serialize;
 use serde_json::json;
 use uuid::Uuid;
@@ -1436,7 +1437,7 @@ fn write_per_request_jsonl(
 }
 
 #[pyfunction]
-#[pyo3(signature = (input_tokens, output_tokens, request_count, extra_engine_args=None, prefill_engine_args=None, decode_engine_args=None, router_config=None, aic_perf_config=None, num_workers=1, num_prefill_workers=1, num_decode_workers=1, replay_concurrency=None, replay_mode="offline", router_mode="round_robin", arrival_speedup_ratio=1.0, request_rate=None, arrival_interval_ms=None, arrival_seed=42, turns_per_session=1, shared_prefix_ratio=0.0, num_prefix_groups=0, inter_turn_delay_ms=0.0, model_name=None, sla_ttft_ms=None, sla_itl_ms=None, sla_e2e_ms=None, capture_per_request=false, capture_planner_details=true, scaling_policy=None))]
+#[pyo3(signature = (input_tokens, output_tokens, request_count, extra_engine_args=None, prefill_engine_args=None, decode_engine_args=None, router_config=None, aic_perf_config=None, num_workers=1, num_prefill_workers=1, num_decode_workers=1, replay_concurrency=None, replay_mode="offline", router_mode="round_robin", arrival_speedup_ratio=1.0, request_rate=None, arrival_interval_ms=None, arrival_seed=42, random_range_ratio=1.0, random_seed=0, turns_per_session=1, shared_prefix_ratio=0.0, num_prefix_groups=0, inter_turn_delay_ms=0.0, model_name=None, sla_ttft_ms=None, sla_itl_ms=None, sla_e2e_ms=None, capture_per_request=false, capture_planner_details=true, scaling_policy=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn run_mocker_synthetic_trace_replay(
     py: Python<'_>,
@@ -1458,6 +1459,8 @@ pub fn run_mocker_synthetic_trace_replay(
     request_rate: Option<f64>,
     arrival_interval_ms: Option<f64>,
     arrival_seed: u64,
+    random_range_ratio: f64,
+    random_seed: u64,
     turns_per_session: usize,
     shared_prefix_ratio: f64,
     num_prefix_groups: usize,
@@ -1527,7 +1530,14 @@ pub fn run_mocker_synthetic_trace_replay(
             || num_prefix_groups > 0
             || inter_turn_delay_ms > 0.0;
 
+        validate_random_range_ratio(random_range_ratio)?;
+
         if use_workload {
+            if random_range_ratio != 1.0 {
+                anyhow::bail!(
+                    "random_range_ratio currently only supports single-turn synthetic replay"
+                );
+            }
             let mut trace = build_synthetic_workload(
                 block_size,
                 input_tokens,
@@ -1653,6 +1663,8 @@ pub fn run_mocker_synthetic_trace_replay(
             output_tokens,
             request_count,
             arrival_timestamps_ms.as_deref(),
+            random_range_ratio,
+            random_seed,
         )?;
 
         match args_selection {
@@ -1908,8 +1920,9 @@ mod tests {
         let poisson_timestamps = ArrivalSpec::PoissonQps { qps: 20.0 }
             .timestamps(8, 42)
             .unwrap();
-        let fixed = build_synthetic_requests(16, 4, 8, Some(&fixed_timestamps)).unwrap();
-        let poisson = build_synthetic_requests(16, 4, 8, Some(&poisson_timestamps)).unwrap();
+        let fixed = build_synthetic_requests(16, 4, 8, Some(&fixed_timestamps), 1.0, 0).unwrap();
+        let poisson =
+            build_synthetic_requests(16, 4, 8, Some(&poisson_timestamps), 1.0, 0).unwrap();
 
         assert_ne!(fixed_timestamps, poisson_timestamps);
         assert_eq!(
@@ -1944,6 +1957,37 @@ mod tests {
                 poisson_request.strict_priority
             );
             assert_eq!(fixed_request.policy_class, poisson_request.policy_class);
+        }
+    }
+
+    #[test]
+    fn synthetic_request_lengths_are_bounded_and_deterministic() {
+        let first = build_synthetic_requests(100, 50, 32, None, 0.8, 7).unwrap();
+        let repeated = build_synthetic_requests(100, 50, 32, None, 0.8, 7).unwrap();
+        let reseeded = build_synthetic_requests(100, 50, 32, None, 0.8, 8).unwrap();
+
+        let lengths = |requests: &[dynamo_mocker::common::protocols::DirectRequest]| {
+            requests
+                .iter()
+                .map(|request| (request.tokens.len(), request.max_output_tokens))
+                .collect::<Vec<_>>()
+        };
+        let first_lengths = lengths(&first);
+
+        assert_eq!(first_lengths, lengths(&repeated));
+        assert_ne!(first_lengths, lengths(&reseeded));
+        assert!(
+            first_lengths
+                .iter()
+                .all(|(isl, osl)| (80..=100).contains(isl) && (40..=50).contains(osl))
+        );
+    }
+
+    #[test]
+    fn synthetic_request_lengths_reject_invalid_ratio() {
+        for ratio in [0.0, -0.1, 1.1, f64::INFINITY, f64::NAN] {
+            let error = build_synthetic_requests(100, 50, 2, None, ratio, 0).unwrap_err();
+            assert!(error.to_string().contains("random_range_ratio"));
         }
     }
 }
@@ -2424,6 +2468,8 @@ fn build_synthetic_requests(
     output_tokens: usize,
     request_count: usize,
     arrival_timestamps_ms: Option<&[f64]>,
+    random_range_ratio: f64,
+    random_seed: u64,
 ) -> anyhow::Result<Vec<DirectRequest>> {
     if input_tokens == 0 {
         anyhow::bail!("input_tokens must be at least 1");
@@ -2434,6 +2480,7 @@ fn build_synthetic_requests(
     if request_count == 0 {
         anyhow::bail!("request_count must be at least 1");
     }
+    validate_random_range_ratio(random_range_ratio)?;
     if let Some(arrival_timestamps_ms) = arrival_timestamps_ms
         && arrival_timestamps_ms.len() != request_count
     {
@@ -2443,14 +2490,23 @@ fn build_synthetic_requests(
         );
     }
 
+    let mut rng = StdRng::seed_from_u64(random_seed);
+    // Follow InferenceX's draw order: sample the complete ISL vector before OSL.
+    let input_lengths =
+        sample_synthetic_lengths(input_tokens, request_count, random_range_ratio, &mut rng)?;
+    let output_lengths =
+        sample_synthetic_lengths(output_tokens, request_count, random_range_ratio, &mut rng)?;
+
     let mut requests = Vec::with_capacity(request_count);
-    for request_idx in 0..request_count {
-        let tokens = (0..input_tokens)
+    for (request_idx, (input_length, output_length)) in
+        input_lengths.into_iter().zip(output_lengths).enumerate()
+    {
+        let tokens = (0..input_length)
             .map(|token_idx| synthetic_token_id(request_idx, token_idx))
             .collect();
         requests.push(DirectRequest {
             tokens,
-            max_output_tokens: output_tokens,
+            max_output_tokens: output_length,
             uuid: Some(Uuid::from_u128((request_idx as u128) + 1)),
             dp_rank: 0,
             arrival_timestamp_ms: arrival_timestamps_ms.map(|values| values[request_idx]),
@@ -2459,6 +2515,35 @@ fn build_synthetic_requests(
     }
 
     Ok(requests)
+}
+
+fn validate_random_range_ratio(random_range_ratio: f64) -> anyhow::Result<()> {
+    if !random_range_ratio.is_finite() || random_range_ratio <= 0.0 || random_range_ratio > 1.0 {
+        anyhow::bail!(
+            "random_range_ratio must be finite and in (0.0, 1.0], got {random_range_ratio}"
+        );
+    }
+    Ok(())
+}
+
+fn sample_synthetic_lengths(
+    upper: usize,
+    count: usize,
+    random_range_ratio: f64,
+    rng: &mut StdRng,
+) -> anyhow::Result<Vec<usize>> {
+    if random_range_ratio == 1.0 {
+        return Ok(vec![upper; count]);
+    }
+    let lower = ((upper as f64) * random_range_ratio) as usize;
+    if lower == 0 {
+        anyhow::bail!(
+            "random_range_ratio={random_range_ratio} gives a zero-token lower bound for length {upper}"
+        );
+    }
+    Ok((0..count)
+        .map(|_| rng.random_range(lower..=upper))
+        .collect())
 }
 
 fn synthetic_token_id(request_idx: usize, token_idx: usize) -> u32 {

--- a/lib/bindings/python/tests/replay/test_replay_cli.py
+++ b/lib/bindings/python/tests/replay/test_replay_cli.py
@@ -134,6 +134,43 @@ def test_replay_cli_subprocess_synthetic_smoke(tmp_path):
 
 
 @pytest.mark.timeout(30)
+def test_replay_cli_subprocess_synthetic_random_lengths(tmp_path):
+    report_path = tmp_path / "synthetic_random_report.json"
+    jsonl_path = tmp_path / "synthetic_random_requests.jsonl"
+
+    completed = _run_replay_cli(
+        tmp_path,
+        "--input-tokens",
+        "100",
+        "--output-tokens",
+        "50",
+        "--request-count",
+        "32",
+        "--replay-concurrency",
+        "8",
+        "--random-range-ratio",
+        "0.8",
+        "--random-seed",
+        "7",
+        "--per-request-jsonl",
+        str(jsonl_path),
+        "--report-json",
+        str(report_path),
+        "--extra-engine-args",
+        '{"block_size":16,"speedup_ratio":1000.0}',
+    )
+
+    report = _assert_replay_cli_outputs(completed, report_path)
+    rows = [json.loads(line) for line in jsonl_path.read_text().splitlines()]
+    lengths = {
+        (row["input_length"], row["requested_output_length"]) for row in rows
+    }
+    assert len(report["per_request"]) == 32
+    assert len(lengths) > 1
+    assert all(80 <= isl <= 100 and 40 <= osl <= 50 for isl, osl in lengths)
+
+
+@pytest.mark.timeout(30)
 @pytest.mark.parametrize("planner_profile_data_kind", ["dir", "npz"])
 def test_replay_cli_subprocess_synthetic_smoke_accepts_planner_profile_data(
     tmp_path, planner_profile_data_kind

--- a/lib/bindings/python/tests/replay/test_replay_smoke.py
+++ b/lib/bindings/python/tests/replay/test_replay_smoke.py
@@ -696,6 +696,51 @@ def test_run_synthetic_concurrency_replay_counts_match(
     )
 
 
+def test_run_synthetic_concurrency_replay_randomizes_lengths_deterministically():
+    def run(seed):
+        return run_synthetic_trace_replay(
+            100,
+            50,
+            32,
+            extra_engine_args=_vllm_args(),
+            replay_mode="offline",
+            replay_concurrency=8,
+            random_range_ratio=0.8,
+            random_seed=seed,
+            capture_per_request=True,
+        )
+
+    first = run(0)
+    repeated = run(0)
+    reseeded = run(1)
+
+    def lengths(report):
+        return [
+            (row["input_length"], row["requested_output_length"])
+            for row in report.per_request
+        ]
+
+    first_lengths = lengths(first)
+    assert first_lengths == lengths(repeated)
+    assert first_lengths != lengths(reseeded)
+    assert len(set(first_lengths)) > 1
+    assert all(80 <= isl <= 100 and 40 <= osl <= 50 for isl, osl in first_lengths)
+
+
+@pytest.mark.parametrize("ratio", [0.0, -0.1, 1.1, float("inf"), float("nan")])
+def test_run_synthetic_replay_rejects_invalid_random_range_ratio(ratio):
+    with pytest.raises(Exception, match="random_range_ratio"):
+        run_synthetic_trace_replay(
+            64,
+            2,
+            2,
+            extra_engine_args=_vllm_args(),
+            replay_mode="offline",
+            replay_concurrency=1,
+            random_range_ratio=ratio,
+        )
+
+
 @pytest.mark.parametrize("replay_mode", ["offline", "online"])
 def test_run_trace_replay_accepts_router_config(tmp_path, replay_mode):
     trace_path = _write_trace_and_args(tmp_path)


### PR DESCRIPTION
## Summary

- add `random_range_ratio` and `random_seed` to single-turn synthetic replay through the Python API, native binding, and CLI
- independently sample ISL and OSL from `[int(ratio * configured_length), configured_length]`, with the complete ISL vector sampled before OSL
- preserve the existing fixed-length behavior by default (`random_range_ratio=1.0`)
- reject invalid ratios and random-length multi-turn workloads explicitly

This is a draft experiment for the predictor-comparison workload. Its reproduction packages currently turn the InferenceX `--random-range-ratio 0.8` workloads into identical fixed-length requests, which can phase-lock closed-loop completions and create large synchronized prefill batches.

### Four-workload H200 oracle-FPM results

All published silicon commands for MiniMax-M2.5 and Kimi-K2.5, at both 1k/1k and 8k/1k, use `--dataset-name random --random-range-ratio 0.8`. The fixed synthetic API path reproduces every packaged A3/oracle TTFT and TPOT point before changing the length distribution.

Using 10 requests per concurrency and seed 0:

| Workload | TTFT fixed | TTFT random 0.8 | TPOT fixed | TPOT random 0.8 |
|---|---:|---:|---:|---:|
| MiniMax-M2.5 1k/1k | 277.53% | 29.07% | 13.14% | 12.33% |
| MiniMax-M2.5 8k/1k | 59.48% | 20.89% | 6.22% | 5.95% |
| Kimi-K2.5 1k/1k | 85.31% | 21.10% | 10.45% | 4.69% |
| Kimi-K2.5 8k/1k | 16.36% | 23.64% | 4.61% | 8.57% |

Across all 28 operating points, point-weighted MAPE changes from 126.48% to 24.05% for TTFT and from 8.91% to 8.24% for TPOT. Random lengths improve both metrics for three of four workloads, but Kimi 8k/1k is a real counterexample: its fixed replay was already unusually close and random replay underpredicts both metrics.

Repeating Kimi with InferenceX's exact NumPy seed-0 target-length draw order gives the same outcome (Kimi 1k/1k: 21.26% TTFT / 4.69% TPOT; Kimi 8k/1k: 24.24% / 9.00%). The Kimi 8k regression is therefore not explained by Rust `StdRng` versus NumPy MT19937.

The seeded Rust RNG matches InferenceX's bounds, independent ISL/OSL distribution, and draw ordering, but not NumPy's exact MT19937 sequence. Exact request-by-request parity still requires exporting tokenizer-final per-request lengths from the silicon benchmark; the recovered commands omitted `--save-detailed`.

## Validation

- `cargo test --manifest-path lib/bindings/python/Cargo.toml synthetic_request_lengths -- --nocapture`
- `cargo clippy --manifest-path lib/bindings/python/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path lib/bindings/python/Cargo.toml -- --check`
- Ruff on the changed Python files
- built and installed the Python bindings with Maturin
- direct Python API smoke: range bounds, variability, and same-seed determinism
- full MiniMax-M2.5 and Kimi-K2.5, 1k/1k and 8k/1k, fixed/random concurrency sweeps against the packaged oracle NPZ files
- checksum verification of all four downloaded reproduction packages and their internal artifacts

Focused pytest execution is pending CI because this local macOS environment does not have `nats-server`; the replay test module's global fixture starts NATS even for in-process offline tests.
