### PR TITLE
fix(gms): keep V1 loader sidecar alive

### DIFF
--- a/lib/gpu_memory_service/tests/test_snapshot_loader.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_loader.py
@@ -16,6 +16,7 @@ from _fake_vmm import FakeVMM
 
 try:
     from gpu_memory_service.cli.snapshot import loader
+    from gpu_memory_service.v1.snapshot import loader as v1_loader
 except ModuleNotFoundError:
     pytest.skip(
         "gpu_memory_service package is not available in this test image",
@@ -114,3 +115,30 @@ def test_load_device_sets_cuda_context_before_storage_client(monkeypatch):
             "clear_existing": True,
         },
     )
+
+
+def test_v1_cli_keeps_alive_after_loading_weights(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(v1_loader, "init_vmm", lambda _device_type: None)
+    monkeypatch.setattr(v1_loader, "get_socket_path", lambda *_args: "/gms.sock")
+    monkeypatch.setattr(
+        v1_loader,
+        "load_weights",
+        lambda *_args, **_kwargs: calls.append("load"),
+    )
+
+    def stop_keepalive(_seconds):
+        calls.append("keepalive")
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(v1_loader.time, "sleep", stop_keepalive)
+
+    with pytest.raises(KeyboardInterrupt):
+        v1_loader.main(
+            [
+                "--checkpoint-dir",
+                str(tmp_path),
+            ]
+        )
+
+    assert calls == ["load", "keepalive"]

--- a/lib/gpu_memory_service/v1/snapshot/loader.py
+++ b/lib/gpu_memory_service/v1/snapshot/loader.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""GMS V1 one-shot exact-allocation weight loader CLI."""
+"""GMS V1 exact-allocation weight loader sidecar CLI."""
 
 from __future__ import annotations
 
 import logging
 import os
+import time
 
 from gpu_memory_service.cli.snapshot.loader import _build_parser as _build_v0_parser
 from gpu_memory_service.common.vmm import VMMDeviceType, init_vmm
@@ -84,7 +85,9 @@ def main(argv: list[str] | None = None) -> None:
         sharded_ssd_queues_per_root=args.sharded_ssd_queues_per_root,
         posix_backend_params=posix_backend_params,
     )
-    logger.info("GMS V1 loader complete; exiting")
+    logger.info("GMS V1 loader complete; waiting for termination")
+    while True:
+        time.sleep(3600)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- keep the GMS V1 snapshot loader process alive after one successful weight load and commit, matching the existing V0 sidecar lifecycle
- prevent Kubernetes from restarting a completed loader and admitting a second RW session after the restored worker acquires RO
- keep `load_weights()` one-shot for direct Python callers
- add a focused CLI test that verifies loading completes before the keepalive begins

This intentionally does not reuse the Snapshot `restore-complete` sentinel: native restore readiness and GMS loader process lifetime are separate contracts.

## Validation

- `.venv/bin/python -m pytest -q lib/gpu_memory_service/tests/test_snapshot_loader.py` — 7 passed
- `.venv/bin/python -m ruff format --check lib/gpu_memory_service/v1/snapshot/loader.py lib/gpu_memory_service/tests/test_snapshot_loader.py` — passed
- `.venv/bin/python -m ruff check lib/gpu_memory_service/v1/snapshot/loader.py lib/gpu_memory_service/tests/test_snapshot_loader.py` — passed
- `.venv/bin/python -m compileall -q lib/gpu_memory_service/v1/snapshot/loader.py lib/gpu_memory_service/tests/test_snapshot_loader.py` — passed
- `git diff --check` — passed

## Related issues

None.

## Reviewer guide

Start with `lib/gpu_memory_service/v1/snapshot/loader.py`; the test only guards the load-before-keepalive ordering.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the V1 snapshot loader’s runtime behavior by keeping the loader active after weights are loaded.
  * Added confirmation logging when loading completes.
* **Tests**
  * Added coverage verifying that the V1 command loads weights successfully and remains available until interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->