### PR TITLE
fix(snapshot): preserve restore sentinel for independent readers

### DIFF
--- a/components/src/dynamo/common/snapshot/lifecycle.py
+++ b/components/src/dynamo/common/snapshot/lifecycle.py
@@ -90,10 +90,11 @@ class SnapshotConfig:
             await asyncio.sleep(SENTINEL_POLL_INTERVAL_SEC)
 
     def _cleanup_ready_and_sentinels(self) -> None:
+        # Keep restore-complete for the kubelet startup probe; the snapshot agent
+        # removes it before restoring the next container incarnation.
         for name in (
             READY_FOR_SNAPSHOT_FILE,
             SNAPSHOT_COMPLETE_FILE,
-            RESTORE_COMPLETE_FILE,
         ):
             path = os.path.join(self.control_dir, name)
             try:

--- a/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
+++ b/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
@@ -52,7 +52,7 @@ async def test_snapshot_lifecycle_resumes_after_restore_sentinel(monkeypatch, tm
         assert await lifecycle is True
         assert controller.resumed is True
         assert not (tmp_path / READY_FOR_SNAPSHOT_FILE).exists()
-        assert not (tmp_path / RESTORE_COMPLETE_FILE).exists()
+        assert (tmp_path / RESTORE_COMPLETE_FILE).read_text(encoding="utf-8") == "done"
     finally:
         if not lifecycle.done():
             lifecycle.cancel()

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -520,12 +520,13 @@ func (w *NodeController) startRestoreForContainer(
 }
 
 // runRestore runs the full restore workflow for one target container:
-//  1. Annotate the pod with restore in_progress
-//  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
-//  3. Write a restore-complete sentinel: the CRIU-restored process resumes
+//  1. Remove any restore-complete sentinel left by an earlier incarnation
+//  2. Annotate the pod with restore in_progress
+//  3. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
+//  4. Write a restore-complete sentinel: the CRIU-restored process resumes
 //     inside the polling loop that waits on this file, exits quiescence,
 //     and resumes the engine
-//  4. Annotate the pod with restore completed
+//  5. Annotate the pod with restore completed
 func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID string, checkpointLocation checkpointLocations, restoreAttemptKey string, startedAt time.Time) error {
 	releaseOnExit := true
 	defer func() {
@@ -574,6 +575,14 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return nil
 	}
 
+	placeholderHostPID, _, err := w.runtime.ResolveContainer(restoreCtx, containerID)
+	if err != nil {
+		return fmt.Errorf("resolve restore standby container: %w", err)
+	}
+	if err := snapshotruntime.RemoveControlSentinel(placeholderHostPID, snapshotprotocol.RestoreCompleteFile); err != nil {
+		return fmt.Errorf("remove stale restore-complete sentinel: %w", err)
+	}
+
 	if err := setRestoreStatus(snapshotprotocol.RestoreStatusInProgress); err != nil {
 		return fmt.Errorf("failed to annotate pod with restore in_progress: %w", err)
 	}
@@ -591,7 +600,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		ContainerName:               containerName,
 		Clientset:                   w.clientset,
 	}
-	placeholderHostPID, err := executor.Restore(restoreCtx, w.runtime, log, req, w.injector)
+	placeholderHostPID, err = executor.Restore(restoreCtx, w.runtime, log, req, w.injector)
 	if err != nil {
 		log.Error(err, "External restore failed")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())

--- a/deploy/snapshot/internal/runtime/control.go
+++ b/deploy/snapshot/internal/runtime/control.go
@@ -32,6 +32,19 @@ func WriteControlSentinel(hostPID int, name string) error {
 	return writeSentinelInDir(dir, name)
 }
 
+// RemoveControlSentinel removes a sentinel from the workload container's
+// snapshot-control volume. A missing sentinel is already removed.
+func RemoveControlSentinel(hostPID int, name string) error {
+	if hostPID <= 0 {
+		return fmt.Errorf("invalid host PID %d for control sentinel %q", hostPID, name)
+	}
+	path := filepath.Join(HostProcPath, strconv.Itoa(hostPID), "root", snapshotprotocol.SnapshotControlMountPath, name)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove control sentinel %s: %w", path, err)
+	}
+	return nil
+}
+
 func writeSentinelInDir(dir, name string) error {
 	tmpPath := filepath.Join(dir, "."+name+".tmp")
 	finalPath := filepath.Join(dir, name)


### PR DESCRIPTION
## Summary

- keep `restore-complete` after the restored workload observes it so the independent kubelet startup probe can observe the same marker
- continue removing the capture-only `ready-for-snapshot` and `snapshot-complete` sentinels
- rely on the snapshot agent cleanup in #12704 to remove retained completion before restoring the next container incarnation

The restored workload and kubelet startup probe are independent readers. The workload must not consume completion before kubelet observes it, while the snapshot agent remains the owner that invalidates stale completion before a later re-restore.

## Stack dependency

Stacked on #12704, which adds the agent-side stale-marker cleanup. Created and linked with `gh stack` as stack #13296.

## Validation

- `PYTHONPATH=$PWD/components/src ../.test-venv/bin/python -m pytest -xvv components/src/dynamo/common/tests/test_snapshot_lifecycle.py` — 2 passed
- `pre-commit run --files components/src/dynamo/common/snapshot/lifecycle.py components/src/dynamo/common/tests/test_snapshot_lifecycle.py` — passed
- `git diff --check` — passed

## Related issues

None.

## Reviewer guide

Start with `components/src/dynamo/common/snapshot/lifecycle.py`; the existing lifecycle test only changes its marker-lifetime expectation.
