### PR TITLE
fix(request-trace): await final gzip flush on sink shutdown

### DIFF
--- a/lib/llm/src/recorder.rs
+++ b/lib/llm/src/recorder.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -26,7 +27,9 @@ where
 #[derive(Debug, Clone)]
 pub struct RecorderOptions {
     pub max_lines_per_file: Option<usize>,
+    /// Stop admission at this count, then drain events already accepted.
     pub max_count: Option<usize>,
+    /// Stop admission at this time, then drain events already accepted.
     pub max_time: Option<f64>,
     pub buffer_bytes: usize,
     pub flush_interval: Option<Duration>,
@@ -49,16 +52,17 @@ impl Default for RecorderOptions {
 /// A generic recorder for events that streams directly to a JSONL file
 #[derive(Debug)]
 pub struct Recorder<T> {
-    /// A sender for events that can be cloned and shared with producers
+    /// Closing the receiver rejects this sender and all producer clones.
     event_tx: mpsc::Sender<T>,
     /// A cancellation token for managing shutdown
     cancel: CancellationToken,
+    /// Prevents abrupt cancellation from interrupting a graceful drain.
+    closing: CancellationToken,
     /// Counter for the number of events written
     event_count: Arc<Mutex<usize>>,
     /// Time when the first event was received
     first_event_time: Arc<Mutex<Option<Instant>>>,
-    /// Handle to the writer task, so shutdown can await the final drain + flush.
-    task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    writer_task: Option<tokio::task::JoinHandle<io::Result<()>>>,
 }
 
 impl<T> Recorder<T>
@@ -73,9 +77,9 @@ where
     /// * `output_path` - Path to the JSONL file to write events to
     /// * `max_lines_per_file` - Maximum number of lines per file before rotating to a new file.
     ///   If None, no rotation will occur.
-    /// * `max_count` - Maximum number of events to record before shutting down.
-    ///   If None, no limit will be applied.
-    /// * `max_time` - Maximum duration in seconds to record before shutting down.
+    /// * `max_count` - Event count at which to stop admission and drain the accepted backlog.
+    ///   If None, no count limit will be applied.
+    /// * `max_time` - Duration in seconds before stopping admission and draining the backlog.
     ///   If None, no time limit will be applied.
     ///
     /// ### Returns
@@ -110,6 +114,8 @@ where
         let event_count = Arc::new(Mutex::new(0));
         let event_count_clone = event_count.clone();
         let cancel_clone = token.clone();
+        let closing = CancellationToken::new();
+        let closing_clone = closing.clone();
         let start_time = Instant::now();
         let first_event_time = Arc::new(Mutex::new(None));
         let first_event_time_clone = first_event_time.clone();
@@ -133,7 +139,7 @@ where
         let file_path = output_path.as_ref().to_path_buf();
 
         // Spawn a task to receive events and write them to the file
-        let task = tokio::spawn(async move {
+        let writer_task = tokio::spawn(async move {
             let start_time = start_time;
             let mut writer = BufWriter::with_capacity(options.buffer_bytes.max(1), file);
             let mut line_count = 0;
@@ -146,72 +152,56 @@ where
                 tokio::time::interval(flush_interval.unwrap_or(Duration::from_secs(1)));
             flush_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-            // Set up max time deadline if specified
-            let max_time_deadline = options.max_time.map(|secs| {
-                let duration = Duration::from_secs_f64(secs);
-                start_time + duration
-            });
+            let max_time_deadline = options
+                .max_time
+                .map(|secs| tokio::time::Instant::now() + Duration::from_secs_f64(secs));
+            let mut draining = false;
 
             loop {
-                // Check time limit if set
-                if let Some(deadline) = max_time_deadline
-                    && Instant::now() >= deadline
-                {
-                    tracing::info!("Recorder reached max time limit, shutting down");
-                    // Flush and cancel
-                    if let Err(e) = writer.flush().await {
-                        tracing::error!("Failed to flush on time limit shutdown: {}", e);
-                    }
-                    cancel_clone.cancel();
-                    return;
-                }
-
                 tokio::select! {
                     biased;
 
-                    _ = cancel_clone.cancelled() => {
-                        // Drain records still queued in the channel so a graceful
-                        // shutdown doesn't truncate them, then flush. Rotation and
-                        // count limits are not enforced on this final drain.
-                        while let Ok(event) = event_rx.try_recv() {
-                            let elapsed_ms = start_time.elapsed().as_millis() as u64;
-                            let entry = RecordEntry {
-                                timestamp: elapsed_ms,
-                                event,
-                            };
-                            match serde_json::to_string(&entry) {
-                                Ok(json) => {
-                                    if let Err(e) = writer.write_all(json.as_bytes()).await {
-                                        tracing::error!("Failed to write event on shutdown: {}", e);
-                                    } else if let Err(e) = writer.write_all(b"\n").await {
-                                        tracing::error!(
-                                            "Failed to write newline on shutdown: {}",
-                                            e
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::error!("Failed to serialize event on shutdown: {}", e);
-                                }
-                            }
-                        }
+                    _ = closing_clone.cancelled(), if !draining => {
+                        event_rx.close();
+                        draining = true;
+                    }
 
-                        // Flush any pending writes before shutting down
-                        if let Err(e) = writer.flush().await {
-                            tracing::error!("Failed to flush on shutdown: {}", e);
+                    _ = cancel_clone.cancelled(), if !draining => {
+                        // Select guards are evaluated once, so close must be checked again here.
+                        event_rx.close();
+                        if closing_clone.is_cancelled() {
+                            draining = true;
+                            continue;
                         }
+                        writer.flush().await?;
+                        return Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "recorder cancelled before graceful shutdown; queued events may be lost",
+                        ));
+                    }
 
-                        tracing::debug!("Recorder task shutting down");
-                        return;
+                    _ = async {
+                        if let Some(deadline) = max_time_deadline {
+                            tokio::time::sleep_until(deadline).await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    }, if !draining => {
+                        event_rx.close();
+                        draining = true;
+                        cancel_clone.cancel();
+                        tracing::info!("Recorder reached max time limit, draining accepted events");
                     }
 
                     _ = flush_tick.tick(), if flush_interval.is_some() => {
-                        if let Err(e) = writer.flush().await {
-                            tracing::error!("Failed to flush on interval: {}", e);
-                        }
+                        writer.flush().await?;
                     }
 
-                    Some(event) = event_rx.recv() => {
+                    event = event_rx.recv() => {
+                        let Some(event) = event else {
+                            return writer.flush().await;
+                        };
+
                         // Update first_event_time if this is the first event
                         {
                             let mut first_time = first_event_time_clone.lock().await;
@@ -228,26 +218,10 @@ where
                             event,
                         };
 
-                        // Serialize to JSON string
-                        let json = match serde_json::to_string(&entry) {
-                            Ok(json) => json,
-                            Err(e) => {
-                                tracing::error!("Failed to serialize event: {}", e);
-                                continue;
-                            }
-                        };
-
-                        // Write JSON line
-                        if let Err(e) = writer.write_all(json.as_bytes()).await {
-                            tracing::error!("Failed to write event: {}", e);
-                            continue;
-                        }
-
-                        // Add a newline
-                        if let Err(e) = writer.write_all(b"\n").await {
-                            tracing::error!("Failed to write newline: {}", e);
-                            continue;
-                        }
+                        let json = serde_json::to_string(&entry)
+                            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                        writer.write_all(json.as_bytes()).await?;
+                        writer.write_all(b"\n").await?;
 
                         // Increment line count
                         line_count += 1;
@@ -256,9 +230,7 @@ where
                         if let Some(max_lines) = options.max_lines_per_file
                             && line_count >= max_lines {
                                 // Flush the current file
-                                if let Err(e) = writer.flush().await {
-                                    tracing::error!("Failed to flush file before rotation: {}", e);
-                                }
+                                writer.flush().await?;
 
                                 // Create new filename with suffix
                                 file_index += 1;
@@ -284,23 +256,19 @@ where
                                 }
                             }
 
-                        // Update event count
                         let mut count = event_count_clone.lock().await;
                         *count += 1;
 
-                        // Check if we've reached the maximum count
                         if let Some(max) = options.max_count
-                            && *count >= max {
-                                tracing::info!("Recorder reached max event count ({}), shutting down", max);
-                                // Flush buffer before shutting down
-                                if let Err(e) = writer.flush().await {
-                                    tracing::error!("Failed to flush on count limit shutdown: {}", e);
-                                }
-                                // Drop the lock before cancelling
-                                drop(count);
-                                cancel_clone.cancel();
-                                return;
-                            }
+                            && *count >= max
+                            && !draining
+                        {
+                            event_rx.close();
+                            draining = true;
+                            drop(count);
+                            cancel_clone.cancel();
+                            tracing::info!("Recorder reached max event count ({}), draining accepted events", max);
+                        }
                     }
                 }
             }
@@ -309,9 +277,10 @@ where
         Ok(Self {
             event_tx,
             cancel: token,
+            closing,
             event_count,
             first_event_time,
-            task: std::sync::Mutex::new(Some(task)),
+            writer_task: Some(writer_task),
         })
     }
 
@@ -336,20 +305,36 @@ where
         }
     }
 
-    /// Shutdown the recorder
+    /// Cancels the writer after flushing buffered bytes; queued events may be lost.
     pub fn shutdown(&self) {
         self.cancel.cancel();
     }
 
-    /// Cancel recording and await the writer task's final drain + flush, so every
-    /// accepted record is durably written before returning. Idempotent: a second
-    /// call is a no-op once the task has been joined.
-    pub async fn shutdown_and_join(&self) {
-        self.cancel.cancel();
-        let handle = self.task.lock().unwrap().take();
-        if let Some(handle) = handle {
-            let _ = handle.await;
+    /// Stops admission, drains accepted events, and waits for the final flush.
+    ///
+    /// Sender clones may remain alive. Cancelling this future does not detach the
+    /// writer task; another call can await the same drain. A configured limit
+    /// stops admission but does not discard the accepted backlog.
+    ///
+    /// # Errors
+    ///
+    /// Returns writer I/O errors, task panics, or an abrupt cancellation that
+    /// stopped the writer before graceful shutdown took effect.
+    pub async fn shutdown_drain(&mut self) -> anyhow::Result<()> {
+        self.closing.cancel();
+        if let Some(writer_task) = self.writer_task.as_mut() {
+            let result = writer_task.await;
+            self.writer_task.take();
+            result
+                .context("recorder writer task panicked")?
+                .context("recorder writer failed")?;
         }
+        Ok(())
+    }
+
+    /// Drains accepted events, flushes, and consumes the recorder.
+    pub async fn close(mut self) -> anyhow::Result<()> {
+        self.shutdown_drain().await
     }
 
     /// Send events from a JSONL file to the provided event sender
@@ -758,5 +743,235 @@ mod tests {
         );
 
         println!("Load test with file rotation completed successfully");
+    }
+
+    /// Parks the writer inside `Serialize` without timing assumptions.
+    struct BarrierGate {
+        parked_tx: mpsc::UnboundedSender<()>,
+        release_rx: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+    }
+
+    /// Event that can block during serialization.
+    #[derive(Clone, Deserialize)]
+    struct BarrierEvent {
+        id: u64,
+        #[serde(skip)]
+        gate: Option<Arc<BarrierGate>>,
+    }
+
+    impl Serialize for BarrierEvent {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            use serde::ser::SerializeStruct;
+            if let Some(gate) = &self.gate {
+                gate.parked_tx.send(()).expect("test still listening");
+                // Ignore the result: a dropped release sender also releases us.
+                let _ = gate.release_rx.lock().unwrap().recv();
+            }
+            let mut state = serializer.serialize_struct("BarrierEvent", 1)?;
+            state.serialize_field("id", &self.id)?;
+            state.end()
+        }
+    }
+
+    fn recorded_ids(path: &Path) -> Vec<u64> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(|line| {
+                let entry: serde_json::Value = serde_json::from_str(line).unwrap();
+                entry["event"]["id"].as_u64().unwrap()
+            })
+            .collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn close_drains_even_when_cancelled_mid_drain() {
+        const EVENTS: u64 = 32;
+
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("cancel_during_close.jsonl");
+
+        let token = CancellationToken::new();
+        let recorder: Recorder<BarrierEvent> = Recorder::new_with_options(
+            token.clone(),
+            &file_path,
+            RecorderOptions {
+                buffer_bytes: 1024 * 1024,
+                flush_interval: None,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let event_tx = recorder.event_sender();
+
+        let (parked_tx, mut parked_rx) = mpsc::unbounded_channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let gate = Arc::new(BarrierGate {
+            parked_tx,
+            release_rx: std::sync::Mutex::new(release_rx),
+        });
+
+        event_tx
+            .send(BarrierEvent {
+                id: 1,
+                gate: Some(gate),
+            })
+            .await
+            .unwrap();
+        parked_rx.recv().await.expect("writer task parked");
+
+        for id in 2..=EVENTS {
+            event_tx
+                .send(BarrierEvent { id, gate: None })
+                .await
+                .expect("send accepted while the writer is busy");
+        }
+        drop(event_tx);
+
+        // Poll once so close disables abrupt cancellation before the token fires.
+        let mut close_fut = Box::pin(recorder.close());
+        assert!(
+            futures::poll!(close_fut.as_mut()).is_pending(),
+            "close cannot finish while the writer task is parked"
+        );
+
+        token.cancel();
+        release_tx.send(()).expect("writer task waiting on release");
+
+        close_fut
+            .await
+            .expect("close after a mid-drain cancellation");
+
+        assert_eq!(
+            recorded_ids(&file_path),
+            (1..=EVENTS).collect::<Vec<_>>(),
+            "every accepted event must survive a cancellation raised during close"
+        );
+    }
+
+    #[tokio::test]
+    async fn close_reports_a_cancellation_that_preceded_it() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("cancelled_before_close.jsonl");
+
+        let token = CancellationToken::new();
+        let recorder = TestEventRecorder::new(token.clone(), &file_path, None, None, None)
+            .await
+            .unwrap();
+
+        token.cancel();
+        // Let abrupt cancellation commit its terminal outcome before close starts.
+        tokio::time::timeout(Duration::from_secs(5), recorder.event_sender().closed())
+            .await
+            .expect("abrupt cancellation must close admission");
+
+        recorder
+            .close()
+            .await
+            .expect_err("close must not claim success after an earlier cancellation");
+    }
+
+    async fn limit_closes_admission_and_drains_permits(options: RecorderOptions) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("limit.jsonl");
+        let recorder: Recorder<BarrierEvent> =
+            Recorder::new_with_options(CancellationToken::new(), &path, options)
+                .await
+                .unwrap();
+        let sender = recorder.event_sender();
+        let permit = sender.reserve().await.unwrap();
+        sender
+            .send(BarrierEvent { id: 1, gate: None })
+            .await
+            .unwrap();
+
+        // A terminal limit must reject ordinary sends before the final flush.
+        tokio::time::timeout(Duration::from_secs(5), sender.closed())
+            .await
+            .expect("the configured limit must close admission");
+        assert!(
+            sender
+                .send(BarrierEvent { id: 3, gate: None })
+                .await
+                .is_err()
+        );
+        let mut close = Box::pin(recorder.close());
+        assert!(futures::poll!(close.as_mut()).is_pending());
+
+        // A permit issued before close is still an accepted channel reservation.
+        permit.send(BarrierEvent { id: 2, gate: None });
+        close.await.unwrap();
+        assert_eq!(recorded_ids(&path), vec![1, 2]);
+        // The sender deliberately remains alive throughout close.
+        drop(sender);
+    }
+
+    #[tokio::test]
+    async fn max_count_rejects_new_sends_and_drains_accepted_permits() {
+        limit_closes_admission_and_drains_permits(RecorderOptions {
+            max_count: Some(1),
+            ..Default::default()
+        })
+        .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn max_time_rejects_new_sends_and_drains_accepted_permits() {
+        limit_closes_admission_and_drains_permits(RecorderOptions {
+            max_time: Some(1.0),
+            ..Default::default()
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_shutdown_wait_can_be_resumed_with_live_senders() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("resume.jsonl");
+        let mut recorder: Recorder<BarrierEvent> =
+            Recorder::new_with_options(CancellationToken::new(), &path, RecorderOptions::default())
+                .await
+                .unwrap();
+        let sender = recorder.event_sender();
+        let permit = sender.reserve().await.unwrap();
+        {
+            let mut shutdown = Box::pin(recorder.shutdown_drain());
+            assert!(futures::poll!(shutdown.as_mut()).is_pending());
+            tokio::time::timeout(Duration::from_secs(5), sender.closed())
+                .await
+                .expect("graceful shutdown must close admission");
+        }
+        let mut shutdown = Box::pin(recorder.shutdown_drain());
+        assert!(futures::poll!(shutdown.as_mut()).is_pending());
+        permit.send(BarrierEvent { id: 1, gate: None });
+        shutdown.await.unwrap();
+        assert!(recorder.event_sender().is_closed());
+        assert_eq!(recorded_ids(&path), vec![1]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn close_propagates_final_flush_failure() {
+        let recorder: Recorder<BarrierEvent> = Recorder::new_with_options(
+            CancellationToken::new(),
+            "/dev/full",
+            RecorderOptions {
+                buffer_bytes: 1024 * 1024,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        recorder
+            .event_sender()
+            .send(BarrierEvent { id: 1, gate: None })
+            .await
+            .unwrap();
+        let error = recorder.close().await.unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<io::Error>().unwrap().raw_os_error(),
+            Some(28)
+        );
     }
 }

--- a/lib/llm/src/recorder.rs
+++ b/lib/llm/src/recorder.rs
@@ -57,6 +57,8 @@ pub struct Recorder<T> {
     event_count: Arc<Mutex<usize>>,
     /// Time when the first event was received
     first_event_time: Arc<Mutex<Option<Instant>>>,
+    /// Handle to the writer task, so shutdown can await the final drain + flush.
+    task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl<T> Recorder<T>
@@ -131,7 +133,7 @@ where
         let file_path = output_path.as_ref().to_path_buf();
 
         // Spawn a task to receive events and write them to the file
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             let start_time = start_time;
             let mut writer = BufWriter::with_capacity(options.buffer_bytes.max(1), file);
             let mut line_count = 0;
@@ -168,6 +170,32 @@ where
                     biased;
 
                     _ = cancel_clone.cancelled() => {
+                        // Drain records still queued in the channel so a graceful
+                        // shutdown doesn't truncate them, then flush. Rotation and
+                        // count limits are not enforced on this final drain.
+                        while let Ok(event) = event_rx.try_recv() {
+                            let elapsed_ms = start_time.elapsed().as_millis() as u64;
+                            let entry = RecordEntry {
+                                timestamp: elapsed_ms,
+                                event,
+                            };
+                            match serde_json::to_string(&entry) {
+                                Ok(json) => {
+                                    if let Err(e) = writer.write_all(json.as_bytes()).await {
+                                        tracing::error!("Failed to write event on shutdown: {}", e);
+                                    } else if let Err(e) = writer.write_all(b"\n").await {
+                                        tracing::error!(
+                                            "Failed to write newline on shutdown: {}",
+                                            e
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to serialize event on shutdown: {}", e);
+                                }
+                            }
+                        }
+
                         // Flush any pending writes before shutting down
                         if let Err(e) = writer.flush().await {
                             tracing::error!("Failed to flush on shutdown: {}", e);
@@ -283,6 +311,7 @@ where
             cancel: token,
             event_count,
             first_event_time,
+            task: std::sync::Mutex::new(Some(task)),
         })
     }
 
@@ -310,6 +339,17 @@ where
     /// Shutdown the recorder
     pub fn shutdown(&self) {
         self.cancel.cancel();
+    }
+
+    /// Cancel recording and await the writer task's final drain + flush, so every
+    /// accepted record is durably written before returning. Idempotent: a second
+    /// call is a no-op once the task has been joined.
+    pub async fn shutdown_and_join(&self) {
+        self.cancel.cancel();
+        let handle = self.task.lock().unwrap().take();
+        if let Some(handle) = handle {
+            let _ = handle.await;
+        }
     }
 
     /// Send events from a JSONL file to the provided event sender

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -139,9 +139,7 @@ impl RequestTraceSink for JsonlRequestTraceSink {
 }
 
 pub struct JsonlGzipRequestTraceSink {
-    /// `JsonlGzipWriter::close` consumes the writer, but the sink only ever has
-    /// `&self`, so the writer lives behind interior mutability and `shutdown`
-    /// takes it out to close it. `None` means shutdown already closed it.
+    // shutdown consumes the writer; None means it has already closed.
     writer: Mutex<Option<JsonlGzipWriter<RequestTraceRecord>>>,
 }
 
@@ -195,8 +193,7 @@ impl RequestTraceSink for JsonlGzipRequestTraceSink {
     }
 
     async fn shutdown(&self) {
-        // Take the writer out under a short-lived guard so `close`, which awaits
-        // the writer task's final flush, does not run while holding the lock.
+        // Release the lock before awaiting the final flush.
         let writer = self.writer.lock().await.take();
         if let Some(writer) = writer
             && let Err(error) = writer.close().await
@@ -437,9 +434,6 @@ mod tests {
     async fn gzip_sink_shutdown_flushes_buffered_record() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("request_trace_shutdown");
-        // Nothing but shutdown can flush this record: the buffer dwarfs one
-        // record, the flush tick is a minute away, and neither roll threshold
-        // can trigger.
         let sink = JsonlGzipRequestTraceSink::new(
             path.display().to_string(),
             JsonlGzipSinkOptions {
@@ -456,7 +450,6 @@ mod tests {
         sink.emit(&sample_record()).await;
 
         RequestTraceSink::shutdown(&sink).await;
-        // A second shutdown must return normally rather than panic.
         RequestTraceSink::shutdown(&sink).await;
 
         let segment = segment_path(&path, 0);

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -13,7 +13,7 @@ use async_nats::jetstream;
 use async_trait::async_trait;
 use dynamo_runtime::config::environment_names::llm::request_trace as env_request_trace;
 use dynamo_runtime::transports::nats;
-use tokio::sync::broadcast;
+use tokio::sync::{Mutex, broadcast};
 use tokio_util::sync::CancellationToken;
 
 use crate::telemetry::jsonl::{JsonlSinkOptions, JsonlWriter};
@@ -139,7 +139,10 @@ impl RequestTraceSink for JsonlRequestTraceSink {
 }
 
 pub struct JsonlGzipRequestTraceSink {
-    writer: JsonlGzipWriter<RequestTraceRecord>,
+    /// `JsonlGzipWriter::close` consumes the writer, but the sink only ever has
+    /// `&self`, so the writer lives behind interior mutability and `shutdown`
+    /// takes it out to close it. `None` means shutdown already closed it.
+    writer: Mutex<Option<JsonlGzipWriter<RequestTraceRecord>>>,
 }
 
 impl JsonlGzipRequestTraceSink {
@@ -147,7 +150,9 @@ impl JsonlGzipRequestTraceSink {
         let writer = JsonlGzipWriter::new(path.clone(), options)
             .await
             .with_context(|| format!("opening gzip jsonl request trace sink at {path}"))?;
-        Ok(Self { writer })
+        Ok(Self {
+            writer: Mutex::new(Some(writer)),
+        })
     }
 
     async fn from_policy(policy: &RequestTracePolicy) -> anyhow::Result<Self> {
@@ -179,8 +184,28 @@ impl RequestTraceSink for JsonlGzipRequestTraceSink {
     }
 
     async fn emit(&self, record: &RequestTraceRecord) {
-        if self.writer.send(record.clone()).await.is_err() {
+        let writer = self.writer.lock().await;
+        let accepted = match writer.as_ref() {
+            Some(writer) => writer.send(record.clone()).await.is_ok(),
+            None => false,
+        };
+        if !accepted {
             tracing::warn!("request trace file sink closed; dropping record");
+        }
+    }
+
+    async fn shutdown(&self) {
+        // Take the writer out under a short-lived guard so `close`, which awaits
+        // the writer task's final flush, does not run while holding the lock.
+        let writer = self.writer.lock().await.take();
+        if let Some(writer) = writer
+            && let Err(error) = writer.close().await
+        {
+            tracing::warn!(
+                target: "dynamo_llm::request_trace",
+                error = %error,
+                "request trace file sink: gzip writer close failed during shutdown"
+            );
         }
     }
 }
@@ -406,5 +431,45 @@ mod tests {
             }
             assert!(content.contains("\"request_id\":\"req-123\""));
         }
+    }
+
+    #[tokio::test]
+    async fn gzip_sink_shutdown_flushes_buffered_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("request_trace_shutdown");
+        // Nothing but shutdown can flush this record: the buffer dwarfs one
+        // record, the flush tick is a minute away, and neither roll threshold
+        // can trigger.
+        let sink = JsonlGzipRequestTraceSink::new(
+            path.display().to_string(),
+            JsonlGzipSinkOptions {
+                buffer_bytes: 1024 * 1024,
+                flush_interval: Duration::from_secs(60),
+                roll_uncompressed_bytes: 1024 * 1024,
+                roll_lines: None,
+                max_segments: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        sink.emit(&sample_record()).await;
+
+        RequestTraceSink::shutdown(&sink).await;
+        // A second shutdown must return normally rather than panic.
+        RequestTraceSink::shutdown(&sink).await;
+
+        let segment = segment_path(&path, 0);
+        assert!(
+            segment.exists(),
+            "shutdown returned without flushing the gzip segment at {}",
+            segment.display()
+        );
+        let bytes = std::fs::read(&segment).unwrap();
+        let mut content = String::new();
+        MultiGzDecoder::new(bytes.as_slice())
+            .read_to_string(&mut content)
+            .unwrap();
+        assert!(content.contains("\"request_id\":\"req-123\""));
     }
 }

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -465,4 +465,43 @@ mod tests {
             .unwrap();
         assert!(content.contains("\"request_id\":\"req-123\""));
     }
+
+    #[tokio::test]
+    async fn gzip_sink_emit_after_shutdown_drops_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("request_trace_after_shutdown");
+        let sink = JsonlGzipRequestTraceSink::new(
+            path.display().to_string(),
+            JsonlGzipSinkOptions {
+                buffer_bytes: 1024 * 1024,
+                flush_interval: Duration::from_secs(60),
+                roll_uncompressed_bytes: 1024 * 1024,
+                roll_lines: None,
+                max_segments: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // After shutdown the writer is gone, so emit() must hit the closed-writer
+        // branch: the record is dropped (with a warning) rather than written, and
+        // nothing panics.
+        RequestTraceSink::shutdown(&sink).await;
+        sink.emit(&sample_record()).await;
+
+        let segment = segment_path(&path, 0);
+        let written = if segment.exists() {
+            let bytes = std::fs::read(&segment).unwrap();
+            let mut content = String::new();
+            let _ = MultiGzDecoder::new(bytes.as_slice()).read_to_string(&mut content);
+            content.contains("\"request_id\":\"req-123\"")
+        } else {
+            false
+        };
+        assert!(
+            !written,
+            "record emitted after shutdown must be dropped, not written to {}",
+            segment.display()
+        );
+    }
 }

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -13,7 +13,7 @@ use async_nats::jetstream;
 use async_trait::async_trait;
 use dynamo_runtime::config::environment_names::llm::request_trace as env_request_trace;
 use dynamo_runtime::transports::nats;
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::telemetry::jsonl::{JsonlSinkOptions, JsonlWriter};
@@ -139,6 +139,9 @@ impl RequestTraceSink for JsonlRequestTraceSink {
 }
 
 pub struct JsonlGzipRequestTraceSink {
+    // Cloned input channel used by emit, so concurrent emits never contend on the
+    // writer lock. Sending fails once the writer task exits, dropping late records.
+    sender: mpsc::Sender<RequestTraceRecord>,
     // shutdown consumes the writer; None means it has already closed.
     writer: Mutex<Option<JsonlGzipWriter<RequestTraceRecord>>>,
 }
@@ -148,7 +151,12 @@ impl JsonlGzipRequestTraceSink {
         let writer = JsonlGzipWriter::new(path.clone(), options)
             .await
             .with_context(|| format!("opening gzip jsonl request trace sink at {path}"))?;
+        // A freshly constructed writer always has its sender, so this is Some.
+        let sender = writer
+            .sender()
+            .expect("newly constructed JsonlGzipWriter always has a sender");
         Ok(Self {
+            sender,
             writer: Mutex::new(Some(writer)),
         })
     }
@@ -182,12 +190,9 @@ impl RequestTraceSink for JsonlGzipRequestTraceSink {
     }
 
     async fn emit(&self, record: &RequestTraceRecord) {
-        let writer = self.writer.lock().await;
-        let accepted = match writer.as_ref() {
-            Some(writer) => writer.send(record.clone()).await.is_ok(),
-            None => false,
-        };
-        if !accepted {
+        // Lock-free: send straight to the writer task's channel. After shutdown the
+        // receiver is gone, so this errors and the record is dropped.
+        if self.sender.send(record.clone()).await.is_err() {
             tracing::warn!("request trace file sink closed; dropping record");
         }
     }

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -95,7 +95,8 @@ impl RequestTraceSink for NatsRequestTraceSink {
 }
 
 pub struct JsonlRequestTraceSink {
-    writer: JsonlWriter<RequestTraceRecord>,
+    /// `None` once the sink has been shut down; further records are dropped.
+    writer: tokio::sync::Mutex<Option<JsonlWriter<RequestTraceRecord>>>,
 }
 
 impl JsonlRequestTraceSink {
@@ -103,7 +104,9 @@ impl JsonlRequestTraceSink {
         let writer = JsonlWriter::new(path.clone(), options)
             .await
             .with_context(|| format!("opening jsonl request trace sink at {path}"))?;
-        Ok(Self { writer })
+        Ok(Self {
+            writer: tokio::sync::Mutex::new(Some(writer)),
+        })
     }
 
     async fn from_policy(policy: &RequestTracePolicy) -> anyhow::Result<Self> {
@@ -132,21 +135,32 @@ impl RequestTraceSink for JsonlRequestTraceSink {
     }
 
     async fn emit(&self, record: &RequestTraceRecord) {
-        if self.writer.send(record.clone()).await.is_err() {
-            tracing::warn!("request trace file sink closed; dropping record");
+        let guard = self.writer.lock().await;
+        match guard.as_ref() {
+            Some(writer) => {
+                if writer.send(record.clone()).await.is_err() {
+                    tracing::warn!("request trace file writer channel closed; dropping record");
+                }
+            }
+            None => tracing::warn!("request trace file sink shut down; dropping record"),
         }
     }
 
     async fn shutdown(&self) {
-        // Drain and flush the buffered writer so a graceful shutdown doesn't
-        // truncate the final records.
-        self.writer.shutdown().await;
+        // Serialize callers until the drain finishes, including concurrent shutdowns.
+        let mut guard = self.writer.lock().await;
+        if let Some(writer) = guard.as_mut() {
+            if let Err(error) = writer.shutdown().await {
+                tracing::warn!(%error, "request trace file sink shutdown failed");
+            }
+            guard.take();
+        }
     }
 }
 
 pub struct JsonlGzipRequestTraceSink {
     // Cloned input channel used by emit, so concurrent emits never contend on the
-    // writer lock. Sending fails once the writer task exits, dropping late records.
+    // writer lock. Sending fails once the writer closes admission for shutdown.
     sender: mpsc::Sender<RequestTraceRecord>,
     // shutdown consumes the writer; None means it has already closed.
     writer: Mutex<Option<JsonlGzipWriter<RequestTraceRecord>>>,
@@ -204,10 +218,11 @@ impl RequestTraceSink for JsonlGzipRequestTraceSink {
     }
 
     async fn shutdown(&self) {
-        // Release the lock before awaiting the final flush.
-        let writer = self.writer.lock().await.take();
-        if let Some(writer) = writer
-            && let Err(error) = writer.close().await
+        // Serialize shutdown callers until the final flush completes. Keep the
+        // writer available if this caller is cancelled while awaiting it.
+        let mut writer = self.writer.lock().await;
+        if let Some(writer) = writer.as_mut()
+            && let Err(error) = writer.shutdown().await
         {
             tracing::warn!(
                 target: "dynamo_llm::request_trace",
@@ -215,6 +230,7 @@ impl RequestTraceSink for JsonlGzipRequestTraceSink {
                 "request trace file sink: gzip writer close failed during shutdown"
             );
         }
+        writer.take();
     }
 }
 
@@ -470,6 +486,42 @@ mod tests {
             segment.display()
         );
         let bytes = std::fs::read(&segment).unwrap();
+        let mut content = String::new();
+        MultiGzDecoder::new(bytes.as_slice())
+            .read_to_string(&mut content)
+            .unwrap();
+        assert!(content.contains("\"request_id\":\"req-123\""));
+    }
+
+    #[tokio::test]
+    async fn gzip_sink_concurrent_shutdown_waits_for_reserved_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("request_trace_concurrent_shutdown");
+        let sink = JsonlGzipRequestTraceSink::new(
+            path.display().to_string(),
+            JsonlGzipSinkOptions::default(),
+        )
+        .await
+        .unwrap();
+        let permit = sink.sender.clone().reserve_owned().await.unwrap();
+        let first = RequestTraceSink::shutdown(&sink);
+        let second = RequestTraceSink::shutdown(&sink);
+        tokio::pin!(first, second);
+        tokio::select! {
+            _ = &mut first => panic!("shutdown abandoned an outstanding permit"),
+            _ = tokio::time::timeout(Duration::from_secs(5), sink.sender.closed()) => {
+                assert!(sink.sender.is_closed(), "shutdown must close admission");
+            }
+        }
+        assert!(futures::poll!(&mut second).is_pending());
+        permit.send(sample_record());
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(first, second);
+        })
+        .await
+        .unwrap();
+
+        let bytes = std::fs::read(segment_path(&path, 0)).unwrap();
         let mut content = String::new();
         MultiGzDecoder::new(bytes.as_slice())
             .read_to_string(&mut content)

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -136,6 +136,12 @@ impl RequestTraceSink for JsonlRequestTraceSink {
             tracing::warn!("request trace file sink closed; dropping record");
         }
     }
+
+    async fn shutdown(&self) {
+        // Drain and flush the buffered writer so a graceful shutdown doesn't
+        // truncate the final records.
+        self.writer.shutdown().await;
+    }
 }
 
 pub struct JsonlGzipRequestTraceSink {
@@ -507,6 +513,31 @@ mod tests {
             !written,
             "record emitted after shutdown must be dropped, not written to {}",
             segment.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn jsonl_sink_shutdown_flushes_buffered_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("request_trace_jsonl_shutdown.jsonl");
+        let sink = JsonlRequestTraceSink::new(
+            path.display().to_string(),
+            JsonlSinkOptions {
+                // Large buffer + long interval: nothing reaches disk until shutdown.
+                buffer_bytes: 1024 * 1024,
+                flush_interval: Duration::from_secs(60),
+            },
+        )
+        .await
+        .unwrap();
+
+        sink.emit(&sample_record()).await;
+        RequestTraceSink::shutdown(&sink).await;
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("\"request_id\":\"req-123\""),
+            "shutdown must flush the buffered record; file was: {content:?}"
         );
     }
 }

--- a/lib/llm/src/telemetry/jsonl.rs
+++ b/lib/llm/src/telemetry/jsonl.rs
@@ -25,13 +25,12 @@ impl Default for JsonlSinkOptions {
     }
 }
 
-/// Channel-backed handle for a buffered JSONL sink. Wraps a `Recorder<T>`,
-/// which appends records to disk on its own background task. Drop cancels
-/// the recorder.
+/// Channel-backed buffered JSONL sink.
+///
+/// Drop may abandon queued records; use [`Self::shutdown`] to drain them.
 pub struct JsonlWriter<T> {
-    tx: mpsc::Sender<T>,
-    // Holding the recorder keeps its background task alive; its Drop cancels.
-    recorder: Recorder<T>,
+    tx: Option<mpsc::Sender<T>>,
+    recorder: Option<Recorder<T>>,
 }
 
 impl<T> JsonlWriter<T>
@@ -53,25 +52,44 @@ where
         .await
         .with_context(|| format!("opening jsonl sink at {path}"))?;
         let tx = recorder.event_sender();
-        Ok(Self { tx, recorder })
+        Ok(Self {
+            tx: Some(tx),
+            recorder: Some(recorder),
+        })
     }
 
     pub async fn send(&self, rec: T) -> Result<(), mpsc::error::SendError<T>> {
-        self.tx.send(rec).await
+        match &self.tx {
+            Some(tx) => tx.send(rec).await,
+            None => Err(mpsc::error::SendError(rec)),
+        }
     }
 
-    /// Flush and finalize the sink: awaits the writer task's final drain + flush
-    /// so buffered records are durably written. Sends after this are dropped.
-    pub async fn shutdown(&self) {
-        self.recorder.shutdown_and_join().await;
+    /// Stops accepting records, drains the queue, and flushes. Calls are idempotent.
+    /// The writer remains closed if draining fails; subsequent sends fail.
+    pub async fn shutdown(&mut self) -> anyhow::Result<()> {
+        self.tx.take();
+        if let Some(recorder) = self.recorder.as_mut() {
+            let result = recorder.shutdown_drain().await;
+            self.recorder.take();
+            result?;
+        }
+        Ok(())
+    }
+
+    /// Drains and consumes the writer.
+    pub async fn close(mut self) -> anyhow::Result<()> {
+        self.shutdown().await
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
-    use serde::{Deserialize, Serialize};
+    use serde::ser::SerializeStruct;
+    use serde::{Deserialize, Serialize, Serializer};
     use tempfile::tempdir;
 
     use super::{JsonlSinkOptions, JsonlWriter};
@@ -80,6 +98,33 @@ mod tests {
     struct TestRecord {
         id: u64,
         name: String,
+    }
+
+    /// Parks the recorder inside `Serialize` without timing assumptions.
+    struct BarrierGate {
+        parked_tx: tokio::sync::mpsc::UnboundedSender<()>,
+        release_rx: Mutex<std::sync::mpsc::Receiver<()>>,
+    }
+
+    /// Record that can block during serialization.
+    #[derive(Clone, Deserialize)]
+    struct BarrierRecord {
+        id: u64,
+        #[serde(skip)]
+        gate: Option<Arc<BarrierGate>>,
+    }
+
+    impl Serialize for BarrierRecord {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            if let Some(gate) = &self.gate {
+                gate.parked_tx.send(()).expect("test still listening");
+                // Ignore the result: a dropped release sender also releases us.
+                let _ = gate.release_rx.lock().unwrap().recv();
+            }
+            let mut state = serializer.serialize_struct("BarrierRecord", 1)?;
+            state.serialize_field("id", &self.id)?;
+            state.end()
+        }
     }
 
     #[tokio::test]
@@ -124,5 +169,107 @@ mod tests {
                 name: "record".to_string()
             }
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_drains_records_queued_behind_a_busy_writer() {
+        const RECORDS: u64 = 32;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("barrier.jsonl");
+
+        let writer: JsonlWriter<BarrierRecord> = JsonlWriter::new(
+            path.display().to_string(),
+            JsonlSinkOptions {
+                buffer_bytes: 1024 * 1024,
+                flush_interval: Duration::from_secs(60),
+            },
+        )
+        .await
+        .unwrap();
+
+        let (parked_tx, mut parked_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let gate = Arc::new(BarrierGate {
+            parked_tx,
+            release_rx: Mutex::new(release_rx),
+        });
+
+        writer
+            .send(BarrierRecord {
+                id: 1,
+                gate: Some(gate),
+            })
+            .await
+            .unwrap();
+        parked_rx.recv().await.expect("writer task parked");
+
+        for id in 2..=RECORDS {
+            writer
+                .send(BarrierRecord { id, gate: None })
+                .await
+                .expect("send accepted while writer is busy");
+        }
+
+        let shutdown = tokio::spawn(async move { writer.close().await });
+        release_tx.send(()).expect("writer task waiting on release");
+        shutdown.await.unwrap().expect("shutdown");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let ids: Vec<u64> = content
+            .lines()
+            .map(|line| {
+                let wrapper: serde_json::Value = serde_json::from_str(line).unwrap();
+                wrapper["event"]["id"].as_u64().unwrap()
+            })
+            .collect();
+        assert_eq!(
+            ids,
+            (1..=RECORDS).collect::<Vec<_>>(),
+            "every accepted record must be written exactly once, in order"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_shutdown_retains_the_pending_drain() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("resume.jsonl");
+        let mut writer: JsonlWriter<TestRecord> =
+            JsonlWriter::new(path.display().to_string(), JsonlSinkOptions::default())
+                .await
+                .unwrap();
+        let sender = writer.tx.as_ref().unwrap().clone();
+        let permit = sender.reserve().await.unwrap();
+        {
+            let mut shutdown = Box::pin(writer.shutdown());
+            assert!(futures::poll!(shutdown.as_mut()).is_pending());
+            tokio::time::timeout(Duration::from_secs(5), sender.closed())
+                .await
+                .expect("graceful shutdown must close admission");
+        }
+        assert!(
+            writer
+                .send(TestRecord {
+                    id: 2,
+                    name: "late".into()
+                })
+                .await
+                .is_err()
+        );
+        let mut shutdown = Box::pin(writer.shutdown());
+        assert!(futures::poll!(shutdown.as_mut()).is_pending());
+        permit.send(TestRecord {
+            id: 1,
+            name: "accepted".into(),
+        });
+        shutdown.await.unwrap();
+        writer.shutdown().await.unwrap();
+        let lines = std::fs::read_to_string(path).unwrap();
+        let records: Vec<serde_json::Value> = lines
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["event"]["id"], 1);
     }
 }

--- a/lib/llm/src/telemetry/jsonl.rs
+++ b/lib/llm/src/telemetry/jsonl.rs
@@ -31,7 +31,7 @@ impl Default for JsonlSinkOptions {
 pub struct JsonlWriter<T> {
     tx: mpsc::Sender<T>,
     // Holding the recorder keeps its background task alive; its Drop cancels.
-    _recorder: Recorder<T>,
+    recorder: Recorder<T>,
 }
 
 impl<T> JsonlWriter<T>
@@ -53,14 +53,17 @@ where
         .await
         .with_context(|| format!("opening jsonl sink at {path}"))?;
         let tx = recorder.event_sender();
-        Ok(Self {
-            tx,
-            _recorder: recorder,
-        })
+        Ok(Self { tx, recorder })
     }
 
     pub async fn send(&self, rec: T) -> Result<(), mpsc::error::SendError<T>> {
         self.tx.send(rec).await
+    }
+
+    /// Flush and finalize the sink: awaits the writer task's final drain + flush
+    /// so buffered records are durably written. Sends after this are dropped.
+    pub async fn shutdown(&self) {
+        self.recorder.shutdown_and_join().await;
     }
 }
 

--- a/lib/llm/src/telemetry/jsonl_gz.rs
+++ b/lib/llm/src/telemetry/jsonl_gz.rs
@@ -93,19 +93,23 @@ where
 
     /// A cloned handle to the writer's input channel, for enqueuing records
     /// concurrently without holding a lock on the writer. `None` after shutdown.
-    /// Sending on the clone fails once the writer task exits, so records emitted
-    /// after shutdown are dropped rather than written.
+    /// Sending on the clone fails once the writer closes admission for shutdown.
     pub fn sender(&self) -> Option<mpsc::Sender<T>> {
         self.tx.clone()
     }
 
     /// Drain all accepted records, flush the active segment, and wait for the
-    /// writer task to exit.
+    /// writer task to exit. Cancelling this wait leaves the task available for a
+    /// subsequent call to await.
     pub async fn shutdown(&mut self) -> anyhow::Result<()> {
         self.tx.take();
         self.shutdown.cancel();
-        if let Some(worker) = self.worker.take() {
-            worker.await.context("gzip jsonl writer task panicked")??;
+        if let Some(worker) = self.worker.as_mut() {
+            // Keep the handle until completion so cancellation of this await
+            // does not prevent a subsequent shutdown from joining the worker.
+            let result = worker.await;
+            self.worker.take();
+            result.context("gzip jsonl writer task panicked")??;
         }
         Ok(())
     }
@@ -274,7 +278,10 @@ async fn run_gzip_writer<T: Serialize>(
         tokio::select! {
             biased;
             _ = shutdown.cancelled() => {
-                while let Ok(rec) = rx.try_recv() {
+                rx.close();
+                // Outstanding permits may still publish after close. Waiting
+                // for None includes them while rejecting new sends.
+                while let Some(rec) = rx.recv().await {
                     if let Err(err) = writer.push(&rec).await {
                         tracing::warn!("gzip jsonl sink dropped record during shutdown: {err}");
                         first_error.get_or_insert(err);
@@ -495,6 +502,74 @@ mod tests {
             .read_to_string(&mut content)
             .expect("gzip segment decompresses");
         content
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_reserved_records_after_cancelled_await() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("shutdown_reserved");
+        let mut writer = JsonlGzipWriter::<TestRecord>::new(
+            path.display().to_string(),
+            JsonlGzipSinkOptions {
+                flush_interval: Duration::from_secs(60),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let sender = writer.sender().unwrap();
+        let permit = sender.clone().reserve_owned().await.unwrap();
+        sender
+            .send(TestRecord {
+                id: 1,
+                name: "queued".into(),
+            })
+            .await
+            .unwrap();
+
+        {
+            let shutdown = writer.shutdown();
+            tokio::pin!(shutdown);
+            tokio::select! {
+                result = &mut shutdown => panic!("shutdown abandoned an outstanding permit: {result:?}"),
+                _ = tokio::time::timeout(Duration::from_secs(5), sender.closed()) => {
+                    assert!(sender.is_closed(), "shutdown must close admission");
+                }
+            }
+            assert!(futures::poll!(&mut shutdown).is_pending());
+        }
+        assert!(
+            sender
+                .send(TestRecord {
+                    id: 3,
+                    name: "rejected".into(),
+                })
+                .await
+                .is_err()
+        );
+
+        let shutdown = writer.shutdown();
+        tokio::pin!(shutdown);
+        assert!(futures::poll!(&mut shutdown).is_pending());
+        permit.send(TestRecord {
+            id: 2,
+            name: "reserved".into(),
+        });
+        tokio::time::timeout(Duration::from_secs(5), shutdown)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let content = read_gzip_jsonl(&segment_path(&path, 0));
+        let ids: Vec<u64> = content
+            .lines()
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line).unwrap()["event"]["id"]
+                    .as_u64()
+                    .unwrap()
+            })
+            .collect();
+        assert_eq!(ids, [1, 2]);
     }
 
     #[tokio::test]

--- a/lib/llm/src/telemetry/jsonl_gz.rs
+++ b/lib/llm/src/telemetry/jsonl_gz.rs
@@ -91,6 +91,14 @@ where
         }
     }
 
+    /// A cloned handle to the writer's input channel, for enqueuing records
+    /// concurrently without holding a lock on the writer. `None` after shutdown.
+    /// Sending on the clone fails once the writer task exits, so records emitted
+    /// after shutdown are dropped rather than written.
+    pub fn sender(&self) -> Option<mpsc::Sender<T>> {
+        self.tx.clone()
+    }
+
     /// Drain all accepted records, flush the active segment, and wait for the
     /// writer task to exit.
     pub async fn shutdown(&mut self) -> anyhow::Result<()> {


### PR DESCRIPTION
Request-trace shutdown could return while accepted records remained in the gzip writer channel or buffer. The gzip sink now awaits its writer through the final segment flush. Shutdown closes receiver admission and drains through channel exhaustion, including records submitted through previously acquired permits. A cancelled shutdown wait retains its task handle for a subsequent call, and concurrent shutdown callers wait for the same completion.

The plain JSONL sink uses the shared Recorder/JsonlWriter lifecycle from #13433 and #13415. It closes admission before draining, preserves normal file rotation, propagates writer errors, and retains its recorder across cancelled waits. Regression tests cover outstanding permits, late-send rejection, resumed shutdown, concurrent callers, final flush, and rollover.

The gzip and plain JSONL regressions passed in GitHub Rust CI. The Pre Merge and full PR workflows passed on commit `e53c6e72f7cc`, including complete vLLM and TRTLLM GPU execution after infrastructure retries. Closes #13288.
