### PR TITLE
feat(gms): supervise V1 snapshot helpers

### DIFF
--- a/lib/gpu_memory_service/cli/server.py
+++ b/lib/gpu_memory_service/cli/server.py
@@ -4,9 +4,8 @@
 """GMS server entry point.
 
 Launches one GMS server process per GPU serving every production GMS tag,
-then supervises them: terminates the rest if any child exits, and propagates
-the first non-zero exit code. Runs until SIGTERM (pod termination kills it)
-or until a child exits.
+then supervises them. V1 restore optionally adds one one-shot loader per GPU.
+Device discovery uses NVML without initializing the CUDA driver.
 """
 
 from __future__ import annotations
@@ -17,14 +16,20 @@ import signal
 import subprocess
 import sys
 import time
+from contextlib import closing
 
+from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
+from gpu_memory_service.v1.client.session import _GMSClientSession
+from gpu_memory_service.v1.device import get_socket_path
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+_PROBE_TIMEOUT_SECONDS = 0.5
 
 
 def _child_command(device: int, device_type: str, use_v1: bool = False) -> list[str]:
@@ -38,33 +43,59 @@ def _child_command(device: int, device_type: str, use_v1: bool = False) -> list[
     return command
 
 
+def _probe_v1_restore_ready(devices: list[int]) -> None:
+    for device in devices:
+        with closing(
+            _GMSClientSession(
+                get_socket_path(device, "weights"),
+                RequestedLockType.RO,
+                connect_timeout=_PROBE_TIMEOUT_SECONDS,
+                admission_timeout=_PROBE_TIMEOUT_SECONDS,
+            )
+        ):
+            pass
+
+
 def _terminate_all(processes: list[subprocess.Popen]) -> None:
     for process in processes:
         if process.poll() is None:
             process.terminate()
 
 
-def _supervise(processes: list[subprocess.Popen]) -> int:
-    """Block until any child exits, terminate the rest, and return its exit code."""
-    while processes:
-        for process in processes:
-            exit_code = process.poll()
+def _supervise(
+    servers: list[subprocess.Popen],
+    loaders: list[subprocess.Popen] | None = None,
+) -> int:
+    """Supervise persistent servers and optional one-shot loaders."""
+    pending_loaders = list(loaders or ())
+    while servers:
+        for server in servers:
+            exit_code = server.poll()
             if exit_code is not None:
-                _terminate_all(processes)
-                return exit_code
+                _terminate_all([*servers, *pending_loaders])
+                return exit_code or 1
+
+        for loader in list(pending_loaders):
+            exit_code = loader.poll()
+            if exit_code is not None:
+                if exit_code:
+                    _terminate_all([*servers, *pending_loaders])
+                    return exit_code
+                pending_loaders.remove(loader)
+
         time.sleep(1)
     return 0
 
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
-        description="GPU Memory Service supervisor (one server per (device, tag)).",
+        description="GPU Memory Service supervisor (one server process per device).",
         allow_abbrev=False,
     )
     parser.add_argument(
         "--use-v1",
         action="store_true",
-        help="Launch the CUDA-only V1 server for both rank-local domains.",
+        help="Launch the CUDA-only V1 server for every visible device.",
     )
     parser.add_argument(
         "--device-type",
@@ -73,35 +104,82 @@ def main(argv: list[str] | None = None) -> None:
         choices=[d.value for d in VMMDeviceType],
         help="VMM device type forwarded to server (default: cuda).",
     )
+    parser.add_argument(
+        "--probe-restore-ready",
+        action="store_true",
+        help="Attempt bounded RO admission on every V1 weights socket and exit.",
+    )
+    parser.add_argument(
+        "--restore-loader",
+        nargs=argparse.REMAINDER,
+        metavar="ARG",
+        help=(
+            "Run one V1 loader per device; all following arguments are passed "
+            "directly to the loader."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.use_v1 and args.device_type != VMMDeviceType.CUDA.value:
         parser.error("--use-v1 only supports --device-type=cuda")
+    if args.probe_restore_ready and not args.use_v1:
+        parser.error("--probe-restore-ready requires --use-v1")
+    if args.restore_loader is not None and not args.use_v1:
+        parser.error("--restore-loader requires --use-v1")
+    if args.probe_restore_ready and args.restore_loader is not None:
+        parser.error("--probe-restore-ready cannot start restore loaders")
 
     init_vmm(VMMDeviceType.from_str(args.device_type))
     vmm = get_vmm()
-    vmm.ensure_initialized()
     devices = vmm.list_devices()
-    processes = []
-    for device in devices:
-        proc = subprocess.Popen(
-            _child_command(device, args.device_type, use_v1=args.use_v1)
-        )
-        logger.info(
-            "Started GMS%s device=%d pid=%d",
-            " V1" if args.use_v1 else "",
-            device,
-            proc.pid,
-        )
-        processes.append(proc)
+    if args.probe_restore_ready:
+        _probe_v1_restore_ready(devices)
+        return
+
+    servers: list[subprocess.Popen] = []
+    loaders: list[subprocess.Popen] = []
 
     def terminate(*_args) -> None:
-        _terminate_all(processes)
+        _terminate_all([*servers, *loaders])
         raise SystemExit(0)
 
     signal.signal(signal.SIGTERM, terminate)
     signal.signal(signal.SIGINT, terminate)
 
-    raise SystemExit(_supervise(processes))
+    try:
+        for device in devices:
+            server = subprocess.Popen(
+                _child_command(device, args.device_type, use_v1=args.use_v1)
+            )
+            logger.info(
+                "Started GMS%s device=%d pid=%d",
+                " V1" if args.use_v1 else "",
+                device,
+                server.pid,
+            )
+            servers.append(server)
+
+        if args.restore_loader is not None:
+            for device in devices:
+                loader = subprocess.Popen(
+                    [
+                        sys.executable,
+                        "-m",
+                        "gpu_memory_service.v1.snapshot.loader",
+                        *args.restore_loader,
+                        "--device",
+                        str(device),
+                    ]
+                )
+                logger.info(
+                    "Started GMS V1 loader device=%d pid=%d",
+                    device,
+                    loader.pid,
+                )
+                loaders.append(loader)
+
+        raise SystemExit(_supervise(servers, loaders))
+    finally:
+        _terminate_all([*servers, *loaders])
 
 
 if __name__ == "__main__":

--- a/lib/gpu_memory_service/cli/server.py
+++ b/lib/gpu_memory_service/cli/server.py
@@ -74,7 +74,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--use-v1",
         action="store_true",
-        help="Launch the CUDA-only V1 server for every visible device.",
+        help="Use the CUDA-only V1 profile for servers, loaders, or the restore-ready probe.",
     )
     parser.add_argument(
         "--device-type",
@@ -86,7 +86,10 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--probe-restore-ready",
         action="store_true",
-        help="Attempt bounded RO admission on every weights socket and exit.",
+        help=(
+            "One-shot: try bounded RO admission on every weights socket and "
+            "exit. Does not start servers or loaders."
+        ),
     )
     parser.add_argument(
         "--enable-loader",
@@ -97,11 +100,14 @@ def main(argv: list[str] | None = None) -> None:
             "--checkpoint-dir, go to the loader. Pass --device to load one GPU."
         ),
     )
+    raw = argv if argv is not None else sys.argv[1:]
+    if "--probe-restore-ready" in raw and "--enable-loader" in raw:
+        parser.error(
+            "--probe-restore-ready is one-shot and cannot start servers or loaders"
+        )
     args = parser.parse_args(argv)
     if args.use_v1 and args.device_type != VMMDeviceType.CUDA.value:
         parser.error("--use-v1 only supports --device-type=cuda")
-    if args.probe_restore_ready and args.enable_loader is not None:
-        parser.error("--probe-restore-ready cannot be combined with --enable-loader")
 
     init_vmm(VMMDeviceType.from_str(args.device_type))
     vmm = get_vmm()

--- a/lib/gpu_memory_service/cli/server.py
+++ b/lib/gpu_memory_service/cli/server.py
@@ -18,6 +18,7 @@ import sys
 import time
 from contextlib import closing
 
+from gpu_memory_service.cli.snapshot import start_v1_per_device
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.v1.client.session import _GMSClientSession
@@ -114,9 +115,8 @@ def main(argv: list[str] | None = None) -> None:
         nargs=argparse.REMAINDER,
         metavar="ARG",
         help=(
-            "Run one V1 loader per visible GPU after the servers start. "
-            "Remaining args go to the loader, including --checkpoint-dir. "
-            "Pass --device to load only that GPU."
+            "Start V1 loaders after the servers. Remaining args, including "
+            "--checkpoint-dir, go to the loader. Pass --device to load one GPU."
         ),
     )
     args = parser.parse_args(argv)
@@ -160,41 +160,13 @@ def main(argv: list[str] | None = None) -> None:
             servers.append(server)
 
         if args.enable_loader is not None:
-            named_device = any(
-                argument == "--device" or argument.startswith("--device=")
-                for argument in args.enable_loader
-            )
-            if named_device or any(
-                argument in {"-h", "--help"} for argument in args.enable_loader
-            ):
-                loader = subprocess.Popen(
-                    [
-                        sys.executable,
-                        "-m",
-                        "gpu_memory_service.v1.snapshot.loader",
-                        *args.enable_loader,
-                    ]
+            loaders.extend(
+                start_v1_per_device(
+                    "gpu_memory_service.v1.snapshot.loader",
+                    args.enable_loader,
+                    devices,
                 )
-                logger.info("Started GMS V1 loader pid=%d", loader.pid)
-                loaders.append(loader)
-            else:
-                for device in devices:
-                    loader = subprocess.Popen(
-                        [
-                            sys.executable,
-                            "-m",
-                            "gpu_memory_service.v1.snapshot.loader",
-                            *args.enable_loader,
-                            "--device",
-                            str(device),
-                        ]
-                    )
-                    logger.info(
-                        "Started GMS V1 loader device=%d pid=%d",
-                        device,
-                        loader.pid,
-                    )
-                    loaders.append(loader)
+            )
 
         raise SystemExit(_supervise(servers, loaders))
     finally:

--- a/lib/gpu_memory_service/cli/server.py
+++ b/lib/gpu_memory_service/cli/server.py
@@ -3,10 +3,9 @@
 
 """GMS server entry point.
 
-Launches one GMS server process per GPU serving every production GMS tag,
-then supervises them. V1 restore optionally adds one one-shot loader per
-visible GPU, or only ``--device`` when the loader remainder names one.
-Device discovery uses NVML without initializing the CUDA driver.
+Launches one GMS server process per GPU, then supervises them. V1 restore
+optionally starts one-shot loaders. Device discovery uses NVML without
+initializing the CUDA driver.
 """
 
 from __future__ import annotations
@@ -19,7 +18,6 @@ import sys
 import time
 from contextlib import closing
 
-from gpu_memory_service.cli.snapshot import should_fan_out_v1
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.v1.client.session import _GMSClientSession
@@ -42,19 +40,6 @@ def _child_command(device: int, device_type: str, use_v1: bool = False) -> list[
     command.extend(["--device", str(device)])
     if not use_v1:
         command.extend(["--device-type", device_type])
-    return command
-
-
-def _loader_command(loader_args: list[str], device: int | None = None) -> list[str]:
-    """Command for one V1 loader; inject ``--device`` only when fanning out."""
-    command = [
-        sys.executable,
-        "-m",
-        "gpu_memory_service.v1.snapshot.loader",
-        *loader_args,
-    ]
-    if device is not None:
-        command.extend(["--device", str(device)])
     return command
 
 
@@ -129,10 +114,9 @@ def main(argv: list[str] | None = None) -> None:
         nargs=argparse.REMAINDER,
         metavar="ARG",
         help=(
-            "Run one V1 loader per visible device after the servers start. "
-            "Pass --device in the following arguments to load only that GPU. "
-            "All following arguments are forwarded to the loader, including "
-            "--checkpoint-dir."
+            "Run one V1 loader per visible GPU after the servers start. "
+            "Remaining args go to the loader, including --checkpoint-dir. "
+            "Pass --device to load only that GPU."
         ),
     )
     args = parser.parse_args(argv)
@@ -176,10 +160,34 @@ def main(argv: list[str] | None = None) -> None:
             servers.append(server)
 
         if args.enable_loader is not None:
-            if should_fan_out_v1(args.enable_loader):
+            named_device = any(
+                argument == "--device" or argument.startswith("--device=")
+                for argument in args.enable_loader
+            )
+            if named_device or any(
+                argument in {"-h", "--help"} for argument in args.enable_loader
+            ):
+                loader = subprocess.Popen(
+                    [
+                        sys.executable,
+                        "-m",
+                        "gpu_memory_service.v1.snapshot.loader",
+                        *args.enable_loader,
+                    ]
+                )
+                logger.info("Started GMS V1 loader pid=%d", loader.pid)
+                loaders.append(loader)
+            else:
                 for device in devices:
                     loader = subprocess.Popen(
-                        _loader_command(args.enable_loader, device)
+                        [
+                            sys.executable,
+                            "-m",
+                            "gpu_memory_service.v1.snapshot.loader",
+                            *args.enable_loader,
+                            "--device",
+                            str(device),
+                        ]
                     )
                     logger.info(
                         "Started GMS V1 loader device=%d pid=%d",
@@ -187,10 +195,6 @@ def main(argv: list[str] | None = None) -> None:
                         loader.pid,
                     )
                     loaders.append(loader)
-            else:
-                loader = subprocess.Popen(_loader_command(args.enable_loader))
-                logger.info("Started GMS V1 loader pid=%d", loader.pid)
-                loaders.append(loader)
 
         raise SystemExit(_supervise(servers, loaders))
     finally:

--- a/lib/gpu_memory_service/cli/server.py
+++ b/lib/gpu_memory_service/cli/server.py
@@ -3,7 +3,7 @@
 
 """GMS server entry point.
 
-Launches one GMS server process per GPU, then supervises them. V1 restore
+Launches one GMS server process per GPU, then supervises them. Restore
 optionally starts one-shot loaders. Device discovery uses NVML without
 initializing the CUDA driver.
 """
@@ -18,7 +18,7 @@ import sys
 import time
 from contextlib import closing
 
-from gpu_memory_service.cli.snapshot import start_v1_per_device
+from gpu_memory_service.cli.snapshot import start_per_device
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.v1.client.session import _GMSClientSession
@@ -115,7 +115,7 @@ def main(argv: list[str] | None = None) -> None:
         nargs=argparse.REMAINDER,
         metavar="ARG",
         help=(
-            "Start V1 loaders after the servers. Remaining args, including "
+            "Start loaders after the servers. Remaining args, including "
             "--checkpoint-dir, go to the loader. Pass --device to load one GPU."
         ),
     )
@@ -124,8 +124,6 @@ def main(argv: list[str] | None = None) -> None:
         parser.error("--use-v1 only supports --device-type=cuda")
     if args.probe_restore_ready and not args.use_v1:
         parser.error("--probe-restore-ready requires --use-v1")
-    if args.enable_loader is not None and not args.use_v1:
-        parser.error("--enable-loader requires --use-v1")
     if args.probe_restore_ready and args.enable_loader is not None:
         parser.error("--probe-restore-ready cannot be combined with --enable-loader")
 
@@ -160,10 +158,13 @@ def main(argv: list[str] | None = None) -> None:
             servers.append(server)
 
         if args.enable_loader is not None:
+            loader_argv = list(args.enable_loader)
+            if args.use_v1:
+                loader_argv.insert(0, "--use-v1")
             loaders.extend(
-                start_v1_per_device(
-                    "gpu_memory_service.v1.snapshot.loader",
-                    args.enable_loader,
+                start_per_device(
+                    "gpu_memory_service.cli.snapshot.loader",
+                    loader_argv,
                     devices,
                 )
             )

--- a/lib/gpu_memory_service/cli/server.py
+++ b/lib/gpu_memory_service/cli/server.py
@@ -19,12 +19,12 @@ import time
 from contextlib import closing
 
 from gpu_memory_service.cli.snapshot import start_per_device
-from gpu_memory_service.client.session import _GMSClientSession as _V0ClientSession
+from gpu_memory_service.client.session import _GMSClientSession as v0_session
 from gpu_memory_service.common.locks import RequestedLockType
-from gpu_memory_service.common.utils import get_socket_path as _v0_socket_path
+from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
-from gpu_memory_service.v1.client.session import _GMSClientSession as _V1ClientSession
-from gpu_memory_service.v1.device import get_socket_path as _v1_socket_path
+from gpu_memory_service.v1.client.session import _GMSClientSession as v1_session
+from gpu_memory_service.v1.device import get_socket_path as v1_get_socket_path
 
 logging.basicConfig(
     level=logging.INFO,
@@ -33,37 +33,6 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 _PROBE_TIMEOUT_SECONDS = 0.5
-
-
-def _child_command(device: int, device_type: str, use_v1: bool = False) -> list[str]:
-    """Command for one child process serving every production tag on one GPU."""
-    command = [sys.executable, "-m", "gpu_memory_service"]
-    if use_v1:
-        command.append("--use-v1")
-    command.extend(["--device", str(device)])
-    if not use_v1:
-        command.extend(["--device-type", device_type])
-    return command
-
-
-def _probe_restore_ready(devices: list[int], use_v1: bool) -> None:
-    timeout_ms = int(_PROBE_TIMEOUT_SECONDS * 1000)
-    for device in devices:
-        if use_v1:
-            session = _V1ClientSession(
-                _v1_socket_path(device, "weights"),
-                RequestedLockType.RO,
-                connect_timeout=_PROBE_TIMEOUT_SECONDS,
-                admission_timeout=_PROBE_TIMEOUT_SECONDS,
-            )
-        else:
-            session = _V0ClientSession(
-                _v0_socket_path(device, "weights"),
-                RequestedLockType.RO,
-                timeout_ms,
-            )
-        with closing(session):
-            pass
 
 
 def _terminate_all(processes: list[subprocess.Popen]) -> None:
@@ -138,7 +107,23 @@ def main(argv: list[str] | None = None) -> None:
     vmm = get_vmm()
     devices = vmm.list_devices()
     if args.probe_restore_ready:
-        _probe_restore_ready(devices, use_v1=args.use_v1)
+        timeout_ms = int(_PROBE_TIMEOUT_SECONDS * 1000)
+        for device in devices:
+            if args.use_v1:
+                session = v1_session(
+                    v1_get_socket_path(device, "weights"),
+                    RequestedLockType.RO,
+                    connect_timeout=_PROBE_TIMEOUT_SECONDS,
+                    admission_timeout=_PROBE_TIMEOUT_SECONDS,
+                )
+            else:
+                session = v0_session(
+                    get_socket_path(device, "weights"),
+                    RequestedLockType.RO,
+                    timeout_ms,
+                )
+            with closing(session):
+                pass
         return
 
     servers: list[subprocess.Popen] = []
@@ -153,16 +138,20 @@ def main(argv: list[str] | None = None) -> None:
 
     try:
         for device in devices:
-            server = subprocess.Popen(
-                _child_command(device, args.device_type, use_v1=args.use_v1)
-            )
+            command = [sys.executable, "-m", "gpu_memory_service"]
+            if args.use_v1:
+                command.append("--use-v1")
+            command.extend(["--device", str(device)])
+            if not args.use_v1:
+                command.extend(["--device-type", args.device_type])
+            process = subprocess.Popen(command)
             logger.info(
                 "Started GMS%s device=%d pid=%d",
                 " V1" if args.use_v1 else "",
                 device,
-                server.pid,
+                process.pid,
             )
-            servers.append(server)
+            servers.append(process)
 
         if args.enable_loader is not None:
             loader_argv = list(args.enable_loader)

--- a/lib/gpu_memory_service/cli/server.py
+++ b/lib/gpu_memory_service/cli/server.py
@@ -4,7 +4,8 @@
 """GMS server entry point.
 
 Launches one GMS server process per GPU serving every production GMS tag,
-then supervises them. V1 restore optionally adds one one-shot loader per GPU.
+then supervises them. V1 restore optionally adds one one-shot loader per
+visible GPU, or only ``--device`` when the loader remainder names one.
 Device discovery uses NVML without initializing the CUDA driver.
 """
 
@@ -18,6 +19,7 @@ import sys
 import time
 from contextlib import closing
 
+from gpu_memory_service.cli.snapshot import should_fan_out_v1
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.v1.client.session import _GMSClientSession
@@ -40,6 +42,19 @@ def _child_command(device: int, device_type: str, use_v1: bool = False) -> list[
     command.extend(["--device", str(device)])
     if not use_v1:
         command.extend(["--device-type", device_type])
+    return command
+
+
+def _loader_command(loader_args: list[str], device: int | None = None) -> list[str]:
+    """Command for one V1 loader; inject ``--device`` only when fanning out."""
+    command = [
+        sys.executable,
+        "-m",
+        "gpu_memory_service.v1.snapshot.loader",
+        *loader_args,
+    ]
+    if device is not None:
+        command.extend(["--device", str(device)])
     return command
 
 
@@ -110,12 +125,14 @@ def main(argv: list[str] | None = None) -> None:
         help="Attempt bounded RO admission on every V1 weights socket and exit.",
     )
     parser.add_argument(
-        "--restore-loader",
+        "--enable-loader",
         nargs=argparse.REMAINDER,
         metavar="ARG",
         help=(
-            "Run one V1 loader per device; all following arguments are passed "
-            "directly to the loader."
+            "Run one V1 loader per visible device after the servers start. "
+            "Pass --device in the following arguments to load only that GPU. "
+            "All following arguments are forwarded to the loader, including "
+            "--checkpoint-dir."
         ),
     )
     args = parser.parse_args(argv)
@@ -123,10 +140,10 @@ def main(argv: list[str] | None = None) -> None:
         parser.error("--use-v1 only supports --device-type=cuda")
     if args.probe_restore_ready and not args.use_v1:
         parser.error("--probe-restore-ready requires --use-v1")
-    if args.restore_loader is not None and not args.use_v1:
-        parser.error("--restore-loader requires --use-v1")
-    if args.probe_restore_ready and args.restore_loader is not None:
-        parser.error("--probe-restore-ready cannot start restore loaders")
+    if args.enable_loader is not None and not args.use_v1:
+        parser.error("--enable-loader requires --use-v1")
+    if args.probe_restore_ready and args.enable_loader is not None:
+        parser.error("--probe-restore-ready cannot be combined with --enable-loader")
 
     init_vmm(VMMDeviceType.from_str(args.device_type))
     vmm = get_vmm()
@@ -158,23 +175,21 @@ def main(argv: list[str] | None = None) -> None:
             )
             servers.append(server)
 
-        if args.restore_loader is not None:
-            for device in devices:
-                loader = subprocess.Popen(
-                    [
-                        sys.executable,
-                        "-m",
-                        "gpu_memory_service.v1.snapshot.loader",
-                        *args.restore_loader,
-                        "--device",
-                        str(device),
-                    ]
-                )
-                logger.info(
-                    "Started GMS V1 loader device=%d pid=%d",
-                    device,
-                    loader.pid,
-                )
+        if args.enable_loader is not None:
+            if should_fan_out_v1(args.enable_loader):
+                for device in devices:
+                    loader = subprocess.Popen(
+                        _loader_command(args.enable_loader, device)
+                    )
+                    logger.info(
+                        "Started GMS V1 loader device=%d pid=%d",
+                        device,
+                        loader.pid,
+                    )
+                    loaders.append(loader)
+            else:
+                loader = subprocess.Popen(_loader_command(args.enable_loader))
+                logger.info("Started GMS V1 loader pid=%d", loader.pid)
                 loaders.append(loader)
 
         raise SystemExit(_supervise(servers, loaders))

--- a/lib/gpu_memory_service/cli/server.py
+++ b/lib/gpu_memory_service/cli/server.py
@@ -19,10 +19,12 @@ import time
 from contextlib import closing
 
 from gpu_memory_service.cli.snapshot import start_per_device
+from gpu_memory_service.client.session import _GMSClientSession as _V0ClientSession
 from gpu_memory_service.common.locks import RequestedLockType
+from gpu_memory_service.common.utils import get_socket_path as _v0_socket_path
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
-from gpu_memory_service.v1.client.session import _GMSClientSession
-from gpu_memory_service.v1.device import get_socket_path
+from gpu_memory_service.v1.client.session import _GMSClientSession as _V1ClientSession
+from gpu_memory_service.v1.device import get_socket_path as _v1_socket_path
 
 logging.basicConfig(
     level=logging.INFO,
@@ -44,16 +46,23 @@ def _child_command(device: int, device_type: str, use_v1: bool = False) -> list[
     return command
 
 
-def _probe_v1_restore_ready(devices: list[int]) -> None:
+def _probe_restore_ready(devices: list[int], use_v1: bool) -> None:
+    timeout_ms = int(_PROBE_TIMEOUT_SECONDS * 1000)
     for device in devices:
-        with closing(
-            _GMSClientSession(
-                get_socket_path(device, "weights"),
+        if use_v1:
+            session = _V1ClientSession(
+                _v1_socket_path(device, "weights"),
                 RequestedLockType.RO,
                 connect_timeout=_PROBE_TIMEOUT_SECONDS,
                 admission_timeout=_PROBE_TIMEOUT_SECONDS,
             )
-        ):
+        else:
+            session = _V0ClientSession(
+                _v0_socket_path(device, "weights"),
+                RequestedLockType.RO,
+                timeout_ms,
+            )
+        with closing(session):
             pass
 
 
@@ -108,7 +117,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--probe-restore-ready",
         action="store_true",
-        help="Attempt bounded RO admission on every V1 weights socket and exit.",
+        help="Attempt bounded RO admission on every weights socket and exit.",
     )
     parser.add_argument(
         "--enable-loader",
@@ -122,8 +131,6 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     if args.use_v1 and args.device_type != VMMDeviceType.CUDA.value:
         parser.error("--use-v1 only supports --device-type=cuda")
-    if args.probe_restore_ready and not args.use_v1:
-        parser.error("--probe-restore-ready requires --use-v1")
     if args.probe_restore_ready and args.enable_loader is not None:
         parser.error("--probe-restore-ready cannot be combined with --enable-loader")
 
@@ -131,7 +138,7 @@ def main(argv: list[str] | None = None) -> None:
     vmm = get_vmm()
     devices = vmm.list_devices()
     if args.probe_restore_ready:
-        _probe_v1_restore_ready(devices)
+        _probe_restore_ready(devices, use_v1=args.use_v1)
         return
 
     servers: list[subprocess.Popen] = []

--- a/lib/gpu_memory_service/cli/snapshot/__init__.py
+++ b/lib/gpu_memory_service/cli/snapshot/__init__.py
@@ -1,2 +1,23 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+"""Snapshot saver/loader CLI helpers."""
+
+from __future__ import annotations
+
+
+def has_device_argument(argv: list[str]) -> bool:
+    """Return True when argv names a single ``--device``.
+
+    ``--device-type`` is not a device selector.
+    """
+    return any(
+        argument == "--device" or argument.startswith("--device=") for argument in argv
+    )
+
+
+def should_fan_out_v1(argv: list[str]) -> bool:
+    """Fan out one V1 child per visible GPU unless the caller named a device."""
+    if any(argument in {"-h", "--help"} for argument in argv):
+        return False
+    return not has_device_argument(argv)

--- a/lib/gpu_memory_service/cli/snapshot/__init__.py
+++ b/lib/gpu_memory_service/cli/snapshot/__init__.py
@@ -5,19 +5,50 @@
 
 from __future__ import annotations
 
+import logging
+import subprocess
+import sys
+import time
 
-def has_device_argument(argv: list[str]) -> bool:
-    """Return True when argv names a single ``--device``.
+from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 
-    ``--device-type`` is not a device selector.
-    """
-    return any(
-        argument == "--device" or argument.startswith("--device=") for argument in argv
-    )
+logger = logging.getLogger(__name__)
 
 
-def should_fan_out_v1(argv: list[str]) -> bool:
-    """Fan out one V1 child per visible GPU unless the caller named a device."""
-    if any(argument in {"-h", "--help"} for argument in argv):
-        return False
-    return not has_device_argument(argv)
+def run_v1_per_device(module: str, argv: list[str], label: str) -> None:
+    init_vmm(VMMDeviceType.CUDA)
+    processes: list[subprocess.Popen] = []
+    try:
+        for device in get_vmm().list_devices():
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    module,
+                    *argv,
+                    "--device",
+                    str(device),
+                ]
+            )
+            logger.info(
+                "Started GMS V1 %s device=%d pid=%d", label, device, process.pid
+            )
+            processes.append(process)
+
+        pending = list(processes)
+        while pending:
+            for process in list(pending):
+                exit_code = process.poll()
+                if exit_code is None:
+                    continue
+                if exit_code:
+                    raise SystemExit(exit_code)
+                pending.remove(process)
+            if pending:
+                time.sleep(1)
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+        for process in processes:
+            process.wait()

--- a/lib/gpu_memory_service/cli/snapshot/__init__.py
+++ b/lib/gpu_memory_service/cli/snapshot/__init__.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Snapshot saver/loader CLI helpers."""
-
 from __future__ import annotations
 
+import importlib
 import logging
 import subprocess
 import sys
@@ -15,26 +14,33 @@ from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 logger = logging.getLogger(__name__)
 
 
-def run_v1_per_device(module: str, argv: list[str], label: str) -> None:
-    init_vmm(VMMDeviceType.CUDA)
-    processes: list[subprocess.Popen] = []
-    try:
-        for device in get_vmm().list_devices():
-            process = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-m",
-                    module,
-                    *argv,
-                    "--device",
-                    str(device),
-                ]
-            )
-            logger.info(
-                "Started GMS V1 %s device=%d pid=%d", label, device, process.pid
-            )
-            processes.append(process)
+def _v1_scoped(argv: list[str]) -> bool:
+    return any(
+        a in {"-h", "--help"} or a == "--device" or a.startswith("--device=")
+        for a in argv
+    )
 
+
+def start_v1_per_device(
+    module: str, argv: list[str], devices: list[int]
+) -> list[subprocess.Popen]:
+    targets: list[int | None] = [None] if _v1_scoped(argv) else list(devices)
+    processes = []
+    for device in targets:
+        extra = [] if device is None else ["--device", str(device)]
+        process = subprocess.Popen([sys.executable, "-m", module, *argv, *extra])
+        logger.info("Started %s device=%s pid=%d", module, device, process.pid)
+        processes.append(process)
+    return processes
+
+
+def run_v1_per_device(module: str, argv: list[str]) -> None:
+    if _v1_scoped(argv):
+        importlib.import_module(module).main(argv)
+        return
+    init_vmm(VMMDeviceType.CUDA)
+    processes = start_v1_per_device(module, argv, get_vmm().list_devices())
+    try:
         pending = list(processes)
         while pending:
             for process in list(pending):

--- a/lib/gpu_memory_service/cli/snapshot/__init__.py
+++ b/lib/gpu_memory_service/cli/snapshot/__init__.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib
 import logging
 import subprocess
 import sys
@@ -14,19 +13,17 @@ from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 logger = logging.getLogger(__name__)
 
 
-def _device_scoped(argv: list[str]) -> bool:
-    return any(
-        a in {"-h", "--help"} or a == "--device" or a.startswith("--device=")
-        for a in argv
-    )
-
-
 def start_per_device(
     module: str, argv: list[str], devices: list[int]
 ) -> list[subprocess.Popen]:
-    targets: list[int | None] = [None] if _device_scoped(argv) else list(devices)
+    scoped = any(
+        argument in {"-h", "--help"}
+        or argument == "--device"
+        or argument.startswith("--device=")
+        for argument in argv
+    )
     processes = []
-    for device in targets:
+    for device in ([None] if scoped else devices):
         extra = [] if device is None else ["--device", str(device)]
         process = subprocess.Popen([sys.executable, "-m", module, *argv, *extra])
         logger.info("Started %s device=%s pid=%d", module, device, process.pid)
@@ -35,11 +32,17 @@ def start_per_device(
 
 
 def run_per_device(module: str, argv: list[str]) -> None:
-    if _device_scoped(argv):
-        importlib.import_module(module).main(argv)
-        return
-    init_vmm(VMMDeviceType.CUDA)
-    processes = start_per_device(module, argv, get_vmm().list_devices())
+    scoped = any(
+        argument in {"-h", "--help"}
+        or argument == "--device"
+        or argument.startswith("--device=")
+        for argument in argv
+    )
+    if not scoped:
+        init_vmm(VMMDeviceType.CUDA)
+    processes = start_per_device(
+        module, argv, [] if scoped else get_vmm().list_devices()
+    )
     try:
         pending = list(processes)
         while pending:

--- a/lib/gpu_memory_service/cli/snapshot/__init__.py
+++ b/lib/gpu_memory_service/cli/snapshot/__init__.py
@@ -23,7 +23,7 @@ def start_per_device(
         for argument in argv
     )
     processes = []
-    for device in ([None] if scoped else devices):
+    for device in [None] if scoped else devices:
         extra = [] if device is None else ["--device", str(device)]
         process = subprocess.Popen([sys.executable, "-m", module, *argv, *extra])
         logger.info("Started %s device=%s pid=%d", module, device, process.pid)

--- a/lib/gpu_memory_service/cli/snapshot/__init__.py
+++ b/lib/gpu_memory_service/cli/snapshot/__init__.py
@@ -14,17 +14,17 @@ from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 logger = logging.getLogger(__name__)
 
 
-def _v1_scoped(argv: list[str]) -> bool:
+def _device_scoped(argv: list[str]) -> bool:
     return any(
         a in {"-h", "--help"} or a == "--device" or a.startswith("--device=")
         for a in argv
     )
 
 
-def start_v1_per_device(
+def start_per_device(
     module: str, argv: list[str], devices: list[int]
 ) -> list[subprocess.Popen]:
-    targets: list[int | None] = [None] if _v1_scoped(argv) else list(devices)
+    targets: list[int | None] = [None] if _device_scoped(argv) else list(devices)
     processes = []
     for device in targets:
         extra = [] if device is None else ["--device", str(device)]
@@ -34,12 +34,12 @@ def start_v1_per_device(
     return processes
 
 
-def run_v1_per_device(module: str, argv: list[str]) -> None:
-    if _v1_scoped(argv):
+def run_per_device(module: str, argv: list[str]) -> None:
+    if _device_scoped(argv):
         importlib.import_module(module).main(argv)
         return
     init_vmm(VMMDeviceType.CUDA)
-    processes = start_v1_per_device(module, argv, get_vmm().list_devices())
+    processes = start_per_device(module, argv, get_vmm().list_devices())
     try:
         pending = list(processes)
         while pending:

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -18,7 +18,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from gpu_memory_service.cli.snapshot import run_v1_per_device
+from gpu_memory_service.cli.snapshot import run_per_device
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.snapshot.backends.sharded_ssd import parse_sharded_ssd_roots
@@ -115,15 +115,32 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=[d.value for d in VMMDeviceType],
         help="VMM device type (default: cuda).",
     )
+    parser.add_argument(
+        "--device",
+        type=int,
+        default=None,
+        help="Device ordinal. Default: every visible GPU.",
+    )
     return parser
 
 
 def _list_checkpoint_devices(
     checkpoint_dir: str | None,
+    device: int | None = None,
 ) -> list[int]:
     vmm = get_vmm()
     vmm.ensure_initialized()
     devices = vmm.list_devices()
+    if device is not None:
+        if device not in devices:
+            raise RuntimeError(
+                f"--device {device} is not visible: visible={devices}"
+            )
+        if checkpoint_dir:
+            path = Path(checkpoint_dir) / f"device-{device}"
+            if not path.is_dir():
+                raise RuntimeError(f"Checkpoint directory {path} is missing")
+        return [device]
     if not checkpoint_dir:
         return devices
 
@@ -163,7 +180,7 @@ def main(argv: list[str] | None = None) -> None:
     selector.add_argument("--use-v1", action="store_true")
     options, remaining = selector.parse_known_args(argv)
     if options.use_v1:
-        run_v1_per_device("gpu_memory_service.v1.snapshot.loader", remaining)
+        run_per_device("gpu_memory_service.v1.snapshot.loader", remaining)
         return
 
     parser = _build_parser()
@@ -189,7 +206,7 @@ def main(argv: list[str] | None = None) -> None:
         ",".join(sharded_ssd_roots) or "-",
         sharded_ssd_queues_per_root,
     )
-    devices = _list_checkpoint_devices(checkpoint_dir)
+    devices = _list_checkpoint_devices(checkpoint_dir, args.device)
 
     t0 = time.monotonic()
     with ThreadPoolExecutor(max_workers=len(devices)) as pool:

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -12,7 +12,6 @@ restored engine on weight load.
 from __future__ import annotations
 
 import argparse
-import importlib
 import logging
 import os
 import time
@@ -164,17 +163,7 @@ def main(argv: list[str] | None = None) -> None:
     selector.add_argument("--use-v1", action="store_true")
     options, remaining = selector.parse_known_args(argv)
     if options.use_v1:
-        if any(argument in {"-h", "--help"} for argument in remaining) or any(
-            argument == "--device" or argument.startswith("--device=")
-            for argument in remaining
-        ):
-            importlib.import_module("gpu_memory_service.v1.snapshot.loader").main(
-                remaining
-            )
-        else:
-            run_v1_per_device(
-                "gpu_memory_service.v1.snapshot.loader", remaining, "loader"
-            )
+        run_v1_per_device("gpu_memory_service.v1.snapshot.loader", remaining)
         return
 
     parser = _build_parser()

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -15,10 +15,13 @@ import argparse
 import importlib
 import logging
 import os
+import subprocess
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+from gpu_memory_service.cli.snapshot import should_fan_out_v1
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.snapshot.backends.sharded_ssd import parse_sharded_ssd_roots
@@ -30,6 +33,48 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+
+def _run_v1_loaders(argv: list[str]) -> None:
+    init_vmm(VMMDeviceType.CUDA)
+    devices = get_vmm().list_devices()
+    processes: list[subprocess.Popen] = []
+    try:
+        for device in devices:
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "gpu_memory_service.v1.snapshot.loader",
+                    *argv,
+                    "--device",
+                    str(device),
+                ]
+            )
+            logger.info(
+                "Started GMS V1 loader device=%d pid=%d",
+                device,
+                process.pid,
+            )
+            processes.append(process)
+
+        pending = list(processes)
+        while pending:
+            for process in list(pending):
+                exit_code = process.poll()
+                if exit_code is None:
+                    continue
+                if exit_code:
+                    raise SystemExit(exit_code)
+                pending.remove(process)
+            if pending:
+                time.sleep(1)
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+        for process in processes:
+            process.wait()
 
 
 def _load_device(
@@ -163,8 +208,11 @@ def main(argv: list[str] | None = None) -> None:
     selector.add_argument("--use-v1", action="store_true")
     options, remaining = selector.parse_known_args(argv)
     if options.use_v1:
-        v1_loader = importlib.import_module("gpu_memory_service.v1.snapshot.loader")
-        v1_loader.main(remaining)
+        if should_fan_out_v1(remaining):
+            _run_v1_loaders(remaining)
+        else:
+            v1_loader = importlib.import_module("gpu_memory_service.v1.snapshot.loader")
+            v1_loader.main(remaining)
         return
 
     parser = _build_parser()

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -133,9 +133,7 @@ def _list_checkpoint_devices(
     devices = vmm.list_devices()
     if device is not None:
         if device not in devices:
-            raise RuntimeError(
-                f"--device {device} is not visible: visible={devices}"
-            )
+            raise RuntimeError(f"--device {device} is not visible: visible={devices}")
         if checkpoint_dir:
             path = Path(checkpoint_dir) / f"device-{device}"
             if not path.is_dir():

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -15,13 +15,11 @@ import argparse
 import importlib
 import logging
 import os
-import subprocess
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from gpu_memory_service.cli.snapshot import should_fan_out_v1
+from gpu_memory_service.cli.snapshot import run_v1_per_device
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.snapshot.backends.sharded_ssd import parse_sharded_ssd_roots
@@ -33,48 +31,6 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
-
-
-def _run_v1_loaders(argv: list[str]) -> None:
-    init_vmm(VMMDeviceType.CUDA)
-    devices = get_vmm().list_devices()
-    processes: list[subprocess.Popen] = []
-    try:
-        for device in devices:
-            process = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-m",
-                    "gpu_memory_service.v1.snapshot.loader",
-                    *argv,
-                    "--device",
-                    str(device),
-                ]
-            )
-            logger.info(
-                "Started GMS V1 loader device=%d pid=%d",
-                device,
-                process.pid,
-            )
-            processes.append(process)
-
-        pending = list(processes)
-        while pending:
-            for process in list(pending):
-                exit_code = process.poll()
-                if exit_code is None:
-                    continue
-                if exit_code:
-                    raise SystemExit(exit_code)
-                pending.remove(process)
-            if pending:
-                time.sleep(1)
-    finally:
-        for process in processes:
-            if process.poll() is None:
-                process.terminate()
-        for process in processes:
-            process.wait()
 
 
 def _load_device(
@@ -208,11 +164,17 @@ def main(argv: list[str] | None = None) -> None:
     selector.add_argument("--use-v1", action="store_true")
     options, remaining = selector.parse_known_args(argv)
     if options.use_v1:
-        if should_fan_out_v1(remaining):
-            _run_v1_loaders(remaining)
+        if any(argument in {"-h", "--help"} for argument in remaining) or any(
+            argument == "--device" or argument.startswith("--device=")
+            for argument in remaining
+        ):
+            importlib.import_module("gpu_memory_service.v1.snapshot.loader").main(
+                remaining
+            )
         else:
-            v1_loader = importlib.import_module("gpu_memory_service.v1.snapshot.loader")
-            v1_loader.main(remaining)
+            run_v1_per_device(
+                "gpu_memory_service.v1.snapshot.loader", remaining, "loader"
+            )
         return
 
     parser = _build_parser()

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -14,6 +14,8 @@ import argparse
 import importlib
 import logging
 import os
+import subprocess
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -30,6 +32,48 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+
+def _run_v1_savers(argv: list[str]) -> None:
+    init_vmm(VMMDeviceType.CUDA)
+    devices = get_vmm().list_devices()
+    processes: list[subprocess.Popen] = []
+    try:
+        for device in devices:
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "gpu_memory_service.v1.snapshot.saver",
+                    *argv,
+                    "--device",
+                    str(device),
+                ]
+            )
+            logger.info(
+                "Started GMS V1 saver device=%d pid=%d",
+                device,
+                process.pid,
+            )
+            processes.append(process)
+
+        pending = list(processes)
+        while pending:
+            for process in list(pending):
+                exit_code = process.poll()
+                if exit_code is None:
+                    continue
+                if exit_code:
+                    raise SystemExit(exit_code)
+                pending.remove(process)
+            if pending:
+                time.sleep(1)
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+        for process in processes:
+            process.wait()
 
 
 def _save_device(
@@ -125,8 +169,11 @@ def main(argv: list[str] | None = None) -> None:
     selector.add_argument("--use-v1", action="store_true")
     options, remaining = selector.parse_known_args(argv)
     if options.use_v1:
-        v1_saver = importlib.import_module("gpu_memory_service.v1.snapshot.saver")
-        v1_saver.main(remaining)
+        if any(argument in {"-h", "--help"} for argument in remaining):
+            v1_saver = importlib.import_module("gpu_memory_service.v1.snapshot.saver")
+            v1_saver.main(remaining)
+        else:
+            _run_v1_savers(remaining)
         return
 
     parser = _build_parser()

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -14,12 +14,10 @@ import argparse
 import importlib
 import logging
 import os
-import subprocess
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from gpu_memory_service.cli.snapshot import should_fan_out_v1
+from gpu_memory_service.cli.snapshot import run_v1_per_device
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.snapshot.backends.sharded_ssd import (
@@ -33,48 +31,6 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
-
-
-def _run_v1_savers(argv: list[str]) -> None:
-    init_vmm(VMMDeviceType.CUDA)
-    devices = get_vmm().list_devices()
-    processes: list[subprocess.Popen] = []
-    try:
-        for device in devices:
-            process = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-m",
-                    "gpu_memory_service.v1.snapshot.saver",
-                    *argv,
-                    "--device",
-                    str(device),
-                ]
-            )
-            logger.info(
-                "Started GMS V1 saver device=%d pid=%d",
-                device,
-                process.pid,
-            )
-            processes.append(process)
-
-        pending = list(processes)
-        while pending:
-            for process in list(pending):
-                exit_code = process.poll()
-                if exit_code is None:
-                    continue
-                if exit_code:
-                    raise SystemExit(exit_code)
-                pending.remove(process)
-            if pending:
-                time.sleep(1)
-    finally:
-        for process in processes:
-            if process.poll() is None:
-                process.terminate()
-        for process in processes:
-            process.wait()
 
 
 def _save_device(
@@ -170,11 +126,17 @@ def main(argv: list[str] | None = None) -> None:
     selector.add_argument("--use-v1", action="store_true")
     options, remaining = selector.parse_known_args(argv)
     if options.use_v1:
-        if should_fan_out_v1(remaining):
-            _run_v1_savers(remaining)
+        if any(argument in {"-h", "--help"} for argument in remaining) or any(
+            argument == "--device" or argument.startswith("--device=")
+            for argument in remaining
+        ):
+            importlib.import_module("gpu_memory_service.v1.snapshot.saver").main(
+                remaining
+            )
         else:
-            v1_saver = importlib.import_module("gpu_memory_service.v1.snapshot.saver")
-            v1_saver.main(remaining)
+            run_v1_per_device(
+                "gpu_memory_service.v1.snapshot.saver", remaining, "saver"
+            )
         return
 
     parser = _build_parser()

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -152,9 +152,7 @@ def main(argv: list[str] | None = None) -> None:
     devices = vmm.list_devices()
     if args.device is not None:
         if args.device not in devices:
-            parser.error(
-                f"--device {args.device} is not visible (visible={devices})"
-            )
+            parser.error(f"--device {args.device} is not visible (visible={devices})")
         devices = [args.device]
     logger.info(
         "Starting GMS save for %d devices lock_timeout_ms=%d sharded_ssd_roots=%s",

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -19,6 +19,7 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+from gpu_memory_service.cli.snapshot import should_fan_out_v1
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.snapshot.backends.sharded_ssd import (
@@ -167,14 +168,9 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> None:
     selector = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
     selector.add_argument("--use-v1", action="store_true")
-    selector.add_argument("--all-devices", action="store_true")
     options, remaining = selector.parse_known_args(argv)
-    if options.all_devices and not options.use_v1:
-        selector.error("--all-devices requires --use-v1")
     if options.use_v1:
-        if options.all_devices and not any(
-            argument in {"-h", "--help"} for argument in remaining
-        ):
+        if should_fan_out_v1(remaining):
             _run_v1_savers(remaining)
         else:
             v1_saver = importlib.import_module("gpu_memory_service.v1.snapshot.saver")

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -167,13 +167,18 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> None:
     selector = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
     selector.add_argument("--use-v1", action="store_true")
+    selector.add_argument("--all-devices", action="store_true")
     options, remaining = selector.parse_known_args(argv)
+    if options.all_devices and not options.use_v1:
+        selector.error("--all-devices requires --use-v1")
     if options.use_v1:
-        if any(argument in {"-h", "--help"} for argument in remaining):
+        if options.all_devices and not any(
+            argument in {"-h", "--help"} for argument in remaining
+        ):
+            _run_v1_savers(remaining)
+        else:
             v1_saver = importlib.import_module("gpu_memory_service.v1.snapshot.saver")
             v1_saver.main(remaining)
-        else:
-            _run_v1_savers(remaining)
         return
 
     parser = _build_parser()

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -16,7 +16,7 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from gpu_memory_service.cli.snapshot import run_v1_per_device
+from gpu_memory_service.cli.snapshot import run_per_device
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.snapshot.backends.sharded_ssd import (
@@ -117,6 +117,12 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=[d.value for d in VMMDeviceType],
         help="VMM device type (default: cuda).",
     )
+    parser.add_argument(
+        "--device",
+        type=int,
+        default=None,
+        help="Device ordinal. Default: every visible GPU.",
+    )
     return parser
 
 
@@ -125,7 +131,7 @@ def main(argv: list[str] | None = None) -> None:
     selector.add_argument("--use-v1", action="store_true")
     options, remaining = selector.parse_known_args(argv)
     if options.use_v1:
-        run_v1_per_device("gpu_memory_service.v1.snapshot.saver", remaining)
+        run_per_device("gpu_memory_service.v1.snapshot.saver", remaining)
         return
 
     parser = _build_parser()
@@ -144,6 +150,12 @@ def main(argv: list[str] | None = None) -> None:
     vmm = get_vmm()
     vmm.ensure_initialized()
     devices = vmm.list_devices()
+    if args.device is not None:
+        if args.device not in devices:
+            parser.error(
+                f"--device {args.device} is not visible (visible={devices})"
+            )
+        devices = [args.device]
     logger.info(
         "Starting GMS save for %d devices lock_timeout_ms=%d sharded_ssd_roots=%s",
         len(devices),

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -11,7 +11,6 @@ after save so the Job completes once tensors are on disk.
 from __future__ import annotations
 
 import argparse
-import importlib
 import logging
 import os
 import time
@@ -126,17 +125,7 @@ def main(argv: list[str] | None = None) -> None:
     selector.add_argument("--use-v1", action="store_true")
     options, remaining = selector.parse_known_args(argv)
     if options.use_v1:
-        if any(argument in {"-h", "--help"} for argument in remaining) or any(
-            argument == "--device" or argument.startswith("--device=")
-            for argument in remaining
-        ):
-            importlib.import_module("gpu_memory_service.v1.snapshot.saver").main(
-                remaining
-            )
-        else:
-            run_v1_per_device(
-                "gpu_memory_service.v1.snapshot.saver", remaining, "saver"
-            )
+        run_v1_per_device("gpu_memory_service.v1.snapshot.saver", remaining)
         return
 
     parser = _build_parser()

--- a/lib/gpu_memory_service/common/vmm/cuda_utils.py
+++ b/lib/gpu_memory_service/common/vmm/cuda_utils.py
@@ -37,6 +37,8 @@ except ImportError:
 
     cuda_runtime = _MissingCudaRuntime()
 
+_cuda_initialized_pid: int | None = None
+
 
 def list_cuda_devices() -> list[int]:
     """Return list of CUDA device indices visible to this process via NVML."""
@@ -76,8 +78,14 @@ def cuda_check_result(result: cuda.CUresult, name: str) -> None:
 
 
 def cuda_ensure_initialized() -> None:
+    """Run ``cuInit`` once per process."""
+    global _cuda_initialized_pid
+    pid = os.getpid()
+    if _cuda_initialized_pid == pid:
+        return
     (result,) = cuda.cuInit(0)
     cuda_check_result(result, "cuInit")
+    _cuda_initialized_pid = pid
 
 
 def cumem_get_allocation_granularity(device: int) -> int:

--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -73,20 +73,6 @@ def test_v1_cli_dispatches_cuda_only_child(monkeypatch, capsys):
     assert "--use-v1 only supports --device-type=cuda" in capsys.readouterr().err
 
 
-def test_enable_loader_requires_use_v1(capsys):
-    with pytest.raises(SystemExit):
-        server.main(["--enable-loader", "--checkpoint-dir", "/ckpt"])
-    assert "--enable-loader requires --use-v1" in capsys.readouterr().err
-
-
-def test_enable_loader_cannot_combine_with_probe(capsys):
-    with pytest.raises(SystemExit):
-        server.main(["--use-v1", "--probe-restore-ready", "--enable-loader"])
-    assert "--probe-restore-ready cannot be combined with --enable-loader" in (
-        capsys.readouterr().err
-    )
-
-
 def test_v1_socket_path_rejects_af_unix_overflow(monkeypatch):
     monkeypatch.setenv("GMS_SOCKET_DIR", "/" + "s" * 200)
     monkeypatch.setattr(v1_device, "get_device_uuid", lambda _device: "GPU-0")

--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -101,7 +101,7 @@ def test_supervisor_terminates_siblings_when_child_exits():
 
     # A clean exit (poll() returning 0) is an exit, not "still running".
     clean = [_Process(exit_code=0), _Process()]
-    assert server._supervise(clean) == 0
+    assert server._supervise(clean) == 1
     assert clean[1].terminated
 
 

--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -87,63 +87,6 @@ def test_enable_loader_cannot_combine_with_probe(capsys):
     )
 
 
-def _stub_supervisor(monkeypatch) -> tuple[list[list[str]], list[tuple[int, int]]]:
-    started: list[list[str]] = []
-    supervised: list[tuple[int, int]] = []
-
-    class _Alive:
-        def __init__(self, command: list[str]) -> None:
-            started.append(command)
-            self.pid = len(started)
-
-        def poll(self) -> None:
-            return None
-
-        def terminate(self) -> None:
-            return None
-
-    monkeypatch.setattr(server, "init_vmm", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        server, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 1])
-    )
-    monkeypatch.setattr(server.signal, "signal", lambda *_args: None)
-    monkeypatch.setattr(server.subprocess, "Popen", _Alive)
-    monkeypatch.setattr(
-        server,
-        "_supervise",
-        lambda servers, loaders=None: (
-            supervised.append((len(servers), len(loaders or []))) or 0
-        ),
-    )
-    return started, supervised
-
-
-@pytest.mark.parametrize(
-    ("remainder", "server_count", "device_suffixes"),
-    [
-        (["--checkpoint-dir", "/ckpt"], 2, [["--device", "0"], ["--device", "1"]]),
-        (["--checkpoint-dir", "/ckpt", "--device", "1"], 2, [["--device", "1"]]),
-    ],
-)
-def test_enable_loader_device_scope(
-    monkeypatch, remainder, server_count, device_suffixes
-):
-    started, supervised = _stub_supervisor(monkeypatch)
-
-    with pytest.raises(SystemExit) as exc:
-        server.main(["--use-v1", "--enable-loader", *remainder])
-
-    assert exc.value.code == 0
-    loaders = [
-        command
-        for command in started
-        if "gpu_memory_service.v1.snapshot.loader" in command
-    ]
-    assert supervised == [(server_count, len(device_suffixes))]
-    assert [command[-2:] for command in loaders] == device_suffixes
-    assert all(command.count("--device") == 1 for command in loaders)
-
-
 def test_v1_socket_path_rejects_af_unix_overflow(monkeypatch):
     monkeypatch.setenv("GMS_SOCKET_DIR", "/" + "s" * 200)
     monkeypatch.setattr(v1_device, "get_device_uuid", lambda _device: "GPU-0")

--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -73,6 +73,161 @@ def test_v1_cli_dispatches_cuda_only_child(monkeypatch, capsys):
     assert "--use-v1 only supports --device-type=cuda" in capsys.readouterr().err
 
 
+def test_loader_command_injects_device_only_when_fanning_out():
+    remainder = ["--checkpoint-dir", "/ckpt", "--transfer-backend", "nixl-gds"]
+    assert server._loader_command(remainder, 1) == [
+        sys.executable,
+        "-m",
+        "gpu_memory_service.v1.snapshot.loader",
+        "--checkpoint-dir",
+        "/ckpt",
+        "--transfer-backend",
+        "nixl-gds",
+        "--device",
+        "1",
+    ]
+    assert server._loader_command(remainder + ["--device", "3"]) == [
+        sys.executable,
+        "-m",
+        "gpu_memory_service.v1.snapshot.loader",
+        "--checkpoint-dir",
+        "/ckpt",
+        "--transfer-backend",
+        "nixl-gds",
+        "--device",
+        "3",
+    ]
+
+
+def test_enable_loader_requires_use_v1(capsys):
+    with pytest.raises(SystemExit):
+        server.main(["--enable-loader", "--checkpoint-dir", "/ckpt"])
+    assert "--enable-loader requires --use-v1" in capsys.readouterr().err
+
+
+def test_enable_loader_cannot_combine_with_probe(capsys):
+    with pytest.raises(SystemExit):
+        server.main(["--use-v1", "--probe-restore-ready", "--enable-loader"])
+    assert "--probe-restore-ready cannot be combined with --enable-loader" in (
+        capsys.readouterr().err
+    )
+
+
+def test_enable_loader_defaults_to_all_visible_devices(monkeypatch):
+    started: list[list[str]] = []
+    supervised: list[tuple[int, int]] = []
+
+    class _Process:
+        def __init__(self, command: list[str]) -> None:
+            started.append(command)
+            self.pid = len(started)
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            return None
+
+    monkeypatch.setattr(server, "init_vmm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "get_vmm",
+        lambda: SimpleNamespace(list_devices=lambda: [0, 1]),
+    )
+    monkeypatch.setattr(server.signal, "signal", lambda *_args: None)
+    monkeypatch.setattr(server.subprocess, "Popen", _Process)
+    monkeypatch.setattr(
+        server,
+        "_supervise",
+        lambda servers, loaders=None: (
+            supervised.append((len(servers), len(loaders or []))) or 0
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        server.main(
+            [
+                "--use-v1",
+                "--enable-loader",
+                "--checkpoint-dir",
+                "/ckpt",
+                "--transfer-backend",
+                "nixl-gds",
+            ]
+        )
+
+    assert exc.value.code == 0
+    assert supervised == [(2, 2)]
+    loader_commands = [
+        command
+        for command in started
+        if "gpu_memory_service.v1.snapshot.loader" in command
+    ]
+    assert [command[-2:] for command in loader_commands] == [
+        ["--device", "0"],
+        ["--device", "1"],
+    ]
+    assert all(
+        "--checkpoint-dir" in command and "/ckpt" in command
+        for command in loader_commands
+    )
+
+
+def test_enable_loader_device_flag_starts_one_loader(monkeypatch):
+    started: list[list[str]] = []
+    supervised: list[tuple[int, int]] = []
+
+    class _Process:
+        def __init__(self, command: list[str]) -> None:
+            started.append(command)
+            self.pid = len(started)
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            return None
+
+    monkeypatch.setattr(server, "init_vmm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "get_vmm",
+        lambda: SimpleNamespace(list_devices=lambda: [0, 1]),
+    )
+    monkeypatch.setattr(server.signal, "signal", lambda *_args: None)
+    monkeypatch.setattr(server.subprocess, "Popen", _Process)
+    monkeypatch.setattr(
+        server,
+        "_supervise",
+        lambda servers, loaders=None: (
+            supervised.append((len(servers), len(loaders or []))) or 0
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        server.main(
+            [
+                "--use-v1",
+                "--enable-loader",
+                "--checkpoint-dir",
+                "/ckpt",
+                "--device",
+                "1",
+            ]
+        )
+
+    assert exc.value.code == 0
+    assert supervised == [(2, 1)]
+    loader_commands = [
+        command
+        for command in started
+        if "gpu_memory_service.v1.snapshot.loader" in command
+    ]
+    assert len(loader_commands) == 1
+    assert loader_commands[0].count("--device") == 1
+    assert loader_commands[0][-2:] == ["--device", "1"]
+
+
 def test_v1_socket_path_rejects_af_unix_overflow(monkeypatch):
     monkeypatch.setenv("GMS_SOCKET_DIR", "/" + "s" * 200)
     monkeypatch.setattr(v1_device, "get_device_uuid", lambda _device: "GPU-0")

--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -21,6 +21,7 @@ if not HAS_GMS:
 from gpu_memory_service.cli import args as cli_args
 from gpu_memory_service.cli import runner, server
 from gpu_memory_service.cli.args import parse_args
+from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.v1 import device as v1_device
 
 pytestmark = [
@@ -71,6 +72,58 @@ def test_v1_cli_dispatches_cuda_only_child(monkeypatch, capsys):
     with pytest.raises(SystemExit):
         server.main(["--use-v1", "--device-type", "xpu"])
     assert "--use-v1 only supports --device-type=cuda" in capsys.readouterr().err
+
+
+def test_probe_restore_ready_uses_v0_session_without_use_v1(monkeypatch):
+    opened = []
+
+    class FakeVMM:
+        def list_devices(self):
+            return [2]
+
+    class FakeSession:
+        def __init__(self, path, lock, timeout_ms):
+            opened.append((path, lock, timeout_ms))
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(server, "init_vmm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "get_vmm", lambda: FakeVMM())
+    monkeypatch.setattr(
+        server, "_v0_socket_path", lambda device, tag: f"/tmp/{device}-{tag}"
+    )
+    monkeypatch.setattr(server, "_V0ClientSession", FakeSession)
+
+    server.main(["--probe-restore-ready"])
+
+    assert opened == [("/tmp/2-weights", RequestedLockType.RO, 500)]
+
+
+def test_probe_restore_ready_uses_v1_session_with_use_v1(monkeypatch):
+    opened = []
+
+    class FakeVMM:
+        def list_devices(self):
+            return [2]
+
+    class FakeSession:
+        def __init__(self, path, lock, *, connect_timeout, admission_timeout):
+            opened.append((path, lock, connect_timeout, admission_timeout))
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(server, "init_vmm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "get_vmm", lambda: FakeVMM())
+    monkeypatch.setattr(
+        server, "_v1_socket_path", lambda device, tag: f"/tmp/{device}-{tag}"
+    )
+    monkeypatch.setattr(server, "_V1ClientSession", FakeSession)
+
+    server.main(["--use-v1", "--probe-restore-ready"])
+
+    assert opened == [("/tmp/2-weights", RequestedLockType.RO, 0.5, 0.5)]
 
 
 def test_v1_socket_path_rejects_af_unix_overflow(monkeypatch):

--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -1,13 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for production GMS process and listener topology."""
+"""Tests for GMS process topology."""
 
 from __future__ import annotations
 
 import asyncio
-import sys
-from types import SimpleNamespace
 
 import pytest
 from _deps import HAS_GMS
@@ -18,10 +16,7 @@ if not HAS_GMS:
         allow_module_level=True,
     )
 
-from gpu_memory_service.cli import args as cli_args
 from gpu_memory_service.cli import runner, server
-from gpu_memory_service.cli.args import parse_args
-from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.v1 import device as v1_device
 
 pytestmark = [
@@ -30,100 +25,6 @@ pytestmark = [
     pytest.mark.none,
     pytest.mark.gpu_0,
 ]
-
-
-def test_child_command_launches_default_multi_tag_runner():
-    assert server._child_command(3, "cuda") == [
-        sys.executable,
-        "-m",
-        "gpu_memory_service",
-        "--device",
-        "3",
-        "--device-type",
-        "cuda",
-    ]
-
-
-def test_v1_cli_dispatches_cuda_only_child(monkeypatch, capsys):
-    calls = []
-    monkeypatch.setattr(
-        runner.importlib,
-        "import_module",
-        lambda name: (
-            calls.append(("import", name))
-            or SimpleNamespace(main=lambda argv: calls.append(("main", argv)))
-        ),
-    )
-
-    runner.main(["--use-v1", "--device", "3"])
-
-    assert calls == [
-        ("import", "gpu_memory_service.v1.cli"),
-        ("main", ["--device", "3"]),
-    ]
-    assert server._child_command(3, "cuda", use_v1=True) == [
-        sys.executable,
-        "-m",
-        "gpu_memory_service",
-        "--use-v1",
-        "--device",
-        "3",
-    ]
-    with pytest.raises(SystemExit):
-        server.main(["--use-v1", "--device-type", "xpu"])
-    assert "--use-v1 only supports --device-type=cuda" in capsys.readouterr().err
-
-
-def test_probe_restore_ready_uses_v0_session_without_use_v1(monkeypatch):
-    opened = []
-
-    class FakeVMM:
-        def list_devices(self):
-            return [2]
-
-    class FakeSession:
-        def __init__(self, path, lock, timeout_ms):
-            opened.append((path, lock, timeout_ms))
-
-        def close(self):
-            pass
-
-    monkeypatch.setattr(server, "init_vmm", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(server, "get_vmm", lambda: FakeVMM())
-    monkeypatch.setattr(
-        server, "_v0_socket_path", lambda device, tag: f"/tmp/{device}-{tag}"
-    )
-    monkeypatch.setattr(server, "_V0ClientSession", FakeSession)
-
-    server.main(["--probe-restore-ready"])
-
-    assert opened == [("/tmp/2-weights", RequestedLockType.RO, 500)]
-
-
-def test_probe_restore_ready_uses_v1_session_with_use_v1(monkeypatch):
-    opened = []
-
-    class FakeVMM:
-        def list_devices(self):
-            return [2]
-
-    class FakeSession:
-        def __init__(self, path, lock, *, connect_timeout, admission_timeout):
-            opened.append((path, lock, connect_timeout, admission_timeout))
-
-        def close(self):
-            pass
-
-    monkeypatch.setattr(server, "init_vmm", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(server, "get_vmm", lambda: FakeVMM())
-    monkeypatch.setattr(
-        server, "_v1_socket_path", lambda device, tag: f"/tmp/{device}-{tag}"
-    )
-    monkeypatch.setattr(server, "_V1ClientSession", FakeSession)
-
-    server.main(["--use-v1", "--probe-restore-ready"])
-
-    assert opened == [("/tmp/2-weights", RequestedLockType.RO, 0.5, 0.5)]
 
 
 def test_v1_socket_path_rejects_af_unix_overflow(monkeypatch):
@@ -156,81 +57,6 @@ def test_supervisor_terminates_siblings_when_child_exits():
     clean = [_Process(exit_code=0), _Process()]
     assert server._supervise(clean) == 1
     assert clean[1].terminated
-
-
-def test_parse_args_defaults_to_one_config_per_production_tag(monkeypatch):
-    # get_socket_path queries the GPU UUID through NVML; stub the hardware.
-    monkeypatch.setattr(
-        cli_args,
-        "get_socket_path",
-        lambda device, tag: f"/sockets/{device}-{tag}.sock",
-    )
-
-    configs = parse_args(["--device", "3"])
-
-    assert [config.tag for config in configs] == ["weights", "kv_cache"]
-    assert [config.socket_path for config in configs] == [
-        "/sockets/3-weights.sock",
-        "/sockets/3-kv_cache.sock",
-    ]
-    assert all(config.device == 3 for config in configs)
-
-    (config,) = parse_args(["--device", "3", "--tag", "kv_cache"])
-    assert config.tag == "kv_cache"
-
-
-def test_parse_args_single_tag_honors_explicit_socket_path():
-    (config,) = parse_args(
-        ["--device", "3", "--tag", "weights", "--socket-path", "/run/gms.sock"]
-    )
-
-    assert config.socket_path == "/run/gms.sock"
-
-
-@pytest.mark.parametrize(
-    "argv",
-    [
-        ["--device", "3", "--tag", "weight"],
-        ["--device", "3", "--tag", "weights", "--tag", "bogus"],
-    ],
-)
-def test_parse_args_rejects_unknown_tags(argv, capsys):
-    with pytest.raises(SystemExit):
-        parse_args(argv)
-
-    assert "invalid choice" in capsys.readouterr().err
-
-
-@pytest.mark.parametrize(
-    "argv",
-    [
-        # Default tags: one socket path cannot serve both listeners.
-        ["--device", "3", "--socket-path", "/run/gms.sock"],
-        # Explicit multiple tags with one socket path.
-        [
-            "--device",
-            "3",
-            "--tag",
-            "weights",
-            "--tag",
-            "kv_cache",
-            "--socket-path",
-            "/run/gms.sock",
-        ],
-    ],
-)
-def test_parse_args_rejects_socket_path_for_multiple_tags(argv, capsys):
-    with pytest.raises(SystemExit):
-        parse_args(argv)
-
-    assert "requires exactly one --tag" in capsys.readouterr().err
-
-
-def test_parse_args_rejects_duplicate_tags(capsys):
-    with pytest.raises(SystemExit):
-        parse_args(["--device", "3", "--tag", "weights", "--tag", "weights"])
-
-    assert "must be unique" in capsys.readouterr().err
 
 
 @pytest.mark.timeout(10)

--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -73,32 +73,6 @@ def test_v1_cli_dispatches_cuda_only_child(monkeypatch, capsys):
     assert "--use-v1 only supports --device-type=cuda" in capsys.readouterr().err
 
 
-def test_loader_command_injects_device_only_when_fanning_out():
-    remainder = ["--checkpoint-dir", "/ckpt", "--transfer-backend", "nixl-gds"]
-    assert server._loader_command(remainder, 1) == [
-        sys.executable,
-        "-m",
-        "gpu_memory_service.v1.snapshot.loader",
-        "--checkpoint-dir",
-        "/ckpt",
-        "--transfer-backend",
-        "nixl-gds",
-        "--device",
-        "1",
-    ]
-    assert server._loader_command(remainder + ["--device", "3"]) == [
-        sys.executable,
-        "-m",
-        "gpu_memory_service.v1.snapshot.loader",
-        "--checkpoint-dir",
-        "/ckpt",
-        "--transfer-backend",
-        "nixl-gds",
-        "--device",
-        "3",
-    ]
-
-
 def test_enable_loader_requires_use_v1(capsys):
     with pytest.raises(SystemExit):
         server.main(["--enable-loader", "--checkpoint-dir", "/ckpt"])
@@ -113,11 +87,11 @@ def test_enable_loader_cannot_combine_with_probe(capsys):
     )
 
 
-def test_enable_loader_defaults_to_all_visible_devices(monkeypatch):
+def _stub_supervisor(monkeypatch) -> tuple[list[list[str]], list[tuple[int, int]]]:
     started: list[list[str]] = []
     supervised: list[tuple[int, int]] = []
 
-    class _Process:
+    class _Alive:
         def __init__(self, command: list[str]) -> None:
             started.append(command)
             self.pid = len(started)
@@ -130,12 +104,10 @@ def test_enable_loader_defaults_to_all_visible_devices(monkeypatch):
 
     monkeypatch.setattr(server, "init_vmm", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
-        server,
-        "get_vmm",
-        lambda: SimpleNamespace(list_devices=lambda: [0, 1]),
+        server, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 1])
     )
     monkeypatch.setattr(server.signal, "signal", lambda *_args: None)
-    monkeypatch.setattr(server.subprocess, "Popen", _Process)
+    monkeypatch.setattr(server.subprocess, "Popen", _Alive)
     monkeypatch.setattr(
         server,
         "_supervise",
@@ -143,89 +115,33 @@ def test_enable_loader_defaults_to_all_visible_devices(monkeypatch):
             supervised.append((len(servers), len(loaders or []))) or 0
         ),
     )
+    return started, supervised
+
+
+@pytest.mark.parametrize(
+    ("remainder", "server_count", "device_suffixes"),
+    [
+        (["--checkpoint-dir", "/ckpt"], 2, [["--device", "0"], ["--device", "1"]]),
+        (["--checkpoint-dir", "/ckpt", "--device", "1"], 2, [["--device", "1"]]),
+    ],
+)
+def test_enable_loader_device_scope(
+    monkeypatch, remainder, server_count, device_suffixes
+):
+    started, supervised = _stub_supervisor(monkeypatch)
 
     with pytest.raises(SystemExit) as exc:
-        server.main(
-            [
-                "--use-v1",
-                "--enable-loader",
-                "--checkpoint-dir",
-                "/ckpt",
-                "--transfer-backend",
-                "nixl-gds",
-            ]
-        )
+        server.main(["--use-v1", "--enable-loader", *remainder])
 
     assert exc.value.code == 0
-    assert supervised == [(2, 2)]
-    loader_commands = [
+    loaders = [
         command
         for command in started
         if "gpu_memory_service.v1.snapshot.loader" in command
     ]
-    assert [command[-2:] for command in loader_commands] == [
-        ["--device", "0"],
-        ["--device", "1"],
-    ]
-    assert all(
-        "--checkpoint-dir" in command and "/ckpt" in command
-        for command in loader_commands
-    )
-
-
-def test_enable_loader_device_flag_starts_one_loader(monkeypatch):
-    started: list[list[str]] = []
-    supervised: list[tuple[int, int]] = []
-
-    class _Process:
-        def __init__(self, command: list[str]) -> None:
-            started.append(command)
-            self.pid = len(started)
-
-        def poll(self) -> None:
-            return None
-
-        def terminate(self) -> None:
-            return None
-
-    monkeypatch.setattr(server, "init_vmm", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        server,
-        "get_vmm",
-        lambda: SimpleNamespace(list_devices=lambda: [0, 1]),
-    )
-    monkeypatch.setattr(server.signal, "signal", lambda *_args: None)
-    monkeypatch.setattr(server.subprocess, "Popen", _Process)
-    monkeypatch.setattr(
-        server,
-        "_supervise",
-        lambda servers, loaders=None: (
-            supervised.append((len(servers), len(loaders or []))) or 0
-        ),
-    )
-
-    with pytest.raises(SystemExit) as exc:
-        server.main(
-            [
-                "--use-v1",
-                "--enable-loader",
-                "--checkpoint-dir",
-                "/ckpt",
-                "--device",
-                "1",
-            ]
-        )
-
-    assert exc.value.code == 0
-    assert supervised == [(2, 1)]
-    loader_commands = [
-        command
-        for command in started
-        if "gpu_memory_service.v1.snapshot.loader" in command
-    ]
-    assert len(loader_commands) == 1
-    assert loader_commands[0].count("--device") == 1
-    assert loader_commands[0][-2:] == ["--device", "1"]
+    assert supervised == [(server_count, len(device_suffixes))]
+    assert [command[-2:] for command in loaders] == device_suffixes
+    assert all(command.count("--device") == 1 for command in loaders)
 
 
 def test_v1_socket_path_rejects_af_unix_overflow(monkeypatch):

--- a/lib/gpu_memory_service/tests/test_snapshot_loader.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_loader.py
@@ -68,6 +68,14 @@ def test_list_checkpoint_devices_rejects_mismatched_checkpoints(
         loader._list_checkpoint_devices(str(tmp_path))
 
 
+def test_list_checkpoint_devices_can_scope_to_one_device(tmp_path, monkeypatch):
+    (tmp_path / "device-0").mkdir()
+    (tmp_path / "device-1").mkdir()
+    monkeypatch.setattr(loader, "get_vmm", lambda: FakeVMM(devices=[0, 1]))
+
+    assert loader._list_checkpoint_devices(str(tmp_path), device=0) == [0]
+
+
 def test_load_device_sets_cuda_context_before_storage_client(monkeypatch):
     calls = []
     fake_vmm = FakeVMM(devices=[3])

--- a/lib/gpu_memory_service/tests/test_snapshot_loader.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_loader.py
@@ -17,6 +17,7 @@ if not HAS_GMS:
 from _fake_vmm import FakeVMM
 
 try:
+    from gpu_memory_service.cli import snapshot as snapshot_cli
     from gpu_memory_service.cli.snapshot import loader
 except ModuleNotFoundError:
     pytest.skip(
@@ -135,13 +136,12 @@ class _ExitedProcess:
 
 def test_v1_loader_defaults_to_all_visible_devices(monkeypatch):
     started: list[list[str]] = []
-
-    monkeypatch.setattr(loader, "init_vmm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(snapshot_cli, "init_vmm", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
-        loader, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 2])
+        snapshot_cli, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 2])
     )
     monkeypatch.setattr(
-        loader.subprocess,
+        snapshot_cli.subprocess,
         "Popen",
         lambda command: started.append(command) or _ExitedProcess(command),
     )
@@ -157,14 +157,10 @@ def test_v1_loader_defaults_to_all_visible_devices(monkeypatch):
     assert all(
         "gpu_memory_service.v1.snapshot.loader" in command for command in started
     )
-    assert all(
-        "--checkpoint-dir" in command and "/ckpt" in command for command in started
-    )
 
 
 def test_v1_loader_device_flag_stays_rank_local(monkeypatch):
     calls: list[tuple[str, list[str]]] = []
-
     monkeypatch.setattr(
         loader.importlib,
         "import_module",

--- a/lib/gpu_memory_service/tests/test_snapshot_loader.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_loader.py
@@ -3,8 +3,6 @@
 
 """Unit tests for the GMS snapshot loader CLI."""
 
-from types import SimpleNamespace
-
 import pytest
 from _deps import HAS_GMS
 
@@ -17,7 +15,6 @@ if not HAS_GMS:
 from _fake_vmm import FakeVMM
 
 try:
-    from gpu_memory_service.cli import snapshot as snapshot_cli
     from gpu_memory_service.cli.snapshot import loader
 except ModuleNotFoundError:
     pytest.skip(
@@ -117,78 +114,3 @@ def test_load_device_sets_cuda_context_before_storage_client(monkeypatch):
             "clear_existing": True,
         },
     )
-
-
-class _ExitedProcess:
-    def __init__(self, command: list[str]) -> None:
-        self.command = command
-        self.pid = 1
-
-    def poll(self) -> int:
-        return 0
-
-    def terminate(self) -> None:
-        return None
-
-    def wait(self) -> int:
-        return 0
-
-
-def test_v1_loader_defaults_to_all_visible_devices(monkeypatch):
-    started: list[list[str]] = []
-    monkeypatch.setattr(snapshot_cli, "init_vmm", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        snapshot_cli, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 2])
-    )
-    monkeypatch.setattr(
-        snapshot_cli.subprocess,
-        "Popen",
-        lambda command: started.append(command) or _ExitedProcess(command),
-    )
-
-    loader.main(
-        ["--use-v1", "--checkpoint-dir", "/ckpt", "--transfer-backend", "nixl-gds"]
-    )
-
-    assert [command[-2:] for command in started] == [
-        ["--device", "0"],
-        ["--device", "2"],
-    ]
-    assert all(
-        "gpu_memory_service.v1.snapshot.loader" in command for command in started
-    )
-
-
-def test_v1_loader_device_flag_stays_rank_local(monkeypatch):
-    calls: list[tuple[str, list[str]]] = []
-    monkeypatch.setattr(
-        loader.importlib,
-        "import_module",
-        lambda name: SimpleNamespace(main=lambda argv: calls.append((name, argv))),
-    )
-
-    loader.main(
-        [
-            "--use-v1",
-            "--checkpoint-dir",
-            "/ckpt",
-            "--device",
-            "1",
-            "--transfer-backend",
-            "nixl-gds",
-        ]
-    )
-
-    assert calls == [
-        (
-            "gpu_memory_service.v1.snapshot.loader",
-            [
-                "--checkpoint-dir",
-                "/ckpt",
-                "--device",
-                "1",
-                "--transfer-backend",
-                "nixl-gds",
-            ],
-        )
-    ]

--- a/lib/gpu_memory_service/tests/test_snapshot_loader.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_loader.py
@@ -3,6 +3,8 @@
 
 """Unit tests for the GMS snapshot loader CLI."""
 
+from types import SimpleNamespace
+
 import pytest
 from _deps import HAS_GMS
 
@@ -114,3 +116,83 @@ def test_load_device_sets_cuda_context_before_storage_client(monkeypatch):
             "clear_existing": True,
         },
     )
+
+
+class _ExitedProcess:
+    def __init__(self, command: list[str]) -> None:
+        self.command = command
+        self.pid = 1
+
+    def poll(self) -> int:
+        return 0
+
+    def terminate(self) -> None:
+        return None
+
+    def wait(self) -> int:
+        return 0
+
+
+def test_v1_loader_defaults_to_all_visible_devices(monkeypatch):
+    started: list[list[str]] = []
+
+    monkeypatch.setattr(loader, "init_vmm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        loader, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 2])
+    )
+    monkeypatch.setattr(
+        loader.subprocess,
+        "Popen",
+        lambda command: started.append(command) or _ExitedProcess(command),
+    )
+
+    loader.main(
+        ["--use-v1", "--checkpoint-dir", "/ckpt", "--transfer-backend", "nixl-gds"]
+    )
+
+    assert [command[-2:] for command in started] == [
+        ["--device", "0"],
+        ["--device", "2"],
+    ]
+    assert all(
+        "gpu_memory_service.v1.snapshot.loader" in command for command in started
+    )
+    assert all(
+        "--checkpoint-dir" in command and "/ckpt" in command for command in started
+    )
+
+
+def test_v1_loader_device_flag_stays_rank_local(monkeypatch):
+    calls: list[tuple[str, list[str]]] = []
+
+    monkeypatch.setattr(
+        loader.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(main=lambda argv: calls.append((name, argv))),
+    )
+
+    loader.main(
+        [
+            "--use-v1",
+            "--checkpoint-dir",
+            "/ckpt",
+            "--device",
+            "1",
+            "--transfer-backend",
+            "nixl-gds",
+        ]
+    )
+
+    assert calls == [
+        (
+            "gpu_memory_service.v1.snapshot.loader",
+            [
+                "--checkpoint-dir",
+                "/ckpt",
+                "--device",
+                "1",
+                "--transfer-backend",
+                "nixl-gds",
+            ],
+        )
+    ]

--- a/lib/gpu_memory_service/tests/test_snapshot_saver.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_saver.py
@@ -3,12 +3,9 @@
 
 """Unit tests for the GMS snapshot saver CLI."""
 
-from types import SimpleNamespace
-
 import pytest
 
 try:
-    from gpu_memory_service.cli import snapshot as snapshot_cli
     from gpu_memory_service.cli.snapshot import saver
 except ModuleNotFoundError:
     pytest.skip(
@@ -61,70 +58,3 @@ def test_save_device_sets_cuda_context_before_storage_client(monkeypatch):
     assert calls[2][2]["socket_path"] == "/tmp/gms-3"
     assert calls[2][2]["device"] == 3
     assert calls[3] == ("save", {"max_workers": 8})
-
-
-class _ExitedProcess:
-    def __init__(self, command: list[str]) -> None:
-        self.command = command
-        self.pid = 1
-
-    def poll(self) -> int:
-        return 0
-
-    def terminate(self) -> None:
-        return None
-
-    def wait(self) -> int:
-        return 0
-
-
-def test_v1_saver_defaults_to_all_visible_devices(monkeypatch):
-    started: list[list[str]] = []
-    monkeypatch.setattr(snapshot_cli, "init_vmm", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        snapshot_cli, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 1])
-    )
-    monkeypatch.setattr(
-        snapshot_cli.subprocess,
-        "Popen",
-        lambda command: started.append(command) or _ExitedProcess(command),
-    )
-
-    saver.main(["--use-v1", "--checkpoint-dir", "/ckpt"])
-
-    assert [command[-2:] for command in started] == [
-        ["--device", "0"],
-        ["--device", "1"],
-    ]
-    assert all("gpu_memory_service.v1.snapshot.saver" in command for command in started)
-
-
-def test_v1_saver_device_flag_stays_rank_local(monkeypatch):
-    calls: list[tuple[str, list[str]]] = []
-    monkeypatch.setattr(
-        saver.importlib,
-        "import_module",
-        lambda name: SimpleNamespace(main=lambda argv: calls.append((name, argv))),
-    )
-
-    saver.main(["--use-v1", "--checkpoint-dir", "/ckpt", "--device", "3"])
-
-    assert calls == [
-        (
-            "gpu_memory_service.v1.snapshot.saver",
-            ["--checkpoint-dir", "/ckpt", "--device", "3"],
-        )
-    ]
-
-
-def test_v1_saver_equals_device_flag_stays_rank_local(monkeypatch):
-    calls: list[list[str]] = []
-    monkeypatch.setattr(
-        saver.importlib,
-        "import_module",
-        lambda name: SimpleNamespace(main=lambda argv: calls.append(argv)),
-    )
-
-    saver.main(["--use-v1", "--checkpoint-dir", "/ckpt", "--device=2"])
-
-    assert calls == [["--checkpoint-dir", "/ckpt", "--device=2"]]

--- a/lib/gpu_memory_service/tests/test_snapshot_saver.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_saver.py
@@ -21,6 +21,15 @@ pytestmark = [
 ]
 
 
+def test_saver_device_defaults_to_all_visible():
+    args = saver._build_parser().parse_args(["--checkpoint-dir", "/ckpt"])
+    assert args.device is None
+    args = saver._build_parser().parse_args(
+        ["--checkpoint-dir", "/ckpt", "--device", "2"]
+    )
+    assert args.device == 2
+
+
 def test_save_device_sets_cuda_context_before_storage_client(monkeypatch):
     calls = []
 

--- a/lib/gpu_memory_service/tests/test_snapshot_saver.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_saver.py
@@ -3,10 +3,16 @@
 
 """Unit tests for the GMS snapshot saver CLI."""
 
+from types import SimpleNamespace
+
 import pytest
 
 try:
-    from gpu_memory_service.cli.snapshot import saver
+    from gpu_memory_service.cli.snapshot import (
+        has_device_argument,
+        saver,
+        should_fan_out_v1,
+    )
 except ModuleNotFoundError:
     pytest.skip(
         "gpu_memory_service package is not available in this test image",
@@ -58,3 +64,110 @@ def test_save_device_sets_cuda_context_before_storage_client(monkeypatch):
     assert calls[2][2]["socket_path"] == "/tmp/gms-3"
     assert calls[2][2]["device"] == 3
     assert calls[3] == ("save", {"max_workers": 8})
+
+
+class _ExitedProcess:
+    def __init__(self, command: list[str]) -> None:
+        self.command = command
+        self.pid = 1
+
+    def poll(self) -> int:
+        return 0
+
+    def terminate(self) -> None:
+        return None
+
+    def wait(self) -> int:
+        return 0
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        ([], False),
+        (["--device-type", "cuda"], False),
+        (["--checkpoint-dir", "/ckpt"], False),
+        (["--device", "0"], True),
+        (["--device=3"], True),
+        (["--checkpoint-dir", "/ckpt", "--device", "1"], True),
+    ],
+)
+def test_has_device_argument(argv, expected):
+    assert has_device_argument(argv) is expected
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["--checkpoint-dir", "/ckpt"], True),
+        (["--device-type", "cuda", "--checkpoint-dir", "/ckpt"], True),
+        (["--checkpoint-dir", "/ckpt", "--device", "0"], False),
+        (["--device=0"], False),
+        (["-h"], False),
+        (["--help", "--checkpoint-dir", "/ckpt"], False),
+    ],
+)
+def test_should_fan_out_v1(argv, expected):
+    assert should_fan_out_v1(argv) is expected
+
+
+def test_v1_saver_defaults_to_all_visible_devices(monkeypatch):
+    started: list[list[str]] = []
+
+    monkeypatch.setattr(saver, "init_vmm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        saver, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 1])
+    )
+    monkeypatch.setattr(
+        saver.subprocess,
+        "Popen",
+        lambda command: started.append(command) or _ExitedProcess(command),
+    )
+
+    saver.main(["--use-v1", "--checkpoint-dir", "/ckpt"])
+
+    assert [command[-2:] for command in started] == [
+        ["--device", "0"],
+        ["--device", "1"],
+    ]
+    assert all(
+        command[:3] == [started[0][0], "-m", "gpu_memory_service.v1.snapshot.saver"]
+        for command in started
+    )
+    assert all(
+        "--checkpoint-dir" in command and "/ckpt" in command for command in started
+    )
+
+
+def test_v1_saver_device_flag_stays_rank_local(monkeypatch):
+    calls: list[tuple[str, list[str] | None]] = []
+
+    monkeypatch.setattr(
+        saver.importlib,
+        "import_module",
+        lambda name: (
+            calls.append(("import", [name]))
+            or SimpleNamespace(main=lambda argv: calls.append(("main", argv)))
+        ),
+    )
+
+    saver.main(["--use-v1", "--checkpoint-dir", "/ckpt", "--device", "3"])
+
+    assert calls == [
+        ("import", ["gpu_memory_service.v1.snapshot.saver"]),
+        ("main", ["--checkpoint-dir", "/ckpt", "--device", "3"]),
+    ]
+
+
+def test_v1_saver_equals_device_flag_stays_rank_local(monkeypatch):
+    calls: list[list[str] | None] = []
+
+    monkeypatch.setattr(
+        saver.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(main=lambda argv: calls.append(argv)),
+    )
+
+    saver.main(["--use-v1", "--checkpoint-dir", "/ckpt", "--device=2"])
+
+    assert calls == [["--checkpoint-dir", "/ckpt", "--device=2"]]

--- a/lib/gpu_memory_service/tests/test_snapshot_saver.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_saver.py
@@ -21,15 +21,6 @@ pytestmark = [
 ]
 
 
-def test_saver_device_defaults_to_all_visible():
-    args = saver._build_parser().parse_args(["--checkpoint-dir", "/ckpt"])
-    assert args.device is None
-    args = saver._build_parser().parse_args(
-        ["--checkpoint-dir", "/ckpt", "--device", "2"]
-    )
-    assert args.device == 2
-
-
 def test_save_device_sets_cuda_context_before_storage_client(monkeypatch):
     calls = []
 

--- a/lib/gpu_memory_service/tests/test_snapshot_saver.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_saver.py
@@ -8,11 +8,8 @@ from types import SimpleNamespace
 import pytest
 
 try:
-    from gpu_memory_service.cli.snapshot import (
-        has_device_argument,
-        saver,
-        should_fan_out_v1,
-    )
+    from gpu_memory_service.cli import snapshot as snapshot_cli
+    from gpu_memory_service.cli.snapshot import saver
 except ModuleNotFoundError:
     pytest.skip(
         "gpu_memory_service package is not available in this test image",
@@ -81,45 +78,14 @@ class _ExitedProcess:
         return 0
 
 
-@pytest.mark.parametrize(
-    ("argv", "expected"),
-    [
-        ([], False),
-        (["--device-type", "cuda"], False),
-        (["--checkpoint-dir", "/ckpt"], False),
-        (["--device", "0"], True),
-        (["--device=3"], True),
-        (["--checkpoint-dir", "/ckpt", "--device", "1"], True),
-    ],
-)
-def test_has_device_argument(argv, expected):
-    assert has_device_argument(argv) is expected
-
-
-@pytest.mark.parametrize(
-    ("argv", "expected"),
-    [
-        (["--checkpoint-dir", "/ckpt"], True),
-        (["--device-type", "cuda", "--checkpoint-dir", "/ckpt"], True),
-        (["--checkpoint-dir", "/ckpt", "--device", "0"], False),
-        (["--device=0"], False),
-        (["-h"], False),
-        (["--help", "--checkpoint-dir", "/ckpt"], False),
-    ],
-)
-def test_should_fan_out_v1(argv, expected):
-    assert should_fan_out_v1(argv) is expected
-
-
 def test_v1_saver_defaults_to_all_visible_devices(monkeypatch):
     started: list[list[str]] = []
-
-    monkeypatch.setattr(saver, "init_vmm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(snapshot_cli, "init_vmm", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
-        saver, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 1])
+        snapshot_cli, "get_vmm", lambda: SimpleNamespace(list_devices=lambda: [0, 1])
     )
     monkeypatch.setattr(
-        saver.subprocess,
+        snapshot_cli.subprocess,
         "Popen",
         lambda command: started.append(command) or _ExitedProcess(command),
     )
@@ -130,38 +96,29 @@ def test_v1_saver_defaults_to_all_visible_devices(monkeypatch):
         ["--device", "0"],
         ["--device", "1"],
     ]
-    assert all(
-        command[:3] == [started[0][0], "-m", "gpu_memory_service.v1.snapshot.saver"]
-        for command in started
-    )
-    assert all(
-        "--checkpoint-dir" in command and "/ckpt" in command for command in started
-    )
+    assert all("gpu_memory_service.v1.snapshot.saver" in command for command in started)
 
 
 def test_v1_saver_device_flag_stays_rank_local(monkeypatch):
-    calls: list[tuple[str, list[str] | None]] = []
-
+    calls: list[tuple[str, list[str]]] = []
     monkeypatch.setattr(
         saver.importlib,
         "import_module",
-        lambda name: (
-            calls.append(("import", [name]))
-            or SimpleNamespace(main=lambda argv: calls.append(("main", argv)))
-        ),
+        lambda name: SimpleNamespace(main=lambda argv: calls.append((name, argv))),
     )
 
     saver.main(["--use-v1", "--checkpoint-dir", "/ckpt", "--device", "3"])
 
     assert calls == [
-        ("import", ["gpu_memory_service.v1.snapshot.saver"]),
-        ("main", ["--checkpoint-dir", "/ckpt", "--device", "3"]),
+        (
+            "gpu_memory_service.v1.snapshot.saver",
+            ["--checkpoint-dir", "/ckpt", "--device", "3"],
+        )
     ]
 
 
 def test_v1_saver_equals_device_flag_stays_rank_local(monkeypatch):
-    calls: list[list[str] | None] = []
-
+    calls: list[list[str]] = []
     monkeypatch.setattr(
         saver.importlib,
         "import_module",

--- a/lib/gpu_memory_service/v1/README.md
+++ b/lib/gpu_memory_service/v1/README.md
@@ -214,8 +214,18 @@ start one rank-local child directly:
 gpu-memory-service --use-v1 --device 0
 ```
 
-Save or load that rank's weight artifact under
-`<checkpoint-dir>/device-0`:
+Save or load every visible device. Artifacts land under
+`<checkpoint-dir>/device-<ordinal>`:
+
+```text
+python -m gpu_memory_service.cli.snapshot.saver --use-v1 \
+  --checkpoint-dir /checkpoints/run/versions/1
+python -m gpu_memory_service.cli.snapshot.loader --use-v1 \
+  --checkpoint-dir /checkpoints/run/versions/1 \
+  --transfer-backend nixl-gds
+```
+
+Pass `--device` to scope save or load to one GPU:
 
 ```text
 python -m gpu_memory_service.cli.snapshot.saver --use-v1 \
@@ -225,10 +235,23 @@ python -m gpu_memory_service.cli.snapshot.loader --use-v1 \
   --transfer-backend nixl-gds
 ```
 
+Restore while starting the servers. `--enable-loader` takes the rest of the
+command line, including `--checkpoint-dir`, and forwards it to each loader.
+Add `--device` in that remainder to load only one GPU:
+
+```text
+python3 -m gpu_memory_service.cli.server --use-v1 --enable-loader \
+  --checkpoint-dir /checkpoints/run/versions/1 \
+  --transfer-backend nixl-gds
+python3 -m gpu_memory_service.cli.server --use-v1 --enable-loader \
+  --checkpoint-dir /checkpoints/run/versions/1 \
+  --transfer-backend nixl-gds --device 0
+```
+
 The loader also accepts `nixl` and `sharded-ssd`, the existing sharded SSD root
 and queue flags, and repeatable `--posix-backend-param KEY=VALUE` overrides.
-Start one server and loader per rank/device with the restored worker's
-`GMS_SOCKET_DIR`. Only the `weights` socket is used by artifact transfer.
+Start the restored worker with `GMS_SOCKET_DIR`. Only the `weights` socket is
+used by artifact transfer.
 
 Select the worker while retaining vLLM's normal load format:
 

--- a/lib/gpu_memory_service/v1/README.md
+++ b/lib/gpu_memory_service/v1/README.md
@@ -214,8 +214,8 @@ start one rank-local child directly:
 gpu-memory-service --use-v1 --device 0
 ```
 
-Save or load every visible device. Artifacts land under
-`<checkpoint-dir>/device-<ordinal>`:
+Save or load every visible device (pass `--device N` for one GPU). Artifacts
+land under `<checkpoint-dir>/device-<ordinal>`:
 
 ```text
 python -m gpu_memory_service.cli.snapshot.saver --use-v1 \
@@ -223,35 +223,15 @@ python -m gpu_memory_service.cli.snapshot.saver --use-v1 \
 python -m gpu_memory_service.cli.snapshot.loader --use-v1 \
   --checkpoint-dir /checkpoints/run/versions/1 \
   --transfer-backend nixl-gds
-```
-
-Pass `--device` to scope save or load to one GPU:
-
-```text
-python -m gpu_memory_service.cli.snapshot.saver --use-v1 \
-  --checkpoint-dir /checkpoints/run/versions/1 --device 0
-python -m gpu_memory_service.cli.snapshot.loader --use-v1 \
-  --checkpoint-dir /checkpoints/run/versions/1 --device 0 \
-  --transfer-backend nixl-gds
-```
-
-Restore while starting the servers. `--enable-loader` takes the rest of the
-command line, including `--checkpoint-dir`, and forwards it to each loader.
-Add `--device` in that remainder to load only one GPU:
-
-```text
 python3 -m gpu_memory_service.cli.server --use-v1 --enable-loader \
   --checkpoint-dir /checkpoints/run/versions/1 \
   --transfer-backend nixl-gds
-python3 -m gpu_memory_service.cli.server --use-v1 --enable-loader \
-  --checkpoint-dir /checkpoints/run/versions/1 \
-  --transfer-backend nixl-gds --device 0
 ```
 
 The loader also accepts `nixl` and `sharded-ssd`, the existing sharded SSD root
 and queue flags, and repeatable `--posix-backend-param KEY=VALUE` overrides.
 Start the restored worker with `GMS_SOCKET_DIR`. Only the `weights` socket is
-used by artifact transfer.
+used by artifact transfer. `--enable-loader` must come last among server flags.
 
 Select the worker while retaining vLLM's normal load format:
 

--- a/lib/gpu_memory_service/v1/cli.py
+++ b/lib/gpu_memory_service/v1/cli.py
@@ -10,7 +10,7 @@ from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from contextlib import ExitStack
 from threading import Event
 
-from gpu_memory_service.common.vmm import get_vmm
+from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, init_vmm
 from gpu_memory_service.v1 import device as device_identity
 from gpu_memory_service.v1.checkpoint import GMSCheckpointLifecycle
 from gpu_memory_service.v1.device import get_socket_path
@@ -48,12 +48,13 @@ def run_servers(
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
-        description="GMS V1 rank-local sidecar",
+        description="GMS V1 single-device server",
         allow_abbrev=False,
     )
     parser.add_argument("--device", type=int, default=0)
     args = parser.parse_args(argv)
 
+    init_vmm(VMMDeviceType.CUDA)
     vmm = get_vmm()
     gpu_uuid = device_identity.get_device_uuid(args.device)
     with ExitStack() as stack:

--- a/lib/gpu_memory_service/v1/device.py
+++ b/lib/gpu_memory_service/v1/device.py
@@ -11,6 +11,8 @@ import tempfile
 from functools import cache
 from uuid import UUID
 
+from gpu_memory_service.common.vmm.cuda_utils import cuda_ensure_initialized
+
 try:
     from cuda.bindings import driver as cuda
 except ImportError:
@@ -47,8 +49,7 @@ def get_device_uuid(device: int) -> str:
             "cuda-python is required for GPU Memory Service device identity"
         )
 
-    (result,) = cuda.cuInit(0)
-    _check_cuda(result, "cuInit")
+    cuda_ensure_initialized()
     result, cuda_device = cuda.cuDeviceGet(device)
     _check_cuda(result, "cuDeviceGet")
     result, uuid = cuda.cuDeviceGetUuid(cuda_device)

--- a/lib/gpu_memory_service/v1/snapshot/loader.py
+++ b/lib/gpu_memory_service/v1/snapshot/loader.py
@@ -40,7 +40,7 @@ def _build_parser():
         "--device",
         type=int,
         default=0,
-        help="CUDA-visible device ordinal. Wrapper CLIs fan out when omitted.",
+        help="CUDA-visible rank-local device ordinal.",
     )
     parser.add_argument(
         "--posix-backend-param",

--- a/lib/gpu_memory_service/v1/snapshot/loader.py
+++ b/lib/gpu_memory_service/v1/snapshot/loader.py
@@ -40,10 +40,7 @@ def _build_parser():
         "--device",
         type=int,
         default=0,
-        help=(
-            "CUDA-visible device ordinal. Omit this flag on the snapshot "
-            "wrapper CLI to run one child per visible device."
-        ),
+        help="CUDA-visible device ordinal. Wrapper CLIs fan out when omitted.",
     )
     parser.add_argument(
         "--posix-backend-param",

--- a/lib/gpu_memory_service/v1/snapshot/loader.py
+++ b/lib/gpu_memory_service/v1/snapshot/loader.py
@@ -36,12 +36,7 @@ def _parse_backend_params(values: list[str]) -> dict[str, str]:
 def _build_parser():
     parser = _build_v0_parser()
     parser.description = "Load exact GMS V1 weights into a fresh rank-local server."
-    parser.add_argument(
-        "--device",
-        type=int,
-        default=0,
-        help="CUDA-visible rank-local device ordinal.",
-    )
+    parser.set_defaults(device=0)
     parser.add_argument(
         "--posix-backend-param",
         action="append",

--- a/lib/gpu_memory_service/v1/snapshot/loader.py
+++ b/lib/gpu_memory_service/v1/snapshot/loader.py
@@ -40,7 +40,10 @@ def _build_parser():
         "--device",
         type=int,
         default=0,
-        help="CUDA-visible rank-local device ordinal.",
+        help=(
+            "CUDA-visible device ordinal. Omit this flag on the snapshot "
+            "wrapper CLI to run one child per visible device."
+        ),
     )
     parser.add_argument(
         "--posix-backend-param",

--- a/lib/gpu_memory_service/v1/snapshot/saver.py
+++ b/lib/gpu_memory_service/v1/snapshot/saver.py
@@ -24,7 +24,10 @@ def _build_parser():
         "--device",
         type=int,
         default=0,
-        help="CUDA-visible rank-local device ordinal.",
+        help=(
+            "CUDA-visible device ordinal. Omit this flag on the snapshot "
+            "wrapper CLI to run one child per visible device."
+        ),
     )
     return parser
 

--- a/lib/gpu_memory_service/v1/snapshot/saver.py
+++ b/lib/gpu_memory_service/v1/snapshot/saver.py
@@ -24,10 +24,7 @@ def _build_parser():
         "--device",
         type=int,
         default=0,
-        help=(
-            "CUDA-visible device ordinal. Omit this flag on the snapshot "
-            "wrapper CLI to run one child per visible device."
-        ),
+        help="CUDA-visible device ordinal. Wrapper CLIs fan out when omitted.",
     )
     return parser
 

--- a/lib/gpu_memory_service/v1/snapshot/saver.py
+++ b/lib/gpu_memory_service/v1/snapshot/saver.py
@@ -20,12 +20,7 @@ from gpu_memory_service.v1.snapshot.weight_artifact import save_weights
 def _build_parser():
     parser = _build_v0_parser()
     parser.description = "Save exact committed GMS V1 weight allocations."
-    parser.add_argument(
-        "--device",
-        type=int,
-        default=0,
-        help="CUDA-visible rank-local device ordinal.",
-    )
+    parser.set_defaults(device=0)
     return parser
 
 

--- a/lib/gpu_memory_service/v1/snapshot/saver.py
+++ b/lib/gpu_memory_service/v1/snapshot/saver.py
@@ -24,7 +24,7 @@ def _build_parser():
         "--device",
         type=int,
         default=0,
-        help="CUDA-visible device ordinal. Wrapper CLIs fan out when omitted.",
+        help="CUDA-visible rank-local device ordinal.",
     )
     return parser
 


### PR DESCRIPTION
## Summary

- **Bare V1:** the context-free supervisor discovers CUDA-visible ordinals through NVML and starts one persistent V1 server process per device. It starts no loader or saver and performs no readiness work.
- **Checkpoint:** the regular one-shot saver CLI (`gpu_memory_service.cli.snapshot.saver --use-v1 --all-devices`) discovers visible ordinals through NVML, starts one existing V1 saver process per device, forwards the saver-owned arguments unchanged, and injects only `--device`. Existing `--use-v1 --device N` calls continue to run exactly one V1 saver. The all-device supervisor exits after all savers succeed; a failed saver terminates remaining saver children and fails the container.
- **Restore:** optional `--restore-loader` supervision starts one existing V1 loader per visible device alongside the persistent servers. Successful loaders exit while servers remain running; any loader failure or persistent-server exit terminates remaining children and fails closed.
- Only per-device saver/loader children initialize CUDA as needed. The outer server and saver coordinators remain context-free.

RO saver admission proves that weights are committed, not that the engine is asleep. The persistent `gms-server` sidecar remains running during capture; main-container readiness/sleep is a separate capture gate. This PR does not add a barrier, sentinel, Redis dependency, protocol, controller flow, rank mapping, probe, or operator/manifest change.

### Process lifecycle

```text
bare:       server supervisor -> persistent server[device 0..N]
checkpoint: regular saver     -> saver[device 0..N] -> exit after all save
            gms-server sidecar remains running; engine sleep is gated separately
restore:    server supervisor -> persistent server[device 0..N]
                              \-> loader[device 0..N] -> exit after restore
```

### Draft validation blocker

This PR remains a draft until the all-device checkpoint/restore lifecycle is exercised in the target multi-GPU container environment with the external engine sleep/readiness gate.

## Validation

- `ruff format --check lib/gpu_memory_service/cli/snapshot/saver.py` — passed
- `ruff check lib/gpu_memory_service/cli/snapshot/saver.py` — passed
- `pre-commit run --files lib/gpu_memory_service/cli/snapshot/saver.py` — all applicable hooks passed
- `.venv/bin/python -m compileall -q lib/gpu_memory_service/cli/snapshot/saver.py` — passed
- `.venv/bin/python -m gpu_memory_service.cli.snapshot.saver --use-v1 --all-devices --help` — passed; existing saver-owned options remain available
- `git diff --check origin/main` — passed

No tests, image builds, live GPU/Kubernetes validation, or model evaluation were run for this focused lifecycle change.

AI assistance was used to inspect and implement the change. The submitter must review every changed line and complete live validation before marking the PR ready.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for launching snapshot savers and restore loaders independently for each device.
  * Added bounded restore-readiness checks and new command-line options for probing and loader control.
  * Added validation to ensure device-wide operations are used only with V1.

* **Bug Fixes**
  * Improved process supervision, cleanup, and failure reporting when servers or loaders exit unexpectedly.
  * Improved CUDA initialization handling across processes.
  * Updated V1 server behavior and help text for single-device operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->