### PR TITLE
build: pin dynamo-llm version in backend-common for cargo publish

### DIFF
--- a/.github/scripts/apply_dev_version.py
+++ b/.github/scripts/apply_dev_version.py
@@ -44,6 +44,18 @@ SUBCRATE_CARGO_TARGETS = [
     "lib/kvbm-physical/Cargo.toml",
 ]
 
+# Member manifests that pin the workspace version inside a dependency
+# inline table, e.g. backend-common's
+# `dynamo-llm = { path = "../llm", version = "1.4.0", default-features = false }`
+# (a direct path dep because cargo cannot express `workspace = true` +
+# `default-features = false`). VERSION_LINE_RE is line-anchored and
+# intentionally skips inline tables, so these files get the same exact-string
+# rewrite as the root path-dep pins (the pinned value always equals
+# [workspace.package].version).
+WORKSPACE_PIN_CARGO_TARGETS = [
+    "lib/backend-common/Cargo.toml",
+]
+
 # Line-anchored: matches `version = "X.Y.Z"` lines. Skips `version.workspace = true`
 # (no quotes) and `version = { ... }` (no string). Safe for sub-crate Cargo.tomls
 # whose only `version = "..."` line is the [package] one; external-crate deps use
@@ -140,12 +152,19 @@ def rewrite_root_cargo(root: Path, suffix: str) -> None:
         return  # already stamped -- idempotent no-op
     new = semver(suffix, base)
 
-    text = re.sub(
-        rf'(\bversion\s*=\s*"){re.escape(base)}(")',
-        lambda mm: f"{mm.group(1)}{new}{mm.group(2)}",
-        text,
-    )
+    pin_re = re.compile(rf'(\bversion\s*=\s*"){re.escape(base)}(")')
+    text = pin_re.sub(lambda mm: f"{mm.group(1)}{new}{mm.group(2)}", text)
     path.write_text(text)
+
+    # Bump the same literal pin where it lives in member manifests (inline
+    # dep tables that VERSION_LINE_RE deliberately skips). The early
+    # "already stamped" return above keeps this idempotent.
+    for rel in WORKSPACE_PIN_CARGO_TARGETS:
+        p = root / rel
+        t = p.read_text()
+        t2 = pin_re.sub(lambda mm: f"{mm.group(1)}{new}{mm.group(2)}", t)
+        if t2 != t:
+            p.write_text(t2)
 
 
 def main() -> int:

--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -23,7 +23,7 @@ integration = ["dynamo-runtime/integration"]
 
 [dependencies]
 dynamo-runtime = { workspace = true }
-dynamo-llm = { path = "../llm", default-features = false }
+dynamo-llm = { path = "../llm", version = "1.4.0", default-features = false }
 dynamo-protocols = { workspace = true }
 
 anyhow = { workspace = true }


### PR DESCRIPTION
cargo publish rejects a path dependency without a version; this is why dynamo-backend-common has missed every crates.io GA since 1.2.1 (the old publish loop masked the error). workspace = true is not an option because the crate needs default-features = false. Verified with cargo publish --dry-run on release/1.4.0.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency version for improved workspace compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->