### PR TITLE
build: backend common publish version 1.4.0

### DIFF
--- a/.github/scripts/apply_dev_version.py
+++ b/.github/scripts/apply_dev_version.py
@@ -44,6 +44,18 @@ SUBCRATE_CARGO_TARGETS = [
     "lib/kvbm-physical/Cargo.toml",
 ]
 
+# Member manifests that pin the workspace version inside a dependency
+# inline table, e.g. backend-common's
+# `dynamo-llm = { path = "../llm", version = "1.4.0", default-features = false }`
+# (a direct path dep because cargo cannot express `workspace = true` +
+# `default-features = false`). VERSION_LINE_RE is line-anchored and
+# intentionally skips inline tables, so these files get the same exact-string
+# rewrite as the root path-dep pins (the pinned value always equals
+# [workspace.package].version).
+WORKSPACE_PIN_CARGO_TARGETS = [
+    "lib/backend-common/Cargo.toml",
+]
+
 # Line-anchored: matches `version = "X.Y.Z"` lines. Skips `version.workspace = true`
 # (no quotes) and `version = { ... }` (no string). Safe for sub-crate Cargo.tomls
 # whose only `version = "..."` line is the [package] one; external-crate deps use
@@ -140,12 +152,19 @@ def rewrite_root_cargo(root: Path, suffix: str) -> None:
         return  # already stamped -- idempotent no-op
     new = semver(suffix, base)
 
-    text = re.sub(
-        rf'(\bversion\s*=\s*"){re.escape(base)}(")',
-        lambda mm: f"{mm.group(1)}{new}{mm.group(2)}",
-        text,
-    )
+    pin_re = re.compile(rf'(\bversion\s*=\s*"){re.escape(base)}(")')
+    text = pin_re.sub(lambda mm: f"{mm.group(1)}{new}{mm.group(2)}", text)
     path.write_text(text)
+
+    # Bump the same literal pin where it lives in member manifests (inline
+    # dep tables that VERSION_LINE_RE deliberately skips). The early
+    # "already stamped" return above keeps this idempotent.
+    for rel in WORKSPACE_PIN_CARGO_TARGETS:
+        p = root / rel
+        t = p.read_text()
+        t2 = pin_re.sub(lambda mm: f"{mm.group(1)}{new}{mm.group(2)}", t)
+        if t2 != t:
+            p.write_text(t2)
 
 
 def main() -> int:

--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -23,7 +23,7 @@ integration = ["dynamo-runtime/integration"]
 
 [dependencies]
 dynamo-runtime = { workspace = true }
-dynamo-llm = { path = "../llm", default-features = false }
+dynamo-llm = { path = "../llm", version = "1.4.0", default-features = false }
 dynamo-protocols = { workspace = true }
 
 anyhow = { workspace = true }


### PR DESCRIPTION
## Overview:

Cherry-pick of #13303 onto release/1.4.0, merged independently to unblock the 1.4.0 crates.io release.
▎ - dynamo-llm path dep in backend-common gets an explicit version = "1.4.0" — cargo publish rejects versionless path deps; this is why dynamo-backend-common has missed every crates.io release since 1.2.1 (the old publish loop masked the error). workspace = true can't express default-features = false.
▎ - apply_dev_version.py learns to stamp workspace-version pins in member manifests (keeps the branch consistent with main; the pin can never go stale under any future stamping).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->