### PR TITLE
build: add description to kvbm-kernels/logical/physical for cargo publish

### DIFF
--- a/lib/kvbm-kernels/Cargo.toml
+++ b/lib/kvbm-kernels/Cargo.toml
@@ -5,6 +5,7 @@
 name = "kvbm-kernels"
 version = "1.4.0"
 edition.workspace = true
+description.workspace = true
 authors.workspace = true
 license.workspace = true
 repository = "https://github.com/ai-dynamo/dynamo.git"

--- a/lib/kvbm-logical/Cargo.toml
+++ b/lib/kvbm-logical/Cargo.toml
@@ -5,6 +5,7 @@
 name = "kvbm-logical"
 version = "1.4.0"
 edition.workspace = true
+description.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/lib/kvbm-physical/Cargo.toml
+++ b/lib/kvbm-physical/Cargo.toml
@@ -5,6 +5,7 @@
 name = "kvbm-physical"
 version = "1.4.0"
 edition.workspace = true
+description.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
crates.io rejects uploads whose manifest has no description ("missing or empty metadata fields: description"). kvbm-kernels, kvbm-logical, and kvbm-physical lost the field on this branch (all three published 1.3.1 WITH "Dynamo Inference Framework"), which blocks their 1.4.0 publish and cascades to every dependent (kvbm-engine, dynamo-mocker, dynamo-llm, dynamo-bench) because cargo resolves the version-rewritten deps against the live index.

Inherit the workspace description, same as kvbm-common already does.

Verified: cargo metadata shows description set for all three; the packaged kvbm-kernels-1.4.0.crate manifest carries description = "Dynamo Inference Framework".

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->