### PR TITLE
fix(container): install NIXL where the loader can find it in the frontend and sglang images (OPS-8275)

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -41,7 +41,12 @@ dynamo:
   nats_version: v2.12.14
   etcd_version: v3.5.33
 
-  nixl_ref: v1.0.1
+  # Keep in step with the framework images: the frontend runs NIXL RDMA against
+  # sglang and vLLM workers, which both ship 1.3.2, and this was the only image
+  # left on 1.0.1. The Rust bindings are unaffected -- ai-dynamo-runtime is
+  # built in wheel_builder_base, before NIXL exists in the image, so nixl-sys
+  # resolves the library with dlopen at runtime rather than linking it.
+  nixl_ref: v1.3.2
   nixl_ucx_ref: v1.21.0
   nixl_gdrcopy_ref: v2.5.2
   nixl_libfabric_repo: https://github.com/ofiwg/libfabric.git
@@ -131,8 +136,9 @@ sglang:
   # Builds the NIXL C++ SDK in wheel_builder so the dev stage can link nixl-sys
   # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang
   # NIXL Python stack — its wheel COPY is narrowed to ai_dynamo*.whl so the SDK
-  # build doesn't leak into the runtime image.
-  nixl_ref: v1.3.0
+  # build doesn't leak into the runtime image. Matches the 1.3.2 that stack
+  # ships, so the SDK the dev stage links is the one the runtime loads.
+  nixl_ref: v1.3.2
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -42,10 +42,21 @@ dynamo:
   etcd_version: v3.5.33
 
   # Keep in step with the framework images: the frontend runs NIXL RDMA against
-  # sglang and vLLM workers, which both ship 1.3.2, and this was the only image
-  # left on 1.0.1. The Rust bindings are unaffected -- ai-dynamo-runtime is
-  # built in wheel_builder_base, before NIXL exists in the image, so nixl-sys
-  # resolves the library with dlopen at runtime rather than linking it.
+  # sglang and vLLM workers, which both ship 1.3.2, and this was the last
+  # section left on 1.0.1.
+  #
+  # Scope: this is the `dynamo` FRAMEWORK ref, not a frontend-only knob.
+  # args.Dockerfile falls back to context[framework].nixl_ref for every target
+  # built from this section -- dynamo-runtime, dev, local-dev and frontend --
+  # and wheel_builder builds NIXL from it, so it is also the NIXL the KVBM
+  # wheel links against (enable_kvbm is true below). That combination is not
+  # new: vLLM already builds KVBM against 1.3.2 and TRT-LLM against 1.3.1, both
+  # with nixl-sys pinned to 1.0.1. This moves `dynamo` onto the same footing
+  # rather than onto a novel one.
+  #
+  # The Rust bindings are unaffected -- ai-dynamo-runtime is built in
+  # wheel_builder_base, before NIXL exists in the image, so nixl-sys resolves
+  # the library with dlopen at runtime rather than linking it.
   nixl_ref: v1.3.2
   nixl_ucx_ref: v1.21.0
   nixl_gdrcopy_ref: v2.5.2

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -181,6 +181,52 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
     export UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install .
 
+# The NIXL Python wheel installed above carries libnixl*.so in a private
+# directory that is on no loader path, and it is the raw meson-python wheel --
+# not auditwheel-repaired -- so it bundles no UCX either. Python reaches the
+# libraries through the extension module's RPATH; Rust nixl-sys does not,
+# because it resolves libnixl_capi.so with a plain dlopen(). Without the native
+# install prefix and UCX below, a frontend serving a worker registered with
+# --frontend-decoding fails twice over: first "NIXL is not supported in stub
+# mode", then "No UCX plugin found" once the loader path alone is fixed. In
+# both cases the model is never added and /v1/models stays empty forever, with
+# nothing exiting non-zero.
+#
+# Take UCX from wheel_builder, which built it and then built NIXL against it,
+# and expose the wheel's own libraries through a stable prefix. Pointing at the
+# wheel rather than copying wheel_builder's separate native install keeps one
+# NIXL per process: this image runs Rust and Python in the same interpreter, so
+# a second copy would mean two libnixl instances with independent state.
+COPY --from=wheel_builder /usr/local/ucx /usr/local/ucx
+# Selected by CUDA major rather than assuming a single nixl-cu* is installed:
+# the nixl meta package can pull more than one alongside each other, and the
+# wrong one would put a mismatched NIXL on the loader path.
+ARG CUDA_MAJOR
+COPY --chmod=755 container/deps/vllm/install_nixl_from_wheel.sh /usr/local/bin/install_nixl_from_wheel
+RUN install_nixl_from_wheel \
+        --cuda-major "${CUDA_MAJOR}" \
+        --site-packages "$(/opt/dynamo/venv/bin/python -c 'import site; print(site.getsitepackages()[0])')" \
+        --prefix /opt/dynamo/nixl \
+        --skip-headers
+ENV NIXL_PREFIX=/opt/dynamo/nixl \
+    NIXL_LIB_DIR=/opt/dynamo/nixl \
+    NIXL_PLUGIN_DIR=/opt/dynamo/nixl/plugins
+ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:/usr/local/ucx/lib:/usr/local/ucx/lib/ucx:${LD_LIBRARY_PATH:-}
+
+# UCX needs these to find RDMA devices; without them it silently drops to TCP.
+USER root
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libibverbs1 \
+        rdma-core \
+        ibverbs-utils \
+        libibumad3 \
+        libnuma1 \
+        librdmacm1 \
+        ibverbs-providers && \
+    rm -rf /var/lib/apt/lists/*
+USER dynamo
+
 # Setup environment for all users
 USER root
 RUN chmod 755 /opt/dynamo/.launch_screen && \

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -284,10 +284,14 @@ ENV LD_LIBRARY_PATH=/opt/dynamo/nixl-ucx-compat${LD_LIBRARY_PATH:+:${LD_LIBRARY_
 # --frontend-decoding -- silently falls back to stub mode. Expose the same
 # stable prefix vLLM uses (cf. templates/vllm_runtime.Dockerfile).
 #
-# Select the wheel by CUDA major rather than assuming a single one is
-# installed: the nixl meta package can pull more than one nixl-cu* alongside
-# each other, and picking the wrong one would put a mismatched NIXL on the
-# loader path. The installer fails the build if that wheel is not laid out as
+# Select the wheel by CUDA major rather than globbing. In THIS image a glob
+# would in fact be unambiguous -- discover_nixl_ucx_layout.py, run by the
+# compat step above, already exits non-zero on more than one nixl-cu*
+# distribution ("expected one nixl-cu* distribution, found N"). Naming the
+# major is still the better contract: it keeps one interface with vLLM
+# (cf. templates/vllm_runtime.Dockerfile), and it states which NIXL this image
+# is meant to load instead of inferring it from whatever happens to be
+# installed. The installer fails the build if that wheel is not laid out as
 # expected, which is what a CUDA-major bump should do -- not produce an image
 # that hangs at startup.
 ARG CUDA_MAJOR

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -274,6 +274,32 @@ RUN --mount=type=bind,source=./container/deps/sglang/install_nixl_ucx_compat.sh,
     --mount=type=bind,source=./container/deps/sglang/discover_nixl_ucx_layout.py,target=/tmp/discover_nixl_ucx_layout.py,readonly \
     bash /tmp/install_nixl_ucx_compat.sh /opt/dynamo/nixl-ucx-compat
 ENV LD_LIBRARY_PATH=/opt/dynamo/nixl-ucx-compat${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+# The compat directory above carries NIXL's UCX dependencies, not libnixl*.so
+# itself -- those live in the wheel's meson-python directory, which is on no
+# loader path. Python consumers reach them through the extension module's
+# RPATH; Rust nixl-sys does not, because it resolves libnixl_capi.so with a
+# plain dlopen(). Without this, any process that uses NIXL without importing
+# the nixl Python package first -- notably dynamo.frontend built with
+# --frontend-decoding -- silently falls back to stub mode. Expose the same
+# stable prefix vLLM uses (cf. templates/vllm_runtime.Dockerfile).
+#
+# Select the wheel by CUDA major rather than assuming a single one is
+# installed: the nixl meta package can pull more than one nixl-cu* alongside
+# each other, and picking the wrong one would put a mismatched NIXL on the
+# loader path. The installer fails the build if that wheel is not laid out as
+# expected, which is what a CUDA-major bump should do -- not produce an image
+# that hangs at startup.
+ARG CUDA_MAJOR
+RUN --mount=type=bind,source=./container/deps/vllm/install_nixl_from_wheel.sh,target=/tmp/install_nixl_from_wheel.sh,readonly \
+    bash /tmp/install_nixl_from_wheel.sh \
+        --cuda-major "${CUDA_MAJOR}" \
+        --site-packages "$(python3 -c 'import site; print(site.getsitepackages()[0])')" \
+        --prefix /opt/dynamo/nixl \
+        --skip-headers
+# Appended, not prepended: the compat directory stays first, as its installer
+# requires.
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}:}/opt/dynamo/nixl:/opt/dynamo/nixl/plugins
 {% endif %}
 
 # Copy tests, deploy and components for CI with correct ownership

--- a/examples/backends/sglang/launch/agg_vision.sh
+++ b/examples/backends/sglang/launch/agg_vision.sh
@@ -92,6 +92,20 @@ BANNER_SUFFIX=""
 if [ "$FRONTEND_DECODING" = true ]; then
     FD_ARGS+=(--frontend-decoding)
     BANNER_SUFFIX=" (Frontend Decoding)"
+
+    # The SGLang image inherits NIXL from the upstream lmsysorg/sglang runtime
+    # stack but does NOT add its native libs to LD_LIBRARY_PATH (cf.
+    # container/templates/dev.Dockerfile: "SGLang dev/local-dev inherit the
+    # upstream SGLang/NIXL runtime stack"). Without this, dynamo.frontend's Rust
+    # runtime hits "NIXL is not supported in stub mode" the moment it tries to
+    # build a media-fetching pipeline. Point the loader at the wheel-shipped .so
+    # files explicitly. We build cuda13 only, so the wheel is nixl_cu13, which
+    # stores its native libs under ".nixl_cu13.mesonpy.libs".
+    NIXL_WHEEL_LIBS="$(python3 -c 'import nixl_cu13, os; print(os.path.join(os.path.dirname(os.path.dirname(nixl_cu13.__file__)), ".nixl_cu13.mesonpy.libs"))' 2>/dev/null || true)"
+    if [ -d "$NIXL_WHEEL_LIBS" ]; then
+        export LD_LIBRARY_PATH="${NIXL_WHEEL_LIBS}:${NIXL_WHEEL_LIBS}/plugins:${LD_LIBRARY_PATH}"
+        export NIXL_PLUGIN_DIR="${NIXL_PLUGIN_DIR:-$NIXL_WHEEL_LIBS/plugins}"
+    fi
 fi
 
 print_launch_banner --multimodal "Launching Aggregated Vision Serving${BANNER_SUFFIX}" "$MODEL" "$HTTP_PORT"

--- a/examples/backends/sglang/launch/agg_vision.sh
+++ b/examples/backends/sglang/launch/agg_vision.sh
@@ -92,20 +92,6 @@ BANNER_SUFFIX=""
 if [ "$FRONTEND_DECODING" = true ]; then
     FD_ARGS+=(--frontend-decoding)
     BANNER_SUFFIX=" (Frontend Decoding)"
-
-    # The SGLang image inherits NIXL from the upstream lmsysorg/sglang runtime
-    # stack but does NOT add its native libs to LD_LIBRARY_PATH (cf.
-    # container/templates/dev.Dockerfile: "SGLang dev/local-dev inherit the
-    # upstream SGLang/NIXL runtime stack"). Without this, dynamo.frontend's Rust
-    # runtime hits "NIXL is not supported in stub mode" the moment it tries to
-    # build a media-fetching pipeline. Point the loader at the wheel-shipped .so
-    # files explicitly. We build cuda13 only, so the wheel is nixl_cu13, which
-    # stores its native libs under ".nixl_cu13.mesonpy.libs".
-    NIXL_WHEEL_LIBS="$(python3 -c 'import nixl_cu13, os; print(os.path.join(os.path.dirname(os.path.dirname(nixl_cu13.__file__)), ".nixl_cu13.mesonpy.libs"))' 2>/dev/null || true)"
-    if [ -d "$NIXL_WHEEL_LIBS" ]; then
-        export LD_LIBRARY_PATH="${NIXL_WHEEL_LIBS}:${NIXL_WHEEL_LIBS}/plugins:${LD_LIBRARY_PATH}"
-        export NIXL_PLUGIN_DIR="${NIXL_PLUGIN_DIR:-$NIXL_WHEEL_LIBS/plugins}"
-    fi
 fi
 
 print_launch_banner --multimodal "Launching Aggregated Vision Serving${BANNER_SUFFIX}" "$MODEL" "$HTTP_PORT"


### PR DESCRIPTION
## Summary

Rust `nixl-sys` loads NIXL with a bare `dlopen("libnixl_capi.so")`. In the `dynamo-frontend` and `sglang-runtime` images nothing on the default loader path provides that soname, so `is_stub()` returns true and any process that uses NIXL without importing the `nixl` Python package first falls into stub mode. Python is unaffected because `nixl_cu13/_bindings*.so` has an RPATH into the wheel's private directories; `dynamo/_core.abi3.so` has none.

The visible symptom: a frontend serving a worker registered with `--frontend-decoding` never adds the model. `/v1/models` stays `{"data":[]}` forever, `dynamo_llm::discovery::controller` retries on a 1→30s backoff, and nothing exits non-zero.

vLLM already fixes this at the image layer ([`templates/vllm_runtime.Dockerfile:59-73`](../blob/main/container/templates/vllm_runtime.Dockerfile#L59-L73), with a comment naming the exact failure). This applies the same treatment to the two images that lack it.

| image | nixl / nixl-cu13 | bare `dlopen` before |
| -- | -- | -- |
| `dynamo-frontend` | 1.0.1 / 1.0.1 | **FAIL** — and ships no UCX at all |
| `sglang-runtime` | 1.3.2 / 1.3.2 | **FAIL** |
| `vllm-runtime` | 1.3.1 / cu13 1.3.2 | OK |
| `trtllm-runtime` | 1.3.1 | OK |

### Changes

1. **`sglang_runtime.Dockerfile`** — run the existing, already-generic `container/deps/vllm/install_nixl_from_wheel.sh` with `--cuda-major ${CUDA_MAJOR} --skip-headers` into `/opt/dynamo/nixl`, and append that prefix to `LD_LIBRARY_PATH`. Appended, not prepended: the existing `nixl-ucx-compat` directory must stay first, as its installer requires. `NIXL_PLUGIN_DIR` is deliberately left unset — the loader path alone is sufficient, and setting it would change plugin resolution for existing sglang workers.

   The compat directory already in this image symlinks the **auditwheel** dir (`nixl_cu13.libs`: UCX, absl), not the **meson-python** dir (`.nixl_cu13.mesonpy.libs`: `libnixl*.so`, `plugins/`). That is why it does not fix the dlopen on its own.

2. **`frontend.Dockerfile`** — same installer, plus `COPY --from=wheel_builder /usr/local/ucx /usr/local/ucx` and the RDMA runtime packages UCX needs to find devices instead of silently dropping to TCP. This image is broken two layers deep: fixing only the loader path moves the error from `NIXL is not supported in stub mode` to `Failed to initialize required backends: [UCX: No UCX plugin found]`, because the frontend installs the raw meson-python wheel, which bundles no UCX.

   UCX is taken from `wheel_builder` — the stage that built it and then built NIXL against it. The NIXL libraries are exposed from the wheel rather than by copying wheel_builder's separate native install: this image runs Rust and Python in one interpreter, so a second copy would mean two `libnixl` instances with independent state.

3. **`examples/backends/sglang/launch/agg_vision.sh`** — drop the inline `LD_LIBRARY_PATH`/`NIXL_PLUGIN_DIR` block (−14 lines); the image now provides it.

4. **`container/context.yaml`** — frontend `nixl_ref` 1.0.1 → 1.3.2 (it was the only image left behind, and it speaks NIXL RDMA to sglang and vLLM workers that both ship 1.3.2); sglang's SDK `nixl_ref` 1.3.0 → 1.3.2 so the headers the dev stage links match the library the runtime loads. TRT-LLM stays 1.3.1 and the scoped sglang-xpu override stays 1.1.0 — both deliberate and separate.

   This does not touch the Rust bindings. `ai-dynamo-runtime` is built in `wheel_builder_base`, which the NIXL stage comes *after*, so `nixl-sys` never sees the SDK at build time and resolves the library with `dlopen` at runtime. `nixl-sys` stays pinned at 1.0.1 and keeps working against 1.3.2 — already the arrangement in the sglang, vLLM and TRT-LLM images.

### Why the image and not the launch script

#12819 (OPS-8072) fixes the failing test at the right layer for that test — it starts `dynamo.frontend` inside the sglang container, and the launch scripts are what it controls. This PR is not a revert; it removes the *need* for the helper, and covers `dynamo-frontend`, which no launch script can reach.

It also removes a silent-failure mode. The shell helper resolves the directory through `python3 -c 'import nixl_cu13...' 2>/dev/null || true`; if the wheel layout changes, that becomes a no-op and the original hang comes back with zero diagnostics (measured below). The installer instead `die`s on any layout mismatch, so a CUDA-major bump fails the build rather than shipping an image that hangs at startup.

Selection is by CUDA **major**, not by globbing for a single `nixl-cu*` directory: `nixl==1.3.2` pulls `nixl-cu12` *and* `nixl-cu13`, so an "expect exactly one" glob would hard-fail the build.

## Validation

Reproduced first on the unpatched image `14b2f1a5c5…-sglang-runtime-test` (no GPU needed): a worker registers a model card with a `media_decoder`, the frontend runs on pure image defaults.

| run | stub errors | Chat ready | `/v1/models` |
| -- | -- | -- | -- |
| control (image defaults) | 8 | 0 | `{"data":[]}` forever |
| + #12819 helper | 0 | 1 | served ~7s |
| helper whose `import nixl_cu13` fails | 7 | 0 | `{"data":[]}` — exit 0, zero diagnostics |

After the fix — fresh containers, pure image defaults, no helper:

| image | bare `dlopen` | served |
| -- | -- | -- |
| sglang as shipped | FAIL | NO |
| sglang + fix | OK | ~6s |
| sglang + fix, multi-wheel (`nixl-cu12` installed alongside) | OK | ~6s |
| `dynamo-frontend` as shipped | FAIL | NO |
| `dynamo-frontend` + fix (shipped 1.0.1 wheel + UCX) | OK | ~9s |
| `dynamo-frontend` + nixl 1.3.2 | OK | ~6s |
| #12819-patched `agg_vision.sh` on unfixed image | — | NO (stub mode) |
| #12819-patched `agg_vision.sh` on fixed image | — | ~6s |

Regression audit on the fixed sglang image: no soname collisions against `ld.so.cache`; Python `nixl_agent` still constructs with the UCX backend; UCX still resolves via `$ORIGIN` into `nixl_cu13.libs`.

Installer negative control: `--cuda-major 99` → `ERROR: expected NIXL wheel libs at .../.nixl_cu99.mesonpy.libs; upstream NIXL wheel layout changed`, exit 1.

`COPY --from=wheel_builder /usr/local/ucx` was exercised with a real UCX 1.21.0 tree (matching `nixl_ucx_ref: v1.21.0`, same `--prefix=/usr/local/ucx`, taken from the TRT-LLM runtime image) standing in for the `wheel_builder` stage, which cannot be built standalone locally; the multi-stage build succeeds and installs the prefix. CI builds the real stage.

Linear: OPS-8275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for NIXL 1.3.2 across Dynamo and SGLang runtime environments.
  * Added CUDA-aware NIXL installation for SGLang deployments.
  * Added NIXL and UCX runtime libraries, plugins, and RDMA/InfiniBand support to frontend images.

* **Bug Fixes**
  * Improved runtime library configuration to ensure compatible NIXL libraries are available during deployment.
  * Simplified SGLang vision launch configuration by removing redundant library discovery settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->