### PR TITLE
feat(vllm): support NixlPushConnector with overlapped prefill/decode dispatch

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -31,6 +31,7 @@ from dynamo.common.configuration.utils import split_served_model_names
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.vllm.backend_args import DynamoVllmArgGroup, DynamoVllmConfig
 from dynamo.vllm.constants import DisaggregationMode
+from dynamo.vllm.kv_connector_protocols import NIXL_CONNECTOR_NAMES
 
 from . import envs
 
@@ -445,23 +446,26 @@ def create_kv_events_config(
 
 
 def _uses_nixl_connector(engine_config: AsyncEngineArgs) -> bool:
-    """Check if the user-provided --kv-transfer-config uses NixlConnector.
+    """Check if the user-provided --kv-transfer-config uses a NIXL connector.
 
-    Handles both direct usage (kv_connector="NixlConnector") and nested usage
-    inside PdConnector (kv_connector_extra_config.connectors contains
-    "NixlConnector").
+    Covers both the pull-mode ``NixlConnector`` and the push-mode
+    ``NixlPushConnector``, in both direct usage (``kv_connector=...``) and
+    nested usage inside PdConnector (``kv_connector_extra_config.connectors``).
     """
     kv_cfg = getattr(engine_config, "kv_transfer_config", None)
     if kv_cfg is None:
         return False
-    if kv_cfg.kv_connector == "NixlConnector":
+    if kv_cfg.kv_connector in NIXL_CONNECTOR_NAMES:
         return True
     # PdConnector wraps multiple connectors in kv_connector_extra_config.
     # Each entry is a dict like {"kv_connector": "NixlConnector", ...}.
     if kv_cfg.kv_connector == "PdConnector":
         extra = kv_cfg.kv_connector_extra_config or {}
         for entry in extra.get("connectors", []):
-            if isinstance(entry, dict) and entry.get("kv_connector") == "NixlConnector":
+            if (
+                isinstance(entry, dict)
+                and entry.get("kv_connector") in NIXL_CONNECTOR_NAMES
+            ):
                 return True
     return False
 

--- a/components/src/dynamo/vllm/kv_connector_protocols.py
+++ b/components/src/dynamo/vllm/kv_connector_protocols.py
@@ -140,6 +140,9 @@ KV_CONNECTOR_PROTOCOLS: Dict[str, Type[KvConnectorProtocol]] = {
 # same side channel, so push belongs here for the same reason pull does.
 NIXL_CONNECTOR_NAMES: Tuple[str, ...] = ("NixlConnector", "NixlPushConnector")
 
+# ``KVTransferConfig.kv_connector`` value that selects push mode.
+PUSH_CONNECTOR_NAME: str = "NixlPushConnector"
+
 # Wrapper connectors that compose sub-connectors under
 # ``kv_connector_extra_config["connectors"]``. ``PdConnector``
 # (kvbm.vllm_integration.connector) subclasses vLLM's ``MultiConnector``
@@ -254,6 +257,36 @@ def _resolve_multi_connector_protocol(
     return KV_CONNECTOR_PROTOCOLS[name](
         _child_vllm_config(vllm_config, kv_cfg, sub_config)
     )
+
+
+def resolve_nixl_push_kv_transfer_config(vllm_config: Any) -> Optional[Any]:
+    """Return the ``KVTransferConfig`` the engine's ``NixlPushConnector`` runs
+    under, or ``None`` when the engine is not in push mode.
+
+    Deliberately *not* routed through :func:`make_kv_connector_protocol`: that
+    raises on any connector it doesn't recognize, which is right at request
+    setup but wrong here. Registration must stay silent for engines using
+    connectors that have no PD protocol at all (LMCache, FlexKV, KVBM alone).
+
+    Resolves through wrapper connectors so the returned config is the child's
+    view, carrying the ``engine_id`` a peer has to name -- the wrapper's would
+    not match the connector that owns the transfer.
+    """
+    kv_cfg = getattr(vllm_config, "kv_transfer_config", None)
+    if kv_cfg is None:
+        return None
+    if kv_cfg.kv_connector == PUSH_CONNECTOR_NAME:
+        return kv_cfg
+    if kv_cfg.kv_connector not in MULTI_CONNECTOR_WRAPPERS:
+        return None
+
+    extra = getattr(kv_cfg, "kv_connector_extra_config", None) or {}
+    if not isinstance(extra, dict):
+        return None
+    for sub in extra.get("connectors") or []:
+        if isinstance(sub, dict) and sub.get("kv_connector") == PUSH_CONNECTOR_NAME:
+            return _child_vllm_config(vllm_config, kv_cfg, sub).kv_transfer_config
+    return None
 
 
 def _child_vllm_config(

--- a/components/src/dynamo/vllm/kv_connector_protocols.py
+++ b/components/src/dynamo/vllm/kv_connector_protocols.py
@@ -58,6 +58,28 @@ class NixlConnectorProtocol(KvConnectorProtocol):
         return prefill_response.kv_transfer_params
 
 
+class NixlPushConnectorProtocol(NixlConnectorProtocol):
+    """Push-based, but with the same ``kv_transfer_params`` shape as pull.
+
+    ``NixlPushConnector`` reverses who moves the KV blocks -- prefill WRITEs
+    into decode's pre-allocated memory instead of decode READing prefill's --
+    but that reversal is negotiated worker-to-worker over NIXL notifications,
+    not through the params the handler sets. So the prefill leg is byte-identical
+    to pull mode (``do_remote_decode`` is what marks this engine as the producer),
+    and the decode leg is still whatever the prefill response reports.
+
+    Inheriting rather than aliasing keeps the registry honest about which
+    connector is configured, and gives the divergence somewhere to land if
+    upstream ever splits the two shapes.
+
+    Note this is the *sequential* handoff, used when the frontend did not
+    pre-dispatch decode. It works -- the prefill worker holds its finished
+    blocks until decode's late registration arrives -- but it forfeits the
+    overlap push mode exists to buy. The overlapped path builds decode's params
+    in the router from discovery, and never consults this class.
+    """
+
+
 class MooncakeConnectorProtocol(KvConnectorProtocol):
     """Push-based: ``transfer_id`` is allocated up front and threaded
     through both sides; bootstrap address is published to the decode
@@ -109,8 +131,14 @@ class MooncakeConnectorProtocol(KvConnectorProtocol):
 # Keyed by ``KVTransferConfig.kv_connector``. One entry per connector.
 KV_CONNECTOR_PROTOCOLS: Dict[str, Type[KvConnectorProtocol]] = {
     "NixlConnector": NixlConnectorProtocol,
+    "NixlPushConnector": NixlPushConnectorProtocol,
     "MooncakeConnector": MooncakeConnectorProtocol,
 }
+
+# Connectors that transfer over NIXL and therefore need the side-channel host
+# resolved before the engine starts. Both directions of the transfer use the
+# same side channel, so push belongs here for the same reason pull does.
+NIXL_CONNECTOR_NAMES: Tuple[str, ...] = ("NixlConnector", "NixlPushConnector")
 
 # Wrapper connectors that compose sub-connectors under
 # ``kv_connector_extra_config["connectors"]``. ``PdConnector``

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -48,6 +48,7 @@ from dynamo.llm import (
 )
 from dynamo.runtime import Endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
+from dynamo.vllm.nixl_push import publish_nixl_push_endpoint
 from dynamo.vllm.router_hints import enable_router_hint_support
 from dynamo.vllm.worker_factory import WorkerFactory
 
@@ -762,6 +763,10 @@ async def register_vllm_model(
 
     # Set topology and KV transfer policy for topology-aware routing
     apply_topology_config(runtime_config)
+
+    # Push-mode KV transfer needs the prefill engine to be nameable before it
+    # has run, so decode can register its blocks while prefill is in flight.
+    publish_nixl_push_endpoint(runtime_config, vllm_config, worker_type, dp_range)
 
     # Configure media decoder for frontend image decoding when enabled
     # This enables frontend to decode images and transfer via NIXL RDMA

--- a/components/src/dynamo/vllm/nixl_push.py
+++ b/components/src/dynamo/vllm/nixl_push.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Discovery advertisement for vLLM's push-mode NIXL KV connector.
+
+Pull mode keeps the prefill engine's NIXL coordinates private: the decode
+worker learns them from the prefill response and then READs. Push mode
+inverts the transfer -- decode registers its freshly allocated blocks with
+prefill, which WRITEs into them -- so decode has to be able to name the
+prefill engine *before* prefill has produced anything. Publishing the
+coordinates to discovery is what lets the frontend dispatch both legs at
+once, which is the entire performance argument for push mode.
+
+Advertising is optional in the strict sense: without it the frontend falls
+back to the sequential handoff, where the prefill worker holds its finished
+blocks until decode's late registration arrives. That is correct but forfeits
+the overlap, so the cases below that decline to advertise log why.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+from dynamo.llm import ModelRuntimeConfig, WorkerType
+from dynamo.vllm.kv_connector_protocols import resolve_nixl_push_kv_transfer_config
+
+logger = logging.getLogger(__name__)
+
+
+def _side_channel_endpoint(vllm_config: VllmConfig) -> Optional[tuple[str, int]]:
+    """Mirror how vLLM's NIXL scheduler derives its own listening address.
+
+    See ``NixlBaseConnectorScheduler.__init__``: the host is the env var
+    verbatim, and the port is the configured base offset by the engine's
+    data-parallel index. Recomputing it here rather than reading it back off
+    the connector is deliberate -- the connector is constructed inside the
+    engine core process and is not reachable from registration.
+    """
+    from vllm import envs as vllm_envs
+
+    host = vllm_envs.VLLM_NIXL_SIDE_CHANNEL_HOST
+    if not host:
+        return None
+    port = (
+        vllm_envs.VLLM_NIXL_SIDE_CHANNEL_PORT
+        + vllm_config.parallel_config.data_parallel_index
+    )
+    return host, port
+
+
+def publish_nixl_push_endpoint(
+    runtime_config: ModelRuntimeConfig,
+    vllm_config: VllmConfig,
+    worker_type: WorkerType,
+    dp_range: tuple[int, int] = (0, 1),
+) -> bool:
+    """Advertise this engine's NIXL push coordinates. Returns whether it did.
+
+    A no-op unless this is a prefill worker running ``NixlPushConnector``:
+    only the prefill side of a push transfer is named by its peer, and only
+    push mode needs naming at all.
+    """
+    if worker_type != WorkerType.Prefill:
+        return False
+
+    kv_transfer_config = resolve_nixl_push_kv_transfer_config(vllm_config)
+    if kv_transfer_config is None:
+        return False
+
+    # One advertised port cannot describe several engines. vLLM gives each
+    # data-parallel rank its own side channel, so a worker fronting more than
+    # one rank would publish coordinates that are wrong for all but the first.
+    # Decline rather than mislead; the sequential handoff still works.
+    if dp_range[1] > 1:
+        logger.warning(
+            "NixlPushConnector prefill worker manages %d data-parallel ranks, "
+            "each with its own NIXL side channel. Not advertising push "
+            "coordinates; the prefill/decode handoff will run sequentially "
+            "instead of overlapped. Use external or hybrid DP load balancing "
+            "to get one rank per worker.",
+            dp_range[1],
+        )
+        return False
+
+    engine_id: Optional[Any] = getattr(kv_transfer_config, "engine_id", None)
+    if not engine_id:
+        logger.warning(
+            "NixlPushConnector prefill worker has no kv_transfer_config."
+            "engine_id; not advertising push coordinates. The handoff will "
+            "run sequentially."
+        )
+        return False
+
+    endpoint = _side_channel_endpoint(vllm_config)
+    if endpoint is None:
+        logger.warning(
+            "VLLM_NIXL_SIDE_CHANNEL_HOST is unset, so this prefill worker has "
+            "no address to publish. Not advertising push coordinates; the "
+            "handoff will run sequentially."
+        )
+        return False
+
+    host, port = endpoint
+    parallel_config = vllm_config.parallel_config
+    runtime_config.set_nixl_push_endpoint(
+        str(engine_id),
+        host,
+        port,
+        parallel_config.tensor_parallel_size,
+        parallel_config.pipeline_parallel_size,
+    )
+    logger.info(
+        "Publishing NIXL push endpoint to discovery: engine_id=%s %s:%d "
+        "(tp=%d, pp=%d)",
+        engine_id,
+        host,
+        port,
+        parallel_config.tensor_parallel_size,
+        parallel_config.pipeline_parallel_size,
+    )
+    return True

--- a/components/src/dynamo/vllm/nixl_push.py
+++ b/components/src/dynamo/vllm/nixl_push.py
@@ -52,6 +52,28 @@ def _side_channel_endpoint(vllm_config: VllmConfig) -> Optional[tuple[str, int]]
     return host, port
 
 
+def _nixl_agent_engine_id(engine_id: Any, parallel_config: Any) -> str:
+    """Mirror how vLLM names the NIXL agent for this engine.
+
+    ``kv_transfer_config.engine_id`` is only the *base* identity. When the
+    engine is data-parallel, vLLM rewrites it per rank as it spawns the engine
+    core (``EngineCoreProc.run_engine_core``, and the Ray actor manager does
+    the same), so the agent decode has to name is ``<base>_dp<rank>``. A dense
+    engine keeps the base ID unsuffixed -- TP and TEP with one DP rank included.
+
+    Getting this wrong in either direction is silent: the peer rejects the
+    handshake with "Remote NIXL agent engine ID mismatch" and the transfer
+    falls back rather than failing loudly.
+    """
+    is_data_parallel = (
+        parallel_config.data_parallel_size > 1
+        or parallel_config.data_parallel_index > 0
+    )
+    if not is_data_parallel:
+        return str(engine_id)
+    return f"{engine_id}_dp{parallel_config.data_parallel_index}"
+
+
 def publish_nixl_push_endpoint(
     runtime_config: ModelRuntimeConfig,
     vllm_config: VllmConfig,
@@ -106,8 +128,27 @@ def publish_nixl_push_endpoint(
 
     host, port = endpoint
     parallel_config = vllm_config.parallel_config
+
+    # Dynamo assigns this worker a DP range; vLLM names its NIXL agent from
+    # the rank it believes it is. If those disagree, the identity published
+    # here would address an engine that does not exist, and a wrong identity
+    # fails the handshake quietly. Decline rather than advertise a
+    # plausible-looking lie.
+    dp_index = parallel_config.data_parallel_index
+    if dp_range[0] != dp_index:
+        logger.warning(
+            "NixlPushConnector prefill worker was assigned a DP range starting "
+            "at %d but vLLM reports data_parallel_index=%d. Not advertising "
+            "push coordinates whose engine identity may be wrong; the handoff "
+            "will run sequentially instead of overlapped.",
+            dp_range[0],
+            dp_index,
+        )
+        return False
+
+    nixl_engine_id = _nixl_agent_engine_id(engine_id, parallel_config)
     runtime_config.set_nixl_push_endpoint(
-        str(engine_id),
+        nixl_engine_id,
         host,
         port,
         parallel_config.tensor_parallel_size,
@@ -116,7 +157,7 @@ def publish_nixl_push_endpoint(
     logger.info(
         "Publishing NIXL push endpoint to discovery: engine_id=%s %s:%d "
         "(tp=%d, pp=%d)",
-        engine_id,
+        nixl_engine_id,
         host,
         port,
         parallel_config.tensor_parallel_size,

--- a/components/src/dynamo/vllm/tests/test_nixl_push.py
+++ b/components/src/dynamo/vllm/tests/test_nixl_push.py
@@ -31,6 +31,7 @@ def _vllm_config(
     engine_id="prefill-engine-001",
     extra_config=None,
     data_parallel_index=0,
+    data_parallel_size=1,
     tensor_parallel_size=4,
     pipeline_parallel_size=2,
 ):
@@ -47,6 +48,7 @@ def _vllm_config(
         kv_transfer_config=kv_transfer_config,
         parallel_config=SimpleNamespace(
             data_parallel_index=data_parallel_index,
+            data_parallel_size=data_parallel_size,
             tensor_parallel_size=tensor_parallel_size,
             pipeline_parallel_size=pipeline_parallel_size,
         ),
@@ -218,3 +220,75 @@ def test_declines_when_engine_id_is_missing(side_channel, caplog):
     )
     runtime_config.set_nixl_push_endpoint.assert_not_called()
     assert "engine_id" in caplog.text
+
+
+def test_dense_engine_advertises_the_unsuffixed_engine_id(side_channel):
+    """TP/TEP with a single DP rank keeps vLLM's base engine ID.
+
+    vLLM only rewrites ``engine_id`` when ``data_parallel_size > 1 or
+    dp_rank > 0`` (``EngineCoreProc.run_engine_core``). Advertising ``_dp0``
+    for a dense TEP engine names an agent that does not exist, and every push
+    handshake is rejected with "Remote NIXL agent engine ID mismatch".
+    """
+    runtime_config = MagicMock()
+
+    publish_nixl_push_endpoint(
+        runtime_config,
+        _vllm_config(data_parallel_size=1, data_parallel_index=0),
+        WorkerType.Prefill,
+        (0, 1),
+    )
+
+    engine_id = runtime_config.set_nixl_push_endpoint.call_args.args[0]
+    assert engine_id == "prefill-engine-001"
+
+
+def test_data_parallel_engine_advertises_the_dp_suffixed_engine_id(side_channel):
+    """Each DP rank gets its own NIXL agent named ``<base>_dp<global_rank>``."""
+    runtime_config = MagicMock()
+
+    publish_nixl_push_endpoint(
+        runtime_config,
+        _vllm_config(data_parallel_size=4, data_parallel_index=2),
+        WorkerType.Prefill,
+        (2, 1),
+    )
+
+    engine_id, _, port, _, _ = runtime_config.set_nixl_push_endpoint.call_args.args
+    assert engine_id == "prefill-engine-001_dp2"
+    assert port == 5602
+
+
+def test_nonzero_dp_index_is_suffixed_even_when_size_is_one(side_channel):
+    """External load balancing can hand a worker rank N with a local size of
+    one; vLLM still suffixes, because its guard is ``size > 1 or rank > 0``."""
+    runtime_config = MagicMock()
+
+    publish_nixl_push_endpoint(
+        runtime_config,
+        _vllm_config(data_parallel_size=1, data_parallel_index=3),
+        WorkerType.Prefill,
+        (3, 1),
+    )
+
+    engine_id = runtime_config.set_nixl_push_endpoint.call_args.args[0]
+    assert engine_id == "prefill-engine-001_dp3"
+
+
+def test_declines_when_dynamo_range_disagrees_with_vllm_rank(side_channel, caplog):
+    """The published identity is derived from vLLM's rank, so if Dynamo's
+    assigned range starts somewhere else one of the two is wrong. Publishing
+    anyway would name a nonexistent agent and fail the handshake silently."""
+    runtime_config = MagicMock()
+
+    assert (
+        publish_nixl_push_endpoint(
+            runtime_config,
+            _vllm_config(data_parallel_size=4, data_parallel_index=2),
+            WorkerType.Prefill,
+            (1, 1),
+        )
+        is False
+    )
+    runtime_config.set_nixl_push_endpoint.assert_not_called()
+    assert "data_parallel_index" in caplog.text

--- a/components/src/dynamo/vllm/tests/test_nixl_push.py
+++ b/components/src/dynamo/vllm/tests/test_nixl_push.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for :mod:`dynamo.vllm.nixl_push`.
+
+Covers which engines advertise NIXL push coordinates and what they publish.
+The address computation is pinned against vLLM's own derivation
+(``NixlBaseConnectorScheduler.__init__``): host straight from the env var,
+port offset by the data-parallel index. No engine is started -- ``vllm_config``
+is a ``SimpleNamespace`` and the env vars are monkeypatched.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from dynamo.llm import WorkerType
+from dynamo.vllm.nixl_push import publish_nixl_push_endpoint
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def _vllm_config(
+    connector="NixlPushConnector",
+    engine_id="prefill-engine-001",
+    extra_config=None,
+    data_parallel_index=0,
+    tensor_parallel_size=4,
+    pipeline_parallel_size=2,
+):
+    kv_transfer_config = (
+        None
+        if connector is None
+        else SimpleNamespace(
+            kv_connector=connector,
+            engine_id=engine_id,
+            kv_connector_extra_config=extra_config,
+        )
+    )
+    return SimpleNamespace(
+        kv_transfer_config=kv_transfer_config,
+        parallel_config=SimpleNamespace(
+            data_parallel_index=data_parallel_index,
+            tensor_parallel_size=tensor_parallel_size,
+            pipeline_parallel_size=pipeline_parallel_size,
+        ),
+    )
+
+
+@pytest.fixture
+def side_channel(monkeypatch):
+    """Set the NIXL side-channel env vars vLLM reads lazily."""
+    monkeypatch.setenv("VLLM_NIXL_SIDE_CHANNEL_HOST", "10.0.0.1")
+    monkeypatch.setenv("VLLM_NIXL_SIDE_CHANNEL_PORT", "5600")
+
+
+def test_publishes_engine_id_and_side_channel_for_push_prefill(side_channel):
+    runtime_config = MagicMock()
+
+    assert (
+        publish_nixl_push_endpoint(
+            runtime_config, _vllm_config(), WorkerType.Prefill, (0, 1)
+        )
+        is True
+    )
+    runtime_config.set_nixl_push_endpoint.assert_called_once_with(
+        "prefill-engine-001", "10.0.0.1", 5600, 4, 2
+    )
+
+
+def test_port_is_offset_by_data_parallel_index(side_channel):
+    """vLLM gives each DP rank its own side channel at base + index; publishing
+    the base for a non-zero rank would point decode at the wrong engine."""
+    runtime_config = MagicMock()
+
+    publish_nixl_push_endpoint(
+        runtime_config,
+        _vllm_config(data_parallel_index=3),
+        WorkerType.Prefill,
+        (3, 1),
+    )
+
+    _, _, port, _, _ = runtime_config.set_nixl_push_endpoint.call_args.args
+    assert port == 5603
+
+
+def test_resolves_push_connector_nested_in_pd_connector(side_channel):
+    """KVBM composition wraps the PD connector; the child's engine_id is the
+    one the peer must name, not the wrapper's."""
+    runtime_config = MagicMock()
+
+    publish_nixl_push_endpoint(
+        runtime_config,
+        _vllm_config(
+            connector="PdConnector",
+            engine_id="wrapper-engine",
+            extra_config={
+                "connectors": [
+                    {"kv_connector": "DynamoConnector"},
+                    {
+                        "kv_connector": "NixlPushConnector",
+                        "engine_id": "child-engine",
+                    },
+                ]
+            },
+        ),
+        WorkerType.Prefill,
+        (0, 1),
+    )
+
+    engine_id = runtime_config.set_nixl_push_endpoint.call_args.args[0]
+    assert engine_id == "child-engine"
+
+
+def test_nested_child_engine_id_falls_back_to_wrapper(side_channel):
+    """vLLM's MultiConnector hands children the wrapper's engine_id when the
+    child entry does not override it."""
+    runtime_config = MagicMock()
+
+    publish_nixl_push_endpoint(
+        runtime_config,
+        _vllm_config(
+            connector="PdConnector",
+            engine_id="wrapper-engine",
+            extra_config={"connectors": [{"kv_connector": "NixlPushConnector"}]},
+        ),
+        WorkerType.Prefill,
+        (0, 1),
+    )
+
+    engine_id = runtime_config.set_nixl_push_endpoint.call_args.args[0]
+    assert engine_id == "wrapper-engine"
+
+
+@pytest.mark.parametrize(
+    "worker_type",
+    [WorkerType.Decode, WorkerType.Aggregated],
+)
+def test_only_prefill_workers_advertise(side_channel, worker_type):
+    """Only the prefill side of a push transfer gets named by its peer."""
+    runtime_config = MagicMock()
+
+    assert (
+        publish_nixl_push_endpoint(runtime_config, _vllm_config(), worker_type, (0, 1))
+        is False
+    )
+    runtime_config.set_nixl_push_endpoint.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "connector",
+    [None, "NixlConnector", "LMCacheConnectorV1", "DynamoConnector"],
+)
+def test_non_push_engines_do_not_advertise(side_channel, connector):
+    """Pull mode keeps these coordinates private, and connectors with no PD
+    protocol at all must not trip an error during registration."""
+    runtime_config = MagicMock()
+
+    assert (
+        publish_nixl_push_endpoint(
+            runtime_config,
+            _vllm_config(connector=connector),
+            WorkerType.Prefill,
+            (0, 1),
+        )
+        is False
+    )
+    runtime_config.set_nixl_push_endpoint.assert_not_called()
+
+
+def test_declines_when_worker_fronts_multiple_dp_ranks(side_channel, caplog):
+    """Each DP rank has its own side channel, so one advertised port would be
+    wrong for every rank but the first. Sequential handoff still works."""
+    runtime_config = MagicMock()
+
+    assert (
+        publish_nixl_push_endpoint(
+            runtime_config, _vllm_config(), WorkerType.Prefill, (0, 4)
+        )
+        is False
+    )
+    runtime_config.set_nixl_push_endpoint.assert_not_called()
+    assert "data-parallel" in caplog.text
+
+
+def test_declines_when_side_channel_host_is_unset(monkeypatch, caplog):
+    monkeypatch.setenv("VLLM_NIXL_SIDE_CHANNEL_HOST", "")
+    runtime_config = MagicMock()
+
+    assert (
+        publish_nixl_push_endpoint(
+            runtime_config, _vllm_config(), WorkerType.Prefill, (0, 1)
+        )
+        is False
+    )
+    runtime_config.set_nixl_push_endpoint.assert_not_called()
+
+
+def test_declines_when_engine_id_is_missing(side_channel, caplog):
+    """Without an engine_id the decode side has nothing to address the
+    registration to, so publishing coordinates would be worse than silence."""
+    runtime_config = MagicMock()
+
+    assert (
+        publish_nixl_push_endpoint(
+            runtime_config,
+            _vllm_config(engine_id=None),
+            WorkerType.Prefill,
+            (0, 1),
+        )
+        is False
+    )
+    runtime_config.set_nixl_push_endpoint.assert_not_called()
+    assert "engine_id" in caplog.text

--- a/components/src/dynamo/vllm/tests/test_vllm_kv_connector_protocols.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_kv_connector_protocols.py
@@ -21,9 +21,11 @@ import pytest
 
 from dynamo.vllm.kv_connector_protocols import (
     KV_CONNECTOR_PROTOCOLS,
+    NIXL_CONNECTOR_NAMES,
     KvConnectorProtocol,
     MooncakeConnectorProtocol,
     NixlConnectorProtocol,
+    NixlPushConnectorProtocol,
     make_kv_connector_protocol,
 )
 
@@ -475,9 +477,81 @@ def test_make_kv_connector_protocol_raises_on_unknown_connector():
 def test_registry_keys_match_vllm_connector_names():
     """Wire-format guard: KV_CONNECTOR_PROTOCOLS keys must match the strings
     vLLM uses in ``KVTransferConfig.kv_connector``."""
-    assert set(KV_CONNECTOR_PROTOCOLS) == {"NixlConnector", "MooncakeConnector"}
+    assert set(KV_CONNECTOR_PROTOCOLS) == {
+        "NixlConnector",
+        "NixlPushConnector",
+        "MooncakeConnector",
+    }
     for cls in KV_CONNECTOR_PROTOCOLS.values():
         assert issubclass(cls, KvConnectorProtocol)
+
+
+# ---------------------------------------------------------------------------
+# NixlPushConnectorProtocol
+# ---------------------------------------------------------------------------
+
+
+def test_make_kv_connector_protocol_dispatches_nixl_push():
+    proto = make_kv_connector_protocol(_config("NixlPushConnector"))
+    assert isinstance(proto, NixlPushConnectorProtocol)
+
+
+def test_nixl_push_prefill_request_matches_pull_mode():
+    """Push reverses who moves the blocks, not what the producer leg declares.
+
+    ``do_remote_decode`` is what marks this engine as the producer in both
+    modes; a divergence here would silently stop the prefill worker from
+    staging its finished blocks for the push.
+    """
+    push = NixlPushConnectorProtocol(_config("NixlPushConnector"))
+    pull = NixlConnectorProtocol(_config("NixlConnector"))
+    assert (
+        push.prefill_request_kv_transfer_params()
+        == pull.prefill_request_kv_transfer_params()
+    )
+
+
+def test_nixl_push_decode_passes_through_engine_response():
+    """The sequential fallback: when the frontend did not pre-dispatch decode,
+    the prefill worker's own response carries the push coordinates."""
+    proto = NixlPushConnectorProtocol(_config("NixlPushConnector"))
+    engine_payload = {
+        "do_remote_prefill": True,
+        "remote_engine_id": "eng-1",
+        "remote_host": "10.0.0.1",
+        "remote_port": 5600,
+    }
+    response = SimpleNamespace(kv_transfer_params=engine_payload)
+    assert proto.decode_request_kv_transfer_params(response) is engine_payload
+
+
+def test_nixl_push_resolves_inside_pd_connector():
+    """KVBM composition must see push as the PD-capable child, same as pull."""
+    proto = make_kv_connector_protocol(
+        _config(
+            "PdConnector",
+            kv_connector_extra_config={
+                "connectors": [
+                    {"kv_connector": "DynamoConnector"},
+                    {"kv_connector": "NixlPushConnector"},
+                ]
+            },
+            engine_id="wrapper-engine",
+        )
+    )
+    assert isinstance(proto, NixlPushConnectorProtocol)
+
+
+def test_nixl_connector_names_cover_every_registered_nixl_protocol():
+    """``NIXL_CONNECTOR_NAMES`` gates side-channel host resolution. A NIXL
+    connector missing from it starts an engine with no reachable side channel.
+    """
+    registered_nixl = {
+        name
+        for name, cls in KV_CONNECTOR_PROTOCOLS.items()
+        if issubclass(cls, NixlConnectorProtocol)
+    }
+    assert set(NIXL_CONNECTOR_NAMES) == registered_nixl
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -341,6 +341,26 @@ def test_uses_nixl_connector_direct_and_nested():
     assert _uses_nixl_connector(_make_engine_cfg()) is False
 
 
+def test_uses_nixl_connector_recognizes_push_mode():
+    """Push mode transfers over the same NIXL side channel as pull, so it must
+    trigger the same side-channel host resolution."""
+    assert _uses_nixl_connector(_make_engine_cfg("NixlPushConnector")) is True
+    assert (
+        _uses_nixl_connector(
+            _make_engine_cfg(
+                "PdConnector",
+                {
+                    "connectors": [
+                        {"kv_connector": "DynamoConnector", "kv_role": "kv_both"},
+                        {"kv_connector": "NixlPushConnector", "kv_role": "kv_both"},
+                    ]
+                },
+            )
+        )
+        is True
+    )
+
+
 def test_uses_dynamo_connector_direct_and_nested():
     """Test _uses_dynamo_connector for direct, nested-in-PdConnector, and absent cases."""
     assert _uses_dynamo_connector(_make_engine_cfg("DynamoConnector")) is True

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -180,7 +180,6 @@ impl Router {
             None,
             model_name.clone(),
             actual_namespace.to_string(),
-            enable_eagle,
             // ext-proc constructs no KvWorkerMonitor; overload publishing is
             // unused on this path (matches the prior namespace-lookup miss).
             None,

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md
@@ -81,6 +81,45 @@ Dynamo supports [vLLM prompt embeddings](https://docs.vllm.ai/en/stable/features
 - Embeddings are sent as base64-encoded PyTorch tensors via the `prompt_embeds` field in the Completions API
 - NATS must be configured with a 15MB max payload for large embeddings (already set in default deployments)
 
+## KV Transfer Connectors for Disaggregated Serving
+
+Disaggregated serving moves the KV cache from the prefill worker to the decode worker over a connector you select with `--kv-transfer-config`. Dynamo supports two NIXL connectors, which differ in who moves the blocks:
+
+| Connector | Direction | Handoff |
+|-----------|-----------|---------|
+| `NixlConnector` | Decode READs from prefill | Decode learns prefill's block locations from the prefill response |
+| `NixlPushConnector` | Prefill WRITEs into decode | Decode registers its allocated blocks with prefill, which pushes into them |
+
+Configure the same connector on both the prefill and decode workers:
+
+```bash
+python -m dynamo.vllm ... \
+  --kv-transfer-config '{"kv_connector":"NixlPushConnector","kv_role":"kv_both"}'
+```
+
+Push mode lets the two legs overlap. Because decode never needs anything computed during prefill — only the prefill engine's identity — the frontend dispatches both legs at once, so decode is already holding allocated blocks when prefill finishes and the transfer starts immediately. Pull mode cannot overlap: its handoff carries block IDs that do not exist until prefill has run.
+
+To make that possible, a prefill worker running `NixlPushConnector` publishes its NIXL side-channel address and engine ID to discovery. If it cannot, the handoff falls back to running sequentially — still correct, because the prefill worker holds its finished blocks until decode's late registration arrives, but without the overlap.
+
+> [!NOTE]
+> Push mode reports no cached-prompt-token details in usage, and does not short-circuit a request that reaches a stop condition during the one-token prefill step. Both follow from dispatching decode before the prefill response exists, and apply equally to SGLang's bootstrap handoff.
+
+### Data Parallelism and Push Mode
+
+vLLM gives each data-parallel rank its own NIXL side channel, at `VLLM_NIXL_SIDE_CHANNEL_PORT` plus the rank index. A Dynamo worker registers one address, so it can only advertise push coordinates when it fronts exactly one rank.
+
+This is satisfied by every deployment except vLLM's *internal* DP load balancing with `--data-parallel-size` greater than 1, where a single worker process fronts all ranks:
+
+| Deployment | Ranks per worker | Advertises |
+|------------|------------------|------------|
+| No data parallelism | 1 | ✅ |
+| External DP load balancing | 1 | ✅ |
+| Hybrid DP load balancing, one local rank | 1 | ✅ |
+| Hybrid DP load balancing, several local ranks | many | ❌ |
+| Internal DP load balancing, `--data-parallel-size` > 1 | all | ❌ |
+
+A worker that cannot advertise logs a warning at startup and runs the sequential handoff. Push mode still works — it just loses the overlap — so this is a performance limitation, not a correctness one. Use external or hybrid DP load balancing with one rank per worker to get the overlapped path; both are recommended for multi-worker DP deployments regardless.
+
 ## Hashing Consistency for KV Events
 
 When using KV-aware routing, ensure deterministic hashing across processes to avoid radix tree mismatches. Choose one of the following:

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md
@@ -108,6 +108,8 @@ To make that possible, a prefill worker running `NixlPushConnector` publishes it
 
 vLLM gives each data-parallel rank its own NIXL side channel, at `VLLM_NIXL_SIDE_CHANNEL_PORT` plus the rank index. A Dynamo worker registers one address, so it can only advertise push coordinates when it fronts exactly one rank.
 
+vLLM also names the NIXL agent per rank: the engine ID is `<base>_dp<rank>` whenever `--data-parallel-size` is greater than 1 or the rank is non-zero, and the unsuffixed base ID otherwise — so tensor- or expert-parallel deployments with a single rank keep the base ID. Dynamo mirrors that derivation when it advertises. Publishing the wrong form is not a loud failure: the peer rejects the handshake with `Remote NIXL agent engine ID mismatch` and the transfer falls back.
+
 This is satisfied by every deployment except vLLM's *internal* DP load balancing with `--data-parallel-size` greater than 1, where a single worker process fronts all ranks:
 
 | Deployment | Ranks per worker | Advertises |

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
@@ -189,9 +189,15 @@ This is not specific to router flags — any card difference splits a set the sa
 - **Applying the flag to only some replicas of a set splits it.** Whether by flag or by an exported `DYN_ROUTER_MODE` that reaches some processes and not others, every member of a set must end up with the same value.
 
 > [!IMPORTANT]
-> An advertised configuration **replaces** the frontend's for that worker set rather than merging with it. If you set `--router-mode kv` on a worker and the frontend was tuned with KV flags such as `--router-temperature`, restate those flags on the worker too, or that set falls back to KV defaults.
+> An advertised configuration **replaces** the frontend's for that worker set rather than merging with it. On a worker, a flag you do not pass means **the default**, not "inherit the frontend's value". If the frontend was tuned with `--router-kv-overlap-score-credit 2.5` and a worker advertises only `--router-mode kv`, that worker set routes with the default `1.0` — the tuning is not inherited, it is replaced. Restate on the worker every flag that matters for it.
 
-Because the flags are shared with the frontend, they read the same environment variables — `--router-mode` reads `DYN_ROUTER_MODE`. Kubernetes scopes environment per service, so a frontend's value does not reach workers, and the launch scripts pass the flag rather than exporting it. The one case to watch is a shell that exports `DYN_ROUTER_MODE` and then starts both the frontend and workers: there the workers advertise it instead of inheriting.
+Merging is not offered because it cannot be done correctly: the KV tuning is flat concrete values with no record of which ones were set explicitly, so a deliberate `1.0` is indistinguishable from a default `1.0`.
+
+Workers and the frontend share defaults exactly — both build their configuration from the same argument groups — so the values only diverge when the frontend is tuned and the worker is not.
+
+The flags also read the same environment variables, and this changes the answer depending on how you deploy. If the frontend's tuning comes from the environment and the worker shares that environment — a single shell starting both — the worker picks the tuning up and nothing is lost. Kubernetes scopes environment per service, so there the worker sees only its own flags. The same intent can therefore produce different routing in the two setups. `--router-mode` itself is the exception in the other direction: a shared `DYN_ROUTER_MODE` makes a worker advertise when you meant it to inherit.
+
+The `Activating prefill router` log line reports the configuration each hop actually resolved — mode, block size, session TTL, and KV tuning — which is the quickest way to confirm what a worker set ended up with.
 
 The frontend-only options (`--router-min-initial-workers`, `--enforce-disagg`, `--admission-control`) are not accepted by workers, since a model card does not carry them.
 

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1709,6 +1709,9 @@ async fn build_local_model(
             Some(DisaggregatedEndpoint {
                 bootstrap_host: Some(host.clone()),
                 bootstrap_port: Some(port),
+                // Bootstrap-style handoff; the NIXL push connector is a vLLM
+                // concern and publishes its coordinates from the Python worker.
+                nixl_push: None,
             })
         }
         _ => None,

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -861,7 +861,6 @@ pub unsafe extern "C" fn create_routers(
             None,
             model_name.clone(),
             actual_namespace.clone(),
-            enable_eagle,
             // C bindings construct no KvWorkerMonitor; overload publishing is
             // unused on this path (matches the prior namespace-lookup miss).
             None,

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -8,7 +8,7 @@ use dynamo_kv_router::protocols::{
     KvTransferEnforcement as RsKvTransferEnforcement, RoutingConstraints as RsRoutingConstraints,
 };
 use dynamo_runtime::protocols::EndpointId;
-use llm_rs::local_model::runtime_config::DisaggregatedEndpoint as RsDisaggregatedEndpoint;
+use llm_rs::local_model::runtime_config::NixlPushEndpoint as RsNixlPushEndpoint;
 use llm_rs::local_model::runtime_config::ModelRuntimeConfig as RsModelRuntimeConfig;
 use llm_rs::local_model::runtime_config::StructuralTagMode as RsStructuralTagMode;
 use llm_rs::local_model::runtime_config::StructuralTagSchemaMode as RsStructuralTagSchemaMode;
@@ -333,9 +333,29 @@ impl ModelRuntimeConfig {
         bootstrap_host: Option<String>,
         bootstrap_port: Option<u16>,
     ) {
-        self.inner.disaggregated_endpoint = Some(RsDisaggregatedEndpoint {
-            bootstrap_host,
-            bootstrap_port,
+        let endpoint = self.inner.disaggregated_endpoint.get_or_insert_default();
+        endpoint.bootstrap_host = bootstrap_host;
+        endpoint.bootstrap_port = bootstrap_port;
+    }
+
+    /// Publish the NIXL side-channel coordinates of a vLLM `NixlPushConnector`
+    /// prefill engine, so the frontend can hand them to decode before this
+    /// worker's prefill has run.
+    fn set_nixl_push_endpoint(
+        &mut self,
+        engine_id: String,
+        host: String,
+        port: u16,
+        tensor_parallel_size: u32,
+        pipeline_parallel_size: u32,
+    ) {
+        let endpoint = self.inner.disaggregated_endpoint.get_or_insert_default();
+        endpoint.nixl_push = Some(RsNixlPushEndpoint {
+            engine_id,
+            host,
+            port,
+            tensor_parallel_size,
+            pipeline_parallel_size,
         });
     }
 
@@ -353,6 +373,25 @@ impl ModelRuntimeConfig {
             .disaggregated_endpoint
             .as_ref()
             .and_then(|e| e.bootstrap_port)
+    }
+
+    /// `(engine_id, host, port, tensor_parallel_size, pipeline_parallel_size)`,
+    /// or `None` when this worker does not run the NIXL push connector.
+    #[getter]
+    fn nixl_push_endpoint(&self) -> Option<(String, String, u16, u32, u32)> {
+        self.inner
+            .disaggregated_endpoint
+            .as_ref()
+            .and_then(|e| e.nixl_push.as_ref())
+            .map(|push| {
+                (
+                    push.engine_id.clone(),
+                    push.host.clone(),
+                    push.port,
+                    push.tensor_parallel_size,
+                    push.pipeline_parallel_size,
+                )
+            })
     }
 
     #[getter]

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -3287,7 +3287,6 @@ mod tests {
             None,
             "topology-model".to_string(),
             worker_set.namespace().to_string(),
-            false,
             None,
         );
         let encoder = crate::kv_router::EncoderRouter::new(

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -653,6 +653,12 @@ where
                 prefill_config.router_track_active_blocks = false;
                 let prefill_enable_eagle = false;
 
+                // This decode set's mode is passed as the *fallback* for the
+                // prefill hop, not as its mode. A prefill worker that declares
+                // its own `router_config` overrides it at activation time (see
+                // `resolve_advertisement_from_cards`), which is what allows a
+                // KV-routed prefill tier in front of a round-robin decode tier.
+
                 Some(PrefillRouter::new_with_selector_factory(
                     None,
                     self.manager.clone(),

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -651,14 +651,9 @@ where
             {
                 let mut prefill_config = router_config.kv_router_config.clone();
                 prefill_config.router_track_active_blocks = false;
-                let prefill_enable_eagle = false;
 
-                // This decode set's mode is passed as the *fallback* for the
-                // prefill hop, not as its mode. A prefill worker that declares
-                // its own `router_config` overrides it at activation time (see
-                // `resolve_advertisement_from_cards`), which is what allows a
-                // KV-routed prefill tier in front of a round-robin decode tier.
-
+                // Fallback only: a prefill worker that declares its own
+                // `router_config` overrides this at activation time.
                 Some(PrefillRouter::new_with_selector_factory(
                     None,
                     self.manager.clone(),
@@ -671,7 +666,6 @@ where
                     router_config.session_affinity_ttl_secs,
                     model_name.clone(),
                     namespace.clone(),
-                    prefill_enable_eagle,
                     worker_monitor.clone(),
                     Some(allocator_trim.clone()),
                 ))

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use tokio::sync::{oneshot, watch};
 
 use dynamo_kv_router::{
@@ -36,21 +36,93 @@ use crate::{
     session_affinity::create_affinity_coordinator,
 };
 
+/// What the prefill worker set advertises about how it wants to be routed to,
+/// resolved from its own model deployment cards at activation time.
+#[derive(Debug)]
+struct PrefillAdvertisement {
+    /// Mode for the prefill hop: the card's own if it declared one, otherwise
+    /// the decode set's mode.
+    router_mode: RouterMode,
+    /// KV tuning that came with an advertised `router_config`. `None` means the
+    /// card declared nothing and the decode set's prefill tuning applies.
+    kv_router_config: Option<KvRouterConfig>,
+    is_eagle: bool,
+    /// Whether the card actually declared a `router_config`, as opposed to
+    /// inheriting. Logged so an ignored override is diagnosable.
+    advertised: bool,
+}
+
+/// Resolve how the prefill hop should be routed from the prefill worker set's
+/// own model deployment cards.
+///
+/// A prefill worker may declare its own `router_config` through
+/// `register_model`. When it does, that mode governs this hop, which is what
+/// lets a deployment run (say) KV-routed prefill in front of round-robin decode.
+/// A worker that declares nothing inherits `decode_router_mode`, preserving the
+/// behavior of every deployment that predates the override.
+fn resolve_advertisement_from_cards(
+    cards: &[ModelDeploymentCard],
+    decode_router_mode: RouterMode,
+) -> Result<PrefillAdvertisement> {
+    let mode_of = |card: &ModelDeploymentCard| {
+        card.router_config
+            .as_ref()
+            .map_or(decode_router_mode, |config| config.router_mode)
+    };
+
+    let Some(first) = cards.first() else {
+        anyhow::bail!("no readable prefill model card; cannot resolve prefill routing");
+    };
+
+    let advertisement = PrefillAdvertisement {
+        router_mode: mode_of(first),
+        kv_router_config: first
+            .router_config
+            .as_ref()
+            .map(|config| config.kv_router_config.clone()),
+        is_eagle: first.runtime_config.enable_eagle,
+        advertised: first.router_config.is_some(),
+    };
+
+    // A prefill fleet mid-rolling-update can disagree about its mode. The first
+    // card wins and the binding is rebuilt whenever the target moves, so this
+    // converges — but a silent split is worth surfacing, since half the fleet is
+    // then being routed on the other half's terms.
+    let disagreeing = cards
+        .iter()
+        .skip(1)
+        .filter(|card| mode_of(card) != advertisement.router_mode)
+        .count();
+    if disagreeing > 0 {
+        tracing::warn!(
+            resolved_mode = ?advertisement.router_mode,
+            disagreeing,
+            total = cards.len(),
+            "Prefill workers advertise conflicting router modes; using the first"
+        );
+    }
+
+    Ok(advertisement)
+}
+
 impl PrefillRouter<DefaultWorkerSelector> {
     /// Create a disabled prefill router that will never activate (passthrough only)
     pub fn disabled(
         model_manager: Arc<ModelManager>,
-        router_mode: RouterMode,
+        decode_router_mode: RouterMode,
         session_affinity_ttl_secs: Option<u64>,
     ) -> Arc<Self> {
-        Self::disabled_with_selector(model_manager, router_mode, session_affinity_ttl_secs)
+        Self::disabled_with_selector(model_manager, decode_router_mode, session_affinity_ttl_secs)
     }
 
+    /// `decode_router_mode` is the owning decode worker set's mode. It governs
+    /// decode-side decisions and is the fallback for the prefill hop; a prefill
+    /// worker that advertises its own `router_config` overrides the latter.
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         activation_rx: oneshot::Receiver<Endpoint>,
         model_manager: Arc<ModelManager>,
-        router_mode: RouterMode,
+        decode_router_mode: RouterMode,
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
         decode_router: Option<Arc<KvRouter>>,
@@ -64,7 +136,7 @@ impl PrefillRouter<DefaultWorkerSelector> {
         Self::new_with_selector_factory(
             Some(activation_rx),
             model_manager,
-            router_mode,
+            decode_router_mode,
             kv_cache_block_size,
             kv_router_config,
             decode_router,
@@ -91,7 +163,7 @@ where
 {
     pub(crate) fn disabled_with_selector(
         model_manager: Arc<ModelManager>,
-        router_mode: RouterMode,
+        decode_router_mode: RouterMode,
         session_affinity_ttl_secs: Option<u64>,
     ) -> Arc<Self> {
         Arc::new(Self {
@@ -103,7 +175,7 @@ where
             decode_session_affinity: std::sync::OnceLock::new(),
             model_manager,
             cancel_token: tokio_util::sync::CancellationToken::new(),
-            router_mode,
+            decode_router_mode,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
             conditional_disagg_policy: make_conditional_disagg_policy(None),
             conditional_disagg_prefill_busy_threshold: None,
@@ -123,7 +195,7 @@ where
     pub(crate) fn new_with_selector_factory(
         activation_rx: Option<oneshot::Receiver<Endpoint>>,
         model_manager: Arc<ModelManager>,
-        router_mode: RouterMode,
+        decode_router_mode: RouterMode,
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
         decode_router: Option<Arc<KvRouter<Sel>>>,
@@ -156,7 +228,7 @@ where
             decode_session_affinity: std::sync::OnceLock::new(),
             model_manager: model_manager.clone(),
             cancel_token: cancel_token.clone(),
-            router_mode,
+            decode_router_mode,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
             conditional_disagg_policy,
             conditional_disagg_prefill_busy_threshold,
@@ -223,11 +295,6 @@ where
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
     ) -> Result<(PrefillBinding<Sel>, Client)> {
-        tracing::info!(
-            router_mode = ?context.router_mode,
-            "Activating prefill router"
-        );
-
         let endpoint_id = endpoint.id();
 
         // Start runtime config watcher for this endpoint (needed for get_disaggregated_endpoint)
@@ -237,27 +304,32 @@ where
             .get_or_create_runtime_config_watcher(&endpoint)
             .await?;
 
-        let inner_router = if context.router_mode.is_kv_routing() {
-            let discovered_cards = endpoint
-                .component()
-                .drt()
-                .discovery()
-                .list(DiscoveryQuery::EndpointModels {
-                    namespace: endpoint_id.namespace.clone(),
-                    component: endpoint_id.component.clone(),
-                    endpoint: endpoint_id.name.clone(),
-                })
-                .await;
-            let is_eagle = match discovered_cards {
-                Ok(instances) => instances
-                    .into_iter()
-                    .find_map(|instance| instance.deserialize_model::<ModelDeploymentCard>().ok())
-                    .map_or(context.is_eagle, |card| card.runtime_config.enable_eagle),
-                Err(error) => {
-                    tracing::warn!(%error, "Failed to read prefill model card; using configured EAGLE mode");
-                    context.is_eagle
-                }
-            };
+        let advertisement = Self::resolve_prefill_advertisement(context, &endpoint).await?;
+        let prefill_router_mode = advertisement.router_mode;
+
+        tracing::info!(
+            ?prefill_router_mode,
+            decode_router_mode = ?context.decode_router_mode,
+            advertised = advertisement.advertised,
+            resolved_is_eagle = advertisement.is_eagle,
+            configured_is_eagle = context.is_eagle,
+            "Activating prefill router"
+        );
+
+        // A prefill card that declares a mode may declare KV tuning alongside it;
+        // honoring only half of its `RouterConfig` would be a trap. Whichever
+        // config wins, `router_track_active_blocks` stays off: prefill routing is
+        // prompt-side, and crediting decode blocks here would double-count load.
+        let kv_router_config = match advertisement.kv_router_config {
+            Some(mut advertised) => {
+                advertised.router_track_active_blocks = false;
+                Some(advertised)
+            }
+            None => kv_router_config,
+        };
+
+        let inner_router = if prefill_router_mode.is_kv_routing() {
+            let is_eagle = advertisement.is_eagle;
 
             // Create KV chooser using the endpoint (this is a prefill router)
             let effective_kv_router_config = kv_router_config.clone().unwrap_or_default();
@@ -311,12 +383,12 @@ where
                 create_affinity_coordinator(context.session_affinity_ttl, client.clone()).await?;
             let prefill_client = client.clone();
 
-            // Create simple push router with the frontend's router mode
+            // Create simple push router with the resolved prefill router mode
             // Note: Per-worker metrics (active_prefill_tokens, active_decode_blocks) are only
             // available in KV routing mode where the router has actual bookkeeping.
             let push_router = PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client_with_monitor(
                 client,
-                context.router_mode,
+                prefill_router_mode,
                 None, // worker_monitor
             )
             .await?;
@@ -326,7 +398,7 @@ where
                     crate::session_affinity::SessionAffinityPushRouter::new_with_coordinator(
                         push_router,
                         affinity,
-                        context.router_mode.is_direct_routing(),
+                        prefill_router_mode.is_direct_routing(),
                     ),
                 )),
                 prefill_client,
@@ -337,9 +409,44 @@ where
             PrefillBinding {
                 endpoint_id,
                 router: inner_router.0,
+                prefill_router_mode,
             },
             inner_router.1,
         ))
+    }
+
+    /// Fetch the prefill worker set's own cards and resolve how the prefill hop
+    /// should be routed.
+    ///
+    /// Returns `Err` rather than silently inheriting when the cards cannot be
+    /// read. `drive_target` retries activation with backoff, and a delayed
+    /// activation is far cheaper than routing an entire deployment with the
+    /// wrong strategy because of one transient discovery miss — a downgrade that
+    /// would persist until the binding was rebuilt.
+    async fn resolve_prefill_advertisement(
+        context: &PrefillBuildContext<Sel>,
+        endpoint: &Endpoint,
+    ) -> Result<PrefillAdvertisement> {
+        let endpoint_id = endpoint.id();
+        let instances = endpoint
+            .component()
+            .drt()
+            .discovery()
+            .list(DiscoveryQuery::EndpointModels {
+                namespace: endpoint_id.namespace.clone(),
+                component: endpoint_id.component.clone(),
+                endpoint: endpoint_id.name.clone(),
+            })
+            .await
+            .with_context(|| format!("listing prefill model cards for {endpoint_id}"))?;
+
+        let cards: Vec<ModelDeploymentCard> = instances
+            .into_iter()
+            .filter_map(|instance| instance.deserialize_model::<ModelDeploymentCard>().ok())
+            .collect();
+
+        resolve_advertisement_from_cards(&cards, context.decode_router_mode)
+            .with_context(|| format!("resolving prefill routing for {endpoint_id}"))
     }
 
     /// Attach the freshly-created prefill `Client` to this WorkerSet's monitor (handed in
@@ -400,7 +507,7 @@ where
             }
             let build_context = PrefillBuildContext {
                 model_manager: router_ref.model_manager.clone(),
-                router_mode: router_ref.router_mode,
+                decode_router_mode: router_ref.decode_router_mode,
                 worker_selector_factory: router_ref
                     .worker_selector_factory
                     .clone()
@@ -519,5 +626,86 @@ where
     #[cfg(test)]
     pub(crate) fn target_endpoint_id(&self) -> Option<dynamo_runtime::protocols::EndpointId> {
         self.target.lock().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entrypoint::RouterConfig;
+    use dynamo_kv_router::config::KvRouterConfig;
+
+    fn card(router_config: Option<RouterConfig>) -> ModelDeploymentCard {
+        let mut card = ModelDeploymentCard::with_name_only("test-model");
+        card.router_config = router_config;
+        card
+    }
+
+    #[test]
+    fn inherits_decode_mode_when_card_advertises_nothing() {
+        // The pre-override behavior: a prefill worker that says nothing is
+        // routed exactly as the decode set is. Every deployment predating this
+        // feature lands here, so it must not shift.
+        let cards = vec![card(None)];
+        let resolved =
+            resolve_advertisement_from_cards(&cards, RouterMode::RoundRobin).expect("resolves");
+        assert_eq!(resolved.router_mode, RouterMode::RoundRobin);
+        assert!(!resolved.advertised);
+        assert!(resolved.kv_router_config.is_none());
+    }
+
+    #[test]
+    fn card_router_config_overrides_decode_mode() {
+        // The headline case: KV-routed prefill in front of round-robin decode.
+        let cards = vec![card(Some(RouterConfig::new(
+            RouterMode::KV,
+            KvRouterConfig::default(),
+        )))];
+        let resolved =
+            resolve_advertisement_from_cards(&cards, RouterMode::RoundRobin).expect("resolves");
+        assert_eq!(resolved.router_mode, RouterMode::KV);
+        assert!(resolved.advertised);
+        assert!(resolved.kv_router_config.is_some());
+    }
+
+    #[test]
+    fn card_can_downgrade_prefill_below_a_kv_decode_set() {
+        // The reverse pairing must work too: round-robin prefill in front of a
+        // KV decode set. Nothing about the override is KV-specific.
+        let cards = vec![card(Some(RouterConfig::new(
+            RouterMode::RoundRobin,
+            KvRouterConfig::default(),
+        )))];
+        let resolved = resolve_advertisement_from_cards(&cards, RouterMode::KV).expect("resolves");
+        assert_eq!(resolved.router_mode, RouterMode::RoundRobin);
+    }
+
+    #[test]
+    fn first_card_wins_when_the_fleet_disagrees() {
+        // A rolling update can leave old (inheriting) and new (advertising)
+        // prefill workers side by side. Resolution must stay deterministic
+        // rather than depending on which card happened to be read.
+        let cards = vec![
+            card(Some(RouterConfig::new(
+                RouterMode::KV,
+                KvRouterConfig::default(),
+            ))),
+            card(None),
+        ];
+        let resolved =
+            resolve_advertisement_from_cards(&cards, RouterMode::RoundRobin).expect("resolves");
+        assert_eq!(resolved.router_mode, RouterMode::KV);
+    }
+
+    #[test]
+    fn no_readable_card_is_an_error_not_a_silent_inherit() {
+        // Activation must fail and be retried rather than quietly routing the
+        // whole deployment with the decode set's mode.
+        let error = resolve_advertisement_from_cards(&[], RouterMode::KV)
+            .expect_err("empty card list must not resolve");
+        assert!(
+            error.to_string().contains("no readable prefill model card"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -42,7 +42,15 @@ struct PrefillAdvertisement {
     router_mode: RouterMode,
     /// `None` when the card declared nothing, so the decode set's tuning applies.
     kv_router_config: Option<KvRouterConfig>,
+    /// Taken from an advertised `router_config` whole, `None` included -- an
+    /// advertisement replaces the decode set's configuration rather than
+    /// merging with it. `None` here when nothing was advertised at all.
+    session_affinity_ttl: Option<Option<std::time::Duration>>,
     is_eagle: bool,
+    /// The prefill workers' own block size, which is what their KV events are
+    /// keyed on. The decode set's value would index this pool at the wrong
+    /// granularity if the two ever differ.
+    kv_cache_block_size: u32,
 }
 
 /// A prefill worker that declares its own `router_config` governs this hop;
@@ -68,7 +76,13 @@ fn resolve_advertisement_from_cards(
             .router_config
             .as_ref()
             .map(|config| config.kv_router_config.clone()),
+        session_affinity_ttl: first.router_config.as_ref().map(|config| {
+            config
+                .session_affinity_ttl_secs
+                .map(std::time::Duration::from_secs)
+        }),
         is_eagle: first.runtime_config.enable_eagle,
+        kv_cache_block_size: first.kv_cache_block_size,
     };
 
     // A fleet mid-rolling-update can disagree. First card wins, but a silent
@@ -292,8 +306,20 @@ where
             decode_router_mode = ?context.decode_router_mode,
             advertised = advertisement.kv_router_config.is_some(),
             is_eagle = advertisement.is_eagle,
+            block_size = advertisement.kv_cache_block_size,
             "Activating prefill router"
         );
+
+        // Everything the hop uses comes from the prefill card when it says so,
+        // falling back to the decode set. A block size of 0 means the card never
+        // declared one, so it cannot be trusted over the decode set's.
+        let prefill_block_size = match advertisement.kv_cache_block_size {
+            0 => kv_cache_block_size,
+            advertised => advertised,
+        };
+        let prefill_session_affinity_ttl = advertisement
+            .session_affinity_ttl
+            .unwrap_or(context.session_affinity_ttl);
 
         // A prefill card that declares a mode may declare KV tuning alongside it;
         // honoring only half of its `RouterConfig` would be a trap. Whichever
@@ -319,7 +345,7 @@ where
                 .model_manager
                 .kv_chooser_for_with_selector(
                     &endpoint,
-                    kv_cache_block_size,
+                    prefill_block_size,
                     selector,
                     prefill_kv_config,
                     context.prefill_load_estimator.clone(),
@@ -333,7 +359,7 @@ where
             // Extract client from kv_chooser to ensure shared state
             let client = kv_chooser.client().clone();
             let affinity =
-                create_affinity_coordinator(context.session_affinity_ttl, client.clone()).await?;
+                create_affinity_coordinator(prefill_session_affinity_ttl, client.clone()).await?;
             let prefill_client = client.clone();
 
             // Build the PushRouter for prefill with KV mode using the shared client
@@ -357,7 +383,7 @@ where
             // Create client for simple router
             let client = endpoint.client().await?;
             let affinity =
-                create_affinity_coordinator(context.session_affinity_ttl, client.clone()).await?;
+                create_affinity_coordinator(prefill_session_affinity_ttl, client.clone()).await?;
             let prefill_client = client.clone();
 
             // Create simple push router with the resolved prefill router mode
@@ -626,6 +652,12 @@ mod tests {
         card
     }
 
+    fn card_with_block_size(block_size: u32) -> ModelDeploymentCard {
+        let mut card = card(None);
+        card.kv_cache_block_size = block_size;
+        card
+    }
+
     #[test]
     fn inherits_decode_mode_when_card_advertises_nothing() {
         // The pre-override behavior: a prefill worker that says nothing is
@@ -666,6 +698,40 @@ mod tests {
         let resolved =
             resolve_advertisement_from_cards(&cards, RouterMode::RoundRobin).expect("resolves");
         assert_eq!(resolved.router_mode, RouterMode::KV);
+    }
+
+    #[test]
+    fn block_size_comes_from_the_prefill_card() {
+        // The prefill pool's KV events are keyed on its own block size. Taking
+        // the decode set's would index this pool at the wrong granularity.
+        let cards = vec![card_with_block_size(64)];
+        let resolved = resolve_advertisement_from_cards(&cards, RouterMode::KV).expect("resolves");
+        assert_eq!(resolved.kv_cache_block_size, 64);
+    }
+
+    #[test]
+    fn session_affinity_ttl_is_taken_whole_or_not_at_all() {
+        // An advertisement replaces the decode set's configuration rather than
+        // merging, so a card that advertises without a TTL means "no affinity",
+        // not "inherit the frontend's". A card advertising nothing means inherit.
+        let advertised = vec![card(Some(RouterConfig::new(
+            RouterMode::KV,
+            KvRouterConfig::default(),
+        )))];
+        assert_eq!(
+            resolve_advertisement_from_cards(&advertised, RouterMode::KV)
+                .expect("resolves")
+                .session_affinity_ttl,
+            Some(None),
+        );
+
+        let silent = vec![card(None)];
+        assert_eq!(
+            resolve_advertisement_from_cards(&silent, RouterMode::KV)
+                .expect("resolves")
+                .session_affinity_ttl,
+            None,
+        );
     }
 
     #[test]

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -301,15 +301,6 @@ where
         let advertisement = Self::resolve_prefill_advertisement(context, &endpoint).await?;
         let prefill_router_mode = advertisement.router_mode;
 
-        tracing::info!(
-            ?prefill_router_mode,
-            decode_router_mode = ?context.decode_router_mode,
-            advertised = advertisement.kv_router_config.is_some(),
-            is_eagle = advertisement.is_eagle,
-            block_size = advertisement.kv_cache_block_size,
-            "Activating prefill router"
-        );
-
         // Everything the hop uses comes from the prefill card when it says so,
         // falling back to the decode set. A block size of 0 means the card never
         // declared one, so it cannot be trusted over the decode set's.
@@ -325,6 +316,7 @@ where
         // honoring only half of its `RouterConfig` would be a trap. Whichever
         // config wins, `router_track_active_blocks` stays off: prefill routing is
         // prompt-side, and crediting decode blocks here would double-count load.
+        let advertised_kv_tuning = advertisement.kv_router_config.is_some();
         let prefill_kv_config = match advertisement.kv_router_config {
             Some(mut advertised) => {
                 advertised.router_track_active_blocks = false;
@@ -332,6 +324,22 @@ where
             }
             None => kv_router_config,
         };
+
+        // Logged once per activation, and deliberately the *resolved* values
+        // rather than what the card asked for. An advertisement replaces the
+        // decode set's configuration rather than merging with it, so a worker
+        // that names a mode without restating tuning silently gets defaults --
+        // this line is what makes that answerable without a rebuild.
+        tracing::info!(
+            ?prefill_router_mode,
+            decode_router_mode = ?context.decode_router_mode,
+            advertised = advertised_kv_tuning,
+            is_eagle = advertisement.is_eagle,
+            block_size = prefill_block_size,
+            session_affinity_ttl = ?prefill_session_affinity_ttl,
+            kv_tuning = ?prefill_kv_config,
+            "Activating prefill router"
+        );
 
         let inner_router = if prefill_router_mode.is_kv_routing() {
             // Create KV chooser using the endpoint (this is a prefill router)

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -36,30 +36,18 @@ use crate::{
     session_affinity::create_affinity_coordinator,
 };
 
-/// What the prefill worker set advertises about how it wants to be routed to,
-/// resolved from its own model deployment cards at activation time.
+/// How the prefill worker set wants to be routed to, resolved from its cards.
 #[derive(Debug)]
 struct PrefillAdvertisement {
-    /// Mode for the prefill hop: the card's own if it declared one, otherwise
-    /// the decode set's mode.
     router_mode: RouterMode,
-    /// KV tuning that came with an advertised `router_config`. `None` means the
-    /// card declared nothing and the decode set's prefill tuning applies.
+    /// `None` when the card declared nothing, so the decode set's tuning applies.
     kv_router_config: Option<KvRouterConfig>,
     is_eagle: bool,
-    /// Whether the card actually declared a `router_config`, as opposed to
-    /// inheriting. Logged so an ignored override is diagnosable.
-    advertised: bool,
 }
 
-/// Resolve how the prefill hop should be routed from the prefill worker set's
-/// own model deployment cards.
-///
-/// A prefill worker may declare its own `router_config` through
-/// `register_model`. When it does, that mode governs this hop, which is what
-/// lets a deployment run (say) KV-routed prefill in front of round-robin decode.
-/// A worker that declares nothing inherits `decode_router_mode`, preserving the
-/// behavior of every deployment that predates the override.
+/// A prefill worker that declares its own `router_config` governs this hop;
+/// one that declares nothing inherits `decode_router_mode`. That is what lets a
+/// deployment run KV-routed prefill in front of round-robin decode.
 fn resolve_advertisement_from_cards(
     cards: &[ModelDeploymentCard],
     decode_router_mode: RouterMode,
@@ -81,13 +69,10 @@ fn resolve_advertisement_from_cards(
             .as_ref()
             .map(|config| config.kv_router_config.clone()),
         is_eagle: first.runtime_config.enable_eagle,
-        advertised: first.router_config.is_some(),
     };
 
-    // A prefill fleet mid-rolling-update can disagree about its mode. The first
-    // card wins and the binding is rebuilt whenever the target moves, so this
-    // converges — but a silent split is worth surfacing, since half the fleet is
-    // then being routed on the other half's terms.
+    // A fleet mid-rolling-update can disagree. First card wins, but a silent
+    // split means half the fleet is routed on the other half's terms.
     let disagreeing = cards
         .iter()
         .skip(1)
@@ -130,7 +115,6 @@ impl PrefillRouter<DefaultWorkerSelector> {
         session_affinity_ttl_secs: Option<u64>,
         model_name: String,
         namespace: String,
-        is_eagle: bool,
         worker_monitor: Option<crate::discovery::KvWorkerMonitor>,
     ) -> Arc<Self> {
         Self::new_with_selector_factory(
@@ -150,7 +134,6 @@ impl PrefillRouter<DefaultWorkerSelector> {
             session_affinity_ttl_secs,
             model_name,
             namespace,
-            is_eagle,
             worker_monitor,
             None,
         )
@@ -183,7 +166,6 @@ where
             prefill_load_estimator: None,
             model_name: String::new(), // Not used for disabled router
             namespace: String::new(),  // Not used for disabled router
-            is_eagle: false,
             task_guard: None,
             lifecycle: std::sync::atomic::AtomicU8::new(PrefillLifecycleState::Pending as u8),
             #[cfg(test)]
@@ -204,7 +186,6 @@ where
         session_affinity_ttl_secs: Option<u64>,
         model_name: String,
         namespace: String,
-        is_eagle: bool,
         worker_monitor: Option<crate::discovery::KvWorkerMonitor>,
         task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
     ) -> Arc<Self> {
@@ -236,7 +217,6 @@ where
             prefill_load_estimator,
             model_name,
             namespace,
-            is_eagle,
             task_guard: task_guard.clone(),
             lifecycle: std::sync::atomic::AtomicU8::new(PrefillLifecycleState::Pending as u8),
             #[cfg(test)]
@@ -310,9 +290,8 @@ where
         tracing::info!(
             ?prefill_router_mode,
             decode_router_mode = ?context.decode_router_mode,
-            advertised = advertisement.advertised,
-            resolved_is_eagle = advertisement.is_eagle,
-            configured_is_eagle = context.is_eagle,
+            advertised = advertisement.kv_router_config.is_some(),
+            is_eagle = advertisement.is_eagle,
             "Activating prefill router"
         );
 
@@ -320,7 +299,7 @@ where
         // honoring only half of its `RouterConfig` would be a trap. Whichever
         // config wins, `router_track_active_blocks` stays off: prefill routing is
         // prompt-side, and crediting decode blocks here would double-count load.
-        let kv_router_config = match advertisement.kv_router_config {
+        let prefill_kv_config = match advertisement.kv_router_config {
             Some(mut advertised) => {
                 advertised.router_track_active_blocks = false;
                 Some(advertised)
@@ -329,10 +308,8 @@ where
         };
 
         let inner_router = if prefill_router_mode.is_kv_routing() {
-            let is_eagle = advertisement.is_eagle;
-
             // Create KV chooser using the endpoint (this is a prefill router)
-            let effective_kv_router_config = kv_router_config.clone().unwrap_or_default();
+            let effective_kv_router_config = prefill_kv_config.clone().unwrap_or_default();
             let selector = (context.worker_selector_factory)(
                 &effective_kv_router_config,
                 crate::worker_type::WorkerType::Prefill,
@@ -344,12 +321,12 @@ where
                     &endpoint,
                     kv_cache_block_size,
                     selector,
-                    kv_router_config,
+                    prefill_kv_config,
                     context.prefill_load_estimator.clone(),
                     Some(crate::worker_type::WorkerType::Prefill),
                     WORKER_TYPE_PREFILL,
                     Some(context.model_name.clone()),
-                    is_eagle,
+                    advertisement.is_eagle,
                 )
                 .await?;
 
@@ -440,13 +417,22 @@ where
             .await
             .with_context(|| format!("listing prefill model cards for {endpoint_id}"))?;
 
+        // An unparseable card is not just a missing EAGLE hint any more: it
+        // drops a worker out of the vote that decides how this hop is routed.
         let cards: Vec<ModelDeploymentCard> = instances
             .into_iter()
-            .filter_map(|instance| instance.deserialize_model::<ModelDeploymentCard>().ok())
+            .filter_map(|instance| {
+                instance
+                    .deserialize_model::<ModelDeploymentCard>()
+                    .inspect_err(|error| {
+                        tracing::debug!(%error, %endpoint_id, "Skipping unreadable prefill card")
+                    })
+                    .ok()
+            })
             .collect();
 
         resolve_advertisement_from_cards(&cards, context.decode_router_mode)
-            .with_context(|| format!("resolving prefill routing for {endpoint_id}"))
+            .with_context(|| format!("prefill endpoint {endpoint_id}"))
     }
 
     /// Attach the freshly-created prefill `Client` to this WorkerSet's monitor (handed in
@@ -515,7 +501,6 @@ where
                 prefill_load_estimator: router_ref.prefill_load_estimator.clone(),
                 session_affinity_ttl: router_ref.session_affinity_ttl,
                 model_name: router_ref.model_name.clone(),
-                is_eagle: router_ref.is_eagle,
             };
             drop(router_ref);
             let build = Self::build_binding(
@@ -650,7 +635,6 @@ mod tests {
         let resolved =
             resolve_advertisement_from_cards(&cards, RouterMode::RoundRobin).expect("resolves");
         assert_eq!(resolved.router_mode, RouterMode::RoundRobin);
-        assert!(!resolved.advertised);
         assert!(resolved.kv_router_config.is_none());
     }
 
@@ -664,20 +648,7 @@ mod tests {
         let resolved =
             resolve_advertisement_from_cards(&cards, RouterMode::RoundRobin).expect("resolves");
         assert_eq!(resolved.router_mode, RouterMode::KV);
-        assert!(resolved.advertised);
         assert!(resolved.kv_router_config.is_some());
-    }
-
-    #[test]
-    fn card_can_downgrade_prefill_below_a_kv_decode_set() {
-        // The reverse pairing must work too: round-robin prefill in front of a
-        // KV decode set. Nothing about the override is KV-specific.
-        let cards = vec![card(Some(RouterConfig::new(
-            RouterMode::RoundRobin,
-            KvRouterConfig::default(),
-        )))];
-        let resolved = resolve_advertisement_from_cards(&cards, RouterMode::KV).expect("resolves");
-        assert_eq!(resolved.router_mode, RouterMode::RoundRobin);
     }
 
     #[test]

--- a/lib/llm/src/kv_router/prefill_router/conditional_bypass.rs
+++ b/lib/llm/src/kv_router/prefill_router/conditional_bypass.rs
@@ -74,7 +74,10 @@ where
         session_affinity: Option<&SessionAffinityId>,
         decode_affinity_target: Option<AffinityTarget>,
     ) -> Result<Option<ConditionalDisaggDecodeDecision>> {
-        if !self.router_mode.is_kv_routing() {
+        // Conditional disagg peeks the decode router to find the cache-hot
+        // decode worker, so it needs the *decode* set in KV mode. A KV prefill
+        // hop in front of a non-KV decode set cannot make this decision.
+        if !self.decode_router_mode.is_kv_routing() {
             return Ok(None);
         }
 

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -193,7 +193,14 @@ where
     decode_session_affinity: OnceLock<AffinityCoordinator>,
     model_manager: Arc<ModelManager>,
     cancel_token: CancellationToken,
-    router_mode: RouterMode,
+    /// Router mode of the decode worker set that owns this prefill router.
+    ///
+    /// This governs decode-side decisions only (conditional disagg peeks the
+    /// decode router, which exists only in KV mode). It is *not* the mode of
+    /// the prefill hop: that is resolved per activation from the prefill
+    /// worker's own card and lives on [`PrefillBinding::prefill_router_mode`].
+    /// It does serve as the fallback when the prefill card advertises none.
+    decode_router_mode: RouterMode,
     session_affinity_ttl: Option<std::time::Duration>,
     conditional_disagg_policy: Box<dyn ConditionalDisaggPolicy>,
     /// Resolved once at construction: dedicated threshold if set, otherwise
@@ -220,6 +227,12 @@ where
 {
     endpoint_id: EndpointId,
     router: InnerPrefillRouter<Sel>,
+    /// Mode the prefill hop was actually built with, resolved at activation
+    /// from the prefill worker's advertised card (falling back to the decode
+    /// set's mode). Kept here rather than on `PrefillRouter` because it is only
+    /// knowable once a prefill target has been discovered, and it changes when
+    /// the binding is rebuilt against a new target.
+    prefill_router_mode: RouterMode,
 }
 
 struct PrefillBuildContext<Sel>
@@ -227,7 +240,8 @@ where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
     model_manager: Arc<ModelManager>,
-    router_mode: RouterMode,
+    /// Fallback mode for the prefill hop when the prefill card advertises none.
+    decode_router_mode: RouterMode,
     worker_selector_factory: WorkerSelectorFactory<Sel>,
     prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
     session_affinity_ttl: Option<std::time::Duration>,
@@ -381,13 +395,6 @@ where
             .as_ref()
             .and_then(|r| r.prefill_worker_id);
 
-        if self.router_mode.is_direct_routing() && preselected_worker.is_none() {
-            return Err(anyhow::anyhow!(
-                "Prefill worker ID required in Direct routing mode but none found in request. \
-                 Expected prefill_worker_id to be set via x-dynamo-prefill-instance-id header by external router (e.g., EPP)."
-            ));
-        }
-
         let tracker = prefill_req.tracker.clone();
         let mut prefill_context =
             Context::with_id_and_metadata(prefill_req, request_id.clone(), metadata.clone());
@@ -400,6 +407,20 @@ where
         let Some(binding) = self.binding.load_full() else {
             return next.generate(context.map(|_| req)).await;
         };
+
+        // Direct routing on the prefill hop requires the caller to name the
+        // worker. This is keyed on the *prefill* mode, not the decode set's:
+        // the two are independently configurable, and an external router (EPP)
+        // may pin prefill while decode still routes normally. Checked after the
+        // binding loads because the prefill mode is only known once a prefill
+        // target has been discovered.
+        if binding.prefill_router_mode.is_direct_routing() && preselected_worker.is_none() {
+            return Err(anyhow::anyhow!(
+                "Prefill worker ID required in Direct routing mode but none found in request. \
+                 Expected prefill_worker_id to be set via x-dynamo-prefill-instance-id header by external router (e.g., EPP)."
+            ));
+        }
+
         let router = &binding.router;
         let endpoint_id = &binding.endpoint_id;
         let prefill_result: Result<(PrefillOutcome, Option<RoutingConstraints>)> = async {

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -138,13 +138,20 @@ fn extract_bootstrap_info(params: &serde_json::Value) -> Option<BootstrapInfo> {
 /// Shaped as the `kv_transfer_params` the vLLM backend forwards straight into
 /// the engine. Only a vLLM worker configured for push mode publishes these
 /// coordinates, so no other backend can reach this path.
-fn nixl_push_handoff(endpoint: &NixlPushEndpoint) -> PrefillResult {
+///
+/// `request_id` identifies the request on the prefill worker, which decode
+/// echoes back in its heartbeats so prefill knows the blocks are still wanted.
+/// Both legs run under this same id (each is dispatched with the frontend's
+/// context id), so it names the prefill-side request without a second lookup.
+/// vLLM reads it unconditionally as `remote_request_id`.
+fn nixl_push_handoff(endpoint: &NixlPushEndpoint, request_id: &str) -> PrefillResult {
     PrefillResult {
         disaggregated_params: serde_json::json!({
             "kv_transfer_params": {
                 "do_remote_decode": false,
                 "do_remote_prefill": true,
                 "remote_engine_id": endpoint.engine_id,
+                "remote_request_id": request_id,
                 "remote_host": endpoint.host,
                 "remote_port": endpoint.port,
                 "tp_size": endpoint.tensor_parallel_size,
@@ -457,7 +464,7 @@ where
         let prefill_result: Result<(PrefillOutcome, Option<RoutingConstraints>)> = async {
             let (prepared, prefill_stream) = router
                 .select_and_dispatch_prefill(prefill_context, |request, target| {
-                    self.prepare_prefill_dispatch(request, target, endpoint_id)
+                    self.prepare_prefill_dispatch(request, target, endpoint_id, &request_id)
                 })
                 .await?;
             let topology_constraints = prepared.topology_constraints;
@@ -649,6 +656,7 @@ where
         request: &mut PreprocessedRequest,
         target: AffinityTarget,
         endpoint_id: &EndpointId,
+        request_id: &str,
     ) -> anyhow::Result<PreparedPrefill> {
         let AffinityTarget { worker_id, dp_rank } = target;
         let topology_constraints =
@@ -660,7 +668,7 @@ where
         let push_handoff = disaggregated_endpoint
             .as_ref()
             .and_then(|endpoint| endpoint.nixl_push.as_ref())
-            .map(nixl_push_handoff);
+            .map(|endpoint| nixl_push_handoff(endpoint, request_id));
         let bootstrap_info = disaggregated_endpoint
             .map(|endpoint| (endpoint_id, endpoint))
             .and_then(|(endpoint_id, endpoint)| {
@@ -1010,7 +1018,7 @@ mod tests {
     /// is a wire contract with the engine, not an internal detail.
     #[test]
     fn nixl_push_handoff_names_the_prefill_engine() {
-        let handoff = nixl_push_handoff(&push_endpoint());
+        let handoff = nixl_push_handoff(&push_endpoint(), "req-42");
 
         assert_eq!(
             handoff.disaggregated_params,
@@ -1019,6 +1027,7 @@ mod tests {
                     "do_remote_decode": false,
                     "do_remote_prefill": true,
                     "remote_engine_id": "prefill-engine-001",
+                    "remote_request_id": "req-42",
                     "remote_host": "10.0.0.1",
                     "remote_port": 5600,
                     "tp_size": 4,
@@ -1028,12 +1037,35 @@ mod tests {
         );
     }
 
+    /// `NixlConnectorMetadata::add_new_req_to_recv` indexes these keys directly
+    /// rather than `.get()`-ing them, so a missing one kills the decode engine
+    /// with a `KeyError` mid-step instead of failing the request.
+    #[test]
+    fn nixl_push_handoff_carries_every_key_vllm_indexes() {
+        let handoff = nixl_push_handoff(&push_endpoint(), "req-42");
+
+        let params = handoff.disaggregated_params["kv_transfer_params"]
+            .as_object()
+            .expect("kv_transfer_params is an object");
+        // `remote_block_ids` is the one exception: vLLM's push scheduler seeds
+        // it itself in `update_state_after_alloc`, because decode allocates the
+        // blocks it will receive into.
+        for key in [
+            "remote_engine_id",
+            "remote_request_id",
+            "remote_host",
+            "remote_port",
+        ] {
+            assert!(params.contains_key(key), "missing {key}");
+        }
+    }
+
     /// Push mode's decode leg allocates its own blocks and tells the prefill
     /// worker where they are. Sending `remote_block_ids` would be pull mode's
     /// contract, and the ids do not exist yet in any case.
     #[test]
     fn nixl_push_handoff_omits_pull_mode_block_ids() {
-        let handoff = nixl_push_handoff(&push_endpoint());
+        let handoff = nixl_push_handoff(&push_endpoint(), "req-42");
 
         let params = handoff.disaggregated_params["kv_transfer_params"]
             .as_object()
@@ -1046,7 +1078,7 @@ mod tests {
     #[test]
     fn nixl_push_handoff_has_no_prompt_token_details() {
         assert!(
-            nixl_push_handoff(&push_endpoint())
+            nixl_push_handoff(&push_endpoint(), "req-42")
                 .prompt_tokens_details
                 .is_none()
         );

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -31,7 +31,7 @@ use futures::stream::{self, StreamExt};
 use crate::{
     discovery::ModelManager,
     kv_router::WorkerSelectorFactory,
-    local_model::runtime_config::ModelRuntimeConfig,
+    local_model::runtime_config::{ModelRuntimeConfig, NixlPushEndpoint},
     protocols::common::{
         extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
         llm_backend::{LLMEngineOutput, PreprocessedRequest},
@@ -96,6 +96,14 @@ enum PrefillOutcome {
         bootstrap_info: BootstrapInfo,
         worker_id: u64,
     },
+    /// Prefill runs in the background while decode registers its blocks with
+    /// it. Unlike [`PrefillOutcome::Completed`], the handoff is synthesized
+    /// from discovery before prefill starts, so nothing here is derived from
+    /// the prefill response.
+    NixlPush {
+        result: PrefillResult,
+        worker_id: u64,
+    },
     Completed {
         result: PrefillResult,
         worker_id: u64,
@@ -118,9 +126,44 @@ fn extract_bootstrap_info(params: &serde_json::Value) -> Option<BootstrapInfo> {
     })
 }
 
+/// Build the decode leg's KV handoff for a prefill worker running vLLM's
+/// `NixlPushConnector`, from the coordinates it published to discovery.
+///
+/// This is the whole reason push mode can overlap the two legs: the payload
+/// names the prefill engine, and everything else the transfer needs (which
+/// blocks, and where they land) is negotiated worker-to-worker over NIXL rather
+/// than relayed through the frontend. Pull mode cannot do this -- its handoff
+/// carries `remote_block_ids`, which do not exist until prefill has run.
+///
+/// Shaped as the `kv_transfer_params` the vLLM backend forwards straight into
+/// the engine. Only a vLLM worker configured for push mode publishes these
+/// coordinates, so no other backend can reach this path.
+fn nixl_push_handoff(endpoint: &NixlPushEndpoint) -> PrefillResult {
+    PrefillResult {
+        disaggregated_params: serde_json::json!({
+            "kv_transfer_params": {
+                "do_remote_decode": false,
+                "do_remote_prefill": true,
+                "remote_engine_id": endpoint.engine_id,
+                "remote_host": endpoint.host,
+                "remote_port": endpoint.port,
+                "tp_size": endpoint.tensor_parallel_size,
+                "pp_size": endpoint.pipeline_parallel_size,
+            }
+        }),
+        // Pull mode lifts this off the prefill response. Decode is dispatched
+        // before that response exists here, so cached-prompt-token reporting is
+        // unavailable in push mode -- the same trade the bootstrap path makes.
+        prompt_tokens_details: None,
+    }
+}
+
 struct PreparedPrefill {
     worker_id: u64,
     bootstrap_info: Option<BootstrapInfo>,
+    /// Set when the selected prefill worker advertised NIXL push coordinates,
+    /// which is what lets decode be dispatched without awaiting prefill.
+    push_handoff: Option<PrefillResult>,
     topology_constraints: Option<RoutingConstraints>,
 }
 
@@ -424,6 +467,15 @@ where
                     bootstrap_info,
                     worker_id: prepared.worker_id,
                 }
+            } else if let Some(result) = prepared.push_handoff {
+                // Awaiting prefill here would defeat the point: decode must be
+                // in flight and holding allocated blocks for the prefill worker
+                // to have somewhere to push to the moment prefill lands.
+                self.spawn_prefill_task(prefill_stream, tracker, prefill_phase_barrier);
+                PrefillOutcome::NixlPush {
+                    result,
+                    worker_id: prepared.worker_id,
+                }
             } else {
                 drop(prefill_phase_barrier);
                 let completion =
@@ -522,6 +574,13 @@ where
                 decode_req.bootstrap_info = Some(bootstrap_info);
                 decode_req.routing_mut().prefill_worker_id = Some(worker_id);
             }
+            PrefillOutcome::NixlPush { result, worker_id } => {
+                decode_req.prefill_result = Some(result);
+                // No `migration_link`: the prefill worker's `engine.generate`
+                // span is only reported on its response, which by design has
+                // not arrived yet.
+                decode_req.routing_mut().prefill_worker_id = Some(worker_id);
+            }
             PrefillOutcome::Completed {
                 result,
                 worker_id,
@@ -595,9 +654,14 @@ where
         let topology_constraints =
             self.preflight_kv_transfer_constraints(Some(endpoint_id), worker_id)?;
 
-        let bootstrap_info = self
+        let disaggregated_endpoint = self
             .model_manager
-            .get_disaggregated_endpoint(endpoint_id, worker_id)
+            .get_disaggregated_endpoint(endpoint_id, worker_id);
+        let push_handoff = disaggregated_endpoint
+            .as_ref()
+            .and_then(|endpoint| endpoint.nixl_push.as_ref())
+            .map(nixl_push_handoff);
+        let bootstrap_info = disaggregated_endpoint
             .map(|endpoint| (endpoint_id, endpoint))
             .and_then(|(endpoint_id, endpoint)| {
                 let host = endpoint.bootstrap_host?;
@@ -622,6 +686,7 @@ where
         Ok(PreparedPrefill {
             worker_id,
             bootstrap_info,
+            push_handoff,
             topology_constraints,
         })
     }
@@ -929,5 +994,61 @@ mod tests {
             "bootstrap_room": 1,
         });
         assert!(extract_bootstrap_info(&params).is_none());
+    }
+
+    fn push_endpoint() -> NixlPushEndpoint {
+        NixlPushEndpoint {
+            engine_id: "prefill-engine-001".to_string(),
+            host: "10.0.0.1".to_string(),
+            port: 5600,
+            tensor_parallel_size: 4,
+            pipeline_parallel_size: 2,
+        }
+    }
+
+    /// vLLM matches these keys by name off `kv_transfer_params`, so the shape
+    /// is a wire contract with the engine, not an internal detail.
+    #[test]
+    fn nixl_push_handoff_names_the_prefill_engine() {
+        let handoff = nixl_push_handoff(&push_endpoint());
+
+        assert_eq!(
+            handoff.disaggregated_params,
+            serde_json::json!({
+                "kv_transfer_params": {
+                    "do_remote_decode": false,
+                    "do_remote_prefill": true,
+                    "remote_engine_id": "prefill-engine-001",
+                    "remote_host": "10.0.0.1",
+                    "remote_port": 5600,
+                    "tp_size": 4,
+                    "pp_size": 2,
+                }
+            })
+        );
+    }
+
+    /// Push mode's decode leg allocates its own blocks and tells the prefill
+    /// worker where they are. Sending `remote_block_ids` would be pull mode's
+    /// contract, and the ids do not exist yet in any case.
+    #[test]
+    fn nixl_push_handoff_omits_pull_mode_block_ids() {
+        let handoff = nixl_push_handoff(&push_endpoint());
+
+        let params = handoff.disaggregated_params["kv_transfer_params"]
+            .as_object()
+            .expect("kv_transfer_params is an object");
+        assert!(!params.contains_key("remote_block_ids"));
+    }
+
+    /// Prefill has not run when this handoff is built, so there is no usage
+    /// report to carry -- the field must be absent rather than fabricated.
+    #[test]
+    fn nixl_push_handoff_has_no_prompt_token_details() {
+        assert!(
+            nixl_push_handoff(&push_endpoint())
+                .prompt_tokens_details
+                .is_none()
+        );
     }
 }

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -193,13 +193,9 @@ where
     decode_session_affinity: OnceLock<AffinityCoordinator>,
     model_manager: Arc<ModelManager>,
     cancel_token: CancellationToken,
-    /// Router mode of the decode worker set that owns this prefill router.
-    ///
-    /// This governs decode-side decisions only (conditional disagg peeks the
-    /// decode router, which exists only in KV mode). It is *not* the mode of
-    /// the prefill hop: that is resolved per activation from the prefill
-    /// worker's own card and lives on [`PrefillBinding::prefill_router_mode`].
-    /// It does serve as the fallback when the prefill card advertises none.
+    /// Mode of the decode set that owns this router. Governs decode-side
+    /// decisions, and is the fallback for the prefill hop -- not its mode. That
+    /// lives on [`PrefillBinding::prefill_router_mode`].
     decode_router_mode: RouterMode,
     session_affinity_ttl: Option<std::time::Duration>,
     conditional_disagg_policy: Box<dyn ConditionalDisaggPolicy>,
@@ -213,7 +209,6 @@ where
     model_name: String,
     /// Namespace (used for logging / lifecycle messages).
     namespace: String,
-    is_eagle: bool,
     task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
     /// Initialization and worker availability state.
     lifecycle: AtomicU8,
@@ -227,11 +222,9 @@ where
 {
     endpoint_id: EndpointId,
     router: InnerPrefillRouter<Sel>,
-    /// Mode the prefill hop was actually built with, resolved at activation
-    /// from the prefill worker's advertised card (falling back to the decode
-    /// set's mode). Kept here rather than on `PrefillRouter` because it is only
-    /// knowable once a prefill target has been discovered, and it changes when
-    /// the binding is rebuilt against a new target.
+    /// Resolved at activation from the prefill card. Lives here rather than on
+    /// `PrefillRouter` because it is unknowable until a target is discovered,
+    /// and changes when the binding is rebuilt.
     prefill_router_mode: RouterMode,
 }
 
@@ -246,7 +239,6 @@ where
     prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
     session_affinity_ttl: Option<std::time::Duration>,
     model_name: String,
-    is_eagle: bool,
 }
 
 pub(crate) trait PrefillRouterLifecycle: Send + Sync {
@@ -408,12 +400,8 @@ where
             return next.generate(context.map(|_| req)).await;
         };
 
-        // Direct routing on the prefill hop requires the caller to name the
-        // worker. This is keyed on the *prefill* mode, not the decode set's:
-        // the two are independently configurable, and an external router (EPP)
-        // may pin prefill while decode still routes normally. Checked after the
-        // binding loads because the prefill mode is only known once a prefill
-        // target has been discovered.
+        // Keyed on the prefill mode, not the decode set's, and checked after
+        // the binding loads because that is where the prefill mode lives.
         if binding.prefill_router_mode.is_direct_routing() && preselected_worker.is_none() {
             return Err(anyhow::anyhow!(
                 "Prefill worker ID required in Direct routing mode but none found in request. \
@@ -889,7 +877,6 @@ mod tests {
             None,
             "test-model".to_string(),
             "test-namespace".to_string(),
-            false,
             None,
         );
         let task_state = Arc::downgrade(&router.activation_task_state);

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -309,6 +309,7 @@ mod tests {
                     name: endpoint_name.to_string(),
                 },
                 router: InnerPrefillRouter::SimpleRouter(shared.clone()),
+                prefill_router_mode: mode,
             },
         )));
         prefill.lifecycle.store(

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -142,6 +142,34 @@ impl FromStr for TokenizerBackend {
     }
 }
 
+/// NIXL side-channel coordinates published by a prefill worker running vLLM's
+/// push-mode KV connector (`NixlPushConnector`).
+///
+/// Pull mode never needs these in discovery: the decode worker learns them from
+/// the prefill response and then issues a NIXL READ. Push mode inverts the
+/// transfer -- the decode worker registers its freshly allocated blocks with the
+/// prefill worker, which WRITEs into them -- so the decode leg must be able to
+/// name the prefill engine *before* prefill finishes. Publishing them here is
+/// what lets the frontend dispatch both legs concurrently.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NixlPushEndpoint {
+    /// The prefill engine's `KVTransferConfig.engine_id`.
+    pub engine_id: String,
+
+    /// `VLLM_NIXL_SIDE_CHANNEL_HOST` as resolved by the prefill worker.
+    pub host: String,
+
+    /// `VLLM_NIXL_SIDE_CHANNEL_PORT` offset by the engine's data-parallel index,
+    /// matching how vLLM's NIXL scheduler derives its own listening port.
+    pub port: u16,
+
+    /// Prefill-side tensor-parallel size.
+    pub tensor_parallel_size: u32,
+
+    /// Prefill-side pipeline-parallel size.
+    pub pipeline_parallel_size: u32,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct DisaggregatedEndpoint {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -149,6 +177,13 @@ pub struct DisaggregatedEndpoint {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bootstrap_port: Option<u16>,
+
+    /// Present only when the worker runs vLLM's `NixlPushConnector`. A frontend
+    /// that predates this field simply routes the hop sequentially, which push
+    /// mode still tolerates -- the prefill worker holds its finished blocks
+    /// until the late registration arrives.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nixl_push: Option<NixlPushEndpoint>,
 }
 
 /// Controls how historical `function.arguments` are serialized before being
@@ -1186,5 +1221,68 @@ mod tests {
         ] {
             assert!(config.validate_config().is_err());
         }
+    }
+
+    #[test]
+    fn nixl_push_endpoint_round_trips_alongside_bootstrap_fields() {
+        let config = ModelRuntimeConfig {
+            disaggregated_endpoint: Some(DisaggregatedEndpoint {
+                bootstrap_host: Some("10.0.0.1".to_string()),
+                bootstrap_port: Some(8998),
+                nixl_push: Some(NixlPushEndpoint {
+                    engine_id: "prefill-engine-001".to_string(),
+                    host: "10.0.0.1".to_string(),
+                    port: 5600,
+                    tensor_parallel_size: 4,
+                    pipeline_parallel_size: 1,
+                }),
+            }),
+            ..Default::default()
+        };
+
+        let decoded: ModelRuntimeConfig =
+            serde_json::from_str(&serde_json::to_string(&config).unwrap()).unwrap();
+
+        assert_eq!(
+            decoded.disaggregated_endpoint,
+            config.disaggregated_endpoint
+        );
+    }
+
+    /// A worker from before push mode publishes `disaggregated_endpoint` without
+    /// `nixl_push`; reading it must not fail closed, since bootstrap-based
+    /// disagg does not involve this field at all.
+    #[test]
+    fn disaggregated_endpoint_without_nixl_push_still_deserializes() {
+        let decoded: DisaggregatedEndpoint =
+            serde_json::from_str(r#"{"bootstrap_host":"10.0.0.1","bootstrap_port":8998}"#).unwrap();
+
+        assert_eq!(decoded.bootstrap_host.as_deref(), Some("10.0.0.1"));
+        assert!(decoded.nixl_push.is_none());
+    }
+
+    /// Push mode has no bootstrap server, so the two halves must be
+    /// independently omittable rather than travelling as a unit.
+    #[test]
+    fn nixl_push_endpoint_serializes_without_bootstrap_fields() {
+        let endpoint = DisaggregatedEndpoint {
+            bootstrap_host: None,
+            bootstrap_port: None,
+            nixl_push: Some(NixlPushEndpoint {
+                engine_id: "prefill-engine-001".to_string(),
+                host: "10.0.0.1".to_string(),
+                port: 5600,
+                tensor_parallel_size: 1,
+                pipeline_parallel_size: 1,
+            }),
+        };
+
+        let encoded = serde_json::to_string(&endpoint).unwrap();
+
+        assert!(!encoded.contains("bootstrap_host"), "{encoded}");
+        assert_eq!(
+            serde_json::from_str::<DisaggregatedEndpoint>(&encoded).unwrap(),
+            endpoint
+        );
     }
 }

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -3816,3 +3816,126 @@ def _test_disagg_per_role_router_modes(
             f"{set(converged)} (KV) while decode spread across "
             f"{set(decode_ids)} (round-robin)"
         )
+
+
+def _test_disagg_per_role_session_affinity(
+    prefill_workers,
+    decode_workers,
+    block_size: int,
+    request,
+    frontend_port: int,
+    test_payload: dict,
+    store_backend: str = "etcd",
+    request_plane: str = "nats",
+):
+    """Validate that session affinity is configured per hop, not per deployment.
+
+    The prefill workers advertise a session-affinity TTL; the decode workers
+    advertise the same router mode without one. Both hops then run round-robin,
+    so the only thing that can pin a session is its own affinity setting:
+
+    1. Repeated requests carrying one session id stay on ONE prefill worker,
+       because that hop has affinity.
+    2. The same requests spread across MULTIPLE decode workers, because that hop
+       does not -- round-robin rotates.
+
+    Assertion 2 is the one that fails if the two hops share a TTL: decode would
+    pin alongside prefill.
+
+    This covers configurability, not expiry. Proving a TTL elapses would mean
+    sleeping past it and asserting a rebind, which is timing-dependent and can
+    re-select the same worker.
+    """
+    num_requests = 4
+
+    with FrontendRouterProcess(
+        request,
+        block_size,
+        frontend_port,
+        decode_workers.namespace,
+        store_backend,
+        request_plane=request_plane,
+        router_mode="round-robin",
+        min_initial_workers=decode_workers.num_workers,
+    ):
+        frontend_url = f"http://localhost:{frontend_port}"
+        chat_url = f"{frontend_url}/v1/chat/completions"
+
+        asyncio.run(
+            wait_for_frontend_ready(
+                frontend_url=frontend_url,
+                expected_num_workers=(
+                    prefill_workers.num_workers + decode_workers.num_workers
+                ),
+                timeout=120,
+                engine_workers=[prefill_workers, decode_workers],
+                store_backend=store_backend,
+                request_plane=request_plane,
+            )
+        )
+
+        session_headers = {"x-dynamo-session-id": f"per-role-ttl-{uuid.uuid4()}"}
+        content = test_payload["messages"][0]["content"]
+
+        async def send_session_requests():
+            prefill_ids: list[int] = []
+            decode_ids: list[int] = []
+            async with aiohttp.ClientSession() as session:
+                for i in range(num_requests):
+                    payload = {
+                        **test_payload,
+                        "messages": [{"role": "user", "content": content}],
+                        "nvext": {"extra_fields": ["worker_id"]},
+                        "stream": True,
+                        "max_tokens": 1,
+                    }
+                    async with session.post(
+                        chat_url, json=payload, headers=session_headers
+                    ) as response:
+                        assert (
+                            response.status == 200
+                        ), f"Request {i + 1} failed with status {response.status}"
+                        # worker_id repeats across chunks of one stream; record
+                        # it once per request so the counts match the requests.
+                        prefill_wid = None
+                        decode_wid = None
+                        body = await response.text()
+                        for data in parse_sse_json_chunks(body):
+                            worker_id_info = data.get("nvext", {}).get("worker_id", {})
+                            if "prefill_worker_id" in worker_id_info:
+                                prefill_wid = worker_id_info["prefill_worker_id"]
+                            if "decode_worker_id" in worker_id_info:
+                                decode_wid = worker_id_info["decode_worker_id"]
+                        if prefill_wid is not None:
+                            prefill_ids.append(prefill_wid)
+                        if decode_wid is not None:
+                            decode_ids.append(decode_wid)
+                    await asyncio.sleep(0.5)
+            return prefill_ids, decode_ids
+
+        prefill_ids, decode_ids = asyncio.run(send_session_requests())
+        logger.info(f"Session-pinned prefill_worker_ids: {prefill_ids}")
+        logger.info(f"Session-pinned decode_worker_ids: {decode_ids}")
+
+        assert (
+            len(prefill_ids) == num_requests
+        ), f"Expected {num_requests} prefill_worker_ids, got {len(prefill_ids)}."
+        assert (
+            len(decode_ids) == num_requests
+        ), f"Expected {num_requests} decode_worker_ids, got {len(decode_ids)}."
+
+        assert len(set(prefill_ids)) == 1, (
+            f"Prefill advertised a session-affinity TTL, so one session must stay "
+            f"pinned to one prefill worker; got {set(prefill_ids)}. Full: {prefill_ids}"
+        )
+        assert len(set(decode_ids)) > 1, (
+            f"Decode advertised no session-affinity TTL, so the same session must "
+            f"not be pinned there; all {num_requests} requests landed on "
+            f"{set(decode_ids)}. That means the hops are sharing one TTL."
+        )
+
+        logger.info(
+            "Verified per-hop session affinity: prefill pinned to "
+            f"{set(prefill_ids)} (TTL advertised) while decode spread across "
+            f"{set(decode_ids)} (no TTL)"
+        )

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -3667,3 +3667,152 @@ def _test_disagg_direct_mode(
 
         asyncio.run(run_direct_mode_tests())
         logger.info("Direct-mode disagg E2E test passed")
+
+
+def _test_disagg_per_role_router_modes(
+    prefill_workers,
+    decode_workers,
+    block_size: int,
+    request,
+    frontend_port: int,
+    test_payload: dict,
+    store_backend: str = "etcd",
+    request_plane: str = "nats",
+):
+    """Validate that prefill and decode tiers can run different router modes.
+
+    The prefill mockers advertise ``RouterConfig(RouterMode.KV)`` in their model
+    deployment cards while the decode mockers advertise nothing, so decode
+    inherits the frontend's ``--router-mode round-robin``. This asserts the two
+    hops are genuinely routed on different terms:
+
+    1. Progressive prefix-extending requests converge on ONE prefill worker,
+       which only KV routing produces — round-robin would rotate.
+    2. Those same requests spread across MORE THAN ONE decode worker, which only
+       round-robin produces — KV routing would converge there too.
+
+    Assertion 2 is the one that fails if the per-role override is ignored and
+    the whole pipeline silently runs in a single mode.
+    """
+    num_requests = 4
+
+    with FrontendRouterProcess(
+        request,
+        block_size,
+        frontend_port,
+        decode_workers.namespace,
+        store_backend,
+        request_plane=request_plane,
+        router_mode="round-robin",
+        min_initial_workers=decode_workers.num_workers,
+    ):
+        frontend_url = f"http://localhost:{frontend_port}"
+        chat_url = f"{frontend_url}/v1/chat/completions"
+
+        logger.info(
+            "Waiting for prefill and decode workers to register with the "
+            "round-robin frontend..."
+        )
+        asyncio.run(
+            wait_for_frontend_ready(
+                frontend_url=frontend_url,
+                expected_num_workers=(
+                    prefill_workers.num_workers + decode_workers.num_workers
+                ),
+                timeout=120,
+                engine_workers=[prefill_workers, decode_workers],
+                store_backend=store_backend,
+                request_plane=request_plane,
+            )
+        )
+
+        async def send_progressive_requests():
+            prefill_worker_ids: list[int] = []
+            decode_worker_ids: list[int] = []
+            base_content = test_payload["messages"][0]["content"]
+
+            async with aiohttp.ClientSession() as session:
+                for i in range(num_requests):
+                    payload = {
+                        **test_payload,
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": " ".join([base_content] * (i + 1)),
+                            }
+                        ],
+                        "nvext": {"extra_fields": ["worker_id"]},
+                        "stream": True,
+                    }
+
+                    async with session.post(chat_url, json=payload) as response:
+                        assert (
+                            response.status == 200
+                        ), f"Request {i + 1} failed with status {response.status}"
+
+                        prefill_wid = None
+                        decode_wid = None
+                        body = await response.text()
+                        for data in parse_sse_json_chunks(body):
+                            worker_id_info = data.get("nvext", {}).get("worker_id", {})
+                            if "prefill_worker_id" in worker_id_info:
+                                prefill_wid = worker_id_info["prefill_worker_id"]
+                            if "decode_worker_id" in worker_id_info:
+                                decode_wid = worker_id_info["decode_worker_id"]
+
+                        logger.info(
+                            f"Request {i + 1}: prefill_worker_id={prefill_wid}, "
+                            f"decode_worker_id={decode_wid}"
+                        )
+                        if prefill_wid is not None:
+                            prefill_worker_ids.append(prefill_wid)
+                        if decode_wid is not None:
+                            decode_worker_ids.append(decode_wid)
+
+                    await asyncio.sleep(1)
+
+            return prefill_worker_ids, decode_worker_ids
+
+        prefill_ids, decode_ids = asyncio.run(send_progressive_requests())
+
+        logger.info(f"Collected prefill_worker_ids: {prefill_ids}")
+        logger.info(f"Collected decode_worker_ids: {decode_ids}")
+
+        assert len(prefill_ids) == num_requests, (
+            f"Expected {num_requests} prefill_worker_ids, got {len(prefill_ids)}. "
+            f"A prefill hop must have run for every request."
+        )
+        assert (
+            len(decode_ids) == num_requests
+        ), f"Expected {num_requests} decode_worker_ids, got {len(decode_ids)}."
+
+        # The prefill tier advertised KV, so prefix reuse must concentrate it.
+        # As in the all-KV disagg test, the TCP request plane can show a
+        # transient on the first request before the initial "stored" KV events
+        # are ingested, so only requests 2..N are required to converge there.
+        converged = prefill_ids[1:] if request_plane == "tcp" else prefill_ids
+        assert len(set(converged)) == 1, (
+            f"Prefill advertised RouterMode.KV, so prefix-extending requests must "
+            f"converge on one prefill worker; got {set(converged)}. "
+            f"Full list: {prefill_ids}"
+        )
+
+        # The decode tier inherited round-robin, so it must NOT converge. If the
+        # prefill card's override had leaked into the decode router (or the
+        # decode set had been dragged into KV mode), these would collapse to one.
+        assert len(set(decode_ids)) > 1, (
+            f"Decode inherited round-robin, so requests must spread across "
+            f"workers; all {num_requests} landed on {set(decode_ids)}. "
+            f"This means the per-role router config did not take effect."
+        )
+
+        assert prefill_ids[0] not in set(decode_ids), (
+            f"Prefill worker {prefill_ids[0]} should not appear in the decode "
+            f"worker set {set(decode_ids)}."
+        )
+
+        logger.info(
+            "Verified per-role router modes: prefill converged on "
+            f"{set(converged)} (KV) while decode spread across "
+            f"{set(decode_ids)} (round-robin)"
+        )

--- a/tests/router/mocker_process.py
+++ b/tests/router/mocker_process.py
@@ -119,6 +119,8 @@ def _build_mocker_command(
                 str(mocker_args["response_replay_trace_path"]),
             ]
         )
+    if "router_mode" in mocker_args:
+        command.extend(["--router-mode", str(mocker_args["router_mode"])])
 
     return command
 

--- a/tests/router/mocker_process.py
+++ b/tests/router/mocker_process.py
@@ -121,6 +121,13 @@ def _build_mocker_command(
         )
     if "router_mode" in mocker_args:
         command.extend(["--router-mode", str(mocker_args["router_mode"])])
+    if "router_session_affinity_ttl_secs" in mocker_args:
+        command.extend(
+            [
+                "--router-session-affinity-ttl-secs",
+                str(mocker_args["router_session_affinity_ttl_secs"]),
+            ]
+        )
 
     return command
 

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -24,6 +24,7 @@ from tests.router.common import (
     _test_busy_threshold_endpoint,
     _test_disagg_direct_mode,
     _test_disagg_per_role_router_modes,
+    _test_disagg_per_role_session_affinity,
     _test_disagg_router_overload_529,
     _test_disagg_topology_required_prefill_pin_match_and_mismatch,
     _test_python_router_bindings,
@@ -1458,6 +1459,51 @@ def test_disagg_per_role_router_modes(
         enable_disagg_bootstrap=False,
     ) as (prefill_workers, decode_workers):
         _test_disagg_per_role_router_modes(
+            prefill_workers=prefill_workers,
+            decode_workers=decode_workers,
+            block_size=BLOCK_SIZE,
+            request=request,
+            frontend_port=allocate_frontend_ports(request, 1)[0],
+            test_payload=TEST_PAYLOAD,
+            request_plane="nats",
+        )
+
+
+@pytest.mark.timeout(180)
+def test_disagg_per_role_session_affinity(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_tokenizers,
+):
+    """Session affinity is configured per hop: prefill pins, decode does not.
+
+    Both tiers advertise round-robin; only prefill advertises a TTL. If the two
+    hops shared a session-affinity setting, decode would pin alongside prefill.
+    """
+    logger.info("Starting per-hop session affinity disagg test")
+
+    shared_namespace = f"test-namespace-{generate_random_suffix()}"
+    base_mocker_args = {
+        "speedup_ratio": SPEEDUP_RATIO,
+        "block_size": BLOCK_SIZE,
+    }
+
+    with launch_disagg_workers(
+        request,
+        shared_namespace,
+        "prefill_first",
+        # Same mode on both tiers, so affinity is the only difference between them.
+        prefill_mocker_args={
+            **base_mocker_args,
+            "router_mode": "round-robin",
+            "router_session_affinity_ttl_secs": 300,
+        },
+        decode_mocker_args={**base_mocker_args, "router_mode": "round-robin"},
+        num_prefill_mockers=2,
+        num_decode_mockers=2,
+        enable_disagg_bootstrap=False,
+    ) as (prefill_workers, decode_workers):
+        _test_disagg_per_role_session_affinity(
             prefill_workers=prefill_workers,
             decode_workers=decode_workers,
             block_size=BLOCK_SIZE,

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -23,6 +23,7 @@ import pytest
 from tests.router.common import (
     _test_busy_threshold_endpoint,
     _test_disagg_direct_mode,
+    _test_disagg_per_role_router_modes,
     _test_disagg_router_overload_529,
     _test_disagg_topology_required_prefill_pin_match_and_mismatch,
     _test_python_router_bindings,
@@ -1423,6 +1424,48 @@ def test_router_decisions_disagg_round_robin_prefill_dp_rank(
         enable_disagg_bootstrap=enable_disagg_bootstrap,
     ) as (prefill_workers, decode_workers):
         run_case(prefill_workers, decode_workers)
+
+
+@pytest.mark.timeout(180)
+def test_disagg_per_role_router_modes(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_tokenizers,
+):
+    """KV-routed prefill in front of round-robin decode, via per-role MDC config.
+
+    The prefill mockers advertise RouterConfig(RouterMode.KV) in their cards; the
+    decode mockers advertise nothing and inherit the frontend's round-robin. Both
+    hops must then route on their own terms rather than sharing one mode.
+    """
+    logger.info("Starting per-role router mode disagg test (KV prefill, RR decode)")
+
+    shared_namespace = f"test-namespace-{generate_random_suffix()}"
+    base_mocker_args = {
+        "speedup_ratio": SPEEDUP_RATIO,
+        "block_size": BLOCK_SIZE,
+    }
+
+    with launch_disagg_workers(
+        request,
+        shared_namespace,
+        "prefill_first",
+        # Only the prefill tier advertises a mode; decode inherits the frontend's.
+        prefill_mocker_args={**base_mocker_args, "router_mode": "kv"},
+        decode_mocker_args=base_mocker_args,
+        num_prefill_mockers=2,
+        num_decode_mockers=2,
+        enable_disagg_bootstrap=False,
+    ) as (prefill_workers, decode_workers):
+        _test_disagg_per_role_router_modes(
+            prefill_workers=prefill_workers,
+            decode_workers=decode_workers,
+            block_size=BLOCK_SIZE,
+            request=request,
+            frontend_port=allocate_frontend_ports(request, 1)[0],
+            test_payload=TEST_PAYLOAD,
+            request_plane="nats",
+        )
 
 
 @pytest.mark.timeout(180)


### PR DESCRIPTION
Stacked on #13197 — base is `gluo/prefill-card-router-mode`, so this diff is the five commits on top. Retarget to `main` once #13197 lands.

## Summary

Adds support for vLLM's push-mode NIXL KV connector (`NixlPushConnector`, available in the pinned vLLM 0.26.0) for disaggregated serving.

The default `NixlConnector` is pull-based: prefill runs, returns its block locations, and decode then READs them. `NixlPushConnector` inverts this — decode registers its freshly allocated blocks with prefill, which WRITEs into them. The point of the inversion is that decode no longer needs anything *computed* during prefill, only the prefill engine's *identity*, so the two legs can be dispatched concurrently and the transfer starts the moment prefill finishes.

Dynamo rejected the connector outright before this change (`Unsupported kv_connector=...` at request setup). Registering it alone would have produced a working but slower-than-pull configuration: with a sequential handoff, push adds a notification round-trip and two engine-step boundaries onto the critical path that a one-sided READ does not have. So this change does both halves — recognize the connector, and give the router what it needs to overlap the legs.

**Advertisement** — a prefill worker in push mode publishes its NIXL engine ID and side-channel address on the `disaggregated_endpoint` it already registers. The field is optional and independent of the existing bootstrap pair, so an older frontend keeps routing sequentially, which push mode tolerates.

**Routing** — when the selected prefill worker advertised those coordinates, `PrefillRouter` synthesizes decode's `kv_transfer_params` from them and routes decode immediately, consuming the prefill stream in the background. This reuses the dispatch shape the SGLang bootstrap path already established.

**Backend** — `NixlPushConnector` is registered as a PD-capable connector and included in the set that triggers side-channel host resolution. The `kv_transfer_params` are unchanged from pull mode on both legs: the reversal is negotiated worker-to-worker over NIXL notifications, not through the params the handler sets.

Enable with the same connector on both tiers:

```bash
--kv-transfer-config '{"kv_connector":"NixlPushConnector","kv_role":"kv_both"}'
```

## Validation

**End-to-end on one GPU (RTX 5880 Ada, 49 GiB), Qwen3-0.6B, prefill + decode co-resident, no parallelism.** Ran `examples/backends/vllm/launch/disagg_same_gpu.sh` unmodified as the pull-mode baseline, then the same script with `NixlPushConnector` substituted into both `--kv-transfer-config` flags, against vLLM 0.26.0.

Four greedy prompts (`temperature=0`, `max_tokens=64`) produced **byte-identical output between the two modes** — same md5 over text and token counts. Correct output is the real check that the KV blocks arrived intact via WRITE rather than READ.

The overlap was confirmed from the dispatch timeline rather than assumed, since a silent fall back to the sequential handoff would also produce correct output:

```
push:  45.502596  prefill  request received
       45.504747  backend  request received   <-- decode dispatched 2.2ms later
       45.555116  prefill  request completed  <-- decode already running 50ms
pull:  09.368171  prefill  request received
       09.429478  prefill  request completed
       09.432664  backend  request received   <-- decode waits for prefill
```

The prefill worker logged `Publishing NIXL push endpoint to discovery: engine_id=66113432-... 10.110.40.102:20097 (tp=1, pp=1)`, with the port matching its configured `VLLM_NIXL_SIDE_CHANNEL_PORT`. 12 concurrent requests all returned 200 with no engine errors, watchdog expiries, or lease reaps.

Static checks and unit tests:

```bash
cargo check --workspace --all-targets                      # clean
cargo clippy --workspace --no-deps --all-targets           # clean
cargo test -p dynamo-llm -p dynamo-backend-common --lib    # 2092 + 137 passed, 0 failed
pytest test_nixl_push.py test_vllm_kv_connector_protocols.py   # 48 passed
pytest test_vllm_unit.py                                   # 139 passed
pre-commit run --files <changed>                           # clean
```

New coverage: handoff wire shape plus the keys vLLM indexes unconditionally, and the fields it must omit (`lib/llm/src/kv_router/prefill_router/mod.rs`); `disaggregated_endpoint` serde round-trip with and without the new field (`lib/llm/src/local_model/runtime_config.rs`); push-connector registration, `PdConnector` nesting, and the side-channel-name set staying in sync with the registry; advertisement gating and address derivation (`test_nixl_push.py`).

**Note on the sixth commit.** The first e2e run killed the decode EngineCore with `KeyError: 'remote_request_id'`. `NixlConnectorMetadata.add_new_req_to_recv` indexes that key directly rather than `.get()`-ing it, and the synthesized handoff omitted it. The unit tests had asserted the payload the code produced rather than the one vLLM consumes, so they passed throughout — the added test now pins the consumed keys. Everything above was re-run after the fix.

## Known limitations

- **No cached-prompt-token details in usage.** Pull mode lifts `prompt_tokens_details` off the prefill response; decode is dispatched before that response exists. Same trade the bootstrap path makes.
- **Terminal prefill is not short-circuited.** A request reaching a stop condition during the one-token prefill step still proceeds to decode. Also inherited from the bootstrap path.
- **Prefill failure surfaces late.** An error after dispatch reaches the client as decode's registration-watchdog timeout rather than an immediate failure — inherent to not awaiting prefill.
- **One data-parallel rank per worker.** vLLM gives each DP rank its own side channel; a worker fronting several has no single address to publish, so it logs a warning and runs the sequential handoff. Affects only vLLM's internal DP load balancing with `--data-parallel-size` > 1; external and hybrid-with-one-local-rank both advertise normally. Documented in the vLLM reference guide. Liftable as a follow-up: `data_parallel_index == data_parallel_rank` upstream, so the router could offset the base port by the rank it selected — it needs a multi-rank deployment to validate.
- **The Rust vLLM sidecar is untouched.** It targets vLLM gRPC 0.25.1, which predates this connector. It never advertises, so it never takes the concurrent path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->