### PR TITLE
docs: repoint the xgrammar structural-tag links to the versioned docs path

### DIFF
--- a/docs/fern/pages/use-cases/tool-calling-and-reasoning/structural-tag.md
+++ b/docs/fern/pages/use-cases/tool-calling-and-reasoning/structural-tag.md
@@ -5,7 +5,7 @@ title: Structural Tag (Guided Decoding for Tool Calls)
 subtitle: Constrain model output to valid tool call format using xgrammar structural tags
 ---
 
-Structural tags use [xgrammar](https://xgrammar.mlc.ai/docs/structural_tag/structural_tag_api.html)
+Structural tags use [xgrammar](https://xgrammar.mlc.ai/docs/latest/structural_tag/structural_tag_api.html)
 guided decoding to constrain model output to a valid tool call format at the
 token level. Instead of hoping the model produces well-formed tool calls,
 structural tags enforce the expected format by restricting the decoding
@@ -205,4 +205,4 @@ To pin the scope and schema, add `--dyn-structural-tag-scope` and `--dyn-structu
 
 - [Tool Call Parsing (Dynamo)](tool-call-parsing.mdx) — parser names and basic tool calling setup
 - [Chat Processors](chat-processors.mdx) — chat processor and engine-fallback parsers
-- [xgrammar Structural Tag Documentation](https://xgrammar.mlc.ai/docs/structural_tag/structural_tag_api.html) — xgrammar format specification
+- [xgrammar Structural Tag Documentation](https://xgrammar.mlc.ai/docs/latest/structural_tag/structural_tag_api.html) — xgrammar format specification


### PR DESCRIPTION
## Summary

xgrammar restructured its docs site under a versioned path; the unversioned `https://xgrammar.mlc.ai/docs/structural_tag/structural_tag_api.html` URL now returns 404, which fails the lychee link check. This repoints both references in `structural-tag.md` to `https://xgrammar.mlc.ai/docs/latest/structural_tag/structural_tag_api.html`.

The same fix for main rides on #13269 (the v1.4.0 tag snapshots this page from the release branch, so it needs the fix here too, before the tag).

## Validation

- `curl` on the old URL returns 404; the new URL returns 200.
- Two occurrences in the file, both updated; no other file references the URL on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->