### PR TITLE
fix(operator): point the autoscaling deprecation at a path that exists

### DIFF
--- a/deploy/operator/api/v1alpha1/common.go
+++ b/deploy/operator/api/v1alpha1/common.go
@@ -56,7 +56,7 @@ type VolumeMount struct {
 }
 
 // Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-// with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md
+// with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
 // for migration guidance. This field will be removed in a future API version.
 type Autoscaling struct {
 	// Deprecated: This field is ignored.

--- a/deploy/operator/api/v1alpha1/common.go
+++ b/deploy/operator/api/v1alpha1/common.go
@@ -56,7 +56,7 @@ type VolumeMount struct {
 }
 
 // Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-// with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
+// with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling
 // for migration guidance. This field will be removed in a future API version.
 type Autoscaling struct {
 	// Deprecated: This field is ignored.

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -91,7 +91,7 @@ type DynamoComponentDeploymentSharedSpec struct {
 	// GPUs/devices, and any runtime-specific resources.
 	Resources *Resources `json:"resources,omitempty"`
 	// Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-	// with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
+	// with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling
 	// for migration guidance. This field will be removed in a future API version.
 	Autoscaling *Autoscaling `json:"autoscaling,omitempty"`
 	// Envs defines additional environment variables to inject into the component containers.

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -91,7 +91,7 @@ type DynamoComponentDeploymentSharedSpec struct {
 	// GPUs/devices, and any runtime-specific resources.
 	Resources *Resources `json:"resources,omitempty"`
 	// Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-	// with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md
+	// with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
 	// for migration guidance. This field will be removed in a future API version.
 	Autoscaling *Autoscaling `json:"autoscaling,omitempty"`
 	// Envs defines additional environment variables to inject into the component containers.

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -73,7 +73,7 @@ spec:
                 autoscaling:
                   description: |-
                     Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-                    with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md
+                    with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
                     for migration guidance. This field will be removed in a future API version.
                   properties:
                     behavior:

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -73,7 +73,7 @@ spec:
                 autoscaling:
                   description: |-
                     Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-                    with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
+                    with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling
                     for migration guidance. This field will be removed in a future API version.
                   properties:
                     behavior:

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -380,7 +380,7 @@ spec:
                       autoscaling:
                         description: |-
                           Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-                          with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md
+                          with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
                           for migration guidance. This field will be removed in a future API version.
                         properties:
                           behavior:

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -380,7 +380,7 @@ spec:
                       autoscaling:
                         description: |-
                           Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-                          with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
+                          with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling
                           for migration guidance. This field will be removed in a future API version.
                         properties:
                           behavior:

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -905,7 +905,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					MaxReplicas: 10,
 				},
 			}),
-			wantWarnings: []string{"spec.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md"},
+			wantWarnings: []string{"spec.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling"},
 		},
 		{
 			name: "deprecated dynamo namespace warning shows calculated namespace",

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -905,7 +905,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					MaxReplicas: 10,
 				},
 			}),
-			wantWarnings: []string{"spec.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md"},
+			wantWarnings: []string{"spec.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md"},
 		},
 		{
 			name: "deprecated dynamo namespace warning shows calculated namespace",

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1340,7 +1340,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			}),
 			wantWarnings: []string{
 				`spec.services[worker].dynamoNamespace is deprecated and ignored. Value "legacy-namespace" will be replaced with "default-test-graph". Remove this field from your configuration`,
-				"spec.services[worker].autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md",
+				"spec.services[worker].autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md",
 			},
 		},
 		{

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1340,7 +1340,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			}),
 			wantWarnings: []string{
 				`spec.services[worker].dynamoNamespace is deprecated and ignored. Value "legacy-namespace" will be replaced with "default-test-graph". Remove this field from your configuration`,
-				"spec.services[worker].autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md",
+				"spec.services[worker].autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling",
 			},
 		},
 		{

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -51,7 +51,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
 	//nolint:staticcheck // SA1019: Intentionally warning about a deprecated preserved field.
 	if spec.Autoscaling != nil {
 		v.warnf(
-			"%s.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md",
+			"%s.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling",
 			fldPath,
 		)
 	}

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -51,7 +51,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
 	//nolint:staticcheck // SA1019: Intentionally warning about a deprecated preserved field.
 	if spec.Autoscaling != nil {
 		v.warnf(
-			"%s.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md",
+			"%s.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md",
 			fldPath,
 		)
 	}

--- a/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
+++ b/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
@@ -40,7 +40,7 @@ Package v1alpha1 contains API Schema definitions for the nvidia.com v1alpha1 API
 
 
 Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
+with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling
 for migration guidance. This field will be removed in a future API version.
 
 
@@ -430,7 +430,7 @@ _Appears in:_
 | `runtimeVersionOverride` _string_ | RuntimeVersionOverride declares the Dynamo runtime compatibility version in this component's<br />main image. DGD admission requires it when spec.extraPodSpec.mainContainer.image has no parseable<br />semantic-version tag; controller-generated DCDs may omit it. Set it also when the parsed tag is<br />not the Dynamo runtime version. Use the canonical MAJOR.MINOR.PATCH value, for example "1.4.0".<br />It does not change the image. Setting or changing an override that resolves to version 1.5.0 or<br />later may trigger a rollout. Keep it consistent with the image's runtime version. |  | Pattern: `^(0\|[1-9][0-9]\{0,3\})\.(0\|[1-9][0-9]\{0,3\})\.(0\|[1-9][0-9]\{0,3\})$` <br />Optional: \{\} <br /> |
 | `globalDynamoNamespace` _boolean_ | GlobalDynamoNamespace indicates that the Component will be placed in the global Dynamo namespace |  |  |
 | `resources` _[Resources](#resources)_ | Resources requested and limits for this component, including CPU, memory,<br />GPUs/devices, and any runtime-specific resources. |  |  |
-| `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md<br />for migration guidance. This field will be removed in a future API version. |  |  |
+| `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling<br />for migration guidance. This field will be removed in a future API version. |  |  |
 | `envs` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Envs defines additional environment variables to inject into the component containers. |  |  |
 | `envFromSecret` _string_ | EnvFromSecret references a Secret whose key/value pairs will be exposed as<br />environment variables in the component containers. |  |  |
 | `volumeMounts` _[VolumeMount](#volumemount) array_ | VolumeMounts references PVCs defined at the top level for volumes to be mounted by the component. |  |  |
@@ -475,7 +475,7 @@ _Appears in:_
 | `runtimeVersionOverride` _string_ | RuntimeVersionOverride declares the Dynamo runtime compatibility version in this component's<br />main image. DGD admission requires it when spec.extraPodSpec.mainContainer.image has no parseable<br />semantic-version tag; controller-generated DCDs may omit it. Set it also when the parsed tag is<br />not the Dynamo runtime version. Use the canonical MAJOR.MINOR.PATCH value, for example "1.4.0".<br />It does not change the image. Setting or changing an override that resolves to version 1.5.0 or<br />later may trigger a rollout. Keep it consistent with the image's runtime version. |  | Pattern: `^(0\|[1-9][0-9]\{0,3\})\.(0\|[1-9][0-9]\{0,3\})\.(0\|[1-9][0-9]\{0,3\})$` <br />Optional: \{\} <br /> |
 | `globalDynamoNamespace` _boolean_ | GlobalDynamoNamespace indicates that the Component will be placed in the global Dynamo namespace |  |  |
 | `resources` _[Resources](#resources)_ | Resources requested and limits for this component, including CPU, memory,<br />GPUs/devices, and any runtime-specific resources. |  |  |
-| `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md<br />for migration guidance. This field will be removed in a future API version. |  |  |
+| `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling<br />for migration guidance. This field will be removed in a future API version. |  |  |
 | `envs` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Envs defines additional environment variables to inject into the component containers. |  |  |
 | `envFromSecret` _string_ | EnvFromSecret references a Secret whose key/value pairs will be exposed as<br />environment variables in the component containers. |  |  |
 | `volumeMounts` _[VolumeMount](#volumemount) array_ | VolumeMounts references PVCs defined at the top level for volumes to be mounted by the component. |  |  |

--- a/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
+++ b/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
@@ -40,7 +40,7 @@ Package v1alpha1 contains API Schema definitions for the nvidia.com v1alpha1 API
 
 
 Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md
+with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
 for migration guidance. This field will be removed in a future API version.
 
 
@@ -430,7 +430,7 @@ _Appears in:_
 | `runtimeVersionOverride` _string_ | RuntimeVersionOverride declares the Dynamo runtime compatibility version in this component's<br />main image. DGD admission requires it when spec.extraPodSpec.mainContainer.image has no parseable<br />semantic-version tag; controller-generated DCDs may omit it. Set it also when the parsed tag is<br />not the Dynamo runtime version. Use the canonical MAJOR.MINOR.PATCH value, for example "1.4.0".<br />It does not change the image. Setting or changing an override that resolves to version 1.5.0 or<br />later may trigger a rollout. Keep it consistent with the image's runtime version. |  | Pattern: `^(0\|[1-9][0-9]\{0,3\})\.(0\|[1-9][0-9]\{0,3\})\.(0\|[1-9][0-9]\{0,3\})$` <br />Optional: \{\} <br /> |
 | `globalDynamoNamespace` _boolean_ | GlobalDynamoNamespace indicates that the Component will be placed in the global Dynamo namespace |  |  |
 | `resources` _[Resources](#resources)_ | Resources requested and limits for this component, including CPU, memory,<br />GPUs/devices, and any runtime-specific resources. |  |  |
-| `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md<br />for migration guidance. This field will be removed in a future API version. |  |  |
+| `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md<br />for migration guidance. This field will be removed in a future API version. |  |  |
 | `envs` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Envs defines additional environment variables to inject into the component containers. |  |  |
 | `envFromSecret` _string_ | EnvFromSecret references a Secret whose key/value pairs will be exposed as<br />environment variables in the component containers. |  |  |
 | `volumeMounts` _[VolumeMount](#volumemount) array_ | VolumeMounts references PVCs defined at the top level for volumes to be mounted by the component. |  |  |
@@ -475,7 +475,7 @@ _Appears in:_
 | `runtimeVersionOverride` _string_ | RuntimeVersionOverride declares the Dynamo runtime compatibility version in this component's<br />main image. DGD admission requires it when spec.extraPodSpec.mainContainer.image has no parseable<br />semantic-version tag; controller-generated DCDs may omit it. Set it also when the parsed tag is<br />not the Dynamo runtime version. Use the canonical MAJOR.MINOR.PATCH value, for example "1.4.0".<br />It does not change the image. Setting or changing an override that resolves to version 1.5.0 or<br />later may trigger a rollout. Keep it consistent with the image's runtime version. |  | Pattern: `^(0\|[1-9][0-9]\{0,3\})\.(0\|[1-9][0-9]\{0,3\})\.(0\|[1-9][0-9]\{0,3\})$` <br />Optional: \{\} <br /> |
 | `globalDynamoNamespace` _boolean_ | GlobalDynamoNamespace indicates that the Component will be placed in the global Dynamo namespace |  |  |
 | `resources` _[Resources](#resources)_ | Resources requested and limits for this component, including CPU, memory,<br />GPUs/devices, and any runtime-specific resources. |  |  |
-| `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md<br />for migration guidance. This field will be removed in a future API version. |  |  |
+| `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md<br />for migration guidance. This field will be removed in a future API version. |  |  |
 | `envs` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Envs defines additional environment variables to inject into the component containers. |  |  |
 | `envFromSecret` _string_ | EnvFromSecret references a Secret whose key/value pairs will be exposed as<br />environment variables in the component containers. |  |  |
 | `volumeMounts` _[VolumeMount](#volumemount) array_ | VolumeMounts references PVCs defined at the top level for volumes to be mounted by the component. |  |  |

--- a/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
@@ -44,7 +44,7 @@ Package v1alpha1 contains API Schema definitions for the nvidia.com v1alpha1 API
 
 <Accordion id="autoscaling" title="Autoscaling">
 Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md
+with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
 for migration guidance. This field will be removed in a future API version.
 
 
@@ -552,7 +552,7 @@ See [Resources](#resources).
 </ParamField>
 
 <ParamField path="autoscaling" type="Autoscaling">
-Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md for migration guidance. This field will be removed in a future API version.
+Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md for migration guidance. This field will be removed in a future API version.
 See [Autoscaling](#autoscaling).
 </ParamField>
 
@@ -713,7 +713,7 @@ See [Resources](#resources).
 </ParamField>
 
 <ParamField path="autoscaling" type="Autoscaling">
-Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md for migration guidance. This field will be removed in a future API version.
+Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md for migration guidance. This field will be removed in a future API version.
 See [Autoscaling](#autoscaling).
 </ParamField>
 

--- a/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
@@ -44,7 +44,7 @@ Package v1alpha1 contains API Schema definitions for the nvidia.com v1alpha1 API
 
 <Accordion id="autoscaling" title="Autoscaling">
 Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter
-with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
+with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling
 for migration guidance. This field will be removed in a future API version.
 
 
@@ -552,7 +552,7 @@ See [Resources](#resources).
 </ParamField>
 
 <ParamField path="autoscaling" type="Autoscaling">
-Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md for migration guidance. This field will be removed in a future API version.
+Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling for migration guidance. This field will be removed in a future API version.
 See [Autoscaling](#autoscaling).
 </ParamField>
 
@@ -713,7 +713,7 @@ See [Resources](#resources).
 </ParamField>
 
 <ParamField path="autoscaling" type="Autoscaling">
-Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md for migration guidance. This field will be removed in a future API version.
+Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See https://docs.nvidia.com/dynamo/latest/knowledge-base/kubernetes/kubernetes-operator/autoscaling for migration guidance. This field will be removed in a future API version.
 See [Autoscaling](#autoscaling).
 </ParamField>
 


### PR DESCRIPTION
## Summary

Fixes #13317.

The deprecation warning for `spec.autoscaling` tells users to "See `docs/kubernetes/autoscaling.md`". That path does not exist:

```
$ ls docs/kubernetes/
ls: docs/kubernetes/: No such file or directory
```

It is not a harmless stale comment. The string reaches users at the moment they need the migration guidance:

- as an admission-webhook warning, printed by `kubectl apply` when a manifest still sets the deprecated field (`internal/webhook/validation/shared_v1alpha1.go:54`)
- in the CRD field description that `kubectl explain dynamographdeployment.spec.services.autoscaling` prints, from the doc comments in `api/v1alpha1/common.go:59` and `api/v1alpha1/dynamocomponentdeployment_types.go:94`

This points it at the page that actually exists, `docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md`.

I did not use a `docs.nvidia.com` URL, which would be friendlier for someone holding only a cluster. The obvious candidate (`https://docs.nvidia.com/dynamo/latest/kubernetes/autoscaling.html`) returns 404, and only the docs root resolves, so picking a published path would have meant guessing and possibly replacing one dead link with another. Happy to switch to the canonical published URL if you can tell me what it is.

The Go doc comments and the webhook string are the source of truth. Everything else in the diff is regenerated from them with the repo's own pinned tooling, not hand-edited:

- `make manifests` (controller-gen v0.17.3) for the two CRD bases
- `make generate-api-docs` (crd-ref-docs) followed by `docs/fern/scripts/gen_kubernetes_api.py` for the two API reference pages

The two envtest expectation strings are updated to match the new warning.

## Validation

Ran locally on macOS, Go 1.26.5.

Reproduced on current `main` first: `grep -rn "docs/kubernetes/autoscaling.md" .` returned 9 hits across Go source, generated CRDs, envtest expectations and generated docs, while `docs/kubernetes/` does not exist. After the change that grep returns nothing.

Confirmed the codegen is faithful before trusting it. Running `make manifests` on a clean tree produces zero diff, so regeneration reflects the source rather than a toolchain version skew:

```
$ git status --porcelain      # clean
$ make manifests
$ git status --porcelain      # still clean
```

Checks:

```
$ python docs/fern/scripts/gen_kubernetes_api.py --check
full-api-reference.mdx: unchanged        # exit 0, no drift

$ pytest docs/fern/scripts/tests/test_gen_kubernetes_api.py
36 passed

$ go build ./...                                              # clean
$ go vet ./internal/webhook/validation/... ./api/v1alpha1/...  # clean
```

`go vet` compiles the test packages, so it covers the two envtest files whose expectations changed.

The diff is 9 files, 13 insertions and 13 deletions, and every changed line contains `autoscaling`, so nothing unrelated was pulled in by regeneration.

Not verified here: I have no cluster, so I did not execute the envtest suite itself (it needs `KUBEBUILDER_ASSETS`) or observe the webhook warning against a live apiserver. The change is a string and its regenerated artifacts.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated autoscaling guidance links across the Kubernetes API reference and operator documentation.
  * Replaced deprecated documentation paths with the current developer-guide autoscaling resources.
  * Updated autoscaling deprecation warnings to direct users to the current guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->