### PR TITLE
fix(docs): walk the reference tab's direct layout in check_reference.sh

### DIFF
--- a/docs/fern/scripts/check_reference.sh
+++ b/docs/fern/scripts/check_reference.sh
@@ -85,7 +85,7 @@ layout = reference.get("layout")
 if layout is None:
     layout = next(
         (
-            variant["layout"]
+            variant.get("layout")
             for variant in reference.get("variants", [])
             if variant.get("title") == "General"
         ),

--- a/docs/fern/scripts/check_reference.sh
+++ b/docs/fern/scripts/check_reference.sh
@@ -17,7 +17,7 @@
 #      allowed remnants.
 #   4. Every absolute /dynamo/dev/reference/... href in components, the data
 #      module, generated assets, and reference pages resolves to a URL the
-#      index.yml Reference General variant actually publishes. Catches nav
+#      index.yml reference tab actually publishes. Catches nav
 #      restructures (e.g. pages moving under a new section slug) that
 #      fern broken-links cannot see because the hrefs live in TSX/JSON.
 #   5. Fern broken-links contains zero errors inside pages/reference/ pages
@@ -67,18 +67,35 @@ def collect(items, prefix, urls):
             urls.add(f"{prefix}/{slug}")
         elif "section" in item:
             slug = item.get("slug") or kebab(item["section"])
+            # A section carrying a path publishes a page at its own URL.
+            if "path" in item:
+                urls.add(f"{prefix}/{slug}")
             collect(item.get("contents", []), f"{prefix}/{slug}", urls)
 
 
-general = next(
-    variant
-    for tab in nav["navigation"]
-    if tab.get("tab") == "reference"
-    for variant in tab.get("variants", [])
-    if variant.get("title") == "General"
+reference = next(
+    (tab for tab in nav["navigation"] if tab.get("tab") == "reference"), None
 )
+if reference is None:
+    sys.exit("index.yml has no reference tab")
+
+# The reference tab holds its nav in a direct `layout`; it used to hold it in
+# a `variants` entry titled General, so keep reading that shape too.
+layout = reference.get("layout")
+if layout is None:
+    layout = next(
+        (
+            variant["layout"]
+            for variant in reference.get("variants", [])
+            if variant.get("title") == "General"
+        ),
+        None,
+    )
+if layout is None:
+    sys.exit("reference tab has neither a layout nor a General variant")
+
 valid: set[str] = set()
-collect(general["layout"], "/dynamo/dev/reference", valid)
+collect(layout, "/dynamo/dev/reference", valid)
 
 href_re = re.compile(r"/dynamo/dev/reference/[a-z0-9/-]+")
 sources = [


### PR DESCRIPTION
## Summary

`docs/fern/scripts/check_reference.sh` step 4 (absolute-href vs nav validation) has been crashing with a bare `StopIteration` since the reference tab in `docs/fern/index.yml` moved from `variants` (with a "General" variant) to a direct `layout`. The step died before validating anything, so absolute `/dynamo/dev/reference/...` hrefs in components, generated assets, and reference pages were not being checked.

This fixes the step to:

- Read the reference tab's direct `layout`, falling back to the `General` variant's layout if the tab ever returns to a `variants` shape (via `.get()`, so a malformed variant reaches the explicit error rather than a `KeyError`), and exit with a clear message if neither shape is present.
- Treat a `section` carrying a `path` as publishing a page at its own URL. The Releases section landing page (`/dynamo/dev/reference/releases`) is linked from `assets/releases-atom.xml`, and the old walker flagged it as unpublished.

Scope note: this branch briefly also carried fixes for the docs-website composition harness (post-v1.4.0 cut) and a dead xgrammar link; #13269 landed equivalent fixes on main first, so those commits were dropped in the rebase and this PR is back to `check_reference.sh` only.

## Validation

Ran `./scripts/check_reference.sh` from `docs/fern/` on the rebased branch: step 4 executes and reports `clean (61 published reference URLs)` — covering the hrefs in `components/`, `scripts/gen_llms_tables.py`, `assets/releases.json`, `assets/releases-atom.xml`, and `pages/reference/` (including `pages/reference/general/`) — and all five steps pass.

Also exercised the layout-resolution logic against three synthetic navs (direct `layout`, `variants` with a `General` title, neither): the first two resolve to the same layout; the third exits with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
