### PR TITLE
test: poll runtime cancellation metrics after abort

### DIFF
--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -383,6 +383,10 @@ def test_request_cancellation_vllm_aggregated(
                 verify_runtime_cancellation_metrics(
                     worker_system_port=worker.system_port,
                     expected_count=idx + 1,
+                    # The worker logs the engine abort before the TCP request
+                    # reader increments cancellation_total. Poll the observable
+                    # counter instead of racing that asynchronous teardown.
+                    max_wait_ms=5000,
                 )
 
 


### PR DESCRIPTION
## Summary

Poll the runtime cancellation counter for up to five seconds after the worker-abort assertion instead of requiring the first metrics scrape to observe the increment.

## Root cause

The worker reports the engine abort before the TCP request reader exits. The runtime cancellation counter is incremented only after that reader loop exits, so an immediate scrape can observe zero even though cancellation has already propagated successfully.

## Impact

The test remains strict about the final counter value and still fails if the metric does not converge within the bounded timeout. It no longer races the asynchronous teardown sequence.

## Validation

- `python -m compileall tests/fault_tolerance/cancellation/test_vllm.py`
- Ruff lint and format checks
- targeted polling-helper validation with a 0-to-1 scrape transition
- `tests/fault_tolerance/cancellation/test_vllm.py::test_request_cancellation_vllm_aggregated[tcp]` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cancellation test reliability by allowing additional time for asynchronous cancellation metrics and connection cleanup to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->