### PR TITLE
fix(sglang): fence GMS V1 TP release

### DIFF
--- a/lib/gpu_memory_service/tests/test_v1_sglang_integration.py
+++ b/lib/gpu_memory_service/tests/test_v1_sglang_integration.py
@@ -30,6 +30,10 @@ _INITIAL_MODEL_LOAD_TARGET = (
 _INIT_ALL_CUDA_GRAPHS_TARGET = (
     "sglang.srt.managers.scheduler.Scheduler.init_all_cuda_graphs"
 )
+_RELEASE_MEMORY_OCCUPATION_TARGET = (
+    "sglang.srt.managers.scheduler_components.weight_updater."
+    "SchedulerWeightUpdaterManager.release_memory_occupation"
+)
 _CREATE_DSA_INDEX_BUFFERS_TARGET = (
     "sglang.srt.mem_cache.memory_pool.DSATokenToKVPool._create_index_buffers"
 )
@@ -55,6 +59,8 @@ def test_sglang_hooks_capture_models_and_delegate_memory_control(monkeypatch):
     adapter._client = client
     adapter._models = []
     monkeypatch.setattr(plugin, "_adapter", lambda: adapter)
+    barrier = Mock()
+    monkeypatch.setattr(plugin.torch.distributed, "barrier", barrier)
     monkeypatch.setenv("DYN_GMS_USE_V1", "true")
 
     plugin.register_gms_v1_plugin()
@@ -65,6 +71,7 @@ def test_sglang_hooks_capture_models_and_delegate_memory_control(monkeypatch):
         _FACTORY_TARGET,
         _CREATE_DSA_INDEX_BUFFERS_TARGET,
         _LAYER_SPLIT_DSA_INDEX_BUFFERS_TARGET,
+        _RELEASE_MEMORY_OCCUPATION_TARGET,
     }
     assert hook_types[_INIT_ALL_CUDA_GRAPHS_TARGET] is HookType.BEFORE
     target, draft = object(), object()
@@ -92,3 +99,8 @@ def test_sglang_hooks_capture_models_and_delegate_memory_control(monkeypatch):
     ]
     client.suspend.assert_called_once_with()
     client.resume.assert_called_once_with()
+
+    release = hooks[_RELEASE_MEMORY_OCCUPATION_TARGET]
+    manager, release_result = Mock(tp_cpu_group=object()), object()
+    assert release(release_result, manager, Mock()) is release_result
+    barrier.assert_called_once_with(group=manager.tp_cpu_group)

--- a/lib/gpu_memory_service/v1/integrations/sglang/plugin.py
+++ b/lib/gpu_memory_service/v1/integrations/sglang/plugin.py
@@ -81,6 +81,12 @@ def register_gms_v1_plugin() -> None:
         with _adapter().region("kv_cache"):
             return original(*args, **kwargs)
 
+    def after_release_memory_occupation(result, manager, *args, **kwargs):
+        # Fence the TP group: ranks that finish releasing early must not race
+        # ahead of ranks still unmapping their share of the weights.
+        torch.distributed.barrier(group=manager.tp_cpu_group)
+        return result
+
     HookRegistry.register(
         "sglang.srt.model_executor.model_runner_components.load_model_utils."
         "load_model_with_memory_saver",
@@ -96,6 +102,12 @@ def register_gms_v1_plugin() -> None:
         "sglang.srt.utils.torch_memory_saver_adapter.TorchMemorySaverAdapter.create",
         lambda _original, *_args, **_kwargs: _adapter(),
         HookType.AROUND,
+    )
+    HookRegistry.register(
+        "sglang.srt.managers.scheduler_components.weight_updater."
+        "SchedulerWeightUpdaterManager.release_memory_occupation",
+        after_release_memory_occupation,
+        HookType.AFTER,
     )
     HookRegistry.register(
         "sglang.srt.mem_cache.memory_pool.DSATokenToKVPool._create_index_buffers",


### PR DESCRIPTION
## Summary

- Add a GMS V1 plugin-scoped `AFTER` hook for SGLang's `SchedulerWeightUpdaterManager.release_memory_occupation`.
- After a rank successfully completes SGLang's original release path, wait on the manager's existing `tp_cpu_group` before returning the original result.
- Extend the focused plugin test to verify hook registration, return preservation, and selection of the CPU TP group.

SGLang v0.5.16 can let the response-producing rank acknowledge `release_memory_occupation` after closing its rank-local GMS weights and KV-cache sockets while another rank in the same TP group still owns its KV-cache socket. Snapshot publication can then reach CRIU with a half-external stream.

Within each participating `tp_cpu_group`, this hook ensures that no rank which successfully completes the original release returns until every member of that group reaches the release-completion barrier. The CPU group is used because GPU mappings have already been suspended.

## Synchronization scope

The barrier intentionally uses SGLang's existing `manager.tp_cpu_group`; it is not a world, DP, PP, or separate EP-group barrier.

| Parallel dimension | Completion behavior |
|---|---|
| TP | Directly fenced by this hook. This is the race fixed by the PR. |
| Conventional DP with `PP=1` | SGLang already fans the control request out to every DP replica and waits for every response. This hook independently fences the TP group inside each replica, so an additional DP collective is not required. |
| Static EP | EP ranks are contained in the enclosing TP-indexed scheduler set, so no separate EP fence is added. |
| PP | Not synchronized across pipeline stages by `tp_cpu_group`. `PP>1` is not claimed as supported by this fix and needs a per-engine completion fence or equivalent response aggregation before snapshot readiness. |
| DP-attention, CP/DCP, elastic EP, and multiple independent engines | Not runtime-validated by this PR; no additional coverage is claimed. |

A world-group barrier would broaden coupling and failure scope without being necessary for the reported and validated `DP=1, PP=1` topology. The correct general invariant is that every CUDA/GMS worker captured in the checkpoint must finish local release before `ready-for-snapshot` is published; this PR implements that invariant for one TP-group engine topology and conventional `PP=1` DP fan-out.

The hook assumes every member receives the same control request and successfully reaches the `AFTER` hook. If a rank fails in the original release path, it does not enter the barrier and peers may wait until the process-group timeout.

This PR is intentionally stacked on #13218 as a separate snapshot-lifecycle fix.

## Validation

- `pre-commit run --files lib/gpu_memory_service/v1/integrations/sglang/plugin.py lib/gpu_memory_service/tests/test_v1_sglang_integration.py`
- `ruff check lib/gpu_memory_service/v1/integrations/sglang/plugin.py lib/gpu_memory_service/tests/test_v1_sglang_integration.py`
- `ruff format --check lib/gpu_memory_service/v1/integrations/sglang/plugin.py lib/gpu_memory_service/tests/test_v1_sglang_integration.py`
- `.venv/bin/python -m py_compile lib/gpu_memory_service/v1/integrations/sglang/plugin.py lib/gpu_memory_service/tests/test_v1_sglang_integration.py`
- Runtime checkpoint/restore validation on `s2877` with SGLang GLM-5.2 at `DP=1, TP=8, PP=1`; the tested composition commit `48e83c40356509eb6c532bb631dfd5a6d6a0022f` contains this fix and produced coherent post-restore inference.
- The focused Python test uses a mocked manager and barrier. `DP>1`, `PP>1`, DP-attention, CP/DCP, and elastic EP topologies were not exercised.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->