### PR TITLE
fix(sglang): publish GMS weights before graph capture

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -532,6 +532,9 @@ async def parse_args(args: list[str]) -> Config:
     video_generation_worker = dynamo_config.video_generation_worker
 
     # ServerArgs is read-only after resolution, so apply Dynamo defaults first.
+    if dynamo_config.enable_gms_v1:
+        parsed_args.enable_memory_saver = True
+
     fpm_source = _forward_pass_metrics_source(dynamo_config)
     if fpm_source and not getattr(parsed_args, "enable_forward_pass_metrics", False):
         parsed_args.enable_forward_pass_metrics = True

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -58,6 +58,18 @@ class DynamoSGLangArgGroup(ArgGroup):
 
         add_negatable_bool_argument(
             g,
+            flag_name="--enable-gms-v1",
+            env_var="DYN_SGL_ENABLE_GMS_V1",
+            default=False,
+            help=(
+                "Enable GMS V1 for Dynamo Snapshot. Requires "
+                "DYN_SNAPSHOT_CONTROL_DIR and cannot be combined with "
+                "--load-format gms."
+            ),
+        )
+
+        add_negatable_bool_argument(
+            g,
             flag_name="--use-sglang-tokenizer",
             env_var="DYN_SGL_USE_TOKENIZER",
             default=False,
@@ -178,6 +190,7 @@ class DynamoSGLangArgGroup(ArgGroup):
 class DynamoSGLangConfig(ConfigBase):
     """Configuration for Dynamo SGLang wrapper (SGLang-specific only)."""
 
+    enable_gms_v1: bool = False
     use_sglang_tokenizer: bool
     # Internal roles derived from the canonical multimodal arguments in args.py.
     multimodal_encode_worker: bool = False

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -41,14 +41,18 @@ async def worker(argv: list[str] | None = None):
     config = await parse_args(argv)
     dump_config(config.dynamo_args.dump_config_to, config)
 
-    if config.server_args.load_format == "gms":
+    enable_gms_v1 = config.dynamo_args.enable_gms_v1
+    if config.server_args.load_format == "gms" and not enable_gms_v1:
         from gpu_memory_service.integrations.sglang import setup_gms
 
         config.server_args.load_format = setup_gms(config.server_args)
 
     # Snapshot mode: engine must be created before runtime so CRIU captures no
     # NATS/etcd connections.
-    snapshot_controller = await prepare_snapshot_engine(config.server_args)
+    snapshot_controller = await prepare_snapshot_engine(
+        config.server_args,
+        enable_gms_v1=enable_gms_v1,
+    )
 
     dynamo_args = config.dynamo_args
     snapshot_engine = None

--- a/components/src/dynamo/sglang/snapshot.py
+++ b/components/src/dynamo/sglang/snapshot.py
@@ -6,6 +6,7 @@
 import asyncio
 import gc
 import logging
+import os
 import time
 from typing import Any
 
@@ -114,6 +115,8 @@ async def warmup_engine(engine: sgl.Engine, server_args: Any) -> None:
 
 async def prepare_snapshot_engine(
     server_args,
+    *,
+    enable_gms_v1: bool = False,
 ) -> EngineSnapshotController[sgl.Engine] | None:
     """Single entry point for Dynamo Snapshot integration.
 
@@ -129,24 +132,33 @@ async def prepare_snapshot_engine(
         process with status 0.
     """
     snapshot_config = SnapshotConfig.from_env()
+    # SGLang loads plugins independently in each scheduler process.
+    os.environ["DYN_SGL_ENABLE_GMS_V1"] = str(enable_gms_v1).lower()
+    if enable_gms_v1 and server_args.load_format == "gms":
+        raise ValueError("--enable-gms-v1 cannot be combined with --load-format gms")
+    if enable_gms_v1 and snapshot_config is None:
+        raise ValueError(
+            "--enable-gms-v1 requires Dynamo Snapshot (DYN_SNAPSHOT_CONTROL_DIR)"
+        )
     if snapshot_config is None:
         return None
 
     configure_snapshot_capture_env()
     logger.info("Snapshot mode enabled (watcher-driven signals)")
 
-    # Enable memory_saver so GPU memory can be released for CRIU.
-    # When using GMS, weights use VA-stable unmap/remap (no CPU backup); GMS
-    # forbids enable_weights_cpu_backup. Otherwise use CPU backup for weights.
-    server_args.enable_memory_saver = True
-    try:
-        from gpu_memory_service.integrations.sglang import is_gms_active
+    if not enable_gms_v1:
+        # Enable memory_saver so GPU memory can be released for CRIU.
+        # GMS-managed weights use VA-stable unmap/remap without CPU backup.
+        # The default Snapshot path keeps SGLang's ordinary TMS CPU backup.
+        server_args.enable_memory_saver = True
+        try:
+            from gpu_memory_service.integrations.sglang import is_gms_active
 
-        _using_gms = is_gms_active()
-    except ImportError:
-        _using_gms = False
-    if not _using_gms:
-        server_args.enable_weights_cpu_backup = True
+            _using_gms = is_gms_active()
+        except ImportError:
+            _using_gms = False
+        if not _using_gms:
+            server_args.enable_weights_cpu_backup = True
 
     start_time = time.time()
     engine = sgl.Engine(server_args=server_args)

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -364,6 +364,27 @@ async def test_parse_args_enables_incremental_streaming_before_resolution(
 
 
 @pytest.mark.asyncio
+async def test_gms_v1_enables_memory_saver_before_resolution(
+    monkeypatch, mock_sglang_cli
+):
+    server_args = SimpleNamespace(
+        disaggregation_mode="null",
+        dllm_algorithm=None,
+        kv_events_config=None,
+        get_model_config=lambda: SimpleNamespace(is_multimodal=False),
+    )
+
+    def resolve(parsed_args):
+        assert parsed_args.enable_memory_saver is True
+        return server_args
+
+    monkeypatch.setattr("dynamo.sglang.args.ServerArgs.from_cli_args", resolve)
+    mock_sglang_cli("--model", "/tmp", "--enable-gms-v1")
+
+    await parse_args(sys.argv[1:])
+
+
+@pytest.mark.asyncio
 async def test_parse_args_applies_dynamo_defaults_before_resolution(
     monkeypatch, mock_sglang_cli
 ):

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -321,10 +321,33 @@ func EnsureIntraPodGPUMemoryService(
 	targetContainers []*corev1.Container,
 	extraClientContainerNames []string,
 ) {
+	ensureIntraPodGPUMemoryService(podSpec, targetContainers, extraClientContainerNames, false)
+}
+
+// EnsureIntraPodGPUMemoryServiceV1 wires the V1 server for clients already
+// configured to use the V1 protocol.
+func EnsureIntraPodGPUMemoryServiceV1(
+	podSpec *corev1.PodSpec,
+	targetContainers []*corev1.Container,
+	extraClientContainerNames []string,
+) {
+	ensureIntraPodGPUMemoryService(podSpec, targetContainers, extraClientContainerNames, true)
+}
+
+func ensureIntraPodGPUMemoryService(
+	podSpec *corev1.PodSpec,
+	targetContainers []*corev1.Container,
+	extraClientContainerNames []string,
+	useV1 bool,
+) {
 	if len(targetContainers) == 0 {
 		return
 	}
-	gms.EnsureServerSidecar(podSpec, targetContainers[0])
+	if useV1 {
+		gms.EnsureV1ServerSidecar(podSpec, targetContainers[0])
+	} else {
+		gms.EnsureServerSidecar(podSpec, targetContainers[0])
+	}
 	for _, container := range targetContainers {
 		gms.EnsureClient(podSpec, container)
 	}

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -293,7 +293,13 @@ func (r *dgdCheckpointsReconciler) createCheckpointCR(
 		); err != nil {
 			return nil, err
 		}
-		if err := prepareCheckpointGMSPodTemplate(&podTemplate, targetContainerName, checkpointID, gmsSpec); err != nil {
+		if err := prepareCheckpointGMSPodTemplate(
+			&podTemplate,
+			targetContainerName,
+			checkpointID,
+			gmsSpec,
+			backendFramework,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -402,6 +408,7 @@ func prepareCheckpointGMSPodTemplate(
 	targetContainerName string,
 	checkpointID string,
 	gmsSpec *nvidiacomv1alpha1.GPUMemoryServiceSpec,
+	backendFramework dynamo.BackendFramework,
 ) error {
 	switch gmsSpec.Mode {
 	case "", nvidiacomv1alpha1.GMSModeIntraPod:
@@ -416,11 +423,20 @@ func prepareCheckpointGMSPodTemplate(
 		return err
 	}
 	ensureCheckpointGMSPodClaim(&podTemplate.Spec, checkpointGMSResourceClaimTemplateName(checkpointID))
-	checkpoint.EnsureIntraPodGPUMemoryService(
-		&podTemplate.Spec,
-		[]*corev1.Container{targetContainer},
-		gmsSpec.ExtraClientContainers,
-	)
+	if backendFramework == dynamo.BackendFrameworkSGLang {
+		dynamo.EnableSGLangGMSV1(targetContainer)
+		checkpoint.EnsureIntraPodGPUMemoryServiceV1(
+			&podTemplate.Spec,
+			[]*corev1.Container{targetContainer},
+			gmsSpec.ExtraClientContainers,
+		)
+	} else {
+		checkpoint.EnsureIntraPodGPUMemoryService(
+			&podTemplate.Spec,
+			[]*corev1.Container{targetContainer},
+			gmsSpec.ExtraClientContainers,
+		)
+	}
 	return nil
 }
 

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -399,6 +399,33 @@ func TestDGDCheckpointsReconciler_CreatePreservesGMSSaverClient(t *testing.T) {
 	require.NotNil(t, controllerRef)
 	assert.Equal(t, "DynamoCheckpoint", controllerRef.Kind)
 	assert.Equal(t, ckpt.Name, controllerRef.Name)
+
+	t.Log("Render the same GMS checkpoint contract for SGLang V1")
+	sglangDGD := dgd.DeepCopy()
+	sglangDGD.Name = "test-sglang-dgd"
+	sglangDGD.UID = types.UID("sglang-dgd-uid")
+	sglangComponent := component.DeepCopy()
+	sglangComponent.Checkpoint.Identity.BackendFramework = string(dynamo.BackendFrameworkSGLang)
+
+	sglangCheckpoint, err := newTestDGDCheckpointsReconciler(reconciler).createCheckpointCR(
+		ctx, sglangDGD, "worker", betaComponent(t, sglangComponent),
+	)
+	require.NoError(t, err)
+	sglangMain := findContainer(
+		sglangCheckpoint.Spec.Job.PodTemplateSpec.Spec.Containers,
+		commonconsts.MainContainerName,
+	)
+	require.NotNil(t, sglangMain)
+	assert.Contains(t, sglangMain.Env, corev1.EnvVar{
+		Name:  "DYN_SGL_ENABLE_GMS_V1",
+		Value: "true",
+	})
+	sglangServer := findContainer(
+		sglangCheckpoint.Spec.Job.PodTemplateSpec.Spec.InitContainers,
+		gms.ServerContainerName,
+	)
+	require.NotNil(t, sglangServer)
+	assert.Equal(t, []string{"--use-v1"}, sglangServer.Args)
 }
 
 func TestDGDCheckpointsReconciler_SyncGMSResourceClaimTemplateUsesTemporaryDGDOwner(t *testing.T) {

--- a/deploy/operator/internal/dynamo/backend_sglang.go
+++ b/deploy/operator/internal/dynamo/backend_sglang.go
@@ -10,10 +10,25 @@ import (
 )
 
 const (
-	SglangPort = "29500"
+	SglangPort        = "29500"
+	sglangGMSV1EnvVar = "DYN_SGL_ENABLE_GMS_V1"
 )
 
 type SGLangBackend struct{}
+
+func usesSGLangSnapshotGMSV1(component *v1beta1.DynamoComponentDeploymentSharedSpec) bool {
+	return GetCheckpoint(component) != nil &&
+		GetGPUMemoryService(component) != nil &&
+		!component.IsInterPodGMSEnabled()
+}
+
+// EnableSGLangGMSV1 selects the V1 client protocol for an SGLang container.
+func EnableSGLangGMSV1(container *corev1.Container) {
+	container.Env = MergeEnvs(container.Env, []corev1.EnvVar{{
+		Name:  sglangGMSV1EnvVar,
+		Value: "true",
+	}})
+}
 
 // isPythonCommand checks if the command is a Python interpreter
 func isPythonCommand(cmd string) bool {
@@ -35,6 +50,10 @@ func (b *SGLangBackend) UpdateContainer(container *corev1.Container, numberOfNod
 			"cache-dir", component.CompilationCache.MountPath,
 			"env-vars-set", false,
 			"next-steps", "upstream SGLang changes needed")
+	}
+
+	if usesSGLangSnapshotGMSV1(component) {
+		EnableSGLangGMSV1(container)
 	}
 
 	// For single node, nothing to do

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1693,7 +1693,11 @@ func GenerateBasePodSpec(
 		if err := dra.ApplyClaim(&podSpec, claimTemplateName); err != nil {
 			return nil, fmt.Errorf("failed to apply DRA claim for GMS: %w", err)
 		}
-		gms.EnsureServerSidecar(&podSpec, &podSpec.Containers[0])
+		if backendFramework == BackendFrameworkSGLang && usesSGLangSnapshotGMSV1(component) {
+			gms.EnsureV1ServerSidecar(&podSpec, &podSpec.Containers[0])
+		} else {
+			gms.EnsureServerSidecar(&podSpec, &podSpec.Containers[0])
+		}
 		for _, name := range gmsSpec.ExtraClientContainers {
 			var container *corev1.Container
 			for i := range podSpec.Containers {

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -6679,6 +6679,43 @@ func TestGenerateBasePodSpec_GPUMemoryServiceExtraClientContainers(t *testing.T)
 	assertGMSClientContainer(t, metricsClient)
 }
 
+func TestGenerateBasePodSpec_SGLangSnapshotUsesGMSV1(t *testing.T) {
+	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		ComponentType: commonconsts.ComponentTypeWorker,
+		Checkpoint:    &v1alpha1.ServiceCheckpointConfig{Enabled: true},
+		GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
+			Enabled: true,
+			Mode:    v1alpha1.GMSModeIntraPod,
+		},
+		ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+			MainContainer: &corev1.Container{
+				Command: []string{"python3"},
+				Args:    []string{"-m", "dynamo.sglang", "--tp", "1"},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceName(commonconsts.KubeResourceGPUNvidia): resource.MustParse("1"),
+					},
+				},
+			},
+		},
+	})
+
+	podSpec, err := GenerateBasePodSpec(
+		component, BackendFrameworkSGLang, &mockSecretsRetriever{},
+		"test-deployment", "default", RoleMain, 1,
+		&configv1alpha1.OperatorConfiguration{},
+		commonconsts.MultinodeDeploymentTypeGrove, "worker",
+		nil, nil, staticContainerGPUCount(1),
+	)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, podSpec.Containers)
+	assert.Equal(t, "true", envVarsToMap(podSpec.Containers[0].Env)[sglangGMSV1EnvVar])
+	server := findInitContainerByName(podSpec, gmsruntime.ServerContainerName)
+	require.NotNil(t, server)
+	assert.Equal(t, []string{"--use-v1"}, server.Args)
+}
+
 func TestGenerateBasePodSpec_GPUMemoryServiceRejectsMissingExtraClientContainers(t *testing.T) {
 	t.Log("Set up intra-pod GMS with two unresolved extra clients")
 	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{

--- a/deploy/operator/internal/gms/gms.go
+++ b/deploy/operator/internal/gms/gms.go
@@ -40,6 +40,16 @@ const (
 // terminates the server when the Job's regular containers exit; a regular
 // container here would keep the Pod in Running forever. Idempotent.
 func EnsureServerSidecar(podSpec *corev1.PodSpec, mainContainer *corev1.Container) {
+	ensureServerSidecar(podSpec, mainContainer, nil)
+}
+
+// EnsureV1ServerSidecar adds a GMS V1 server. Every client in the pod must use
+// the V1 protocol.
+func EnsureV1ServerSidecar(podSpec *corev1.PodSpec, mainContainer *corev1.Container) {
+	ensureServerSidecar(podSpec, mainContainer, []string{"--use-v1"})
+}
+
+func ensureServerSidecar(podSpec *corev1.PodSpec, mainContainer *corev1.Container, args []string) {
 	if podSpec == nil || mainContainer == nil {
 		return
 	}
@@ -47,6 +57,7 @@ func EnsureServerSidecar(podSpec *corev1.PodSpec, mainContainer *corev1.Containe
 	EnsureClient(podSpec, mainContainer)
 
 	sidecar := Container(ServerContainerName, ServerModule, mainContainer.Image)
+	sidecar.Args = args
 	sidecar.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
 	for i := range podSpec.InitContainers {
 		if podSpec.InitContainers[i].Name == sidecar.Name {

--- a/lib/gpu_memory_service/pyproject.toml
+++ b/lib/gpu_memory_service/pyproject.toml
@@ -38,6 +38,9 @@ keywords = ["llm", "genai", "inference", "nvidia", "gpu", "memory", "dynamo"]
 gpu-memory-service = "gpu_memory_service.cli.runner:main"
 gms-storage-client = "gpu_memory_service.cli.storage_runner:main"
 
+[project.entry-points."sglang.srt.plugins"]
+gms-v1 = "gpu_memory_service.v1.integrations.sglang.plugin:register_gms_v1_plugin"
+
 [project.optional-dependencies]
 test = [
     "pytest>=8.3.4",

--- a/lib/gpu_memory_service/setup.py
+++ b/lib/gpu_memory_service/setup.py
@@ -87,6 +87,7 @@ setup(
         "gpu_memory_service.v1.server",
         "gpu_memory_service.v1.snapshot",
         "gpu_memory_service.v1.integrations",
+        "gpu_memory_service.v1.integrations.sglang",
         "gpu_memory_service.v1.integrations.vllm",
     ],
     package_dir={
@@ -117,7 +118,10 @@ setup(
         "console_scripts": [
             "gpu-memory-service=gpu_memory_service.cli.runner:main",
             "gms-storage-client=gpu_memory_service.cli.storage_runner:main",
-        ]
+        ],
+        "sglang.srt.plugins": [
+            "gms-v1=gpu_memory_service.v1.integrations.sglang.plugin:register_gms_v1_plugin",
+        ],
     },
     ext_modules=_create_ext_modules(),
     cmdclass={"build_ext": BuildExtension},

--- a/lib/gpu_memory_service/tests/test_v1_mempool_client.py
+++ b/lib/gpu_memory_service/tests/test_v1_mempool_client.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import contextmanager
+from unittest.mock import Mock
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="torch is required")
+
+import gpu_memory_service.v1.client.mempool as mempool_module  # noqa: E402
+from gpu_memory_service.v1.client.mempool import TorchMempoolMemoryClient  # noqa: E402
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.none,
+]
+
+
+def test_weight_and_kv_lifecycle(monkeypatch):
+    client = object.__new__(TorchMempoolMemoryClient)
+    client._device = 0
+    client._state, client._weights_state = "RUNNING", "OPEN"
+    client._weights_pool, client._kv_cache_pool = object(), object()
+    client._active_domain = Mock()
+    client._weights = Mock(mappings=("mapping",))
+    client._kv_cache = Mock()
+    monkeypatch.setattr(client, "_destroy_weights_pool", Mock())
+    monkeypatch.setattr(client, "_raise_if_allocator_failed", Mock())
+    regions = []
+
+    @contextmanager
+    def use_pool(domain, pool):
+        client._active_domain.get.return_value = domain
+        regions.append((domain, pool))
+        yield
+
+    monkeypatch.setattr(client, "_use_pool", use_pool)
+    client._weights.create_mapping.return_value = 11
+    client._kv_cache.create_mapping.return_value = 22
+    copy_tensors = Mock()
+    monkeypatch.setattr(
+        mempool_module,
+        "copy_non_parameter_tensors_to_default_allocator",
+        copy_tensors,
+    )
+    monkeypatch.setattr(torch.cuda, "synchronize", Mock())
+    monkeypatch.setattr(torch.cuda, "empty_cache", Mock())
+    monkeypatch.setattr(mempool_module.gc, "collect", Mock())
+
+    with client.weight_region():
+        assert client._malloc(10, 0, 0) == 11
+    models = (object(), object(), object())
+    client.publish_weights(models)
+    client.suspend()
+    assert client._state == "SUSPENDED"
+    client.resume()
+    with client.kv_cache_region():
+        assert client._malloc(20, 0, 0) == 22
+
+    assert regions == [
+        (mempool_module._WEIGHTS, client._weights_pool),
+        (mempool_module._KV_CACHE, client._kv_cache_pool),
+    ]
+    client._weights.create_mapping.assert_called_once_with(10)
+    client._kv_cache.create_mapping.assert_called_once_with(20)
+    copy_tensors.assert_called_once_with(models, ("mapping",))
+    client._weights.commit.assert_called_once_with()
+    assert client._state == "RUNNING"
+    assert client._weights_state == "PUBLISHED"

--- a/lib/gpu_memory_service/tests/test_v1_parameter_storage.py
+++ b/lib/gpu_memory_service/tests/test_v1_parameter_storage.py
@@ -25,11 +25,13 @@ pytestmark = [
 
 def test_copy_out_preserves_tensorimpls_and_nonparameter_aliases() -> None:
     model = torch.nn.Module()
+    draft_model = torch.nn.Module()
     source = torch.arange(64, dtype=torch.float32)
     source_storage = source.untyped_storage()
     model.weight = torch.nn.Parameter(source[:32])
     model.overlapping_weight = torch.nn.Parameter(source[16:40])
     model.strided_weight = torch.nn.Parameter(source[32:52:2])
+    draft_model.weight = torch.nn.Parameter(source[60:64])
     model.register_buffer("overlap", model.weight[8:24])
     model.overlap_alias = model.overlap[4:12]
     model.register_buffer(
@@ -73,6 +75,7 @@ def test_copy_out_preserves_tensorimpls_and_nonparameter_aliases() -> None:
             ("weight", model.weight),
             ("overlapping_weight", model.overlapping_weight),
             ("strided_weight", model.strided_weight),
+            ("draft_weight", draft_model.weight),
             ("overlap", model.overlap),
             ("overlap_alias", model.overlap_alias),
             ("empty_view", model.empty_view),
@@ -87,7 +90,10 @@ def test_copy_out_preserves_tensorimpls_and_nonparameter_aliases() -> None:
         model.empty_view.stride(),
     )
 
-    accounting = copy_non_parameter_tensors_to_default_allocator(model, (mapping,))
+    accounting = copy_non_parameter_tensors_to_default_allocator(
+        (model, draft_model),
+        (mapping,),
+    )
 
     assert {
         name: int(tensor._cdata)
@@ -95,6 +101,7 @@ def test_copy_out_preserves_tensorimpls_and_nonparameter_aliases() -> None:
             ("weight", model.weight),
             ("overlapping_weight", model.overlapping_weight),
             ("strided_weight", model.strided_weight),
+            ("draft_weight", draft_model.weight),
             ("overlap", model.overlap),
             ("overlap_alias", model.overlap_alias),
             ("empty_view", model.empty_view),
@@ -105,6 +112,7 @@ def test_copy_out_preserves_tensorimpls_and_nonparameter_aliases() -> None:
     assert int(model.weight.untyped_storage()._cdata) == original_storage
     assert int(model.overlapping_weight.untyped_storage()._cdata) == original_storage
     assert int(model.strided_weight.untyped_storage()._cdata) == original_storage
+    assert int(draft_model.weight.untyped_storage()._cdata) == original_storage
     assert int(model.empty_view.untyped_storage()._cdata) != original_storage
     assert (
         model.empty_view.storage_offset(),
@@ -125,6 +133,7 @@ def test_copy_out_preserves_tensorimpls_and_nonparameter_aliases() -> None:
     assert int(outside.untyped_storage()._cdata) == outside_storage
     assert outside.tolist() == list(map(float, range(8)))
     assert model.weight.tolist() == list(map(float, range(32)))
+    assert draft_model.weight.tolist() == list(map(float, range(60, 64)))
     assert model.overlap.tolist() == list(map(float, range(8, 24)))
     assert model.disjoint.tolist() == [48.0, 49.0, 50.0, 51.0]
     assert workspace.tolist() == [56.0, 57.0, 58.0, 59.0]
@@ -133,4 +142,4 @@ def test_copy_out_preserves_tensorimpls_and_nonparameter_aliases() -> None:
         model.overlap_alias.fill_(23)
     assert model.overlap.tolist()[4:12] == [23.0] * 8
     assert model.weight.tolist()[12:20] == list(map(float, range(12, 20)))
-    assert accounting == (51 * 4, (16 + 4 + 4) * 4)
+    assert accounting == (55 * 4, (16 + 4 + 4) * 4)

--- a/lib/gpu_memory_service/tests/test_v1_sglang_integration.py
+++ b/lib/gpu_memory_service/tests/test_v1_sglang_integration.py
@@ -35,12 +35,15 @@ def test_sglang_hooks_capture_models_and_delegate_memory_control(monkeypatch):
     adapter._models = []
     monkeypatch.setattr(plugin, "_adapter", lambda: adapter)
     monkeypatch.setenv("DYN_SGL_ENABLE_GMS_V1", "true")
+    barrier = Mock()
+    monkeypatch.setattr(plugin.torch.distributed, "barrier", barrier)
 
     plugin.register_gms_v1_plugin()
 
     assert hooks.keys() == {
         plugin._INITIAL_MODEL_LOAD_TARGET,
         plugin._FACTORY_TARGET,
+        plugin._RELEASE_MEMORY_OCCUPATION_TARGET,
     }
     target, draft = object(), object()
     observe_model = hooks[plugin._INITIAL_MODEL_LOAD_TARGET]
@@ -49,6 +52,10 @@ def test_sglang_hooks_capture_models_and_delegate_memory_control(monkeypatch):
 
     original_factory = Mock()
     assert hooks[plugin._FACTORY_TARGET](original_factory, enable=True) is adapter
+    release = hooks[plugin._RELEASE_MEMORY_OCCUPATION_TARGET]
+    manager, release_result = Mock(tp_cpu_group=object()), object()
+    assert release(release_result, manager, Mock()) is release_result
+    barrier.assert_called_once_with(group=manager.tp_cpu_group)
     with (
         adapter.region("weights", enable_cpu_backup=True),
         adapter.region("kv_cache", enable_cpu_backup=False),

--- a/lib/gpu_memory_service/tests/test_v1_sglang_integration.py
+++ b/lib/gpu_memory_service/tests/test_v1_sglang_integration.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from contextlib import nullcontext
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -22,9 +22,11 @@ pytestmark = [
 
 def test_sglang_hooks_capture_models_and_delegate_memory_control(monkeypatch):
     hooks = {}
+    hook_types = {}
 
     def capture_hook(_registry, target, hook, hook_type=HookType.AFTER, **_kwargs):
         hooks[target] = hook
+        hook_types[target] = hook_type
 
     monkeypatch.setattr(HookRegistry, "register", classmethod(capture_hook))
     client = Mock()
@@ -42,13 +44,17 @@ def test_sglang_hooks_capture_models_and_delegate_memory_control(monkeypatch):
 
     assert hooks.keys() == {
         plugin._INITIAL_MODEL_LOAD_TARGET,
+        plugin._INIT_ALL_CUDA_GRAPHS_TARGET,
         plugin._FACTORY_TARGET,
         plugin._RELEASE_MEMORY_OCCUPATION_TARGET,
     }
+    assert hook_types[plugin._INIT_ALL_CUDA_GRAPHS_TARGET] is HookType.BEFORE
     target, draft = object(), object()
     observe_model = hooks[plugin._INITIAL_MODEL_LOAD_TARGET]
     observe_model(Mock(model=target))
     observe_model(Mock(model=draft), is_draft_worker=True)
+    hooks[plugin._INIT_ALL_CUDA_GRAPHS_TARGET](Mock())
+    client.publish_weights.assert_called_once_with([target, draft])
 
     original_factory = Mock()
     assert hooks[plugin._FACTORY_TARGET](original_factory, enable=True) is adapter
@@ -66,6 +72,9 @@ def test_sglang_hooks_capture_models_and_delegate_memory_control(monkeypatch):
 
     client.weight_region.assert_called_once_with()
     client.kv_cache_region.assert_called_once_with()
-    client.publish_weights.assert_called_once_with([target, draft])
+    assert client.publish_weights.call_args_list == [
+        call([target, draft]),
+        call([target, draft]),
+    ]
     client.suspend.assert_called_once_with()
     client.resume.assert_called_once_with()

--- a/lib/gpu_memory_service/tests/test_v1_sglang_integration.py
+++ b/lib/gpu_memory_service/tests/test_v1_sglang_integration.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import nullcontext
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip("sglang", reason="SGLang is required")
+
+import gpu_memory_service.v1.integrations.sglang.plugin as plugin  # noqa: E402
+from sglang.srt.plugins.hook_registry import HookRegistry, HookType  # noqa: E402
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.sglang,
+    pytest.mark.core,
+]
+
+
+def test_sglang_hooks_capture_models_and_delegate_memory_control(monkeypatch):
+    hooks = {}
+
+    def capture_hook(_registry, target, hook, hook_type=HookType.AFTER, **_kwargs):
+        hooks[target] = hook
+
+    monkeypatch.setattr(HookRegistry, "register", classmethod(capture_hook))
+    client = Mock()
+    client.weight_region.return_value = nullcontext()
+    client.kv_cache_region.return_value = nullcontext()
+    adapter = object.__new__(plugin.GMSV1MemorySaverAdapter)
+    adapter._client = client
+    adapter._models = []
+    monkeypatch.setattr(plugin, "_adapter", lambda: adapter)
+    monkeypatch.setenv("DYN_SGL_ENABLE_GMS_V1", "true")
+
+    plugin.register_gms_v1_plugin()
+
+    assert hooks.keys() == {
+        plugin._INITIAL_MODEL_LOAD_TARGET,
+        plugin._FACTORY_TARGET,
+    }
+    target, draft = object(), object()
+    observe_model = hooks[plugin._INITIAL_MODEL_LOAD_TARGET]
+    observe_model(Mock(model=target))
+    observe_model(Mock(model=draft), is_draft_worker=True)
+
+    original_factory = Mock()
+    assert hooks[plugin._FACTORY_TARGET](original_factory, enable=True) is adapter
+    with (
+        adapter.region("weights", enable_cpu_backup=True),
+        adapter.region("kv_cache", enable_cpu_backup=False),
+    ):
+        pass
+    adapter.pause("weights")
+    adapter.resume("weights")
+
+    client.weight_region.assert_called_once_with()
+    client.kv_cache_region.assert_called_once_with()
+    client.publish_weights.assert_called_once_with([target, draft])
+    client.suspend.assert_called_once_with()
+    client.resume.assert_called_once_with()

--- a/lib/gpu_memory_service/tests/test_v1_vllm_backend.py
+++ b/lib/gpu_memory_service/tests/test_v1_vllm_backend.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import nullcontext
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip("vllm", reason="vLLM is required")
+
+import gpu_memory_service.v1.integrations.vllm.backend as backend_module  # noqa: E402
+from vllm.device_allocator.sleep_mode_backend import (  # noqa: E402
+    SleepModeBackendFactory,
+)
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.vllm,
+    pytest.mark.core,
+]
+
+
+def test_factory_backend_delegates_capture_and_memory_control(monkeypatch):
+    client = Mock()
+    client.weight_region.return_value = nullcontext()
+    client.kv_cache_region.return_value = nullcontext()
+    monkeypatch.setattr(
+        backend_module,
+        "TorchMempoolMemoryClient",
+        Mock(return_value=client),
+    )
+
+    backend = SleepModeBackendFactory.create_backend(Mock(sleep_mode_backend="gms-v1"))
+    model = object()
+    with backend.capture_weights(lambda: model), backend.capture_kv_cache():
+        pass
+
+    client.weight_region.assert_called_once_with()
+    client.publish_weights.assert_called_once_with((model,))
+    client.kv_cache_region.assert_called_once_with()
+
+    backend.suspend()
+
+    assert backend.state() == "SUSPENDED"
+    client.suspend.assert_called_once_with()
+
+    client.resume.side_effect = RuntimeError("resume rejected")
+    with pytest.raises(RuntimeError, match="resume rejected"):
+        backend.resume()
+    assert backend.state() == "SUSPENDED"
+
+    client.resume.side_effect = None
+    backend.resume()
+
+    assert backend.state() == "RUNNING"
+    assert client.resume.call_count == 2

--- a/lib/gpu_memory_service/v1/client/mempool.py
+++ b/lib/gpu_memory_service/v1/client/mempool.py
@@ -1,0 +1,333 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-local Torch MemPool ownership for a GMS V1 client."""
+
+from __future__ import annotations
+
+import gc
+import logging
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from time import monotonic
+from typing import TYPE_CHECKING
+
+import torch
+from gpu_memory_service.client.torch.extensions import _allocator_ext
+from gpu_memory_service.common import utils as common_utils
+from gpu_memory_service.common.locks import RequestedLockType
+from gpu_memory_service.common.vmm import get_vmm
+from gpu_memory_service.v1.client.memory_manager import GMSClientMemoryManager
+from gpu_memory_service.v1.client.parameter_storage import (
+    copy_non_parameter_tensors_to_default_allocator,
+)
+from gpu_memory_service.v1.device import get_socket_path
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+logger = logging.getLogger(__name__)
+_WEIGHTS = "weights"
+_KV_CACHE = "kv_cache"
+_allocator_owner_lock = threading.Lock()
+_allocator_owner: object | None = None
+_allocator_initializing: object | None = None
+
+
+def _reserve_allocator(owner: object) -> None:
+    global _allocator_initializing
+    with _allocator_owner_lock:
+        if _allocator_owner is not None or _allocator_initializing is not None:
+            raise RuntimeError(
+                "GMS V1 supports exactly one Torch MemPool client per process"
+            )
+        _allocator_initializing = owner
+
+
+def _claim_allocator(owner: object, malloc: object, free: object) -> None:
+    global _allocator_initializing, _allocator_owner
+    with _allocator_owner_lock:
+        if _allocator_initializing is not owner:
+            raise RuntimeError("GMS V1 allocator initialization was not reserved")
+        _allocator_ext.init_module(malloc, free)
+        _allocator_owner = owner
+        _allocator_initializing = None
+
+
+def _release_allocator_reservation(owner: object) -> None:
+    global _allocator_initializing
+    with _allocator_owner_lock:
+        if _allocator_initializing is owner:
+            _allocator_initializing = None
+
+
+class TorchMempoolMemoryClient:
+    """Own GMS weight and KV domains behind Torch MemPool contexts.
+
+    Lifecycle operations are serialized by the inference engine. Only the
+    allocator callbacks may execute concurrently.
+    """
+
+    def __init__(self) -> None:
+        self._state = "RUNNING"
+        self._weights_state = "OPEN"
+        weights: GMSClientMemoryManager | None = None
+        kv_cache: GMSClientMemoryManager | None = None
+        _reserve_allocator(self)
+        try:
+            self._device = torch.cuda.current_device()
+            vmm = get_vmm()
+            weights = GMSClientMemoryManager(
+                get_socket_path(self._device, _WEIGHTS),
+                vmm,
+                self._device,
+            )
+            kv_cache = GMSClientMemoryManager(
+                get_socket_path(self._device, _KV_CACHE),
+                vmm,
+                self._device,
+            )
+            self._weights = weights
+            self._kv_cache = kv_cache
+            self._active_domain: ContextVar[str | None] = ContextVar(
+                "gms_v1_active_domain",
+                default=None,
+            )
+            self._allocator_failure: Exception | None = None
+            self._allocator_failure_lock = threading.Lock()
+            self._unmanaged_pool = None
+            self._weights.connect(RequestedLockType.RW)
+            self._kv_cache.connect(RequestedLockType.RW)
+            self._pluggable_allocator = torch.cuda.CUDAPluggableAllocator(
+                _allocator_ext.__file__,
+                "my_malloc",
+                "my_free",
+            )
+            with torch.cuda.device(self._device):
+                self._weights_pool = torch.cuda.MemPool(
+                    allocator=self._pluggable_allocator.allocator()
+                )
+                self._kv_cache_pool = torch.cuda.MemPool(
+                    allocator=self._pluggable_allocator.allocator()
+                )
+            # The native shim retains these callback pointers for process life.
+            self._malloc_callback = self._malloc
+            self._free_callback = self._free
+            _claim_allocator(self, self._malloc_callback, self._free_callback)
+        except BaseException:
+            self._disconnect_managers_after_failure(kv_cache, weights)
+            _release_allocator_reservation(self)
+            raise
+
+    @contextmanager
+    def weight_region(self) -> Iterator[None]:
+        """Route one of possibly many model loads into the weight domain."""
+        self._require_running()
+        self._require_weights_open()
+        try:
+            with self._use_pool(_WEIGHTS, self._weights_pool):
+                yield
+            self._raise_if_allocator_failed()
+        except BaseException:
+            self._fail()
+            raise
+
+    @contextmanager
+    def kv_cache_region(self) -> Iterator[None]:
+        """Route a KV allocation region into the reusable KV domain."""
+        self._require_running()
+        try:
+            with self._use_pool(_KV_CACHE, self._kv_cache_pool):
+                yield
+            self._raise_if_allocator_failed()
+        except BaseException:
+            self._fail()
+            raise
+
+    @contextmanager
+    def unmanaged_region(self) -> Iterator[None]:
+        """Route temporary allocations through an ordinary Torch MemPool."""
+        self._require_running()
+        if self._unmanaged_pool is None:
+            with torch.cuda.device(self._device):
+                self._unmanaged_pool = torch.cuda.MemPool()
+        with (
+            torch.cuda.device(self._device),
+            torch.cuda.use_mem_pool(self._unmanaged_pool, device=self._device),
+        ):
+            yield
+
+    def publish_weights(self, models: Iterable[object]) -> None:
+        """Commit all model Parameters captured by preceding weight regions."""
+        if self._weights_state == "PUBLISHED":
+            return
+        self._require_weights_open()
+        self._weights_state = "PUBLISHING"
+        try:
+            models = tuple(models)
+            if not models:
+                raise RuntimeError("GMS V1 did not observe any loaded models")
+            if any(model is None for model in models):
+                raise TypeError("GMS V1 model must not be None")
+            copy_non_parameter_tensors_to_default_allocator(
+                models,
+                self._weights.mappings,
+            )
+            torch.cuda.synchronize(self._device)
+            self._destroy_weights_pool()
+            self._raise_if_allocator_failed()
+            self._weights.commit()
+        except BaseException:
+            self._fail()
+            raise
+        self._weights_state = "PUBLISHED"
+        logger.info(
+            "GMS weights committed device=%d models=%d allocations=%d",
+            self._device,
+            len(models),
+            len(self._weights.mappings),
+        )
+
+    def suspend(self) -> None:
+        """Unmap all client-owned GPU memory."""
+        if self._state != "RUNNING":
+            raise RuntimeError(f"cannot suspend GMS V1 from {self._state}")
+        if self._weights_state != "PUBLISHED":
+            raise RuntimeError(
+                f"cannot suspend GMS V1 with weights in {self._weights_state}"
+            )
+
+        try:
+            gc.collect()
+            self._raise_if_allocator_failed()
+            torch.cuda.empty_cache()
+            self._raise_if_allocator_failed()
+            self._weights.unmap_all_vas()
+            self._weights.disconnect()
+            self._kv_cache.unmap_all_vas()
+            self._kv_cache.disconnect()
+            self._state = "SUSPENDED"
+        except Exception:  # noqa: BLE001
+            common_utils.fail(
+                "GMS V1 suspend failed; terminating the worker process",
+                exc_info=True,
+            )
+
+    def resume(self) -> None:
+        """Reconnect and remap all client-owned GPU memory."""
+        if self._state != "SUSPENDED":
+            raise RuntimeError(f"cannot resume GMS V1 from {self._state}")
+
+        try:
+            self._state = "RESUMING"
+            wake_t0 = monotonic()
+            self._kv_cache.connect(RequestedLockType.RW)
+            self._kv_cache.reallocate_all_handles()
+            self._kv_cache.remap_all_vas()
+            self._weights.connect(RequestedLockType.RO)
+            self._weights.remap_all_vas()
+            self._state = "RUNNING"
+            logger.info(
+                "GMS V1 wake complete device=%d total_elapsed=%.3fs",
+                self._device,
+                monotonic() - wake_t0,
+            )
+        except Exception:  # noqa: BLE001
+            common_utils.fail(
+                "GMS V1 resume failed; terminating the worker process",
+                exc_info=True,
+            )
+
+    @contextmanager
+    def _use_pool(self, domain: str, pool: object) -> Iterator[None]:
+        token = self._active_domain.set(domain)
+        try:
+            with (
+                torch.cuda.device(self._device),
+                torch.cuda.use_mem_pool(pool, device=self._device),
+            ):
+                yield
+        finally:
+            self._active_domain.reset(token)
+
+    def _destroy_weights_pool(self) -> None:
+        gc.collect()
+        weights_pool = self._weights_pool
+        self._weights_pool = None
+        del weights_pool
+        gc.collect()
+
+    def _require_weights_open(self) -> None:
+        if self._weights_state != "OPEN":
+            raise RuntimeError(
+                f"cannot capture or publish GMS V1 weights from {self._weights_state}"
+            )
+
+    def _require_running(self) -> None:
+        if self._state != "RUNNING":
+            raise RuntimeError(f"cannot allocate with GMS V1 from {self._state}")
+
+    def _fail(self) -> None:
+        if self._state == "FAILED" and self._weights_state == "FAILED":
+            return
+        self._state = "FAILED"
+        self._weights_state = "FAILED"
+        self._disconnect_managers_after_failure(self._kv_cache, self._weights)
+
+    def _malloc(self, size: int, device: int, _stream: int) -> int:
+        try:
+            if device != self._device:
+                raise RuntimeError(
+                    f"allocator callback device {device} != {self._device}"
+                )
+            domain = self._active_domain.get()
+            if domain == _WEIGHTS:
+                return self._weights.create_mapping(size)
+            if domain == _KV_CACHE:
+                return self._kv_cache.create_mapping(size)
+            raise RuntimeError("GMS allocator callback has no active domain")
+        except Exception as exc:
+            self._record_allocator_failure(exc)
+            raise
+
+    def _free(self, va: int, size: int, device: int, _stream: int) -> None:
+        try:
+            if device != self._device:
+                raise RuntimeError(
+                    f"allocator callback device {device} != {self._device}"
+                )
+            if self._weights.owns(va):
+                self._weights.destroy_mapping(va, size)
+                return
+            if self._kv_cache.owns(va):
+                self._kv_cache.destroy_mapping(va, size)
+                return
+            raise RuntimeError(f"GMS allocator does not own VA 0x{va:x}")
+        except Exception as exc:  # noqa: BLE001
+            self._record_allocator_failure(exc)
+
+    def _record_allocator_failure(self, failure: Exception) -> None:
+        with self._allocator_failure_lock:
+            if self._allocator_failure is None:
+                self._allocator_failure = failure
+
+    def _raise_if_allocator_failed(self) -> None:
+        with self._allocator_failure_lock:
+            failure = self._allocator_failure
+        if failure is not None:
+            raise RuntimeError("allocator callback failed") from failure
+
+    @staticmethod
+    def _disconnect_managers_after_failure(
+        *managers: GMSClientMemoryManager | None,
+    ) -> None:
+        for manager in managers:
+            if manager is None:
+                continue
+            try:
+                manager.disconnect()
+            except BaseException:
+                logger.exception(
+                    "GMS V1 disconnect failed while preserving an earlier error"
+                )

--- a/lib/gpu_memory_service/v1/client/parameter_storage.py
+++ b/lib/gpu_memory_service/v1/client/parameter_storage.py
@@ -3,14 +3,14 @@
 
 """Move non-Parameter tensors out of GMS storage before weight publication.
 
-Dynamo Snapshot invokes this copy only after a whole engine has been put to
-sleep by GMS. Restore preserves the same Python/Torch process state, TensorImpls,
-post-partition StorageImpl graph, layouts, allocation IDs, and CUDA VA
-reservations. Model construction, loading, and this copy do not run again after
-restore. The rank-local GMS sidecar survives separately and retains committed
-weight backing. Copies made with Torch's default allocator are ordinary
-process-owned Snapshot state. KV physical backing and contents are not retained;
-fresh backing is mapped at preserved VAs.
+Dynamo Snapshot invokes this copy while a whole engine is paused, before GMS
+publishes and unmaps its weights. Restore preserves the same Python/Torch process
+state, TensorImpls, post-partition StorageImpl graph, layouts, allocation IDs,
+and CUDA VA reservations. Model construction, loading, and this copy do not run
+again after restore. The rank-local GMS sidecar survives separately and retains
+committed weight backing. Copies made with Torch's default allocator are
+ordinary process-owned Snapshot state. KV physical backing and contents are not
+retained; fresh backing is mapped at preserved VAs.
 
 One GMS source storage may contain Parameters and other tensor views::
 
@@ -138,16 +138,17 @@ def _clone_storage_spans_and_rebind_tensors(
     return copied_bytes
 
 
-def _iter_live_tensors(model: object):
-    yield from model.parameters()
+def _iter_live_tensors(models: Iterable[object]):
+    for model in models:
+        yield from model.parameters()
     for value in gc.get_objects():
         if issubclass(type(value), torch.Tensor) and value.layout is torch.strided:
             yield value
 
 
-def _discover_live_tensors(model: object) -> list[tuple[torch.Tensor, bool]]:
+def _discover_live_tensors(models: Iterable[object]) -> list[tuple[torch.Tensor, bool]]:
     objects: dict[int, tuple[torch.Tensor, bool]] = {}
-    for tensor in _iter_live_tensors(model):
+    for tensor in _iter_live_tensors(models):
         tensor_id = int(tensor._cdata)
         tensor_object = objects.get(tensor_id)
         if tensor_object is None:
@@ -178,7 +179,7 @@ def _containing_mapping(
 
 
 def copy_non_parameter_tensors_to_default_allocator(
-    model: object,
+    models: Iterable[object],
     mappings: tuple[LocalMapping, ...],
 ) -> tuple[int, int]:
     """Copy live non-Parameters out of GMS and return span/copy byte counts."""
@@ -187,7 +188,7 @@ def copy_non_parameter_tensors_to_default_allocator(
     mapping_bases = tuple(mapping.base for mapping in mappings)
     retained_parameter_spans: list[tuple[int, int]] = []
     non_parameters: list[torch.Tensor] = []
-    for tensor, is_parameter in _discover_live_tensors(model):
+    for tensor, is_parameter in _discover_live_tensors(models):
         if _containing_mapping(tensor, mappings, mapping_bases) is None:
             continue
         if not is_parameter:

--- a/lib/gpu_memory_service/v1/integrations/sglang/__init__.py
+++ b/lib/gpu_memory_service/v1/integrations/sglang/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang integration for GMS V1."""

--- a/lib/gpu_memory_service/v1/integrations/sglang/plugin.py
+++ b/lib/gpu_memory_service/v1/integrations/sglang/plugin.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang plugin adapter for the process-local GMS V1 Torch MemPool client."""
+
+from __future__ import annotations
+
+import os
+from contextlib import nullcontext
+from functools import cache
+
+import torch
+from gpu_memory_service.v1.client.mempool import TorchMempoolMemoryClient
+from sglang.srt.plugins.hook_registry import HookRegistry, HookType
+from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+
+_FACTORY_TARGET = (
+    "sglang.srt.utils.torch_memory_saver_adapter.TorchMemorySaverAdapter.create"
+)
+_INITIAL_MODEL_LOAD_TARGET = (
+    "sglang.srt.model_executor.model_runner_components.load_model_utils."
+    "load_model_with_memory_saver"
+)
+
+
+class GMSV1MemorySaverAdapter(TorchMemorySaverAdapter):
+    """Share one GMS V1 client across SGLang's process-local adapters."""
+
+    def __init__(self) -> None:
+        self._client: TorchMempoolMemoryClient | None = None
+        self._models: list[object] = []
+
+    @property
+    def client(self) -> TorchMempoolMemoryClient:
+        if self._client is None:
+            self._client = TorchMempoolMemoryClient()
+        return self._client
+
+    def configure_subprocess(self):
+        return nullcontext()
+
+    def region(self, tag: str, enable_cpu_backup: bool = False):
+        if tag == "weights":
+            return self.client.weight_region()
+        if tag == "kv_cache":
+            return self.client.kv_cache_region()
+        return nullcontext()
+
+    def cuda_graph(self, **kwargs):
+        kwargs.pop("tag", None)
+        kwargs.pop("enable_cpu_backup", None)
+        cuda_graph = kwargs.pop("cuda_graph")
+        return torch.cuda.graph(cuda_graph, **kwargs)
+
+    def disable(self):
+        return self.client.unmanaged_region()
+
+    def pause(self, tag: str) -> None:
+        if tag == "weights":
+            self.client.publish_weights(self._models)
+            self.client.suspend()
+
+    def resume(self, tag: str) -> None:
+        if tag == "weights":
+            self.client.resume()
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    def observe_model(self, model: object) -> None:
+        self._models.append(model)
+
+
+@cache
+def _adapter() -> GMSV1MemorySaverAdapter:
+    return GMSV1MemorySaverAdapter()
+
+
+def _around_adapter_factory(original_factory, *args, **kwargs):
+    enable = args[0] if args else kwargs["enable"]
+    if not enable:
+        return original_factory(*args, **kwargs)
+    return _adapter()
+
+
+def _after_initial_model_load(result, *args, **kwargs) -> None:
+    _adapter().observe_model(result.model)
+
+
+def register_gms_v1_plugin() -> None:
+    """Register the GMS hooks in SGLang processes where Dynamo enabled them."""
+    if os.environ.get("DYN_SGL_ENABLE_GMS_V1") != "true":
+        return
+    HookRegistry.register(
+        _INITIAL_MODEL_LOAD_TARGET,
+        _after_initial_model_load,
+        HookType.AFTER,
+    )
+    HookRegistry.register(
+        _FACTORY_TARGET,
+        _around_adapter_factory,
+        HookType.AROUND,
+    )

--- a/lib/gpu_memory_service/v1/integrations/sglang/plugin.py
+++ b/lib/gpu_memory_service/v1/integrations/sglang/plugin.py
@@ -21,6 +21,10 @@ _INITIAL_MODEL_LOAD_TARGET = (
     "sglang.srt.model_executor.model_runner_components.load_model_utils."
     "load_model_with_memory_saver"
 )
+_RELEASE_MEMORY_OCCUPATION_TARGET = (
+    "sglang.srt.managers.scheduler_components.weight_updater."
+    "SchedulerWeightUpdaterManager.release_memory_occupation"
+)
 
 
 class GMSV1MemorySaverAdapter(TorchMemorySaverAdapter):
@@ -88,6 +92,11 @@ def _after_initial_model_load(result, *args, **kwargs) -> None:
     _adapter().observe_model(result.model)
 
 
+def _after_release_memory_occupation(result, manager, *args, **kwargs):
+    torch.distributed.barrier(group=manager.tp_cpu_group)
+    return result
+
+
 def register_gms_v1_plugin() -> None:
     """Register the GMS hooks in SGLang processes where Dynamo enabled them."""
     if os.environ.get("DYN_SGL_ENABLE_GMS_V1") != "true":
@@ -101,4 +110,9 @@ def register_gms_v1_plugin() -> None:
         _FACTORY_TARGET,
         _around_adapter_factory,
         HookType.AROUND,
+    )
+    HookRegistry.register(
+        _RELEASE_MEMORY_OCCUPATION_TARGET,
+        _after_release_memory_occupation,
+        HookType.AFTER,
     )

--- a/lib/gpu_memory_service/v1/integrations/sglang/plugin.py
+++ b/lib/gpu_memory_service/v1/integrations/sglang/plugin.py
@@ -21,6 +21,9 @@ _INITIAL_MODEL_LOAD_TARGET = (
     "sglang.srt.model_executor.model_runner_components.load_model_utils."
     "load_model_with_memory_saver"
 )
+_INIT_ALL_CUDA_GRAPHS_TARGET = (
+    "sglang.srt.managers.scheduler.Scheduler.init_all_cuda_graphs"
+)
 _RELEASE_MEMORY_OCCUPATION_TARGET = (
     "sglang.srt.managers.scheduler_components.weight_updater."
     "SchedulerWeightUpdaterManager.release_memory_occupation"
@@ -61,7 +64,7 @@ class GMSV1MemorySaverAdapter(TorchMemorySaverAdapter):
 
     def pause(self, tag: str) -> None:
         if tag == "weights":
-            self.client.publish_weights(self._models)
+            self._publish_weights()
             self.client.suspend()
 
     def resume(self, tag: str) -> None:
@@ -74,6 +77,9 @@ class GMSV1MemorySaverAdapter(TorchMemorySaverAdapter):
 
     def observe_model(self, model: object) -> None:
         self._models.append(model)
+
+    def _publish_weights(self) -> None:
+        self.client.publish_weights(self._models)
 
 
 @cache
@@ -92,6 +98,11 @@ def _after_initial_model_load(result, *args, **kwargs) -> None:
     _adapter().observe_model(result.model)
 
 
+def _before_init_all_cuda_graphs(_scheduler: object) -> None:
+    # Publication rebinds non-Parameter tensors, so it must precede graph capture.
+    _adapter()._publish_weights()
+
+
 def _after_release_memory_occupation(result, manager, *args, **kwargs):
     torch.distributed.barrier(group=manager.tp_cpu_group)
     return result
@@ -105,6 +116,11 @@ def register_gms_v1_plugin() -> None:
         _INITIAL_MODEL_LOAD_TARGET,
         _after_initial_model_load,
         HookType.AFTER,
+    )
+    HookRegistry.register(
+        _INIT_ALL_CUDA_GRAPHS_TARGET,
+        _before_init_all_cuda_graphs,
+        HookType.BEFORE,
     )
     HookRegistry.register(
         _FACTORY_TARGET,

--- a/lib/gpu_memory_service/v1/integrations/vllm/backend.py
+++ b/lib/gpu_memory_service/v1/integrations/vllm/backend.py
@@ -1,300 +1,56 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""vLLM routing, Torch allocation, and GMS V1 lifecycle ownership."""
+"""vLLM sleep-mode integration for the GMS V1 Torch MemPool client."""
 
 from __future__ import annotations
 
-import gc
-import threading
 from contextlib import contextmanager
-from contextvars import ContextVar
-from time import monotonic
 from typing import TYPE_CHECKING
 
-import torch
-from gpu_memory_service.client.torch.extensions import _allocator_ext
-from gpu_memory_service.common import utils as common_utils
-from gpu_memory_service.common.locks import RequestedLockType
-from gpu_memory_service.common.vmm import get_vmm
-from gpu_memory_service.v1.client.memory_manager import GMSClientMemoryManager
-from gpu_memory_service.v1.client.parameter_storage import (
-    copy_non_parameter_tensors_to_default_allocator,
-)
-from gpu_memory_service.v1.device import get_socket_path
+from gpu_memory_service.v1.client.mempool import TorchMempoolMemoryClient
 from vllm.device_allocator.sleep_mode_backend import (
     SleepModeBackend,
     SleepModeBackendFactory,
 )
-from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
 BACKEND_NAME = "gms-v1"
-logger = init_logger("vllm.gpu_memory_service.v1")
-_WEIGHTS = "weights"
-_KV_CACHE = "kv_cache"
-_allocator_owner_lock = threading.Lock()
-_allocator_owner: object | None = None
-_allocator_initializing: object | None = None
-
-
-def _reserve_allocator(owner: object) -> None:
-    """Reserve construction of the one supported V1 allocator backend."""
-    global _allocator_initializing
-    with _allocator_owner_lock:
-        if _allocator_owner is not None or _allocator_initializing is not None:
-            raise RuntimeError(
-                "GMS V1 supports exactly one allocator backend per process; "
-                "a V1 backend is already initialized"
-            )
-        _allocator_initializing = owner
-
-
-def _claim_allocator(owner: object, malloc: object, free: object) -> None:
-    """Install callbacks and publish a fully initialized V1 process owner."""
-    global _allocator_initializing, _allocator_owner
-    with _allocator_owner_lock:
-        if _allocator_initializing is not owner:
-            raise RuntimeError("GMS V1 allocator initialization was not reserved")
-        _allocator_ext.init_module(malloc, free)
-        _allocator_owner = owner
-        _allocator_initializing = None
-
-
-def _release_allocator_reservation(owner: object) -> None:
-    global _allocator_initializing
-    with _allocator_owner_lock:
-        if _allocator_initializing is owner:
-            _allocator_initializing = None
 
 
 class GMSV1SleepModeBackend(SleepModeBackend):
-    """Own the rank-local GMS Parameter and ephemeral KV domains."""
+    """Expose GMS V1 through vLLM's sleep-mode backend contract."""
 
     def __init__(self) -> None:
         super().__init__()
-        weights: GMSClientMemoryManager | None = None
-        kv_cache: GMSClientMemoryManager | None = None
-        _reserve_allocator(self)
-        try:
-            self._device = torch.cuda.current_device()
-            vmm = get_vmm()
-            weights = GMSClientMemoryManager(
-                get_socket_path(self._device, _WEIGHTS),
-                vmm,
-                self._device,
-            )
-            kv_cache = GMSClientMemoryManager(
-                get_socket_path(self._device, _KV_CACHE),
-                vmm,
-                self._device,
-            )
-            self._weights = weights
-            self._kv_cache = kv_cache
-            self._active_domain: ContextVar[str | None] = ContextVar(
-                "gms_v1_active_domain",
-                default=None,
-            )
-            self._allocator_failure: Exception | None = None
-            self._allocator_failure_lock = threading.Lock()
-            self._weights.connect(RequestedLockType.RW)
-            self._kv_cache.connect(RequestedLockType.RW)
-            self._pluggable_allocator = torch.cuda.CUDAPluggableAllocator(
-                _allocator_ext.__file__,
-                "my_malloc",
-                "my_free",
-            )
-            with torch.cuda.device(self._device):
-                self._weights_pool = torch.cuda.MemPool(
-                    allocator=self._pluggable_allocator.allocator()
-                )
-                self._kv_cache_pool = torch.cuda.MemPool(
-                    allocator=self._pluggable_allocator.allocator()
-                )
-            # The shared native shim keeps callback pointers for process lifetime.
-            # Pin these exact bound-method objects on their V1 backend owner.
-            self._malloc_callback = self._malloc
-            self._free_callback = self._free
-            _claim_allocator(self, self._malloc_callback, self._free_callback)
-        except BaseException:
-            self._disconnect_managers_after_failure(kv_cache, weights)
-            _release_allocator_reservation(self)
-            raise
+        self._client = TorchMempoolMemoryClient()
 
     @contextmanager
     def capture_weights(self, model: Callable[[], object]) -> Iterator[None]:
-        try:
-            with self._use_pool(_WEIGHTS, self._weights_pool):
-                yield
+        with self._client.weight_region():
+            yield
+        self._client.publish_weights((model(),))
 
-            copy_non_parameter_tensors_to_default_allocator(
-                model(),
-                self._weights.mappings,
-            )
-            torch.cuda.synchronize(self._device)
-            self._destroy_weights_pool()
-            self._raise_if_allocator_failed()
-            self._weights.commit()
-        except BaseException:
-            self._disconnect_after_failure()
-            raise
-
-        logger.info(
-            "GMS weights committed device=%d allocations=%d",
-            self._device,
-            len(self._weights.mappings),
-        )
-
-    @contextmanager
-    def capture_kv_cache(self) -> Iterator[None]:
-        try:
-            with self._use_pool(_KV_CACHE, self._kv_cache_pool):
-                yield
-            self._raise_if_allocator_failed()
-        except BaseException:
-            self._disconnect_after_failure()
-            raise
+    def capture_kv_cache(self):
+        return self._client.kv_cache_region()
 
     def suspend(self, level: int = 1) -> None:
         if level != 1:
             raise ValueError("GMS V1 supports only whole-engine level 1 suspend")
-        if self._state != "RUNNING":
-            raise RuntimeError(f"cannot suspend GMS V1 from {self._state}")
-
-        try:
-            gc.collect()
-            self._raise_if_allocator_failed()
-            torch.cuda.empty_cache()
-            self._raise_if_allocator_failed()
-            self._weights.unmap_all_vas()
-            self._weights.disconnect()
-            self._kv_cache.unmap_all_vas()
-            self._kv_cache.disconnect()
-            self._state = "SUSPENDED"
-        except Exception:  # noqa: BLE001
-            common_utils.fail(
-                "GMS V1 suspend failed; terminating the worker process",
-                exc_info=True,
-            )
+        self._client.suspend()
+        self._state = "SUSPENDED"
 
     def resume(self, tags: list[str] | None = None) -> None:
         if tags is not None:
             raise ValueError("GMS V1 does not support partial-tag resume")
-        if self._state != "SUSPENDED":
-            raise RuntimeError(f"cannot resume GMS V1 from {self._state}")
-
-        try:
-            self._state = "RESUMING"
-            wake_t0 = monotonic()
-
-            self._kv_cache.connect(RequestedLockType.RW)
-            self._kv_cache.reallocate_all_handles()
-            self._kv_cache.remap_all_vas()
-
-            self._weights.connect(RequestedLockType.RO)
-            self._weights.remap_all_vas()
-            self._state = "RUNNING"
-            logger.info(
-                "GMS V1 wake complete device=%d total_elapsed=%.3fs",
-                self._device,
-                monotonic() - wake_t0,
-            )
-        except Exception:  # noqa: BLE001
-            common_utils.fail(
-                "GMS V1 resume failed; terminating the worker process",
-                exc_info=True,
-            )
+        self._client.resume()
+        self._state = "RUNNING"
 
     @classmethod
     def preserves_communicators(cls) -> bool:
         return True
-
-    @contextmanager
-    def _use_pool(self, domain: str, pool: object) -> Iterator[None]:
-        token = self._active_domain.set(domain)
-        try:
-            with (
-                torch.cuda.device(self._device),
-                torch.cuda.use_mem_pool(pool, device=self._device),
-            ):
-                yield
-        finally:
-            self._active_domain.reset(token)
-
-    def _destroy_weights_pool(self) -> None:
-        """Prune GMS mappings not retained by live model Parameters.
-
-        Deleting the temporary MemPool releases its cached and unreferenced
-        blocks through the allocator free callback. Blocks still owned by live
-        Parameter storage remain mapped and become the committed weight set.
-        """
-        gc.collect()
-        weights_pool = self._weights_pool
-        self._weights_pool = None
-        del weights_pool
-        gc.collect()
-
-    def _malloc(self, size: int, device: int, _stream: int) -> int:
-        try:
-            if device != self._device:
-                raise RuntimeError(
-                    f"allocator callback device {device} != {self._device}"
-                )
-            domain = self._active_domain.get()
-            if domain == _WEIGHTS:
-                return self._weights.create_mapping(size)
-            if domain == _KV_CACHE:
-                return self._kv_cache.create_mapping(size)
-            raise RuntimeError("GMS allocator callback has no active domain")
-        except Exception as exc:
-            self._record_allocator_failure(exc)
-            raise
-
-    def _free(self, va: int, size: int, device: int, _stream: int) -> None:
-        try:
-            if device != self._device:
-                raise RuntimeError(
-                    f"allocator callback device {device} != {self._device}"
-                )
-            if self._weights.owns(va):
-                self._weights.destroy_mapping(va, size)
-                return
-            if self._kv_cache.owns(va):
-                self._kv_cache.destroy_mapping(va, size)
-                return
-            raise RuntimeError(f"GMS allocator does not own VA 0x{va:x}")
-        except Exception as exc:  # noqa: BLE001
-            self._record_allocator_failure(exc)
-
-    def _record_allocator_failure(self, failure: Exception) -> None:
-        with self._allocator_failure_lock:
-            if self._allocator_failure is None:
-                self._allocator_failure = failure
-
-    def _raise_if_allocator_failed(self) -> None:
-        with self._allocator_failure_lock:
-            failure = self._allocator_failure
-        if failure is not None:
-            raise RuntimeError("allocator callback failed") from failure
-
-    def _disconnect_after_failure(self) -> None:
-        self._disconnect_managers_after_failure(self._kv_cache, self._weights)
-
-    @staticmethod
-    def _disconnect_managers_after_failure(
-        *managers: GMSClientMemoryManager | None,
-    ) -> None:
-        for manager in managers:
-            if manager is None:
-                continue
-            try:
-                manager.disconnect()
-            except BaseException:
-                logger.exception(
-                    "GMS V1 disconnect failed while preserving an earlier error"
-                )
 
 
 SleepModeBackendFactory.register_backend(


### PR DESCRIPTION
## Summary

SGLang captures CUDA graphs before GMS V1 first publishes model weights. Weight publication moves live non-`Parameter` tensors out of the GMS weight pool with `Tensor.set_()`, but already-instantiated CUDA graph nodes retain their original raw pointers. Once the old mapping is removed, the first post-restore graph replay can read an unmapped address and trigger Xid 31.

This change publishes all observed target and optional draft model weights immediately before `Scheduler.init_all_cuda_graphs()`. Graph warmup and capture therefore see the tensors' final storage addresses. Publication during pause remains as an idempotent fallback.

The change is intentionally limited to the SGLang GMS V1 adapter and its existing integration test. It adds no graph-recapture path, protocol change, or allocation-classification mechanism.

## Validation

- Existing SGLang GMS V1 hook test: `1 passed`
- `pre-commit run --files lib/gpu_memory_service/v1/integrations/sglang/plugin.py lib/gpu_memory_service/tests/test_v1_sglang_integration.py`: passed
- Python compile checks for both changed files: passed
- Verified against pinned SGLang 0.5.16 that target/draft model loading, memory-pool creation, and attention-backend initialization precede `Scheduler.init_all_cuda_graphs()`
- TP8 GLM-5.2 GMS V1 checkpoint/restore A/B on B200:
  - CUDA graphs enabled: first post-restore inference produced Xid 31 on all eight GPUs
  - CUDA graphs disabled: checkpoint/restore completed and two coherent HTTP 200 inference requests passed with no new Xid
  - Disabling both SGLang custom all-reduce and FlashInfer fused all-reduce did not eliminate the graph-enabled fault

Stacked on the TP release barrier change because both are required by the current SGLang GMS V1 snapshot validation stack.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Fixed-image TP8 acceptance

Fresh Build on Demand images from composed head `48e83c40356509eb6c532bb631dfd5a6d6a0022f` passed the full SGLang GLM-5.2 NVFP4 TP8 snapshot/restore test on B200 with:

- target decode CUDA graphs through BS128;
- EAGLE draft decode and extend CUDA graphs through BS128;
- SGLang custom all-reduce with multicast enabled;
- FlashInfer fused all-reduce using the `mnnvl` backend;
- GMS V1 weight restoration on all eight devices.

Results:

- checkpoint: `14m14.109s` (`2m35.051s` CUDA + `11m38.713s` CRIU);
- restore: `1m51.592s` (`37.723s` CRIU + `1m10.568s` CUDA);
- two coherent post-restore HTTP 200 completions (`42` and `Hot.`);
- no new Xid or MMU faults.

HiCache was disabled for this acceptance because its configured 200 GiB pinned host cache independently cgroup-OOMed the source process before checkpoint. SGLang also auto-disables target prefill graphs for this model because MLA is incompatible with breakable prefill graphs; all supported target/draft graph paths remained enabled.
