### PR TITLE
ci(docs): prove gen_llms_tables determinism in docs CI

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -107,6 +107,44 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Check generated release docs determinism
+        run: |
+          set -euo pipefail
+
+          python3 docs/fern/scripts/gen_llms_tables.py --check
+
+          tmp_dir=$(mktemp -d)
+          trap 'rm -rf "$tmp_dir"' EXIT
+          mkdir -p "$tmp_dir/first" "$tmp_dir/second"
+          cp -R docs "$tmp_dir/first/docs"
+          cp -R docs "$tmp_dir/second/docs"
+
+          TZ=UTC LC_ALL=C PYTHONHASHSEED=1 SOURCE_DATE_EPOCH=0 \
+            python3 "$tmp_dir/first/docs/fern/scripts/gen_llms_tables.py"
+          TZ=Pacific/Honolulu LC_ALL=C.UTF-8 PYTHONHASHSEED=2 SOURCE_DATE_EPOCH=4102444800 \
+            python3 "$tmp_dir/second/docs/fern/scripts/gen_llms_tables.py"
+
+          outputs=(
+            docs/fern/pages/reference/general/compatibility.mdx
+            docs/fern/pages/reference/general/release-artifacts.mdx
+            docs/fern/pages/reference/general/model-early-access-builds.mdx
+            docs/fern/pages/reference/general/releases-machine-readable.mdx
+            docs/fern/pages/reference/general/releases/release-history.mdx
+            docs/fern/assets/releases.json
+            docs/fern/assets/releases-atom.xml
+          )
+          failed=0
+          for output in "${outputs[@]}"; do
+            if ! cmp -s "$tmp_dir/first/$output" "$tmp_dir/second/$output"; then
+              echo "::error file=$output::Generator output is not byte-identical across runs"
+              diff -u "$tmp_dir/first/$output" "$tmp_dir/second/$output" || true
+              failed=1
+            fi
+          done
+          if (( failed )); then
+            exit 1
+          fi
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -119,11 +119,6 @@ jobs:
           cp -R docs "$tmp_dir/first/docs"
           cp -R docs "$tmp_dir/second/docs"
 
-          TZ=UTC LC_ALL=C PYTHONHASHSEED=1 SOURCE_DATE_EPOCH=0 \
-            python3 "$tmp_dir/first/docs/fern/scripts/gen_llms_tables.py"
-          TZ=Pacific/Honolulu LC_ALL=C.UTF-8 PYTHONHASHSEED=2 SOURCE_DATE_EPOCH=4102444800 \
-            python3 "$tmp_dir/second/docs/fern/scripts/gen_llms_tables.py"
-
           outputs=(
             docs/fern/pages/reference/general/compatibility.mdx
             docs/fern/pages/reference/general/release-artifacts.mdx
@@ -133,11 +128,43 @@ jobs:
             docs/fern/assets/releases.json
             docs/fern/assets/releases-atom.xml
           )
+
+          # Force both runs to actually WRITE every output: drop the whole-file
+          # assets and CRLF-corrupt the spliced pages. A copied-through current
+          # tree would skip every write on the unchanged fast-path, leaving cmp
+          # comparing the originals with themselves and proving nothing about
+          # how the generator writes.
+          for tree in first second; do
+            rm -f "$tmp_dir/$tree/docs/fern/assets/releases.json" \
+                  "$tmp_dir/$tree/docs/fern/assets/releases-atom.xml"
+            for output in "${outputs[@]}"; do
+              case "$output" in
+                *.mdx) sed -i 's/$/\r/' "$tmp_dir/$tree/$output" ;;
+              esac
+            done
+          done
+
+          TZ=UTC LC_ALL=C PYTHONHASHSEED=1 SOURCE_DATE_EPOCH=0 \
+            python3 "$tmp_dir/first/docs/fern/scripts/gen_llms_tables.py"
+          TZ=Pacific/Honolulu LC_ALL=C.UTF-8 PYTHONHASHSEED=2 SOURCE_DATE_EPOCH=4102444800 \
+            python3 "$tmp_dir/second/docs/fern/scripts/gen_llms_tables.py"
+
           failed=0
           for output in "${outputs[@]}"; do
             if ! cmp -s "$tmp_dir/first/$output" "$tmp_dir/second/$output"; then
               echo "::error file=$output::Generator output is not byte-identical across runs"
               diff -u "$tmp_dir/first/$output" "$tmp_dir/second/$output" || true
+              failed=1
+            fi
+            # Committed-bytes comparison only where the output is committed
+            # (the two assets stop being tracked once publish-time generation
+            # lands; temp-vs-temp and the CR scan still cover them).
+            if [ -f "$output" ] && ! cmp -s "$tmp_dir/first/$output" "$output"; then
+              echo "::error file=$output::Regenerated output does not match the committed bytes"
+              failed=1
+            fi
+            if LC_ALL=C grep -q $'\r' "$tmp_dir/first/$output"; then
+              echo "::error file=$output::Generator output contains CR bytes; outputs must be LF-only"
               failed=1
             fi
           done

--- a/docs/fern/scripts/gen_llms_tables.py
+++ b/docs/fern/scripts/gen_llms_tables.py
@@ -1342,7 +1342,8 @@ def main(argv: list[str]) -> int:
         if args.check:
             print(f"{name}: STALE (regeneration would change it)")
         else:
-            path.write_text(new_text, encoding="utf-8")
+            with path.open("w", encoding="utf-8", newline="\n") as output:
+                output.write(new_text)
             print(f"{name}: wrote {len(new_text.encode('utf-8'))} bytes")
 
     if args.check and stale:

--- a/docs/fern/scripts/gen_llms_tables.py
+++ b/docs/fern/scripts/gen_llms_tables.py
@@ -1334,17 +1334,20 @@ def main(argv: list[str]) -> int:
             if path.is_relative_to(REFERENCE_DIR)
             else path.name
         )
-        old_text = path.read_text(encoding="utf-8") if path.is_file() else None
-        if new_text == old_text:
+        # Compare and write raw bytes: read_text() would normalize CRLF away,
+        # letting a wrongly-encoded output pass as "unchanged" (and --check
+        # as fresh) without ever being healed.
+        old_bytes = path.read_bytes() if path.is_file() else None
+        new_bytes = new_text.encode("utf-8")
+        if new_bytes == old_bytes:
             print(f"{name}: unchanged")
             continue
         stale.append(name)
         if args.check:
             print(f"{name}: STALE (regeneration would change it)")
         else:
-            with path.open("w", encoding="utf-8", newline="\n") as output:
-                output.write(new_text)
-            print(f"{name}: wrote {len(new_text.encode('utf-8'))} bytes")
+            path.write_bytes(new_bytes)
+            print(f"{name}: wrote {len(new_bytes)} bytes")
 
     if args.check and stale:
         print(


### PR DESCRIPTION
## Summary

First step of the generated-docs conflict-reduction plan (reducing whole-file merge conflicts on regenerated docs artifacts, which cost several rebase/re-CI cycles during v1.4.0).

- Pin the one remaining nondeterminism in `docs/fern/scripts/gen_llms_tables.py`: outputs are now written as explicit LF bytes instead of platform-dependent newline translation. The atom feed's `<updated>` already derives from release dates, not build time, so no other source of drift existed.
- Add a CI assertion to the `broken-links-check` job in `docs-link-check.yml`: run the generator twice in temp trees under deliberately different timezone, locale, `PYTHONHASHSEED`, and `SOURCE_DATE_EPOCH`, and require all seven outputs (five marker-spliced pages + `releases.json` + `releases-atom.xml`) to be byte-identical, alongside the existing committed-tree `--check`.

Determinism must be proven while the whole-file assets are still committed. A stacked follow-up PR moves `releases.json` and `releases-atom.xml` to publish-time generation and deletes them from git.

## Validation

- Generator idempotence: second run changes zero bytes.
- Two-run byte-identity passes locally via the same mechanism as the CI step, across different TZ/locale/hashseed/epoch.
- `gen_llms_tables.py --check` exits 0; generator unit hooks pass (14/14).
- `pre-commit run` passes on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of generated release documentation across locales, time zones, hash seeds, and timestamps.
  * Standardized generated documentation files to use UTF-8 encoding and Unix-style line endings.

* **Tests**
  * Added automated checks that detect unexpected differences in generated documentation and report failures clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->