### PR TITLE
fix(vllm): warm up generation before snapshot capture

### DIFF
--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -6,6 +6,9 @@ import logging
 import os
 from collections.abc import Callable
 
+from vllm import SamplingParams
+from vllm.inputs import TokensPrompt
+
 from dynamo.common.snapshot.lifecycle import (
     EngineSnapshotController,
     SnapshotConfig,
@@ -13,6 +16,7 @@ from dynamo.common.snapshot.lifecycle import (
 )
 
 from .args import Config
+from .constants import DisaggregationMode
 from .handlers import VllmEnginePauseController
 from .worker_factory import EngineSetupResult
 
@@ -39,6 +43,32 @@ async def prepare_snapshot_engine(
     config.engine_args.enable_sleep_mode = True
 
     engine = setup_vllm_engine(config)
+    if (
+        config.disaggregation_mode == DisaggregationMode.AGGREGATED
+        and not config.realtime
+        and not config.enable_multimodal
+        and not config.route_to_encoder
+        and engine[1].model_config.runner_type == "generate"
+    ):
+        logger.info("Running vLLM snapshot warmup generation")
+        prompt = TokensPrompt(prompt_token_ids=[1, 2, 3, 4])
+        sampling_params = SamplingParams(
+            temperature=0,
+            max_tokens=16,
+            ignore_eos=True,
+        )
+        async for _ in engine[0].generate(
+            prompt,
+            sampling_params,
+            request_id="dynamo-snapshot-warmup",
+        ):
+            pass
+        logger.info("vLLM snapshot warmup generation completed")
+    else:
+        logger.info(
+            "Skipping vLLM snapshot warmup: only ordinary aggregated "
+            "generation workers are supported"
+        )
     gc.collect()
     snapshot_controller = EngineSnapshotController(
         engine=engine,


### PR DESCRIPTION
## Summary

- run one deterministic direct vLLM generation after engine construction and before the existing snapshot pause/checkpoint lifecycle
- fully consume the request so scheduler, decode, CUDA Graph, and configured speculative-decoding paths have executed before capture
- limit the warmup to ordinary aggregated generation workers; unsupported worker modes keep the existing lifecycle without added mode-specific machinery
- fail snapshot creation directly if the warmup generation fails

This closes a lifecycle gap where snapshot-mode vLLM could finish engine initialization and immediately pause without completing any real generation. Engine initialization captures graphs and allocates runtime state, but it does not exercise the live request lifecycle that must remain coherent across restore.

## Validation

- `git diff --check`
- `ruff check components/src/dynamo/vllm/snapshot.py`
- `ruff format --check components/src/dynamo/vllm/snapshot.py`
- `python3 -m py_compile components/src/dynamo/vllm/snapshot.py`
- `pre-commit run ruff --files components/src/dynamo/vllm/snapshot.py`
- GPU checkpoint/restore validation on s2877: pending build-on-demand image
