### PR TITLE
fix(router): propagate OTel trace context

### DIFF
--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -6,6 +6,7 @@ use std::{sync::Arc, time::Duration};
 use dynamo_kv_router::protocols::{TokensWithHashes, WorkerWithDpRank};
 use dynamo_runtime::{
     error::{ErrorType, match_error_chain},
+    logging::get_distributed_tracing_context,
     metrics::frontend_perf::{STAGE_ROUTE, StageGuard},
     pipeline::{
         AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
@@ -359,19 +360,36 @@ impl KvPushRouter {
                     .await
             }
         };
-        let dispatch_result = cancel_on_stop(
-            request_context.as_ref(),
-            dispatch.instrument(tracing::info_span!(
+        let route_span = if let Some(trace_context) = get_distributed_tracing_context() {
+            tracing::info_span!(
+                target: "request_span",
                 "kv_router.route_request",
                 request_id = %context_id,
                 worker_id = selection.instance_id,
                 dp_rank = selection.dp_rank,
                 overlap_blocks = selection.overlap_amount,
                 phase = ?phase,
-            )),
-        )
-        .await
-        .and_then(|result| result);
+                trace_id = trace_context.trace_id.as_str(),
+                parent_id = trace_context.span_id.as_str(),
+                trace_flags = trace_context.trace_flags.as_str(),
+                tracestate = trace_context.tracestate.as_deref(),
+                x_request_id = trace_context.x_request_id.as_deref(),
+            )
+        } else {
+            tracing::info_span!(
+                target: "request_span",
+                "kv_router.route_request",
+                request_id = %context_id,
+                worker_id = selection.instance_id,
+                dp_rank = selection.dp_rank,
+                overlap_blocks = selection.overlap_amount,
+                phase = ?phase,
+            )
+        };
+        let dispatch_result =
+            cancel_on_stop(request_context.as_ref(), dispatch.instrument(route_span))
+                .await
+                .and_then(|result| result);
         let response_stream = match dispatch_result {
             Ok(stream) => stream,
             Err(error) => {


### PR DESCRIPTION
## Summary

Fix OTel trace propagation through KV router dispatch by making `kv_router.route_request` a request span and carrying the active distributed trace context on it.

This allows downstream worker dispatch to inject the correct `traceparent`.

Closes #13345

## Validation

- Verified in an internal deployment that LiteLLM, Dynamo, and SGLang spans can be connected into one OTel trace.
- `cargo fmt --all -- --check` could not run locally because the Rust toolchain manifest is missing for `1.96.1-aarch64-apple-darwin`.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved distributed tracing for KV route requests.
  * Request traces now include available trace identifiers and related metadata, making request flows easier to follow across services.
  * Existing cancellation and result handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->