### PR TITLE
fix(sglang): update resolved ServerArgs before engine initialization

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -18,6 +18,7 @@ from sglang.srt.managers.io_struct import ProfileReq
 
 import dynamo.sglang._compat as sglang_compat
 import dynamo.sglang.args as sglang_args
+import dynamo.sglang.snapshot as sglang_snapshot
 from dynamo.common.constants import DisaggregationMode, EmbeddingTransferMode
 from dynamo.common.snapshot.constants import SNAPSHOT_CONTROL_DIR_ENV
 from dynamo.sglang._compat import (
@@ -437,6 +438,37 @@ def test_compat_filters_async_generate_kwargs_for_older_engines():
     assert filter_supported_async_generate_kwargs(OldEngine(), kwargs) == {
         "input_ids": [1, 2, 3]
     }
+
+
+@pytest.mark.asyncio
+async def test_snapshot_disables_forward_pass_metrics_before_engine_init(monkeypatch):
+    class EngineCreated(Exception):
+        pass
+
+    server_args = SimpleNamespace(enable_forward_pass_metrics=True)
+    events = []
+
+    def update_server_args(args, source, **fields):
+        events.append(("update", source, fields))
+        for name, value in fields.items():
+            setattr(args, name, value)
+
+    def create_engine(*, server_args):
+        events.append(("engine", server_args.enable_forward_pass_metrics))
+        raise EngineCreated
+
+    monkeypatch.setattr(sglang_snapshot.SnapshotConfig, "from_env", lambda: object())
+    monkeypatch.setattr(sglang_snapshot, "configure_snapshot_capture_env", lambda: None)
+    monkeypatch.setattr(sglang_snapshot, "override_server_args", update_server_args)
+    monkeypatch.setattr(sglang_snapshot.sgl, "Engine", create_engine)
+
+    with pytest.raises(EngineCreated):
+        await sglang_snapshot.prepare_snapshot_engine(server_args)
+
+    assert events[0][0] == "update"
+    assert events[0][1] == "dynamo.snapshot"
+    assert events[0][2]["enable_forward_pass_metrics"] is False
+    assert events[1] == ("engine", False)
 
 
 def test_compat_keeps_async_generate_kwargs_for_newer_engines():


### PR DESCRIPTION
## Overview:

Fix SGLang worker startup failures caused by directly assigning to resolved
`ServerArgs` before engine initialization.

This PR:

- Adds a compatibility helper for updating resolved but unpublished `ServerArgs`
- Uses it when configuring forward-pass metrics worker identity and IPC
- Uses it when enabling snapshot memory-management options
- Preserves compatibility with older SGLang versions and diffusion stubs

## Details:

Newer SGLang versions make `ServerArgs` read-only after configuration
resolution. Dynamo currently updates forward-pass metrics fields using direct
assignment:

```python
server_args.forward_pass_metrics_worker_id = ...
server_args.forward_pass_metrics_ipc_name = ...
```

This causes worker startup to fail with:
```
AttributeError: server_args.forward_pass_metrics_worker_id assigned after resolution; server_args is read-only -- use get_context().override(source, ...) to change resolved config; a value one runner owns travels as a constructor argument.
```


## Where should the reviewer start?
Start with `components/src/dynamo/sglang/_compat.py`, which introduces the
version-compatible pre-publication update helper.

Then review its two call sites:

- `components/src/dynamo/sglang/publisher.py` for forward-pass metrics identity
- `components/src/dynamo/sglang/snapshot.py` for snapshot memory settings

The compatibility behavior is covered in
`components/src/dynamo/sglang/tests/test_sglang_unit.py`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when configuring SGLang server settings before publication.
  * Ensured worker metrics and snapshot-related settings are applied across supported configuration interfaces.
  * Preserved memory-saving behavior while conditionally enabling CPU weight backup.

* **Tests**
  * Added coverage for modern, legacy, and fallback server-configuration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->