### PR TITLE
perf(snapshot): increase rootfs extraction tar blocking factor

### DIFF
--- a/deploy/snapshot/internal/runtime/overlay.go
+++ b/deploy/snapshot/internal/runtime/overlay.go
@@ -169,7 +169,7 @@ func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
 	// The rootfs diff only contains overlay upperdir changes (runtime-generated files
 	// like triton caches, tmp files) — base image files should not be overwritten.
 	log.Info("Applying rootfs diff", "target", targetRoot)
-	cmd := exec.Command("tar", "--skip-old-files", "-C", targetRoot, "-xf", rootfsDiffPath)
+	cmd := exec.Command("tar", "--skip-old-files", "--blocking-factor=2048", "-C", targetRoot, "-xf", rootfsDiffPath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Summary

- use 1 MiB GNU tar records instead of the 10 KiB default during rootfs extraction
- match the measured 1 MiB-rsize VAST NFS restore path

## Validation

- `git diff --check`
- `cd deploy/snapshot && go test ./internal/runtime -run 'Test(Capture|Apply)RootfsDiff$' -count=1`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved root filesystem archive extraction reliability during deployment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->