### PR TITLE
fix(mocker): pin startup to Dynamo runtime

### DIFF
--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -1285,7 +1285,7 @@ pub async fn make_mocker_engine(
     let engine = Arc::new(MockerExecutionContext::new(args));
     let startup_engine = Arc::clone(&engine);
     let cancel_token = distributed_runtime.primary_token();
-    tokio::spawn(async move {
+    distributed_runtime.runtime().primary().spawn(async move {
         let component = loop {
             if cancel_token.is_cancelled() {
                 tracing::debug!("Mocker engine startup cancelled");


### PR DESCRIPTION
## Summary

- Spawn mocker startup on the owning `DistributedRuntime` primary executor instead of the ambient PyO3 Tokio runtime.
- Keep `LiveEngine` scheduler tasks, KV event publishing, and forward-pass metrics on the configured Dynamo runtime.
- Leave the broader PyO3 runtime-initialization path unchanged; this is intentionally a one-line mocker fix.

## Validation

- Built and installed the Rust Python bindings with `maturin develop --uv`, then installed the editable Python package.
- Ran a live eight-worker mocker with in-memory discovery, TCP requests, and ZMQ events. A temporary diagnostic probe reported matching DRT and current Tokio runtime IDs (`expected=1`, `actual=1`); the probe was removed before commit.
- Sampled one-worker and eight-worker processes on a 10-core macOS host: both had 12 Tokio worker threads, confirming executor pools do not multiply per mocker. Total process threads increased only from 26 to 33 for the additional worker-owned transport/service threads.
- `cargo test -p dynamo-mocker live --lib` — 51 passed.
- `cargo fmt --all -- --check` and commit hooks passed.
- `cargo test -p dynamo-llm mocker --lib` is not runnable on macOS because existing Linux-only NUMA/direct-I/O code references `dynamo_memory::numa`, `fallocate`, and `O_DIRECT`; the cross-language build and live launch both completed successfully.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous mocker startup by using the runtime’s primary execution system, providing more consistent behavior during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->