### PR TITLE
fix(docs): broken links that caused docs link check / lychee failed

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -55,3 +55,17 @@
 # The v1.4.0 release entry lands with the current-release promotion; the tag
 # URL 404s from CI until v1.4.0 is cut. Remove after the tag exists.
 ^https://github\.com/ai-dynamo/dynamo/releases/tag/v1\.4\.0$
+
+# Discord invite link; connection refused from GitHub runners.
+^https://discord\.gg/
+
+# Google Docs and YouTube are rate-limited / time out from GitHub runners.
+^https://docs\.google\.com/document/
+^https://www\.youtube\.com/
+
+# Dell newsroom pages are slow and time out from GitHub runners.
+^https://www\.dell\.com/en-us/dt/corporate/newsroom/
+
+# xgrammar docs site intermittently times out from GitHub runners.
+^https://xgrammar\.mlc\.ai/
+


### PR DESCRIPTION
The  [lychee link checker](https://github.com/ai-dynamo/dynamo/blob/main/.github/workflows/docs-link-check.yml)  has been failing on `main` since August 16, 2026 because some external URLs time out, refuse connections, or return 404 errors when accessed from GitHub Actions runners. For example, see [this failed workflow run](https://github.com/ai-dynamo/dynamo/actions/runs/32002502121/job/95305414453?pr=11700).

This PR adds the affected URL patterns to [.lycheeignore](https://github.com/ai-dynamo/dynamo/blob/main/.lycheeignore), following the existing conventions in the file.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added link-check exclusions for Discord invites, Google Docs, YouTube, Dell newsroom pages, xgrammar documentation, and a removed VS Code Marketplace extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->