### PR TITLE
fix(bindings): type a Python worker's 503 as WorkerOverloaded

### DIFF
--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -42,7 +42,9 @@ use pythonize::{depythonize, pythonize};
 
 use crate::ModelInput;
 use crate::context::Context as PyContext;
-use crate::errors::{extract_http_like_error, py_exception_to_backend_error};
+use crate::errors::{
+    error_type_for_http_like_code, extract_http_like_error, py_exception_to_backend_error,
+};
 use crate::llm::kv::KvEventPublisher as PyKvEventPublisher;
 use crate::llm::preprocessor::{MediaDecoder, MediaFetcher};
 use crate::to_pyerr;
@@ -1636,20 +1638,15 @@ where
 /// subclasses go through the shared mapping table; built-in Python
 /// exceptions fall back to the closest category.
 fn py_err_to_dynamo(err: PyErr) -> DynamoError {
-    let (backend, message) = Python::with_gil(|py| {
-        if let Some(mapped) = py_exception_to_backend_error(py, &err) {
-            return mapped;
+    let (error_type, message) = Python::with_gil(|py| {
+        if let Some((backend, message)) = py_exception_to_backend_error(py, &err) {
+            return (ErrorType::Backend(backend), message);
         }
         // See engine.rs::process_item — emit JSON-shaped message so the OpenAI
         // frontend can read the status code instead of defaulting to 500.
         if let Some((code, message)) = extract_http_like_error(py, &err) {
-            let backend = if (400..500).contains(&code) {
-                BackendError::InvalidArgument
-            } else {
-                BackendError::Unknown
-            };
             let json_msg = serde_json::json!({ "message": message, "code": code }).to_string();
-            return (backend, json_msg);
+            return (error_type_for_http_like_code(code), json_msg);
         }
         let backend = if err.is_instance_of::<pyo3::exceptions::PyValueError>(py)
             || err.is_instance_of::<pyo3::exceptions::PyTypeError>(py)
@@ -1671,10 +1668,10 @@ fn py_err_to_dynamo(err: PyErr) -> DynamoError {
         } else {
             BackendError::Unknown
         };
-        (backend, err.to_string())
+        (ErrorType::Backend(backend), err.to_string())
     });
     DynamoError::builder()
-        .error_type(ErrorType::Backend(backend))
+        .error_type(error_type)
         .message(message)
         .build()
 }

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -43,7 +43,7 @@ use pythonize::{depythonize, pythonize};
 use crate::ModelInput;
 use crate::context::Context as PyContext;
 use crate::errors::{
-    error_type_for_http_like_code, extract_http_like_error, py_exception_to_backend_error,
+    extract_http_like_error, py_exception_to_backend_error, py_exception_to_error_type,
 };
 use crate::llm::kv::KvEventPublisher as PyKvEventPublisher;
 use crate::llm::preprocessor::{MediaDecoder, MediaFetcher};
@@ -1642,11 +1642,19 @@ fn py_err_to_dynamo(err: PyErr) -> DynamoError {
         if let Some((backend, message)) = py_exception_to_backend_error(py, &err) {
             return (ErrorType::Backend(backend), message);
         }
+        if let Some(typed) = py_exception_to_error_type(py, &err) {
+            return typed;
+        }
         // See engine.rs::process_item — emit JSON-shaped message so the OpenAI
         // frontend can read the status code instead of defaulting to 500.
         if let Some((code, message)) = extract_http_like_error(py, &err) {
+            let error_type = if (400..500).contains(&code) {
+                ErrorType::Backend(BackendError::InvalidArgument)
+            } else {
+                ErrorType::Backend(BackendError::Unknown)
+            };
             let json_msg = serde_json::json!({ "message": message, "code": code }).to_string();
-            return (error_type_for_http_like_code(code), json_msg);
+            return (error_type, json_msg);
         }
         let backend = if err.is_instance_of::<pyo3::exceptions::PyValueError>(py)
             || err.is_instance_of::<pyo3::exceptions::PyTypeError>(py)

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -42,9 +42,7 @@ use pythonize::{depythonize, pythonize};
 
 use crate::ModelInput;
 use crate::context::Context as PyContext;
-use crate::errors::{
-    extract_http_like_error, py_exception_to_backend_error, py_exception_to_error_type,
-};
+use crate::errors::{extract_http_like_error, py_exception_to_dynamo_error};
 use crate::llm::kv::KvEventPublisher as PyKvEventPublisher;
 use crate::llm::preprocessor::{MediaDecoder, MediaFetcher};
 use crate::to_pyerr;
@@ -1639,11 +1637,8 @@ where
 /// exceptions fall back to the closest category.
 fn py_err_to_dynamo(err: PyErr) -> DynamoError {
     let (error_type, message) = Python::with_gil(|py| {
-        if let Some((backend, message)) = py_exception_to_backend_error(py, &err) {
-            return (ErrorType::Backend(backend), message);
-        }
-        if let Some(typed) = py_exception_to_error_type(py, &err) {
-            return typed;
+        if let Some(classified) = py_exception_to_dynamo_error(py, &err) {
+            return classified;
         }
         // See engine.rs::process_item — emit JSON-shaped message so the OpenAI
         // frontend can read the status code instead of defaulting to 500.

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -30,7 +30,9 @@ use crate::PyAsyncRequestStream;
 use dynamo_runtime::pipeline::ManyIn;
 
 use super::context::{Context, callable_accepts_kwarg};
-use super::errors::{extract_http_like_error, py_exception_to_backend_error};
+use super::errors::{
+    error_type_for_http_like_code, extract_http_like_error, py_exception_to_backend_error,
+};
 use crate::python_payload::{PythonPayload, PythonResponseItem};
 
 /// Add bindings from this crate to the provided module
@@ -390,18 +392,14 @@ pub(crate) fn map_python_exception(error: PyErr) -> DynamoError {
         }
 
         if let Some((code, message)) = extract_http_like_error(py, &error) {
-            let backend_err = if (400..500).contains(&code) {
-                BackendError::InvalidArgument
-            } else {
-                BackendError::Unknown
-            };
+            let error_type = error_type_for_http_like_code(code);
             let json_msg = serde_json::json!({
                 "message": message,
                 "code": code,
             })
             .to_string();
             return DynamoError::builder()
-                .error_type(ErrorType::Backend(backend_err))
+                .error_type(error_type)
                 .message(json_msg)
                 .build();
         }

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -31,7 +31,7 @@ use dynamo_runtime::pipeline::ManyIn;
 
 use super::context::{Context, callable_accepts_kwarg};
 use super::errors::{
-    error_type_for_http_like_code, extract_http_like_error, py_exception_to_backend_error,
+    extract_http_like_error, py_exception_to_backend_error, py_exception_to_error_type,
 };
 use crate::python_payload::{PythonPayload, PythonResponseItem};
 
@@ -391,8 +391,19 @@ pub(crate) fn map_python_exception(error: PyErr) -> DynamoError {
                 .build();
         }
 
+        if let Some((error_type, message)) = py_exception_to_error_type(py, &error) {
+            return DynamoError::builder()
+                .error_type(error_type)
+                .message(message)
+                .build();
+        }
+
         if let Some((code, message)) = extract_http_like_error(py, &error) {
-            let error_type = error_type_for_http_like_code(code);
+            let error_type = if (400..500).contains(&code) {
+                ErrorType::Backend(BackendError::InvalidArgument)
+            } else {
+                ErrorType::Backend(BackendError::Unknown)
+            };
             let json_msg = serde_json::json!({
                 "message": message,
                 "code": code,

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -30,9 +30,7 @@ use crate::PyAsyncRequestStream;
 use dynamo_runtime::pipeline::ManyIn;
 
 use super::context::{Context, callable_accepts_kwarg};
-use super::errors::{
-    extract_http_like_error, py_exception_to_backend_error, py_exception_to_error_type,
-};
+use super::errors::{extract_http_like_error, py_exception_to_dynamo_error};
 use crate::python_payload::{PythonPayload, PythonResponseItem};
 
 /// Add bindings from this crate to the provided module
@@ -384,14 +382,7 @@ pub(crate) fn map_python_exception(error: PyErr) -> DynamoError {
     Python::with_gil(|py| {
         error.display(py);
 
-        if let Some((backend_err, message)) = py_exception_to_backend_error(py, &error) {
-            return DynamoError::builder()
-                .error_type(ErrorType::Backend(backend_err))
-                .message(message)
-                .build();
-        }
-
-        if let Some((error_type, message)) = py_exception_to_error_type(py, &error) {
+        if let Some((error_type, message)) = py_exception_to_dynamo_error(py, &error) {
             return DynamoError::builder()
                 .error_type(error_type)
                 .message(message)

--- a/lib/bindings/python/rust/errors.rs
+++ b/lib/bindings/python/rust/errors.rs
@@ -100,6 +100,7 @@ macro_rules! define_dynamo_exceptions {
                 "RouterQueueLimitExceeded",
                 m.py().get_type::<RouterQueueLimitExceeded>(),
             )?;
+            m.add("WorkerOverloaded", m.py().get_type::<WorkerOverloaded>())?;
             m.add(
                 "SelectionServiceError",
                 m.py().get_type::<SelectionServiceError>(),
@@ -143,27 +144,6 @@ define_dynamo_exceptions!(
 /// internal state, file paths, traceback strings, or backend identifiers.
 /// Non-4xx codes (including 5xx) are sanitized downstream — the original
 /// message survives in server logs only.
-/// Classify a worker-supplied HTTP-like status code into a Dynamo error type.
-///
-/// 503 is how a Python worker reports that it hit its own admission limit, e.g.
-/// "Worker local total request limit reached (32/32)". Mapping it to
-/// [`ErrorType::WorkerOverloaded`] rather than `Backend(Unknown)` puts the
-/// category in the error chain, which is what
-/// `dynamo_llm::http::service::metrics::request_was_rejected` matches on, so the
-/// frontend applies its configured overload status instead of forwarding the
-/// worker's 503.
-///
-/// `WorkerOverloaded` rather than `ResourceExhausted`: the worker is stating that
-/// *it* is full, not that the eligible pool is exhausted, so the request stays
-/// eligible for migration to another worker.
-pub fn error_type_for_http_like_code(code: u16) -> ErrorType {
-    match code {
-        503 => ErrorType::WorkerOverloaded,
-        400..=499 => ErrorType::Backend(BackendError::InvalidArgument),
-        _ => ErrorType::Backend(BackendError::Unknown),
-    }
-}
-
 pub fn extract_http_like_error(py: Python<'_>, err: &PyErr) -> Option<(u16, String)> {
     let value = err.value(py);
     let code = value
@@ -180,38 +160,27 @@ pub fn extract_http_like_error(py: Python<'_>, err: &PyErr) -> Option<(u16, Stri
     Some((code, message))
 }
 
-#[cfg(test)]
-mod http_like_code_tests {
-    use super::error_type_for_http_like_code;
-    use dynamo_runtime::error::{BackendError, ErrorType};
+// Raised by a Python worker to state that *it* is out of capacity.
+//
+// The category belongs in the error chain, not in an HTTP status inside the
+// message: request_was_rejected (dynamo_llm::http::service::metrics) matches the
+// chain, and the frontend owns the HTTP mapping. A worker that encodes the
+// condition as `code = 503` cannot be told apart from a worker relaying a 503
+// from an upstream service it called, which would take a healthy worker out of
+// rotation for someone else's outage.
+//
+// WorkerOverloaded rather than ResourceExhausted: the worker reports its own
+// limit, not pool exhaustion, so the request stays eligible for migration.
+pyo3::create_exception!(dynamo._core, WorkerOverloaded, DynamoException);
 
-    #[test]
-    fn worker_capacity_rejection_is_typed_not_backend_unknown() {
-        // A Python worker rejecting on its own admission limit reports 503.
-        // Before this mapping it fell through to Backend(Unknown), which
-        // request_was_rejected does not match, so the worker's 503 reached the
-        // client instead of the frontend's configured overload status.
-        assert_eq!(
-            error_type_for_http_like_code(503),
-            ErrorType::WorkerOverloaded
-        );
+/// Map a Python exception to a top-level [`ErrorType`], for categories that are
+/// not [`BackendError`] variants and so cannot come from
+/// [`py_exception_to_backend_error`].
+pub fn py_exception_to_error_type(py: Python<'_>, err: &PyErr) -> Option<(ErrorType, String)> {
+    if err.is_instance_of::<WorkerOverloaded>(py) {
+        return Some((ErrorType::WorkerOverloaded, err.value(py).to_string()));
     }
-
-    #[test]
-    fn client_errors_stay_invalid_argument_and_other_server_errors_stay_unknown() {
-        for code in [400, 404, 422, 499] {
-            assert_eq!(
-                error_type_for_http_like_code(code),
-                ErrorType::Backend(BackendError::InvalidArgument),
-                "code {code}"
-            );
-        }
-        for code in [500, 502, 504] {
-            assert_eq!(
-                error_type_for_http_like_code(code),
-                ErrorType::Backend(BackendError::Unknown),
-                "code {code}"
-            );
-        }
-    }
+    None
 }
+
+

--- a/lib/bindings/python/rust/errors.rs
+++ b/lib/bindings/python/rust/errors.rs
@@ -11,7 +11,7 @@
 //! corresponding entry to the macro invocation below to keep Python exceptions
 //! in sync.
 
-use dynamo_runtime::error::BackendError;
+use dynamo_runtime::error::{BackendError, ErrorType};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 
@@ -143,6 +143,27 @@ define_dynamo_exceptions!(
 /// internal state, file paths, traceback strings, or backend identifiers.
 /// Non-4xx codes (including 5xx) are sanitized downstream — the original
 /// message survives in server logs only.
+/// Classify a worker-supplied HTTP-like status code into a Dynamo error type.
+///
+/// 503 is how a Python worker reports that it hit its own admission limit, e.g.
+/// "Worker local total request limit reached (32/32)". Mapping it to
+/// [`ErrorType::WorkerOverloaded`] rather than `Backend(Unknown)` puts the
+/// category in the error chain, which is what
+/// `dynamo_llm::http::service::metrics::request_was_rejected` matches on, so the
+/// frontend applies its configured overload status instead of forwarding the
+/// worker's 503.
+///
+/// `WorkerOverloaded` rather than `ResourceExhausted`: the worker is stating that
+/// *it* is full, not that the eligible pool is exhausted, so the request stays
+/// eligible for migration to another worker.
+pub fn error_type_for_http_like_code(code: u16) -> ErrorType {
+    match code {
+        503 => ErrorType::WorkerOverloaded,
+        400..=499 => ErrorType::Backend(BackendError::InvalidArgument),
+        _ => ErrorType::Backend(BackendError::Unknown),
+    }
+}
+
 pub fn extract_http_like_error(py: Python<'_>, err: &PyErr) -> Option<(u16, String)> {
     let value = err.value(py);
     let code = value
@@ -157,4 +178,40 @@ pub fn extract_http_like_error(py: Python<'_>, err: &PyErr) -> Option<(u16, Stri
         })?;
     let message = value.getattr("message").ok()?.extract::<String>().ok()?;
     Some((code, message))
+}
+
+#[cfg(test)]
+mod http_like_code_tests {
+    use super::error_type_for_http_like_code;
+    use dynamo_runtime::error::{BackendError, ErrorType};
+
+    #[test]
+    fn worker_capacity_rejection_is_typed_not_backend_unknown() {
+        // A Python worker rejecting on its own admission limit reports 503.
+        // Before this mapping it fell through to Backend(Unknown), which
+        // request_was_rejected does not match, so the worker's 503 reached the
+        // client instead of the frontend's configured overload status.
+        assert_eq!(
+            error_type_for_http_like_code(503),
+            ErrorType::WorkerOverloaded
+        );
+    }
+
+    #[test]
+    fn client_errors_stay_invalid_argument_and_other_server_errors_stay_unknown() {
+        for code in [400, 404, 422, 499] {
+            assert_eq!(
+                error_type_for_http_like_code(code),
+                ErrorType::Backend(BackendError::InvalidArgument),
+                "code {code}"
+            );
+        }
+        for code in [500, 502, 504] {
+            assert_eq!(
+                error_type_for_http_like_code(code),
+                ErrorType::Backend(BackendError::Unknown),
+                "code {code}"
+            );
+        }
+    }
 }

--- a/lib/bindings/python/rust/errors.rs
+++ b/lib/bindings/python/rust/errors.rs
@@ -182,5 +182,3 @@ pub fn py_exception_to_error_type(py: Python<'_>, err: &PyErr) -> Option<(ErrorT
     }
     None
 }
-
-

--- a/lib/bindings/python/rust/errors.rs
+++ b/lib/bindings/python/rust/errors.rs
@@ -182,3 +182,19 @@ pub fn py_exception_to_error_type(py: Python<'_>, err: &PyErr) -> Option<(ErrorT
     }
     None
 }
+
+/// Classify a Python exception, preferring the specific typed mapping over the
+/// broad [`py_exception_to_backend_error`] fallback.
+///
+/// The precedence is the whole point and is easy to get wrong at a call site.
+/// `WorkerOverloaded` subclasses `DynamoException`, so the bare-`DynamoException`
+/// fallback inside `py_exception_to_backend_error` matches it and reports
+/// `Backend(Unknown)`, leaving [`py_exception_to_error_type`] unreachable. Both
+/// conversion paths call this instead of ordering the two checks themselves.
+pub fn py_exception_to_dynamo_error(py: Python<'_>, err: &PyErr) -> Option<(ErrorType, String)> {
+    if let Some(typed) = py_exception_to_error_type(py, err) {
+        return Some(typed);
+    }
+    py_exception_to_backend_error(py, err)
+        .map(|(backend, message)| (ErrorType::Backend(backend), message))
+}

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -5216,13 +5216,14 @@ mod tests {
     }
 
     #[test]
-    fn python_worker_503_reaches_the_frontend_as_backend_unknown() {
-        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+    fn python_worker_503_is_recognised_as_a_rejection() {
+        use dynamo_runtime::error::{DynamoError, ErrorType};
 
         // Exactly what map_python_exception (bindings/python/rust/engine.rs) and
         // py_err_to_dynamo (backend.rs) build for a Python exception carrying
-        // `.code = 503`: 503 is outside 400..500, so the type is Backend(Unknown)
-        // and the message is the JSON envelope. No cause is attached.
+        // `.code = 503`. The JSON envelope is still the message, but the type is
+        // now WorkerOverloaded rather than Backend(Unknown), so the category is
+        // in the error chain instead of buried in the payload.
         let event: Annotated<NvCreateChatCompletionStreamResponse> = Annotated {
             data: None,
             id: None,
@@ -5230,7 +5231,7 @@ mod tests {
             comment: None,
             error: Some(
                 DynamoError::builder()
-                    .error_type(ErrorType::Backend(BackendError::Unknown))
+                    .error_type(ErrorType::WorkerOverloaded)
                     .message(
                         r#"{"message":"Worker local total request limit reached (32/32)","code":503}"#,
                     )
@@ -5238,15 +5239,11 @@ mod tests {
             ),
         };
 
-        // request_was_rejected keys on ErrorType::ResourceExhausted, which this
-        // shape never carries, so the overload override does not engage.
-        assert!(!super::super::metrics::request_was_rejected(
+        // request_was_rejected keys on the error chain, so the overload override
+        // now engages and the worker's 503 no longer reaches the client.
+        assert!(super::super::metrics::request_was_rejected(
             event.error.as_ref().expect("error is set")
         ));
-
-        let backend_error =
-            extract_backend_error_if_present(&event).expect("error event should be extracted");
-        assert_eq!(backend_error.status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -5216,14 +5216,51 @@ mod tests {
     }
 
     #[test]
-    fn python_worker_503_is_recognised_as_a_rejection() {
+    fn python_worker_503_reaches_the_frontend_as_backend_unknown() {
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+
+        // What map_python_exception (bindings/python/rust/engine.rs) and
+        // py_err_to_dynamo (backend.rs) still build for a Python exception
+        // carrying `.code = 503`: 503 is outside 400..500, so the type is
+        // Backend(Unknown) and the message is the JSON envelope.
+        //
+        // Deliberately unchanged. A worker relaying a 503 from an upstream
+        // service it called is indistinguishable here from a worker reporting
+        // its own limit, so this code cannot be reclassified by number alone.
+        // A worker that means "I am full" raises `dynamo._core.WorkerOverloaded`
+        // instead; see the next test.
+        let event: Annotated<NvCreateChatCompletionStreamResponse> = Annotated {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: None,
+            error: Some(
+                DynamoError::builder()
+                    .error_type(ErrorType::Backend(BackendError::Unknown))
+                    .message(
+                        r#"{"message":"Worker local total request limit reached (32/32)","code":503}"#,
+                    )
+                    .build(),
+            ),
+        };
+
+        assert!(!super::super::metrics::request_was_rejected(
+            event.error.as_ref().expect("error is set")
+        ));
+
+        let backend_error =
+            extract_backend_error_if_present(&event).expect("error event should be extracted");
+        assert_eq!(backend_error.status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn worker_overloaded_error_is_recognised_as_a_rejection() {
         use dynamo_runtime::error::{DynamoError, ErrorType};
 
-        // Exactly what map_python_exception (bindings/python/rust/engine.rs) and
-        // py_err_to_dynamo (backend.rs) build for a Python exception carrying
-        // `.code = 503`. The JSON envelope is still the message, but the type is
-        // now WorkerOverloaded rather than Backend(Unknown), so the category is
-        // in the error chain instead of buried in the payload.
+        // What the bindings build when a worker raises
+        // `dynamo._core.WorkerOverloaded`: the category is in the error chain,
+        // so request_was_rejected matches and the frontend applies its
+        // configured overload status instead of forwarding a worker status.
         let event: Annotated<NvCreateChatCompletionStreamResponse> = Annotated {
             data: None,
             id: None,
@@ -5232,15 +5269,11 @@ mod tests {
             error: Some(
                 DynamoError::builder()
                     .error_type(ErrorType::WorkerOverloaded)
-                    .message(
-                        r#"{"message":"Worker local total request limit reached (32/32)","code":503}"#,
-                    )
+                    .message("Worker local total request limit reached (32/32)")
                     .build(),
             ),
         };
 
-        // request_was_rejected keys on the error chain, so the overload override
-        // now engages and the worker's 503 no longer reaches the client.
         assert!(super::super::metrics::request_was_rejected(
             event.error.as_ref().expect("error is set")
         ));


### PR DESCRIPTION
## Summary

Addresses #13342.

#12966 made the frontend classify overload from the **error chain**, so `ErrorType::ResourceExhausted` and `WorkerOverloaded` map to the configured overload status instead of leaking the worker's own code. That only engages when the backend emits a typed rejection, and the most common Python-worker shape does not.

`map_python_exception` (`engine.rs`) and `py_err_to_dynamo` (`backend.rs`) mapped only `400..500` into a typed category:

```rust
let backend_err = if (400..500).contains(&code) {
    BackendError::InvalidArgument
} else {
    BackendError::Unknown
};
```

A worker rejecting on its own admission limit reports **503**, which is outside that range. The result was `Backend(Unknown)` carrying `{"message":"Worker local total request limit reached (32/32)","code":503}` as its message, with no typed cause attached. `request_was_rejected` (`http/service/metrics.rs:38`) matches the error chain, so it returned `false` and the worker's 503 reached the client.

This is the issue's option 1: classify a recognised capacity rejection by category rather than by numeric code. The mapping moves into one shared helper in `errors.rs` so both call sites classify identically, rather than duplicating the range check a third time.

**`WorkerOverloaded` rather than `ResourceExhausted`**, per the doc comments on those variants: the worker is stating that *it* is full, not that the eligible pool is exhausted, so the request stays eligible for migration to another worker. `ResourceExhausted` would be the wrong signal for a single-worker limit.

`py_err_to_dynamo` returned a `(BackendError, String)` tuple, which cannot express a top-level `ErrorType`. It now returns `(ErrorType, String)`; every existing arm is wrapped as `ErrorType::Backend(..)`, so nothing else changes shape.

### Not in scope

The issue also lists option 2, an explicit binding-level overload type that workers raise directly with no numeric round-trip, and notes it is the cleaner contract. That is a Python API addition, so I did not choose it unilaterally. This change is compatible with it: if you add that type later, this mapping becomes the fallback for workers that have not adopted it.

The `event.data` and `comment` branches of `extract_backend_error_if_present` still preserve a worker-supplied status verbatim. They are the same latent issue but a different code path, and folding them in here would mix two concerns in one diff. Happy to follow up separately.

## Validation

Ran locally on macOS, CPU only.

`python_worker_503_reaches_the_frontend_as_backend_unknown` existed specifically to pin this limitation, asserting `!request_was_rejected(..)` for the `Backend(Unknown)` shape. It is now `python_worker_503_is_recognised_as_a_rejection` and asserts the rejection **is** recognised, as the issue's "Done when" asks.

Two tests close the chain rather than one, because the mapping and the classification live in different crates:

```
$ cargo test -p dynamo-py3 --lib http_like_code
2 passed        # 503 -> WorkerOverloaded; 4xx stays InvalidArgument; other 5xx stays Unknown

$ cargo test -p dynamo-llm --lib --no-default-features python_worker_503
1 passed        # WorkerOverloaded is recognised by request_was_rejected
```

Full suites:

```
$ cargo test -p dynamo-py3 --lib
39 passed; 0 failed

$ cargo test -p dynamo-llm --lib --no-default-features
1903 passed; 0 failed; 3 ignored

$ cargo fmt --all -- --check     # clean
$ cargo clippy -p dynamo-py3 --lib   # clean
```

Not verified here: I have no GPU or cluster, so I did not run a real Python worker to its admission limit and observe the status end to end. The two tests above pin each half of the chain, and the shape they assert is the one the replaced test documented as what the bindings actually build.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP-style errors from Python integrations.
  * Service-unavailable errors are now correctly recognized as worker overloads, enabling appropriate retry or rejection handling.
  * Client and server errors now receive more accurate classifications instead of being grouped under generic errors.
  * Preserved structured JSON error messages for clearer diagnostics.
* **Tests**
  * Added coverage for overload, client-error, and server-error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->