### PR TITLE
fix(kv-router): component-scope RouterRequestMetrics for disaggregated routers

### DIFF
--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -307,7 +307,7 @@ where
     // Eagerly register router request metrics so they appear as zeros even in
     // non-KV modes (Direct, Random, RoundRobin) where KvPushRouter is never created.
     // In KV mode, KvPushRouter::new() also calls from_component() (idempotent via
-    // OnceLock), which covers the standalone router path as well.
+    // the component-keyed cache), which covers the standalone router path as well.
     RouterRequestMetrics::from_component(client.endpoint.component());
 
     let prefill_router = prefill_chooser.unwrap_or_else(|| {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -366,6 +366,7 @@ where
     lora_filter: Option<Arc<crate::lora::LoraFilter>>,
     endpoint_registration: Option<dynamo_runtime::discovery::EndpointRegistrationLease>,
     teardown_task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
+    request_metrics: Arc<metrics::RouterRequestMetrics>,
 }
 
 fn resolve_tracking_model_name(
@@ -556,6 +557,8 @@ where
             None
         };
 
+        let request_metrics = metrics::RouterRequestMetrics::from_component(component);
+
         tracing::info!("KV Routing initialized");
         let cancellation_token = cancellation_guard.disarm();
         Ok(Self {
@@ -576,6 +579,7 @@ where
             lora_filter,
             endpoint_registration: None,
             teardown_task_guard: None,
+            request_metrics,
         })
     }
 
@@ -1133,16 +1137,16 @@ where
         }
 
         // Observe per-request shared cache metrics.
-        if is_admitted_routing
-            && let Some(hits) = sc_hits_for_metrics
-            && let Some(m) = metrics::RouterRequestMetrics::get()
-        {
+        if is_admitted_routing && let Some(hits) = sc_hits_for_metrics {
             if num_blocks > 0 {
-                m.shared_cache_hit_rate
+                self.request_metrics
+                    .shared_cache_hit_rate
                     .observe(hits.total_hits as f64 / num_blocks as f64);
             }
             let beyond = hits.hits_beyond(response.effective_overlap_blocks.round() as u32);
-            m.shared_cache_beyond_blocks.observe(beyond as f64);
+            self.request_metrics
+                .shared_cache_beyond_blocks
+                .observe(beyond as f64);
         }
 
         #[cfg(feature = "bench")]

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -47,6 +47,8 @@
 use std::sync::{Arc, LazyLock, OnceLock};
 use std::time::Duration;
 
+use dashmap::DashMap;
+
 use dynamo_runtime::component::Component;
 use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::metrics::prometheus_names::{
@@ -831,6 +833,7 @@ impl RoutingOverheadMetrics {
 /// distinct `dynamo_component` labels, so pools can be monitored and scaled
 /// independently.
 pub struct RouterRequestMetrics {
+    pub requests_started_total: prometheus::IntCounter,
     pub requests_total: prometheus::IntCounter,
     pub time_to_first_token_seconds: prometheus::Histogram,
     pub inter_token_latency_seconds: prometheus::Histogram,
@@ -844,153 +847,158 @@ pub struct RouterRequestMetrics {
     pub overlap_blocks_lost: HistogramVec,
 }
 
-static ROUTER_REQUEST_METRICS: OnceLock<Arc<RouterRequestMetrics>> = OnceLock::new();
-static ROUTER_REQUESTS_STARTED_TOTAL: OnceLock<prometheus::IntCounter> = OnceLock::new();
+static ROUTER_REQUEST_METRICS: LazyLock<DashMap<(Component, u64), Arc<RouterRequestMetrics>>> =
+    LazyLock::new(DashMap::new);
 
 impl RouterRequestMetrics {
-    /// Returns the registered metrics if `from_component()` was called earlier.
-    pub fn get() -> Option<Arc<Self>> {
-        ROUTER_REQUEST_METRICS.get().cloned()
-    }
-
     /// Total requests admitted by the router scheduler.
     pub fn requests_started_total(&self) -> &prometheus::IntCounter {
-        ROUTER_REQUESTS_STARTED_TOTAL
-            .get()
-            .expect("router request metrics must be initialized")
+        &self.requests_started_total
     }
 
-    /// Create from a Component, memoized in a static OnceLock.
+    /// Create from a Component, memoized in a runtime-scoped cache.
     /// Uses the MetricsHierarchy API which auto-prepends `dynamo_component_`,
     /// injects hierarchy labels, and registers with the DRT `MetricsRegistry`.
     /// Also adds `router_id` (discovery instance_id) to distinguish router instances.
     ///
-    /// Called eagerly by `KvPushRouter::new()` so metrics appear as zeros at startup.
+    /// Called eagerly when a KV router or scheduler is created so metrics appear as zeros at startup.
     pub fn from_component(component: &Component) -> Arc<Self> {
-        ROUTER_REQUEST_METRICS
-            .get_or_init(|| {
-                let instance_id = component.drt().discovery().instance_id();
-                let router_id = instance_id.to_string();
-                let extra_labels: &[(&str, &str)] = &[(labels::ROUTER_ID, &router_id)];
+        // Deduplicate by (component identity, runtime connection id). The connection id
+        // identifies the DRT instance; without it, a component recreated after a DRT
+        // restart would reuse metrics registered against the previous runtime.
+        let connection_id = component
+            .connection_id()
+            .expect("Component must be backed by a DistributedRuntime");
+        let cache_key = (component.clone(), connection_id);
 
-                let metrics = component.metrics();
-                let requests_started_total = metrics
-                    .create_intcounter(
-                        &router_metric(frontend_service::REQUESTS_STARTED_TOTAL),
-                        "Total number of requests admitted by the router scheduler",
-                        extra_labels,
-                    )
-                    .expect("failed to create router_requests_started_total");
-                assert!(
-                    ROUTER_REQUESTS_STARTED_TOTAL
-                        .set(requests_started_total)
-                        .is_ok(),
-                    "router_requests_started_total already initialized"
-                );
-                let requests_total = metrics
-                    .create_intcounter(
-                        &router_metric(frontend_service::REQUESTS_TOTAL),
-                        "Total number of requests processed by the router",
-                        extra_labels,
-                    )
-                    .expect("failed to create router_requests_total");
-                let time_to_first_token_seconds = metrics
-                    .create_histogram(
-                        &router_metric(frontend_service::TIME_TO_FIRST_TOKEN_SECONDS),
-                        "Time to first token observed at the router",
-                        extra_labels,
-                        Some(generate_log_buckets(0.001, 480.0, 18)),
-                    )
-                    .expect("failed to create router_time_to_first_token_seconds");
-                let inter_token_latency_seconds = metrics
-                    .create_histogram(
-                        &router_metric(frontend_service::INTER_TOKEN_LATENCY_SECONDS),
-                        "Average inter-token latency observed at the router",
-                        extra_labels,
-                        Some(generate_log_buckets(0.001, 2.0, 13)),
-                    )
-                    .expect("failed to create router_inter_token_latency_seconds");
-                let input_sequence_tokens = metrics
-                    .create_histogram(
-                        &router_metric(frontend_service::INPUT_SEQUENCE_TOKENS),
-                        "Input sequence length in tokens observed at the router",
-                        extra_labels,
-                        Some(generate_log_buckets(50.0, 128000.0, 12)),
-                    )
-                    .expect("failed to create router_input_sequence_tokens");
-                let output_sequence_tokens = metrics
-                    .create_histogram(
-                        &router_metric(frontend_service::OUTPUT_SEQUENCE_TOKENS),
-                        "Output sequence length in tokens observed at the router",
-                        extra_labels,
-                        Some(generate_log_buckets(50.0, 32000.0, 10)),
-                    )
-                    .expect("failed to create router_output_sequence_tokens");
-                let kv_hit_rate = metrics
-                    .create_histogram(
-                        &router_metric(frontend_service::KV_HIT_RATE),
-                        "Predicted KV cache hit rate at routing time (0.0-1.0)",
-                        extra_labels,
-                        Some(prometheus::linear_buckets(0.0, 0.05, 21).unwrap()),
-                    )
-                    .expect("failed to create router_kv_hit_rate");
-                let kv_transfer_estimated_latency_seconds = metrics
-                    .create_histogram(
-                        &router_metric(frontend_service::KV_TRANSFER_ESTIMATED_LATENCY_SECONDS),
-                        "Upper-bound estimation of KV cache transfer latency in disaggregated serving (prefill_complete to first_token)",
-                        extra_labels,
-                        Some(generate_log_buckets(0.001, 10.0, 15)),
-                    )
-                    .expect("failed to create router_kv_transfer_estimated_latency_seconds");
-                let shared_cache_hit_rate = metrics
-                    .create_histogram(
-                        &router_metric(frontend_service::SHARED_CACHE_HIT_RATE),
-                        "Fraction of request blocks found in the shared KV cache (0.0-1.0)",
-                        extra_labels,
-                        Some(prometheus::linear_buckets(0.0, 0.05, 21).unwrap()),
-                    )
-                    .expect("failed to create router_shared_cache_hit_rate");
-                let shared_cache_beyond_blocks = metrics
-                    .create_histogram(
-                        &router_metric(frontend_service::SHARED_CACHE_BEYOND_BLOCKS),
-                        "Shared cache blocks beyond device overlap for the selected worker",
-                        extra_labels,
-                        Some(prometheus::exponential_buckets(1.0, 2.0, 12).unwrap()),
-                    )
-                    .expect("failed to create router_shared_cache_beyond_blocks");
-                let non_max_overlap_selections_total = metrics
-                    .create_intcountervec(
-                        &router_metric(frontend_service::NON_MAX_OVERLAP_SELECTIONS_TOTAL),
-                        "Total admitted prefill scheduler selections with less KV cache overlap than another eligible worker",
-                        &[labels::WORKER_TYPE],
-                        extra_labels,
-                    )
-                    .expect("failed to create router_non_max_overlap_selections_total");
-                let overlap_blocks_lost = metrics
-                    .create_histogramvec(
-                        &router_metric(frontend_service::OVERLAP_BLOCKS_LOST),
-                        "Difference in effective KV cache overlap between the highest-overlap eligible prefill worker and selected worker",
-                        &[labels::WORKER_TYPE],
-                        extra_labels,
-                        Some(prometheus::exponential_buckets(0.25, 2.0, 16).unwrap()),
-                    )
-                    .expect("failed to create router_overlap_blocks_lost");
-                non_max_overlap_selections_total.with_label_values(&[WORKER_TYPE_PREFILL]);
-                overlap_blocks_lost.with_label_values(&[WORKER_TYPE_PREFILL]);
-                Arc::new(Self {
-                    requests_total,
-                    time_to_first_token_seconds,
-                    inter_token_latency_seconds,
-                    input_sequence_tokens,
-                    output_sequence_tokens,
-                    kv_hit_rate,
-                    kv_transfer_estimated_latency_seconds,
-                    shared_cache_hit_rate,
-                    shared_cache_beyond_blocks,
-                    non_max_overlap_selections_total,
-                    overlap_blocks_lost,
-                })
-            })
+        // Fast path: return an already cached instance.
+        if let Some(metrics) = ROUTER_REQUEST_METRICS.get(&cache_key) {
+            return Arc::clone(metrics.value());
+        }
+
+        // Build the metrics outside the cache so a creation failure does not leave
+        // the shared map in an inconsistent state.
+        let instance_id = component.drt().discovery().instance_id();
+        let router_id = instance_id.to_string();
+        let extra_labels: &[(&str, &str)] = &[(labels::ROUTER_ID, &router_id)];
+
+        let metrics = component.metrics();
+        let requests_started_total = metrics
+            .create_intcounter(
+                &router_metric(frontend_service::REQUESTS_STARTED_TOTAL),
+                "Total number of requests admitted by the router scheduler",
+                extra_labels,
+            )
+            .expect("failed to create router_requests_started_total");
+        let requests_total = metrics
+            .create_intcounter(
+                &router_metric(frontend_service::REQUESTS_TOTAL),
+                "Total number of requests processed by the router",
+                extra_labels,
+            )
+            .expect("failed to create router_requests_total");
+        let time_to_first_token_seconds = metrics
+            .create_histogram(
+                &router_metric(frontend_service::TIME_TO_FIRST_TOKEN_SECONDS),
+                "Time to first token observed at the router",
+                extra_labels,
+                Some(generate_log_buckets(0.001, 480.0, 18)),
+            )
+            .expect("failed to create router_time_to_first_token_seconds");
+        let inter_token_latency_seconds = metrics
+            .create_histogram(
+                &router_metric(frontend_service::INTER_TOKEN_LATENCY_SECONDS),
+                "Average inter-token latency observed at the router",
+                extra_labels,
+                Some(generate_log_buckets(0.001, 2.0, 13)),
+            )
+            .expect("failed to create router_inter_token_latency_seconds");
+        let input_sequence_tokens = metrics
+            .create_histogram(
+                &router_metric(frontend_service::INPUT_SEQUENCE_TOKENS),
+                "Input sequence length in tokens observed at the router",
+                extra_labels,
+                Some(generate_log_buckets(50.0, 128000.0, 12)),
+            )
+            .expect("failed to create router_input_sequence_tokens");
+        let output_sequence_tokens = metrics
+            .create_histogram(
+                &router_metric(frontend_service::OUTPUT_SEQUENCE_TOKENS),
+                "Output sequence length in tokens observed at the router",
+                extra_labels,
+                Some(generate_log_buckets(50.0, 32000.0, 10)),
+            )
+            .expect("failed to create router_output_sequence_tokens");
+        let kv_hit_rate = metrics
+            .create_histogram(
+                &router_metric(frontend_service::KV_HIT_RATE),
+                "Predicted KV cache hit rate at routing time (0.0-1.0)",
+                extra_labels,
+                Some(prometheus::linear_buckets(0.0, 0.05, 21).unwrap()),
+            )
+            .expect("failed to create router_kv_hit_rate");
+        let kv_transfer_estimated_latency_seconds = metrics
+            .create_histogram(
+                &router_metric(frontend_service::KV_TRANSFER_ESTIMATED_LATENCY_SECONDS),
+                "Upper-bound estimation of KV cache transfer latency in disaggregated serving (prefill_complete to first_token)",
+                extra_labels,
+                Some(generate_log_buckets(0.001, 10.0, 15)),
+            )
+            .expect("failed to create router_kv_transfer_estimated_latency_seconds");
+        let shared_cache_hit_rate = metrics
+            .create_histogram(
+                &router_metric(frontend_service::SHARED_CACHE_HIT_RATE),
+                "Fraction of request blocks found in the shared KV cache (0.0-1.0)",
+                extra_labels,
+                Some(prometheus::linear_buckets(0.0, 0.05, 21).unwrap()),
+            )
+            .expect("failed to create router_shared_cache_hit_rate");
+        let shared_cache_beyond_blocks = metrics
+            .create_histogram(
+                &router_metric(frontend_service::SHARED_CACHE_BEYOND_BLOCKS),
+                "Shared cache blocks beyond device overlap for the selected worker",
+                extra_labels,
+                Some(prometheus::exponential_buckets(1.0, 2.0, 12).unwrap()),
+            )
+            .expect("failed to create router_shared_cache_beyond_blocks");
+        let non_max_overlap_selections_total = metrics
+            .create_intcountervec(
+                &router_metric(frontend_service::NON_MAX_OVERLAP_SELECTIONS_TOTAL),
+                "Total admitted prefill scheduler selections with less KV cache overlap than another eligible worker",
+                &[labels::WORKER_TYPE],
+                extra_labels,
+            )
+            .expect("failed to create router_non_max_overlap_selections_total");
+        let overlap_blocks_lost = metrics
+            .create_histogramvec(
+                &router_metric(frontend_service::OVERLAP_BLOCKS_LOST),
+                "Difference in effective KV cache overlap between the highest-overlap eligible prefill worker and selected worker",
+                &[labels::WORKER_TYPE],
+                extra_labels,
+                Some(prometheus::exponential_buckets(0.25, 2.0, 16).unwrap()),
+            )
+            .expect("failed to create router_overlap_blocks_lost");
+        non_max_overlap_selections_total.with_label_values(&[WORKER_TYPE_PREFILL]);
+        overlap_blocks_lost.with_label_values(&[WORKER_TYPE_PREFILL]);
+        let new_metrics = Arc::new(Self {
+            requests_started_total,
+            requests_total,
+            time_to_first_token_seconds,
+            inter_token_latency_seconds,
+            input_sequence_tokens,
+            output_sequence_tokens,
+            kv_hit_rate,
+            kv_transfer_estimated_latency_seconds,
+            shared_cache_hit_rate,
+            shared_cache_beyond_blocks,
+            non_max_overlap_selections_total,
+            overlap_blocks_lost,
+        });
+
+        // Insert race-free: if another thread won the race, use its instance.
+        ROUTER_REQUEST_METRICS
+            .entry((component.clone(), connection_id))
+            .or_insert_with(|| Arc::clone(&new_metrics))
             .clone()
     }
 

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -70,6 +70,7 @@ where
             workers_with_configs.borrow().clone();
 
         let router_id = endpoint.drt().discovery().instance_id();
+        let request_metrics = RouterRequestMetrics::from_component(endpoint.component());
         let slots = create_multi_worker_sequences(
             endpoint,
             block_size as usize,
@@ -119,13 +120,13 @@ where
             worker_type,
             watch_worker_configs,
         )?);
+
         if worker_type == WORKER_TYPE_PREFILL {
             let locality_observer: NonMaxOverlapSelectionObserver =
                 Arc::new(move |request_id, selection| {
                     let overlap_blocks_lost = selection.overlap_blocks_lost();
-                    if let Some(metrics) = RouterRequestMetrics::get() {
-                        metrics.observe_non_max_overlap_selection(worker_type, overlap_blocks_lost);
-                    }
+                    request_metrics
+                        .observe_non_max_overlap_selection(worker_type, overlap_blocks_lost);
                     tracing::debug!(
                         request_id,
                         worker_type,


### PR DESCRIPTION
## Overview:

Fix `RouterRequestMetrics` attribution in disaggregated deployments. Previously these metrics were stored in a process-wide `OnceLock<Arc<RouterRequestMetrics>>`, so when a frontend created both a prefill and a decode router, the second router reused the metric instance registered against the first router's `MetricsHierarchy`. As a result, metrics like `router_requests_started_total` and `router_requests_total` were all labeled with the first router's `dynamo_component`, making per-component dashboards unreliable.

This PR replaces the global `OnceLock` with a `LazyLock<DashMap<(Component, u64), Arc<RouterRequestMetrics>>>` cache, so each router component gets its own metric instance with the correct `dynamo_component` label.

## Details:

- `lib/llm/src/kv_router/metrics.rs`
  - Added `requests_started_total` as a field on `RouterRequestMetrics`.
  - Removed the global `ROUTER_REQUESTS_STARTED_TOTAL` `OnceLock`.
  - Replaced `ROUTER_REQUEST_METRICS: OnceLock<Arc<RouterRequestMetrics>>` with `LazyLock<DashMap<(Component, u64), Arc<RouterRequestMetrics>>>`.
  - `RouterRequestMetrics::from_component()` now creates or returns a component-scoped instance.

- `lib/llm/src/kv_router.rs`
  - `KvRouter` now stores its own `request_metrics: Arc<RouterRequestMetrics>`.

- `lib/llm/src/kv_router/scheduler.rs`
  - `KvScheduler::start()` initializes the correct component-scoped `RouterRequestMetrics`

## Where should the reviewer start?

- `lib/llm/src/kv_router/metrics.rs` — the core `RouterRequestMetrics` cache change.
- `lib/llm/src/kv_router.rs` and `lib/llm/src/kv_router/scheduler.rs` — wiring the per-router metrics instance through to usage sites.


## Validation

Start a disaggregated frontend with one prefill and one decode mocker:

```sh
python3 -m dynamo.frontend \
  --router-mode kv --discovery-backend file

python3 -m dynamo.mocker --discovery-backend file \
  --model-path /root/.cache/models/Qwen3-0.6B/ \
  --disaggregation-mode prefill

python3 -m dynamo.mocker --discovery-backend file \
  --model-path /root/.cache/models/Qwen3-0.6B/ \
  --disaggregation-mode decode
```

### Before this PR
Only one dynamo_component series existed, so prefill and decode router data were merged under whichever component initialized first, such as `router_requests_started_total` and `router_requests_total`:
```sh
dynamo_component_router_requests_started_total{dynamo_component="backend",dynamo_namespace="dynamo",router_id="8477299395291497500",worker_id="75a56ae2a6fbc41c"} 0

dynamo_component_router_requests_total{dynamo_component="backend",dynamo_namespace="dynamo",router_id="8477299395291497500",worker_id="75a56ae2a6fbc41c"} 0
```

### After this PR
Each router component now has its own metric instance. Before any request arrives:
```sh
dynamo_component_router_requests_started_total{dynamo_component="prefill",...} 0
dynamo_component_router_requests_started_total{dynamo_component="backend",...} 0

dynamo_component_router_requests_total{dynamo_component="prefill",...} 0
dynamo_component_router_requests_total{dynamo_component="backend",...} 0
```

After sending one request:
```sh
dynamo_component_router_requests_started_total{dynamo_component="prefill",dynamo_namespace="dynamo",router_id="6429778486761977849",worker_id="593b29779fe577f9"} 1
dynamo_component_router_requests_started_total{dynamo_component="backend",dynamo_namespace="dynamo",router_id="6429778486761977849",worker_id="593b29779fe577f9"} 1

dynamo_component_router_requests_total{dynamo_component="prefill",dynamo_namespace="dynamo",router_id="6429778486761977849",worker_id="593b29779fe577f9"} 1
dynamo_component_router_requests_total{dynamo_component="backend",dynamo_namespace="dynamo",router_id="6429778486761977849",worker_id="593b29779fe577f9"} 1

```

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #13364 

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing metric tracking for admitted and scheduled requests.
  * Ensured metrics remain isolated and accurate across different service components.
  * Preserved exclusion of non-admitted requests from routing metrics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->