### PR TITLE
fix(snapshot): release checkpoint after ready status

### DIFF
--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -46,15 +46,16 @@ import (
 // informer over PodSnapshotContent work orders filtered to this node, with typed
 // reads/writes via an uncached controller-runtime client.
 type NodeController struct {
-	config       *types.AgentConfig
-	clientset    kubernetes.Interface
-	client       client.Client
-	dynClient    dynamic.Interface
-	runtime      snapshotruntime.Runtime
-	injector     executor.Mounter
-	log          logr.Logger
-	holderID     string
-	checkpointFn func(ctx context.Context, params CheckpointParams) error
+	config              *types.AgentConfig
+	clientset           kubernetes.Interface
+	client              client.Client
+	dynClient           dynamic.Interface
+	runtime             snapshotruntime.Runtime
+	injector            executor.Mounter
+	log                 logr.Logger
+	holderID            string
+	checkpointFn        func(ctx context.Context, params CheckpointParams) error
+	releaseCheckpointFn func(containerPID int) error
 
 	inFlight   map[string]struct{}
 	inFlightMu sync.Mutex
@@ -132,6 +133,9 @@ func NewNodeController(
 		stopCh:    make(chan struct{}),
 	}
 	w.checkpointFn = w.executorCheckpoint
+	w.releaseCheckpointFn = func(containerPID int) error {
+		return snapshotruntime.WriteControlSentinel(containerPID, snapshotprotocol.SnapshotCompleteFile)
+	}
 	return w, nil
 }
 

--- a/deploy/snapshot/internal/controller/podsnapshotcontent.go
+++ b/deploy/snapshot/internal/controller/podsnapshotcontent.go
@@ -211,11 +211,11 @@ func (w *NodeController) reconcileSourcePod(ctx context.Context, pod *corev1.Pod
 		return w.setSnapshotContentFailed(ctx, content, "ContainerChanged", err)
 	}
 
-	// Resume: a present artifact with unwritten status means a prior dump finished but the
-	// status write did not. The artifact dir exists only after the executor's atomic rename,
-	// so its presence means a completed dump.
+	// Resume: a present artifact with unwritten status means a prior dump finished before the
+	// Ready-and-release sequence completed. The artifact dir exists only after the executor's
+	// atomic rename, so its presence means a completed dump.
 	if artifactPresent(loc.HostPath) {
-		return w.setSnapshotContentSucceeded(ctx, content)
+		return w.markCheckpointReadyAndRelease(ctx, content, containerPID)
 	}
 
 	leaseKey := client.ObjectKey{Namespace: content.Spec.PodSnapshotRef.Namespace, Name: checkpointLeaseName(id)}
@@ -232,9 +232,9 @@ func (w *NodeController) reconcileSourcePod(ctx context.Context, pod *corev1.Pod
 	return nil
 }
 
-// runCheckpoint executes the dump under a renewed lease and writes the terminal status.
-// The container ID, host PID, and resolved locations are pre-resolved by the reconciler so
-// the dump does not re-resolve them.
+// runCheckpoint executes the dump under a renewed lease, writes the Ready status, then releases
+// the target process. The container ID, host PID, and resolved locations are pre-resolved by the
+// reconciler so the dump does not re-resolve them.
 func (w *NodeController) runCheckpoint(
 	ctx context.Context,
 	content *nvidiacomv1alpha1.PodSnapshotContent,
@@ -292,8 +292,8 @@ func (w *NodeController) runCheckpoint(
 		return
 	}
 
-	if err := w.setSnapshotContentSucceeded(ctx, content); err != nil {
-		logger.Error(err, "Failed to write PodSnapshotContent ready status", "content", content.Name)
+	if err := w.markCheckpointReadyAndRelease(ctx, content, containerPID); err != nil {
+		return
 	}
 }
 
@@ -420,6 +420,23 @@ func (w *NodeController) setSnapshotContentSucceeded(ctx context.Context, conten
 	return w.client.Status().Patch(ctx, content, patch)
 }
 
+// markCheckpointReadyAndRelease makes Ready durable before allowing the target process to exit.
+// A failed Ready patch leaves the target blocked. A failed release kills it so the Job cannot
+// report success with an unreleased target.
+func (w *NodeController) markCheckpointReadyAndRelease(ctx context.Context, content *nvidiacomv1alpha1.PodSnapshotContent, containerPID int) error {
+	logger := logr.FromContextOrDiscard(ctx)
+	if err := w.setSnapshotContentSucceeded(ctx, content); err != nil {
+		logger.Error(err, "Failed to write PodSnapshotContent ready status", "content", content.Name)
+		return err
+	}
+	if err := w.releaseCheckpointFn(containerPID); err != nil {
+		logger.Error(err, "Failed to write snapshot-complete sentinel", "content", content.Name)
+		w.killCheckpointProcess(logger, containerPID, "checkpoint sentinel failed")
+		return fmt.Errorf("write snapshot-complete sentinel: %w", err)
+	}
+	return nil
+}
+
 // setSnapshotContentFailed patches status with the Failed condition. Uses optimistic locking so
 // that a concurrent failure write wins and this patch is rejected rather than overwriting it.
 func (w *NodeController) setSnapshotContentFailed(ctx context.Context, content *nvidiacomv1alpha1.PodSnapshotContent, reason string, cause error) error {
@@ -434,9 +451,9 @@ func (w *NodeController) setSnapshotContentFailed(ctx context.Context, content *
 }
 
 // executorCheckpoint is the production checkpointFn. The reconciler has already resolved the
-// container ID and host PID. It runs executor.Checkpoint to the destination, verifies the
-// artifact directory, and writes the snapshot-complete sentinel. On dump or verification
-// failure it SIGKILLs the CUDA-locked process before returning the error.
+// container ID and host PID. It runs executor.Checkpoint to the destination and verifies the
+// artifact directory. On dump or verification failure it SIGKILLs the CUDA-locked process before
+// returning the error.
 func (w *NodeController) executorCheckpoint(ctx context.Context, params CheckpointParams) error {
 	log := logr.FromContextOrDiscard(ctx)
 
@@ -466,10 +483,6 @@ func (w *NodeController) executorCheckpoint(ctx context.Context, params Checkpoi
 		return fmt.Errorf("verify checkpoint path %s: not a directory", params.HostPath)
 	}
 
-	if err := snapshotruntime.WriteControlSentinel(params.ContainerPID, snapshotprotocol.SnapshotCompleteFile); err != nil {
-		w.killCheckpointProcess(log, params.ContainerPID, "checkpoint sentinel failed")
-		return fmt.Errorf("write snapshot-complete sentinel: %w", err)
-	}
 	return nil
 }
 

--- a/deploy/snapshot/internal/controller/podsnapshotcontent_coverage_test.go
+++ b/deploy/snapshot/internal/controller/podsnapshotcontent_coverage_test.go
@@ -50,6 +50,7 @@ func makeNodeControllerWithInterceptor(t *testing.T, fc *fakeCheckpointer, funcs
 		contentIndexer: idx,
 	}
 	w.checkpointFn = fc.fn
+	w.releaseCheckpointFn = func(int) error { return nil }
 	return w
 }
 
@@ -200,6 +201,35 @@ func TestSetSnapshotContentSucceeded_StatusPatchErrorReturnsError(t *testing.T) 
 
 	require.Error(t, err)
 	assert.Nil(t, meta.FindStatusCondition(getContent(t, w, content.Name).Status.Conditions, nvidiacomv1alpha1.PodSnapshotConditionReady))
+}
+
+func TestRunCheckpoint_ReadyPatchErrorDoesNotRelease(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-x", "node-a", "x")
+	funcs := interceptor.Funcs{
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+			return errors.New("status patch rejected")
+		},
+	}
+	w := makeNodeControllerWithInterceptor(t, &fakeCheckpointer{}, funcs, content)
+	released := false
+	w.releaseCheckpointFn = func(int) error {
+		released = true
+		return nil
+	}
+	pod := &corev1.Pod{}
+	leaseKey := client.ObjectKey{Namespace: "inference", Name: "checkpoint-lease-x"}
+	loc := checkpointLocations{
+		HostPath:      w.config.Storage.BasePath,
+		ContainerPath: w.config.Storage.BasePath,
+	}
+
+	w.runCheckpoint(context.Background(), content, pod, "main", "abc123", 7, "x", loc, leaseKey, "x")
+
+	assert.False(t, released)
+	assert.Nil(t, meta.FindStatusCondition(
+		getContent(t, w, content.Name).Status.Conditions,
+		nvidiacomv1alpha1.PodSnapshotConditionReady,
+	))
 }
 
 func TestSetSnapshotContentFailed_StatusPatchErrorReturnsError(t *testing.T) {

--- a/deploy/snapshot/internal/controller/podsnapshotcontent_test.go
+++ b/deploy/snapshot/internal/controller/podsnapshotcontent_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -96,6 +98,7 @@ func makeNodeController(t *testing.T, fc *fakeCheckpointer, objs ...client.Objec
 		contentIndexer: idx,
 	}
 	w.checkpointFn = fc.fn
+	w.releaseCheckpointFn = func(int) error { return nil }
 	return w
 }
 
@@ -416,18 +419,25 @@ func TestReconcileSnapshotContent_OpaqueNameUsesPodLabel(t *testing.T) {
 	}, time.Second, 5*time.Millisecond)
 }
 
-func TestReconcileSnapshotContent_ResumeWritesReady(t *testing.T) {
+func TestReconcileSnapshotContent_ResumeWritesReadyAndReleases(t *testing.T) {
 	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
 	pod := makeSourcePod("abc")
 	fc := &fakeCheckpointer{}
 	w := makeNodeController(t, fc, content, pod)
 	w.runtime = &fakeRuntime{resolveContainerPID: 4242}
+	released := false
+	w.releaseCheckpointFn = func(containerPID int) error {
+		assert.Equal(t, 4242, containerPID)
+		released = true
+		return nil
+	}
 	// Pre-create the artifact directory at the resolved destination so the resume check fires.
 	dest := filepath.Join(w.config.Storage.BasePath, "abc", "versions", "1")
 	require.NoError(t, os.MkdirAll(dest, 0o755))
 
 	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
 	assert.False(t, fc.wasCalled())
+	assert.True(t, released)
 	got := getContent(t, w, content.Name)
 	cond := meta.FindStatusCondition(got.Status.Conditions, nvidiacomv1alpha1.PodSnapshotConditionReady)
 	require.NotNil(t, cond)
@@ -616,7 +626,7 @@ func TestReconcileSourcePod_ContainersWinsOverLegacyAnnotation(t *testing.T) {
 		"target must come from PodRef.Containers, not the legacy target-containers annotation")
 }
 
-func TestRunCheckpoint_WritesReadyOnSuccess(t *testing.T) {
+func TestRunCheckpoint_WritesReadyBeforeRelease(t *testing.T) {
 	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
 	fc := &fakeCheckpointer{}
 	w := makeNodeController(t, fc, content)
@@ -626,13 +636,22 @@ func TestRunCheckpoint_WritesReadyOnSuccess(t *testing.T) {
 		HostPath:      filepath.Join(w.config.Storage.BasePath, "abc", "versions", "1"),
 		ContainerPath: filepath.Join(w.config.Storage.BasePath, "abc", "versions", "1"),
 	}
+	released := false
+	w.releaseCheckpointFn = func(containerPID int) error {
+		assert.Equal(t, 7, containerPID)
+		cond := meta.FindStatusCondition(
+			getContent(t, w, content.Name).Status.Conditions,
+			nvidiacomv1alpha1.PodSnapshotConditionReady,
+		)
+		require.NotNil(t, cond, "Ready must be observable before the target is released")
+		released = true
+		return nil
+	}
 
 	w.runCheckpoint(context.Background(), content, pod, "main", "abc123", 7, "abc", loc, leaseKey, "abc")
 
 	assert.True(t, fc.wasCalled())
-	got := getContent(t, w, content.Name)
-	cond := meta.FindStatusCondition(got.Status.Conditions, nvidiacomv1alpha1.PodSnapshotConditionReady)
-	require.NotNil(t, cond)
+	assert.True(t, released)
 }
 
 func TestRunCheckpoint_WritesFailedOnError(t *testing.T) {
@@ -652,6 +671,38 @@ func TestRunCheckpoint_WritesFailedOnError(t *testing.T) {
 	cond := meta.FindStatusCondition(got.Status.Conditions, nvidiacomv1alpha1.PodSnapshotConditionFailed)
 	require.NotNil(t, cond)
 	assert.Equal(t, "CheckpointFailed", cond.Reason)
+}
+
+func TestRunCheckpoint_ReleaseFailureKillsTarget(t *testing.T) {
+	target := exec.Command("sleep", "30")
+	require.NoError(t, target.Start())
+	t.Cleanup(func() {
+		if target.ProcessState == nil {
+			_ = target.Process.Kill()
+		}
+	})
+
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	w := makeNodeController(t, &fakeCheckpointer{}, content)
+	w.releaseCheckpointFn = func(int) error { return errors.New("sentinel write rejected") }
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "worker-0", Namespace: "inference", UID: types.UID("pod-uid")}}
+	leaseKey := client.ObjectKey{Namespace: "inference", Name: "checkpoint-lease-abc"}
+	loc := checkpointLocations{
+		HostPath:      filepath.Join(w.config.Storage.BasePath, "abc", "versions", "1"),
+		ContainerPath: filepath.Join(w.config.Storage.BasePath, "abc", "versions", "1"),
+	}
+
+	w.runCheckpoint(context.Background(), content, pod, "main", "abc123", target.Process.Pid, "abc", loc, leaseKey, "abc")
+
+	err := target.Wait()
+	require.Error(t, err)
+	waitStatus, ok := target.ProcessState.Sys().(syscall.WaitStatus)
+	require.True(t, ok)
+	assert.Equal(t, syscall.SIGKILL, waitStatus.Signal())
+	require.NotNil(t, meta.FindStatusCondition(
+		getContent(t, w, content.Name).Status.Conditions,
+		nvidiacomv1alpha1.PodSnapshotConditionReady,
+	))
 }
 
 // mustUnstructured converts a typed object to the *unstructured.Unstructured the dynamic informer


### PR DESCRIPTION
## Summary

- persist `PodSnapshotContent` Ready before writing the `snapshot-complete` sentinel that releases the checkpoint target
- keep the target blocked when the Ready status patch fails
- fail closed by killing the target when release fails after Ready is durable, allowing the existing Job failure to win
- apply the same Ready-before-release ordering when recovering an already-completed checkpoint artifact

This closes a race where the target could exit, the source Pod could become `Succeeded`, and a concurrent node-agent reconciliation could report `SourcePodGone` before capture success was durable. Kubernetes Job completion continues to provide the existing join between successful PodSnapshot capture and required helper containers such as `gms-saver`.

## Validation

```text
cd deploy/snapshot
go test ./internal/controller
go test -race ./internal/controller
go test ./internal/controller \
  -run 'TestRunCheckpoint_(WritesReadyBeforeRelease|ReadyPatchErrorDoesNotRelease|ReleaseFailureKillsTarget)$|TestReconcileSnapshotContent_ResumeWritesReadyAndReleases$' \
  -count=20
```

All commands passed.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/13366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Checkpoint operations now record a Ready status before releasing the target process.
  - Resume operations complete correctly without repeating capture work.
  - Failed status updates no longer release the checkpoint prematurely.
  - If process release fails, the checkpoint process is terminated while its Ready status is preserved.
- **Tests**
  - Added coverage for checkpoint completion, resume behavior, status-update failures, and release failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->