### PR TITLE
feat(request-trace): record agent router timeline

### DIFF
--- a/components/src/dynamo/thunderagent_router/__main__.py
+++ b/components/src/dynamo/thunderagent_router/__main__.py
@@ -121,6 +121,17 @@ def _inject_thunderagent_route_proof(
     chunk["engine_data"] = engine_data
 
 
+def _inject_router_timeline(chunk: Any, timeline: dict[str, Any]) -> None:
+    """Forward router admission and hop attribution to the frontend trace."""
+    if not isinstance(chunk, dict):
+        return
+    routing_data = chunk.get("routing_data")
+    if not isinstance(routing_data, dict):
+        routing_data = {}
+    routing_data["router_timeline"] = dict(timeline)
+    chunk["routing_data"] = routing_data
+
+
 class ThunderAgentRouterHandler:
     def __init__(
         self,
@@ -210,15 +221,24 @@ class ThunderAgentRouterHandler:
                 else None
             )
             first_chunk = True
+            timeline: dict[str, Any] = {
+                "router_admission_wait_ms": 0.0,
+                "router_hold_reason": None,
+                "proxy_instance_id": None,
+                "serving_worker_id": None,
+            }
             async for chunk in await self._kv_router.generate_from_request(
                 preprocessed  # type: ignore[arg-type]
             ):
-                if proof is not None:
-                    if first_chunk:
-                        first_chunk = False
-                        selected_worker = self._extract_worker_id(chunk)
-                        if selected_worker is not None:
+                if first_chunk:
+                    first_chunk = False
+                    selected_worker = self._extract_worker_id(chunk)
+                    if selected_worker is not None:
+                        timeline["serving_worker_id"] = selected_worker
+                        if proof is not None:
                             proof["selected_worker_id"] = selected_worker
+                    _inject_router_timeline(chunk, timeline)
+                if proof is not None:
                     _inject_thunderagent_route_proof(chunk, proof)
                 yield chunk
             return
@@ -236,12 +256,13 @@ class ThunderAgentRouterHandler:
         logger.debug(
             "thunderagent.route path=program program=%s prompt_tokens=%d "
             "worker_hint=%s waited_seconds=%.4f was_paused=%s "
-            "soft_demoted=%s priority_jump=%.3f",
+            "hold_reason=%s soft_demoted=%s priority_jump=%.3f",
             program_id,
             estimated_prompt_tokens,
             worker_pin,
             decision.waited_seconds,
             decision.was_paused,
+            decision.hold_reason,
             decision.was_soft_demoted,
             decision.priority_jump,
         )
@@ -262,7 +283,13 @@ class ThunderAgentRouterHandler:
         completion_tokens_seen = 0
         usage_completion_seen = False
         first_chunk = True
-        selected_worker_id = None
+        selected_worker_id = worker_pin
+        timeline = {
+            "router_admission_wait_ms": decision.waited_seconds * 1000.0,
+            "router_hold_reason": decision.hold_reason,
+            "proxy_instance_id": None,
+            "serving_worker_id": worker_pin,
+        }
         proof = (
             {
                 "handled_by": "thunderagent_router",
@@ -282,12 +309,18 @@ class ThunderAgentRouterHandler:
             async for chunk in await self._kv_router.generate_from_request(
                 preprocessed  # type: ignore[arg-type]
             ):
-                if first_chunk and worker_pin is None:
+                if first_chunk:
                     first_chunk = False
                     selected_worker = self._extract_worker_id(chunk)
+                    if selected_worker is None:
+                        selected_worker = worker_pin
                     if selected_worker is not None:
-                        await self._scheduler.assign_worker(program_id, selected_worker)
+                        if worker_pin is None:
+                            await self._scheduler.assign_worker(
+                                program_id, selected_worker
+                            )
                         selected_worker_id = selected_worker
+                        timeline["serving_worker_id"] = selected_worker
                         if proof is not None:
                             proof["selected_worker_id"] = selected_worker
                         logger.debug(
@@ -296,6 +329,7 @@ class ThunderAgentRouterHandler:
                             program_id,
                             selected_worker,
                         )
+                    _inject_router_timeline(chunk, timeline)
 
                 usage = (
                     chunk.get("completion_usage") if isinstance(chunk, dict) else None

--- a/components/src/dynamo/thunderagent_router/program_state.py
+++ b/components/src/dynamo/thunderagent_router/program_state.py
@@ -40,6 +40,7 @@ class Program:
 
     step_count: int = 0
     marked_for_pause: bool = False
+    hold_reason: Optional[str] = None
     # monotonic seconds; >0 means priority demotion active
     soft_demoted_until: float = 0.0
     waiting: Optional[asyncio.Event] = field(default=None, repr=False)

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -35,6 +35,7 @@ class PauseDecision:
     was_paused: bool = False
     was_soft_demoted: bool = False
     assigned_worker_hint: Optional[int] = None
+    hold_reason: Optional[str] = None
 
 
 @dataclass
@@ -144,6 +145,8 @@ class ThunderAgentScheduler:
             if soft_demoted:
                 priority_jump += self._cfg.soft_demote_priority_jump
 
+            hold_reason = program.hold_reason if was_paused else None
+            program.hold_reason = None
             return PauseDecision(
                 program_id=program_id,
                 priority_jump=priority_jump,
@@ -151,6 +154,7 @@ class ThunderAgentScheduler:
                 was_paused=was_paused,
                 was_soft_demoted=soft_demoted,
                 assigned_worker_hint=program.assigned_worker_id,
+                hold_reason=hold_reason,
             )
 
     def _admit_locked(
@@ -195,6 +199,7 @@ class ThunderAgentScheduler:
         # All workers full: queue until the scheduler tick resumes us.
         program.waiting = program.waiting or asyncio.Event()
         program.lifecycle = ProgramLifecycle.PAUSED
+        program.hold_reason = "admission_full"
         self._table.paused[program_id] = None
         self._stat_pauses += 1
         logger.info(
@@ -429,6 +434,7 @@ class ThunderAgentScheduler:
             return False
         program.lifecycle = ProgramLifecycle.PAUSED
         program.assigned_worker_id = None
+        program.hold_reason = "pressure"
         if program.waiting is None:
             program.waiting = asyncio.Event()
         else:

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -153,6 +153,7 @@ async def test_pause_acting_then_before_request_blocks_until_resume():
 
     decision = await asyncio.wait_for(waiter, timeout=1.0)
     assert decision.was_paused is True
+    assert decision.hold_reason == "pressure"
     assert decision.priority_jump == cfg.resume_priority_boost
     assert decision.assigned_worker_hint == 1
     metrics = await router.metrics_snapshot()
@@ -202,6 +203,7 @@ async def test_new_program_queues_before_first_request_when_capacity_full():
         router._resume_program(router._table.programs["new"], target_worker_id=1)
     decision = await asyncio.wait_for(waiter, timeout=1.0)
     assert decision.was_paused is True
+    assert decision.hold_reason == "admission_full"
 
 
 @pytest.mark.asyncio

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -257,6 +257,9 @@ fn drain_router_routing_data(
     if let Some(worker_id) = routing_data.worker_id {
         tracker.set_external_worker_info(worker_id);
     }
+    if let Some(router_timeline) = routing_data.router_timeline {
+        tracker.set_external_router_timeline(router_timeline);
+    }
     if let Some(token_ids) = routing_data.token_ids {
         tracker.set_external_query_token_ids(token_ids);
     }

--- a/lib/llm/src/protocols/common/timing.rs
+++ b/lib/llm/src/protocols/common/timing.rs
@@ -174,6 +174,9 @@ pub struct RequestTracker {
     /// process. First-write-wins.
     external_timing: OnceLock<TimingInfo>,
 
+    /// Router-hop metadata forwarded by a standalone proxy such as ThunderAgent.
+    external_router_timeline: OnceLock<RouterTimeline>,
+
     /// Tokenized prompt forwarded from a standalone router's query-only response
     /// (GAIE Stage 1), so the frontend can surface it in `nvext.token_ids` without
     /// re-tokenizing. Lives here rather than on `routing_data` because the preprocessor
@@ -196,10 +199,26 @@ pub struct RoutingData {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worker_id: Option<WorkerIdInfo>,
 
+    /// Admission and hop attribution measured by an external router.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub router_timeline: Option<RouterTimeline>,
+
     /// Tokenized prompt returned by a query-only (GAIE Stage 1) response so it can be
     /// reused without re-tokenizing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_ids: Option<Vec<u32>>,
+}
+
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct RouterTimeline {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub router_admission_wait_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub router_hold_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_instance_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serving_worker_id: Option<u64>,
 }
 
 impl RequestTracker {
@@ -237,6 +256,7 @@ impl RequestTracker {
             router_queue_depth: OnceLock::new(),
             prefill_complete_time: OnceLock::new(),
             external_timing: OnceLock::new(),
+            external_router_timeline: OnceLock::new(),
             external_query_token_ids: OnceLock::new(),
         }
     }
@@ -626,6 +646,15 @@ impl RequestTracker {
         let _ = self.external_timing.set(timing);
     }
 
+    /// Store router-hop metadata forwarded by a standalone proxy. First-write-wins.
+    pub fn set_external_router_timeline(&self, timeline: RouterTimeline) {
+        let _ = self.external_router_timeline.set(timeline);
+    }
+
+    pub fn router_timeline(&self) -> Option<RouterTimeline> {
+        self.external_router_timeline.get().cloned()
+    }
+
     /// Stash the tokenized prompt forwarded by a standalone router's query-only response
     /// (GAIE Stage 1) so `build_response_nvext` can surface it in `nvext.token_ids`.
     /// First-write-wins.
@@ -890,6 +919,23 @@ mod tests {
         // First-write-wins: a later forward does not clobber.
         tracker.set_external_query_token_ids(vec![44, 55]);
         assert_eq!(tracker.query_token_ids(), Some(&[11u32, 22, 33][..]));
+    }
+
+    #[test]
+    fn test_external_router_timeline_round_trip_is_first_write_wins() {
+        let tracker = RequestTracker::new();
+        let expected = RouterTimeline {
+            router_admission_wait_ms: Some(12.5),
+            router_hold_reason: Some("pressure".to_string()),
+            proxy_instance_id: None,
+            serving_worker_id: Some(99),
+        };
+        tracker.set_external_router_timeline(expected.clone());
+        tracker.set_external_router_timeline(RouterTimeline {
+            serving_worker_id: Some(100),
+            ..Default::default()
+        });
+        assert_eq!(tracker.router_timeline(), Some(expected));
     }
 
     #[test]

--- a/lib/llm/src/request_trace/agent_context.rs
+++ b/lib/llm/src/request_trace/agent_context.rs
@@ -203,6 +203,15 @@ pub(crate) fn request_metrics(
                 decode_dp_rank: worker.decode_dp_rank,
             })
     });
+    let router_timeline = tracker.and_then(RequestTracker::router_timeline);
+    let proxy_instance_id = router_timeline
+        .as_ref()
+        .and_then(|timeline| timeline.proxy_instance_id)
+        .or_else(|| {
+            router_timeline.as_ref()?;
+            let worker = worker.as_ref()?;
+            worker.decode_worker_id.or(worker.prefill_worker_id)
+        });
 
     RequestTraceMetrics {
         request_id,
@@ -226,6 +235,16 @@ pub(crate) fn request_metrics(
         queue_depth: timing
             .as_ref()
             .and_then(|timing| timing.router_queue_depth.map(|v| v as u64)),
+        router_admission_wait_ms: router_timeline
+            .as_ref()
+            .and_then(|timeline| timeline.router_admission_wait_ms),
+        router_hold_reason: router_timeline
+            .as_ref()
+            .and_then(|timeline| timeline.router_hold_reason.clone()),
+        proxy_instance_id,
+        serving_worker_id: router_timeline
+            .as_ref()
+            .and_then(|timeline| timeline.serving_worker_id),
         worker,
         replay: None,
         finish_reason_metadata: None,
@@ -526,7 +545,7 @@ mod tests {
     use crate::protocols::common::extensions::AgentContext;
     use crate::protocols::common::{
         self,
-        timing::{RequestTracker, WORKER_TYPE_DECODE},
+        timing::{RequestTracker, RouterTimeline, WORKER_TYPE_DECODE},
     };
     use crate::protocols::openai::{
         chat_completions::NvCreateChatCompletionStreamResponse,
@@ -618,6 +637,30 @@ mod tests {
         assert_eq!(metrics.queue_depth, None);
         assert!(metrics.finish_reason_metadata.is_none());
         assert!(metrics.worker.is_none());
+    }
+
+    #[test]
+    fn test_request_metrics_disambiguates_proxy_and_serving_worker() {
+        let tracker = RequestTracker::new();
+        tracker.record_worker(44, None, WORKER_TYPE_DECODE);
+        tracker.set_external_router_timeline(RouterTimeline {
+            router_admission_wait_ms: Some(12.5),
+            router_hold_reason: Some("pressure".to_string()),
+            proxy_instance_id: None,
+            serving_worker_id: Some(99),
+        });
+
+        let metrics = request_metrics(
+            "req-1".to_string(),
+            None,
+            "test-model".to_string(),
+            Some(&tracker),
+        );
+
+        assert_eq!(metrics.router_admission_wait_ms, Some(12.5));
+        assert_eq!(metrics.router_hold_reason.as_deref(), Some("pressure"));
+        assert_eq!(metrics.proxy_instance_id, Some(44));
+        assert_eq!(metrics.serving_worker_id, Some(99));
     }
 
     #[tokio::test]

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -36,6 +36,7 @@ fn sanitize_request(request: &mut RequestTraceMetrics) {
     request.kv_hit_rate = sanitize_finite(request.kv_hit_rate);
     request.kv_transfer_estimated_latency_ms =
         sanitize_finite(request.kv_transfer_estimated_latency_ms);
+    request.router_admission_wait_ms = sanitize_finite(request.router_admission_wait_ms);
 }
 
 fn event_time_unix_ms_from_request(request: &RequestTraceMetrics) -> u64 {
@@ -77,6 +78,10 @@ pub(crate) fn emit_request_end(
         kv_hit_rate: None,
         kv_transfer_estimated_latency_ms: None,
         queue_depth: None,
+        router_admission_wait_ms: None,
+        router_hold_reason: None,
+        proxy_instance_id: None,
+        serving_worker_id: None,
         worker: None,
         replay: Some(replay),
         finish_reason_metadata: None,

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -328,6 +328,10 @@ mod tests {
                 kv_hit_rate: None,
                 kv_transfer_estimated_latency_ms: None,
                 queue_depth: None,
+                router_admission_wait_ms: None,
+                router_hold_reason: None,
+                proxy_instance_id: None,
+                serving_worker_id: None,
                 worker: None,
                 replay: Some(RequestReplayMetrics {
                     trace_block_size: 2,

--- a/lib/llm/src/request_trace/types.rs
+++ b/lib/llm/src/request_trace/types.rs
@@ -111,6 +111,14 @@ pub struct RequestTraceMetrics {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub queue_depth: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub router_admission_wait_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub router_hold_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy_instance_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serving_worker_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub worker: Option<RequestTraceWorkerInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replay: Option<RequestReplayMetrics>,
@@ -332,6 +340,10 @@ mod tests {
                 kv_hit_rate: None,
                 kv_transfer_estimated_latency_ms: None,
                 queue_depth: None,
+                router_admission_wait_ms: None,
+                router_hold_reason: None,
+                proxy_instance_id: None,
+                serving_worker_id: None,
                 worker: None,
                 replay: Some(RequestReplayMetrics {
                     trace_block_size: 2,


### PR DESCRIPTION
### Summary

This adds request-scoped router admission and hop attribution to Dynamo request traces for agent workloads routed through ThunderAgent. It makes proxy delay and backend worker identity directly observable without changing routing or cache policy.

### How This Was Implemented

- Add an optional `RouterTimeline` payload to `routing_data` and store it first-write-wins on the frontend request tracker.
- Record `router_admission_wait_ms`, `router_hold_reason`, `proxy_instance_id`, and `serving_worker_id` as additive optional fields in `dynamo.request.trace.v1`.
- Preserve ThunderAgent pause reasons (`admission_full` or `pressure`) through resume and attach the timeline to the first backend response chunk.
- Treat the existing frontend worker attribution as the proxy instance when a forwarded timeline is present, while retaining the selected backend worker separately.

<details>
<summary>Walkthrough</summary>

#### Mental model

ThunderAgent is a proxy worker from the frontend's perspective, but it selects another worker that actually serves the model request. The frontend now records both hops plus any time the agent continuation spent waiting for admission.

```mermaid
flowchart LR
    Client["Agent request"] --> Frontend["Dynamo frontend"]
    Frontend --> Proxy["ThunderAgent proxy"]
    Proxy -->|"admission wait + hold reason"| Scheduler["ThunderAgent scheduler"]
    Proxy -->|"selected worker"| Backend["Serving worker"]
    Backend -->|"first chunk + routing_data.router_timeline"| Frontend
    Frontend --> Trace["dynamo.request.trace.v1"]
```

#### State and ordering

The scheduler stores the hold reason on the program when it pauses. `before_request` returns that reason after resume and clears it, so the reason describes only the wait that just completed. The frontend request tracker uses `OnceLock`, matching existing external timing behavior: the first forwarded router timeline wins and later chunks cannot overwrite request attribution.

When ThunderAgent cannot provide its own proxy ID, request-trace assembly uses the frontend's existing worker attribution as `proxy_instance_id`. `serving_worker_id` comes from the worker selected by the downstream KV router, so the existing `worker` field remains compatible while the two physical hops are explicit.

#### Request lifecycle

Passthrough requests attach a zero admission wait and the backend worker selected on the first chunk. Program requests attach the measured wait, the resume reason, the sticky worker hint when available, and then confirm or populate the actual backend worker from the first chunk. The frontend drains `routing_data.router_timeline` during preprocessing and emits the four optional fields at request end.

#### Boundaries and limitations

This change does not add cache policy, admission policy, or load-generation behavior. The fields are optional for wire compatibility, and non-finite admission wait values are removed before trace serialization. Requests that do not traverse a router timeline continue to emit the existing trace shape.

</details>

### Validation

- `SWAGGER_UI_DOWNLOAD_URL=<cached-swagger-ui.zip> CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p dynamo-llm --lib --no-default-features`
- `cargo fmt --all -- --check`
- `python3 -m compileall -q components/src/dynamo/thunderagent_router`
- ThunderAgent scheduler smoke with dependency stubs covering both `pressure` and `admission_full` holds.
- Not run: `cargo test -p dynamo-llm --lib request_trace --no-default-features`; the test-profile build exhausted the 2.2 GiB free filesystem before linking.
- Not run: repository pytest suite; this worktree has no local `.venv`, and another checkout's environment was not reused.
