### PR TITLE
fix(frontend): surface backend error finish reasons on /v1/completions

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2763,7 +2763,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             )
 
         if self.model_config is None:
-            raise ValueError("ModelConfig is unavailable for prompt_embeds validation.")
+            # Not `ValueError`: the bindings map that to `Backend(InvalidArgument)`
+            # -> 400, and a worker without a ModelConfig is our fault, not the
+            # caller's. `RuntimeError` keeps it a 500.
+            raise RuntimeError(
+                "ModelConfig is unavailable for prompt_embeds validation."
+            )
 
         try:
             return safe_load_prompt_embeds(
@@ -2808,7 +2813,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         multi_modal_data: Dict[str, Any] | None,
         log_prefix: str = "",
         mm_processor_kwargs: Dict[str, Any] | None = None,
-    ) -> tuple[TokensPrompt | EmbedsPrompt | None, Dict[str, Any] | None]:
+    ) -> TokensPrompt | EmbedsPrompt | None:
         """
         Build a prompt from request, handling both prompt_embeds and token_ids.
 
@@ -2820,10 +2825,19 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             mm_processor_kwargs: Optional multimodal processor kwargs (e.g.
                 use_audio_in_video) forwarded to the vLLM engine.
 
-        Returns:
-            Tuple of (prompt, error_dict) where:
-            - On success: (prompt, None)
-            - On failure: (None, error_dict to yield)
+        Raises:
+            InvalidArgument: `prompt_embeds` was sent to a worker started
+                without `--enable-prompt-embeds`.
+            ValueError: `prompt_embeds` was supplied but could not be decoded.
+                `_decode_prompt_embeds` re-types every decode failure to
+                `ValueError`, so this covers a genuine bad tensor and a
+                resource fault such as OOM alike.
+
+        Both map to `Backend(InvalidArgument)` -> HTTP 400 with the message
+        forwarded verbatim. An in-band `finish_reason` error cannot: it carries
+        no error type, so it decodes as `Unknown` -> 500, and the frontend
+        sanitizes 5xx bodies. The caller would get a bare "Internal server
+        error".
         """
         if "prompt_embeds" in request and request["prompt_embeds"]:
             if not self.config.engine_args.enable_prompt_embeds:
@@ -2834,13 +2848,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     f"Rejected prompt_embeds for {log_prefix.lower().strip() or 'request'} "
                     f"{request_id}: {msg}"
                 )
-                return (
-                    None,
-                    {
-                        "finish_reason": f"error: Invalid prompt_embeds: {msg}",
-                        "token_ids": [],
-                    },
-                )
+                raise InvalidArgument(f"Invalid prompt_embeds: {msg}")
             try:
                 prompt, tensor = self._create_prompt_from_embeddings(
                     request["prompt_embeds"]
@@ -2850,19 +2858,15 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     f"dtype={tensor.dtype}, sequence_length={tensor.shape[0]}, "
                     f"request_id={request_id}"
                 )
-                return prompt, None
+                return prompt
             except Exception as e:
                 logger.error(
-                    f"Failed to process prompt_embeds for {log_prefix.lower().strip() or 'request'} "
-                    f"{request_id}: {e}"
+                    "Failed to process prompt_embeds for %s %s: %s",
+                    log_prefix.lower().strip() or "request",
+                    request_id,
+                    e,
                 )
-                return (
-                    None,
-                    {
-                        "finish_reason": f"error: Invalid prompt_embeds: {e}",
-                        "token_ids": [],
-                    },
-                )
+                raise
         # Text-only PD + encoder-worker path.
         # Normal path: use token IDs.
         # Prefer frontend-forwarded mm_hashes for hash consistency with the
@@ -2875,7 +2879,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             multi_modal_data,
             mm_processor_kwargs,
         )
-        return prompt, None
+        return prompt
 
     @staticmethod
     def _build_completion_usage(
@@ -3289,8 +3293,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # Firstly extract disaggregated params from prefill result if available
         prefill_result = request.get("prefill_result")
         if prefill_result and isinstance(prefill_result, dict):
-            # `disaggregated_params` may be explicitly None (prefill error path,
-            # or _build_disaggregated_params returning None when empty), so use
+            # `disaggregated_params` may be explicitly None
+            # (`_build_disaggregated_params` returns None when empty), so use
             # `or {}` rather than a .get default — the default only applies when
             # the key is absent, not when it is present-but-None.
             disaggregated_params = prefill_result.get("disaggregated_params") or {}
@@ -3360,27 +3364,22 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         with _nvtx.annotate("mm_backend:build_prompt", color="yellow"):
             if custom_prompt is not None:
                 prompt = custom_prompt
-                error = None
             elif pre_rendered is not None:
                 # pre_rendered is a MultiModalInput dict with "type": "multimodal".
                 # The engine's InputProcessor.process_inputs() will see the "type"
                 # key and skip the HF processor entirely.
                 prompt = pre_rendered
-                error = None
                 logger.debug(
                     "[mm-routing] Request %s: using pre-rendered MultiModalInput",
                     request_id,
                 )
             else:
-                prompt, error = self._build_prompt_from_request(
+                prompt = self._build_prompt_from_request(
                     request,
                     request_id,
                     multi_modal_data,
                     mm_processor_kwargs=mm_processor_kwargs,
                 )
-        if error is not None:
-            yield error
-            return
 
         _apply_nvext_cache_salt(request, prompt)
 
@@ -3675,18 +3674,13 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         mm_processor_kwargs = prepared_input.mm_processor_kwargs
 
         # Build prompt from request (handles both prompt_embeds and token_ids)
-        prompt, error = self._build_prompt_from_request(
+        prompt = self._build_prompt_from_request(
             request,
             request_id,
             multi_modal_data,
             log_prefix="Prefill ",
             mm_processor_kwargs=mm_processor_kwargs,
         )
-        if error is not None:
-            # Prefill errors need disaggregated_params field
-            error["disaggregated_params"] = None
-            yield error
-            return
 
         _apply_nvext_cache_salt(request, prompt)
 

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -22,6 +22,7 @@ import dynamo.vllm.handlers as mod
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
+from dynamo.llm.exceptions import InvalidArgument
 from dynamo.vllm.multimodal_utils.protocol import (
     PatchedTokensPrompt,
     vLLMMultimodalRequest,
@@ -744,7 +745,7 @@ class TestDecodeWorkerMultimodalBranching:
             disaggregation_mode="DECODE",
         )
         handler._build_prompt_from_request = MagicMock(
-            return_value=(None, {"status": "error", "message": "test stop"})
+            side_effect=InvalidArgument("test stop")
         )
         request = {
             "token_ids": [1, 2, 3],
@@ -759,13 +760,10 @@ class TestDecodeWorkerMultimodalBranching:
             },
         }
         context = MagicMock()
-        chunks = []
-        async for chunk in handler._generate_token_mode(request, context, "req-1"):
-            chunks.append(chunk)
-
         # Should reach _build_prompt_from_request (not error at decode guard)
-        assert len(chunks) == 1
-        assert chunks[0]["message"] == "test stop"
+        with pytest.raises(InvalidArgument, match="test stop"):
+            async for _ in handler._generate_token_mode(request, context, "req-1"):
+                pass
 
     async def test_aggregated_mode_calls_extract_multimodal_data(self):
         """Aggregated mode delegates media loading to the shared processor."""
@@ -777,7 +775,7 @@ class TestDecodeWorkerMultimodalBranching:
         # Return an error from _build_prompt_from_request so _generate_token_mode
         # yields it and returns early — no need to mock the engine.
         handler._build_prompt_from_request = MagicMock(
-            return_value=(None, {"status": "error", "message": "test stop"})
+            side_effect=InvalidArgument("test stop")
         )
 
         request = {
@@ -789,13 +787,11 @@ class TestDecodeWorkerMultimodalBranching:
         }
         context = MagicMock()
 
-        chunks = []
-        async for chunk in handler._generate_token_mode(request, context, "req-1"):
-            chunks.append(chunk)
+        with pytest.raises(InvalidArgument, match="test stop"):
+            async for _ in handler._generate_token_mode(request, context, "req-1"):
+                pass
 
         handler._multimodal_request_processor.extract_multimodal_data.assert_awaited_once()
-        assert len(chunks) == 1
-        assert chunks[0]["status"] == "error"
 
     async def test_decode_only_bypass_annotation_runs_as_agg(self):
         """Decode worker with conditional-disagg bypass annotation runs as AGG."""
@@ -807,7 +803,7 @@ class TestDecodeWorkerMultimodalBranching:
             return_value=None
         )
         handler._build_prompt_from_request = MagicMock(
-            return_value=(None, {"status": "error", "message": "test stop"})
+            side_effect=InvalidArgument("test stop")
         )
 
         request = {
@@ -820,13 +816,11 @@ class TestDecodeWorkerMultimodalBranching:
         }
         context = MagicMock()
 
-        chunks = []
-        async for chunk in handler._generate_token_mode(request, context, "req-1"):
-            chunks.append(chunk)
+        with pytest.raises(InvalidArgument, match="test stop"):
+            async for _ in handler._generate_token_mode(request, context, "req-1"):
+                pass
 
         handler._multimodal_request_processor.extract_multimodal_data.assert_awaited_once()
-        assert len(chunks) == 1
-        assert chunks[0]["message"] == "test stop"
 
     async def test_decode_only_bypass_annotation_text_only_does_not_require_prefill_kv_params(
         self,
@@ -834,7 +828,7 @@ class TestDecodeWorkerMultimodalBranching:
         """Text-only bypass does not require incoming prefill KV params."""
         handler = _make_decode_handler(disaggregation_mode="DECODE")
         handler._build_prompt_from_request = MagicMock(
-            return_value=(None, {"status": "error", "message": "stop"})
+            side_effect=InvalidArgument("stop")
         )
 
         request = {
@@ -846,12 +840,9 @@ class TestDecodeWorkerMultimodalBranching:
         }
         context = MagicMock()
 
-        chunks = []
-        async for chunk in handler._generate_token_mode(request, context, "req-1"):
-            chunks.append(chunk)
-
-        assert len(chunks) == 1
-        assert chunks[0]["message"] == "stop"
+        with pytest.raises(InvalidArgument, match="stop"):
+            async for _ in handler._generate_token_mode(request, context, "req-1"):
+                pass
 
     async def test_decode_only_bypass_annotation_text_mode_runs_as_agg(self):
         """Text-mode conditional-disagg bypass is not treated as decode-only."""
@@ -911,14 +902,13 @@ class TestDecodeWorkerMultimodalBranching:
     ):
         handler = _make_decode_handler(disaggregation_mode="AGGREGATED")
 
-        prompt, error = handler._build_prompt_from_request(
+        prompt = handler._build_prompt_from_request(
             {"token_ids": [1, 2, 3]},
             "request-prompt",
             multi_modal_data=None,
             mm_processor_kwargs=mm_processor_kwargs,
         )
 
-        assert error is None
         if mm_processor_kwargs is None:
             assert "mm_processor_kwargs" not in prompt
         else:
@@ -941,23 +931,17 @@ async def test_prefill_delegates_mode_policy_to_shared_processor():
         )
     )
     handler._multimodal_request_processor = processor
-    handler._build_prompt_from_request = MagicMock(
-        return_value=(None, {"status": "error", "message": "stop"})
-    )
+    handler._build_prompt_from_request = MagicMock(side_effect=InvalidArgument("stop"))
     context = MagicMock()
 
-    chunks = [
-        chunk
-        async for chunk in handler._generate_token_mode(
+    with pytest.raises(InvalidArgument, match="stop"):
+        async for _ in handler._generate_token_mode(
             {"token_ids": [1, 2]},
             context,
             "request-prefill",
-        )
-    ]
+        ):
+            pass
 
-    assert chunks == [
-        {"status": "error", "message": "stop", "disaggregated_params": None}
-    ]
     processor.prepare_input.assert_awaited_once_with(
         {"token_ids": [1, 2]},
         "request-prefill",
@@ -1235,7 +1219,7 @@ class TestDeferredAbort:
         handler.input_param_manager = MagicMock()
         handler.input_param_manager.get_input_param.return_value = [1, 2, 3]
         handler._resolve_lora_request = MagicMock(return_value=None)
-        handler._build_prompt_from_request = MagicMock(return_value=(MagicMock(), None))
+        handler._build_prompt_from_request = MagicMock(return_value=MagicMock())
 
         # Capture the guard created inside the handler and wrap close() so
         # the test can assert that the handler awaited it.

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -244,7 +244,16 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
             delta.top_logprobs,
         );
 
-        let finish_reason = delta.finish_reason.map(Into::into);
+        // `CompletionFinishReason` has no error variant, so the blanket `From`
+        // would flatten a failed request into `stop` and drop the message.
+        // Returning `Err` makes the postprocessor emit an error annotation the
+        // HTTP layer can answer with a non-2xx, as the chat path already does.
+        let finish_reason = match delta.finish_reason {
+            Some(common::FinishReason::Error(err_msg)) => {
+                return Err(anyhow::anyhow!(err_msg));
+            }
+            other => other.map(Into::into),
+        };
         let stop_reason = delta.stop_reason.clone();
 
         // create choice
@@ -707,6 +716,59 @@ mod tests {
             assert!(
                 nvext.get("engine_data").is_none() || nvext.get("engine_data").unwrap().is_null(),
                 "engine_data should not appear when backend provides None"
+            );
+        }
+    }
+
+    #[test]
+    fn error_finish_reason_fails_the_choice_and_keeps_the_message() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-error-finish".to_string());
+        let mut output = final_backend_output();
+        output.finish_reason = Some(common::FinishReason::Error(
+            "Invalid prompt_embeds: Failed to decode prompt_embeds as PyTorch tensor".to_string(),
+        ));
+
+        let err = generator
+            .choice_from_postprocessor(output)
+            .expect_err("a backend error must not become a successful completion");
+
+        assert!(
+            err.to_string().contains("Invalid prompt_embeds"),
+            "the worker's message must survive, got: {err}"
+        );
+    }
+
+    #[test]
+    fn non_error_finish_reasons_still_map_to_openai() {
+        use dynamo_protocols::types::CompletionFinishReason;
+
+        for (backend, expected) in [
+            (common::FinishReason::EoS, CompletionFinishReason::Stop),
+            (common::FinishReason::Stop, CompletionFinishReason::Stop),
+            (
+                common::FinishReason::Cancelled,
+                CompletionFinishReason::Stop,
+            ),
+            (common::FinishReason::Length, CompletionFinishReason::Length),
+            (
+                common::FinishReason::ContentFilter,
+                CompletionFinishReason::ContentFilter,
+            ),
+        ] {
+            let request = create_test_request();
+            let mut generator = request.response_generator("req-ok-finish".to_string());
+            let mut output = final_backend_output();
+            output.finish_reason = Some(backend.clone());
+
+            let response = generator
+                .choice_from_postprocessor(output)
+                .unwrap_or_else(|e| panic!("{backend:?} must still succeed, got: {e}"));
+
+            assert_eq!(
+                response.inner.choices[0].finish_reason,
+                Some(expected),
+                "{backend:?} mapped to the wrong OpenAI finish reason"
             );
         }
     }

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -29,7 +29,7 @@ from typing import Generator
 
 import pytest
 import torch
-from openai import OpenAI
+from openai import BadRequestError, OpenAI
 
 from tests.utils.device import detect_target_device
 from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
@@ -246,13 +246,18 @@ class TestPromptEmbedsE2E:
 
         Non-streaming mode should surface invalid prompt_embeds as an error and
         the OpenAI client should raise an exception.
+
+        The status must be 400. A 5xx body is sanitized to "Internal server
+        error" (lib/llm/src/http/service/openai.rs), which would still satisfy a
+        bare `pytest.raises` and a keyword match on "error" while telling the
+        caller nothing about what they sent.
         """
         # Create data that passes Rust validation (valid base64, >100 bytes)
         # but fails Python torch.load()
         invalid_data = b"this is not a valid pytorch tensor format!" * 10
         invalid_base64 = base64.b64encode(invalid_data).decode("utf-8")
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(BadRequestError) as exc_info:
             dynamo_client.completions.create(
                 model=TEST_MODEL,
                 prompt="",
@@ -263,9 +268,8 @@ class TestPromptEmbedsE2E:
 
         error_msg = str(exc_info.value).lower()
         assert any(
-            keyword in error_msg
-            for keyword in ["pytorch", "tensor", "invalid", "decode", "error"]
-        ), f"Expected tensor decode error, got: {error_msg}"
+            keyword in error_msg for keyword in ["pytorch", "tensor", "decode"]
+        ), f"Expected the worker's decode message, got: {error_msg}"
 
     def test_usage_prompt_tokens_not_zero(self, dynamo_client):
         """

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -266,9 +266,10 @@ class TestPromptEmbedsE2E:
                 extra_body={"prompt_embeds": invalid_base64},
             )
 
-        error_msg = str(exc_info.value).lower()
-        assert any(
-            keyword in error_msg for keyword in ["pytorch", "tensor", "decode"]
+        assert exc_info.value.status_code == 400
+        error_msg = str(exc_info.value)
+        assert (
+            "Failed to decode prompt_embeds as PyTorch tensor" in error_msg
         ), f"Expected the worker's decode message, got: {error_msg}"
 
     def test_usage_prompt_tokens_not_zero(self, dynamo_client):


### PR DESCRIPTION
## Overview:

A vLLM worker that rejects malformed `prompt_embeds` produced HTTP 200 with `finish_reason: "stop"`, an empty completion and no message. The caller had nothing to raise on, so the nightly test `test_invalid_tensor_data_rejected` failed with `DID NOT RAISE`.

Two independent defects produced the one symptom.

**Chat and completions disagreed on** `FinishReason::Error`**.** The chat delta generator returns an error for it; the completions generator ran it through the blanket `From<FinishReason> for CompletionFinishReason`, whose last arm maps `Error(_) => Stop`. `CompletionFinishReason` has no error variant, so the conversion is lossy by construction and the message is dropped with the `_`.

**A 5xx body is sanitized, so a non-2xx alone is not enough.** The HTTP layer forwards a backend message only for 4xx, because 5xx text may contain internal paths. Fixing only the Rust side yields 500 with "Internal server error", which satisfies the nightly test purely because its keyword list contains the bare word "error" while telling the caller nothing. Rust cannot promote this to 400 on its own: `FinishReason::Error(String)` is also how the detokenizer reports its own failures, which are server faults, so mapping the variant to 400 would mislabel them and suppress retries. The classification exists only at the raise site.

## Details:

`completions/delta.rs` now matches `FinishReason::Error` and returns it, mirroring `chat_completions/delta.rs`. The postprocessor turns that into an error annotation the HTTP preflight answers with a non-2xx. This is the backstop for every producer that still reports errors in band.

`handlers.py::_build_prompt_from_request` raises instead of returning `(prompt, error_dict)`. The `--enable-prompt-embeds`-unset branch raises `InvalidArgument`; decode failures propagate unchanged, since the bindings already map `ValueError` and `TypeError` to `Backend(InvalidArgument)`, which is 400 carrying the message. No new exception type was needed. Removing the error returns leaves the function with a single return value, so the tuple, the `error = None` assignments and both `if error is not None` blocks disappear; the Python change is a net deletion.

### Before / after

Invalid `prompt_embeds`, non-streaming:

```
before  200  finish_reason=stop, empty, 0 tokens
after   400  ValueError: Failed to decode prompt_embeds
             as PyTorch tensor: pop from empty list
```

## Where should the reviewer start?

`lib/llm/src/protocols/openai/completions/delta.rs` is the smallest and most load-bearing hunk: one `match` replacing `.map(Into::into)`. Compare it against `chat_completions/delta.rs`, which already did exactly this.

Then `components/src/dynamo/vllm/handlers.py::_build_prompt_from_request`, where the return contract changes from `(prompt, error_dict)` to `prompt`. The two call sites in the same file and the mocks in `test_vllm_worker_handler.py` follow from that change.

## Validation

Local venv, file discovery and tcp request plane, `Qwen/Qwen3-0.6B`, vLLM 0.26.0.

* `test_invalid_tensor_data_rejected` passes. Full `test_prompt_embeds.py`: 5 passed.
* `test_vllm_worker_handler.py`: 69 passed, matching baseline.
* `dynamo-llm` lib: 2087 passed.
* Two Rust regression tests. The error test fails without the fix hunk; the five-variant sweep passes with and without, so it guards against the new match over-triggering rather than restating the fix.
* The nightly test now pins `BadRequestError`, `status_code == 400` and the exact decode message. The previous assertion accepted any exception whose text contained "error", which a sanitized 500 also satisfies, so it could not tell the fixed behavior from the broken one.
* **Disaggregated prefill and decode**, NixlConnector KV transfer: invalid `prompt_embeds` returns the same 400 with the message intact. Verified in the worker logs that the prefill worker raised exactly once (no retry), and that the decode worker never received the failing request, so no decode work is stranded. A plain-prompt control through the same deployment returns 200 and generates normally.

## Known limitations

* Streaming `/v1/completions` still returns 200 with a generic body. That path has no pre-commit error peek and the SSE error formatter discards its argument. Pre-existing, affects all streaming endpoints and all error types.
* `MissingMultimodalHandoffError` still reports in band. Now a loud 500 rather than a silent 200, but its message is still lost. Left for a follow-up.

## Related Issues

* Relates to ai-dynamo/dynamo#8549

That issue reports the *bare* `finish_reason: "error"` form reaching the frontend and producing a 500. This PR does not fix that form, which is still rejected at deserialization on purpose, but it is the same underlying problem: worker and frontend disagree on how a generation error is represented.