### PR TITLE
fix(vllm): preserve prompt embedding errors

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2738,15 +2738,23 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             )
 
         if self.model_config is None:
-            raise ValueError("ModelConfig is unavailable for prompt_embeds validation.")
+            raise RuntimeError(
+                "ModelConfig is unavailable for prompt_embeds validation."
+            )
 
         try:
             return safe_load_prompt_embeds(
                 self.model_config, prompt_embeds_base64.encode()
             )
+        except (MemoryError, torch.OutOfMemoryError):
+            # Resource failures are server-side faults. Preserve their type so
+            # the bindings return a retryable 5xx instead of a client 400.
+            raise
         except Exception as e:
             logger.error(f"Failed to decode prompt_embeds: {e}")
-            raise ValueError(f"Failed to decode prompt_embeds as PyTorch tensor: {e}")
+            raise ValueError(
+                f"Failed to decode prompt_embeds as PyTorch tensor: {e}"
+            ) from e
 
     def _create_prompt_from_embeddings(
         self, prompt_embeds_base64: str
@@ -2783,7 +2791,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         multi_modal_data: Dict[str, Any] | None,
         log_prefix: str = "",
         mm_processor_kwargs: Dict[str, Any] | None = None,
-    ) -> tuple[TokensPrompt | EmbedsPrompt | None, Dict[str, Any] | None]:
+    ) -> TokensPrompt | EmbedsPrompt:
         """
         Build a prompt from request, handling both prompt_embeds and token_ids.
 
@@ -2796,11 +2804,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 use_audio_in_video) forwarded to the vLLM engine.
 
         Returns:
-            Tuple of (prompt, None). The second field preserves the existing
-            worker-handler contract.
+            The vLLM prompt built from prompt embeddings or token IDs.
 
         Raises:
-            InvalidArgument: prompt embeddings are disabled or cannot be decoded.
+            InvalidArgument: Prompt embeddings are disabled.
+            ValueError: Prompt embeddings cannot be decoded or validated.
         """
         if "prompt_embeds" in request and request["prompt_embeds"]:
             if not self.config.engine_args.enable_prompt_embeds:
@@ -2823,7 +2831,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     f"dtype={tensor.dtype}, sequence_length={tensor.shape[0]}, "
                     f"request_id={request_id}"
                 )
-                return prompt, None
+                return prompt
             except Exception as exc:
                 logger.error(
                     "Failed to process prompt_embeds for %s %s: %s",
@@ -2831,7 +2839,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     request_id,
                     exc,
                 )
-                raise InvalidArgument(f"Invalid prompt_embeds: {exc}") from exc
+                raise
         # Text-only PD + encoder-worker path.
         # Normal path: use token IDs.
         # Prefer frontend-forwarded mm_hashes for hash consistency with the
@@ -2844,7 +2852,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             multi_modal_data,
             mm_processor_kwargs,
         )
-        return prompt, None
+        return prompt
 
     @staticmethod
     def _build_completion_usage(
@@ -3329,27 +3337,22 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         with _nvtx.annotate("mm_backend:build_prompt", color="yellow"):
             if custom_prompt is not None:
                 prompt = custom_prompt
-                error = None
             elif pre_rendered is not None:
                 # pre_rendered is a MultiModalInput dict with "type": "multimodal".
                 # The engine's InputProcessor.process_inputs() will see the "type"
                 # key and skip the HF processor entirely.
                 prompt = pre_rendered
-                error = None
                 logger.debug(
                     "[mm-routing] Request %s: using pre-rendered MultiModalInput",
                     request_id,
                 )
             else:
-                prompt, error = self._build_prompt_from_request(
+                prompt = self._build_prompt_from_request(
                     request,
                     request_id,
                     multi_modal_data,
                     mm_processor_kwargs=mm_processor_kwargs,
                 )
-        if error is not None:
-            yield error
-            return
 
         _apply_nvext_cache_salt(request, prompt)
 
@@ -3644,18 +3647,13 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         mm_processor_kwargs = prepared_input.mm_processor_kwargs
 
         # Build prompt from request (handles both prompt_embeds and token_ids)
-        prompt, error = self._build_prompt_from_request(
+        prompt = self._build_prompt_from_request(
             request,
             request_id,
             multi_modal_data,
             log_prefix="Prefill ",
             mm_processor_kwargs=mm_processor_kwargs,
         )
-        if error is not None:
-            # Prefill errors need disaggregated_params field
-            error["disaggregated_params"] = None
-            yield error
-            return
 
         _apply_nvext_cache_salt(request, prompt)
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2796,9 +2796,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 use_audio_in_video) forwarded to the vLLM engine.
 
         Returns:
-            Tuple of (prompt, error_dict) where:
-            - On success: (prompt, None)
-            - On failure: (None, error_dict to yield)
+            Tuple of (prompt, None). The second field preserves the existing
+            worker-handler contract.
+
+        Raises:
+            InvalidArgument: prompt embeddings are disabled or cannot be decoded.
         """
         if "prompt_embeds" in request and request["prompt_embeds"]:
             if not self.config.engine_args.enable_prompt_embeds:
@@ -2806,16 +2808,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     "Set `--enable-prompt-embeds` to allow `prompt_embeds` in request."
                 )
                 logger.error(
-                    f"Rejected prompt_embeds for {log_prefix.lower().strip() or 'request'} "
-                    f"{request_id}: {msg}"
+                    "Rejected prompt_embeds for %s %s: %s",
+                    log_prefix.lower().strip() or "request",
+                    request_id,
+                    msg,
                 )
-                return (
-                    None,
-                    {
-                        "finish_reason": f"error: Invalid prompt_embeds: {msg}",
-                        "token_ids": [],
-                    },
-                )
+                raise InvalidArgument(f"Invalid prompt_embeds: {msg}")
             try:
                 prompt, tensor = self._create_prompt_from_embeddings(
                     request["prompt_embeds"]
@@ -2826,18 +2824,14 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     f"request_id={request_id}"
                 )
                 return prompt, None
-            except Exception as e:
+            except Exception as exc:
                 logger.error(
-                    f"Failed to process prompt_embeds for {log_prefix.lower().strip() or 'request'} "
-                    f"{request_id}: {e}"
+                    "Failed to process prompt_embeds for %s %s: %s",
+                    log_prefix.lower().strip() or "request",
+                    request_id,
+                    exc,
                 )
-                return (
-                    None,
-                    {
-                        "finish_reason": f"error: Invalid prompt_embeds: {e}",
-                        "token_ids": [],
-                    },
-                )
+                raise InvalidArgument(f"Invalid prompt_embeds: {exc}") from exc
         # Text-only PD + encoder-worker path.
         # Normal path: use token IDs.
         # Prefer frontend-forwarded mm_hashes for hash consistency with the

--- a/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
@@ -99,6 +99,28 @@ class TestPromptEmbedsDecode:
         with pytest.raises(ValueError, match=error_match):
             mock_handler._decode_prompt_embeds(invalid_input)
 
+    def test_missing_model_config_is_server_error(self, mock_handler):
+        mock_handler.model_config = None
+
+        with pytest.raises(RuntimeError, match="ModelConfig is unavailable"):
+            mock_handler._decode_prompt_embeds("unused")
+
+    @pytest.mark.parametrize(
+        "error",
+        [MemoryError("host allocation failed"), torch.OutOfMemoryError("OOM")],
+        ids=["memory-error", "torch-oom"],
+    )
+    def test_decode_resource_errors_propagate(self, mock_handler, monkeypatch, error):
+        monkeypatch.setattr(
+            "dynamo.vllm.handlers.safe_load_prompt_embeds",
+            Mock(side_effect=error),
+        )
+
+        with pytest.raises(type(error)) as exc_info:
+            mock_handler._decode_prompt_embeds("unused")
+
+        assert exc_info.value is error
+
     def test_decode_numpy_format_rejected(self, mock_handler):
         """Test that NumPy format is rejected (PyTorch format required)."""
         embeddings = np.random.randn(10, 768).astype(np.float32)

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -744,7 +744,7 @@ class TestDecodeWorkerMultimodalBranching:
             disaggregation_mode="DECODE",
         )
         handler._build_prompt_from_request = MagicMock(
-            return_value=(None, {"status": "error", "message": "test stop"})
+            side_effect=RuntimeError("test stop")
         )
         request = {
             "token_ids": [1, 2, 3],
@@ -759,13 +759,12 @@ class TestDecodeWorkerMultimodalBranching:
             },
         }
         context = MagicMock()
-        chunks = []
-        async for chunk in handler._generate_token_mode(request, context, "req-1"):
-            chunks.append(chunk)
+        with pytest.raises(RuntimeError, match="test stop"):
+            async for _ in handler._generate_token_mode(request, context, "req-1"):
+                pass
 
         # Should reach _build_prompt_from_request (not error at decode guard)
-        assert len(chunks) == 1
-        assert chunks[0]["message"] == "test stop"
+        handler._build_prompt_from_request.assert_called_once()
 
     async def test_aggregated_mode_calls_extract_multimodal_data(self):
         """Aggregated mode delegates media loading to the shared processor."""
@@ -774,10 +773,10 @@ class TestDecodeWorkerMultimodalBranching:
             return_value=None
         )
 
-        # Return an error from _build_prompt_from_request so _generate_token_mode
-        # yields it and returns early — no need to mock the engine.
+        # Raise from _build_prompt_from_request so generation stops before the
+        # engine call — no need to mock the engine.
         handler._build_prompt_from_request = MagicMock(
-            return_value=(None, {"status": "error", "message": "test stop"})
+            side_effect=RuntimeError("test stop")
         )
 
         request = {
@@ -789,13 +788,11 @@ class TestDecodeWorkerMultimodalBranching:
         }
         context = MagicMock()
 
-        chunks = []
-        async for chunk in handler._generate_token_mode(request, context, "req-1"):
-            chunks.append(chunk)
+        with pytest.raises(RuntimeError, match="test stop"):
+            async for _ in handler._generate_token_mode(request, context, "req-1"):
+                pass
 
         handler._multimodal_request_processor.extract_multimodal_data.assert_awaited_once()
-        assert len(chunks) == 1
-        assert chunks[0]["status"] == "error"
 
     async def test_decode_only_bypass_annotation_runs_as_agg(self):
         """Decode worker with conditional-disagg bypass annotation runs as AGG."""
@@ -807,7 +804,7 @@ class TestDecodeWorkerMultimodalBranching:
             return_value=None
         )
         handler._build_prompt_from_request = MagicMock(
-            return_value=(None, {"status": "error", "message": "test stop"})
+            side_effect=RuntimeError("test stop")
         )
 
         request = {
@@ -820,22 +817,18 @@ class TestDecodeWorkerMultimodalBranching:
         }
         context = MagicMock()
 
-        chunks = []
-        async for chunk in handler._generate_token_mode(request, context, "req-1"):
-            chunks.append(chunk)
+        with pytest.raises(RuntimeError, match="test stop"):
+            async for _ in handler._generate_token_mode(request, context, "req-1"):
+                pass
 
         handler._multimodal_request_processor.extract_multimodal_data.assert_awaited_once()
-        assert len(chunks) == 1
-        assert chunks[0]["message"] == "test stop"
 
     async def test_decode_only_bypass_annotation_text_only_does_not_require_prefill_kv_params(
         self,
     ):
         """Text-only bypass does not require incoming prefill KV params."""
         handler = _make_decode_handler(disaggregation_mode="DECODE")
-        handler._build_prompt_from_request = MagicMock(
-            return_value=(None, {"status": "error", "message": "stop"})
-        )
+        handler._build_prompt_from_request = MagicMock(side_effect=RuntimeError("stop"))
 
         request = {
             "token_ids": [1, 2, 3],
@@ -846,12 +839,9 @@ class TestDecodeWorkerMultimodalBranching:
         }
         context = MagicMock()
 
-        chunks = []
-        async for chunk in handler._generate_token_mode(request, context, "req-1"):
-            chunks.append(chunk)
-
-        assert len(chunks) == 1
-        assert chunks[0]["message"] == "stop"
+        with pytest.raises(RuntimeError, match="stop"):
+            async for _ in handler._generate_token_mode(request, context, "req-1"):
+                pass
 
     async def test_decode_only_bypass_annotation_text_mode_runs_as_agg(self):
         """Text-mode conditional-disagg bypass is not treated as decode-only."""
@@ -911,14 +901,13 @@ class TestDecodeWorkerMultimodalBranching:
     ):
         handler = _make_decode_handler(disaggregation_mode="AGGREGATED")
 
-        prompt, error = handler._build_prompt_from_request(
+        prompt = handler._build_prompt_from_request(
             {"token_ids": [1, 2, 3]},
             "request-prompt",
             multi_modal_data=None,
             mm_processor_kwargs=mm_processor_kwargs,
         )
 
-        assert error is None
         if mm_processor_kwargs is None:
             assert "mm_processor_kwargs" not in prompt
         else:
@@ -934,6 +923,20 @@ class TestDecodeWorkerMultimodalBranching:
                 "request-prompt",
                 multi_modal_data=None,
             )
+
+    async def test_handler_prompt_builder_preserves_server_errors(self):
+        handler = _make_decode_handler(disaggregation_mode="AGGREGATED")
+        server_error = RuntimeError("backend allocation failed")
+        handler._create_prompt_from_embeddings = MagicMock(side_effect=server_error)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            handler._build_prompt_from_request(
+                {"prompt_embeds": "unused"},
+                "request-prompt",
+                multi_modal_data=None,
+            )
+
+        assert exc_info.value is server_error
 
 
 @pytest.mark.asyncio
@@ -952,23 +955,16 @@ async def test_prefill_delegates_mode_policy_to_shared_processor():
         )
     )
     handler._multimodal_request_processor = processor
-    handler._build_prompt_from_request = MagicMock(
-        return_value=(None, {"status": "error", "message": "stop"})
-    )
+    handler._build_prompt_from_request = MagicMock(side_effect=RuntimeError("stop"))
     context = MagicMock()
 
-    chunks = [
-        chunk
-        async for chunk in handler._generate_token_mode(
+    with pytest.raises(RuntimeError, match="stop"):
+        async for _ in handler._generate_token_mode(
             {"token_ids": [1, 2]},
             context,
             "request-prefill",
-        )
-    ]
-
-    assert chunks == [
-        {"status": "error", "message": "stop", "disaggregated_params": None}
-    ]
+        ):
+            pass
     processor.prepare_input.assert_awaited_once_with(
         {"token_ids": [1, 2]},
         "request-prefill",
@@ -1246,7 +1242,7 @@ class TestDeferredAbort:
         handler.input_param_manager = MagicMock()
         handler.input_param_manager.get_input_param.return_value = [1, 2, 3]
         handler._resolve_lora_request = MagicMock(return_value=None)
-        handler._build_prompt_from_request = MagicMock(return_value=(MagicMock(), None))
+        handler._build_prompt_from_request = MagicMock(return_value=MagicMock())
 
         # Capture the guard created inside the handler and wrap close() so
         # the test can assert that the handler awaited it.

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -924,6 +924,17 @@ class TestDecodeWorkerMultimodalBranching:
         else:
             assert prompt["mm_processor_kwargs"] is mm_processor_kwargs
 
+    async def test_handler_prompt_builder_rejects_disabled_prompt_embeds(self):
+        handler = _make_decode_handler(disaggregation_mode="AGGREGATED")
+        handler.config.engine_args.enable_prompt_embeds = False
+
+        with pytest.raises(mod.InvalidArgument, match="--enable-prompt-embeds"):
+            handler._build_prompt_from_request(
+                {"prompt_embeds": "unused"},
+                "request-prompt",
+                multi_modal_data=None,
+            )
+
 
 @pytest.mark.asyncio
 async def test_prefill_delegates_mode_policy_to_shared_processor():

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -248,6 +248,7 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
         // Keep completions aligned with the chat-completions delta generator.
         let finish_reason = match delta.finish_reason {
             Some(common::FinishReason::Error(err_msg)) => {
+                self.tracker.record_finish();
                 return Err(anyhow::anyhow!(err_msg));
             }
             Some(reason) => Some(reason.into()),
@@ -454,12 +455,14 @@ mod tests {
         output.finish_reason = Some(common::FinishReason::Error(
             "invalid prompt embeddings".to_string(),
         ));
+        assert!(generator.tracker().total_time_ms().is_none());
 
         let error = generator
             .choice_from_postprocessor(output)
             .expect_err("backend error must fail the response");
 
-        assert!(error.to_string().contains("invalid prompt embeddings"));
+        assert_eq!(error.to_string(), "invalid prompt embeddings");
+        assert!(generator.tracker().total_time_ms().is_some());
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -244,7 +244,15 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
             delta.top_logprobs,
         );
 
-        let finish_reason = delta.finish_reason.map(Into::into);
+        // Backend errors are response errors, not successful OpenAI stop reasons.
+        // Keep completions aligned with the chat-completions delta generator.
+        let finish_reason = match delta.finish_reason {
+            Some(common::FinishReason::Error(err_msg)) => {
+                return Err(anyhow::anyhow!(err_msg));
+            }
+            Some(reason) => Some(reason.into()),
+            None => None,
+        };
         let stop_reason = delta.stop_reason.clone();
 
         // create choice
@@ -436,6 +444,22 @@ mod tests {
             .expect("choice generation");
 
         assert!(response.nvext.is_none());
+    }
+
+    #[test]
+    fn test_backend_error_is_not_converted_to_stop() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-backend-error".to_string());
+        let mut output = final_backend_output();
+        output.finish_reason = Some(common::FinishReason::Error(
+            "invalid prompt embeddings".to_string(),
+        ));
+
+        let error = generator
+            .choice_from_postprocessor(output)
+            .expect_err("backend error must fail the response");
+
+        assert!(error.to_string().contains("invalid prompt embeddings"));
     }
 
     #[test]

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -45,9 +45,7 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.vllm,
     pytest.mark.core,
-    # TODO: revert to pytest.mark.nightly after pre_merge validation
-    # on this PR (see .ai/ci-guidelines.md).
-    pytest.mark.pre_merge,
+    pytest.mark.nightly,
     pytest.mark.gpu_1,
     pytest.mark.xpu_1,
     pytest.mark.model(TEST_MODEL),

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -29,7 +29,7 @@ from typing import Generator
 
 import pytest
 import torch
-from openai import OpenAI
+from openai import BadRequestError, OpenAI
 
 from tests.utils.device import detect_target_device
 from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
@@ -45,7 +45,9 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.vllm,
     pytest.mark.core,
-    pytest.mark.nightly,
+    # TODO: revert to pytest.mark.nightly after pre_merge validation
+    # on this PR (see .ai/ci-guidelines.md).
+    pytest.mark.pre_merge,
     pytest.mark.gpu_1,
     pytest.mark.xpu_1,
     pytest.mark.model(TEST_MODEL),
@@ -252,7 +254,7 @@ class TestPromptEmbedsE2E:
         invalid_data = b"this is not a valid pytorch tensor format!" * 10
         invalid_base64 = base64.b64encode(invalid_data).decode("utf-8")
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(BadRequestError) as exc_info:
             dynamo_client.completions.create(
                 model=TEST_MODEL,
                 prompt="",
@@ -261,11 +263,11 @@ class TestPromptEmbedsE2E:
                 extra_body={"prompt_embeds": invalid_base64},
             )
 
-        error_msg = str(exc_info.value).lower()
-        assert any(
-            keyword in error_msg
-            for keyword in ["pytorch", "tensor", "invalid", "decode", "error"]
-        ), f"Expected tensor decode error, got: {error_msg}"
+        assert exc_info.value.status_code == 400
+        error_msg = str(exc_info.value)
+        assert (
+            "Failed to decode prompt_embeds as PyTorch tensor" in error_msg
+        ), f"Expected the worker's tensor decode error, got: {error_msg}"
 
     def test_usage_prompt_tokens_not_zero(self, dynamo_client):
         """


### PR DESCRIPTION
## Summary

- raise `InvalidArgument` when prompt embeddings are disabled or cannot be decoded
- propagate backend `FinishReason::Error` through the legacy completions response generator
- add focused regression coverage for the disabled-embeddings and completions-error paths

Fixes DIS-2677.

## Root cause

The vLLM worker encoded malformed prompt-embedding failures as a terminal backend output. The legacy completions generator then converted the backend error into a normal OpenAI `stop` finish reason, causing an invalid request to appear successful.

## Fix

The worker now raises the existing typed `InvalidArgument`, producing HTTP 400 with the original decoder message. The completions generator treats any backend error as a response error, matching the chat-completions path.

## Validation

Tested locally on NVIDIA RTX 6000 Ada, CUDA 13, Torch 2.11.0+cu130, vLLM 0.26.0, and Qwen/Qwen3-0.6B.

- exact nightly GPU test `TestPromptEmbedsE2E::test_invalid_tensor_data_rejected`: 1 passed
- full prompt-embeddings GPU module: 5 passed
- full vLLM `gpu_0` unit suite: 1,118 passed, 6 skipped
- completions delta Rust tests: 13 passed
- production release wheel build passed
- pre-commit and formatting checks passed

The full `dynamo-llm` library run completed with 2,078 passed and three unrelated baseline failures that reproduced identically on clean `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid prompt-embedding requests now return a clear invalid-argument error.
  * Prompt-embedding failures include improved diagnostic context.
  * Backend completion errors are now surfaced as response errors instead of being reported as normal stop reasons.

* **Tests**
  * Added regression coverage for invalid prompt embeddings and backend completion errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->