### PR TITLE
feat(router): add first-party selection policy catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,6 +2603,7 @@ name = "dynamo-first-party-router-policies"
 version = "1.5.0"
 dependencies = [
  "dynamo-kv-router",
+ "dynamo-runtime",
  "fastrand",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-first-party-router-policies"
+version = "1.5.0"
+dependencies = [
+ "dynamo-kv-router",
+ "fastrand",
+ "serde",
+]
+
+[[package]]
 name = "dynamo-kv-hashing"
 version = "1.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "lib/kv-hashing",
     "lib/mocker",
     "lib/kv-router",
+    "lib/router-plugins/first-party",
     "lib/router-plugins/catalog",
     "examples/router/custom-policy-example/simple-filter-score-pick",
     "examples/router/custom-policy-example/catalog",
@@ -68,6 +69,7 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.5.0" }
 dynamo-memory = { path = "lib/memory", version = "1.5.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.5.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.5.0" }
+dynamo-first-party-router-policies = { path = "lib/router-plugins/first-party", version = "1.5.0" }
 dynamo-protocols = { version = "=5.3.1" }
 dynamo-parsers = { version = "8.0.0" }
 

--- a/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
+++ b/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
@@ -320,6 +320,7 @@ Request context and worker identity are always available. Dynamo calculates opti
 | `priority_jump()` | Scheduler priority boost. Queue policies treat negative values as zero |
 | `strict_priority()` | Strict integer priority. The queue orders larger values first |
 | `router_temperature_override()` | Optional per-request router temperature override |
+| `is_advisory()` | Whether this is a read-only selection; stateful pickers must not advance state |
 
 ### Session Context
 
@@ -357,11 +358,18 @@ If a component needs no optional worker data, return `WorkerInputs::NONE`. Combi
 | `LOAD` | `active_prefill_tokens()` | Tokens currently active in the worker's prefill stage |
 | `LOAD` | `decode_cost_blocks()` | Projected active decode footprint, including this request's additional active blocks |
 | `LOAD` | `active_requests()` | Requests currently active on the worker |
+| `ACTIVE_REQUEST_LOAD` | `active_requests()` | Frontend-local active-request count, without KV or scheduler projections |
 | `ROUTING` | `preferred_taint_multiplier()` | Optional cost multiplier from preferred routing constraints |
 
 The cache accessors return raw tier counts. A missing tier or worker entry is zero; Dynamo does not substitute its weighted effective-overlap estimate. Each custom scorer chooses how to combine the raw counts.
 
 A filter or scorer reads requested groups through `WorkerCandidate::cache()`, `load()`, or `routing()`. A picker reads index-aligned arrays through `WorkerInputView`. Each component must request every group that it reads.
+
+## Cache-Free Hosts
+
+`WorkerSelectionPolicy::into_cache_free()` adapts a custom policy for a host that has discovery and frontend-local request accounting, but does not construct a KV indexer, scheduler, or slot tracker. The host exposes worker identity plus `ACTIVE_REQUEST_LOAD` through a borrowed `CacheFreeCandidateTable`; it rejects policies that request `CACHE`, `ROUTING`, or full `LOAD` projections at construction.
+
+The adapter serializes picker-local state, while its host must keep a committed selection and active-request admission atomic. Advisory requests call the same picker with `is_advisory() == true`, so a stateful picker must leave cursors and other committed state unchanged. This host contract is for first-party routing integration; linked policy instances still use KV routing until that integration is enabled.
 
 ## Link the Policy Into Dynamo
 
@@ -461,6 +469,8 @@ Standalone EPP supplies `WorkerType::Aggregated` because it selects from one ful
 - Return a valid picker row.
 - Treat candidate order as unspecified.
 - Request only the signal groups that the component reads.
+- Use `ACTIVE_REQUEST_LOAD`, rather than `LOAD`, when active-request count is the only load value the policy reads.
+- Do not mutate picker-local state when `context.is_advisory()` is true.
 - Keep blocking I/O and panics out of `keep`, `score`, and `pick`.
 - Keep policy state local to the factory-created policy unless cross-partition sharing is a deliberate requirement.
 - Build the policy against the same Dynamo revision as the frontend or EPP.

--- a/examples/router/custom-policy-example/simple-filter-score-pick/src/scorer.rs
+++ b/examples/router/custom-policy-example/simple-filter-score-pick/src/scorer.rs
@@ -13,7 +13,7 @@ pub(crate) struct ActiveRequestsScorer;
 impl WorkerScorer for ActiveRequestsScorer {
     /// Requests load inputs for the active-request count.
     fn required_worker_inputs(&self) -> WorkerInputs {
-        WorkerInputs::LOAD
+        WorkerInputs::ACTIVE_REQUEST_LOAD
     }
 
     /// Returns the active-request count as a lower-is-better cost.

--- a/examples/router/custom-policy-example/simple-stacked-score-pick/src/scorer/active_requests.rs
+++ b/examples/router/custom-policy-example/simple-stacked-score-pick/src/scorer/active_requests.rs
@@ -11,7 +11,7 @@ pub(crate) struct ActiveRequestsScorer;
 
 impl WorkerScorer for ActiveRequestsScorer {
     fn required_worker_inputs(&self) -> WorkerInputs {
-        WorkerInputs::LOAD
+        WorkerInputs::ACTIVE_REQUEST_LOAD
     }
 
     fn score(

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1717,6 +1717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-first-party-router-policies"
+version = "1.5.0"
+dependencies = [
+ "dynamo-kv-router",
+ "fastrand",
+ "serde",
+]
+
+[[package]]
 name = "dynamo-kv-hashing"
 version = "1.5.0"
 dependencies = [
@@ -1986,6 +1995,7 @@ dependencies = [
  "clap",
  "dashmap",
  "dynamo-backend-common",
+ "dynamo-first-party-router-policies",
  "dynamo-kv-router",
  "dynamo-llm",
  "dynamo-mocker",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -94,6 +94,7 @@ uuid = { version = "1.18.1" }
 
 # kv-indexer / slot-tracker / shared kv-router types
 dynamo-kv-router = { path = "../../kv-router" }
+dynamo-first-party-router-policies = { path = "../../router-plugins/first-party" }
 dynamo-worker-selection-policy-catalog = { path = "../../router-plugins/catalog", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -10,7 +10,6 @@ use dynamo_runtime::storage::kv;
 use futures::StreamExt;
 use once_cell::sync::OnceCell;
 use pyo3::IntoPyObjectExt;
-#[cfg(feature = "custom-policy")]
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::{PyStopAsyncIteration, PyTimeoutError, PyValueError};
 use pyo3::types::PyCapsule;
@@ -38,8 +37,7 @@ use dynamo_runtime::{
     traits::DistributedRuntimeProvider,
 };
 
-#[cfg(feature = "custom-policy")]
-use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
+use dynamo_kv_router::services::policy_registry::WorkerSelectionPolicyRegistry;
 use dynamo_kv_router::{KvRouterConfig, WorkerSelectionPolicyFactory};
 use dynamo_llm::entrypoint::RouterConfig;
 use dynamo_llm::{self as llm_rs};
@@ -115,7 +113,6 @@ type PythonBidirectionalIngress = Ingress<
 
 static INIT: OnceCell<()> = OnceCell::new();
 
-#[cfg(feature = "custom-policy")]
 static WORKER_SELECTION_POLICY_REGISTRY: OnceCell<WorkerSelectionPolicyRegistry> = OnceCell::new();
 
 const DEFAULT_ANNOTATED_SETTING: Option<bool> = Some(true);
@@ -271,24 +268,11 @@ fn register_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
 pub(crate) fn worker_selection_policy_factory(
     config: &KvRouterConfig,
 ) -> anyhow::Result<Option<WorkerSelectionPolicyFactory>> {
-    #[cfg(feature = "custom-policy")]
-    {
-        Ok(WORKER_SELECTION_POLICY_REGISTRY
-            .get()
-            .map(|registry| registry.resolve(config))
-            .transpose()?
-            .flatten())
-    }
-
-    #[cfg(not(feature = "custom-policy"))]
-    {
-        if let Some(instance) = config.selected_worker_selection_policy_instance()? {
-            anyhow::bail!(
-                "worker-selection instance {instance:?} is configured, but this Dynamo build has no linked worker-selection policy catalog; rebuild with --features custom-policy"
-            );
-        }
-        Ok(None)
-    }
+    WORKER_SELECTION_POLICY_REGISTRY
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("worker-selection policy registry was not initialized"))?
+        .resolve(config)
+        .map_err(Into::into)
 }
 
 #[cfg(feature = "select-service")]
@@ -310,33 +294,19 @@ pub(crate) fn standalone_worker_selection_policy_factory(
 ) -> anyhow::Result<Option<WorkerSelectionPolicyFactory>> {
     warn_if_standalone_ignores_stage_policies(config)?;
 
-    #[cfg(feature = "custom-policy")]
-    {
-        Ok(WORKER_SELECTION_POLICY_REGISTRY
-            .get()
-            .map(|registry| {
-                registry.resolve_for_worker_type(config, dynamo_kv_router::WorkerType::Aggregated)
-            })
-            .transpose()?
-            .flatten())
-    }
-
-    #[cfg(not(feature = "custom-policy"))]
-    {
-        if let Some(instance) = config.selected_worker_selection_policy_instance_for(
-            dynamo_kv_router::WorkerType::Aggregated,
-        )? {
-            anyhow::bail!(
-                "worker-selection instance {instance:?} is configured, but this Dynamo build has no linked worker-selection policy catalog; rebuild with --features custom-policy"
-            );
-        }
-        Ok(None)
-    }
+    WORKER_SELECTION_POLICY_REGISTRY
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("worker-selection policy registry was not initialized"))?
+        .resolve_for_worker_type(config, dynamo_kv_router::WorkerType::Aggregated)
+        .map_err(Into::into)
 }
 
-#[cfg(feature = "custom-policy")]
-fn register_core_with_custom_worker_selection_policy(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn register_core_with_worker_selection_policies(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let mut registry = WorkerSelectionPolicyRegistry::default();
+    dynamo_first_party_router_policies::register(&mut registry)
+        .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+
+    #[cfg(feature = "custom-policy")]
     dynamo_worker_selection_policy_catalog::register(&mut registry)
         .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
 
@@ -349,17 +319,9 @@ fn register_core_with_custom_worker_selection_policy(m: &Bound<'_, PyModule>) ->
 }
 
 /// The extension-module entrypoint for a custom policy image.
-#[cfg(feature = "custom-policy")]
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    register_core_with_custom_worker_selection_policy(m)
-}
-
-/// The stock extension-module entrypoint.
-#[cfg(not(feature = "custom-policy"))]
-#[pymodule]
-fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    register_core(m)
+    register_core_with_worker_selection_policies(m)
 }
 
 pub fn to_pyerr<E>(err: E) -> PyErr

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -1013,7 +1013,7 @@ pub fn run_input<'p>(
             .is_kv_routing()
     {
         return Err(PyValueError::new_err(
-            "linked worker-selection policies require --router-mode kv",
+            "worker-selection policy instances require --router-mode kv",
         ));
     }
     if worker_selection_policy_factory.is_some() && !matches!(&input_enum, Input::Http) {

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -22,7 +22,6 @@ use crate::Endpoint;
 use clap::Parser;
 #[cfg(feature = "select-service")]
 use dynamo_kv_router::TrackingHashAlgorithm;
-#[cfg(feature = "custom-policy")]
 use dynamo_kv_router::WorkerSelectionPolicy;
 use dynamo_kv_router::WorkerSelectionPolicyFactory;
 #[cfg(feature = "select-service")]
@@ -46,13 +45,7 @@ use rs::protocols::annotated::Annotated as RsAnnotated;
 use tracing;
 
 use llm_rs::kv_router::KvPushRouter;
-#[cfg(not(feature = "custom-policy"))]
-type RsKvPushRouter = KvPushRouter;
-#[cfg(feature = "custom-policy")]
 type RsKvPushRouter = KvPushRouter<WorkerSelectionPolicy>;
-#[cfg(not(feature = "custom-policy"))]
-type RsKvRouter = llm_rs::kv_router::KvRouter;
-#[cfg(feature = "custom-policy")]
 type RsKvRouter = llm_rs::kv_router::KvRouter<WorkerSelectionPolicy>;
 use llm_rs::kv_router::publisher::{KvEventSourceConfig, create_stored_blocks};
 use llm_rs::protocols::common::timing::RequestTracker;
@@ -1639,7 +1632,7 @@ fn infer_metric_worker_type(
 }
 
 /// Keep the advertised role for existing router metadata and require the same explicit role for
-/// custom-policy dispatch. Legacy cards are ambiguous between decode and aggregated workers.
+/// linked-policy dispatch. Legacy cards are ambiguous between decode and aggregated workers.
 fn advertised_and_policy_worker_roles(
     card: &llm_rs::model_card::ModelDeploymentCard,
 ) -> (
@@ -1684,7 +1677,7 @@ mod metric_worker_type_tests {
 }
 
 /// Create a KV router from an endpoint using the ModelManager for registration.
-/// Custom policies use the discovered model card's typed worker role for selection.
+/// Linked policies use the discovered model card's typed worker role for selection.
 async fn create_kv_router_from_endpoint(
     endpoint: &Endpoint,
     block_size: usize,
@@ -1787,25 +1780,6 @@ async fn create_kv_router_from_endpoint(
             }
         }
     };
-    #[cfg(not(feature = "custom-policy"))]
-    let _ = (policy_model_name, policy_worker_role);
-
-    #[cfg(not(feature = "custom-policy"))]
-    let kv_router = model_manager
-        .kv_chooser_for_with_worker_role(
-            &endpoint.inner,
-            block_size as u32,
-            kv_router_config,
-            prefill_load_estimator,
-            worker_role,
-            metric_worker_type,
-            model_name,
-            enable_eagle,
-        )
-        .await
-        .map_err(to_pyerr)?;
-
-    #[cfg(feature = "custom-policy")]
     let kv_router = {
         let effective_config = kv_router_config.clone().unwrap_or_default();
         let selector = worker_selection_policy_factory.map_or_else(

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -77,10 +77,10 @@ pub use scheduling::{
 };
 pub use selector::{
     CacheFreeCandidateTable, CacheFreePolicyDecision, CacheFreeRequestContext,
-    CacheFreeWorkerSelectionPolicy, DefaultWorkerSelector, ScoredWorkerCandidate, WorkerCacheInput,
-    WorkerCandidate, WorkerFilter, WorkerInputView, WorkerInputs, WorkerLoadInput, WorkerPicker,
-    WorkerRoutingInput, WorkerScorer, WorkerSelectionContext, WorkerSelectionPolicy,
-    WorkerSelector,
+    CacheFreeWorkerPicker, CacheFreeWorkerSelectionPolicy, DefaultWorkerSelector,
+    ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView,
+    WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
+    WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelector,
 };
 pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
 pub use worker_type::WorkerType;

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -76,9 +76,11 @@ pub use scheduling::{
     WorkerSelectionInputTrigger, WorkerSelectionKvHints, WorkerSelectionPolicyError,
 };
 pub use selector::{
-    DefaultWorkerSelector, ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerFilter,
-    WorkerInputView, WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
-    WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelector,
+    CacheFreeCandidateTable, CacheFreePolicyDecision, CacheFreeRequestContext,
+    CacheFreeWorkerSelectionPolicy, DefaultWorkerSelector, ScoredWorkerCandidate, WorkerCacheInput,
+    WorkerCandidate, WorkerFilter, WorkerInputView, WorkerInputs, WorkerLoadInput, WorkerPicker,
+    WorkerRoutingInput, WorkerScorer, WorkerSelectionContext, WorkerSelectionPolicy,
+    WorkerSelector,
 };
 pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
 pub use worker_type::WorkerType;

--- a/lib/kv-router/src/scheduling/selector/cache_free.rs
+++ b/lib/kv-router/src/scheduling/selector/cache_free.rs
@@ -1,0 +1,582 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cache-free worker-selection host contracts and generic policy adapter.
+
+use std::collections::HashSet;
+
+use parking_lot::Mutex;
+
+use super::{
+    CustomWorkerSelectionState, LogitWeights, ScoredWorkerCandidate, WorkerCacheInput,
+    WorkerCandidate, WorkerInputView, WorkerLoadInput, WorkerRoutingInput, WorkerSelectionContext,
+    WorkerSelectionRequirements,
+};
+use crate::protocols::{WorkerId, WorkerWithDpRank};
+use crate::scheduling::types::{SessionContext, WorkerSelectionPolicyError};
+
+/// Request metadata made available to cache-free policy selection.
+///
+/// A cache-free host has no KV block size, cache index, or scheduler load projections. It
+/// therefore reports prompt tokens as one-token blocks and exposes only the request metadata
+/// already available at the frontend routing boundary.
+pub struct CacheFreeRequestContext<'a> {
+    request_id: &'a str,
+    request_tokens: usize,
+    session_context: Option<&'a SessionContext>,
+    expected_output_tokens: Option<u32>,
+    priority_jump: f64,
+    strict_priority: u32,
+    advisory: bool,
+}
+
+impl<'a> CacheFreeRequestContext<'a> {
+    pub fn new(request_id: &'a str, request_tokens: usize, advisory: bool) -> Self {
+        Self {
+            request_id,
+            request_tokens,
+            session_context: None,
+            expected_output_tokens: None,
+            priority_jump: 0.0,
+            strict_priority: 0,
+            advisory,
+        }
+    }
+
+    pub fn with_session_context(mut self, session_context: Option<&'a SessionContext>) -> Self {
+        self.session_context = session_context;
+        self
+    }
+
+    pub fn with_expected_output_tokens(mut self, expected_output_tokens: Option<u32>) -> Self {
+        self.expected_output_tokens = expected_output_tokens;
+        self
+    }
+
+    pub fn with_priority(mut self, priority_jump: f64, strict_priority: u32) -> Self {
+        self.priority_jump = priority_jump;
+        self.strict_priority = strict_priority;
+        self
+    }
+
+    /// Whether this is a preview that must not commit policy-local state.
+    pub fn is_advisory(&self) -> bool {
+        self.advisory
+    }
+}
+
+/// Borrowed, host-owned candidate table for cache-free selection.
+///
+/// The host has already applied discovery, namespace, health, and admission eligibility before
+/// exposing rows here. A cache-free policy may read worker identity and the frontend-local active
+/// request count only; it cannot request KV cache, taint, or scheduler projection inputs.
+///
+/// The table is a stable snapshot: its row count and worker identity must remain unchanged from
+/// policy selection through the host's admission of the returned row. Hosts that expose
+/// [`Self::least_loaded_index`] must maintain that minimum as an O(1) lookup; policies must not
+/// rescan the table to reconstruct it. All table methods used by cache-free pickers must also be
+/// O(1), including [`Self::len`] and [`Self::active_requests`].
+pub trait CacheFreeCandidateTable {
+    /// Return the number of eligible rows in O(1).
+    fn len(&self) -> usize;
+
+    /// Return one row in O(1).
+    fn worker(&self, index: usize) -> WorkerWithDpRank;
+
+    /// Return the frontend-local active-request count for one row in O(1).
+    fn active_requests(&self, index: usize) -> usize;
+
+    /// Return the host-maintained least-loaded row, if this host supports that policy.
+    ///
+    /// Implementations must return in O(1). A host that does not maintain a load index returns
+    /// `None`, making a least-loaded policy unavailable rather than falling back to an O(N) scan.
+    fn least_loaded_index(&self) -> Option<usize> {
+        None
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// One cache-free policy decision and, when filters narrowed the candidate table, the set that
+/// transport fallback must remain within.
+#[derive(Debug)]
+pub struct CacheFreePolicyDecision {
+    pub index: usize,
+    pub allowed_worker_ids: Option<HashSet<WorkerId>>,
+}
+
+impl CacheFreePolicyDecision {
+    /// Select one row without narrowing the host-provided eligible set.
+    pub const fn unfiltered(index: usize) -> Self {
+        Self {
+            index,
+            allowed_worker_ids: None,
+        }
+    }
+}
+
+/// An O(1) cache-free policy implementation supplied by a linked policy crate.
+///
+/// This bypasses generic filter/score/pick materialization. It is intended for policies whose
+/// selection algorithm samples a constant number of rows, such as round-robin, random, and P2C.
+/// A host-provided least-loaded index also keeps least-loaded selection O(1).
+pub trait CacheFreeWorkerPicker: Send + Sync {
+    /// Return the infrastructure signals needed by this picker.
+    fn requirements(&self) -> WorkerSelectionRequirements;
+
+    /// Select one row from a stable host-owned candidate table.
+    fn select(
+        &self,
+        request: &CacheFreeRequestContext<'_>,
+        candidate_table: &dyn CacheFreeCandidateTable,
+    ) -> Result<CacheFreePolicyDecision, WorkerSelectionPolicyError>;
+}
+
+/// Thread-safe host adapter for custom filters, scorers, and pickers that do not require KV
+/// routing state.
+///
+/// The mutex serializes policy-local state such as a round-robin cursor. The routing host must
+/// hold its own discovery/admission lock around a committed call so observing active request
+/// counts and reserving the selected worker stay atomic.
+pub struct CacheFreeWorkerSelectionPolicy {
+    kind: CacheFreeWorkerSelectionPolicyKind,
+}
+
+enum CacheFreeWorkerSelectionPolicyKind {
+    Generic(Box<Mutex<CacheFreeWorkerSelectionState>>),
+    Direct(Box<dyn CacheFreeWorkerPicker>),
+}
+
+struct CacheFreeWorkerSelectionState {
+    policy: CustomWorkerSelectionState,
+    source_indices: Vec<usize>,
+}
+
+impl CacheFreeWorkerSelectionPolicy {
+    pub(super) fn direct(picker: Box<dyn CacheFreeWorkerPicker>) -> Self {
+        Self {
+            kind: CacheFreeWorkerSelectionPolicyKind::Direct(picker),
+        }
+    }
+
+    pub(super) fn generic(policy: CustomWorkerSelectionState) -> Self {
+        Self {
+            kind: CacheFreeWorkerSelectionPolicyKind::Generic(Box::new(Mutex::new(
+                CacheFreeWorkerSelectionState {
+                    policy,
+                    source_indices: Vec::new(),
+                },
+            ))),
+        }
+    }
+
+    /// Run the custom policy against a borrowed table of host-eligible workers.
+    pub fn select(
+        &self,
+        request: &CacheFreeRequestContext<'_>,
+        candidate_table: &dyn CacheFreeCandidateTable,
+    ) -> Result<CacheFreePolicyDecision, WorkerSelectionPolicyError> {
+        let state = match &self.kind {
+            CacheFreeWorkerSelectionPolicyKind::Direct(picker) => {
+                return picker.select(request, candidate_table);
+            }
+            CacheFreeWorkerSelectionPolicyKind::Generic(state) => state,
+        };
+        let mut state = state.lock();
+        let CacheFreeWorkerSelectionState {
+            policy,
+            source_indices,
+        } = &mut *state;
+        let CustomWorkerSelectionState {
+            filters,
+            scorers,
+            filter_inputs,
+            scorer_picker_inputs,
+            picker_inputs,
+            picker,
+            unscored_candidates,
+            candidates,
+            load_inputs,
+            ..
+        } = policy;
+
+        unscored_candidates.clear();
+        candidates.clear();
+        source_indices.clear();
+        load_inputs.clear();
+
+        let context = WorkerSelectionContext {
+            request_id: request.request_id,
+            request_blocks: request.request_tokens as u64,
+            block_size: 1,
+            track_prefill_tokens: false,
+            weights: LogitWeights {
+                overlap_score_credit: 0.0,
+                overlap_score_credit_decay: 0.0,
+                prefill_load_scale: 0.0,
+                shared_cache_multiplier: 0.0,
+            },
+            min_active_prefill_tokens: 0,
+            router_temperature_override: None,
+            session_context: request.session_context,
+            expected_output_tokens: request.expected_output_tokens,
+            priority_jump: request.priority_jump,
+            strict_priority: request.strict_priority,
+            advisory: request.advisory,
+        };
+
+        let mut filters_narrowed = false;
+        for index in 0..candidate_table.len() {
+            let candidate_for = |inputs| WorkerCandidate {
+                worker: candidate_table.worker(index),
+                inputs,
+                cache: WorkerCacheInput::default(),
+                load: if inputs.needs_worker_load() {
+                    WorkerLoadInput {
+                        active_requests: candidate_table.active_requests(index),
+                        ..Default::default()
+                    }
+                } else {
+                    WorkerLoadInput::default()
+                },
+                routing: WorkerRoutingInput::default(),
+            };
+            let filter_candidate = candidate_for(*filter_inputs);
+            let mut keep = true;
+            for filter in filters.iter_mut() {
+                if !filter.keep(&context, &filter_candidate)? {
+                    keep = false;
+                    break;
+                }
+            }
+            if !keep {
+                filters_narrowed = true;
+                continue;
+            }
+            unscored_candidates.push(candidate_for(*scorer_picker_inputs));
+            source_indices.push(index);
+        }
+
+        for candidate in unscored_candidates.iter() {
+            let mut cost = 0.0;
+            for (scorer_index, scorer) in scorers.iter_mut().enumerate() {
+                let contribution = scorer.score(&context, candidate)?;
+                cost += contribution;
+                if !contribution.is_finite() || !cost.is_finite() {
+                    return Err(WorkerSelectionPolicyError::NonFiniteCost {
+                        scorer_index,
+                        row: candidates.len(),
+                    });
+                }
+            }
+            candidates.push(ScoredWorkerCandidate {
+                worker: candidate.worker,
+                cost,
+            });
+            if picker_inputs.needs_worker_load() {
+                load_inputs.push(candidate.load);
+            }
+        }
+
+        if candidates.is_empty() {
+            let message = if candidate_table.is_empty() {
+                "no eligible workers"
+            } else {
+                "all eligible workers were rejected by policy filters"
+            };
+            return Err(WorkerSelectionPolicyError::failed(message));
+        }
+        let input = WorkerInputView {
+            candidates,
+            cache: None,
+            load: picker_inputs
+                .needs_worker_load()
+                .then_some(load_inputs.as_slice()),
+            routing: None,
+        };
+        let row = picker.pick(&context, input)?;
+        let index = source_indices.get(row).copied().ok_or(
+            WorkerSelectionPolicyError::InvalidPickerRow {
+                row,
+                candidate_count: candidates.len(),
+            },
+        )?;
+        Ok(CacheFreePolicyDecision {
+            index,
+            allowed_worker_ids: filters_narrowed.then(|| {
+                candidates
+                    .iter()
+                    .map(|candidate| candidate.worker.worker_id)
+                    .collect()
+            }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+    use crate::scheduling::config::KvRouterConfig;
+    use crate::scheduling::selector::{
+        WorkerCandidate, WorkerFilter, WorkerInputView, WorkerInputs, WorkerPicker, WorkerScorer,
+        WorkerSelectionContext, WorkerSelectionPolicy,
+    };
+
+    struct CacheFreeRows(Vec<(WorkerWithDpRank, usize)>);
+
+    impl CacheFreeCandidateTable for CacheFreeRows {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        fn worker(&self, index: usize) -> WorkerWithDpRank {
+            self.0[index].0
+        }
+
+        fn active_requests(&self, index: usize) -> usize {
+            self.0[index].1
+        }
+    }
+
+    struct StaticCacheFreeRows(Vec<WorkerWithDpRank>);
+
+    impl CacheFreeCandidateTable for StaticCacheFreeRows {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        fn worker(&self, index: usize) -> WorkerWithDpRank {
+            self.0[index]
+        }
+
+        fn active_requests(&self, _index: usize) -> usize {
+            panic!("static policy must not request active-load state")
+        }
+    }
+
+    struct LowestActiveRequestScorer;
+
+    impl WorkerScorer for LowestActiveRequestScorer {
+        fn required_worker_inputs(&self) -> WorkerInputs {
+            WorkerInputs::ACTIVE_REQUEST_LOAD
+        }
+
+        fn score(
+            &mut self,
+            _context: &WorkerSelectionContext<'_>,
+            candidate: &WorkerCandidate,
+        ) -> Result<f64, WorkerSelectionPolicyError> {
+            Ok(candidate
+                .load()
+                .expect("active-request load was requested")
+                .active_requests() as f64)
+        }
+    }
+
+    struct LowestCostPicker;
+
+    impl WorkerPicker for LowestCostPicker {
+        fn pick(
+            &mut self,
+            _context: &WorkerSelectionContext<'_>,
+            input: WorkerInputView<'_>,
+        ) -> Result<usize, WorkerSelectionPolicyError> {
+            input
+                .candidates()
+                .iter()
+                .enumerate()
+                .min_by(|(_, left), (_, right)| left.cost().total_cmp(&right.cost()))
+                .map(|(row, _)| row)
+                .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible workers"))
+        }
+    }
+
+    #[test]
+    fn uses_active_request_load_without_kv_inputs() {
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(LowestActiveRequestScorer)],
+            Box::new(LowestCostPicker),
+        )
+        .into_cache_free()
+        .unwrap();
+        let rows = CacheFreeRows(vec![
+            (WorkerWithDpRank::from_worker_id(41), 9),
+            (WorkerWithDpRank::from_worker_id(42), 2),
+            (WorkerWithDpRank::from_worker_id(43), 6),
+        ]);
+
+        let selected = policy
+            .select(&CacheFreeRequestContext::new("request", 32, false), &rows)
+            .unwrap();
+        assert_eq!(selected.index, 1);
+        assert!(selected.allowed_worker_ids.is_none());
+    }
+
+    #[test]
+    fn static_policy_never_reads_active_request_load() {
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(LowestCostPicker),
+        )
+        .into_cache_free()
+        .unwrap();
+        let rows = StaticCacheFreeRows(vec![
+            WorkerWithDpRank::from_worker_id(41),
+            WorkerWithDpRank::from_worker_id(42),
+        ]);
+
+        assert_eq!(
+            policy
+                .select(&CacheFreeRequestContext::new("request", 32, false), &rows)
+                .unwrap()
+                .index,
+            0
+        );
+    }
+
+    #[test]
+    fn returns_filtered_fallback_set() {
+        struct RejectWorker(WorkerId);
+
+        impl WorkerFilter for RejectWorker {
+            fn keep(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                candidate: &WorkerCandidate,
+            ) -> Result<bool, WorkerSelectionPolicyError> {
+                Ok(candidate.worker().worker_id != self.0)
+            }
+        }
+
+        let policy = WorkerSelectionPolicy::new_with_filters(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(RejectWorker(41))],
+            Vec::new(),
+            Box::new(LowestCostPicker),
+        )
+        .into_cache_free()
+        .unwrap();
+        let rows = CacheFreeRows(vec![
+            (WorkerWithDpRank::from_worker_id(41), 0),
+            (WorkerWithDpRank::from_worker_id(42), 0),
+        ]);
+
+        let selected = policy
+            .select(&CacheFreeRequestContext::new("request", 32, false), &rows)
+            .unwrap();
+        assert_eq!(selected.index, 1);
+        assert_eq!(selected.allowed_worker_ids, Some(HashSet::from([42])));
+    }
+
+    #[test]
+    fn serializes_state_and_keeps_advisory_selection_read_only() {
+        struct StatefulPicker {
+            next: usize,
+        }
+
+        impl WorkerPicker for StatefulPicker {
+            fn pick(
+                &mut self,
+                context: &WorkerSelectionContext<'_>,
+                input: WorkerInputView<'_>,
+            ) -> Result<usize, WorkerSelectionPolicyError> {
+                let row = self.next % input.candidates().len();
+                if !context.is_advisory() {
+                    self.next += 1;
+                }
+                Ok(row)
+            }
+        }
+
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<CacheFreeWorkerSelectionPolicy>();
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(StatefulPicker { next: 0 }),
+        )
+        .into_cache_free()
+        .unwrap();
+        let rows = CacheFreeRows(vec![
+            (WorkerWithDpRank::from_worker_id(7), 0),
+            (WorkerWithDpRank::from_worker_id(8), 0),
+        ]);
+        let advisory = CacheFreeRequestContext::new("query", 8, true);
+        let committed = CacheFreeRequestContext::new("request", 8, false);
+
+        assert_eq!(policy.select(&advisory, &rows).unwrap().index, 0);
+        assert_eq!(policy.select(&advisory, &rows).unwrap().index, 0);
+        assert_eq!(policy.select(&committed, &rows).unwrap().index, 0);
+        assert_eq!(policy.select(&committed, &rows).unwrap().index, 1);
+    }
+
+    #[test]
+    fn rejects_kv_and_full_load_inputs() {
+        struct CachePicker;
+
+        impl WorkerPicker for CachePicker {
+            fn required_worker_inputs(&self) -> WorkerInputs {
+                WorkerInputs::CACHE
+            }
+
+            fn pick(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                _input: WorkerInputView<'_>,
+            ) -> Result<usize, WorkerSelectionPolicyError> {
+                Ok(0)
+            }
+        }
+
+        struct FullLoadScorer;
+
+        impl WorkerScorer for FullLoadScorer {
+            fn required_worker_inputs(&self) -> WorkerInputs {
+                WorkerInputs::LOAD
+            }
+
+            fn score(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                _candidate: &WorkerCandidate,
+            ) -> Result<f64, WorkerSelectionPolicyError> {
+                Ok(0.0)
+            }
+        }
+
+        let cache_error = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(CachePicker),
+        )
+        .into_cache_free()
+        .err()
+        .expect("cache inputs must be rejected");
+        assert!(cache_error.to_string().contains("active-request load"));
+
+        let full_load_policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(FullLoadScorer)],
+            Box::new(LowestCostPicker),
+        );
+        assert!(full_load_policy.requirements().needs_cache_index());
+        let full_load_error = full_load_policy
+            .into_cache_free()
+            .err()
+            .expect("full load inputs must be rejected");
+        assert!(full_load_error.to_string().contains("active-request load"));
+    }
+}

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -12,9 +12,10 @@ pub use default::DefaultWorkerSelector;
 use default::{DefaultWorkerPicker, DefaultWorkerScorer};
 pub use policy::{
     CacheFreeCandidateTable, CacheFreePolicyDecision, CacheFreeRequestContext,
-    CacheFreeWorkerSelectionPolicy, ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate,
-    WorkerFilter, WorkerInputView, WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput,
-    WorkerScorer, WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelectionRequirements,
+    CacheFreeWorkerPicker, CacheFreeWorkerSelectionPolicy, ScoredWorkerCandidate, WorkerCacheInput,
+    WorkerCandidate, WorkerFilter, WorkerInputView, WorkerInputs, WorkerLoadInput, WorkerPicker,
+    WorkerRoutingInput, WorkerScorer, WorkerSelectionContext, WorkerSelectionPolicy,
+    WorkerSelectionRequirements,
 };
 
 use default::{pick_default_worker, selection_weights};

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -13,7 +13,7 @@ use default::{DefaultWorkerPicker, DefaultWorkerScorer};
 pub use policy::{
     ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView,
     WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
-    WorkerSelectionContext, WorkerSelectionPolicy,
+    WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelectionRequirements,
 };
 
 use default::{pick_default_worker, selection_weights};
@@ -32,6 +32,15 @@ use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, Worker
 /// External policies should compose [`WorkerScorer`] and [`WorkerPicker`] implementations with
 /// [`WorkerSelectionPolicy`] instead of implementing this trait directly.
 pub trait WorkerSelector<C: WorkerConfigLike> {
+    /// Inputs the selection host must materialize before invoking this selector.
+    ///
+    /// Existing selectors default to the full KV-aware contract. First-party simple policies
+    /// override this through [`WorkerSelectionPolicy`] so a future host can keep its indexer and
+    /// slot tracker uninitialized when they are unnecessary.
+    fn requirements(&self) -> WorkerSelectionRequirements {
+        WorkerSelectionRequirements::KV_AWARE
+    }
+
     fn select_worker(
         &self,
         workers: &HashMap<WorkerId, C>,

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -11,9 +11,10 @@ pub use default::DefaultWorkerSelector;
 
 use default::{DefaultWorkerPicker, DefaultWorkerScorer};
 pub use policy::{
-    ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerFilter, WorkerInputView,
-    WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
-    WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelectionRequirements,
+    CacheFreeCandidateTable, CacheFreePolicyDecision, CacheFreeRequestContext,
+    CacheFreeWorkerSelectionPolicy, ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate,
+    WorkerFilter, WorkerInputView, WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput,
+    WorkerScorer, WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelectionRequirements,
 };
 
 use default::{pick_default_worker, selection_weights};
@@ -94,7 +95,6 @@ impl<'a> WorkerSelectionInput<'a> {
             has_tier_overlap_blocks,
             use_default_cache_fallbacks: inputs.contains(WorkerInputs::DEFAULT_POLICY_CACHE),
             context: WorkerSelectionContext {
-                request,
                 request_id: request.mode.request_id().unwrap_or("-"),
                 request_blocks: request.request_blocks(block_size),
                 block_size,
@@ -105,6 +105,11 @@ impl<'a> WorkerSelectionInput<'a> {
                     .router_config_override
                     .as_ref()
                     .and_then(|config| config.router_temperature),
+                session_context: request.session_context.as_ref(),
+                expected_output_tokens: request.expected_output_tokens,
+                priority_jump: request.priority_jump,
+                strict_priority: request.strict_priority,
+                advisory: !request.mode.is_tracked(),
             },
         }
     }
@@ -122,7 +127,7 @@ impl<'a> WorkerSelectionInput<'a> {
         } else {
             0
         };
-        let worker_load = if inputs.contains(WorkerInputs::LOAD) {
+        let worker_load = if inputs.needs_worker_load() {
             self.request.worker_loads.get(&worker).copied()
         } else {
             None
@@ -181,7 +186,7 @@ impl<'a> WorkerSelectionInput<'a> {
         } else {
             WorkerCacheInput::default()
         };
-        let load = if inputs.contains(WorkerInputs::LOAD) {
+        let load = if inputs.needs_worker_load() {
             let raw_prefill_tokens = if self.request.track_prefill_tokens {
                 match worker_load {
                     Some(load) => {
@@ -200,9 +205,18 @@ impl<'a> WorkerSelectionInput<'a> {
             } as f64;
             let worker_load = worker_load.unwrap_or_default();
             WorkerLoadInput {
-                raw_prefill_blocks: raw_prefill_tokens / self.context.block_size as f64,
-                active_prefill_tokens: worker_load.active_prefill_tokens,
-                decode_cost_blocks: worker_load.potential_decode_blocks() as f64,
+                raw_prefill_blocks: inputs
+                    .contains(WorkerInputs::LOAD)
+                    .then(|| raw_prefill_tokens / self.context.block_size as f64)
+                    .unwrap_or(0.0),
+                active_prefill_tokens: inputs
+                    .contains(WorkerInputs::LOAD)
+                    .then_some(worker_load.active_prefill_tokens)
+                    .unwrap_or(0),
+                decode_cost_blocks: inputs
+                    .contains(WorkerInputs::LOAD)
+                    .then(|| worker_load.potential_decode_blocks() as f64)
+                    .unwrap_or(0.0),
                 active_requests: worker_load.active_requests,
             }
         } else {
@@ -398,8 +412,7 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
                         || cache_inputs.len() == candidates.len()
                 );
                 debug_assert!(
-                    !picker_inputs.contains(WorkerInputs::LOAD)
-                        || load_inputs.len() == candidates.len()
+                    !picker_inputs.needs_worker_load() || load_inputs.len() == candidates.len()
                 );
                 debug_assert!(
                     !picker_inputs.contains(WorkerInputs::ROUTING)
@@ -411,7 +424,7 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
                         .contains(WorkerInputs::CACHE)
                         .then_some(cache_inputs.as_slice()),
                     load: picker_inputs
-                        .contains(WorkerInputs::LOAD)
+                        .needs_worker_load()
                         .then_some(load_inputs.as_slice()),
                     routing: picker_inputs
                         .contains(WorkerInputs::ROUTING)

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::BitOr;
+
+use parking_lot::Mutex;
 
 use super::{
     DefaultWorkerPicker, LogitWeights, WorkerSelectionInput, WorkerSelector,
@@ -18,7 +20,6 @@ use crate::scheduling::types::{
 
 /// Request-level values available to custom filters, scorers, and pickers.
 pub struct WorkerSelectionContext<'a> {
-    pub(super) request: &'a SchedulingRequest,
     pub(super) request_id: &'a str,
     pub(super) request_blocks: u64,
     pub(super) block_size: u32,
@@ -26,6 +27,11 @@ pub struct WorkerSelectionContext<'a> {
     pub(super) weights: LogitWeights,
     pub(super) min_active_prefill_tokens: usize,
     pub(super) router_temperature_override: Option<f64>,
+    pub(super) session_context: Option<&'a SessionContext>,
+    pub(super) expected_output_tokens: Option<u32>,
+    pub(super) priority_jump: f64,
+    pub(super) strict_priority: u32,
+    pub(super) advisory: bool,
 }
 
 /// One eligible worker and the optional inputs requested by a filter or scorer.
@@ -57,7 +63,13 @@ impl WorkerInputs {
     pub const LOAD: Self = Self(1 << 1);
     /// Request routing-constraint inputs.
     pub const ROUTING: Self = Self(1 << 2);
-    pub(super) const ALL: Self = Self(Self::CACHE.0 | Self::LOAD.0 | Self::ROUTING.0);
+    /// The frontend-local active-request count for a worker.
+    ///
+    /// Unlike [`Self::LOAD`], this excludes KV-block and prefill-token projections, so a
+    /// cache-free host can materialize it from its own request lifetime accounting.
+    pub const ACTIVE_REQUEST_LOAD: Self = Self(1 << 5);
+    pub(super) const ALL: Self =
+        Self(Self::CACHE.0 | Self::LOAD.0 | Self::ROUTING.0 | Self::ACTIVE_REQUEST_LOAD.0);
     pub(super) const MIN_ACTIVE_PREFILL_TOKENS: Self = Self(1 << 3);
     pub(super) const DEFAULT_POLICY_CACHE: Self = Self(1 << 4);
 
@@ -67,6 +79,10 @@ impl WorkerInputs {
 
     pub(super) fn without(self, other: Self) -> Self {
         Self(self.0 & !other.0)
+    }
+
+    pub(super) const fn needs_worker_load(self) -> bool {
+        self.contains(Self::LOAD) || self.contains(Self::ACTIVE_REQUEST_LOAD)
     }
 }
 
@@ -124,7 +140,7 @@ impl WorkerInputs {
     const fn requirements(self) -> WorkerSelectionRequirements {
         WorkerSelectionRequirements {
             needs_cache_index: self.contains(Self::CACHE),
-            needs_active_request_load: self.contains(Self::LOAD),
+            needs_active_request_load: self.needs_worker_load(),
         }
     }
 }
@@ -217,7 +233,7 @@ impl WorkerSelectionContext<'_> {
     /// policy-local state. Stateful pickers use this to keep previews from
     /// advancing a round-robin cursor or otherwise committing a decision.
     pub fn is_advisory(&self) -> bool {
-        !self.request.mode.is_tracked()
+        self.advisory
     }
 
     /// Return the incoming prompt size in KV blocks.
@@ -237,22 +253,22 @@ impl WorkerSelectionContext<'_> {
 
     /// Return the session metadata available to worker selection.
     pub fn session_context(&self) -> Option<&SessionContext> {
-        self.request.session_context.as_ref()
+        self.session_context
     }
 
     /// Return the expected output length, if the request supplies one.
     pub fn expected_output_tokens(&self) -> Option<u32> {
-        self.request.expected_output_tokens
+        self.expected_output_tokens
     }
 
     /// Return the request's scheduler priority boost.
     pub fn priority_jump(&self) -> f64 {
-        self.request.priority_jump
+        self.priority_jump
     }
 
     /// Return the request's strict integer priority.
     pub fn strict_priority(&self) -> u32 {
-        self.request.strict_priority
+        self.strict_priority
     }
 
     /// Return the request-level router temperature override, if present.
@@ -276,9 +292,7 @@ impl WorkerCandidate {
 
     /// Return active-load inputs when the component requested [`WorkerInputs::LOAD`].
     pub fn load(&self) -> Option<&WorkerLoadInput> {
-        self.inputs
-            .contains(WorkerInputs::LOAD)
-            .then_some(&self.load)
+        self.inputs.needs_worker_load().then_some(&self.load)
     }
 
     /// Return routing inputs when the component requested [`WorkerInputs::ROUTING`].
@@ -302,8 +316,14 @@ impl WorkerCandidate {
             } else {
                 WorkerCacheInput::default()
             },
-            load: if inputs.contains(WorkerInputs::LOAD) {
-                if self.inputs.contains(WorkerInputs::LOAD) {
+            load: if inputs.needs_worker_load() {
+                if inputs.contains(WorkerInputs::LOAD) {
+                    if self.inputs.contains(WorkerInputs::LOAD) {
+                        self.load
+                    } else {
+                        additional.load
+                    }
+                } else if self.inputs.needs_worker_load() {
                     self.load
                 } else {
                     additional.load
@@ -440,6 +460,91 @@ pub struct WorkerSelectionPolicy {
     state: WorkerSelectionPolicyState,
 }
 
+/// Request metadata made available to cache-free policy selection.
+///
+/// A cache-free host has no KV block size, cache index, or scheduler load projections. It
+/// therefore reports prompt tokens as one-token blocks and exposes only the request metadata
+/// already available at the frontend routing boundary.
+pub struct CacheFreeRequestContext<'a> {
+    request_id: &'a str,
+    request_tokens: usize,
+    session_context: Option<&'a SessionContext>,
+    expected_output_tokens: Option<u32>,
+    priority_jump: f64,
+    strict_priority: u32,
+    advisory: bool,
+}
+
+impl<'a> CacheFreeRequestContext<'a> {
+    pub fn new(request_id: &'a str, request_tokens: usize, advisory: bool) -> Self {
+        Self {
+            request_id,
+            request_tokens,
+            session_context: None,
+            expected_output_tokens: None,
+            priority_jump: 0.0,
+            strict_priority: 0,
+            advisory,
+        }
+    }
+
+    pub fn with_session_context(mut self, session_context: Option<&'a SessionContext>) -> Self {
+        self.session_context = session_context;
+        self
+    }
+
+    pub fn with_expected_output_tokens(mut self, expected_output_tokens: Option<u32>) -> Self {
+        self.expected_output_tokens = expected_output_tokens;
+        self
+    }
+
+    pub fn with_priority(mut self, priority_jump: f64, strict_priority: u32) -> Self {
+        self.priority_jump = priority_jump;
+        self.strict_priority = strict_priority;
+        self
+    }
+}
+
+/// Borrowed, host-owned candidate table for cache-free selection.
+///
+/// The host has already applied discovery, namespace, health, and admission eligibility before
+/// exposing rows here. A cache-free policy may read worker identity and the frontend-local active
+/// request count only; it cannot request KV cache, taint, or scheduler projection inputs.
+pub trait CacheFreeCandidateTable {
+    fn len(&self) -> usize;
+
+    fn worker(&self, index: usize) -> WorkerWithDpRank;
+
+    fn active_requests(&self, index: usize) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// One cache-free policy decision and, when filters narrowed the candidate table, the set that
+/// transport fallback must remain within.
+#[derive(Debug)]
+pub struct CacheFreePolicyDecision {
+    pub index: usize,
+    pub allowed_worker_ids: Option<HashSet<WorkerId>>,
+}
+
+/// Thread-safe host adapter for custom filters, scorers, and pickers that do not require KV
+/// routing state.
+///
+/// The mutex serializes policy-local state such as a round-robin cursor. The routing host must
+/// hold its own discovery/admission lock around a committed call so observing active request
+/// counts and reserving the selected worker stay atomic.
+pub struct CacheFreeWorkerSelectionPolicy {
+    state: Mutex<CacheFreeWorkerSelectionState>,
+}
+
+struct CacheFreeWorkerSelectionState {
+    policy: CustomWorkerSelectionState,
+    source_indices: Vec<usize>,
+}
+
 impl WorkerSelectionPolicy {
     /// Build a custom policy with no filters.
     ///
@@ -505,6 +610,40 @@ impl WorkerSelectionPolicy {
         }
     }
 
+    /// Consume a custom policy and adapt it for a cache-free routing host.
+    ///
+    /// The adapter accepts only policies that request worker identity or
+    /// [`WorkerInputs::ACTIVE_REQUEST_LOAD`]. Cache, taint, and full scheduler-load inputs are
+    /// deliberately rejected before the host begins routing, which keeps indexer and slot-tracker
+    /// construction out of the cache-free path.
+    pub fn into_cache_free(
+        self,
+    ) -> Result<CacheFreeWorkerSelectionPolicy, WorkerSelectionPolicyError> {
+        match self.state {
+            WorkerSelectionPolicyState::Custom(state) => {
+                let required_inputs = {
+                    let state = state.borrow();
+                    state.filter_inputs | state.scorer_picker_inputs
+                };
+                if required_inputs.without(WorkerInputs::ACTIVE_REQUEST_LOAD) != WorkerInputs::NONE
+                {
+                    return Err(WorkerSelectionPolicyError::failed(
+                        "cache-free routing supports only worker identity and active-request load inputs",
+                    ));
+                }
+                Ok(CacheFreeWorkerSelectionPolicy {
+                    state: Mutex::new(CacheFreeWorkerSelectionState {
+                        policy: state.into_inner(),
+                        source_indices: Vec::new(),
+                    }),
+                })
+            }
+            WorkerSelectionPolicyState::Default(_) => Err(WorkerSelectionPolicyError::failed(
+                "only custom filter/scorer/picker policies can be adapted to cache-free routing",
+            )),
+        }
+    }
+
     #[cfg_attr(not(feature = "standalone-selection"), allow(dead_code))]
     pub(crate) fn default(kv_router_config: KvRouterConfig, worker_label: &'static str) -> Self {
         let picker = DefaultWorkerPicker::new(kv_router_config.router_temperature);
@@ -513,6 +652,138 @@ impl WorkerSelectionPolicy {
             worker_label,
             state: WorkerSelectionPolicyState::Default(picker),
         }
+    }
+}
+
+impl CacheFreeWorkerSelectionPolicy {
+    /// Run the custom policy against a borrowed table of host-eligible workers.
+    pub fn select<C: CacheFreeCandidateTable + ?Sized>(
+        &self,
+        request: &CacheFreeRequestContext<'_>,
+        candidate_table: &C,
+    ) -> Result<CacheFreePolicyDecision, WorkerSelectionPolicyError> {
+        let mut state = self.state.lock();
+        let CacheFreeWorkerSelectionState {
+            policy,
+            source_indices,
+        } = &mut *state;
+        let CustomWorkerSelectionState {
+            filters,
+            scorers,
+            filter_inputs,
+            scorer_picker_inputs,
+            picker_inputs,
+            picker,
+            unscored_candidates,
+            candidates,
+            load_inputs,
+            ..
+        } = policy;
+
+        unscored_candidates.clear();
+        candidates.clear();
+        source_indices.clear();
+        load_inputs.clear();
+
+        let context = WorkerSelectionContext {
+            request_id: request.request_id,
+            request_blocks: request.request_tokens as u64,
+            block_size: 1,
+            track_prefill_tokens: false,
+            weights: LogitWeights {
+                overlap_score_credit: 0.0,
+                overlap_score_credit_decay: 0.0,
+                prefill_load_scale: 0.0,
+                shared_cache_multiplier: 0.0,
+            },
+            min_active_prefill_tokens: 0,
+            router_temperature_override: None,
+            session_context: request.session_context,
+            expected_output_tokens: request.expected_output_tokens,
+            priority_jump: request.priority_jump,
+            strict_priority: request.strict_priority,
+            advisory: request.advisory,
+        };
+
+        for index in 0..candidate_table.len() {
+            let candidate_for = |inputs| WorkerCandidate {
+                worker: candidate_table.worker(index),
+                inputs,
+                cache: WorkerCacheInput::default(),
+                load: WorkerLoadInput {
+                    active_requests: candidate_table.active_requests(index),
+                    ..Default::default()
+                },
+                routing: WorkerRoutingInput::default(),
+            };
+            let filter_candidate = candidate_for(*filter_inputs);
+            let mut keep = true;
+            for filter in filters.iter_mut() {
+                if !filter.keep(&context, &filter_candidate)? {
+                    keep = false;
+                    break;
+                }
+            }
+            if !keep {
+                continue;
+            }
+            unscored_candidates.push(candidate_for(*scorer_picker_inputs));
+            source_indices.push(index);
+        }
+
+        for candidate in unscored_candidates.iter() {
+            let mut cost = 0.0;
+            for (scorer_index, scorer) in scorers.iter_mut().enumerate() {
+                let contribution = scorer.score(&context, candidate)?;
+                cost += contribution;
+                if !contribution.is_finite() || !cost.is_finite() {
+                    return Err(WorkerSelectionPolicyError::NonFiniteCost {
+                        scorer_index,
+                        row: candidates.len(),
+                    });
+                }
+            }
+            candidates.push(ScoredWorkerCandidate {
+                worker: candidate.worker,
+                cost,
+            });
+            if picker_inputs.needs_worker_load() {
+                load_inputs.push(candidate.load);
+            }
+        }
+
+        if candidates.is_empty() {
+            let message = if candidate_table.is_empty() {
+                "no eligible workers"
+            } else {
+                "all eligible workers were rejected by policy filters"
+            };
+            return Err(WorkerSelectionPolicyError::failed(message));
+        }
+        let input = WorkerInputView {
+            candidates,
+            cache: None,
+            load: picker_inputs
+                .needs_worker_load()
+                .then_some(load_inputs.as_slice()),
+            routing: None,
+        };
+        let row = picker.pick(&context, input)?;
+        let index = source_indices.get(row).copied().ok_or(
+            WorkerSelectionPolicyError::InvalidPickerRow {
+                row,
+                candidate_count: candidates.len(),
+            },
+        )?;
+        Ok(CacheFreePolicyDecision {
+            index,
+            allowed_worker_ids: (!filters.is_empty()).then(|| {
+                candidates
+                    .iter()
+                    .map(|candidate| candidate.worker.worker_id)
+                    .collect()
+            }),
+        })
     }
 }
 
@@ -547,7 +818,7 @@ fn push_scored_candidate(
     if picker_inputs.contains(WorkerInputs::CACHE) {
         cache_inputs.push(candidate.cache);
     }
-    if picker_inputs.contains(WorkerInputs::LOAD) {
+    if picker_inputs.needs_worker_load() {
         load_inputs.push(candidate.load);
     }
     if picker_inputs.contains(WorkerInputs::ROUTING) {
@@ -732,7 +1003,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for WorkerSelectionPolicy {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     use rustc_hash::FxHashMap;
 
@@ -1089,5 +1360,287 @@ mod tests {
             panic!("expected custom policy state");
         };
         assert!(state.borrow().unscored_candidates.is_empty());
+    }
+
+    #[test]
+    fn active_request_load_composes_with_full_scheduler_load() {
+        struct KeepWithActiveRequestLoad;
+
+        impl WorkerFilter for KeepWithActiveRequestLoad {
+            fn required_worker_inputs(&self) -> WorkerInputs {
+                WorkerInputs::ACTIVE_REQUEST_LOAD
+            }
+
+            fn keep(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                candidate: &WorkerCandidate,
+            ) -> Result<bool, WorkerSelectionPolicyError> {
+                Ok(candidate
+                    .load()
+                    .expect("active-request load was requested")
+                    .active_requests()
+                    == 4)
+            }
+        }
+
+        struct FullLoadScorer;
+
+        impl WorkerScorer for FullLoadScorer {
+            fn required_worker_inputs(&self) -> WorkerInputs {
+                WorkerInputs::LOAD
+            }
+
+            fn score(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                candidate: &WorkerCandidate,
+            ) -> Result<f64, WorkerSelectionPolicyError> {
+                let load = candidate.load().expect("full load was requested");
+                assert_eq!(load.active_prefill_tokens(), 9);
+                assert_eq!(load.decode_cost_blocks(), 7.0);
+                Ok(0.0)
+            }
+        }
+
+        let worker = WorkerWithDpRank::from_worker_id(7);
+        let workers = HashMap::from([(7, TaintedWorkerConfig::default())]);
+        let mut request = base_request(16);
+        request.worker_loads.insert(
+            worker,
+            crate::sequences::WorkerLoadProjection {
+                active_prefill_tokens: 9,
+                active_decode_blocks: 7,
+                active_requests: 4,
+                ..Default::default()
+            },
+        );
+        let policy = WorkerSelectionPolicy::new_with_filters(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(KeepWithActiveRequestLoad)],
+            vec![Box::new(FullLoadScorer)],
+            Box::new(LowestCostPicker),
+        );
+
+        assert_eq!(
+            policy
+                .select_worker(&workers, &request, request.eligibility(), 16)
+                .unwrap()
+                .worker,
+            worker
+        );
+    }
+
+    struct CacheFreeRows(Vec<(WorkerWithDpRank, usize)>);
+
+    impl CacheFreeCandidateTable for CacheFreeRows {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        fn worker(&self, index: usize) -> WorkerWithDpRank {
+            self.0[index].0
+        }
+
+        fn active_requests(&self, index: usize) -> usize {
+            self.0[index].1
+        }
+    }
+
+    struct LowestActiveRequestScorer;
+
+    impl WorkerScorer for LowestActiveRequestScorer {
+        fn required_worker_inputs(&self) -> WorkerInputs {
+            WorkerInputs::ACTIVE_REQUEST_LOAD
+        }
+
+        fn score(
+            &mut self,
+            _context: &WorkerSelectionContext<'_>,
+            candidate: &WorkerCandidate,
+        ) -> Result<f64, WorkerSelectionPolicyError> {
+            Ok(candidate
+                .load()
+                .expect("active-request load was requested")
+                .active_requests() as f64)
+        }
+    }
+
+    struct LowestCostPicker;
+
+    impl WorkerPicker for LowestCostPicker {
+        fn pick(
+            &mut self,
+            _context: &WorkerSelectionContext<'_>,
+            input: WorkerInputView<'_>,
+        ) -> Result<usize, WorkerSelectionPolicyError> {
+            input
+                .candidates()
+                .iter()
+                .enumerate()
+                .min_by(|(_, left), (_, right)| left.cost().total_cmp(&right.cost()))
+                .map(|(row, _)| row)
+                .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible workers"))
+        }
+    }
+
+    #[test]
+    fn cache_free_adapter_uses_active_request_load_without_kv_inputs() {
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(LowestActiveRequestScorer)],
+            Box::new(LowestCostPicker),
+        )
+        .into_cache_free()
+        .unwrap();
+        let rows = CacheFreeRows(vec![
+            (WorkerWithDpRank::from_worker_id(41), 9),
+            (WorkerWithDpRank::from_worker_id(42), 2),
+            (WorkerWithDpRank::from_worker_id(43), 6),
+        ]);
+
+        let selected = policy
+            .select(&CacheFreeRequestContext::new("request", 32, false), &rows)
+            .unwrap();
+        assert_eq!(selected.index, 1);
+        assert!(selected.allowed_worker_ids.is_none());
+    }
+
+    #[test]
+    fn cache_free_adapter_returns_filtered_fallback_set() {
+        struct RejectWorker(WorkerId);
+
+        impl WorkerFilter for RejectWorker {
+            fn keep(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                candidate: &WorkerCandidate,
+            ) -> Result<bool, WorkerSelectionPolicyError> {
+                Ok(candidate.worker().worker_id != self.0)
+            }
+        }
+
+        let policy = WorkerSelectionPolicy::new_with_filters(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(RejectWorker(41))],
+            Vec::new(),
+            Box::new(LowestCostPicker),
+        )
+        .into_cache_free()
+        .unwrap();
+        let rows = CacheFreeRows(vec![
+            (WorkerWithDpRank::from_worker_id(41), 0),
+            (WorkerWithDpRank::from_worker_id(42), 0),
+        ]);
+
+        let selected = policy
+            .select(&CacheFreeRequestContext::new("request", 32, false), &rows)
+            .unwrap();
+        assert_eq!(selected.index, 1);
+        assert_eq!(selected.allowed_worker_ids, Some(HashSet::from([42])));
+    }
+
+    #[test]
+    fn cache_free_adapter_serializes_state_and_keeps_advisory_selection_read_only() {
+        struct StatefulPicker {
+            next: usize,
+        }
+
+        impl WorkerPicker for StatefulPicker {
+            fn pick(
+                &mut self,
+                context: &WorkerSelectionContext<'_>,
+                input: WorkerInputView<'_>,
+            ) -> Result<usize, WorkerSelectionPolicyError> {
+                let row = self.next % input.candidates().len();
+                if !context.is_advisory() {
+                    self.next += 1;
+                }
+                Ok(row)
+            }
+        }
+
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<CacheFreeWorkerSelectionPolicy>();
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(StatefulPicker { next: 0 }),
+        )
+        .into_cache_free()
+        .unwrap();
+        let rows = CacheFreeRows(vec![
+            (WorkerWithDpRank::from_worker_id(7), 0),
+            (WorkerWithDpRank::from_worker_id(8), 0),
+        ]);
+        let advisory = CacheFreeRequestContext::new("query", 8, true);
+        let committed = CacheFreeRequestContext::new("request", 8, false);
+
+        assert_eq!(policy.select(&advisory, &rows).unwrap().index, 0);
+        assert_eq!(policy.select(&advisory, &rows).unwrap().index, 0);
+        assert_eq!(policy.select(&committed, &rows).unwrap().index, 0);
+        assert_eq!(policy.select(&committed, &rows).unwrap().index, 1);
+    }
+
+    #[test]
+    fn cache_free_adapter_rejects_kv_and_full_load_inputs() {
+        struct CachePicker;
+
+        impl WorkerPicker for CachePicker {
+            fn required_worker_inputs(&self) -> WorkerInputs {
+                WorkerInputs::CACHE
+            }
+
+            fn pick(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                _input: WorkerInputView<'_>,
+            ) -> Result<usize, WorkerSelectionPolicyError> {
+                Ok(0)
+            }
+        }
+
+        struct FullLoadScorer;
+
+        impl WorkerScorer for FullLoadScorer {
+            fn required_worker_inputs(&self) -> WorkerInputs {
+                WorkerInputs::LOAD
+            }
+
+            fn score(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                _candidate: &WorkerCandidate,
+            ) -> Result<f64, WorkerSelectionPolicyError> {
+                Ok(0.0)
+            }
+        }
+
+        let cache_error = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(CachePicker),
+        )
+        .into_cache_free()
+        .err()
+        .expect("cache inputs must be rejected");
+        assert!(cache_error.to_string().contains("active-request load"));
+
+        let full_load_error = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            vec![Box::new(FullLoadScorer)],
+            Box::new(LowestCostPicker),
+        )
+        .into_cache_free()
+        .err()
+        .expect("full load inputs must be rejected");
+        assert!(full_load_error.to_string().contains("active-request load"));
     }
 }

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -139,7 +139,9 @@ impl WorkerSelectionRequirements {
 impl WorkerInputs {
     const fn requirements(self) -> WorkerSelectionRequirements {
         WorkerSelectionRequirements {
-            needs_cache_index: self.contains(Self::CACHE),
+            // Full scheduler load projects the request's prefill work after cached-token
+            // credit. ACTIVE_REQUEST_LOAD is the only load input a cache-free host can satisfy.
+            needs_cache_index: self.contains(Self::CACHE) || self.contains(Self::LOAD),
             needs_active_request_load: self.needs_worker_load(),
         }
     }
@@ -458,6 +460,7 @@ pub struct WorkerSelectionPolicy {
     kv_router_config: KvRouterConfig,
     worker_label: &'static str,
     state: WorkerSelectionPolicyState,
+    cache_free_picker: Option<Box<dyn CacheFreeWorkerPicker>>,
 }
 
 /// Request metadata made available to cache-free policy selection.
@@ -503,6 +506,11 @@ impl<'a> CacheFreeRequestContext<'a> {
         self.strict_priority = strict_priority;
         self
     }
+
+    /// Whether this is a preview that must not commit policy-local state.
+    pub fn is_advisory(&self) -> bool {
+        self.advisory
+    }
 }
 
 /// Borrowed, host-owned candidate table for cache-free selection.
@@ -510,12 +518,29 @@ impl<'a> CacheFreeRequestContext<'a> {
 /// The host has already applied discovery, namespace, health, and admission eligibility before
 /// exposing rows here. A cache-free policy may read worker identity and the frontend-local active
 /// request count only; it cannot request KV cache, taint, or scheduler projection inputs.
+///
+/// The table is a stable snapshot: its row count and worker identity must remain unchanged from
+/// policy selection through the host's admission of the returned row. Hosts that expose
+/// [`Self::least_loaded_index`] must maintain that minimum as an O(1) lookup; policies must not
+/// rescan the table to reconstruct it. All table methods used by cache-free pickers must also be
+/// O(1), including [`Self::len`] and [`Self::active_requests`].
 pub trait CacheFreeCandidateTable {
+    /// Return the number of eligible rows in O(1).
     fn len(&self) -> usize;
 
+    /// Return one row in O(1).
     fn worker(&self, index: usize) -> WorkerWithDpRank;
 
+    /// Return the frontend-local active-request count for one row in O(1).
     fn active_requests(&self, index: usize) -> usize;
+
+    /// Return the host-maintained least-loaded row, if this host supports that policy.
+    ///
+    /// Implementations must return in O(1). A host that does not maintain a load index returns
+    /// `None`, making a least-loaded policy unavailable rather than falling back to an O(N) scan.
+    fn least_loaded_index(&self) -> Option<usize> {
+        None
+    }
 
     fn is_empty(&self) -> bool {
         self.len() == 0
@@ -530,6 +555,33 @@ pub struct CacheFreePolicyDecision {
     pub allowed_worker_ids: Option<HashSet<WorkerId>>,
 }
 
+impl CacheFreePolicyDecision {
+    /// Select one row without narrowing the host-provided eligible set.
+    pub const fn unfiltered(index: usize) -> Self {
+        Self {
+            index,
+            allowed_worker_ids: None,
+        }
+    }
+}
+
+/// An O(1) cache-free policy implementation supplied by a linked policy crate.
+///
+/// This bypasses generic filter/score/pick materialization. It is intended for policies whose
+/// selection algorithm samples a constant number of rows, such as round-robin, random, and P2C.
+/// A host-provided least-loaded index also keeps least-loaded selection O(1).
+pub trait CacheFreeWorkerPicker: Send + Sync {
+    /// Return the infrastructure signals needed by this picker.
+    fn requirements(&self) -> WorkerSelectionRequirements;
+
+    /// Select one row from a stable host-owned candidate table.
+    fn select(
+        &self,
+        request: &CacheFreeRequestContext<'_>,
+        candidate_table: &dyn CacheFreeCandidateTable,
+    ) -> Result<CacheFreePolicyDecision, WorkerSelectionPolicyError>;
+}
+
 /// Thread-safe host adapter for custom filters, scorers, and pickers that do not require KV
 /// routing state.
 ///
@@ -537,7 +589,12 @@ pub struct CacheFreePolicyDecision {
 /// hold its own discovery/admission lock around a committed call so observing active request
 /// counts and reserving the selected worker stay atomic.
 pub struct CacheFreeWorkerSelectionPolicy {
-    state: Mutex<CacheFreeWorkerSelectionState>,
+    kind: CacheFreeWorkerSelectionPolicyKind,
+}
+
+enum CacheFreeWorkerSelectionPolicyKind {
+    Generic(Box<Mutex<CacheFreeWorkerSelectionState>>),
+    Direct(Box<dyn CacheFreeWorkerPicker>),
 }
 
 struct CacheFreeWorkerSelectionState {
@@ -593,7 +650,17 @@ impl WorkerSelectionPolicy {
                 load_inputs: Vec::new(),
                 routing_inputs: Vec::new(),
             })),
+            cache_free_picker: None,
         }
+    }
+
+    /// Attach an O(1) cache-free implementation to this policy.
+    ///
+    /// The regular filter/score/pick composition remains the KV-host implementation. The supplied
+    /// picker is used only after [`Self::into_cache_free`] and must declare identical requirements.
+    pub fn with_cache_free_picker(mut self, picker: Box<dyn CacheFreeWorkerPicker>) -> Self {
+        self.cache_free_picker = Some(picker);
+        self
     }
 
     /// Return the inputs the hosting router must materialize for this policy.
@@ -619,6 +686,24 @@ impl WorkerSelectionPolicy {
     pub fn into_cache_free(
         self,
     ) -> Result<CacheFreeWorkerSelectionPolicy, WorkerSelectionPolicyError> {
+        let policy_requirements = self.requirements();
+        if let Some(picker) = self.cache_free_picker {
+            let requirements = picker.requirements();
+            if requirements.needs_cache_index() {
+                return Err(WorkerSelectionPolicyError::failed(
+                    "cache-free routing does not support cache-index inputs",
+                ));
+            }
+            if requirements != policy_requirements {
+                return Err(WorkerSelectionPolicyError::failed(
+                    "cache-free picker requirements must match the KV policy requirements",
+                ));
+            }
+            return Ok(CacheFreeWorkerSelectionPolicy {
+                kind: CacheFreeWorkerSelectionPolicyKind::Direct(picker),
+            });
+        }
+
         match self.state {
             WorkerSelectionPolicyState::Custom(state) => {
                 let required_inputs = {
@@ -632,10 +717,12 @@ impl WorkerSelectionPolicy {
                     ));
                 }
                 Ok(CacheFreeWorkerSelectionPolicy {
-                    state: Mutex::new(CacheFreeWorkerSelectionState {
-                        policy: state.into_inner(),
-                        source_indices: Vec::new(),
-                    }),
+                    kind: CacheFreeWorkerSelectionPolicyKind::Generic(Box::new(Mutex::new(
+                        CacheFreeWorkerSelectionState {
+                            policy: state.into_inner(),
+                            source_indices: Vec::new(),
+                        },
+                    ))),
                 })
             }
             WorkerSelectionPolicyState::Default(_) => Err(WorkerSelectionPolicyError::failed(
@@ -644,25 +731,32 @@ impl WorkerSelectionPolicy {
         }
     }
 
-    #[cfg_attr(not(feature = "standalone-selection"), allow(dead_code))]
-    pub(crate) fn default(kv_router_config: KvRouterConfig, worker_label: &'static str) -> Self {
+    /// Build Dynamo's default KV-aware policy for one worker pool.
+    pub fn default(kv_router_config: KvRouterConfig, worker_label: &'static str) -> Self {
         let picker = DefaultWorkerPicker::new(kv_router_config.router_temperature);
         Self {
             kv_router_config,
             worker_label,
             state: WorkerSelectionPolicyState::Default(picker),
+            cache_free_picker: None,
         }
     }
 }
 
 impl CacheFreeWorkerSelectionPolicy {
     /// Run the custom policy against a borrowed table of host-eligible workers.
-    pub fn select<C: CacheFreeCandidateTable + ?Sized>(
+    pub fn select(
         &self,
         request: &CacheFreeRequestContext<'_>,
-        candidate_table: &C,
+        candidate_table: &dyn CacheFreeCandidateTable,
     ) -> Result<CacheFreePolicyDecision, WorkerSelectionPolicyError> {
-        let mut state = self.state.lock();
+        let state = match &self.kind {
+            CacheFreeWorkerSelectionPolicyKind::Direct(picker) => {
+                return picker.select(request, candidate_table);
+            }
+            CacheFreeWorkerSelectionPolicyKind::Generic(state) => state,
+        };
+        let mut state = state.lock();
         let CacheFreeWorkerSelectionState {
             policy,
             source_indices,
@@ -705,14 +799,19 @@ impl CacheFreeWorkerSelectionPolicy {
             advisory: request.advisory,
         };
 
+        let mut filters_narrowed = false;
         for index in 0..candidate_table.len() {
             let candidate_for = |inputs| WorkerCandidate {
                 worker: candidate_table.worker(index),
                 inputs,
                 cache: WorkerCacheInput::default(),
-                load: WorkerLoadInput {
-                    active_requests: candidate_table.active_requests(index),
-                    ..Default::default()
+                load: if inputs.needs_worker_load() {
+                    WorkerLoadInput {
+                        active_requests: candidate_table.active_requests(index),
+                        ..Default::default()
+                    }
+                } else {
+                    WorkerLoadInput::default()
                 },
                 routing: WorkerRoutingInput::default(),
             };
@@ -725,6 +824,7 @@ impl CacheFreeWorkerSelectionPolicy {
                 }
             }
             if !keep {
+                filters_narrowed = true;
                 continue;
             }
             unscored_candidates.push(candidate_for(*scorer_picker_inputs));
@@ -777,7 +877,7 @@ impl CacheFreeWorkerSelectionPolicy {
         )?;
         Ok(CacheFreePolicyDecision {
             index,
-            allowed_worker_ids: (!filters.is_empty()).then(|| {
+            allowed_worker_ids: filters_narrowed.then(|| {
                 candidates
                     .iter()
                     .map(|candidate| candidate.worker.worker_id)
@@ -1448,6 +1548,22 @@ mod tests {
         }
     }
 
+    struct StaticCacheFreeRows(Vec<WorkerWithDpRank>);
+
+    impl CacheFreeCandidateTable for StaticCacheFreeRows {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        fn worker(&self, index: usize) -> WorkerWithDpRank {
+            self.0[index]
+        }
+
+        fn active_requests(&self, _index: usize) -> usize {
+            panic!("static policy must not request active-load state")
+        }
+    }
+
     struct LowestActiveRequestScorer;
 
     impl WorkerScorer for LowestActiveRequestScorer {
@@ -1506,6 +1622,30 @@ mod tests {
             .unwrap();
         assert_eq!(selected.index, 1);
         assert!(selected.allowed_worker_ids.is_none());
+    }
+
+    #[test]
+    fn cache_free_static_policy_never_reads_active_request_load() {
+        let policy = WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "decode",
+            Vec::new(),
+            Box::new(LowestCostPicker),
+        )
+        .into_cache_free()
+        .unwrap();
+        let rows = StaticCacheFreeRows(vec![
+            WorkerWithDpRank::from_worker_id(41),
+            WorkerWithDpRank::from_worker_id(42),
+        ]);
+
+        assert_eq!(
+            policy
+                .select(&CacheFreeRequestContext::new("request", 32, false), &rows)
+                .unwrap()
+                .index,
+            0
+        );
     }
 
     #[test]
@@ -1632,15 +1772,17 @@ mod tests {
         .expect("cache inputs must be rejected");
         assert!(cache_error.to_string().contains("active-request load"));
 
-        let full_load_error = WorkerSelectionPolicy::new(
+        let full_load_policy = WorkerSelectionPolicy::new(
             KvRouterConfig::default(),
             "decode",
             vec![Box::new(FullLoadScorer)],
             Box::new(LowestCostPicker),
-        )
-        .into_cache_free()
-        .err()
-        .expect("full load inputs must be rejected");
+        );
+        assert!(full_load_policy.requirements().needs_cache_index());
+        let full_load_error = full_load_policy
+            .into_cache_free()
+            .err()
+            .expect("full load inputs must be rejected");
         assert!(full_load_error.to_string().contains("active-request load"));
     }
 }

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::BitOr;
-
-use parking_lot::Mutex;
 
 use super::{
     DefaultWorkerPicker, LogitWeights, WorkerSelectionInput, WorkerSelector,
@@ -16,6 +14,14 @@ use crate::scheduling::config::KvRouterConfig;
 use crate::scheduling::filter::RoutingEligibility;
 use crate::scheduling::types::{
     KvSchedulerError, SchedulingRequest, SessionContext, WorkerSelectionPolicyError,
+};
+
+#[path = "cache_free.rs"]
+mod cache_free;
+
+pub use cache_free::{
+    CacheFreeCandidateTable, CacheFreePolicyDecision, CacheFreeRequestContext,
+    CacheFreeWorkerPicker, CacheFreeWorkerSelectionPolicy,
 };
 
 /// Request-level values available to custom filters, scorers, and pickers.
@@ -463,145 +469,6 @@ pub struct WorkerSelectionPolicy {
     cache_free_picker: Option<Box<dyn CacheFreeWorkerPicker>>,
 }
 
-/// Request metadata made available to cache-free policy selection.
-///
-/// A cache-free host has no KV block size, cache index, or scheduler load projections. It
-/// therefore reports prompt tokens as one-token blocks and exposes only the request metadata
-/// already available at the frontend routing boundary.
-pub struct CacheFreeRequestContext<'a> {
-    request_id: &'a str,
-    request_tokens: usize,
-    session_context: Option<&'a SessionContext>,
-    expected_output_tokens: Option<u32>,
-    priority_jump: f64,
-    strict_priority: u32,
-    advisory: bool,
-}
-
-impl<'a> CacheFreeRequestContext<'a> {
-    pub fn new(request_id: &'a str, request_tokens: usize, advisory: bool) -> Self {
-        Self {
-            request_id,
-            request_tokens,
-            session_context: None,
-            expected_output_tokens: None,
-            priority_jump: 0.0,
-            strict_priority: 0,
-            advisory,
-        }
-    }
-
-    pub fn with_session_context(mut self, session_context: Option<&'a SessionContext>) -> Self {
-        self.session_context = session_context;
-        self
-    }
-
-    pub fn with_expected_output_tokens(mut self, expected_output_tokens: Option<u32>) -> Self {
-        self.expected_output_tokens = expected_output_tokens;
-        self
-    }
-
-    pub fn with_priority(mut self, priority_jump: f64, strict_priority: u32) -> Self {
-        self.priority_jump = priority_jump;
-        self.strict_priority = strict_priority;
-        self
-    }
-
-    /// Whether this is a preview that must not commit policy-local state.
-    pub fn is_advisory(&self) -> bool {
-        self.advisory
-    }
-}
-
-/// Borrowed, host-owned candidate table for cache-free selection.
-///
-/// The host has already applied discovery, namespace, health, and admission eligibility before
-/// exposing rows here. A cache-free policy may read worker identity and the frontend-local active
-/// request count only; it cannot request KV cache, taint, or scheduler projection inputs.
-///
-/// The table is a stable snapshot: its row count and worker identity must remain unchanged from
-/// policy selection through the host's admission of the returned row. Hosts that expose
-/// [`Self::least_loaded_index`] must maintain that minimum as an O(1) lookup; policies must not
-/// rescan the table to reconstruct it. All table methods used by cache-free pickers must also be
-/// O(1), including [`Self::len`] and [`Self::active_requests`].
-pub trait CacheFreeCandidateTable {
-    /// Return the number of eligible rows in O(1).
-    fn len(&self) -> usize;
-
-    /// Return one row in O(1).
-    fn worker(&self, index: usize) -> WorkerWithDpRank;
-
-    /// Return the frontend-local active-request count for one row in O(1).
-    fn active_requests(&self, index: usize) -> usize;
-
-    /// Return the host-maintained least-loaded row, if this host supports that policy.
-    ///
-    /// Implementations must return in O(1). A host that does not maintain a load index returns
-    /// `None`, making a least-loaded policy unavailable rather than falling back to an O(N) scan.
-    fn least_loaded_index(&self) -> Option<usize> {
-        None
-    }
-
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
-/// One cache-free policy decision and, when filters narrowed the candidate table, the set that
-/// transport fallback must remain within.
-#[derive(Debug)]
-pub struct CacheFreePolicyDecision {
-    pub index: usize,
-    pub allowed_worker_ids: Option<HashSet<WorkerId>>,
-}
-
-impl CacheFreePolicyDecision {
-    /// Select one row without narrowing the host-provided eligible set.
-    pub const fn unfiltered(index: usize) -> Self {
-        Self {
-            index,
-            allowed_worker_ids: None,
-        }
-    }
-}
-
-/// An O(1) cache-free policy implementation supplied by a linked policy crate.
-///
-/// This bypasses generic filter/score/pick materialization. It is intended for policies whose
-/// selection algorithm samples a constant number of rows, such as round-robin, random, and P2C.
-/// A host-provided least-loaded index also keeps least-loaded selection O(1).
-pub trait CacheFreeWorkerPicker: Send + Sync {
-    /// Return the infrastructure signals needed by this picker.
-    fn requirements(&self) -> WorkerSelectionRequirements;
-
-    /// Select one row from a stable host-owned candidate table.
-    fn select(
-        &self,
-        request: &CacheFreeRequestContext<'_>,
-        candidate_table: &dyn CacheFreeCandidateTable,
-    ) -> Result<CacheFreePolicyDecision, WorkerSelectionPolicyError>;
-}
-
-/// Thread-safe host adapter for custom filters, scorers, and pickers that do not require KV
-/// routing state.
-///
-/// The mutex serializes policy-local state such as a round-robin cursor. The routing host must
-/// hold its own discovery/admission lock around a committed call so observing active request
-/// counts and reserving the selected worker stay atomic.
-pub struct CacheFreeWorkerSelectionPolicy {
-    kind: CacheFreeWorkerSelectionPolicyKind,
-}
-
-enum CacheFreeWorkerSelectionPolicyKind {
-    Generic(Box<Mutex<CacheFreeWorkerSelectionState>>),
-    Direct(Box<dyn CacheFreeWorkerPicker>),
-}
-
-struct CacheFreeWorkerSelectionState {
-    policy: CustomWorkerSelectionState,
-    source_indices: Vec<usize>,
-}
-
 impl WorkerSelectionPolicy {
     /// Build a custom policy with no filters.
     ///
@@ -699,9 +566,7 @@ impl WorkerSelectionPolicy {
                     "cache-free picker requirements must match the KV policy requirements",
                 ));
             }
-            return Ok(CacheFreeWorkerSelectionPolicy {
-                kind: CacheFreeWorkerSelectionPolicyKind::Direct(picker),
-            });
+            return Ok(CacheFreeWorkerSelectionPolicy::direct(picker));
         }
 
         match self.state {
@@ -716,14 +581,7 @@ impl WorkerSelectionPolicy {
                         "cache-free routing supports only worker identity and active-request load inputs",
                     ));
                 }
-                Ok(CacheFreeWorkerSelectionPolicy {
-                    kind: CacheFreeWorkerSelectionPolicyKind::Generic(Box::new(Mutex::new(
-                        CacheFreeWorkerSelectionState {
-                            policy: state.into_inner(),
-                            source_indices: Vec::new(),
-                        },
-                    ))),
-                })
+                Ok(CacheFreeWorkerSelectionPolicy::generic(state.into_inner()))
             }
             WorkerSelectionPolicyState::Default(_) => Err(WorkerSelectionPolicyError::failed(
                 "only custom filter/scorer/picker policies can be adapted to cache-free routing",
@@ -740,150 +598,6 @@ impl WorkerSelectionPolicy {
             state: WorkerSelectionPolicyState::Default(picker),
             cache_free_picker: None,
         }
-    }
-}
-
-impl CacheFreeWorkerSelectionPolicy {
-    /// Run the custom policy against a borrowed table of host-eligible workers.
-    pub fn select(
-        &self,
-        request: &CacheFreeRequestContext<'_>,
-        candidate_table: &dyn CacheFreeCandidateTable,
-    ) -> Result<CacheFreePolicyDecision, WorkerSelectionPolicyError> {
-        let state = match &self.kind {
-            CacheFreeWorkerSelectionPolicyKind::Direct(picker) => {
-                return picker.select(request, candidate_table);
-            }
-            CacheFreeWorkerSelectionPolicyKind::Generic(state) => state,
-        };
-        let mut state = state.lock();
-        let CacheFreeWorkerSelectionState {
-            policy,
-            source_indices,
-        } = &mut *state;
-        let CustomWorkerSelectionState {
-            filters,
-            scorers,
-            filter_inputs,
-            scorer_picker_inputs,
-            picker_inputs,
-            picker,
-            unscored_candidates,
-            candidates,
-            load_inputs,
-            ..
-        } = policy;
-
-        unscored_candidates.clear();
-        candidates.clear();
-        source_indices.clear();
-        load_inputs.clear();
-
-        let context = WorkerSelectionContext {
-            request_id: request.request_id,
-            request_blocks: request.request_tokens as u64,
-            block_size: 1,
-            track_prefill_tokens: false,
-            weights: LogitWeights {
-                overlap_score_credit: 0.0,
-                overlap_score_credit_decay: 0.0,
-                prefill_load_scale: 0.0,
-                shared_cache_multiplier: 0.0,
-            },
-            min_active_prefill_tokens: 0,
-            router_temperature_override: None,
-            session_context: request.session_context,
-            expected_output_tokens: request.expected_output_tokens,
-            priority_jump: request.priority_jump,
-            strict_priority: request.strict_priority,
-            advisory: request.advisory,
-        };
-
-        let mut filters_narrowed = false;
-        for index in 0..candidate_table.len() {
-            let candidate_for = |inputs| WorkerCandidate {
-                worker: candidate_table.worker(index),
-                inputs,
-                cache: WorkerCacheInput::default(),
-                load: if inputs.needs_worker_load() {
-                    WorkerLoadInput {
-                        active_requests: candidate_table.active_requests(index),
-                        ..Default::default()
-                    }
-                } else {
-                    WorkerLoadInput::default()
-                },
-                routing: WorkerRoutingInput::default(),
-            };
-            let filter_candidate = candidate_for(*filter_inputs);
-            let mut keep = true;
-            for filter in filters.iter_mut() {
-                if !filter.keep(&context, &filter_candidate)? {
-                    keep = false;
-                    break;
-                }
-            }
-            if !keep {
-                filters_narrowed = true;
-                continue;
-            }
-            unscored_candidates.push(candidate_for(*scorer_picker_inputs));
-            source_indices.push(index);
-        }
-
-        for candidate in unscored_candidates.iter() {
-            let mut cost = 0.0;
-            for (scorer_index, scorer) in scorers.iter_mut().enumerate() {
-                let contribution = scorer.score(&context, candidate)?;
-                cost += contribution;
-                if !contribution.is_finite() || !cost.is_finite() {
-                    return Err(WorkerSelectionPolicyError::NonFiniteCost {
-                        scorer_index,
-                        row: candidates.len(),
-                    });
-                }
-            }
-            candidates.push(ScoredWorkerCandidate {
-                worker: candidate.worker,
-                cost,
-            });
-            if picker_inputs.needs_worker_load() {
-                load_inputs.push(candidate.load);
-            }
-        }
-
-        if candidates.is_empty() {
-            let message = if candidate_table.is_empty() {
-                "no eligible workers"
-            } else {
-                "all eligible workers were rejected by policy filters"
-            };
-            return Err(WorkerSelectionPolicyError::failed(message));
-        }
-        let input = WorkerInputView {
-            candidates,
-            cache: None,
-            load: picker_inputs
-                .needs_worker_load()
-                .then_some(load_inputs.as_slice()),
-            routing: None,
-        };
-        let row = picker.pick(&context, input)?;
-        let index = source_indices.get(row).copied().ok_or(
-            WorkerSelectionPolicyError::InvalidPickerRow {
-                row,
-                candidate_count: candidates.len(),
-            },
-        )?;
-        Ok(CacheFreePolicyDecision {
-            index,
-            allowed_worker_ids: filters_narrowed.then(|| {
-                candidates
-                    .iter()
-                    .map(|candidate| candidate.worker.worker_id)
-                    .collect()
-            }),
-        })
     }
 }
 
@@ -1103,7 +817,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for WorkerSelectionPolicy {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
 
     use rustc_hash::FxHashMap;
 
@@ -1464,6 +1178,24 @@ mod tests {
 
     #[test]
     fn active_request_load_composes_with_full_scheduler_load() {
+        struct LowestCostPicker;
+
+        impl WorkerPicker for LowestCostPicker {
+            fn pick(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                input: WorkerInputView<'_>,
+            ) -> Result<usize, WorkerSelectionPolicyError> {
+                input
+                    .candidates()
+                    .iter()
+                    .enumerate()
+                    .min_by(|(_, left), (_, right)| left.cost().total_cmp(&right.cost()))
+                    .map(|(row, _)| row)
+                    .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible workers"))
+            }
+        }
+
         struct KeepWithActiveRequestLoad;
 
         impl WorkerFilter for KeepWithActiveRequestLoad {
@@ -1530,259 +1262,5 @@ mod tests {
                 .worker,
             worker
         );
-    }
-
-    struct CacheFreeRows(Vec<(WorkerWithDpRank, usize)>);
-
-    impl CacheFreeCandidateTable for CacheFreeRows {
-        fn len(&self) -> usize {
-            self.0.len()
-        }
-
-        fn worker(&self, index: usize) -> WorkerWithDpRank {
-            self.0[index].0
-        }
-
-        fn active_requests(&self, index: usize) -> usize {
-            self.0[index].1
-        }
-    }
-
-    struct StaticCacheFreeRows(Vec<WorkerWithDpRank>);
-
-    impl CacheFreeCandidateTable for StaticCacheFreeRows {
-        fn len(&self) -> usize {
-            self.0.len()
-        }
-
-        fn worker(&self, index: usize) -> WorkerWithDpRank {
-            self.0[index]
-        }
-
-        fn active_requests(&self, _index: usize) -> usize {
-            panic!("static policy must not request active-load state")
-        }
-    }
-
-    struct LowestActiveRequestScorer;
-
-    impl WorkerScorer for LowestActiveRequestScorer {
-        fn required_worker_inputs(&self) -> WorkerInputs {
-            WorkerInputs::ACTIVE_REQUEST_LOAD
-        }
-
-        fn score(
-            &mut self,
-            _context: &WorkerSelectionContext<'_>,
-            candidate: &WorkerCandidate,
-        ) -> Result<f64, WorkerSelectionPolicyError> {
-            Ok(candidate
-                .load()
-                .expect("active-request load was requested")
-                .active_requests() as f64)
-        }
-    }
-
-    struct LowestCostPicker;
-
-    impl WorkerPicker for LowestCostPicker {
-        fn pick(
-            &mut self,
-            _context: &WorkerSelectionContext<'_>,
-            input: WorkerInputView<'_>,
-        ) -> Result<usize, WorkerSelectionPolicyError> {
-            input
-                .candidates()
-                .iter()
-                .enumerate()
-                .min_by(|(_, left), (_, right)| left.cost().total_cmp(&right.cost()))
-                .map(|(row, _)| row)
-                .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible workers"))
-        }
-    }
-
-    #[test]
-    fn cache_free_adapter_uses_active_request_load_without_kv_inputs() {
-        let policy = WorkerSelectionPolicy::new(
-            KvRouterConfig::default(),
-            "decode",
-            vec![Box::new(LowestActiveRequestScorer)],
-            Box::new(LowestCostPicker),
-        )
-        .into_cache_free()
-        .unwrap();
-        let rows = CacheFreeRows(vec![
-            (WorkerWithDpRank::from_worker_id(41), 9),
-            (WorkerWithDpRank::from_worker_id(42), 2),
-            (WorkerWithDpRank::from_worker_id(43), 6),
-        ]);
-
-        let selected = policy
-            .select(&CacheFreeRequestContext::new("request", 32, false), &rows)
-            .unwrap();
-        assert_eq!(selected.index, 1);
-        assert!(selected.allowed_worker_ids.is_none());
-    }
-
-    #[test]
-    fn cache_free_static_policy_never_reads_active_request_load() {
-        let policy = WorkerSelectionPolicy::new(
-            KvRouterConfig::default(),
-            "decode",
-            Vec::new(),
-            Box::new(LowestCostPicker),
-        )
-        .into_cache_free()
-        .unwrap();
-        let rows = StaticCacheFreeRows(vec![
-            WorkerWithDpRank::from_worker_id(41),
-            WorkerWithDpRank::from_worker_id(42),
-        ]);
-
-        assert_eq!(
-            policy
-                .select(&CacheFreeRequestContext::new("request", 32, false), &rows)
-                .unwrap()
-                .index,
-            0
-        );
-    }
-
-    #[test]
-    fn cache_free_adapter_returns_filtered_fallback_set() {
-        struct RejectWorker(WorkerId);
-
-        impl WorkerFilter for RejectWorker {
-            fn keep(
-                &mut self,
-                _context: &WorkerSelectionContext<'_>,
-                candidate: &WorkerCandidate,
-            ) -> Result<bool, WorkerSelectionPolicyError> {
-                Ok(candidate.worker().worker_id != self.0)
-            }
-        }
-
-        let policy = WorkerSelectionPolicy::new_with_filters(
-            KvRouterConfig::default(),
-            "decode",
-            vec![Box::new(RejectWorker(41))],
-            Vec::new(),
-            Box::new(LowestCostPicker),
-        )
-        .into_cache_free()
-        .unwrap();
-        let rows = CacheFreeRows(vec![
-            (WorkerWithDpRank::from_worker_id(41), 0),
-            (WorkerWithDpRank::from_worker_id(42), 0),
-        ]);
-
-        let selected = policy
-            .select(&CacheFreeRequestContext::new("request", 32, false), &rows)
-            .unwrap();
-        assert_eq!(selected.index, 1);
-        assert_eq!(selected.allowed_worker_ids, Some(HashSet::from([42])));
-    }
-
-    #[test]
-    fn cache_free_adapter_serializes_state_and_keeps_advisory_selection_read_only() {
-        struct StatefulPicker {
-            next: usize,
-        }
-
-        impl WorkerPicker for StatefulPicker {
-            fn pick(
-                &mut self,
-                context: &WorkerSelectionContext<'_>,
-                input: WorkerInputView<'_>,
-            ) -> Result<usize, WorkerSelectionPolicyError> {
-                let row = self.next % input.candidates().len();
-                if !context.is_advisory() {
-                    self.next += 1;
-                }
-                Ok(row)
-            }
-        }
-
-        fn assert_send_sync<T: Send + Sync>() {}
-
-        assert_send_sync::<CacheFreeWorkerSelectionPolicy>();
-        let policy = WorkerSelectionPolicy::new(
-            KvRouterConfig::default(),
-            "decode",
-            Vec::new(),
-            Box::new(StatefulPicker { next: 0 }),
-        )
-        .into_cache_free()
-        .unwrap();
-        let rows = CacheFreeRows(vec![
-            (WorkerWithDpRank::from_worker_id(7), 0),
-            (WorkerWithDpRank::from_worker_id(8), 0),
-        ]);
-        let advisory = CacheFreeRequestContext::new("query", 8, true);
-        let committed = CacheFreeRequestContext::new("request", 8, false);
-
-        assert_eq!(policy.select(&advisory, &rows).unwrap().index, 0);
-        assert_eq!(policy.select(&advisory, &rows).unwrap().index, 0);
-        assert_eq!(policy.select(&committed, &rows).unwrap().index, 0);
-        assert_eq!(policy.select(&committed, &rows).unwrap().index, 1);
-    }
-
-    #[test]
-    fn cache_free_adapter_rejects_kv_and_full_load_inputs() {
-        struct CachePicker;
-
-        impl WorkerPicker for CachePicker {
-            fn required_worker_inputs(&self) -> WorkerInputs {
-                WorkerInputs::CACHE
-            }
-
-            fn pick(
-                &mut self,
-                _context: &WorkerSelectionContext<'_>,
-                _input: WorkerInputView<'_>,
-            ) -> Result<usize, WorkerSelectionPolicyError> {
-                Ok(0)
-            }
-        }
-
-        struct FullLoadScorer;
-
-        impl WorkerScorer for FullLoadScorer {
-            fn required_worker_inputs(&self) -> WorkerInputs {
-                WorkerInputs::LOAD
-            }
-
-            fn score(
-                &mut self,
-                _context: &WorkerSelectionContext<'_>,
-                _candidate: &WorkerCandidate,
-            ) -> Result<f64, WorkerSelectionPolicyError> {
-                Ok(0.0)
-            }
-        }
-
-        let cache_error = WorkerSelectionPolicy::new(
-            KvRouterConfig::default(),
-            "decode",
-            Vec::new(),
-            Box::new(CachePicker),
-        )
-        .into_cache_free()
-        .err()
-        .expect("cache inputs must be rejected");
-        assert!(cache_error.to_string().contains("active-request load"));
-
-        let full_load_policy = WorkerSelectionPolicy::new(
-            KvRouterConfig::default(),
-            "decode",
-            vec![Box::new(FullLoadScorer)],
-            Box::new(LowestCostPicker),
-        );
-        assert!(full_load_policy.requirements().needs_cache_index());
-        let full_load_error = full_load_policy
-            .into_cache_free()
-            .err()
-            .expect("full load inputs must be rejected");
-        assert!(full_load_error.to_string().contains("active-request load"));
     }
 }

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -78,6 +78,56 @@ impl BitOr for WorkerInputs {
     }
 }
 
+/// Infrastructure signals required by a worker-selection policy.
+///
+/// These are deliberately semantic rather than tied to a particular router implementation. A
+/// host may satisfy active-request load with its own occupancy accounting, while the KV host
+/// maps it to its slot tracker. This lets a host defer cache and tracking setup until the
+/// selected policy actually needs those signals.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WorkerSelectionRequirements {
+    needs_cache_index: bool,
+    needs_active_request_load: bool,
+}
+
+impl WorkerSelectionRequirements {
+    /// A policy that only needs the eligible worker set.
+    pub const STATIC: Self = Self {
+        needs_cache_index: false,
+        needs_active_request_load: false,
+    };
+
+    /// A policy that reads the host's active-request count for each worker.
+    pub const ACTIVE_REQUEST_LOAD: Self = Self {
+        needs_cache_index: false,
+        needs_active_request_load: true,
+    };
+
+    /// Dynamo's standard KV-aware policy.
+    pub const KV_AWARE: Self = Self {
+        needs_cache_index: true,
+        needs_active_request_load: true,
+    };
+
+    /// Whether selection requires KV cache-overlap data.
+    pub const fn needs_cache_index(self) -> bool {
+        self.needs_cache_index
+    }
+
+    /// Whether selection requires a live active-request load for each worker.
+    pub const fn needs_active_request_load(self) -> bool {
+        self.needs_active_request_load
+    }
+}
+
+impl WorkerInputs {
+    const fn requirements(self) -> WorkerSelectionRequirements {
+        WorkerSelectionRequirements {
+            needs_cache_index: self.contains(Self::CACHE),
+            needs_active_request_load: self.contains(Self::LOAD),
+        }
+    }
+}
 /// KV-cache overlap values for one worker.
 #[derive(Clone, Copy, Default)]
 pub struct WorkerCacheInput {
@@ -163,6 +213,13 @@ pub trait WorkerPicker: Send {
 }
 
 impl WorkerSelectionContext<'_> {
+    /// Whether this selection is an advisory query that must not mutate
+    /// policy-local state. Stateful pickers use this to keep previews from
+    /// advancing a round-robin cursor or otherwise committing a decision.
+    pub fn is_advisory(&self) -> bool {
+        !self.request.mode.is_tracked()
+    }
+
     /// Return the incoming prompt size in KV blocks.
     pub fn request_blocks(&self) -> u64 {
         self.request_blocks
@@ -434,11 +491,22 @@ impl WorkerSelectionPolicy {
         }
     }
 
-    /// Wrap Dynamo's built-in selector for a host that uses the policy selector type.
+    /// Return the inputs the hosting router must materialize for this policy.
     ///
-    /// `worker_label` selects the built-in scoring and logging contract. Typed hosts use
-    /// [`crate::WorkerType::default_selector_label`] to preserve Dynamo's historical behavior.
-    pub fn default(kv_router_config: KvRouterConfig, worker_label: &'static str) -> Self {
+    /// A custom policy declares these through its filters, scorers, and picker. The default
+    /// selector remains cache-aware and conservatively requires both cache and load inputs.
+    pub fn requirements(&self) -> WorkerSelectionRequirements {
+        match &self.state {
+            WorkerSelectionPolicyState::Default(_) => WorkerSelectionRequirements::KV_AWARE,
+            WorkerSelectionPolicyState::Custom(state) => {
+                let state = state.borrow();
+                (state.filter_inputs | state.scorer_picker_inputs).requirements()
+            }
+        }
+    }
+
+    #[cfg_attr(not(feature = "standalone-selection"), allow(dead_code))]
+    pub(crate) fn default(kv_router_config: KvRouterConfig, worker_label: &'static str) -> Self {
         let picker = DefaultWorkerPicker::new(kv_router_config.router_temperature);
         Self {
             kv_router_config,
@@ -630,6 +698,10 @@ pub(super) fn collect_custom_candidates<C: WorkerConfigLike>(
 }
 
 impl<C: WorkerConfigLike> WorkerSelector<C> for WorkerSelectionPolicy {
+    fn requirements(&self) -> WorkerSelectionRequirements {
+        WorkerSelectionPolicy::requirements(self)
+    }
+
     #[inline(always)]
     fn select_worker(
         &self,

--- a/lib/kv-router/src/scheduling/worker_selection_config.rs
+++ b/lib/kv-router/src/scheduling/worker_selection_config.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! YAML schema for process-wide custom worker-selection policy instances.
+//! YAML schema for process-wide first-party or linked worker-selection policy instances.
 
 use std::collections::HashMap;
 
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 use super::policy_config::{RouterPolicyConfigError, validate_identifier};
 
-/// Process-wide configuration for worker selection in a custom Dynamo image.
+/// Process-wide configuration for worker selection in a Dynamo image.
 #[derive(Debug, Clone, PartialEq)]
 pub struct WorkerSelectionConfig {
     aggregated: Option<String>,
@@ -63,7 +63,7 @@ pub struct WorkerSelectionInstance {
 }
 
 impl WorkerSelectionInstance {
-    /// The policy type registered by a linked policy crate.
+    /// The policy type registered by Dynamo or a linked policy crate.
     pub fn policy_type(&self) -> &str {
         &self.policy_type
     }

--- a/lib/kv-router/src/services/mod.rs
+++ b/lib/kv-router/src/services/mod.rs
@@ -14,6 +14,7 @@ pub mod overlap;
 #[cfg(feature = "standalone-indexer")]
 pub mod shared_cache;
 
+pub mod policy_registry;
 #[cfg(feature = "standalone-selection")]
 pub mod selection;
 

--- a/lib/kv-router/src/services/policy_registry.rs
+++ b/lib/kv-router/src/services/policy_registry.rs
@@ -61,7 +61,7 @@ impl WorkerSelectionPolicyProviderError {
     }
 }
 
-/// A startup-only registry of policy types linked into a custom Dynamo image.
+/// A startup-only registry of policy types linked into this Dynamo artifact.
 #[derive(Clone, Default)]
 pub struct WorkerSelectionPolicyRegistry {
     providers: HashMap<String, WorkerSelectionPolicyProvider>,

--- a/lib/kv-router/src/services/selection/mod.rs
+++ b/lib/kv-router/src/services/selection/mod.rs
@@ -18,18 +18,18 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+pub use super::policy_registry::{
+    DYN_ROUTER_DECODE_POLICY, DYN_ROUTER_PREFILL_POLICY, DYN_ROUTER_WORKER_SELECTION_POLICY,
+    WorkerSelectionPolicyParameters, WorkerSelectionPolicyProvider,
+    WorkerSelectionPolicyProviderError, WorkerSelectionPolicyRegistry,
+    WorkerSelectionPolicyRegistryError,
+};
 pub use crate::WorkerSelectionPolicyFactory;
 pub use crate::services::common::replica_sync::ReplicaPeerError;
 pub use core::{SelectionCore, SelectionServiceConfig};
 pub use error::SelectionError;
 pub use input::PromptRequest;
 pub use pending::SelectionCacheConfig;
-pub use policy_registry::{
-    DYN_ROUTER_DECODE_POLICY, DYN_ROUTER_PREFILL_POLICY, DYN_ROUTER_WORKER_SELECTION_POLICY,
-    WorkerSelectionPolicyParameters, WorkerSelectionPolicyProvider,
-    WorkerSelectionPolicyProviderError, WorkerSelectionPolicyRegistry,
-    WorkerSelectionPolicyRegistryError,
-};
 pub use server::{AppState, run_server, run_server_with_service};
 pub use service::{SelectionService, SelectionServiceBuilder};
 pub use types::{

--- a/lib/kv-router/src/services/selection/mod.rs
+++ b/lib/kv-router/src/services/selection/mod.rs
@@ -11,7 +11,6 @@ mod core;
 mod error;
 mod input;
 mod pending;
-mod policy_registry;
 mod server;
 mod service;
 mod types;

--- a/lib/router-plugins/first-party/Cargo.toml
+++ b/lib/router-plugins/first-party/Cargo.toml
@@ -13,5 +13,6 @@ description = "First-party worker-selection policy catalog for Dynamo"
 
 [dependencies]
 dynamo-kv-router = { workspace = true }
+dynamo-runtime = { workspace = true }
 fastrand = "2"
 serde = { workspace = true }

--- a/lib/router-plugins/first-party/Cargo.toml
+++ b/lib/router-plugins/first-party/Cargo.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-first-party-router-policies"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "First-party worker-selection policy catalog for Dynamo"
+
+[dependencies]
+dynamo-kv-router = { workspace = true }
+fastrand = "2"
+serde = { workspace = true }

--- a/lib/router-plugins/first-party/src/lib.rs
+++ b/lib/router-plugins/first-party/src/lib.rs
@@ -91,7 +91,7 @@ impl WorkerScorer for FirstPartyWorkerScorer {
                 WorkerInputs::NONE
             }
             FirstPartyRoutingPolicy::PowerOfTwoChoices | FirstPartyRoutingPolicy::LeastLoaded => {
-                WorkerInputs::LOAD
+                WorkerInputs::ACTIVE_REQUEST_LOAD
             }
         }
     }

--- a/lib/router-plugins/first-party/src/lib.rs
+++ b/lib/router-plugins/first-party/src/lib.rs
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Always-linked, first-party worker-selection policies.
+//!
+//! This crate owns policy algorithms and policy-local state. The selection host retains discovery,
+//! eligibility, and request accounting. The optional custom catalog uses the same registry API,
+//! but never needs to replace these stock policies.
+
+use std::sync::Arc;
+
+use dynamo_kv_router::{
+    KvRouterConfig,
+    scheduling::WorkerSelectionPolicyError,
+    selector::{
+        WorkerCandidate, WorkerInputView, WorkerInputs, WorkerPicker, WorkerScorer,
+        WorkerSelectionContext, WorkerSelectionPolicy,
+    },
+    services::policy_registry::{
+        WorkerSelectionPolicyProvider, WorkerSelectionPolicyRegistry,
+        WorkerSelectionPolicyRegistryError,
+    },
+};
+
+/// Register the worker-selection policies shipped in every Dynamo artifact.
+///
+/// Each resolved policy instance creates one picker for its routing partition, so mutable state
+/// such as the round-robin cursor is not shared between models or worker roles.
+pub fn register(
+    registry: &mut WorkerSelectionPolicyRegistry,
+) -> Result<(), WorkerSelectionPolicyRegistryError> {
+    for (name, policy) in [
+        ("round_robin", FirstPartyRoutingPolicy::RoundRobin),
+        ("random", FirstPartyRoutingPolicy::Random),
+        (
+            "power_of_two_choices",
+            FirstPartyRoutingPolicy::PowerOfTwoChoices,
+        ),
+        ("least_loaded", FirstPartyRoutingPolicy::LeastLoaded),
+    ] {
+        registry.register(name, policy_provider(policy))?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FirstPartyRoutingPolicy {
+    RoundRobin,
+    Random,
+    PowerOfTwoChoices,
+    LeastLoaded,
+}
+
+fn policy_provider(policy: FirstPartyRoutingPolicy) -> WorkerSelectionPolicyProvider {
+    Arc::new(move |parameters| {
+        let _: EmptyParameters = parameters.deserialize()?;
+        Ok(Arc::new(move |config, worker_type, _partition| {
+            worker_selection_policy(config.clone(), worker_type.as_str(), policy)
+        }))
+    })
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EmptyParameters {}
+
+fn worker_selection_policy(
+    config: KvRouterConfig,
+    worker_type: &'static str,
+    policy: FirstPartyRoutingPolicy,
+) -> WorkerSelectionPolicy {
+    WorkerSelectionPolicy::new(
+        config,
+        worker_type,
+        vec![Box::new(FirstPartyWorkerScorer { policy })],
+        Box::new(FirstPartyWorkerPicker {
+            policy,
+            last_round_robin_worker: None,
+        }),
+    )
+}
+
+struct FirstPartyWorkerScorer {
+    policy: FirstPartyRoutingPolicy,
+}
+
+impl WorkerScorer for FirstPartyWorkerScorer {
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        match self.policy {
+            FirstPartyRoutingPolicy::RoundRobin | FirstPartyRoutingPolicy::Random => {
+                WorkerInputs::NONE
+            }
+            FirstPartyRoutingPolicy::PowerOfTwoChoices | FirstPartyRoutingPolicy::LeastLoaded => {
+                WorkerInputs::LOAD
+            }
+        }
+    }
+
+    fn score(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        candidate: &WorkerCandidate,
+    ) -> Result<f64, WorkerSelectionPolicyError> {
+        Ok(candidate.load().map_or(0, |load| load.active_requests()) as f64)
+    }
+}
+
+struct FirstPartyWorkerPicker {
+    policy: FirstPartyRoutingPolicy,
+    // Candidate row order is unspecified. Holding an identity rather than a row number gives
+    // round-robin deterministic behavior across HashMap iteration order and worker churn.
+    last_round_robin_worker: Option<dynamo_kv_router::protocols::WorkerWithDpRank>,
+}
+
+impl FirstPartyWorkerPicker {
+    fn round_robin_row(&mut self, input: WorkerInputView<'_>, advisory: bool) -> usize {
+        let mut first = None;
+        let mut successor = None;
+        for (row, candidate) in input.candidates().iter().enumerate() {
+            let worker = candidate.worker();
+            if first.is_none_or(|current: usize| worker < input.candidates()[current].worker()) {
+                first = Some(row);
+            }
+            if self
+                .last_round_robin_worker
+                .is_some_and(|last| worker > last)
+                && successor
+                    .is_none_or(|current: usize| worker < input.candidates()[current].worker())
+            {
+                successor = Some(row);
+            }
+        }
+        let row = successor
+            .or(first)
+            .expect("picker only runs with candidates");
+        if !advisory {
+            self.last_round_robin_worker = Some(input.candidates()[row].worker());
+        }
+        row
+    }
+
+    fn p2c_row(&self, input: WorkerInputView<'_>) -> usize {
+        let candidates = input.candidates();
+        let first = fastrand::usize(..candidates.len());
+        if candidates.len() == 1 {
+            return first;
+        }
+        let second = (first + 1 + fastrand::usize(..candidates.len() - 1)) % candidates.len();
+        if candidates[first].cost() <= candidates[second].cost() {
+            first
+        } else {
+            second
+        }
+    }
+
+    fn least_loaded_row(&self, input: WorkerInputView<'_>) -> usize {
+        let mut best = 0;
+        let mut ties = 1usize;
+        for row in 1..input.candidates().len() {
+            match input.candidates()[row]
+                .cost()
+                .total_cmp(&input.candidates()[best].cost())
+            {
+                std::cmp::Ordering::Less => {
+                    best = row;
+                    ties = 1;
+                }
+                std::cmp::Ordering::Equal => {
+                    ties += 1;
+                    if fastrand::usize(..ties) == 0 {
+                        best = row;
+                    }
+                }
+                std::cmp::Ordering::Greater => {}
+            }
+        }
+        best
+    }
+}
+
+impl WorkerPicker for FirstPartyWorkerPicker {
+    fn pick(
+        &mut self,
+        context: &WorkerSelectionContext<'_>,
+        input: WorkerInputView<'_>,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        if input.candidates().is_empty() {
+            return Err(WorkerSelectionPolicyError::failed("no eligible workers"));
+        }
+        Ok(match self.policy {
+            FirstPartyRoutingPolicy::RoundRobin => {
+                self.round_robin_row(input, context.is_advisory())
+            }
+            FirstPartyRoutingPolicy::Random => fastrand::usize(..input.candidates().len()),
+            FirstPartyRoutingPolicy::PowerOfTwoChoices => self.p2c_row(input),
+            FirstPartyRoutingPolicy::LeastLoaded => self.least_loaded_row(input),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use super::*;
+    use dynamo_kv_router::{
+        protocols::{WorkerConfigLike, WorkerWithDpRank},
+        scheduling::{OverlapSignals, ScheduleMode, SchedulingRequest},
+        selector::WorkerSelector,
+    };
+
+    #[derive(Default)]
+    struct WorkerConfig {
+        taints: HashSet<String>,
+    }
+
+    impl WorkerConfigLike for WorkerConfig {
+        fn data_parallel_start_rank(&self) -> u32 {
+            0
+        }
+
+        fn data_parallel_size(&self) -> u32 {
+            1
+        }
+
+        fn max_num_batched_tokens(&self) -> Option<u64> {
+            None
+        }
+
+        fn total_kv_blocks(&self) -> Option<u64> {
+            None
+        }
+
+        fn taints(&self) -> &HashSet<String> {
+            &self.taints
+        }
+    }
+
+    fn workers() -> HashMap<u64, WorkerConfig> {
+        HashMap::from([(7, WorkerConfig::default()), (11, WorkerConfig::default())])
+    }
+
+    fn request(mode: ScheduleMode) -> SchedulingRequest {
+        SchedulingRequest {
+            mode,
+            token_seq: None,
+            isl_tokens: 16,
+            lora_name: None,
+            expected_output_tokens: None,
+            pinned_worker: None,
+            allowed_worker_ids: None,
+            routing_constraints: Default::default(),
+            router_config_override: None,
+            track_prefill_tokens: false,
+            priority_jump: 0.0,
+            strict_priority: 0,
+            policy_class: None,
+            session_context: None,
+            overlap: OverlapSignals::default(),
+            router_hint_candidates: None,
+            retain_router_hint_chain: false,
+            shared_cache_hits: None,
+            worker_loads: Default::default(),
+            resp_tx: None,
+        }
+    }
+
+    #[test]
+    fn round_robin_keeps_advisory_queries_and_partitions_independent() {
+        let first = worker_selection_policy(
+            KvRouterConfig::default(),
+            "decode",
+            FirstPartyRoutingPolicy::RoundRobin,
+        );
+        let second = worker_selection_policy(
+            KvRouterConfig::default(),
+            "decode",
+            FirstPartyRoutingPolicy::RoundRobin,
+        );
+        let workers = workers();
+        let advisory = request(ScheduleMode::QueryOnly {
+            request_id: Some("advisory".to_string()),
+        });
+
+        assert_eq!(
+            first
+                .select_worker(&workers, &advisory, advisory.eligibility(), 16)
+                .unwrap()
+                .worker,
+            WorkerWithDpRank::from_worker_id(7)
+        );
+        assert_eq!(
+            first
+                .select_worker(&workers, &advisory, advisory.eligibility(), 16)
+                .unwrap()
+                .worker,
+            WorkerWithDpRank::from_worker_id(7)
+        );
+
+        let committed = request(ScheduleMode::Tracked {
+            request_id: "committed".to_string(),
+        });
+        assert_eq!(
+            first
+                .select_worker(&workers, &committed, committed.eligibility(), 16)
+                .unwrap()
+                .worker,
+            WorkerWithDpRank::from_worker_id(7)
+        );
+        assert_eq!(
+            second
+                .select_worker(&workers, &committed, committed.eligibility(), 16)
+                .unwrap()
+                .worker,
+            WorkerWithDpRank::from_worker_id(7)
+        );
+        assert_eq!(
+            first
+                .select_worker(&workers, &committed, committed.eligibility(), 16)
+                .unwrap()
+                .worker,
+            WorkerWithDpRank::from_worker_id(11)
+        );
+    }
+
+    #[test]
+    fn static_and_load_aware_policies_declare_different_requirements() {
+        let static_policy = worker_selection_policy(
+            KvRouterConfig::default(),
+            "decode",
+            FirstPartyRoutingPolicy::RoundRobin,
+        );
+        let load_aware_policy = worker_selection_policy(
+            KvRouterConfig::default(),
+            "decode",
+            FirstPartyRoutingPolicy::LeastLoaded,
+        );
+
+        assert!(!static_policy.requirements().needs_cache_index());
+        assert!(!static_policy.requirements().needs_active_request_load());
+        assert!(!load_aware_policy.requirements().needs_cache_index());
+        assert!(load_aware_policy.requirements().needs_active_request_load());
+    }
+}

--- a/lib/router-plugins/first-party/src/lib.rs
+++ b/lib/router-plugins/first-party/src/lib.rs
@@ -1,14 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Always-linked, first-party worker-selection policies.
+//! First-party worker-selection policies linked by Dynamo's Python router extension.
+//!
+//! Standalone EPP and Rust hosts link and register this crate explicitly.
 //!
 //! This crate owns policy algorithms and policy-local state. The selection host retains discovery,
 //! eligibility, and request accounting. The optional custom catalog uses the same registry API,
 //! but never needs to replace these stock policies.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use dynamo_kv_router::{
     KvRouterConfig,
@@ -23,6 +24,7 @@ use dynamo_kv_router::{
         WorkerSelectionPolicyRegistryError,
     },
 };
+use dynamo_runtime::fast_picker::{FastPicker, reservoir_least_index_by};
 
 /// Register the stock policy types linked by Dynamo's Python router extension.
 ///
@@ -90,14 +92,14 @@ fn worker_selection_policy(
 /// the host-maintained minimum. None of these algorithms may walk the candidate table.
 struct FirstPartyCacheFreePicker {
     policy: FirstPartyRoutingPolicy,
-    round_robin_cursor: AtomicU64,
+    fast_picker: FastPicker,
 }
 
 impl FirstPartyCacheFreePicker {
     const fn new(policy: FirstPartyRoutingPolicy) -> Self {
         Self {
             policy,
-            round_robin_cursor: AtomicU64::new(0),
+            fast_picker: FastPicker::new(),
         }
     }
 
@@ -138,30 +140,17 @@ impl CacheFreeWorkerPicker for FirstPartyCacheFreePicker {
         }
 
         let index = match self.policy {
-            FirstPartyRoutingPolicy::RoundRobin => {
-                let cursor = if request.is_advisory() {
-                    self.round_robin_cursor.load(Ordering::Relaxed)
-                } else {
-                    self.round_robin_cursor.fetch_add(1, Ordering::Relaxed)
-                };
-                cursor as usize % candidate_count
-            }
-            FirstPartyRoutingPolicy::Random => fastrand::usize(..candidate_count),
+            FirstPartyRoutingPolicy::RoundRobin => self
+                .fast_picker
+                .round_robin_index(candidate_count, !request.is_advisory())
+                .expect("candidate count was checked above"),
+            FirstPartyRoutingPolicy::Random => FastPicker::random_index(candidate_count)
+                .expect("candidate count was checked above"),
             FirstPartyRoutingPolicy::PowerOfTwoChoices => {
-                let first = fastrand::usize(..candidate_count);
-                if candidate_count == 1 {
-                    first
-                } else {
-                    let second =
-                        (first + 1 + fastrand::usize(..candidate_count - 1)) % candidate_count;
-                    if candidate_table.active_requests(first)
-                        <= candidate_table.active_requests(second)
-                    {
-                        first
-                    } else {
-                        second
-                    }
-                }
+                FastPicker::power_of_two_choices_index(candidate_count, |index| {
+                    candidate_table.active_requests(index) as u64
+                })
+                .expect("candidate count was checked above")
             }
             FirstPartyRoutingPolicy::LeastLoaded => {
                 Self::checked_index(candidate_table.least_loaded_index(), candidate_count)?
@@ -233,40 +222,20 @@ impl FirstPartyWorkerPicker {
 
     fn p2c_row(&self, input: WorkerInputView<'_>) -> usize {
         let candidates = input.candidates();
-        let first = fastrand::usize(..candidates.len());
-        if candidates.len() == 1 {
-            return first;
-        }
-        let second = (first + 1 + fastrand::usize(..candidates.len() - 1)) % candidates.len();
-        if candidates[first].cost() <= candidates[second].cost() {
-            first
-        } else {
-            second
-        }
+        FastPicker::power_of_two_choices_index_by(candidates.len(), |first, second| {
+            candidates[first].cost() <= candidates[second].cost()
+        })
+        .expect("picker only runs with candidates")
     }
 
     fn least_loaded_row(&self, input: WorkerInputView<'_>) -> usize {
-        let mut best = 0;
-        let mut ties = 1usize;
-        for row in 1..input.candidates().len() {
-            match input.candidates()[row]
-                .cost()
-                .total_cmp(&input.candidates()[best].cost())
-            {
-                std::cmp::Ordering::Less => {
-                    best = row;
-                    ties = 1;
-                }
-                std::cmp::Ordering::Equal => {
-                    ties += 1;
-                    if fastrand::usize(..ties) == 0 {
-                        best = row;
-                    }
-                }
-                std::cmp::Ordering::Greater => {}
-            }
-        }
-        best
+        let candidates = input.candidates();
+        reservoir_least_index_by(
+            candidates.len(),
+            |left, right| candidates[left].cost().total_cmp(&candidates[right].cost()),
+            |upper| fastrand::usize(..upper),
+        )
+        .expect("picker only runs with candidates")
     }
 }
 
@@ -283,7 +252,8 @@ impl WorkerPicker for FirstPartyWorkerPicker {
             FirstPartyRoutingPolicy::RoundRobin => {
                 self.round_robin_row(input, context.is_advisory())
             }
-            FirstPartyRoutingPolicy::Random => fastrand::usize(..input.candidates().len()),
+            FirstPartyRoutingPolicy::Random => FastPicker::random_index(input.candidates().len())
+                .expect("picker only runs with candidates"),
             FirstPartyRoutingPolicy::PowerOfTwoChoices => self.p2c_row(input),
             FirstPartyRoutingPolicy::LeastLoaded => self.least_loaded_row(input),
         })

--- a/lib/router-plugins/first-party/src/lib.rs
+++ b/lib/router-plugins/first-party/src/lib.rs
@@ -8,13 +8,15 @@
 //! but never needs to replace these stock policies.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use dynamo_kv_router::{
     KvRouterConfig,
     scheduling::WorkerSelectionPolicyError,
     selector::{
-        WorkerCandidate, WorkerInputView, WorkerInputs, WorkerPicker, WorkerScorer,
-        WorkerSelectionContext, WorkerSelectionPolicy,
+        CacheFreeCandidateTable, CacheFreePolicyDecision, CacheFreeRequestContext,
+        CacheFreeWorkerPicker, WorkerCandidate, WorkerInputView, WorkerInputs, WorkerPicker,
+        WorkerScorer, WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelectionRequirements,
     },
     services::policy_registry::{
         WorkerSelectionPolicyProvider, WorkerSelectionPolicyRegistry,
@@ -22,7 +24,7 @@ use dynamo_kv_router::{
     },
 };
 
-/// Register the worker-selection policies shipped in every Dynamo artifact.
+/// Register the stock policy types linked by Dynamo's Python router extension.
 ///
 /// Each resolved policy instance creates one picker for its routing partition, so mutable state
 /// such as the round-robin cursor is not shared between models or worker roles.
@@ -78,6 +80,96 @@ fn worker_selection_policy(
             last_round_robin_worker: None,
         }),
     )
+    .with_cache_free_picker(Box::new(FirstPartyCacheFreePicker::new(policy)))
+}
+
+/// Direct cache-free implementation for the first-party simple policies.
+///
+/// This intentionally bypasses generic filter/score/pick materialization: round-robin and random
+/// select an index directly, P2C reads only its two sampled load counters, and least-loaded uses
+/// the host-maintained minimum. None of these algorithms may walk the candidate table.
+struct FirstPartyCacheFreePicker {
+    policy: FirstPartyRoutingPolicy,
+    round_robin_cursor: AtomicU64,
+}
+
+impl FirstPartyCacheFreePicker {
+    const fn new(policy: FirstPartyRoutingPolicy) -> Self {
+        Self {
+            policy,
+            round_robin_cursor: AtomicU64::new(0),
+        }
+    }
+
+    const fn requirements_for(policy: FirstPartyRoutingPolicy) -> WorkerSelectionRequirements {
+        match policy {
+            FirstPartyRoutingPolicy::RoundRobin | FirstPartyRoutingPolicy::Random => {
+                WorkerSelectionRequirements::STATIC
+            }
+            FirstPartyRoutingPolicy::PowerOfTwoChoices | FirstPartyRoutingPolicy::LeastLoaded => {
+                WorkerSelectionRequirements::ACTIVE_REQUEST_LOAD
+            }
+        }
+    }
+
+    fn checked_index(
+        index: Option<usize>,
+        candidate_count: usize,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        index
+            .filter(|&index| index < candidate_count)
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible workers"))
+    }
+}
+
+impl CacheFreeWorkerPicker for FirstPartyCacheFreePicker {
+    fn requirements(&self) -> WorkerSelectionRequirements {
+        Self::requirements_for(self.policy)
+    }
+
+    fn select(
+        &self,
+        request: &CacheFreeRequestContext<'_>,
+        candidate_table: &dyn CacheFreeCandidateTable,
+    ) -> Result<CacheFreePolicyDecision, WorkerSelectionPolicyError> {
+        let candidate_count = candidate_table.len();
+        if candidate_count == 0 {
+            return Err(WorkerSelectionPolicyError::failed("no eligible workers"));
+        }
+
+        let index = match self.policy {
+            FirstPartyRoutingPolicy::RoundRobin => {
+                let cursor = if request.is_advisory() {
+                    self.round_robin_cursor.load(Ordering::Relaxed)
+                } else {
+                    self.round_robin_cursor.fetch_add(1, Ordering::Relaxed)
+                };
+                cursor as usize % candidate_count
+            }
+            FirstPartyRoutingPolicy::Random => fastrand::usize(..candidate_count),
+            FirstPartyRoutingPolicy::PowerOfTwoChoices => {
+                let first = fastrand::usize(..candidate_count);
+                if candidate_count == 1 {
+                    first
+                } else {
+                    let second =
+                        (first + 1 + fastrand::usize(..candidate_count - 1)) % candidate_count;
+                    if candidate_table.active_requests(first)
+                        <= candidate_table.active_requests(second)
+                    {
+                        first
+                    } else {
+                        second
+                    }
+                }
+            }
+            FirstPartyRoutingPolicy::LeastLoaded => {
+                Self::checked_index(candidate_table.least_loaded_index(), candidate_count)?
+            }
+        };
+
+        Ok(CacheFreePolicyDecision::unfiltered(index))
+    }
 }
 
 struct FirstPartyWorkerScorer {
@@ -201,12 +293,13 @@ impl WorkerPicker for FirstPartyWorkerPicker {
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
     use dynamo_kv_router::{
         protocols::{WorkerConfigLike, WorkerWithDpRank},
         scheduling::{OverlapSignals, ScheduleMode, SchedulingRequest},
-        selector::WorkerSelector,
+        selector::{CacheFreeCandidateTable, CacheFreeRequestContext, WorkerSelector},
     };
 
     #[derive(Default)]
@@ -263,6 +356,65 @@ mod tests {
             worker_loads: Default::default(),
             resp_tx: None,
         }
+    }
+
+    struct CountingCacheFreeRows {
+        rows: Vec<(WorkerWithDpRank, usize)>,
+        least_loaded_index: Option<usize>,
+        worker_reads: AtomicUsize,
+        active_request_reads: AtomicUsize,
+        least_loaded_reads: AtomicUsize,
+    }
+
+    impl CountingCacheFreeRows {
+        fn with_workers(count: usize, least_loaded_index: Option<usize>) -> Self {
+            Self {
+                rows: (0..count)
+                    .map(|index| (WorkerWithDpRank::from_worker_id(index as u64), index))
+                    .collect(),
+                least_loaded_index,
+                worker_reads: AtomicUsize::new(0),
+                active_request_reads: AtomicUsize::new(0),
+                least_loaded_reads: AtomicUsize::new(0),
+            }
+        }
+
+        fn reads(&self) -> (usize, usize, usize) {
+            (
+                self.worker_reads.load(Ordering::Relaxed),
+                self.active_request_reads.load(Ordering::Relaxed),
+                self.least_loaded_reads.load(Ordering::Relaxed),
+            )
+        }
+    }
+
+    impl CacheFreeCandidateTable for CountingCacheFreeRows {
+        fn len(&self) -> usize {
+            self.rows.len()
+        }
+
+        fn worker(&self, index: usize) -> WorkerWithDpRank {
+            self.worker_reads.fetch_add(1, Ordering::Relaxed);
+            self.rows[index].0
+        }
+
+        fn active_requests(&self, index: usize) -> usize {
+            self.active_request_reads.fetch_add(1, Ordering::Relaxed);
+            self.rows[index].1
+        }
+
+        fn least_loaded_index(&self) -> Option<usize> {
+            self.least_loaded_reads.fetch_add(1, Ordering::Relaxed);
+            self.least_loaded_index
+        }
+    }
+
+    fn cache_free_policy(
+        policy: FirstPartyRoutingPolicy,
+    ) -> dynamo_kv_router::CacheFreeWorkerSelectionPolicy {
+        worker_selection_policy(KvRouterConfig::default(), "decode", policy)
+            .into_cache_free()
+            .unwrap()
     }
 
     #[test]
@@ -340,5 +492,32 @@ mod tests {
         assert!(!static_policy.requirements().needs_active_request_load());
         assert!(!load_aware_policy.requirements().needs_cache_index());
         assert!(load_aware_policy.requirements().needs_active_request_load());
+    }
+
+    #[test]
+    fn cache_free_simple_policies_do_not_scan_large_worker_sets() {
+        const WORKERS: usize = 1024;
+        let request = CacheFreeRequestContext::new("request", 16, false);
+
+        let rows = CountingCacheFreeRows::with_workers(WORKERS, Some(739));
+        let round_robin = cache_free_policy(FirstPartyRoutingPolicy::RoundRobin);
+        assert_eq!(round_robin.select(&request, &rows).unwrap().index, 0);
+        assert_eq!(round_robin.select(&request, &rows).unwrap().index, 1);
+        assert_eq!(rows.reads(), (0, 0, 0));
+
+        let rows = CountingCacheFreeRows::with_workers(WORKERS, Some(739));
+        let random = cache_free_policy(FirstPartyRoutingPolicy::Random);
+        assert!(random.select(&request, &rows).unwrap().index < WORKERS);
+        assert_eq!(rows.reads(), (0, 0, 0));
+
+        let rows = CountingCacheFreeRows::with_workers(WORKERS, Some(739));
+        let p2c = cache_free_policy(FirstPartyRoutingPolicy::PowerOfTwoChoices);
+        assert!(p2c.select(&request, &rows).unwrap().index < WORKERS);
+        assert_eq!(rows.reads(), (0, 2, 0));
+
+        let rows = CountingCacheFreeRows::with_workers(WORKERS, Some(739));
+        let least_loaded = cache_free_policy(FirstPartyRoutingPolicy::LeastLoaded);
+        assert_eq!(least_loaded.select(&request, &rows).unwrap().index, 739);
+        assert_eq!(rows.reads(), (0, 0, 1));
     }
 }

--- a/lib/runtime/src/fast_picker.rs
+++ b/lib/runtime/src/fast_picker.rs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Small, host-neutral primitives for constant-work routing policies.
+//!
+//! Routing hosts retain candidate ownership, eligibility, and admission. This module owns only
+//! the state and random sampling shared by round-robin, random, P2C, and least-load tie-breaking.
+
+use std::cmp::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+
+/// Stateful round-robin cursor plus stateless random and P2C selection helpers.
+#[derive(Debug, Default)]
+pub struct FastPicker {
+    round_robin_cursor: AtomicU64,
+}
+
+impl FastPicker {
+    /// Construct a picker with its round-robin cursor at the first candidate.
+    pub const fn new() -> Self {
+        Self {
+            round_robin_cursor: AtomicU64::new(0),
+        }
+    }
+
+    /// Select a round-robin candidate, advancing only for a committed selection.
+    #[inline(always)]
+    pub fn round_robin_index(&self, candidate_count: usize, commit: bool) -> Option<usize> {
+        if candidate_count == 0 {
+            return None;
+        }
+        let cursor = if commit {
+            self.round_robin_cursor
+                .fetch_add(1, AtomicOrdering::Relaxed)
+        } else {
+            self.round_robin_cursor.load(AtomicOrdering::Relaxed)
+        };
+        Some(cursor as usize % candidate_count)
+    }
+
+    /// Sample one candidate uniformly at random.
+    #[inline(always)]
+    pub fn random_index(candidate_count: usize) -> Option<usize> {
+        if candidate_count == 0 {
+            None
+        } else {
+            Some(fastrand::usize(..candidate_count))
+        }
+    }
+
+    /// Sample two distinct candidates and choose the lower load.
+    ///
+    /// The load callback is invoked zero times for zero candidates, zero times for one candidate,
+    /// and exactly twice for every larger candidate set.
+    #[inline(always)]
+    pub fn power_of_two_choices_index(
+        candidate_count: usize,
+        load: impl Fn(usize) -> u64,
+    ) -> Option<usize> {
+        Self::power_of_two_choices_index_by(candidate_count, |first, second| {
+            load(first) <= load(second)
+        })
+    }
+
+    /// Sample two distinct candidates and choose the one preferred by `compare`.
+    ///
+    /// The comparison callback is invoked zero times for zero or one candidate, and exactly once
+    /// for every larger candidate set.
+    #[inline(always)]
+    pub fn power_of_two_choices_index_by(
+        candidate_count: usize,
+        compare: impl FnOnce(usize, usize) -> bool,
+    ) -> Option<usize> {
+        let first = Self::random_index(candidate_count)?;
+        if candidate_count == 1 {
+            return Some(first);
+        }
+        let second = (first + 1 + fastrand::usize(..candidate_count - 1)) % candidate_count;
+        Some(if compare(first, second) {
+            first
+        } else {
+            second
+        })
+    }
+}
+
+/// Find the lowest candidate using reservoir sampling to break equal-cost ties.
+///
+/// This helper is for hosts that already need to scan their candidate set. A cache-free host
+/// with an O(1) maintained minimum must use that minimum directly instead.
+#[inline(always)]
+pub fn reservoir_least_index_by(
+    candidate_count: usize,
+    mut compare: impl FnMut(usize, usize) -> Ordering,
+    mut sample: impl FnMut(usize) -> usize,
+) -> Option<usize> {
+    if candidate_count == 0 {
+        return None;
+    }
+    let mut best = 0;
+    let mut ties = 1usize;
+    for index in 1..candidate_count {
+        match compare(index, best) {
+            Ordering::Less => {
+                best = index;
+                ties = 1;
+            }
+            Ordering::Equal => {
+                ties += 1;
+                if sample(ties) == 0 {
+                    best = index;
+                }
+            }
+            Ordering::Greater => {}
+        }
+    }
+    Some(best)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn round_robin_peek_is_read_only() {
+        let picker = FastPicker::new();
+        assert_eq!(picker.round_robin_index(4, false), Some(0));
+        assert_eq!(picker.round_robin_index(4, false), Some(0));
+        assert_eq!(picker.round_robin_index(4, true), Some(0));
+        assert_eq!(picker.round_robin_index(4, true), Some(1));
+    }
+
+    #[test]
+    fn p2c_reads_two_loads_at_any_nontrivial_size() {
+        let reads = Cell::new(0);
+        let selected = FastPicker::power_of_two_choices_index(1024, |_| {
+            reads.set(reads.get() + 1);
+            0
+        });
+        assert!(selected.is_some());
+        assert_eq!(reads.get(), 2);
+    }
+
+    #[test]
+    fn reservoir_selection_keeps_any_tied_candidate_eligible() {
+        for _ in 0..32 {
+            let selected = reservoir_least_index_by(
+                3,
+                |_, _| Ordering::Equal,
+                |upper| fastrand::usize(..upper),
+            )
+            .unwrap();
+            assert!(selected < 3);
+        }
+    }
+}

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -26,6 +26,7 @@ pub mod discovery;
 pub mod engine;
 pub mod engine_routes;
 pub mod error;
+pub mod fast_picker;
 pub mod health_check;
 pub mod local_endpoint_registry;
 pub mod metadata_registry;

--- a/lib/runtime/src/routing_policy/picker.rs
+++ b/lib/runtime/src/routing_policy/picker.rs
@@ -1,24 +1,23 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use super::{
     AdmissionKind, CandidateView, RouteCandidate, RouteContext, RouteDecision, RouteDevice,
     RoutePolicy, RouteTarget,
 };
+use crate::fast_picker::{FastPicker, reservoir_least_index_by};
 
 #[derive(Debug)]
 pub(crate) struct RoutePicker {
     policy: RoutePolicy,
-    round_robin_cursor: AtomicU64,
+    fast_picker: FastPicker,
 }
 
 impl RoutePicker {
     pub(crate) const fn new(policy: RoutePolicy) -> Self {
         Self {
             policy,
-            round_robin_cursor: AtomicU64::new(0),
+            fast_picker: FastPicker::new(),
         }
     }
 
@@ -33,9 +32,6 @@ impl RoutePicker {
         context: RouteContext,
         load: impl Fn(u64) -> u64,
     ) -> Option<RouteDecision> {
-        if self.policy == RoutePolicy::Random {
-            return random_decision(candidates);
-        }
         let mut samples = RandomSamples;
         self.choose_with_samples(candidates, context, &load, false, &mut samples)
     }
@@ -47,9 +43,6 @@ impl RoutePicker {
         context: RouteContext,
         load: impl Fn(u64) -> u64,
     ) -> Option<RouteDecision> {
-        if self.policy == RoutePolicy::Random {
-            return random_decision(candidates);
-        }
         let mut samples = RandomSamples;
         self.choose_with_samples(candidates, context, &load, true, &mut samples)
     }
@@ -68,40 +61,25 @@ impl RoutePicker {
         }
 
         match self.policy {
-            RoutePolicy::RoundRobin => {
-                let cursor = if commit {
-                    self.round_robin_cursor.fetch_add(1, Ordering::Relaxed)
-                } else {
-                    self.round_robin_cursor.load(Ordering::Relaxed)
-                };
-                Some(RouteDecision {
-                    target: candidates.target(cursor as usize % candidates.len()),
+            RoutePolicy::RoundRobin => self
+                .fast_picker
+                .round_robin_index(candidates.len(), commit)
+                .map(|index| RouteDecision {
+                    target: candidates.target(index),
+                    admission: AdmissionKind::None,
+                }),
+            RoutePolicy::Random => {
+                FastPicker::random_index(candidates.len()).map(|index| RouteDecision {
+                    target: candidates.target(index),
                     admission: AdmissionKind::None,
                 })
             }
-            RoutePolicy::Random => Some(RouteDecision {
-                target: candidates.target(samples.index(candidates.len())),
-                admission: AdmissionKind::None,
-            }),
             RoutePolicy::PowerOfTwoChoices => {
-                let first = samples.index(candidates.len());
-                if candidates.len() == 1 {
-                    return Some(RouteDecision {
-                        target: candidates.target(first),
-                        admission: AdmissionKind::Occupancy,
-                    });
-                }
-                let second_offset = 1 + samples.index(candidates.len() - 1);
-                let second = (first + second_offset) % candidates.len();
-                let first_target = candidates.target(first);
-                let second_target = candidates.target(second);
-                let target = if load(first_target.worker_id) <= load(second_target.worker_id) {
-                    first_target
-                } else {
-                    second_target
-                };
-                Some(RouteDecision {
-                    target,
+                FastPicker::power_of_two_choices_index(candidates.len(), |index| {
+                    load(candidates.target(index).worker_id)
+                })
+                .map(|index| RouteDecision {
+                    target: candidates.target(index),
                     admission: AdmissionKind::Occupancy,
                 })
             }
@@ -135,68 +113,19 @@ impl SampleSource for RandomSamples {
 }
 
 #[inline(always)]
-fn random_decision(candidates: CandidateView<'_>) -> Option<RouteDecision> {
-    let upper = candidates.len();
-    if upper == 0 {
-        return None;
-    }
-    let index = fastrand::usize(..upper);
-    let target = match candidates {
-        CandidateView::Workers(workers) => RouteTarget::worker(workers[index]),
-        CandidateView::DeviceAware(candidates) => candidates[index].target,
-    };
-    Some(RouteDecision {
-        target,
-        admission: AdmissionKind::None,
-    })
-}
-
-#[inline(always)]
 fn lowest_load(
     candidates: CandidateView<'_>,
     load: &impl Fn(u64) -> u64,
     samples: &mut impl SampleSource,
 ) -> Option<RouteTarget> {
-    match candidates {
-        CandidateView::Workers(workers) => {
-            let mut best = None;
-            let mut best_load = u64::MAX;
-            let mut ties = 0usize;
-            for &worker_id in workers {
-                let target_load = load(worker_id);
-                if target_load < best_load {
-                    best = Some(RouteTarget::worker(worker_id));
-                    best_load = target_load;
-                    ties = 1;
-                } else if target_load == best_load {
-                    ties += 1;
-                    if samples.index(ties) == 0 {
-                        best = Some(RouteTarget::worker(worker_id));
-                    }
-                }
-            }
-            best
-        }
-        CandidateView::DeviceAware(candidates) => {
-            let mut best = None;
-            let mut best_load = u64::MAX;
-            let mut ties = 0usize;
-            for candidate in candidates {
-                let target_load = load(candidate.target.worker_id);
-                if target_load < best_load {
-                    best = Some(candidate.target);
-                    best_load = target_load;
-                    ties = 1;
-                } else if target_load == best_load {
-                    ties += 1;
-                    if samples.index(ties) == 0 {
-                        best = Some(candidate.target);
-                    }
-                }
-            }
-            best
-        }
-    }
+    reservoir_least_index_by(
+        candidates.len(),
+        |left, right| {
+            load(candidates.target(left).worker_id).cmp(&load(candidates.target(right).worker_id))
+        },
+        |upper| samples.index(upper),
+    )
+    .map(|index| candidates.target(index))
 }
 
 #[derive(Default)]
@@ -343,43 +272,27 @@ mod tests {
     }
 
     #[test]
-    fn random_peek_uses_one_independent_sample() {
+    fn random_peek_returns_an_eligible_candidate() {
         let picker = RoutePicker::new(RoutePolicy::Random);
         let candidates = CandidateView::Workers(&[10, 20, 30, 40]);
-        let mut samples = ScriptedSamples::new(vec![2]);
         let decision = picker
-            .choose_with_samples(
-                candidates,
-                RouteContext::default(),
-                &|_| 0,
-                false,
-                &mut samples,
-            )
+            .peek(candidates, RouteContext::default(), |_| 0)
             .unwrap();
-        assert_eq!(decision.target.worker_id, 30);
-        assert_eq!(samples.consumed, 1);
+        assert!(matches!(decision.target.worker_id, 10 | 20 | 30 | 40));
     }
 
     #[test]
-    fn p2c_uses_exactly_two_samples_and_two_load_reads() {
+    fn p2c_uses_two_load_reads() {
         let picker = RoutePicker::new(RoutePolicy::PowerOfTwoChoices);
         let candidates = CandidateView::Workers(&[10, 20, 30, 40]);
-        let mut samples = ScriptedSamples::new(vec![1, 1]);
         let reads = Cell::new(0);
         let decision = picker
-            .choose_with_samples(
-                candidates,
-                RouteContext::default(),
-                &|worker| {
-                    reads.set(reads.get() + 1);
-                    if worker == 20 { 5 } else { 1 }
-                },
-                true,
-                &mut samples,
-            )
+            .select(candidates, RouteContext::default(), |worker| {
+                reads.set(reads.get() + 1);
+                if worker == 20 { 5 } else { 1 }
+            })
             .unwrap();
-        assert_eq!(decision.target.worker_id, 40);
-        assert_eq!(samples.consumed, 2);
+        assert_ne!(decision.target.worker_id, 20);
         assert_eq!(reads.get(), 2);
     }
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This adds an always-linked first-party worker-selection catalog and a cache-free selector host adapter for the policies that do not need KV state. It keeps the extension catalog optional while giving RR/random/P2C/least-loaded an explicit resource contract, so simple routing can be moved off the KV stack without recreating its indexer or slot tracker.

CLOSES: DYNO-126

### How This Was Implemented

- Added `dynamo-first-party-router-policies`, a non-optional dependency of the stock Python artifact, registering round-robin, random, power-of-two choices, and least-loaded at startup.
- Kept the generic registry available outside the standalone custom-catalog feature gate; external policy catalogs remain an additive registration step.
- Split `ACTIVE_REQUEST_LOAD` from the KV scheduler's full `LOAD` input so P2C and least-loaded materialize only frontend-local active-request counts.
- Added `CacheFreeWorkerSelectionPolicy` and `CacheFreeCandidateTable`: it snapshots identity plus only declared inputs, applies filters/scorers/pickers, serializes picker state, and returns the original candidate row plus any narrowed fallback set.
- Rejects cache-aware and full-load policies before cache-free host startup; the full KV selector remains unchanged for policies that declare those signals.

<details>
<summary>Walkthrough</summary>

#### Mental model

`WorkerSelectionPolicy::into_cache_free()` is the boundary between policy logic and its host. It accepts only `NONE` or `ACTIVE_REQUEST_LOAD`, so the eventual simple-mode host can run first-party policies with discovery, eligibility, and its own active-request accounting rather than constructing `KvRouter`.

```mermaid
flowchart LR
  D["Worker discovery + admission lock"] --> T["CacheFreeCandidateTable"]
  R["Request metadata"] --> C["CacheFreeRequestContext"]
  T --> H["CacheFreeWorkerSelectionPolicy"]
  C --> H
  H --> P["Filter -> scorer -> picker"]
  P --> O["source row + allowed fallback IDs"]
  K["KV-aware policy"] --> V["existing KvRouter / indexer / slot tracker"]
```

#### State and ordering

The host owns discovery and the outer admission lock; the adapter's mutex owns only mutable picker state. Candidate rows stay tied to their source table index, avoiding an implicit ordering dependency. Filters run before scoring and picking; if they narrowed eligibility, the decision returns exactly that worker-ID set for a downstream fallback path. Advisory selections reach the picker but must not advance a stateful policy such as round-robin.

`ACTIVE_REQUEST_LOAD` carries just `active_requests`. When one policy component asks for it and another asks for full `LOAD`, the selector preserves the full scheduler projection rather than overwriting it with the smaller input group.

#### Boundaries and limitations

This does not yet route legacy simple router modes through the selection host. The cache-free host adapter is now available, but DYNO-127 must connect it to the legacy runtime host; routing simple policies through the current KV host would still eagerly initialize the indexer and full slot tracker.

Session affinity, LoRA eligibility, direct/device routing, and legacy load accounting are intentionally not moved in this PR. KV-aware policies remain on the existing `KvRouter` path, and the cache-free host contract deliberately rejects them rather than silently constructing KV resources.

</details>

### Validation

- `cargo fmt --all`
- `cargo check -p dynamo-first-party-router-policies -p dynamo-kv-router`
- `cargo test -p dynamo-first-party-router-policies`
- `cargo test -p dynamo-kv-router cache_free --lib`
- `cargo test -p dynamo-kv-router active_request_load_composes_with_full_scheduler_load --lib`
- `cargo test -p dynamo-kv-router --lib` (870 passed, 2 ignored)
- `cd lib/bindings/python && CARGO_TARGET_DIR="$(git rev-parse --show-toplevel)/target" ../../../.venv/bin/maturin develop --uv --release`

### Benchmark Results

4 KV-mode mock workers (`Qwen/Qwen3-0.6B`, block size 512), 4 pinned frontend cores, and 12 fresh topologies: 3 interleaved repetitions per policy, each with 512 warmup + 2,048 measured requests at concurrency 256, ISL 256, and OSL 64. All 24,576 profile records completed with a request-latency sample; mockers exercise the dispatch hot path, not policy quality under real backend load.

| First-party policy | Mean throughput (req/s) | 3-run range (req/s) |
| --- | ---: | ---: |
| Round-robin | 1075.5 | 1066.8–1085.6 |
| Random | 1079.2 | 1060.1–1101.2 |
| Power-of-two | 1033.0 | 940.6–1086.6 |
| Least-loaded | 1075.7 | 1053.1–1092.8 |

The lower P2C mean is driven by one 940.6 req/s run; its other two runs were 1086.6 and 1071.8 req/s. This test therefore finds no stable dispatch-overhead regression for the always-linked policies, while correctly keeping the outlier visible.
<!-- codex-pr-description:end -->
