### PR TITLE
fix(llm): warn on invalid tokenizer cache budget

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -63,9 +63,22 @@ fn tokenizer_cache_enabled(value: Option<&str>) -> bool {
 }
 
 fn tokenizer_cache_bytes(value: Option<&str>) -> usize {
-    value
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_TOKENIZER_CACHE_BYTES)
+    match value {
+        Some(value) => match value.parse::<usize>() {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::warn!(
+                    env_var = "DYN_TOKENIZER_CACHE_BYTES",
+                    value,
+                    default = DEFAULT_TOKENIZER_CACHE_BYTES,
+                    %error,
+                    "Failed to parse tokenizer cache byte budget; using default"
+                );
+                DEFAULT_TOKENIZER_CACHE_BYTES
+            }
+        },
+        None => DEFAULT_TOKENIZER_CACHE_BYTES,
+    }
 }
 
 fn tokenizer_cache_token_observer(model: &str) -> crate::tokenizers::CacheTokenUsageFn {


### PR DESCRIPTION
## Summary

- warn when `DYN_TOKENIZER_CACHE_BYTES` cannot parse and Dynamo uses the 64 MiB default
- include the rejected value, parse error, and effective default in the structured log

## Validation

- `cargo fmt --check --package dynamo-llm`
- `cargo test -p dynamo-llm tokenizer_cache_bytes_defaults_to_64_mib_and_accepts_valid_overrides`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the tokenizer cache size configuration.
  * Invalid cache size values now generate a warning and safely fall back to the 64 MiB default.
  * Missing configuration values continue to use the default without disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->