### PR TITLE
refactor(planner): structure Sweeper preset config

### DIFF
--- a/aisimulate/examples/sweeper/configs/smart_sweep.yaml
+++ b/aisimulate/examples/sweeper/configs/smart_sweep.yaml
@@ -14,7 +14,8 @@ adapters:
       mode: [kv_router, round_robin]
   dynamo.planner:
     search_space:
-      scaling_policy: [disabled, throughput_180_5, hybrid_180_5]
+      scaling_policy:
+        preset: [disabled, throughput_180_5, hybrid_180_5]
       # Other Planner search dimensions use adapter defaults.
 workload:
   trace_path: /data/replay/traffic.jsonl   # or omit and set a synthetic load (see below)

--- a/components/src/dynamo/planner/simulation/load_predictor.py
+++ b/components/src/dynamo/planner/simulation/load_predictor.py
@@ -88,6 +88,46 @@ _VALID_FAMILIES = frozenset(
 )
 
 
+def complete_predictor_preset(entry: str | dict[str, Any]) -> dict[str, Any]:
+    """Expand one predictor preset into every public predictor knob."""
+
+    if isinstance(entry, str):
+        preset = LOAD_PREDICTOR_PRESETS[entry]
+        family = preset["family"]
+        log1p = preset["log1p"]
+        prophet_window_size = preset.get(
+            "prophet_window_size", _DEFAULTS["prophet_window_size"]
+        )
+        kalman_q_level = preset.get("q_level", _DEFAULTS["q_level"])
+        kalman_q_trend = preset.get("q_trend", _DEFAULTS["q_trend"])
+        kalman_r = preset.get("r", _DEFAULTS["r"])
+        kalman_min_points = preset.get("min_points", _DEFAULTS["min_points"])
+    else:
+        family = entry["load_predictor"]
+        if family not in _VALID_FAMILIES:
+            raise ValueError(
+                f"load_predictor must be one of {sorted(_VALID_FAMILIES)}, got {family!r}"
+            )
+        log1p = bool(entry.get("load_predictor_log1p", False))
+        prophet_window_size = entry.get(
+            "prophet_window_size", _DEFAULTS["prophet_window_size"]
+        )
+        kalman_q_level = entry.get("kalman_q_level", _DEFAULTS["q_level"])
+        kalman_q_trend = entry.get("kalman_q_trend", _DEFAULTS["q_trend"])
+        kalman_r = entry.get("kalman_r", _DEFAULTS["r"])
+        kalman_min_points = entry.get("kalman_min_points", _DEFAULTS["min_points"])
+
+    return {
+        "load_predictor": family,
+        "load_predictor_log1p": log1p,
+        "prophet_window_size": prophet_window_size,
+        "kalman_q_level": kalman_q_level,
+        "kalman_q_trend": kalman_q_trend,
+        "kalman_r": kalman_r,
+        "kalman_min_points": kalman_min_points,
+    }
+
+
 @dataclass(frozen=True)
 class Window:
     """One aggregated traffic window."""
@@ -136,23 +176,15 @@ class LoadPredictorResult:
 
 
 def _internal_preset(entry: str | dict[str, Any]) -> dict[str, Any]:
-    if not isinstance(entry, dict):
-        return LOAD_PREDICTOR_PRESETS[entry]
-    family = entry["load_predictor"]
-    if family not in _VALID_FAMILIES:
-        raise ValueError(
-            f"load_predictor must be one of {sorted(_VALID_FAMILIES)}, got {family!r}"
-        )
+    complete = complete_predictor_preset(entry)
     return {
-        "family": family,
-        "log1p": bool(entry.get("load_predictor_log1p", False)),
-        "prophet_window_size": entry.get(
-            "prophet_window_size", _DEFAULTS["prophet_window_size"]
-        ),
-        "q_level": entry.get("kalman_q_level", _DEFAULTS["q_level"]),
-        "q_trend": entry.get("kalman_q_trend", _DEFAULTS["q_trend"]),
-        "r": entry.get("kalman_r", _DEFAULTS["r"]),
-        "min_points": entry.get("kalman_min_points", _DEFAULTS["min_points"]),
+        "family": complete["load_predictor"],
+        "log1p": complete["load_predictor_log1p"],
+        "prophet_window_size": complete["prophet_window_size"],
+        "q_level": complete["kalman_q_level"],
+        "q_trend": complete["kalman_q_trend"],
+        "r": complete["kalman_r"],
+        "min_points": complete["kalman_min_points"],
     }
 
 

--- a/components/src/dynamo/planner/simulation/provider.py
+++ b/components/src/dynamo/planner/simulation/provider.py
@@ -288,7 +288,7 @@ class PlannerSearchSpace(BaseModel):
                 f"{_LEGACY_PRESET_REMOVAL_NOTE} Legacy fields: "
                 f"{', '.join(legacy_fields)}.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=4,
             )
         return upgraded
 

--- a/components/src/dynamo/planner/simulation/provider.py
+++ b/components/src/dynamo/planner/simulation/provider.py
@@ -5,12 +5,13 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from copy import deepcopy
 from enum import Enum
 from typing import Any, cast
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from tqdm import tqdm  # type: ignore[import-untyped]
 
 from aisimulate.sweeper.provider import (
@@ -25,6 +26,7 @@ from aisimulate.sweeper.provider import (
 
 from .load_predictor import (
     LOAD_PREDICTOR_PRESETS,
+    complete_predictor_preset,
     predictor_fields,
     sweep_load_predictor,
 )
@@ -100,82 +102,195 @@ def _default_load_predictors() -> list[str | dict[str, Any]]:
     return list(LOAD_PREDICTOR_PRESETS)
 
 
+def _validate_preset_entries(
+    name: str,
+    values: list[str | dict[str, Any]],
+    presets: frozenset[str],
+    allowed_keys: frozenset[str],
+    required_keys: frozenset[str],
+) -> None:
+    if not values:
+        raise ValueError(f"{name}.preset must list at least one choice")
+    for value in values:
+        if isinstance(value, str):
+            if value not in presets:
+                raise ValueError(
+                    f"{name}.preset has invalid choice {value!r}; "
+                    f"allowed: {sorted(presets)}"
+                )
+            continue
+        unknown = set(value) - allowed_keys
+        missing = required_keys - set(value)
+        if unknown:
+            raise ValueError(
+                f"{name}.preset mapping has unknown keys {sorted(unknown)}; "
+                f"allowed: {sorted(allowed_keys)}"
+            )
+        if missing:
+            raise ValueError(
+                f"{name}.preset mapping is missing required keys {sorted(missing)}"
+            )
+
+
+class ScalingPolicySearch(BaseModel):
+    """Preset choices that cover every scaling-policy knob."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    preset: list[str | dict[str, Any]] = Field(
+        default_factory=_default_scaling_policies
+    )
+
+    @model_validator(mode="after")
+    def _validate_preset(self) -> ScalingPolicySearch:
+        _validate_preset_entries(
+            "scaling_policy",
+            self.preset,
+            frozenset(SCALING_POLICIES),
+            _SCALING_KEYS,
+            _SCALING_KEYS,
+        )
+        return self
+
+
+class FpmSamplingSearch(BaseModel):
+    """Preset choices that cover every FPM-sampling knob."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    preset: list[str | dict[str, Any]] = Field(default_factory=_default_fpm_sampling)
+
+    @model_validator(mode="after")
+    def _validate_preset(self) -> FpmSamplingSearch:
+        _validate_preset_entries(
+            "fpm_sampling",
+            self.preset,
+            frozenset(FPM_SAMPLING),
+            _FPM_KEYS,
+            _FPM_KEYS,
+        )
+        return self
+
+
+class LoadSensitivitySearch(BaseModel):
+    """Preset choices that cover every load-sensitivity knob."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    preset: list[str | dict[str, Any]] = Field(
+        default_factory=_default_load_sensitivity
+    )
+
+    @model_validator(mode="after")
+    def _validate_preset(self) -> LoadSensitivitySearch:
+        _validate_preset_entries(
+            "load_sensitivity",
+            self.preset,
+            frozenset(LOAD_SENSITIVITY),
+            _LOAD_KEYS,
+            _LOAD_KEYS,
+        )
+        return self
+
+
+class LoadPredictorSearch(BaseModel):
+    """Preset choices that cover every load-predictor knob."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    preset: list[str | dict[str, Any]] = Field(default_factory=_default_load_predictors)
+
+    @field_validator("preset", mode="after")
+    @classmethod
+    def _complete_custom_presets(
+        cls, values: list[str | dict[str, Any]]
+    ) -> list[str | dict[str, Any]]:
+        del cls
+        completed: list[str | dict[str, Any]] = []
+        for value in values:
+            if isinstance(value, str):
+                completed.append(value)
+                continue
+            unknown = set(value) - _PREDICTOR_KEYS
+            if unknown:
+                raise ValueError(
+                    "load_predictor.preset mapping has unknown keys "
+                    f"{sorted(unknown)}; allowed: {sorted(_PREDICTOR_KEYS)}"
+                )
+            if "load_predictor" not in value:
+                raise ValueError(
+                    "load_predictor.preset mapping is missing required key "
+                    "'load_predictor'"
+                )
+            completed.append(complete_predictor_preset(value))
+        return completed
+
+    @model_validator(mode="after")
+    def _validate_preset(self) -> LoadPredictorSearch:
+        _validate_preset_entries(
+            "load_predictor",
+            self.preset,
+            frozenset(LOAD_PREDICTOR_PRESETS),
+            _PREDICTOR_KEYS,
+            _PREDICTOR_KEYS,
+        )
+        return self
+
+
+_LEGACY_PRESET_REMOVAL_NOTE = (
+    "Legacy flat Dynamo Planner Sweeper preset fields are deprecated and will be "
+    "removed after the 1.5 release. Nest choices under each sub-item's 'preset' field."
+)
+
+
 class PlannerSearchSpace(BaseModel):
     """Validated Planner-owned search space."""
 
     model_config = ConfigDict(extra="forbid")
 
-    scaling_policy: list[str | dict[str, Any]] = Field(
-        default_factory=_default_scaling_policies
+    scaling_policy: ScalingPolicySearch = Field(default_factory=ScalingPolicySearch)
+    fpm_sampling: FpmSamplingSearch = Field(default_factory=FpmSamplingSearch)
+    load_sensitivity: LoadSensitivitySearch = Field(
+        default_factory=LoadSensitivitySearch
     )
-    fpm_sampling: list[str | dict[str, Any]] = Field(
-        default_factory=_default_fpm_sampling
-    )
-    load_sensitivity: list[str | dict[str, Any]] = Field(
-        default_factory=_default_load_sensitivity
-    )
-    load_predictor_candidates: list[str | dict[str, Any]] = Field(
-        default_factory=_default_load_predictors
-    )
+    load_predictor: LoadPredictorSearch = Field(default_factory=LoadPredictorSearch)
     min_endpoint: int | None = Field(default=None, ge=1)
     prefill_min_endpoint: int | None = Field(default=None, ge=1)
     decode_min_endpoint: int | None = Field(default=None, ge=1)
 
-    @model_validator(mode="after")
-    def _validate_choices(self) -> PlannerSearchSpace:
-        specifications = (
-            (
-                "scaling_policy",
-                self.scaling_policy,
-                frozenset(SCALING_POLICIES),
-                _SCALING_KEYS,
-                _SCALING_KEYS,
-            ),
-            (
-                "fpm_sampling",
-                self.fpm_sampling,
-                frozenset(FPM_SAMPLING),
-                _FPM_KEYS,
-                _FPM_KEYS,
-            ),
-            (
-                "load_sensitivity",
-                self.load_sensitivity,
-                frozenset(LOAD_SENSITIVITY),
-                _LOAD_KEYS,
-                _LOAD_KEYS,
-            ),
-            (
-                "load_predictor_candidates",
-                self.load_predictor_candidates,
-                frozenset(LOAD_PREDICTOR_PRESETS),
-                _PREDICTOR_KEYS,
-                frozenset({"load_predictor"}),
-            ),
-        )
-        for name, values, presets, allowed_keys, required_keys in specifications:
-            if not values:
-                raise ValueError(f"{name} must list at least one choice")
-            for value in values:
-                if isinstance(value, str):
-                    if value not in presets:
-                        raise ValueError(
-                            f"{name} has invalid choice {value!r}; "
-                            f"allowed: {sorted(presets)}"
-                        )
-                    continue
-                unknown = set(value) - allowed_keys
-                missing = required_keys - set(value)
-                if unknown:
-                    raise ValueError(
-                        f"{name} dict has unknown keys {sorted(unknown)}; "
-                        f"allowed: {sorted(allowed_keys)}"
-                    )
-                if missing:
-                    raise ValueError(
-                        f"{name} dict is missing required keys {sorted(missing)}"
-                    )
-        return self
+    @model_validator(mode="before")
+    @classmethod
+    def _upgrade_legacy_flat_presets(cls, data: Any) -> Any:
+        # Backward compatibility: remove this conversion after the 1.5 release.
+        if not isinstance(data, Mapping):
+            return data
+
+        upgraded = dict(data)
+        legacy_fields: list[str] = []
+        for name in ("scaling_policy", "fpm_sampling", "load_sensitivity"):
+            value = upgraded.get(name)
+            if value is not None and not isinstance(value, (Mapping, BaseModel)):
+                upgraded[name] = {"preset": value}
+                legacy_fields.append(name)
+
+        if "load_predictor_candidates" in upgraded:
+            if "load_predictor" in upgraded:
+                raise ValueError(
+                    "load_predictor_candidates cannot be combined with load_predictor"
+                )
+            upgraded["load_predictor"] = {
+                "preset": upgraded.pop("load_predictor_candidates")
+            }
+            legacy_fields.append("load_predictor_candidates")
+
+        if legacy_fields:
+            warnings.warn(
+                f"{_LEGACY_PRESET_REMOVAL_NOTE} Legacy fields: "
+                f"{', '.join(legacy_fields)}.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        return upgraded
 
 
 def _plain(value: Any) -> Any:
@@ -273,7 +388,7 @@ class DynamoPlannerSweepConfigProvider:
         raw_sla = context.goal.get("sla")
         sla = raw_sla if isinstance(raw_sla, Mapping) else None
         kept, dropped = _policy_filter(
-            space.scaling_policy,
+            space.scaling_policy.preset,
             optimization_target=optimization_target,
             sla=sla,
         )
@@ -304,7 +419,7 @@ class DynamoPlannerSweepConfigProvider:
         trace_path = context.workload.get("trace_path")
         predictor_result = sweep_load_predictor(
             policies=kept,
-            candidates=space.load_predictor_candidates,
+            candidates=space.load_predictor.preset,
             trace_path=str(trace_path) if trace_path is not None else None,
             show_progress=context.show_progress,
         )
@@ -316,8 +431,10 @@ class DynamoPlannerSweepConfigProvider:
             "scaling_policy": _json_choices(kept)
         }
         if planner_enabled:
-            local_choices["fpm_sampling"] = _json_choices(space.fpm_sampling)
-            local_choices["load_sensitivity"] = _json_choices(space.load_sensitivity)
+            local_choices["fpm_sampling"] = _json_choices(space.fpm_sampling.preset)
+            local_choices["load_sensitivity"] = _json_choices(
+                space.load_sensitivity.preset
+            )
         fragment = SearchSpaceFragment(
             choices_by_branch={
                 mode: deepcopy(local_choices)

--- a/components/src/dynamo/planner/tests/unit/test_planner_sweep_config_provider.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_sweep_config_provider.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import replace
 
 import pytest
@@ -148,6 +149,96 @@ def test_legacy_flat_presets_warn_and_remain_compatible() -> None:
     assert space.fpm_sampling.preset == ["default"]
     assert space.load_sensitivity.preset == ["default"]
     assert space.load_predictor.preset == ["constant_last"]
+
+
+def test_legacy_warning_points_to_user_callsite() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        create_provider().generate_search_space(
+            {"scaling_policy": ["disabled"]},
+            _sweep_context(),
+        )
+
+    assert len(caught) == 1
+    assert caught[0].category is FutureWarning
+    assert caught[0].filename == __file__
+
+
+def test_legacy_and_structured_inputs_generate_identical_plans() -> None:
+    adapter = create_provider()
+    structured = {
+        "scaling_policy": {"preset": ["throughput_180_5"]},
+        "fpm_sampling": {"preset": ["fine"]},
+        "load_sensitivity": {"preset": ["conservative"]},
+        "load_predictor": {"preset": ["constant_last"]},
+        "min_endpoint": 2,
+    }
+    legacy = {
+        "scaling_policy": ["throughput_180_5"],
+        "fpm_sampling": ["fine"],
+        "load_sensitivity": ["conservative"],
+        "load_predictor_candidates": ["constant_last"],
+        "min_endpoint": 2,
+    }
+
+    structured_plan = adapter.generate_search_space(structured, _sweep_context())
+    with pytest.warns(FutureWarning, match="removed after the 1.5 release"):
+        legacy_plan = adapter.generate_search_space(legacy, _sweep_context())
+
+    assert legacy_plan == structured_plan
+    selection = {
+        "scaling_policy": "throughput_180_5",
+        "fpm_sampling": "fine",
+        "load_sensitivity": "conservative",
+    }
+    assert adapter.materialize_replay(
+        legacy_plan,
+        selection,
+        _candidate_context(),
+    ) == adapter.materialize_replay(
+        structured_plan,
+        selection,
+        _candidate_context(),
+    )
+
+
+def test_pre_refactor_serialized_plan_state_still_materializes() -> None:
+    adapter = create_provider()
+    structured_plan = adapter.generate_search_space(
+        {
+            "scaling_policy": {"preset": ["throughput_180_5"]},
+            "fpm_sampling": {"preset": ["fine"]},
+            "load_sensitivity": {"preset": ["conservative"]},
+            "load_predictor": {"preset": ["constant_last"]},
+        },
+        _sweep_context(),
+    )
+    legacy_state = dict(structured_plan.state)
+    legacy_state["search_space"] = {
+        "scaling_policy": ["throughput_180_5"],
+        "fpm_sampling": ["fine"],
+        "load_sensitivity": ["conservative"],
+        "load_predictor_candidates": ["constant_last"],
+    }
+    legacy_plan = replace(structured_plan, state=legacy_state)
+    selection = {
+        "scaling_policy": "throughput_180_5",
+        "fpm_sampling": "fine",
+        "load_sensitivity": "conservative",
+    }
+
+    with pytest.warns(FutureWarning, match="removed after the 1.5 release"):
+        legacy_spec = adapter.materialize_replay(
+            legacy_plan,
+            selection,
+            _candidate_context(),
+        )
+
+    assert legacy_spec == adapter.materialize_replay(
+        structured_plan,
+        selection,
+        _candidate_context(),
+    )
 
 
 def test_legacy_predictor_field_conflicts_with_structured_subitem() -> None:

--- a/components/src/dynamo/planner/tests/unit/test_planner_sweep_config_provider.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_sweep_config_provider.py
@@ -73,17 +73,129 @@ def _candidate_context() -> CandidateContext:
     return CandidateContext(sample=sample, backend_deployment=deployment)
 
 
+def test_structured_preset_subitems_preserve_all_families() -> None:
+    space = planner_provider_module.PlannerSearchSpace.model_validate(
+        {
+            "scaling_policy": {"preset": ["hybrid_180_5"]},
+            "fpm_sampling": {"preset": ["fine"]},
+            "load_sensitivity": {"preset": ["conservative"]},
+            "load_predictor": {"preset": ["kalman_reactive_log1p"]},
+        }
+    )
+
+    assert space.scaling_policy.preset == ["hybrid_180_5"]
+    assert space.fpm_sampling.preset == ["fine"]
+    assert space.load_sensitivity.preset == ["conservative"]
+    assert space.load_predictor.preset == ["kalman_reactive_log1p"]
+
+
+def test_custom_predictor_preset_is_completed_with_every_knob() -> None:
+    space = planner_provider_module.PlannerSearchSpace.model_validate(
+        {
+            "load_predictor": {
+                "preset": [{"load_predictor": "kalman"}],
+            }
+        }
+    )
+
+    entry = space.load_predictor.preset[0]
+    assert isinstance(entry, dict)
+    assert set(entry) == planner_provider_module._PREDICTOR_KEYS
+    assert entry["load_predictor"] == "kalman"
+    assert entry["prophet_window_size"] == 50
+    assert entry["kalman_min_points"] == 5
+
+
+def test_custom_predictor_preset_rejects_unknown_knob() -> None:
+    with pytest.raises(ValueError, match="unknown keys"):
+        planner_provider_module.PlannerSearchSpace.model_validate(
+            {
+                "load_predictor": {
+                    "preset": [
+                        {
+                            "load_predictor": "constant",
+                            "unknown": 1,
+                        }
+                    ]
+                }
+            }
+        )
+
+
+def test_structured_custom_preset_rejects_missing_subitem_knob() -> None:
+    with pytest.raises(ValueError, match="missing required keys"):
+        planner_provider_module.PlannerSearchSpace.model_validate(
+            {
+                "scaling_policy": {
+                    "preset": [{"enable_throughput_scaling": True}],
+                }
+            }
+        )
+
+
+def test_legacy_flat_presets_warn_and_remain_compatible() -> None:
+    with pytest.warns(FutureWarning, match="removed after the 1.5 release"):
+        space = planner_provider_module.PlannerSearchSpace.model_validate(
+            {
+                "scaling_policy": ["throughput_180_5"],
+                "fpm_sampling": ["default"],
+                "load_sensitivity": ["default"],
+                "load_predictor_candidates": ["constant_last"],
+            }
+        )
+
+    assert space.scaling_policy.preset == ["throughput_180_5"]
+    assert space.fpm_sampling.preset == ["default"]
+    assert space.load_sensitivity.preset == ["default"]
+    assert space.load_predictor.preset == ["constant_last"]
+
+
+def test_legacy_predictor_field_conflicts_with_structured_subitem() -> None:
+    with pytest.raises(
+        ValueError,
+        match="load_predictor_candidates cannot be combined with load_predictor",
+    ):
+        planner_provider_module.PlannerSearchSpace.model_validate(
+            {
+                "load_predictor": {"preset": ["constant_last"]},
+                "load_predictor_candidates": ["arima_raw"],
+            }
+        )
+
+
+def test_legacy_partial_predictor_mapping_is_completed() -> None:
+    with pytest.warns(FutureWarning, match="removed after the 1.5 release"):
+        space = planner_provider_module.PlannerSearchSpace.model_validate(
+            {
+                "load_predictor_candidates": [
+                    {
+                        "load_predictor": "kalman",
+                        "kalman_q_level": 3.0,
+                    }
+                ]
+            }
+        )
+
+    entry = space.load_predictor.preset[0]
+    assert isinstance(entry, dict)
+    assert set(entry) == planner_provider_module._PREDICTOR_KEYS
+    assert entry["kalman_q_level"] == 3.0
+    assert entry["kalman_min_points"] == 5
+
+
 def test_non_goodput_filters_predictive_throughput_policies() -> None:
     adapter = create_provider()
 
     plan = adapter.generate_search_space(
         {
-            "scaling_policy": [
-                "disabled",
-                "throughput_180_5",
-                "load_180_5",
-                "hybrid_600_5",
-            ]
+            "scaling_policy": {
+                "preset": [
+                    "disabled",
+                    "throughput_180_5",
+                    "load_180_5",
+                    "hybrid_600_5",
+                ]
+            }
         },
         _sweep_context(target="throughput"),
     )
@@ -112,10 +224,10 @@ def test_pareto_goodput_uses_sla_planner_target() -> None:
 
     plan = adapter.generate_search_space(
         {
-            "scaling_policy": ["throughput_180_5"],
-            "fpm_sampling": ["default"],
-            "load_sensitivity": ["default"],
-            "load_predictor_candidates": ["constant_last"],
+            "scaling_policy": {"preset": ["throughput_180_5"]},
+            "fpm_sampling": {"preset": ["default"]},
+            "load_sensitivity": {"preset": ["default"]},
+            "load_predictor": {"preset": ["constant_last"]},
         },
         context,
     )
@@ -145,7 +257,7 @@ def test_default_pareto_keeps_throughput_planner_target() -> None:
     )
 
     plan = create_provider().generate_search_space(
-        {"scaling_policy": ["disabled"]},
+        {"scaling_policy": {"preset": ["disabled"]}},
         context,
     )
 
@@ -156,7 +268,7 @@ def test_default_pareto_keeps_throughput_planner_target() -> None:
 def test_disabled_policy_materializes_no_runtime_hook() -> None:
     adapter = create_provider()
     plan = adapter.generate_search_space(
-        {"scaling_policy": ["disabled"]},
+        {"scaling_policy": {"preset": ["disabled"]}},
         _sweep_context(),
     )
 
@@ -180,10 +292,10 @@ def test_scaling_policy_materializes_legacy_planner_payload() -> None:
     adapter = create_provider()
     plan = adapter.generate_search_space(
         {
-            "scaling_policy": ["throughput_180_5"],
-            "fpm_sampling": ["fine"],
-            "load_sensitivity": ["conservative"],
-            "load_predictor_candidates": ["constant_last"],
+            "scaling_policy": {"preset": ["throughput_180_5"]},
+            "fpm_sampling": {"preset": ["fine"]},
+            "load_sensitivity": {"preset": ["conservative"]},
+            "load_predictor": {"preset": ["constant_last"]},
             "min_endpoint": 2,
         },
         _sweep_context(),
@@ -239,10 +351,10 @@ def test_custom_float_interval_resolves_predictor_and_preserves_selection() -> N
     }
     plan = adapter.generate_search_space(
         {
-            "scaling_policy": [custom_policy],
-            "fpm_sampling": ["default"],
-            "load_sensitivity": ["default"],
-            "load_predictor_candidates": ["constant_last"],
+            "scaling_policy": {"preset": [custom_policy]},
+            "fpm_sampling": {"preset": ["default"]},
+            "load_sensitivity": {"preset": ["default"]},
+            "load_predictor": {"preset": ["constant_last"]},
         },
         _sweep_context(),
     )
@@ -270,9 +382,9 @@ def test_disaggregated_scaling_preserves_both_engine_gpu_counts() -> None:
     adapter = create_provider()
     plan = adapter.generate_search_space(
         {
-            "scaling_policy": ["load_180_5"],
-            "fpm_sampling": ["default"],
-            "load_sensitivity": ["default"],
+            "scaling_policy": {"preset": ["load_180_5"]},
+            "fpm_sampling": {"preset": ["default"]},
+            "load_sensitivity": {"preset": ["default"]},
             "prefill_min_endpoint": 2,
             "decode_min_endpoint": 3,
         },
@@ -340,7 +452,7 @@ def test_policy_pruning_diagnostics_remain_visible(monkeypatch) -> None:
     monkeypatch.setattr(planner_provider_module.tqdm, "write", messages.append)
 
     create_provider().generate_search_space(
-        {"scaling_policy": ["disabled", "throughput_180_5"]},
+        {"scaling_policy": {"preset": ["disabled", "throughput_180_5"]}},
         replace(_sweep_context(target="throughput"), show_progress=True),
     )
 

--- a/components/src/dynamo/planner/tests/unit/test_simulation_load_predictor.py
+++ b/components/src/dynamo/planner/tests/unit/test_simulation_load_predictor.py
@@ -19,6 +19,7 @@ from dynamo.planner.simulation.load_predictor import (
     Window,
     _entry_label,
     _internal_preset,
+    complete_predictor_preset,
     evaluate_preset,
     predictor_fields,
     sweep_load_predictor,
@@ -72,6 +73,10 @@ def test_predictor_search_values_decode_with_family_defaults() -> None:
         "family": "prophet",
         "log1p": True,
         "prophet_window_size": 20,
+        "q_level": 1.0,
+        "q_trend": 0.1,
+        "r": 10.0,
+        "min_points": 5,
     }
     internal = _internal_preset(
         {
@@ -87,6 +92,21 @@ def test_predictor_search_values_decode_with_family_defaults() -> None:
 
     with pytest.raises(ValueError, match="load_predictor must be one of"):
         _internal_preset({"load_predictor": "bogus"})
+
+
+def test_every_named_predictor_preset_covers_every_knob() -> None:
+    expected = {
+        "load_predictor",
+        "load_predictor_log1p",
+        "prophet_window_size",
+        "kalman_q_level",
+        "kalman_q_trend",
+        "kalman_r",
+        "kalman_min_points",
+    }
+
+    for name in load_predictor.LOAD_PREDICTOR_PRESETS:
+        assert set(complete_predictor_preset(name)) == expected
 
 
 def test_predictor_fields_emit_only_selected_family() -> None:

--- a/components/src/dynamo/planner/tests/unit/test_simulation_presets.py
+++ b/components/src/dynamo/planner/tests/unit/test_simulation_presets.py
@@ -13,6 +13,8 @@ pytest.importorskip(
 )
 
 from dynamo.planner.simulation.presets import (
+    FPM_SAMPLING,
+    LOAD_SENSITIVITY,
     SCALING_POLICIES,
     fpm_fields,
     load_sensitivity_fields,
@@ -87,6 +89,28 @@ def test_fpm_and_sensitivity_accept_presets_and_custom_search_values() -> None:
         "load_scaling_down_sensitivity": 75,
         "load_min_observations": 4,
     }
+
+
+def test_every_named_preset_covers_its_complete_subitem() -> None:
+    scaling_keys = {
+        "enable_throughput_scaling",
+        "enable_load_scaling",
+        "throughput_adjustment_interval_seconds",
+        "load_adjustment_interval_seconds",
+    }
+    for name in SCALING_POLICIES:
+        assert set(scaling_fields(name)) == scaling_keys
+
+    fpm_keys = {"max_num_fpm_samples", "fpm_sample_bucket_size"}
+    for name in FPM_SAMPLING:
+        assert set(fpm_fields(name)) == fpm_keys
+
+    sensitivity_keys = {
+        "load_scaling_down_sensitivity",
+        "load_min_observations",
+    }
+    for name in LOAD_SENSITIVITY:
+        assert set(load_sensitivity_fields(name)) == sensitivity_keys
 
 
 def test_throughput_intervals_mix_presets_and_custom_search_values() -> None:

--- a/components/src/dynamo/replay/tests/test_simulation_integration.py
+++ b/components/src/dynamo/replay/tests/test_simulation_integration.py
@@ -55,10 +55,10 @@ def _config(
     adapters = {
         "dynamo.planner": {
             "search_space": {
-                "scaling_policy": [scaling_policy],
-                "fpm_sampling": ["default"],
-                "load_sensitivity": ["default"],
-                "load_predictor_candidates": ["constant_last"],
+                "scaling_policy": {"preset": [scaling_policy]},
+                "fpm_sampling": {"preset": ["default"]},
+                "load_sensitivity": {"preset": ["default"]},
+                "load_predictor": {"preset": ["constant_last"]},
             }
         }
     }

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/dynamo-integration.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/dynamo-integration.md
@@ -73,10 +73,30 @@ adapters:
       overlap_score_credit: [0.0, 0.5, 1.0]
   dynamo.planner:
     search_space:
-      scaling_policy: [disabled, load_180_5]
-      fpm_sampling: [default]
-      load_sensitivity: [default]
+      scaling_policy:
+        preset: [disabled, load_180_5]
+      fpm_sampling:
+        preset: [default]
+      load_sensitivity:
+        preset: [default]
 ```
+
+> [!WARNING]
+> The legacy flat Planner preset lists remain accepted for backward compatibility but emit a
+> `FutureWarning`. They will be removed after the 1.5 release. Nest each list under its sub-item's
+> `preset` field.
+
+Each Planner preset sub-item owns a complete knob set:
+
+| Sub-item | Knobs covered by every preset |
+|---|---|
+| `scaling_policy` | Throughput/load enablement and both adjustment intervals |
+| `fpm_sampling` | Maximum FPM samples and sample-bucket size |
+| `load_sensitivity` | Scale-down sensitivity and minimum observations |
+| `load_predictor` | Predictor family, log transform, Prophet window, and all Kalman parameters |
+
+Named presets and custom mappings are validated against the complete sub-item. The provider fills
+family defaults for conditionally inactive predictor knobs before validation.
 
 The Planner provider derives load-predictor parameters from all configured scaling intervals during
 `generate_search_space`. Enabled candidates materialize a concrete `PlannerConfig` runtime hook.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/planner-goodput-per-gpu-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/planner-goodput-per-gpu-sweep.md
@@ -148,7 +148,7 @@ spread within the `load_180_10` family is noise).
   runs TPOT ~78 ms (near the 50 ms ITL bound) and TTFT ~1100 ms (under the 2000 ms bound),
   letting goodput dip to ~1000 while avg_gpu drops to ~8 → goodput/gpu peaks. The conservative
   predictive policies keep latency low but waste GPUs.
-- **Caveat:** `load_*` policies don't use `planner_fpm_sampling` (it only affects predictive
+- **Caveat:** `load_*` policies don't use `fpm_sampling` (it only affects predictive
   throughput scaling), so the `sens`/`fpm` spread *within* the `load_180_10` family (117–121) is
   mostly mocker noise (~5%). The robust conclusion is the **policy family** (`load_180_10`), not
   a precise `sens`/`fpm` setting.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/planner-goodput-per-gpu-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/planner-goodput-per-gpu-sweep.md
@@ -74,10 +74,13 @@ adapters:
       temperature: [0.0]
   dynamo.planner:
     search_space:
-      scaling_policy: [throughput_180_5, throughput_600_5, load_180_5,
-                       load_180_10, hybrid_180_5, hybrid_600_5]
-      load_sensitivity: [aggressive, default, conservative]
-      fpm_sampling: [small, default, large, fine]
+      scaling_policy:
+        preset: [throughput_180_5, throughput_600_5, load_180_5,
+                 load_180_10, hybrid_180_5, hybrid_600_5]
+      load_sensitivity:
+        preset: [aggressive, default, conservative]
+      fpm_sampling:
+        preset: [small, default, large, fine]
 workload:
   trace_path: <toolagent_trace.jsonl>            # open-loop: no replay_concurrency
   trace_format: mooncake

--- a/docs/fern/pages/reference/api/python/planner.mdx
+++ b/docs/fern/pages/reference/api/python/planner.mdx
@@ -225,7 +225,7 @@ Planner search-space preparation and replay-spec materialization.
 from dynamo.planner.simulation import DynamoPlannerSweepConfigProvider
 ```
 
-[`components/src/dynamo/planner/simulation/provider.py#L258`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/simulation/provider.py#L258)
+[`components/src/dynamo/planner/simulation/provider.py#L373`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/simulation/provider.py#L373)
 
 **Public methods**
 
@@ -237,7 +237,7 @@ generate_search_space(search_spec: Mapping[str, JSONValue], context: SweepContex
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/simulation/provider.py#L266)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/simulation/provider.py#L381)
 
 <h4 id="api-dynamo-planner-simulation-provider-dynamoplannersweepconfigprovider-materialize-replay">materialize_replay</h4>
 
@@ -247,7 +247,7 @@ materialize_replay(plan: AdapterSearchPlan, selection: Mapping[str, JSONValue], 
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/simulation/provider.py#L345)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/simulation/provider.py#L462)
 </Accordion>
 
 <Accordion id="api-dynamo-planner-errors-emptytargetreplicaserror" title="EmptyTargetReplicasError (class)">
@@ -1715,5 +1715,5 @@ from dynamo.planner.simulation import create_provider
 create_provider() -> DynamoPlannerSweepConfigProvider
 ```
 
-[`components/src/dynamo/planner/simulation/provider.py#L472`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/simulation/provider.py#L472)
+[`components/src/dynamo/planner/simulation/provider.py#L589`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/simulation/provider.py#L589)
 </Accordion>


### PR DESCRIPTION
## Summary

- Structure the Dynamo Planner Sweeper search space into `scaling_policy.preset`, `fpm_sampling.preset`, `load_sensitivity.preset`, and `load_predictor.preset` sub-items.
- Validate that every named or custom preset covers the complete knob set owned by its sub-item; normalize predictor presets with defaults for all predictor knobs.
- Preserve the legacy flat list shape through a compatibility converter that emits a `FutureWarning` and is marked for removal after the 1.5 release.
- Update the Sweeper example and Planner integration documentation to use the structured shape.

## Validation

- `124 passed`: Sweeper config/provider contracts plus Planner preset, provider, and load-predictor tests.
- File-scoped pre-commit hooks: isort, black, flake8, Ruff, YAML, codespell, documentation, and marker checks passed.
- Three independent agent reviews found no backward-compatibility or sweep-behavior blocker; parity tests cover legacy/new plans, replay materialization, and pre-refactor serialized plan state.
- The real Replay integration process-pool test was attempted but the local bindings lack the `aic-forward-pass` feature; it stopped at that environment capability check.
