### PR TITLE
fix(frontend): forward the tools array to the chat template

### DIFF
--- a/components/src/dynamo/common/tests/test_input_params.py
+++ b/components/src/dynamo/common/tests/test_input_params.py
@@ -62,6 +62,32 @@ def test_absent_tools_are_not_passed_to_the_chat_template():
     assert "tools" not in tokenizer.kwargs
 
 
+def test_tool_choice_none_keeps_tools_out_of_the_template():
+    # The ModelInput::Tokens path drops tool_dicts for tool_choice="none" so the
+    # model does not see the tools and emit raw XML tool calls in its prose.
+    # Rendering them here would make the two paths disagree about "none".
+    tokenizer = RecordingTokenizer()
+
+    InputParamManager(tokenizer).get_input_param(
+        {"messages": MESSAGES, "tools": TOOLS, "tool_choice": "none"},
+        use_tokenizer=True,
+    )
+
+    assert "tools" not in tokenizer.kwargs
+
+
+@pytest.mark.parametrize("tool_choice", ["auto", "required"])
+def test_tools_are_forwarded_for_non_none_tool_choice(tool_choice):
+    tokenizer = RecordingTokenizer()
+
+    InputParamManager(tokenizer).get_input_param(
+        {"messages": MESSAGES, "tools": TOOLS, "tool_choice": tool_choice},
+        use_tokenizer=True,
+    )
+
+    assert tokenizer.kwargs.get("tools") == TOOLS
+
+
 def test_explicit_chat_template_kwargs_tools_win():
     # chat_template_kwargs is a deliberate escape hatch, and forwarding the
     # request's tools as a keyword alongside it would raise

--- a/components/src/dynamo/common/tests/test_input_params.py
+++ b/components/src/dynamo/common/tests/test_input_params.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dynamo.common.utils.input_params module."""
+
+from typing import Any
+
+import pytest
+
+from dynamo.common.utils.input_params import InputParamManager
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class RecordingTokenizer:
+    """Captures the keyword arguments the manager renders the template with."""
+
+    chat_template = ""
+
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] = {}
+
+    def apply_chat_template(self, messages: Any, **kwargs: Any) -> str:
+        self.kwargs = kwargs
+        return "rendered"
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object"}},
+    }
+]
+
+MESSAGES = [{"role": "user", "content": "What is the weather in Tokyo?"}]
+
+
+def test_tools_are_forwarded_to_the_chat_template():
+    # Without this the worker templates as if no tools existed, so the model
+    # cannot emit a tool call and the request returns finish_reason=stop.
+    tokenizer = RecordingTokenizer()
+
+    InputParamManager(tokenizer).get_input_param(
+        {"messages": MESSAGES, "tools": TOOLS}, use_tokenizer=True
+    )
+
+    assert tokenizer.kwargs.get("tools") == TOOLS
+
+
+def test_absent_tools_are_not_passed_to_the_chat_template():
+    # A request without tools must render exactly as before.
+    tokenizer = RecordingTokenizer()
+
+    InputParamManager(tokenizer).get_input_param(
+        {"messages": MESSAGES}, use_tokenizer=True
+    )
+
+    assert "tools" not in tokenizer.kwargs
+
+
+def test_explicit_chat_template_kwargs_tools_win():
+    # chat_template_kwargs is a deliberate escape hatch, and forwarding the
+    # request's tools as a keyword alongside it would raise
+    # "got multiple values for keyword argument 'tools'".
+    tokenizer = RecordingTokenizer()
+    override = [{"type": "function", "function": {"name": "override"}}]
+
+    InputParamManager(tokenizer).get_input_param(
+        {
+            "messages": MESSAGES,
+            "tools": TOOLS,
+            "chat_template_kwargs": {"tools": override},
+        },
+        use_tokenizer=True,
+    )
+
+    assert tokenizer.kwargs.get("tools") == override

--- a/components/src/dynamo/common/utils/input_params.py
+++ b/components/src/dynamo/common/utils/input_params.py
@@ -80,7 +80,18 @@ class InputParamManager:
                 # tool call. Routed through extra_kwargs rather than passed as a
                 # keyword so an explicit chat_template_kwargs["tools"] still wins
                 # instead of colliding into a duplicate-keyword TypeError.
-                if "tools" in request and "tools" not in extra_kwargs:
+                #
+                # Skipped for tool_choice="none" to match the ModelInput::Tokens
+                # path, which drops tool_dicts in that case
+                # (frontend/prepost.py, exclude_tools_when_tool_choice_none)
+                # precisely so the model does not see the tools and emit raw XML
+                # tool calls in its prose. Forwarding them here regardless would
+                # make the two paths disagree about what "none" renders.
+                if (
+                    "tools" in request
+                    and "tools" not in extra_kwargs
+                    and request.get("tool_choice") != "none"
+                ):
                     extra_kwargs["tools"] = request["tools"]
 
                 # Inject reasoning_content as <think> blocks into content,

--- a/components/src/dynamo/common/utils/input_params.py
+++ b/components/src/dynamo/common/utils/input_params.py
@@ -73,6 +73,16 @@ class InputParamManager:
                 for reserved in ("tokenize", "add_generation_prompt"):
                     extra_kwargs.pop(reserved, None)
 
+                # The OpenAI `tools` array is a template input like the ones
+                # above: apply_chat_template renders the model's tool block from
+                # it. Without it the prompt is built as if no tools existed, so
+                # the model is never told they are available and cannot emit a
+                # tool call. Routed through extra_kwargs rather than passed as a
+                # keyword so an explicit chat_template_kwargs["tools"] still wins
+                # instead of colliding into a duplicate-keyword TypeError.
+                if "tools" in request and "tools" not in extra_kwargs:
+                    extra_kwargs["tools"] = request["tools"]
+
                 # Inject reasoning_content as <think> blocks into content,
                 # but only if the template doesn't handle it natively.
                 # Templates like Nemotron and Qwen3 reference reasoning_content


### PR DESCRIPTION
## Summary

Fixes #13396.

A worker started with `--use-vllm-tokenizer` registers `ModelInput::Text`, so chat requests are forwarded whole and the worker builds the prompt itself through `InputParamManager`. That path renders the chat template from `request["messages"]` alone and never passes `request["tools"]` — the string `tools` did not appear anywhere in the file.

The model is therefore never told the tools exist and cannot emit a tool call. The failure is silent: the request returns HTTP 200 with `finish_reason=stop` and `tool_calls: null`, so a caller sees a plausible answer rather than an error. @stu-cao measured it directly, sending the same request with and without `tools` and getting an identical `prompt_tokens` of 49 — the tool block never rendered.

`apply_chat_template` accepts `tools=` and renders the model tool block from it, so the tools only need to reach it. This reads as an oversight rather than a decision: the same function already forwards `chat_template_kwargs` and `chat_template_args`, and injects `reasoning_content` when the template does not handle it natively, so template inputs are otherwise marshalled carefully.

One deliberate difference from the one-line fix suggested in the issue. The tools are set through `extra_kwargs` instead of being passed as a keyword argument:

```python
if "tools" in request and "tools" not in extra_kwargs:
    extra_kwargs["tools"] = request["tools"]
```

A request may legitimately carry `chat_template_kwargs: {"tools": ...}`. Passing `tools=` alongside that dict raises `TypeError: got multiple values for keyword argument 'tools'` — exactly the failure the neighbouring `reserved` loop already exists to prevent for `tokenize` and `add_generation_prompt`. Routing through the same dict keeps an explicit override winning and makes the collision unrepresentable.

Scope is limited to the `ModelInput::Text` path. `ModelInput::Tokens` builds `tool_dicts` in `dynamo/frontend/prepost.py` and already renders tools correctly.

## Validation

`pytest components/src/dynamo/common/tests/test_input_params.py` — 3 passed.

The regression test fails on the unfixed code, verified by reverting only `input_params.py` and keeping the tests:

```
FAILED test_input_params.py::test_tools_are_forwarded_to_the_chat_template
E   where {'tokenize': False, 'add_generation_prompt': True} = RecordingTokenizer.kwargs
1 failed, 2 passed
```

The tests use a recording stub for the tokenizer, so they assert the tools reach `apply_chat_template` without downloading a model. Two guard cases accompany the regression test: a request with no tools must render exactly as before, and an explicit `chat_template_kwargs["tools"]` must win rather than collide.

`pre-commit run --files` on both changed files passes.

Not verified here: no GPU, so the end-to-end `prompt_tokens` delta against `poolside/Laguna-S-2.1-FP8` in the issue is the reporter's measurement, not mine.

The issue also notes that `--dyn-chat-processor vllm` becomes silently inert when `--use-vllm-tokenizer` is set, because the `Text` branch never consults `chat_engine_factory`. That is a separate defect and is left to the issue rather than bundled here.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat templates now support request-provided tools, enabling tool-aware prompt rendering.
  * Explicit chat-template tool settings take precedence over request tools.

* **Bug Fixes**
  * Prevented duplicate tool arguments when rendering chat templates.
  * Requests without tools continue to omit tool configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->