### PR TITLE
fix(router): reconcile request-path overload marks (#12540) [cherry-pick → release/1.4.0]

### DIFF
--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -148,6 +148,40 @@ fn publish_overloaded_instances(
     }
 }
 
+fn overload_reconciliation_needed(
+    decode_client: &Client,
+    prefill_client_holder: &RwLock<Option<Client>>,
+) -> bool {
+    decode_client.overload_reconciliation_needed()
+        || prefill_client_holder
+            .read()
+            .unwrap()
+            .as_ref()
+            .is_some_and(Client::overload_reconciliation_needed)
+}
+
+fn publish_overloaded_instances_if_needed(
+    decode_client: &Client,
+    prefill_client_holder: &RwLock<Option<Client>>,
+    overloaded_tracker: &OverloadedWorkerTracker,
+    overloaded_changed: bool,
+) -> bool {
+    // NOTE: Recovery still relies on load producers publishing after meaningful capacity or
+    // lifecycle changes. This only prevents the next observation from being suppressed when
+    // request-path backpressure changed Client state outside this monitor's cached set.
+    if !overloaded_changed && !overload_reconciliation_needed(decode_client, prefill_client_holder)
+    {
+        return false;
+    }
+
+    publish_overloaded_instances(
+        decode_client,
+        prefill_client_holder,
+        &overloaded_tracker.ids(),
+    );
+    true
+}
+
 /// Configuration for worker load thresholds used in overload detection.
 ///
 /// All thresholds are opt-in. An unset (`None`) field means the corresponding
@@ -1050,14 +1084,12 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                             overloaded_tracker.update_worker(worker_id, worker_overloaded)
                         };
 
-                        if overloaded_changed {
-                            let overloaded_instances = overloaded_tracker.ids();
-                            publish_overloaded_instances(
-                                &client,
-                                &prefill_client_holder,
-                                &overloaded_instances,
-                            );
-                        }
+                        publish_overloaded_instances_if_needed(
+                            &client,
+                            &prefill_client_holder,
+                            &overloaded_tracker,
+                            overloaded_changed,
+                        );
                     }
 
                     // Handle decode endpoint instance changes (for ITL and decode metrics cleanup)
@@ -1216,7 +1248,8 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 mod tests {
     use super::{
         LoadMembership, LoadThresholdConfig, OverloadedWorkerTracker, WorkerLoadState,
-        classify_load_membership, compute_overloaded_instances, publish_overloaded_instances,
+        classify_load_membership, compute_overloaded_instances, overload_reconciliation_needed,
+        publish_overloaded_instances, publish_overloaded_instances_if_needed,
     };
     use dynamo_kv_router::protocols::ActiveLoad;
     use std::collections::HashSet;
@@ -1646,6 +1679,53 @@ mod tests {
             .into_iter()
             .collect();
         assert_eq!(overloaded, HashSet::from([1]));
+    }
+
+    #[tokio::test]
+    async fn unchanged_low_metric_reconciles_request_path_overload() {
+        use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
+        use std::sync::RwLock;
+
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let client = drt
+            .namespace("test_request_path_overload_reconciliation".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("decode".to_string())
+            .client()
+            .await
+            .unwrap();
+        let prefill_client_holder = RwLock::new(None);
+        let mut tracker = OverloadedWorkerTracker::default();
+
+        assert!(!tracker.update_worker(7, false));
+        client.mark_overloaded_immediate(7);
+        assert_eq!(client.overloaded_instance_ids(), Some(HashSet::from([7])));
+
+        let overloaded_changed = tracker.update_worker(7, false);
+        assert!(
+            !overloaded_changed,
+            "the monitor's cached set remains empty"
+        );
+        assert!(overload_reconciliation_needed(
+            &client,
+            &prefill_client_holder
+        ));
+
+        assert!(publish_overloaded_instances_if_needed(
+            &client,
+            &prefill_client_holder,
+            &tracker,
+            overloaded_changed,
+        ));
+
+        assert_eq!(client.overloaded_instance_ids(), None);
+        assert!(!client.overload_reconciliation_needed());
+        rt.shutdown();
     }
 
     /// Regression: the overloaded set must reach the prefill

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, LazyLock, Mutex as StdMutex},
@@ -378,6 +378,7 @@ impl RoutingInstances {
 struct RoutingInstancesState {
     snapshot: ArcSwap<RoutingInstances>,
     update_lock: StdMutex<()>,
+    overload_reconciliation_needed: AtomicBool,
     instance_avail_tx: tokio::sync::watch::Sender<Vec<u64>>,
 }
 
@@ -390,6 +391,7 @@ impl RoutingInstancesState {
             Self {
                 snapshot: ArcSwap::from_pointee(snapshot),
                 update_lock: StdMutex::new(()),
+                overload_reconciliation_needed: AtomicBool::new(false),
                 instance_avail_tx,
             },
             instance_avail_rx,
@@ -447,6 +449,8 @@ impl RoutingInstancesState {
             .copied()
             .collect::<HashSet<_>>();
         let _guard = self.update_lock.lock().unwrap();
+        self.overload_reconciliation_needed
+            .store(false, Ordering::Release);
         let current = self.snapshot.load();
         if current.overloaded_ids == overloaded_ids {
             return false;
@@ -458,12 +462,16 @@ impl RoutingInstancesState {
     }
 
     fn mark_overloaded_immediate(&self, instance_id: u64) {
-        self.update(
-            move |current| current.mark_overloaded(instance_id),
-            // Routable set is unchanged — only the derived free set shrinks —
-            // so there's no need to republish routable_ids.
-            false,
-        );
+        let _guard = self.update_lock.lock().unwrap();
+        let current = self.snapshot.load();
+        let next = Arc::new(current.mark_overloaded(instance_id));
+        self.snapshot.store(next);
+        self.overload_reconciliation_needed
+            .store(true, Ordering::Release);
+    }
+
+    fn overload_reconciliation_needed(&self) -> bool {
+        self.overload_reconciliation_needed.load(Ordering::Acquire)
     }
 
     fn clear_overloaded_for_removed(&self, removed_instance_ids: &[u64]) {
@@ -639,6 +647,12 @@ impl Client {
     pub fn set_overloaded_instances(&self, overloaded_instance_ids: &[u64]) -> bool {
         self.routing_instances
             .set_overloaded_instances(overloaded_instance_ids)
+    }
+
+    /// Whether request-path backpressure changed overload state after the monitor's
+    /// most recent metric publication.
+    pub fn overload_reconciliation_needed(&self) -> bool {
+        self.routing_instances.overload_reconciliation_needed()
     }
 
     /// Mark an instance overloaded immediately. A worker returning


### PR DESCRIPTION
Cherry-pick of #12540 onto `release/1.4.0`.

**Original PR:** #12540 — `fix(router): reconcile request-path overload marks [DYN-3849]`
**Original commit:** `1ec4a44b` (author @GuanLuo/Yan Ru Pei)

### What
Fixes the KV-router **overload self-latching deadlock**: request-path `mark_overloaded_immediate` marks workers overloaded, but the overloaded set only cleared on an `ActiveLoad` event with no periodic reconcile — so once all prefill workers get marked it can latch permanently (availability drops to ~0). This adds a reconciliation pass so request-path overload marks are reconciled against live state.

Files: `lib/llm/src/discovery/worker_monitor.rs`, `lib/runtime/src/component/client.rs` (+110/−16).

### Conflict resolution (one hunk, `client.rs`)
`release/1.4.0` changed `RoutingInstancesState::new()` to return a tuple `(Self, watch::Receiver)` (the `instance_avail_tx`/`_rx` feature); #12540 adds a new struct field `overload_reconciliation_needed: AtomicBool`. Resolved by keeping the tuple-returning form and adding the new field to the `Self { … }` initializer. Struct definition + all other references applied cleanly; `AtomicBool`/`Ordering` already imported.

### Why (release-relevant)
Surfaced as an Amazon Ads **1.3.0 availability incident** (router deadlock, DYN-3849). #12540 merged to `main` 2026-08-02 — **after the 1.4.0 code freeze (7/28)** — so it is absent from `v1.4.0`. This CP targets a **1.4.1** patch.

⚠️ **Needs a build/test check** before merge — the cherry-pick applied but the `client.rs` conflict was hand-resolved; please run `cargo build`/clippy on this branch. Flagging for the release owner (this rides only if a 1.4.1 patch is greenlit).

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->