### PR TITLE
fix(request-trace): drain plain JSONL records on shutdown

### DIFF
--- a/lib/llm/src/recorder.rs
+++ b/lib/llm/src/recorder.rs
@@ -157,12 +157,11 @@ where
             });
 
             loop {
-                // Check time limit if set
-                if let Some(deadline) = max_time_deadline
+                if !closing_clone.is_cancelled()
+                    && let Some(deadline) = max_time_deadline
                     && Instant::now() >= deadline
                 {
                     tracing::info!("Recorder reached max time limit, shutting down");
-                    // Flush and cancel
                     if let Err(e) = writer.flush().await {
                         tracing::error!("Failed to flush on time limit shutdown: {}", e);
                     }
@@ -173,9 +172,12 @@ where
                 tokio::select! {
                     biased;
 
-                    // Graceful close disables this higher-priority abrupt path.
                     _ = cancel_clone.cancelled(), if !closing_clone.is_cancelled() => {
-                        // Flush any pending writes before shutting down
+                        // Select guards are evaluated once, so close must be checked again here.
+                        if closing_clone.is_cancelled() {
+                            continue;
+                        }
+
                         if let Err(e) = writer.flush().await {
                             tracing::error!("Failed to flush on shutdown: {}", e);
                         }
@@ -273,23 +275,21 @@ where
                                 }
                             }
 
-                        // Update event count
                         let mut count = event_count_clone.lock().await;
                         *count += 1;
 
-                        // Check if we've reached the maximum count
                         if let Some(max) = options.max_count
-                            && *count >= max {
-                                tracing::info!("Recorder reached max event count ({}), shutting down", max);
-                                // Flush buffer before shutting down
-                                if let Err(e) = writer.flush().await {
-                                    tracing::error!("Failed to flush on count limit shutdown: {}", e);
-                                }
-                                // Drop the lock before cancelling
-                                drop(count);
-                                cancel_clone.cancel();
-                                return;
+                            && *count >= max
+                            && !closing_clone.is_cancelled()
+                        {
+                            tracing::info!("Recorder reached max event count ({}), shutting down", max);
+                            if let Err(e) = writer.flush().await {
+                                tracing::error!("Failed to flush on count limit shutdown: {}", e);
                             }
+                            drop(count);
+                            cancel_clone.cancel();
+                            return;
+                        }
                     }
                 }
             }

--- a/lib/llm/src/recorder.rs
+++ b/lib/llm/src/recorder.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -49,14 +50,18 @@ impl Default for RecorderOptions {
 /// A generic recorder for events that streams directly to a JSONL file
 #[derive(Debug)]
 pub struct Recorder<T> {
-    /// A sender for events that can be cloned and shared with producers
-    event_tx: mpsc::Sender<T>,
+    /// A sender for events that can be cloned and shared with producers.
+    /// Only `None` while [`Recorder::close`] drains, and `close` consumes the
+    /// recorder, so no other caller can observe the gap.
+    event_tx: Option<mpsc::Sender<T>>,
     /// A cancellation token for managing shutdown
     cancel: CancellationToken,
     /// Counter for the number of events written
     event_count: Arc<Mutex<usize>>,
     /// Time when the first event was received
     first_event_time: Arc<Mutex<Option<Instant>>>,
+    /// Handle for the background writer task, so a caller can await its final flush
+    writer_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl<T> Recorder<T>
@@ -131,7 +136,7 @@ where
         let file_path = output_path.as_ref().to_path_buf();
 
         // Spawn a task to receive events and write them to the file
-        tokio::spawn(async move {
+        let writer_task = tokio::spawn(async move {
             let start_time = start_time;
             let mut writer = BufWriter::with_capacity(options.buffer_bytes.max(1), file);
             let mut line_count = 0;
@@ -183,7 +188,21 @@ where
                         }
                     }
 
-                    Some(event) = event_rx.recv() => {
+                    event = event_rx.recv() => {
+                        // `recv` yields `None` only once every sender is gone, so every
+                        // queued event has already been written by this point. Matching it
+                        // explicitly (rather than with a refutable `Some(event)` pattern,
+                        // which `select!` would simply disable) is what lets a caller close
+                        // the channel and await the final flush.
+                        let Some(event) = event else {
+                            if let Err(e) = writer.flush().await {
+                                tracing::error!("Failed to flush on channel close: {}", e);
+                            }
+
+                            tracing::debug!("Recorder task shutting down after channel close");
+                            return;
+                        };
+
                         // Update first_event_time if this is the first event
                         {
                             let mut first_time = first_event_time_clone.lock().await;
@@ -279,16 +298,20 @@ where
         });
 
         Ok(Self {
-            event_tx,
+            event_tx: Some(event_tx),
             cancel: token,
             event_count,
             first_event_time,
+            writer_task: Some(writer_task),
         })
     }
 
     /// Get a sender that can be used to send events to the recorder
     pub fn event_sender(&self) -> mpsc::Sender<T> {
-        self.event_tx.clone()
+        self.event_tx
+            .as_ref()
+            .expect("event_tx is only taken by close(), which consumes the recorder")
+            .clone()
     }
 
     /// Get the count of recorded events
@@ -307,9 +330,27 @@ where
         }
     }
 
-    /// Shutdown the recorder
+    /// Shutdown the recorder abruptly: cancel the writer task, which flushes only
+    /// the bytes already buffered and abandons anything still queued. Use
+    /// [`Recorder::close`] when queued events must reach the file.
     pub fn shutdown(&self) {
         self.cancel.cancel();
+    }
+
+    /// Close the recorder gracefully: drop the recorder's own sender and wait for
+    /// the writer task to drain every queued event and flush.
+    ///
+    /// The wait is bounded by the channel rather than by a timeout. Dropping the
+    /// last sender closes the channel, so no further event can be queued and the
+    /// writer task sees `None` after at most the events already accepted.
+    /// Callers holding a clone from [`Recorder::event_sender`] must drop it
+    /// first, otherwise the channel stays open and this call waits for them.
+    pub async fn close(mut self) -> anyhow::Result<()> {
+        drop(self.event_tx.take());
+        if let Some(writer_task) = self.writer_task.take() {
+            writer_task.await.context("recorder writer task panicked")?;
+        }
+        Ok(())
     }
 
     /// Send events from a JSONL file to the provided event sender

--- a/lib/llm/src/recorder.rs
+++ b/lib/llm/src/recorder.rs
@@ -50,22 +50,16 @@ impl Default for RecorderOptions {
 /// A generic recorder for events that streams directly to a JSONL file
 #[derive(Debug)]
 pub struct Recorder<T> {
-    /// A sender for events that can be cloned and shared with producers.
-    /// Only `None` while [`Recorder::close`] drains, and `close` consumes the
-    /// recorder, so no other caller can observe the gap.
+    /// Taken only by the consuming [`Recorder::close`] path.
     event_tx: Option<mpsc::Sender<T>>,
     /// A cancellation token for managing shutdown
     cancel: CancellationToken,
-    /// Set by [`Recorder::close`] before it drops the sender, to mark a graceful
-    /// close as in progress. While it is set the writer task stops honouring
-    /// `cancel`, so a cancellation raised during the drain cannot cut the drain
-    /// short. Owned by this recorder alone and never handed out.
+    /// Prevents abrupt cancellation from interrupting a graceful drain.
     closing: CancellationToken,
     /// Counter for the number of events written
     event_count: Arc<Mutex<usize>>,
     /// Time when the first event was received
     first_event_time: Arc<Mutex<Option<Instant>>>,
-    /// Handle for the background writer task, so a caller can await its final flush
     writer_task: Option<tokio::task::JoinHandle<()>>,
 }
 
@@ -179,10 +173,7 @@ where
                 tokio::select! {
                     biased;
 
-                    // Disabled once a graceful close is in progress. `select!` is
-                    // `biased`, so without this guard an already-cancelled token would
-                    // win every iteration and the drain arm below would never be
-                    // reached, abandoning events `close` promised to write.
+                    // Graceful close disables this higher-priority abrupt path.
                     _ = cancel_clone.cancelled(), if !closing_clone.is_cancelled() => {
                         // Flush any pending writes before shutting down
                         if let Err(e) = writer.flush().await {
@@ -200,11 +191,7 @@ where
                     }
 
                     event = event_rx.recv() => {
-                        // `recv` yields `None` only once every sender is gone, so every
-                        // queued event has already been written by this point. Matching it
-                        // explicitly (rather than with a refutable `Some(event)` pattern,
-                        // which `select!` would simply disable) is what lets a caller close
-                        // the channel and await the final flush.
+                        // An explicit `None` arm lets close await the final flush.
                         let Some(event) = event else {
                             if let Err(e) = writer.flush().await {
                                 tracing::error!("Failed to flush on channel close: {}", e);
@@ -342,36 +329,21 @@ where
         }
     }
 
-    /// Shutdown the recorder abruptly: cancel the writer task, which flushes only
-    /// the bytes already buffered and abandons anything still queued. Use
-    /// [`Recorder::close`] when queued events must reach the file.
+    /// Cancels the writer after flushing buffered bytes; queued events may be lost.
     pub fn shutdown(&self) {
         self.cancel.cancel();
     }
 
-    /// Close the recorder gracefully: drop the recorder's own sender and wait for
-    /// the writer task to drain every queued event and flush.
+    /// Drains queued events and flushes the writer.
     ///
-    /// The wait is bounded by the channel rather than by a timeout. Dropping the
-    /// last sender closes the channel, so no further event can be queued and the
-    /// writer task sees `None` after at most the events already accepted.
-    /// Callers holding a clone from [`Recorder::event_sender`] must drop it
-    /// first, otherwise the channel stays open and this call waits for them.
-    ///
-    /// The drain takes precedence over the cancellation token passed to the
-    /// constructor: a cancellation raised once this call is under way no longer
-    /// cuts the drain short.
+    /// Sender clones must be dropped first. Cancellation after close begins does
+    /// not interrupt the drain.
     ///
     /// # Errors
     ///
-    /// Returns an error if the writer task panicked, or if the cancellation token
-    /// had **already** been cancelled when this was called. In that case the
-    /// writer task had stopped before the graceful path could take effect, so
-    /// events queued at that point were abandoned and this call cannot make the
-    /// guarantee its name implies. It reports that rather than returning `Ok`.
+    /// Returns an error if the writer task panicked or cancellation preceded close.
     pub async fn close(mut self) -> anyhow::Result<()> {
-        // Order matters: block the abrupt branch before closing the channel, so a
-        // cancellation racing this call cannot preempt the drain.
+        // Disable abrupt cancellation before closing the channel.
         self.closing.cancel();
         let cancelled_before_close = self.cancel.is_cancelled();
 
@@ -796,16 +768,13 @@ mod tests {
         println!("Load test with file rotation completed successfully");
     }
 
-    /// Two-way handshake used to park the writer task inside `Serialize` for as
-    /// long as the test needs, with no sleeping on either side: the writer
-    /// announces it is parked, then blocks until released.
+    /// Parks the writer inside `Serialize` without timing assumptions.
     struct BarrierGate {
         parked_tx: mpsc::UnboundedSender<()>,
         release_rx: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
     }
 
-    /// Event whose serialization blocks on a [`BarrierGate`] when one is
-    /// attached. The gate is never serialized, so the on-disk shape is `{"id":N}`.
+    /// Event that can block during serialization.
     #[derive(Clone, Deserialize)]
     struct BarrierEvent {
         id: u64,
@@ -838,16 +807,6 @@ mod tests {
             .collect()
     }
 
-    /// A cancellation raised *after* `close` has started must not cut the drain
-    /// short. The writer task's `select!` is `biased` with the cancellation branch
-    /// first, so without the graceful-close guard the cancellation would win the
-    /// next iteration and abandon everything still queued.
-    ///
-    /// Determinism comes from two things and no sleeping: the writer task is
-    /// parked inside record 1's `Serialize` and so cannot poll the `select!` at
-    /// all, and `close`'s future is polled once by hand before the cancellation,
-    /// which runs everything up to its first `.await` — the graceful-close signal
-    /// and the sender drop.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn close_drains_even_when_cancelled_mid_drain() {
         const EVENTS: u64 = 32;
@@ -860,8 +819,6 @@ mod tests {
             token.clone(),
             &file_path,
             RecorderOptions {
-                // Large buffer and no flush timer, so only the drain on channel
-                // close can get these records to disk.
                 buffer_bytes: 1024 * 1024,
                 flush_interval: None,
                 ..Default::default()
@@ -878,7 +835,6 @@ mod tests {
             release_rx: std::sync::Mutex::new(release_rx),
         });
 
-        // Event 1 parks the writer task inside its own serialization.
         event_tx
             .send(BarrierEvent {
                 id: 1,
@@ -888,7 +844,6 @@ mod tests {
             .unwrap();
         parked_rx.recv().await.expect("writer task parked");
 
-        // Events 2..=N queue up behind the parked writer.
         for id in 2..=EVENTS {
             event_tx
                 .send(BarrierEvent { id, gate: None })
@@ -897,17 +852,13 @@ mod tests {
         }
         drop(event_tx);
 
-        // Drive `close` up to its first `.await`: the graceful-close signal is set
-        // and the recorder's own sender is dropped, but the writer task is still
-        // parked and has not observed either.
+        // Poll once so close disables abrupt cancellation before the token fires.
         let mut close_fut = Box::pin(recorder.close());
         assert!(
             futures::poll!(close_fut.as_mut()).is_pending(),
             "close cannot finish while the writer task is parked"
         );
 
-        // Now cancel, then release. The writer wakes with the token already
-        // cancelled and must still drain.
         token.cancel();
         release_tx.send(()).expect("writer task waiting on release");
 
@@ -922,9 +873,6 @@ mod tests {
         );
     }
 
-    /// `close` cannot honour its guarantee when the token was cancelled before it
-    /// was ever called: the writer task has already stopped and whatever was
-    /// queued is gone. It must report that rather than returning `Ok`.
     #[tokio::test]
     async fn close_reports_a_cancellation_that_preceded_it() {
         let dir = tempdir().unwrap();
@@ -937,13 +885,9 @@ mod tests {
 
         token.cancel();
 
-        let error = recorder
+        recorder
             .close()
             .await
             .expect_err("close must not claim success after an earlier cancellation");
-        assert!(
-            error.to_string().contains("already cancelled"),
-            "unexpected error: {error}"
-        );
     }
 }

--- a/lib/llm/src/recorder.rs
+++ b/lib/llm/src/recorder.rs
@@ -56,6 +56,11 @@ pub struct Recorder<T> {
     event_tx: Option<mpsc::Sender<T>>,
     /// A cancellation token for managing shutdown
     cancel: CancellationToken,
+    /// Set by [`Recorder::close`] before it drops the sender, to mark a graceful
+    /// close as in progress. While it is set the writer task stops honouring
+    /// `cancel`, so a cancellation raised during the drain cannot cut the drain
+    /// short. Owned by this recorder alone and never handed out.
+    closing: CancellationToken,
     /// Counter for the number of events written
     event_count: Arc<Mutex<usize>>,
     /// Time when the first event was received
@@ -113,6 +118,8 @@ where
         let event_count = Arc::new(Mutex::new(0));
         let event_count_clone = event_count.clone();
         let cancel_clone = token.clone();
+        let closing = CancellationToken::new();
+        let closing_clone = closing.clone();
         let start_time = Instant::now();
         let first_event_time = Arc::new(Mutex::new(None));
         let first_event_time_clone = first_event_time.clone();
@@ -172,7 +179,11 @@ where
                 tokio::select! {
                     biased;
 
-                    _ = cancel_clone.cancelled() => {
+                    // Disabled once a graceful close is in progress. `select!` is
+                    // `biased`, so without this guard an already-cancelled token would
+                    // win every iteration and the drain arm below would never be
+                    // reached, abandoning events `close` promised to write.
+                    _ = cancel_clone.cancelled(), if !closing_clone.is_cancelled() => {
                         // Flush any pending writes before shutting down
                         if let Err(e) = writer.flush().await {
                             tracing::error!("Failed to flush on shutdown: {}", e);
@@ -300,6 +311,7 @@ where
         Ok(Self {
             event_tx: Some(event_tx),
             cancel: token,
+            closing,
             event_count,
             first_event_time,
             writer_task: Some(writer_task),
@@ -345,11 +357,34 @@ where
     /// writer task sees `None` after at most the events already accepted.
     /// Callers holding a clone from [`Recorder::event_sender`] must drop it
     /// first, otherwise the channel stays open and this call waits for them.
+    ///
+    /// The drain takes precedence over the cancellation token passed to the
+    /// constructor: a cancellation raised once this call is under way no longer
+    /// cuts the drain short.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the writer task panicked, or if the cancellation token
+    /// had **already** been cancelled when this was called. In that case the
+    /// writer task had stopped before the graceful path could take effect, so
+    /// events queued at that point were abandoned and this call cannot make the
+    /// guarantee its name implies. It reports that rather than returning `Ok`.
     pub async fn close(mut self) -> anyhow::Result<()> {
+        // Order matters: block the abrupt branch before closing the channel, so a
+        // cancellation racing this call cannot preempt the drain.
+        self.closing.cancel();
+        let cancelled_before_close = self.cancel.is_cancelled();
+
         drop(self.event_tx.take());
         if let Some(writer_task) = self.writer_task.take() {
             writer_task.await.context("recorder writer task panicked")?;
         }
+
+        anyhow::ensure!(
+            !cancelled_before_close,
+            "recorder was already cancelled when close was called; \
+             events still queued at that point were abandoned"
+        );
         Ok(())
     }
 
@@ -759,5 +794,156 @@ mod tests {
         );
 
         println!("Load test with file rotation completed successfully");
+    }
+
+    /// Two-way handshake used to park the writer task inside `Serialize` for as
+    /// long as the test needs, with no sleeping on either side: the writer
+    /// announces it is parked, then blocks until released.
+    struct BarrierGate {
+        parked_tx: mpsc::UnboundedSender<()>,
+        release_rx: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+    }
+
+    /// Event whose serialization blocks on a [`BarrierGate`] when one is
+    /// attached. The gate is never serialized, so the on-disk shape is `{"id":N}`.
+    #[derive(Clone, Deserialize)]
+    struct BarrierEvent {
+        id: u64,
+        #[serde(skip)]
+        gate: Option<Arc<BarrierGate>>,
+    }
+
+    impl Serialize for BarrierEvent {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            use serde::ser::SerializeStruct;
+            if let Some(gate) = &self.gate {
+                gate.parked_tx.send(()).expect("test still listening");
+                // Ignore the result: a dropped release sender also releases us.
+                let _ = gate.release_rx.lock().unwrap().recv();
+            }
+            let mut state = serializer.serialize_struct("BarrierEvent", 1)?;
+            state.serialize_field("id", &self.id)?;
+            state.end()
+        }
+    }
+
+    fn recorded_ids(path: &Path) -> Vec<u64> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(|line| {
+                let entry: serde_json::Value = serde_json::from_str(line).unwrap();
+                entry["event"]["id"].as_u64().unwrap()
+            })
+            .collect()
+    }
+
+    /// A cancellation raised *after* `close` has started must not cut the drain
+    /// short. The writer task's `select!` is `biased` with the cancellation branch
+    /// first, so without the graceful-close guard the cancellation would win the
+    /// next iteration and abandon everything still queued.
+    ///
+    /// Determinism comes from two things and no sleeping: the writer task is
+    /// parked inside record 1's `Serialize` and so cannot poll the `select!` at
+    /// all, and `close`'s future is polled once by hand before the cancellation,
+    /// which runs everything up to its first `.await` — the graceful-close signal
+    /// and the sender drop.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn close_drains_even_when_cancelled_mid_drain() {
+        const EVENTS: u64 = 32;
+
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("cancel_during_close.jsonl");
+
+        let token = CancellationToken::new();
+        let recorder: Recorder<BarrierEvent> = Recorder::new_with_options(
+            token.clone(),
+            &file_path,
+            RecorderOptions {
+                // Large buffer and no flush timer, so only the drain on channel
+                // close can get these records to disk.
+                buffer_bytes: 1024 * 1024,
+                flush_interval: None,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let event_tx = recorder.event_sender();
+
+        let (parked_tx, mut parked_rx) = mpsc::unbounded_channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let gate = Arc::new(BarrierGate {
+            parked_tx,
+            release_rx: std::sync::Mutex::new(release_rx),
+        });
+
+        // Event 1 parks the writer task inside its own serialization.
+        event_tx
+            .send(BarrierEvent {
+                id: 1,
+                gate: Some(gate),
+            })
+            .await
+            .unwrap();
+        parked_rx.recv().await.expect("writer task parked");
+
+        // Events 2..=N queue up behind the parked writer.
+        for id in 2..=EVENTS {
+            event_tx
+                .send(BarrierEvent { id, gate: None })
+                .await
+                .expect("send accepted while the writer is busy");
+        }
+        drop(event_tx);
+
+        // Drive `close` up to its first `.await`: the graceful-close signal is set
+        // and the recorder's own sender is dropped, but the writer task is still
+        // parked and has not observed either.
+        let mut close_fut = Box::pin(recorder.close());
+        assert!(
+            futures::poll!(close_fut.as_mut()).is_pending(),
+            "close cannot finish while the writer task is parked"
+        );
+
+        // Now cancel, then release. The writer wakes with the token already
+        // cancelled and must still drain.
+        token.cancel();
+        release_tx.send(()).expect("writer task waiting on release");
+
+        close_fut
+            .await
+            .expect("close after a mid-drain cancellation");
+
+        assert_eq!(
+            recorded_ids(&file_path),
+            (1..=EVENTS).collect::<Vec<_>>(),
+            "every accepted event must survive a cancellation raised during close"
+        );
+    }
+
+    /// `close` cannot honour its guarantee when the token was cancelled before it
+    /// was ever called: the writer task has already stopped and whatever was
+    /// queued is gone. It must report that rather than returning `Ok`.
+    #[tokio::test]
+    async fn close_reports_a_cancellation_that_preceded_it() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("cancelled_before_close.jsonl");
+
+        let token = CancellationToken::new();
+        let recorder = TestEventRecorder::new(token.clone(), &file_path, None, None, None)
+            .await
+            .unwrap();
+
+        token.cancel();
+
+        let error = recorder
+            .close()
+            .await
+            .expect_err("close must not claim success after an earlier cancellation");
+        assert!(
+            error.to_string().contains("already cancelled"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/lib/llm/src/recorder.rs
+++ b/lib/llm/src/recorder.rs
@@ -27,7 +27,9 @@ where
 #[derive(Debug, Clone)]
 pub struct RecorderOptions {
     pub max_lines_per_file: Option<usize>,
+    /// Stop admission at this count, then drain events already accepted.
     pub max_count: Option<usize>,
+    /// Stop admission at this time, then drain events already accepted.
     pub max_time: Option<f64>,
     pub buffer_bytes: usize,
     pub flush_interval: Option<Duration>,
@@ -50,8 +52,8 @@ impl Default for RecorderOptions {
 /// A generic recorder for events that streams directly to a JSONL file
 #[derive(Debug)]
 pub struct Recorder<T> {
-    /// Taken only by the consuming [`Recorder::close`] path.
-    event_tx: Option<mpsc::Sender<T>>,
+    /// Closing the receiver rejects this sender and all producer clones.
+    event_tx: mpsc::Sender<T>,
     /// A cancellation token for managing shutdown
     cancel: CancellationToken,
     /// Prevents abrupt cancellation from interrupting a graceful drain.
@@ -60,7 +62,7 @@ pub struct Recorder<T> {
     event_count: Arc<Mutex<usize>>,
     /// Time when the first event was received
     first_event_time: Arc<Mutex<Option<Instant>>>,
-    writer_task: Option<tokio::task::JoinHandle<()>>,
+    writer_task: Option<tokio::task::JoinHandle<io::Result<()>>>,
 }
 
 impl<T> Recorder<T>
@@ -75,9 +77,9 @@ where
     /// * `output_path` - Path to the JSONL file to write events to
     /// * `max_lines_per_file` - Maximum number of lines per file before rotating to a new file.
     ///   If None, no rotation will occur.
-    /// * `max_count` - Maximum number of events to record before shutting down.
-    ///   If None, no limit will be applied.
-    /// * `max_time` - Maximum duration in seconds to record before shutting down.
+    /// * `max_count` - Event count at which to stop admission and drain the accepted backlog.
+    ///   If None, no count limit will be applied.
+    /// * `max_time` - Duration in seconds before stopping admission and draining the backlog.
     ///   If None, no time limit will be applied.
     ///
     /// ### Returns
@@ -150,57 +152,54 @@ where
                 tokio::time::interval(flush_interval.unwrap_or(Duration::from_secs(1)));
             flush_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-            // Set up max time deadline if specified
-            let max_time_deadline = options.max_time.map(|secs| {
-                let duration = Duration::from_secs_f64(secs);
-                start_time + duration
-            });
+            let max_time_deadline = options
+                .max_time
+                .map(|secs| tokio::time::Instant::now() + Duration::from_secs_f64(secs));
+            let mut draining = false;
 
             loop {
-                if !closing_clone.is_cancelled()
-                    && let Some(deadline) = max_time_deadline
-                    && Instant::now() >= deadline
-                {
-                    tracing::info!("Recorder reached max time limit, shutting down");
-                    if let Err(e) = writer.flush().await {
-                        tracing::error!("Failed to flush on time limit shutdown: {}", e);
-                    }
-                    cancel_clone.cancel();
-                    return;
-                }
-
                 tokio::select! {
                     biased;
 
-                    _ = cancel_clone.cancelled(), if !closing_clone.is_cancelled() => {
+                    _ = closing_clone.cancelled(), if !draining => {
+                        event_rx.close();
+                        draining = true;
+                    }
+
+                    _ = cancel_clone.cancelled(), if !draining => {
                         // Select guards are evaluated once, so close must be checked again here.
+                        event_rx.close();
                         if closing_clone.is_cancelled() {
+                            draining = true;
                             continue;
                         }
+                        writer.flush().await?;
+                        return Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "recorder cancelled before graceful shutdown; queued events may be lost",
+                        ));
+                    }
 
-                        if let Err(e) = writer.flush().await {
-                            tracing::error!("Failed to flush on shutdown: {}", e);
+                    _ = async {
+                        if let Some(deadline) = max_time_deadline {
+                            tokio::time::sleep_until(deadline).await;
+                        } else {
+                            std::future::pending::<()>().await;
                         }
-
-                        tracing::debug!("Recorder task shutting down");
-                        return;
+                    }, if !draining => {
+                        event_rx.close();
+                        draining = true;
+                        cancel_clone.cancel();
+                        tracing::info!("Recorder reached max time limit, draining accepted events");
                     }
 
                     _ = flush_tick.tick(), if flush_interval.is_some() => {
-                        if let Err(e) = writer.flush().await {
-                            tracing::error!("Failed to flush on interval: {}", e);
-                        }
+                        writer.flush().await?;
                     }
 
                     event = event_rx.recv() => {
-                        // An explicit `None` arm lets close await the final flush.
                         let Some(event) = event else {
-                            if let Err(e) = writer.flush().await {
-                                tracing::error!("Failed to flush on channel close: {}", e);
-                            }
-
-                            tracing::debug!("Recorder task shutting down after channel close");
-                            return;
+                            return writer.flush().await;
                         };
 
                         // Update first_event_time if this is the first event
@@ -219,26 +218,10 @@ where
                             event,
                         };
 
-                        // Serialize to JSON string
-                        let json = match serde_json::to_string(&entry) {
-                            Ok(json) => json,
-                            Err(e) => {
-                                tracing::error!("Failed to serialize event: {}", e);
-                                continue;
-                            }
-                        };
-
-                        // Write JSON line
-                        if let Err(e) = writer.write_all(json.as_bytes()).await {
-                            tracing::error!("Failed to write event: {}", e);
-                            continue;
-                        }
-
-                        // Add a newline
-                        if let Err(e) = writer.write_all(b"\n").await {
-                            tracing::error!("Failed to write newline: {}", e);
-                            continue;
-                        }
+                        let json = serde_json::to_string(&entry)
+                            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                        writer.write_all(json.as_bytes()).await?;
+                        writer.write_all(b"\n").await?;
 
                         // Increment line count
                         line_count += 1;
@@ -247,9 +230,7 @@ where
                         if let Some(max_lines) = options.max_lines_per_file
                             && line_count >= max_lines {
                                 // Flush the current file
-                                if let Err(e) = writer.flush().await {
-                                    tracing::error!("Failed to flush file before rotation: {}", e);
-                                }
+                                writer.flush().await?;
 
                                 // Create new filename with suffix
                                 file_index += 1;
@@ -280,15 +261,13 @@ where
 
                         if let Some(max) = options.max_count
                             && *count >= max
-                            && !closing_clone.is_cancelled()
+                            && !draining
                         {
-                            tracing::info!("Recorder reached max event count ({}), shutting down", max);
-                            if let Err(e) = writer.flush().await {
-                                tracing::error!("Failed to flush on count limit shutdown: {}", e);
-                            }
+                            event_rx.close();
+                            draining = true;
                             drop(count);
                             cancel_clone.cancel();
-                            return;
+                            tracing::info!("Recorder reached max event count ({}), draining accepted events", max);
                         }
                     }
                 }
@@ -296,7 +275,7 @@ where
         });
 
         Ok(Self {
-            event_tx: Some(event_tx),
+            event_tx,
             cancel: token,
             closing,
             event_count,
@@ -307,10 +286,7 @@ where
 
     /// Get a sender that can be used to send events to the recorder
     pub fn event_sender(&self) -> mpsc::Sender<T> {
-        self.event_tx
-            .as_ref()
-            .expect("event_tx is only taken by close(), which consumes the recorder")
-            .clone()
+        self.event_tx.clone()
     }
 
     /// Get the count of recorded events
@@ -334,30 +310,31 @@ where
         self.cancel.cancel();
     }
 
-    /// Drains queued events and flushes the writer.
+    /// Stops admission, drains accepted events, and waits for the final flush.
     ///
-    /// Sender clones must be dropped first. Cancellation after close begins does
-    /// not interrupt the drain.
+    /// Sender clones may remain alive. Cancelling this future does not detach the
+    /// writer task; another call can await the same drain. A configured limit
+    /// stops admission but does not discard the accepted backlog.
     ///
     /// # Errors
     ///
-    /// Returns an error if the writer task panicked or cancellation preceded close.
-    pub async fn close(mut self) -> anyhow::Result<()> {
-        // Disable abrupt cancellation before closing the channel.
+    /// Returns writer I/O errors, task panics, or an abrupt cancellation that
+    /// stopped the writer before graceful shutdown took effect.
+    pub async fn shutdown_drain(&mut self) -> anyhow::Result<()> {
         self.closing.cancel();
-        let cancelled_before_close = self.cancel.is_cancelled();
-
-        drop(self.event_tx.take());
-        if let Some(writer_task) = self.writer_task.take() {
-            writer_task.await.context("recorder writer task panicked")?;
+        if let Some(writer_task) = self.writer_task.as_mut() {
+            let result = writer_task.await;
+            self.writer_task.take();
+            result
+                .context("recorder writer task panicked")?
+                .context("recorder writer failed")?;
         }
-
-        anyhow::ensure!(
-            !cancelled_before_close,
-            "recorder was already cancelled when close was called; \
-             events still queued at that point were abandoned"
-        );
         Ok(())
+    }
+
+    /// Drains accepted events, flushes, and consumes the recorder.
+    pub async fn close(mut self) -> anyhow::Result<()> {
+        self.shutdown_drain().await
     }
 
     /// Send events from a JSONL file to the provided event sender
@@ -884,10 +861,117 @@ mod tests {
             .unwrap();
 
         token.cancel();
+        // Let abrupt cancellation commit its terminal outcome before close starts.
+        tokio::time::timeout(Duration::from_secs(5), recorder.event_sender().closed())
+            .await
+            .expect("abrupt cancellation must close admission");
 
         recorder
             .close()
             .await
             .expect_err("close must not claim success after an earlier cancellation");
+    }
+
+    async fn limit_closes_admission_and_drains_permits(options: RecorderOptions) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("limit.jsonl");
+        let recorder: Recorder<BarrierEvent> =
+            Recorder::new_with_options(CancellationToken::new(), &path, options)
+                .await
+                .unwrap();
+        let sender = recorder.event_sender();
+        let permit = sender.reserve().await.unwrap();
+        sender
+            .send(BarrierEvent { id: 1, gate: None })
+            .await
+            .unwrap();
+
+        // A terminal limit must reject ordinary sends before the final flush.
+        tokio::time::timeout(Duration::from_secs(5), sender.closed())
+            .await
+            .expect("the configured limit must close admission");
+        assert!(
+            sender
+                .send(BarrierEvent { id: 3, gate: None })
+                .await
+                .is_err()
+        );
+        let mut close = Box::pin(recorder.close());
+        assert!(futures::poll!(close.as_mut()).is_pending());
+
+        // A permit issued before close is still an accepted channel reservation.
+        permit.send(BarrierEvent { id: 2, gate: None });
+        close.await.unwrap();
+        assert_eq!(recorded_ids(&path), vec![1, 2]);
+        // The sender deliberately remains alive throughout close.
+        drop(sender);
+    }
+
+    #[tokio::test]
+    async fn max_count_rejects_new_sends_and_drains_accepted_permits() {
+        limit_closes_admission_and_drains_permits(RecorderOptions {
+            max_count: Some(1),
+            ..Default::default()
+        })
+        .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn max_time_rejects_new_sends_and_drains_accepted_permits() {
+        limit_closes_admission_and_drains_permits(RecorderOptions {
+            max_time: Some(1.0),
+            ..Default::default()
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_shutdown_wait_can_be_resumed_with_live_senders() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("resume.jsonl");
+        let mut recorder: Recorder<BarrierEvent> =
+            Recorder::new_with_options(CancellationToken::new(), &path, RecorderOptions::default())
+                .await
+                .unwrap();
+        let sender = recorder.event_sender();
+        let permit = sender.reserve().await.unwrap();
+        {
+            let mut shutdown = Box::pin(recorder.shutdown_drain());
+            assert!(futures::poll!(shutdown.as_mut()).is_pending());
+            tokio::time::timeout(Duration::from_secs(5), sender.closed())
+                .await
+                .expect("graceful shutdown must close admission");
+        }
+        let mut shutdown = Box::pin(recorder.shutdown_drain());
+        assert!(futures::poll!(shutdown.as_mut()).is_pending());
+        permit.send(BarrierEvent { id: 1, gate: None });
+        shutdown.await.unwrap();
+        assert!(recorder.event_sender().is_closed());
+        assert_eq!(recorded_ids(&path), vec![1]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn close_propagates_final_flush_failure() {
+        let recorder: Recorder<BarrierEvent> = Recorder::new_with_options(
+            CancellationToken::new(),
+            "/dev/full",
+            RecorderOptions {
+                buffer_bytes: 1024 * 1024,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        recorder
+            .event_sender()
+            .send(BarrierEvent { id: 1, gate: None })
+            .await
+            .unwrap();
+        let error = recorder.close().await.unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<io::Error>().unwrap().raw_os_error(),
+            Some(28)
+        );
     }
 }

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -95,7 +95,8 @@ impl RequestTraceSink for NatsRequestTraceSink {
 }
 
 pub struct JsonlRequestTraceSink {
-    writer: JsonlWriter<RequestTraceRecord>,
+    /// `None` once the sink has been shut down; further records are dropped.
+    writer: tokio::sync::Mutex<Option<JsonlWriter<RequestTraceRecord>>>,
 }
 
 impl JsonlRequestTraceSink {
@@ -103,7 +104,9 @@ impl JsonlRequestTraceSink {
         let writer = JsonlWriter::new(path.clone(), options)
             .await
             .with_context(|| format!("opening jsonl request trace sink at {path}"))?;
-        Ok(Self { writer })
+        Ok(Self {
+            writer: tokio::sync::Mutex::new(Some(writer)),
+        })
     }
 
     async fn from_policy(policy: &RequestTracePolicy) -> anyhow::Result<Self> {
@@ -132,8 +135,24 @@ impl RequestTraceSink for JsonlRequestTraceSink {
     }
 
     async fn emit(&self, record: &RequestTraceRecord) {
-        if self.writer.send(record.clone()).await.is_err() {
-            tracing::warn!("request trace file sink closed; dropping record");
+        let guard = self.writer.lock().await;
+        match guard.as_ref() {
+            Some(writer) if writer.send(record.clone()).await.is_ok() => {}
+            _ => tracing::warn!("request trace file sink closed; dropping record"),
+        }
+    }
+
+    async fn shutdown(&self) {
+        // Take the writer out under a short-lived guard so the drain below is
+        // not awaited while the lock is held. Taking also makes this idempotent.
+        let writer = {
+            let mut guard = self.writer.lock().await;
+            guard.take()
+        };
+        if let Some(writer) = writer
+            && let Err(error) = writer.close().await
+        {
+            tracing::warn!(%error, "request trace file sink shutdown failed");
         }
     }
 }
@@ -368,6 +387,47 @@ mod tests {
         assert!(content.contains("\"schema\":\"dynamo.request.trace.v1\""));
         assert!(!content.contains("agent_context"));
         assert!(!content.contains("\"tool\""));
+    }
+
+    /// Records accepted by `emit` must survive shutdown. The buffer is 1 MiB
+    /// and the flush interval 60s, so nothing but the shutdown drain can get
+    /// them to disk, and the file is read once with no sleep or polling.
+    #[tokio::test]
+    async fn jsonl_sink_shutdown_flushes_accepted_records() {
+        const RECORDS: usize = 16;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("request_trace.jsonl");
+        let sink = JsonlRequestTraceSink::new(
+            path.display().to_string(),
+            JsonlSinkOptions {
+                buffer_bytes: 1024 * 1024,
+                flush_interval: Duration::from_secs(60),
+            },
+        )
+        .await
+        .unwrap();
+
+        for index in 0..RECORDS {
+            let mut record = sample_record();
+            if let Some(request) = record.request.as_mut() {
+                request.request_id = format!("req-{index}");
+            }
+            sink.emit(&record).await;
+        }
+
+        // Shutting down twice must be harmless.
+        RequestTraceSink::shutdown(&sink).await;
+        RequestTraceSink::shutdown(&sink).await;
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content.lines().count(), RECORDS);
+        for index in 0..RECORDS {
+            assert!(
+                content.contains(&format!("\"request_id\":\"req-{index}\"")),
+                "record {index} missing from the file after shutdown"
+            );
+        }
     }
 
     #[tokio::test]

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -146,8 +146,7 @@ impl RequestTraceSink for JsonlRequestTraceSink {
     }
 
     async fn shutdown(&self) {
-        // Take the writer out under a short-lived guard so the drain below is
-        // not awaited while the lock is held. Taking also makes this idempotent.
+        // Taking the writer makes shutdown idempotent without holding the lock while draining.
         let writer = {
             let mut guard = self.writer.lock().await;
             guard.take()
@@ -392,9 +391,6 @@ mod tests {
         assert!(!content.contains("\"tool\""));
     }
 
-    /// Records accepted by `emit` must survive shutdown. The buffer is 1 MiB
-    /// and the flush interval 60s, so nothing but the shutdown drain can get
-    /// them to disk, and the file is read once with no sleep or polling.
     #[tokio::test]
     async fn jsonl_sink_shutdown_flushes_accepted_records() {
         const RECORDS: usize = 16;
@@ -419,7 +415,6 @@ mod tests {
             sink.emit(&record).await;
         }
 
-        // Shutting down twice must be harmless.
         RequestTraceSink::shutdown(&sink).await;
         RequestTraceSink::shutdown(&sink).await;
 

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -136,9 +136,12 @@ impl RequestTraceSink for JsonlRequestTraceSink {
 
     async fn emit(&self, record: &RequestTraceRecord) {
         let guard = self.writer.lock().await;
-        match guard.as_ref() {
-            Some(writer) if writer.send(record.clone()).await.is_ok() => {}
-            _ => tracing::warn!("request trace file sink closed; dropping record"),
+        let sent = match guard.as_ref() {
+            Some(writer) => writer.send(record.clone()).await.is_ok(),
+            None => false,
+        };
+        if !sent {
+            tracing::warn!("request trace file sink closed; dropping record");
         }
     }
 

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -136,25 +136,24 @@ impl RequestTraceSink for JsonlRequestTraceSink {
 
     async fn emit(&self, record: &RequestTraceRecord) {
         let guard = self.writer.lock().await;
-        let sent = match guard.as_ref() {
-            Some(writer) => writer.send(record.clone()).await.is_ok(),
-            None => false,
-        };
-        if !sent {
-            tracing::warn!("request trace file sink closed; dropping record");
+        match guard.as_ref() {
+            Some(writer) => {
+                if writer.send(record.clone()).await.is_err() {
+                    tracing::warn!("request trace file writer channel closed; dropping record");
+                }
+            }
+            None => tracing::warn!("request trace file sink shut down; dropping record"),
         }
     }
 
     async fn shutdown(&self) {
-        // Taking the writer makes shutdown idempotent without holding the lock while draining.
-        let writer = {
-            let mut guard = self.writer.lock().await;
-            guard.take()
-        };
-        if let Some(writer) = writer
-            && let Err(error) = writer.close().await
-        {
-            tracing::warn!(%error, "request trace file sink shutdown failed");
+        // Serialize callers until the drain finishes, including concurrent shutdowns.
+        let mut guard = self.writer.lock().await;
+        if let Some(writer) = guard.as_mut() {
+            if let Err(error) = writer.shutdown().await {
+                tracing::warn!(%error, "request trace file sink shutdown failed");
+            }
+            guard.take();
         }
     }
 }

--- a/lib/llm/src/telemetry/jsonl.rs
+++ b/lib/llm/src/telemetry/jsonl.rs
@@ -25,15 +25,11 @@ impl Default for JsonlSinkOptions {
     }
 }
 
-/// Channel-backed handle for a buffered JSONL sink. Wraps a `Recorder<T>`,
-/// which appends records to disk on its own background task.
+/// Channel-backed buffered JSONL sink.
 ///
-/// Drop cancels the recorder, but cannot wait for its final flush and abandons
-/// whatever is still queued. Call [`Self::shutdown`] or [`Self::close`] when
-/// every accepted record must reach the file.
+/// Drop may abandon queued records; use [`Self::shutdown`] to drain them.
 pub struct JsonlWriter<T> {
     tx: Option<mpsc::Sender<T>>,
-    // Holding the recorder keeps its background task alive; its Drop cancels.
     recorder: Option<Recorder<T>>,
 }
 
@@ -65,13 +61,11 @@ where
     pub async fn send(&self, rec: T) -> Result<(), mpsc::error::SendError<T>> {
         match &self.tx {
             Some(tx) => tx.send(rec).await,
-            // After shutdown the sink behaves exactly like a closed channel.
             None => Err(mpsc::error::SendError(rec)),
         }
     }
 
-    /// Stop accepting records and wait for every already-accepted record to be
-    /// written and flushed. Idempotent: a second call is a no-op.
+    /// Stops accepting records, drains the queue, and flushes. Calls are idempotent.
     pub async fn shutdown(&mut self) -> anyhow::Result<()> {
         self.tx.take();
         if let Some(recorder) = self.recorder.take() {
@@ -80,7 +74,7 @@ where
         Ok(())
     }
 
-    /// Consuming form of [`Self::shutdown`].
+    /// Drains and consumes the writer.
     pub async fn close(mut self) -> anyhow::Result<()> {
         self.shutdown().await
     }
@@ -103,16 +97,13 @@ mod tests {
         name: String,
     }
 
-    /// Two-way handshake used to park the recorder's writer task inside
-    /// `Serialize` for as long as the test needs, with no sleeping on either
-    /// side: the writer announces it is parked, then blocks until released.
+    /// Parks the recorder inside `Serialize` without timing assumptions.
     struct BarrierGate {
         parked_tx: tokio::sync::mpsc::UnboundedSender<()>,
         release_rx: Mutex<std::sync::mpsc::Receiver<()>>,
     }
 
-    /// Test record whose serialization blocks on a [`BarrierGate`] when one is
-    /// attached. The gate is never serialized, so the on-disk shape is `{"id":N}`.
+    /// Record that can block during serialization.
     #[derive(Clone, Deserialize)]
     struct BarrierRecord {
         id: u64,
@@ -177,13 +168,6 @@ mod tests {
         );
     }
 
-    /// Every record accepted by `send` must reach the file once `shutdown`
-    /// returns, even when the writer task is still busy with an earlier record
-    /// and a queue has built up behind it.
-    ///
-    /// The buffer is 1 MiB and the flush interval 60s, so neither a size-based
-    /// flush nor a timer tick can rescue the queued records: only the drain on
-    /// channel close can.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shutdown_drains_records_queued_behind_a_busy_writer() {
         const RECORDS: u64 = 32;
@@ -208,7 +192,6 @@ mod tests {
             release_rx: Mutex::new(release_rx),
         });
 
-        // Record 1 parks the writer task inside its own serialization.
         writer
             .send(BarrierRecord {
                 id: 1,
@@ -218,7 +201,6 @@ mod tests {
             .unwrap();
         parked_rx.recv().await.expect("writer task parked");
 
-        // Records 2..=N are accepted into the channel while the writer is stuck.
         for id in 2..=RECORDS {
             writer
                 .send(BarrierRecord { id, gate: None })

--- a/lib/llm/src/telemetry/jsonl.rs
+++ b/lib/llm/src/telemetry/jsonl.rs
@@ -26,12 +26,15 @@ impl Default for JsonlSinkOptions {
 }
 
 /// Channel-backed handle for a buffered JSONL sink. Wraps a `Recorder<T>`,
-/// which appends records to disk on its own background task. Drop cancels
-/// the recorder.
+/// which appends records to disk on its own background task.
+///
+/// Drop cancels the recorder, but cannot wait for its final flush and abandons
+/// whatever is still queued. Call [`Self::shutdown`] or [`Self::close`] when
+/// every accepted record must reach the file.
 pub struct JsonlWriter<T> {
-    tx: mpsc::Sender<T>,
+    tx: Option<mpsc::Sender<T>>,
     // Holding the recorder keeps its background task alive; its Drop cancels.
-    _recorder: Recorder<T>,
+    recorder: Option<Recorder<T>>,
 }
 
 impl<T> JsonlWriter<T>
@@ -54,21 +57,42 @@ where
         .with_context(|| format!("opening jsonl sink at {path}"))?;
         let tx = recorder.event_sender();
         Ok(Self {
-            tx,
-            _recorder: recorder,
+            tx: Some(tx),
+            recorder: Some(recorder),
         })
     }
 
     pub async fn send(&self, rec: T) -> Result<(), mpsc::error::SendError<T>> {
-        self.tx.send(rec).await
+        match &self.tx {
+            Some(tx) => tx.send(rec).await,
+            // After shutdown the sink behaves exactly like a closed channel.
+            None => Err(mpsc::error::SendError(rec)),
+        }
+    }
+
+    /// Stop accepting records and wait for every already-accepted record to be
+    /// written and flushed. Idempotent: a second call is a no-op.
+    pub async fn shutdown(&mut self) -> anyhow::Result<()> {
+        self.tx.take();
+        if let Some(recorder) = self.recorder.take() {
+            recorder.close().await?;
+        }
+        Ok(())
+    }
+
+    /// Consuming form of [`Self::shutdown`].
+    pub async fn close(mut self) -> anyhow::Result<()> {
+        self.shutdown().await
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
-    use serde::{Deserialize, Serialize};
+    use serde::ser::SerializeStruct;
+    use serde::{Deserialize, Serialize, Serializer};
     use tempfile::tempdir;
 
     use super::{JsonlSinkOptions, JsonlWriter};
@@ -77,6 +101,36 @@ mod tests {
     struct TestRecord {
         id: u64,
         name: String,
+    }
+
+    /// Two-way handshake used to park the recorder's writer task inside
+    /// `Serialize` for as long as the test needs, with no sleeping on either
+    /// side: the writer announces it is parked, then blocks until released.
+    struct BarrierGate {
+        parked_tx: tokio::sync::mpsc::UnboundedSender<()>,
+        release_rx: Mutex<std::sync::mpsc::Receiver<()>>,
+    }
+
+    /// Test record whose serialization blocks on a [`BarrierGate`] when one is
+    /// attached. The gate is never serialized, so the on-disk shape is `{"id":N}`.
+    #[derive(Clone, Deserialize)]
+    struct BarrierRecord {
+        id: u64,
+        #[serde(skip)]
+        gate: Option<Arc<BarrierGate>>,
+    }
+
+    impl Serialize for BarrierRecord {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            if let Some(gate) = &self.gate {
+                gate.parked_tx.send(()).expect("test still listening");
+                // Ignore the result: a dropped release sender also releases us.
+                let _ = gate.release_rx.lock().unwrap().recv();
+            }
+            let mut state = serializer.serialize_struct("BarrierRecord", 1)?;
+            state.serialize_field("id", &self.id)?;
+            state.end()
+        }
     }
 
     #[tokio::test]
@@ -120,6 +174,74 @@ mod tests {
                 id: 1,
                 name: "record".to_string()
             }
+        );
+    }
+
+    /// Every record accepted by `send` must reach the file once `shutdown`
+    /// returns, even when the writer task is still busy with an earlier record
+    /// and a queue has built up behind it.
+    ///
+    /// The buffer is 1 MiB and the flush interval 60s, so neither a size-based
+    /// flush nor a timer tick can rescue the queued records: only the drain on
+    /// channel close can.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_drains_records_queued_behind_a_busy_writer() {
+        const RECORDS: u64 = 32;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("barrier.jsonl");
+
+        let writer: JsonlWriter<BarrierRecord> = JsonlWriter::new(
+            path.display().to_string(),
+            JsonlSinkOptions {
+                buffer_bytes: 1024 * 1024,
+                flush_interval: Duration::from_secs(60),
+            },
+        )
+        .await
+        .unwrap();
+
+        let (parked_tx, mut parked_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let gate = Arc::new(BarrierGate {
+            parked_tx,
+            release_rx: Mutex::new(release_rx),
+        });
+
+        // Record 1 parks the writer task inside its own serialization.
+        writer
+            .send(BarrierRecord {
+                id: 1,
+                gate: Some(gate),
+            })
+            .await
+            .unwrap();
+        parked_rx.recv().await.expect("writer task parked");
+
+        // Records 2..=N are accepted into the channel while the writer is stuck.
+        for id in 2..=RECORDS {
+            writer
+                .send(BarrierRecord { id, gate: None })
+                .await
+                .expect("send accepted while writer is busy");
+        }
+
+        let shutdown = tokio::spawn(async move { writer.close().await });
+        release_tx.send(()).expect("writer task waiting on release");
+        shutdown.await.unwrap().expect("shutdown");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let ids: Vec<u64> = content
+            .lines()
+            .map(|line| {
+                let wrapper: serde_json::Value = serde_json::from_str(line).unwrap();
+                wrapper["event"]["id"].as_u64().unwrap()
+            })
+            .collect();
+        assert_eq!(
+            ids,
+            (1..=RECORDS).collect::<Vec<_>>(),
+            "every accepted record must be written exactly once, in order"
         );
     }
 }

--- a/lib/llm/src/telemetry/jsonl.rs
+++ b/lib/llm/src/telemetry/jsonl.rs
@@ -66,10 +66,13 @@ where
     }
 
     /// Stops accepting records, drains the queue, and flushes. Calls are idempotent.
+    /// The writer remains closed if draining fails; subsequent sends fail.
     pub async fn shutdown(&mut self) -> anyhow::Result<()> {
         self.tx.take();
-        if let Some(recorder) = self.recorder.take() {
-            recorder.close().await?;
+        if let Some(recorder) = self.recorder.as_mut() {
+            let result = recorder.shutdown_drain().await;
+            self.recorder.take();
+            result?;
         }
         Ok(())
     }
@@ -225,5 +228,48 @@ mod tests {
             (1..=RECORDS).collect::<Vec<_>>(),
             "every accepted record must be written exactly once, in order"
         );
+    }
+
+    #[tokio::test]
+    async fn cancelled_shutdown_retains_the_pending_drain() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("resume.jsonl");
+        let mut writer: JsonlWriter<TestRecord> =
+            JsonlWriter::new(path.display().to_string(), JsonlSinkOptions::default())
+                .await
+                .unwrap();
+        let sender = writer.tx.as_ref().unwrap().clone();
+        let permit = sender.reserve().await.unwrap();
+        {
+            let mut shutdown = Box::pin(writer.shutdown());
+            assert!(futures::poll!(shutdown.as_mut()).is_pending());
+            tokio::time::timeout(Duration::from_secs(5), sender.closed())
+                .await
+                .expect("graceful shutdown must close admission");
+        }
+        assert!(
+            writer
+                .send(TestRecord {
+                    id: 2,
+                    name: "late".into()
+                })
+                .await
+                .is_err()
+        );
+        let mut shutdown = Box::pin(writer.shutdown());
+        assert!(futures::poll!(shutdown.as_mut()).is_pending());
+        permit.send(TestRecord {
+            id: 1,
+            name: "accepted".into(),
+        });
+        shutdown.await.unwrap();
+        writer.shutdown().await.unwrap();
+        let lines = std::fs::read_to_string(path).unwrap();
+        let records: Vec<serde_json::Value> = lines
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["event"]["id"], 1);
     }
 }


### PR DESCRIPTION
## Summary

The plain JSONL request-trace sink could accept records and stop before queued data reached its file. Graceful shutdown now closes receiver admission, drains accepted records and outstanding channel permits through the normal accounting and rotation path, and awaits the writer's final flush. Configured count and time limits stop admission but allow the accepted backlog to drain.

Writer errors and prior abrupt cancellation are reported to callers. Cancelling a shutdown wait retains the task handle so another call can await completion. JsonlWriter retains its recorder during that wait, and the request-trace sink serializes concurrent shutdown callers. The same recorder implementation is used in #13298 and #13415; gzip-specific behavior is covered by #13298.

## Validation

Regressions cover count/time limits with outstanding permits, late-send rejection, live sender clones, resumed shutdown waits, cancellation during drain, and final flush failure. These regressions, Pre Merge, and the full PR workflow passed in GitHub CI on `819ac191680a`. The TRTLLM retry completed with 14 parallel GPU tests and 193 sequential tests passing after the original runner interruption. Closes #13385.
