### PR TITLE
fix(runtime): stop stalled health-check drains from lingering

### DIFF
--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -230,7 +230,10 @@ impl HealthCheckManager {
 
         // Spawn task to send health check and wait for response
         tokio::spawn(async move {
-            let result = tokio::time::timeout(timeout, async {
+            // One deadline for the whole canary: the request and the drain that follows it
+            // share it, so a single slow response cannot buy the drain a second full budget.
+            let deadline = tokio::time::Instant::now() + timeout;
+            let result = tokio::time::timeout_at(deadline, async {
                 let request = SingleIn::new(payload);
                 match engine.generate(request).await {
                     Ok(mut response_stream) => {
@@ -257,17 +260,16 @@ impl HealthCheckManager {
 
                         // We need to consume the rest of the stream to avoid warnings on the
                         // frontend. This stays on its own task so a slow tail cannot delay
-                        // the health-status write below, and it is bounded by the same
-                        // request timeout so a stream that never closes cannot park it
-                        // forever.
+                        // the health-status write below, and it runs against the canary's
+                        // deadline so a stream that never closes cannot park it forever.
                         let drain_subject = endpoint_subject_owned.clone();
                         tokio::spawn(async move {
-                            match drain_response_stream(response_stream, timeout, drain_cancel)
+                            match drain_response_stream(response_stream, deadline, drain_cancel)
                                 .await
                             {
                                 DrainOutcome::Completed => {}
                                 DrainOutcome::TimedOut => warn!(
-                                    "Health check response stream from {} did not close within {:?}; abandoning the remainder",
+                                    "Health check response stream from {} did not close within the {:?} health check budget; abandoning the remainder",
                                     drain_subject, timeout
                                 ),
                                 DrainOutcome::Cancelled => debug!(
@@ -316,20 +318,31 @@ impl HealthCheckManager {
     }
 }
 
+/// How long the drain keeps reading after signalling `stop_generating()`, so an engine that
+/// only observes the stop on its next poll can flush and close instead of writing into a
+/// receiver that has already gone away.
+const STOP_GRACE: Duration = Duration::from_millis(100);
+
 /// Consume whatever is left of a canary response stream, under an explicit lifetime bound.
 ///
 /// The remainder has to be read rather than dropped outright, or the frontend logs warnings
 /// about an abandoned response stream. But a backend that emits one item and then never
-/// closes its stream must not be able to park this task forever: `budget` caps the wait and
-/// `cancel` releases it on runtime shutdown. When either fires, the engine is told to stop
-/// producing before the stream is dropped, so the producer is not left writing into a
-/// receiver nobody reads.
+/// closes its stream must not be able to park this task forever: `deadline` caps the wait and
+/// `cancel` releases it on runtime shutdown. `deadline` is the canary's own deadline, shared
+/// with the request that produced the stream, so the two cannot bound the same health check
+/// twice.
+///
+/// When the wait ends without the stream closing, the engine is told to stop producing and
+/// the stream is then polled for a further [`STOP_GRACE`] before being dropped. Signalling
+/// and dropping in the same breath would leave the producer facing a vanished receiver — the
+/// case the stop signal exists to avoid — because nothing would have polled the stream
+/// between the two.
 ///
 /// The outcome of the drain never affects the recorded health status. The endpoint answered;
 /// whether its tail was well-behaved is a separate question.
 async fn drain_response_stream<S>(
     mut stream: S,
-    budget: Duration,
+    deadline: tokio::time::Instant,
     cancel: CancellationToken,
 ) -> DrainOutcome
 where
@@ -339,12 +352,15 @@ where
 
     let outcome = tokio::select! {
         _ = (&mut stream).for_each(|_| async {}) => DrainOutcome::Completed,
-        _ = tokio::time::sleep(budget) => DrainOutcome::TimedOut,
+        _ = tokio::time::sleep_until(deadline) => DrainOutcome::TimedOut,
         _ = cancel.cancelled() => DrainOutcome::Cancelled,
     };
 
     if outcome != DrainOutcome::Completed {
         context.stop_generating();
+        // Bounded, and deliberately not selected against `cancel`: on shutdown this is the
+        // window that lets the producer notice the stop, and it is short enough to spend.
+        let _ = tokio::time::timeout(STOP_GRACE, (&mut stream).for_each(|_| async {})).await;
     }
 
     outcome
@@ -505,12 +521,12 @@ mod bounded_drain_tests {
             Duration::from_secs(5),
             drain_response_stream(
                 response_stream,
-                Duration::from_millis(100),
+                tokio::time::Instant::now() + Duration::from_millis(100),
                 CancellationToken::new(),
             ),
         )
         .await
-        .expect("drain must return once its budget elapses");
+        .expect("drain must return once its deadline passes");
 
         assert_eq!(outcome, DrainOutcome::TimedOut);
         assert_eq!(
@@ -541,10 +557,14 @@ mod bounded_drain_tests {
 
         let outcome = tokio::time::timeout(
             Duration::from_secs(5),
-            drain_response_stream(response_stream, Duration::from_secs(3600), cancel),
+            drain_response_stream(
+                response_stream,
+                tokio::time::Instant::now() + Duration::from_secs(3600),
+                cancel,
+            ),
         )
         .await
-        .expect("a cancelled drain must return without waiting out its budget");
+        .expect("a cancelled drain must return without waiting out its deadline");
 
         assert_eq!(outcome, DrainOutcome::Cancelled);
         assert_eq!(live.load(Ordering::SeqCst), 0);
@@ -561,7 +581,7 @@ mod bounded_drain_tests {
             let response_stream = one_item_then_pending(&live);
             handles.push(tokio::spawn(drain_response_stream(
                 response_stream,
-                Duration::from_millis(100),
+                tokio::time::Instant::now() + Duration::from_millis(100),
                 CancellationToken::new(),
             )));
         }
@@ -600,7 +620,7 @@ mod bounded_drain_tests {
         let started = std::time::Instant::now();
         let outcome = drain_response_stream(
             response_stream,
-            Duration::from_secs(3600),
+            tokio::time::Instant::now() + Duration::from_secs(3600),
             CancellationToken::new(),
         )
         .await;
@@ -613,13 +633,106 @@ mod bounded_drain_tests {
         );
         assert!(
             started.elapsed() < Duration::from_secs(5),
-            "a terminating stream must return on its own, not on the budget"
+            "a terminating stream must return on its own, not on the deadline"
         );
         assert_eq!(live.load(Ordering::SeqCst), 0);
         assert!(
             !context.is_stopped(),
             "a stream that ended on its own needs no stop signal"
         );
+    }
+
+    /// The drain shares the canary's deadline rather than starting a fresh budget, so a
+    /// request that already spent the whole budget leaves the drain nothing to spend. Without
+    /// this, a slow first response and a non-closing tail together hold a canary for close to
+    /// twice `request_timeout`.
+    #[tokio::test]
+    async fn drain_does_not_extend_a_deadline_the_request_already_spent() {
+        let live = Arc::new(AtomicUsize::new(0));
+        let response_stream = one_item_then_pending(&live);
+
+        // What `send_health_check_request` would pass after the request consumed the budget.
+        let spent = tokio::time::Instant::now();
+
+        let started = std::time::Instant::now();
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            drain_response_stream(response_stream, spent, CancellationToken::new()),
+        )
+        .await
+        .expect("an already-spent deadline must not buy the drain a second budget");
+
+        assert_eq!(outcome, DrainOutcome::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "the drain must give up at once, not wait out a fresh budget of its own"
+        );
+        assert_eq!(live.load(Ordering::SeqCst), 0);
+    }
+
+    /// A producer that only notices `stop_generating()` on its next poll must still get that
+    /// poll. Signalling and dropping in the same breath would strand it against a receiver
+    /// that is already gone — the condition the stop signal exists to prevent.
+    #[tokio::test]
+    async fn drain_keeps_reading_after_the_stop_signal() {
+        let flushed = Arc::new(AtomicUsize::new(0));
+
+        let context = Context::new(()).context();
+        let inner = FlushOnStopStream {
+            context: context.clone(),
+            flushed: flushed.clone(),
+            done: false,
+        };
+        let response_stream: ManyOut<TestResponse> =
+            ResponseStream::new(Box::pin(inner), context.clone());
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            drain_response_stream(
+                response_stream,
+                tokio::time::Instant::now() + Duration::from_millis(50),
+                CancellationToken::new(),
+            ),
+        )
+        .await
+        .expect("the grace window must be bounded");
+
+        assert_eq!(outcome, DrainOutcome::TimedOut);
+        assert!(context.is_stopped());
+        assert_eq!(
+            flushed.load(Ordering::SeqCst),
+            1,
+            "the stream must be polled again after the stop signal, not dropped unread"
+        );
+    }
+
+    /// Yields nothing until the engine is told to stop, then flushes one final item and
+    /// closes. Before the stop it parks without registering a waker, which is what an engine
+    /// waiting on its own producer looks like from here.
+    struct FlushOnStopStream {
+        context: Arc<dyn AsyncEngineContext>,
+        flushed: Arc<AtomicUsize>,
+        done: bool,
+    }
+
+    impl Stream for FlushOnStopStream {
+        type Item = TestResponse;
+
+        fn poll_next(
+            self: Pin<&mut Self>,
+            _cx: &mut TaskContext<'_>,
+        ) -> Poll<Option<TestResponse>> {
+            let me = self.get_mut();
+            if !me.context.is_stopped() {
+                return Poll::Pending;
+            }
+            if !me.done {
+                me.done = true;
+                me.flushed.fetch_add(1, Ordering::SeqCst);
+                return Poll::Ready(Some(healthy_item()));
+            }
+            Poll::Ready(None)
+        }
     }
 }
 

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -224,14 +224,11 @@ impl HealthCheckManager {
         let endpoint_subject_owned = endpoint_subject.to_string();
         let payload = payload.clone();
         let timeout = self.config.request_timeout;
-        // Child of the runtime's endpoint shutdown token, so an in-flight drain is released
-        // when the runtime goes down and deregisters from the token tree when it ends.
+        // Runtime shutdown cancels any drain that is still waiting on its stream.
         let drain_cancel = self.drt.child_token();
 
         // Spawn task to send health check and wait for response
         tokio::spawn(async move {
-            // One deadline for the whole canary: the request and the drain that follows it
-            // share it, so a single slow response cannot buy the drain a second full budget.
             let deadline = tokio::time::Instant::now() + timeout;
             let result = tokio::time::timeout_at(deadline, async {
                 let request = SingleIn::new(payload);
@@ -258,10 +255,7 @@ impl HealthCheckManager {
                             false
                         };
 
-                        // We need to consume the rest of the stream to avoid warnings on the
-                        // frontend. This stays on its own task so a slow tail cannot delay
-                        // the health-status write below, and it runs against the canary's
-                        // deadline so a stream that never closes cannot park it forever.
+                        // Drain separately so a slow tail does not delay the health verdict.
                         let drain_subject = endpoint_subject_owned.clone();
                         tokio::spawn(async move {
                             match drain_response_stream(response_stream, deadline, drain_cancel)
@@ -318,28 +312,9 @@ impl HealthCheckManager {
     }
 }
 
-/// How long the drain keeps reading after signalling `stop_generating()`, so an engine that
-/// only observes the stop on its next poll can flush and close instead of writing into a
-/// receiver that has already gone away.
 const STOP_GRACE: Duration = Duration::from_millis(100);
 
-/// Consume whatever is left of a canary response stream, under an explicit lifetime bound.
-///
-/// The remainder has to be read rather than dropped outright, or the frontend logs warnings
-/// about an abandoned response stream. But a backend that emits one item and then never
-/// closes its stream must not be able to park this task forever: `deadline` caps the wait and
-/// `cancel` releases it on runtime shutdown. `deadline` is the canary's own deadline, shared
-/// with the request that produced the stream, so the two cannot bound the same health check
-/// twice.
-///
-/// When the wait ends without the stream closing, the engine is told to stop producing and
-/// the stream is then polled for a further [`STOP_GRACE`] before being dropped. Signalling
-/// and dropping in the same breath would leave the producer facing a vanished receiver — the
-/// case the stop signal exists to avoid — because nothing would have polled the stream
-/// between the two.
-///
-/// The outcome of the drain never affects the recorded health status. The endpoint answered;
-/// whether its tail was well-behaved is a separate question.
+/// Drain a canary response until completion, its shared deadline, or runtime shutdown.
 async fn drain_response_stream<S>(
     mut stream: S,
     deadline: tokio::time::Instant,
@@ -358,22 +333,17 @@ where
 
     if outcome != DrainOutcome::Completed {
         context.stop_generating();
-        // Bounded, and deliberately not selected against `cancel`: on shutdown this is the
-        // window that lets the producer notice the stop, and it is short enough to spend.
+        // Keep polling briefly so the producer can observe the stop signal.
         let _ = tokio::time::timeout(STOP_GRACE, (&mut stream).for_each(|_| async {})).await;
     }
 
     outcome
 }
 
-/// How a call to [`drain_response_stream`] ended.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DrainOutcome {
-    /// The stream ended on its own and was read to completion.
     Completed,
-    /// The budget elapsed first; the remainder was abandoned.
     TimedOut,
-    /// The cancellation token fired first; the remainder was abandoned.
     Cancelled,
 }
 
@@ -432,12 +402,6 @@ pub async fn get_health_check_status(
     }))
 }
 
-// ============================================================
-// Bounded-drain tests. These run at default features on purpose: the two modules below
-// need a live NATS server via `create_test_drt_async` and are gated behind
-// `feature = "integration"`, so a regression test placed in either would not run under
-// `cargo test -p dynamo-runtime --lib`.
-// ============================================================
 #[cfg(test)]
 mod bounded_drain_tests {
     use super::*;
@@ -451,8 +415,6 @@ mod bounded_drain_tests {
 
     type TestResponse = Annotated<serde_json::Value>;
 
-    /// Decrements a shared counter when dropped, so a test can observe the moment the
-    /// drain actually releases a response stream instead of inferring it from timing.
     struct DropProbe(Arc<AtomicUsize>);
 
     impl DropProbe {
@@ -468,7 +430,6 @@ mod bounded_drain_tests {
         }
     }
 
-    /// Carries a [`DropProbe`] for the lifetime of the wrapped stream.
     struct ProbedStream<S> {
         inner: S,
         _probe: DropProbe,
@@ -482,8 +443,6 @@ mod bounded_drain_tests {
         }
     }
 
-    /// Wraps `inner` into the same `ManyOut` shape the canary receives from a local engine,
-    /// with a drop probe attached to the stream itself.
     fn probed_response_stream<S>(inner: S, live: &Arc<AtomicUsize>) -> ManyOut<TestResponse>
     where
         S: Stream<Item = TestResponse> + Unpin + Send + 'static,
@@ -499,8 +458,6 @@ mod bounded_drain_tests {
         Annotated::from_data(serde_json::json!({"token": "ok"}))
     }
 
-    /// One healthy item, then a tail that never yields and never closes — the backend
-    /// shape described in the issue.
     fn one_item_then_pending(live: &Arc<AtomicUsize>) -> ManyOut<TestResponse> {
         probed_response_stream(
             stream::iter([healthy_item()]).chain(stream::pending()),
@@ -508,8 +465,6 @@ mod bounded_drain_tests {
         )
     }
 
-    /// A non-terminating response stream must be released once the budget elapses, not
-    /// held for the life of the process.
     #[tokio::test]
     async fn bounded_drain_releases_a_stream_that_never_closes() {
         let live = Arc::new(AtomicUsize::new(0));
@@ -540,8 +495,6 @@ mod bounded_drain_tests {
         );
     }
 
-    /// Runtime shutdown must release an in-flight drain rather than leaving it parked for
-    /// the remainder of its budget.
     #[tokio::test]
     async fn cancelled_drain_releases_the_stream_before_the_budget_elapses() {
         let live = Arc::new(AtomicUsize::new(0));
@@ -571,7 +524,6 @@ mod bounded_drain_tests {
         assert!(context.is_stopped());
     }
 
-    /// Several canary intervals in a row must not accumulate live response streams.
     #[tokio::test]
     async fn repeated_drains_do_not_accumulate_live_streams() {
         let live = Arc::new(AtomicUsize::new(0));
@@ -602,8 +554,6 @@ mod bounded_drain_tests {
         );
     }
 
-    /// Negative control: a well-behaved stream must still be drained to completion, which
-    /// is why the drain exists at all (dropping it early produces frontend warnings).
     #[tokio::test]
     async fn terminating_stream_is_drained_completely_and_promptly() {
         let live = Arc::new(AtomicUsize::new(0));
@@ -642,16 +592,11 @@ mod bounded_drain_tests {
         );
     }
 
-    /// The drain shares the canary's deadline rather than starting a fresh budget, so a
-    /// request that already spent the whole budget leaves the drain nothing to spend. Without
-    /// this, a slow first response and a non-closing tail together hold a canary for close to
-    /// twice `request_timeout`.
     #[tokio::test]
     async fn drain_does_not_extend_a_deadline_the_request_already_spent() {
         let live = Arc::new(AtomicUsize::new(0));
         let response_stream = one_item_then_pending(&live);
 
-        // What `send_health_check_request` would pass after the request consumed the budget.
         let spent = tokio::time::Instant::now();
 
         let started = std::time::Instant::now();
@@ -670,9 +615,6 @@ mod bounded_drain_tests {
         assert_eq!(live.load(Ordering::SeqCst), 0);
     }
 
-    /// A producer that only notices `stop_generating()` on its next poll must still get that
-    /// poll. Signalling and dropping in the same breath would strand it against a receiver
-    /// that is already gone — the condition the stop signal exists to prevent.
     #[tokio::test]
     async fn drain_keeps_reading_after_the_stop_signal() {
         let flushed = Arc::new(AtomicUsize::new(0));
@@ -706,9 +648,6 @@ mod bounded_drain_tests {
         );
     }
 
-    /// Yields nothing until the engine is told to stop, then flushes one final item and
-    /// closes. Before the stop it parks without registering a waker, which is what an engine
-    /// waiting on its own producer looks like from here.
     struct FlushOnStopStream {
         context: Arc<dyn AsyncEngineContext>,
         flushed: Arc<AtomicUsize>,

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -3,15 +3,16 @@
 
 use crate::DistributedRuntime;
 use crate::config::HealthStatus;
-use crate::engine::AsyncEngine;
+use crate::engine::{AsyncEngine, AsyncEngineContextProvider};
 use crate::pipeline::SingleIn;
 use crate::protocols::maybe_error::MaybeError;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 /// Configuration for health check behavior
@@ -223,6 +224,9 @@ impl HealthCheckManager {
         let endpoint_subject_owned = endpoint_subject.to_string();
         let payload = payload.clone();
         let timeout = self.config.request_timeout;
+        // Child of the runtime's endpoint shutdown token, so an in-flight drain is released
+        // when the runtime goes down and deregisters from the token tree when it ends.
+        let drain_cancel = self.drt.child_token();
 
         // Spawn task to send health check and wait for response
         tokio::spawn(async move {
@@ -251,9 +255,26 @@ impl HealthCheckManager {
                             false
                         };
 
+                        // We need to consume the rest of the stream to avoid warnings on the
+                        // frontend. This stays on its own task so a slow tail cannot delay
+                        // the health-status write below, and it is bounded by the same
+                        // request timeout so a stream that never closes cannot park it
+                        // forever.
+                        let drain_subject = endpoint_subject_owned.clone();
                         tokio::spawn(async move {
-                            // We need to consume the rest of the stream to avoid warnings on the frontend.
-                            response_stream.for_each(|_| async {}).await;
+                            match drain_response_stream(response_stream, timeout, drain_cancel)
+                                .await
+                            {
+                                DrainOutcome::Completed => {}
+                                DrainOutcome::TimedOut => warn!(
+                                    "Health check response stream from {} did not close within {:?}; abandoning the remainder",
+                                    drain_subject, timeout
+                                ),
+                                DrainOutcome::Cancelled => debug!(
+                                    "Runtime shutdown released the health check response drain for {}",
+                                    drain_subject
+                                ),
+                            }
                         });
 
                         // Update health status based on response
@@ -293,6 +314,51 @@ impl HealthCheckManager {
 
         Ok(())
     }
+}
+
+/// Consume whatever is left of a canary response stream, under an explicit lifetime bound.
+///
+/// The remainder has to be read rather than dropped outright, or the frontend logs warnings
+/// about an abandoned response stream. But a backend that emits one item and then never
+/// closes its stream must not be able to park this task forever: `budget` caps the wait and
+/// `cancel` releases it on runtime shutdown. When either fires, the engine is told to stop
+/// producing before the stream is dropped, so the producer is not left writing into a
+/// receiver nobody reads.
+///
+/// The outcome of the drain never affects the recorded health status. The endpoint answered;
+/// whether its tail was well-behaved is a separate question.
+async fn drain_response_stream<S>(
+    mut stream: S,
+    budget: Duration,
+    cancel: CancellationToken,
+) -> DrainOutcome
+where
+    S: Stream + AsyncEngineContextProvider + Unpin,
+{
+    let context = stream.context();
+
+    let outcome = tokio::select! {
+        _ = (&mut stream).for_each(|_| async {}) => DrainOutcome::Completed,
+        _ = tokio::time::sleep(budget) => DrainOutcome::TimedOut,
+        _ = cancel.cancelled() => DrainOutcome::Cancelled,
+    };
+
+    if outcome != DrainOutcome::Completed {
+        context.stop_generating();
+    }
+
+    outcome
+}
+
+/// How a call to [`drain_response_stream`] ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DrainOutcome {
+    /// The stream ended on its own and was read to completion.
+    Completed,
+    /// The budget elapsed first; the remainder was abandoned.
+    TimedOut,
+    /// The cancellation token fired first; the remainder was abandoned.
+    Cancelled,
 }
 
 /// Start health check manager for the distributed runtime
@@ -348,6 +414,213 @@ pub async fn get_health_check_status(
         "endpoints_checked": endpoint_subjects.len(),
         "endpoint_statuses": endpoint_statuses,
     }))
+}
+
+// ============================================================
+// Bounded-drain tests. These run at default features on purpose: the two modules below
+// need a live NATS server via `create_test_drt_async` and are gated behind
+// `feature = "integration"`, so a regression test placed in either would not run under
+// `cargo test -p dynamo-runtime --lib`.
+// ============================================================
+#[cfg(test)]
+mod bounded_drain_tests {
+    use super::*;
+    use crate::engine::AsyncEngineContext;
+    use crate::pipeline::{Context, ManyOut, ResponseStream};
+    use crate::protocols::annotated::Annotated;
+    use futures::stream::{self, Stream, StreamExt};
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context as TaskContext, Poll};
+
+    type TestResponse = Annotated<serde_json::Value>;
+
+    /// Decrements a shared counter when dropped, so a test can observe the moment the
+    /// drain actually releases a response stream instead of inferring it from timing.
+    struct DropProbe(Arc<AtomicUsize>);
+
+    impl DropProbe {
+        fn new(live: &Arc<AtomicUsize>) -> Self {
+            live.fetch_add(1, Ordering::SeqCst);
+            Self(live.clone())
+        }
+    }
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Carries a [`DropProbe`] for the lifetime of the wrapped stream.
+    struct ProbedStream<S> {
+        inner: S,
+        _probe: DropProbe,
+    }
+
+    impl<S: Stream + Unpin> Stream for ProbedStream<S> {
+        type Item = S::Item;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Option<S::Item>> {
+            Pin::new(&mut self.get_mut().inner).poll_next(cx)
+        }
+    }
+
+    /// Wraps `inner` into the same `ManyOut` shape the canary receives from a local engine,
+    /// with a drop probe attached to the stream itself.
+    fn probed_response_stream<S>(inner: S, live: &Arc<AtomicUsize>) -> ManyOut<TestResponse>
+    where
+        S: Stream<Item = TestResponse> + Unpin + Send + 'static,
+    {
+        let probed = ProbedStream {
+            inner,
+            _probe: DropProbe::new(live),
+        };
+        ResponseStream::new(Box::pin(probed), Context::new(()).context())
+    }
+
+    fn healthy_item() -> TestResponse {
+        Annotated::from_data(serde_json::json!({"token": "ok"}))
+    }
+
+    /// One healthy item, then a tail that never yields and never closes — the backend
+    /// shape described in the issue.
+    fn one_item_then_pending(live: &Arc<AtomicUsize>) -> ManyOut<TestResponse> {
+        probed_response_stream(
+            stream::iter([healthy_item()]).chain(stream::pending()),
+            live,
+        )
+    }
+
+    /// A non-terminating response stream must be released once the budget elapses, not
+    /// held for the life of the process.
+    #[tokio::test]
+    async fn bounded_drain_releases_a_stream_that_never_closes() {
+        let live = Arc::new(AtomicUsize::new(0));
+        let response_stream = one_item_then_pending(&live);
+        let context: Arc<dyn AsyncEngineContext> = response_stream.context();
+        assert_eq!(live.load(Ordering::SeqCst), 1);
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            drain_response_stream(
+                response_stream,
+                Duration::from_millis(100),
+                CancellationToken::new(),
+            ),
+        )
+        .await
+        .expect("drain must return once its budget elapses");
+
+        assert_eq!(outcome, DrainOutcome::TimedOut);
+        assert_eq!(
+            live.load(Ordering::SeqCst),
+            0,
+            "the response stream must be dropped when the drain gives up"
+        );
+        assert!(
+            context.is_stopped(),
+            "the engine must be told to stop producing before the stream is dropped"
+        );
+    }
+
+    /// Runtime shutdown must release an in-flight drain rather than leaving it parked for
+    /// the remainder of its budget.
+    #[tokio::test]
+    async fn cancelled_drain_releases_the_stream_before_the_budget_elapses() {
+        let live = Arc::new(AtomicUsize::new(0));
+        let response_stream = one_item_then_pending(&live);
+        let context: Arc<dyn AsyncEngineContext> = response_stream.context();
+
+        let cancel = CancellationToken::new();
+        let canceller = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            canceller.cancel();
+        });
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            drain_response_stream(response_stream, Duration::from_secs(3600), cancel),
+        )
+        .await
+        .expect("a cancelled drain must return without waiting out its budget");
+
+        assert_eq!(outcome, DrainOutcome::Cancelled);
+        assert_eq!(live.load(Ordering::SeqCst), 0);
+        assert!(context.is_stopped());
+    }
+
+    /// Several canary intervals in a row must not accumulate live response streams.
+    #[tokio::test]
+    async fn repeated_drains_do_not_accumulate_live_streams() {
+        let live = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+
+        for _ in 0..5 {
+            let response_stream = one_item_then_pending(&live);
+            handles.push(tokio::spawn(drain_response_stream(
+                response_stream,
+                Duration::from_millis(100),
+                CancellationToken::new(),
+            )));
+        }
+        assert_eq!(live.load(Ordering::SeqCst), 5, "five canary intervals ran");
+
+        for handle in handles {
+            let outcome = tokio::time::timeout(Duration::from_secs(5), handle)
+                .await
+                .expect("every drain must end within its budget")
+                .expect("drain task must not panic");
+            assert_eq!(outcome, DrainOutcome::TimedOut);
+        }
+
+        assert_eq!(
+            live.load(Ordering::SeqCst),
+            0,
+            "live response streams must return to zero rather than grow per interval"
+        );
+    }
+
+    /// Negative control: a well-behaved stream must still be drained to completion, which
+    /// is why the drain exists at all (dropping it early produces frontend warnings).
+    #[tokio::test]
+    async fn terminating_stream_is_drained_completely_and_promptly() {
+        let live = Arc::new(AtomicUsize::new(0));
+        let consumed = Arc::new(AtomicUsize::new(0));
+        let counter = consumed.clone();
+
+        let inner = stream::iter(0..4).map(move |_| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            healthy_item()
+        });
+        let response_stream = probed_response_stream(Box::pin(inner), &live);
+        let context: Arc<dyn AsyncEngineContext> = response_stream.context();
+
+        let started = std::time::Instant::now();
+        let outcome = drain_response_stream(
+            response_stream,
+            Duration::from_secs(3600),
+            CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(outcome, DrainOutcome::Completed);
+        assert_eq!(
+            consumed.load(Ordering::SeqCst),
+            4,
+            "every item must still be consumed; the bound must not truncate a healthy stream"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "a terminating stream must return on its own, not on the budget"
+        );
+        assert_eq!(live.load(Ordering::SeqCst), 0);
+        assert!(
+            !context.is_stopped(),
+            "a stream that ended on its own needs no stop signal"
+        );
+    }
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

The health-check canary used to inspect the first response item and then drain the rest of the stream in a detached task with no deadline or cancellation. If an endpoint produced one item and never closed the stream, every canary interval left another task holding the response stream and engine context.

The request and its background drain now share one deadline. Runtime shutdown also cancels the drain. When either limit is reached, the canary asks the engine to stop generating and keeps polling for up to 100 ms so the producer can observe that signal before the stream is dropped. Streams that close normally are still consumed completely, and the drain result does not change the endpoint's health status.

Six focused unit tests cover timeout, shutdown cancellation, repeated drains, the shared deadline, polling after the stop signal, and normal completion.

Closes #13429

## Validation

- `cargo check -p dynamo-runtime --lib --all-features`
- `cargo check --workspace --all-targets`
- `cargo test -p dynamo-runtime --lib bounded_drain`: 6 passed
- `cargo clippy -p dynamo-runtime --all-targets`
- `cargo fmt --all`
- `pre-commit run --files lib/runtime/src/health_check.rs`
- Independent live NATS and etcd verification: `cargo test -p dynamo-runtime --lib --features integration health_check` passed all 17 tests in five consecutive runs

The complete crate run encountered an intermittent FileStore watcher test that also fails on clean `main`; the reviewer could not attribute its higher observed frequency on this branch. GPU paths and real-engine load behavior were not exercised. The 100 ms post-stop polling period is covered by a test stream rather than a live vLLM or SGLang worker.
