### PR TITLE
feat(router): add opt-in session prefix indexer

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -661,8 +661,8 @@ class KvRouterArgGroup(ArgGroup):
         )
         add_negatable_bool_argument(
             g,
-            flag_name="--enable-session-prefix-index",
-            env_var="DYN_ENABLE_SESSION_PREFIX_INDEX",
+            flag_name="--router-session-prefix-index",
+            env_var="DYN_ROUTER_SESSION_PREFIX_INDEX",
             default=False,
             help=(
                 "[EXPERIMENTAL] KV Router: Track per-session block lineage in a logical "

--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -57,6 +57,7 @@ _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "router_queue_policy",
     "use_remote_indexer",
     "serve_indexer",
+    "enable_session_prefix_index",
     "shared_cache_multiplier",
     "shared_cache_type",
     "conditional_disagg_enabled",
@@ -218,6 +219,7 @@ class KvRouterConfigBase(ConfigBase):
     router_queue_policy: str
     use_remote_indexer: bool = False
     serve_indexer: bool = False
+    enable_session_prefix_index: bool = False
     shared_cache_multiplier: float = 0.0
     shared_cache_type: str = "none"
     conditional_disagg_enabled: bool = False
@@ -656,6 +658,18 @@ class KvRouterArgGroup(ArgGroup):
                 "component via the request plane instead of maintaining a local radix tree."
             ),
             dest="use_remote_indexer",
+        )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--enable-session-prefix-index",
+            env_var="DYN_ENABLE_SESSION_PREFIX_INDEX",
+            default=False,
+            help=(
+                "[EXPERIMENTAL] KV Router: Track per-session block lineage in a logical "
+                "prefix index that outlives engine cache eviction. Nothing consumes the "
+                "index for routing decisions yet."
+            ),
+            dest="enable_session_prefix_index",
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -682,6 +682,7 @@ class KvRouterArgGroup(ArgGroup):
             flag_name="--router-session-prefix-index-max-sessions",
             env_var="DYN_ROUTER_SESSION_PREFIX_INDEX_MAX_SESSIONS",
             default=_DEFAULT_SESSION_PREFIX_INDEX_MAX_SESSIONS,
+            dest="session_prefix_index_max_sessions",
             help=(
                 "[EXPERIMENTAL] KV Router: Maximum sessions retained by the logical "
                 "prefix index before least-recently-used eviction. Zero is clamped "

--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -27,6 +27,8 @@ from dynamo.common.configuration.utils import (
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_SESSION_PREFIX_INDEX_MAX_SESSIONS = 16_384
+
 # Authoritative field list — used by kv_router_kwargs() to extract values.
 _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "overlap_score_weight",
@@ -58,6 +60,7 @@ _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "use_remote_indexer",
     "serve_indexer",
     "enable_session_prefix_index",
+    "session_prefix_index_max_sessions",
     "shared_cache_multiplier",
     "shared_cache_type",
     "conditional_disagg_enabled",
@@ -220,6 +223,9 @@ class KvRouterConfigBase(ConfigBase):
     use_remote_indexer: bool = False
     serve_indexer: bool = False
     enable_session_prefix_index: bool = False
+    session_prefix_index_max_sessions: int = (
+        _DEFAULT_SESSION_PREFIX_INDEX_MAX_SESSIONS
+    )
     shared_cache_multiplier: float = 0.0
     shared_cache_type: str = "none"
     conditional_disagg_enabled: bool = False
@@ -670,6 +676,18 @@ class KvRouterArgGroup(ArgGroup):
                 "index for routing decisions yet."
             ),
             dest="enable_session_prefix_index",
+        )
+        add_argument(
+            g,
+            flag_name="--router-session-prefix-index-max-sessions",
+            env_var="DYN_ROUTER_SESSION_PREFIX_INDEX_MAX_SESSIONS",
+            default=_DEFAULT_SESSION_PREFIX_INDEX_MAX_SESSIONS,
+            help=(
+                "[EXPERIMENTAL] KV Router: Maximum sessions retained by the logical "
+                "prefix index before least-recently-used eviction. Zero is clamped "
+                "to one."
+            ),
+            arg_type=int,
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -206,12 +206,12 @@ def test_session_prefix_index_is_opt_in_and_reaches_the_binding() -> None:
     assert default_kwargs["enable_session_prefix_index"] is False
 
     enabled_kwargs = KvRouterConfigBase.from_cli_args(
-        parser.parse_args(["--enable-session-prefix-index"])
+        parser.parse_args(["--router-session-prefix-index"])
     ).kv_router_kwargs()
     assert enabled_kwargs["enable_session_prefix_index"] is True
 
     disabled_kwargs = KvRouterConfigBase.from_cli_args(
-        parser.parse_args(["--no-enable-session-prefix-index"])
+        parser.parse_args(["--no-router-session-prefix-index"])
     ).kv_router_kwargs()
     assert disabled_kwargs["enable_session_prefix_index"] is False
 
@@ -221,7 +221,7 @@ def test_session_prefix_index_is_opt_in_and_reaches_the_binding() -> None:
 def test_session_prefix_index_environment_flows_to_binding_kwargs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("DYN_ENABLE_SESSION_PREFIX_INDEX", "true")
+    monkeypatch.setenv("DYN_ROUTER_SESSION_PREFIX_INDEX", "true")
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)
 
@@ -229,7 +229,7 @@ def test_session_prefix_index_environment_flows_to_binding_kwargs(
     assert kwargs["enable_session_prefix_index"] is True
 
     overridden = KvRouterConfigBase.from_cli_args(
-        parser.parse_args(["--no-enable-session-prefix-index"])
+        parser.parse_args(["--no-router-session-prefix-index"])
     ).kv_router_kwargs()
     assert overridden["enable_session_prefix_index"] is False
 

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -17,6 +17,14 @@ from dynamo.common.configuration.groups.kv_router_args import (
 )
 from dynamo.frontend.frontend_args import FrontendArgGroup, FrontendConfig
 
+# `dynamo._core` is the compiled pyo3 extension. It is present in a normal dev
+# build but absent from a pure-Python checkout, so guard it at collection rather
+# than letting the import error out mid-test.
+KvRouterConfig = pytest.importorskip(
+    "dynamo._core",
+    reason="the compiled dynamo._core binding is not built in this environment",
+).KvRouterConfig
+
 pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
 
 
@@ -211,8 +219,6 @@ def test_session_prefix_index_is_opt_in_and_reaches_the_binding() -> None:
 
     # The kwargs dict is unpacked straight into the Rust binding, so a name that
     # does not match the pyo3 signature fails here rather than at serve time.
-    from dynamo._core import KvRouterConfig
-
     KvRouterConfig(**enabled_kwargs)
 
 

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -17,9 +17,7 @@ from dynamo.common.configuration.groups.kv_router_args import (
 )
 from dynamo.frontend.frontend_args import FrontendArgGroup, FrontendConfig
 
-# `dynamo._core` is the compiled pyo3 extension. It is present in a normal dev
-# build but absent from a pure-Python checkout, so guard it at collection rather
-# than letting the import error out mid-test.
+# Skip collection when the optional pyo3 extension is unavailable.
 KvRouterConfig = pytest.importorskip(
     "dynamo._core",
     reason="the compiled dynamo._core binding is not built in this environment",
@@ -217,16 +215,12 @@ def test_session_prefix_index_is_opt_in_and_reaches_the_binding() -> None:
     ).kv_router_kwargs()
     assert disabled_kwargs["enable_session_prefix_index"] is False
 
-    # The kwargs dict is unpacked straight into the Rust binding, so a name that
-    # does not match the pyo3 signature fails here rather than at serve time.
     KvRouterConfig(**enabled_kwargs)
 
 
 def test_session_prefix_index_environment_flows_to_binding_kwargs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # The env var is consumed when the flag is registered, so it has to be set
-    # before the group builds its arguments.
     monkeypatch.setenv("DYN_ENABLE_SESSION_PREFIX_INDEX", "true")
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)
@@ -234,7 +228,6 @@ def test_session_prefix_index_environment_flows_to_binding_kwargs(
     kwargs = KvRouterConfigBase.from_cli_args(parser.parse_args([])).kv_router_kwargs()
     assert kwargs["enable_session_prefix_index"] is True
 
-    # An explicit flag still wins over the environment.
     overridden = KvRouterConfigBase.from_cli_args(
         parser.parse_args(["--no-enable-session-prefix-index"])
     ).kv_router_kwargs()

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -17,12 +17,6 @@ from dynamo.common.configuration.groups.kv_router_args import (
 )
 from dynamo.frontend.frontend_args import FrontendArgGroup, FrontendConfig
 
-# Skip collection when the optional pyo3 extension is unavailable.
-KvRouterConfig = pytest.importorskip(
-    "dynamo._core",
-    reason="the compiled dynamo._core binding is not built in this environment",
-).KvRouterConfig
-
 pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
 
 
@@ -197,6 +191,11 @@ def test_decode_active_request_weight_flows_to_binding_kwargs() -> None:
 
 
 def test_session_prefix_index_is_opt_in_and_reaches_the_binding() -> None:
+    KvRouterConfig = pytest.importorskip(
+        "dynamo._core",
+        reason="the compiled dynamo._core binding is not built in this environment",
+    ).KvRouterConfig
+
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)
 

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -190,6 +190,51 @@ def test_decode_active_request_weight_flows_to_binding_kwargs() -> None:
     assert kwargs["decode_active_request_weight"] == 64.0
 
 
+def test_session_prefix_index_is_opt_in_and_reaches_the_binding() -> None:
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+
+    default_kwargs = KvRouterConfigBase.from_cli_args(
+        parser.parse_args([])
+    ).kv_router_kwargs()
+    assert default_kwargs["enable_session_prefix_index"] is False
+
+    enabled_kwargs = KvRouterConfigBase.from_cli_args(
+        parser.parse_args(["--enable-session-prefix-index"])
+    ).kv_router_kwargs()
+    assert enabled_kwargs["enable_session_prefix_index"] is True
+
+    disabled_kwargs = KvRouterConfigBase.from_cli_args(
+        parser.parse_args(["--no-enable-session-prefix-index"])
+    ).kv_router_kwargs()
+    assert disabled_kwargs["enable_session_prefix_index"] is False
+
+    # The kwargs dict is unpacked straight into the Rust binding, so a name that
+    # does not match the pyo3 signature fails here rather than at serve time.
+    from dynamo._core import KvRouterConfig
+
+    KvRouterConfig(**enabled_kwargs)
+
+
+def test_session_prefix_index_environment_flows_to_binding_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The env var is consumed when the flag is registered, so it has to be set
+    # before the group builds its arguments.
+    monkeypatch.setenv("DYN_ENABLE_SESSION_PREFIX_INDEX", "true")
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+
+    kwargs = KvRouterConfigBase.from_cli_args(parser.parse_args([])).kv_router_kwargs()
+    assert kwargs["enable_session_prefix_index"] is True
+
+    # An explicit flag still wins over the environment.
+    overridden = KvRouterConfigBase.from_cli_args(
+        parser.parse_args(["--no-enable-session-prefix-index"])
+    ).kv_router_kwargs()
+    assert overridden["enable_session_prefix_index"] is False
+
+
 def test_load_aware_cli_applies_no_cache_load_balancing_preset() -> None:
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -241,7 +241,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_approximate_cache_policy="ttl", router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, conditional_disagg_enabled=false, conditional_disagg_policy="isl_bounding", conditional_disagg_eff_isl_threshold=2048, conditional_disagg_eff_isl_ratio_threshold=0.7, conditional_disagg_prefill_busy_threshold=None, conditional_disagg_decode_busy_threshold=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, decode_active_request_weight=0.0, router_policy_config=None, router_prefill_policy=None, router_decode_policy=None, router_tracking_hash="public-xxh3-v1", router_tracking_key_file=None, router_tracking_key_id=None))]
+    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_approximate_cache_policy="ttl", router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, enable_session_prefix_index=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, conditional_disagg_enabled=false, conditional_disagg_policy="isl_bounding", conditional_disagg_eff_isl_threshold=2048, conditional_disagg_eff_isl_ratio_threshold=0.7, conditional_disagg_prefill_busy_threshold=None, conditional_disagg_decode_busy_threshold=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, decode_active_request_weight=0.0, router_policy_config=None, router_prefill_policy=None, router_decode_policy=None, router_tracking_hash="public-xxh3-v1", router_tracking_key_file=None, router_tracking_key_id=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: Option<f64>,
@@ -262,6 +262,7 @@ impl KvRouterConfig {
         router_queue_policy: &str,
         use_remote_indexer: bool,
         serve_indexer: bool,
+        enable_session_prefix_index: bool,
         shared_cache_multiplier: f64,
         shared_cache_type: &str,
         router_predicted_ttl_secs: Option<f64>,
@@ -327,6 +328,7 @@ impl KvRouterConfig {
             router_queue_policy: router_queue_policy.parse().map_err(PyValueError::new_err)?,
             use_remote_indexer,
             serve_indexer,
+            enable_session_prefix_index,
             shared_cache_multiplier,
             shared_cache_type: shared_cache_type.parse().map_err(PyValueError::new_err)?,
             conditional_disagg_enabled,

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -20,6 +20,7 @@ use dynamo_kv_router::config::{
     KvRouterConfig as RsKvRouterConfig, RouterPrefillLoadModel as RsRouterPrefillLoadModel,
     apply_deprecated_overlap_score_weight_override,
 };
+use dynamo_kv_router::session_prefix_index::DEFAULT_MAX_SESSIONS;
 use dynamo_llm::discovery::LoadThresholdConfig as RsLoadThresholdConfig;
 use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::RouterConfig as RsRouterConfig;
@@ -241,7 +242,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_approximate_cache_policy="ttl", router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, enable_session_prefix_index=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, conditional_disagg_enabled=false, conditional_disagg_policy="isl_bounding", conditional_disagg_eff_isl_threshold=2048, conditional_disagg_eff_isl_ratio_threshold=0.7, conditional_disagg_prefill_busy_threshold=None, conditional_disagg_decode_busy_threshold=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, decode_active_request_weight=0.0, router_policy_config=None, router_prefill_policy=None, router_decode_policy=None, router_tracking_hash="public-xxh3-v1", router_tracking_key_file=None, router_tracking_key_id=None))]
+    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_approximate_cache_policy="ttl", router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, enable_session_prefix_index=false, session_prefix_index_max_sessions=DEFAULT_MAX_SESSIONS, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, conditional_disagg_enabled=false, conditional_disagg_policy="isl_bounding", conditional_disagg_eff_isl_threshold=2048, conditional_disagg_eff_isl_ratio_threshold=0.7, conditional_disagg_prefill_busy_threshold=None, conditional_disagg_decode_busy_threshold=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, decode_active_request_weight=0.0, router_policy_config=None, router_prefill_policy=None, router_decode_policy=None, router_tracking_hash="public-xxh3-v1", router_tracking_key_file=None, router_tracking_key_id=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: Option<f64>,
@@ -263,6 +264,7 @@ impl KvRouterConfig {
         use_remote_indexer: bool,
         serve_indexer: bool,
         enable_session_prefix_index: bool,
+        session_prefix_index_max_sessions: usize,
         shared_cache_multiplier: f64,
         shared_cache_type: &str,
         router_predicted_ttl_secs: Option<f64>,
@@ -329,6 +331,7 @@ impl KvRouterConfig {
             use_remote_indexer,
             serve_indexer,
             enable_session_prefix_index,
+            session_prefix_index_max_sessions,
             shared_cache_multiplier,
             shared_cache_type: shared_cache_type.parse().map_err(PyValueError::new_err)?,
             conditional_disagg_enabled,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1849,6 +1849,9 @@ class KvRouterConfig:
             use_remote_indexer: Query a remote KV indexer served from the worker component (default: False).
             serve_indexer: Serve this router's local indexer from the worker component (default: False).
             enable_session_prefix_index: Track per-session block lineage in a logical prefix index that outlives engine cache eviction (default: False).
+                Lineage is currently partial: the router feeds the index from routing-lookup matches only. Stored-block KV events carry no session ID, so blocks a session produced but never matched on a later lookup are not recorded.
+                The index neither holds nor restores KV cache, so a match is a routing hint rather than a guarantee that the blocks are still resident.
+                Retention is bounded: a session is released when a request marks it final, and failing that the least recently used session is evicted once the tracked-session cap is reached.
             shared_cache_multiplier: Credit multiplier for shared cache hits beyond the device prefix (default: 0.0).
             shared_cache_type: External shared KV cache type, "none" or "hicache" (default: "none").
             conditional_disagg_enabled: Enable conditional-disagg bypass from prefill to decode (default: False).

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1850,7 +1850,7 @@ class KvRouterConfig:
             serve_indexer: Serve this router's local indexer from the worker component (default: False).
             enable_session_prefix_index: Track per-session block lineage in a logical prefix index that outlives engine cache eviction (default: False).
                 The index records routing-lookup matches for inspection but does not influence routing decisions. Stored-block KV events carry no session ID, so blocks a session produced but never matched on a later lookup are not recorded.
-                The index neither holds nor restores KV cache. Finalized query-only sessions remain until least-recently-used eviction; other finalized sessions are released, and the tracked-session cap evicts the least recently used session.
+                The index neither holds nor restores KV cache. Each frontier retains at most 1,024 lineage nodes. Finalized query-only sessions remain until least-recently-used eviction; other finalized sessions are released, and the tracked-session cap evicts the least recently used session.
             shared_cache_multiplier: Credit multiplier for shared cache hits beyond the device prefix (default: 0.0).
             shared_cache_type: External shared KV cache type, "none" or "hicache" (default: "none").
             conditional_disagg_enabled: Enable conditional-disagg bypass from prefill to decode (default: False).

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1849,9 +1849,8 @@ class KvRouterConfig:
             use_remote_indexer: Query a remote KV indexer served from the worker component (default: False).
             serve_indexer: Serve this router's local indexer from the worker component (default: False).
             enable_session_prefix_index: Track per-session block lineage in a logical prefix index that outlives engine cache eviction (default: False).
-                Lineage is currently partial: the router feeds the index from routing-lookup matches only. Stored-block KV events carry no session ID, so blocks a session produced but never matched on a later lookup are not recorded.
-                The index neither holds nor restores KV cache, so a match is a routing hint rather than a guarantee that the blocks are still resident.
-                Retention is bounded: a session is released when a request marks it final, and failing that the least recently used session is evicted once the tracked-session cap is reached.
+                The index records routing-lookup matches for inspection but does not influence routing decisions. Stored-block KV events carry no session ID, so blocks a session produced but never matched on a later lookup are not recorded.
+                The index neither holds nor restores KV cache. Finalized query-only sessions remain until least-recently-used eviction; other finalized sessions are released, and the tracked-session cap evicts the least recently used session.
             shared_cache_multiplier: Credit multiplier for shared cache hits beyond the device prefix (default: 0.0).
             shared_cache_type: External shared KV cache type, "none" or "hicache" (default: "none").
             conditional_disagg_enabled: Enable conditional-disagg bypass from prefill to decode (default: False).

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1774,6 +1774,7 @@ class KvRouterConfig:
         use_remote_indexer: bool = False,
         serve_indexer: bool = False,
         enable_session_prefix_index: bool = False,
+        session_prefix_index_max_sessions: int = 16384,
         shared_cache_multiplier: float = 0.0,
         shared_cache_type: str = "none",
         router_predicted_ttl_secs: Optional[float] = None,
@@ -1851,6 +1852,7 @@ class KvRouterConfig:
             enable_session_prefix_index: Track per-session block lineage in a logical prefix index that outlives engine cache eviction (default: False).
                 The index records routing-lookup matches for inspection but does not influence routing decisions. Stored-block KV events carry no session ID, so blocks a session produced but never matched on a later lookup are not recorded.
                 The index neither holds nor restores KV cache. Each frontier retains at most 1,024 lineage nodes. Finalized query-only sessions remain until least-recently-used eviction; other finalized sessions are released, and the tracked-session cap evicts the least recently used session.
+            session_prefix_index_max_sessions: Maximum sessions retained by the logical prefix index before least-recently-used eviction (default: 16384). Zero is clamped to one.
             shared_cache_multiplier: Credit multiplier for shared cache hits beyond the device prefix (default: 0.0).
             shared_cache_type: External shared KV cache type, "none" or "hicache" (default: "none").
             conditional_disagg_enabled: Enable conditional-disagg bypass from prefill to decode (default: False).

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1773,6 +1773,7 @@ class KvRouterConfig:
         router_queue_policy: str = "fcfs",
         use_remote_indexer: bool = False,
         serve_indexer: bool = False,
+        enable_session_prefix_index: bool = False,
         shared_cache_multiplier: float = 0.0,
         shared_cache_type: str = "none",
         router_predicted_ttl_secs: Optional[float] = None,
@@ -1847,6 +1848,7 @@ class KvRouterConfig:
                 "wspt": weighted shortest processing time (Smith's rule) — optimizes average TTFT.
             use_remote_indexer: Query a remote KV indexer served from the worker component (default: False).
             serve_indexer: Serve this router's local indexer from the worker component (default: False).
+            enable_session_prefix_index: Track per-session block lineage in a logical prefix index that outlives engine cache eviction (default: False).
             shared_cache_multiplier: Credit multiplier for shared cache hits beyond the device prefix (default: 0.0).
             shared_cache_type: External shared KV cache type, "none" or "hicache" (default: "none").
             conditional_disagg_enabled: Enable conditional-disagg bypass from prefill to decode (default: False).

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -21,6 +21,7 @@ pub mod router_hint;
 pub mod scheduling;
 pub mod sequences;
 pub mod services;
+pub mod session_prefix_index;
 pub mod tracking_hash;
 pub mod worker_type;
 pub mod zmq_wire;
@@ -79,6 +80,9 @@ pub use selector::{
     DefaultWorkerSelector, ScoredWorkerCandidate, WorkerCacheInput, WorkerCandidate, WorkerFilter,
     WorkerInputView, WorkerInputs, WorkerLoadInput, WorkerPicker, WorkerRoutingInput, WorkerScorer,
     WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelector,
+};
+pub use session_prefix_index::{
+    LogicalNode, NodeId, SessionId, SessionPrefixIndexError, SessionPrefixIndexer,
 };
 pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
 pub use worker_type::WorkerType;

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -833,11 +833,7 @@ pub struct KvRouterConfig {
     #[serde(default)]
     pub serve_indexer: bool,
 
-    /// Enable the session-aware logical prefix index. When true the router
-    /// keeps a per-session record of the block chains each session has matched,
-    /// which survives engine eviction of the underlying blocks. Off by default:
-    /// it costs memory proportional to tracked session lineage and nothing in
-    /// the routing decision consumes it yet.
+    /// Enable bounded per-session logical prefix tracking.
     #[serde(default, skip_serializing_if = "is_default")]
     pub enable_session_prefix_index: bool,
 
@@ -2040,8 +2036,6 @@ worker_selection:
     fn session_prefix_index_flag_defaults_off_and_survives_the_wire() {
         assert!(!KvRouterConfig::default().enable_session_prefix_index);
 
-        // Absent from the wire is the off state, so an older writer that never
-        // heard of the flag still deserializes into a working config.
         let from_legacy: KvRouterConfig = serde_json::from_value(serde_json::json!({})).unwrap();
         assert!(!from_legacy.enable_session_prefix_index);
 

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -637,6 +637,8 @@ struct KvRouterConfigSerde {
     serve_indexer: bool,
     #[serde(default)]
     enable_session_prefix_index: bool,
+    #[serde(default = "default_session_prefix_index_max_sessions")]
+    session_prefix_index_max_sessions: usize,
     shared_cache_multiplier: f64,
     shared_cache_type: SharedCacheType,
     router_predicted_ttl_secs: Option<f64>,
@@ -684,6 +686,7 @@ impl Default for KvRouterConfigSerde {
             use_remote_indexer: config.use_remote_indexer,
             serve_indexer: config.serve_indexer,
             enable_session_prefix_index: config.enable_session_prefix_index,
+            session_prefix_index_max_sessions: config.session_prefix_index_max_sessions,
             shared_cache_multiplier: config.shared_cache_multiplier,
             shared_cache_type: config.shared_cache_type,
             router_predicted_ttl_secs: config.router_predicted_ttl_secs,
@@ -837,6 +840,13 @@ pub struct KvRouterConfig {
     #[serde(default, skip_serializing_if = "is_default")]
     pub enable_session_prefix_index: bool,
 
+    /// Maximum number of sessions retained by the logical prefix index.
+    #[serde(
+        default = "default_session_prefix_index_max_sessions",
+        skip_serializing_if = "is_default_session_prefix_index_max_sessions"
+    )]
+    pub session_prefix_index_max_sessions: usize,
+
     /// Multiplier for shared cache hits when scoring workers (0.0 to 1.0).
     /// Blocks available in the shared cache are less valuable than device-local blocks
     /// because they need to be fetched. A value of 0.5 means each shared cache hit
@@ -895,6 +905,14 @@ fn default_conditional_disagg_eff_isl_threshold() -> usize {
     crate::conditional_disagg::DEFAULT_CONDITIONAL_DISAGG_EFF_ISL_THRESHOLD
 }
 
+fn default_session_prefix_index_max_sessions() -> usize {
+    crate::session_prefix_index::DEFAULT_MAX_SESSIONS
+}
+
+fn is_default_session_prefix_index_max_sessions(value: &usize) -> bool {
+    *value == default_session_prefix_index_max_sessions()
+}
+
 fn default_conditional_disagg_eff_isl_ratio_threshold() -> f64 {
     crate::conditional_disagg::DEFAULT_CONDITIONAL_DISAGG_EFF_ISL_RATIO_THRESHOLD
 }
@@ -941,6 +959,7 @@ impl Default for KvRouterConfig {
             use_remote_indexer: false,
             serve_indexer: false,
             enable_session_prefix_index: false,
+            session_prefix_index_max_sessions: default_session_prefix_index_max_sessions(),
             shared_cache_multiplier: 0.0,
             shared_cache_type: SharedCacheType::default(),
             router_predicted_ttl_secs: None,
@@ -1006,6 +1025,7 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
             use_remote_indexer: compat.use_remote_indexer,
             serve_indexer: compat.serve_indexer,
             enable_session_prefix_index: compat.enable_session_prefix_index,
+            session_prefix_index_max_sessions: compat.session_prefix_index_max_sessions,
             shared_cache_multiplier: compat.shared_cache_multiplier,
             shared_cache_type: compat.shared_cache_type,
             router_predicted_ttl_secs: compat.router_predicted_ttl_secs,

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -635,6 +635,8 @@ struct KvRouterConfigSerde {
     router_queue_policy: RouterQueuePolicy,
     use_remote_indexer: bool,
     serve_indexer: bool,
+    #[serde(default)]
+    enable_session_prefix_index: bool,
     shared_cache_multiplier: f64,
     shared_cache_type: SharedCacheType,
     router_predicted_ttl_secs: Option<f64>,
@@ -681,6 +683,7 @@ impl Default for KvRouterConfigSerde {
             router_queue_policy: config.router_queue_policy,
             use_remote_indexer: config.use_remote_indexer,
             serve_indexer: config.serve_indexer,
+            enable_session_prefix_index: config.enable_session_prefix_index,
             shared_cache_multiplier: config.shared_cache_multiplier,
             shared_cache_type: config.shared_cache_type,
             router_predicted_ttl_secs: config.router_predicted_ttl_secs,
@@ -830,6 +833,14 @@ pub struct KvRouterConfig {
     #[serde(default)]
     pub serve_indexer: bool,
 
+    /// Enable the session-aware logical prefix index. When true the router
+    /// keeps a per-session record of the block chains each session has matched,
+    /// which survives engine eviction of the underlying blocks. Off by default:
+    /// it costs memory proportional to tracked session lineage and nothing in
+    /// the routing decision consumes it yet.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub enable_session_prefix_index: bool,
+
     /// Multiplier for shared cache hits when scoring workers (0.0 to 1.0).
     /// Blocks available in the shared cache are less valuable than device-local blocks
     /// because they need to be fetched. A value of 0.5 means each shared cache hit
@@ -933,6 +944,7 @@ impl Default for KvRouterConfig {
             router_queue_policy: RouterQueuePolicy::default(),
             use_remote_indexer: false,
             serve_indexer: false,
+            enable_session_prefix_index: false,
             shared_cache_multiplier: 0.0,
             shared_cache_type: SharedCacheType::default(),
             router_predicted_ttl_secs: None,
@@ -997,6 +1009,7 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
             router_queue_policy: compat.router_queue_policy,
             use_remote_indexer: compat.use_remote_indexer,
             serve_indexer: compat.serve_indexer,
+            enable_session_prefix_index: compat.enable_session_prefix_index,
             shared_cache_multiplier: compat.shared_cache_multiplier,
             shared_cache_type: compat.shared_cache_type,
             router_predicted_ttl_secs: compat.router_predicted_ttl_secs,
@@ -2024,6 +2037,29 @@ worker_selection:
     }
 
     #[test]
+    fn session_prefix_index_flag_defaults_off_and_survives_the_wire() {
+        assert!(!KvRouterConfig::default().enable_session_prefix_index);
+
+        // Absent from the wire is the off state, so an older writer that never
+        // heard of the flag still deserializes into a working config.
+        let from_legacy: KvRouterConfig = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(!from_legacy.enable_session_prefix_index);
+
+        let enabled = KvRouterConfig {
+            enable_session_prefix_index: true,
+            ..Default::default()
+        };
+        let encoded = serde_json::to_value(&enabled).unwrap();
+        assert_eq!(
+            encoded.get("enable_session_prefix_index"),
+            Some(&serde_json::json!(true)),
+            "an explicitly enabled flag must be carried on the wire"
+        );
+        let decoded: KvRouterConfig = serde_json::from_value(encoded).unwrap();
+        assert!(decoded.enable_session_prefix_index);
+    }
+
+    #[test]
     fn kv_router_config_preserves_v1_3_wire_compatibility() {
         let _: KvRouterConfig = serde_json::from_value(serde_json::json!({
             "durable_kv_events": false,
@@ -2044,6 +2080,7 @@ worker_selection:
             "conditional_disagg_eff_isl_ratio_threshold",
             "conditional_disagg_prefill_busy_threshold",
             "conditional_disagg_decode_busy_threshold",
+            "enable_session_prefix_index",
         ] {
             assert!(value.get(post_v1_3_field).is_none(), "{post_v1_3_field}");
         }

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -1,50 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Session-aware logical prefix index.
+//! Session lineage retained independently of physical cache eviction.
 //!
-//! The physical indexers (`indexer::*`) answer "which worker holds this block
-//! right now". They are driven by engine cache events, so a block that the
-//! engine evicts disappears from them immediately. That is correct for routing
-//! but it destroys the only record of what a *session* has previously produced.
-//!
-//! This module keeps a separate, logical view: a forest of
-//! [`ExternalSequenceBlockHash`] nodes plus, per session, the set of nodes that
-//! are currently the deepest known point of that session's block chains. Nodes
-//! are never dropped because the engine evicted or cleared the underlying
-//! blocks; they are dropped only when the owning session goes, either through
-//! [`SessionPrefixIndexer::remove_session`] or through the capacity bound
-//! below. Eviction changes where a block lives, not whether the session ever
-//! produced it.
-//!
-//! Retention is bounded. The router calls [`SessionPrefixIndexer::remove_session`]
-//! when a request marks its session final, but that signal is optional and many
-//! clients never send it, so the index also caps how many sessions it tracks
-//! ([`DEFAULT_MAX_SESSIONS`], overridable via
-//! [`SessionPrefixIndexer::with_max_sessions`]). Passing the cap evicts the
-//! least recently touched session by exactly the path `remove_session` takes.
-//! Both halves are needed: the lifecycle signal reclaims promptly when it
-//! arrives, and the cap is what makes growth bounded when it never does.
-//!
-//! Structure follows the enhancement proposal:
-//!
-//! - `nodes`: a [`SlotMap`] arena of [`LogicalNode`], so a [`NodeId`] handed out
-//!   to a caller cannot silently alias a different node after a removal.
-//! - `hash_to_node`: reverse index from block hash to arena slot. Numeric key,
-//!   so [`FxHashMap`] per the crate guidance.
-//! - `sessions`: session id to frontier node set. The key is caller-supplied
-//!   text, so this uses [`std::collections::HashMap`] rather than `FxHashMap`,
-//!   again per the crate guidance.
-//!
-//! [`ExternalSequenceBlockHash`] is treated as opaque: this module compares and
-//! hashes it and never interprets, derives, or recomputes its value.
-//!
-//! Deviation from the proposal's literal signatures: the session parameters are
-//! taken as `&str` rather than an owned `SessionId`. The route-time caller only
-//! holds a borrow, and an owned parameter would force a `String` allocation on
-//! every routed request even when the session is already known. The owned
-//! [`SessionId`] alias is still what the map stores, and a clone happens only on
-//! first insert.
+//! Final-session removal and an LRU session cap bound retention.
 
 use std::collections::{BTreeMap, HashMap};
 
@@ -57,14 +16,7 @@ use crate::protocols::ExternalSequenceBlockHash;
 /// Logical session identity as owned by this index.
 pub type SessionId = String;
 
-/// Default ceiling on tracked sessions, past which the least recently touched
-/// session is evicted.
-///
-/// Sized so the common case never reaches it — a router serving far fewer
-/// concurrent sessions than this behaves exactly as if the index were
-/// unbounded — while a router that never receives an end-of-session signal
-/// still settles at a fixed footprint instead of growing for the life of the
-/// process.
+/// Default tracked-session ceiling before LRU eviction.
 pub const DEFAULT_MAX_SESSIONS: usize = 16_384;
 
 new_key_type! {
@@ -72,11 +24,7 @@ new_key_type! {
     pub struct NodeId;
 }
 
-/// One logical block in the session forest.
-///
-/// Holds its own hash, its parent link, and the liveness counters that decide
-/// when the node can be reclaimed: how many session frontier sets point at it,
-/// and how many children it still has.
+/// One block and its liveness links in the logical session forest.
 #[derive(Clone, Copy, Debug)]
 pub struct LogicalNode {
     block_hash: ExternalSequenceBlockHash,
@@ -86,22 +34,18 @@ pub struct LogicalNode {
 }
 
 impl LogicalNode {
-    /// The block hash this node stands for.
     pub fn block_hash(&self) -> ExternalSequenceBlockHash {
         self.block_hash
     }
 
-    /// The parent node, or `None` when this node is a root of the forest.
     pub fn parent(&self) -> Option<NodeId> {
         self.parent
     }
 
-    /// Number of sessions whose frontier set currently contains this node.
     pub fn frontier_refs(&self) -> u32 {
         self.frontier_refs
     }
 
-    /// Number of direct children currently attached to this node.
     pub fn child_count(&self) -> u32 {
         self.child_count
     }
@@ -110,50 +54,30 @@ impl LogicalNode {
 /// Errors surfaced by [`SessionPrefixIndexer`].
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SessionPrefixIndexError {
-    /// A lineage query named an anchor hash the index has never seen. Returning
-    /// an empty lineage here would be indistinguishable from "this session has
-    /// no blocks past the anchor", so it is reported as an error instead.
+    /// A lineage query named an unknown anchor hash.
     #[error("unknown anchor block hash {0:?}")]
     UnknownAnchor(ExternalSequenceBlockHash),
 
-    /// A stored-blocks update tried to attach a block under a parent other than
-    /// the one already recorded. Within one hash domain a unique block chain
-    /// maps to a unique external sequence-hash chain, so this is a producer,
-    /// configuration, or protocol error rather than a routing condition.
+    /// A block was attached beneath a conflicting parent.
     #[error("block {block:?} is already parented elsewhere")]
     ConflictingParent {
-        /// The block whose recorded parent disagrees with the update.
         block: ExternalSequenceBlockHash,
     },
 
-    /// A stored-blocks update tried to attach a block underneath a block that
-    /// the first one already sits at or above. Applying it would close a parent
-    /// cycle, and every walk of the forest follows parent links, so the cycle
-    /// would turn later reads into non-terminating loops holding the write
-    /// lock. Rejected before the arena is touched.
+    /// A graft would create a parent cycle.
     #[error("block {block:?} would become its own ancestor")]
     CyclicParent {
-        /// The block whose graft would close the cycle.
         block: ExternalSequenceBlockHash,
     },
 }
 
-/// Session-aware logical prefix index.
-///
-/// Cheap to share: all methods take `&self` and lock internally, so the router
-/// can hold this behind an `Arc` next to its physical indexer.
+/// Thread-safe session-aware logical prefix index.
 #[derive(Debug, Default)]
 pub struct SessionPrefixIndexer {
     state: RwLock<IndexState>,
 }
 
-/// One session's retained state: the deepest nodes it has reached, and when it
-/// was last touched, which is what the capacity bound evicts on.
-///
-/// `last_touch` is `None` only between the entry's creation and the
-/// [`IndexState::touch_session`] call that immediately follows it. Making that
-/// gap explicit matters: a numeric sentinel would alias whichever session
-/// legitimately holds that sequence number and evict it instead.
+// None distinguishes an untouched entry from touch sequence zero.
 #[derive(Debug, Default)]
 struct SessionEntry {
     frontiers: FxHashSet<NodeId>,
@@ -165,12 +89,8 @@ struct IndexState {
     nodes: SlotMap<NodeId, LogicalNode>,
     hash_to_node: FxHashMap<ExternalSequenceBlockHash, NodeId>,
     sessions: HashMap<SessionId, SessionEntry>,
-    /// Touch sequence to session id, so the least recently touched session is
-    /// the first entry. Kept in lockstep with [`SessionEntry::last_touch`]:
-    /// every session in `sessions` has exactly one entry here.
+    // Kept in lockstep with SessionEntry::last_touch.
     lru: BTreeMap<u64, SessionId>,
-    /// Monotonic touch counter. `u64` at one touch per routed request does not
-    /// wrap in any realistic process lifetime.
     next_touch: u64,
     max_sessions: usize,
 }
@@ -189,16 +109,11 @@ impl Default for IndexState {
 }
 
 impl SessionPrefixIndexer {
-    /// Create an empty index holding at most [`DEFAULT_MAX_SESSIONS`] sessions.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Create an empty index holding at most `max_sessions` sessions.
-    ///
-    /// A cap of zero is raised to one: an index that could retain nothing would
-    /// discard each session as it was recorded, which is not a useful state to
-    /// let a caller configure by accident.
+    /// Creates an index and clamps a zero session cap to one.
     pub fn with_max_sessions(max_sessions: usize) -> Self {
         Self {
             state: RwLock::new(IndexState {
@@ -208,24 +123,19 @@ impl SessionPrefixIndexer {
         }
     }
 
-    /// The ceiling on tracked sessions.
     pub fn max_sessions(&self) -> usize {
         self.state.read().max_sessions
     }
 
-    /// Resolve a block hash to its arena slot, if this index knows the block.
     pub fn get_node_from_hash(&self, block_hash: ExternalSequenceBlockHash) -> Option<NodeId> {
         self.state.read().hash_to_node.get(&block_hash).copied()
     }
 
-    /// Read a node by handle. Returns `None` for a stale handle.
     pub fn get_node(&self, node_id: NodeId) -> Option<LogicalNode> {
         self.state.read().nodes.get(node_id).copied()
     }
 
-    /// The deepest known nodes of every chain this session has touched.
-    ///
-    /// Empty for an unknown session. Order is unspecified.
+    /// Returns unordered frontier nodes, or an empty vector for an unknown session.
     pub fn get_session_frontiers(&self, session_id: &str) -> Vec<NodeId> {
         self.state
             .read()
@@ -235,13 +145,7 @@ impl SessionPrefixIndexer {
             .unwrap_or_default()
     }
 
-    /// Every block chain this session has touched, root first.
-    ///
-    /// One inner vector per frontier. With `anchor_hash` set, each chain is
-    /// truncated to start at the anchor and chains that do not pass through it
-    /// are omitted; an anchor the index has never seen is an error. An unknown
-    /// session yields an empty result, which is not an error: a session that has
-    /// not been routed yet legitimately has no lineage.
+    /// Returns root-first chains, optionally filtered and truncated at an anchor.
     pub fn get_session_block_lineage(
         &self,
         session_id: &str,
@@ -270,7 +174,6 @@ impl SessionPrefixIndexer {
             let start = match anchor_node {
                 Some(anchor) => match path.iter().position(|&node| node == anchor) {
                     Some(position) => position,
-                    // This frontier's chain does not pass through the anchor.
                     None => continue,
                 },
                 None => 0,
@@ -285,15 +188,7 @@ impl SessionPrefixIndexer {
         Ok(lineages)
     }
 
-    /// Record a route-time cache hit for `session_id` at `matched_hash`.
-    ///
-    /// Returns whether the session's frontier set moved. A hit on a block at or
-    /// above a frontier the session already holds is not an advance, so a
-    /// re-route of the same prefix leaves the index untouched. An unknown hash
-    /// is admitted as a new root: the router matched the block, so it exists,
-    /// even though a match alone carries no parent link. A later
-    /// [`Self::update_session_from_stored_blocks`] carrying that parent grafts
-    /// the chain onto this same node rather than creating a second root.
+    /// Records a route-time match and reports whether the frontier advanced.
     pub fn update_session_from_match(
         &self,
         session_id: &str,
@@ -304,16 +199,8 @@ impl SessionPrefixIndexer {
         Ok(state.advance_frontier(session_id, node))
     }
 
-    /// Record a chain of blocks stored under `parent_hash` for `session_id`.
-    ///
-    /// Blocks are applied in order and existing nodes are reused, so replaying
-    /// the same chain does not grow the arena. Returns whether the session's
-    /// frontier set moved.
-    ///
-    /// Not currently driven by the KV event stream: the cache event schema
-    /// carries no session identity, so there is no honest way to attribute a
-    /// stored-block event to a session yet. It is the ingest half of the
-    /// proposal's API and is exercised by this module's tests.
+    /// Records a stored block chain and reports whether the frontier advanced.
+    /// KV events do not yet supply the session identity required by this API.
     pub fn update_session_from_stored_blocks(
         &self,
         session_id: &str,
@@ -325,16 +212,14 @@ impl SessionPrefixIndexer {
         }
 
         let mut state = self.state.write();
-        // Validate the whole chain before touching the arena, so a rejected
-        // update leaves no half-applied nodes behind.
+        // Reject the whole update before mutating the arena.
         state.validate_chain(parent_hash, block_hashes)?;
 
         let mut parent = parent_hash.map(|hash| state.resolve_or_insert_root(hash));
         for &block_hash in block_hashes {
             let node = match state.hash_to_node.get(&block_hash).copied() {
                 Some(existing) => {
-                    // Known only as a root so far; graft it under the parent
-                    // this event supplies instead of leaving it detached.
+                    // Graft nodes previously known only as roots.
                     if let (None, Some(expected)) = (state.nodes[existing].parent, parent) {
                         state.nodes[existing].parent = Some(expected);
                         state.nodes[expected].child_count += 1;
@@ -350,21 +235,16 @@ impl SessionPrefixIndexer {
         Ok(state.advance_frontier(session_id, leaf))
     }
 
-    /// Drop a session and reclaim the nodes no other session still needs.
-    ///
-    /// Returns whether the session was known. This is the only path that
-    /// removes logical nodes; block eviction never does.
+    /// Removes a session and reclaims its unshared nodes.
     pub fn remove_session(&self, session_id: &str) -> bool {
         let mut state = self.state.write();
         state.drop_session(session_id)
     }
 
-    /// Number of logical nodes currently retained.
     pub fn node_count(&self) -> usize {
         self.state.read().nodes.len()
     }
 
-    /// Number of sessions currently tracked.
     pub fn session_count(&self) -> usize {
         self.state.read().sessions.len()
     }
@@ -389,17 +269,7 @@ impl IndexState {
         node
     }
 
-    /// Read-only check that no block in the chain is already parented somewhere
-    /// other than where this chain would put it, and that applying the chain
-    /// cannot close a parent cycle.
-    ///
-    /// The cycle half matters because a block already known only as a root has
-    /// `parent == None` and so passes the conflict check, after which the apply
-    /// loop would graft it under whatever parent this call supplies — including
-    /// one of its own descendants. `dominators` is every hash that will sit at
-    /// or above the chain once it is applied: the supplied parent, everything
-    /// already above that parent, and the chain's own earlier blocks. A block
-    /// that appears in that set is being asked to become its own ancestor.
+    // Reject conflicting parents and graft cycles before mutation.
     fn validate_chain(
         &self,
         parent_hash: Option<ExternalSequenceBlockHash>,
@@ -434,10 +304,7 @@ impl IndexState {
         Ok(())
     }
 
-    /// Remove a session and reclaim what no other session needs, returning
-    /// whether the session was known. Shared by the public
-    /// [`SessionPrefixIndexer::remove_session`] and by capacity eviction, so
-    /// both reclaim by exactly the same path.
+    // Public removal and capacity eviction share this reclamation path.
     fn drop_session(&mut self, session_id: &str) -> bool {
         let Some(entry) = self.sessions.remove(session_id) else {
             return false;
@@ -451,7 +318,6 @@ impl IndexState {
         true
     }
 
-    /// Mark `session_id` as the most recently used session.
     fn touch_session(&mut self, session_id: &str) {
         let seq = self.next_touch;
         let Some(entry) = self.sessions.get_mut(session_id) else {
@@ -465,17 +331,11 @@ impl IndexState {
         self.lru.insert(seq, session_id.to_string());
     }
 
-    /// Evict least recently touched sessions until the cap is respected.
-    ///
-    /// Called after a session is recorded rather than before, so the session
-    /// that just arrived is the most recently touched one and is never the
-    /// victim of its own insertion.
+    // Enforce the cap after touching the newly recorded session.
     fn enforce_session_cap(&mut self) {
         while self.sessions.len() > self.max_sessions {
             let Some((_, victim)) = self.lru.pop_first() else {
-                // `lru` and `sessions` are maintained together, so this is
-                // unreachable; breaking rather than looping keeps a bookkeeping
-                // bug from becoming a hang.
+                // Avoid a hang if LRU bookkeeping is ever inconsistent.
                 debug_assert!(false, "lru is empty while sessions is over capacity");
                 break;
             };
@@ -499,13 +359,7 @@ impl IndexState {
         }
     }
 
-    /// Walk parent links from `tail`, root first.
-    ///
-    /// Bounded by the arena size. An acyclic forest cannot yield a longer path,
-    /// so the bound never truncates a well-formed walk; it is a backstop that
-    /// makes a corrupted arena degrade into a short answer rather than spin
-    /// forever while holding the index lock. `validate_chain` is what actually
-    /// keeps the forest acyclic.
+    // Bound parent walks so corrupted cycles cannot hang while holding the lock.
     fn path_to_root(&self, tail: NodeId) -> Vec<NodeId> {
         let limit = self.nodes.len();
         let mut path = Vec::new();
@@ -523,9 +377,6 @@ impl IndexState {
         path
     }
 
-    /// Is `candidate` at or above `node` in the forest?
-    ///
-    /// Bounded on the same reasoning as [`Self::path_to_root`].
     fn is_ancestor_or_self(&self, candidate: NodeId, node: NodeId) -> bool {
         let limit = self.nodes.len();
         let mut current = Some(node);
@@ -545,9 +396,7 @@ impl IndexState {
         false
     }
 
-    /// Move `session_id`'s frontier set to include `node`, returning whether
-    /// anything changed. Frontiers that `node` now subsumes are dropped so a
-    /// session holds only the deepest point of each chain it has touched.
+    // Keep only the deepest frontier on each chain.
     fn advance_frontier(&mut self, session_id: &str, node: NodeId) -> bool {
         let already_reached = self.sessions.get(session_id).is_some_and(|entry| {
             entry
@@ -556,9 +405,7 @@ impl IndexState {
                 .any(|&frontier| self.is_ancestor_or_self(node, frontier))
         });
         if already_reached {
-            // The frontier does not move, but the session is demonstrably still
-            // being routed, so it must not drift towards eviction while a
-            // genuinely idle session outranks it.
+            // Repeated matches still refresh LRU order.
             self.touch_session(session_id);
             return false;
         }
@@ -592,9 +439,7 @@ impl IndexState {
         true
     }
 
-    /// Drop one frontier reference and reclaim the now-unreachable tail above
-    /// it. A node survives while any session still points at it or any child
-    /// still hangs off it, so shared prefixes outlive the first session to go.
+    // Reclaim ancestors until reaching a shared frontier or parent.
     fn release_frontier(&mut self, frontier: NodeId) {
         self.nodes[frontier].frontier_refs -= 1;
 
@@ -619,8 +464,6 @@ mod tests {
     use super::*;
     use crate::test_utils::make_blocks;
 
-    /// Block hashes as the engine publishes them, via the shared event builder
-    /// so these fixtures cannot drift from the real event shape.
     fn hashes(ids: Vec<u64>) -> Vec<ExternalSequenceBlockHash> {
         make_blocks(ids)
             .into_iter()
@@ -673,14 +516,12 @@ mod tests {
             .unwrap();
         assert_eq!(indexer.get_session_frontiers("s1").len(), 1);
 
-        // Re-route lands on the middle of the chain the session already owns.
         assert!(
             !indexer.update_session_from_match("s1", chain[1]).unwrap(),
             "a match above the current frontier must not move it"
         );
         assert_eq!(lineage_of(&indexer, "s1"), vec![chain.clone()]);
 
-        // A brand new session hitting the middle stops there.
         assert!(indexer.update_session_from_match("s2", chain[1]).unwrap());
         assert_eq!(lineage_of(&indexer, "s2"), vec![chain[..2].to_vec()]);
     }
@@ -718,12 +559,10 @@ mod tests {
         let chain = hashes(vec![1, 2]);
         let indexer = SessionPrefixIndexer::new();
 
-        // Route-time hit on the child arrives first, with no parent context.
         indexer.update_session_from_match("s1", chain[1]).unwrap();
         let child = indexer.get_node_from_hash(chain[1]).unwrap();
         assert_eq!(indexer.get_node(child).unwrap().parent(), None);
 
-        // The stored-block chain then supplies the missing parent link.
         indexer
             .update_session_from_stored_blocks("s1", Some(chain[0]), &chain[1..])
             .unwrap();
@@ -834,10 +673,6 @@ mod tests {
 
     #[test]
     fn eviction_shaped_replay_does_not_lose_lineage() {
-        // The physical indexers would have dropped these blocks on a Removed or
-        // Cleared event. This index has no such path: only remove_session drops
-        // nodes, so a session re-routed after eviction still reads back its
-        // full chain.
         let chain = hashes(vec![1, 2]);
         let indexer = SessionPrefixIndexer::new();
 
@@ -929,7 +764,6 @@ mod tests {
 
         indexer.update_session_from_match("s1", chain[0]).unwrap();
         indexer.update_session_from_match("s2", chain[1]).unwrap();
-        // Touch s1 so s2 becomes the least recently used of the two.
         indexer.update_session_from_match("s1", chain[1]).unwrap();
 
         indexer.update_session_from_match("s3", chain[2]).unwrap();
@@ -990,13 +824,10 @@ mod tests {
         let chain = hashes(vec![1, 2, 3]);
         let indexer = SessionPrefixIndexer::new();
 
-        // Build A -> B -> C.
         indexer
             .update_session_from_stored_blocks("s1", None, &chain)
             .unwrap();
 
-        // Now claim A is stored under C. Accepting that would make A its own
-        // ancestor and leave the parent walks looping forever.
         let err = indexer
             .update_session_from_stored_blocks("s1", Some(chain[2]), &chain[..1])
             .expect_err("grafting an ancestor under its own descendant must fail");
@@ -1008,7 +839,6 @@ mod tests {
             "expected CyclicParent for the offending block, got {err:?}"
         );
 
-        // The rejected update must leave the original forest intact.
         assert_eq!(
             lineage_of(&indexer, "s1"),
             vec![chain.clone()],
@@ -1021,8 +851,6 @@ mod tests {
         let chain = hashes(vec![1, 2]);
         let indexer = SessionPrefixIndexer::new();
 
-        // A -> B -> A within a single event: the cycle closes on a node this
-        // very chain created, so the check cannot rely on existing parents.
         let repeating = vec![chain[0], chain[1], chain[0]];
         let err = indexer
             .update_session_from_stored_blocks("s1", None, &repeating)

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Session lineage retained independently of physical cache eviction.
+//! Hash-keyed nodes and parent edges are shared across sessions, so a lineage may contain ancestors learned from another session and does not prove this session matched every block.
 //!
 //! Final-session removal, an LRU session cap, and a lineage-depth cap bound retention.
 
@@ -162,6 +163,7 @@ impl SessionPrefixIndexer {
     }
 
     /// Returns root-first chains, optionally filtered and truncated at an anchor.
+    /// Hash-keyed nodes and parent edges are shared, so a chain may include ancestors learned from another session and does not prove this session matched every block.
     pub fn get_session_block_lineage(
         &self,
         session_id: &str,

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -5,7 +5,10 @@
 //!
 //! Final-session removal, an LRU session cap, and a lineage-depth cap bound retention.
 
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    cmp::Reverse,
+    collections::{BTreeMap, HashMap},
+};
 
 use parking_lot::RwLock;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -196,14 +199,12 @@ impl SessionPrefixIndexer {
         matched_hash: ExternalSequenceBlockHash,
     ) -> Result<bool, SessionPrefixIndexError> {
         let mut state = self.state.write();
-        let parent = state
-            .sessions
-            .get(session_id)
-            .filter(|entry| entry.frontiers.len() == 1)
-            .and_then(|entry| entry.frontiers.iter().next().copied());
+        let continuation = state.deepest_frontier(session_id);
         let node = match state.hash_to_node.get(&matched_hash).copied() {
             Some(node) => {
-                if let Some(parent) = parent
+                let already_reached = state.session_has_reached(session_id, node);
+                if let Some(parent) = continuation
+                    && !already_reached
                     && state.nodes[node].parent.is_none()
                     && !state.is_ancestor_or_self(node, parent)
                 {
@@ -212,9 +213,9 @@ impl SessionPrefixIndexer {
                 }
                 node
             }
-            None => state.insert_node(matched_hash, parent),
+            None => state.insert_node(matched_hash, continuation),
         };
-        Ok(state.advance_frontier(session_id, node))
+        Ok(state.advance_match_frontier(session_id, node, continuation))
     }
 
     /// Records a stored block chain and reports whether the frontier advanced.
@@ -414,15 +415,51 @@ impl IndexState {
         false
     }
 
-    // Keep only the deepest frontier on each chain.
-    fn advance_frontier(&mut self, session_id: &str, node: NodeId) -> bool {
-        let already_reached = self.sessions.get(session_id).is_some_and(|entry| {
+    fn session_has_reached(&self, session_id: &str, node: NodeId) -> bool {
+        self.sessions.get(session_id).is_some_and(|entry| {
             entry
                 .frontiers
                 .iter()
                 .any(|&frontier| self.is_ancestor_or_self(node, frontier))
-        });
-        if already_reached {
+        })
+    }
+
+    fn deepest_frontier(&self, session_id: &str) -> Option<NodeId> {
+        self.sessions.get(session_id).and_then(|entry| {
+            entry.frontiers.iter().copied().max_by_key(|&frontier| {
+                (
+                    self.path_to_root(frontier).len(),
+                    Reverse(self.nodes[frontier].block_hash),
+                )
+            })
+        })
+    }
+
+    fn advance_match_frontier(
+        &mut self,
+        session_id: &str,
+        node: NodeId,
+        continuation: Option<NodeId>,
+    ) -> bool {
+        let advanced = self.advance_frontier(session_id, node);
+        if !advanced {
+            return false;
+        }
+
+        if let Some(continuation) = continuation
+            && self
+                .sessions
+                .get_mut(session_id)
+                .is_some_and(|entry| entry.frontiers.remove(&continuation))
+        {
+            self.release_frontier(continuation);
+        }
+        true
+    }
+
+    // Keep only the deepest frontier on each chain.
+    fn advance_frontier(&mut self, session_id: &str, node: NodeId) -> bool {
+        if self.session_has_reached(session_id, node) {
             // Repeated matches still refresh LRU order.
             self.touch_session(session_id);
             return false;
@@ -554,6 +591,43 @@ mod tests {
 
         assert_eq!(indexer.get_session_frontiers("s1").len(), 1);
         assert_eq!(lineage_of(&indexer, "s1"), vec![chain]);
+    }
+
+    #[test]
+    fn route_matches_replace_one_of_multiple_frontiers() {
+        let trunk = hashes(vec![1]);
+        let shallow = hashes(vec![2]);
+        let deep = hashes(vec![3, 4]);
+        let unrelated = hashes(vec![5, 6]);
+        let next = hashes(vec![7]);
+        let indexer = SessionPrefixIndexer::new();
+
+        indexer
+            .update_session_from_stored_blocks("s1", None, &trunk)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s1", Some(trunk[0]), &shallow)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s1", Some(trunk[0]), &deep)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("other", None, &unrelated)
+            .unwrap();
+
+        indexer
+            .update_session_from_match("s1", unrelated[1])
+            .unwrap();
+        indexer.update_session_from_match("s1", next[0]).unwrap();
+
+        assert_eq!(indexer.get_session_frontiers("s1").len(), 2);
+        assert_eq!(
+            lineage_of(&indexer, "s1"),
+            vec![
+                vec![trunk[0], shallow[0]],
+                vec![unrelated[0], unrelated[1], next[0]],
+            ]
+        );
     }
 
     #[test]

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -1,0 +1,729 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Session-aware logical prefix index.
+//!
+//! The physical indexers (`indexer::*`) answer "which worker holds this block
+//! right now". They are driven by engine cache events, so a block that the
+//! engine evicts disappears from them immediately. That is correct for routing
+//! but it destroys the only record of what a *session* has previously produced.
+//!
+//! This module keeps a separate, logical view: a forest of
+//! [`ExternalSequenceBlockHash`] nodes plus, per session, the set of nodes that
+//! are currently the deepest known point of that session's block chains. Nodes
+//! are never dropped because the engine evicted or cleared the underlying
+//! blocks; they are dropped only when the owning session is cleaned up through
+//! [`SessionPrefixIndexer::remove_session`]. Eviction changes where a block
+//! lives, not whether the session ever produced it.
+//!
+//! Structure follows the enhancement proposal:
+//!
+//! - `nodes`: a [`SlotMap`] arena of [`LogicalNode`], so a [`NodeId`] handed out
+//!   to a caller cannot silently alias a different node after a removal.
+//! - `hash_to_node`: reverse index from block hash to arena slot. Numeric key,
+//!   so [`FxHashMap`] per the crate guidance.
+//! - `sessions`: session id to frontier node set. The key is caller-supplied
+//!   text, so this uses [`std::collections::HashMap`] rather than `FxHashMap`,
+//!   again per the crate guidance.
+//!
+//! [`ExternalSequenceBlockHash`] is treated as opaque: this module compares and
+//! hashes it and never interprets, derives, or recomputes its value.
+//!
+//! Deviation from the proposal's literal signatures: the session parameters are
+//! taken as `&str` rather than an owned `SessionId`. The route-time caller only
+//! holds a borrow, and an owned parameter would force a `String` allocation on
+//! every routed request even when the session is already known. The owned
+//! [`SessionId`] alias is still what the map stores, and a clone happens only on
+//! first insert.
+
+use std::collections::HashMap;
+
+use parking_lot::RwLock;
+use rustc_hash::{FxHashMap, FxHashSet};
+use slotmap::{SlotMap, new_key_type};
+
+use crate::protocols::ExternalSequenceBlockHash;
+
+/// Logical session identity as owned by this index.
+pub type SessionId = String;
+
+new_key_type! {
+    /// Generational handle to a [`LogicalNode`] in the arena.
+    pub struct NodeId;
+}
+
+/// One logical block in the session forest.
+///
+/// Holds its own hash, its parent link, and the liveness counters that decide
+/// when the node can be reclaimed: how many session frontier sets point at it,
+/// and how many children it still has.
+#[derive(Clone, Copy, Debug)]
+pub struct LogicalNode {
+    block_hash: ExternalSequenceBlockHash,
+    parent: Option<NodeId>,
+    frontier_refs: u32,
+    child_count: u32,
+}
+
+impl LogicalNode {
+    /// The block hash this node stands for.
+    pub fn block_hash(&self) -> ExternalSequenceBlockHash {
+        self.block_hash
+    }
+
+    /// The parent node, or `None` when this node is a root of the forest.
+    pub fn parent(&self) -> Option<NodeId> {
+        self.parent
+    }
+
+    /// Number of sessions whose frontier set currently contains this node.
+    pub fn frontier_refs(&self) -> u32 {
+        self.frontier_refs
+    }
+
+    /// Number of direct children currently attached to this node.
+    pub fn child_count(&self) -> u32 {
+        self.child_count
+    }
+}
+
+/// Errors surfaced by [`SessionPrefixIndexer`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SessionPrefixIndexError {
+    /// A lineage query named an anchor hash the index has never seen. Returning
+    /// an empty lineage here would be indistinguishable from "this session has
+    /// no blocks past the anchor", so it is reported as an error instead.
+    #[error("unknown anchor block hash {0:?}")]
+    UnknownAnchor(ExternalSequenceBlockHash),
+
+    /// A stored-blocks update tried to attach a block under a parent other than
+    /// the one already recorded. Within one hash domain a unique block chain
+    /// maps to a unique external sequence-hash chain, so this is a producer,
+    /// configuration, or protocol error rather than a routing condition.
+    #[error("block {block:?} is already parented elsewhere")]
+    ConflictingParent {
+        /// The block whose recorded parent disagrees with the update.
+        block: ExternalSequenceBlockHash,
+    },
+}
+
+/// Session-aware logical prefix index.
+///
+/// Cheap to share: all methods take `&self` and lock internally, so the router
+/// can hold this behind an `Arc` next to its physical indexer.
+#[derive(Debug, Default)]
+pub struct SessionPrefixIndexer {
+    state: RwLock<IndexState>,
+}
+
+#[derive(Debug, Default)]
+struct IndexState {
+    nodes: SlotMap<NodeId, LogicalNode>,
+    hash_to_node: FxHashMap<ExternalSequenceBlockHash, NodeId>,
+    sessions: HashMap<SessionId, FxHashSet<NodeId>>,
+}
+
+impl SessionPrefixIndexer {
+    /// Create an empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve a block hash to its arena slot, if this index knows the block.
+    pub fn get_node_from_hash(&self, block_hash: ExternalSequenceBlockHash) -> Option<NodeId> {
+        self.state.read().hash_to_node.get(&block_hash).copied()
+    }
+
+    /// Read a node by handle. Returns `None` for a stale handle.
+    pub fn get_node(&self, node_id: NodeId) -> Option<LogicalNode> {
+        self.state.read().nodes.get(node_id).copied()
+    }
+
+    /// The deepest known nodes of every chain this session has touched.
+    ///
+    /// Empty for an unknown session. Order is unspecified.
+    pub fn get_session_frontiers(&self, session_id: &str) -> Vec<NodeId> {
+        self.state
+            .read()
+            .sessions
+            .get(session_id)
+            .map(|frontiers| frontiers.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// Every block chain this session has touched, root first.
+    ///
+    /// One inner vector per frontier. With `anchor_hash` set, each chain is
+    /// truncated to start at the anchor and chains that do not pass through it
+    /// are omitted; an anchor the index has never seen is an error. An unknown
+    /// session yields an empty result, which is not an error: a session that has
+    /// not been routed yet legitimately has no lineage.
+    pub fn get_session_block_lineage(
+        &self,
+        session_id: &str,
+        anchor_hash: Option<ExternalSequenceBlockHash>,
+    ) -> Result<Vec<Vec<ExternalSequenceBlockHash>>, SessionPrefixIndexError> {
+        let state = self.state.read();
+
+        let anchor_node = match anchor_hash {
+            Some(hash) => Some(
+                state
+                    .hash_to_node
+                    .get(&hash)
+                    .copied()
+                    .ok_or(SessionPrefixIndexError::UnknownAnchor(hash))?,
+            ),
+            None => None,
+        };
+
+        let Some(frontiers) = state.sessions.get(session_id) else {
+            return Ok(Vec::new());
+        };
+
+        let mut lineages = Vec::with_capacity(frontiers.len());
+        for &frontier in frontiers {
+            let path = state.path_to_root(frontier);
+            let start = match anchor_node {
+                Some(anchor) => match path.iter().position(|&node| node == anchor) {
+                    Some(position) => position,
+                    // This frontier's chain does not pass through the anchor.
+                    None => continue,
+                },
+                None => 0,
+            };
+            lineages.push(
+                path[start..]
+                    .iter()
+                    .map(|&node| state.nodes[node].block_hash)
+                    .collect(),
+            );
+        }
+        Ok(lineages)
+    }
+
+    /// Record a route-time cache hit for `session_id` at `matched_hash`.
+    ///
+    /// Returns whether the session's frontier set moved. A hit on a block at or
+    /// above a frontier the session already holds is not an advance, so a
+    /// re-route of the same prefix leaves the index untouched. An unknown hash
+    /// is admitted as a new root: the router matched the block, so it exists,
+    /// even though a match alone carries no parent link. A later
+    /// [`Self::update_session_from_stored_blocks`] carrying that parent grafts
+    /// the chain onto this same node rather than creating a second root.
+    pub fn update_session_from_match(
+        &self,
+        session_id: &str,
+        matched_hash: ExternalSequenceBlockHash,
+    ) -> Result<bool, SessionPrefixIndexError> {
+        let mut state = self.state.write();
+        let node = state.resolve_or_insert_root(matched_hash);
+        Ok(state.advance_frontier(session_id, node))
+    }
+
+    /// Record a chain of blocks stored under `parent_hash` for `session_id`.
+    ///
+    /// Blocks are applied in order and existing nodes are reused, so replaying
+    /// the same chain does not grow the arena. Returns whether the session's
+    /// frontier set moved.
+    ///
+    /// Not currently driven by the KV event stream: the cache event schema
+    /// carries no session identity, so there is no honest way to attribute a
+    /// stored-block event to a session yet. It is the ingest half of the
+    /// proposal's API and is exercised by this module's tests.
+    pub fn update_session_from_stored_blocks(
+        &self,
+        session_id: &str,
+        parent_hash: Option<ExternalSequenceBlockHash>,
+        block_hashes: &[ExternalSequenceBlockHash],
+    ) -> Result<bool, SessionPrefixIndexError> {
+        if block_hashes.is_empty() {
+            return Ok(false);
+        }
+
+        let mut state = self.state.write();
+        // Validate the whole chain before touching the arena, so a rejected
+        // update leaves no half-applied nodes behind.
+        state.validate_chain(parent_hash, block_hashes)?;
+
+        let mut parent = parent_hash.map(|hash| state.resolve_or_insert_root(hash));
+        for &block_hash in block_hashes {
+            let node = match state.hash_to_node.get(&block_hash).copied() {
+                Some(existing) => {
+                    // Known only as a root so far; graft it under the parent
+                    // this event supplies instead of leaving it detached.
+                    if let (None, Some(expected)) = (state.nodes[existing].parent, parent) {
+                        state.nodes[existing].parent = Some(expected);
+                        state.nodes[expected].child_count += 1;
+                    }
+                    existing
+                }
+                None => state.insert_node(block_hash, parent),
+            };
+            parent = Some(node);
+        }
+
+        let leaf = parent.expect("non-empty block chain always yields a node");
+        Ok(state.advance_frontier(session_id, leaf))
+    }
+
+    /// Drop a session and reclaim the nodes no other session still needs.
+    ///
+    /// Returns whether the session was known. This is the only path that
+    /// removes logical nodes; block eviction never does.
+    pub fn remove_session(&self, session_id: &str) -> bool {
+        let mut state = self.state.write();
+        let Some(frontiers) = state.sessions.remove(session_id) else {
+            return false;
+        };
+        for frontier in frontiers {
+            state.release_frontier(frontier);
+        }
+        true
+    }
+
+    /// Number of logical nodes currently retained.
+    pub fn node_count(&self) -> usize {
+        self.state.read().nodes.len()
+    }
+
+    /// Number of sessions currently tracked.
+    pub fn session_count(&self) -> usize {
+        self.state.read().sessions.len()
+    }
+}
+
+impl IndexState {
+    fn insert_node(
+        &mut self,
+        block_hash: ExternalSequenceBlockHash,
+        parent: Option<NodeId>,
+    ) -> NodeId {
+        let node = self.nodes.insert(LogicalNode {
+            block_hash,
+            parent,
+            frontier_refs: 0,
+            child_count: 0,
+        });
+        self.hash_to_node.insert(block_hash, node);
+        if let Some(parent) = parent {
+            self.nodes[parent].child_count += 1;
+        }
+        node
+    }
+
+    /// Read-only check that no block in the chain is already parented somewhere
+    /// other than where this chain would put it.
+    fn validate_chain(
+        &self,
+        parent_hash: Option<ExternalSequenceBlockHash>,
+        block_hashes: &[ExternalSequenceBlockHash],
+    ) -> Result<(), SessionPrefixIndexError> {
+        let mut expected_parent = parent_hash;
+        for &block_hash in block_hashes {
+            if let Some(&existing) = self.hash_to_node.get(&block_hash)
+                && let Some(recorded) = self.nodes[existing].parent
+                && Some(self.nodes[recorded].block_hash) != expected_parent
+            {
+                return Err(SessionPrefixIndexError::ConflictingParent { block: block_hash });
+            }
+            expected_parent = Some(block_hash);
+        }
+        Ok(())
+    }
+
+    fn resolve_or_insert_root(&mut self, block_hash: ExternalSequenceBlockHash) -> NodeId {
+        match self.hash_to_node.get(&block_hash).copied() {
+            Some(node) => node,
+            None => self.insert_node(block_hash, None),
+        }
+    }
+
+    fn path_to_root(&self, tail: NodeId) -> Vec<NodeId> {
+        let mut path = Vec::new();
+        let mut current = Some(tail);
+        while let Some(node) = current {
+            path.push(node);
+            current = self.nodes[node].parent;
+        }
+        path.reverse();
+        path
+    }
+
+    /// Is `candidate` at or above `node` in the forest?
+    fn is_ancestor_or_self(&self, candidate: NodeId, node: NodeId) -> bool {
+        let mut current = Some(node);
+        while let Some(walk) = current {
+            if walk == candidate {
+                return true;
+            }
+            current = self.nodes[walk].parent;
+        }
+        false
+    }
+
+    /// Move `session_id`'s frontier set to include `node`, returning whether
+    /// anything changed. Frontiers that `node` now subsumes are dropped so a
+    /// session holds only the deepest point of each chain it has touched.
+    fn advance_frontier(&mut self, session_id: &str, node: NodeId) -> bool {
+        if let Some(frontiers) = self.sessions.get(session_id)
+            && frontiers
+                .iter()
+                .any(|&frontier| self.is_ancestor_or_self(node, frontier))
+        {
+            return false;
+        }
+
+        let subsumed: Vec<NodeId> = self
+            .sessions
+            .get(session_id)
+            .map(|frontiers| {
+                frontiers
+                    .iter()
+                    .copied()
+                    .filter(|&frontier| self.is_ancestor_or_self(frontier, node))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        for frontier in &subsumed {
+            self.nodes[*frontier].frontier_refs -= 1;
+        }
+        self.nodes[node].frontier_refs += 1;
+
+        let frontiers = self.sessions.entry(session_id.to_string()).or_default();
+        for frontier in subsumed {
+            frontiers.remove(&frontier);
+        }
+        frontiers.insert(node);
+        true
+    }
+
+    /// Drop one frontier reference and reclaim the now-unreachable tail above
+    /// it. A node survives while any session still points at it or any child
+    /// still hangs off it, so shared prefixes outlive the first session to go.
+    fn release_frontier(&mut self, frontier: NodeId) {
+        self.nodes[frontier].frontier_refs -= 1;
+
+        let mut current = Some(frontier);
+        while let Some(node) = current {
+            let entry = self.nodes[node];
+            if entry.frontier_refs > 0 || entry.child_count > 0 {
+                break;
+            }
+            self.nodes.remove(node);
+            self.hash_to_node.remove(&entry.block_hash);
+            if let Some(parent) = entry.parent {
+                self.nodes[parent].child_count -= 1;
+            }
+            current = entry.parent;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::make_blocks;
+
+    /// Block hashes as the engine publishes them, via the shared event builder
+    /// so these fixtures cannot drift from the real event shape.
+    fn hashes(ids: Vec<u64>) -> Vec<ExternalSequenceBlockHash> {
+        make_blocks(ids)
+            .into_iter()
+            .map(|block| block.block_hash)
+            .collect()
+    }
+
+    fn lineage_of(
+        indexer: &SessionPrefixIndexer,
+        session: &str,
+    ) -> Vec<Vec<ExternalSequenceBlockHash>> {
+        let mut lineages = indexer
+            .get_session_block_lineage(session, None)
+            .expect("lineage query without an anchor cannot fail");
+        lineages.sort();
+        lineages
+    }
+
+    #[test]
+    fn match_creates_lineage_and_repeat_is_idempotent() {
+        let chain = hashes(vec![1, 2, 3]);
+        let indexer = SessionPrefixIndexer::new();
+
+        assert!(
+            indexer.update_session_from_match("s1", chain[0]).unwrap(),
+            "first match must advance the frontier"
+        );
+        assert_eq!(indexer.node_count(), 1);
+        assert_eq!(lineage_of(&indexer, "s1"), vec![vec![chain[0]]]);
+
+        assert!(
+            !indexer.update_session_from_match("s1", chain[0]).unwrap(),
+            "re-matching the same block is not an advance"
+        );
+        assert_eq!(
+            indexer.node_count(),
+            1,
+            "a repeated match must not grow the arena"
+        );
+        assert_eq!(indexer.get_session_frontiers("s1").len(), 1);
+    }
+
+    #[test]
+    fn deeper_match_replaces_the_shallower_frontier() {
+        let chain = hashes(vec![1, 2, 3]);
+        let indexer = SessionPrefixIndexer::new();
+
+        indexer
+            .update_session_from_stored_blocks("s1", None, &chain)
+            .unwrap();
+        assert_eq!(indexer.get_session_frontiers("s1").len(), 1);
+
+        // Re-route lands on the middle of the chain the session already owns.
+        assert!(
+            !indexer.update_session_from_match("s1", chain[1]).unwrap(),
+            "a match above the current frontier must not move it"
+        );
+        assert_eq!(lineage_of(&indexer, "s1"), vec![chain.clone()]);
+
+        // A brand new session hitting the middle stops there.
+        assert!(indexer.update_session_from_match("s2", chain[1]).unwrap());
+        assert_eq!(lineage_of(&indexer, "s2"), vec![chain[..2].to_vec()]);
+    }
+
+    #[test]
+    fn stored_blocks_reuse_shared_prefix_nodes() {
+        let trunk = hashes(vec![1, 2]);
+        let branch = hashes(vec![3]);
+        let indexer = SessionPrefixIndexer::new();
+
+        indexer
+            .update_session_from_stored_blocks("s1", None, &trunk)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s2", None, &trunk)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s2", Some(trunk[1]), &branch)
+            .unwrap();
+
+        assert_eq!(
+            indexer.node_count(),
+            3,
+            "the shared trunk must be stored once, not per session"
+        );
+        assert_eq!(lineage_of(&indexer, "s1"), vec![trunk.clone()]);
+        assert_eq!(
+            lineage_of(&indexer, "s2"),
+            vec![vec![trunk[0], trunk[1], branch[0]]]
+        );
+    }
+
+    #[test]
+    fn stored_blocks_graft_onto_a_node_first_seen_as_a_match() {
+        let chain = hashes(vec![1, 2]);
+        let indexer = SessionPrefixIndexer::new();
+
+        // Route-time hit on the child arrives first, with no parent context.
+        indexer.update_session_from_match("s1", chain[1]).unwrap();
+        let child = indexer.get_node_from_hash(chain[1]).unwrap();
+        assert_eq!(indexer.get_node(child).unwrap().parent(), None);
+
+        // The stored-block chain then supplies the missing parent link.
+        indexer
+            .update_session_from_stored_blocks("s1", Some(chain[0]), &chain[1..])
+            .unwrap();
+
+        assert_eq!(
+            indexer.get_node_from_hash(chain[1]),
+            Some(child),
+            "grafting must keep the original node handle valid"
+        );
+        assert_eq!(
+            indexer.node_count(),
+            2,
+            "grafting must not leave a duplicate root behind"
+        );
+        assert_eq!(lineage_of(&indexer, "s1"), vec![chain]);
+    }
+
+    #[test]
+    fn conflicting_parent_is_rejected() {
+        let chain = hashes(vec![1, 2, 3]);
+        let indexer = SessionPrefixIndexer::new();
+
+        indexer
+            .update_session_from_stored_blocks("s1", None, &chain[..2])
+            .unwrap();
+
+        let err = indexer
+            .update_session_from_stored_blocks("s1", Some(chain[2]), &chain[1..2])
+            .expect_err("re-parenting a known block violates the hash invariant");
+        assert_eq!(
+            err,
+            SessionPrefixIndexError::ConflictingParent { block: chain[1] }
+        );
+    }
+
+    #[test]
+    fn branching_session_keeps_one_frontier_per_chain() {
+        let trunk = hashes(vec![1]);
+        let left = hashes(vec![2]);
+        let right = hashes(vec![3]);
+        let indexer = SessionPrefixIndexer::new();
+
+        indexer
+            .update_session_from_stored_blocks("s1", None, &trunk)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s1", Some(trunk[0]), &left)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s1", Some(trunk[0]), &right)
+            .unwrap();
+
+        assert_eq!(
+            indexer.get_session_frontiers("s1").len(),
+            2,
+            "each branch keeps its own frontier"
+        );
+        assert_eq!(
+            lineage_of(&indexer, "s1"),
+            vec![vec![trunk[0], left[0]], vec![trunk[0], right[0]]]
+        );
+    }
+
+    #[test]
+    fn lineage_anchor_truncates_and_filters() {
+        let trunk = hashes(vec![1, 2]);
+        let left = hashes(vec![3]);
+        let right = hashes(vec![4]);
+        let indexer = SessionPrefixIndexer::new();
+
+        indexer
+            .update_session_from_stored_blocks("s1", None, &trunk)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s1", Some(trunk[1]), &left)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s1", None, &right)
+            .unwrap();
+
+        let anchored = indexer
+            .get_session_block_lineage("s1", Some(trunk[1]))
+            .unwrap();
+        assert_eq!(
+            anchored,
+            vec![vec![trunk[1], left[0]]],
+            "anchoring drops chains that miss the anchor and trims the rest"
+        );
+    }
+
+    #[test]
+    fn unknown_anchor_is_an_error_and_unknown_session_is_empty() {
+        let chain = hashes(vec![1]);
+        let missing = hashes(vec![99]);
+        let indexer = SessionPrefixIndexer::new();
+        indexer.update_session_from_match("s1", chain[0]).unwrap();
+
+        assert_eq!(
+            indexer.get_session_block_lineage("s1", Some(missing[0])),
+            Err(SessionPrefixIndexError::UnknownAnchor(missing[0]))
+        );
+        assert_eq!(
+            indexer.get_session_block_lineage("unrouted", None),
+            Ok(Vec::new()),
+            "a session with no routed requests is empty, not an error"
+        );
+    }
+
+    #[test]
+    fn eviction_shaped_replay_does_not_lose_lineage() {
+        // The physical indexers would have dropped these blocks on a Removed or
+        // Cleared event. This index has no such path: only remove_session drops
+        // nodes, so a session re-routed after eviction still reads back its
+        // full chain.
+        let chain = hashes(vec![1, 2]);
+        let indexer = SessionPrefixIndexer::new();
+
+        indexer
+            .update_session_from_stored_blocks("s1", None, &chain)
+            .unwrap();
+        let before = lineage_of(&indexer, "s1");
+
+        indexer.update_session_from_match("s1", chain[0]).unwrap();
+
+        assert_eq!(
+            lineage_of(&indexer, "s1"),
+            before,
+            "re-matching a shallow block must not truncate the recorded lineage"
+        );
+        assert_eq!(indexer.node_count(), 2);
+    }
+
+    #[test]
+    fn removing_a_session_frees_only_its_exclusive_tail() {
+        let trunk = hashes(vec![1, 2]);
+        let tail = hashes(vec![3]);
+        let indexer = SessionPrefixIndexer::new();
+
+        indexer
+            .update_session_from_stored_blocks("s1", None, &trunk)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s2", None, &trunk)
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s2", Some(trunk[1]), &tail)
+            .unwrap();
+        assert_eq!(indexer.node_count(), 3);
+
+        assert!(indexer.remove_session("s2"));
+        assert_eq!(
+            indexer.node_count(),
+            2,
+            "only the tail s2 held exclusively is reclaimed"
+        );
+        assert_eq!(indexer.get_node_from_hash(tail[0]), None);
+        assert_eq!(
+            lineage_of(&indexer, "s1"),
+            vec![trunk.clone()],
+            "the surviving session keeps the shared trunk"
+        );
+
+        assert!(indexer.remove_session("s1"));
+        assert_eq!(
+            indexer.node_count(),
+            0,
+            "the last session out releases every slot"
+        );
+        assert_eq!(indexer.session_count(), 0);
+        assert_eq!(indexer.get_node_from_hash(trunk[0]), None);
+
+        assert!(
+            !indexer.remove_session("s1"),
+            "removing an unknown session reports that nothing was removed"
+        );
+    }
+
+    #[test]
+    fn stale_node_handles_do_not_alias_after_reuse() {
+        let first = hashes(vec![1]);
+        let second = hashes(vec![2]);
+        let indexer = SessionPrefixIndexer::new();
+
+        indexer.update_session_from_match("s1", first[0]).unwrap();
+        let stale = indexer.get_node_from_hash(first[0]).unwrap();
+        indexer.remove_session("s1");
+
+        indexer.update_session_from_match("s2", second[0]).unwrap();
+        let fresh = indexer.get_node_from_hash(second[0]).unwrap();
+
+        assert_ne!(stale, fresh, "the generational key must not be reissued");
+        assert!(
+            indexer.get_node(stale).is_none(),
+            "a handle to a removed node must not resolve to its replacement"
+        );
+    }
+}

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -424,11 +424,27 @@ impl IndexState {
         })
     }
 
+    fn depth_to_root(&self, tail: NodeId) -> usize {
+        let limit = self.nodes.len();
+        let mut depth = 0usize;
+        let mut current = Some(tail);
+        while let Some(node) = current {
+            if depth >= limit {
+                debug_assert!(false, "parent cycle in session prefix index forest");
+                tracing::error!("session prefix index parent walk exceeded the arena; truncating");
+                break;
+            }
+            depth += 1;
+            current = self.nodes[node].parent;
+        }
+        depth
+    }
+
     fn deepest_frontier(&self, session_id: &str) -> Option<NodeId> {
         self.sessions.get(session_id).and_then(|entry| {
             entry.frontiers.iter().copied().max_by_key(|&frontier| {
                 (
-                    self.path_to_root(frontier).len(),
+                    self.depth_to_root(frontier),
                     Reverse(self.nodes[frontier].block_hash),
                 )
             })

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -12,9 +12,19 @@
 //! [`ExternalSequenceBlockHash`] nodes plus, per session, the set of nodes that
 //! are currently the deepest known point of that session's block chains. Nodes
 //! are never dropped because the engine evicted or cleared the underlying
-//! blocks; they are dropped only when the owning session is cleaned up through
-//! [`SessionPrefixIndexer::remove_session`]. Eviction changes where a block
-//! lives, not whether the session ever produced it.
+//! blocks; they are dropped only when the owning session goes, either through
+//! [`SessionPrefixIndexer::remove_session`] or through the capacity bound
+//! below. Eviction changes where a block lives, not whether the session ever
+//! produced it.
+//!
+//! Retention is bounded. The router calls [`SessionPrefixIndexer::remove_session`]
+//! when a request marks its session final, but that signal is optional and many
+//! clients never send it, so the index also caps how many sessions it tracks
+//! ([`DEFAULT_MAX_SESSIONS`], overridable via
+//! [`SessionPrefixIndexer::with_max_sessions`]). Passing the cap evicts the
+//! least recently touched session by exactly the path `remove_session` takes.
+//! Both halves are needed: the lifecycle signal reclaims promptly when it
+//! arrives, and the cap is what makes growth bounded when it never does.
 //!
 //! Structure follows the enhancement proposal:
 //!
@@ -36,7 +46,7 @@
 //! [`SessionId`] alias is still what the map stores, and a clone happens only on
 //! first insert.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use parking_lot::RwLock;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -46,6 +56,16 @@ use crate::protocols::ExternalSequenceBlockHash;
 
 /// Logical session identity as owned by this index.
 pub type SessionId = String;
+
+/// Default ceiling on tracked sessions, past which the least recently touched
+/// session is evicted.
+///
+/// Sized so the common case never reaches it — a router serving far fewer
+/// concurrent sessions than this behaves exactly as if the index were
+/// unbounded — while a router that never receives an end-of-session signal
+/// still settles at a fixed footprint instead of growing for the life of the
+/// process.
+pub const DEFAULT_MAX_SESSIONS: usize = 16_384;
 
 new_key_type! {
     /// Generational handle to a [`LogicalNode`] in the arena.
@@ -105,6 +125,17 @@ pub enum SessionPrefixIndexError {
         /// The block whose recorded parent disagrees with the update.
         block: ExternalSequenceBlockHash,
     },
+
+    /// A stored-blocks update tried to attach a block underneath a block that
+    /// the first one already sits at or above. Applying it would close a parent
+    /// cycle, and every walk of the forest follows parent links, so the cycle
+    /// would turn later reads into non-terminating loops holding the write
+    /// lock. Rejected before the arena is touched.
+    #[error("block {block:?} would become its own ancestor")]
+    CyclicParent {
+        /// The block whose graft would close the cycle.
+        block: ExternalSequenceBlockHash,
+    },
 }
 
 /// Session-aware logical prefix index.
@@ -116,17 +147,70 @@ pub struct SessionPrefixIndexer {
     state: RwLock<IndexState>,
 }
 
+/// One session's retained state: the deepest nodes it has reached, and when it
+/// was last touched, which is what the capacity bound evicts on.
+///
+/// `last_touch` is `None` only between the entry's creation and the
+/// [`IndexState::touch_session`] call that immediately follows it. Making that
+/// gap explicit matters: a numeric sentinel would alias whichever session
+/// legitimately holds that sequence number and evict it instead.
 #[derive(Debug, Default)]
+struct SessionEntry {
+    frontiers: FxHashSet<NodeId>,
+    last_touch: Option<u64>,
+}
+
+#[derive(Debug)]
 struct IndexState {
     nodes: SlotMap<NodeId, LogicalNode>,
     hash_to_node: FxHashMap<ExternalSequenceBlockHash, NodeId>,
-    sessions: HashMap<SessionId, FxHashSet<NodeId>>,
+    sessions: HashMap<SessionId, SessionEntry>,
+    /// Touch sequence to session id, so the least recently touched session is
+    /// the first entry. Kept in lockstep with [`SessionEntry::last_touch`]:
+    /// every session in `sessions` has exactly one entry here.
+    lru: BTreeMap<u64, SessionId>,
+    /// Monotonic touch counter. `u64` at one touch per routed request does not
+    /// wrap in any realistic process lifetime.
+    next_touch: u64,
+    max_sessions: usize,
+}
+
+impl Default for IndexState {
+    fn default() -> Self {
+        Self {
+            nodes: SlotMap::default(),
+            hash_to_node: FxHashMap::default(),
+            sessions: HashMap::default(),
+            lru: BTreeMap::default(),
+            next_touch: 0,
+            max_sessions: DEFAULT_MAX_SESSIONS,
+        }
+    }
 }
 
 impl SessionPrefixIndexer {
-    /// Create an empty index.
+    /// Create an empty index holding at most [`DEFAULT_MAX_SESSIONS`] sessions.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Create an empty index holding at most `max_sessions` sessions.
+    ///
+    /// A cap of zero is raised to one: an index that could retain nothing would
+    /// discard each session as it was recorded, which is not a useful state to
+    /// let a caller configure by accident.
+    pub fn with_max_sessions(max_sessions: usize) -> Self {
+        Self {
+            state: RwLock::new(IndexState {
+                max_sessions: max_sessions.max(1),
+                ..IndexState::default()
+            }),
+        }
+    }
+
+    /// The ceiling on tracked sessions.
+    pub fn max_sessions(&self) -> usize {
+        self.state.read().max_sessions
     }
 
     /// Resolve a block hash to its arena slot, if this index knows the block.
@@ -147,7 +231,7 @@ impl SessionPrefixIndexer {
             .read()
             .sessions
             .get(session_id)
-            .map(|frontiers| frontiers.iter().copied().collect())
+            .map(|entry| entry.frontiers.iter().copied().collect())
             .unwrap_or_default()
     }
 
@@ -176,12 +260,12 @@ impl SessionPrefixIndexer {
             None => None,
         };
 
-        let Some(frontiers) = state.sessions.get(session_id) else {
+        let Some(entry) = state.sessions.get(session_id) else {
             return Ok(Vec::new());
         };
 
-        let mut lineages = Vec::with_capacity(frontiers.len());
-        for &frontier in frontiers {
+        let mut lineages = Vec::with_capacity(entry.frontiers.len());
+        for &frontier in &entry.frontiers {
             let path = state.path_to_root(frontier);
             let start = match anchor_node {
                 Some(anchor) => match path.iter().position(|&node| node == anchor) {
@@ -272,13 +356,7 @@ impl SessionPrefixIndexer {
     /// removes logical nodes; block eviction never does.
     pub fn remove_session(&self, session_id: &str) -> bool {
         let mut state = self.state.write();
-        let Some(frontiers) = state.sessions.remove(session_id) else {
-            return false;
-        };
-        for frontier in frontiers {
-            state.release_frontier(frontier);
-        }
-        true
+        state.drop_session(session_id)
     }
 
     /// Number of logical nodes currently retained.
@@ -312,23 +390,106 @@ impl IndexState {
     }
 
     /// Read-only check that no block in the chain is already parented somewhere
-    /// other than where this chain would put it.
+    /// other than where this chain would put it, and that applying the chain
+    /// cannot close a parent cycle.
+    ///
+    /// The cycle half matters because a block already known only as a root has
+    /// `parent == None` and so passes the conflict check, after which the apply
+    /// loop would graft it under whatever parent this call supplies — including
+    /// one of its own descendants. `dominators` is every hash that will sit at
+    /// or above the chain once it is applied: the supplied parent, everything
+    /// already above that parent, and the chain's own earlier blocks. A block
+    /// that appears in that set is being asked to become its own ancestor.
     fn validate_chain(
         &self,
         parent_hash: Option<ExternalSequenceBlockHash>,
         block_hashes: &[ExternalSequenceBlockHash],
     ) -> Result<(), SessionPrefixIndexError> {
+        let mut dominators: FxHashSet<ExternalSequenceBlockHash> = FxHashSet::default();
+        if let Some(parent_hash) = parent_hash {
+            dominators.insert(parent_hash);
+            if let Some(&parent_node) = self.hash_to_node.get(&parent_hash) {
+                dominators.extend(
+                    self.path_to_root(parent_node)
+                        .into_iter()
+                        .map(|node| self.nodes[node].block_hash),
+                );
+            }
+        }
+
         let mut expected_parent = parent_hash;
         for &block_hash in block_hashes {
+            if dominators.contains(&block_hash) {
+                return Err(SessionPrefixIndexError::CyclicParent { block: block_hash });
+            }
             if let Some(&existing) = self.hash_to_node.get(&block_hash)
                 && let Some(recorded) = self.nodes[existing].parent
                 && Some(self.nodes[recorded].block_hash) != expected_parent
             {
                 return Err(SessionPrefixIndexError::ConflictingParent { block: block_hash });
             }
+            dominators.insert(block_hash);
             expected_parent = Some(block_hash);
         }
         Ok(())
+    }
+
+    /// Remove a session and reclaim what no other session needs, returning
+    /// whether the session was known. Shared by the public
+    /// [`SessionPrefixIndexer::remove_session`] and by capacity eviction, so
+    /// both reclaim by exactly the same path.
+    fn drop_session(&mut self, session_id: &str) -> bool {
+        let Some(entry) = self.sessions.remove(session_id) else {
+            return false;
+        };
+        if let Some(last_touch) = entry.last_touch {
+            self.lru.remove(&last_touch);
+        }
+        for frontier in entry.frontiers {
+            self.release_frontier(frontier);
+        }
+        true
+    }
+
+    /// Mark `session_id` as the most recently used session.
+    fn touch_session(&mut self, session_id: &str) {
+        let seq = self.next_touch;
+        let Some(entry) = self.sessions.get_mut(session_id) else {
+            return;
+        };
+        let previous = entry.last_touch.replace(seq);
+        self.next_touch += 1;
+        if let Some(previous) = previous {
+            self.lru.remove(&previous);
+        }
+        self.lru.insert(seq, session_id.to_string());
+    }
+
+    /// Evict least recently touched sessions until the cap is respected.
+    ///
+    /// Called after a session is recorded rather than before, so the session
+    /// that just arrived is the most recently touched one and is never the
+    /// victim of its own insertion.
+    fn enforce_session_cap(&mut self) {
+        while self.sessions.len() > self.max_sessions {
+            let Some((_, victim)) = self.lru.pop_first() else {
+                // `lru` and `sessions` are maintained together, so this is
+                // unreachable; breaking rather than looping keeps a bookkeeping
+                // bug from becoming a hang.
+                debug_assert!(false, "lru is empty while sessions is over capacity");
+                break;
+            };
+            if let Some(entry) = self.sessions.remove(&victim) {
+                for frontier in entry.frontiers {
+                    self.release_frontier(frontier);
+                }
+            }
+            tracing::debug!(
+                session_id = %victim,
+                max_sessions = self.max_sessions,
+                "session prefix index evicted its least recently used session"
+            );
+        }
     }
 
     fn resolve_or_insert_root(&mut self, block_hash: ExternalSequenceBlockHash) -> NodeId {
@@ -338,10 +499,23 @@ impl IndexState {
         }
     }
 
+    /// Walk parent links from `tail`, root first.
+    ///
+    /// Bounded by the arena size. An acyclic forest cannot yield a longer path,
+    /// so the bound never truncates a well-formed walk; it is a backstop that
+    /// makes a corrupted arena degrade into a short answer rather than spin
+    /// forever while holding the index lock. `validate_chain` is what actually
+    /// keeps the forest acyclic.
     fn path_to_root(&self, tail: NodeId) -> Vec<NodeId> {
+        let limit = self.nodes.len();
         let mut path = Vec::new();
         let mut current = Some(tail);
         while let Some(node) = current {
+            if path.len() >= limit {
+                debug_assert!(false, "parent cycle in session prefix index forest");
+                tracing::error!("session prefix index parent walk exceeded the arena; truncating");
+                break;
+            }
             path.push(node);
             current = self.nodes[node].parent;
         }
@@ -350,11 +524,21 @@ impl IndexState {
     }
 
     /// Is `candidate` at or above `node` in the forest?
+    ///
+    /// Bounded on the same reasoning as [`Self::path_to_root`].
     fn is_ancestor_or_self(&self, candidate: NodeId, node: NodeId) -> bool {
+        let limit = self.nodes.len();
         let mut current = Some(node);
+        let mut steps = 0usize;
         while let Some(walk) = current {
             if walk == candidate {
                 return true;
+            }
+            steps += 1;
+            if steps > limit {
+                debug_assert!(false, "parent cycle in session prefix index forest");
+                tracing::error!("session prefix index ancestry walk exceeded the arena; aborting");
+                return false;
             }
             current = self.nodes[walk].parent;
         }
@@ -365,19 +549,26 @@ impl IndexState {
     /// anything changed. Frontiers that `node` now subsumes are dropped so a
     /// session holds only the deepest point of each chain it has touched.
     fn advance_frontier(&mut self, session_id: &str, node: NodeId) -> bool {
-        if let Some(frontiers) = self.sessions.get(session_id)
-            && frontiers
+        let already_reached = self.sessions.get(session_id).is_some_and(|entry| {
+            entry
+                .frontiers
                 .iter()
                 .any(|&frontier| self.is_ancestor_or_self(node, frontier))
-        {
+        });
+        if already_reached {
+            // The frontier does not move, but the session is demonstrably still
+            // being routed, so it must not drift towards eviction while a
+            // genuinely idle session outranks it.
+            self.touch_session(session_id);
             return false;
         }
 
         let subsumed: Vec<NodeId> = self
             .sessions
             .get(session_id)
-            .map(|frontiers| {
-                frontiers
+            .map(|entry| {
+                entry
+                    .frontiers
                     .iter()
                     .copied()
                     .filter(|&frontier| self.is_ancestor_or_self(frontier, node))
@@ -390,11 +581,14 @@ impl IndexState {
         }
         self.nodes[node].frontier_refs += 1;
 
-        let frontiers = self.sessions.entry(session_id.to_string()).or_default();
+        let entry = self.sessions.entry(session_id.to_string()).or_default();
         for frontier in subsumed {
-            frontiers.remove(&frontier);
+            entry.frontiers.remove(&frontier);
         }
-        frontiers.insert(node);
+        entry.frontiers.insert(node);
+
+        self.touch_session(session_id);
+        self.enforce_session_cap();
         true
     }
 
@@ -724,6 +918,125 @@ mod tests {
         assert!(
             indexer.get_node(stale).is_none(),
             "a handle to a removed node must not resolve to its replacement"
+        );
+    }
+
+    #[test]
+    fn passing_the_session_cap_evicts_the_least_recently_used_session() {
+        let chain = hashes(vec![1, 2, 3]);
+        let indexer = SessionPrefixIndexer::with_max_sessions(2);
+        assert_eq!(indexer.max_sessions(), 2);
+
+        indexer.update_session_from_match("s1", chain[0]).unwrap();
+        indexer.update_session_from_match("s2", chain[1]).unwrap();
+        // Touch s1 so s2 becomes the least recently used of the two.
+        indexer.update_session_from_match("s1", chain[1]).unwrap();
+
+        indexer.update_session_from_match("s3", chain[2]).unwrap();
+
+        assert!(
+            lineage_of(&indexer, "s2").is_empty(),
+            "the least recently touched session is the one evicted"
+        );
+        assert!(
+            !lineage_of(&indexer, "s1").is_empty(),
+            "a recently touched session survives the eviction"
+        );
+        assert!(
+            !lineage_of(&indexer, "s3").is_empty(),
+            "the session that triggered the eviction is retained"
+        );
+    }
+
+    #[test]
+    fn eviction_releases_the_evicted_session_arena_nodes() {
+        let chain = hashes(vec![1, 2]);
+        let indexer = SessionPrefixIndexer::with_max_sessions(1);
+
+        indexer.update_session_from_match("s1", chain[0]).unwrap();
+        let evicted = indexer.get_node_from_hash(chain[0]).unwrap();
+
+        indexer.update_session_from_match("s2", chain[1]).unwrap();
+
+        assert!(
+            indexer.get_node(evicted).is_none(),
+            "eviction must reclaim the arena exactly as remove_session does"
+        );
+        assert!(
+            indexer.get_node_from_hash(chain[0]).is_none(),
+            "the evicted session's hash index entry must go with its node"
+        );
+    }
+
+    #[test]
+    fn a_zero_session_cap_is_clamped_to_one_tracked_session() {
+        let chain = hashes(vec![1]);
+        let indexer = SessionPrefixIndexer::with_max_sessions(0);
+
+        assert_eq!(
+            indexer.max_sessions(),
+            1,
+            "a cap of zero would track nothing"
+        );
+        indexer.update_session_from_match("s1", chain[0]).unwrap();
+        assert!(
+            !lineage_of(&indexer, "s1").is_empty(),
+            "the sole tracked session must survive its own insertion"
+        );
+    }
+
+    #[test]
+    fn a_chain_that_would_close_a_cycle_is_rejected() {
+        let chain = hashes(vec![1, 2, 3]);
+        let indexer = SessionPrefixIndexer::new();
+
+        // Build A -> B -> C.
+        indexer
+            .update_session_from_stored_blocks("s1", None, &chain)
+            .unwrap();
+
+        // Now claim A is stored under C. Accepting that would make A its own
+        // ancestor and leave the parent walks looping forever.
+        let err = indexer
+            .update_session_from_stored_blocks("s1", Some(chain[2]), &chain[..1])
+            .expect_err("grafting an ancestor under its own descendant must fail");
+        assert!(
+            matches!(
+                err,
+                SessionPrefixIndexError::CyclicParent { block } if block == chain[0]
+            ),
+            "expected CyclicParent for the offending block, got {err:?}"
+        );
+
+        // The rejected update must leave the original forest intact.
+        assert_eq!(
+            lineage_of(&indexer, "s1"),
+            vec![chain.clone()],
+            "a rejected chain must not half-apply"
+        );
+    }
+
+    #[test]
+    fn a_block_repeated_within_one_chain_is_rejected() {
+        let chain = hashes(vec![1, 2]);
+        let indexer = SessionPrefixIndexer::new();
+
+        // A -> B -> A within a single event: the cycle closes on a node this
+        // very chain created, so the check cannot rely on existing parents.
+        let repeating = vec![chain[0], chain[1], chain[0]];
+        let err = indexer
+            .update_session_from_stored_blocks("s1", None, &repeating)
+            .expect_err("a chain that revisits its own block must fail");
+        assert!(
+            matches!(
+                err,
+                SessionPrefixIndexError::CyclicParent { block } if block == chain[0]
+            ),
+            "expected CyclicParent for the repeated block, got {err:?}"
+        );
+        assert!(
+            lineage_of(&indexer, "s1").is_empty(),
+            "a rejected chain must not create any nodes"
         );
     }
 }

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -191,7 +191,24 @@ impl SessionPrefixIndexer {
         matched_hash: ExternalSequenceBlockHash,
     ) -> Result<bool, SessionPrefixIndexError> {
         let mut state = self.state.write();
-        let node = state.resolve_or_insert_root(matched_hash);
+        let parent = state
+            .sessions
+            .get(session_id)
+            .filter(|entry| entry.frontiers.len() == 1)
+            .and_then(|entry| entry.frontiers.iter().next().copied());
+        let node = match state.hash_to_node.get(&matched_hash).copied() {
+            Some(node) => {
+                if let Some(parent) = parent
+                    && state.nodes[node].parent.is_none()
+                    && !state.is_ancestor_or_self(node, parent)
+                {
+                    state.nodes[node].parent = Some(parent);
+                    state.nodes[parent].child_count += 1;
+                }
+                node
+            }
+            None => state.insert_node(matched_hash, parent),
+        };
         Ok(state.advance_frontier(session_id, node))
     }
 
@@ -500,6 +517,19 @@ mod tests {
             "a repeated match must not grow the arena"
         );
         assert_eq!(indexer.get_session_frontiers("s1").len(), 1);
+    }
+
+    #[test]
+    fn sequential_matches_extend_one_lineage() {
+        let chain = hashes(vec![1, 2, 3]);
+        let indexer = SessionPrefixIndexer::new();
+
+        for &block_hash in &chain {
+            assert!(indexer.update_session_from_match("s1", block_hash).unwrap());
+        }
+
+        assert_eq!(indexer.get_session_frontiers("s1").len(), 1);
+        assert_eq!(lineage_of(&indexer, "s1"), vec![chain]);
     }
 
     #[test]

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -35,6 +35,7 @@ new_key_type! {
 pub struct LogicalNode {
     block_hash: ExternalSequenceBlockHash,
     parent: Option<NodeId>,
+    parent_edge_refs: u32,
     frontier_refs: u32,
     child_count: u32,
 }
@@ -82,8 +83,14 @@ pub struct SessionPrefixIndexer {
 // None distinguishes an untouched entry from touch sequence zero.
 #[derive(Debug, Default)]
 struct SessionEntry {
-    frontiers: FxHashSet<NodeId>,
+    frontiers: FxHashMap<NodeId, SessionFrontier>,
     last_touch: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SessionFrontier {
+    retained_root: NodeId,
+    len: usize,
 }
 
 #[derive(Debug)]
@@ -150,7 +157,7 @@ impl SessionPrefixIndexer {
             .read()
             .sessions
             .get(session_id)
-            .map(|entry| entry.frontiers.iter().copied().collect())
+            .map(|entry| entry.frontiers.keys().copied().collect())
             .unwrap_or_default()
     }
 
@@ -178,8 +185,8 @@ impl SessionPrefixIndexer {
         };
 
         let mut lineages = Vec::with_capacity(entry.frontiers.len());
-        for &frontier in &entry.frontiers {
-            let path = state.path_to_root(frontier);
+        for (&frontier, session_frontier) in &entry.frontiers {
+            let path = state.path_from_retained_root(frontier, *session_frontier);
             let start = match anchor_node {
                 Some(anchor) => match path.iter().position(|&node| node == anchor) {
                     Some(position) => position,
@@ -205,6 +212,7 @@ impl SessionPrefixIndexer {
     ) -> Result<bool, SessionPrefixIndexError> {
         let mut state = self.state.write();
         let continuation = state.deepest_frontier(session_id);
+        let mut attached = false;
         let node = match state.hash_to_node.get(&matched_hash).copied() {
             Some(node) => {
                 let already_reached = state.session_has_reached(session_id, node);
@@ -214,13 +222,24 @@ impl SessionPrefixIndexer {
                     && !state.is_ancestor_or_self(node, parent)
                 {
                     state.nodes[node].parent = Some(parent);
-                    state.nodes[parent].child_count += 1;
+                    state.nodes[parent].child_count = state.nodes[parent]
+                        .child_count
+                        .checked_add(1)
+                        .expect("a parent child count must not overflow");
+                    attached = true;
                 }
                 node
             }
-            None => state.insert_node(matched_hash, continuation),
+            None => {
+                attached = continuation.is_some();
+                state.insert_node(matched_hash, continuation)
+            }
         };
-        Ok(state.advance_match_frontier(session_id, node, continuation))
+        let advanced = state.advance_match_frontier(session_id, node, continuation);
+        if attached {
+            state.detach_unretained_parent_edge(node);
+        }
+        Ok(advanced)
     }
 
     /// Records a stored block chain and reports whether the frontier advanced.
@@ -240,23 +259,41 @@ impl SessionPrefixIndexer {
         state.validate_chain(parent_hash, block_hashes)?;
 
         let mut parent = parent_hash.map(|hash| state.resolve_or_insert_root(hash));
+        let mut attached_nodes = Vec::new();
         for &block_hash in block_hashes {
             let node = match state.hash_to_node.get(&block_hash).copied() {
                 Some(existing) => {
                     // Graft nodes previously known only as roots.
                     if let (None, Some(expected)) = (state.nodes[existing].parent, parent) {
                         state.nodes[existing].parent = Some(expected);
-                        state.nodes[expected].child_count += 1;
+                        state.nodes[expected].child_count = state.nodes[expected]
+                            .child_count
+                            .checked_add(1)
+                            .expect("a parent child count must not overflow");
+                        attached_nodes.push(existing);
                     }
                     existing
                 }
-                None => state.insert_node(block_hash, parent),
+                None => {
+                    let node = state.insert_node(block_hash, parent);
+                    if parent.is_some() {
+                        attached_nodes.push(node);
+                    }
+                    node
+                }
             };
             parent = Some(node);
         }
 
         let leaf = parent.expect("non-empty block chain always yields a node");
-        Ok(state.advance_frontier(session_id, leaf))
+        let advanced = state.advance_frontier(session_id, leaf);
+        if !attached_nodes.is_empty() {
+            state.refresh_session_cutoffs(session_id);
+        }
+        for node in attached_nodes {
+            state.detach_unretained_parent_edge(node);
+        }
+        Ok(advanced)
     }
 
     /// Removes a session and reclaims its unshared nodes.
@@ -283,12 +320,16 @@ impl IndexState {
         let node = self.nodes.insert(LogicalNode {
             block_hash,
             parent,
+            parent_edge_refs: 0,
             frontier_refs: 0,
             child_count: 0,
         });
         self.hash_to_node.insert(block_hash, node);
         if let Some(parent) = parent {
-            self.nodes[parent].child_count += 1;
+            self.nodes[parent].child_count = self.nodes[parent]
+                .child_count
+                .checked_add(1)
+                .expect("a parent child count must not overflow");
         }
         node
     }
@@ -336,8 +377,8 @@ impl IndexState {
         if let Some(last_touch) = entry.last_touch {
             self.lru.remove(&last_touch);
         }
-        for frontier in entry.frontiers {
-            self.release_frontier(frontier);
+        for (frontier, session_frontier) in entry.frontiers {
+            self.release_frontier(frontier, session_frontier);
         }
         true
     }
@@ -358,16 +399,16 @@ impl IndexState {
     // Enforce the cap after touching the newly recorded session.
     fn enforce_session_cap(&mut self) {
         while self.sessions.len() > self.max_sessions {
-            let Some((_, victim)) = self.lru.pop_first() else {
+            let Some(victim) = self
+                .lru
+                .first_key_value()
+                .map(|(_, session_id)| session_id.clone())
+            else {
                 // Avoid a hang if LRU bookkeeping is ever inconsistent.
                 debug_assert!(false, "lru is empty while sessions is over capacity");
                 break;
             };
-            if let Some(entry) = self.sessions.remove(&victim) {
-                for frontier in entry.frontiers {
-                    self.release_frontier(frontier);
-                }
-            }
+            self.drop_session(&victim);
             tracing::debug!(
                 session_id = %victim,
                 max_sessions = self.max_sessions,
@@ -401,6 +442,28 @@ impl IndexState {
         path
     }
 
+    fn path_from_retained_root(
+        &self,
+        frontier: NodeId,
+        session_frontier: SessionFrontier,
+    ) -> Vec<NodeId> {
+        let mut path = Vec::with_capacity(session_frontier.len);
+        let mut current = frontier;
+        for _ in 0..session_frontier.len {
+            path.push(current);
+            if current == session_frontier.retained_root {
+                break;
+            }
+            current = self.nodes[current]
+                .parent
+                .expect("a retained session interval must remain connected");
+        }
+        debug_assert_eq!(path.last(), Some(&session_frontier.retained_root));
+        debug_assert_eq!(path.len(), session_frontier.len);
+        path.reverse();
+        path
+    }
+
     fn is_ancestor_or_self(&self, candidate: NodeId, node: NodeId) -> bool {
         let limit = self.nodes.len();
         let mut current = Some(node);
@@ -422,37 +485,65 @@ impl IndexState {
 
     fn session_has_reached(&self, session_id: &str, node: NodeId) -> bool {
         self.sessions.get(session_id).is_some_and(|entry| {
-            entry
-                .frontiers
-                .iter()
-                .any(|&frontier| self.is_ancestor_or_self(node, frontier))
+            entry.frontiers.iter().any(|(&frontier, session_frontier)| {
+                self.session_frontier_contains(frontier, *session_frontier, node)
+            })
         })
     }
 
-    fn depth_to_root(&self, tail: NodeId) -> usize {
+    fn session_frontier_contains(
+        &self,
+        frontier: NodeId,
+        session_frontier: SessionFrontier,
+        candidate: NodeId,
+    ) -> bool {
+        let mut current = frontier;
+        for _ in 0..session_frontier.len {
+            if current == candidate {
+                return true;
+            }
+            if current == session_frontier.retained_root {
+                return false;
+            }
+            current = self.nodes[current]
+                .parent
+                .expect("a retained session interval must remain connected");
+        }
+        debug_assert!(false, "retained session root was not reached");
+        false
+    }
+
+    fn retained_frontier(&self, frontier: NodeId) -> SessionFrontier {
         let limit = self.nodes.len();
-        let mut depth = 0usize;
-        let mut current = Some(tail);
-        while let Some(node) = current {
-            if depth >= limit {
+        let mut retained_root = frontier;
+        let mut len = 1usize;
+        while len < self.max_session_depth {
+            let Some(parent) = self.nodes[retained_root].parent else {
+                break;
+            };
+            if len >= limit {
                 debug_assert!(false, "parent cycle in session prefix index forest");
                 tracing::error!("session prefix index parent walk exceeded the arena; truncating");
                 break;
             }
-            depth += 1;
-            current = self.nodes[node].parent;
+            retained_root = parent;
+            len += 1;
         }
-        depth
+        SessionFrontier { retained_root, len }
     }
 
     fn deepest_frontier(&self, session_id: &str) -> Option<NodeId> {
         self.sessions.get(session_id).and_then(|entry| {
-            entry.frontiers.iter().copied().max_by_key(|&frontier| {
-                (
-                    self.depth_to_root(frontier),
-                    Reverse(self.nodes[frontier].block_hash),
-                )
-            })
+            entry
+                .frontiers
+                .iter()
+                .max_by_key(|(frontier, session_frontier)| {
+                    (
+                        session_frontier.len,
+                        Reverse(self.nodes[**frontier].block_hash),
+                    )
+                })
+                .map(|(&frontier, _)| frontier)
         })
     }
 
@@ -467,13 +558,14 @@ impl IndexState {
             return false;
         }
 
-        if let Some(continuation) = continuation
-            && self
-                .sessions
+        let replaced = continuation.and_then(|continuation| {
+            self.sessions
                 .get_mut(session_id)
-                .is_some_and(|entry| entry.frontiers.remove(&continuation))
-        {
-            self.release_frontier(continuation);
+                .and_then(|entry| entry.frontiers.remove(&continuation))
+                .map(|session_frontier| (continuation, session_frontier))
+        });
+        if let Some((frontier, session_frontier)) = replaced {
+            self.release_frontier(frontier, session_frontier);
         }
         true
     }
@@ -486,68 +578,161 @@ impl IndexState {
             return false;
         }
 
-        let subsumed: Vec<NodeId> = self
+        let subsumed: Vec<(NodeId, SessionFrontier)> = self
             .sessions
             .get(session_id)
             .map(|entry| {
                 entry
                     .frontiers
                     .iter()
-                    .copied()
-                    .filter(|&frontier| self.is_ancestor_or_self(frontier, node))
+                    .filter(|(frontier, _)| self.is_ancestor_or_self(**frontier, node))
+                    .map(|(&frontier, &session_frontier)| (frontier, session_frontier))
                     .collect()
             })
             .unwrap_or_default();
 
-        for frontier in &subsumed {
-            self.nodes[*frontier].frontier_refs -= 1;
-        }
-        self.nodes[node].frontier_refs += 1;
+        let session_frontier = self.retained_frontier(node);
+        self.acquire_frontier(node, session_frontier);
 
         let entry = self.sessions.entry(session_id.to_string()).or_default();
-        for frontier in subsumed {
+        for &(frontier, _) in &subsumed {
             entry.frontiers.remove(&frontier);
         }
-        entry.frontiers.insert(node);
+        entry.frontiers.insert(node, session_frontier);
 
-        self.enforce_frontier_depth(node);
+        for (frontier, session_frontier) in subsumed {
+            self.release_frontier(frontier, session_frontier);
+        }
+
         self.touch_session(session_id);
         self.enforce_session_cap();
         true
     }
 
-    fn enforce_frontier_depth(&mut self, frontier: NodeId) {
-        let path = self.path_to_root(frontier);
-        if path.len() <= self.max_session_depth {
+    fn refresh_session_cutoffs(&mut self, session_id: &str) {
+        let changes: Vec<(NodeId, SessionFrontier, SessionFrontier)> = self
+            .sessions
+            .get(session_id)
+            .map(|entry| {
+                entry
+                    .frontiers
+                    .iter()
+                    .filter_map(|(&frontier, &old)| {
+                        let new = self.retained_frontier(frontier);
+                        (new != old).then_some((frontier, old, new))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        if changes.is_empty() {
             return;
         }
 
-        let new_root = path[path.len() - self.max_session_depth];
-        let old_parent = self.nodes[new_root]
-            .parent
-            .take()
-            .expect("a truncated path has an older parent");
-        self.nodes[old_parent].child_count -= 1;
-        self.reclaim_unreferenced(Some(old_parent));
+        for &(frontier, _, new) in &changes {
+            self.acquire_frontier(frontier, new);
+        }
+        let entry = self
+            .sessions
+            .get_mut(session_id)
+            .expect("session cutoffs came from an existing session");
+        for &(frontier, _, new) in &changes {
+            entry.frontiers.insert(frontier, new);
+        }
+        for (frontier, old, _) in changes {
+            self.release_frontier(frontier, old);
+        }
     }
 
-    // Reclaim ancestors until reaching a shared frontier or parent.
-    fn release_frontier(&mut self, frontier: NodeId) {
-        self.nodes[frontier].frontier_refs -= 1;
+    fn acquire_frontier(&mut self, frontier: NodeId, session_frontier: SessionFrontier) {
+        self.nodes[frontier].frontier_refs = self.nodes[frontier]
+            .frontier_refs
+            .checked_add(1)
+            .expect("a frontier session count must not overflow");
 
-        self.reclaim_unreferenced(Some(frontier));
+        let mut child = frontier;
+        for _ in 1..session_frontier.len {
+            let parent = self.nodes[child]
+                .parent
+                .expect("a retained session interval must remain connected");
+            self.nodes[child].parent_edge_refs = self.nodes[child]
+                .parent_edge_refs
+                .checked_add(1)
+                .expect("a retained parent edge count must not overflow");
+            child = parent;
+        }
+        debug_assert_eq!(child, session_frontier.retained_root);
+    }
+
+    fn release_frontier(&mut self, frontier: NodeId, session_frontier: SessionFrontier) {
+        let mut child = frontier;
+        let mut detached_edges = Vec::new();
+        for _ in 1..session_frontier.len {
+            let parent = self.nodes[child]
+                .parent
+                .expect("a retained session interval must remain connected");
+            let edge_refs = &mut self.nodes[child].parent_edge_refs;
+            *edge_refs = edge_refs
+                .checked_sub(1)
+                .expect("a released parent edge must have a retained interval");
+            if *edge_refs == 0 {
+                detached_edges.push(child);
+            }
+            child = parent;
+        }
+        debug_assert_eq!(child, session_frontier.retained_root);
+
+        self.nodes[frontier].frontier_refs = self.nodes[frontier]
+            .frontier_refs
+            .checked_sub(1)
+            .expect("a released frontier must have a session reference");
+
+        let mut reclaim = Vec::with_capacity(detached_edges.len() + 1);
+        reclaim.push(frontier);
+        for child in detached_edges {
+            if let Some(parent) = self.detach_parent_edge(child) {
+                reclaim.push(parent);
+            }
+        }
+        for node in reclaim {
+            self.reclaim_unreferenced(Some(node));
+        }
+    }
+
+    fn detach_unretained_parent_edge(&mut self, child: NodeId) {
+        if !self.nodes.contains_key(child) || self.nodes[child].parent_edge_refs > 0 {
+            return;
+        }
+        if let Some(parent) = self.detach_parent_edge(child) {
+            self.reclaim_unreferenced(Some(parent));
+        }
+    }
+
+    fn detach_parent_edge(&mut self, child: NodeId) -> Option<NodeId> {
+        debug_assert_eq!(self.nodes[child].parent_edge_refs, 0);
+        let parent = self.nodes[child].parent.take()?;
+        self.nodes[parent].child_count = self.nodes[parent]
+            .child_count
+            .checked_sub(1)
+            .expect("a detached parent edge must have a child reference");
+        Some(parent)
     }
 
     fn reclaim_unreferenced(&mut self, mut current: Option<NodeId>) {
         while let Some(node) = current {
+            if !self.nodes.contains_key(node) {
+                break;
+            }
             let entry = self.nodes[node];
-            if entry.frontier_refs > 0 || entry.child_count > 0 {
+            if entry.frontier_refs > 0 || entry.child_count > 0 || entry.parent_edge_refs > 0 {
                 break;
             }
             self.nodes.remove(node);
             self.hash_to_node.remove(&entry.block_hash);
             if let Some(parent) = entry.parent {
-                self.nodes[parent].child_count -= 1;
+                self.nodes[parent].child_count = self.nodes[parent]
+                    .child_count
+                    .checked_sub(1)
+                    .expect("a reclaimed parent edge must have a child reference");
             }
             current = entry.parent;
         }
@@ -969,9 +1154,9 @@ mod tests {
         let chain = hashes(vec![1, 2, 3, 4, 5]);
         let indexer = SessionPrefixIndexer::with_limits(DEFAULT_MAX_SESSIONS, 3);
 
-        for &block_hash in &chain {
-            indexer.update_session_from_match("s1", block_hash).unwrap();
-        }
+        indexer
+            .update_session_from_stored_blocks("s1", None, &chain)
+            .unwrap();
 
         assert_eq!(lineage_of(&indexer, "s1"), vec![chain[2..].to_vec()]);
         assert_eq!(indexer.node_count(), 3);
@@ -981,6 +1166,79 @@ mod tests {
         for &block_hash in &chain[2..] {
             assert!(indexer.get_node_from_hash(block_hash).is_some());
         }
+    }
+
+    #[test]
+    fn one_session_cutoff_preserves_another_sessions_shared_lineage() {
+        let chain = hashes(vec![1, 2, 3, 4]);
+        let indexer = SessionPrefixIndexer::with_limits(DEFAULT_MAX_SESSIONS, 3);
+
+        indexer
+            .update_session_from_stored_blocks("s1", None, &chain[..3])
+            .unwrap();
+        indexer
+            .update_session_from_stored_blocks("s2", None, &chain[..3])
+            .unwrap();
+        indexer.update_session_from_match("s1", chain[3]).unwrap();
+
+        assert_eq!(lineage_of(&indexer, "s1"), vec![chain[1..].to_vec()]);
+        assert_eq!(lineage_of(&indexer, "s2"), vec![chain[..3].to_vec()]);
+        assert!(
+            indexer
+                .get_session_block_lineage("s1", Some(chain[0]))
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            indexer
+                .get_session_block_lineage("s1", Some(chain[1]))
+                .unwrap(),
+            vec![chain[1..].to_vec()]
+        );
+
+        assert!(indexer.remove_session("s2"));
+        assert_eq!(indexer.get_node_from_hash(chain[0]), None);
+        assert_eq!(lineage_of(&indexer, "s1"), vec![chain[1..].to_vec()]);
+
+        let reverse = SessionPrefixIndexer::with_limits(DEFAULT_MAX_SESSIONS, 3);
+        reverse
+            .update_session_from_stored_blocks("s1", None, &chain[..3])
+            .unwrap();
+        reverse
+            .update_session_from_stored_blocks("s2", None, &chain[..3])
+            .unwrap();
+        reverse.update_session_from_match("s1", chain[3]).unwrap();
+
+        assert!(reverse.remove_session("s1"));
+        assert_eq!(lineage_of(&reverse, "s2"), vec![chain[..3].to_vec()]);
+        assert_eq!(reverse.get_node_from_hash(chain[3]), None);
+        assert!(reverse.remove_session("s2"));
+        assert_eq!(reverse.node_count(), 0);
+    }
+
+    #[test]
+    fn depth_one_and_sibling_branches_release_exact_intervals() {
+        let chain = hashes(vec![1, 2, 3, 4]);
+        let depth_one = SessionPrefixIndexer::with_limits(DEFAULT_MAX_SESSIONS, 1);
+        depth_one
+            .update_session_from_stored_blocks("s1", None, &chain[..3])
+            .unwrap();
+        assert_eq!(lineage_of(&depth_one, "s1"), vec![vec![chain[2]]]);
+        assert_eq!(depth_one.node_count(), 1);
+
+        let branches = SessionPrefixIndexer::with_limits(DEFAULT_MAX_SESSIONS, 3);
+        branches
+            .update_session_from_stored_blocks("s1", None, &chain[..3])
+            .unwrap();
+        branches
+            .update_session_from_stored_blocks("s1", Some(chain[1]), &chain[3..])
+            .unwrap();
+        assert_eq!(
+            lineage_of(&branches, "s1"),
+            vec![chain[..3].to_vec(), vec![chain[0], chain[1], chain[3]]]
+        );
+        assert!(branches.remove_session("s1"));
+        assert_eq!(branches.node_count(), 0);
     }
 
     #[test]

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -119,9 +119,14 @@ impl SessionPrefixIndexer {
 
     /// Creates an index and clamps a zero session cap to one.
     pub fn with_max_sessions(max_sessions: usize) -> Self {
+        Self::with_limits(max_sessions, DEFAULT_MAX_SESSION_DEPTH)
+    }
+
+    fn with_limits(max_sessions: usize, max_session_depth: usize) -> Self {
         Self {
             state: RwLock::new(IndexState {
                 max_sessions: max_sessions.max(1),
+                max_session_depth: max_session_depth.max(1),
                 ..IndexState::default()
             }),
         }
@@ -957,6 +962,25 @@ mod tests {
             !lineage_of(&indexer, "s1").is_empty(),
             "the sole tracked session must survive its own insertion"
         );
+    }
+
+    #[test]
+    fn lineage_depth_limit_reclaims_detached_ancestors() {
+        let chain = hashes(vec![1, 2, 3, 4, 5]);
+        let indexer = SessionPrefixIndexer::with_limits(DEFAULT_MAX_SESSIONS, 3);
+
+        for &block_hash in &chain {
+            indexer.update_session_from_match("s1", block_hash).unwrap();
+        }
+
+        assert_eq!(lineage_of(&indexer, "s1"), vec![chain[2..].to_vec()]);
+        assert_eq!(indexer.node_count(), 3);
+        for &block_hash in &chain[..2] {
+            assert_eq!(indexer.get_node_from_hash(block_hash), None);
+        }
+        for &block_hash in &chain[2..] {
+            assert!(indexer.get_node_from_hash(block_hash).is_some());
+        }
     }
 
     #[test]

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -60,15 +60,11 @@ pub enum SessionPrefixIndexError {
 
     /// A block was attached beneath a conflicting parent.
     #[error("block {block:?} is already parented elsewhere")]
-    ConflictingParent {
-        block: ExternalSequenceBlockHash,
-    },
+    ConflictingParent { block: ExternalSequenceBlockHash },
 
     /// A graft would create a parent cycle.
     #[error("block {block:?} would become its own ancestor")]
-    CyclicParent {
-        block: ExternalSequenceBlockHash,
-    },
+    CyclicParent { block: ExternalSequenceBlockHash },
 }
 
 /// Thread-safe session-aware logical prefix index.

--- a/lib/kv-router/src/session_prefix_index.rs
+++ b/lib/kv-router/src/session_prefix_index.rs
@@ -3,7 +3,7 @@
 
 //! Session lineage retained independently of physical cache eviction.
 //!
-//! Final-session removal and an LRU session cap bound retention.
+//! Final-session removal, an LRU session cap, and a lineage-depth cap bound retention.
 
 use std::collections::{BTreeMap, HashMap};
 
@@ -18,6 +18,9 @@ pub type SessionId = String;
 
 /// Default tracked-session ceiling before LRU eviction.
 pub const DEFAULT_MAX_SESSIONS: usize = 16_384;
+
+/// Maximum nodes retained in any session-frontier lineage.
+pub const DEFAULT_MAX_SESSION_DEPTH: usize = 1_024;
 
 new_key_type! {
     /// Generational handle to a [`LogicalNode`] in the arena.
@@ -89,6 +92,7 @@ struct IndexState {
     lru: BTreeMap<u64, SessionId>,
     next_touch: u64,
     max_sessions: usize,
+    max_session_depth: usize,
 }
 
 impl Default for IndexState {
@@ -100,6 +104,7 @@ impl Default for IndexState {
             lru: BTreeMap::default(),
             next_touch: 0,
             max_sessions: DEFAULT_MAX_SESSIONS,
+            max_session_depth: DEFAULT_MAX_SESSION_DEPTH,
         }
     }
 }
@@ -447,16 +452,35 @@ impl IndexState {
         }
         entry.frontiers.insert(node);
 
+        self.enforce_frontier_depth(node);
         self.touch_session(session_id);
         self.enforce_session_cap();
         true
+    }
+
+    fn enforce_frontier_depth(&mut self, frontier: NodeId) {
+        let path = self.path_to_root(frontier);
+        if path.len() <= self.max_session_depth {
+            return;
+        }
+
+        let new_root = path[path.len() - self.max_session_depth];
+        let old_parent = self.nodes[new_root]
+            .parent
+            .take()
+            .expect("a truncated path has an older parent");
+        self.nodes[old_parent].child_count -= 1;
+        self.reclaim_unreferenced(Some(old_parent));
     }
 
     // Reclaim ancestors until reaching a shared frontier or parent.
     fn release_frontier(&mut self, frontier: NodeId) {
         self.nodes[frontier].frontier_refs -= 1;
 
-        let mut current = Some(frontier);
+        self.reclaim_unreferenced(Some(frontier));
+    }
+
+    fn reclaim_unreferenced(&mut self, mut current: Option<NodeId>) {
         while let Some(node) = current {
             let entry = self.nodes[node];
             if entry.frontier_refs > 0 || entry.child_count > 0 {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -14,17 +14,18 @@ use std::{
 use anyhow::Result;
 use dynamo_kv_router::{
     DEFAULT_ROUTING_GROUP, KvSchedulerError, PrefillLoadEstimator, RoutingPartitionRef,
-    SharedKvCache, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
+    SessionPrefixIndexer, SharedKvCache, TrackingHashAlgorithm, TrackingHashContext,
+    TrackingHashScope,
     config::{KvRouterConfig, RouterConfigOverride, min_initial_workers_from_env},
     indexer::{
         ApproximateLruIncarnation, ApproximateLruRequestId, ApproximateLruStats, KvRouterError,
-        RoutingDecisionHashes,
+        MatchDetails, RoutingDecisionHashes,
     },
     protocols::KV_EVENT_SUBJECT,
     protocols::{
-        BlockExtraInfo, BlockHashOptions, LocalBlockHash, PrefillLoadHint, RouterEvent,
-        RouterRequest, RouterResponse, RoutingConstraints, TokensWithHashes, WorkerConfigLike,
-        WorkerId, WorkerWithDpRank, compute_block_hash_for_seq,
+        BlockExtraInfo, BlockHashOptions, ExternalSequenceBlockHash, LocalBlockHash,
+        PrefillLoadHint, RouterEvent, RouterRequest, RouterResponse, RoutingConstraints,
+        TokensWithHashes, WorkerConfigLike, WorkerId, WorkerWithDpRank, compute_block_hash_for_seq,
     },
     router_hint::{RouterHint, RouterHintRootCandidates},
     scheduling::{
@@ -543,6 +544,37 @@ where
     lora_filter: Option<Arc<crate::lora::LoraFilter>>,
     endpoint_registration: Option<dynamo_runtime::discovery::EndpointRegistrationLease>,
     teardown_task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
+    /// Session-aware logical prefix index, present only when
+    /// `enable_session_prefix_index` is set. Held as an optional field rather
+    /// than threaded through the constructor signature so no caller has to
+    /// change to opt out.
+    session_prefix_index: Option<Arc<SessionPrefixIndexer>>,
+}
+
+/// The deepest block this lookup matched anywhere, as the last matched hash of
+/// the worker with the highest device overlap.
+///
+/// The session index records what the session's prefix reached, not which
+/// worker served it, so this deliberately runs before worker selection: the
+/// scheduler may pick a less-overlapping worker for load reasons, and that
+/// choice says nothing about how much prefix the session actually has.
+/// Ties break on the hash so the choice is stable across map iteration orders.
+fn deepest_matched_hash(details: &MatchDetails) -> Option<ExternalSequenceBlockHash> {
+    details
+        .last_matched_hashes
+        .iter()
+        .max_by_key(|(worker, hash)| {
+            (
+                details
+                    .overlap_scores
+                    .scores
+                    .get(*worker)
+                    .copied()
+                    .unwrap_or(0),
+                **hash,
+            )
+        })
+        .map(|(_, hash)| *hash)
 }
 
 fn resolve_tracking_model_name(
@@ -761,6 +793,10 @@ where
             None
         };
 
+        let session_prefix_index = kv_router_config
+            .enable_session_prefix_index
+            .then(|| Arc::new(SessionPrefixIndexer::new()));
+
         tracing::info!("KV Routing initialized");
         let cancellation_token = cancellation_guard.disarm();
         Ok(Self {
@@ -783,6 +819,7 @@ where
             lora_filter,
             endpoint_registration: None,
             teardown_task_guard: None,
+            session_prefix_index,
         })
     }
 
@@ -1316,6 +1353,18 @@ where
         let router_hint_candidates = retain_router_hint_chain
             .then(|| tiered_matches.router_hint_root_candidates().cloned())
             .flatten();
+
+        // Feed the session prefix index while the match details are still in
+        // scope. A failure here is a bookkeeping problem, never a routing one,
+        // so it is logged and the request continues.
+        if let Some(index) = self.session_prefix_index.as_ref()
+            && let Some(session) = session_context.as_ref()
+            && let Some(matched_hash) = deepest_matched_hash(&tiered_matches.device)
+            && let Err(err) = index.update_session_from_match(session.session_id(), matched_hash)
+        {
+            tracing::warn!(%err, "failed to record session prefix match");
+        }
+
         drop(tiered_matches);
         let find_matches_elapsed = start.elapsed();
 
@@ -2154,6 +2203,37 @@ mod tests {
             assert_eq!(requirement, expected);
             assert_eq!(requirement.should_subscribe(&config), should_subscribe);
         }
+    }
+
+    #[test]
+    fn deepest_matched_hash_follows_the_largest_overlap() {
+        let shallow = WorkerWithDpRank::new(1, 0);
+        let deep = WorkerWithDpRank::new(2, 0);
+
+        assert_eq!(
+            deepest_matched_hash(&MatchDetails::default()),
+            None,
+            "no match means nothing to record"
+        );
+
+        let mut overlap_scores = OverlapScores::new();
+        overlap_scores.scores.insert(shallow, 1);
+        overlap_scores.scores.insert(deep, 4);
+        let details = MatchDetails {
+            overlap_scores,
+            last_matched_hashes: [
+                (shallow, ExternalSequenceBlockHash(101)),
+                (deep, ExternalSequenceBlockHash(104)),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        assert_eq!(
+            deepest_matched_hash(&details),
+            Some(ExternalSequenceBlockHash(104)),
+            "the session reached as far as the best-matching worker proves it did"
+        );
     }
 
     #[test]

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -544,22 +544,12 @@ where
     lora_filter: Option<Arc<crate::lora::LoraFilter>>,
     endpoint_registration: Option<dynamo_runtime::discovery::EndpointRegistrationLease>,
     teardown_task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
-    /// Session-aware logical prefix index, present only when
-    /// `enable_session_prefix_index` is set. Held as an optional field rather
-    /// than threaded through the constructor signature so no caller has to
-    /// change to opt out.
+    /// Optional session-aware logical prefix index.
     session_prefix_index: Option<Arc<SessionPrefixIndexer>>,
 }
 
-/// The deepest device-tier block this lookup matched, as the last matched hash
-/// of the worker with the highest device overlap. Lower cache tiers are not
-/// considered; the only caller passes device match details.
-///
-/// The session index records what the session's prefix reached, not which
-/// worker served it, so this deliberately runs before worker selection: the
-/// scheduler may pick a less-overlapping worker for load reasons, and that
-/// choice says nothing about how much prefix the session actually has.
-/// Ties break on the hash so the choice is stable across map iteration orders.
+/// Returns the deepest device-tier match with stable hash tie-breaking.
+/// Lineage records matched prefix depth rather than the selected worker.
 fn deepest_matched_hash(details: &MatchDetails) -> Option<ExternalSequenceBlockHash> {
     details
         .last_matched_hashes
@@ -1355,9 +1345,7 @@ where
             .then(|| tiered_matches.router_hint_root_candidates().cloned())
             .flatten();
 
-        // Feed the session prefix index while the match details are still in
-        // scope. A failure here is a bookkeeping problem, never a routing one,
-        // so it is logged and the request continues.
+        // Indexing failures never affect routing.
         if let Some(index) = self.session_prefix_index.as_ref()
             && let Some(session) = session_context.as_ref()
         {
@@ -1368,13 +1356,7 @@ where
                 tracing::warn!(%err, "failed to record session prefix match");
             }
 
-            // Release the session once the request says it is over. These two
-            // markers are the only end-of-session signal the router sees, and
-            // both are optional, so this reclaims promptly when a client sends
-            // one without being the only thing that bounds the index — the
-            // indexer's own session cap covers clients that never send either.
-            // Ordering matters: reclaim after recording, so a final request
-            // that also carries a match does not leave the match behind.
+            // Reclaim after recording the final match.
             let session_over = session.session_final() == Some(true)
                 || session
                     .kv_hints()

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -784,9 +784,11 @@ where
             None
         };
 
-        let session_prefix_index = kv_router_config
-            .enable_session_prefix_index
-            .then(|| Arc::new(SessionPrefixIndexer::new()));
+        let session_prefix_index = kv_router_config.enable_session_prefix_index.then(|| {
+            Arc::new(SessionPrefixIndexer::with_max_sessions(
+                kv_router_config.session_prefix_index_max_sessions,
+            ))
+        });
 
         tracing::info!("KV Routing initialized");
         let cancellation_token = cancellation_guard.disarm();

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -1266,6 +1266,7 @@ where
                 request_id: context_id.map(str::to_string),
             },
         };
+        let query_only = matches!(&mode, ScheduleMode::QueryOnly { .. });
         let isl_tokens = tokens.len();
         let hash_options = BlockHashOptions {
             block_mm_infos,
@@ -1361,7 +1362,7 @@ where
                 || session
                     .kv_hints()
                     .is_some_and(|hints| hints.evict_session());
-            if session_over {
+            if session_over && !query_only {
                 index.remove_session(session.session_id());
             }
         }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -551,8 +551,9 @@ where
     session_prefix_index: Option<Arc<SessionPrefixIndexer>>,
 }
 
-/// The deepest block this lookup matched anywhere, as the last matched hash of
-/// the worker with the highest device overlap.
+/// The deepest device-tier block this lookup matched, as the last matched hash
+/// of the worker with the highest device overlap. Lower cache tiers are not
+/// considered; the only caller passes device match details.
 ///
 /// The session index records what the session's prefix reached, not which
 /// worker served it, so this deliberately runs before worker selection: the
@@ -1359,10 +1360,28 @@ where
         // so it is logged and the request continues.
         if let Some(index) = self.session_prefix_index.as_ref()
             && let Some(session) = session_context.as_ref()
-            && let Some(matched_hash) = deepest_matched_hash(&tiered_matches.device)
-            && let Err(err) = index.update_session_from_match(session.session_id(), matched_hash)
         {
-            tracing::warn!(%err, "failed to record session prefix match");
+            if let Some(matched_hash) = deepest_matched_hash(&tiered_matches.device)
+                && let Err(err) =
+                    index.update_session_from_match(session.session_id(), matched_hash)
+            {
+                tracing::warn!(%err, "failed to record session prefix match");
+            }
+
+            // Release the session once the request says it is over. These two
+            // markers are the only end-of-session signal the router sees, and
+            // both are optional, so this reclaims promptly when a client sends
+            // one without being the only thing that bounds the index — the
+            // indexer's own session cap covers clients that never send either.
+            // Ordering matters: reclaim after recording, so a final request
+            // that also carries a match does not leave the match behind.
+            let session_over = session.session_final() == Some(true)
+                || session
+                    .kv_hints()
+                    .is_some_and(|hints| hints.evict_session());
+            if session_over {
+                index.remove_session(session.session_id());
+            }
         }
 
         drop(tiered_matches);

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -2238,6 +2238,24 @@ mod tests {
             Some(ExternalSequenceBlockHash(104)),
             "the session reached as far as the best-matching worker proves it did"
         );
+
+        let mut tied_scores = OverlapScores::new();
+        tied_scores.scores.insert(shallow, 2);
+        tied_scores.scores.insert(deep, 2);
+        let tied = MatchDetails {
+            overlap_scores: tied_scores,
+            last_matched_hashes: [
+                (shallow, ExternalSequenceBlockHash(101)),
+                (deep, ExternalSequenceBlockHash(104)),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        assert_eq!(
+            deepest_matched_hash(&tied),
+            Some(ExternalSequenceBlockHash(104))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Physical KV indexers discard block records after engine eviction, so they cannot retain a session's earlier block lineage. This change adds an optional logical session-prefix index keyed by `ExternalSequenceBlockHash`.

The index shares common prefix nodes, rejects conflicting or cyclic parent updates, and uses generational node IDs so reused slots cannot be confused with removed nodes. Sequential route matches continue the deepest known frontier, using the block hash to break equal-depth ties. If a matched block already belongs to another chain, it replaces that continuation instead of adding another route-time frontier. Each session frontier records its own retained root and returns at most 1,024 lineage nodes. Shared parent edges remain attached while any retained session path crosses them, then detach and reclaim unreferenced ancestors, so one session's cutoff cannot shorten another session's lineage. Session-final and eviction hints remove state during admitted routing, while a least-recently-used session limit bounds retention when clients provide no lifecycle signal.

The feature is disabled by default and is exposed through `KvRouterConfig`, `--router-session-prefix-index`, and `DYN_ROUTER_SESSION_PREFIX_INDEX`. The session limit defaults to 16,384 and can be changed through `KvRouterConfig.session_prefix_index_max_sessions`, `--router-session-prefix-index-max-sessions`, or `DYN_ROUTER_SESSION_PREFIX_INDEX_MAX_SESSIONS`; zero is treated as one. Lookups with session context record the deepest device-tier match, including query-only lookups, but the index does not affect worker selection. Finalized query-only sessions remain until least-recently-used eviction because query-only calls do not apply lifecycle removal.

The index uses one shared write lock for route-time updates. Its lock hold time and effect on routing latency have not been measured at production session counts, so both need measurement at the expected scale before the default-disabled feature is enabled.

Stored-block events do not carry a session ID, so production lineage is partial and prefill and decode routers keep separate in-process indexes. Python parser and environment tests still collect when the optional native binding is unavailable; only the test that constructs `KvRouterConfig` skips in that environment.

Relates to #13279 and [DYN-4046](https://linear.app/nvidia/issue/DYN-4046/dynamo-side-session-prefix-indexer-implementation)

## Validation

- `rustfmt --edition 2024 --check lib/kv-router/src/session_prefix_index.rs lib/kv-router/src/scheduling/config.rs lib/llm/src/kv_router.rs lib/bindings/python/rust/llm/entrypoint.rs`
- `git diff --check`

No tests were run at the current head. The enabled route-time path was not exercised with a live worker.
