### PR TITLE
fix(llm): bound speculative prefill warmup lifetime

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -704,14 +704,7 @@ where
                 } else if let Some(tk) = tokenizer.clone() {
                     let PromptFormatter::OAI(formatter) =
                         prompt_formatter_from_mdc(card).context("prompt_formatter_from_mdc")?;
-                    // Chat is the only surface here that runs speculative
-                    // prefill, so it is the only one given the runtime's
-                    // shutdown token: a child token, so cancelling it cannot
-                    // disturb the runtime. The in-process chat pipeline built
-                    // by `entrypoint::input::common::build_pipeline` is a
-                    // second chat surface and is not wired; there the runtime
-                    // and the process go down together, and the warmup's own
-                    // lifetime bound still applies.
+                    // Only chat pipelines use speculative prefill.
                     let preprocessor = OpenAIPreprocessor::new_with_parts_and_cancel(
                         card.clone(),
                         formatter,

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -704,9 +704,14 @@ where
                 } else if let Some(tk) = tokenizer.clone() {
                     let PromptFormatter::OAI(formatter) =
                         prompt_formatter_from_mdc(card).context("prompt_formatter_from_mdc")?;
-                    // Chat is the only surface that runs speculative prefill, so
-                    // it is the only one that needs the runtime's shutdown token:
-                    // a child token so cancelling it cannot disturb the runtime.
+                    // Chat is the only surface here that runs speculative
+                    // prefill, so it is the only one given the runtime's
+                    // shutdown token: a child token, so cancelling it cannot
+                    // disturb the runtime. The in-process chat pipeline built
+                    // by `entrypoint::input::common::build_pipeline` is a
+                    // second chat surface and is not wired; there the runtime
+                    // and the process go down together, and the warmup's own
+                    // lifetime bound still applies.
                     let preprocessor = OpenAIPreprocessor::new_with_parts_and_cancel(
                         card.clone(),
                         formatter,

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1449,15 +1449,14 @@ mod tests {
             worker_set.set_lifecycle_cancellation(cancellation.clone());
             worker_set.chat_engine = Some(engine);
             let retained_engine = worker_set.chat_engine.clone().unwrap();
-            let request = serde_json::from_value::<NvCreateChatCompletionRequest>(
-                serde_json::json!({
+            let request =
+                serde_json::from_value::<NvCreateChatCompletionRequest>(serde_json::json!({
                     "model": "mock-llama",
                     "messages": [{"role": "user", "content": "What is the answer?"}],
                     "stream": true,
                     "nvext": {"agent_hints": {"speculative_prefill": true}}
-                }),
-            )
-            .unwrap();
+                }))
+                .unwrap();
             let mut response = retained_engine
                 .generate(SingleIn::new(request))
                 .await

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -704,9 +704,16 @@ where
                 } else if let Some(tk) = tokenizer.clone() {
                     let PromptFormatter::OAI(formatter) =
                         prompt_formatter_from_mdc(card).context("prompt_formatter_from_mdc")?;
-                    let preprocessor =
-                        OpenAIPreprocessor::new_with_parts(card.clone(), formatter, tk.clone())
-                            .context("OpenAIPreprocessor.new_with_parts")?;
+                    // Chat is the only surface that runs speculative prefill, so
+                    // it is the only one that needs the runtime's shutdown token:
+                    // a child token so cancelling it cannot disturb the runtime.
+                    let preprocessor = OpenAIPreprocessor::new_with_parts_and_cancel(
+                        card.clone(),
+                        formatter,
+                        tk.clone(),
+                        Some(self.drt.child_token()),
+                    )
+                    .context("OpenAIPreprocessor.new_with_parts_and_cancel")?;
                     Some(
                         routing
                             .build_pipeline::<

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -702,16 +702,9 @@ where
                             .context("python chat_engine_factory")?,
                     )
                 } else if let Some(tk) = tokenizer.clone() {
-                    let PromptFormatter::OAI(formatter) =
-                        prompt_formatter_from_mdc(card).context("prompt_formatter_from_mdc")?;
                     // Only chat pipelines use speculative prefill.
-                    let preprocessor = OpenAIPreprocessor::new_with_parts_and_cancel(
-                        card.clone(),
-                        formatter,
-                        tk.clone(),
-                        Some(self.drt.child_token()),
-                    )
-                    .context("OpenAIPreprocessor.new_with_parts_and_cancel")?;
+                    let preprocessor =
+                        worker_set_chat_preprocessor(card, tk.clone(), &cancellation)?;
                     Some(
                         routing
                             .build_pipeline::<
@@ -1352,6 +1345,23 @@ fn canonicalize_json(value: &mut serde_json::Value) {
     }
 }
 
+fn worker_set_chat_preprocessor(
+    card: &ModelDeploymentCard,
+    tokenizer: crate::tokenizers::Tokenizer,
+    cancellation: &CancellationToken,
+) -> anyhow::Result<Arc<OpenAIPreprocessor>> {
+    let PromptFormatter::OAI(formatter) =
+        prompt_formatter_from_mdc(card).context("prompt_formatter_from_mdc")?;
+    // A retained pipeline must stop its warmups when its WorkerSet is retired.
+    OpenAIPreprocessor::new_with_parts_and_cancel(
+        card.clone(),
+        formatter,
+        tokenizer,
+        Some(cancellation.clone()),
+    )
+    .context("OpenAIPreprocessor.new_with_parts_and_cancel")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1359,6 +1369,140 @@ mod tests {
     use crate::model_card::ModelDeploymentCard;
     use dynamo_runtime::engine::AsyncEngine;
     use dynamo_runtime::pipeline::Error;
+
+    #[tokio::test]
+    async fn retired_worker_set_prevents_late_prefill_from_retained_chat_pipeline() {
+        use crate::protocols::common::llm_backend::{BackendOutput, PreprocessedRequest};
+        use dynamo_runtime::engine::AsyncEngineContextProvider;
+        use dynamo_runtime::pipeline::ResponseStream;
+        use futures::StreamExt;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        #[derive(Debug, Default)]
+        struct CompletingBackend {
+            calls: AtomicUsize,
+            speculative_dispatch: Notify,
+            finish_response: Arc<Notify>,
+        }
+
+        #[async_trait]
+        impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<BackendOutput>>, Error>
+            for CompletingBackend
+        {
+            async fn generate(
+                &self,
+                request: SingleIn<PreprocessedRequest>,
+            ) -> Result<ManyOut<Annotated<BackendOutput>>, Error> {
+                let call = self.calls.fetch_add(1, Ordering::SeqCst);
+                let (_, context) = request.transfer(());
+                if call > 0 {
+                    self.speculative_dispatch.notify_one();
+                    return Ok(ResponseStream::new(
+                        Box::pin(futures::stream::empty()),
+                        context.context(),
+                    ));
+                }
+                let finish_response = self.finish_response.clone();
+                let stream = futures::stream::once(async move {
+                    finish_response.notified().await;
+                    Annotated::from_data(
+                        serde_json::from_value::<BackendOutput>(serde_json::json!({
+                            "token_ids": [42],
+                            "tokens": ["The answer is 42."],
+                            "text": "The answer is 42.",
+                            "finish_reason": "stop",
+                            "index": 0
+                        }))
+                        .unwrap(),
+                    )
+                });
+                Ok(ResponseStream::new(Box::pin(stream), context.context()))
+            }
+        }
+
+        // The live case proves this response actually triggers speculative dispatch.
+        for retire_worker_set in [false, true] {
+            let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
+            let card = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
+            let runtime_cancellation = CancellationToken::new();
+            let cancellation = runtime_cancellation.child_token();
+            let preprocessor =
+                worker_set_chat_preprocessor(&card, card.tokenizer().unwrap(), &cancellation)
+                    .unwrap()
+                    .into_operator();
+            let backend = Arc::new(CompletingBackend::default());
+            let source = SegmentSource::<
+                SingleIn<NvCreateChatCompletionRequest>,
+                ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
+            >::new();
+            let engine = source
+                .link(preprocessor.forward_edge())
+                .unwrap()
+                .link(ServiceBackend::from_engine(backend.clone()))
+                .unwrap()
+                .link(preprocessor.backward_edge())
+                .unwrap()
+                .link_terminal(source)
+                .unwrap();
+            let mut worker_set = WorkerSet::new("retired-prefill".into(), "test".into(), card);
+            worker_set.set_lifecycle_cancellation(cancellation.clone());
+            worker_set.chat_engine = Some(engine);
+            let retained_engine = worker_set.chat_engine.clone().unwrap();
+            let request = serde_json::from_value::<NvCreateChatCompletionRequest>(
+                serde_json::json!({
+                    "model": "mock-llama",
+                    "messages": [{"role": "user", "content": "What is the answer?"}],
+                    "stream": true,
+                    "nvext": {"agent_hints": {"speculative_prefill": true}}
+                }),
+            )
+            .unwrap();
+            let mut response = retained_engine
+                .generate(SingleIn::new(request))
+                .await
+                .unwrap();
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+            let worker_set = Some(worker_set);
+            let live_worker_set = if retire_worker_set {
+                drop(worker_set);
+                assert!(cancellation.is_cancelled());
+                None
+            } else {
+                worker_set
+            };
+            assert!(!runtime_cancellation.is_cancelled());
+            backend.finish_response.notify_one();
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while response.next().await.is_some() {}
+            })
+            .await
+            .expect("the client response must complete after WorkerSet retirement");
+
+            if retire_worker_set {
+                assert!(
+                    tokio::time::timeout(
+                        Duration::from_secs(1),
+                        backend.speculative_dispatch.notified(),
+                    )
+                    .await
+                    .is_err(),
+                    "the retained pipeline dispatched a warmup after WorkerSet retirement"
+                );
+                assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+            } else {
+                tokio::time::timeout(
+                    Duration::from_secs(5),
+                    backend.speculative_dispatch.notified(),
+                )
+                .await
+                .expect("the live WorkerSet must dispatch its warmup");
+                assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
+            }
+            drop(live_worker_set);
+            drop(retained_engine);
+        }
+    }
 
     fn test_endpoint_id(name: &str) -> EndpointId {
         EndpointId {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -7116,6 +7116,7 @@ impl
         let final_stream = speculative_prefill::maybe_wrap_stream(
             final_stream,
             &request,
+            &request_id,
             &next,
             &self.formatter,
             &self.tokenizer,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -52,6 +52,7 @@ use std::{
     pin::Pin,
     sync::{Arc, Mutex, OnceLock},
 };
+use tokio_util::sync::CancellationToken;
 use tracing;
 
 #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
@@ -1569,6 +1570,11 @@ pub struct OpenAIPreprocessor {
     token_budget: Option<TokenBudget>,
     /// Model context limit used by the embedding truncation contract.
     context_length: u32,
+    /// Shutdown signal handed to detached speculative-prefill tasks. `None`
+    /// for callers that have no runtime to derive a token from (the C
+    /// bindings, the ext-proc gateway, tests); those tasks are still bounded
+    /// by the module's own timeout.
+    speculative_prefill_cancel: Option<CancellationToken>,
     /// Per-image token-count engine. `None` when the feature is disabled, the
     /// model isn't covered by the registry, or `preprocessor_config.json` is
     /// unreadable.
@@ -2238,7 +2244,7 @@ impl OpenAIPreprocessor {
         let tokenizer = mdc.tokenizer()?;
         let PromptFormatter::OAI(formatter) = embedding_prompt_formatter(&mdc)?;
         let embedding_tokenizers = EmbeddingTokenizerState::new(&mdc)?;
-        Self::new_with_parts_inner(mdc, formatter, tokenizer, Some(embedding_tokenizers))
+        Self::new_with_parts_inner(mdc, formatter, tokenizer, Some(embedding_tokenizers), None)
     }
 
     pub fn new_with_parts(
@@ -2246,7 +2252,20 @@ impl OpenAIPreprocessor {
         formatter: Arc<dyn OAIPromptFormatter>,
         tokenizer: crate::tokenizers::Tokenizer,
     ) -> Result<Arc<Self>> {
-        Self::new_with_parts_inner(mdc, formatter, tokenizer, None)
+        Self::new_with_parts_and_cancel(mdc, formatter, tokenizer, None)
+    }
+
+    /// Same as [`OpenAIPreprocessor::new_with_parts`], plus the shutdown token
+    /// that detached speculative-prefill tasks watch. Pass the owning
+    /// runtime's token so those tasks end with the runtime; `None` leaves them
+    /// bounded only by their own timeout.
+    pub fn new_with_parts_and_cancel(
+        mdc: ModelDeploymentCard,
+        formatter: Arc<dyn OAIPromptFormatter>,
+        tokenizer: crate::tokenizers::Tokenizer,
+        speculative_prefill_cancel: Option<CancellationToken>,
+    ) -> Result<Arc<Self>> {
+        Self::new_with_parts_inner(mdc, formatter, tokenizer, None, speculative_prefill_cancel)
     }
 
     fn new_with_parts_inner(
@@ -2254,6 +2273,7 @@ impl OpenAIPreprocessor {
         formatter: Arc<dyn OAIPromptFormatter>,
         tokenizer: crate::tokenizers::Tokenizer,
         embedding_tokenizers: Option<EmbeddingTokenizerState>,
+        speculative_prefill_cancel: Option<CancellationToken>,
     ) -> Result<Arc<Self>> {
         let mdcsum = mdc.mdcsum().to_string();
         let tokenizer: Arc<dyn Tokenizer> = (*tokenizer).clone();
@@ -2562,6 +2582,7 @@ impl OpenAIPreprocessor {
             media_loader,
             token_budget,
             context_length,
+            speculative_prefill_cancel,
             #[cfg(feature = "mm-routing")]
             image_token_counter,
             #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
@@ -7098,6 +7119,7 @@ impl
             &next,
             &self.formatter,
             &self.tokenizer,
+            self.speculative_prefill_cancel.as_ref(),
         );
 
         let final_stream = crate::request_trace::wrap_chat_request_end_stream(

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1570,10 +1570,7 @@ pub struct OpenAIPreprocessor {
     token_budget: Option<TokenBudget>,
     /// Model context limit used by the embedding truncation contract.
     context_length: u32,
-    /// Shutdown signal handed to detached speculative-prefill tasks. `None`
-    /// for callers that have no runtime to derive a token from (the C
-    /// bindings, the ext-proc gateway, tests); those tasks are still bounded
-    /// by the module's own timeout.
+    /// Optional shutdown signal for detached speculative-prefill tasks.
     speculative_prefill_cancel: Option<CancellationToken>,
     /// Per-image token-count engine. `None` when the feature is disabled, the
     /// model isn't covered by the registry, or `preprocessor_config.json` is
@@ -2255,10 +2252,7 @@ impl OpenAIPreprocessor {
         Self::new_with_parts_and_cancel(mdc, formatter, tokenizer, None)
     }
 
-    /// Same as [`OpenAIPreprocessor::new_with_parts`], plus the shutdown token
-    /// that detached speculative-prefill tasks watch. Pass the owning
-    /// runtime's token so those tasks end with the runtime; `None` leaves them
-    /// bounded only by their own timeout.
+    /// Builds a preprocessor with an optional speculative-prefill shutdown token.
     pub fn new_with_parts_and_cancel(
         mdc: ModelDeploymentCard,
         formatter: Arc<dyn OAIPromptFormatter>,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1570,8 +1570,8 @@ pub struct OpenAIPreprocessor {
     token_budget: Option<TokenBudget>,
     /// Model context limit used by the embedding truncation contract.
     context_length: u32,
-    /// Optional shutdown signal for detached speculative-prefill tasks.
-    speculative_prefill_cancel: Option<CancellationToken>,
+    /// Tracks warmups and cancels them when this preprocessor is retired.
+    speculative_prefill_tasks: speculative_prefill::PrefillTasks,
     /// Per-image token-count engine. `None` when the feature is disabled, the
     /// model isn't covered by the registry, or `preprocessor_config.json` is
     /// unreadable.
@@ -2576,7 +2576,9 @@ impl OpenAIPreprocessor {
             media_loader,
             token_budget,
             context_length,
-            speculative_prefill_cancel,
+            speculative_prefill_tasks: speculative_prefill::PrefillTasks::new(
+                speculative_prefill_cancel.as_ref(),
+            ),
             #[cfg(feature = "mm-routing")]
             image_token_counter,
             #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
@@ -7114,7 +7116,7 @@ impl
             &next,
             &self.formatter,
             &self.tokenizer,
-            self.speculative_prefill_cancel.as_ref(),
+            &self.speculative_prefill_tasks,
         );
 
         let final_stream = crate::request_trace::wrap_chat_request_end_stream(

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -35,45 +35,13 @@ use crate::protocols::openai::chat_completions::{
 use crate::tokenizers::traits::Tokenizer;
 use dynamo_renderer::{OAIChatLikeRequest, OAIPromptFormatter};
 
-/// Upper bound on the lifetime of one dispatched speculative-prefill warmup.
-///
-/// The warmup is a best-effort KV-cache fill for a turn the user may never
-/// send, and it is dispatched on a context nobody else holds, so nothing
-/// upstream can ever stop it. A backend that returns a stream which stays
-/// pending instead of reaching EOF would otherwise pin one task — and
-/// everything it captured — for the life of the process, once per request
-/// that used the hint. The value is generous relative to a `max_tokens=1`
-/// request on a healthy backend and short relative to a human turn: a warmup
-/// that has not finished by now has already lost the race with the next turn
-/// it was warming for.
-///
-/// The bound covers the warmup only. It is armed after the client's turn has
-/// finished, because that is when the warmup is dispatched; a turn is allowed
-/// to take as long as it likes.
+/// Maximum lifetime of one dispatched speculative-prefill warmup.
 const PREFILL_TASK_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// How long the warmup is polled after its downstream has been asked to stop.
-///
-/// `stop_generating` is only a signal. A downstream that acts on it does so
-/// from inside the response stream — the KV router's `monitor_response_stream`
-/// selects on `context.stopped()` and, when that wins, runs `guard.abort()`
-/// before ending the stream. That code lives in the stream this task is
-/// draining, so it can only run if the stream is polled again after the
-/// signal. Dropping straight after signalling therefore guarantees the very
-/// cleanup the signal was asking for never happens.
-///
-/// So the bail-out paths keep draining for this long before letting go. A
-/// downstream that honours the stop ends its stream well inside the window and
-/// the task finishes early; one that ignores it costs this much extra and is
-/// then dropped exactly as before. Short next to [`PREFILL_TASK_TIMEOUT`],
-/// because by this point the warmup has already lost its race.
+/// Maximum downstream cleanup time after a warmup is stopped.
 const PREFILL_WIND_DOWN_GRACE: Duration = Duration::from_secs(5);
 
-/// Publication slot for the warmup stream's context.
-///
-/// [`prefill_task`] fills it before draining so that the bounding wrapper in
-/// [`maybe_wrap_stream`] can reach the downstream context on the timeout and
-/// cancellation paths.
+/// Makes the downstream context reachable from timeout and cancellation paths.
 type PrefillContextSlot = Mutex<Option<Arc<dyn AsyncEngineContext>>>;
 
 /// A minimal `OAIChatLikeRequest` for speculative next-turn prefill.
@@ -115,13 +83,7 @@ impl OAIChatLikeRequest for SpeculativePrefillRequest {
 /// a background task that renders the next-turn prefix and fires a
 /// `max_tokens=1` request through the pipeline to warm the KV cache.
 ///
-/// Once dispatched, the warmup is bounded by [`PREFILL_TASK_TIMEOUT`], and the
-/// task ends at any point when `cancel` — where supplied — is cancelled;
-/// nothing else can stop it, because it runs on a context of its own and no
-/// owner keeps its handle. Either ending asks the downstream to stop and then
-/// drains it for up to [`PREFILL_WIND_DOWN_GRACE`] so that request can actually
-/// be acted on. `request_id` identifies the client request that produced the
-/// warmup, so an abandoned or cancelled one can be traced back.
+/// Warmups stop on timeout or cancellation and allow bounded downstream cleanup.
 ///
 /// When the flag is not set, returns the stream unmodified with zero overhead.
 pub fn maybe_wrap_stream(
@@ -156,20 +118,11 @@ pub fn maybe_wrap_stream(
     let request_id = request_id.to_string();
     let model = request.inner.model.clone();
     tokio::spawn(async move {
-        // Waiting for the client's turn to end is deliberately outside the
-        // bound below: `tx` lives in the wrapper stream returned here, so `rx`
-        // resolves — with `Err` once that stream is dropped — as soon as the
-        // client's generation ends, one way or the other. Charging the wait to
-        // the warmup's budget would spend the whole bound on the turn, and any
-        // turn longer than the bound would never get a warmup at all.
-        //
-        // Cancellation is polled first, here and below. `biased` polls in
-        // source order, so with the work arm first a terminal chunk that lands
-        // in the same poll as a cancellation would win and dispatch a warmup
-        // into a runtime that is already shutting down.
+        // The warmup timeout begins after the client turn completes.
         let response_text = tokio::select! {
             biased;
 
+            // Biased selects must check cancellation before ready work.
             () = cancelled(cancel.clone()) => {
                 tracing::debug!(
                     request_id = %request_id,
@@ -182,17 +135,13 @@ pub fn maybe_wrap_stream(
             received = rx => {
                 match received {
                     Ok(response_text) => response_text,
-                    // No terminal chunk: no assistant turn to warm against.
                     Err(_) => return,
                 }
             }
         };
 
         let context_slot = PrefillContextSlot::new(None);
-        // Pinned and polled by reference so that neither `select!` arm consumes
-        // it: on the bail-out arms the warmup future — and with it the
-        // downstream stream — is still alive while `stop_downstream` runs, and
-        // is dropped only when this block ends.
+        // Keep the warmup alive for bounded cleanup after cancellation or timeout.
         let mut warmup = std::pin::pin!(prefill_task(
             next,
             formatter,
@@ -202,10 +151,6 @@ pub fn maybe_wrap_stream(
             &context_slot,
         ));
 
-        // The arms only decide *whether* to wind down; the winding down itself
-        // happens below. Both arms borrow `warmup` — the timeout arm holds it
-        // for as long as that future lives — so draining it further has to wait
-        // until this block has ended and released the borrow.
         let wind_down = tokio::select! {
             biased;
 
@@ -244,13 +189,7 @@ pub fn maybe_wrap_stream(
         };
 
         if wind_down {
-            // Only a warmup that got as far as its downstream has anything to
-            // wind down, and the slot is how we know. An empty slot means the
-            // cancellation arm won before `warmup` was ever polled, so the
-            // future is still unstarted — and draining it would start it,
-            // dispatching into the very shutdown the arm exists to avoid. The
-            // bound is deliberately read into a local first: holding the lock
-            // guard across the await below would be both wrong and unbuildable.
+            // Never poll an unstarted warmup during shutdown.
             let dispatched = context_slot.lock().is_some();
 
             if !dispatched {
@@ -263,10 +202,6 @@ pub fn maybe_wrap_stream(
             }
 
             stop_downstream(&context_slot);
-            // Dropping the non-winning arm released the borrow but not the
-            // future itself: `warmup` was pinned separately and the stream it
-            // holds is still open, so the downstream can still be polled and
-            // still act on the stop it was just sent.
             if tokio::time::timeout(PREFILL_WIND_DOWN_GRACE, &mut warmup)
                 .await
                 .is_err()
@@ -303,8 +238,7 @@ pub fn maybe_wrap_stream(
     }))
 }
 
-/// Resolves when `token` is cancelled, and never when there is no token, so
-/// the caller's timeout remains the only bound in that case.
+/// Waits forever when no cancellation token is supplied.
 async fn cancelled(token: Option<CancellationToken>) {
     match token {
         Some(token) => token.cancelled().await,
@@ -312,12 +246,7 @@ async fn cancelled(token: Option<CancellationToken>) {
     }
 }
 
-/// Asks the warmup's downstream to wind down, so the KV router's
-/// `RequestGuard` still gets a chance at its normal lifecycle.
-///
-/// This only raises the flag and wakes whoever is waiting on it. The caller
-/// must then keep polling the warmup — see [`PREFILL_WIND_DOWN_GRACE`] — or
-/// the downstream never gets the chance to act on it.
+/// Signals downstream; the caller must keep polling for cleanup to run.
 fn stop_downstream(slot: &PrefillContextSlot) {
     if let Some(context) = slot.lock().take() {
         context.stop_generating();
@@ -375,19 +304,12 @@ async fn prefill_task(
         uuid::Uuid::new_v4().to_string(),
         Default::default(),
     );
-    // Published before the call, not after it. `generate` is itself a place the
-    // warmup can sit for a long time — the KV router waits for a worker in
-    // there — and a stop that arrives during that wait has to find a handle in
-    // the slot or it lands on nothing. The router wraps that wait in
-    // `cancel_on_stop`, so a request context that is already stopped ends the
-    // call promptly rather than after the whole grace window.
+    // Publish before generate, which can block while waiting for a worker.
     *context_slot.lock() = Some(context.context());
 
-    // Drain the stream so the KV router's RequestGuard runs its full lifecycle
-    // (mark_prefill_completed, block tracking, free) instead of relying on drop.
+    // Draining lets the KV router finish RequestGuard cleanup.
     if let Ok(mut stream) = next.generate(context).await {
-        // Swapped for the stream's own context once there is one, so a stop
-        // during the drain reaches the stream rather than only the request.
+        // Stops during draining target the response stream.
         *context_slot.lock() = Some(stream.context());
         while stream.next().await.is_some() {}
     }
@@ -420,8 +342,6 @@ mod tests {
     type BackendEngine =
         dyn AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<BackendOutput>>, Error>;
 
-    /// Flips a shared flag when dropped, so a test can observe the exact moment
-    /// the detached task lets go of the downstream stream it was draining.
     struct DropProbe(Arc<AtomicBool>);
 
     impl Drop for DropProbe {
@@ -430,9 +350,6 @@ mod tests {
         }
     }
 
-    /// The failure this module has to survive: a backend that accepts the
-    /// warmup request and hands back a stream which never yields and never
-    /// reaches EOF. Draining it is an await that by itself never returns.
     #[derive(Debug, Default)]
     struct StallingBackend {
         generate_calls: AtomicUsize,
@@ -449,8 +366,6 @@ mod tests {
             self.stream_dropped.load(Ordering::SeqCst)
         }
 
-        /// Whether the downstream was asked to wind down, i.e. whether
-        /// `stop_generating` reached the context the backend published.
         fn was_asked_to_stop(&self) -> bool {
             self.context
                 .lock()
@@ -475,8 +390,6 @@ mod tests {
 
             let probe = DropProbe(self.stream_dropped.clone());
             let stalled = futures::stream::poll_fn(move |_cx| {
-                // Touched so the probe is owned by the stream and released
-                // only when the stream itself is dropped.
                 let _ = &probe;
                 Poll::Pending
             });
@@ -485,12 +398,6 @@ mod tests {
         }
     }
 
-    /// The downstream that makes `stop_generating` worth sending: it behaves
-    /// like the KV router's `monitor_response_stream`, which selects on
-    /// `context.stopped()` and, when that arm wins, runs `guard.abort()` and
-    /// ends the stream. That cleanup lives *inside* the stream, so it only runs
-    /// if the stream is polled after the stop — which is what
-    /// [`PREFILL_WIND_DOWN_GRACE`] exists to allow.
     #[derive(Debug, Default)]
     struct WindDownBackend {
         generate_calls: AtomicUsize,
@@ -504,8 +411,6 @@ mod tests {
             self.stream_dropped.load(Ordering::SeqCst)
         }
 
-        /// Whether the downstream got far enough to run its own cleanup, the
-        /// way the KV router's `RequestGuard` would.
         fn cleanup_ran(&self) -> bool {
             self.cleanup_ran.load(Ordering::SeqCst)
         }
@@ -535,8 +440,6 @@ mod tests {
             let probe = DropProbe(self.stream_dropped.clone());
             let cleanup = self.cleanup_ran.clone();
             let watched = ctx.clone();
-            // Yields nothing and stays pending until it is asked to stop, at
-            // which point it runs its cleanup and ends.
             let winding =
                 futures::stream::unfold(Some((watched, cleanup, probe)), |state| async move {
                     let (watched, cleanup, probe) = state?;
@@ -550,10 +453,6 @@ mod tests {
         }
     }
 
-    /// A backend that never returns a stream, because the wait for a worker is
-    /// itself somewhere the warmup can be stuck when the runtime goes down.
-    /// It mirrors the router's `cancel_on_stop`: it publishes the request
-    /// context, waits, and ends the call once that context is stopped.
     #[derive(Debug, Default)]
     struct StalledInGenerateBackend {
         generate_calls: AtomicUsize,
@@ -565,8 +464,6 @@ mod tests {
             self.generate_calls.load(Ordering::SeqCst)
         }
 
-        /// Whether the stop reached the request context — which it can only do
-        /// if that context was published before `generate` was awaited.
         fn was_asked_to_stop(&self) -> bool {
             self.context
                 .lock()
@@ -589,8 +486,6 @@ mod tests {
             let ctx = context.context();
             *self.context.lock() = Some(ctx.clone());
 
-            // No stream is ever produced: the call sits here until the request
-            // context is stopped, then reports the cancellation.
             ctx.stopped().await;
             Err(Error::msg("cancelled while selecting a worker"))
         }
@@ -641,8 +536,6 @@ mod tests {
         }
     }
 
-    /// One upstream chunk carrying `text`, terminal when `finish` is set: the
-    /// terminal chunk is what releases the warmup.
     fn chunk(text: &str, finish: bool) -> Annotated<NvCreateChatCompletionStreamResponse> {
         #[allow(deprecated)]
         let choice = ChatChoiceStream {
@@ -683,9 +576,6 @@ mod tests {
         ]))
     }
 
-    /// The same two chunks, but with `turn` of (virtual) thinking time between
-    /// them, so the terminal chunk — and with it the warmup's dispatch — lands
-    /// only after the client's generation has run that long.
     fn slow_upstream(
         turn: Duration,
     ) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>> {
@@ -711,8 +601,6 @@ mod tests {
             .collect()
     }
 
-    /// Lets the detached task run up to its next suspension point without
-    /// advancing the paused clock.
     async fn settle() {
         for _ in 0..16 {
             tokio::task::yield_now().await;
@@ -735,8 +623,6 @@ mod tests {
             &tokenizer,
             None,
         );
-        // Only the test's own handle and the detached task's clone remain, so
-        // the strong count is a faithful release probe.
         drop(engine);
 
         let items: Vec<_> = wrapped.collect().await;
@@ -746,9 +632,6 @@ mod tests {
             "client stream must be passed through intact"
         );
 
-        // The warmup is genuinely in flight and genuinely stuck: it reached the
-        // backend, and well past the point where a healthy max_tokens=1 request
-        // would have finished it is still holding the stream.
         settle().await;
         assert_eq!(backend.generate_calls(), 1, "warmup should have dispatched");
         tokio::time::sleep(PREFILL_TASK_TIMEOUT / 2).await;
@@ -777,10 +660,6 @@ mod tests {
         );
     }
 
-    /// A reasoning turn that outlives the bound must still get its warmup: the
-    /// bound belongs to the warmup, not to the client's generation. Arming it
-    /// at spawn instead spends the whole budget waiting for the terminal chunk,
-    /// and the warmup is abandoned before it is ever dispatched.
     #[tokio::test(start_paused = true)]
     async fn a_turn_longer_than_the_bound_still_gets_its_warmup() {
         let (formatter, tokenizer) = sample_model_parts();
@@ -799,8 +678,6 @@ mod tests {
         );
         drop(engine);
 
-        // The clock auto-advances past the bound here, while the warmup is
-        // still waiting for the turn to finish.
         let started = Instant::now();
         let items: Vec<_> = wrapped.collect().await;
         assert_eq!(items.len(), 2);
@@ -832,9 +709,6 @@ mod tests {
             "warmup should be released once its own bound elapses"
         );
         assert_eq!(Arc::strong_count(&backend), 1);
-        // Bracketed with the half-bound check above: release happened after
-        // dispatch + bound/2 and by dispatch + 1.5 * bound, so the bound really
-        // is measured from dispatch and not from the task's spawn.
         assert!(dispatched.elapsed() < PREFILL_TASK_TIMEOUT * 2);
     }
 
@@ -873,8 +747,6 @@ mod tests {
             "cancellation should reach the downstream context"
         );
 
-        // This backend ignores the stop, so it is held for the grace window and
-        // then dropped anyway. The bound is on the grace, not on the backend.
         tokio::time::sleep(PREFILL_WIND_DOWN_GRACE).await;
         settle().await;
 
@@ -883,14 +755,9 @@ mod tests {
             "a downstream that ignores the stop should still be released once the grace elapses"
         );
         assert_eq!(Arc::strong_count(&backend), 1);
-        // Proves the release came from cancellation and not from the timeout.
         assert!(started.elapsed() < PREFILL_TASK_TIMEOUT);
     }
 
-    /// The wind-down is only worth sending if the downstream can act on it.
-    /// A downstream that watches its context the way the KV router does must
-    /// get to finish its own cleanup, and must do so inside the grace rather
-    /// than being dropped mid-flight.
     #[tokio::test(start_paused = true)]
     async fn a_downstream_that_honours_the_stop_completes_its_own_cleanup() {
         let (formatter, tokenizer) = sample_model_parts();
@@ -930,8 +797,6 @@ mod tests {
             backend.stream_dropped(),
             "the stream should be released once it has wound down"
         );
-        // It wound down of its own accord, well inside the grace, rather than
-        // being cut off when the grace expired.
         assert!(
             cancelled_at.elapsed() < PREFILL_WIND_DOWN_GRACE,
             "wind-down should complete inside the grace window"
@@ -939,16 +804,6 @@ mod tests {
         assert_eq!(Arc::strong_count(&backend), 1);
     }
 
-    /// A token cancelled before the task ever runs must dispatch nothing.
-    ///
-    /// This pins the precondition, not the arm order. The ordering hazard the
-    /// arms guard against — a terminal chunk and a cancellation becoming ready
-    /// in the *same* poll, where `biased` source order decides the winner — is
-    /// not forceable from a test: whether the detached task observes the two
-    /// wakeups together or one at a time is up to the scheduler, and this test
-    /// passes under either arm order. The reorder above is therefore a
-    /// defensive fix for a real but unforceable race, and this test covers the
-    /// case that can be pinned deterministically.
     #[tokio::test(start_paused = true)]
     async fn an_already_cancelled_token_dispatches_nothing() {
         let (formatter, tokenizer) = sample_model_parts();
@@ -956,8 +811,6 @@ mod tests {
         let engine: Arc<BackendEngine> = backend.clone();
 
         let cancel = CancellationToken::new();
-        // Cancelled before the task ever runs, while `upstream()` has its
-        // terminal chunk ready immediately: both arms are ready on first poll.
         cancel.cancel();
 
         let request = chat_request(true);
@@ -995,14 +848,6 @@ mod tests {
         );
     }
 
-    /// A warmup still waiting for a worker must be reachable by the stop.
-    ///
-    /// `generate` is not instantaneous — the KV router waits for a worker
-    /// inside it — so the handle the bail-out paths need has to be in the slot
-    /// before that call is awaited, not after it returns. Published late, the
-    /// stop lands on an empty slot, the router's `cancel_on_stop` never fires,
-    /// and the grace window is spent waiting on a call that was never told to
-    /// end.
     #[tokio::test(start_paused = true)]
     async fn a_warmup_still_waiting_for_a_worker_is_reachable_by_the_stop() {
         let (formatter, tokenizer) = sample_model_parts();
@@ -1040,8 +885,6 @@ mod tests {
             "a warmup stuck in generate must still be reachable by the stop"
         );
 
-        // And because it was reachable, the call ends on the stop rather than
-        // outliving the grace window.
         settle().await;
         assert_eq!(
             Arc::strong_count(&backend),

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -357,11 +357,19 @@ async fn prefill_task(
         uuid::Uuid::new_v4().to_string(),
         Default::default(),
     );
+    // Published before the call, not after it. `generate` is itself a place the
+    // warmup can sit for a long time — the KV router waits for a worker in
+    // there — and a stop that arrives during that wait has to find a handle in
+    // the slot or it lands on nothing. The router wraps that wait in
+    // `cancel_on_stop`, so a request context that is already stopped ends the
+    // call promptly rather than after the whole grace window.
+    *context_slot.lock() = Some(context.context());
+
     // Drain the stream so the KV router's RequestGuard runs its full lifecycle
     // (mark_prefill_completed, block tracking, free) instead of relying on drop.
     if let Ok(mut stream) = next.generate(context).await {
-        // Published before the drain, because a drain that never returns is
-        // exactly the case in which the caller needs this handle.
+        // Swapped for the stream's own context once there is one, so a stop
+        // during the drain reaches the stream rather than only the request.
         *context_slot.lock() = Some(stream.context());
         while stream.next().await.is_some() {}
     }
@@ -521,6 +529,52 @@ mod tests {
                 });
 
             Ok(ResponseStream::new(Box::pin(winding), ctx))
+        }
+    }
+
+    /// A backend that never returns a stream, because the wait for a worker is
+    /// itself somewhere the warmup can be stuck when the runtime goes down.
+    /// It mirrors the router's `cancel_on_stop`: it publishes the request
+    /// context, waits, and ends the call once that context is stopped.
+    #[derive(Debug, Default)]
+    struct StalledInGenerateBackend {
+        generate_calls: AtomicUsize,
+        context: Mutex<Option<Arc<dyn AsyncEngineContext>>>,
+    }
+
+    impl StalledInGenerateBackend {
+        fn generate_calls(&self) -> usize {
+            self.generate_calls.load(Ordering::SeqCst)
+        }
+
+        /// Whether the stop reached the request context — which it can only do
+        /// if that context was published before `generate` was awaited.
+        fn was_asked_to_stop(&self) -> bool {
+            self.context
+                .lock()
+                .as_ref()
+                .map(|ctx| ctx.is_stopped())
+                .unwrap_or(false)
+        }
+    }
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<BackendOutput>>, Error>
+        for StalledInGenerateBackend
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<BackendOutput>>, Error> {
+            self.generate_calls.fetch_add(1, Ordering::SeqCst);
+            let (_request, context) = request.transfer(());
+            let ctx = context.context();
+            *self.context.lock() = Some(ctx.clone());
+
+            // No stream is ever produced: the call sits here until the request
+            // context is stopped, then reports the cancellation.
+            ctx.stopped().await;
+            Err(Error::msg("cancelled while selecting a worker"))
         }
     }
 
@@ -920,6 +974,61 @@ mod tests {
             Arc::strong_count(&backend),
             1,
             "the task should have released the engine without dispatching"
+        );
+    }
+
+    /// A warmup still waiting for a worker must be reachable by the stop.
+    ///
+    /// `generate` is not instantaneous — the KV router waits for a worker
+    /// inside it — so the handle the bail-out paths need has to be in the slot
+    /// before that call is awaited, not after it returns. Published late, the
+    /// stop lands on an empty slot, the router's `cancel_on_stop` never fires,
+    /// and the grace window is spent waiting on a call that was never told to
+    /// end.
+    #[tokio::test(start_paused = true)]
+    async fn a_warmup_still_waiting_for_a_worker_is_reachable_by_the_stop() {
+        let (formatter, tokenizer) = sample_model_parts();
+        let backend = Arc::new(StalledInGenerateBackend::default());
+        let engine: Arc<BackendEngine> = backend.clone();
+
+        let cancel = CancellationToken::new();
+        let request = chat_request(true);
+        let wrapped = maybe_wrap_stream(
+            upstream(),
+            &request,
+            "req-stalled-in-generate",
+            &engine,
+            &formatter,
+            &tokenizer,
+            Some(&cancel),
+        );
+        drop(engine);
+
+        let items: Vec<_> = wrapped.collect().await;
+        assert_eq!(items.len(), 2);
+
+        settle().await;
+        assert_eq!(
+            backend.generate_calls(),
+            1,
+            "the warmup should be in flight, still waiting for a worker"
+        );
+
+        cancel.cancel();
+        settle().await;
+
+        assert!(
+            backend.was_asked_to_stop(),
+            "a warmup stuck in generate must still be reachable by the stop"
+        );
+
+        // And because it was reachable, the call ends on the stop rather than
+        // outliving the grace window.
+        settle().await;
+        assert_eq!(
+            Arc::strong_count(&backend),
+            1,
+            "the task should have released the engine once generate returned"
         );
     }
 

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -35,9 +35,9 @@ use crate::protocols::openai::chat_completions::{
 use crate::tokenizers::traits::Tokenizer;
 use dynamo_renderer::{OAIChatLikeRequest, OAIPromptFormatter};
 
-/// Upper bound on the lifetime of one detached speculative-prefill task.
+/// Upper bound on the lifetime of one dispatched speculative-prefill warmup.
 ///
-/// The task is a best-effort KV-cache warmup for a turn the user may never
+/// The warmup is a best-effort KV-cache fill for a turn the user may never
 /// send, and it is dispatched on a context nobody else holds, so nothing
 /// upstream can ever stop it. A backend that returns a stream which stays
 /// pending instead of reaching EOF would otherwise pin one task — and
@@ -46,6 +46,10 @@ use dynamo_renderer::{OAIChatLikeRequest, OAIPromptFormatter};
 /// request on a healthy backend and short relative to a human turn: a warmup
 /// that has not finished by now has already lost the race with the next turn
 /// it was warming for.
+///
+/// The bound covers the warmup only. It is armed after the client's turn has
+/// finished, because that is when the warmup is dispatched; a turn is allowed
+/// to take as long as it likes.
 const PREFILL_TASK_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Publication slot for the warmup stream's context.
@@ -53,7 +57,7 @@ const PREFILL_TASK_TIMEOUT: Duration = Duration::from_secs(60);
 /// [`prefill_task`] fills it before draining so that the bounding wrapper in
 /// [`maybe_wrap_stream`] can reach the downstream context on the timeout and
 /// cancellation paths.
-type PrefillContextSlot = Arc<Mutex<Option<Arc<dyn AsyncEngineContext>>>>;
+type PrefillContextSlot = Mutex<Option<Arc<dyn AsyncEngineContext>>>;
 
 /// A minimal `OAIChatLikeRequest` for speculative next-turn prefill.
 /// Holds the full conversation (including a new assistant message) and
@@ -94,14 +98,17 @@ impl OAIChatLikeRequest for SpeculativePrefillRequest {
 /// a background task that renders the next-turn prefix and fires a
 /// `max_tokens=1` request through the pipeline to warm the KV cache.
 ///
-/// The spawned task is bounded by [`PREFILL_TASK_TIMEOUT`] and, when `cancel`
-/// is supplied, also ends when that token is cancelled; nothing else can stop
-/// it, because it runs on a context of its own and no owner keeps its handle.
+/// Once dispatched, the warmup is bounded by [`PREFILL_TASK_TIMEOUT`], and the
+/// task ends at any point when `cancel` — where supplied — is cancelled;
+/// nothing else can stop it, because it runs on a context of its own and no
+/// owner keeps its handle. `request_id` identifies the client request that
+/// produced the warmup, so an abandoned or cancelled one can be traced back.
 ///
 /// When the flag is not set, returns the stream unmodified with zero overhead.
 pub fn maybe_wrap_stream(
     stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>>,
     request: &NvCreateChatCompletionRequest,
+    request_id: &str,
     next: &Arc<
         dyn AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<BackendOutput>>, Error>,
     >,
@@ -127,50 +134,80 @@ pub fn maybe_wrap_stream(
     let tokenizer = tokenizer.clone();
     let messages = request.inner.messages.clone();
     let cancel = cancel.cloned();
+    let request_id = request_id.to_string();
+    let model = request.inner.model.clone();
     tokio::spawn(async move {
-        let context_slot: PrefillContextSlot = Arc::new(Mutex::new(None));
+        // Waiting for the client's turn to end is deliberately outside the
+        // bound below: `tx` lives in the wrapper stream returned here, so `rx`
+        // resolves — with `Err` once that stream is dropped — as soon as the
+        // client's generation ends, one way or the other. Charging the wait to
+        // the warmup's budget would spend the whole bound on the turn, and any
+        // turn longer than the bound would never get a warmup at all.
+        let response_text = tokio::select! {
+            biased;
 
-        let warmup = {
-            let context_slot = context_slot.clone();
-            async move {
-                let Ok(response_text) = rx.await else {
-                    return;
-                };
-                if let Err(e) = prefill_task(
-                    next,
-                    formatter,
-                    tokenizer,
-                    messages,
-                    response_text,
-                    &context_slot,
-                )
-                .await
-                {
-                    tracing::warn!(error = %e, "Speculative prefill failed");
+            received = rx => {
+                match received {
+                    Ok(response_text) => response_text,
+                    // No terminal chunk: no assistant turn to warm against.
+                    Err(_) => return,
                 }
             }
+
+            () = cancelled(cancel.clone()) => {
+                tracing::debug!(
+                    request_id = %request_id,
+                    model = %model,
+                    "Speculative prefill cancelled by runtime shutdown before dispatch"
+                );
+                return;
+            }
         };
+
+        let context_slot = PrefillContextSlot::new(None);
         // Pinned and polled by reference so that neither `select!` arm consumes
         // it: on the bail-out arms the warmup future — and with it the
         // downstream stream — is still alive while `stop_downstream` runs, and
         // is dropped only when this block ends.
-        let mut warmup = std::pin::pin!(warmup);
+        let mut warmup = std::pin::pin!(prefill_task(
+            next,
+            formatter,
+            tokenizer,
+            messages,
+            response_text,
+            &context_slot,
+        ));
 
         tokio::select! {
             biased;
 
             outcome = tokio::time::timeout(PREFILL_TASK_TIMEOUT, &mut warmup) => {
-                if outcome.is_err() {
-                    tracing::warn!(
-                        timeout_secs = PREFILL_TASK_TIMEOUT.as_secs(),
-                        "Speculative prefill exceeded its lifetime bound; abandoning warmup"
-                    );
-                    stop_downstream(&context_slot);
+                match outcome {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => tracing::warn!(
+                        request_id = %request_id,
+                        model = %model,
+                        error = %e,
+                        "Speculative prefill failed"
+                    ),
+                    Err(_) => {
+                        tracing::warn!(
+                            request_id = %request_id,
+                            model = %model,
+                            timeout_secs = PREFILL_TASK_TIMEOUT.as_secs(),
+                            "Speculative prefill exceeded its lifetime bound; abandoning warmup"
+                        );
+                        stop_downstream(&context_slot);
+                    }
                 }
             }
 
             () = cancelled(cancel) => {
-                tracing::debug!("Speculative prefill cancelled by runtime shutdown");
+                tracing::debug!(
+                    request_id = %request_id,
+                    model = %model,
+                    "Speculative prefill cancelled by runtime shutdown"
+                );
                 stop_downstream(&context_slot);
             }
         }
@@ -457,6 +494,22 @@ mod tests {
         ]))
     }
 
+    /// The same two chunks, but with `turn` of (virtual) thinking time between
+    /// them, so the terminal chunk — and with it the warmup's dispatch — lands
+    /// only after the client's generation has run that long.
+    fn slow_upstream(
+        turn: Duration,
+    ) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>> {
+        Box::pin(
+            futures::stream::once(async { chunk("everest is ", false) }).chain(
+                futures::stream::once(async move {
+                    tokio::time::sleep(turn).await;
+                    chunk("8849 m tall.", true)
+                }),
+            ),
+        )
+    }
+
     fn text_of(items: &[Annotated<NvCreateChatCompletionStreamResponse>]) -> String {
         items
             .iter()
@@ -484,8 +537,15 @@ mod tests {
         let engine: Arc<BackendEngine> = backend.clone();
 
         let request = chat_request(true);
-        let wrapped =
-            maybe_wrap_stream(upstream(), &request, &engine, &formatter, &tokenizer, None);
+        let wrapped = maybe_wrap_stream(
+            upstream(),
+            &request,
+            "req-bound",
+            &engine,
+            &formatter,
+            &tokenizer,
+            None,
+        );
         // Only the test's own handle and the detached task's clone remain, so
         // the strong count is a faithful release probe.
         drop(engine);
@@ -528,6 +588,67 @@ mod tests {
         );
     }
 
+    /// A reasoning turn that outlives the bound must still get its warmup: the
+    /// bound belongs to the warmup, not to the client's generation. Arming it
+    /// at spawn instead spends the whole budget waiting for the terminal chunk,
+    /// and the warmup is abandoned before it is ever dispatched.
+    #[tokio::test(start_paused = true)]
+    async fn a_turn_longer_than_the_bound_still_gets_its_warmup() {
+        let (formatter, tokenizer) = sample_model_parts();
+        let backend = Arc::new(StallingBackend::default());
+        let engine: Arc<BackendEngine> = backend.clone();
+
+        let request = chat_request(true);
+        let wrapped = maybe_wrap_stream(
+            slow_upstream(PREFILL_TASK_TIMEOUT * 2),
+            &request,
+            "req-long-turn",
+            &engine,
+            &formatter,
+            &tokenizer,
+            None,
+        );
+        drop(engine);
+
+        // The clock auto-advances past the bound here, while the warmup is
+        // still waiting for the turn to finish.
+        let started = Instant::now();
+        let items: Vec<_> = wrapped.collect().await;
+        assert_eq!(items.len(), 2);
+        assert!(
+            started.elapsed() > PREFILL_TASK_TIMEOUT,
+            "the turn must outlast the bound for this test to mean anything"
+        );
+
+        let dispatched = Instant::now();
+        settle().await;
+        assert_eq!(
+            backend.generate_calls(),
+            1,
+            "a turn longer than the bound must still dispatch its warmup"
+        );
+
+        tokio::time::sleep(PREFILL_TASK_TIMEOUT / 2).await;
+        settle().await;
+        assert!(
+            !backend.stream_dropped(),
+            "warmup abandoned before its own bound elapsed"
+        );
+
+        tokio::time::sleep(PREFILL_TASK_TIMEOUT).await;
+        settle().await;
+        assert!(backend.was_asked_to_stop());
+        assert!(
+            backend.stream_dropped(),
+            "warmup should be released once its own bound elapses"
+        );
+        assert_eq!(Arc::strong_count(&backend), 1);
+        // Bracketed with the half-bound check above: release happened after
+        // dispatch + bound/2 and by dispatch + 1.5 * bound, so the bound really
+        // is measured from dispatch and not from the task's spawn.
+        assert!(dispatched.elapsed() < PREFILL_TASK_TIMEOUT * 2);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn stalled_warmup_is_released_when_the_runtime_token_is_cancelled() {
         let (formatter, tokenizer) = sample_model_parts();
@@ -539,6 +660,7 @@ mod tests {
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
+            "req-cancel",
             &engine,
             &formatter,
             &tokenizer,
@@ -577,8 +699,15 @@ mod tests {
         let engine: Arc<BackendEngine> = backend.clone();
 
         let request = chat_request(false);
-        let wrapped =
-            maybe_wrap_stream(upstream(), &request, &engine, &formatter, &tokenizer, None);
+        let wrapped = maybe_wrap_stream(
+            upstream(),
+            &request,
+            "req-disabled",
+            &engine,
+            &formatter,
+            &tokenizer,
+            None,
+        );
         drop(engine);
 
         let items: Vec<_> = wrapped.collect().await;

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -52,6 +52,23 @@ use dynamo_renderer::{OAIChatLikeRequest, OAIPromptFormatter};
 /// to take as long as it likes.
 const PREFILL_TASK_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// How long the warmup is polled after its downstream has been asked to stop.
+///
+/// `stop_generating` is only a signal. A downstream that acts on it does so
+/// from inside the response stream — the KV router's `monitor_response_stream`
+/// selects on `context.stopped()` and, when that wins, runs `guard.abort()`
+/// before ending the stream. That code lives in the stream this task is
+/// draining, so it can only run if the stream is polled again after the
+/// signal. Dropping straight after signalling therefore guarantees the very
+/// cleanup the signal was asking for never happens.
+///
+/// So the bail-out paths keep draining for this long before letting go. A
+/// downstream that honours the stop ends its stream well inside the window and
+/// the task finishes early; one that ignores it costs this much extra and is
+/// then dropped exactly as before. Short next to [`PREFILL_TASK_TIMEOUT`],
+/// because by this point the warmup has already lost its race.
+const PREFILL_WIND_DOWN_GRACE: Duration = Duration::from_secs(5);
+
 /// Publication slot for the warmup stream's context.
 ///
 /// [`prefill_task`] fills it before draining so that the bounding wrapper in
@@ -101,8 +118,10 @@ impl OAIChatLikeRequest for SpeculativePrefillRequest {
 /// Once dispatched, the warmup is bounded by [`PREFILL_TASK_TIMEOUT`], and the
 /// task ends at any point when `cancel` — where supplied — is cancelled;
 /// nothing else can stop it, because it runs on a context of its own and no
-/// owner keeps its handle. `request_id` identifies the client request that
-/// produced the warmup, so an abandoned or cancelled one can be traced back.
+/// owner keeps its handle. Either ending asks the downstream to stop and then
+/// drains it for up to [`PREFILL_WIND_DOWN_GRACE`] so that request can actually
+/// be acted on. `request_id` identifies the client request that produced the
+/// warmup, so an abandoned or cancelled one can be traced back.
 ///
 /// When the flag is not set, returns the stream unmodified with zero overhead.
 pub fn maybe_wrap_stream(
@@ -143,16 +162,13 @@ pub fn maybe_wrap_stream(
         // client's generation ends, one way or the other. Charging the wait to
         // the warmup's budget would spend the whole bound on the turn, and any
         // turn longer than the bound would never get a warmup at all.
+        //
+        // Cancellation is polled first, here and below. `biased` polls in
+        // source order, so with the work arm first a terminal chunk that lands
+        // in the same poll as a cancellation would win and dispatch a warmup
+        // into a runtime that is already shutting down.
         let response_text = tokio::select! {
             biased;
-
-            received = rx => {
-                match received {
-                    Ok(response_text) => response_text,
-                    // No terminal chunk: no assistant turn to warm against.
-                    Err(_) => return,
-                }
-            }
 
             () = cancelled(cancel.clone()) => {
                 tracing::debug!(
@@ -161,6 +177,14 @@ pub fn maybe_wrap_stream(
                     "Speculative prefill cancelled by runtime shutdown before dispatch"
                 );
                 return;
+            }
+
+            received = rx => {
+                match received {
+                    Ok(response_text) => response_text,
+                    // No terminal chunk: no assistant turn to warm against.
+                    Err(_) => return,
+                }
             }
         };
 
@@ -178,29 +202,12 @@ pub fn maybe_wrap_stream(
             &context_slot,
         ));
 
-        tokio::select! {
+        // The arms only decide *whether* to wind down; the winding down itself
+        // happens below. Both arms borrow `warmup` — the timeout arm holds it
+        // for as long as that future lives — so draining it further has to wait
+        // until this block has ended and released the borrow.
+        let wind_down = tokio::select! {
             biased;
-
-            outcome = tokio::time::timeout(PREFILL_TASK_TIMEOUT, &mut warmup) => {
-                match outcome {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => tracing::warn!(
-                        request_id = %request_id,
-                        model = %model,
-                        error = %e,
-                        "Speculative prefill failed"
-                    ),
-                    Err(_) => {
-                        tracing::warn!(
-                            request_id = %request_id,
-                            model = %model,
-                            timeout_secs = PREFILL_TASK_TIMEOUT.as_secs(),
-                            "Speculative prefill exceeded its lifetime bound; abandoning warmup"
-                        );
-                        stop_downstream(&context_slot);
-                    }
-                }
-            }
 
             () = cancelled(cancel) => {
                 tracing::debug!(
@@ -208,7 +215,50 @@ pub fn maybe_wrap_stream(
                     model = %model,
                     "Speculative prefill cancelled by runtime shutdown"
                 );
-                stop_downstream(&context_slot);
+                true
+            }
+
+            outcome = tokio::time::timeout(PREFILL_TASK_TIMEOUT, &mut warmup) => {
+                match outcome {
+                    Ok(Ok(())) => false,
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            request_id = %request_id,
+                            model = %model,
+                            error = %e,
+                            "Speculative prefill failed"
+                        );
+                        false
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            request_id = %request_id,
+                            model = %model,
+                            timeout_secs = PREFILL_TASK_TIMEOUT.as_secs(),
+                            "Speculative prefill exceeded its lifetime bound; abandoning warmup"
+                        );
+                        true
+                    }
+                }
+            }
+        };
+
+        if wind_down {
+            stop_downstream(&context_slot);
+            // Dropping the non-winning arm released the borrow but not the
+            // future itself: `warmup` was pinned separately and the stream it
+            // holds is still open, so the downstream can still be polled and
+            // still act on the stop it was just sent.
+            if tokio::time::timeout(PREFILL_WIND_DOWN_GRACE, &mut warmup)
+                .await
+                .is_err()
+            {
+                tracing::debug!(
+                    request_id = %request_id,
+                    model = %model,
+                    grace_secs = PREFILL_WIND_DOWN_GRACE.as_secs(),
+                    "Speculative prefill downstream did not wind down; dropping the stream"
+                );
             }
         }
     });
@@ -244,10 +294,12 @@ async fn cancelled(token: Option<CancellationToken>) {
     }
 }
 
-/// Asks the warmup's downstream to wind down before the stream is dropped, so
-/// the KV router's `RequestGuard` still gets a chance at its normal lifecycle.
-/// A downstream that ignores the request is not a problem: the caller drops
-/// the stream regardless, so the task ends either way.
+/// Asks the warmup's downstream to wind down, so the KV router's
+/// `RequestGuard` still gets a chance at its normal lifecycle.
+///
+/// This only raises the flag and wakes whoever is waiting on it. The caller
+/// must then keep polling the warmup — see [`PREFILL_WIND_DOWN_GRACE`] — or
+/// the downstream never gets the chance to act on it.
 fn stop_downstream(slot: &PrefillContextSlot) {
     if let Some(context) = slot.lock().take() {
         context.stop_generating();
@@ -404,6 +456,71 @@ mod tests {
             });
 
             Ok(ResponseStream::new(Box::pin(stalled), ctx))
+        }
+    }
+
+    /// The downstream that makes `stop_generating` worth sending: it behaves
+    /// like the KV router's `monitor_response_stream`, which selects on
+    /// `context.stopped()` and, when that arm wins, runs `guard.abort()` and
+    /// ends the stream. That cleanup lives *inside* the stream, so it only runs
+    /// if the stream is polled after the stop — which is what
+    /// [`PREFILL_WIND_DOWN_GRACE`] exists to allow.
+    #[derive(Debug, Default)]
+    struct WindDownBackend {
+        generate_calls: AtomicUsize,
+        stream_dropped: Arc<AtomicBool>,
+        cleanup_ran: Arc<AtomicBool>,
+        context: Mutex<Option<Arc<dyn AsyncEngineContext>>>,
+    }
+
+    impl WindDownBackend {
+        fn stream_dropped(&self) -> bool {
+            self.stream_dropped.load(Ordering::SeqCst)
+        }
+
+        /// Whether the downstream got far enough to run its own cleanup, the
+        /// way the KV router's `RequestGuard` would.
+        fn cleanup_ran(&self) -> bool {
+            self.cleanup_ran.load(Ordering::SeqCst)
+        }
+
+        fn was_asked_to_stop(&self) -> bool {
+            self.context
+                .lock()
+                .as_ref()
+                .map(|ctx| ctx.is_stopped())
+                .unwrap_or(false)
+        }
+    }
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<BackendOutput>>, Error>
+        for WindDownBackend
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<BackendOutput>>, Error> {
+            self.generate_calls.fetch_add(1, Ordering::SeqCst);
+            let (_request, context) = request.transfer(());
+            let ctx = context.context();
+            *self.context.lock() = Some(ctx.clone());
+
+            let probe = DropProbe(self.stream_dropped.clone());
+            let cleanup = self.cleanup_ran.clone();
+            let watched = ctx.clone();
+            // Yields nothing and stays pending until it is asked to stop, at
+            // which point it runs its cleanup and ends.
+            let winding =
+                futures::stream::unfold(Some((watched, cleanup, probe)), |state| async move {
+                    let (watched, cleanup, probe) = state?;
+                    let _ = &probe;
+                    watched.stopped().await;
+                    cleanup.store(true, Ordering::SeqCst);
+                    None::<(Annotated<BackendOutput>, _)>
+                });
+
+            Ok(ResponseStream::new(Box::pin(winding), ctx))
         }
     }
 
@@ -683,13 +800,127 @@ mod tests {
             backend.was_asked_to_stop(),
             "cancellation should reach the downstream context"
         );
+
+        // This backend ignores the stop, so it is held for the grace window and
+        // then dropped anyway. The bound is on the grace, not on the backend.
+        tokio::time::sleep(PREFILL_WIND_DOWN_GRACE).await;
+        settle().await;
+
         assert!(
             backend.stream_dropped(),
-            "cancellation should release the stalled downstream stream"
+            "a downstream that ignores the stop should still be released once the grace elapses"
         );
         assert_eq!(Arc::strong_count(&backend), 1);
         // Proves the release came from cancellation and not from the timeout.
         assert!(started.elapsed() < PREFILL_TASK_TIMEOUT);
+    }
+
+    /// The wind-down is only worth sending if the downstream can act on it.
+    /// A downstream that watches its context the way the KV router does must
+    /// get to finish its own cleanup, and must do so inside the grace rather
+    /// than being dropped mid-flight.
+    #[tokio::test(start_paused = true)]
+    async fn a_downstream_that_honours_the_stop_completes_its_own_cleanup() {
+        let (formatter, tokenizer) = sample_model_parts();
+        let backend = Arc::new(WindDownBackend::default());
+        let engine: Arc<BackendEngine> = backend.clone();
+        let cancel = CancellationToken::new();
+
+        let request = chat_request(true);
+        let wrapped = maybe_wrap_stream(
+            upstream(),
+            &request,
+            "req-wind-down",
+            &engine,
+            &formatter,
+            &tokenizer,
+            Some(&cancel),
+        );
+        drop(engine);
+
+        let items: Vec<_> = wrapped.collect().await;
+        assert_eq!(items.len(), 2);
+
+        settle().await;
+        assert!(!backend.cleanup_ran(), "nothing should wind down yet");
+
+        let cancelled_at = Instant::now();
+        cancel.cancel();
+        settle().await;
+
+        assert!(backend.was_asked_to_stop());
+        assert!(
+            backend.cleanup_ran(),
+            "a downstream watching its context must get to run its cleanup; \
+             signalling and dropping in the same poll would skip it"
+        );
+        assert!(
+            backend.stream_dropped(),
+            "the stream should be released once it has wound down"
+        );
+        // It wound down of its own accord, well inside the grace, rather than
+        // being cut off when the grace expired.
+        assert!(
+            cancelled_at.elapsed() < PREFILL_WIND_DOWN_GRACE,
+            "wind-down should complete inside the grace window"
+        );
+        assert_eq!(Arc::strong_count(&backend), 1);
+    }
+
+    /// A token cancelled before the task ever runs must dispatch nothing.
+    ///
+    /// This pins the precondition, not the arm order. The ordering hazard the
+    /// arms guard against — a terminal chunk and a cancellation becoming ready
+    /// in the *same* poll, where `biased` source order decides the winner — is
+    /// not forceable from a test: whether the detached task observes the two
+    /// wakeups together or one at a time is up to the scheduler, and this test
+    /// passes under either arm order. The reorder above is therefore a
+    /// defensive fix for a real but unforceable race, and this test covers the
+    /// case that can be pinned deterministically.
+    #[tokio::test(start_paused = true)]
+    async fn an_already_cancelled_token_dispatches_nothing() {
+        let (formatter, tokenizer) = sample_model_parts();
+        let backend = Arc::new(StallingBackend::default());
+        let engine: Arc<BackendEngine> = backend.clone();
+
+        let cancel = CancellationToken::new();
+        // Cancelled before the task ever runs, while `upstream()` has its
+        // terminal chunk ready immediately: both arms are ready on first poll.
+        cancel.cancel();
+
+        let request = chat_request(true);
+        let wrapped = maybe_wrap_stream(
+            upstream(),
+            &request,
+            "req-already-cancelled",
+            &engine,
+            &formatter,
+            &tokenizer,
+            Some(&cancel),
+        );
+        drop(engine);
+
+        let items: Vec<_> = wrapped.collect().await;
+        assert_eq!(
+            items.len(),
+            2,
+            "the client stream is passed through regardless"
+        );
+
+        settle().await;
+        tokio::time::sleep(PREFILL_TASK_TIMEOUT).await;
+        settle().await;
+
+        assert_eq!(
+            backend.generate_calls(),
+            0,
+            "no warmup may be dispatched once the runtime is already shutting down"
+        );
+        assert_eq!(
+            Arc::strong_count(&backend),
+            1,
+            "the task should have released the engine without dispatching"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -10,6 +10,7 @@
 
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use dynamo_protocols::types::{
@@ -19,8 +20,10 @@ use dynamo_protocols::types::{
 use futures::Stream;
 use futures::stream::StreamExt;
 use minijinja::value::Value;
+use parking_lot::Mutex;
+use tokio_util::sync::CancellationToken;
 
-use dynamo_runtime::engine::AsyncEngine;
+use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider};
 use dynamo_runtime::pipeline::{Context as PipelineContext, Error, ManyOut, SingleIn};
 use dynamo_runtime::protocols::annotated::Annotated;
 
@@ -31,6 +34,26 @@ use crate::protocols::openai::chat_completions::{
 };
 use crate::tokenizers::traits::Tokenizer;
 use dynamo_renderer::{OAIChatLikeRequest, OAIPromptFormatter};
+
+/// Upper bound on the lifetime of one detached speculative-prefill task.
+///
+/// The task is a best-effort KV-cache warmup for a turn the user may never
+/// send, and it is dispatched on a context nobody else holds, so nothing
+/// upstream can ever stop it. A backend that returns a stream which stays
+/// pending instead of reaching EOF would otherwise pin one task — and
+/// everything it captured — for the life of the process, once per request
+/// that used the hint. The value is generous relative to a `max_tokens=1`
+/// request on a healthy backend and short relative to a human turn: a warmup
+/// that has not finished by now has already lost the race with the next turn
+/// it was warming for.
+const PREFILL_TASK_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Publication slot for the warmup stream's context.
+///
+/// [`prefill_task`] fills it before draining so that the bounding wrapper in
+/// [`maybe_wrap_stream`] can reach the downstream context on the timeout and
+/// cancellation paths.
+type PrefillContextSlot = Arc<Mutex<Option<Arc<dyn AsyncEngineContext>>>>;
 
 /// A minimal `OAIChatLikeRequest` for speculative next-turn prefill.
 /// Holds the full conversation (including a new assistant message) and
@@ -71,6 +94,10 @@ impl OAIChatLikeRequest for SpeculativePrefillRequest {
 /// a background task that renders the next-turn prefix and fires a
 /// `max_tokens=1` request through the pipeline to warm the KV cache.
 ///
+/// The spawned task is bounded by [`PREFILL_TASK_TIMEOUT`] and, when `cancel`
+/// is supplied, also ends when that token is cancelled; nothing else can stop
+/// it, because it runs on a context of its own and no owner keeps its handle.
+///
 /// When the flag is not set, returns the stream unmodified with zero overhead.
 pub fn maybe_wrap_stream(
     stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>>,
@@ -80,6 +107,7 @@ pub fn maybe_wrap_stream(
     >,
     formatter: &Arc<dyn OAIPromptFormatter>,
     tokenizer: &Arc<dyn Tokenizer>,
+    cancel: Option<&CancellationToken>,
 ) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>> {
     let enabled = request
         .nvext
@@ -98,12 +126,53 @@ pub fn maybe_wrap_stream(
     let formatter = formatter.clone();
     let tokenizer = tokenizer.clone();
     let messages = request.inner.messages.clone();
+    let cancel = cancel.cloned();
     tokio::spawn(async move {
-        let Ok(response_text) = rx.await else {
-            return;
+        let context_slot: PrefillContextSlot = Arc::new(Mutex::new(None));
+
+        let warmup = {
+            let context_slot = context_slot.clone();
+            async move {
+                let Ok(response_text) = rx.await else {
+                    return;
+                };
+                if let Err(e) = prefill_task(
+                    next,
+                    formatter,
+                    tokenizer,
+                    messages,
+                    response_text,
+                    &context_slot,
+                )
+                .await
+                {
+                    tracing::warn!(error = %e, "Speculative prefill failed");
+                }
+            }
         };
-        if let Err(e) = prefill_task(next, formatter, tokenizer, messages, response_text).await {
-            tracing::warn!(error = %e, "Speculative prefill failed");
+        // Pinned and polled by reference so that neither `select!` arm consumes
+        // it: on the bail-out arms the warmup future — and with it the
+        // downstream stream — is still alive while `stop_downstream` runs, and
+        // is dropped only when this block ends.
+        let mut warmup = std::pin::pin!(warmup);
+
+        tokio::select! {
+            biased;
+
+            outcome = tokio::time::timeout(PREFILL_TASK_TIMEOUT, &mut warmup) => {
+                if outcome.is_err() {
+                    tracing::warn!(
+                        timeout_secs = PREFILL_TASK_TIMEOUT.as_secs(),
+                        "Speculative prefill exceeded its lifetime bound; abandoning warmup"
+                    );
+                    stop_downstream(&context_slot);
+                }
+            }
+
+            () = cancelled(cancel) => {
+                tracing::debug!("Speculative prefill cancelled by runtime shutdown");
+                stop_downstream(&context_slot);
+            }
         }
     });
 
@@ -129,6 +198,25 @@ pub fn maybe_wrap_stream(
     }))
 }
 
+/// Resolves when `token` is cancelled, and never when there is no token, so
+/// the caller's timeout remains the only bound in that case.
+async fn cancelled(token: Option<CancellationToken>) {
+    match token {
+        Some(token) => token.cancelled().await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Asks the warmup's downstream to wind down before the stream is dropped, so
+/// the KV router's `RequestGuard` still gets a chance at its normal lifecycle.
+/// A downstream that ignores the request is not a problem: the caller drops
+/// the stream regardless, so the task ends either way.
+fn stop_downstream(slot: &PrefillContextSlot) {
+    if let Some(context) = slot.lock().take() {
+        context.stop_generating();
+    }
+}
+
 /// Fire-and-forget task that renders the next-turn prefix and sends it
 /// through the pipeline as a `max_tokens=1` request to warm the KV cache.
 async fn prefill_task(
@@ -139,6 +227,7 @@ async fn prefill_task(
     tokenizer: Arc<dyn Tokenizer>,
     original_messages: Vec<ChatCompletionRequestMessage>,
     response_text: String,
+    context_slot: &PrefillContextSlot,
 ) -> Result<()> {
     let assistant_msg =
         ChatCompletionRequestMessage::Assistant(ChatCompletionRequestAssistantMessage {
@@ -182,8 +271,333 @@ async fn prefill_task(
     // Drain the stream so the KV router's RequestGuard runs its full lifecycle
     // (mark_prefill_completed, block tracking, free) instead of relying on drop.
     if let Ok(mut stream) = next.generate(context).await {
+        // Published before the drain, because a drain that never returns is
+        // exactly the case in which the caller needs this handle.
+        *context_slot.lock() = Some(stream.context());
         while stream.next().await.is_some() {}
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::task::Poll;
+
+    use async_trait::async_trait;
+    use dynamo_protocols::types::{
+        ChatChoiceStream, ChatCompletionRequestUserMessage,
+        ChatCompletionRequestUserMessageContent, ChatCompletionStreamResponseDelta,
+        CreateChatCompletionRequest, CreateChatCompletionStreamResponse, FinishReason,
+    };
+    use dynamo_renderer::PromptFormatter;
+    use dynamo_runtime::pipeline::ResponseStream;
+    use tokio::time::Instant;
+
+    use crate::model_card::ModelDeploymentCard;
+    use crate::preprocessor::prompt::prompt_formatter_from_mdc;
+    use crate::protocols::common::extensions::{AgentHints, NvExt};
+
+    use super::*;
+
+    type BackendEngine =
+        dyn AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<BackendOutput>>, Error>;
+
+    /// Flips a shared flag when dropped, so a test can observe the exact moment
+    /// the detached task lets go of the downstream stream it was draining.
+    struct DropProbe(Arc<AtomicBool>);
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// The failure this module has to survive: a backend that accepts the
+    /// warmup request and hands back a stream which never yields and never
+    /// reaches EOF. Draining it is an await that by itself never returns.
+    #[derive(Debug, Default)]
+    struct StallingBackend {
+        generate_calls: AtomicUsize,
+        stream_dropped: Arc<AtomicBool>,
+        context: Mutex<Option<Arc<dyn AsyncEngineContext>>>,
+    }
+
+    impl StallingBackend {
+        fn generate_calls(&self) -> usize {
+            self.generate_calls.load(Ordering::SeqCst)
+        }
+
+        fn stream_dropped(&self) -> bool {
+            self.stream_dropped.load(Ordering::SeqCst)
+        }
+
+        /// Whether the downstream was asked to wind down, i.e. whether
+        /// `stop_generating` reached the context the backend published.
+        fn was_asked_to_stop(&self) -> bool {
+            self.context
+                .lock()
+                .as_ref()
+                .map(|ctx| ctx.is_stopped())
+                .unwrap_or(false)
+        }
+    }
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<BackendOutput>>, Error>
+        for StallingBackend
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<BackendOutput>>, Error> {
+            self.generate_calls.fetch_add(1, Ordering::SeqCst);
+            let (_request, context) = request.transfer(());
+            let ctx = context.context();
+            *self.context.lock() = Some(ctx.clone());
+
+            let probe = DropProbe(self.stream_dropped.clone());
+            let stalled = futures::stream::poll_fn(move |_cx| {
+                // Touched so the probe is owned by the stream and released
+                // only when the stream itself is dropped.
+                let _ = &probe;
+                Poll::Pending
+            });
+
+            Ok(ResponseStream::new(Box::pin(stalled), ctx))
+        }
+    }
+
+    fn sample_model_parts() -> (Arc<dyn OAIPromptFormatter>, Arc<dyn Tokenizer>) {
+        let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
+        let mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
+        let PromptFormatter::OAI(formatter) = prompt_formatter_from_mdc(&mdc).unwrap();
+        let tokenizer = mdc.tokenizer().unwrap();
+        let tokenizer: Arc<dyn Tokenizer> = (*tokenizer).clone();
+        (formatter, tokenizer)
+    }
+
+    fn chat_request(speculative_prefill: bool) -> NvCreateChatCompletionRequest {
+        let messages = vec![ChatCompletionRequestMessage::User(
+            ChatCompletionRequestUserMessage {
+                content: ChatCompletionRequestUserMessageContent::Text(
+                    "how tall is everest?".to_string(),
+                ),
+                name: None,
+            },
+        )];
+
+        let nvext = speculative_prefill.then(|| NvExt {
+            agent_hints: Some(AgentHints {
+                speculative_prefill: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        NvCreateChatCompletionRequest {
+            inner: CreateChatCompletionRequest {
+                model: "mock-llama".to_string(),
+                messages,
+                stream: Some(true),
+                ..Default::default()
+            },
+            common: Default::default(),
+            nvext,
+            chat_template_args: None,
+            thinking: None,
+            media_io_kwargs: None,
+            return_tokens_as_token_ids: None,
+            unsupported_fields: Default::default(),
+        }
+    }
+
+    /// One upstream chunk carrying `text`, terminal when `finish` is set: the
+    /// terminal chunk is what releases the warmup.
+    fn chunk(text: &str, finish: bool) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        #[allow(deprecated)]
+        let choice = ChatChoiceStream {
+            index: 0,
+            delta: ChatCompletionStreamResponseDelta {
+                role: None,
+                content: Some(ChatCompletionMessageContent::Text(text.to_string())),
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: finish.then_some(FinishReason::Stop),
+            logprobs: None,
+        };
+
+        Annotated::from_data(NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "chatcmpl-test".to_string(),
+                object: "chat.completion.chunk".to_string(),
+                created: 0,
+                model: "mock-llama".to_string(),
+                system_fingerprint: None,
+                service_tier: None,
+                choices: vec![choice],
+                usage: None,
+            },
+            nvext: None,
+            llm_metrics: None,
+        })
+    }
+
+    fn upstream()
+    -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>> {
+        Box::pin(futures::stream::iter(vec![
+            chunk("everest is ", false),
+            chunk("8849 m tall.", true),
+        ]))
+    }
+
+    fn text_of(items: &[Annotated<NvCreateChatCompletionStreamResponse>]) -> String {
+        items
+            .iter()
+            .filter_map(|item| item.data.as_ref())
+            .flat_map(|resp| resp.inner.choices.iter())
+            .filter_map(|choice| match choice.delta.content {
+                Some(ChatCompletionMessageContent::Text(ref text)) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Lets the detached task run up to its next suspension point without
+    /// advancing the paused clock.
+    async fn settle() {
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_warmup_is_released_when_the_lifetime_bound_elapses() {
+        let (formatter, tokenizer) = sample_model_parts();
+        let backend = Arc::new(StallingBackend::default());
+        let engine: Arc<BackendEngine> = backend.clone();
+
+        let request = chat_request(true);
+        let wrapped =
+            maybe_wrap_stream(upstream(), &request, &engine, &formatter, &tokenizer, None);
+        // Only the test's own handle and the detached task's clone remain, so
+        // the strong count is a faithful release probe.
+        drop(engine);
+
+        let items: Vec<_> = wrapped.collect().await;
+        assert_eq!(
+            items.len(),
+            2,
+            "client stream must be passed through intact"
+        );
+
+        // The warmup is genuinely in flight and genuinely stuck: it reached the
+        // backend, and well past the point where a healthy max_tokens=1 request
+        // would have finished it is still holding the stream.
+        settle().await;
+        assert_eq!(backend.generate_calls(), 1, "warmup should have dispatched");
+        tokio::time::sleep(PREFILL_TASK_TIMEOUT / 2).await;
+        settle().await;
+        assert!(
+            !backend.stream_dropped(),
+            "warmup abandoned before its bound elapsed"
+        );
+        assert_eq!(Arc::strong_count(&backend), 2);
+
+        tokio::time::sleep(PREFILL_TASK_TIMEOUT).await;
+        settle().await;
+
+        assert!(
+            backend.was_asked_to_stop(),
+            "downstream context should be told to stop before the stream is dropped"
+        );
+        assert!(
+            backend.stream_dropped(),
+            "stalled downstream stream should be released once the bound elapses"
+        );
+        assert_eq!(
+            Arc::strong_count(&backend),
+            1,
+            "detached task should have released the engine it captured"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_warmup_is_released_when_the_runtime_token_is_cancelled() {
+        let (formatter, tokenizer) = sample_model_parts();
+        let backend = Arc::new(StallingBackend::default());
+        let engine: Arc<BackendEngine> = backend.clone();
+        let cancel = CancellationToken::new();
+
+        let request = chat_request(true);
+        let wrapped = maybe_wrap_stream(
+            upstream(),
+            &request,
+            &engine,
+            &formatter,
+            &tokenizer,
+            Some(&cancel),
+        );
+        drop(engine);
+
+        let started = Instant::now();
+        let items: Vec<_> = wrapped.collect().await;
+        assert_eq!(items.len(), 2);
+
+        settle().await;
+        assert_eq!(backend.generate_calls(), 1, "warmup should have dispatched");
+        assert!(!backend.stream_dropped());
+
+        cancel.cancel();
+        settle().await;
+
+        assert!(
+            backend.was_asked_to_stop(),
+            "cancellation should reach the downstream context"
+        );
+        assert!(
+            backend.stream_dropped(),
+            "cancellation should release the stalled downstream stream"
+        );
+        assert_eq!(Arc::strong_count(&backend), 1);
+        // Proves the release came from cancellation and not from the timeout.
+        assert!(started.elapsed() < PREFILL_TASK_TIMEOUT);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn without_the_hint_the_stream_is_untouched_and_nothing_is_dispatched() {
+        let (formatter, tokenizer) = sample_model_parts();
+        let backend = Arc::new(StallingBackend::default());
+        let engine: Arc<BackendEngine> = backend.clone();
+
+        let request = chat_request(false);
+        let wrapped =
+            maybe_wrap_stream(upstream(), &request, &engine, &formatter, &tokenizer, None);
+        drop(engine);
+
+        let items: Vec<_> = wrapped.collect().await;
+        assert_eq!(items.len(), 2);
+        assert_eq!(text_of(&items), "everest is 8849 m tall.");
+
+        settle().await;
+        tokio::time::sleep(PREFILL_TASK_TIMEOUT * 2).await;
+        settle().await;
+
+        assert_eq!(
+            backend.generate_calls(),
+            0,
+            "the disabled path must never dispatch a warmup"
+        );
+        assert_eq!(
+            Arc::strong_count(&backend),
+            1,
+            "the disabled path must not capture the engine at all"
+        );
+    }
 }

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -244,6 +244,24 @@ pub fn maybe_wrap_stream(
         };
 
         if wind_down {
+            // Only a warmup that got as far as its downstream has anything to
+            // wind down, and the slot is how we know. An empty slot means the
+            // cancellation arm won before `warmup` was ever polled, so the
+            // future is still unstarted — and draining it would start it,
+            // dispatching into the very shutdown the arm exists to avoid. The
+            // bound is deliberately read into a local first: holding the lock
+            // guard across the await below would be both wrong and unbuildable.
+            let dispatched = context_slot.lock().is_some();
+
+            if !dispatched {
+                tracing::debug!(
+                    request_id = %request_id,
+                    model = %model,
+                    "Speculative prefill dropped before dispatch; nothing to wind down"
+                );
+                return;
+            }
+
             stop_downstream(&context_slot);
             // Dropping the non-winning arm released the borrow but not the
             // future itself: `warmup` was pinned separately and the stream it

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -729,7 +729,10 @@ mod tests {
         drop(first);
         drop(second);
         let replacement = PrefillTasks::new(None);
-        assert!(Arc::ptr_eq(&admission, &replacement.preprocessing_admission));
+        assert!(Arc::ptr_eq(
+            &admission,
+            &replacement.preprocessing_admission
+        ));
     }
 
     #[tokio::test(start_paused = true)]
@@ -797,7 +800,11 @@ mod tests {
             );
             assert_eq!(wrapped.collect::<Vec<_>>().await.len(), 2);
             wait_for_dispatch(&entered).await;
-            assert_eq!(tracker.len(), 2, "track the async task and blocking closure");
+            assert_eq!(
+                tracker.len(),
+                2,
+                "track the async task and blocking closure"
+            );
             assert_eq!(admission.available_permits(), 0);
 
             match termination {
@@ -848,7 +855,11 @@ mod tests {
             assert!(tracker.wait().now_or_never().is_some());
             assert_eq!(retained_formatter.strong_count(), 0);
             assert_eq!(admission.available_permits(), 1);
-            assert_eq!(backend.generate_calls(), 0, "cancelled work must not dispatch");
+            assert_eq!(
+                backend.generate_calls(),
+                0,
+                "cancelled work must not dispatch"
+            );
 
             // Once the old closure returns, a new owner can use the recovered slot.
             let mut replacement = test_tasks(None);

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -9,7 +9,7 @@
 //! and send a `max_tokens=1` request through the pipeline to warm the KV cache.
 
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -21,6 +21,7 @@ use futures::Stream;
 use futures::stream::StreamExt;
 use minijinja::value::Value;
 use parking_lot::Mutex;
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
@@ -36,20 +37,30 @@ use crate::protocols::openai::chat_completions::{
 use crate::tokenizers::traits::Tokenizer;
 use dynamo_renderer::{OAIChatLikeRequest, OAIPromptFormatter};
 
-/// Maximum lifetime of one dispatched speculative-prefill warmup.
+/// Maximum asynchronous warmup lifetime after the client turn completes.
+/// Started synchronous preprocessing may outlive this deadline.
 const PREFILL_TASK_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Maximum downstream cleanup time after a warmup is stopped.
 const PREFILL_WIND_DOWN_GRACE: Duration = Duration::from_secs(5);
 
+/// Speculation must not fill the blocking pool when preprocessing stalls.
+/// Share admission across models and replacement WorkerSets, without a wait queue.
+const MAX_BLOCKING_PREFILLS: usize = 4;
+static BLOCKING_PREFILL_ADMISSION: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(MAX_BLOCKING_PREFILLS)));
+
 /// Makes the downstream context reachable from timeout and cancellation paths.
 type PrefillContextSlot = Mutex<Option<Arc<dyn AsyncEngineContext>>>;
 
 /// Owns a preprocessor's warmups, including tasks waiting for a client turn.
-/// Dropping the preprocessor requests cooperative, bounded cleanup of every task.
+/// Dropping the preprocessor cancels warmups and bounds downstream cleanup.
+/// Started blocking work remains tracked and holds admission until it returns;
+/// synchronous formatter/tokenizer calls cannot be forcibly cancelled.
 pub(super) struct PrefillTasks {
     cancel: CancellationToken,
     tracker: TaskTracker,
+    preprocessing_admission: Arc<Semaphore>,
 }
 
 impl PrefillTasks {
@@ -59,8 +70,29 @@ impl PrefillTasks {
                 .map(CancellationToken::child_token)
                 .unwrap_or_default(),
             tracker: TaskTracker::new(),
+            preprocessing_admission: BLOCKING_PREFILL_ADMISSION.clone(),
         }
     }
+
+    fn preprocessing(
+        &self,
+        formatter: Arc<dyn OAIPromptFormatter>,
+        tokenizer: Arc<dyn Tokenizer>,
+    ) -> PrefillPreprocessing {
+        PrefillPreprocessing {
+            formatter,
+            tokenizer,
+            admission: self.preprocessing_admission.clone(),
+            tracker: self.tracker.clone(),
+        }
+    }
+}
+
+struct PrefillPreprocessing {
+    formatter: Arc<dyn OAIPromptFormatter>,
+    tokenizer: Arc<dyn Tokenizer>,
+    admission: Arc<Semaphore>,
+    tracker: TaskTracker,
 }
 
 impl Drop for PrefillTasks {
@@ -109,7 +141,9 @@ impl OAIChatLikeRequest for SpeculativePrefillRequest {
 /// a background task that renders the next-turn prefix and fires a
 /// `max_tokens=1` request through the pipeline to warm the KV cache.
 ///
-/// Warmups stop on timeout or cancellation and allow bounded downstream cleanup.
+/// Timeout or cancellation prevents late dispatch and bounds downstream cleanup.
+/// Blocking preprocessing retains its admission slot and tracking until it returns.
+/// If preprocessing admission is full, the optional warmup is skipped.
 ///
 /// When the flag is not set, returns the stream unmodified with zero overhead.
 pub(super) fn maybe_wrap_stream(
@@ -137,8 +171,7 @@ pub(super) fn maybe_wrap_stream(
     let (tx, rx) = tokio::sync::oneshot::channel::<String>();
 
     let next = next.clone();
-    let formatter = formatter.clone();
-    let tokenizer = tokenizer.clone();
+    let preprocessing = tasks.preprocessing(formatter.clone(), tokenizer.clone());
     let messages = request.inner.messages.clone();
     let cancel = tasks.cancel.clone();
     let request_id = request_id.to_string();
@@ -171,8 +204,7 @@ pub(super) fn maybe_wrap_stream(
         // Keep the warmup alive for bounded cleanup after cancellation or timeout.
         let mut warmup = std::pin::pin!(prefill_task(
             next,
-            formatter,
-            tokenizer,
+            preprocessing,
             messages,
             response_text,
             &context_slot,
@@ -280,13 +312,25 @@ async fn prefill_task(
     next: Arc<
         dyn AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<BackendOutput>>, Error>,
     >,
-    formatter: Arc<dyn OAIPromptFormatter>,
-    tokenizer: Arc<dyn Tokenizer>,
+    preprocessing: PrefillPreprocessing,
     original_messages: Vec<ChatCompletionRequestMessage>,
     response_text: String,
     context_slot: &PrefillContextSlot,
     cancel: &CancellationToken,
 ) -> Result<()> {
+    if cancel.is_cancelled() {
+        return Ok(());
+    }
+    let PrefillPreprocessing {
+        formatter,
+        tokenizer,
+        admission,
+        tracker,
+    } = preprocessing;
+    let Ok(permit) = admission.try_acquire_owned() else {
+        tracing::debug!("Skipping speculative prefill: preprocessing admission is full");
+        return Ok(());
+    };
     let assistant_msg =
         ChatCompletionRequestMessage::Assistant(ChatCompletionRequestAssistantMessage {
             content: Some(ChatCompletionRequestAssistantMessageContent::Text(
@@ -300,20 +344,22 @@ async fn prefill_task(
 
     let prefill_request = SpeculativePrefillRequest::new(messages);
     let preprocessing_cancel = cancel.clone();
-    // Rendering and tokenization are synchronous and may be expensive. A running
-    // blocking operation cannot be interrupted, but it must never dispatch work.
-    let token_ids = tokio::task::spawn_blocking(move || -> Result<Option<Vec<u32>>> {
-        if preprocessing_cancel.is_cancelled() {
-            return Ok(None);
-        }
-        let formatted_prompt = formatter.render(&prefill_request)?;
-        if preprocessing_cancel.is_cancelled() {
-            return Ok(None);
-        }
-        let encoding = tokenizer.encode(&formatted_prompt)?;
-        Ok(Some(encoding.token_ids().to_vec()))
-    })
-    .await??;
+    // The tracker token and permit belong to the closure, not its JoinHandle.
+    // Cancelling the async warmup cannot free admission while this work continues.
+    let token_ids = tracker
+        .spawn_blocking(move || -> Result<Option<Vec<u32>>> {
+            let _permit = permit;
+            if preprocessing_cancel.is_cancelled() {
+                return Ok(None);
+            }
+            let formatted_prompt = formatter.render(&prefill_request)?;
+            if preprocessing_cancel.is_cancelled() {
+                return Ok(None);
+            }
+            let encoding = tokenizer.encode(&formatted_prompt)?;
+            Ok(Some(encoding.token_ids().to_vec()))
+        })
+        .await??;
     let Some(token_ids) = token_ids else {
         return Ok(());
     };
@@ -652,6 +698,183 @@ mod tests {
         }
     }
 
+    fn test_tasks(parent: Option<&CancellationToken>) -> PrefillTasks {
+        let mut tasks = PrefillTasks::new(parent);
+        tasks.preprocessing_admission = Arc::new(Semaphore::new(1));
+        tasks
+    }
+
+    async fn wait_for_tracked_tasks(tracker: &TaskTracker, expected: usize) {
+        // Blocking-pool completion uses wall time, not the paused Tokio clock.
+        let started = std::time::Instant::now();
+        while tracker.len() != expected {
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "expected {expected} tracked tasks, found {}",
+                tracker.len()
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[test]
+    fn replacement_owners_share_process_preprocessing_admission() {
+        let first = PrefillTasks::new(None);
+        let second = PrefillTasks::new(None);
+        assert!(Arc::ptr_eq(
+            &first.preprocessing_admission,
+            &second.preprocessing_admission
+        ));
+        let admission = first.preprocessing_admission.clone();
+        drop(first);
+        drop(second);
+        let replacement = PrefillTasks::new(None);
+        assert!(Arc::ptr_eq(&admission, &replacement.preprocessing_admission));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn blocked_preprocessing_retains_tracking_and_admission_after_warmup_ends() {
+        use futures::FutureExt;
+
+        struct GatedFormatter {
+            inner: Arc<dyn OAIPromptFormatter>,
+            entered: Arc<tokio::sync::Notify>,
+            calls: Arc<AtomicUsize>,
+            release: Mutex<std::sync::mpsc::Receiver<()>>,
+        }
+
+        impl OAIPromptFormatter for GatedFormatter {
+            fn supports_add_generation_prompt(&self) -> bool {
+                self.inner.supports_add_generation_prompt()
+            }
+
+            fn render(&self, request: &dyn OAIChatLikeRequest) -> Result<String> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.entered.notify_one();
+                self.release.lock().recv_timeout(Duration::from_secs(10))?;
+                self.inner.render(request)
+            }
+        }
+
+        #[derive(Clone, Copy)]
+        enum Termination {
+            OwnerDrop,
+            ParentCancellation,
+            Timeout,
+        }
+
+        for termination in [
+            Termination::OwnerDrop,
+            Termination::ParentCancellation,
+            Termination::Timeout,
+        ] {
+            let (normal_formatter, tokenizer) = sample_model_parts();
+            let (release_tx, release_rx) = std::sync::mpsc::channel();
+            let entered = Arc::new(tokio::sync::Notify::new());
+            let calls = Arc::new(AtomicUsize::new(0));
+            let formatter: Arc<dyn OAIPromptFormatter> = Arc::new(GatedFormatter {
+                inner: normal_formatter.clone(),
+                entered: entered.clone(),
+                calls: calls.clone(),
+                release: Mutex::new(release_rx),
+            });
+            let retained_formatter = Arc::downgrade(&formatter);
+            let parent = CancellationToken::new();
+            let tasks = test_tasks(Some(&parent));
+            let admission = tasks.preprocessing_admission.clone();
+            let tracker = tasks.tracker.clone();
+            let backend = Arc::new(StallingBackend::default());
+            let engine: Arc<BackendEngine> = backend.clone();
+            let request = chat_request(true);
+            let wrapped = maybe_wrap_stream(
+                upstream(),
+                &request,
+                "req-blocked-preprocessing",
+                &engine,
+                &formatter,
+                &tokenizer,
+                &tasks,
+            );
+            assert_eq!(wrapped.collect::<Vec<_>>().await.len(), 2);
+            wait_for_dispatch(&entered).await;
+            assert_eq!(tracker.len(), 2, "track the async task and blocking closure");
+            assert_eq!(admission.available_permits(), 0);
+
+            match termination {
+                Termination::OwnerDrop => drop(tasks),
+                Termination::ParentCancellation => {
+                    parent.cancel();
+                    wait_for_tracked_tasks(&tracker, 1).await;
+                    drop(tasks);
+                }
+                Termination::Timeout => {
+                    tokio::time::advance(PREFILL_TASK_TIMEOUT).await;
+                    wait_for_tracked_tasks(&tracker, 1).await;
+                    drop(tasks);
+                }
+            }
+            wait_for_tracked_tasks(&tracker, 1).await;
+            assert!(tracker.is_closed());
+            assert!(tracker.wait().now_or_never().is_none());
+            assert_eq!(admission.available_permits(), 0);
+            assert_eq!(backend.generate_calls(), 0);
+
+            // Replacement owners cannot bypass the permit held by the old closure.
+            // Each saturated warmup must finish without queueing blocking work.
+            for _ in 0..3 {
+                let mut replacement = test_tasks(None);
+                replacement.preprocessing_admission = admission.clone();
+                let wrapped = maybe_wrap_stream(
+                    upstream(),
+                    &request,
+                    "req-saturated-preprocessing",
+                    &engine,
+                    &formatter,
+                    &tokenizer,
+                    &replacement,
+                );
+                assert_eq!(wrapped.collect::<Vec<_>>().await.len(), 2);
+                replacement.tracker.close();
+                wait_for_tracked_tasks(&replacement.tracker, 0).await;
+                assert!(replacement.tracker.wait().now_or_never().is_some());
+                assert_eq!(calls.load(Ordering::SeqCst), 1);
+                assert_eq!(backend.generate_calls(), 0);
+            }
+
+            drop(formatter);
+            assert_eq!(retained_formatter.strong_count(), 1);
+            release_tx.send(()).unwrap();
+            wait_for_tracked_tasks(&tracker, 0).await;
+            assert!(tracker.wait().now_or_never().is_some());
+            assert_eq!(retained_formatter.strong_count(), 0);
+            assert_eq!(admission.available_permits(), 1);
+            assert_eq!(backend.generate_calls(), 0, "cancelled work must not dispatch");
+
+            // Once the old closure returns, a new owner can use the recovered slot.
+            let mut replacement = test_tasks(None);
+            replacement.preprocessing_admission = admission.clone();
+            let replacement_tracker = replacement.tracker.clone();
+            let backend = Arc::new(WindDownBackend::default());
+            let engine: Arc<BackendEngine> = backend.clone();
+            let wrapped = maybe_wrap_stream(
+                upstream(),
+                &request,
+                "req-recovered-preprocessing",
+                &engine,
+                &normal_formatter,
+                &tokenizer,
+                &replacement,
+            );
+            assert_eq!(wrapped.collect::<Vec<_>>().await.len(), 2);
+            wait_for_dispatch(&backend.dispatched).await;
+            assert_eq!(backend.generate_calls.load(Ordering::SeqCst), 1);
+            drop(replacement);
+            wait_for_tracked_tasks(&replacement_tracker, 0).await;
+            assert!(backend.cleanup_ran());
+            assert_eq!(admission.available_permits(), 1);
+        }
+    }
+
     async fn wait_for_dispatch(dispatched: &tokio::sync::Notify) {
         // Keep paused time from advancing while the blocking pool preprocesses.
         // Wait for an actual dispatch rather than assuming a fixed yield count.
@@ -708,6 +931,7 @@ mod tests {
         };
         let backend = Arc::new(StallingBackend::default());
         let context_slot = PrefillContextSlot::new(None);
+        let tasks = test_tasks(None);
         // Call the warmup directly so the outer select cannot mask a missing
         // post-preprocessing cancellation check. The current-thread runtime also
         // requires rendering to yield the executor for the cancelling task.
@@ -715,8 +939,7 @@ mod tests {
             Duration::from_secs(5),
             prefill_task(
                 backend.clone(),
-                formatter,
-                tokenizer,
+                tasks.preprocessing(formatter, tokenizer),
                 chat_request(true).inner.messages,
                 "8849 m tall.".to_string(),
                 &context_slot,
@@ -790,14 +1013,14 @@ mod tests {
         };
         let backend = Arc::new(StallingBackend::default());
         let context_slot = PrefillContextSlot::new(None);
+        let tasks = test_tasks(None);
         // Cancellation occurs after the formatter check. Call directly so only
         // the final pre-dispatch check can prevent the downstream request.
         tokio::time::timeout(
             Duration::from_secs(5),
             prefill_task(
                 backend.clone(),
-                formatter,
-                tokenizer,
+                tasks.preprocessing(formatter, tokenizer),
                 chat_request(true).inner.messages,
                 "8849 m tall.".to_string(),
                 &context_slot,
@@ -821,7 +1044,7 @@ mod tests {
         let (formatter, tokenizer) = sample_model_parts();
         let backend = Arc::new(StallingBackend::default());
         let engine: Arc<BackendEngine> = backend.clone();
-        let tasks = PrefillTasks::new(None);
+        let tasks = test_tasks(None);
         let tracker = tasks.tracker.clone();
         let request = chat_request(true);
         let wrapped = maybe_wrap_stream(
@@ -860,7 +1083,7 @@ mod tests {
         let (formatter, tokenizer) = sample_model_parts();
         let backend = Arc::new(StallingBackend::default());
         let engine: Arc<BackendEngine> = backend.clone();
-        let tasks = PrefillTasks::new(None);
+        let tasks = test_tasks(None);
         let tracker = tasks.tracker.clone();
         let request = chat_request(true);
         let wrapped = maybe_wrap_stream(
@@ -890,7 +1113,7 @@ mod tests {
         let engine: Arc<BackendEngine> = backend.clone();
 
         let request = chat_request(true);
-        let tasks = PrefillTasks::new(None);
+        let tasks = test_tasks(None);
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -944,7 +1167,7 @@ mod tests {
         let engine: Arc<BackendEngine> = backend.clone();
 
         let request = chat_request(true);
-        let tasks = PrefillTasks::new(None);
+        let tasks = test_tasks(None);
         let wrapped = maybe_wrap_stream(
             slow_upstream(PREFILL_TASK_TIMEOUT * 2),
             &request,
@@ -998,7 +1221,7 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let request = chat_request(true);
-        let tasks = PrefillTasks::new(Some(&cancel));
+        let tasks = test_tasks(Some(&cancel));
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -1045,7 +1268,7 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let request = chat_request(true);
-        let tasks = PrefillTasks::new(Some(&cancel));
+        let tasks = test_tasks(Some(&cancel));
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -1094,7 +1317,7 @@ mod tests {
         cancel.cancel();
 
         let request = chat_request(true);
-        let tasks = PrefillTasks::new(Some(&cancel));
+        let tasks = test_tasks(Some(&cancel));
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -1137,7 +1360,7 @@ mod tests {
 
         let cancel = CancellationToken::new();
         let request = chat_request(true);
-        let tasks = PrefillTasks::new(Some(&cancel));
+        let tasks = test_tasks(Some(&cancel));
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -1182,7 +1405,7 @@ mod tests {
         let engine: Arc<BackendEngine> = backend.clone();
 
         let request = chat_request(false);
-        let tasks = PrefillTasks::new(None);
+        let tasks = test_tasks(None);
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -167,6 +167,7 @@ pub(super) fn maybe_wrap_stream(
         };
 
         let context_slot = PrefillContextSlot::new(None);
+        let warmup_cancel = cancel.child_token();
         // Keep the warmup alive for bounded cleanup after cancellation or timeout.
         let mut warmup = std::pin::pin!(prefill_task(
             next,
@@ -175,6 +176,7 @@ pub(super) fn maybe_wrap_stream(
             messages,
             response_text,
             &context_slot,
+            &warmup_cancel,
         ));
 
         let wind_down = tokio::select! {
@@ -215,6 +217,7 @@ pub(super) fn maybe_wrap_stream(
         };
 
         if wind_down {
+            warmup_cancel.cancel();
             // Never poll an unstarted warmup during shutdown.
             let dispatched = context_slot.lock().is_some();
 
@@ -282,6 +285,7 @@ async fn prefill_task(
     original_messages: Vec<ChatCompletionRequestMessage>,
     response_text: String,
     context_slot: &PrefillContextSlot,
+    cancel: &CancellationToken,
 ) -> Result<()> {
     let assistant_msg =
         ChatCompletionRequestMessage::Assistant(ChatCompletionRequestAssistantMessage {
@@ -295,15 +299,26 @@ async fn prefill_task(
     messages.push(assistant_msg);
 
     let prefill_request = SpeculativePrefillRequest::new(messages);
-    let formatted_prompt = formatter.render(&prefill_request)?;
-    let encoding = tokenizer.encode(&formatted_prompt)?;
-    let token_ids = encoding.token_ids().to_vec();
+    let preprocessing_cancel = cancel.clone();
+    // Rendering and tokenization are synchronous and may be expensive. A running
+    // blocking operation cannot be interrupted, but it must never dispatch work.
+    let token_ids = tokio::task::spawn_blocking(move || -> Result<Option<Vec<u32>>> {
+        if preprocessing_cancel.is_cancelled() {
+            return Ok(None);
+        }
+        let formatted_prompt = formatter.render(&prefill_request)?;
+        if preprocessing_cancel.is_cancelled() {
+            return Ok(None);
+        }
+        let encoding = tokenizer.encode(&formatted_prompt)?;
+        Ok(Some(encoding.token_ids().to_vec()))
+    })
+    .await??;
+    let Some(token_ids) = token_ids else {
+        return Ok(());
+    };
 
-    tracing::info!(
-        num_tokens = token_ids.len(),
-        "Speculative prefill: sending next-turn prefix"
-    );
-
+    let num_tokens = token_ids.len();
     let preprocessed = PreprocessedRequest::builder()
         .model("speculative_prefill".to_string())
         .token_ids(token_ids)
@@ -322,6 +337,12 @@ async fn prefill_task(
         uuid::Uuid::new_v4().to_string(),
         Default::default(),
     );
+    // The outer select cannot preempt a poll already in progress. Recheck after
+    // preprocessing, immediately before publishing the context and dispatching.
+    if cancel.is_cancelled() {
+        return Ok(());
+    }
+    tracing::info!(num_tokens, "Speculative prefill: sending next-turn prefix");
     // Publish before generate, which can block while waiting for a worker.
     *context_slot.lock() = Some(context.context());
 
@@ -421,6 +442,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct WindDownBackend {
         generate_calls: AtomicUsize,
+        dispatched: tokio::sync::Notify,
         stream_dropped: Arc<AtomicBool>,
         cleanup_ran: Arc<AtomicBool>,
         context: Mutex<Option<Arc<dyn AsyncEngineContext>>>,
@@ -469,6 +491,7 @@ mod tests {
                     None::<(Annotated<BackendOutput>, _)>
                 });
 
+            self.dispatched.notify_one();
             Ok(ResponseStream::new(Box::pin(winding), ctx))
         }
     }
@@ -476,6 +499,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct StalledInGenerateBackend {
         generate_calls: AtomicUsize,
+        dispatched: tokio::sync::Notify,
         context: Mutex<Option<Arc<dyn AsyncEngineContext>>>,
     }
 
@@ -506,6 +530,7 @@ mod tests {
             let ctx = context.context();
             *self.context.lock() = Some(ctx.clone());
 
+            self.dispatched.notify_one();
             ctx.stopped().await;
             Err(Error::msg("cancelled while selecting a worker"))
         }
@@ -627,6 +652,170 @@ mod tests {
         }
     }
 
+    async fn wait_for_dispatch(dispatched: &tokio::sync::Notify) {
+        // Keep paused time from advancing while the blocking pool preprocesses.
+        // Wait for an actual dispatch rather than assuming a fixed yield count.
+        let started = std::time::Instant::now();
+        loop {
+            tokio::select! {
+                biased;
+                () = dispatched.notified() => return,
+                () = tokio::task::yield_now() => {}
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(10),
+                "preprocessing did not dispatch the warmup"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_blocked_preprocessing_prevents_dispatch() {
+        struct BlockingFormatter {
+            inner: Arc<dyn OAIPromptFormatter>,
+            entered: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+            release: Mutex<std::sync::mpsc::Receiver<()>>,
+        }
+
+        impl OAIPromptFormatter for BlockingFormatter {
+            fn supports_add_generation_prompt(&self) -> bool {
+                self.inner.supports_add_generation_prompt()
+            }
+
+            fn render(&self, request: &dyn OAIChatLikeRequest) -> Result<String> {
+                self.entered.lock().take().unwrap().send(()).unwrap();
+                self.release.lock().recv_timeout(Duration::from_secs(10))?;
+                self.inner.render(request)
+            }
+        }
+
+        let (formatter, tokenizer) = sample_model_parts();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let formatter = Arc::new(BlockingFormatter {
+            inner: formatter,
+            entered: Mutex::new(Some(entered_tx)),
+            release: Mutex::new(release_rx),
+        });
+        let cancel = CancellationToken::new();
+        let cancelling_task = {
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                entered_rx.await.unwrap();
+                cancel.cancel();
+                release_tx.send(()).unwrap();
+            })
+        };
+        let backend = Arc::new(StallingBackend::default());
+        let context_slot = PrefillContextSlot::new(None);
+        // Call the warmup directly so the outer select cannot mask a missing
+        // post-preprocessing cancellation check. The current-thread runtime also
+        // requires rendering to yield the executor for the cancelling task.
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            prefill_task(
+                backend.clone(),
+                formatter,
+                tokenizer,
+                chat_request(true).inner.messages,
+                "8849 m tall.".to_string(),
+                &context_slot,
+                &cancel,
+            ),
+        )
+        .await
+        .expect("cancelled rendering must not dispatch a stalled warmup")
+        .unwrap();
+        cancelling_task.await.unwrap();
+        assert!(cancel.is_cancelled());
+        assert!(context_slot.lock().is_none());
+        assert_eq!(backend.generate_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_tokenization_prevents_dispatch() {
+        use crate::tokenizers::traits::{Decoder, Encoder};
+        use crate::tokenizers::{DecodeResult, EncodeSegment, Encoding};
+
+        struct BlockingTokenizer {
+            inner: Arc<dyn Tokenizer>,
+            entered: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+            release: Mutex<std::sync::mpsc::Receiver<()>>,
+        }
+
+        impl Encoder for BlockingTokenizer {
+            fn encode(&self, input: &str) -> Result<Encoding> {
+                self.entered.lock().take().unwrap().send(()).unwrap();
+                self.release.lock().recv_timeout(Duration::from_secs(10))?;
+                self.inner.encode(input)
+            }
+
+            fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
+                self.inner.encode_batch(inputs)
+            }
+
+            fn encode_segments(&self, segments: &[EncodeSegment<'_>]) -> Result<Encoding> {
+                self.inner.encode_segments(segments)
+            }
+        }
+
+        impl Decoder for BlockingTokenizer {
+            fn decode(&self, token_ids: &[u32], skip_special_tokens: bool) -> Result<DecodeResult> {
+                self.inner.decode(token_ids, skip_special_tokens)
+            }
+        }
+
+        impl Tokenizer for BlockingTokenizer {
+            fn validate_prefix_cache(&self) -> Result<()> {
+                self.inner.validate_prefix_cache()
+            }
+        }
+
+        let (formatter, tokenizer) = sample_model_parts();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let tokenizer = Arc::new(BlockingTokenizer {
+            inner: tokenizer,
+            entered: Mutex::new(Some(entered_tx)),
+            release: Mutex::new(release_rx),
+        });
+        let cancel = CancellationToken::new();
+        let cancelling_task = {
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                entered_rx.await.unwrap();
+                cancel.cancel();
+                release_tx.send(()).unwrap();
+            })
+        };
+        let backend = Arc::new(StallingBackend::default());
+        let context_slot = PrefillContextSlot::new(None);
+        // Cancellation occurs after the formatter check. Call directly so only
+        // the final pre-dispatch check can prevent the downstream request.
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            prefill_task(
+                backend.clone(),
+                formatter,
+                tokenizer,
+                chat_request(true).inner.messages,
+                "8849 m tall.".to_string(),
+                &context_slot,
+                &cancel,
+            ),
+        )
+        .await
+        .expect("cancelled tokenization must not dispatch a stalled warmup")
+        .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), cancelling_task)
+            .await
+            .expect("the tokenizer must signal entry and receive cancellation")
+            .unwrap();
+        assert!(cancel.is_cancelled());
+        assert!(context_slot.lock().is_none());
+        assert_eq!(backend.generate_calls(), 0);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn dropping_owner_stops_and_drains_a_permanently_pending_warmup() {
         let (formatter, tokenizer) = sample_model_parts();
@@ -647,7 +836,7 @@ mod tests {
         drop(engine);
         let items: Vec<_> = wrapped.collect().await;
         assert_eq!(items.len(), 2);
-        backend.dispatched.notified().await;
+        wait_for_dispatch(&backend.dispatched).await;
         assert_eq!(tracker.len(), 1);
 
         let stopped = backend.context.lock().as_ref().unwrap().clone();
@@ -720,7 +909,7 @@ mod tests {
             "client stream must be passed through intact"
         );
 
-        settle().await;
+        wait_for_dispatch(&backend.dispatched).await;
         assert_eq!(backend.generate_calls(), 1, "warmup should have dispatched");
         tokio::time::sleep(PREFILL_TASK_TIMEOUT / 2).await;
         settle().await;
@@ -776,7 +965,7 @@ mod tests {
         );
 
         let dispatched = Instant::now();
-        settle().await;
+        wait_for_dispatch(&backend.dispatched).await;
         assert_eq!(
             backend.generate_calls(),
             1,
@@ -825,7 +1014,7 @@ mod tests {
         let items: Vec<_> = wrapped.collect().await;
         assert_eq!(items.len(), 2);
 
-        settle().await;
+        wait_for_dispatch(&backend.dispatched).await;
         assert_eq!(backend.generate_calls(), 1, "warmup should have dispatched");
         assert!(!backend.stream_dropped());
 
@@ -871,7 +1060,7 @@ mod tests {
         let items: Vec<_> = wrapped.collect().await;
         assert_eq!(items.len(), 2);
 
-        settle().await;
+        wait_for_dispatch(&backend.dispatched).await;
         assert!(!backend.cleanup_ran(), "nothing should wind down yet");
 
         let cancelled_at = Instant::now();
@@ -963,7 +1152,7 @@ mod tests {
         let items: Vec<_> = wrapped.collect().await;
         assert_eq!(items.len(), 2);
 
-        settle().await;
+        wait_for_dispatch(&backend.dispatched).await;
         assert_eq!(
             backend.generate_calls(),
             1,

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -22,6 +22,7 @@ use futures::stream::StreamExt;
 use minijinja::value::Value;
 use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 
 use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider};
 use dynamo_runtime::pipeline::{Context as PipelineContext, Error, ManyOut, SingleIn};
@@ -43,6 +44,31 @@ const PREFILL_WIND_DOWN_GRACE: Duration = Duration::from_secs(5);
 
 /// Makes the downstream context reachable from timeout and cancellation paths.
 type PrefillContextSlot = Mutex<Option<Arc<dyn AsyncEngineContext>>>;
+
+/// Owns a preprocessor's warmups, including tasks waiting for a client turn.
+/// Dropping the preprocessor requests cooperative, bounded cleanup of every task.
+pub(super) struct PrefillTasks {
+    cancel: CancellationToken,
+    tracker: TaskTracker,
+}
+
+impl PrefillTasks {
+    pub(super) fn new(parent: Option<&CancellationToken>) -> Self {
+        Self {
+            cancel: parent
+                .map(CancellationToken::child_token)
+                .unwrap_or_default(),
+            tracker: TaskTracker::new(),
+        }
+    }
+}
+
+impl Drop for PrefillTasks {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.tracker.close();
+    }
+}
 
 /// A minimal `OAIChatLikeRequest` for speculative next-turn prefill.
 /// Holds the full conversation (including a new assistant message) and
@@ -86,7 +112,7 @@ impl OAIChatLikeRequest for SpeculativePrefillRequest {
 /// Warmups stop on timeout or cancellation and allow bounded downstream cleanup.
 ///
 /// When the flag is not set, returns the stream unmodified with zero overhead.
-pub fn maybe_wrap_stream(
+pub(super) fn maybe_wrap_stream(
     stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>>,
     request: &NvCreateChatCompletionRequest,
     request_id: &str,
@@ -95,7 +121,7 @@ pub fn maybe_wrap_stream(
     >,
     formatter: &Arc<dyn OAIPromptFormatter>,
     tokenizer: &Arc<dyn Tokenizer>,
-    cancel: Option<&CancellationToken>,
+    tasks: &PrefillTasks,
 ) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>> {
     let enabled = request
         .nvext
@@ -114,16 +140,16 @@ pub fn maybe_wrap_stream(
     let formatter = formatter.clone();
     let tokenizer = tokenizer.clone();
     let messages = request.inner.messages.clone();
-    let cancel = cancel.cloned();
+    let cancel = tasks.cancel.clone();
     let request_id = request_id.to_string();
     let model = request.inner.model.clone();
-    tokio::spawn(async move {
+    tasks.tracker.spawn(async move {
         // The warmup timeout begins after the client turn completes.
         let response_text = tokio::select! {
             biased;
 
             // Biased selects must check cancellation before ready work.
-            () = cancelled(cancel.clone()) => {
+            () = cancel.cancelled() => {
                 tracing::debug!(
                     request_id = %request_id,
                     model = %model,
@@ -154,7 +180,7 @@ pub fn maybe_wrap_stream(
         let wind_down = tokio::select! {
             biased;
 
-            () = cancelled(cancel) => {
+            () = cancel.cancelled() => {
                 tracing::debug!(
                     request_id = %request_id,
                     model = %model,
@@ -238,14 +264,6 @@ pub fn maybe_wrap_stream(
     }))
 }
 
-/// Waits forever when no cancellation token is supplied.
-async fn cancelled(token: Option<CancellationToken>) {
-    match token {
-        Some(token) => token.cancelled().await,
-        None => std::future::pending().await,
-    }
-}
-
 /// Signals downstream; the caller must keep polling for cleanup to run.
 fn stop_downstream(slot: &PrefillContextSlot) {
     if let Some(context) = slot.lock().take() {
@@ -253,7 +271,7 @@ fn stop_downstream(slot: &PrefillContextSlot) {
     }
 }
 
-/// Fire-and-forget task that renders the next-turn prefix and sends it
+/// Tracked task that renders the next-turn prefix and sends it
 /// through the pipeline as a `max_tokens=1` request to warm the KV cache.
 async fn prefill_task(
     next: Arc<
@@ -353,6 +371,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct StallingBackend {
         generate_calls: AtomicUsize,
+        dispatched: tokio::sync::Notify,
         stream_dropped: Arc<AtomicBool>,
         context: Mutex<Option<Arc<dyn AsyncEngineContext>>>,
     }
@@ -387,6 +406,7 @@ mod tests {
             let (_request, context) = request.transfer(());
             let ctx = context.context();
             *self.context.lock() = Some(ctx.clone());
+            self.dispatched.notify_one();
 
             let probe = DropProbe(self.stream_dropped.clone());
             let stalled = futures::stream::poll_fn(move |_cx| {
@@ -608,12 +628,80 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn dropping_owner_stops_and_drains_a_permanently_pending_warmup() {
+        let (formatter, tokenizer) = sample_model_parts();
+        let backend = Arc::new(StallingBackend::default());
+        let engine: Arc<BackendEngine> = backend.clone();
+        let tasks = PrefillTasks::new(None);
+        let tracker = tasks.tracker.clone();
+        let request = chat_request(true);
+        let wrapped = maybe_wrap_stream(
+            upstream(),
+            &request,
+            "req-owner-drop",
+            &engine,
+            &formatter,
+            &tokenizer,
+            &tasks,
+        );
+        drop(engine);
+        let items: Vec<_> = wrapped.collect().await;
+        assert_eq!(items.len(), 2);
+        backend.dispatched.notified().await;
+        assert_eq!(tracker.len(), 1);
+
+        let stopped = backend.context.lock().as_ref().unwrap().clone();
+        let started = Instant::now();
+        drop(tasks);
+        stopped.stopped().await;
+        assert!(
+            !backend.stream_dropped(),
+            "cleanup must get its grace period"
+        );
+        assert!(!tracker.is_empty(), "the draining task must remain tracked");
+        tracker.wait().await;
+
+        assert_eq!(started.elapsed(), PREFILL_WIND_DOWN_GRACE);
+        assert!(backend.stream_dropped());
+        assert_eq!(Arc::strong_count(&backend), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dropping_owner_cancels_tasks_waiting_for_client_completion() {
+        let (formatter, tokenizer) = sample_model_parts();
+        let backend = Arc::new(StallingBackend::default());
+        let engine: Arc<BackendEngine> = backend.clone();
+        let tasks = PrefillTasks::new(None);
+        let tracker = tasks.tracker.clone();
+        let request = chat_request(true);
+        let wrapped = maybe_wrap_stream(
+            upstream(),
+            &request,
+            "req-owner-before-dispatch",
+            &engine,
+            &formatter,
+            &tokenizer,
+            &tasks,
+        );
+        drop(engine);
+        assert_eq!(tracker.len(), 1);
+        drop(tasks);
+        tracker.wait().await;
+
+        let items: Vec<_> = wrapped.collect().await;
+        assert_eq!(items.len(), 2);
+        assert_eq!(backend.generate_calls(), 0);
+        assert_eq!(Arc::strong_count(&backend), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn stalled_warmup_is_released_when_the_lifetime_bound_elapses() {
         let (formatter, tokenizer) = sample_model_parts();
         let backend = Arc::new(StallingBackend::default());
         let engine: Arc<BackendEngine> = backend.clone();
 
         let request = chat_request(true);
+        let tasks = PrefillTasks::new(None);
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -621,7 +709,7 @@ mod tests {
             &engine,
             &formatter,
             &tokenizer,
-            None,
+            &tasks,
         );
         drop(engine);
 
@@ -656,7 +744,7 @@ mod tests {
         assert_eq!(
             Arc::strong_count(&backend),
             1,
-            "detached task should have released the engine it captured"
+            "tracked task should have released the engine it captured"
         );
     }
 
@@ -667,6 +755,7 @@ mod tests {
         let engine: Arc<BackendEngine> = backend.clone();
 
         let request = chat_request(true);
+        let tasks = PrefillTasks::new(None);
         let wrapped = maybe_wrap_stream(
             slow_upstream(PREFILL_TASK_TIMEOUT * 2),
             &request,
@@ -674,7 +763,7 @@ mod tests {
             &engine,
             &formatter,
             &tokenizer,
-            None,
+            &tasks,
         );
         drop(engine);
 
@@ -720,6 +809,7 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let request = chat_request(true);
+        let tasks = PrefillTasks::new(Some(&cancel));
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -727,7 +817,7 @@ mod tests {
             &engine,
             &formatter,
             &tokenizer,
-            Some(&cancel),
+            &tasks,
         );
         drop(engine);
 
@@ -766,6 +856,7 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let request = chat_request(true);
+        let tasks = PrefillTasks::new(Some(&cancel));
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -773,7 +864,7 @@ mod tests {
             &engine,
             &formatter,
             &tokenizer,
-            Some(&cancel),
+            &tasks,
         );
         drop(engine);
 
@@ -814,6 +905,7 @@ mod tests {
         cancel.cancel();
 
         let request = chat_request(true);
+        let tasks = PrefillTasks::new(Some(&cancel));
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -821,7 +913,7 @@ mod tests {
             &engine,
             &formatter,
             &tokenizer,
-            Some(&cancel),
+            &tasks,
         );
         drop(engine);
 
@@ -856,6 +948,7 @@ mod tests {
 
         let cancel = CancellationToken::new();
         let request = chat_request(true);
+        let tasks = PrefillTasks::new(Some(&cancel));
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -863,7 +956,7 @@ mod tests {
             &engine,
             &formatter,
             &tokenizer,
-            Some(&cancel),
+            &tasks,
         );
         drop(engine);
 
@@ -900,6 +993,7 @@ mod tests {
         let engine: Arc<BackendEngine> = backend.clone();
 
         let request = chat_request(false);
+        let tasks = PrefillTasks::new(None);
         let wrapped = maybe_wrap_stream(
             upstream(),
             &request,
@@ -907,7 +1001,7 @@ mod tests {
             &engine,
             &formatter,
             &tokenizer,
-            None,
+            &tasks,
         );
         drop(engine);
 


### PR DESCRIPTION
Speculative prefill could retain request resources indefinitely when a backend stalled in generation or returned a response stream that never ended. Each preprocessor now owns its warmup tasks and cancels them when dropped. Discovery chat pipelines also inherit their WorkerSet's lifecycle cancellation, so retirement prevents late warmups even when an in-flight request retains the pipeline. After the client response finishes, the asynchronous warmup has a 60-second deadline; cancellation or timeout signals any downstream context and allows up to five seconds of cleanup.

Rendering and tokenization run on the blocking pool, with cancellation checked between operations and before dispatch. A process-wide limit admits at most four speculative preprocessing operations, including work retained by a dropped preprocessor or replaced WorkerSet. Each blocking closure owns its admission permit and remains tracked until it returns. Saturated warmups are skipped without queuing more blocking work. A synchronous operation that has already started cannot be forcibly cancelled; its result cannot dispatch a cancelled warmup.

Regressions cover stalled streams, cooperative cleanup, WorkerSet retirement, and cancellation during preprocessing. Additional cases hold a formatter blocked across owner drop, parent cancellation, and timeout, verify that replacement owners cannot bypass admission, and check that tracking and admission recover only after the closure returns. Pre Merge and full PR CI passed on `7e1bebf81bd`, including all thirteen speculative-prefill tests and the retained-pipeline WorkerSet-retirement regression. Closes #13409.
