### PR TITLE
docs: note Kimi-K3 DSpark load crash from draft embedding sharing in vLLM spec decoding

### DIFF
--- a/docs/fern/pages/developer-guide/additional-resources/speculative-decoding/speculative-decoding-with-vllm.md
+++ b/docs/fern/pages/developer-guide/additional-resources/speculative-decoding/speculative-decoding-with-vllm.md
@@ -109,6 +109,32 @@ See `examples/backends/vllm/launch/agg_spec_decoding.sh` for the full configurat
 
 - Currently only supports Eagle3 as the draft model
 - Requires compatible model architectures between target and draft
+- The draft checkpoint should carry its own `embed_tokens` weights
+
+### Draft Checkpoints Without Their Own `embed_tokens`
+
+Some draft checkpoints ship no embedding table of their own and expect vLLM to share the
+target model's. vLLM detects this at load and logs a line such as:
+
+```text
+Detected EAGLE model without its own embed_tokens in the checkpoint.
+Sharing target model embedding weights with the draft model.
+```
+
+> [!WARNING]
+> On some vLLM builds this path fails at load with `AttributeError: 'NoneType' object has
+> no attribute 'weight'`, raised while vLLM compares the target and draft embedding
+> dimensions. Every tensor-parallel worker fails identically during `WorkerProc` init, so
+> the engine never becomes ready and no request is ever served.
+
+The fault is in vLLM's speculative-decoding proposer, not in Dynamo: the dimension check
+dereferences the draft embedding on exactly the branch that runs when the draft has no
+embedding to dereference. Dynamo passes `--speculative-config` through to vLLM unchanged
+and has no configuration that avoids the branch.
+
+To work around it, use a draft checkpoint that ships its own `embed_tokens`, run a vLLM
+build whose dimension check skips a missing draft embedding, or drop `--speculative-config`
+and serve the target model on its own.
 
 ## See Also
 

--- a/docs/fern/pages/developer-guide/additional-resources/speculative-decoding/speculative-decoding-with-vllm.md
+++ b/docs/fern/pages/developer-guide/additional-resources/speculative-decoding/speculative-decoding-with-vllm.md
@@ -109,12 +109,14 @@ See `examples/backends/vllm/launch/agg_spec_decoding.sh` for the full configurat
 
 - Currently only supports Eagle3 as the draft model
 - Requires compatible model architectures between target and draft
-- The draft checkpoint should carry its own `embed_tokens` weights
+- Draft checkpoints that share the target's embedding table instead of shipping their
+  own `embed_tokens` weights are not loadable on every vLLM build (see below)
 
 ### Draft Checkpoints Without Their Own `embed_tokens`
 
-Some draft checkpoints ship no embedding table of their own and expect vLLM to share the
-target model's. vLLM detects this at load and logs a line such as:
+The Quick Start configuration above is not affected: its Eagle3 draft ships its own
+embedding table. This section covers draft checkpoints that ship none and expect vLLM to
+share the target model's instead. vLLM detects that at load and logs a line such as:
 
 ```text
 Detected EAGLE model without its own embed_tokens in the checkpoint.
@@ -122,19 +124,24 @@ Sharing target model embedding weights with the draft model.
 ```
 
 > [!WARNING]
-> On some vLLM builds this path fails at load with `AttributeError: 'NoneType' object has
-> no attribute 'weight'`, raised while vLLM compares the target and draft embedding
-> dimensions. Every tensor-parallel worker fails identically during `WorkerProc` init, so
-> the engine never becomes ready and no request is ever served.
+> On the `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-kimi-k3-dev.1` image
+> (vLLM `0.1.dev19251+g13c59a3da.d20260726`), that sharing path fails at load with
+> `AttributeError: 'NoneType' object has no attribute 'weight'`. The traceback lands in
+> vLLM's speculative-decoding proposer (`vllm/v1/spec_decode/llm_base_proposer.py`) while
+> it compares the target and draft embedding dimensions. Every tensor-parallel worker
+> fails identically during `WorkerProc` init, so the engine never becomes ready and no
+> request is ever served. Reported with `moonshotai/Kimi-K3` plus the
+> `Inferact/Kimi-K3-DSpark` draft on TP16.
 
-The fault is in vLLM's speculative-decoding proposer, not in Dynamo: the dimension check
-dereferences the draft embedding on exactly the branch that runs when the draft has no
-embedding to dereference. Dynamo passes `--speculative-config` through to vLLM unchanged
-and has no configuration that avoids the branch.
+The failure is on the vLLM side of the boundary, not in Dynamo: Dynamo passes
+`--speculative-config` through to vLLM unchanged and has no setting that changes how the
+draft embedding is resolved. Other vLLM builds carry a different version of that code, so
+whether a given image is affected has to be checked against the image, not assumed from
+this note.
 
-To work around it, use a draft checkpoint that ships its own `embed_tokens`, run a vLLM
-build whose dimension check skips a missing draft embedding, or drop `--speculative-config`
-and serve the target model on its own.
+Workarounds: use a draft checkpoint that ships its own `embed_tokens`, run a vLLM build
+that loads the shared-embedding path successfully, or drop `--speculative-config` and
+serve the target model on its own.
 
 ## See Also
 


### PR DESCRIPTION
# Issue #12843 — Kimi-K3 DSpark speculative decoding crashes at load

## 1. Root cause

The crash is **not in this repository**. It is a defect in the vLLM build shipped inside
`nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-kimi-k3-dev.1`
(vLLM `0.1.dev19251+g13c59a3da.d20260726`), in
`vllm/v1/spec_decode/llm_base_proposer.py`.

The proposer's `load_model` path does two things in sequence:

1. When the draft checkpoint carries no embedding table of its own, it turns on embedding
   sharing with the target model and logs
   `Detected EAGLE model without its own embed_tokens in the checkpoint. Sharing target
   model embedding weights with the draft model.` (`llm_base_proposer.py:1449` in the
   reporter's log).
2. It then runs a dimension-compatibility check that unconditionally reads
   `draft_embed.weight`, where `draft_embed` is `self.model.model.embed_tokens`.

Branch 2 only executes on the branch where branch 1 has already established that the draft
has no `embed_tokens`, so `draft_embed` is `None` and the check raises
`AttributeError: 'NoneType' object has no attribute 'weight'`. Because model loading runs
per rank, all 16 TP `WorkerProc` children die identically and the engine never reaches a
serving state. The reporter's own analysis matches this, and the requested remedy —
"guard the embedding-sharing dimension check to skip `None` draft embeddings" — is a
one-line change in that vLLM file.

The correct upstream fix is to skip (or short-circuit) the dimension check when
`draft_embed is None`, e.g.:

```python
if share_embeddings and draft_embed is not None:
    if isinstance(target_embed_tokens.weight, torch.Tensor) and isinstance(
        draft_embed.weight, torch.Tensor
    ):
        ...
```

### Why no Dynamo code change can fix it

I checked every surface where Dynamo could plausibly intervene:

- Dynamo does not vendor, fork, or patch vLLM. `container/templates/vllm_runtime.Dockerfile`
  builds on the upstream `vllm/vllm-openai` image and installs `vllm-omni` from PyPI
  (`container/deps/vllm/install_vllm_omni.sh`). There are no `.patch` files anywhere in the
  repo, and no monkey-patching of vLLM classes in `components/src/dynamo/vllm/` or
  `lib/bindings/kvbm/python/kvbm/vllm_integration/`.
- Nothing named `proposer`, `spec_decode`, `embed_tokens`, or `share_embeddings` exists in
  Dynamo's own source. Dynamo's only speculative-decoding code is
  `components/src/dynamo/vllm/capacity.py::get_spec_decode_runtime_data`, which reads
  `num_speculative_tokens`/`method` for router metadata *after* the engine is already up —
  it never runs in this failure.
- `--speculative-config` is registered by `AsyncEngineArgs.add_cli_args` in
  `components/src/dynamo/vllm/args.py` and passed to vLLM unmodified;
  `update_engine_config_with_dynamo` does not touch it.
- The crash is inside `WorkerProc`, a separate process spawned by vLLM's
  `MultiprocExecutor`. The only Dynamo-reachable hook that runs there is a
  `vllm.general_plugins` entry point, and this repo defines none (the one referenced in the
  Dockerfile belongs to the ModelExpress package). Registering one to monkey-patch a
  private symbol in a fork-specific module I cannot inspect would be neither minimal nor
  verifiable.
- There is no config-level pre-emption of the sort Dynamo already uses for other upstream
  vLLM incompatibilities (`disable_hybrid_kv_cache_manager_for_incompatible_pd_connector`
  in `kv_connector_protocols.py`): whether embedding sharing is taken is decided by the
  draft checkpoint's tensors, not by anything in `VllmConfig`.
- A startup preflight that inspects the draft checkpoint for `embed_tokens` was considered
  and rejected: a draft *without* its own `embed_tokens` is the normal, supported EAGLE
  shape on vLLM builds that carry the guard, so such a check would warn or fail on
  perfectly healthy deployments.

## 2. The fix in this repo, and why

Dynamo publishes the image the reporter hit, so the actionable in-repo change is to
document the failure mode where a user configuring vLLM speculative decoding will look for
it. I extended the **Limitations** section of the vLLM speculative-decoding guide with a
new subsection, `Draft Checkpoints Without Their Own embed_tokens`, that:

- names the exact vLLM log line that precedes the crash, so the failure is greppable;
- states the exact `AttributeError` and that every TP worker fails during `WorkerProc` init;
- attributes the defect to vLLM's proposer rather than Dynamo, and explains why Dynamo has
  no configuration that avoids the branch;
- gives the three real options: use a draft checkpoint that ships `embed_tokens`, run a
  vLLM build whose dimension check skips a missing draft embedding, or drop
  `--speculative-config`.

This matches how the repo already handles upstream-caused engine crashes — see the
`GMS + Expert Parallel Crash at Model Load` and
`Disagg Decode + EAGLE3 Speculative Decoding Crashes Silently` entries in
`docs/fern/pages/reference/general/releases/known-issues.mdx`, both of which are upstream
vLLM defects documented rather than worked around in Dynamo code.

I deliberately did **not** answer the issue's first request ("confirm intended
DSpark-on-Kimi-K3 support path"). That is a support-policy statement for the maintainers of
the `1.4.0-kimi-k3-dev` image line; asserting it in the docs would be inventing policy.

I also did not add an entry to `known-issues.mdx`: that page is explicitly "mirrored
verbatim from each release's GitHub release notes" and is grouped per shipped release, and
`1.4.0-kimi-k3-dev.1` is a pre-release model-specific image with no section on that page.

## 3. Files changed

| File | Change |
|------|--------|
| `docs/fern/pages/developer-guide/additional-resources/speculative-decoding/speculative-decoding-with-vllm.md` | New `Limitations` bullet plus a `Draft Checkpoints Without Their Own embed_tokens` subsection documenting the load-time crash, its upstream origin, and the workarounds |
| `NOTES.md` | This file |
| `.oss-scan-subject` | Commit subject |

No code, test, or container change. There is no Dynamo code in the failing path, so there
is nothing to unit-test; the repo has no test suite covering docs prose.

## 4. Risk and uncertainty

- **Risk of the change itself: none.** Docs-only, in an existing page, no navigation or
  frontmatter change.
- **Uncertainty about the root cause: low.** The reporter supplied the failing expression
  (`draft_embed.weight`), the preceding log line, and the file. Both are internally
  consistent and the contradiction is unambiguous. I could not read the vLLM source
  directly: `llm_base_proposer.py` does not exist in mainline vLLM (mainline has
  `eagle.py`, `ngram_proposer.py`, and friends), it is specific to the fork baked into the
  `kimi-k3-dev` image, and vLLM is not installed in this checkout. Line numbers and the
  exact enclosing function name are therefore taken from the report, not verified.
- **Uncertainty about scope: moderate.** The reporter lists two further blockers — a config
  schema rejection until `ptd_token_id` is present, and an expected failure from a missing
  `mask_hidden` buffer on the K3 DSpark draft head. Both are out of scope here and neither
  is addressed. Fixing this one crash will not make the reported deployment work.
- **This PR does not stop the crash.** A user who applies it and re-runs the reported
  command still crashes. Only a vLLM-side guard (or a different draft checkpoint) does.
  That limitation is stated plainly in the docs text rather than papered over.

## 5. How I verified it

- `python3 docs/fern/scripts/check_asset_paths.py <file>` — passes ("no site-absolute asset
  paths").
- `python3 docs/fern/scripts/convert_callouts.py <file> /tmp/out.md` — the `> [!WARNING]`
  block converts to a Fern `<Warning>` component as the style guide requires for `.md`
  pages (`docs/fern/pages/community/contributing/documentation/documentation-style-guide.md`,
  "Admonitions").
- `python3 -m codespell_lib --ignore-words codespell.txt <file>` — clean.
- Trailing-whitespace and end-of-file-newline checks (the `trailing-whitespace` and
  `end-of-file-fixer` pre-commit hooks) — clean.
- Style-guide conformance checked by hand: SPDX header and frontmatter untouched, no body
  `# H1`, `vLLM` cased correctly throughout, code fence language-tagged (`text`).
- Searches backing the "no Dynamo code in the path" claim: repo-wide greps for
  `llm_base_proposer`, `proposer`, `embed_tokens`, `share_embeddings`, `has_own_embed`,
  `spec_decode`, and `dspark`; inspection of `components/src/dynamo/vllm/{args,main,
  capacity,worker_factory,kv_connector_protocols}.py`, `container/templates/
  vllm_runtime.Dockerfile`, `container/deps/vllm/`, and `pyproject.toml` entry points.
- Not verified: the runtime behaviour, because reproducing needs GB200 NVL72 with TP16,
  `moonshotai/Kimi-K3`, `Inferact/Kimi-K3-DSpark`, and the `1.4.0-kimi-k3-dev.1` image.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on vLLM limitations when Eagle draft checkpoints do not include their own token embeddings.
  * Documented potential initialization errors, unchanged argument handling, and available workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->