### PR TITLE
fix(trtllm): apply full stop conditions during PREFILL, not just max_tokens

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1130,15 +1130,10 @@ class HandlerBase(BaseGenerativeHandler):
             if default_max_tokens is not None:
                 sampling_params.max_tokens = default_max_tokens
 
-        # PREFILL forces max_tokens=1 above but must still apply the full stop
-        # conditions to match native TRT-LLM context_only behavior -- it
-        # overrides only max_tokens, not the rest of the request's stop
-        # parameters. Skipping ignore_eos here in particular let TRT-LLM treat
-        # EOS as a stop condition on prefill's single sampled token, so a
-        # prompt whose first token happened to be EOS terminated the request
-        # right there instead of letting the KV handoff to decode proceed --
-        # the request "succeeded" with zero visible output instead of
-        # continuing generation normally.
+        # PREFILL forces max_tokens=1 above but must still apply the rest of
+        # the stop conditions (native TRT-LLM context_only overrides only
+        # max_tokens). Without this, TRT-LLM could stop on EOS at that single
+        # forced token and skip the KV handoff to decode entirely.
         if (
             is_generation_stage(CommonDisaggregationMode[self.disaggregation_mode.name])
             or self.disaggregation_mode == DisaggregationMode.PREFILL

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1130,7 +1130,19 @@ class HandlerBase(BaseGenerativeHandler):
             if default_max_tokens is not None:
                 sampling_params.max_tokens = default_max_tokens
 
-        if is_generation_stage(CommonDisaggregationMode[self.disaggregation_mode.name]):
+        # PREFILL forces max_tokens=1 above but must still apply the full stop
+        # conditions to match native TRT-LLM context_only behavior -- it
+        # overrides only max_tokens, not the rest of the request's stop
+        # parameters. Skipping ignore_eos here in particular let TRT-LLM treat
+        # EOS as a stop condition on prefill's single sampled token, so a
+        # prompt whose first token happened to be EOS terminated the request
+        # right there instead of letting the KV handoff to decode proceed --
+        # the request "succeeded" with zero visible output instead of
+        # continuing generation normally.
+        if (
+            is_generation_stage(CommonDisaggregationMode[self.disaggregation_mode.name])
+            or self.disaggregation_mode == DisaggregationMode.PREFILL
+        ):
             apply_stop_conditions_to_sampling_params(
                 sampling_params, request["stop_conditions"]
             )

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -1034,7 +1034,16 @@ class TestGenerateLocally:
         assert kwargs["cache_salt"] == "tenant-a"
 
     @pytest.mark.asyncio
-    async def test_prefill_skips_generation_stop_conditions(self):
+    async def test_prefill_applies_stop_conditions_matching_native_context_only(self):
+        # PREFILL forces max_tokens=1 (asserted separately below) but must
+        # otherwise apply the full stop conditions, matching native TRT-LLM
+        # context_only behavior: it overrides only max_tokens, not the rest
+        # of the request's stop parameters. Skipping ignore_eos here in
+        # particular let TRT-LLM treat EOS as a stop condition on prefill's
+        # single sampled token, so a prompt whose first token happened to be
+        # EOS terminated the request right there instead of letting the KV
+        # handoff to decode proceed -- the request "succeeded" with zero
+        # visible output instead of continuing generation normally.
         handler = self._make_handler()
         handler.disaggregation_mode = DisaggregationMode.PREFILL
         handler.disagg_machine_id = 0
@@ -1069,9 +1078,53 @@ class TestGenerateLocally:
         _, kwargs = handler.engine.llm.generate_async.call_args
         sampling_params = kwargs["sampling_params"]
         assert sampling_params.max_tokens == 1
-        assert sampling_params.min_tokens is None
+        assert sampling_params.min_tokens == 8
+        assert sampling_params.ignore_eos is True
+        assert set(sampling_params.stop_token_ids) == {100, 300}
+        assert kwargs["streaming"] is False
+
+    @pytest.mark.asyncio
+    async def test_prefill_does_not_force_ignore_eos_when_not_requested(self):
+        # Negative case: a request that doesn't ask to ignore EOS or expose a
+        # visible stop token must not have ignore_eos forced on during
+        # prefill. min_tokens and the hidden stop token are still preserved,
+        # same as the positive case -- only ignore_eos differs here.
+        handler = self._make_handler()
+        handler.disaggregation_mode = DisaggregationMode.PREFILL
+        handler.disagg_machine_id = 0
+        handler.default_sampling_params = MockSamplingParams(stop_token_ids=[300])
+        generation_result = MagicMock()
+
+        async def empty_aiter(_self):
+            for _ in ():
+                yield
+
+        generation_result.__aiter__ = empty_aiter
+        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
+
+        request = {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {
+                "max_tokens": 10,
+                "min_tokens": 8,
+                "ignore_eos": False,
+                "stop_token_ids_hidden": [100],
+            },
+            "sampling_options": {},
+        }
+
+        chunks = [
+            c async for c in handler.generate_locally(request, self._make_context())
+        ]
+        assert chunks == []
+
+        handler.engine.llm.generate_async.assert_called_once()
+        _, kwargs = handler.engine.llm.generate_async.call_args
+        sampling_params = kwargs["sampling_params"]
+        assert sampling_params.max_tokens == 1
+        assert sampling_params.min_tokens == 8
         assert sampling_params.ignore_eos is False
-        assert sampling_params.stop_token_ids == [300]
+        assert set(sampling_params.stop_token_ids) == {100, 300}
         assert kwargs["streaming"] is False
 
 


### PR DESCRIPTION
## Summary

- `PREFILL` forces `max_tokens=1` (context-only) but was gating the rest of stop-condition handling on `is_generation_stage(...)`, which `PREFILL` never satisfies. As a result `ignore_eos` (and the rest of `stop_conditions`) was silently dropped during prefill.
- When a caller requested `ignore_eos=true` and the prompt's first sampled token happened to be EOS, TRT-LLM treated it as a stop condition on that single forced token and terminated the request right there instead of letting the KV handoff to decode proceed. The request completed with HTTP 200 and `output_tokens=1`, but no visible content was ever produced.
- This regressed in `d3e815a9c` (#11671), which added the `is_generation_stage` gate around `apply_stop_conditions_to_sampling_params(...)`.
- Found via internal testing.

## Fix

Apply `apply_stop_conditions_to_sampling_params(...)` for `PREFILL` as well as generation-stage workers, matching native TRT-LLM `context_only` behavior: only `max_tokens` is overridden, the rest of the request's stop parameters (`min_tokens`, `ignore_eos`, `stop_token_ids`) pass through unchanged.

## Validation

- Updated `test_prefill_skips_generation_stop_conditions` (renamed to `test_prefill_applies_stop_conditions_matching_native_context_only`) to assert `min_tokens`, `ignore_eos`, and `stop_token_ids` are now applied during prefill, matching native `context_only` semantics.
- Added `test_prefill_does_not_force_ignore_eos_when_not_requested` covering the negative case: `ignore_eos` stays `False` when not requested, while `min_tokens`/hidden stop tokens are still preserved.
- `isort`, `black`, `flake8`, `codespell`, `ruff`, and the repo's `pytest-marker-report` pre-commit hook all pass on the changed files.
- Could not run the full pytest suite locally (no GPU/`torch` in this environment); relying on CI for execution.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stop conditions are now consistently applied during both prefill and generation stages.
  * Prefill requests continue to limit output to one token while preserving other settings, including minimum tokens, EOS handling, and stop-token behavior.
  * Explicitly setting EOS handling to false is now preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->