### PR TITLE
feat(operator): elastic-EP autoscale reconciler behind a default-off gate (Phase 6)

### DIFF
--- a/deploy/operator/internal/controller/dgd_component_program.go
+++ b/deploy/operator/internal/controller/dgd_component_program.go
@@ -57,7 +57,7 @@ func (r *DynamoGraphDeploymentReconciler) newComponentProgram() *componentProgra
 		restartProgress:    newComponentRestartProgressResolver(r.Client),
 		workloads:          newComponentWorkloadsReconciler(r.Client, r.Recorder, rollout),
 		scalingAdapters:    newDGDScalingAdaptersReconciler(r.Client, r.Recorder),
-		elasticEPAutoscale: newDGDElasticEPAutoscaleReconciler(r.Client, r.RuntimeConfig.Gate),
+		elasticEPAutoscale: newDGDElasticEPAutoscaleReconciler(r.Client, r.APIReader, r.RuntimeConfig.Gate),
 		lwsEnabled:         r.RuntimeConfig.Gate.Enabled(features.LWS),
 	}
 }

--- a/deploy/operator/internal/controller/dgd_component_program.go
+++ b/deploy/operator/internal/controller/dgd_component_program.go
@@ -28,13 +28,14 @@ import (
 )
 
 type componentProgram struct {
-	sharedResources *dgdSharedResourcesReconciler
-	rollout         *dgdWorkerRolloutReconciler
-	restart         *dgdRestartReconciler
-	restartProgress *componentRestartProgressResolver
-	workloads       *componentWorkloadsReconciler
-	scalingAdapters *dgdScalingAdaptersReconciler
-	lwsEnabled      bool
+	sharedResources    *dgdSharedResourcesReconciler
+	rollout            *dgdWorkerRolloutReconciler
+	restart            *dgdRestartReconciler
+	restartProgress    *componentRestartProgressResolver
+	workloads          *componentWorkloadsReconciler
+	scalingAdapters    *dgdScalingAdaptersReconciler
+	elasticEPAutoscale *dgdElasticEPAutoscaleReconciler
+	lwsEnabled         bool
 }
 
 // newComponentProgram wires the DCD pathway at the DGD composition root.
@@ -51,12 +52,13 @@ func (r *DynamoGraphDeploymentReconciler) newComponentProgram() *componentProgra
 			r.SSHKeyManager,
 			r.RBACManager,
 		),
-		rollout:         rollout,
-		restart:         newDGDRestartReconciler(),
-		restartProgress: newComponentRestartProgressResolver(r.Client),
-		workloads:       newComponentWorkloadsReconciler(r.Client, r.Recorder, rollout),
-		scalingAdapters: newDGDScalingAdaptersReconciler(r.Client, r.Recorder),
-		lwsEnabled:      r.RuntimeConfig.Gate.Enabled(features.LWS),
+		rollout:            rollout,
+		restart:            newDGDRestartReconciler(),
+		restartProgress:    newComponentRestartProgressResolver(r.Client),
+		workloads:          newComponentWorkloadsReconciler(r.Client, r.Recorder, rollout),
+		scalingAdapters:    newDGDScalingAdaptersReconciler(r.Client, r.Recorder),
+		elasticEPAutoscale: newDGDElasticEPAutoscaleReconciler(r.Client, r.RuntimeConfig.Gate),
+		lwsEnabled:         r.RuntimeConfig.Gate.Enabled(features.LWS),
 	}
 }
 
@@ -132,6 +134,13 @@ func (p *componentProgram) Reconcile(
 			log.FromContext(ctx).Error(err, "Failed to reconcile scaling adapters")
 			return programResult, fmt.Errorf("failed to reconcile scaling adapters: %w", err)
 		}
+	}
+
+	// Phase 6: converge the elastic-EP engine's data-parallel size on joined capacity. Gated
+	// off by default; a no-op unless ElasticEPAutoscale is enabled. It never fails the program
+	// -- a scale hiccup must not wedge the DGD reconcile.
+	if err := p.elasticEPAutoscale.Reconcile(ctx, req.DGD); err != nil {
+		log.FromContext(ctx).Error(err, "elastic-EP autoscale reconcile failed")
 	}
 
 	programResult.applyReconcileResult(req.DGD.Generation, result)

--- a/deploy/operator/internal/controller/dgd_elastic_ep_autoscale_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_elastic_ep_autoscale_reconciler.go
@@ -1,0 +1,253 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// elasticEPFollowerSuffix mirrors commonconsts.GroveRoleSuffixFollower, which lands with the
+// Phase-4 follower (a sibling branch). It is duplicated here so Phase 6 stays independent of
+// Phase 4; when both merge this reverts to the shared const.
+const elasticEPFollowerSuffix = "flw"
+
+// dgdElasticEPAutoscaleReconciler is Phase 6: it reads the get_ep_capacity endpoint over the
+// Phase-3 leader Service and converges the engine's data-parallel size on the owned capacity
+// that has joined. It does nothing unless the ElasticEPAutoscale gate is on (default off,
+// until the scale_elastic_ep rollback #12991 lands) -- an operator that can wedge a serving
+// engine unattended is worse than a human choosing to take the risk.
+type dgdElasticEPAutoscaleReconciler struct {
+	client       client.Client
+	gate         features.Gate
+	httpClient   *http.Client
+	settleWindow time.Duration
+	now          func() time.Time
+
+	mu    sync.Mutex
+	state map[string]*epAutoscaleState
+}
+
+// epAutoscaleState is the per-leader settle-window and fire-once memory. In-memory is enough
+// for a draft (it resets on operator restart, which only re-opens a settle window); the design
+// calls for recording the last-applied topology in status, which is the durable home.
+type epAutoscaleState struct {
+	lastObserved int
+	observedAt   time.Time
+	lastApplied  int
+}
+
+func newDGDElasticEPAutoscaleReconciler(c client.Client, gate features.Gate) *dgdElasticEPAutoscaleReconciler {
+	return &dgdElasticEPAutoscaleReconciler{
+		client:       c,
+		gate:         gate,
+		httpClient:   &http.Client{Timeout: 30 * time.Second},
+		settleWindow: 60 * time.Second, // starting point; tune from join times on the target cluster
+		now:          time.Now,
+		state:        map[string]*epAutoscaleState{},
+	}
+}
+
+// Reconcile is a no-op unless the gate is on. Per-leader failures are logged and swallowed: an
+// HTTP hiccup or a busy engine must not wedge the whole DGD reconcile.
+func (r *dgdElasticEPAutoscaleReconciler) Reconcile(ctx context.Context, dgd *nvidiacomv1beta1.DynamoGraphDeployment) error {
+	if r.gate == nil || !r.gate.Enabled(features.ElasticEPAutoscale) {
+		return nil
+	}
+	logger := log.FromContext(ctx)
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		if c := dynamo.GetMainContainer(component); c == nil || !dynamo.IsElasticEPRayLaunch(c) {
+			continue
+		}
+		if err := r.reconcileComponent(ctx, dgd, component); err != nil {
+			logger.Info("elastic-EP autoscale: deferring", "component", component.ComponentName, "reason", err.Error())
+		}
+	}
+	return nil
+}
+
+func (r *dgdElasticEPAutoscaleReconciler) reconcileComponent(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) error {
+	logger := log.FromContext(ctx)
+	componentName := component.ComponentName
+	// The leader's headless Service is named the same way the render names it.
+	leaderService := dynamo.GetDCDResourceName(dgd, componentName, "")
+	baseURL := elasticEPLeaderBaseURL(leaderService, dgd.Namespace)
+	key := dgd.Namespace + "/" + componentName
+
+	cap, err := readEPCapacity(ctx, r.httpClient, baseURL)
+	if err != nil {
+		return err
+	}
+
+	ownedIPs, err := r.ownedPodIPs(ctx, dgd, componentName)
+	if err != nil {
+		return err
+	}
+	observed := dynamo.OwnedRayNodeCount(cap, ownedIPs)
+	desired := 1 + r.desiredFollowers(ctx, dgd, componentName)
+	decision := dynamo.DecideEPScale(cap.DataParallelSize, observed, desired)
+
+	// Phase 7b visibility: the three numbers that make the deployment's state legible from
+	// outside -- desired followers, joined capacity, and the engine's current size -- plus the
+	// Ray total so a superseded-generation node shows up as the difference.
+	logger.Info("elastic-EP autoscale",
+		"component", componentName,
+		"desired", desired, "observedOwned", observed, "current", cap.DataParallelSize,
+		"rayNodesTotal", len(cap.Nodes), "action", decision.Action.String(), "target", decision.Target)
+
+	switch decision.Action {
+	case dynamo.EPScaleFault:
+		logger.Info("elastic-EP autoscale: FAULT -- owned capacity fell below the running size; not scaling (recovery, not scale-down)",
+			"component", componentName, "current", cap.DataParallelSize, "observedOwned", observed)
+		return nil
+	case dynamo.EPScaleNone:
+		r.markObserved(key, observed)
+		return nil
+	}
+
+	// Grow waits for the settle window so a spike of several followers costs one rebuild, not
+	// several; shrink is desire-driven and need not wait.
+	if decision.Action == dynamo.EPScaleGrow && !r.settled(key, observed) {
+		logger.Info("elastic-EP autoscale: waiting for arrivals to settle before growing",
+			"component", componentName, "observedOwned", observed, "settleWindow", r.settleWindow)
+		return nil
+	}
+
+	// Fire once per change: reconcilers run continuously, and the endpoint takes a target, so a
+	// repeated call to the same size is at best wasteful and at worst a needless rebuild.
+	if r.alreadyApplied(key, decision.Target) {
+		return nil
+	}
+	if err := scaleElasticEP(ctx, r.httpClient, baseURL, decision.Target); err != nil {
+		if errors.Is(err, errEngineBusy) {
+			logger.Info("elastic-EP autoscale: engine busy, will retry on the next reconcile", "component", componentName)
+			return nil
+		}
+		return fmt.Errorf("scale to %d: %w", decision.Target, err)
+	}
+	r.recordApplied(key, decision.Target)
+	logger.Info("elastic-EP autoscale: applied", "component", componentName,
+		"action", decision.Action.String(), "newDataParallelSize", decision.Target)
+	return nil
+}
+
+// ownedPodIPs returns the pod IPs of this deployment's Running elastic-EP worker pods -- the
+// leader and its followers. OwnedRayNodeCount intersects these with what Ray reports, so a
+// superseded-generation pod still alive in Ray is filtered out.
+func (r *dgdElasticEPAutoscaleReconciler) ownedPodIPs(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	componentName string,
+) (map[string]struct{}, error) {
+	pods := &corev1.PodList{}
+	if err := r.client.List(ctx, pods,
+		client.InNamespace(dgd.Namespace),
+		client.MatchingLabels{
+			commonconsts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+			commonconsts.KubeLabelDynamoComponentType:       commonconsts.ComponentTypeWorker,
+		},
+	); err != nil {
+		return nil, err
+	}
+	ips := make(map[string]struct{}, len(pods.Items))
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Status.Phase == corev1.PodRunning && p.Status.PodIP != "" && p.DeletionTimestamp == nil {
+			ips[p.Status.PodIP] = struct{}{}
+		}
+	}
+	return ips, nil
+}
+
+// desiredFollowers is the follower count the scaling adapter is driving -- the resting Deployment
+// replica count of the synthesized "<leader>-flw" follower. Zero when the follower Deployment is
+// absent (e.g. before the follower has been created), which yields a desired data-parallel size
+// of one: the leader alone.
+func (r *dgdElasticEPAutoscaleReconciler) desiredFollowers(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	componentName string,
+) int {
+	followerDCD := dynamo.GetDCDResourceName(dgd, componentName, "") + "-" + elasticEPFollowerSuffix
+	dep := &appsv1.Deployment{}
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: dgd.Namespace, Name: followerDCD}, dep); err != nil {
+		return 0
+	}
+	if dep.Spec.Replicas == nil {
+		return 0
+	}
+	return int(*dep.Spec.Replicas)
+}
+
+// --- settle window + fire-once state ---
+
+func (r *dgdElasticEPAutoscaleReconciler) settled(key string, observed int) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s := r.state[key]
+	if s == nil || s.lastObserved != observed {
+		r.state[key] = &epAutoscaleState{lastObserved: observed, observedAt: r.now()}
+		return false // capacity just changed -> (re)open the window
+	}
+	return r.now().Sub(s.observedAt) >= r.settleWindow
+}
+
+func (r *dgdElasticEPAutoscaleReconciler) markObserved(key string, observed int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s := r.state[key]
+	if s == nil || s.lastObserved != observed {
+		r.state[key] = &epAutoscaleState{lastObserved: observed, observedAt: r.now()}
+	}
+}
+
+func (r *dgdElasticEPAutoscaleReconciler) alreadyApplied(key string, target int) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s := r.state[key]
+	return s != nil && s.lastApplied == target
+}
+
+func (r *dgdElasticEPAutoscaleReconciler) recordApplied(key string, target int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s := r.state[key]
+	if s == nil {
+		s = &epAutoscaleState{}
+		r.state[key] = s
+	}
+	s.lastApplied = target
+}

--- a/deploy/operator/internal/controller/dgd_elastic_ep_autoscale_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_elastic_ep_autoscale_reconciler.go
@@ -46,7 +46,11 @@ const elasticEPFollowerSuffix = "flw"
 // until the scale_elastic_ep rollback #12991 lands) -- an operator that can wedge a serving
 // engine unattended is worse than a human choosing to take the risk.
 type dgdElasticEPAutoscaleReconciler struct {
-	client       client.Client
+	client client.Client
+	// podReader is an UNCACHED reader. The manager's cached client has no Pod informer (this
+	// controller does not watch Pods), so listing pods through it returns empty -- which a
+	// cluster run caught as observedOwned=0 for a leader whose IP plainly matched Ray.
+	podReader    client.Reader
 	gate         features.Gate
 	httpClient   *http.Client
 	settleWindow time.Duration
@@ -65,9 +69,10 @@ type epAutoscaleState struct {
 	lastApplied  int
 }
 
-func newDGDElasticEPAutoscaleReconciler(c client.Client, gate features.Gate) *dgdElasticEPAutoscaleReconciler {
+func newDGDElasticEPAutoscaleReconciler(c client.Client, podReader client.Reader, gate features.Gate) *dgdElasticEPAutoscaleReconciler {
 	return &dgdElasticEPAutoscaleReconciler{
 		client:       c,
+		podReader:    podReader,
 		gate:         gate,
 		httpClient:   &http.Client{Timeout: 30 * time.Second},
 		settleWindow: 60 * time.Second, // starting point; tune from join times on the target cluster
@@ -173,7 +178,7 @@ func (r *dgdElasticEPAutoscaleReconciler) ownedPodIPs(
 	componentName string,
 ) (map[string]struct{}, error) {
 	pods := &corev1.PodList{}
-	if err := r.client.List(ctx, pods,
+	if err := r.podReader.List(ctx, pods,
 		client.InNamespace(dgd.Namespace),
 		client.MatchingLabels{
 			commonconsts.KubeLabelDynamoGraphDeploymentName: dgd.Name,

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -72,6 +72,9 @@ type rbacManager interface {
 // DynamoGraphDeploymentReconciler reconciles a DynamoGraphDeployment object
 type DynamoGraphDeploymentReconciler struct {
 	client.Client
+	// APIReader is an uncached reader for objects this controller does not watch (e.g. Pods),
+	// which the cached Client cannot serve.
+	APIReader             client.Reader
 	Config                *configv1alpha1.OperatorConfiguration
 	RuntimeConfig         *commoncontroller.RuntimeConfig
 	RestConfig            *rest.Config

--- a/deploy/operator/internal/controller/elastic_ep_autoscale.go
+++ b/deploy/operator/internal/controller/elastic_ep_autoscale.go
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+)
+
+// The engine control plane serves its routes over HTTP on the system port under /engine/.
+// The reconciler reaches them over the network at the Phase-3 headless leader Service -- NOT
+// by kubectl exec like the manual scale script, which only did so because port-forward proved
+// unreliable through the API proxy.
+const (
+	epCapacityRoute = "/engine/control/ep_capacity"
+	epScaleRoute    = "/engine/control/scale_elastic_ep"
+)
+
+// elasticEPLeaderBaseURL is the http://host:port the leader's engine control plane answers on.
+// host is the Phase-3 headless Service <component>-ray, addressed cluster-internally.
+func elasticEPLeaderBaseURL(componentName, namespace string) string {
+	svc := dynamo.ElasticEPLeaderServiceName(componentName)
+	return fmt.Sprintf("http://%s.%s.svc:%d", svc, namespace, consts.DynamoSystemPort)
+}
+
+// readEPCapacity GETs (POSTs, per the route contract) the current elastic-EP capacity.
+func readEPCapacity(ctx context.Context, hc *http.Client, baseURL string) (dynamo.EPCapacity, error) {
+	var cap dynamo.EPCapacity
+	if err := postEngineRoute(ctx, hc, baseURL+epCapacityRoute, map[string]any{}, &cap); err != nil {
+		return dynamo.EPCapacity{}, err
+	}
+	if cap.Status != "ok" {
+		return dynamo.EPCapacity{}, fmt.Errorf("ep_capacity returned status %q", cap.Status)
+	}
+	return cap, nil
+}
+
+// scaleElasticEPResult is the scale_elastic_ep reply; both fields are checked because the
+// endpoint takes a target, not a delta -- a reply that succeeded at the wrong size is a failure.
+type scaleElasticEPResult struct {
+	Status              string `json:"status"`
+	NewDataParallelSize int    `json:"new_data_parallel_size"`
+}
+
+// scaleElasticEP asks the engine to converge on target ranks. It accepts the result only when
+// status is "ok" AND the echoed new_data_parallel_size matches target. It returns errEngineBusy
+// when the engine is mid-scale so the caller can requeue rather than treat it as a failure.
+func scaleElasticEP(ctx context.Context, hc *http.Client, baseURL string, target int) error {
+	var res scaleElasticEPResult
+	err := postEngineRoute(ctx, hc, baseURL+epScaleRoute,
+		map[string]any{"new_data_parallel_size": target}, &res)
+	if err != nil {
+		return err
+	}
+	if res.Status == "busy" {
+		return errEngineBusy
+	}
+	if res.Status != "ok" {
+		return fmt.Errorf("scale_elastic_ep returned status %q", res.Status)
+	}
+	if res.NewDataParallelSize != target {
+		return fmt.Errorf("scale_elastic_ep acknowledged size %d, wanted %d", res.NewDataParallelSize, target)
+	}
+	return nil
+}
+
+// errEngineBusy signals a scale is already in progress; treat as requeue, not failure, or a
+// slow scale reads as a broken deployment.
+var errEngineBusy = fmt.Errorf("engine busy: scale already in progress")
+
+func postEngineRoute(ctx context.Context, hc *http.Client, url string, body any, out any) error {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s: HTTP %d: %s", url, resp.StatusCode, string(raw))
+	}
+	if out != nil {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return fmt.Errorf("%s: decode response: %w", url, err)
+		}
+	}
+	return nil
+}

--- a/deploy/operator/internal/controller/elastic_ep_autoscale_client_test.go
+++ b/deploy/operator/internal/controller/elastic_ep_autoscale_client_test.go
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestScaleElasticEP_ContractChecks(t *testing.T) {
+	tests := []struct {
+		name       string
+		reply      map[string]any
+		httpStatus int
+		wantErr    bool
+		wantBusy   bool
+	}{
+		{
+			name:  "ok and echoed size matches -> success",
+			reply: map[string]any{"status": "ok", "new_data_parallel_size": 3},
+		},
+		{
+			name:    "ok but echoed a different size -> failure (endpoint takes a target, not a delta)",
+			reply:   map[string]any{"status": "ok", "new_data_parallel_size": 2},
+			wantErr: true,
+		},
+		{
+			name:     "busy -> requeue signal, not a hard failure",
+			reply:    map[string]any{"status": "busy"},
+			wantErr:  true,
+			wantBusy: true,
+		},
+		{
+			name:    "error status -> failure",
+			reply:   map[string]any{"status": "error", "message": "boom"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != epScaleRoute {
+					t.Errorf("unexpected path %q", r.URL.Path)
+				}
+				var body map[string]any
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				if body["new_data_parallel_size"] == nil {
+					t.Error("request must carry new_data_parallel_size")
+				}
+				if tt.httpStatus != 0 {
+					w.WriteHeader(tt.httpStatus)
+				}
+				_ = json.NewEncoder(w).Encode(tt.reply)
+			}))
+			defer srv.Close()
+
+			err := scaleElasticEP(context.Background(), srv.Client(), srv.URL, 3)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("scaleElasticEP err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantBusy && !errors.Is(err, errEngineBusy) {
+				t.Errorf("busy reply should surface errEngineBusy so the caller requeues; got %v", err)
+			}
+		})
+	}
+}
+
+func TestReadEPCapacity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != epCapacityRoute {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok", "data_parallel_size": 2, "tensor_parallel_size": 1,
+			"data_parallel_backend": "ray",
+			"nodes":                 []map[string]any{{"node_ip": "10.0.0.1", "total_gpus": 4}},
+		})
+	}))
+	defer srv.Close()
+
+	cap, err := readEPCapacity(context.Background(), srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("readEPCapacity: %v", err)
+	}
+	if cap.DataParallelSize != 2 || cap.DataParallelBackend != "ray" || len(cap.Nodes) != 1 {
+		t.Errorf("unexpected capacity: %+v", cap)
+	}
+}
+
+func TestElasticEPLeaderBaseURL(t *testing.T) {
+	got := elasticEPLeaderBaseURL("Leader", "tzulingk-ft-tests")
+	want := "http://leader-ray.tzulingk-ft-tests.svc:9090"
+	if got != want {
+		t.Errorf("elasticEPLeaderBaseURL = %q, want %q", got, want)
+	}
+}

--- a/deploy/operator/internal/controller/setup.go
+++ b/deploy/operator/internal/controller/setup.go
@@ -87,6 +87,7 @@ func SetupDynamoComponentDeployment(mgr ctrl.Manager, opts DynamoComponentDeploy
 func SetupDynamoGraphDeployment(mgr ctrl.Manager, opts DynamoGraphDeploymentSetupOptions) error {
 	if err := (&DynamoGraphDeploymentReconciler{
 		Client:                mgr.GetClient(),
+		APIReader:             mgr.GetAPIReader(),
 		Recorder:              mgr.GetEventRecorder("dynamographdeployment"),
 		Config:                opts.Config,
 		RuntimeConfig:         opts.RuntimeConfig,

--- a/deploy/operator/internal/dynamo/elastic_ep_scale.go
+++ b/deploy/operator/internal/dynamo/elastic_ep_scale.go
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dynamo
+
+// Elastic-EP autoscale decision logic (Phase 6). This file is deliberately pure -- no
+// Kubernetes client, no HTTP -- because the arithmetic here is the part most likely to be
+// subtly wrong, and the fault case is dangerous to get wrong. The reconciler that owns the
+// settle window, the HTTP call, and status lives in the controller package.
+
+// EPCapacity mirrors the read-only get_ep_capacity engine response (Phase 5, #13179).
+type EPCapacity struct {
+	Status              string      `json:"status"`
+	DataParallelSize    int         `json:"data_parallel_size"`
+	TensorParallelSize  int         `json:"tensor_parallel_size"`
+	DataParallelBackend string      `json:"data_parallel_backend"`
+	TotalGPUs           *float64    `json:"total_gpus"`
+	AvailableGPUs       *float64    `json:"available_gpus"`
+	UsedGPUs            *float64    `json:"used_gpus"`
+	Nodes               []EPRayNode `json:"nodes"`
+}
+
+// EPRayNode is one node in the Ray cluster as the engine sees it. node_ip is the address the
+// raylet registered, which for elastic EP is the pod IP (the launch passes
+// --node-ip-address="$POD_IP"), so it can be intersected with this deployment's pod IPs.
+type EPRayNode struct {
+	NodeIP    string  `json:"node_ip"`
+	TotalGPUs float64 `json:"total_gpus"`
+}
+
+// EPScaleAction is what the reconciler should do with the engine's data-parallel size.
+type EPScaleAction int
+
+const (
+	// EPScaleNone: the engine already runs at the right size; do nothing.
+	EPScaleNone EPScaleAction = iota
+	// EPScaleGrow: more owned capacity has joined than the engine uses; grow into it.
+	EPScaleGrow
+	// EPScaleShrink: the desired follower count fell; shrink to it.
+	EPScaleShrink
+	// EPScaleFault: owned capacity dropped below what the engine is running on -- a pod
+	// holding live ranks died or drained. This is NOT a scale-down signal; scaling to match
+	// would shrink around dead ranks. The reconciler must route this to recovery, not scale.
+	EPScaleFault
+)
+
+func (a EPScaleAction) String() string {
+	switch a {
+	case EPScaleGrow:
+		return "grow"
+	case EPScaleShrink:
+		return "shrink"
+	case EPScaleFault:
+		return "fault"
+	default:
+		return "none"
+	}
+}
+
+// EPScaleDecision is the outcome of DecideEPScale.
+type EPScaleDecision struct {
+	Action EPScaleAction
+	// Target is the data-parallel size to request. For Fault and None it echoes the current
+	// size (nothing is sent).
+	Target int
+}
+
+// OwnedRayNodeCount is the generation filter: it counts only the Ray nodes this deployment's
+// CURRENT generation owns, by intersecting what the engine reports with the set of pod IPs
+// the operator knows belong to the live generation. During validation a pod from a superseded
+// generation was still alive in the Ray cluster; counting it would let the reconciler grow the
+// engine onto a rank it does not own and cannot manage. Anything Ray reports that is not in
+// ownedPodIPs is noise to report, not capacity to use.
+//
+// Under one pod per node this count is also the data-parallel target directly: one node, one
+// rank, so the arithmetic is a division that always comes out even and the reconciler never
+// reasons about partially filled pods.
+func OwnedRayNodeCount(cap EPCapacity, ownedPodIPs map[string]struct{}) int {
+	owned := 0
+	for _, n := range cap.Nodes {
+		if _, ok := ownedPodIPs[n.NodeIP]; ok {
+			owned++
+		}
+	}
+	return owned
+}
+
+// DecideEPScale converges the engine's data-parallel size on the owned capacity that has
+// joined, bounded by desire. The three numbers must not be confused:
+//
+//   - current:  the size the engine is running at right now (capacity.DataParallelSize).
+//   - observed: owned Ray nodes that have joined (OwnedRayNodeCount) -- current-generation only.
+//   - desired:  the target data-parallel size implied by the scaling adapter's follower count
+//     (1 leader + desiredFollowers), owned by whoever drives the adapter.
+//
+// Rules, in order, straight from the design:
+//   - Shrink is driven ONLY by desire falling. If desired < current, shrink to desired.
+//   - Otherwise, observation falling below current is a FAULT (a live rank's pod died), never a
+//     scale-down -- scaling to match would shrink around dead ranks. Route to recovery.
+//   - Otherwise growth is driven by observation and bounded by desire: grow to min(observed, desired).
+//
+// The lower bound is one rank; a caller must never pass desired < 1. Deriving the target from
+// observation alone -- the obvious formulation -- gets growth right and loss dangerously wrong,
+// which is why shrink and fault are separated here rather than collapsed into "match observed".
+func DecideEPScale(current, observed, desired int) EPScaleDecision {
+	if desired < 1 {
+		desired = 1
+	}
+
+	// Desire fell: shrink unconditionally to it (Phase 7). This is the only scale-down trigger.
+	if desired < current {
+		return EPScaleDecision{Action: EPScaleShrink, Target: desired}
+	}
+
+	// Not shrinking, yet fewer owned ranks are alive than the engine runs on: a rank died.
+	if observed < current {
+		return EPScaleDecision{Action: EPScaleFault, Target: current}
+	}
+
+	// Grow into joined capacity, but never past what the driver asked for.
+	target := observed
+	if desired < target {
+		target = desired
+	}
+	if target > current {
+		return EPScaleDecision{Action: EPScaleGrow, Target: target}
+	}
+
+	return EPScaleDecision{Action: EPScaleNone, Target: current}
+}

--- a/deploy/operator/internal/dynamo/elastic_ep_scale_test.go
+++ b/deploy/operator/internal/dynamo/elastic_ep_scale_test.go
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dynamo
+
+import "testing"
+
+func TestDecideEPScale(t *testing.T) {
+	tests := []struct {
+		name                       string
+		current, observed, desired int
+		wantAction                 EPScaleAction
+		wantTarget                 int
+	}{
+		{
+			name:    "converged: nothing joined beyond current, desire matches",
+			current: 3, observed: 3, desired: 3, wantAction: EPScaleNone, wantTarget: 3,
+		},
+		{
+			name:    "grow: four owned nodes joined, desire allows it -> one call to 4",
+			current: 1, observed: 4, desired: 4, wantAction: EPScaleGrow, wantTarget: 4,
+		},
+		{
+			name:    "grow bounded by desire: five joined but only four desired -> grow to 4",
+			current: 1, observed: 5, desired: 4, wantAction: EPScaleGrow, wantTarget: 4,
+		},
+		{
+			name:    "grow partial: two of four desired have joined -> use what's available, grow to 2",
+			current: 1, observed: 2, desired: 4, wantAction: EPScaleGrow, wantTarget: 2,
+		},
+		{
+			name:    "no grow: desire raised but nothing new has joined yet",
+			current: 2, observed: 2, desired: 5, wantAction: EPScaleNone, wantTarget: 2,
+		},
+		{
+			name:    "shrink: desired fell below current -> shrink to desired, ignoring observed",
+			current: 4, observed: 4, desired: 2, wantAction: EPScaleShrink, wantTarget: 2,
+		},
+		{
+			name:    "shrink to the one-rank floor",
+			current: 3, observed: 3, desired: 1, wantAction: EPScaleShrink, wantTarget: 1,
+		},
+		{
+			name:    "shrink clamps a below-floor desire up to one",
+			current: 3, observed: 3, desired: 0, wantAction: EPScaleShrink, wantTarget: 1,
+		},
+		{
+			name:    "FAULT: a live rank's pod died (observed < current) and we are not shrinking -> do not scale",
+			current: 4, observed: 2, desired: 4, wantAction: EPScaleFault, wantTarget: 4,
+		},
+		{
+			name:    "FAULT even when idle desire is higher: never scale down to match lost capacity",
+			current: 3, observed: 1, desired: 8, wantAction: EPScaleFault, wantTarget: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DecideEPScale(tt.current, tt.observed, tt.desired)
+			if got.Action != tt.wantAction || got.Target != tt.wantTarget {
+				t.Errorf("DecideEPScale(current=%d, observed=%d, desired=%d) = {%s, %d}, want {%s, %d}",
+					tt.current, tt.observed, tt.desired, got.Action, got.Target, tt.wantAction, tt.wantTarget)
+			}
+		})
+	}
+}
+
+func TestOwnedRayNodeCount_GenerationFilter(t *testing.T) {
+	cap := EPCapacity{
+		Nodes: []EPRayNode{
+			{NodeIP: "10.0.0.1", TotalGPUs: 4}, // leader (owned)
+			{NodeIP: "10.0.0.2", TotalGPUs: 4}, // current-gen follower (owned)
+			{NodeIP: "10.9.9.9", TotalGPUs: 4}, // superseded-generation pod still alive in Ray (NOISE)
+		},
+	}
+	owned := map[string]struct{}{
+		"10.0.0.1": {},
+		"10.0.0.2": {},
+		"10.0.0.3": {}, // a desired pod not yet joined -- present in ownership, absent from Ray
+	}
+
+	t.Log("only Ray nodes whose IP is an owned current-generation pod count; the superseded pod is excluded")
+	if got := OwnedRayNodeCount(cap, owned); got != 2 {
+		t.Errorf("OwnedRayNodeCount = %d, want 2 (leader + one joined follower; superseded 10.9.9.9 excluded)", got)
+	}
+
+	t.Log("counting every live Ray node instead would over-count and grow the engine onto a rank it does not own")
+	if len(cap.Nodes) == 2 {
+		t.Fatal("test fixture should include the superseded node to prove it is filtered")
+	}
+}
+
+func TestOwnedRayNodeCount_Empty(t *testing.T) {
+	if got := OwnedRayNodeCount(EPCapacity{}, map[string]struct{}{"10.0.0.1": {}}); got != 0 {
+		t.Errorf("no Ray nodes -> owned 0, got %d", got)
+	}
+}

--- a/deploy/operator/internal/features/gates.go
+++ b/deploy/operator/internal/features/gates.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
@@ -123,6 +124,24 @@ const (
 	// Requires: N/A
 	// Default: true, since v1.0.0
 	GPUDiscovery Name = "gpuDiscovery"
+
+	// ElasticEPAutoscale enables the operator to fire elastic-EP scale calls on its own
+	// initiative (Phase 6). It is OFF by default and gated deliberately: until
+	// https://github.com/ai-dynamo/dynamo/pull/12991 gives scale_elastic_ep a clean
+	// rollback, a failed grow can leave the engine holding a reserved-but-dead rank and
+	// serving nothing while the pod still looks healthy -- an operator that can wedge a
+	// serving engine unattended is worse than a human choosing to take the risk. Flip the
+	// default to true once that rollback lands.
+	//
+	// Owner: @tzulingk
+	// Experimental since: v1.3.0
+	// Beta since: N/A
+	// GA since: N/A
+	// Configuration: DYN_OPERATOR_ENABLE_ELASTIC_EP_AUTOSCALE=1
+	// Auto-detection: N/A
+	// Requires: elastic-EP leader Service (Phase 3) and get_ep_capacity (Phase 5)
+	// Default: false
+	ElasticEPAutoscale Name = "elasticEPAutoscale"
 )
 
 var allNames = [...]Name{
@@ -134,6 +153,7 @@ var allNames = [...]Name{
 	DRA,
 	Istio,
 	GPUDiscovery,
+	ElasticEPAutoscale,
 }
 
 // Gate reports whether operator features are enabled.
@@ -143,14 +163,15 @@ type Gate interface {
 
 // Gates is the complete set of operator feature gates.
 type Gates struct {
-	Checkpoint       bool `json:"checkpoint"`
-	Grove            bool `json:"grove"`
-	LWS              bool `json:"lws"`
-	KaiScheduler     bool `json:"kaiScheduler"`
-	VolcanoScheduler bool `json:"volcanoScheduler"`
-	DRA              bool `json:"dra"`
-	Istio            bool `json:"istio"`
-	GPUDiscovery     bool `json:"gpuDiscovery"`
+	Checkpoint         bool `json:"checkpoint"`
+	Grove              bool `json:"grove"`
+	LWS                bool `json:"lws"`
+	KaiScheduler       bool `json:"kaiScheduler"`
+	VolcanoScheduler   bool `json:"volcanoScheduler"`
+	DRA                bool `json:"dra"`
+	Istio              bool `json:"istio"`
+	GPUDiscovery       bool `json:"gpuDiscovery"`
+	ElasticEPAutoscale bool `json:"elasticEPAutoscale"`
 }
 
 // Defaults returns the default feature gates.
@@ -163,6 +184,9 @@ func Defaults() Gates {
 // New detects cluster capabilities and resolves them with operator configuration.
 func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorConfiguration) (Gates, error) {
 	gates := Defaults()
+	// Off unless explicitly opted in; see the ElasticEPAutoscale gate doc for why it stays
+	// gated until the scale_elastic_ep rollback (#12991) lands.
+	gates.ElasticEPAutoscale = os.Getenv("DYN_OPERATOR_ENABLE_ELASTIC_EP_AUTOSCALE") == "1"
 	gates.Checkpoint = config.Checkpoint.Enabled
 	gates.GPUDiscovery = config.Namespace.Restricted == "" || ptr.Deref(config.GPU.DiscoveryEnabled, true)
 

--- a/deploy/operator/internal/features/gates_test.go
+++ b/deploy/operator/internal/features/gates_test.go
@@ -52,14 +52,15 @@ func TestGateRegistryIsComplete(t *testing.T) {
 
 func allEnabledGates() Gates {
 	return Gates{
-		Checkpoint:       true,
-		Grove:            true,
-		LWS:              true,
-		KaiScheduler:     true,
-		VolcanoScheduler: true,
-		DRA:              true,
-		Istio:            true,
-		GPUDiscovery:     true,
+		Checkpoint:         true,
+		Grove:              true,
+		LWS:                true,
+		KaiScheduler:       true,
+		VolcanoScheduler:   true,
+		DRA:                true,
+		Istio:              true,
+		GPUDiscovery:       true,
+		ElasticEPAutoscale: true,
 	}
 }
 


### PR DESCRIPTION
#### Overview:

Part of the on-demand elastic-EP follower feature (DYN-3686). This is **Phase 6**: the reconciler that makes the engine's GPU count follow load **automatically** — it reads how much capacity has joined and tells the engine to grow into it (or shrink). It is **stacked on #13178** (the leader Service it calls) and is **OFF by default** behind a feature gate.

#### Background (for reviewers without the context):

**What is elastic EP?** Mixture-of-Experts models spread experts across GPUs. *Elastic* EP lets a **running** deployment add/remove GPUs as load changes: extra pods (followers) join the leader's Ray cluster as data-parallel ranks, and `scale_elastic_ep` changes how many ranks the engine runs.

**Where this sits:** Phase 2 (#12943) Ray head → Phase 3 (#13178) leader Service → Phase 4 (#13180) the follower pod → Phase 5 (#13179) the `get_ep_capacity` readout → **Phase 6 (this PR)** the reconciler that reads Phase 5 and fires the scale.

**Why it's gated OFF by default.** A failed grow can leave the engine holding a reserved-but-dead rank and serving nothing while the pod still looks healthy. Until [#12991](https://github.com/ai-dynamo/dynamo/pull/12991) gives `scale_elastic_ep` a clean rollback, an operator that fires scale calls on its own initiative is worse than a human choosing to take the risk. So this ships behind `DYN_OPERATOR_ENABLE_ELASTIC_EP_AUTOSCALE=1` (default false); flip the default when #12991 lands.

#### What this PR does:

**The decision logic is pure and exhaustively unit-tested** (`internal/dynamo/elastic_ep_scale.go`) — it's the part most likely to be subtly wrong:
- `DecideEPScale` keeps three numbers distinct: **current** (engine size), **observed** (owned Ray nodes that have joined), **desired** (`1 + follower count`). **Growth** is driven by observation, bounded by desire. **Shrink** is driven *only* by desire falling. **Observation dropping below current is a FAULT** — a live rank's pod died — **never a scale-down**, because matching to it would shrink around dead ranks (routes to recovery instead). Floor of one rank.
- `OwnedRayNodeCount` is the **generation filter**: it intersects what Ray reports with this deployment's *current-generation* pod IPs, so a superseded-generation pod still alive in Ray is counted as noise, not capacity (this actually bit us during validation).

**The reconciler** (`internal/controller`):
- Calls `/engine/control/{ep_capacity,scale_elastic_ep}` on the system port **over the network** (the Phase-3 Service), not `kubectl exec`. `scale_elastic_ep` is accepted only when `status==ok` **and** the echoed `new_data_parallel_size` matches the target; a `busy` reply requeues rather than fails.
- A **settle window** (wait for arrivals to stop) so a spike of N followers costs one engine rebuild, not N; a **fire-once-per-change** guard; grow waits for the window, shrink need not.
- Wired into the component program as a **gated, non-fatal** phase — a scale hiccup never wedges the DGD reconcile.

**Scope / follow-ups (called out):** durable status fields (Phase 7b: desired/joined/current + per-follower reason) and a periodic requeue are noted in code as follow-ups; the follower-suffix const is duplicated locally to keep this a clean **sibling of #13178** (the shared const lands with Phase 4, #13180).

#### Validation:

- **Unit tests, all green:** `DecideEPScale` (10 cases incl. grow/grow-bounded/partial/shrink/floor/**fault**), `OwnedRayNodeCount` (generation filter excludes the superseded node), the HTTP client contract (`status==ok` **and** echoed size; `busy`→requeue; wrong-size→error), and the leader-URL builder. `go build ./...`, `gofmt`, `go vet` clean; the features gate-registry completeness test updated for the new gate.
- **Cluster test:** in progress — deploying the operator with the gate ON against an elastic-EP leader and confirming the reconciler reads capacity, computes the decision, and fires `scale_elastic_ep` over the network. Result to follow.

#### Where should the reviewer start?

`deploy/operator/internal/dynamo/elastic_ep_scale.go` — `DecideEPScale` (the three-number rule + the fault case) and `OwnedRayNodeCount` (the generation filter), then the reconciler in `internal/controller/dgd_elastic_ep_autoscale_reconciler.go`.
