### PR TITLE
chore: regenerate kustomize OpenAPI schema after PodSnapshot migration

### DIFF
--- a/recipes/kustomize/components/dynamo-openapi/dynamo-openapi.json
+++ b/recipes/kustomize/components/dynamo-openapi/dynamo-openapi.json
@@ -1283,48 +1283,6 @@
         }
       ]
     },
-    "nvidia.com.v1alpha1.PodSnapshot": {
-      "properties": {
-        "apiVersion": {
-          "type": "string"
-        },
-        "kind": {
-          "type": "string"
-        },
-        "metadata": {
-          "type": "object"
-        }
-      },
-      "type": "object",
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "nvidia.com",
-          "kind": "PodSnapshot",
-          "version": "v1alpha1"
-        }
-      ]
-    },
-    "nvidia.com.v1alpha1.PodSnapshotContent": {
-      "properties": {
-        "apiVersion": {
-          "type": "string"
-        },
-        "kind": {
-          "type": "string"
-        },
-        "metadata": {
-          "type": "object"
-        }
-      },
-      "type": "object",
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "nvidia.com",
-          "kind": "PodSnapshotContent",
-          "version": "v1alpha1"
-        }
-      ]
-    },
     "nvidia.com.v1beta1.DynamoComponentDeployment": {
       "properties": {
         "apiVersion": {


### PR DESCRIPTION
## Overview:

#13177 moved the PodSnapshot CRDs out without regenerating the kustomize OpenAPI schema, so `Pre Merge | Recipe Check` currently fails on every PR. This regenerates the file with `python3 scripts/generate_kustomize_openapi.py` (42 stale lines removed, nothing else).

## Where should the reviewer start?

The single regenerated file. Verified `scripts/generate_kustomize_openapi.py --check` passes after this change.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete PodSnapshot and PodSnapshotContent schema definitions from the Kubernetes API documentation.
  * Updated the generated OpenAPI document to reflect the currently supported resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->