### PR TITLE
fix(operator): gate checkpoint controller on snapshot API

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -667,12 +667,12 @@ func registerControllers(
 	}); err != nil {
 		return err
 	}
-	if runtimeConfig.Gate.Enabled(features.Checkpoint) {
-		if err := controller.SetupDynamoCheckpoint(mgr, setupOptions); err != nil {
-			return err
-		}
-	} else {
-		setupLog.Info("Skipping DynamoCheckpoint controller because the checkpoint feature gate is disabled")
+	// A disabled gate omits the external watch while retaining finalizer cleanup reconciliation.
+	if !runtimeConfig.Gate.Enabled(features.Checkpoint) {
+		setupLog.Info("Registering DynamoCheckpoint controller without PodSnapshot watch because the checkpoint feature gate is disabled")
+	}
+	if err := controller.SetupDynamoCheckpoint(mgr, setupOptions); err != nil {
+		return err
 	}
 	// PodSnapshot/PodSnapshotContent reconciliation is owned by the external
 	// Snapshot operator (github.com/ai-dynamo/snapshot).

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -667,8 +667,12 @@ func registerControllers(
 	}); err != nil {
 		return err
 	}
-	if err := controller.SetupDynamoCheckpoint(mgr, setupOptions); err != nil {
-		return err
+	if runtimeConfig.Gate.Enabled(features.Checkpoint) {
+		if err := controller.SetupDynamoCheckpoint(mgr, setupOptions); err != nil {
+			return err
+		}
+	} else {
+		setupLog.Info("Skipping DynamoCheckpoint controller because the checkpoint feature gate is disabled")
 	}
 	// PodSnapshot/PodSnapshotContent reconciliation is owned by the external
 	// Snapshot operator (github.com/ai-dynamo/snapshot).

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -669,7 +669,10 @@ func registerControllers(
 	}
 	// A disabled gate omits the external watch while retaining finalizer cleanup reconciliation.
 	if !runtimeConfig.Gate.Enabled(features.Checkpoint) {
-		setupLog.Info("Registering DynamoCheckpoint controller without PodSnapshot watch because the checkpoint feature gate is disabled")
+		setupLog.Info(
+			"Registering DynamoCheckpoint controller without PodSnapshot watch",
+			"reason", "checkpoint feature gate is disabled",
+		)
 	}
 	if err := controller.SetupDynamoCheckpoint(mgr, setupOptions); err != nil {
 		return err

--- a/deploy/operator/internal/controller/dgd_epp_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_epp_reconciler.go
@@ -101,7 +101,10 @@ func (r *dgdEPPReconciler) Reconcile(
 	meshEnabled := r.runtimeConfig.Gate.Enabled(features.Istio)
 	istioAvailable := meshEnabled
 	if !meshEnabled {
-		istioAvailable = features.DetectIstioDestinationRuleAvailability(ctx, r.restConfig)
+		istioAvailable, err = features.DetectIstioDestinationRuleAvailability(ctx, r.restConfig)
+		if err != nil {
+			return fmt.Errorf("detect Istio DestinationRule API availability: %w", err)
+		}
 	}
 	if istioAvailable {
 		destinationRule := dynamo.GenerateEPPDestinationRule(eppServiceName, dgd.Namespace, r.config.ServiceMesh)

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -700,7 +700,7 @@ func (r *CheckpointReconciler) FinalizeResource(ctx context.Context, ckpt *nvidi
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CheckpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&nvidiacomv1alpha1.DynamoCheckpoint{}).
 		Owns(&batchv1.Job{}, builder.WithPredicates(predicate.Funcs{
 			// Ignore creation - we don't need to reconcile when we just created the Job
@@ -708,8 +708,11 @@ func (r *CheckpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			DeleteFunc:  func(de event.DeleteEvent) bool { return true },
 			UpdateFunc:  func(ue event.UpdateEvent) bool { return true },
 			GenericFunc: func(ge event.GenericEvent) bool { return true },
-		})).
-		Owns(&snapshotv1alpha1.PodSnapshot{}, builder.WithPredicates(predicate.Funcs{
+		}))
+
+	// Watch the external API only when Checkpoint is enabled and availability was verified.
+	if r.RuntimeConfig.Gate.Enabled(features.Checkpoint) {
+		controllerBuilder = controllerBuilder.Owns(&snapshotv1alpha1.PodSnapshot{}, builder.WithPredicates(predicate.Funcs{
 			// Ignore create (we just created it). Watch update (status mirror) and
 			// delete (re-enqueue to recreate / unblock). Delete is safe: reconcile
 			// exits at the deletion-timestamp guard before reaching observePodSnapshot.
@@ -717,7 +720,10 @@ func (r *CheckpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			DeleteFunc:  func(de event.DeleteEvent) bool { return true },
 			UpdateFunc:  func(ue event.UpdateEvent) bool { return true },
 			GenericFunc: func(ge event.GenericEvent) bool { return false },
-		})).
+		}))
+	}
+
+	return controllerBuilder.
 		Watches(&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(mapSourcePodToCheckpoint),
 			builder.WithPredicates(predicate.Funcs{

--- a/deploy/operator/internal/controller/setup.go
+++ b/deploy/operator/internal/controller/setup.go
@@ -145,6 +145,9 @@ func SetupDynamoModel(mgr ctrl.Manager, opts DynamoModelSetupOptions) error {
 	return nil
 }
 
+// SetupDynamoCheckpoint always registers the reconciler so existing checkpoint finalizers can
+// converge when Checkpoint is disabled. CheckpointReconciler.SetupWithManager omits the external
+// PodSnapshot watch unless the resolved Checkpoint gate is enabled.
 func SetupDynamoCheckpoint(mgr ctrl.Manager, opts SetupOptions) error {
 	if err := (&CheckpointReconciler{
 		Client:        mgr.GetClient(),

--- a/deploy/operator/internal/controller/setup_envtest_test.go
+++ b/deploy/operator/internal/controller/setup_envtest_test.go
@@ -15,9 +15,16 @@ import (
 	"time"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/testing/operatorenv"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
@@ -29,14 +36,24 @@ func TestSetupDynamoCheckpointWithSnapshotAPIAvailability(t *testing.T) {
 		crdPaths          []string
 		wantGateEnabled   bool
 		wantGateError     bool
+		verifyFinalizer   bool
 	}{
 		{
 			name:            "API absent and checkpoint disabled",
 			crdPaths:        []string{filepath.Join("..", "..", "config", "crd", "bases")},
 			wantGateEnabled: false,
+			verifyFinalizer: true,
 		},
 		{
-			name:              "API present",
+			name: "API present and checkpoint disabled",
+			crdPaths: []string{
+				filepath.Join("..", "..", "config", "crd", "bases"),
+				filepath.Join("testing", "nvidia"),
+			},
+			wantGateEnabled: false,
+		},
+		{
+			name:              "API present and checkpoint enabled",
 			checkpointEnabled: true,
 			crdPaths: []string{
 				filepath.Join("..", "..", "config", "crd", "bases"),
@@ -67,9 +84,12 @@ func TestSetupDynamoCheckpointWithSnapshotAPIAvailability(t *testing.T) {
 
 			t.Log("Create a manager with a short controller cache-sync timeout")
 			mgr, err := ctrl.NewManager(testEnv.RESTConfig(), ctrl.Options{
-				Scheme:     testEnv.Scheme(),
-				Metrics:    metricsserver.Options{BindAddress: "0"},
-				Controller: controllerconfig.Controller{CacheSyncTimeout: time.Second},
+				Scheme:  testEnv.Scheme(),
+				Metrics: metricsserver.Options{BindAddress: "0"},
+				Controller: controllerconfig.Controller{
+					CacheSyncTimeout:   time.Second,
+					SkipNameValidation: ptr.To(true),
+				},
 			})
 			if err != nil {
 				t.Fatalf("create manager: %v", err)
@@ -91,14 +111,38 @@ func TestSetupDynamoCheckpointWithSnapshotAPIAvailability(t *testing.T) {
 			}
 			testEnv.RuntimeConfig().Gate = gates
 
-			t.Log("Register the DynamoCheckpoint controller only when its feature gate is enabled")
-			if gates.Enabled(features.Checkpoint) {
-				if err := SetupDynamoCheckpoint(mgr, SetupOptions{
-					Config:        testEnv.OperatorConfig(),
-					RuntimeConfig: testEnv.RuntimeConfig(),
-				}); err != nil {
-					t.Fatalf("setup DynamoCheckpoint controller: %v", err)
+			t.Log("Register the DynamoCheckpoint controller with watches selected by its feature gate")
+			if err := SetupDynamoCheckpoint(mgr, SetupOptions{
+				Config:        testEnv.OperatorConfig(),
+				RuntimeConfig: testEnv.RuntimeConfig(),
+			}); err != nil {
+				t.Fatalf("setup DynamoCheckpoint controller: %v", err)
+			}
+
+			var deletingCheckpoint client.ObjectKey
+			if tt.verifyFinalizer {
+				t.Log("Create and delete a finalized checkpoint before starting the disabled controller")
+				checkpoint := &nvidiacomv1alpha1.DynamoCheckpoint{
+					ObjectMeta: metav1.ObjectMeta{Name: "finalizer-cleanup", Namespace: testEnv.Namespace()},
+					Spec: nvidiacomv1alpha1.DynamoCheckpointSpec{
+						Identity: nvidiacomv1alpha1.DynamoCheckpointIdentity{
+							Model: "test-model", BackendFramework: "vllm",
+						},
+						Job: nvidiacomv1alpha1.DynamoCheckpointJobConfig{
+							PodTemplateSpec: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "test"}}},
+							},
+						},
+					},
 				}
+				commoncontroller.AddFinalizer(checkpoint)
+				if err := testEnv.Client().Create(context.Background(), checkpoint); err != nil {
+					t.Fatalf("create finalized checkpoint: %v", err)
+				}
+				if err := testEnv.Client().Delete(context.Background(), checkpoint); err != nil {
+					t.Fatalf("delete finalized checkpoint: %v", err)
+				}
+				deletingCheckpoint = client.ObjectKeyFromObject(checkpoint)
 			}
 
 			t.Log("Start the manager and require it to remain available beyond cache synchronization")
@@ -107,12 +151,33 @@ func TestSetupDynamoCheckpointWithSnapshotAPIAvailability(t *testing.T) {
 			go func() {
 				done <- mgr.Start(ctx)
 			}()
-			select {
-			case err := <-done:
+			if tt.verifyFinalizer {
+				t.Log("Require the disabled controller to remove the finalizer and complete deletion")
+				deadline := time.Now().Add(5 * time.Second)
+				for time.Now().Before(deadline) {
+					checkpoint := &nvidiacomv1alpha1.DynamoCheckpoint{}
+					err := testEnv.Client().Get(context.Background(), deletingCheckpoint, checkpoint)
+					if apierrors.IsNotFound(err) {
+						break
+					}
+					if err != nil {
+						t.Fatalf("get deleting checkpoint: %v", err)
+					}
+					time.Sleep(50 * time.Millisecond)
+				}
+				checkpoint := &nvidiacomv1alpha1.DynamoCheckpoint{}
+				if err := testEnv.Client().Get(context.Background(), deletingCheckpoint, checkpoint); !apierrors.IsNotFound(err) {
+					t.Fatalf("checkpoint still exists after finalizer cleanup: %v", err)
+				}
 				cancel()
-				t.Fatalf("manager exited during startup: %v", err)
-			case <-time.After(2 * time.Second):
-				cancel()
+			} else {
+				select {
+				case err := <-done:
+					cancel()
+					t.Fatalf("manager exited during startup: %v", err)
+				case <-time.After(2 * time.Second):
+					cancel()
+				}
 			}
 			if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
 				t.Fatalf("stop manager: %v", err)

--- a/deploy/operator/internal/controller/setup_envtest_test.go
+++ b/deploy/operator/internal/controller/setup_envtest_test.go
@@ -1,0 +1,122 @@
+//go:build !clustertest
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/testing/operatorenv"
+	ctrl "sigs.k8s.io/controller-runtime"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+func TestSetupDynamoCheckpointWithSnapshotAPIAvailability(t *testing.T) {
+	tests := []struct {
+		name              string
+		checkpointEnabled bool
+		crdPaths          []string
+		wantGateEnabled   bool
+		wantGateError     bool
+	}{
+		{
+			name:            "API absent and checkpoint disabled",
+			crdPaths:        []string{filepath.Join("..", "..", "config", "crd", "bases")},
+			wantGateEnabled: false,
+		},
+		{
+			name:              "API present",
+			checkpointEnabled: true,
+			crdPaths: []string{
+				filepath.Join("..", "..", "config", "crd", "bases"),
+				filepath.Join("testing", "nvidia"),
+			},
+			wantGateEnabled: true,
+		},
+		{
+			name:              "API absent and checkpoint enabled",
+			checkpointEnabled: true,
+			crdPaths:          []string{filepath.Join("..", "..", "config", "crd", "bases")},
+			wantGateError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Start an API server with the scenario's CRDs installed")
+			testEnv := operatorenv.New(operatorenv.Options{
+				CRDDirectoryPaths: tt.crdPaths,
+				Config: &configv1alpha1.OperatorConfiguration{
+					Checkpoint: configv1alpha1.CheckpointConfiguration{Enabled: tt.checkpointEnabled},
+				},
+				SetupWebhooks: func(ctrl.Manager, operatorenv.WebhookSetupOptions) error {
+					return nil
+				},
+			}).RunT(t)
+
+			t.Log("Create a manager with a short controller cache-sync timeout")
+			mgr, err := ctrl.NewManager(testEnv.RESTConfig(), ctrl.Options{
+				Scheme:     testEnv.Scheme(),
+				Metrics:    metricsserver.Options{BindAddress: "0"},
+				Controller: controllerconfig.Controller{CacheSyncTimeout: time.Second},
+			})
+			if err != nil {
+				t.Fatalf("create manager: %v", err)
+			}
+
+			t.Log("Resolve feature gates from configuration and cluster API availability")
+			gates, err := features.New(context.Background(), mgr, testEnv.OperatorConfig())
+			if tt.wantGateError {
+				if err == nil {
+					t.Fatal("resolve feature gates succeeded, want unavailable PodSnapshot API error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolve feature gates: %v", err)
+			}
+			if got := gates.Enabled(features.Checkpoint); got != tt.wantGateEnabled {
+				t.Fatalf("Checkpoint gate = %v, want %v", got, tt.wantGateEnabled)
+			}
+			testEnv.RuntimeConfig().Gate = gates
+
+			t.Log("Register the DynamoCheckpoint controller only when its feature gate is enabled")
+			if gates.Enabled(features.Checkpoint) {
+				if err := SetupDynamoCheckpoint(mgr, SetupOptions{
+					Config:        testEnv.OperatorConfig(),
+					RuntimeConfig: testEnv.RuntimeConfig(),
+				}); err != nil {
+					t.Fatalf("setup DynamoCheckpoint controller: %v", err)
+				}
+			}
+
+			t.Log("Start the manager and require it to remain available beyond cache synchronization")
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() {
+				done <- mgr.Start(ctx)
+			}()
+			select {
+			case err := <-done:
+				cancel()
+				t.Fatalf("manager exited during startup: %v", err)
+			case <-time.After(2 * time.Second):
+				cancel()
+			}
+			if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
+				t.Fatalf("stop manager: %v", err)
+			}
+		})
+	}
+}

--- a/deploy/operator/internal/features/gates.go
+++ b/deploy/operator/internal/features/gates.go
@@ -13,7 +13,9 @@ import (
 	"reflect"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 	resourcev1 "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -33,8 +35,8 @@ const (
 	// Beta since: N/A
 	// GA since: N/A
 	// Configuration: checkpoint.enabled
-	// Auto-detection: N/A
-	// Requires: N/A
+	// Auto-detection: nvidia.com/v1alpha1 PodSnapshot resource
+	// Requires: Snapshot operator serving nvidia.com/v1alpha1 PodSnapshot resources
 	// Default: false
 	Checkpoint Name = "checkpoint"
 
@@ -163,10 +165,18 @@ func Defaults() Gates {
 // New detects cluster capabilities and resolves them with operator configuration.
 func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorConfiguration) (Gates, error) {
 	gates := Defaults()
-	gates.Checkpoint = config.Checkpoint.Enabled
 	gates.GPUDiscovery = config.Namespace.Restricted == "" || ptr.Deref(config.GPU.DiscoveryEnabled, true)
 
 	var err error
+	podSnapshotAvailable, err := detectPodSnapshotAvailability(ctx, mgr.GetConfig())
+	if err != nil {
+		return Gates{}, err
+	}
+
+	if gates.Checkpoint, err = resolve(ptr.To(config.Checkpoint.Enabled), podSnapshotAvailable,
+		"checkpoint is explicitly enabled in config but the nvidia.com/v1alpha1 PodSnapshot API was not detected in the cluster"); err != nil {
+		return Gates{}, err
+	}
 	if gates.Grove, err = resolve(config.Orchestrators.Grove.Enabled, detectAPIGroup(ctx, mgr, "grove.io", ""),
 		"Grove is explicitly enabled in config but the Grove API group was not detected in the cluster"); err != nil {
 		return Gates{}, err
@@ -218,6 +228,36 @@ func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorC
 // DetectInferencePoolAvailability checks whether the Gateway API Inference Extension is registered.
 func DetectInferencePoolAvailability(ctx context.Context, mgr ctrl.Manager) bool {
 	return detectAPIGroup(ctx, mgr, "inference.networking.k8s.io", "")
+}
+
+func detectPodSnapshotAvailability(ctx context.Context, cfg *rest.Config) (bool, error) {
+	logger := log.FromContext(ctx)
+	resource := snapshotv1alpha1.GroupVersion.WithResource("podsnapshots")
+	logValues := []any{"groupVersion", resource.GroupVersion().String(), "resource", resource.Resource}
+	if cfg == nil {
+		return false, errors.New("PodSnapshot API detection failed, no discovery client available")
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return false, fmt.Errorf("create discovery client for PodSnapshot API detection: %w", err)
+	}
+	apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion(resource.GroupVersion().String())
+	if apierrors.IsNotFound(err) {
+		logger.Info("API resource not available", logValues...)
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("discover PodSnapshot API resource: %w", err)
+	}
+	for _, candidate := range apiResourceList.APIResources {
+		if candidate.Name == resource.Resource {
+			logger.Info("API resource is available", logValues...)
+			return true, nil
+		}
+	}
+	logger.Info("API resource not available", logValues...)
+	return false, nil
 }
 
 // resolve uses auto-detection when unset, disables on false, and requires availability on true.

--- a/deploy/operator/internal/features/gates.go
+++ b/deploy/operator/internal/features/gates.go
@@ -170,7 +170,14 @@ func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorC
 	var err error
 	// Enable Checkpoint only when explicitly configured and its external API dependency is available.
 	if config.Checkpoint.Enabled {
-		podSnapshotAvailable, detectErr := detectPodSnapshotAvailability(ctx, mgr.GetConfig())
+		podSnapshotResource := snapshotv1alpha1.GroupVersion.WithResource("podsnapshots")
+		podSnapshotAvailable, detectErr := detectAPIAvailability(
+			ctx,
+			mgr.GetConfig(),
+			podSnapshotResource.Group,
+			podSnapshotResource.Version,
+			podSnapshotResource.Resource,
+		)
 		if detectErr != nil {
 			return Gates{}, detectErr
 		}
@@ -179,13 +186,14 @@ func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorC
 			return Gates{}, err
 		}
 	}
-	if gates.Grove, err = resolve(config.Orchestrators.Grove.Enabled, detectAPIGroup(ctx, mgr, "grove.io", ""),
+	if gates.Grove, err = resolve(config.Orchestrators.Grove.Enabled,
+		detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "grove.io", "", ""),
 		"Grove is explicitly enabled in config but the Grove API group was not detected in the cluster"); err != nil {
 		return Gates{}, err
 	}
 
-	lwsAvailable := detectAPIGroup(ctx, mgr, "leaderworkerset.x-k8s.io", "")
-	volcanoAvailable := detectAPIGroup(ctx, mgr, "scheduling.volcano.sh", "")
+	lwsAvailable := detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "leaderworkerset.x-k8s.io", "", "")
+	volcanoAvailable := detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "scheduling.volcano.sh", "", "")
 	if ptr.Deref(config.Orchestrators.LWS.Enabled, lwsAvailable && volcanoAvailable) {
 		if !lwsAvailable {
 			return Gates{}, fmt.Errorf("LWS is explicitly enabled in config but the LWS API group was not detected in the cluster")
@@ -203,12 +211,19 @@ func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorC
 		gates.VolcanoScheduler = true
 	}
 
-	if gates.KaiScheduler, err = resolve(config.Orchestrators.KaiScheduler.Enabled, detectAPIGroup(ctx, mgr, "scheduling.run.ai", ""),
+	if gates.KaiScheduler, err = resolve(config.Orchestrators.KaiScheduler.Enabled,
+		detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "scheduling.run.ai", "", ""),
 		"Kai-scheduler is explicitly enabled in config but the scheduling.run.ai API group was not detected in the cluster"); err != nil {
 		return Gates{}, err
 	}
 	if gates.DRA, err = resolve(config.DRA.Enabled,
-		detectAPIGroup(ctx, mgr, resourcev1.SchemeGroupVersion.Group, resourcev1.SchemeGroupVersion.Version),
+		detectOptionalAPIAvailability(
+			ctx,
+			mgr.GetConfig(),
+			resourcev1.SchemeGroupVersion.Group,
+			resourcev1.SchemeGroupVersion.Version,
+			"",
+		),
 		"DRA is explicitly enabled in config but the resource.k8s.io/v1 API was not detected in the cluster (requires Kubernetes 1.34+)"); err != nil {
 		return Gates{}, err
 	}
@@ -229,44 +244,75 @@ func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorC
 
 // DetectInferencePoolAvailability checks whether the Gateway API Inference Extension is registered.
 func DetectInferencePoolAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectAPIGroup(ctx, mgr, "inference.networking.k8s.io", "")
+	return detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "inference.networking.k8s.io", "", "")
 }
 
-// detectPodSnapshotAvailability reports whether PodSnapshot is discoverable.
+// detectAPIAvailability reports whether an API group, version, or resource is discoverable.
+// An empty version checks only the group. An empty resource checks the group and optional version.
 // A nil cfg is supported and returns an error because discovery is unavailable.
-func detectPodSnapshotAvailability(ctx context.Context, cfg *rest.Config) (bool, error) {
+func detectAPIAvailability(ctx context.Context, cfg *rest.Config, group, version, resource string) (bool, error) {
 	logger := log.FromContext(ctx)
-	resource := snapshotv1alpha1.GroupVersion.WithResource("podsnapshots")
-	logValues := []any{"groupVersion", resource.GroupVersion().String(), "resource", resource.Resource}
+	logValues := []any{"group", group}
+	if version != "" {
+		logValues = append(logValues, "version", version)
+	}
+	if resource != "" {
+		logValues = append(logValues, "resource", resource)
+	}
 	if cfg == nil {
-		return false, errors.New("PodSnapshot API detection failed, no discovery client available")
+		return false, errors.New("API detection failed, no discovery client available")
+	}
+	if resource != "" && version == "" {
+		return false, errors.New("API resource detection requires a version")
 	}
 
 	// Create a client for direct API resource discovery.
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
-		return false, fmt.Errorf("create discovery client for PodSnapshot API detection: %w", err)
+		return false, fmt.Errorf("create API discovery client: %w", err)
 	}
 
+	// Group-only detection uses the server group index and optionally matches a served version.
+	if resource == "" {
+		apiGroups, err := discoveryClient.ServerGroups()
+		if err != nil {
+			return false, fmt.Errorf("list server API groups: %w", err)
+		}
+		available := apiGroupServesVersion(apiGroups, group, version)
+		logger.Info("API availability detected", append(logValues, "available", available)...)
+		return available, nil
+	}
 	// Query the exact group version and distinguish absence from discovery failures.
-	apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion(resource.GroupVersion().String())
+	groupVersion := group + "/" + version
+	apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion(groupVersion)
 	if apierrors.IsNotFound(err) {
-		logger.Info("API resource not available", logValues...)
+		logger.Info("API availability detected", append(logValues, "available", false)...)
 		return false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("discover PodSnapshot API resource: %w", err)
+		return false, fmt.Errorf("discover %s API resources: %w", groupVersion, err)
 	}
 
-	// Match the exact resource because other Dynamo APIs share this group version.
+	// Match the exact resource within the discovered group version.
 	for _, candidate := range apiResourceList.APIResources {
-		if candidate.Name == resource.Resource {
-			logger.Info("API resource is available", logValues...)
+		if candidate.Name == resource {
+			logger.Info("API availability detected", append(logValues, "available", true)...)
 			return true, nil
 		}
 	}
-	logger.Info("API resource not available", logValues...)
+	logger.Info("API availability detected", append(logValues, "available", false)...)
 	return false, nil
+}
+
+// detectOptionalAPIAvailability degrades discovery errors to unavailable for optional integrations.
+func detectOptionalAPIAvailability(ctx context.Context, cfg *rest.Config, group, version, resource string) bool {
+	available, err := detectAPIAvailability(ctx, cfg, group, version, resource)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "API availability detection failed",
+			"group", group, "version", version, "resource", resource)
+		return false
+	}
+	return available
 }
 
 // resolve uses auto-detection when unset, disables on false, and requires availability on true.
@@ -283,64 +329,9 @@ func resolve(configured *bool, available bool, unavailableMessage string) (bool,
 	return true, nil
 }
 
-func detectAPIGroup(ctx context.Context, mgr ctrl.Manager, groupName, version string) bool {
-	logger := log.FromContext(ctx)
-	logValues := []any{"group", groupName}
-	if version != "" {
-		logValues = append(logValues, "version", version)
-	}
-
-	cfg := mgr.GetConfig()
-	if cfg == nil {
-		logger.Info("detection failed, no discovery client available", logValues...)
-		return false
-	}
-
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		logger.Error(err, "detection failed, could not create discovery client", logValues...)
-		return false
-	}
-	apiGroups, err := discoveryClient.ServerGroups()
-	if err != nil {
-		logger.Error(err, "detection failed, could not list server groups", logValues...)
-		return false
-	}
-	if apiGroupServesVersion(apiGroups, groupName, version) {
-		logger.Info("API group is available", logValues...)
-		return true
-	}
-	logger.Info("API group not available", logValues...)
-	return false
-}
-
 // DetectIstioDestinationRuleAvailability checks whether DestinationRule is registered.
 func DetectIstioDestinationRuleAvailability(ctx context.Context, cfg *rest.Config) bool {
-	logger := log.FromContext(ctx)
-	logValues := []any{"groupVersion", "networking.istio.io/v1beta1", "resource", "destinationrules"}
-	if cfg == nil {
-		logger.Info("detection failed, no discovery client available", logValues...)
-		return false
-	}
-
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		logger.Error(err, "detection failed, could not create discovery client", logValues...)
-		return false
-	}
-	apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion("networking.istio.io/v1beta1")
-	if err != nil {
-		logger.Info("API resource not available", append(logValues, "error", err.Error())...)
-		return false
-	}
-	for _, resource := range apiResourceList.APIResources {
-		if resource.Name == "destinationrules" {
-			logger.Info("API resource is available", logValues...)
-			return true
-		}
-	}
-	logger.Info("API resource not available", logValues...)
-	return false
+	return detectOptionalAPIAvailability(ctx, cfg, "networking.istio.io", "v1beta1", "destinationrules")
 }
 
 func apiGroupServesVersion(apiGroups *metav1.APIGroupList, groupName, version string) bool {

--- a/deploy/operator/internal/features/gates.go
+++ b/deploy/operator/internal/features/gates.go
@@ -186,14 +186,23 @@ func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorC
 			return Gates{}, err
 		}
 	}
-	if gates.Grove, err = resolve(config.Orchestrators.Grove.Enabled,
-		detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "grove.io", "", ""),
+	groveAvailable, err := detectAPIAvailability(ctx, mgr.GetConfig(), "grove.io", "", "")
+	if err != nil {
+		return Gates{}, err
+	}
+	if gates.Grove, err = resolve(config.Orchestrators.Grove.Enabled, groveAvailable,
 		"Grove is explicitly enabled in config but the Grove API group was not detected in the cluster"); err != nil {
 		return Gates{}, err
 	}
 
-	lwsAvailable := detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "leaderworkerset.x-k8s.io", "", "")
-	volcanoAvailable := detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "scheduling.volcano.sh", "", "")
+	lwsAvailable, err := detectAPIAvailability(ctx, mgr.GetConfig(), "leaderworkerset.x-k8s.io", "", "")
+	if err != nil {
+		return Gates{}, err
+	}
+	volcanoAvailable, err := detectAPIAvailability(ctx, mgr.GetConfig(), "scheduling.volcano.sh", "", "")
+	if err != nil {
+		return Gates{}, err
+	}
 	if ptr.Deref(config.Orchestrators.LWS.Enabled, lwsAvailable && volcanoAvailable) {
 		if !lwsAvailable {
 			return Gates{}, fmt.Errorf("LWS is explicitly enabled in config but the LWS API group was not detected in the cluster")
@@ -211,24 +220,34 @@ func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorC
 		gates.VolcanoScheduler = true
 	}
 
-	if gates.KaiScheduler, err = resolve(config.Orchestrators.KaiScheduler.Enabled,
-		detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "scheduling.run.ai", "", ""),
+	kaiSchedulerAvailable, err := detectAPIAvailability(ctx, mgr.GetConfig(), "scheduling.run.ai", "", "")
+	if err != nil {
+		return Gates{}, err
+	}
+	if gates.KaiScheduler, err = resolve(config.Orchestrators.KaiScheduler.Enabled, kaiSchedulerAvailable,
 		"Kai-scheduler is explicitly enabled in config but the scheduling.run.ai API group was not detected in the cluster"); err != nil {
 		return Gates{}, err
 	}
-	if gates.DRA, err = resolve(config.DRA.Enabled,
-		detectOptionalAPIAvailability(
-			ctx,
-			mgr.GetConfig(),
-			resourcev1.SchemeGroupVersion.Group,
-			resourcev1.SchemeGroupVersion.Version,
-			"",
-		),
+	draAvailable, err := detectAPIAvailability(
+		ctx,
+		mgr.GetConfig(),
+		resourcev1.SchemeGroupVersion.Group,
+		resourcev1.SchemeGroupVersion.Version,
+		"",
+	)
+	if err != nil {
+		return Gates{}, err
+	}
+	if gates.DRA, err = resolve(config.DRA.Enabled, draAvailable,
 		"DRA is explicitly enabled in config but the resource.k8s.io/v1 API was not detected in the cluster (requires Kubernetes 1.34+)"); err != nil {
 		return Gates{}, err
 	}
 	if config.ServiceMesh.IsEnabled() {
-		if gates.Istio, err = resolve(config.ServiceMesh.Enabled, DetectIstioDestinationRuleAvailability(ctx, mgr.GetConfig()),
+		istioAvailable, detectErr := DetectIstioDestinationRuleAvailability(ctx, mgr.GetConfig())
+		if detectErr != nil {
+			return Gates{}, detectErr
+		}
+		if gates.Istio, err = resolve(config.ServiceMesh.Enabled, istioAvailable,
 			"service mesh is explicitly enabled in config but the networking.istio.io DestinationRule API was not detected in the cluster"); err != nil {
 			return Gates{}, err
 		}
@@ -243,8 +262,8 @@ func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorC
 }
 
 // DetectInferencePoolAvailability checks whether the Gateway API Inference Extension is registered.
-func DetectInferencePoolAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectOptionalAPIAvailability(ctx, mgr.GetConfig(), "inference.networking.k8s.io", "", "")
+func DetectInferencePoolAvailability(ctx context.Context, mgr ctrl.Manager) (bool, error) {
+	return detectAPIAvailability(ctx, mgr.GetConfig(), "inference.networking.k8s.io", "", "")
 }
 
 // detectAPIAvailability reports whether an API group, version, or resource is discoverable.
@@ -304,17 +323,6 @@ func detectAPIAvailability(ctx context.Context, cfg *rest.Config, group, version
 	return false, nil
 }
 
-// detectOptionalAPIAvailability degrades discovery errors to unavailable for optional integrations.
-func detectOptionalAPIAvailability(ctx context.Context, cfg *rest.Config, group, version, resource string) bool {
-	available, err := detectAPIAvailability(ctx, cfg, group, version, resource)
-	if err != nil {
-		log.FromContext(ctx).Error(err, "API availability detection failed",
-			"group", group, "version", version, "resource", resource)
-		return false
-	}
-	return available
-}
-
 // resolve uses auto-detection when unset, disables on false, and requires availability on true.
 func resolve(configured *bool, available bool, unavailableMessage string) (bool, error) {
 	if configured == nil {
@@ -330,8 +338,8 @@ func resolve(configured *bool, available bool, unavailableMessage string) (bool,
 }
 
 // DetectIstioDestinationRuleAvailability checks whether DestinationRule is registered.
-func DetectIstioDestinationRuleAvailability(ctx context.Context, cfg *rest.Config) bool {
-	return detectOptionalAPIAvailability(ctx, cfg, "networking.istio.io", "v1beta1", "destinationrules")
+func DetectIstioDestinationRuleAvailability(ctx context.Context, cfg *rest.Config) (bool, error) {
+	return detectAPIAvailability(ctx, cfg, "networking.istio.io", "v1beta1", "destinationrules")
 }
 
 func apiGroupServesVersion(apiGroups *metav1.APIGroupList, groupName, version string) bool {

--- a/deploy/operator/internal/features/gates.go
+++ b/deploy/operator/internal/features/gates.go
@@ -168,14 +168,16 @@ func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorC
 	gates.GPUDiscovery = config.Namespace.Restricted == "" || ptr.Deref(config.GPU.DiscoveryEnabled, true)
 
 	var err error
-	podSnapshotAvailable, err := detectPodSnapshotAvailability(ctx, mgr.GetConfig())
-	if err != nil {
-		return Gates{}, err
-	}
-
-	if gates.Checkpoint, err = resolve(ptr.To(config.Checkpoint.Enabled), podSnapshotAvailable,
-		"checkpoint is explicitly enabled in config but the nvidia.com/v1alpha1 PodSnapshot API was not detected in the cluster"); err != nil {
-		return Gates{}, err
+	// Enable Checkpoint only when explicitly configured and its external API dependency is available.
+	if config.Checkpoint.Enabled {
+		podSnapshotAvailable, detectErr := detectPodSnapshotAvailability(ctx, mgr.GetConfig())
+		if detectErr != nil {
+			return Gates{}, detectErr
+		}
+		if gates.Checkpoint, err = resolve(ptr.To(true), podSnapshotAvailable,
+			"checkpoint is explicitly enabled in config but the nvidia.com/v1alpha1 PodSnapshot API was not detected in the cluster"); err != nil {
+			return Gates{}, err
+		}
 	}
 	if gates.Grove, err = resolve(config.Orchestrators.Grove.Enabled, detectAPIGroup(ctx, mgr, "grove.io", ""),
 		"Grove is explicitly enabled in config but the Grove API group was not detected in the cluster"); err != nil {
@@ -230,6 +232,8 @@ func DetectInferencePoolAvailability(ctx context.Context, mgr ctrl.Manager) bool
 	return detectAPIGroup(ctx, mgr, "inference.networking.k8s.io", "")
 }
 
+// detectPodSnapshotAvailability reports whether PodSnapshot is discoverable.
+// A nil cfg is supported and returns an error because discovery is unavailable.
 func detectPodSnapshotAvailability(ctx context.Context, cfg *rest.Config) (bool, error) {
 	logger := log.FromContext(ctx)
 	resource := snapshotv1alpha1.GroupVersion.WithResource("podsnapshots")
@@ -238,10 +242,13 @@ func detectPodSnapshotAvailability(ctx context.Context, cfg *rest.Config) (bool,
 		return false, errors.New("PodSnapshot API detection failed, no discovery client available")
 	}
 
+	// Create a client for direct API resource discovery.
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
 		return false, fmt.Errorf("create discovery client for PodSnapshot API detection: %w", err)
 	}
+
+	// Query the exact group version and distinguish absence from discovery failures.
 	apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion(resource.GroupVersion().String())
 	if apierrors.IsNotFound(err) {
 		logger.Info("API resource not available", logValues...)
@@ -250,6 +257,8 @@ func detectPodSnapshotAvailability(ctx context.Context, cfg *rest.Config) (bool,
 	if err != nil {
 		return false, fmt.Errorf("discover PodSnapshot API resource: %w", err)
 	}
+
+	// Match the exact resource because other Dynamo APIs share this group version.
 	for _, candidate := range apiResourceList.APIResources {
 		if candidate.Name == resource.Resource {
 			logger.Info("API resource is available", logValues...)

--- a/deploy/operator/internal/features/gates_test.go
+++ b/deploy/operator/internal/features/gates_test.go
@@ -105,7 +105,7 @@ func TestAPIGroupServesVersion(t *testing.T) {
 	}
 }
 
-func TestDetectPodSnapshotAvailability(t *testing.T) {
+func TestDetectAPIAvailabilityForResource(t *testing.T) {
 	tests := []struct {
 		name       string
 		statusCode int
@@ -153,14 +153,30 @@ func TestDetectPodSnapshotAvailability(t *testing.T) {
 			defer server.Close()
 
 			t.Log("Detect whether the exact PodSnapshot resource is available")
-			got, err := detectPodSnapshotAvailability(context.Background(), &rest.Config{Host: server.URL})
+			got, err := detectAPIAvailability(
+				context.Background(),
+				&rest.Config{Host: server.URL},
+				"nvidia.com",
+				"v1alpha1",
+				"podsnapshots",
+			)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("detectPodSnapshotAvailability() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("detectAPIAvailability() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if got != tt.want {
-				t.Errorf("detectPodSnapshotAvailability() = %v, want %v", got, tt.want)
+				t.Errorf("detectAPIAvailability() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDetectAPIAvailabilityRequiresVersionForResource(t *testing.T) {
+	available, err := detectAPIAvailability(context.Background(), &rest.Config{}, "nvidia.com", "", "podsnapshots")
+	if err == nil {
+		t.Fatal("detectAPIAvailability() error = nil, want resource version validation error")
+	}
+	if available {
+		t.Error("detectAPIAvailability() = true, want false")
 	}
 }
 

--- a/deploy/operator/internal/features/gates_test.go
+++ b/deploy/operator/internal/features/gates_test.go
@@ -8,9 +8,12 @@ package features
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 func TestDefaults(t *testing.T) {
@@ -97,6 +100,65 @@ func TestAPIGroupServesVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := apiGroupServesVersion(apiGroups, tt.groupName, tt.version); got != tt.want {
 				t.Fatalf("apiGroupServesVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectPodSnapshotAvailability(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name:       "API group version absent",
+			statusCode: http.StatusNotFound,
+			body:       `{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"NotFound","code":404}`,
+		},
+		{
+			name:       "PodSnapshot resource absent",
+			statusCode: http.StatusOK,
+			body:       `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"nvidia.com/v1alpha1","resources":[]}`,
+		},
+		{
+			name:       "PodSnapshot resource present",
+			statusCode: http.StatusOK,
+			body:       `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"nvidia.com/v1alpha1","resources":[{"name":"podsnapshots","singularName":"podsnapshot","namespaced":true,"kind":"PodSnapshot","verbs":["get","list","watch"]}]}`,
+			want:       true,
+		},
+		{
+			name:       "discovery error",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"InternalError","code":500}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Serve the scenario's API resource discovery response")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/apis/nvidia.com/v1alpha1" {
+					t.Errorf("discovery path = %q, want %q", r.URL.Path, "/apis/nvidia.com/v1alpha1")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				if _, err := w.Write([]byte(tt.body)); err != nil {
+					t.Errorf("write discovery response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			t.Log("Detect whether the exact PodSnapshot resource is available")
+			got, err := detectPodSnapshotAvailability(context.Background(), &rest.Config{Host: server.URL})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("detectPodSnapshotAvailability() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("detectPodSnapshotAvailability() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/deploy/operator/internal/testing/operatorenv/env.go
+++ b/deploy/operator/internal/testing/operatorenv/env.go
@@ -337,6 +337,11 @@ func (e *TestEnv) RESTConfig() *rest.Config {
 	return rest.CopyConfig(e.rt.config)
 }
 
+// Scheme returns the runtime scheme used by the envtest API server and its clients.
+func (e *TestEnv) Scheme() *k8sruntime.Scheme {
+	return e.rt.scheme
+}
+
 // AddUser provisions an authenticated envtest user and returns its REST configuration.
 // Authorization must be granted separately so it does not alter the admission identity.
 func (e *TestEnv) AddUser(user envtest.User) (*rest.Config, error) {

--- a/deploy/operator/internal/testing/operatorenv/env.go
+++ b/deploy/operator/internal/testing/operatorenv/env.go
@@ -470,6 +470,8 @@ func defaultOperatorConfig(in *configv1alpha1.OperatorConfiguration) *configv1al
 }
 
 func defaultRuntimeConfig(cfg *configv1alpha1.OperatorConfiguration) *commoncontroller.RuntimeConfig {
+	// Build config-derived defaults before the envtest API server exists. Tests that override
+	// dependency CRDs must resolve API-derived gates with features.New after creating a manager.
 	gate := features.Defaults()
 	gate.Checkpoint = cfg.Checkpoint.Enabled
 	gate.GPUDiscovery = cfg.Namespace.Restricted == "" || ptr.Deref(cfg.GPU.DiscoveryEnabled, true)

--- a/deploy/operator/internal/testing/operatorenv/scheme.go
+++ b/deploy/operator/internal/testing/operatorenv/scheme.go
@@ -10,6 +10,7 @@ import (
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	istioclientsetscheme "istio.io/client-go/pkg/clientset/versioned/scheme"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -38,6 +39,7 @@ func newScheme() *runtime.Scheme {
 	utilruntime.Must(nvidiacomv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(nvidiacomv1beta1.AddToScheme(scheme))
 	utilruntime.Must(grovev1alpha1.AddToScheme(scheme))
+	utilruntime.Must(snapshotv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(istioclientsetscheme.AddToScheme(scheme))
 	utilruntime.Must(lwsscheme.AddToScheme(scheme))

--- a/deploy/operator/internal/webhook/validation/shared_helpers.go
+++ b/deploy/operator/internal/webhook/validation/shared_helpers.go
@@ -155,7 +155,11 @@ func invalidVLLMDistributedExecutorBackendAnnotation(annotations map[string]stri
 // inferencePoolAvailabilityError checks the InferencePool API.
 // ctx and mgr must not be nil.
 func inferencePoolAvailabilityError(ctx context.Context, mgr ctrl.Manager) error {
-	if features.DetectInferencePoolAvailability(ctx, mgr) {
+	available, err := features.DetectInferencePoolAvailability(ctx, mgr)
+	if err != nil {
+		return fmt.Errorf("detect InferencePool API availability: %w", err)
+	}
+	if available {
 		return nil
 	}
 	return fmt.Errorf(


### PR DESCRIPTION
## Summary

- resolve the Checkpoint gate from `checkpoint.enabled` and exact `nvidia.com/v1alpha1/podsnapshots` availability
- skip Snapshot discovery entirely when checkpointing is disabled
- always register the DynamoCheckpoint reconciler for finalizer cleanup, but add its external PodSnapshot watch only when the resolved gate is enabled
- distinguish an absent API from discovery failures when checkpointing is explicitly enabled

## Findings

[PR #13177](https://github.com/ai-dynamo/dynamo/pull/13177) moved PodSnapshot ownership to the external Snapshot project but left the `Owns(PodSnapshot)` watch unconditional. Without the external CRD, controller-runtime times out synchronizing that source and terminates manager startup:

```text
failed to wait for dynamocheckpoint caches to sync kind source: *v1alpha1.PodSnapshot: timed out waiting for cache to be synced for kind source: *v1alpha1.PodSnapshot
```

Dynamo CRDs also serve `nvidia.com/v1alpha1`, so checking only the group/version is insufficient. The probe must verify the exact `podsnapshots` resource. [PR #13444](https://github.com/ai-dynamo/dynamo/pull/13444) is unrelated.

## Related Issues

- No linked issue. This fixes the startup regression introduced by [#13177](https://github.com/ai-dynamo/dynamo/pull/13177).

## Reviewer Guide

Start with:

1. `deploy/operator/internal/features/gates.go` for Checkpoint gate resolution and exact resource discovery
2. `deploy/operator/internal/controller/dynamocheckpoint_controller.go` for conditional PodSnapshot watch registration
3. `deploy/operator/internal/controller/setup_envtest_test.go` for startup and finalizer regression coverage

## Validation

- reproduced the pre-fix manager cache-sync timeout without the Snapshot CRD
- envtest: API absent and Checkpoint disabled starts without the external watch
- envtest: API present and Checkpoint disabled remains disabled
- envtest: API present and Checkpoint enabled registers the PodSnapshot watch
- envtest: API absent and Checkpoint explicitly enabled returns a clear gate-resolution error
- envtest: disabled controller removes a pre-existing DynamoCheckpoint finalizer and completes deletion
- unit coverage: absent group/version, absent resource, present resource, and discovery server error
- `make envtest`
- `go vet ./cmd ./internal/features ./internal/controller ./internal/testing/operatorenv`
- commit hooks, including DCO sign-off
