### PR TITLE
fix(operator): gate checkpoint controller setup

### DIFF
--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -700,7 +700,7 @@ func (r *CheckpointReconciler) FinalizeResource(ctx context.Context, ckpt *nvidi
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CheckpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&nvidiacomv1alpha1.DynamoCheckpoint{}).
 		Owns(&batchv1.Job{}, builder.WithPredicates(predicate.Funcs{
 			// Ignore creation - we don't need to reconcile when we just created the Job
@@ -708,8 +708,10 @@ func (r *CheckpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			DeleteFunc:  func(de event.DeleteEvent) bool { return true },
 			UpdateFunc:  func(ue event.UpdateEvent) bool { return true },
 			GenericFunc: func(ge event.GenericEvent) bool { return true },
-		})).
-		Owns(&snapshotv1alpha1.PodSnapshot{}, builder.WithPredicates(predicate.Funcs{
+		}))
+
+	if r.RuntimeConfig.Gate.Enabled(features.Checkpoint) {
+		ctrlBuilder = ctrlBuilder.Owns(&snapshotv1alpha1.PodSnapshot{}, builder.WithPredicates(predicate.Funcs{
 			// Ignore create (we just created it). Watch update (status mirror) and
 			// delete (re-enqueue to recreate / unblock). Delete is safe: reconcile
 			// exits at the deletion-timestamp guard before reaching observePodSnapshot.
@@ -717,8 +719,7 @@ func (r *CheckpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			DeleteFunc:  func(de event.DeleteEvent) bool { return true },
 			UpdateFunc:  func(ue event.UpdateEvent) bool { return true },
 			GenericFunc: func(ge event.GenericEvent) bool { return false },
-		})).
-		Watches(&corev1.Pod{},
+		})).Watches(&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(mapSourcePodToCheckpoint),
 			builder.WithPredicates(predicate.Funcs{
 				// Only checkpoint-source pods, and only their appearance: handleCreating waits solely
@@ -730,7 +731,10 @@ func (r *CheckpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				DeleteFunc:  func(de event.DeleteEvent) bool { return false },
 				GenericFunc: func(ge event.GenericEvent) bool { return false },
 			}),
-		).
+		)
+	}
+
+	return ctrlBuilder.
 		WithEventFilter(commonController.EphemeralDeploymentEventFilter(r.Config, r.RuntimeConfig)).
 		Complete(r)
 }

--- a/deploy/operator/internal/features/gates.go
+++ b/deploy/operator/internal/features/gates.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
@@ -34,7 +35,7 @@ const (
 	// GA since: N/A
 	// Configuration: checkpoint.enabled
 	// Auto-detection: N/A
-	// Requires: N/A
+	// Requires: Snapshot serving nvidia.com/v1alpha1
 	// Default: false
 	Checkpoint Name = "checkpoint"
 
@@ -163,7 +164,15 @@ func Defaults() Gates {
 // New detects cluster capabilities and resolves them with operator configuration.
 func New(ctx context.Context, mgr ctrl.Manager, config *configv1alpha1.OperatorConfiguration) (Gates, error) {
 	gates := Defaults()
-	gates.Checkpoint = config.Checkpoint.Enabled
+	if config.Checkpoint.Enabled {
+		var err error
+		if gates.Checkpoint, err = resolveCheckpoint(
+			config.Checkpoint.Enabled,
+			detectAPIGroup(ctx, mgr, snapshotv1alpha1.GroupVersion.Group, snapshotv1alpha1.GroupVersion.Version),
+		); err != nil {
+			return Gates{}, err
+		}
+	}
 	gates.GPUDiscovery = config.Namespace.Restricted == "" || ptr.Deref(config.GPU.DiscoveryEnabled, true)
 
 	var err error
@@ -230,6 +239,17 @@ func resolve(configured *bool, available bool, unavailableMessage string) (bool,
 	}
 	if !available {
 		return false, errors.New(unavailableMessage)
+	}
+	return true, nil
+}
+
+func resolveCheckpoint(enabled, snapshotAvailable bool) (bool, error) {
+	if !enabled {
+		return false, nil
+	}
+	if !snapshotAvailable {
+		return false, fmt.Errorf("checkpoint is enabled in config but the Snapshot API group %s/%s was not detected in the cluster",
+			snapshotv1alpha1.GroupVersion.Group, snapshotv1alpha1.GroupVersion.Version)
 	}
 	return true, nil
 }

--- a/deploy/operator/internal/features/gates_test.go
+++ b/deploy/operator/internal/features/gates_test.go
@@ -102,6 +102,32 @@ func TestAPIGroupServesVersion(t *testing.T) {
 	}
 }
 
+func TestResolveCheckpoint(t *testing.T) {
+	tests := []struct {
+		name              string
+		enabled           bool
+		snapshotAvailable bool
+		want              bool
+		wantErr           bool
+	}{
+		{name: "disabled does not require snapshot API", enabled: false, snapshotAvailable: false, want: false},
+		{name: "enabled with snapshot API is enabled", enabled: true, snapshotAvailable: true, want: true},
+		{name: "enabled without snapshot API fails", enabled: true, snapshotAvailable: false, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveCheckpoint(tt.enabled, tt.snapshotAvailable)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveCheckpoint() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveCheckpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGateContext(t *testing.T) {
 	want := Gates{Grove: true}
 	got, ok := GateFrom(WithGate(context.Background(), want))


### PR DESCRIPTION
## Summary
- Keep the DynamoCheckpoint reconciler registered so existing checkpoint finalizers can still be cleaned up.
- Gate only the Snapshot-dependent PodSnapshot/source-pod watches behind `checkpoint.enabled`.
- Fail fast during feature gate resolution when checkpointing is enabled without the external Snapshot API installed.

## Root Cause
The operator previously registered the DynamoCheckpoint controller unconditionally, and that controller always watched `PodSnapshot`. After snapshot moved to the external `github.com/ai-dynamo/snapshot` project, default deploy-test clusters without the snapshot CRD could crash the manager during cache sync and make admission/conversion webhooks unavailable.

## Where should the reviewer start?
Start with `deploy/operator/internal/controller/dynamocheckpoint_controller.go`, where the reconciler still watches DynamoCheckpoint and cleanup Jobs but only adds Snapshot-dependent watches when checkpointing is enabled. Then check `deploy/operator/internal/features/gates.go` for the explicit Snapshot API availability check.

## Related Issues
No linked issue. This was found while investigating deploy-test failures on PR #13091.

## Validation
- `go test ./internal/features` from `deploy/operator`
- `go test ./cmd` from `deploy/operator`
- `go test ./internal/controller` from `deploy/operator`