### PR TITLE
fix(operator): complete snapshot migration follow-up cleanup

### DIFF
--- a/.github/actions/build-deploy-component/action.yml
+++ b/.github/actions/build-deploy-component/action.yml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: 'Build Deploy Component'
-description: 'Build and push a deploy component container (operator, snapshot, or power-agent)'
+description: 'Build and push a deploy component container (operator, checkpoint-placeholder, or power-agent)'
 
 inputs:
   component:
-    description: 'Component to build: operator, snapshot, or power-agent'
+    description: 'Component to build: operator, checkpoint-placeholder, or power-agent'
     required: true
   image_tag:
     description: 'Image tag to apply to built images'
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ''
   target:
-    description: 'Dockerfile target to build. Defaults to agent for snapshot and the default target for operator.'
+    description: 'Dockerfile target to build. Defaults to the default target for each component.'
     required: false
     default: ''
   builder_name:
@@ -68,13 +68,13 @@ inputs:
       When 'true', build with ENABLE_SOURCE_ARCHIVAL=true and extract /sources/
       as a workflow artifact. Off by default — top-level callers opt in
       (post-merge-ci.yml sets true for push to main / release branches).
-      Applies to the inline-compliance components (operator, snapshot); no
-      effect for power-agent.
+      Applies to the inline-compliance component (operator); no effect for
+      checkpoint-placeholder or power-agent.
     required: false
     default: 'false'
   diff_event_context:
     description: |
-      OSRB CSV diff baseline context (operator + snapshot): pr | push | ''. Empty
+      OSRB CSV diff baseline context (operator): pr | push | ''. Empty
       skips baseline resolution and ships a baseline_unavailable diff. Selects
       the rule in container/compliance/resolve_diff_base.py.
     required: false
@@ -117,32 +117,21 @@ runs:
           echo "build_platforms=linux/amd64" >> $GITHUB_OUTPUT
         fi
         # Compliance /legal + /sboms are captured on a single platform: the
-        # operator's Go-only build is arch-invariant, and snapshot ships amd64
-        # only (cuda-checkpoint has no arm64 binary). Both baselines have an
-        # -amd64 variant.
+        # operator's Go-only build is arch-invariant.
         echo "compliance_platform=linux/amd64" >> $GITHUB_OUTPUT
         # Per-component inline-compliance baseline *stem* + whether to run the
         # inline license/SBOM stages. The licenses stage appends
         # -${TARGETARCH}.cdx.json to subtract each arch's own floor.
         #
         # run_compliance gates the extract/upload steps: it is true only for the
-        # shipped, /legal-bearing stage. The snapshot `placeholder` target is a
-        # restore image built FROM an arbitrary framework runtime (not
-        # cuda-dl-base) and carries no /legal, so it must NOT run compliance —
-        # only the default `agent` build does. power-agent has no baseline at all.
-        EFFECTIVE_TARGET="${{ inputs.target }}"
-        if [[ -z "${EFFECTIVE_TARGET}" && "${{ inputs.component }}" == "snapshot" ]]; then
-          EFFECTIVE_TARGET="agent"
-        fi
+        # shipped, /legal-bearing stage. checkpoint-placeholder and power-agent
+        # have no baseline.
         BASELINE_STEM=""
         RUN_COMPLIANCE=""
         case "${{ inputs.component }}" in
           operator)
             BASELINE_STEM="go@66dcc593"
             [[ -z "${{ inputs.target }}" ]] && RUN_COMPLIANCE="true" ;;
-          snapshot)
-            BASELINE_STEM="cuda-dl-base@8315e245"
-            [[ "${EFFECTIVE_TARGET}" == "agent" ]] && RUN_COMPLIANCE="true" ;;
         esac
         echo "baseline_stem=${BASELINE_STEM}" >> $GITHUB_OUTPUT
         echo "run_compliance=${RUN_COMPLIANCE}" >> $GITHUB_OUTPUT
@@ -186,9 +175,6 @@ runs:
         echo "flags for docker buildx: ${TAGGING_FLAGS}"
 
         TARGET="${{ inputs.target }}"
-        if [[ -z "${TARGET}" && "${{ inputs.component }}" == "snapshot" ]]; then
-          TARGET="agent"
-        fi
 
         TARGET_FLAG=""
         if [[ -n "${TARGET}" ]]; then
@@ -196,7 +182,7 @@ runs:
         fi
 
         BUILD_ARGS=("--build-arg" "DOCKER_PROXY=${ECR_REGISTRY}/dockerhub/")
-        # Inline-compliance build args (operator + snapshot). BASELINE_SBOM_FILE
+        # Inline-compliance build args (operator). BASELINE_SBOM_FILE
         # is the per-arch baseline *stem*; the licenses stage appends
         # -${TARGETARCH}.cdx.json to subtract each arch's own floor (mirrors
         # container/context.yaml). Empty stem (power-agent) → no compliance.
@@ -234,7 +220,7 @@ runs:
           echo "| \`${image_uri}\` |" >> $GITHUB_STEP_SUMMARY
         done
 
-    # Inline-compliance extraction (operator + snapshot). Reuses the warm BuildKit
+    # Inline-compliance extraction (operator). Reuses the warm BuildKit
     # cache from the push step above; compliance_artifact is FROM scratch so the
     # export is a few MB regardless of runtime image size.
     - name: Compliance extract
@@ -273,7 +259,7 @@ runs:
         mv /tmp/compliance/osrb-deps.csv "/tmp/compliance/osrb-${{ inputs.component }}-${ARCH}-${SHA8}.csv"
         mv /tmp/compliance/osrb.cdx.json "/tmp/compliance/osrb-${{ inputs.component }}-${ARCH}-${SHA8}.cdx.json"
 
-    # Inline-compliance OSRB diff (operator + snapshot). Resolves a baseline build,
+    # Inline-compliance OSRB diff (operator). Resolves a baseline build,
     # downloads its compliance artifact, and emits osrb-<component>-<arch>-<sha8>.diff.csv
     # next to the full CSV — the same resolve -> fetch -> diff flow the framework
     # images get from shared-build-image.yml + the compliance-extract action,
@@ -309,8 +295,8 @@ runs:
         fi
         CURRENT_VERSION=$(grep -m1 -E '^version[[:space:]]*=' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/' || true)
         # The compliance artifact is compliance-<image_tag>, and image_tag is
-        # <github.sha>-<suffix> (e.g. -operator, -snapshot-agent), so the baseline
-        # lookup targets compliance-<baseSHA>-<suffix>. Derive the suffix from
+        # <github.sha>-<suffix> (e.g. -operator), so the baseline lookup
+        # targets compliance-<baseSHA>-<suffix>. Derive the suffix from
         # image_tag by stripping the leading <sha>- (the SHA carries no dash).
         ARTIFACT_PREFIX="${IMAGE_TAG#*-}"
         python3 container/compliance/resolve_diff_base.py \
@@ -355,8 +341,8 @@ runs:
 
     # Emit osrb-<component>-<arch>-<sha8>.diff.csv next to the full CSV, plus a
     # self-describing baseline/ folder. Always runs so a diff (real or a
-    # baseline_unavailable marker) always ships. The operator + snapshot compliance
-    # artifacts are single-platform and flat, so both the current and baseline
+    # baseline_unavailable marker) always ships. The operator compliance
+    # artifact is single-platform and flat, so both the current and baseline
     # CSVs sit directly under their dest dirs (arch_dir ".").
     - name: Compute OSRB diff
       if: ${{ steps.settings.outputs.run_compliance == 'true' && always() }}

--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -470,6 +470,29 @@ runs:
       run: |
         echo "${DOCKERHUB_PASS}" | helm registry login registry-1.docker.io -u "${DOCKERHUB_USER}" --password-stdin
 
+    # The operator refuses to start when checkpoint is enabled unless the
+    # PodSnapshot API exists. Snapshot-agent (which owns that CRD) is installed
+    # in a later job, so apply the CRDs first and let that later job adopt them.
+    - name: Install snapshot CRDs for checkpoint
+      if: inputs.checkpoint_enabled == 'true'
+      shell: bash
+      env:
+        # Keep in lockstep with .github/actions/setup-snapshot-agent/action.yml.
+        SNAPSHOT_CHART_VERSION: 0.1.0-alpha.1
+      run: |
+        echo "::group::Install snapshot CRDs before operator start"
+        set -euo pipefail
+        VKUBECONFIG="${{ github.workspace }}/.kubeconfig-vcluster"
+        helm show crds oci://ghcr.io/ai-dynamo/snapshot/snapshot \
+          --version "${SNAPSHOT_CHART_VERSION}" \
+          | kubectl --kubeconfig="${VKUBECONFIG}" \
+              apply --server-side --force-conflicts --field-manager=ci-setup -f -
+        kubectl --kubeconfig="${VKUBECONFIG}" wait --for=condition=established \
+          crd/podsnapshots.nvidia.com \
+          crd/podsnapshotcontents.nvidia.com \
+          --timeout=120s
+        echo "::endgroup::"
+
     - name: Install Dynamo platform via Helm
       shell: bash
       env:

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -215,8 +215,9 @@ snapshot:
   # Where the pinned github.com/ai-dynamo/snapshot chart version/values live --
   # a version bump or install-config change must trigger the deploy-snapshot-
   # agent-checkpoint-*/deploy-test-checkpoint-* jobs, not just 'operator'.
+  # Chart.lock is gitignored (never appears in a PR diff) and so is
+  # intentionally not listed here.
   - 'deploy/helm/charts/platform/Chart.yaml'
-  - 'deploy/helm/charts/platform/Chart.lock'
   - 'deploy/helm/charts/platform/values.yaml'
 
 # Framework-local snapshot lifecycle files, plus TRT-LLM's unit test. These gate
@@ -244,9 +245,6 @@ deploy:
   - 'deploy/helm/**'
   - 'deploy/utils/**'
   - 'deploy/checkpoint-placeholder/**'
-  # Nothing exists here anymore; kept so the coverage check below still
-  # classifies deletions under this now-defunct path.
-  - 'deploy/snapshot/**'
   - 'tests/deploy/**'
   # Standalone CRD apiVersion converter: not used by the deploy-test harness and
   # has no CI test wiring, so it should not trigger the operator deploy pipeline.

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -330,8 +330,8 @@ jobs:
     secrets: inherit
 
   # ============================================================================
-  # OPTIONAL NIGHTLY IMAGES (operator, planner, frontend, snapshot agent,
-  # runtime EFA variants)
+  # OPTIONAL NIGHTLY IMAGES (operator, planner, frontend, runtime EFA
+  # variants)
   # ============================================================================
   # Built HERE — not reused from post-merge — for two reasons:
   #   1. OSRB from the get-go: GitLab's nvbug:attach-compliance resolves
@@ -1029,8 +1029,8 @@ jobs:
     # strictly: release.yml copies their -nightly ECR images to NGC and extracts
     # wheels from the dynamo-pipeline image, so a failed build must not publish a
     # partial release. manual-release-approval is `skipped` on cron, `success` on dispatch.
-    # The optional-image builds (operator, planner, frontend, snapshot agent,
-    # EFA variants) are ORDERING-ONLY needs (deliberately absent from the
+    # The optional-image builds (operator, planner, frontend, EFA variants)
+    # are ORDERING-ONLY needs (deliberately absent from the
     # gate below): release.yml copies them fail-soft, so a flake in any of
     # them must not block the runtime nightly — but the copy step has to run
     # after they finish or the crane probe would race the builds.

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -36,7 +36,6 @@ jobs:
       api_docs: ${{ steps.changes.outputs.api_docs }}
       fern_components: ${{ steps.changes.outputs.fern_components }}
       operator: ${{ steps.changes.outputs.operator }}
-      snapshot: ${{ steps.changes.outputs.snapshot }}
       rust: ${{ steps.changes.outputs.rust }}
     steps:
       - name: Checkout code

--- a/container/compliance/collect_sources.py
+++ b/container/compliance/collect_sources.py
@@ -25,8 +25,8 @@ Per-ecosystem strategy (matches the plan in
            subset and tars it.
 
   go       go mod vendor per Go module. For the dynamo runtime
-           templates this is empty (no Go binaries); operator /
-           snapshot-agent / EPP have it.
+           templates this is empty (no Go binaries); operator / EPP
+           have it.
 
   native   preserve source tarballs for from-source components
            (criu, ucx, libfabric, ffmpeg, gdrcopy, NIXL, etc.).

--- a/container/compliance/generators/go.py
+++ b/container/compliance/generators/go.py
@@ -3,7 +3,7 @@
 """NOTICES-Go.txt generator.
 
 Reads CycloneDX SBOMs produced by `cyclonedx-gomod app -licenses -json` in
-each Go builder stage (operator/snapshot-agent/EPP). Same shape as rust.py:
+each Go builder stage (operator/EPP). Same shape as rust.py:
 walk components, filter by purl prefix, normalize licenses, dedupe.
 
 Expected upstream Dockerfile pattern (in each Go builder):

--- a/deploy/helm/charts/platform/components/operator/templates/manager-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/manager-rbac.yaml
@@ -136,7 +136,6 @@ rules:
   - dynamographdeploymentrequests/finalizers
   - dynamographdeployments/finalizers
   - dynamomodels/finalizers
-  - podsnapshots/finalizers
   verbs:
   - update
 - apiGroups:
@@ -148,7 +147,6 @@ rules:
   - dynamographdeployments/status
   - dynamographdeploymentscalingadapters/status
   - dynamomodels/status
-  - podsnapshots/status
   verbs:
   - get
   - patch
@@ -337,57 +335,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-deviceclass-reader
-subjects:
-- kind: ServiceAccount
-  name: '{{ include "dynamo-operator.fullname" . }}-controller-manager'
-  namespace: '{{ .Release.Namespace }}'
----
-# Helm keeps PodSnapshotContent access separate because a namespace-restricted Role cannot grant it.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-podsnapshotcontents
-  labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: dynamo-operator
-    app.kubernetes.io/part-of: dynamo-operator
-  {{- include "dynamo-operator.labels" . | nindent 4 }}
-rules:
-- apiGroups:
-  - nvidia.com
-  resources:
-  - podsnapshotcontents
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - nvidia.com
-  resources:
-  - podsnapshotcontents/status
-  verbs:
-  - get
-  - patch
-  - update
----
-# Helm binds the separate cluster-scoped PodSnapshotContent grant to the controller ServiceAccount.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-podsnapshotcontents-binding
-  labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: dynamo-operator
-    app.kubernetes.io/part-of: dynamo-operator
-  {{- include "dynamo-operator.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-podsnapshotcontents
 subjects:
 - kind: ServiceAccount
   name: '{{ include "dynamo-operator.fullname" . }}-controller-manager'

--- a/deploy/operator/internal/checkpointjob/doc.go
+++ b/deploy/operator/internal/checkpointjob/doc.go
@@ -9,7 +9,4 @@
 // package, which is Go-internal and so not importable from Dynamo. It is now
 // Dynamo-owned: there is no upstream source of truth for it, and fixes made
 // in the Snapshot repo's own copy do not flow here automatically.
-// github.com/ai-dynamo/snapshot's SnapshotJob CRD (tracked there as
-// RUN-39806) is the planned long-term replacement for this package once it
-// ships.
 package checkpointjob

--- a/deploy/operator/internal/controller/checkpoint_podsnapshot_test.go
+++ b/deploy/operator/internal/controller/checkpoint_podsnapshot_test.go
@@ -143,7 +143,7 @@ func foreignPodSnapshot(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) *snapshotv1alp
 			Labels:    map[string]string{consts.SnapshotOwnerLabel: ckpt.Name},
 		},
 		Spec: snapshotv1alpha1.PodSnapshotSpec{
-			Source: snapshotv1alpha1.PodSnapshotSource{PodRef: snapshotv1alpha1.PodReference{Name: "someone-else"}},
+			Source: snapshotv1alpha1.PodSnapshotSource{PodRef: snapshotv1alpha1.PodReference{Name: "someone-else", Containers: []string{"main"}}},
 		},
 	}
 }

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -339,6 +339,15 @@ func (r *CheckpointReconciler) failPendingCheckpoint(
 }
 
 func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (ctrl.Result, error) {
+	if !r.RuntimeConfig.Gate.Enabled(features.Checkpoint) {
+		if ckpt.Status.Message == checkpointDisabledMessage {
+			return ctrl.Result{}, nil
+		}
+		ckpt.Status.Message = checkpointDisabledMessage
+		r.Recorder.Eventf(ckpt, nil, corev1.EventTypeWarning, "CheckpointDisabled", "Validate", checkpointDisabledMessage)
+		return ctrl.Result{}, r.Status().Update(ctx, ckpt)
+	}
+
 	if ckpt.Status.JobName == "" {
 		ckpt.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhasePending
 		ckpt.Status.Message = "checkpoint job is missing from status"
@@ -377,14 +386,6 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 		// not the source pod has appeared (k8s sets JobFailed/DeadlineExceeded on unschedulable Jobs).
 		if failed, message := checkpointJobFailed(job); failed {
 			return r.failCreating(ctx, ckpt, "JobFailed", message)
-		}
-		if !r.RuntimeConfig.Gate.Enabled(features.Checkpoint) {
-			if ckpt.Status.Message == checkpointDisabledMessage {
-				return ctrl.Result{}, nil
-			}
-			ckpt.Status.Message = checkpointDisabledMessage
-			r.Recorder.Eventf(ckpt, nil, corev1.EventTypeWarning, "CheckpointDisabled", "Validate", checkpointDisabledMessage)
-			return ctrl.Result{}, r.Status().Update(ctx, ckpt)
 		}
 
 		pod, perr := r.findSourcePod(ctx, job)

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -33,6 +33,7 @@ import (
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -662,19 +663,96 @@ func TestCheckpointReconciler_Reconcile(t *testing.T) {
 		assert.Empty(t, jobs.Items)
 	})
 
-	t.Run("disabled checkpoint gate does not block deletion", func(t *testing.T) {
-		ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhasePending)
-		ckpt.DeletionTimestamp = ptr.To(metav1.Now())
-		commonController.AddFinalizer(ckpt)
-		r := makeCheckpointReconciler(s, ckpt)
+	t.Run("Creating checkpoint is paused without the PodSnapshot API when checkpoint gate is disabled", func(t *testing.T) {
+		t.Log("Create a fake client whose scheme intentionally omits the external snapshot API")
+		schemeWithoutSnapshot := runtime.NewScheme()
+		require.NoError(t, nvidiacomv1alpha1.AddToScheme(schemeWithoutSnapshot))
+		require.NoError(t, batchv1.AddToScheme(schemeWithoutSnapshot))
+		ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhaseCreating)
+		ckpt.Status.JobName = defaultCheckpointJobName
+		r := makeCheckpointReconciler(schemeWithoutSnapshot, ckpt)
 		r.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{}}
 
+		t.Log("Reconcile the Creating checkpoint with no checkpoint Job present")
 		result, err := r.Reconcile(ctx, ctrl.Request{
 			NamespacedName: types.NamespacedName{Name: ckpt.Name, Namespace: testNamespace},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, ctrl.Result{}, result)
 
+		t.Log("Verify reconciliation paused before accessing PodSnapshot resources")
+		updated := &nvidiacomv1alpha1.DynamoCheckpoint{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: ckpt.Name, Namespace: testNamespace}, updated))
+		assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseCreating, updated.Status.Phase)
+		assert.Equal(t, checkpointDisabledMessage, updated.Status.Message)
+	})
+
+	t.Run("disabled checkpoint gate completes automatic checkpoint cleanup before deletion", func(t *testing.T) {
+		t.Log("Create an automatic checkpoint, snapshot-agent storage, and a completed cleanup Job")
+		cfg := &configv1alpha1.OperatorConfiguration{}
+		snapshotAgent := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-agent",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					snapshotprotocol.SnapshotAgentLabelKey: snapshotprotocol.SnapshotAgentLabelValue,
+				},
+			},
+			Spec: appsv1.DaemonSetSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: snapshotprotocol.SnapshotAgentContainerName,
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      snapshotprotocol.SnapshotAgentVolumeName,
+								MountPath: "/checkpoints",
+							}},
+						}},
+						Volumes: []corev1.Volume{{
+							Name: snapshotprotocol.SnapshotAgentVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "snapshot-pvc",
+								},
+							},
+						}},
+					},
+				},
+			},
+		}
+		ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhaseReady)
+		ckpt.UID = types.UID("ckpt-uid")
+		ckpt.Annotations = map[string]string{
+			consts.CheckpointAutoAnnotation: consts.KubeLabelValueTrue,
+		}
+		ckpt.DeletionTimestamp = ptr.To(metav1.Now())
+		commonController.AddFinalizer(ckpt)
+		job, err := buildCheckpointCleanupJob(cfg, ckpt, testHash, snapshotprotocol.Storage{
+			Type:     snapshotprotocol.StorageTypePVC,
+			PVCName:  "snapshot-pvc",
+			BasePath: "/checkpoints",
+		})
+		require.NoError(t, err)
+		job.Status.Conditions = []batchv1.JobCondition{{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+		}}
+		require.NoError(t, appsv1.AddToScheme(s))
+		r := makeCheckpointReconciler(s, ckpt, job, snapshotAgent)
+		r.Config = cfg
+		r.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{}}
+
+		t.Log("Reconcile deletion while the checkpoint gate is disabled")
+		result, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: ckpt.Name, Namespace: testNamespace},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		t.Log("Verify artifact cleanup completed before the checkpoint finalizer was removed")
+		currentJob := &batchv1.Job{}
+		err = r.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, currentJob)
+		require.True(t, apierrors.IsNotFound(err), "expected completed cleanup job to be removed, got %v", err)
 		updated := &nvidiacomv1alpha1.DynamoCheckpoint{}
 		err = r.Get(ctx, types.NamespacedName{Name: ckpt.Name, Namespace: testNamespace}, updated)
 		if !apierrors.IsNotFound(err) {
@@ -991,7 +1069,6 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 		snap := ownedSnapshot(ckpt, snapshotv1alpha1.PodSnapshotConditionReady)
 
 		r := makeCheckpointReconciler(s, ckpt, job, snap, newOwnedPod(podNameFromJob(job.Name), job))
-		r.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{}}
 		_, err := r.handleCreating(ctx, ckpt)
 		require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Follow-up to #13177 that completes the remaining Snapshot migration cleanup.

- Remove dead Snapshot component build, compliance, CI filter, and workflow paths.
- Remove unused PodSnapshot status/finalizer and PodSnapshotContent RBAC.
- Remove stale Snapshot replacement notes from the checkpoint job package.
- Fix the external PodSnapshot test fixture to satisfy its `containers` validation.
- Stop `Creating` DynamoCheckpoint reconciliation before any PodSnapshot API access when the Checkpoint gate is disabled, while keeping deletion and finalizer cleanup reachable.

This branch is rebased on:

- #13448, which always registers the DynamoCheckpoint controller and conditionally adds the external PodSnapshot watch.
- #13444, which regenerated the Kustomize OpenAPI schema after the PodSnapshot CRDs moved out of this repository.

## Validation

- `go test ./internal/controller -run '^(TestCheckpointReconciler_Reconcile|TestCheckpointReconciler_HandleCreating|TestCheckpointReconciler_FinalizeResourceCleansRetainedAutoCheckpointOnCRDelete)$' -count=1`
- `KUBEBUILDER_ASSETS=<envtest-assets> go test ./internal/controller -count=1`
- `KUBEBUILDER_ASSETS=<envtest-assets> go test $(go list ./... | grep -vE '/(e2e|test|cmd)($|/)') -count=1`
- `git diff --check origin/main...HEAD`

## Review notes

Start with:

- `deploy/operator/internal/controller/dynamocheckpoint_controller.go`
- `deploy/operator/internal/controller/dynamocheckpoint_controller_test.go`
- `.github/actions/build-deploy-component/action.yml`
- `deploy/helm/charts/platform/components/operator/templates/manager-rbac.yaml`

The generated recipe OpenAPI file and the unrelated `consts.go` comment edits are no longer part of this PR.

## Related

- Follow-up to #13177
- Incorporates the merged fixes from #13444 and #13448 through the rebase
