### PR TITLE
fix(operator): pause checkpoint reconciliation when disabled

### DIFF
--- a/deploy/operator/internal/controller/checkpoint_coverage_test.go
+++ b/deploy/operator/internal/controller/checkpoint_coverage_test.go
@@ -327,6 +327,33 @@ func TestCheckpointReconcilePreservesLegacyReadyJob(t *testing.T) {
 	}
 }
 
+func TestCheckpointReconcileCleansTerminalJobWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	t.Log("Create a failed checkpoint with a retained owned Job")
+	ckpt := newOwnedCheckpoint()
+	ckpt.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhaseFailed
+	ckpt.Status.JobName = defaultCheckpointJobName
+	ckpt.Status.Message = "capture failed"
+	job := healthyCheckpointJob(defaultCheckpointJobName)
+	setCheckpointJobOwner(ckpt, job)
+	reconciler := makeCheckpointReconciler(checkpointTestScheme(), ckpt, job)
+	reconciler.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{}}
+
+	t.Log("Reconcile while the Checkpoint gate is disabled")
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(ckpt)})
+	require.NoError(t, err)
+
+	t.Log("Observe the retained Job deleted without changing the terminal checkpoint message")
+	storedJob := &batchv1.Job{}
+	err = reconciler.Get(ctx, client.ObjectKeyFromObject(job), storedJob)
+	require.True(t, apierrors.IsNotFound(err), "retained terminal Job still exists: %v", err)
+	storedCheckpoint := &nvidiacomv1alpha1.DynamoCheckpoint{}
+	require.NoError(t, reconciler.Get(ctx, client.ObjectKeyFromObject(ckpt), storedCheckpoint))
+	assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseFailed, storedCheckpoint.Status.Phase)
+	assert.Equal(t, "capture failed", storedCheckpoint.Status.Message)
+}
+
 func TestCheckpointTerminalStatusIsDurableBeforeJobCleanup(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -121,6 +121,13 @@ func (r *CheckpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	// Retry terminal Job cleanup before parking checkpoints while the feature is disabled.
+	if isTerminalCheckpointPhase(ckpt.Status.Phase) && ckpt.Status.JobName != "" {
+		if err := r.cleanupTerminalCheckpointJob(ctx, ckpt); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Report active checkpoints as disabled before accessing the external API.
 	if !r.RuntimeConfig.Gate.Enabled(features.Checkpoint) {
 		switch ckpt.Status.Phase {
@@ -152,15 +159,6 @@ func (r *CheckpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, err
 		}
 		if err := r.Get(ctx, req.NamespacedName, ckpt); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
-	// A Failed phase, or Ready with the new success proof, is the durable record that permits
-	// deleting its Job. Do this before duplicate or artifact-version normalization can discard the
-	// retained Job reference.
-	if isTerminalCheckpointPhase(ckpt.Status.Phase) && ckpt.Status.JobName != "" {
-		if err := r.cleanupTerminalCheckpointJob(ctx, ckpt); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -51,7 +51,7 @@ import (
 	snapshotv1alpha1 "github.com/ai-dynamo/snapshot/api/v1alpha1"
 )
 
-const checkpointDisabledMessage = "checkpoint functionality is disabled in the operator configuration"
+const checkpointDisabledMessage = "checkpoint functionality is unavailable; verify that it is enabled in the operator configuration and the PodSnapshot API is installed"
 
 var errCheckpointCleanupPending = errors.New("checkpoint cleanup pending")
 
@@ -117,6 +117,22 @@ func (r *CheckpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				logger.Error(err, "Failed to remove finalizer")
 				return ctrl.Result{}, err
 			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Report active checkpoints as disabled before accessing the external API.
+	if !r.RuntimeConfig.Gate.Enabled(features.Checkpoint) {
+		switch ckpt.Status.Phase {
+		case "", nvidiacomv1alpha1.DynamoCheckpointPhasePending, nvidiacomv1alpha1.DynamoCheckpointPhaseCreating:
+			if ckpt.Status.Message == checkpointDisabledMessage {
+				return ctrl.Result{}, nil
+			}
+			ckpt.Status.Message = checkpointDisabledMessage
+			if err := r.Status().Update(ctx, ckpt); err != nil {
+				return ctrl.Result{}, err
+			}
+			r.Recorder.Eventf(ckpt, nil, corev1.EventTypeWarning, "CheckpointDisabled", "Validate", checkpointDisabledMessage)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -231,14 +247,6 @@ func (r *CheckpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *CheckpointReconciler) handlePending(ctx context.Context, ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	if !r.RuntimeConfig.Gate.Enabled(features.Checkpoint) {
-		if ckpt.Status.Message == checkpointDisabledMessage {
-			return ctrl.Result{}, nil
-		}
-		ckpt.Status.Message = checkpointDisabledMessage
-		r.Recorder.Eventf(ckpt, nil, corev1.EventTypeWarning, "CheckpointDisabled", "Validate", checkpointDisabledMessage)
-		return ctrl.Result{}, r.Status().Update(ctx, ckpt)
-	}
 	if err := checkpoint.ValidatePreparedGPUMemoryServicePodTemplate(ckpt); err != nil {
 		return r.failPendingCheckpoint(ctx, ckpt, "GMSPodTemplateNotPrepared", err)
 	}
@@ -378,15 +386,6 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 		if failed, message := checkpointJobFailed(job); failed {
 			return r.failCreating(ctx, ckpt, "JobFailed", message)
 		}
-		if !r.RuntimeConfig.Gate.Enabled(features.Checkpoint) {
-			if ckpt.Status.Message == checkpointDisabledMessage {
-				return ctrl.Result{}, nil
-			}
-			ckpt.Status.Message = checkpointDisabledMessage
-			r.Recorder.Eventf(ckpt, nil, corev1.EventTypeWarning, "CheckpointDisabled", "Validate", checkpointDisabledMessage)
-			return ctrl.Result{}, r.Status().Update(ctx, ckpt)
-		}
-
 		pod, perr := r.findSourcePod(ctx, job)
 		if perr != nil {
 			if client.IgnoreNotFound(perr) == nil {

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -655,7 +655,7 @@ func TestCheckpointReconciler_Reconcile(t *testing.T) {
 		updated := &nvidiacomv1alpha1.DynamoCheckpoint{}
 		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: ckpt.Name, Namespace: testNamespace}, updated))
 		assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhasePending, updated.Status.Phase)
-		assert.Contains(t, updated.Status.Message, "checkpoint functionality is disabled")
+		assert.Equal(t, checkpointDisabledMessage, updated.Status.Message)
 
 		jobs := &batchv1.JobList{}
 		require.NoError(t, r.List(ctx, jobs, client.InNamespace(testNamespace)))
@@ -939,7 +939,9 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 		r := makeCheckpointReconciler(s, ckpt, job, newOwnedPod("worker-0", job))
 		r.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{}}
 
-		_, err := r.handleCreating(ctx, ckpt)
+		_, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: ckpt.Name, Namespace: testNamespace},
+		})
 		require.NoError(t, err)
 
 		var snaps snapshotv1alpha1.PodSnapshotList

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -939,6 +939,7 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 		r := makeCheckpointReconciler(s, ckpt, job, newOwnedPod("worker-0", job))
 		r.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{}}
 
+		t.Log("Reconcile the Creating checkpoint with the Checkpoint gate disabled")
 		_, err := r.Reconcile(ctx, ctrl.Request{
 			NamespacedName: types.NamespacedName{Name: ckpt.Name, Namespace: testNamespace},
 		})

--- a/deploy/operator/internal/controller/setup_envtest_test.go
+++ b/deploy/operator/internal/controller/setup_envtest_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -183,5 +185,89 @@ func TestSetupDynamoCheckpointWithSnapshotAPIAvailability(t *testing.T) {
 				t.Fatalf("stop manager: %v", err)
 			}
 		})
+	}
+}
+
+func TestDisabledCheckpointReconcileWithoutSnapshotAPI(t *testing.T) {
+	t.Log("Start an API server without the PodSnapshot CRD")
+	testEnv := operatorenv.New(operatorenv.Options{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		Config: &configv1alpha1.OperatorConfiguration{
+			Checkpoint: configv1alpha1.CheckpointConfiguration{Enabled: false},
+		},
+		SetupWebhooks: func(ctrl.Manager, operatorenv.WebhookSetupOptions) error {
+			return nil
+		},
+	}).RunT(t)
+
+	t.Log("Create an existing checkpoint in the Creating phase")
+	checkpoint := &nvidiacomv1alpha1.DynamoCheckpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: "creating-checkpoint", Namespace: testEnv.Namespace()},
+		Spec: nvidiacomv1alpha1.DynamoCheckpointSpec{
+			Identity: nvidiacomv1alpha1.DynamoCheckpointIdentity{
+				Model: "test-model", BackendFramework: "vllm",
+			},
+			Job: nvidiacomv1alpha1.DynamoCheckpointJobConfig{
+				PodTemplateSpec: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "test"}}},
+				},
+			},
+		},
+	}
+	if err := testEnv.Client().Create(context.Background(), checkpoint); err != nil {
+		t.Fatalf("create checkpoint: %v", err)
+	}
+	checkpoint.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhaseCreating
+	checkpoint.Status.JobName = "checkpoint-job"
+	if err := testEnv.Client().Status().Update(context.Background(), checkpoint); err != nil {
+		t.Fatalf("set checkpoint status: %v", err)
+	}
+
+	t.Log("Reconcile with the Checkpoint gate disabled")
+	recorder := events.NewFakeRecorder(1)
+	reconciler := &CheckpointReconciler{
+		Client:        testEnv.Client(),
+		Config:        testEnv.OperatorConfig(),
+		RuntimeConfig: testEnv.RuntimeConfig(),
+		Recorder:      recorder,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(checkpoint),
+	})
+	if err != nil {
+		t.Fatalf("disabled reconcile accessed the unavailable PodSnapshot API: %v", err)
+	}
+
+	t.Log("Observe the disabled status and warning event")
+	stored := &nvidiacomv1alpha1.DynamoCheckpoint{}
+	if err := testEnv.Client().Get(context.Background(), client.ObjectKeyFromObject(checkpoint), stored); err != nil {
+		t.Fatalf("get reconciled checkpoint: %v", err)
+	}
+	if stored.Status.Phase != nvidiacomv1alpha1.DynamoCheckpointPhaseCreating {
+		t.Fatalf("checkpoint phase = %q, want %q", stored.Status.Phase, nvidiacomv1alpha1.DynamoCheckpointPhaseCreating)
+	}
+	if stored.Status.Message != checkpointDisabledMessage {
+		t.Fatalf("checkpoint message = %q, want %q", stored.Status.Message, checkpointDisabledMessage)
+	}
+	select {
+	case event := <-recorder.Events:
+		if !strings.Contains(event, "CheckpointDisabled") {
+			t.Fatalf("event = %q, want CheckpointDisabled warning", event)
+		}
+	default:
+		t.Fatal("CheckpointDisabled warning event was not emitted")
+	}
+
+	t.Log("Reconcile the disabled checkpoint again without emitting a duplicate event")
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(checkpoint),
+	})
+	if err != nil {
+		t.Fatalf("repeat disabled reconcile: %v", err)
+	}
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("repeat reconcile emitted duplicate event %q", event)
+	default:
 	}
 }


### PR DESCRIPTION
## Summary

- stop active DynamoCheckpoint reconciliation before accessing the PodSnapshot API when the Checkpoint feature gate is disabled
- preserve finalizer cleanup and terminal checkpoint status
- report an actionable disabled status and emit the warning event only once
- add envtest coverage for an existing Creating checkpoint when the PodSnapshot CRD is absent

Follow-up to https://github.com/ai-dynamo/dynamo/pull/13448#discussion_r3803365209

## Validation

- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use 1.30.0 --bin-dir /Users/carlory/.herdr/worktrees/dynamo/fix-checkpoint-disabled-reconcile/deploy/operator/bin -p path)" go test ./internal/controller -count=1`
- focused regression tests for disabled Pending and Creating checkpoints
- pre-commit hooks
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when checkpoint functionality is disabled.
  * Reconciliation now reports that checkpointing is unavailable and may require configuration or PodSnapshot API installation.
  * Checkpoint resources retain their current phase while receiving a clear status message.
  * Added a warning event without making external API calls or emitting duplicates on repeated reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->