### PR TITLE
feat(planner): request transactionally admitted replicas (5/6)

### DIFF
--- a/components/src/dynamo/planner/connectors/base.py
+++ b/components/src/dynamo/planner/connectors/base.py
@@ -11,7 +11,15 @@ capability discovery, and replica-state introspection for one deployment mode.
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Optional, Protocol, TypeGuard, runtime_checkable
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Mapping,
+    Optional,
+    Protocol,
+    TypeGuard,
+    runtime_checkable,
+)
 
 from dynamo.planner.config.defaults import SubComponentType, TargetReplica
 from dynamo.planner.monitoring.worker_info import WorkerInfo
@@ -150,6 +158,65 @@ class PowerAwareConnector(Protocol):
         ...
 
 
+@dataclass(frozen=True)
+class DynamoGraphPowerBudgetComponentSnapshot:
+    """One bounded component row from a DGPB status snapshot."""
+
+    name: str
+    ready_replicas: int
+    committed_replicas: int
+    updated_replicas: int
+    terminating_replicas: int
+
+    @property
+    def settled(self) -> bool:
+        """Whether committed, updated, and serving inventory has converged."""
+
+        return (
+            self.committed_replicas == self.updated_replicas == self.ready_replicas
+            and self.terminating_replicas == 0
+        )
+
+
+@dataclass(frozen=True)
+class DynamoGraphPowerBudgetSnapshot:
+    """Read-only operator-owned policy and aggregate inventory for one tick."""
+
+    budget_watts: int
+    min_endpoint: int
+    phase: str
+    inventory_epoch: int
+    rollout_in_progress: bool
+    components: tuple[DynamoGraphPowerBudgetComponentSnapshot, ...]
+    conditions: tuple[Mapping[str, object], ...]
+
+    def ready_replicas(self, component_name: str) -> int:
+        """Return the ready count for ``component_name`` from this snapshot."""
+
+        for component in self.components:
+            if component.name == component_name:
+                return component.ready_replicas
+        raise KeyError(component_name)
+
+
+@runtime_checkable
+class TransactionalPowerAwareConnector(Protocol):
+    """Optional cached DGPB observation capability for transactional power mode.
+
+    ``get_power_budget_snapshot`` never performs API I/O. The Kubernetes
+    connector refreshes the cache while collecting worker counts, and the
+    orchestrator consumes it once the current planning tick has observed it.
+    """
+
+    def get_power_budget_snapshot(
+        self,
+    ) -> Optional[DynamoGraphPowerBudgetSnapshot]:
+        ...
+
+    def consume_power_budget_snapshot(self) -> None:
+        ...
+
+
 _POWER_AWARE_REQUIRED: tuple[str, ...] = (
     "get_graph_deployment",
     "get_component_power_configs",
@@ -173,9 +240,24 @@ def is_power_aware_connector(obj: object) -> TypeGuard[PowerAwareConnector]:
     )
 
 
+def is_transactional_power_aware_connector(
+    obj: object,
+) -> TypeGuard[TransactionalPowerAwareConnector]:
+    """Return True when ``obj`` exposes the cached DGPB observation boundary."""
+
+    return all(
+        callable(inspect.getattr_static(obj, name, None))
+        for name in ("get_power_budget_snapshot", "consume_power_budget_snapshot")
+    )
+
+
 __all__ = [
+    "DynamoGraphPowerBudgetComponentSnapshot",
+    "DynamoGraphPowerBudgetSnapshot",
     "PlannerConnector",
     "PowerAwareConnector",
+    "TransactionalPowerAwareConnector",
     "WorkerInfoProvider",
     "is_power_aware_connector",
+    "is_transactional_power_aware_connector",
 ]

--- a/components/src/dynamo/planner/connectors/clients/kubernetes_api.py
+++ b/components/src/dynamo/planner/connectors/clients/kubernetes_api.py
@@ -39,6 +39,7 @@ DYNAMO_API_VERSION = "v1beta1"
 DYNAMO_WORKER_METADATA_API_VERSION = "v1alpha1"
 DGD_PLURAL = "dynamographdeployments"
 DGDSA_PLURAL = "dynamographdeploymentscalingadapters"
+DGPB_PLURAL = "dynamographpowerbudgets"
 # During a rollout old Pods are still active and carry the previous cap, so
 # progressing phases must block pod-annotation settlement.
 # Failed is terminal (the operator sets endTime) and must NOT be treated as a
@@ -116,12 +117,35 @@ class KubernetesAPI:
                 )
             raise
 
+    def get_graph_power_budget(self, graph_deployment_name: str) -> Optional[dict]:
+        """Read the operator-owned DGPB for a graph, or ``None`` on 404."""
+
+        try:
+            return self.custom_api.get_namespaced_custom_object(
+                group=NVIDIA_API_GROUP,
+                version=DYNAMO_API_VERSION,
+                namespace=self.current_namespace,
+                plural=DGPB_PLURAL,
+                name=graph_deployment_name,
+            )
+        except client.ApiException as exc:
+            if exc.status == 404:
+                return None
+            raise
+
     def update_service_replicas(
-        self, graph_deployment_name: str, service_name: str, replicas: int
+        self,
+        graph_deployment_name: str,
+        service_name: str,
+        replicas: int,
+        *,
+        transactional: bool = False,
     ) -> None:
         """
         Update replicas for a component using Scale subresource when DGDSA exists.
-        Falls back to a direct DGD patch when the component does not have a DGDSA.
+        Falls back to a direct DGD patch when the component does not have a
+        DGDSA, except in transactional mode where DGDSA is the only request
+        ingress and a 404 is returned to the caller.
 
         Args:
             graph_deployment_name: Name of the DynamoGraphDeployment
@@ -144,7 +168,7 @@ class KubernetesAPI:
             logger.info(f"Scaled DGDSA {adapter_name} to {replicas} replicas")
 
         except client.ApiException as e:
-            if e.status == 404:
+            if e.status == 404 and not transactional:
                 # DGDSA doesn't exist - fall back to a direct DGD patch.
                 logger.info(
                     f"DGDSA {adapter_name} not found, falling back to DGD update"
@@ -247,7 +271,10 @@ class KubernetesAPI:
         )
 
     def update_graph_replicas(
-        self, graph_deployment_name: str, component_name: str, replicas: int
+        self,
+        graph_deployment_name: str,
+        component_name: str,
+        replicas: int,
     ) -> None:
         """
         Update replicas for a component. Now uses DGDSA when available.

--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -20,7 +20,11 @@ import os
 from typing import Optional
 
 from dynamo.planner.config.defaults import SubComponentType, TargetReplica
-from dynamo.planner.connectors.base import PlannerConnector
+from dynamo.planner.connectors.base import (
+    DynamoGraphPowerBudgetComponentSnapshot,
+    DynamoGraphPowerBudgetSnapshot,
+    PlannerConnector,
+)
 from dynamo.planner.connectors.clients.kubernetes_api import (
     DYNAMO_WORKER_METADATA_API_VERSION,
     NVIDIA_API_GROUP,
@@ -61,6 +65,8 @@ CURRENT_WORKER_HASH_ANNOTATION = "nvidia.com/current-worker-hash"
 CURRENT_WORKER_HASH_V2_ANNOTATION = "nvidia.com/current-worker-hash-v2"
 WORKER_COMPONENT_TYPES = {"worker", "prefill", "decode"}
 WORKER_SUFFIX_COMPONENT_KINDS = {"Deployment", "LeaderWorkerSet"}
+POWER_CONTROL_MODE_ANNOTATION = "dynamo.nvidia.com/power-control-mode"
+TRANSACTIONAL_REPLICA_FENCE = "transactional-replica-fence"
 
 
 class KubernetesConnector(PlannerConnector):
@@ -94,10 +100,45 @@ class KubernetesConnector(PlannerConnector):
         # For backwards compatibility
         self.graph_deployment_name = self.parent_dgd_name
         self.raise_not_ready = raise_not_ready
+        self._power_budget_snapshot: Optional[DynamoGraphPowerBudgetSnapshot] = None
+        self._power_budget_snapshot_observed = False
+        self._transactional_power_control = False
+        self._transactional_policy_logged = False
 
     async def async_init(self):
         """No-op asynchronous lifecycle hook."""
         return
+
+    def _deployment_uses_transactional_power(self, deployment: dict) -> bool:
+        annotations = deployment.get("metadata", {}).get("annotations", {}) or {}
+        transactional = self._transactional_power_control or (
+            annotations.get(POWER_CONTROL_MODE_ANNOTATION)
+            == TRANSACTIONAL_REPLICA_FENCE
+        )
+        if transactional:
+            self._transactional_power_control = True
+        return transactional
+
+    def _request_component_replicas(
+        self,
+        service_name: str,
+        replicas: int,
+        *,
+        transactional: bool,
+    ) -> None:
+        if transactional:
+            self.kube_api.update_service_replicas(
+                self.graph_deployment_name,
+                service_name,
+                replicas,
+                transactional=True,
+            )
+        else:
+            self.kube_api.update_graph_replicas(
+                self.graph_deployment_name,
+                service_name,
+                replicas,
+            )
 
     def get_worker_runtime_namespace(self, base_dynamo_namespace: str) -> str:
         """Return the Dynamo namespace used by the current worker generation.
@@ -176,10 +217,10 @@ class KubernetesConnector(PlannerConnector):
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
 
         service = get_component_from_type_or_name(deployment, sub_component_type)
-        self.kube_api.update_graph_replicas(
-            self.graph_deployment_name,
+        self._request_component_replicas(
             service.name,
             service.number_replicas() + 1,
+            transactional=self._deployment_uses_transactional_power(deployment),
         )
         if blocking:
             await self.kube_api.wait_for_graph_deployment_ready(
@@ -195,10 +236,10 @@ class KubernetesConnector(PlannerConnector):
 
         service = get_component_from_type_or_name(deployment, sub_component_type)
         if service.number_replicas() > 0:
-            self.kube_api.update_graph_replicas(
-                self.graph_deployment_name,
+            self._request_component_replicas(
                 service.name,
                 service.number_replicas() - 1,
+                transactional=self._deployment_uses_transactional_power(deployment),
             )
             if blocking:
                 await self.kube_api.wait_for_graph_deployment_ready(
@@ -355,6 +396,181 @@ class KubernetesConnector(PlannerConnector):
         rather than duck-typing via ``getattr``.
         """
         return self.kube_api.get_graph_deployment(self.graph_deployment_name)
+
+    def get_power_budget_snapshot(
+        self,
+    ) -> Optional[DynamoGraphPowerBudgetSnapshot]:
+        """Return the current tick's cached DGPB observation without API I/O."""
+
+        return self._power_budget_snapshot
+
+    def consume_power_budget_snapshot(self) -> None:
+        """Allow the next Planner refresh cycle to observe a new DGPB snapshot."""
+
+        self._power_budget_snapshot_observed = False
+
+    @staticmethod
+    def _snapshot_int(value: object, field: str, *, minimum: int = 0) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+            raise DeploymentValidationError(
+                [f"DGPB {field} must be an integer >= {minimum}"]
+            )
+        return value
+
+    @classmethod
+    def _parse_power_budget_snapshot(
+        cls, resource: dict
+    ) -> DynamoGraphPowerBudgetSnapshot:
+        """Validate the narrow DGPB policy/inventory surface Planner consumes."""
+
+        spec = resource.get("spec")
+        status = resource.get("status")
+        if not isinstance(spec, dict) or not isinstance(status, dict):
+            raise DeploymentValidationError(
+                ["DGPB must contain spec and status objects"]
+            )
+
+        policy = spec.get("policy")
+        if not isinstance(policy, dict):
+            raise DeploymentValidationError(["DGPB spec.policy must be an object"])
+        budget_watts = cls._snapshot_int(
+            spec.get("budgetWatts"), "spec.budgetWatts", minimum=1
+        )
+        min_endpoint = cls._snapshot_int(
+            policy.get("minEndpoint"), "spec.policy.minEndpoint", minimum=1
+        )
+        inventory_epoch = cls._snapshot_int(
+            status.get("inventoryEpoch", 0), "status.inventoryEpoch"
+        )
+        phase = status.get("phase", "")
+        if not isinstance(phase, str):
+            raise DeploymentValidationError(["DGPB status.phase must be a string"])
+        rollout_in_progress = status.get("rolloutInProgress", False)
+        if not isinstance(rollout_in_progress, bool):
+            raise DeploymentValidationError(
+                ["DGPB status.rolloutInProgress must be a boolean"]
+            )
+
+        committed = status.get("committedReplicaTargets", {})
+        if not isinstance(committed, dict):
+            raise DeploymentValidationError(
+                ["DGPB status.committedReplicaTargets must be an object"]
+            )
+        committed_targets = {
+            name: cls._snapshot_int(
+                replicas, f"status.committedReplicaTargets[{name!r}]"
+            )
+            for name, replicas in committed.items()
+            if isinstance(name, str) and name
+        }
+        if len(committed_targets) != len(committed):
+            raise DeploymentValidationError(
+                ["DGPB committed replica target names must be non-empty strings"]
+            )
+
+        raw_components = status.get("components", [])
+        if not isinstance(raw_components, list):
+            raise DeploymentValidationError(["DGPB status.components must be a list"])
+        components: list[DynamoGraphPowerBudgetComponentSnapshot] = []
+        seen_names: set[str] = set()
+        for index, row in enumerate(raw_components):
+            if not isinstance(row, dict):
+                raise DeploymentValidationError(
+                    [f"DGPB status.components[{index}] must be an object"]
+                )
+            name = row.get("name")
+            if not isinstance(name, str) or not name or name in seen_names:
+                raise DeploymentValidationError(
+                    ["DGPB component names must be unique non-empty strings"]
+                )
+            seen_names.add(name)
+            replica_status = row.get("replicaStatus")
+            if not isinstance(replica_status, dict):
+                raise DeploymentValidationError(
+                    [f"DGPB component {name!r} replicaStatus must be an object"]
+                )
+            available = replica_status.get("availableReplicas")
+            serving = (
+                available
+                if available is not None
+                else replica_status.get("readyReplicas", 0)
+            )
+            components.append(
+                DynamoGraphPowerBudgetComponentSnapshot(
+                    name=name,
+                    ready_replicas=cls._snapshot_int(
+                        serving, f"component {name!r} serving replicas"
+                    ),
+                    committed_replicas=committed_targets.get(name, 0),
+                    updated_replicas=cls._snapshot_int(
+                        replica_status.get("updatedReplicas", 0),
+                        f"component {name!r} updatedReplicas",
+                    ),
+                    terminating_replicas=cls._snapshot_int(
+                        row.get("terminatingReplicas", 0),
+                        f"component {name!r} terminatingReplicas",
+                    ),
+                )
+            )
+
+        raw_conditions = status.get("conditions", [])
+        if not isinstance(raw_conditions, list) or not all(
+            isinstance(condition, dict) for condition in raw_conditions
+        ):
+            raise DeploymentValidationError(
+                ["DGPB status.conditions must be a list of objects"]
+            )
+        return DynamoGraphPowerBudgetSnapshot(
+            budget_watts=budget_watts,
+            min_endpoint=min_endpoint,
+            phase=phase,
+            inventory_epoch=inventory_epoch,
+            rollout_in_progress=rollout_in_progress,
+            components=tuple(components),
+            conditions=tuple(dict(condition) for condition in raw_conditions),
+        )
+
+    def _observe_power_budget_snapshot(
+        self,
+    ) -> Optional[DynamoGraphPowerBudgetSnapshot]:
+        if self._power_budget_snapshot_observed:
+            return self._power_budget_snapshot
+
+        resource = self.kube_api.get_graph_power_budget(self.graph_deployment_name)
+        if resource is None:
+            if self._transactional_power_control:
+                raise DeploymentValidationError(
+                    [
+                        "Transactional power control was already observed, but its "
+                        f"DGPB {self.graph_deployment_name!r} is now missing"
+                    ]
+                )
+            self._power_budget_snapshot = None
+            self._power_budget_snapshot_observed = True
+            return None
+
+        snapshot = self._parse_power_budget_snapshot(resource)
+        self._transactional_power_control = True
+        self._power_budget_snapshot = snapshot
+        self._power_budget_snapshot_observed = True
+        if not self._transactional_policy_logged:
+            logger.info(
+                "Transactional power control detected for %s: PlannerConfig."
+                "total_gpu_power_limit and PlannerConfig.min_endpoint are inactive; "
+                "using DGPB policy budgetWatts=%s minEndpoint=%s",
+                self.graph_deployment_name,
+                snapshot.budget_watts,
+                snapshot.min_endpoint,
+            )
+            self._transactional_policy_logged = True
+        logger.debug(
+            "Observed DGPB %s inventoryEpoch=%s phase=%s conditions=%s",
+            self.graph_deployment_name,
+            snapshot.inventory_epoch,
+            snapshot.phase,
+            [condition.get("type") for condition in snapshot.conditions],
+        )
+        return snapshot
 
     def get_gpu_counts(
         self,
@@ -758,7 +974,27 @@ class KubernetesConnector(PlannerConnector):
         prefill_component_name: Optional[str],
         decode_component_name: Optional[str],
     ) -> tuple[int, int, bool]:
+        power_budget = self._observe_power_budget_snapshot()
+        if power_budget is not None:
+            return self._transactional_worker_counts_from_snapshot(
+                power_budget,
+                prefill_component_name=prefill_component_name,
+                decode_component_name=decode_component_name,
+            )
+
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
+        annotations = deployment.get("metadata", {}).get("annotations", {}) or {}
+        if (
+            annotations.get(POWER_CONTROL_MODE_ANNOTATION)
+            == TRANSACTIONAL_REPLICA_FENCE
+        ):
+            self._transactional_power_control = True
+            raise DeploymentValidationError(
+                [
+                    f"Transactional DGD {self.graph_deployment_name!r} has no DGPB; "
+                    "refusing to fall back to DGD and Pod inventory"
+                ]
+            )
         dgd_name = deployment.get("metadata", {}).get("name", "")
         pods = self.kube_api.list_pods_for_graph(dgd_name) if dgd_name else []
         pods_by_component = self.kube_api.partition_pods_by_component(pods)
@@ -769,6 +1005,45 @@ class KubernetesConnector(PlannerConnector):
             pods_by_component=pods_by_component,
             power_aware=True,
         )
+
+    def _transactional_worker_counts_from_snapshot(
+        self,
+        snapshot: DynamoGraphPowerBudgetSnapshot,
+        *,
+        prefill_component_name: Optional[str],
+        decode_component_name: Optional[str],
+    ) -> tuple[int, int, bool]:
+        """Resolve serving counts and the global hold from one DGPB snapshot."""
+
+        rows = {component.name: component for component in snapshot.components}
+        missing = [
+            name
+            for name in (prefill_component_name, decode_component_name)
+            if name is not None and name not in rows
+        ]
+        if missing:
+            raise DeploymentValidationError(
+                [
+                    "DGPB status is missing required component row(s): "
+                    + ", ".join(sorted(missing))
+                ]
+            )
+
+        prefill = (
+            rows[prefill_component_name].ready_replicas if prefill_component_name else 0
+        )
+        decode = (
+            rows[decode_component_name].ready_replicas if decode_component_name else 0
+        )
+        relevant = [
+            rows[name]
+            for name in (prefill_component_name, decode_component_name)
+            if name is not None
+        ]
+        all_stable = not snapshot.rollout_in_progress and all(
+            component.settled for component in relevant
+        )
+        return prefill, decode, all_stable
 
     def _worker_counts_from_snapshot(
         self,
@@ -856,8 +1131,14 @@ class KubernetesConnector(PlannerConnector):
             raise EmptyTargetReplicasError()
 
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
+        transactional = self._deployment_uses_transactional_power(deployment)
 
-        if not self.kube_api.is_deployment_ready(deployment):
+        # The DGD is the committed mirror in transactional mode and is often
+        # intentionally unready while an admitted rollout is applying. Safe
+        # reductions and cancellation requests must still reach DGDSA during
+        # that window. Preserve the legacy Ready guard only for direct-DGD
+        # (static) scaling.
+        if not transactional and not self.kube_api.is_deployment_ready(deployment):
             if self.raise_not_ready:
                 logger.warning(
                     "Deployment %s is not ready, rejecting this scaling",
@@ -880,14 +1161,18 @@ class KubernetesConnector(PlannerConnector):
                 component_name=target_replica.component_name,
             )
             current_replicas = service.number_replicas()
-            if current_replicas != target_replica.desired_replicas:
+            # In transactional mode DGD spec is the committed mirror, not the
+            # current request. Always write an explicit DGDSA request so a
+            # proposal equal to the commitment can cancel a different pending
+            # request. Static mode retains its existing no-op suppression.
+            if transactional or current_replicas != target_replica.desired_replicas:
                 logger.info(
                     f"Updating {target_replica.sub_component_type.value} component {service.name} to desired replica count {target_replica.desired_replicas}"
                 )
-                self.kube_api.update_graph_replicas(
-                    self.graph_deployment_name,
+                self._request_component_replicas(
                     service.name,
                     target_replica.desired_replicas,
+                    transactional=transactional,
                 )
             else:
                 logger.info(

--- a/components/src/dynamo/planner/environment/base.py
+++ b/components/src/dynamo/planner/environment/base.py
@@ -10,7 +10,11 @@ from typing import Optional
 from dynamo.planner.config.backend_components import WORKER_COMPONENT_NAMES
 from dynamo.planner.config.defaults import SubComponentType, TargetReplica
 from dynamo.planner.config.planner_config import PlannerConfig
-from dynamo.planner.connectors.base import PlannerConnector, is_power_aware_connector
+from dynamo.planner.connectors.base import (
+    PlannerConnector,
+    is_power_aware_connector,
+    is_transactional_power_aware_connector,
+)
 from dynamo.planner.core.budget import minimum_power_footprint_fits
 from dynamo.planner.core.types import FpmObservations, TrafficObservation
 from dynamo.planner.environment.interface import (
@@ -129,6 +133,17 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
         await self._refresh_deployment_state()
 
     async def refresh(self) -> DeploymentState:
+        # A Planner refresh is the DGPB observation-cycle boundary. Invalidate
+        # the connector cache before any count read so the first tick and a
+        # retry after any pre-engine failure cannot reuse the prior snapshot.
+        # Multiple count reads within this refresh (for example after a runtime
+        # namespace change) still share the one newly observed snapshot.
+        if (
+            self.config.enable_power_awareness
+            and is_transactional_power_aware_connector(self.controller)
+        ):
+            self.controller.consume_power_budget_snapshot()
+
         namespace_changed = False
         if self.runtime_namespace_source is not None:
             namespace_changed = (
@@ -196,11 +211,12 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
         return self.controller.get_graph_deployment()
 
     async def _wait_for_startup_dgd_snapshot(self) -> Optional[dict]:
-        """Wait for readiness; when power is on, return a settled DGD snapshot.
+        """Discover transactional policy before choosing the startup wait.
 
-        The settled wait (observedGeneration + pod annotation convergence) is
-        only required to permanently cache DGD-owned power caps. Power-disabled
-        planners keep the standard ``wait_for_deployment_ready`` path.
+        Transactional cap/topology inputs are immutable and worker readiness is
+        represented by DGPB aggregate status, so a restart during an admitted
+        rollout must not block on the Phase-1 DGD/Pod settlement loop. Static
+        power mode retains that legacy convergence boundary.
         """
         if self.config.enable_power_awareness:
             if not is_power_aware_connector(self.controller):
@@ -214,6 +230,14 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
                         "this connector does not."
                     ]
                 )
+            if is_transactional_power_aware_connector(self.controller):
+                if self.controller.get_power_budget_snapshot() is None:
+                    # This call only discovers/caches DGPB. Worker names are
+                    # resolved from the DGD later; passing backend defaults
+                    # here would reject valid renamed component rows.
+                    await self.controller.get_power_aware_worker_counts()
+                if self.controller.get_power_budget_snapshot() is not None:
+                    return self.controller.get_graph_deployment()
             prefill_name, decode_name = self._power_component_names()
             return await self.controller.wait_for_settled_graph_deployment(
                 include_planner=False,
@@ -376,7 +400,26 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
             self._adopt_power_config(state.prefill, prefill_cfg)
         if self.require_decode and decode_cfg is not None:
             self._adopt_power_config(state.decode, decode_cfg)
+        self._adopt_cached_transactional_power_policy()
         self._validate_minimum_power_footprint(prefill_cfg, decode_cfg)
+
+    def _adopt_cached_transactional_power_policy(self) -> None:
+        """Adopt operator-owned policy before startup feasibility validation.
+
+        Worker-count discovery populates the connector's DGPB cache before
+        startup cap validation. Reading that cache performs no API I/O and does
+        not consume the observation cycle; the engine remains responsible for
+        consuming it on its first tick. Static power-aware connectors retain
+        the PlannerConfig policy unchanged.
+        """
+
+        if not is_transactional_power_aware_connector(self.controller):
+            return
+        snapshot = self.controller.get_power_budget_snapshot()
+        if snapshot is None:
+            return
+        self.config.total_gpu_power_limit = snapshot.budget_watts
+        self.config.min_endpoint = snapshot.min_endpoint
 
     def _resolve_power_configs(
         self,

--- a/components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py
+++ b/components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py
@@ -68,6 +68,10 @@ from dynamo.planner.config.planner_config import resolve_min_endpoint
 if TYPE_CHECKING:
     import grpc.aio
 
+from dynamo.planner.connectors.base import (
+    DynamoGraphPowerBudgetSnapshot,
+    is_transactional_power_aware_connector,
+)
 from dynamo.planner.core.budget import (
     apply_power_budget,
     proportional_clamp_pair,
@@ -140,6 +144,8 @@ class OrchestratorEngineAdapter:
         self._config = config
         self._capabilities = capabilities
         self._observe_plugin = observe_plugin
+        self._power_budget_snapshot: Optional[DynamoGraphPowerBudgetSnapshot] = None
+        self._adopt_transactional_power_policy()
         # Clock is shared with all sub-components (CircuitBreaker,
         # PluginRegistryServer, PluginScheduler, LocalPlannerOrchestrator).
         # Default ``WallClock`` is correct for production / K8s smoke
@@ -279,6 +285,29 @@ class OrchestratorEngineAdapter:
     @property
     def plugins_bootstrapped(self) -> bool:
         return self._plugins_bootstrapped
+
+    def _adopt_transactional_power_policy(self) -> None:
+        """Adopt immutable DGPB policy from the connector's cached observation.
+
+        The environment owns API-read cycle boundaries and the connector owns
+        refresh-cycle caching. The engine only observes that cache, so it cannot
+        add a second DGPB read to a planning tick or write a commit/release vote.
+        """
+
+        environment = getattr(self._observe_plugin, "environment", None)
+        controller = getattr(environment, "controller", None)
+        if not is_transactional_power_aware_connector(controller):
+            return
+        snapshot = controller.get_power_budget_snapshot()
+        if snapshot is None:
+            return
+        self._power_budget_snapshot = snapshot
+        # PlannerConfig parsing remains an early startup requirement for
+        # compatibility, but transactional policy is operator-owned after DGPB
+        # discovery. Mutating the shared model makes every built-in plugin and
+        # the final clamp consume the same immutable values.
+        self._config.total_gpu_power_limit = snapshot.budget_watts
+        self._config.min_endpoint = snapshot.min_endpoint
 
     def _register_builtin_plugins(self) -> None:
         """Register the in-process builtins that implement local planning."""
@@ -526,6 +555,10 @@ class OrchestratorEngineAdapter:
         scheduled_tick: ScheduledTick,
         tick_input: TickInput,
     ) -> PlannerEffects:
+        # Adopt the single DGPB observation made during this environment
+        # refresh before plugin or final-budget logic reads PlannerConfig.
+        self._adopt_transactional_power_policy()
+
         # NOTE: we intentionally do NOT gate plugins via ``plugin.enabled``
         # on top of ``ScheduledTick.run_*_scaling`` flags. Each plugin's
         # own config-toggle check (``if not self._config.enable_load_scaling:
@@ -1019,13 +1052,17 @@ class OrchestratorEngineAdapter:
         if self._config.enable_power_awareness:
             # Suppress only a proven stable no-op. During a rollout ``expected``
             # is unknown, so an explicit target equal to transient ready may be
-            # intentional cancellation of the in-flight desired count.
-            expected_p = worker_counts.expected_num_prefill
-            expected_d = worker_counts.expected_num_decode
-            if num_p is not None and expected_p is not None and num_p == expected_p:
-                num_p = None
-            if num_d is not None and expected_d is not None and num_d == expected_d:
-                num_d = None
+            # intentional cancellation of the in-flight desired count. A
+            # settled transactional snapshot has the same ambiguity: DGPB
+            # exposes committed counts, not a possibly pending DGDSA request,
+            # so every explicit target must reach DGDSA and overwrite it.
+            if getattr(self, "_power_budget_snapshot", None) is None:
+                expected_p = worker_counts.expected_num_prefill
+                expected_d = worker_counts.expected_num_decode
+                if num_p is not None and expected_p is not None and num_p == expected_p:
+                    num_p = None
+                if num_d is not None and expected_d is not None and num_d == expected_d:
+                    num_d = None
             if num_p is None and num_d is None:
                 return None
         else:

--- a/components/src/dynamo/planner/tests/plugins/orchestrator/test_engine_adapter.py
+++ b/components/src/dynamo/planner/tests/plugins/orchestrator/test_engine_adapter.py
@@ -25,6 +25,10 @@ from __future__ import annotations
 import pytest
 
 from dynamo.planner.config.planner_config import PlannerConfig
+from dynamo.planner.connectors.base import (
+    DynamoGraphPowerBudgetComponentSnapshot,
+    DynamoGraphPowerBudgetSnapshot,
+)
 from dynamo.planner.core.types import (
     EngineCapabilities,
     FpmObservations,
@@ -145,6 +149,134 @@ def _disagg_config_sla_no_budget() -> PlannerConfig:
         max_gpu_budget=-1,
         min_gpu_budget=-1,
     )
+
+
+class _SnapshotController:
+    def __init__(self, snapshot: DynamoGraphPowerBudgetSnapshot) -> None:
+        self.snapshot = snapshot
+        self.reads = 0
+        self.consumes = 0
+
+    def get_power_budget_snapshot(self) -> DynamoGraphPowerBudgetSnapshot:
+        self.reads += 1
+        return self.snapshot
+
+    def consume_power_budget_snapshot(self) -> None:
+        self.consumes += 1
+
+
+class _SnapshotObserver:
+    def __init__(self, controller: _SnapshotController) -> None:
+        self.environment = type("Environment", (), {"controller": controller})()
+
+
+def _transactional_snapshot(*, rollout: bool) -> DynamoGraphPowerBudgetSnapshot:
+    return DynamoGraphPowerBudgetSnapshot(
+        budget_watts=1600,
+        min_endpoint=2,
+        phase="Applying" if rollout else "Idle",
+        inventory_epoch=9,
+        rollout_in_progress=rollout,
+        components=(
+            DynamoGraphPowerBudgetComponentSnapshot(
+                name="prefill",
+                ready_replicas=2,
+                committed_replicas=2,
+                updated_replicas=2,
+                terminating_replicas=0,
+            ),
+            DynamoGraphPowerBudgetComponentSnapshot(
+                name="decode",
+                ready_replicas=2,
+                committed_replicas=2,
+                updated_replicas=2,
+                terminating_replicas=0,
+            ),
+        ),
+        conditions=(),
+    )
+
+
+def test_transactional_rollout_restart_adopts_snapshot_without_voting():
+    """Restart reads DGPB policy and retains the global hold without voting."""
+
+    config = PlannerConfig(
+        mode="disagg",
+        enable_load_scaling=True,
+        enable_throughput_scaling=True,
+        optimization_target="sla",
+        served_model_name="test",
+        enable_power_awareness=True,
+        total_gpu_power_limit=9999,
+        min_endpoint=1,
+    )
+    capabilities = _disagg_caps()
+    assert capabilities.prefill is not None
+    assert capabilities.decode is not None
+    capabilities.prefill.power_watts_per_replica = 400
+    capabilities.decode.power_watts_per_replica = 400
+    controller = _SnapshotController(_transactional_snapshot(rollout=True))
+    observer = _SnapshotObserver(controller)
+
+    first = OrchestratorEngineAdapter(
+        config, capabilities, observe_plugin=observer  # type: ignore[arg-type]
+    )
+    restarted = OrchestratorEngineAdapter(
+        config, capabilities, observe_plugin=observer  # type: ignore[arg-type]
+    )
+
+    assert config.total_gpu_power_limit == 1600
+    assert config.min_endpoint == 2
+    assert controller.reads == 2
+    assert controller.consumes == 0
+
+    rolling_counts = WorkerCounts(
+        ready_num_prefill=2,
+        ready_num_decode=2,
+        expected_num_prefill=None,
+        expected_num_decode=None,
+        prefill_scaling_in_progress=True,
+        decode_scaling_in_progress=True,
+    )
+    assert first._apply_power_final_budget(3, 3, rolling_counts) == (None, None)
+    assert restarted._apply_power_final_budget(3, 3, rolling_counts) == (None, None)
+
+    restarted._adopt_transactional_power_policy()
+    assert controller.consumes == 0
+
+
+def test_transactional_projection_emits_committed_target_to_cancel_pending_request():
+    """DGPB commitment cannot prove that the DGDSA request is already equal."""
+
+    config = PlannerConfig(
+        mode="disagg",
+        enable_load_scaling=True,
+        enable_throughput_scaling=True,
+        optimization_target="sla",
+        served_model_name="test",
+        enable_power_awareness=True,
+        total_gpu_power_limit=9999,
+        min_endpoint=1,
+    )
+    controller = _SnapshotController(_transactional_snapshot(rollout=False))
+    adapter = OrchestratorEngineAdapter(
+        config,
+        _disagg_caps(),
+        observe_plugin=_SnapshotObserver(controller),  # type: ignore[arg-type]
+    )
+    counts = WorkerCounts(
+        ready_num_prefill=2,
+        ready_num_decode=2,
+        expected_num_prefill=2,
+        expected_num_decode=2,
+    )
+    outcome = _apply_outcome([ComponentTarget(sub_component_type="decode", replicas=2)])
+
+    decision = adapter._project_scale_to(outcome, counts)
+
+    assert decision is not None
+    assert decision.num_prefill is None
+    assert decision.num_decode == 2
 
 
 def _make_fpm(worker_id: str = "w1", dp_rank: int = 0):

--- a/components/src/dynamo/planner/tests/unit/test_dgpb_observation.py
+++ b/components/src/dynamo/planner/tests/unit/test_dgpb_observation.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dynamo.planner.connectors.kubernetes import KubernetesConnector
+from dynamo.planner.errors import DeploymentValidationError
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _component(
+    name: str,
+    *,
+    committed: int,
+    updated: int,
+    ready: int,
+    terminating: int = 0,
+) -> dict:
+    return {
+        "name": name,
+        "replicaStatus": {
+            "replicas": ready,
+            "updatedReplicas": updated,
+            "readyReplicas": ready,
+        },
+        "terminatingReplicas": terminating,
+        "_committed": committed,
+    }
+
+
+def _dgpb(*components: dict, rollout: bool = False) -> dict:
+    rows = []
+    committed = {}
+    for component in components:
+        row = dict(component)
+        committed[row["name"]] = row.pop("_committed")
+        rows.append(row)
+    return {
+        "metadata": {"name": "test-graph"},
+        "spec": {"budgetWatts": 4200, "policy": {"minEndpoint": 2}},
+        "status": {
+            "inventoryEpoch": 17,
+            "phase": "Idle",
+            "committedReplicaTargets": committed,
+            "components": rows,
+            "rolloutInProgress": rollout,
+            "conditions": [
+                {
+                    "type": "PowerInfeasible",
+                    "status": "False",
+                    "reason": "Feasible",
+                }
+            ],
+        },
+    }
+
+
+@pytest.fixture
+def connector_and_api(monkeypatch):
+    api = Mock()
+    api.get_graph_power_budget = Mock()
+    api.get_graph_deployment = Mock()
+    api.list_pods_for_graph = Mock(return_value=[])
+    api.partition_pods_by_component = Mock(return_value={})
+    monkeypatch.setattr(
+        "dynamo.planner.connectors.kubernetes.KubernetesAPI",
+        Mock(return_value=api),
+    )
+    with patch.dict(os.environ, {"DYN_PARENT_DGD_K8S_NAME": "test-graph"}):
+        return KubernetesConnector("test-dynamo-namespace"), api
+
+
+@pytest.mark.asyncio
+async def test_transactional_tick_uses_one_dgpb_snapshot(connector_and_api):
+    connector, api = connector_and_api
+    api.get_graph_power_budget.return_value = _dgpb(
+        _component("prefill", committed=2, updated=2, ready=2),
+        _component("decode", committed=4, updated=4, ready=4),
+    )
+
+    first = await connector.get_power_aware_worker_counts("prefill", "decode")
+    second = await connector.get_power_aware_worker_counts("prefill", "decode")
+
+    assert first == second == (2, 4, True)
+    api.get_graph_power_budget.assert_called_once_with("test-graph")
+    api.get_graph_deployment.assert_not_called()
+    api.list_pods_for_graph.assert_not_called()
+
+    snapshot = connector.get_power_budget_snapshot()
+    assert snapshot is not None
+    assert snapshot.budget_watts == 4200
+    assert snapshot.min_endpoint == 2
+    assert snapshot.inventory_epoch == 17
+    assert snapshot.phase == "Idle"
+    assert snapshot.conditions[0]["reason"] == "Feasible"
+
+    connector.consume_power_budget_snapshot()
+    await connector.get_power_aware_worker_counts("prefill", "decode")
+    assert api.get_graph_power_budget.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_transactional_rollout_signal_holds_all_roles(connector_and_api):
+    connector, api = connector_and_api
+    api.get_graph_power_budget.return_value = _dgpb(
+        _component("prefill", committed=2, updated=2, ready=2),
+        _component("decode", committed=4, updated=4, ready=4),
+        rollout=True,
+    )
+
+    assert await connector.get_power_aware_worker_counts("prefill", "decode") == (
+        2,
+        4,
+        False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_transactional_component_convergence_uses_committed_vector(
+    connector_and_api,
+):
+    connector, api = connector_and_api
+    api.get_graph_power_budget.return_value = _dgpb(
+        _component("prefill", committed=3, updated=2, ready=2),
+        _component("decode", committed=4, updated=4, ready=4),
+    )
+
+    assert await connector.get_power_aware_worker_counts("prefill", "decode") == (
+        2,
+        4,
+        False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_static_dgd_retains_legacy_inventory_path(connector_and_api):
+    connector, api = connector_and_api
+    api.get_graph_power_budget.return_value = None
+    api.get_graph_deployment.return_value = {
+        "metadata": {"name": "test-graph"},
+        "spec": {
+            "components": [
+                {"name": "prefill", "type": "prefill", "replicas": 2},
+                {"name": "decode", "type": "decode", "replicas": 4},
+            ]
+        },
+    }
+    api.partition_pods_by_component.return_value = {}
+    api.get_service_replica_status.side_effect = [(2, True), (4, True)]
+    api.has_terminating_pods.return_value = False
+    api.is_rolling_update_blocking_settlement.return_value = (False, "")
+
+    assert await connector.get_power_aware_worker_counts("prefill", "decode") == (
+        2,
+        4,
+        True,
+    )
+    api.get_graph_deployment.assert_called_once_with("test-graph")
+    api.list_pods_for_graph.assert_called_once_with("test-graph")
+
+
+@pytest.mark.asyncio
+async def test_transactional_dgd_never_downgrades_when_dgpb_is_missing(
+    connector_and_api,
+):
+    connector, api = connector_and_api
+    api.get_graph_power_budget.return_value = None
+    api.get_graph_deployment.return_value = {
+        "metadata": {
+            "name": "test-graph",
+            "annotations": {
+                "dynamo.nvidia.com/power-control-mode": "transactional-replica-fence"
+            },
+        }
+    }
+
+    with pytest.raises(DeploymentValidationError, match="has no DGPB"):
+        await connector.get_power_aware_worker_counts("prefill", "decode")
+    api.list_pods_for_graph.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_observed_transactional_dgpb_missing_retries_fail_closed(
+    connector_and_api,
+):
+    connector, api = connector_and_api
+    api.get_graph_power_budget.return_value = _dgpb(
+        _component("decode", committed=1, updated=1, ready=1)
+    )
+    await connector.get_power_aware_worker_counts(None, "decode")
+    connector.consume_power_budget_snapshot()
+    api.get_graph_power_budget.return_value = None
+
+    with pytest.raises(DeploymentValidationError, match="now missing"):
+        await connector.get_power_aware_worker_counts(None, "decode")
+    with pytest.raises(DeploymentValidationError, match="now missing"):
+        await connector.get_power_aware_worker_counts(None, "decode")
+
+    assert api.get_graph_power_budget.call_count == 3
+    api.get_graph_deployment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_transactional_policy_log_is_emitted_once(connector_and_api, caplog):
+    connector, api = connector_and_api
+    api.get_graph_power_budget.return_value = _dgpb(
+        _component("decode", committed=1, updated=1, ready=1)
+    )
+
+    with caplog.at_level(logging.INFO):
+        await connector.get_power_aware_worker_counts(None, "decode")
+        connector.consume_power_budget_snapshot()
+        await connector.get_power_aware_worker_counts(None, "decode")
+
+    records = [
+        record
+        for record in caplog.records
+        if "PlannerConfig.total_gpu_power_limit" in record.getMessage()
+    ]
+    assert len(records) == 1
+    assert "budgetWatts=4200 minEndpoint=2" in records[0].getMessage()

--- a/components/src/dynamo/planner/tests/unit/test_kube.py
+++ b/components/src/dynamo/planner/tests/unit/test_kube.py
@@ -110,6 +110,28 @@ def test_get_graph_deployment_from_name(k8s_api, mock_custom_api):
     )
 
 
+def test_get_graph_power_budget_is_read_only_get(k8s_api, mock_custom_api):
+    resource = {"metadata": {"name": "test-deployment"}, "spec": {}}
+    mock_custom_api.get_namespaced_custom_object.return_value = resource
+
+    assert k8s_api.get_graph_power_budget("test-deployment") == resource
+    mock_custom_api.get_namespaced_custom_object.assert_called_once_with(
+        group="nvidia.com",
+        version="v1beta1",
+        namespace=k8s_api.current_namespace,
+        plural="dynamographpowerbudgets",
+        name="test-deployment",
+    )
+
+
+def test_get_graph_power_budget_404_means_static(k8s_api, mock_custom_api):
+    mock_custom_api.get_namespaced_custom_object.side_effect = client.ApiException(
+        status=404
+    )
+
+    assert k8s_api.get_graph_power_budget("test-deployment") is None
+
+
 def test_update_service_replicas_uses_dgdsa_scale(k8s_api, mock_custom_api):
     """Test that update_service_replicas uses DGDSA Scale API when available"""
     mock_custom_api.patch_namespaced_custom_object_scale.return_value = None
@@ -185,6 +207,24 @@ def test_update_service_replicas_fallback_to_dgd(k8s_api, mock_custom_api):
         _return_http_data_only=True,
         collection_formats={},
     )
+
+
+def test_update_service_replicas_transactional_404_never_falls_back(
+    k8s_api, mock_custom_api
+):
+    mock_custom_api.patch_namespaced_custom_object_scale.side_effect = (
+        client.ApiException(status=404)
+    )
+
+    with pytest.raises(client.ApiException) as exc_info:
+        k8s_api.update_service_replicas(
+            "test-deployment", "test-component", 1, transactional=True
+        )
+
+    assert exc_info.value.status == 404
+    mock_custom_api.get_namespaced_custom_object.assert_not_called()
+    mock_custom_api.patch_namespaced_custom_object.assert_not_called()
+    mock_custom_api.api_client.call_api.assert_not_called()
 
 
 def test_update_service_replicas_propagates_other_errors(k8s_api, mock_custom_api):

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -49,6 +49,8 @@ pytestmark = [
 def mock_kube_api():
     mock_api = Mock()
     mock_api.get_graph_deployment = Mock()
+    mock_api.get_graph_power_budget = Mock(return_value=None)
+    mock_api.update_service_replicas = Mock()
     mock_api.update_graph_replicas = AsyncMock()
     mock_api.wait_for_graph_deployment_ready = AsyncMock()
     mock_api.is_deployment_ready = Mock()
@@ -506,6 +508,24 @@ async def test_add_component_increases_replicas(kubernetes_connector, mock_kube_
 
 
 @pytest.mark.asyncio
+async def test_add_component_transactional_uses_only_dgdsa(
+    kubernetes_connector, mock_kube_api
+):
+    deployment = _deployment(_component("decode-worker", "decode", replicas=1))
+    deployment["metadata"]["annotations"] = {
+        "dynamo.nvidia.com/power-control-mode": "transactional-replica-fence"
+    }
+    mock_kube_api.get_graph_deployment.return_value = deployment
+
+    await kubernetes_connector.add_component(SubComponentType.DECODE, blocking=False)
+
+    mock_kube_api.update_service_replicas.assert_called_once_with(
+        "test-graph", "decode-worker", 2, transactional=True
+    )
+    mock_kube_api.update_graph_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_add_component_with_no_replicas_specified(
     kubernetes_connector, mock_kube_api
 ):
@@ -652,6 +672,75 @@ async def test_set_component_replicas(kubernetes_connector, mock_kube_api):
     ]
     mock_kube_api.update_graph_replicas.assert_has_calls(expected_calls, any_order=True)
     mock_kube_api.wait_for_graph_deployment_ready.assert_called_once_with("test-graph")
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas_transactional_uses_only_dgdsa(
+    kubernetes_connector, mock_kube_api
+):
+    target_replicas = [
+        TargetReplica(sub_component_type=SubComponentType.DECODE, desired_replicas=3)
+    ]
+    deployment = _deployment(_component("decode-worker", "decode", replicas=1))
+    deployment["metadata"]["annotations"] = {
+        "dynamo.nvidia.com/power-control-mode": "transactional-replica-fence"
+    }
+    mock_kube_api.get_graph_deployment.return_value = deployment
+    mock_kube_api.is_deployment_ready.return_value = True
+
+    await kubernetes_connector.set_component_replicas(target_replicas, blocking=False)
+
+    mock_kube_api.update_service_replicas.assert_called_once_with(
+        "test-graph", "decode-worker", 3, transactional=True
+    )
+    mock_kube_api.update_graph_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas_transactional_can_cancel_pending_request(
+    kubernetes_connector, mock_kube_api
+):
+    """DGD shows commitment, so an equal request must still reach DGDSA."""
+
+    target_replicas = [
+        TargetReplica(sub_component_type=SubComponentType.DECODE, desired_replicas=1)
+    ]
+    deployment = _deployment(_component("decode-worker", "decode", replicas=1))
+    deployment["metadata"]["annotations"] = {
+        "dynamo.nvidia.com/power-control-mode": "transactional-replica-fence"
+    }
+    mock_kube_api.get_graph_deployment.return_value = deployment
+    mock_kube_api.is_deployment_ready.return_value = True
+
+    await kubernetes_connector.set_component_replicas(target_replicas, blocking=False)
+
+    mock_kube_api.update_service_replicas.assert_called_once_with(
+        "test-graph", "decode-worker", 1, transactional=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas_transactional_ignores_dgd_ready_guard(
+    kubernetes_connector, mock_kube_api
+):
+    """Applying DGD state must not block a safe DGDSA cancellation."""
+
+    target_replicas = [
+        TargetReplica(sub_component_type=SubComponentType.DECODE, desired_replicas=1)
+    ]
+    deployment = _deployment(_component("decode-worker", "decode", replicas=2))
+    deployment["metadata"]["annotations"] = {
+        "dynamo.nvidia.com/power-control-mode": "transactional-replica-fence"
+    }
+    mock_kube_api.get_graph_deployment.return_value = deployment
+    mock_kube_api.is_deployment_ready.return_value = False
+
+    await kubernetes_connector.set_component_replicas(target_replicas, blocking=False)
+
+    mock_kube_api.is_deployment_ready.assert_not_called()
+    mock_kube_api.update_service_replicas.assert_called_once_with(
+        "test-graph", "decode-worker", 1, transactional=True
+    )
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/planner/tests/unit/test_power_environment.py
+++ b/components/src/dynamo/planner/tests/unit/test_power_environment.py
@@ -16,7 +16,10 @@ import pytest
 from kubernetes.client import ApiException
 
 from dynamo.planner.config.planner_config import PlannerConfig
-from dynamo.planner.connectors.base import is_power_aware_connector
+from dynamo.planner.connectors.base import (
+    DynamoGraphPowerBudgetSnapshot,
+    is_power_aware_connector,
+)
 from dynamo.planner.environment.base import PlannerEnvironmentImpl
 from dynamo.planner.errors import DeploymentValidationError, PowerAnnotationInvalidError
 from dynamo.planner.monitoring.dgd_services import (
@@ -88,6 +91,26 @@ def _controller(prefill_watts=700, decode_watts=1200, *, gpus_per_replica=1):
         )
     )
     return controller
+
+
+def _with_transactional_policy(controller, *, budget_watts, min_endpoint):
+    controller.get_power_budget_snapshot = Mock(
+        return_value=_dgpb_snapshot(budget_watts, min_endpoint)
+    )
+    controller.consume_power_budget_snapshot = Mock()
+    return controller
+
+
+def _dgpb_snapshot(budget_watts=5000, min_endpoint=1):
+    return DynamoGraphPowerBudgetSnapshot(
+        budget_watts=budget_watts,
+        min_endpoint=min_endpoint,
+        phase="Idle",
+        inventory_epoch=1,
+        rollout_in_progress=False,
+        components=(),
+        conditions=(),
+    )
 
 
 def _refresh_controller(prefill_cfg, decode_cfg):
@@ -179,6 +202,94 @@ def test_init_infeasible_minimum_footprint_raises():
     env = _env(_controller(700, 1200), budget=1000)
     with pytest.raises(DeploymentValidationError, match="Infeasible power budget"):
         env._load_static_power_caps_at_startup()
+
+
+def test_init_uses_cached_dgpb_policy_instead_of_inactive_planner_fields():
+    controller = _with_transactional_policy(
+        _controller(700, 1200), budget_watts=5000, min_endpoint=1
+    )
+    env = _env(controller, budget=1000, min_endpoint=9)
+
+    env._load_static_power_caps_at_startup()
+
+    assert env.config.total_gpu_power_limit == 5000
+    assert env.config.min_endpoint == 1
+    controller.get_power_budget_snapshot.assert_called_once_with()
+    controller.consume_power_budget_snapshot.assert_not_called()
+
+
+def test_init_fails_when_cached_dgpb_policy_is_infeasible():
+    controller = _with_transactional_policy(
+        _controller(700, 1200), budget_watts=1000, min_endpoint=1
+    )
+    env = _env(controller, budget=10000, min_endpoint=1)
+
+    with pytest.raises(
+        DeploymentValidationError,
+        match=r"min_endpoint=1.*total_gpu_power_limit=1000W",
+    ):
+        env._load_static_power_caps_at_startup()
+
+
+def test_init_static_connector_keeps_planner_policy():
+    env = _env(_controller(700, 1200), budget=5000, min_endpoint=2)
+
+    env._load_static_power_caps_at_startup()
+
+    assert env.config.total_gpu_power_limit == 5000
+    assert env.config.min_endpoint == 2
+
+
+@pytest.mark.asyncio
+async def test_startup_discovers_dgpb_before_legacy_settlement_wait():
+    controller = _controller()
+    snapshot_cache = {"value": None}
+    snapshot = _dgpb_snapshot()
+    deployment = _dgd(
+        _worker("prefill", comp_type="prefill"),
+        _worker("decode", comp_type="decode"),
+    )
+
+    controller.get_power_budget_snapshot = Mock(
+        side_effect=lambda: snapshot_cache["value"]
+    )
+    controller.consume_power_budget_snapshot = Mock()
+
+    async def observe_dgpb():
+        snapshot_cache["value"] = snapshot
+        return 1, 1, False
+
+    controller.get_power_aware_worker_counts = AsyncMock(side_effect=observe_dgpb)
+    controller.get_graph_deployment.return_value = deployment
+    env = _env(controller)
+
+    observed = await env._wait_for_startup_dgd_snapshot()
+
+    assert observed is deployment
+    controller.get_power_aware_worker_counts.assert_awaited_once_with()
+    controller.wait_for_settled_graph_deployment.assert_not_awaited()
+    controller.get_graph_deployment.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_refresh_starts_dgpb_cycle_before_observing_counts():
+    controller = _refresh_controller(_cfg("prefill", 700), _cfg("decode", 1200))
+    events = []
+    controller.get_power_budget_snapshot = Mock(return_value=_dgpb_snapshot())
+    controller.consume_power_budget_snapshot = Mock(
+        side_effect=lambda: events.append("consume")
+    )
+
+    async def observe_counts(**_kwargs):
+        events.append("observe")
+        return 1, 1, True
+
+    controller.get_power_aware_worker_counts = AsyncMock(side_effect=observe_counts)
+    env = _env(controller)
+
+    await env.refresh()
+
+    assert events == ["consume", "observe"]
 
 
 def test_awareness_off_is_a_noop():


### PR DESCRIPTION
## Overview:

Moves the Planner's transactional replica decisions onto Operator-owned DGPB state and DGDSA requests.

## Details:

- Adopts the immutable DGPB budget and minimum policy as authoritative at startup.
- Reads committed and actual worker counts from DGPB without static DGD/Pod fallback.
- Writes requested replica targets through DGDSA, including reductions and cancellation of pending requests.
- Holds global scaling while Operator rollout state is active and preserves the static path for non-enrolled deployments.

## Where should the reviewer start?

Start with `connectors/kubernetes.py`, `environment/base.py`, and `plugins/orchestrator/engine_adapter.py`.

## Stack

Part 5 of 6. Depends on #13458.

## Validation

- WSL Planner suite: 217 passed.
- DGPB discovery, startup authority, cancellation, and rollout-hold regressions are covered.

## Related Issues

- Relates to #13255
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->