### PR TITLE
feat(deploy): wire transactional power controls (6/6)

### DIFF
--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -41,6 +41,28 @@ The Dynamo Platform Helm chart deploys the complete Dynamo Kubernetes Platform i
 
 ## 🔄 Upgrading Notes
 
+### Power-aware Planner Phase 2 is default-off
+
+Upgrades preserve Phase 1 behavior. The platform chart does not grant the
+Planner Phase 2 DGPB/Pod permissions unless explicitly enabled:
+
+```yaml
+dynamo-operator:
+  planner:
+    powerAwareness:
+      enabled: false
+```
+
+Before setting this to `true`, qualify the exact GPU SKU, driver, and DCGM
+pair, deploy the Power Agent chart with `agent.transactional.enabled=true`
+only on a labeled canary node pool, and verify that every transactional runtime
+image contains `dynamo-power-gate`. Enroll one DGD, wait for its
+`DynamoGraphPowerBudget` `status.phase` to reach `Idle` rather than
+`Unqualified`, and inspect a pending DGDSA's `status.pendingReason` for
+`UnqualifiedHardware` before expanding the Power Agent `nodeSelector`. Keep
+the setting false for static-only clusters.
+
+
 ### Runtime version override for custom runtime images (v1.4.0+)
 
 Each `DynamoGraphDeployment` (DGD) or standalone `DynamoComponentDeployment` (DCD)

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -41,6 +41,28 @@ The Dynamo Platform Helm chart deploys the complete Dynamo Kubernetes Platform i
 
 ## 🔄 Upgrading Notes
 
+### Power-aware Planner Phase 2 is default-off
+
+Upgrades preserve Phase 1 behavior. The platform chart does not grant the
+Planner Phase 2 DGPB/Pod permissions unless explicitly enabled:
+
+```yaml
+dynamo-operator:
+  planner:
+    powerAwareness:
+      enabled: false
+```
+
+Before setting this to `true`, qualify the exact GPU SKU, driver, and DCGM
+pair, deploy the Power Agent chart with `agent.transactional.enabled=true`
+only on a labeled canary node pool, and verify that every transactional runtime
+image contains `dynamo-power-gate`. Enroll one DGD, wait for its
+`DynamoGraphPowerBudget` `status.phase` to reach `Idle` rather than
+`Unqualified`, and inspect a pending DGDSA's `status.pendingReason` for
+`UnqualifiedHardware` before expanding the Power Agent `nodeSelector`. Keep
+the setting false for static-only clusters.
+
+
 ### Runtime version override for custom runtime images (v1.4.0+)
 
 Each `DynamoGraphDeployment` (DGD) or standalone `DynamoComponentDeployment` (DCD)

--- a/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
+++ b/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
@@ -255,6 +255,7 @@ rules:
   - dynamographdeploymentrequests
   - dynamographdeployments
   - dynamographdeploymentscalingadapters
+  - dynamographpowerbudgets
   - dynamomodels
   verbs:
   - create
@@ -271,6 +272,7 @@ rules:
   - dynamocomponentdeployments/finalizers
   - dynamographdeploymentrequests/finalizers
   - dynamographdeployments/finalizers
+  - dynamographpowerbudgets/finalizers
   - dynamomodels/finalizers
   verbs:
   - update
@@ -282,6 +284,7 @@ rules:
   - dynamographdeploymentrequests/status
   - dynamographdeployments/status
   - dynamographdeploymentscalingadapters/status
+  - dynamographpowerbudgets/status
   - dynamomodels/status
   verbs:
   - get

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -102,6 +102,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: DYNAMO_POWER_QUALIFICATION_CATALOG
+          value: {{ .Values.dynamo.powerManagement.qualificationCatalog | default dict | toJson | quote }}
         imagePullPolicy: {{ .Values.controllerManager.manager.image.pullPolicy | quote }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
         livenessProbe:

--- a/deploy/helm/charts/platform/components/operator/templates/planner.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/planner.yaml
@@ -49,6 +49,11 @@ rules:
   resources: ["dynamoworkermetadatas"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- if .Values.planner.powerAwareness.enabled }}
+# DGPB is the operator-owned transactional policy/inventory snapshot. Planner
+# reads one object by name and never writes its spec, status, or subresources.
+- apiGroups: ["nvidia.com"]
+  resources: ["dynamographpowerbudgets"]
+  verbs: ["get"]
 # Pods (list only): startup settlement reads non-terminal pod annotations to
 # verify the DGD-owned power cap has propagated before caching it. No write
 # surface: caps are authored on the DGD podTemplate and enforced by the Power
@@ -100,6 +105,11 @@ rules:
   resources: ["dynamoworkermetadatas"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- if .Values.planner.powerAwareness.enabled }}
+# DGPB is the operator-owned transactional policy/inventory snapshot. Planner
+# reads one object by name and never writes its spec, status, or subresources.
+- apiGroups: ["nvidia.com"]
+  resources: ["dynamographpowerbudgets"]
+  verbs: ["get"]
 # Pods (list only): startup settlement reads non-terminal pod annotations to
 # verify the DGD-owned power cap has propagated before caching it. No write
 # surface: caps are authored on the DGD podTemplate and enforced by the Power

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -115,6 +115,17 @@ dynamo:
 
   groveTerminationDelay: 15m
 
+  # Power-aware transactional control remains default-off at the DGD level.
+  # Qualify each exact nvidia.com/gpu.product value on the deployed
+  # driver/DCGM/image pool before enrolling a DGD. An empty catalog keeps
+  # transactional workloads fail-closed as UnqualifiedHardware.
+  powerManagement:
+    qualificationCatalog: {}
+    # NVIDIA-GB200:
+    #   minWatts: 200
+    #   defaultWatts: 1200
+    #   maxWatts: 1200
+
   dockerRegistry:
     server: ''
     # set to true if you want to use the kubernetes secret for the registry credentials

--- a/deploy/helm/charts/platform/tests/planner_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/planner_rbac_test.yaml
@@ -36,6 +36,34 @@ tests:
               - list
         documentIndex: 0
 
+  - it: grants only DGPB get in ClusterRole when powerAwareness is enabled
+    set:
+      dynamo-operator.planner.powerAwareness.enabled: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - nvidia.com
+            resources:
+              - dynamographpowerbudgets
+            verbs:
+              - get
+        documentIndex: 0
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - nvidia.com
+            resources:
+              - dynamographpowerbudgets
+            verbs:
+              - create
+              - update
+              - patch
+              - delete
+        documentIndex: 0
+
   # ── namespace-restricted mode ─────────────────────────────────────────────────
 
   - it: omits pods/list from Role when powerAwareness is disabled in namespace-restricted mode
@@ -69,4 +97,34 @@ tests:
               - pods
             verbs:
               - list
+        documentIndex: 1
+
+  - it: grants only DGPB get in Role when powerAwareness is enabled in namespace-restricted mode
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.upgradeCRD: false
+      dynamo-operator.planner.powerAwareness.enabled: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - nvidia.com
+            resources:
+              - dynamographpowerbudgets
+            verbs:
+              - get
+        documentIndex: 1
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - nvidia.com
+            resources:
+              - dynamographpowerbudgets
+            verbs:
+              - create
+              - update
+              - patch
+              - delete
         documentIndex: 1

--- a/deploy/helm/charts/platform/tests/power_qualification_catalog_test.yaml
+++ b/deploy/helm/charts/platform/tests/power_qualification_catalog_test.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: Operator power qualification catalog
+templates:
+  - charts/dynamo-operator/templates/deployment.yaml
+  - charts/dynamo-operator/templates/operator-config.yaml
+
+tests:
+  - it: renders a fail-closed empty catalog by default
+    template: charts/dynamo-operator/templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DYNAMO_POWER_QUALIFICATION_CATALOG
+            value: '{}'
+
+  - it: renders exact qualified product bounds as immutable JSON
+    template: charts/dynamo-operator/templates/deployment.yaml
+    set:
+      dynamo-operator.dynamo.powerManagement.qualificationCatalog.NVIDIA-GB200.minWatts: 200
+      dynamo-operator.dynamo.powerManagement.qualificationCatalog.NVIDIA-GB200.defaultWatts: 1200
+      dynamo-operator.dynamo.powerManagement.qualificationCatalog.NVIDIA-GB200.maxWatts: 1200
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DYNAMO_POWER_QUALIFICATION_CATALOG
+            value: '{"NVIDIA-GB200":{"defaultWatts":1200,"maxWatts":1200,"minWatts":200}}'

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -105,6 +105,13 @@ dynamo-operator:
     # -- DEVELOPMENT AND TESTING ONLY: Enable GPU discovery in namespace-restricted mode.
     enabled: true
 
+  planner:
+    powerAwareness:
+      # -- Grant the Planner the read-only DGPB and Pod access required by
+      # Phase 2 transactional power planning. Default-off for graduated
+      # hardware-pool canaries; enabling this does not enroll a DGD by itself.
+      enabled: false
+
   # -- The Dynamo discovery backend to use. Default is "kubernetes" for Kubernetes API service discovery. Set to "etcd" to use ETCD for discovery. --
   discoveryBackend: "kubernetes"
 
@@ -147,6 +154,18 @@ dynamo-operator:
   dynamo:
     # -- How long to wait before forcefully terminating Grove instances
     groveTerminationDelay: 4h
+
+    # Power-aware transactional control remains default-off at the DGD level.
+    # When enabling it, qualify each exact nvidia.com/gpu.product value on the
+    # deployed driver/DCGM/image pool and add its observed limits here. The
+    # Operator reads this immutable process-start snapshot; an empty catalog
+    # fails transactional workloads closed as UnqualifiedHardware.
+    powerManagement:
+      qualificationCatalog: {}
+      # NVIDIA-GB200:
+      #   minWatts: 200
+      #   defaultWatts: 1200
+      #   maxWatts: 1200
 
     # Docker registry configuration for private repositories
     dockerRegistry:

--- a/deploy/helm/charts/power-agent/README.md
+++ b/deploy/helm/charts/power-agent/README.md
@@ -1,0 +1,242 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Power Agent
+
+The Power Agent applies per-GPU power caps on each selected node. Its existing
+static behavior remains the default. Phase 2 transactional enforcement is an
+explicit, qualified-hardware canary feature.
+
+## Transactional canary rollout
+
+Do not enable transactional mode until the exact GPU SKU, driver, Power Agent
+image, and selected actuator mode have passed qualification. The default NVML
+actuator does not require a DCGM hostengine. The optional DCGM actuator must
+also qualify its DCGM client and hostengine combination. `dcgm-exporter`
+remains the cluster monitoring path in either mode; it is not the Power
+Agent's cap-write transport. Use an otherwise idle canary node and record the
+immutable image digests and hardware/software versions with the result.
+
+The approved Phase 2 qualification matrix is explicit; do not substitute the
+weaker row for the stronger one:
+
+| Environment | Exact GPU product | Architecture | Required actuator evidence |
+| --- | --- | --- | --- |
+| Azure AKS | `NVIDIA-A100-SXM4-80GB` | `amd64` | NVML qualification |
+| GB200 cluster | `NVIDIA-GB200` | `arm64` | NVML/DCGM parity |
+
+Adding another environment, product, or architecture requires its own
+qualification record. In particular, an NVML-only GB200 run does not replace
+the required GB200 parity result.
+
+1. Label a small canary node pool and keep all non-canary nodes excluded by the
+   chart's `nodeSelector`.
+2. Confirm every GPU is idle and at its factory default power limit.
+3. Run the actuator fixture during an approved hardware window. The
+   Kubernetes harness requests the supplied GPU count on one exact-product
+   node, refuses busy/non-default devices, qualifies
+   minimum/default/maximum plus both clamp directions, exercises
+   source-mounted gate/CUDA ordering, saves immutable evidence, and deletes
+   only its uniquely named Job and ConfigMap. For the default NVML path, use
+   `--actuator-mode nvml`; no DCGM image or hostengine is needed:
+
+   ```bash
+   python3 deploy/power-agent/tests/run_k8s_hardware_qualification.py \
+     --kubectl kubectl \
+     --context <approved-context> \
+     --namespace <approved-namespace> \
+     --gpu-product <exact-nvidia.com/gpu.product-value> \
+     --gpu-count <all-gpus-on-one-canary-node> \
+     --architecture <amd64-or-arm64> \
+     --actuator-mode nvml \
+     --evidence-dir <local-evidence-directory>
+   ```
+
+   For the optional DCGM actuator, use parity mode. Before creating the Job,
+   this mode verifies the live version reported by every ready Pod behind the
+   DCGM Service (the hostengine namespace, Service, and container default to
+   the GPU Operator's standard names):
+
+   ```bash
+   python3 deploy/power-agent/tests/run_k8s_hardware_qualification.py \
+     --kubectl kubectl \
+     --context <approved-context> \
+     --namespace <approved-namespace> \
+     --gpu-product <exact-nvidia.com/gpu.product-value> \
+     --gpu-count <all-gpus-on-one-canary-node> \
+     --architecture <amd64-or-arm64> \
+     --actuator-mode nvml-dcgm-parity \
+     --dcgm-image <hostengine-compatible-dcgm-image> \
+     --hostengine-host <node-local-hostengine-service> \
+     --expected-hostengine-version <approved-live-hostengine-version> \
+     --evidence-dir <local-evidence-directory>
+   ```
+
+   The lower-level source-checkout command remains available inside an
+   already prepared qualification container:
+
+   ```bash
+   python deploy/power-agent/tests/e2e_actuator_parity.py \
+     --hostengine-host nvidia-dcgm.gpu-operator.svc.cluster.local \
+     --hostengine-port 5555 \
+     --skip-busy-gpus \
+     --require-default-before-write
+   ```
+
+   The released Power Agent image intentionally omits `tests/`. To qualify an
+   immutable release digest, first create a ConfigMap from the checkout's
+   fixture, then run a one-shot Pod on an otherwise idle node that is not being
+   controlled by another Power Agent:
+
+   ```bash
+   kubectl -n <namespace> create configmap power-agent-parity-fixture \
+     --from-file=e2e_actuator_parity.py=deploy/power-agent/tests/e2e_actuator_parity.py \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+
+   ```yaml
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: power-agent-actuator-qualification
+     namespace: <namespace>
+   spec:
+     nodeName: <idle-canary-node>
+     restartPolicy: Never
+     runtimeClassName: nvidia
+     hostPID: true
+     containers:
+       - name: qualify
+         image: <power-agent-image>@sha256:<digest>
+         command: ["python3", "/qualification/e2e_actuator_parity.py"]
+         args:
+           - --hostengine-host
+           - nvidia-dcgm.gpu-operator.svc.cluster.local
+           - --hostengine-port
+           - "5555"
+           - --skip-busy-gpus
+           - --require-default-before-write
+         env:
+           - name: PYTHONPATH
+             value: /app:/opt/dcgm/python
+           - name: NVIDIA_VISIBLE_DEVICES
+             value: all
+           - name: NVIDIA_DRIVER_CAPABILITIES
+             value: compute,utility
+         securityContext:
+           privileged: true
+         volumeMounts:
+           - name: fixture
+             mountPath: /qualification
+             readOnly: true
+     volumes:
+       - name: fixture
+         configMap:
+           name: power-agent-parity-fixture
+   ```
+
+   This mounts only the qualification script; `PYTHONPATH` makes it import the
+   actuator from `/app` while retaining the image's vendored DCGM bindings in
+   `/opt/dcgm/python`. Save the Pod logs, then delete the Pod and ConfigMap
+   after confirming every GPU is back at its entry cap.
+
+   The fixture must report matching UUID-keyed NVML and DCGM results for every
+   accepted write, restore every tested GPU to its entry/default cap, and pass
+   the final parity check. A read-only discovery pass is available with
+   `--read-only`, but it does not qualify cap writes.
+4. Verify each transactional worker runtime image contains the
+   `dynamo-power-gate` executable. A missing executable must prevent the
+   original backend command from running; it is a release blocker, not a
+   condition to bypass.
+5. Enable transactional access only on the Power Agent canary release:
+
+   ```yaml
+   agent:
+     transactional:
+       enabled: true
+   nodeSelector:
+     dynamo.nvidia.com/power-phase-2-canary: "true"
+   ```
+
+   This adds Pod `patch` permission and a read-only kubelet PodResources socket
+   mount. Namespace-restricted mode limits Pod access to the release namespace.
+6. Enable the paired Planner capability in the platform release:
+
+   ```yaml
+   dynamo-operator:
+     planner:
+       powerAwareness:
+         enabled: true
+   ```
+
+7. Enroll one DGD. Before widening the canary, require its
+   `DynamoGraphPowerBudget` `status.phase` to reach `Idle`, rather than
+   `Unqualified`, and independently read every accepted Agent report's GPU
+   UUID and cap with `nvidia-smi`. If a scale request remains pending, inspect
+   the DGDSA `status.pendingReason` for `UnqualifiedHardware`.
+
+Treat an unknown SKU, any assigned live minimum/maximum pair different from the
+catalog-qualified range, failed or stale readback, DCGM reconnect ambiguity,
+missing gate, or backend start without a valid report as a failed
+qualification. Do not mock or waive these outcomes.
+
+## Qualification record
+
+Keep one record for each exact hardware and software pool. Record the GPU
+product label, GPU count, driver, actuator mode, Power Agent image digest,
+minimum/default/maximum limits, requested test cap, and observed post-clamp
+cap. For DCGM mode, also record the DCGM client and hostengine versions. A tag
+without its resolved digest is not sufficient.
+
+Complete one row for every runtime image advertised for transactional use.
+Do not enable a backend whose row lacks immutable image evidence.
+
+| Backend | Image digest | Gate on `PATH` | Missing-gate negative test | Report precedes backend/CUDA initialization | Checkpoint rejected | Result |
+| --- | --- | --- | --- | --- | --- | --- |
+| vLLM | Required | Required | Required | Required | Required | PASS required |
+| SGLang | Required | Required | Required | Required | Required | PASS required |
+| TensorRT-LLM | Required | Required | Required | Required | Required | PASS required |
+
+For the missing-gate negative test, launch the rendered gate command against an
+image known not to contain `dynamo-power-gate`; the original command must write
+a marker if reached. Qualification passes only when the container fails and the
+marker is absent. Use
+`deploy/power-agent/tests/e2e_gate_entrypoint.py` only for source-mounted gate
+qualification; it does not prove that a released runtime image contains the
+installed console script.
+
+Exercise every lifecycle row on the approved canary and attach timestamps,
+Pod UIDs, GPU UUIDs, Agent reports, independent `nvidia-smi` reads, and relevant
+events or logs. Restore all tested GPUs to their entry cap before ending the
+window.
+
+| Scenario | Required observation |
+| --- | --- |
+| NVML and DCGM writes | Each path reports a UUID-bound successful write/readback that independently matches the target; an all-skipped or matching-failure run fails. |
+| Safe-default conflict | Backend marker stays absent and DGPB charges `U_c`, even when safe-default write/readback succeeds. |
+| Agent restart | Transactional cap remains live, durable ownership reloads, and fresh evidence is republished. |
+| DaemonSet rollout | Each unavailable Agent retains transactional caps; replacement reports match independent reads before the DGPB returns to `Idle`. |
+| DCGM reconnect | Ambiguous or failed identity closes the fence; recovery republishes exact UUID-bound evidence. |
+| Device re-enumeration | UUID identity survives index changes and no cap is accepted for the wrong GPU. |
+| Same-name Pod replacement | Old UID evidence is rejected; the new backend waits for a new UID-bound allocation report. |
+| External cap change | Agent detects and repairs the change; accepted report and independent read agree afterward. |
+| Unknown eligible SKU | DGPB enters `Unqualified`, scale-up is blocked, and ordinary reconciliation clears it only after operator-owned qualification data is corrected. |
+| Assigned live-range drift | DGPB charges `max(U_c, reportedLiveMaximum)` and remains `Unqualified` until the exact catalog range is observed. |
+| Static regression | Transactional flags remain false, Phase 1 RBAC/mounts/rendering are unchanged, and shutdown restores static caps. |
+
+A run is qualified only when all applicable rows are PASS. Record a missing
+runtime image, unavailable DCGM combination, insufficient cluster permission,
+or absent operator qualification source as BLOCKED with the exact artifact or
+authority needed; do not replace it with a mock result.
+
+## Rollback
+
+Stop new transactional enrollment and scale enrolled workloads to a safe
+state. The enrollment annotation is immutable: replace the DGD without that
+annotation, or delete it, rather than trying to patch it away. Wait for its
+worker Pods to disappear and verify the Agent has restored every released GPU
+UUID to its factory default. Then set both feature flags to `false` and remove
+the canary label. Leaving `agent.transactional.enabled=false` preserves the
+Phase 1 RBAC and does not mount the PodResources socket.

--- a/deploy/helm/charts/power-agent/templates/_helpers.tpl
+++ b/deploy/helm/charts/power-agent/templates/_helpers.tpl
@@ -220,14 +220,15 @@ not both enabled, and that dev mode has a pinned nodeName. Surfaces at
 {{- end -}}
 
 {{/*
-Validate the pod termination grace period. SIGTERM cleanup restores managed GPU
-caps from run()'s finally after any in-flight pod LIST returns, so very small
-values defeat the safety invariant this knob exists to protect.
+Validate the pod termination grace period. SIGTERM cleanup restores static GPU
+caps, retains active transactional ownership, and persists final state from
+run()'s finally after any in-flight pod LIST returns, so very small values
+defeat the safety invariant this knob exists to protect.
 */}}
 {{- define "power-agent.validateTerminationGracePeriod" -}}
 {{- $grace := int .Values.terminationGracePeriodSeconds -}}
 {{- if lt $grace 60 -}}
-{{- fail (printf "terminationGracePeriodSeconds=%d is too low for safe Power Agent shutdown; must be >= 60 seconds so SIGTERM cleanup has time to restore managed GPU caps after an in-flight pod LIST returns. Default is 60." $grace) -}}
+{{- fail (printf "terminationGracePeriodSeconds=%d is too low for safe Power Agent shutdown; must be >= 60 seconds so SIGTERM cleanup has time to restore static caps and persist transactional ownership after an in-flight pod LIST returns. Default is 60." $grace) -}}
 {{- end -}}
 {{- end -}}
 
@@ -246,6 +247,17 @@ Pod objects (no leftover ImagePullBackOff, no leftover RBAC).
 {{- $a := .Values.agent.actuator | default "" -}}
 {{- if not (or (eq $a "nvml") (eq $a "dcgm")) -}}
 {{- fail (printf "agent.actuator must be 'nvml' or 'dcgm'; got %q" $a) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Transactional mode needs the production DaemonSet's kubelet PodResources
+socket. Dev-pod mode intentionally retains its Phase 1 surface, and an install
+with both workload modes disabled would provide no enforcing Agent.
+*/}}
+{{- define "power-agent.validateTransactional" -}}
+{{- if and .Values.agent.transactional.enabled (not .Values.daemonset.enabled) -}}
+{{- fail "agent.transactional.enabled=true requires daemonset.enabled=true; transactional mode needs the production DaemonSet" -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/charts/power-agent/templates/daemonset.yaml
+++ b/deploy/helm/charts/power-agent/templates/daemonset.yaml
@@ -1,6 +1,7 @@
 {{- include "power-agent.validateImageTag" . -}}
 {{- include "power-agent.validateMutex" . -}}
 {{- include "power-agent.validateActuator" . -}}
+{{- include "power-agent.validateTransactional" . -}}
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -37,10 +38,11 @@ spec:
       # returned by nvmlDeviceGetComputeRunningProcesses. See power_agent.py
       # _extract_pod_uid_from_cgroup.
       hostPID: true
-      # Graceful shutdown restores default TGP on managed GPUs before exit
-      # (the reconcile loop runs the restore after SIGTERM, not the signal
-      # handler itself). Give it headroom to finish within the grace period;
-      # the pod LIST best-effort bounds (see power_agent.py
+      # Graceful shutdown restores static ownership to default TGP and keeps
+      # active transactional caps for the replacement Agent (the reconcile
+      # loop performs cleanup after SIGTERM, not the signal handler itself).
+      # Give it headroom to finish within the grace period; the pod LIST
+      # best-effort bounds (see power_agent.py
       # K8S_LIST_*_TIMEOUT_S) substantially limit cleanup delay if SIGTERM lands
       # mid-LIST. Configurable so operators on high-density nodes can extend it.
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
@@ -127,6 +129,11 @@ spec:
               readOnly: true
             - name: state
               mountPath: /var/lib/dynamo-power-agent
+            {{- if .Values.agent.transactional.enabled }}
+            - name: pod-resources
+              mountPath: /var/lib/kubelet/pod-resources
+              readOnly: true
+            {{- end }}
       volumes:
         - name: proc
           hostPath:
@@ -135,4 +142,10 @@ spec:
           hostPath:
             path: {{ .Values.state.hostPath | quote }}
             type: DirectoryOrCreate
+        {{- if .Values.agent.transactional.enabled }}
+        - name: pod-resources
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+            type: Directory
+        {{- end }}
 {{- end }}

--- a/deploy/helm/charts/power-agent/templates/dev-pod.yaml
+++ b/deploy/helm/charts/power-agent/templates/dev-pod.yaml
@@ -1,6 +1,7 @@
 {{- include "power-agent.validateDevImageTag" . -}}
 {{- include "power-agent.validateMutex" . -}}
 {{- include "power-agent.validateActuator" . -}}
+{{- include "power-agent.validateTransactional" . -}}
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/deploy/helm/charts/power-agent/templates/role.yaml
+++ b/deploy/helm/charts/power-agent/templates/role.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+{{- include "power-agent.validateTransactional" . -}}
 {{- if .Values.rbac.create }}
 {{- $effectiveRestricted := include "power-agent.effectiveNamespaceRestricted" . }}
 {{- if eq $effectiveRestricted "true" }}
@@ -21,7 +22,13 @@ rules:
   # instead of the cluster-wide default; see daemonset.yaml + dev-pod.yaml.
   - apiGroups: [""]
     resources: ["pods"]
+    {{- if .Values.agent.transactional.enabled }}
+    # Patch owns the bounded enforcement-report annotation. Kubernetes RBAC
+    # cannot restrict it to that key, so every bound namespace trusts the Agent.
+    verbs: ["get", "list", "watch", "patch"]
+    {{- else }}
     verbs: ["get", "list", "watch"]
+    {{- end }}
 {{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -30,11 +37,18 @@ metadata:
   labels:
     {{- include "power-agent.labels" . | nindent 4 }}
 rules:
-  # Cluster-wide pod read: the production DS sees worker pods in any
+  # Cluster-wide Pod access: the production DS sees worker pods in any
   # namespace on its node (GPU workloads may be spread across tenant
-  # namespaces). Verbs limited to read-only — the agent never mutates pods.
+  # namespaces).
   - apiGroups: [""]
     resources: ["pods"]
+    {{- if .Values.agent.transactional.enabled }}
+    # Patch is required for the one bounded enforcement-report annotation.
+    # Kubernetes RBAC cannot restrict patch to one annotation key, so this is
+    # the chart's explicit trusted-node-Agent privilege boundary.
+    verbs: ["get", "list", "watch", "patch"]
+    {{- else }}
     verbs: ["get", "list", "watch"]
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/charts/power-agent/tests/transactional_access_test.yaml
+++ b/deploy/helm/charts/power-agent/tests/transactional_access_test.yaml
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: transactional Pod access and kubelet PodResources mount
+release:
+  name: power-agent
+  namespace: dynamo-system
+
+tests:
+  - it: preserves exact Phase 1 cluster-wide Pod verbs by default
+    templates:
+      - templates/role.yaml
+    set:
+      image.tag: v1.0.0
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list", "watch"]
+
+  - it: preserves exact Phase 1 namespace-scoped Pod verbs by default
+    templates:
+      - templates/role.yaml
+    set:
+      image.tag: v1.0.0
+      rbac.namespaceRestricted: true
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: dynamo-system
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list", "watch"]
+
+  - it: does not mount kubelet PodResources by default
+    templates:
+      - templates/daemonset.yaml
+    set:
+      image.tag: v1.0.0
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: pod-resources
+            mountPath: /var/lib/kubelet/pod-resources
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: pod-resources
+            hostPath:
+              path: /var/lib/kubelet/pod-resources
+              type: Directory
+
+  - it: grants exact cluster-wide transactional Pod verbs when enabled
+    templates:
+      - templates/role.yaml
+    set:
+      image.tag: v1.0.0
+      agent.transactional.enabled: true
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list", "watch", "patch"]
+
+  - it: grants exact namespace-scoped transactional Pod verbs when enabled
+    templates:
+      - templates/role.yaml
+    set:
+      image.tag: v1.0.0
+      agent.transactional.enabled: true
+      rbac.namespaceRestricted: true
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list", "watch", "patch"]
+
+  - it: mounts kubelet PodResources read-only when transactional mode is enabled
+    templates:
+      - templates/daemonset.yaml
+    set:
+      image.tag: v1.0.0
+      agent.transactional.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: pod-resources
+            mountPath: /var/lib/kubelet/pod-resources
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: pod-resources
+            hostPath:
+              path: /var/lib/kubelet/pod-resources
+              type: Directory
+
+  - it: rejects transactional dev-pod mode
+    templates:
+      - templates/role.yaml
+    set:
+      daemonset.enabled: false
+      dev.enabled: true
+      dev.nodeName: gpu-node
+      agent.transactional.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "agent.transactional.enabled=true requires daemonset.enabled=true; transactional mode needs the production DaemonSet"
+
+  - it: rejects transactional mode when no Agent workload is enabled
+    templates:
+      - templates/role.yaml
+    set:
+      daemonset.enabled: false
+      dev.enabled: false
+      agent.transactional.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "agent.transactional.enabled=true requires daemonset.enabled=true; transactional mode needs the production DaemonSet"

--- a/deploy/helm/charts/power-agent/values.yaml
+++ b/deploy/helm/charts/power-agent/values.yaml
@@ -31,6 +31,14 @@ imagePullSecrets: []
 #   - name: ngc-secret
 
 agent:
+  transactional:
+    # Phase 2 transactional enforcement is deliberately default-off. Enable
+    # only after qualifying the exact GPU/driver/DCGM pool and installing an
+    # operator/runtime image set that includes the DGPB controller and
+    # dynamo-power-gate. When false, the chart preserves the Phase 1 RBAC and
+    # does not mount kubelet's PodResources socket.
+    enabled: false
+
   # Per-SKU safety floor. The agent applies this cap to an opted-in GPU (one
   # whose pod carries dynamo.nvidia.com/gpu-power-limit) when the annotated
   # value cannot be used:
@@ -115,21 +123,23 @@ agent:
     # that already-set target; issued right after Set it re-applies a value
     # that is already current, so it is redundant. An earlier revision exposed
     # it behind an `enforce` flag; that flag was removed as dead config. Notes:
-    #   - The cap does NOT survive Power Agent restart (SIGTERM restores
-    #     default regardless).
+    #   - On Power Agent shutdown, static ownership restores the factory
+    #     default. Transactional ownership intentionally retains its live cap
+    #     so a replacement Agent can resume the same durable GPU identity.
     #   - External `nvidia-smi -pl` clobbering is repaired on the Power
     #     Agent's next 15-s reconcile (which re-issues dcgmConfigSet),
     #     same as NVML.
 
-# Pod termination grace period (seconds). On SIGTERM the agent restores each
-# managed GPU's default power cap before exit; that cleanup runs from the
+# Pod termination grace period (seconds). On SIGTERM the agent restores static
+# ownership to the factory default and retains active transactional caps for a
+# replacement Agent. That cleanup and durable-state work runs from the
 # reconcile loop's `finally`, AFTER any in-flight pod LIST returns. The LIST is
 # best-effort bounded client- and server-side (K8S_LIST_*_TIMEOUT_S in
 # power_agent.py) to substantially limit cleanup delay, but the default is set
 # to 60s (2× the previous 30s) to leave headroom for the LIST to return and for
-# per-GPU restore on high-density nodes. Kubelet SIGKILLs the pod when this
-# elapses, so values below 60s are rejected by the chart; too-small values risk
-# killing the agent mid-cleanup and leaving managed caps live. Applies to both
+# per-GPU identity-safe cleanup on high-density nodes. Kubelet SIGKILLs the pod
+# when this elapses, so values below 60s are rejected by the chart; too-small
+# values risk interrupting ownership cleanup or persistence. Applies to both
 # DaemonSet and dev-pod modes.
 terminationGracePeriodSeconds: 60
 
@@ -203,19 +213,21 @@ rbac:
 daemonset:
   enabled: true
 
-  # Conservative default by design: when a Power Agent restarts, the GPUs
-  # on its node have no power-cap enforcement until it comes back. If worker
-  # pods on that node carry DGD-owned per-GPU cap annotations (applied by the
-  # operator), those caps are not enforced during the gap. `maxUnavailable: 1`
-  # ensures only one node's worth of GPUs ever loses enforcement at a time.
+  # Conservative default by design. In static mode, a Power Agent restart
+  # restores managed GPUs and may leave an enforcement gap until replacement.
+  # In transactional mode, durable ownership retains active caps across Agent
+  # replacement, while the unavailable Agent still delays fresh evidence and
+  # identity-safe cleanup. `maxUnavailable: 1` bounds either exposure to one
+  # node at a time.
   #
   # Override for large fleets: on clusters with hundreds of GPU nodes,
   # a 1-at-a-time rollout (~30s/pod × N nodes) gets slow. Operators can
   # opt into faster rollouts with:
   #   --set daemonset.updateStrategy.rollingUpdate.maxUnavailable=10%
-  # (or any percentage / integer). The trade-off is more concurrent
-  # enforcement gaps during a rollout; safe when the agent's reconcile
-  # interval (15s) is much shorter than the rollout duration anyway.
+  # (or any percentage / integer). The trade-off is more concurrent static
+  # enforcement gaps, or more nodes without fresh transactional reports,
+  # during the rollout. Qualify that wider exposure before overriding the
+  # conservative default.
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Overview:

Wires transactional power controls into the Power Agent and platform Helm charts, including production qualification configuration.

## Details:

- Adds required Pod RBAC, PodResources socket access, gate settings, and qualification catalog/provider values.
- Wires Planner DGPB read access and Operator identity/configuration.
- Adds Helm regression coverage and deployment guidance for static versus transactional ownership.
- Records successful Azure A100 NVML and AWS GB200 NVML/DCGM qualification.

## Where should the reviewer start?

Start with the Power Agent `daemonset.yaml` and `role.yaml`, then the platform chart Operator values and tests.

## Stack

Part 6 of 6. Depends on #13459.

## Validation

- Power Agent Helm suite: 58 passed.
- Platform Helm suite: 40 passed.
- Azure AKS, NVIDIA A100, amd64: NVML clamp, gated startup, missing-gate rejection, and cap restoration.
- AWS, NVIDIA GB200, arm64: NVML/DCGM parity, clamp, gated startup, and cap restoration.

## Related Issues

- Relates to #13255
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->