### PR TITLE
fix(kv-router): index canonical sequence hashes in the DC CKF

### DIFF
--- a/lib/bench/kv_router/common/dc_ckf_parity.rs
+++ b/lib/bench/kv_router/common/dc_ckf_parity.rs
@@ -316,6 +316,7 @@ mod tests {
     use super::*;
 
     fn stored(worker: u64, event_id: u64, hash: u64) -> RouterEvent {
+        const EXTERNAL_MASK: u64 = 0xB3EC_4A11_7E57_F00D;
         RouterEvent::new(
             worker,
             KvCacheEvent {
@@ -324,7 +325,7 @@ mod tests {
                     parent_hash: None,
                     start_position: None,
                     blocks: vec![KvCacheStoredBlockData {
-                        block_hash: ExternalSequenceBlockHash(hash),
+                        block_hash: ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK),
                         tokens_hash: LocalBlockHash(hash),
                         mm_extra_info: None,
                     }],
@@ -335,12 +336,13 @@ mod tests {
     }
 
     fn removed(worker: u64, event_id: u64, hash: u64) -> RouterEvent {
+        const EXTERNAL_MASK: u64 = 0xB3EC_4A11_7E57_F00D;
         RouterEvent::new(
             worker,
             KvCacheEvent {
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
-                    block_hashes: vec![ExternalSequenceBlockHash(hash)],
+                    block_hashes: vec![ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK)],
                 }),
                 dp_rank: 0,
             },

--- a/lib/bench/kv_router/common/dc_ckf_shared.rs
+++ b/lib/bench/kv_router/common/dc_ckf_shared.rs
@@ -493,6 +493,7 @@ mod tests {
     }
 
     fn stored(event_id: u64, dp_rank: u32, hashes: &[u64]) -> KvCacheEvent {
+        const EXTERNAL_MASK: u64 = 0x5A4E_D00D_7711_0202;
         KvCacheEvent {
             event_id,
             dp_rank,
@@ -502,7 +503,7 @@ mod tests {
                 blocks: hashes
                     .iter()
                     .map(|hash| KvCacheStoredBlockData {
-                        block_hash: ExternalSequenceBlockHash(*hash),
+                        block_hash: ExternalSequenceBlockHash(*hash ^ EXTERNAL_MASK),
                         tokens_hash: LocalBlockHash(*hash),
                         mm_extra_info: None,
                     })
@@ -512,6 +513,7 @@ mod tests {
     }
 
     fn removed(event_id: u64, dp_rank: u32, hashes: &[u64]) -> KvCacheEvent {
+        const EXTERNAL_MASK: u64 = 0x5A4E_D00D_7711_0202;
         KvCacheEvent {
             event_id,
             dp_rank,
@@ -519,7 +521,7 @@ mod tests {
                 block_hashes: hashes
                     .iter()
                     .copied()
-                    .map(ExternalSequenceBlockHash)
+                    .map(|hash| ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK))
                     .collect(),
             }),
         }

--- a/lib/bench/kv_router/common/dc_ckf_shared.rs
+++ b/lib/bench/kv_router/common/dc_ckf_shared.rs
@@ -6,7 +6,10 @@ use std::io::{BufReader, Read};
 use std::path::Path;
 
 use anyhow::{Context, bail};
-use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, WorkerWithDpRank};
+use dynamo_kv_router::indexer::cuckoo::CanonicalSequenceBlockHash;
+use dynamo_kv_router::protocols::{
+    ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData, WorkerWithDpRank,
+};
 use dynamo_mocker::loadgen::{SessionTrace, Trace};
 use dynamo_mocker::replay::ReplayWorkerArtifacts;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -394,8 +397,14 @@ fn verify_sha256(expected: &str, actual: &str) -> anyhow::Result<()> {
 
 #[derive(Default)]
 struct PoolCapacityTracker {
-    members: FxHashMap<WorkerWithDpRank, FxHashSet<u64>>,
-    global_degrees: FxHashMap<u64, u32>,
+    /// Per-source engine vocabulary, mirroring the real CKF: capacity is sized by canonical
+    /// hashes, because different sources can assign different external ids to identical
+    /// canonical content and the filter deduplicates on the canonical domain.
+    lineage: FxHashMap<
+        WorkerWithDpRank,
+        FxHashMap<ExternalSequenceBlockHash, CanonicalSequenceBlockHash>,
+    >,
+    global_degrees: FxHashMap<CanonicalSequenceBlockHash, u32>,
     peak_active_distinct: usize,
     event_count: usize,
 }
@@ -403,14 +412,10 @@ struct PoolCapacityTracker {
 impl PoolCapacityTracker {
     fn apply(&mut self, member: WorkerWithDpRank, event: &KvCacheEvent) -> anyhow::Result<()> {
         match &event.data {
-            KvCacheEventData::Stored(stored) => {
-                for block in &stored.blocks {
-                    self.store(member, block.block_hash.0)?;
-                }
-            }
+            KvCacheEventData::Stored(stored) => self.store(member, stored)?,
             KvCacheEventData::Removed(removed) => {
                 for hash in &removed.block_hashes {
-                    self.remove(member, hash.0)?;
+                    self.remove(member, *hash)?;
                 }
             }
             KvCacheEventData::Cleared => self.clear(member)?,
@@ -423,46 +428,69 @@ impl PoolCapacityTracker {
         Ok(())
     }
 
-    fn store(&mut self, member: WorkerWithDpRank, hash: u64) -> anyhow::Result<()> {
-        if !self.members.entry(member).or_default().insert(hash) {
-            return Ok(());
+    fn store(&mut self, member: WorkerWithDpRank, stored: &KvCacheStoreData) -> anyhow::Result<()> {
+        let lineage = self.lineage.entry(member).or_default();
+        let mut previous = match stored.parent_hash {
+            Some(parent) => Some(
+                *lineage
+                    .get(&parent)
+                    .with_context(|| format!("capacity tracker: unknown parent {}", parent.0))?,
+            ),
+            None => None,
+        };
+        for block in &stored.blocks {
+            let canonical = previous.map_or_else(
+                || CanonicalSequenceBlockHash::root(block.tokens_hash),
+                |parent| parent.child(block.tokens_hash),
+            );
+            previous = Some(canonical);
+            if lineage.insert(block.block_hash, canonical).is_some() {
+                continue;
+            }
+            let degree = self.global_degrees.entry(canonical).or_default();
+            *degree = degree
+                .checked_add(1)
+                .context("DC CKF ownership degree overflow while sizing corpus")?;
         }
-        let degree = self.global_degrees.entry(hash).or_default();
-        *degree = degree
-            .checked_add(1)
-            .context("DC CKF ownership degree overflow while sizing corpus")?;
         Ok(())
     }
 
-    fn remove(&mut self, member: WorkerWithDpRank, hash: u64) -> anyhow::Result<()> {
-        let Some(hashes) = self.members.get_mut(&member) else {
+    fn remove(
+        &mut self,
+        member: WorkerWithDpRank,
+        hash: ExternalSequenceBlockHash,
+    ) -> anyhow::Result<()> {
+        let Some(lineage) = self.lineage.get_mut(&member) else {
             return Ok(());
         };
-        if !hashes.remove(&hash) {
+        let Some(canonical) = lineage.remove(&hash) else {
             return Ok(());
+        };
+        if lineage.is_empty() {
+            self.lineage.remove(&member);
         }
-        if hashes.is_empty() {
-            self.members.remove(&member);
-        }
-        self.decrement(hash)
+        self.decrement(canonical)
     }
 
     fn clear(&mut self, member: WorkerWithDpRank) -> anyhow::Result<()> {
-        let Some(hashes) = self.members.remove(&member) else {
+        let Some(lineage) = self.lineage.remove(&member) else {
             return Ok(());
         };
-        for hash in hashes {
-            self.decrement(hash)?;
+        for (_, canonical) in lineage {
+            self.decrement(canonical)?;
         }
         Ok(())
     }
 
-    fn decrement(&mut self, hash: u64) -> anyhow::Result<()> {
-        let Some(degree) = self.global_degrees.get_mut(&hash) else {
-            bail!("capacity tracker lost ownership degree for hash {hash}");
+    fn decrement(&mut self, canonical: CanonicalSequenceBlockHash) -> anyhow::Result<()> {
+        let Some(degree) = self.global_degrees.get_mut(&canonical) else {
+            bail!(
+                "capacity tracker lost ownership degree for canonical hash {}",
+                canonical.as_u64()
+            );
         };
         if *degree == 1 {
-            self.global_degrees.remove(&hash);
+            self.global_degrees.remove(&canonical);
         } else {
             *degree -= 1;
         }
@@ -492,8 +520,13 @@ mod tests {
         Ok(file)
     }
 
-    fn stored(event_id: u64, dp_rank: u32, hashes: &[u64]) -> KvCacheEvent {
+    fn source_external(dp_rank: u32, hash: u64) -> ExternalSequenceBlockHash {
+        // Real engines assign per-process ids, so the fixture derives source-local externals.
         const EXTERNAL_MASK: u64 = 0x5A4E_D00D_7711_0202;
+        ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK ^ ((dp_rank as u64) << 48))
+    }
+
+    fn stored(event_id: u64, dp_rank: u32, hashes: &[u64]) -> KvCacheEvent {
         KvCacheEvent {
             event_id,
             dp_rank,
@@ -503,7 +536,7 @@ mod tests {
                 blocks: hashes
                     .iter()
                     .map(|hash| KvCacheStoredBlockData {
-                        block_hash: ExternalSequenceBlockHash(*hash ^ EXTERNAL_MASK),
+                        block_hash: source_external(dp_rank, *hash),
                         tokens_hash: LocalBlockHash(*hash),
                         mm_extra_info: None,
                     })
@@ -513,15 +546,13 @@ mod tests {
     }
 
     fn removed(event_id: u64, dp_rank: u32, hashes: &[u64]) -> KvCacheEvent {
-        const EXTERNAL_MASK: u64 = 0x5A4E_D00D_7711_0202;
         KvCacheEvent {
             event_id,
             dp_rank,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: hashes
                     .iter()
-                    .copied()
-                    .map(|hash| ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK))
+                    .map(|hash| source_external(dp_rank, *hash))
                     .collect(),
             }),
         }

--- a/lib/bench/kv_router/common/dc_ckf_shared.rs
+++ b/lib/bench/kv_router/common/dc_ckf_shared.rs
@@ -520,13 +520,14 @@ mod tests {
         Ok(file)
     }
 
-    fn source_external(dp_rank: u32, hash: u64) -> ExternalSequenceBlockHash {
-        // Real engines assign per-process ids, so the fixture derives source-local externals.
+    fn source_external(worker: u64, dp_rank: u32, hash: u64) -> ExternalSequenceBlockHash {
+        // Real engines assign per-process ids, so the fixture derives externals that differ
+        // per worker and per rank; only the canonical domain may deduplicate across sources.
         const EXTERNAL_MASK: u64 = 0x5A4E_D00D_7711_0202;
-        ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK ^ ((dp_rank as u64) << 48))
+        ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK ^ (worker << 32) ^ ((dp_rank as u64) << 48))
     }
 
-    fn stored(event_id: u64, dp_rank: u32, hashes: &[u64]) -> KvCacheEvent {
+    fn stored(worker: u64, event_id: u64, dp_rank: u32, hashes: &[u64]) -> KvCacheEvent {
         KvCacheEvent {
             event_id,
             dp_rank,
@@ -536,7 +537,7 @@ mod tests {
                 blocks: hashes
                     .iter()
                     .map(|hash| KvCacheStoredBlockData {
-                        block_hash: source_external(dp_rank, *hash),
+                        block_hash: source_external(worker, dp_rank, *hash),
                         tokens_hash: LocalBlockHash(*hash),
                         mm_extra_info: None,
                     })
@@ -545,14 +546,14 @@ mod tests {
         }
     }
 
-    fn removed(event_id: u64, dp_rank: u32, hashes: &[u64]) -> KvCacheEvent {
+    fn removed(worker: u64, event_id: u64, dp_rank: u32, hashes: &[u64]) -> KvCacheEvent {
         KvCacheEvent {
             event_id,
             dp_rank,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: hashes
                     .iter()
-                    .map(|hash| source_external(dp_rank, *hash))
+                    .map(|hash| source_external(worker, dp_rank, *hash))
                     .collect(),
             }),
         }
@@ -687,17 +688,19 @@ mod tests {
                 trace_distinct_hash_upper_bound: 2,
             }],
         };
+        // Both workers store the same canonical [10, 20] prefix under worker-local external
+        // ids; external counting would report a peak of 5, canonical counting reports 3.
         let artifacts = vec![
             ReplayWorkerArtifacts {
                 kv_events: vec![
-                    timed(1, stored(1, 0, &[10, 20])),
-                    timed(3, removed(2, 0, &[10, 20])),
+                    timed(1, stored(0, 1, 0, &[10, 20])),
+                    timed(3, removed(0, 2, 0, &[10, 20])),
                 ],
                 ..Default::default()
             },
             ReplayWorkerArtifacts {
                 kv_events: vec![
-                    timed(2, stored(1, 0, &[20, 30])),
+                    timed(2, stored(1, 1, 0, &[10, 20, 30])),
                     timed(
                         4,
                         KvCacheEvent {

--- a/lib/bench/kv_router/dc_ckf_consumer_bench.rs
+++ b/lib/bench/kv_router/dc_ckf_consumer_bench.rs
@@ -485,6 +485,7 @@ fn generate_lane_state(
         let outcome = state.apply_event(stored_event(
             member,
             hash_offset as u64 + 1,
+            (!hash_offset.is_multiple_of(query_depth)).then(|| sequence_hashes[hash_offset - 1]),
             sequence_hash,
             local_hash,
         ));
@@ -528,6 +529,7 @@ fn generate_lane_state(
         let store = state.apply_event(stored_event(
             member,
             baseline_hashes as u64 + frame_pair as u64 * 2 + 2,
+            (!hash_offset.is_multiple_of(query_depth)).then(|| sequence_hashes[hash_offset - 1]),
             hash,
             local_hashes[hash_offset],
         ));
@@ -571,18 +573,21 @@ fn lane_hash_base(lane: usize) -> anyhow::Result<u64> {
 fn stored_event(
     member: WorkerWithDpRank,
     event_id: u64,
+    parent_sequence_hash: Option<u64>,
     sequence_hash: u64,
     local_hash: LocalBlockHash,
 ) -> RouterEvent {
+    const EXTERNAL_MASK: u64 = 0x8E11_6E5E_3A7A_2026;
     RouterEvent::new(
         member.worker_id,
         KvCacheEvent {
             event_id,
             data: KvCacheEventData::Stored(KvCacheStoreData {
-                parent_hash: None,
+                parent_hash: parent_sequence_hash
+                    .map(|hash| ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK)),
                 start_position: None,
                 blocks: vec![KvCacheStoredBlockData {
-                    block_hash: ExternalSequenceBlockHash(sequence_hash),
+                    block_hash: ExternalSequenceBlockHash(sequence_hash ^ EXTERNAL_MASK),
                     tokens_hash: local_hash,
                     mm_extra_info: None,
                 }],
@@ -593,12 +598,13 @@ fn stored_event(
 }
 
 fn removed_event(member: WorkerWithDpRank, event_id: u64, hash: u64) -> RouterEvent {
+    const EXTERNAL_MASK: u64 = 0x8E11_6E5E_3A7A_2026;
     RouterEvent::new(
         member.worker_id,
         KvCacheEvent {
             event_id,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
-                block_hashes: vec![ExternalSequenceBlockHash(hash)],
+                block_hashes: vec![ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK)],
             }),
             dp_rank: member.dp_rank,
         },

--- a/lib/bench/kv_router/dc_ckf_relay_bench.rs
+++ b/lib/bench/kv_router/dc_ckf_relay_bench.rs
@@ -30,8 +30,8 @@ use dynamo_kv_router::identity::{
     CacheSemanticsId, DcId, IdentitySource, IndexerDomainId, PoolId, RoutingScopeId,
 };
 use dynamo_kv_router::indexer::cuckoo::{
-    CkfConfig, ConsumerInstanceId, DcCkfDelta, DcCkfDeltaSink, DcCkfPublicationBatch,
-    DcCkfPublisher, DcCkfState, LaneLease, ProducerIdentity,
+    CanonicalSequenceBlockHash, CkfConfig, ConsumerInstanceId, DcCkfDelta, DcCkfDeltaSink,
+    DcCkfPublicationBatch, DcCkfPublisher, DcCkfState, LaneLease, ProducerIdentity,
 };
 use dynamo_kv_router::protocols::{
     ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheEventError, RouterEvent,
@@ -520,15 +520,14 @@ fn actor_snapshot(
         .saturating_add(size_of::<ActorPublisher>())
         .saturating_add(memory.filter_bytes())
         .saturating_add(memory.dirty_tracking_bytes())
+        .saturating_add(memory.source_lineage_capacity().saturating_mul(size_of::<(
+            ExternalSequenceBlockHash,
+            CanonicalSequenceBlockHash,
+        )>()))
         .saturating_add(
             memory
-                .member_set_capacity()
-                .saturating_mul(size_of::<ExternalSequenceBlockHash>()),
-        )
-        .saturating_add(
-            memory
-                .refcount_capacity()
-                .saturating_mul(size_of::<(ExternalSequenceBlockHash, u32)>()),
+                .canonical_owner_capacity()
+                .saturating_mul(size_of::<(CanonicalSequenceBlockHash, u32)>()),
         )
         .saturating_add(
             memory

--- a/lib/kv-router/src/indexer/cuckoo.rs
+++ b/lib/kv-router/src/indexer/cuckoo.rs
@@ -19,9 +19,8 @@ mod tests;
 pub use adapter::*;
 pub use canonical::CanonicalSequenceBlockHash;
 pub use dc::{
-    DcCkfAggregationStats, DcCkfEventOutcome, DcCkfFormatIdentity, DcCkfFormatIdentityError,
-    DcCkfMemoryStats, DcCkfPublicationBatch, DcCkfPublicationStats, DcCkfRankReplacement,
-    DcCkfState, DcCkfStats,
+    DcCkfAggregationStats, DcCkfEventOutcome, DcCkfFormatIdentity, DcCkfMemoryStats,
+    DcCkfPublicationBatch, DcCkfPublicationStats, DcCkfRankReplacement, DcCkfState, DcCkfStats,
 };
 pub use failure::{
     CkfCommitState, CkfFailureAction, CkfFailureDisposition, CkfFailureDomain, CkfFailurePoint,

--- a/lib/kv-router/src/indexer/cuckoo.rs
+++ b/lib/kv-router/src/indexer/cuckoo.rs
@@ -4,6 +4,7 @@
 mod adapter;
 mod addressing;
 mod bucket;
+mod canonical;
 mod dc;
 mod failure;
 mod global;
@@ -16,9 +17,11 @@ mod search;
 mod tests;
 
 pub use adapter::*;
+pub use canonical::CanonicalSequenceBlockHash;
 pub use dc::{
-    DcCkfAggregationStats, DcCkfEventOutcome, DcCkfFormatIdentity, DcCkfMemoryStats,
-    DcCkfPublicationBatch, DcCkfPublicationStats, DcCkfState, DcCkfStats,
+    DcCkfAggregationStats, DcCkfEventOutcome, DcCkfFormatIdentity, DcCkfFormatIdentityError,
+    DcCkfMemoryStats, DcCkfPublicationBatch, DcCkfPublicationStats, DcCkfRankReplacement,
+    DcCkfState, DcCkfStats,
 };
 pub use failure::{
     CkfCommitState, CkfFailureAction, CkfFailureDisposition, CkfFailureDomain, CkfFailurePoint,

--- a/lib/kv-router/src/indexer/cuckoo/README.md
+++ b/lib/kv-router/src/indexer/cuckoo/README.md
@@ -37,15 +37,19 @@ therefore a distinct DC within that domain.
 
 `DcCkfState` keeps the exact state needed to make mutation decisions:
 
-- `member_blocks[(worker, dp_rank)]` records exact full-hash ownership.
-- `dc_refcounts[full_hash]` equals the number of members that own the hash.
-- A full hash contributes one physical fingerprint to the CKF while its refcount is nonzero.
-- Additional owners change the refcount without inserting another CKF copy.
-- Different full hashes that map to the same representation contribute separate physical copies.
-- An unknown `(member, full_hash)` removal is an idempotent no-op. It never deletes by fingerprint.
+- `source_lineage[(worker, dp_rank)]` maps each source's engine-specific external block id to
+  the canonical Dynamo sequence hash derived from its `tokens_hash` chain. Engine vocabulary
+  never crosses this boundary: only canonical hashes reach ownership, residency, or the filter.
+- `canonical_owners[canonical]` carries the owner count together with a residency flag.
+- A canonical hash contributes one physical fingerprint to the CKF while it is resident.
+- Additional owners (or same-source external aliases) change the count without inserting
+  another CKF copy, so identical content deduplicates across sources.
+- An unknown `(member, external)` removal is an idempotent no-op. It never deletes by
+  fingerprint, and removals resolve through source lineage because `Removed` events carry only
+  external ids.
 
-The CKF is a lossy projection, not the authority. A packed fingerprint has no full-hash identity,
-so exact ownership and refcounts must remain on the producer side.
+The CKF is a lossy projection, not the authority. A packed fingerprint has no canonical-hash
+identity, so exact lineage and ownership must remain on the producer side.
 
 Store and remove transitions are consequently:
 
@@ -71,11 +75,11 @@ locking. Cuckoo insertion may relocate resident fingerprints with bounded forwar
 those writes back if no path succeeds. `max_kicks` is a bounded-search limit; reaching it does not
 prove that the table is full.
 
-Capacity exhaustion is an observable, pre-commit omission for the affected block. It does not add
-an exact ownership edge, change a refcount, dirty a bucket, fence the pool, or retire the consumer
-lane. Service continues, a later remove is an unknown no-op, and a later store may retry after
-occupancy changes. This permits stable false negatives relative to the source cache without
-corrupting tracked producer state.
+Capacity exhaustion omits only the physical admission: exact lineage and ownership still commit
+(`CkfCommitState::ExactCommittedPhysicalOmitted`), so a later remove resolves normally and a
+repeated store re-offers the block on a relocation-free path once occupancy changes. It does not
+dirty a bucket, fence the pool, or retire the consumer lane. This permits stable false negatives
+relative to the source cache without corrupting tracked producer state.
 
 ## Publication protocol
 
@@ -150,7 +154,7 @@ Recovery targets the state whose commit became uncertain:
 - Suspect exact producer state requires a producer-generation rebuild.
 - A trustworthy producer with an uncertain publication stream needs a new lease and snapshot.
 - An uncertain consumer lane needs lane retirement and a new snapshot, not producer recovery.
-- Ordinary pre-commit capacity exhaustion is an omission and requires no recovery.
+- Ordinary capacity exhaustion omits only physical admission and requires no recovery.
 
 The in-process `LocalCkfAdapter` exercises this complete boundary today. Non-local transport can
 carry the same snapshot/delta protocol without moving exact full-hash ownership into the global

--- a/lib/kv-router/src/indexer/cuckoo/adapter.rs
+++ b/lib/kv-router/src/indexer/cuckoo/adapter.rs
@@ -274,8 +274,9 @@ impl LocalCkfAdapter {
     }
 
     /// Apply one actor-serialized event and synchronously hand any resulting publication to the
-    /// bounded ingestion FIFO. Capacity exhaustion remains the event's observable pre-commit
-    /// omission; it neither retires the lease nor starts snapshot recovery.
+    /// bounded ingestion FIFO. Capacity exhaustion commits exact lineage and ownership while
+    /// omitting only the physical admission; it neither retires the lease nor starts snapshot
+    /// recovery.
     pub fn apply_event(
         &mut self,
         event: RouterEvent,

--- a/lib/kv-router/src/indexer/cuckoo/adapter.rs
+++ b/lib/kv-router/src/indexer/cuckoo/adapter.rs
@@ -469,6 +469,7 @@ mod tests {
     }
 
     fn stored(event_id: u64, hash: u64) -> RouterEvent {
+        const EXTERNAL_MASK: u64 = 0xA17A_9E31_52C4_D607;
         RouterEvent::new(
             1,
             KvCacheEvent {
@@ -477,7 +478,7 @@ mod tests {
                     parent_hash: None,
                     start_position: None,
                     blocks: vec![KvCacheStoredBlockData {
-                        block_hash: ExternalSequenceBlockHash(hash),
+                        block_hash: ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK),
                         tokens_hash: LocalBlockHash(hash),
                         mm_extra_info: None,
                     }],
@@ -488,12 +489,13 @@ mod tests {
     }
 
     fn removed(event_id: u64, hash: u64) -> RouterEvent {
+        const EXTERNAL_MASK: u64 = 0xA17A_9E31_52C4_D607;
         RouterEvent::new(
             1,
             KvCacheEvent {
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
-                    block_hashes: vec![ExternalSequenceBlockHash(hash)],
+                    block_hashes: vec![ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK)],
                 }),
                 dp_rank: 0,
             },
@@ -571,8 +573,8 @@ mod tests {
         assert_ne!(adapter.indexer().ready_lanes(), 0);
         adapter.exact_consumer_drain().unwrap();
 
-        let unknown = adapter.apply_event(removed(100, omitted)).unwrap();
-        assert_eq!(unknown.unknown_removals, 1);
+        let omitted_removal = adapter.apply_event(removed(100, omitted)).unwrap();
+        assert_eq!(omitted_removal.unknown_removals, 0);
         assert_ne!(adapter.indexer().ready_lanes(), 0);
         for (offset, hash) in inserted.into_iter().enumerate() {
             adapter

--- a/lib/kv-router/src/indexer/cuckoo/canonical.rs
+++ b/lib/kv-router/src/indexer/cuckoo/canonical.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::protocols::{LocalBlockHash, compute_next_seq_hash};
+
+/// Dynamo's canonical rolling sequence hash for one KV-cache block.
+///
+/// Engine-specific block identifiers must be translated to this type before
+/// they enter CKF ownership, residency, or publication state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CanonicalSequenceBlockHash(u64);
+
+impl CanonicalSequenceBlockHash {
+    /// Start a canonical sequence. The first sequence hash is the block's local token hash.
+    pub const fn root(tokens_hash: LocalBlockHash) -> Self {
+        Self(tokens_hash.0)
+    }
+
+    /// Extend a canonical sequence with the next block's local token hash.
+    pub fn child(self, tokens_hash: LocalBlockHash) -> Self {
+        Self(compute_next_seq_hash(self.0, tokens_hash))
+    }
+
+    /// Return the wire-compatible `u64` fingerprint input.
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::protocols::{LocalBlockHash, compute_next_seq_hash};
+
+    use super::CanonicalSequenceBlockHash;
+
+    #[test]
+    fn root_and_child_match_dynamo_sequence_hashing() {
+        let first = LocalBlockHash(17);
+        let second = LocalBlockHash(23);
+        let root = CanonicalSequenceBlockHash::root(first);
+
+        assert_eq!(root.as_u64(), first.0);
+        assert_eq!(
+            root.child(second).as_u64(),
+            compute_next_seq_hash(first.0, second)
+        );
+    }
+}

--- a/lib/kv-router/src/indexer/cuckoo/dc.rs
+++ b/lib/kv-router/src/indexer/cuckoo/dc.rs
@@ -10,18 +10,19 @@
 //! A snapshot therefore establishes one physical base, and only that producer's
 //! ordered absolute-image deltas may extend it byte-for-byte.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::protocols::{
-    ExternalSequenceBlockHash, KvCacheEventData, KvCacheEventError, RouterEvent, StorageTier,
+    ExternalSequenceBlockHash, KvCacheEventData, KvCacheEventError, KvCacheStoreData, RouterEvent,
     WorkerId, WorkerWithDpRank,
 };
 
 use super::addressing::CkfAddressing;
 use super::bucket::{CuckooBucketStore, OwnedPackedCkfLane, PackedBucket};
+use super::canonical::CanonicalSequenceBlockHash;
 use super::global::GlobalCkfBucketImage;
 use super::mutator::{CuckooInsertionScratch, CuckooMutator, lane_rng_seed};
 use super::{CkfBuildError, CkfConfig, bucket_count, validate_config};
@@ -39,6 +40,18 @@ pub struct DcCkfFormatIdentity {
     slots_per_bucket: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum DcCkfFormatIdentityError {
+    #[error("unsupported CKF format version {actual} (expected {expected})")]
+    FormatVersion { expected: u16, actual: u16 },
+    #[error("unsupported CKF fingerprint width {actual} (expected {expected})")]
+    FingerprintBits { expected: u8, actual: u8 },
+    #[error("unsupported CKF slots per bucket {actual} (expected {expected})")]
+    SlotsPerBucket { expected: u8, actual: u8 },
+    #[error("CKF bucket count {0} is not a power of two greater than one")]
+    BucketCount(usize),
+}
+
 impl DcCkfFormatIdentity {
     pub(super) const fn new(seed: u64, bucket_count: usize) -> Self {
         Self {
@@ -48,6 +61,43 @@ impl DcCkfFormatIdentity {
             fingerprint_bits: FINGERPRINT_BITS,
             slots_per_bucket: SLOTS_PER_BUCKET,
         }
+    }
+
+    pub fn try_from_parts(
+        format_version: u16,
+        seed: u64,
+        bucket_count: usize,
+        fingerprint_bits: u8,
+        slots_per_bucket: u8,
+    ) -> Result<Self, DcCkfFormatIdentityError> {
+        if format_version != FORMAT_VERSION {
+            return Err(DcCkfFormatIdentityError::FormatVersion {
+                expected: FORMAT_VERSION,
+                actual: format_version,
+            });
+        }
+        if fingerprint_bits != FINGERPRINT_BITS {
+            return Err(DcCkfFormatIdentityError::FingerprintBits {
+                expected: FINGERPRINT_BITS,
+                actual: fingerprint_bits,
+            });
+        }
+        if slots_per_bucket != SLOTS_PER_BUCKET {
+            return Err(DcCkfFormatIdentityError::SlotsPerBucket {
+                expected: SLOTS_PER_BUCKET,
+                actual: slots_per_bucket,
+            });
+        }
+        if bucket_count < 2 || !bucket_count.is_power_of_two() {
+            return Err(DcCkfFormatIdentityError::BucketCount(bucket_count));
+        }
+        Ok(Self {
+            format_version,
+            seed,
+            bucket_count,
+            fingerprint_bits,
+            slots_per_bucket,
+        })
     }
 
     pub const fn format_version(&self) -> u16 {
@@ -120,6 +170,7 @@ pub struct DcCkfAggregationStats {
     contribution_count: usize,
     unique_block_count: usize,
     unknown_removals: u64,
+    parent_not_found: u64,
     capacity_failures: u64,
     occupied_bucket_count: usize,
     occupied_slot_count: usize,
@@ -142,6 +193,10 @@ impl DcCkfAggregationStats {
         self.unknown_removals
     }
 
+    pub const fn parent_not_found(&self) -> u64 {
+        self.parent_not_found
+    }
+
     pub const fn capacity_failures(&self) -> u64 {
         self.capacity_failures
     }
@@ -162,6 +217,7 @@ pub struct DcCkfPublicationStats {
     physical_touches: u64,
     distinct_touched_buckets: u64,
     emitted_images: u64,
+    materialized_batches: u64,
     net_reverted_buckets: u64,
 }
 
@@ -182,6 +238,10 @@ impl DcCkfPublicationStats {
         self.emitted_images
     }
 
+    pub const fn materialized_batches(&self) -> u64 {
+        self.materialized_batches
+    }
+
     pub const fn net_reverted_buckets(&self) -> u64 {
         self.net_reverted_buckets
     }
@@ -190,20 +250,20 @@ impl DcCkfPublicationStats {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct DcCkfMemoryStats {
-    member_set_capacity: usize,
-    refcount_capacity: usize,
+    source_lineage_capacity: usize,
+    canonical_owner_capacity: usize,
     filter_bytes: usize,
     dirty_tracking_bytes: usize,
     insertion_scratch_capacity: usize,
 }
 
 impl DcCkfMemoryStats {
-    pub const fn member_set_capacity(&self) -> usize {
-        self.member_set_capacity
+    pub const fn source_lineage_capacity(&self) -> usize {
+        self.source_lineage_capacity
     }
 
-    pub const fn refcount_capacity(&self) -> usize {
-        self.refcount_capacity
+    pub const fn canonical_owner_capacity(&self) -> usize {
+        self.canonical_owner_capacity
     }
 
     pub const fn filter_bytes(&self) -> usize {
@@ -324,6 +384,7 @@ impl DirtyWindow {
 struct PublicationWindow {
     dirty: DirtyWindow,
     images: Vec<GlobalCkfBucketImage>,
+    materialization_enabled: bool,
     pending_events: usize,
 }
 
@@ -332,6 +393,7 @@ impl PublicationWindow {
         Ok(Self {
             dirty: DirtyWindow::new(bucket_count)?,
             images: Vec::new(),
+            materialization_enabled: true,
             pending_events: 0,
         })
     }
@@ -340,18 +402,126 @@ impl PublicationWindow {
 #[derive(Debug, Default)]
 struct DcCkfTelemetry {
     unknown_removals: u64,
+    parent_not_found: u64,
     capacity_failures: u64,
     physical_touches: u64,
     distinct_touched_buckets: u64,
     emitted_images: u64,
+    materialized_batches: u64,
     net_reverted_buckets: u64,
+}
+
+/// Reusable per-event working memory for the store path.
+///
+/// One Stored event needs several transient containers; renting them from the allocator on
+/// every event serializes ingest actors on the allocator at saturation, so they live for the
+/// lifetime of their owner and are wiped between events, mirroring `remove_scratch`.
+#[derive(Debug, Default)]
+struct StoreScratch {
+    new_mappings: Vec<(ExternalSequenceBlockHash, CanonicalSequenceBlockHash)>,
+    candidates: Vec<CanonicalSequenceBlockHash>,
+    /// Already-mapped blocks the source still claims. These carry no new exact state, so they
+    /// are re-offered for admission only on the relocation-free path.
+    reoffered: Vec<CanonicalSequenceBlockHash>,
+    batch_mappings: FxHashMap<ExternalSequenceBlockHash, CanonicalSequenceBlockHash>,
+    candidate_set: FxHashSet<CanonicalSequenceBlockHash>,
+    reoffer_set: FxHashSet<CanonicalSequenceBlockHash>,
+    owner_increments: FxHashMap<CanonicalSequenceBlockHash, u32>,
+}
+
+impl StoreScratch {
+    fn clear(&mut self) {
+        self.new_mappings.clear();
+        self.candidates.clear();
+        self.reoffered.clear();
+        self.batch_mappings.clear();
+        self.candidate_set.clear();
+        self.reoffer_set.clear();
+        self.owner_increments.clear();
+    }
+}
+
+/// Owner count and physical residency for one canonical hash.
+///
+/// Residency lives in the ownership entry because it is only meaningful for an owned hash, and
+/// the padding in a `(hash, u32)` map entry already pays for the flag. Dropping the last owner
+/// therefore clears residency by construction rather than through a second synchronized removal.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Ownership {
+    owners: u32,
+    resident: bool,
+}
+
+/// Exact source state reconstructed from one replay-ordered rank tree dump.
+#[derive(Debug, Default)]
+pub struct DcCkfRankReplacement {
+    source_lineage: FxHashMap<ExternalSequenceBlockHash, CanonicalSequenceBlockHash>,
+    canonical_candidates: Vec<CanonicalSequenceBlockHash>,
+    scratch: StoreScratch,
+}
+
+impl DcCkfRankReplacement {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append one replay-ordered store to this rank replacement.
+    ///
+    /// Parent-addressed entries must follow their parent. Positional entries with a
+    /// non-zero start and no known parent are not a canonical replay form.
+    pub fn push_store(&mut self, store: &KvCacheStoreData) -> Result<(), KvCacheEventError> {
+        let mut scratch = std::mem::take(&mut self.scratch);
+        let result = self.push_store_with_scratch(store, &mut scratch);
+        self.scratch = scratch;
+        result
+    }
+
+    fn push_store_with_scratch(
+        &mut self,
+        store: &KvCacheStoreData,
+        scratch: &mut StoreScratch,
+    ) -> Result<(), KvCacheEventError> {
+        prepare_store(&self.source_lineage, store, scratch)?;
+        self.source_lineage
+            .try_reserve(scratch.new_mappings.len())
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        self.canonical_candidates
+            .try_reserve(scratch.candidates.len())
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        for &(external, canonical) in &scratch.new_mappings {
+            self.source_lineage.insert(external, canonical);
+        }
+        self.canonical_candidates
+            .extend_from_slice(&scratch.candidates);
+        Ok(())
+    }
+
+    /// Append one replay-ordered event when it targets primary GPU residency.
+    ///
+    /// Valid non-primary events are irrelevant to this Device CKF and are ignored. Unknown or
+    /// invalid residency encodings fail closed before any replacement state is changed.
+    pub fn push_event(&mut self, event: RouterEvent) -> Result<(), KvCacheEventError> {
+        match event.targets_primary() {
+            Ok(true) => {}
+            Ok(false) => return Ok(()),
+            Err(_) => return Err(KvCacheEventError::UnsupportedResidencyDomain),
+        }
+        let KvCacheEventData::Stored(store) = event.event.data else {
+            return Err(KvCacheEventError::InvalidBlockSequence);
+        };
+        self.push_store(&store)
+    }
 }
 
 /// Exact and physical CKF state for one DC-local indexer pool.
 #[derive(Debug)]
 pub struct DcCkfState {
-    member_blocks: FxHashMap<WorkerWithDpRank, FxHashSet<ExternalSequenceBlockHash>>,
-    dc_refcounts: FxHashMap<ExternalSequenceBlockHash, u32>,
+    source_lineage: FxHashMap<
+        WorkerWithDpRank,
+        FxHashMap<ExternalSequenceBlockHash, CanonicalSequenceBlockHash>,
+    >,
+    canonical_owners: FxHashMap<CanonicalSequenceBlockHash, Ownership>,
+    resident_count: usize,
     filter: OwnedPackedCkfLane,
     addressing: CkfAddressing,
     config: CkfConfig,
@@ -361,6 +531,7 @@ pub struct DcCkfState {
     publication: PublicationWindow,
     telemetry: DcCkfTelemetry,
     remove_scratch: Vec<ExternalSequenceBlockHash>,
+    store_scratch: StoreScratch,
     #[cfg(test)]
     fail_next_snapshot_allocation: bool,
 }
@@ -370,8 +541,9 @@ impl DcCkfState {
         validate_config(config)?;
         let bucket_count = bucket_count(config.expected_blocks_per_dc)?;
         Ok(Self {
-            member_blocks: FxHashMap::default(),
-            dc_refcounts: FxHashMap::default(),
+            source_lineage: FxHashMap::default(),
+            canonical_owners: FxHashMap::default(),
+            resident_count: 0,
             filter: OwnedPackedCkfLane::new(bucket_count)?,
             addressing: CkfAddressing::new(bucket_count, config.seed),
             config,
@@ -382,6 +554,7 @@ impl DcCkfState {
             publication: PublicationWindow::new(bucket_count)?,
             telemetry: DcCkfTelemetry::default(),
             remove_scratch: Vec::new(),
+            store_scratch: StoreScratch::default(),
             #[cfg(test)]
             fail_next_snapshot_allocation: false,
         })
@@ -392,32 +565,48 @@ impl DcCkfState {
     }
 
     pub fn apply_event(&mut self, event: RouterEvent) -> DcCkfEventOutcome {
-        if event.storage_tier != StorageTier::Device
-            && !matches!(event.event.data, KvCacheEventData::Cleared)
-        {
-            return DcCkfEventOutcome {
-                first_error: None,
-                publication: None,
-                unknown_removals: 0,
-                publication_boundary: false,
-            };
+        match event.targets_primary() {
+            Ok(true) => {}
+            Ok(false) => {
+                return DcCkfEventOutcome {
+                    first_error: None,
+                    publication: None,
+                    unknown_removals: 0,
+                    publication_boundary: false,
+                };
+            }
+            Err(_) => {
+                return DcCkfEventOutcome {
+                    first_error: Some(KvCacheEventError::UnsupportedResidencyDomain),
+                    publication: None,
+                    unknown_removals: 0,
+                    publication_boundary: false,
+                };
+            }
         }
         self.publication.pending_events = self.publication.pending_events.saturating_add(1);
         let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
         let mut first_error = None;
         let mut unknown_removals = 0usize;
         match event.event.data {
-            KvCacheEventData::Stored(store) => {
-                for block in store.blocks {
-                    if let Err(error) = self.store(worker, block.block_hash) {
-                        if matches!(error, KvCacheEventError::CapacityExhausted) {
-                            self.telemetry.capacity_failures =
-                                self.telemetry.capacity_failures.saturating_add(1);
-                        }
-                        retain_first_error(&mut first_error, error);
+            KvCacheEventData::Stored(store) => match self.store_batch(worker, &store) {
+                Ok(capacity_failures) => {
+                    if capacity_failures != 0 {
+                        self.telemetry.capacity_failures = self
+                            .telemetry
+                            .capacity_failures
+                            .saturating_add(capacity_failures as u64);
+                        first_error = Some(KvCacheEventError::CapacityExhausted);
                     }
                 }
-            }
+                Err(error) => {
+                    if matches!(error, KvCacheEventError::ParentBlockNotFound) {
+                        self.telemetry.parent_not_found =
+                            self.telemetry.parent_not_found.saturating_add(1);
+                    }
+                    retain_first_error(&mut first_error, error);
+                }
+            },
             KvCacheEventData::Removed(remove) => {
                 for hash in remove.block_hashes {
                     match self.remove(worker, hash) {
@@ -463,12 +652,24 @@ impl DcCkfState {
         &mut self,
         worker_id: WorkerId,
     ) -> Result<Option<DcCkfPublicationBatch>, KvCacheEventError> {
-        let members: Vec<_> = self
-            .member_blocks
-            .keys()
-            .copied()
-            .filter(|member| member.worker_id == worker_id)
-            .collect();
+        let mut members = Vec::new();
+        members
+            .try_reserve(self.source_lineage.len())
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        members.extend(
+            self.source_lineage
+                .keys()
+                .copied()
+                .filter(|member| member.worker_id == worker_id),
+        );
+        let mapping_count = members.iter().try_fold(0usize, |count, member| {
+            count.checked_add(self.source_lineage.get(member).map_or(0, FxHashMap::len))
+        });
+        let mapping_count = mapping_count.ok_or(KvCacheEventError::AllocationFailed)?;
+        self.remove_scratch
+            .try_reserve(mapping_count)
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        self.reserve_publication_scratch(mapping_count.min(self.format.bucket_count))?;
         for member in members {
             self.remove_member(member)?;
         }
@@ -478,34 +679,46 @@ impl DcCkfState {
     pub fn replace_rank(
         &mut self,
         worker: WorkerWithDpRank,
-        hashes: HashSet<ExternalSequenceBlockHash>,
+        replacement: DcCkfRankReplacement,
     ) -> Result<Option<DcCkfPublicationBatch>, KvCacheEventError> {
         let mut replacements = HashMap::new();
-        replacements.insert(worker, hashes);
+        replacements
+            .try_reserve(1)
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        replacements.insert(worker, replacement);
         self.replace_ranks(replacements)
     }
 
     /// Transactionally replace several ranks through one off-side pool rebuild.
     pub fn replace_ranks(
         &mut self,
-        replacements: HashMap<WorkerWithDpRank, HashSet<ExternalSequenceBlockHash>>,
+        replacements: HashMap<WorkerWithDpRank, DcCkfRankReplacement>,
     ) -> Result<Option<DcCkfPublicationBatch>, KvCacheEventError> {
         let mut replacement = Self::new(self.config).map_err(|error| match error {
             CkfBuildError::AllocationFailed => KvCacheEventError::AllocationFailed,
             _ => KvCacheEventError::IndexerInvariantViolation,
         })?;
-        for (&member, blocks) in &self.member_blocks {
-            if replacements.contains_key(&member) {
-                continue;
-            }
-            for &hash in blocks {
-                replacement.store(member, hash)?;
-            }
+        let mut retained = Vec::new();
+        retained
+            .try_reserve(self.source_lineage.len())
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        retained.extend(
+            self.source_lineage
+                .iter()
+                .filter(|(member, _)| !replacements.contains_key(member)),
+        );
+        retained.sort_unstable_by_key(|(member, _)| **member);
+        for (&member, lineage) in retained {
+            replacement.install_replacement(member, replacement_from_lineage(lineage)?)?;
         }
-        for (member, hashes) in replacements {
-            for hash in hashes {
-                replacement.store(member, hash)?;
-            }
+        let mut ordered_replacements = Vec::new();
+        ordered_replacements
+            .try_reserve(replacements.len())
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        ordered_replacements.extend(replacements);
+        ordered_replacements.sort_unstable_by_key(|(member, _)| *member);
+        for (member, rank_replacement) in ordered_replacements {
+            replacement.install_replacement(member, rank_replacement)?;
         }
 
         replacement.publication.dirty.clear();
@@ -535,13 +748,19 @@ impl DcCkfState {
         }
         replacement.publication.pending_events = 1;
         replacement.telemetry.unknown_removals = self.telemetry.unknown_removals;
-        replacement.telemetry.capacity_failures = self.telemetry.capacity_failures;
+        replacement.telemetry.parent_not_found = self.telemetry.parent_not_found;
+        replacement.telemetry.capacity_failures = self
+            .telemetry
+            .capacity_failures
+            .saturating_add(replacement.telemetry.capacity_failures);
         replacement.telemetry.physical_touches = self
             .telemetry
             .physical_touches
             .saturating_add(replacement.telemetry.physical_touches);
         replacement.telemetry.distinct_touched_buckets = self.telemetry.distinct_touched_buckets;
         replacement.telemetry.emitted_images = self.telemetry.emitted_images;
+        replacement.telemetry.materialized_batches = self.telemetry.materialized_batches;
+        replacement.publication.materialization_enabled = self.publication.materialization_enabled;
         replacement.telemetry.net_reverted_buckets = self.telemetry.net_reverted_buckets;
         *self = replacement;
         Ok(self.drain_publication())
@@ -549,6 +768,11 @@ impl DcCkfState {
 
     pub fn flush(&mut self) -> Option<DcCkfPublicationBatch> {
         self.drain_publication()
+    }
+
+    /// Controls whether publication boundaries materialize bucket-image payloads.
+    pub fn set_publication_materialization_enabled(&mut self, enabled: bool) {
+        self.publication.materialization_enabled = enabled;
     }
 
     pub fn has_pending_publication(&self) -> bool {
@@ -591,24 +815,30 @@ impl DcCkfState {
     pub fn stats(&self) -> DcCkfStats {
         DcCkfStats {
             aggregation: DcCkfAggregationStats {
-                member_count: self.member_blocks.len(),
-                contribution_count: self.member_blocks.values().map(FxHashSet::len).sum(),
-                unique_block_count: self.dc_refcounts.len(),
+                member_count: self.source_lineage.len(),
+                contribution_count: self.source_lineage.values().map(FxHashMap::len).sum(),
+                unique_block_count: self.canonical_owners.len(),
                 unknown_removals: self.telemetry.unknown_removals,
+                parent_not_found: self.telemetry.parent_not_found,
                 capacity_failures: self.telemetry.capacity_failures,
                 occupied_bucket_count: self.current_occupied_bucket_count(),
-                occupied_slot_count: self.dc_refcounts.len(),
+                occupied_slot_count: self.resident_count,
             },
             publication: DcCkfPublicationStats {
                 pending_events: self.publication.pending_events,
                 physical_touches: self.telemetry.physical_touches,
                 distinct_touched_buckets: self.telemetry.distinct_touched_buckets,
                 emitted_images: self.telemetry.emitted_images,
+                materialized_batches: self.telemetry.materialized_batches,
                 net_reverted_buckets: self.telemetry.net_reverted_buckets,
             },
             memory: DcCkfMemoryStats {
-                member_set_capacity: self.member_blocks.values().map(FxHashSet::capacity).sum(),
-                refcount_capacity: self.dc_refcounts.capacity(),
+                source_lineage_capacity: self
+                    .source_lineage
+                    .values()
+                    .map(FxHashMap::capacity)
+                    .sum(),
+                canonical_owner_capacity: self.canonical_owners.capacity(),
                 filter_bytes: self.filter.byte_len(),
                 dirty_tracking_bytes: self.publication.dirty.byte_len(),
                 insertion_scratch_capacity: self.insertion_scratch.capacity(),
@@ -617,12 +847,12 @@ impl DcCkfState {
     }
 
     pub fn member_block_count(&self, worker: WorkerWithDpRank) -> usize {
-        self.member_blocks.get(&worker).map_or(0, FxHashSet::len)
+        self.source_lineage.get(&worker).map_or(0, FxHashMap::len)
     }
 
     pub fn member_counts(&self) -> Vec<(WorkerWithDpRank, usize)> {
         let mut counts: Vec<_> = self
-            .member_blocks
+            .source_lineage
             .iter()
             .map(|(&worker, blocks)| (worker, blocks.len()))
             .collect();
@@ -630,8 +860,8 @@ impl DcCkfState {
         counts
     }
 
-    pub fn contains(&self, hash: ExternalSequenceBlockHash) -> bool {
-        let probe = self.addressing.prepare(hash.0);
+    pub fn contains(&self, hash: CanonicalSequenceBlockHash) -> bool {
+        let probe = self.addressing.prepare(hash.as_u64());
         self.filter
             .load_bucket(probe.bucket_a)
             .contains(probe.fingerprint)
@@ -645,143 +875,362 @@ impl DcCkfState {
         self.publication.pending_events >= self.config.publish_every_n_events
     }
 
-    fn store(
+    fn store_batch(
         &mut self,
         worker: WorkerWithDpRank,
-        hash: ExternalSequenceBlockHash,
-    ) -> Result<bool, KvCacheEventError> {
-        if self
-            .member_blocks
-            .get(&worker)
-            .is_some_and(|member| member.contains(&hash))
-        {
-            return Ok(false);
-        }
-        let new_member = if self.member_blocks.contains_key(&worker) {
-            self.member_blocks
-                .get_mut(&worker)
-                .ok_or(KvCacheEventError::IndexerInvariantViolation)?
-                .try_reserve(1)
-                .map_err(|_| KvCacheEventError::AllocationFailed)?;
-            None
-        } else {
-            self.member_blocks
-                .try_reserve(1)
-                .map_err(|_| KvCacheEventError::AllocationFailed)?;
-            let mut member = FxHashSet::default();
-            member
-                .try_reserve(1)
-                .map_err(|_| KvCacheEventError::AllocationFailed)?;
-            Some(member)
-        };
+        store: &KvCacheStoreData,
+    ) -> Result<usize, KvCacheEventError> {
+        // The scratch moves out for the duration of the call so its buffers can be filled
+        // while `self` is mutated, and moves back even on the error path so the retained
+        // capacity survives.
+        let mut scratch = std::mem::take(&mut self.store_scratch);
+        let result = self.store_batch_with_scratch(worker, store, &mut scratch);
+        self.store_scratch = scratch;
+        result
+    }
 
-        let current = self.dc_refcounts.get(&hash).copied().unwrap_or(0);
-        if current == u32::MAX {
-            return Err(KvCacheEventError::OwnershipDegreeOverflow);
+    fn store_batch_with_scratch(
+        &mut self,
+        worker: WorkerWithDpRank,
+        store: &KvCacheStoreData,
+        scratch: &mut StoreScratch,
+    ) -> Result<usize, KvCacheEventError> {
+        let empty_lineage = FxHashMap::default();
+        let lineage = self.source_lineage.get(&worker).unwrap_or(&empty_lineage);
+        prepare_store(lineage, store, scratch)?;
+        if scratch.new_mappings.is_empty()
+            && scratch.candidates.is_empty()
+            && scratch.reoffered.is_empty()
+        {
+            return Ok(0);
         }
-        if current == 0 {
-            self.dc_refcounts
-                .try_reserve(1)
+
+        scratch
+            .owner_increments
+            .try_reserve(scratch.new_mappings.len())
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        for &(_, canonical) in &scratch.new_mappings {
+            let increment = scratch.owner_increments.entry(canonical).or_default();
+            *increment = increment
+                .checked_add(1)
+                .ok_or(KvCacheEventError::OwnershipDegreeOverflow)?;
+        }
+        for (&canonical, &increment) in &scratch.owner_increments {
+            self.canonical_owners
+                .get(&canonical)
+                .map_or(0, |ownership| ownership.owners)
+                .checked_add(increment)
+                .ok_or(KvCacheEventError::OwnershipDegreeOverflow)?;
+        }
+
+        if !scratch.new_mappings.is_empty() {
+            if let Some(lineage) = self.source_lineage.get_mut(&worker) {
+                lineage
+                    .try_reserve(scratch.new_mappings.len())
+                    .map_err(|_| KvCacheEventError::AllocationFailed)?;
+            } else {
+                self.source_lineage
+                    .try_reserve(1)
+                    .map_err(|_| KvCacheEventError::AllocationFailed)?;
+            }
+            let missing_owner_entries = scratch
+                .owner_increments
+                .keys()
+                .filter(|canonical| !self.canonical_owners.contains_key(canonical))
+                .count();
+            self.canonical_owners
+                .try_reserve(missing_owner_entries)
                 .map_err(|_| KvCacheEventError::AllocationFailed)?;
-            self.reserve_publication_scratch(self.config.max_kicks.saturating_add(1))?;
-            let dirty = &mut self.publication.dirty;
-            let physical_touches = &mut self.telemetry.physical_touches;
-            CuckooMutator::new(&self.filter, &self.addressing, self.config.max_kicks)
-                .insert_with_originals(
-                    hash,
-                    &mut self.rng,
-                    &mut self.insertion_scratch,
-                    |bucket, original| {
-                        *physical_touches = physical_touches.saturating_add(1);
-                        dirty.mark(bucket, original);
-                    },
-                )?;
-            // NOTE: Capacity failure returns above before any exact-state write. The omitted edge
-            // is intentionally untracked, so a later Remove is an idempotent unknown removal.
-            self.dc_refcounts.insert(hash, 1);
-        } else {
-            *self
-                .dc_refcounts
-                .get_mut(&hash)
-                .ok_or(KvCacheEventError::IndexerInvariantViolation)? = current + 1;
         }
-        let inserted = if let Some(mut member) = new_member {
-            let inserted = member.insert(hash);
-            self.member_blocks.insert(worker, member);
-            inserted
-        } else {
-            self.member_blocks
-                .get_mut(&worker)
-                .expect("validated member must remain present through actor-owned commit")
-                .insert(hash)
-        };
-        debug_assert!(inserted);
-        Ok(true)
+
+        let admission_candidates = scratch
+            .candidates
+            .iter()
+            .filter(|canonical| !self.is_resident(canonical))
+            .count();
+        // A relocation-free admission writes exactly one bucket, so re-offers add one touch each.
+        let reoffered_admissions = scratch
+            .reoffered
+            .iter()
+            .filter(|canonical| !self.is_resident(canonical))
+            .count();
+        let maximum_new_touches = admission_candidates
+            .checked_mul(self.config.max_kicks.saturating_add(1))
+            .and_then(|touches| touches.checked_add(reoffered_admissions))
+            .ok_or(KvCacheEventError::AllocationFailed)?
+            .min(self.format.bucket_count);
+        self.reserve_publication_scratch(maximum_new_touches)?;
+
+        if !scratch.new_mappings.is_empty() {
+            if let Some(lineage) = self.source_lineage.get_mut(&worker) {
+                for &(external, canonical) in &scratch.new_mappings {
+                    let previous = lineage.insert(external, canonical);
+                    debug_assert!(previous.is_none());
+                }
+            } else {
+                let mut lineage = FxHashMap::default();
+                lineage
+                    .try_reserve(scratch.new_mappings.len())
+                    .map_err(|_| KvCacheEventError::AllocationFailed)?;
+                for &(external, canonical) in &scratch.new_mappings {
+                    lineage.insert(external, canonical);
+                }
+                self.source_lineage.insert(worker, lineage);
+            }
+            for (&canonical, &increment) in &scratch.owner_increments {
+                let ownership = self.canonical_owners.entry(canonical).or_default();
+                ownership.owners += increment;
+            }
+        }
+
+        let mut capacity_failures = 0usize;
+        for &canonical in &scratch.candidates {
+            if self.is_resident(&canonical) {
+                continue;
+            }
+            match self.insert_canonical(canonical) {
+                Ok(()) => {
+                    self.mark_resident(canonical);
+                }
+                Err(KvCacheEventError::CapacityExhausted) => {
+                    capacity_failures = capacity_failures.saturating_add(1);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        // A block omitted for capacity has no other retry path while it keeps a single owner, so
+        // re-offer it whenever the source repeats it. This is deliberately relocation-free: the
+        // regime that produces omissions is a saturated filter, where a full kick search would
+        // burn `max_kicks` relocations and a rollback per repeat. A failure here is not reported
+        // as a new capacity omission because the first store already reported it.
+        for &canonical in &scratch.reoffered {
+            if self.is_resident(&canonical) {
+                continue;
+            }
+            match self.insert_canonical_without_relocation(canonical) {
+                Ok(()) => self.mark_resident(canonical),
+                Err(KvCacheEventError::CapacityExhausted) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(capacity_failures)
+    }
+
+    fn install_replacement(
+        &mut self,
+        worker: WorkerWithDpRank,
+        replacement: DcCkfRankReplacement,
+    ) -> Result<(), KvCacheEventError> {
+        if self.source_lineage.contains_key(&worker) {
+            return Err(KvCacheEventError::IndexerInvariantViolation);
+        }
+        if replacement.source_lineage.is_empty() {
+            return Ok(());
+        }
+
+        let mut owner_increments = FxHashMap::<CanonicalSequenceBlockHash, u32>::default();
+        owner_increments
+            .try_reserve(replacement.source_lineage.len())
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        for &canonical in replacement.source_lineage.values() {
+            let increment = owner_increments.entry(canonical).or_default();
+            *increment = increment
+                .checked_add(1)
+                .ok_or(KvCacheEventError::OwnershipDegreeOverflow)?;
+        }
+        for (&canonical, &increment) in &owner_increments {
+            self.canonical_owners
+                .get(&canonical)
+                .map_or(0, |ownership| ownership.owners)
+                .checked_add(increment)
+                .ok_or(KvCacheEventError::OwnershipDegreeOverflow)?;
+        }
+
+        self.source_lineage
+            .try_reserve(1)
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        self.canonical_owners
+            .try_reserve(owner_increments.len())
+            .map_err(|_| KvCacheEventError::AllocationFailed)?;
+        let maximum_new_touches = replacement
+            .canonical_candidates
+            .len()
+            .checked_mul(self.config.max_kicks.saturating_add(1))
+            .ok_or(KvCacheEventError::AllocationFailed)?
+            .min(self.format.bucket_count);
+        self.reserve_publication_scratch(maximum_new_touches)?;
+
+        self.source_lineage
+            .insert(worker, replacement.source_lineage);
+        for (canonical, increment) in owner_increments {
+            let ownership = self.canonical_owners.entry(canonical).or_default();
+            ownership.owners += increment;
+        }
+        for canonical in replacement.canonical_candidates {
+            if self.is_resident(&canonical) {
+                continue;
+            }
+            match self.insert_canonical(canonical) {
+                Ok(()) => {
+                    self.mark_resident(canonical);
+                }
+                Err(KvCacheEventError::CapacityExhausted) => {
+                    self.telemetry.capacity_failures =
+                        self.telemetry.capacity_failures.saturating_add(1);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
+    }
+
+    fn is_resident(&self, canonical: &CanonicalSequenceBlockHash) -> bool {
+        self.canonical_owners
+            .get(canonical)
+            .is_some_and(|ownership| ownership.resident)
+    }
+
+    /// Record a successful admission. The owner entry always exists here: every admission
+    /// candidate comes from a mapping whose ownership was committed earlier in the same operation.
+    fn mark_resident(&mut self, canonical: CanonicalSequenceBlockHash) {
+        match self.canonical_owners.get_mut(&canonical) {
+            Some(ownership) => {
+                debug_assert!(!ownership.resident);
+                ownership.resident = true;
+                self.resident_count += 1;
+            }
+            None => debug_assert!(false, "admitted a canonical hash with no owner"),
+        }
+    }
+
+    fn insert_canonical(
+        &mut self,
+        hash: CanonicalSequenceBlockHash,
+    ) -> Result<(), KvCacheEventError> {
+        let dirty = &mut self.publication.dirty;
+        let physical_touches = &mut self.telemetry.physical_touches;
+        CuckooMutator::new(&self.filter, &self.addressing, self.config.max_kicks)
+            .insert_with_originals(
+                hash,
+                &mut self.rng,
+                &mut self.insertion_scratch,
+                |bucket, original| {
+                    *physical_touches = physical_touches.saturating_add(1);
+                    dirty.mark(bucket, original);
+                },
+            )
+    }
+
+    /// Admit a hash only if one of its two home buckets already has a free slot.
+    ///
+    /// `max_kicks` of zero makes [`CuckooMutator`] skip the relocation search entirely, so this
+    /// costs two bucket loads and never rolls back speculative writes.
+    fn insert_canonical_without_relocation(
+        &mut self,
+        hash: CanonicalSequenceBlockHash,
+    ) -> Result<(), KvCacheEventError> {
+        let dirty = &mut self.publication.dirty;
+        let physical_touches = &mut self.telemetry.physical_touches;
+        CuckooMutator::new(&self.filter, &self.addressing, 0).insert_with_originals(
+            hash,
+            &mut self.rng,
+            &mut self.insertion_scratch,
+            |bucket, original| {
+                *physical_touches = physical_touches.saturating_add(1);
+                dirty.mark(bucket, original);
+            },
+        )
     }
 
     fn remove(
         &mut self,
         worker: WorkerWithDpRank,
-        hash: ExternalSequenceBlockHash,
+        external: ExternalSequenceBlockHash,
     ) -> Result<bool, KvCacheEventError> {
-        let Some(member) = self.member_blocks.get(&worker) else {
+        let Some(canonical) = self
+            .source_lineage
+            .get(&worker)
+            .and_then(|lineage| lineage.get(&external))
+            .copied()
+        else {
             return Ok(false);
         };
-        if !member.contains(&hash) {
-            return Ok(false);
-        }
-        let current = self
-            .dc_refcounts
-            .get(&hash)
+        let ownership = self
+            .canonical_owners
+            .get(&canonical)
             .copied()
             .ok_or(KvCacheEventError::IndexerInvariantViolation)?;
-        if current == 1 {
+        let current = ownership.owners;
+        let remove_resident = current == 1 && ownership.resident;
+        if remove_resident {
             self.reserve_publication_scratch(1)?;
+        }
+        let mut lineage = self
+            .source_lineage
+            .remove(&worker)
+            .ok_or(KvCacheEventError::IndexerInvariantViolation)?;
+        if lineage.get(&external) != Some(&canonical) {
+            self.source_lineage.insert(worker, lineage);
+            return Err(KvCacheEventError::IndexerInvariantViolation);
+        }
+        if remove_resident {
             let dirty = &mut self.publication.dirty;
             let physical_touches = &mut self.telemetry.physical_touches;
-            CuckooMutator::new(&self.filter, &self.addressing, self.config.max_kicks)
-                .remove_with_original(hash, |bucket, original| {
-                    *physical_touches = physical_touches.saturating_add(1);
-                    dirty.mark(bucket, original);
-                })?;
+            if let Err(error) =
+                CuckooMutator::new(&self.filter, &self.addressing, self.config.max_kicks)
+                    .remove_with_original(canonical, |bucket, original| {
+                        *physical_touches = physical_touches.saturating_add(1);
+                        dirty.mark(bucket, original);
+                    })
+            {
+                self.source_lineage.insert(worker, lineage);
+                return Err(error);
+            }
         }
-        let member = self
-            .member_blocks
-            .get_mut(&worker)
-            .expect("validated member must remain present through actor-owned commit");
-        let removed = member.remove(&hash);
-        let member_is_empty = member.is_empty();
-        debug_assert!(removed);
+
         if current == 1 {
-            self.dc_refcounts.remove(&hash);
+            if self.canonical_owners.remove(&canonical).is_none() {
+                self.source_lineage.insert(worker, lineage);
+                return Err(KvCacheEventError::IndexerInvariantViolation);
+            }
+            if remove_resident {
+                self.resident_count -= 1;
+            }
         } else {
-            *self
-                .dc_refcounts
-                .get_mut(&hash)
-                .expect("validated refcount must remain present through actor-owned commit") =
-                current - 1;
+            let Some(ownership) = self.canonical_owners.get_mut(&canonical) else {
+                self.source_lineage.insert(worker, lineage);
+                return Err(KvCacheEventError::IndexerInvariantViolation);
+            };
+            ownership.owners = current - 1;
         }
-        if member_is_empty {
-            self.member_blocks.remove(&worker);
+        let removed = lineage.remove(&external);
+        debug_assert_eq!(removed, Some(canonical));
+        if !lineage.is_empty() {
+            self.source_lineage.insert(worker, lineage);
         }
         Ok(true)
     }
 
     fn remove_member(&mut self, worker: WorkerWithDpRank) -> Result<(), KvCacheEventError> {
         self.remove_scratch.clear();
-        let Some(member) = self.member_blocks.get(&worker) else {
+        let Some(lineage) = self.source_lineage.get(&worker) else {
             return Ok(());
         };
         self.remove_scratch
-            .try_reserve(member.len())
+            .try_reserve(lineage.len())
             .map_err(|_| KvCacheEventError::AllocationFailed)?;
-        self.remove_scratch.extend(member.iter().copied());
+        // Every mapping can become the source's last owner after earlier mappings in this clear
+        // are removed, including aliases of one canonical hash. Reserve before the first mutation.
+        let maximum_new_touches = lineage.len().min(self.format.bucket_count);
+        self.remove_scratch.extend(lineage.keys().copied());
+        self.reserve_publication_scratch(maximum_new_touches)?;
         for index in 0..self.remove_scratch.len() {
             let hash = self.remove_scratch[index];
             self.remove(worker, hash)?;
         }
         self.remove_scratch.clear();
-        self.member_blocks.remove(&worker);
+        self.source_lineage.remove(&worker);
         Ok(())
     }
 
@@ -790,36 +1239,44 @@ impl DcCkfState {
             return None;
         }
         let distinct_touched = self.publication.dirty.buckets.len() as u64;
+        let mut emitted_images = 0u64;
         self.publication.images.clear();
         for (index, &bucket) in self.publication.dirty.buckets.iter().enumerate() {
             let value = self.filter.load_bucket(bucket).0;
             if value != self.publication.dirty.originals[index] {
-                self.publication
-                    .images
-                    .push(GlobalCkfBucketImage::new(bucket, value));
+                emitted_images = emitted_images.saturating_add(1);
+                if self.publication.materialization_enabled {
+                    self.publication
+                        .images
+                        .push(GlobalCkfBucketImage::new(bucket, value));
+                }
             }
         }
-        // NOTE: Publication intentionally transfers ownership of this image buffer. Defer buffer
+        // Publication transfers ownership only while a consumer lease needs payloads. Keeping the
+        // scratch buffer in the disabled path avoids a fresh allocation at every boundary. Defer
         // pooling or shared payloads until the non-local transport and fanout shape are fixed and
         // profiles show that allocation or copying is material.
-        let images = std::mem::take(&mut self.publication.images);
+        let images = self
+            .publication
+            .materialization_enabled
+            .then(|| std::mem::take(&mut self.publication.images));
         self.publication.dirty.clear();
         self.telemetry.distinct_touched_buckets = self
             .telemetry
             .distinct_touched_buckets
             .saturating_add(distinct_touched);
-        self.telemetry.emitted_images = self
-            .telemetry
-            .emitted_images
-            .saturating_add(images.len() as u64);
+        self.telemetry.emitted_images =
+            self.telemetry.emitted_images.saturating_add(emitted_images);
         self.telemetry.net_reverted_buckets = self
             .telemetry
             .net_reverted_buckets
-            .saturating_add(distinct_touched.saturating_sub(images.len() as u64));
+            .saturating_add(distinct_touched.saturating_sub(emitted_images));
         self.publication.pending_events = 0;
+        let images = images?;
         if images.is_empty() {
             return None;
         }
+        self.telemetry.materialized_batches = self.telemetry.materialized_batches.saturating_add(1);
         Some(DcCkfPublicationBatch { images })
     }
 
@@ -827,6 +1284,11 @@ impl DcCkfState {
         &mut self,
         maximum_new_touches: usize,
     ) -> Result<(), KvCacheEventError> {
+        let maximum_new_touches = maximum_new_touches.min(
+            self.format
+                .bucket_count
+                .saturating_sub(self.publication.dirty.buckets.len()),
+        );
         self.publication.dirty.try_reserve(maximum_new_touches)?;
         let maximum_images = self
             .publication
@@ -849,6 +1311,130 @@ impl DcCkfState {
     }
 }
 
+fn prepare_store(
+    lineage: &FxHashMap<ExternalSequenceBlockHash, CanonicalSequenceBlockHash>,
+    store: &KvCacheStoreData,
+    scratch: &mut StoreScratch,
+) -> Result<(), KvCacheEventError> {
+    scratch.clear();
+    if store.blocks.is_empty() {
+        return Ok(());
+    }
+
+    let parent = if let Some(parent) = store.parent_hash {
+        Some(
+            lineage
+                .get(&parent)
+                .copied()
+                .ok_or(KvCacheEventError::ParentBlockNotFound)?,
+        )
+    } else {
+        if store.start_position.is_some_and(|position| position != 0) {
+            return Err(KvCacheEventError::InvalidBlockSequence);
+        }
+        None
+    };
+
+    // try_reserve on a reused container only reserves the shortfall, so the fail-closed
+    // AllocationFailed contract is unchanged while steady-state events never touch the
+    // allocator.
+    scratch
+        .new_mappings
+        .try_reserve(store.blocks.len())
+        .map_err(|_| KvCacheEventError::AllocationFailed)?;
+    scratch
+        .candidates
+        .try_reserve(store.blocks.len())
+        .map_err(|_| KvCacheEventError::AllocationFailed)?;
+    scratch
+        .reoffered
+        .try_reserve(store.blocks.len())
+        .map_err(|_| KvCacheEventError::AllocationFailed)?;
+    scratch
+        .batch_mappings
+        .try_reserve(store.blocks.len())
+        .map_err(|_| KvCacheEventError::AllocationFailed)?;
+    scratch
+        .candidate_set
+        .try_reserve(store.blocks.len())
+        .map_err(|_| KvCacheEventError::AllocationFailed)?;
+    scratch
+        .reoffer_set
+        .try_reserve(store.blocks.len())
+        .map_err(|_| KvCacheEventError::AllocationFailed)?;
+
+    let mut previous = parent;
+    for block in &store.blocks {
+        let canonical = previous.map_or_else(
+            || CanonicalSequenceBlockHash::root(block.tokens_hash),
+            |parent| parent.child(block.tokens_hash),
+        );
+        previous = Some(canonical);
+
+        let existing = lineage
+            .get(&block.block_hash)
+            .copied()
+            .or_else(|| scratch.batch_mappings.get(&block.block_hash).copied());
+        match existing {
+            Some(existing) if existing != canonical => {
+                return Err(KvCacheEventError::InvalidBlockSequence);
+            }
+            Some(_) => {
+                if scratch.reoffer_set.insert(canonical) {
+                    scratch.reoffered.push(canonical);
+                }
+            }
+            None => {
+                scratch.batch_mappings.insert(block.block_hash, canonical);
+                scratch.new_mappings.push((block.block_hash, canonical));
+                if scratch.candidate_set.insert(canonical) {
+                    scratch.candidates.push(canonical);
+                }
+            }
+        }
+    }
+
+    // A canonical hash introduced by this batch is admitted with full relocation, so it must not
+    // also be re-offered on the cheap path.
+    let StoreScratch {
+        reoffered,
+        candidate_set,
+        ..
+    } = scratch;
+    reoffered.retain(|canonical| !candidate_set.contains(canonical));
+    Ok(())
+}
+
+fn replacement_from_lineage(
+    lineage: &FxHashMap<ExternalSequenceBlockHash, CanonicalSequenceBlockHash>,
+) -> Result<DcCkfRankReplacement, KvCacheEventError> {
+    let mut ordered = Vec::new();
+    ordered
+        .try_reserve(lineage.len())
+        .map_err(|_| KvCacheEventError::AllocationFailed)?;
+    ordered.extend(
+        lineage
+            .iter()
+            .map(|(&external, &canonical)| (external, canonical)),
+    );
+    ordered.sort_unstable();
+
+    let mut replacement = DcCkfRankReplacement::new();
+    replacement
+        .source_lineage
+        .try_reserve(ordered.len())
+        .map_err(|_| KvCacheEventError::AllocationFailed)?;
+    replacement
+        .canonical_candidates
+        .try_reserve(ordered.len())
+        .map_err(|_| KvCacheEventError::AllocationFailed)?;
+    for (external, canonical) in ordered {
+        replacement.source_lineage.insert(external, canonical);
+        replacement.canonical_candidates.push(canonical);
+    }
+    Ok(replacement)
+}
+
 fn retain_first_error(slot: &mut Option<KvCacheEventError>, error: KvCacheEventError) {
     if slot.is_none() {
         *slot = Some(error);
@@ -860,25 +1446,101 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::protocols::{
-        KvCacheEvent, KvCacheRemoveData, KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash,
+        BlockHashOptions, KvCacheEvent, KvCacheRemoveData, KvCacheStoreData,
+        KvCacheStoredBlockData, LocalBlockHash, ResidencyDomain, StorageTier, WireResidencyDomain,
+        compute_block_hash_for_seq,
     };
 
     use super::*;
+
+    const EXTERNAL_MASK: u64 = 0xA5A5_5A5A_D3C4_B2E1;
+
+    fn external(hash: u64) -> ExternalSequenceBlockHash {
+        ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK)
+    }
+
+    fn canonical_root(hash: u64) -> CanonicalSequenceBlockHash {
+        CanonicalSequenceBlockHash::root(LocalBlockHash(hash))
+    }
+
+    fn canonical_chain(hashes: &[u64]) -> Vec<CanonicalSequenceBlockHash> {
+        let Some((&first, rest)) = hashes.split_first() else {
+            return Vec::new();
+        };
+        let mut current = canonical_root(first);
+        let mut canonical = vec![current];
+        canonical.extend(rest.iter().map(|&hash| {
+            current = current.child(LocalBlockHash(hash));
+            current
+        }));
+        canonical
+    }
+
+    fn store_data(
+        parent_hash: Option<ExternalSequenceBlockHash>,
+        hashes: &[u64],
+    ) -> KvCacheStoreData {
+        KvCacheStoreData {
+            parent_hash,
+            start_position: None,
+            blocks: hashes
+                .iter()
+                .copied()
+                .map(|hash| KvCacheStoredBlockData {
+                    block_hash: external(hash),
+                    tokens_hash: LocalBlockHash(hash),
+                    mm_extra_info: None,
+                })
+                .collect(),
+        }
+    }
 
     fn stored(worker: WorkerWithDpRank, event_id: u64, hashes: &[u64]) -> RouterEvent {
         RouterEvent::new(
             worker.worker_id,
             KvCacheEvent {
                 event_id,
+                data: KvCacheEventData::Stored(store_data(None, hashes)),
+                dp_rank: worker.dp_rank,
+            },
+        )
+    }
+
+    fn stored_with_parent(
+        worker: WorkerWithDpRank,
+        event_id: u64,
+        parent: u64,
+        hashes: &[u64],
+    ) -> RouterEvent {
+        RouterEvent::new(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(store_data(Some(external(parent)), hashes)),
+                dp_rank: worker.dp_rank,
+            },
+        )
+    }
+
+    fn stored_exact(
+        worker: WorkerWithDpRank,
+        event_id: u64,
+        parent_hash: Option<ExternalSequenceBlockHash>,
+        start_position: Option<u32>,
+        blocks: &[(ExternalSequenceBlockHash, LocalBlockHash)],
+    ) -> RouterEvent {
+        RouterEvent::new(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
-                    parent_hash: None,
-                    start_position: None,
-                    blocks: hashes
+                    parent_hash,
+                    start_position,
+                    blocks: blocks
                         .iter()
-                        .copied()
-                        .map(|hash| KvCacheStoredBlockData {
-                            block_hash: ExternalSequenceBlockHash(hash),
-                            tokens_hash: LocalBlockHash(hash),
+                        .map(|&(block_hash, tokens_hash)| KvCacheStoredBlockData {
+                            block_hash,
+                            tokens_hash,
                             mm_extra_info: None,
                         })
                         .collect(),
@@ -894,15 +1556,34 @@ mod tests {
             KvCacheEvent {
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
-                    block_hashes: hashes
-                        .iter()
-                        .copied()
-                        .map(ExternalSequenceBlockHash)
-                        .collect(),
+                    block_hashes: hashes.iter().copied().map(external).collect(),
                 }),
                 dp_rank: worker.dp_rank,
             },
         )
+    }
+
+    fn removed_exact(
+        worker: WorkerWithDpRank,
+        event_id: u64,
+        hashes: &[ExternalSequenceBlockHash],
+    ) -> RouterEvent {
+        RouterEvent::new(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Removed(KvCacheRemoveData {
+                    block_hashes: hashes.to_vec(),
+                }),
+                dp_rank: worker.dp_rank,
+            },
+        )
+    }
+
+    fn replacement(hashes: &[u64]) -> DcCkfRankReplacement {
+        let mut replacement = DcCkfRankReplacement::new();
+        replacement.push_store(&store_data(None, hashes)).unwrap();
+        replacement
     }
 
     fn cleared(worker_id: WorkerId, dp_rank: u32, event_id: u64) -> RouterEvent {
@@ -920,19 +1601,19 @@ mod tests {
     fn shared_ownership_survives_nonfinal_then_final_removal() {
         let first = WorkerWithDpRank::new(1, 0);
         let second = WorkerWithDpRank::new(2, 0);
-        let hash = ExternalSequenceBlockHash(11);
+        let hash = canonical_root(11);
         let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
 
-        state.apply_event(stored(first, 1, &[hash.0]));
-        state.apply_event(stored(second, 1, &[hash.0]));
+        state.apply_event(stored(first, 1, &[11]));
+        state.apply_event(stored(second, 1, &[11]));
         assert_eq!(state.stats().aggregation().contribution_count(), 2);
         assert_eq!(state.stats().aggregation().unique_block_count(), 1);
 
-        state.apply_event(removed(first, 2, &[hash.0]));
+        state.apply_event(removed(first, 2, &[11]));
         assert!(state.contains(hash));
         assert_eq!(state.stats().aggregation().unique_block_count(), 1);
 
-        state.apply_event(removed(second, 2, &[hash.0]));
+        state.apply_event(removed(second, 2, &[11]));
         assert!(!state.contains(hash));
         assert_eq!(state.stats().aggregation().member_count(), 0);
         assert_eq!(state.stats().aggregation().unique_block_count(), 0);
@@ -943,12 +1624,12 @@ mod tests {
         let first_rank = WorkerWithDpRank::new(1, 0);
         let second_rank = WorkerWithDpRank::new(1, 1);
         let other_worker = WorkerWithDpRank::new(2, 0);
-        let shared = ExternalSequenceBlockHash(11);
+        let shared = canonical_root(11);
         let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
 
-        state.apply_event(stored(first_rank, 1, &[shared.0]));
+        state.apply_event(stored(first_rank, 1, &[11]));
         state.apply_event(stored(second_rank, 1, &[12]));
-        state.apply_event(stored(other_worker, 1, &[shared.0]));
+        state.apply_event(stored(other_worker, 1, &[11]));
         state.apply_event(cleared(first_rank.worker_id, first_rank.dp_rank, 2));
 
         assert_eq!(state.member_block_count(first_rank), 0);
@@ -961,21 +1642,100 @@ mod tests {
     #[test]
     fn non_device_store_is_ignored_but_unknown_device_remove_is_counted() {
         let worker = WorkerWithDpRank::new(1, 0);
-        let resident = ExternalSequenceBlockHash(7);
+        let resident = canonical_root(7);
         let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
-        let mut host_store = stored(worker, 1, &[resident.0]);
+        let mut host_store = stored(worker, 1, &[7]);
         host_store.storage_tier = StorageTier::HostPinned;
 
         let ignored = state.apply_event(host_store);
         assert!(!ignored.publication_boundary());
         assert_eq!(state.stats().aggregation().contribution_count(), 0);
 
-        state.apply_event(stored(worker, 2, &[resident.0]));
+        state.apply_event(stored(worker, 2, &[7]));
         let unknown = state.apply_event(removed(worker, 3, &[99]));
         assert_eq!(unknown.unknown_removals(), 1);
         assert_eq!(state.stats().aggregation().unknown_removals(), 1);
         assert_eq!(state.stats().aggregation().contribution_count(), 1);
         assert!(state.contains(resident));
+    }
+
+    #[test]
+    fn cache_owner_clear_is_ignored_without_mutating_primary_state() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let canonical = canonical_root(7);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+        state.apply_event(stored(worker, 1, &[7]));
+        state.barrier_snapshot().unwrap();
+        let before_stats = state.stats();
+        let before_lineage = state.source_lineage.clone();
+        let before_owners = state.canonical_owners.clone();
+        let mut cache_owner_clear = cleared(worker.worker_id, worker.dp_rank, 2);
+        cache_owner_clear.residency_domain =
+            WireResidencyDomain::explicit(ResidencyDomain::CacheOwner);
+
+        let outcome = state.apply_event(cache_owner_clear);
+
+        assert!(outcome.first_error().is_none());
+        assert!(!outcome.publication_boundary());
+        assert!(outcome.publication().is_none());
+        assert_eq!(state.stats(), before_stats);
+        assert_eq!(state.source_lineage, before_lineage);
+        assert_eq!(state.canonical_owners, before_owners);
+        assert!(state.is_resident(&canonical));
+        assert!(!state.has_pending_publication());
+    }
+
+    #[test]
+    fn unknown_residency_fails_closed_without_mutating_primary_state() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let canonical = canonical_root(7);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+        state.apply_event(stored(worker, 1, &[7]));
+        state.barrier_snapshot().unwrap();
+        let before_stats = state.stats();
+        let before_lineage = state.source_lineage.clone();
+        let before_owners = state.canonical_owners.clone();
+        let mut invalid = cleared(worker.worker_id, worker.dp_rank, 2);
+        invalid.residency_domain = WireResidencyDomain::Unknown("future_domain".into());
+
+        let outcome = state.apply_event(invalid);
+
+        assert_eq!(
+            outcome.first_error(),
+            Some(&KvCacheEventError::UnsupportedResidencyDomain)
+        );
+        assert!(!outcome.publication_boundary());
+        assert!(outcome.publication().is_none());
+        assert_eq!(state.stats(), before_stats);
+        assert_eq!(state.source_lineage, before_lineage);
+        assert_eq!(state.canonical_owners, before_owners);
+        assert!(state.is_resident(&canonical));
+        assert!(!state.has_pending_publication());
+    }
+
+    #[test]
+    fn recovery_ignores_cache_owner_clear_and_rejects_unknown_residency_atomically() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let mut replacement = DcCkfRankReplacement::new();
+        replacement.push_event(stored(worker, 1, &[7])).unwrap();
+        let before_lineage = replacement.source_lineage.clone();
+        let before_candidates = replacement.canonical_candidates.clone();
+
+        let mut cache_owner_clear = cleared(worker.worker_id, worker.dp_rank, 2);
+        cache_owner_clear.residency_domain =
+            WireResidencyDomain::explicit(ResidencyDomain::CacheOwner);
+        replacement.push_event(cache_owner_clear).unwrap();
+        assert_eq!(replacement.source_lineage, before_lineage);
+        assert_eq!(replacement.canonical_candidates, before_candidates);
+
+        let mut invalid = stored(worker, 3, &[8]);
+        invalid.residency_domain = WireResidencyDomain::Unknown("future_domain".into());
+        assert_eq!(
+            replacement.push_event(invalid),
+            Err(KvCacheEventError::UnsupportedResidencyDomain)
+        );
+        assert_eq!(replacement.source_lineage, before_lineage);
+        assert_eq!(replacement.canonical_candidates, before_candidates);
     }
 
     #[test]
@@ -989,12 +1749,497 @@ mod tests {
             outcome.first_error(),
             Some(KvCacheEventError::CapacityExhausted)
         ));
-        let member = state.member_blocks.get(&worker).unwrap();
-        assert!(!member.is_empty());
-        assert!(member.len() < hashes.len());
-        assert_eq!(member.len(), state.dc_refcounts.len());
-        assert!(member.iter().all(|hash| state.dc_refcounts[hash] == 1));
-        assert!(member.iter().copied().all(|hash| state.contains(hash)));
+        let lineage = state.source_lineage.get(&worker).unwrap();
+        assert_eq!(lineage.len(), hashes.len());
+        assert_eq!(lineage.len(), state.canonical_owners.len());
+        assert!(state.resident_count < hashes.len());
+        assert!(
+            lineage
+                .values()
+                .all(|canonical| state.canonical_owners[canonical].owners == 1)
+        );
+        assert!(
+            state
+                .canonical_owners
+                .iter()
+                .filter(|(_, ownership)| ownership.resident)
+                .map(|(&hash, _)| hash)
+                .all(|hash| state.contains(hash))
+        );
+    }
+
+    #[test]
+    fn root_and_batched_chain_use_canonical_token_hashes_not_external_ids() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let tokens = [101, 202, 303];
+        let canonical = canonical_chain(&tokens);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+
+        let outcome = state.apply_event(stored(worker, 1, &tokens));
+
+        assert!(outcome.first_error().is_none());
+        for (&token, &canonical) in tokens.iter().zip(&canonical) {
+            assert_ne!(external(token).0, canonical.as_u64());
+            assert!(state.contains(canonical));
+            assert_eq!(state.source_lineage[&worker][&external(token)], canonical);
+        }
+    }
+
+    #[test]
+    fn parent_addressed_chain_matches_batched_canonical_sequence() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let root_external = ExternalSequenceBlockHash(90_001);
+        let child_external = ExternalSequenceBlockHash(90_002);
+        let grandchild_external = ExternalSequenceBlockHash(90_003);
+        let tokens = [11, 22, 33];
+        let canonical = canonical_chain(&tokens);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+
+        state.apply_event(stored_exact(
+            worker,
+            1,
+            None,
+            None,
+            &[(root_external, LocalBlockHash(tokens[0]))],
+        ));
+        state.apply_event(stored_exact(
+            worker,
+            2,
+            Some(root_external),
+            None,
+            &[(child_external, LocalBlockHash(tokens[1]))],
+        ));
+        state.apply_event(stored_exact(
+            worker,
+            3,
+            Some(child_external),
+            None,
+            &[(grandchild_external, LocalBlockHash(tokens[2]))],
+        ));
+
+        assert_eq!(state.source_lineage[&worker][&root_external], canonical[0]);
+        assert_eq!(state.source_lineage[&worker][&child_external], canonical[1]);
+        assert_eq!(
+            state.source_lineage[&worker][&grandchild_external],
+            canonical[2]
+        );
+        assert!(canonical.into_iter().all(|hash| state.contains(hash)));
+    }
+
+    #[test]
+    fn captured_vllm_and_sglang_ids_map_to_the_same_dynamo_root() {
+        let vllm = WorkerWithDpRank::new(1, 0);
+        let sglang = WorkerWithDpRank::new(2, 0);
+        let canonical = canonical_root(3_727_940_790_060_946_254);
+        let vllm_external = ExternalSequenceBlockHash(5_151_625_331_053_002_286);
+        let sglang_external = ExternalSequenceBlockHash(16_481_235_979_017_058_908);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+
+        for (worker, external) in [(vllm, vllm_external), (sglang, sglang_external)] {
+            state.apply_event(stored_exact(
+                worker,
+                1,
+                None,
+                None,
+                &[(external, LocalBlockHash(canonical.as_u64()))],
+            ));
+        }
+
+        assert_ne!(vllm_external.0, canonical.as_u64());
+        assert_ne!(sglang_external.0, canonical.as_u64());
+        assert_eq!(state.canonical_owners[&canonical].owners, 2);
+        assert!(state.is_resident(&canonical));
+    }
+
+    #[test]
+    fn unknown_parent_rejects_source_event_without_partial_state() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+
+        let outcome = state.apply_event(stored_exact(
+            worker,
+            1,
+            Some(ExternalSequenceBlockHash(404)),
+            None,
+            &[(ExternalSequenceBlockHash(405), LocalBlockHash(7))],
+        ));
+
+        assert_eq!(
+            outcome.first_error(),
+            Some(&KvCacheEventError::ParentBlockNotFound)
+        );
+        assert_eq!(state.member_block_count(worker), 0);
+        assert!(state.canonical_owners.is_empty());
+        assert_eq!(state.resident_count, 0);
+        assert_eq!(state.stats().aggregation().parent_not_found(), 1);
+    }
+
+    #[test]
+    fn conflicting_external_remap_rejects_the_entire_batch() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let existing = ExternalSequenceBlockHash(7001);
+        let new_external = ExternalSequenceBlockHash(7002);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+        state.apply_event(stored_exact(
+            worker,
+            1,
+            None,
+            None,
+            &[(existing, LocalBlockHash(11))],
+        ));
+        let before_lineage = state.source_lineage[&worker].clone();
+        let before_owners = state.canonical_owners.clone();
+
+        let outcome = state.apply_event(stored_exact(
+            worker,
+            2,
+            None,
+            None,
+            &[
+                (existing, LocalBlockHash(99)),
+                (new_external, LocalBlockHash(22)),
+            ],
+        ));
+
+        assert_eq!(
+            outcome.first_error(),
+            Some(&KvCacheEventError::InvalidBlockSequence)
+        );
+        assert_eq!(state.source_lineage[&worker], before_lineage);
+        assert_eq!(state.canonical_owners, before_owners);
+        assert!(!state.source_lineage[&worker].contains_key(&new_external));
+    }
+
+    #[test]
+    fn different_external_ids_share_one_canonical_owner_domain() {
+        let first = WorkerWithDpRank::new(1, 0);
+        let second = WorkerWithDpRank::new(2, 0);
+        let first_external = ExternalSequenceBlockHash(80_001);
+        let second_external = ExternalSequenceBlockHash(90_001);
+        let canonical = canonical_root(42);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+
+        state.apply_event(stored_exact(
+            first,
+            1,
+            None,
+            None,
+            &[(first_external, LocalBlockHash(42))],
+        ));
+        state.apply_event(stored_exact(
+            second,
+            1,
+            None,
+            None,
+            &[(second_external, LocalBlockHash(42))],
+        ));
+        assert_eq!(state.canonical_owners[&canonical].owners, 2);
+
+        state.apply_event(removed_exact(first, 2, &[first_external]));
+        assert_eq!(state.canonical_owners[&canonical].owners, 1);
+        assert!(state.is_resident(&canonical));
+        state.apply_event(removed_exact(second, 2, &[second_external]));
+        assert!(!state.canonical_owners.contains_key(&canonical));
+        assert!(!state.is_resident(&canonical));
+    }
+
+    #[test]
+    fn clear_removes_all_same_source_aliases_of_one_canonical_hash() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let first_external = ExternalSequenceBlockHash(81_001);
+        let second_external = ExternalSequenceBlockHash(81_002);
+        let canonical = canonical_root(42);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+        for (event_id, external) in [(1, first_external), (2, second_external)] {
+            state.apply_event(stored_exact(
+                worker,
+                event_id,
+                None,
+                None,
+                &[(external, LocalBlockHash(42))],
+            ));
+        }
+        assert_eq!(state.canonical_owners[&canonical].owners, 2);
+
+        let outcome = state.apply_event(cleared(worker.worker_id, worker.dp_rank, 3));
+
+        assert!(outcome.first_error().is_none());
+        assert!(state.source_lineage.is_empty());
+        assert!(state.canonical_owners.is_empty());
+        assert_eq!(state.resident_count, 0);
+    }
+
+    #[test]
+    fn omitted_owner_keeps_lineage_and_later_owner_retries_admission() {
+        let first = WorkerWithDpRank::new(1, 0);
+        let second = WorkerWithDpRank::new(2, 0);
+        let mut state = DcCkfState::new(CkfConfig::new(1)).unwrap();
+        let omitted_token = (1..10_000)
+            .find(|&token| {
+                matches!(
+                    state
+                        .apply_event(stored(first, token, &[token]))
+                        .first_error(),
+                    Some(KvCacheEventError::CapacityExhausted)
+                )
+            })
+            .expect("tiny filter must produce a deterministic omission");
+        let omitted = canonical_root(omitted_token);
+        assert!(!state.is_resident(&omitted));
+        assert_eq!(state.canonical_owners[&omitted].owners, 1);
+        let duplicate = state.apply_event(stored(first, 10_000, &[omitted_token]));
+        assert!(duplicate.first_error().is_none());
+        assert_eq!(state.canonical_owners[&omitted].owners, 1);
+        assert!(!state.is_resident(&omitted));
+
+        let freed = *state
+            .canonical_owners
+            .iter()
+            .find(|(_, ownership)| ownership.resident)
+            .map(|(hash, _)| hash)
+            .unwrap();
+        state.apply_event(removed(first, 10_001, &[freed.as_u64()]));
+        assert!(!state.is_resident(&freed));
+
+        let second_external = ExternalSequenceBlockHash(omitted_token ^ 0x55AA_00FF);
+        let admitted = state.apply_event(stored_exact(
+            second,
+            1,
+            None,
+            None,
+            &[(second_external, LocalBlockHash(omitted_token))],
+        ));
+        assert!(admitted.first_error().is_none());
+        assert!(state.is_resident(&omitted));
+        assert_eq!(state.canonical_owners[&omitted].owners, 2);
+
+        state.apply_event(removed_exact(second, 2, &[second_external]));
+        assert_eq!(state.canonical_owners[&omitted].owners, 1);
+        assert!(state.is_resident(&omitted));
+        state.apply_event(removed(first, 10_002, &[omitted_token]));
+        assert!(!state.canonical_owners.contains_key(&omitted));
+        assert!(!state.is_resident(&omitted));
+    }
+
+    #[test]
+    fn repeated_store_readmits_an_omitted_block_once_its_home_bucket_frees() {
+        let filler = WorkerWithDpRank::new(1, 0);
+        let claimant = WorkerWithDpRank::new(2, 0);
+        let mut state = DcCkfState::new(CkfConfig::new(1)).unwrap();
+        let omitted_token = (1..10_000)
+            .find(|&token| {
+                matches!(
+                    state
+                        .apply_event(stored(filler, token, &[token]))
+                        .first_error(),
+                    Some(KvCacheEventError::CapacityExhausted)
+                )
+            })
+            .expect("tiny filter must produce a deterministic omission");
+        let omitted = canonical_root(omitted_token);
+        state.apply_event(stored(claimant, 1, &[omitted_token]));
+        assert_eq!(state.canonical_owners[&omitted].owners, 2);
+        assert!(!state.is_resident(&omitted));
+
+        // Free the filter without touching the claimant's lineage.
+        state.apply_event(cleared(filler.worker_id, filler.dp_rank, 2));
+        assert_eq!(state.canonical_owners[&omitted].owners, 1);
+        assert!(!state.is_resident(&omitted));
+
+        // The claimant is the only owner, so a repeat is the sole remaining retry path.
+        let repeat = state.apply_event(stored(claimant, 3, &[omitted_token]));
+
+        assert!(repeat.first_error().is_none());
+        assert_eq!(state.canonical_owners[&omitted].owners, 1);
+        assert!(state.is_resident(&omitted));
+        assert!(state.contains(omitted));
+        assert_eq!(state.member_block_count(claimant), 1);
+    }
+
+    #[test]
+    fn repeated_store_of_a_saturated_block_reports_no_new_capacity_omission() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let mut state = DcCkfState::new(CkfConfig::new(1)).unwrap();
+        let omitted_token = (1..10_000)
+            .find(|&token| {
+                matches!(
+                    state
+                        .apply_event(stored(worker, token, &[token]))
+                        .first_error(),
+                    Some(KvCacheEventError::CapacityExhausted)
+                )
+            })
+            .expect("tiny filter must produce a deterministic omission");
+        let failures_after_first_store = state.stats().aggregation().capacity_failures();
+
+        let repeat = state.apply_event(stored(worker, 10_000, &[omitted_token]));
+
+        assert!(repeat.first_error().is_none());
+        assert_eq!(
+            state.stats().aggregation().capacity_failures(),
+            failures_after_first_store
+        );
+        assert!(!state.is_resident(&canonical_root(omitted_token)));
+    }
+
+    #[test]
+    fn omitted_parent_still_canonicalizes_child_and_removes_by_external_id() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let mut state = DcCkfState::new(CkfConfig::new(1)).unwrap();
+        let omitted_token = (1..10_000)
+            .find(|&token| {
+                matches!(
+                    state
+                        .apply_event(stored(worker, token, &[token]))
+                        .first_error(),
+                    Some(KvCacheEventError::CapacityExhausted)
+                )
+            })
+            .expect("tiny filter must produce a deterministic omission");
+        let parent = canonical_root(omitted_token);
+        let child_token = 20_001;
+        let child = parent.child(LocalBlockHash(child_token));
+
+        let outcome = state.apply_event(stored_with_parent(
+            worker,
+            10_001,
+            omitted_token,
+            &[child_token],
+        ));
+
+        assert!(!matches!(
+            outcome.first_error(),
+            Some(KvCacheEventError::ParentBlockNotFound)
+        ));
+        assert_eq!(state.source_lineage[&worker][&external(child_token)], child);
+        state.apply_event(removed(worker, 10_002, &[omitted_token]));
+        assert!(!state.source_lineage[&worker].contains_key(&external(omitted_token)));
+        assert!(state.source_lineage[&worker].contains_key(&external(child_token)));
+    }
+
+    #[test]
+    fn recovery_rebuild_preserves_query_state_and_live_external_removal() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let root_external = ExternalSequenceBlockHash(5001);
+        let child_external = ExternalSequenceBlockHash(5002);
+        let root_store = KvCacheStoreData {
+            parent_hash: None,
+            start_position: None,
+            blocks: vec![KvCacheStoredBlockData {
+                block_hash: root_external,
+                tokens_hash: LocalBlockHash(31),
+                mm_extra_info: None,
+            }],
+        };
+        let child_store = KvCacheStoreData {
+            parent_hash: Some(root_external),
+            start_position: None,
+            blocks: vec![KvCacheStoredBlockData {
+                block_hash: child_external,
+                tokens_hash: LocalBlockHash(32),
+                mm_extra_info: None,
+            }],
+        };
+        let canonical = canonical_chain(&[31, 32]);
+        let mut replacement = DcCkfRankReplacement::new();
+        replacement.push_store(&root_store).unwrap();
+        replacement.push_store(&child_store).unwrap();
+        let mut live = DcCkfState::new(CkfConfig::new(32)).unwrap();
+        live.apply_event(stored_exact(
+            worker,
+            1,
+            None,
+            None,
+            &[(root_external, LocalBlockHash(31))],
+        ));
+        live.apply_event(stored_exact(
+            worker,
+            2,
+            Some(root_external),
+            None,
+            &[(child_external, LocalBlockHash(32))],
+        ));
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+
+        state.replace_rank(worker, replacement).unwrap();
+        for &hash in &canonical {
+            assert_eq!(live.contains(hash), state.contains(hash));
+            assert!(state.contains(hash));
+        }
+
+        state.apply_event(removed_exact(worker, 3, &[child_external]));
+        assert!(state.is_resident(&canonical[0]));
+        assert!(!state.is_resident(&canonical[1]));
+        assert!(!state.source_lineage[&worker].contains_key(&child_external));
+    }
+
+    #[test]
+    fn recovery_rejects_child_before_parent_and_nonzero_orphan_position() {
+        let parent = ExternalSequenceBlockHash(6001);
+        let child_store = KvCacheStoreData {
+            parent_hash: Some(parent),
+            start_position: None,
+            blocks: vec![KvCacheStoredBlockData {
+                block_hash: ExternalSequenceBlockHash(6002),
+                tokens_hash: LocalBlockHash(2),
+                mm_extra_info: None,
+            }],
+        };
+        let orphan_positional = KvCacheStoreData {
+            parent_hash: None,
+            start_position: Some(7),
+            blocks: vec![KvCacheStoredBlockData {
+                block_hash: ExternalSequenceBlockHash(6003),
+                tokens_hash: LocalBlockHash(3),
+                mm_extra_info: None,
+            }],
+        };
+        let mut replacement = DcCkfRankReplacement::new();
+
+        assert_eq!(
+            replacement.push_store(&child_store),
+            Err(KvCacheEventError::ParentBlockNotFound)
+        );
+        assert_eq!(
+            replacement.push_store(&orphan_positional),
+            Err(KvCacheEventError::InvalidBlockSequence)
+        );
+        assert!(replacement.source_lineage.is_empty());
+        assert!(replacement.canonical_candidates.is_empty());
+    }
+
+    #[test]
+    fn lora_salted_block_removal_uses_external_lineage_only() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let local = compute_block_hash_for_seq(
+            &(0..8).collect::<Vec<u32>>(),
+            4,
+            BlockHashOptions {
+                lora_name: Some("tenant-adapter"),
+                ..Default::default()
+            },
+        );
+        assert_eq!(local.len(), 2);
+        let root = CanonicalSequenceBlockHash::root(local[0]);
+        let child = root.child(local[1]);
+        let root_external = ExternalSequenceBlockHash(0x1111_2222);
+        let child_external = ExternalSequenceBlockHash(0x3333_4444);
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+
+        state.apply_event(stored_exact(
+            worker,
+            1,
+            None,
+            None,
+            &[(root_external, local[0]), (child_external, local[1])],
+        ));
+        assert!(state.is_resident(&root));
+        assert!(state.is_resident(&child));
+
+        state.apply_event(removed_exact(worker, 2, &[child_external]));
+        assert!(state.is_resident(&root));
+        assert!(!state.is_resident(&child));
+        assert!(!state.source_lineage[&worker].contains_key(&child_external));
     }
 
     #[test]
@@ -1012,30 +2257,58 @@ mod tests {
     }
 
     #[test]
-    fn failed_transactional_replacement_preserves_previous_rank() {
+    fn disabled_publication_materialization_survives_rank_replacement() {
         let worker = WorkerWithDpRank::new(1, 0);
-        let original = ExternalSequenceBlockHash(1);
-        let mut state = DcCkfState::new(CkfConfig::new(1)).unwrap();
-        state.apply_event(stored(worker, 1, &[original.0]));
-        let before_counts = state.member_counts();
-        let replacement = (100..200).map(ExternalSequenceBlockHash).collect();
+        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
+        state.set_publication_materialization_enabled(false);
 
-        assert!(state.replace_rank(worker, replacement).is_err());
-        assert_eq!(state.member_counts(), before_counts);
-        assert!(state.contains(original));
+        let first = state.apply_event(stored(worker, 1, &[7]));
+        assert!(first.publication_boundary());
+        assert!(first.publication().is_none());
+        assert!(state.stats().publication().emitted_images() > 0);
+        assert_eq!(state.stats().publication().materialized_batches(), 0);
+
+        let recovered = state.replace_rank(worker, replacement(&[7])).unwrap();
+        assert!(recovered.is_none());
+        assert!(!state.publication.materialization_enabled);
+        assert_eq!(state.stats().publication().materialized_batches(), 0);
+
+        let next = state.apply_event(stored_with_parent(worker, 2, 7, &[8]));
+        assert!(next.publication_boundary());
+        assert!(next.publication().is_none());
+        assert_eq!(state.stats().publication().materialized_batches(), 0);
+    }
+
+    #[test]
+    fn saturated_replacement_commits_lineage_and_omits_only_residency() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let original = canonical_root(1);
+        let mut state = DcCkfState::new(CkfConfig::new(1)).unwrap();
+        state.apply_event(stored(worker, 1, &[1]));
+        let hashes: Vec<_> = (100..200).collect();
+
+        state.replace_rank(worker, replacement(&hashes)).unwrap();
+
+        assert_eq!(state.member_block_count(worker), hashes.len());
+        assert_eq!(state.canonical_owners.len(), hashes.len());
+        assert!(state.resident_count < hashes.len());
+        assert!(!state.contains(original));
+        assert!(state.stats().aggregation().capacity_failures() > 0);
     }
 
     #[test]
     fn replacing_one_shared_owner_preserves_the_other_without_an_intermediate_reset() {
         let replaced = WorkerWithDpRank::new(1, 0);
         let survivor = WorkerWithDpRank::new(2, 0);
-        let shared = ExternalSequenceBlockHash(77);
+        let shared = canonical_root(77);
         let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
-        state.apply_event(stored(replaced, 1, &[shared.0]));
-        state.apply_event(stored(survivor, 1, &[shared.0]));
+        state.apply_event(stored(replaced, 1, &[77]));
+        state.apply_event(stored(survivor, 1, &[77]));
         let (_, before) = state.barrier_snapshot().unwrap();
 
-        let publication = state.replace_rank(replaced, HashSet::new()).unwrap();
+        let publication = state
+            .replace_rank(replaced, DcCkfRankReplacement::new())
+            .unwrap();
 
         assert_eq!(state.member_block_count(replaced), 0);
         assert_eq!(state.member_block_count(survivor), 1);
@@ -1052,7 +2325,7 @@ mod tests {
     #[test]
     fn replacement_diff_includes_the_pending_publication_window() {
         let worker = WorkerWithDpRank::new(1, 0);
-        let hash = ExternalSequenceBlockHash(7);
+        let hash = canonical_root(7);
         let mut config = CkfConfig::new(32);
         config.publish_every_n_events = 16;
         let mut state = DcCkfState::new(config).unwrap();
@@ -1060,12 +2333,12 @@ mod tests {
 
         assert!(
             state
-                .apply_event(stored(worker, 1, &[hash.0]))
+                .apply_event(stored(worker, 1, &[7]))
                 .publication()
                 .is_none()
         );
         let publication = state
-            .replace_rank(worker, [hash].into_iter().collect())
+            .replace_rank(worker, replacement(&[7]))
             .unwrap()
             .expect("replacement must publish the pending state");
         let mut reconstructed = base.to_vec();
@@ -1093,7 +2366,7 @@ mod tests {
         );
         assert!(
             state
-                .replace_rank(worker, HashSet::new())
+                .replace_rank(worker, DcCkfRankReplacement::new())
                 .unwrap()
                 .is_none()
         );
@@ -1111,28 +2384,19 @@ mod tests {
         state.apply_event(stored(retained, 1, &[3]));
 
         let replacements = [
-            (
-                first,
-                [10, 11]
-                    .into_iter()
-                    .map(ExternalSequenceBlockHash)
-                    .collect(),
-            ),
-            (
-                second,
-                [20].into_iter().map(ExternalSequenceBlockHash).collect(),
-            ),
+            (first, replacement(&[10, 11])),
+            (second, replacement(&[20])),
         ]
         .into_iter()
         .collect();
         state.replace_ranks(replacements).unwrap();
 
-        assert!(!state.contains(ExternalSequenceBlockHash(1)));
-        assert!(!state.contains(ExternalSequenceBlockHash(2)));
-        assert!(state.contains(ExternalSequenceBlockHash(3)));
-        assert!(state.contains(ExternalSequenceBlockHash(10)));
-        assert!(state.contains(ExternalSequenceBlockHash(11)));
-        assert!(state.contains(ExternalSequenceBlockHash(20)));
+        assert!(!state.contains(canonical_root(1)));
+        assert!(!state.contains(canonical_root(2)));
+        assert!(state.contains(canonical_root(3)));
+        assert!(state.contains(canonical_root(10)));
+        assert!(state.contains(canonical_chain(&[10, 11])[1]));
+        assert!(state.contains(canonical_root(20)));
         assert_eq!(state.member_block_count(first), 2);
         assert_eq!(state.member_block_count(second), 1);
         assert_eq!(state.member_block_count(retained), 1);
@@ -1190,11 +2454,11 @@ mod tests {
 
         replay.apply_event(stored(worker, 1, &[1, 2, 3]));
         replay.apply_event(removed(worker, 2, &[2]));
-        replay.apply_event(stored(worker, 3, &[2]));
+        replay.apply_event(stored_with_parent(worker, 3, 1, &[2]));
 
-        assert_eq!(direct.member_blocks, replay.member_blocks);
-        assert_eq!(direct.dc_refcounts, replay.dc_refcounts);
-        for hash in [1, 2, 3].map(ExternalSequenceBlockHash) {
+        assert_eq!(direct.source_lineage, replay.source_lineage);
+        assert_eq!(direct.canonical_owners, replay.canonical_owners);
+        for hash in canonical_chain(&[1, 2, 3]) {
             assert!(direct.contains(hash));
             assert!(replay.contains(hash));
         }
@@ -1215,10 +2479,11 @@ mod tests {
             })
             .unwrap();
 
-        state.apply_event(stored(worker, 1, &[first, second]));
-        state.apply_event(removed(worker, 2, &[first]));
-        assert!(state.contains(ExternalSequenceBlockHash(second)));
-        state.apply_event(removed(worker, 3, &[second]));
-        assert!(!state.contains(ExternalSequenceBlockHash(second)));
+        state.apply_event(stored(worker, 1, &[first]));
+        state.apply_event(stored(worker, 2, &[second]));
+        state.apply_event(removed(worker, 3, &[first]));
+        assert!(state.contains(canonical_root(second)));
+        state.apply_event(removed(worker, 4, &[second]));
+        assert!(!state.contains(canonical_root(second)));
     }
 }

--- a/lib/kv-router/src/indexer/cuckoo/dc.rs
+++ b/lib/kv-router/src/indexer/cuckoo/dc.rs
@@ -40,18 +40,6 @@ pub struct DcCkfFormatIdentity {
     slots_per_bucket: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum DcCkfFormatIdentityError {
-    #[error("unsupported CKF format version {actual} (expected {expected})")]
-    FormatVersion { expected: u16, actual: u16 },
-    #[error("unsupported CKF fingerprint width {actual} (expected {expected})")]
-    FingerprintBits { expected: u8, actual: u8 },
-    #[error("unsupported CKF slots per bucket {actual} (expected {expected})")]
-    SlotsPerBucket { expected: u8, actual: u8 },
-    #[error("CKF bucket count {0} is not a power of two greater than one")]
-    BucketCount(usize),
-}
-
 impl DcCkfFormatIdentity {
     pub(super) const fn new(seed: u64, bucket_count: usize) -> Self {
         Self {
@@ -61,43 +49,6 @@ impl DcCkfFormatIdentity {
             fingerprint_bits: FINGERPRINT_BITS,
             slots_per_bucket: SLOTS_PER_BUCKET,
         }
-    }
-
-    pub fn try_from_parts(
-        format_version: u16,
-        seed: u64,
-        bucket_count: usize,
-        fingerprint_bits: u8,
-        slots_per_bucket: u8,
-    ) -> Result<Self, DcCkfFormatIdentityError> {
-        if format_version != FORMAT_VERSION {
-            return Err(DcCkfFormatIdentityError::FormatVersion {
-                expected: FORMAT_VERSION,
-                actual: format_version,
-            });
-        }
-        if fingerprint_bits != FINGERPRINT_BITS {
-            return Err(DcCkfFormatIdentityError::FingerprintBits {
-                expected: FINGERPRINT_BITS,
-                actual: fingerprint_bits,
-            });
-        }
-        if slots_per_bucket != SLOTS_PER_BUCKET {
-            return Err(DcCkfFormatIdentityError::SlotsPerBucket {
-                expected: SLOTS_PER_BUCKET,
-                actual: slots_per_bucket,
-            });
-        }
-        if bucket_count < 2 || !bucket_count.is_power_of_two() {
-            return Err(DcCkfFormatIdentityError::BucketCount(bucket_count));
-        }
-        Ok(Self {
-            format_version,
-            seed,
-            bucket_count,
-            fingerprint_bits,
-            slots_per_bucket,
-        })
     }
 
     pub const fn format_version(&self) -> u16 {
@@ -217,7 +168,6 @@ pub struct DcCkfPublicationStats {
     physical_touches: u64,
     distinct_touched_buckets: u64,
     emitted_images: u64,
-    materialized_batches: u64,
     net_reverted_buckets: u64,
 }
 
@@ -236,10 +186,6 @@ impl DcCkfPublicationStats {
 
     pub const fn emitted_images(&self) -> u64 {
         self.emitted_images
-    }
-
-    pub const fn materialized_batches(&self) -> u64 {
-        self.materialized_batches
     }
 
     pub const fn net_reverted_buckets(&self) -> u64 {
@@ -383,8 +329,6 @@ impl DirtyWindow {
 #[derive(Debug)]
 struct PublicationWindow {
     dirty: DirtyWindow,
-    images: Vec<GlobalCkfBucketImage>,
-    materialization_enabled: bool,
     pending_events: usize,
 }
 
@@ -392,8 +336,6 @@ impl PublicationWindow {
     fn new(bucket_count: usize) -> Result<Self, CkfBuildError> {
         Ok(Self {
             dirty: DirtyWindow::new(bucket_count)?,
-            images: Vec::new(),
-            materialization_enabled: true,
             pending_events: 0,
         })
     }
@@ -407,7 +349,6 @@ struct DcCkfTelemetry {
     physical_touches: u64,
     distinct_touched_buckets: u64,
     emitted_images: u64,
-    materialized_batches: u64,
     net_reverted_buckets: u64,
 }
 
@@ -516,6 +457,10 @@ impl DcCkfRankReplacement {
 /// Exact and physical CKF state for one DC-local indexer pool.
 #[derive(Debug)]
 pub struct DcCkfState {
+    /// Per-source engine vocabulary. Lineage and ownership commit even when physical admission
+    /// is capacity-omitted, so CKF capacity does not bound this memory; the operative bound is
+    /// the source engine's own KV-cache block count, because the engine emits `Removed` when it
+    /// evicts and `clear_worker`/rank replacement drop a source wholesale.
     source_lineage: FxHashMap<
         WorkerWithDpRank,
         FxHashMap<ExternalSequenceBlockHash, CanonicalSequenceBlockHash>,
@@ -534,6 +479,10 @@ pub struct DcCkfState {
     store_scratch: StoreScratch,
     #[cfg(test)]
     fail_next_snapshot_allocation: bool,
+    #[cfg(test)]
+    fail_next_store_reserve: bool,
+    #[cfg(test)]
+    fail_replacement_install_after: Option<usize>,
 }
 
 impl DcCkfState {
@@ -557,6 +506,10 @@ impl DcCkfState {
             store_scratch: StoreScratch::default(),
             #[cfg(test)]
             fail_next_snapshot_allocation: false,
+            #[cfg(test)]
+            fail_next_store_reserve: false,
+            #[cfg(test)]
+            fail_replacement_install_after: None,
         })
     }
 
@@ -717,7 +670,13 @@ impl DcCkfState {
             .map_err(|_| KvCacheEventError::AllocationFailed)?;
         ordered_replacements.extend(replacements);
         ordered_replacements.sort_unstable_by_key(|(member, _)| *member);
-        for (member, rank_replacement) in ordered_replacements {
+        // The index feeds the test-only install failpoint; release builds discard it.
+        #[allow(clippy::unused_enumerate_index)]
+        for (_index, (member, rank_replacement)) in ordered_replacements.into_iter().enumerate() {
+            #[cfg(test)]
+            if self.fail_replacement_install_after == Some(_index) {
+                return Err(KvCacheEventError::AllocationFailed);
+            }
             replacement.install_replacement(member, rank_replacement)?;
         }
 
@@ -726,11 +685,6 @@ impl DcCkfState {
             .publication
             .dirty
             .try_reserve(self.format.bucket_count)?;
-        replacement
-            .publication
-            .images
-            .try_reserve(self.format.bucket_count)
-            .map_err(|_| KvCacheEventError::AllocationFailed)?;
         for (bucket, published) in self.publication.dirty.touched_with_originals() {
             if replacement.filter.load_bucket(bucket) != published {
                 replacement.publication.dirty.mark(bucket, published);
@@ -759,8 +713,6 @@ impl DcCkfState {
             .saturating_add(replacement.telemetry.physical_touches);
         replacement.telemetry.distinct_touched_buckets = self.telemetry.distinct_touched_buckets;
         replacement.telemetry.emitted_images = self.telemetry.emitted_images;
-        replacement.telemetry.materialized_batches = self.telemetry.materialized_batches;
-        replacement.publication.materialization_enabled = self.publication.materialization_enabled;
         replacement.telemetry.net_reverted_buckets = self.telemetry.net_reverted_buckets;
         *self = replacement;
         Ok(self.drain_publication())
@@ -768,11 +720,6 @@ impl DcCkfState {
 
     pub fn flush(&mut self) -> Option<DcCkfPublicationBatch> {
         self.drain_publication()
-    }
-
-    /// Controls whether publication boundaries materialize bucket-image payloads.
-    pub fn set_publication_materialization_enabled(&mut self, enabled: bool) {
-        self.publication.materialization_enabled = enabled;
     }
 
     pub fn has_pending_publication(&self) -> bool {
@@ -829,7 +776,6 @@ impl DcCkfState {
                 physical_touches: self.telemetry.physical_touches,
                 distinct_touched_buckets: self.telemetry.distinct_touched_buckets,
                 emitted_images: self.telemetry.emitted_images,
-                materialized_batches: self.telemetry.materialized_batches,
                 net_reverted_buckets: self.telemetry.net_reverted_buckets,
             },
             memory: DcCkfMemoryStats {
@@ -844,6 +790,13 @@ impl DcCkfState {
                 insertion_scratch_capacity: self.insertion_scratch.capacity(),
             },
         }
+    }
+
+    /// Lifetime count of physical admissions omitted for capacity, including omissions that
+    /// happen while installing rank replacements. Exposed unconditionally so ingest hosts can
+    /// surface recovery omissions the way they surface live ones.
+    pub const fn lifetime_capacity_omissions(&self) -> u64 {
+        self.telemetry.capacity_failures
     }
 
     pub fn member_block_count(&self, worker: WorkerWithDpRank) -> usize {
@@ -903,6 +856,11 @@ impl DcCkfState {
             && scratch.reoffered.is_empty()
         {
             return Ok(0);
+        }
+        #[cfg(test)]
+        if self.fail_next_store_reserve {
+            self.fail_next_store_reserve = false;
+            return Err(KvCacheEventError::AllocationFailed);
         }
 
         scratch
@@ -1239,45 +1197,40 @@ impl DcCkfState {
             return None;
         }
         let distinct_touched = self.publication.dirty.buckets.len() as u64;
-        let mut emitted_images = 0u64;
-        self.publication.images.clear();
+        let mut emitted_images = 0usize;
         for (index, &bucket) in self.publication.dirty.buckets.iter().enumerate() {
-            let value = self.filter.load_bucket(bucket).0;
-            if value != self.publication.dirty.originals[index] {
-                emitted_images = emitted_images.saturating_add(1);
-                if self.publication.materialization_enabled {
-                    self.publication
-                        .images
-                        .push(GlobalCkfBucketImage::new(bucket, value));
-                }
+            if self.filter.load_bucket(bucket).0 != self.publication.dirty.originals[index] {
+                emitted_images += 1;
             }
         }
-        // Publication transfers ownership only while a consumer lease needs payloads. Keeping the
-        // scratch buffer in the disabled path avoids a fresh allocation at every boundary. Defer
-        // pooling or shared payloads until the non-local transport and fanout shape are fixed and
-        // profiles show that allocation or copying is material.
-        let images = self
-            .publication
-            .materialization_enabled
-            .then(|| std::mem::take(&mut self.publication.images));
+        // The dirty scratch is reserved for worst-case rollback (candidates * (max_kicks + 1)
+        // touches), so the payload is materialized into an exact-size vector in a second pass
+        // instead of letting that capacity escape into the fan-out queue with the batch.
+        let images = (emitted_images > 0).then(|| {
+            let mut images = Vec::with_capacity(emitted_images);
+            for (index, &bucket) in self.publication.dirty.buckets.iter().enumerate() {
+                let value = self.filter.load_bucket(bucket).0;
+                if value != self.publication.dirty.originals[index] {
+                    images.push(GlobalCkfBucketImage::new(bucket, value));
+                }
+            }
+            images
+        });
         self.publication.dirty.clear();
         self.telemetry.distinct_touched_buckets = self
             .telemetry
             .distinct_touched_buckets
             .saturating_add(distinct_touched);
-        self.telemetry.emitted_images =
-            self.telemetry.emitted_images.saturating_add(emitted_images);
+        self.telemetry.emitted_images = self
+            .telemetry
+            .emitted_images
+            .saturating_add(emitted_images as u64);
         self.telemetry.net_reverted_buckets = self
             .telemetry
             .net_reverted_buckets
-            .saturating_add(distinct_touched.saturating_sub(emitted_images));
+            .saturating_add(distinct_touched.saturating_sub(emitted_images as u64));
         self.publication.pending_events = 0;
-        let images = images?;
-        if images.is_empty() {
-            return None;
-        }
-        self.telemetry.materialized_batches = self.telemetry.materialized_batches.saturating_add(1);
-        Some(DcCkfPublicationBatch { images })
+        Some(DcCkfPublicationBatch { images: images? })
     }
 
     fn reserve_publication_scratch(
@@ -1289,17 +1242,7 @@ impl DcCkfState {
                 .bucket_count
                 .saturating_sub(self.publication.dirty.buckets.len()),
         );
-        self.publication.dirty.try_reserve(maximum_new_touches)?;
-        let maximum_images = self
-            .publication
-            .dirty
-            .buckets
-            .len()
-            .saturating_add(maximum_new_touches);
-        self.publication
-            .images
-            .try_reserve(maximum_images)
-            .map_err(|_| KvCacheEventError::AllocationFailed)
+        self.publication.dirty.try_reserve(maximum_new_touches)
     }
 
     fn current_occupied_bucket_count(&self) -> usize {
@@ -1408,27 +1351,20 @@ fn prepare_store(
 fn replacement_from_lineage(
     lineage: &FxHashMap<ExternalSequenceBlockHash, CanonicalSequenceBlockHash>,
 ) -> Result<DcCkfRankReplacement, KvCacheEventError> {
-    let mut ordered = Vec::new();
-    ordered
-        .try_reserve(lineage.len())
-        .map_err(|_| KvCacheEventError::AllocationFailed)?;
-    ordered.extend(
-        lineage
-            .iter()
-            .map(|(&external, &canonical)| (external, canonical)),
-    );
-    ordered.sort_unstable();
-
+    // Retained lineage is trusted state copied straight into the off-side rebuild. Admission
+    // order does not need canonicalizing: publication ships absolute bucket images taken from
+    // the final filter, so consumer parity is order-independent, and replay equivalence is
+    // logical rather than byte-level (`replay_churn_requires_logical_and_membership_not_byte_parity`).
     let mut replacement = DcCkfRankReplacement::new();
     replacement
         .source_lineage
-        .try_reserve(ordered.len())
+        .try_reserve(lineage.len())
         .map_err(|_| KvCacheEventError::AllocationFailed)?;
     replacement
         .canonical_candidates
-        .try_reserve(ordered.len())
+        .try_reserve(lineage.len())
         .map_err(|_| KvCacheEventError::AllocationFailed)?;
-    for (external, canonical) in ordered {
+    for (&external, &canonical) in lineage {
         replacement.source_lineage.insert(external, canonical);
         replacement.canonical_candidates.push(canonical);
     }
@@ -2257,26 +2193,96 @@ mod tests {
     }
 
     #[test]
-    fn disabled_publication_materialization_survives_rank_replacement() {
+    fn valid_sibling_before_conflicting_remap_commits_nothing() {
         let worker = WorkerWithDpRank::new(1, 0);
-        let mut state = DcCkfState::new(CkfConfig::new(32)).unwrap();
-        state.set_publication_materialization_enabled(false);
+        let mut state = DcCkfState::new(CkfConfig::new(64)).unwrap();
+        assert!(
+            state
+                .apply_event(stored(worker, 1, &[7]))
+                .first_error()
+                .is_none()
+        );
+        state.barrier_snapshot().unwrap();
+        let lineage_before = state.source_lineage.clone();
+        let owners_before = state.canonical_owners.clone();
 
-        let first = state.apply_event(stored(worker, 1, &[7]));
-        assert!(first.publication_boundary());
-        assert!(first.publication().is_none());
-        assert!(state.stats().publication().emitted_images() > 0);
-        assert_eq!(state.stats().publication().materialized_batches(), 0);
+        // A valid new sibling precedes a remap of block 7's external id onto a different chain.
+        let conflict = stored_exact(
+            worker,
+            2,
+            None,
+            None,
+            &[
+                (external(8), LocalBlockHash(8)),
+                (external(7), LocalBlockHash(9)),
+            ],
+        );
+        let outcome = state.apply_event(conflict);
 
-        let recovered = state.replace_rank(worker, replacement(&[7])).unwrap();
-        assert!(recovered.is_none());
-        assert!(!state.publication.materialization_enabled);
-        assert_eq!(state.stats().publication().materialized_batches(), 0);
+        assert_eq!(
+            outcome.first_error(),
+            Some(&KvCacheEventError::InvalidBlockSequence)
+        );
+        assert_eq!(state.source_lineage, lineage_before);
+        assert_eq!(state.canonical_owners, owners_before);
+        assert!(!state.is_resident(&canonical_root(8)));
+        assert!(state.drain_publication().is_none());
+    }
 
-        let next = state.apply_event(stored_with_parent(worker, 2, 7, &[8]));
-        assert!(next.publication_boundary());
-        assert!(next.publication().is_none());
-        assert_eq!(state.stats().publication().materialized_batches(), 0);
+    #[test]
+    fn replacement_failure_after_valid_prefix_leaves_state_untouched() {
+        let existing = WorkerWithDpRank::new(1, 0);
+        let mut state = DcCkfState::new(CkfConfig::new(64)).unwrap();
+        assert!(
+            state
+                .apply_event(stored(existing, 1, &[7]))
+                .first_error()
+                .is_none()
+        );
+        state.barrier_snapshot().unwrap();
+        let lineage_before = state.source_lineage.clone();
+        let owners_before = state.canonical_owners.clone();
+
+        let mut replacements = HashMap::new();
+        replacements.insert(WorkerWithDpRank::new(2, 0), replacement(&[11]));
+        replacements.insert(WorkerWithDpRank::new(3, 0), replacement(&[13]));
+        state.fail_replacement_install_after = Some(1);
+
+        let error = state.replace_ranks(replacements).unwrap_err();
+        assert_eq!(error, KvCacheEventError::AllocationFailed);
+        assert_eq!(state.source_lineage, lineage_before);
+        assert_eq!(state.canonical_owners, owners_before);
+        assert!(state.is_resident(&canonical_root(7)));
+        assert!(!state.is_resident(&canonical_root(11)));
+        assert!(!state.is_resident(&canonical_root(13)));
+        assert!(state.drain_publication().is_none());
+    }
+
+    #[test]
+    fn store_reserve_failure_commits_nothing() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let mut state = DcCkfState::new(CkfConfig::new(64)).unwrap();
+        assert!(
+            state
+                .apply_event(stored(worker, 1, &[7]))
+                .first_error()
+                .is_none()
+        );
+        state.barrier_snapshot().unwrap();
+        let lineage_before = state.source_lineage.clone();
+        let owners_before = state.canonical_owners.clone();
+        state.fail_next_store_reserve = true;
+
+        let outcome = state.apply_event(stored(worker, 2, &[8, 9]));
+
+        assert_eq!(
+            outcome.first_error(),
+            Some(&KvCacheEventError::AllocationFailed)
+        );
+        assert_eq!(state.source_lineage, lineage_before);
+        assert_eq!(state.canonical_owners, owners_before);
+        assert!(!state.is_resident(&canonical_root(8)));
+        assert!(state.drain_publication().is_none());
     }
 
     #[test]

--- a/lib/kv-router/src/indexer/cuckoo/failure.rs
+++ b/lib/kv-router/src/indexer/cuckoo/failure.rs
@@ -14,8 +14,12 @@ pub enum CkfFailureDomain {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CkfCommitState {
     /// The failed physical operation made no uncertain authoritative write in the relevant
-    /// domain. Deterministic exact metadata may still record an intentional lossy omission.
+    /// domain.
     KnownUnchanged,
+    /// Exact lineage and ownership committed deterministically while the physical admission
+    /// was intentionally omitted. Removal stays resolvable and a repeated store may re-admit
+    /// the block; only the presence fingerprint is missing.
+    ExactCommittedPhysicalOmitted,
     /// At least one authoritative write may have occurred and completion cannot be proven.
     Uncertain,
 }
@@ -57,7 +61,7 @@ impl CkfFailurePoint {
     /// Recovery is selected from the state whose commit became uncertain—not merely from the
     /// error's name.
     pub const fn disposition(self) -> CkfFailureDisposition {
-        use CkfCommitState::{KnownUnchanged, Uncertain};
+        use CkfCommitState::{ExactCommittedPhysicalOmitted, KnownUnchanged, Uncertain};
         use CkfFailureAction::{
             ContinueCapacityOmission, DeactivateAndSnapshot, FenceAndRebuildProducer, RejectSource,
             ReportResourceFailure, RetrySnapshot,
@@ -67,7 +71,7 @@ impl CkfFailurePoint {
         match self {
             Self::BoundedRelocationFailure => CkfFailureDisposition {
                 domain: ProducerCore,
-                commit: KnownUnchanged,
+                commit: ExactCommittedPhysicalOmitted,
                 recovery_domain: None,
                 action: ContinueCapacityOmission,
             },
@@ -118,7 +122,10 @@ mod tests {
     #[test]
     fn dispositions_target_only_the_domain_requiring_recovery() {
         let capacity = CkfFailurePoint::BoundedRelocationFailure.disposition();
-        assert_eq!(capacity.commit, CkfCommitState::KnownUnchanged);
+        assert_eq!(
+            capacity.commit,
+            CkfCommitState::ExactCommittedPhysicalOmitted
+        );
         assert_eq!(capacity.recovery_domain, None);
         assert_eq!(capacity.action, CkfFailureAction::ContinueCapacityOmission);
 

--- a/lib/kv-router/src/indexer/cuckoo/failure.rs
+++ b/lib/kv-router/src/indexer/cuckoo/failure.rs
@@ -13,7 +13,8 @@ pub enum CkfFailureDomain {
 /// What is known about the relevant domain at the point of failure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CkfCommitState {
-    /// This operation made no authoritative write in the relevant domain.
+    /// The failed physical operation made no uncertain authoritative write in the relevant
+    /// domain. Deterministic exact metadata may still record an intentional lossy omission.
     KnownUnchanged,
     /// At least one authoritative write may have occurred and completion cannot be proven.
     Uncertain,

--- a/lib/kv-router/src/indexer/cuckoo/mutator.rs
+++ b/lib/kv-router/src/indexer/cuckoo/mutator.rs
@@ -6,7 +6,8 @@ use rustc_hash::FxHashSet;
 
 use super::addressing::CkfAddressing;
 use super::bucket::{CuckooBucketStore, PackedBucket};
-use crate::protocols::{ExternalSequenceBlockHash, KvCacheEventError};
+use super::canonical::CanonicalSequenceBlockHash;
+use crate::protocols::KvCacheEventError;
 
 const SPLITMIX_INCREMENT: u64 = 0x9E37_79B9_7F4A_7C15;
 
@@ -54,7 +55,7 @@ impl CuckooInsertionScratch {
 
 #[cfg(test)]
 pub(super) struct DcWriterState {
-    pub(super) resident: FxHashSet<ExternalSequenceBlockHash>,
+    pub(super) resident: FxHashSet<CanonicalSequenceBlockHash>,
     pub(super) rng: u64,
     pub(super) scratch: CuckooInsertionScratch,
 }
@@ -96,7 +97,7 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
     #[cfg(test)]
     pub(super) fn insert(
         &self,
-        hash: ExternalSequenceBlockHash,
+        hash: CanonicalSequenceBlockHash,
         rng: &mut u64,
         scratch: &mut CuckooInsertionScratch,
         mut on_dirty: impl FnMut(DirtyBucket),
@@ -112,7 +113,7 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
     /// pre-mutation image without observing rolled-back insertions.
     pub(super) fn insert_with_originals(
         &self,
-        hash: ExternalSequenceBlockHash,
+        hash: CanonicalSequenceBlockHash,
         rng: &mut u64,
         scratch: &mut CuckooInsertionScratch,
         mut on_touched: impl FnMut(usize, PackedBucket),
@@ -127,13 +128,13 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
 
     fn insert_inner(
         &self,
-        hash: ExternalSequenceBlockHash,
+        hash: CanonicalSequenceBlockHash,
         rng: &mut u64,
         scratch: &mut CuckooInsertionScratch,
     ) -> Result<(), KvCacheEventError> {
         debug_assert!(self.store.bucket_count().is_power_of_two());
         scratch.clear();
-        let probe = self.addressing.prepare(hash.0);
+        let probe = self.addressing.prepare(hash.as_u64());
 
         if self.insert_into_empty(probe.bucket_a, probe.fingerprint, scratch)
             || self.insert_into_empty(probe.bucket_b, probe.fingerprint, scratch)
@@ -170,10 +171,10 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
     #[cfg(test)]
     pub(super) fn remove(
         &self,
-        hash: ExternalSequenceBlockHash,
+        hash: CanonicalSequenceBlockHash,
         mut on_dirty: impl FnMut(DirtyBucket),
     ) -> Result<(), KvCacheEventError> {
-        let probe = self.addressing.prepare(hash.0);
+        let probe = self.addressing.prepare(hash.as_u64());
         for bucket in [probe.bucket_a, probe.bucket_b] {
             let before = self.store.load_bucket(bucket);
             let Some(slot) = before.first(probe.fingerprint) else {
@@ -193,10 +194,10 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
 
     pub(super) fn remove_with_original(
         &self,
-        hash: ExternalSequenceBlockHash,
+        hash: CanonicalSequenceBlockHash,
         mut on_touched: impl FnMut(usize, PackedBucket),
     ) -> Result<(), KvCacheEventError> {
-        let probe = self.addressing.prepare(hash.0);
+        let probe = self.addressing.prepare(hash.as_u64());
         for bucket in [probe.bucket_a, probe.bucket_b] {
             let before = self.store.load_bucket(bucket);
             let Some(slot) = before.first(probe.fingerprint) else {

--- a/lib/kv-router/src/indexer/cuckoo/mutator.rs
+++ b/lib/kv-router/src/indexer/cuckoo/mutator.rs
@@ -163,7 +163,8 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
         }
 
         // NOTE: Exhausting this bounded kick search does not prove the table is full. Roll back
-        // every speculative write so the caller can treat it as a pre-commit capacity omission.
+        // every speculative write so the caller can omit only the physical admission while its
+        // exact lineage and ownership stay committed.
         self.rollback(scratch);
         Err(KvCacheEventError::CapacityExhausted)
     }

--- a/lib/kv-router/src/indexer/cuckoo/publication.rs
+++ b/lib/kv-router/src/indexer/cuckoo/publication.rs
@@ -248,6 +248,7 @@ mod tests {
     }
 
     fn stored(worker: WorkerWithDpRank, event_id: u64, hash: u64) -> RouterEvent {
+        const EXTERNAL_MASK: u64 = 0xC1F1_001D_5EED_7788;
         RouterEvent::new(
             worker.worker_id,
             KvCacheEvent {
@@ -256,7 +257,7 @@ mod tests {
                     parent_hash: None,
                     start_position: None,
                     blocks: vec![KvCacheStoredBlockData {
-                        block_hash: ExternalSequenceBlockHash(hash),
+                        block_hash: ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK),
                         tokens_hash: LocalBlockHash(hash),
                         mm_extra_info: None,
                     }],

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -3,7 +3,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::protocols::{ExternalSequenceBlockHash, LocalBlockHash, compute_seq_hash_for_block};
+use crate::protocols::{LocalBlockHash, compute_seq_hash_for_block};
 
 use super::addressing::{CkfAddressing, CkfProbe};
 use super::bucket::{CuckooBucketStore, PackedBucket, TransposedCkfTable};
@@ -14,9 +14,13 @@ use super::search::{
     find_prefix_depths_with_test_trace, fixed_window_prefix_depths, linear_prefix_depths,
     refine_binary_level_with_test_trace,
 };
-use super::{CkfConfig, DC_COUNT};
+use super::{CanonicalSequenceBlockHash, CkfConfig, DC_COUNT};
 
 const TEST_SEED: u64 = 0x1234_5678_9ABC_DEF0;
+
+fn canonical(hash: u64) -> CanonicalSequenceBlockHash {
+    CanonicalSequenceBlockHash::root(LocalBlockHash(hash))
+}
 
 const fn search_trace_event(
     kind: SearchTraceKind,
@@ -155,7 +159,7 @@ fn bounded_relocation_rolls_back_every_write_and_emits_no_dirty_bucket() {
     let mut state = DcWriterState::new(8, 1, TEST_SEED).unwrap();
     let mut dirty = Vec::new();
     let result = CuckooMutator::new(&view, &addressing, 1).insert(
-        ExternalSequenceBlockHash(999),
+        canonical(999),
         &mut state.rng,
         &mut state.scratch,
         |bucket| dirty.push(bucket),
@@ -741,9 +745,7 @@ fn store_remove_churn_drains_every_physical_slot() {
     let view = table.lane(0);
     let addressing = CkfAddressing::new(64, TEST_SEED);
     let mut state = DcWriterState::new(128, 500, TEST_SEED).unwrap();
-    let hashes: Vec<_> = (0..128)
-        .map(|hash| ExternalSequenceBlockHash(10_000 + hash))
-        .collect();
+    let hashes: Vec<_> = (0..128).map(|hash| canonical(10_000 + hash)).collect();
     let mutator = CuckooMutator::new(&view, &addressing, 500);
     for &hash in &hashes {
         mutator
@@ -1343,9 +1345,7 @@ fn fill_study_table(
         }
         while state.resident.len() < target {
             let hash = noise.next();
-            if query_hashes.contains(&hash)
-                || state.resident.contains(&ExternalSequenceBlockHash(hash))
-            {
+            if query_hashes.contains(&hash) || state.resident.contains(&canonical(hash)) {
                 continue;
             }
             insert_study_hash(&view, &addressing, &mut state, hash, max_kicks);
@@ -1367,7 +1367,7 @@ fn insert_study_hash<S: CuckooBucketStore>(
     hash: u64,
     max_kicks: usize,
 ) {
-    let hash = ExternalSequenceBlockHash(hash);
+    let hash = canonical(hash);
     if state.resident.contains(&hash) {
         return;
     }
@@ -1430,8 +1430,8 @@ impl StudyRng {
 fn colliding_hashes(
     addressing: CkfAddressing,
 ) -> (
-    ExternalSequenceBlockHash,
-    ExternalSequenceBlockHash,
+    CanonicalSequenceBlockHash,
+    CanonicalSequenceBlockHash,
     CkfProbe,
 ) {
     let mut seen = FxHashMap::default();
@@ -1439,11 +1439,7 @@ fn colliding_hashes(
         let probe = addressing.prepare(hash);
         let key = (probe.fingerprint, probe.bucket_a, probe.bucket_b);
         if let Some(first) = seen.insert(key, hash) {
-            return (
-                ExternalSequenceBlockHash(first),
-                ExternalSequenceBlockHash(hash),
-                probe,
-            );
+            return (canonical(first), canonical(hash), probe);
         }
     }
     panic!("failed to find deterministic CKF representation collision")

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -180,7 +180,13 @@ pub enum WorkerKvQueryResponse {
         events: Vec<RouterEvent>,
         last_event_id: u64,
     },
-    /// Full tree dump (with synthetic 0-indexed event IDs).
+    /// Full replay-ordered tree dump (with synthetic 0-indexed event IDs).
+    ///
+    /// Parent-addressed stored events appear after the event that introduces their parent.
+    /// Consumers may therefore rebuild exact source state in one pass. Indexers that describe
+    /// state positionally may use `start_position`; consumers that require parent-addressed
+    /// replay must reject unsupported non-zero orphan positions rather than treating them as
+    /// independent roots.
     /// Includes `last_event_id`: the newest real event ID in the worker's buffer
     /// at the time of the dump, so the caller can set its tracking cursor correctly.
     TreeDump {

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -1326,7 +1326,10 @@ pub enum KvCacheEventError {
     #[error("Invalid block sequence")]
     InvalidBlockSequence,
 
-    /// A bounded, pre-commit index omission; this does not prove the backing table is full.
+    /// A bounded physical-index omission; this does not prove the backing table is full.
+    ///
+    /// An indexer may still commit exact source lineage and ownership so removal and later
+    /// re-admission remain correct.
     #[error("Indexer capacity exhausted")]
     CapacityExhausted,
 

--- a/lib/llm/src/kv_dc_relay/actor.rs
+++ b/lib/llm/src/kv_dc_relay/actor.rs
@@ -20,11 +20,13 @@ use dynamo_kv_router::indexer::cuckoo::DcCkfStats;
 use dynamo_kv_router::indexer::cuckoo::PublisherEmitOutcome;
 use dynamo_kv_router::indexer::cuckoo::{
     CkfFailureAction, CkfFailureDisposition, CkfFailurePoint, DcCkfDelta, DcCkfDeltaSink,
-    DcCkfPublisher, DcCkfSnapshot, DcCkfState, LaneLease, ProducerIdentity,
+    DcCkfPublisher, DcCkfRankReplacement, DcCkfSnapshot, DcCkfState, LaneLease, ProducerIdentity,
 };
+#[cfg(test)]
+use dynamo_kv_router::protocols::ExternalSequenceBlockHash;
 use dynamo_kv_router::protocols::{
-    DpRank, ExternalSequenceBlockHash, KvCacheEventData, KvCacheEventError, RouterEvent,
-    StorageTier, WorkerId, WorkerWithDpRank,
+    DpRank, KvCacheEventData, KvCacheEventError, RouterEvent, StorageTier, WorkerId,
+    WorkerWithDpRank,
 };
 #[cfg(feature = "ckf-diagnostics")]
 use parking_lot::Mutex;
@@ -1002,10 +1004,11 @@ async fn run_actor(
                 if let Some(error) = first_error {
                     let disposition = event_failure_point(error).disposition();
                     if disposition.action == CkfFailureAction::ContinueCapacityOmission {
-                        // NOTE: A bounded relocation miss is a pre-commit lossy-index omission.
-                        // Do not turn it into a lifecycle fault: the affected block is unchanged,
-                        // successful sibling blocks remain committed, a later Store may retry, and
-                        // an omitted hash's Remove remains a safe no-op.
+                        // NOTE: A bounded relocation miss is a deterministic physical-index
+                        // omission. Exact source lineage and ownership remain committed, while the
+                        // failed fingerprint is non-resident. Do not turn it into a lifecycle
+                        // fault: successful siblings remain committed, a new owner may retry
+                        // admission, and removal still resolves through source lineage.
                         capacity_omission_events = capacity_omission_events.saturating_add(1);
                         if capacity_omission_events == 1 {
                             tracing::warn!(
@@ -1057,8 +1060,8 @@ async fn run_actor(
             } => {
                 #[cfg(feature = "ckf-diagnostics")]
                 let rebuild_started = Instant::now();
-                let result = replacement_batch_hashes(replacements)
-                    .and_then(|hashes| state.replace_ranks(hashes).map_err(Into::into))
+                let result = replacement_batch_states(replacements)
+                    .and_then(|states| state.replace_ranks(states).map_err(Into::into))
                     .and_then(|publication| {
                         if let Some(batch) = publication {
                             publish_batch(batch, &mut publisher, &diagnostics)?;
@@ -1178,12 +1181,12 @@ async fn run_actor(
     }
 }
 
-fn replacement_hashes(
+fn replacement_state(
     worker_id: WorkerId,
     dp_rank: DpRank,
     events: Vec<RouterEvent>,
-) -> Result<HashSet<ExternalSequenceBlockHash>, KvDcRelayError> {
-    let mut hashes = HashSet::new();
+) -> Result<DcCkfRankReplacement, KvDcRelayError> {
+    let mut replacement = DcCkfRankReplacement::new();
     for event in events {
         if event.worker_id != worker_id || event.event.dp_rank != dp_rank {
             return Err(KvDcRelayError::InvalidTreeDump {
@@ -1202,23 +1205,36 @@ fn replacement_hashes(
                 message: "tree dump contains a non-Stored event".to_string(),
             });
         };
-        hashes.try_reserve(store.blocks.len()).map_err(|_| {
+        replacement
+            .push_store(&store)
+            .map_err(|error| match error {
+                KvCacheEventError::AllocationFailed => KvDcRelayError::Build(
+                    dynamo_kv_router::indexer::cuckoo::CkfBuildError::AllocationFailed,
+                ),
+                _ => KvDcRelayError::InvalidTreeDump {
+                    worker_id,
+                    dp_rank,
+                    message: format!("tree dump is not canonical replay order: {error}"),
+                },
+            })?;
+    }
+    Ok(replacement)
+}
+
+fn replacement_batch_states(
+    replacements: Vec<RankReplacement>,
+) -> Result<HashMap<WorkerWithDpRank, DcCkfRankReplacement>, KvDcRelayError> {
+    let mut states_by_rank = HashMap::new();
+    states_by_rank
+        .try_reserve(replacements.len())
+        .map_err(|_| {
             KvDcRelayError::Build(
                 dynamo_kv_router::indexer::cuckoo::CkfBuildError::AllocationFailed,
             )
         })?;
-        hashes.extend(store.blocks.into_iter().map(|block| block.block_hash));
-    }
-    Ok(hashes)
-}
-
-fn replacement_batch_hashes(
-    replacements: Vec<RankReplacement>,
-) -> Result<HashMap<WorkerWithDpRank, HashSet<ExternalSequenceBlockHash>>, KvDcRelayError> {
-    let mut hashes_by_rank = HashMap::new();
     for replacement in replacements {
         let member = WorkerWithDpRank::new(replacement.worker_id, replacement.dp_rank);
-        if hashes_by_rank.contains_key(&member) {
+        if states_by_rank.contains_key(&member) {
             return Err(KvDcRelayError::InvalidTreeDump {
                 worker_id: replacement.worker_id,
                 dp_rank: replacement.dp_rank,
@@ -1228,14 +1244,14 @@ fn replacement_batch_hashes(
                 ),
             });
         }
-        let hashes = replacement_hashes(
+        let state = replacement_state(
             replacement.worker_id,
             replacement.dp_rank,
             replacement.events,
         )?;
-        hashes_by_rank.insert(member, hashes);
+        states_by_rank.insert(member, state);
     }
-    Ok(hashes_by_rank)
+    Ok(states_by_rank)
 }
 
 fn publish_batch(
@@ -1329,6 +1345,8 @@ mod tests {
         }
     }
 
+    const EXTERNAL_MASK: u64 = 0xBADC_0FFE_E0DD_F00D;
+
     fn scope(_name: &str) -> StreamScope {
         let dc_id = DcId::new(2);
         let domain = IndexerDomainId::new(
@@ -1358,7 +1376,7 @@ mod tests {
                         .iter()
                         .copied()
                         .map(|hash| KvCacheStoredBlockData {
-                            block_hash: ExternalSequenceBlockHash(hash),
+                            block_hash: ExternalSequenceBlockHash(hash ^ EXTERNAL_MASK),
                             tokens_hash: LocalBlockHash(hash),
                             mm_extra_info: None,
                         })
@@ -1802,6 +1820,12 @@ mod tests {
         let source = event_failure_point(KvCacheEventError::OwnershipDegreeOverflow).disposition();
         assert_eq!(source.action, CkfFailureAction::RejectSource);
         assert_eq!(source.commit, CkfCommitState::KnownUnchanged);
+
+        let missing_parent =
+            event_failure_point(KvCacheEventError::ParentBlockNotFound).disposition();
+        assert_eq!(missing_parent.action, CkfFailureAction::RejectSource);
+        assert_eq!(missing_parent.domain, CkfFailureDomain::ProducerCore);
+        assert_eq!(missing_parent.commit, CkfCommitState::KnownUnchanged);
 
         let invariant =
             event_failure_point(KvCacheEventError::IndexerInvariantViolation).disposition();

--- a/lib/llm/src/kv_dc_relay/actor.rs
+++ b/lib/llm/src/kv_dc_relay/actor.rs
@@ -25,8 +25,7 @@ use dynamo_kv_router::indexer::cuckoo::{
 #[cfg(test)]
 use dynamo_kv_router::protocols::ExternalSequenceBlockHash;
 use dynamo_kv_router::protocols::{
-    DpRank, KvCacheEventData, KvCacheEventError, RouterEvent, StorageTier, WorkerId,
-    WorkerWithDpRank,
+    DpRank, KvCacheEventData, KvCacheEventError, RouterEvent, WorkerId, WorkerWithDpRank,
 };
 #[cfg(feature = "ckf-diagnostics")]
 use parking_lot::Mutex;
@@ -1195,28 +1194,16 @@ fn replacement_state(
                 message: "event identity does not match replacement rank".to_string(),
             });
         }
-        if event.storage_tier != StorageTier::Device {
-            continue;
-        }
-        let KvCacheEventData::Stored(store) = event.event.data else {
-            return Err(KvDcRelayError::InvalidTreeDump {
+        replacement.push_event(event).map_err(|error| match error {
+            KvCacheEventError::AllocationFailed => KvDcRelayError::Build(
+                dynamo_kv_router::indexer::cuckoo::CkfBuildError::AllocationFailed,
+            ),
+            _ => KvDcRelayError::InvalidTreeDump {
                 worker_id,
                 dp_rank,
-                message: "tree dump contains a non-Stored event".to_string(),
-            });
-        };
-        replacement
-            .push_store(&store)
-            .map_err(|error| match error {
-                KvCacheEventError::AllocationFailed => KvDcRelayError::Build(
-                    dynamo_kv_router::indexer::cuckoo::CkfBuildError::AllocationFailed,
-                ),
-                _ => KvDcRelayError::InvalidTreeDump {
-                    worker_id,
-                    dp_rank,
-                    message: format!("tree dump is not canonical replay order: {error}"),
-                },
-            })?;
+                message: format!("tree dump is not canonical replay order: {error}"),
+            },
+        })?;
     }
     Ok(replacement)
 }

--- a/lib/llm/src/kv_dc_relay/actor.rs
+++ b/lib/llm/src/kv_dc_relay/actor.rs
@@ -463,16 +463,12 @@ impl KvDcRelayHandle {
         Ok(())
     }
 
-    async fn replace_ranks(
+    async fn replace_rank_states(
         &self,
-        replacements: Vec<RankReplacement>,
+        states: HashMap<WorkerWithDpRank, DcCkfRankReplacement>,
+        payload_weight: usize,
     ) -> Result<(), KvDcRelayError> {
-        let weight = replacements
-            .iter()
-            .flat_map(|replacement| &replacement.events)
-            .map(event_payload_weight)
-            .fold(0usize, usize::saturating_add)
-            .min(DEFAULT_PENDING_BLOCK_PERMITS) as u32;
+        let weight = payload_weight.min(DEFAULT_PENDING_BLOCK_PERMITS) as u32;
         let permit = self
             .payload_permits
             .clone()
@@ -480,7 +476,7 @@ impl KvDcRelayHandle {
             .await
             .map_err(|_| KvDcRelayError::ShuttingDown)?;
         self.submit(|response| ActorCommand::ReplaceRanks {
-            replacements,
+            states,
             _payload_permit: permit,
             response,
         })
@@ -490,17 +486,20 @@ impl KvDcRelayHandle {
     #[cfg(test)]
     async fn replace_rank(
         &self,
-        publisher_id: PublisherId,
+        _publisher_id: PublisherId,
         worker_id: WorkerId,
         dp_rank: DpRank,
         events: Vec<RouterEvent>,
     ) -> Result<(), KvDcRelayError> {
-        self.replace_ranks(vec![RankReplacement {
-            publisher_id,
-            worker_id,
-            dp_rank,
-            events,
-        }])
+        let weight = events
+            .iter()
+            .map(event_payload_weight)
+            .fold(0usize, usize::saturating_add);
+        let state = replacement_state(worker_id, dp_rank, events)?;
+        self.replace_rank_states(
+            HashMap::from([(WorkerWithDpRank::new(worker_id, dp_rank), state)]),
+            weight,
+        )
         .await
     }
 
@@ -644,19 +643,88 @@ impl KvDcRelayRecoveryTarget {
             state.flush_scheduled = false;
             std::mem::take(&mut state.pending)
         };
-        let (replacements, responses): (Vec<_>, Vec<_>) = pending
-            .into_iter()
-            .map(|pending| (pending.replacement, pending.response))
-            .unzip();
+        // Replacement states are built off the actor, and a malformed dump stays local to
+        // its rank: only pool-wide failures (allocation, actor invariants) reject the batch.
+        let mut states: HashMap<WorkerWithDpRank, DcCkfRankReplacement> = HashMap::new();
+        let mut waiters = Vec::new();
+        let mut payload_weight = 0usize;
+        let mut pending = pending.into_iter();
+        let mut batch_error: Option<String> = None;
+        if states.try_reserve(pending.len()).is_err() || waiters.try_reserve(pending.len()).is_err()
+        {
+            batch_error = Some(
+                KvDcRelayError::Build(
+                    dynamo_kv_router::indexer::cuckoo::CkfBuildError::AllocationFailed,
+                )
+                .to_string(),
+            );
+        }
+        for item in pending.by_ref() {
+            if batch_error.is_some() {
+                break;
+            }
+            let replacement = item.replacement;
+            let member = WorkerWithDpRank::new(replacement.worker_id, replacement.dp_rank);
+            if states.contains_key(&member) {
+                // A duplicate rank in one window means the earlier entry is already being
+                // installed; failing only the later waiter keeps the anomaly rank-local.
+                let _ = item.response.send(Err(KvDcRelayError::InvalidTreeDump {
+                    worker_id: replacement.worker_id,
+                    dp_rank: replacement.dp_rank,
+                    message: format!(
+                        "replacement batch contains the same rank more than once (publisher {})",
+                        replacement.publisher_id
+                    ),
+                }
+                .to_string()));
+                continue;
+            }
+            let weight = replacement
+                .events
+                .iter()
+                .map(event_payload_weight)
+                .fold(0usize, usize::saturating_add);
+            match replacement_state(
+                replacement.worker_id,
+                replacement.dp_rank,
+                replacement.events,
+            ) {
+                Ok(state) => {
+                    states.insert(member, state);
+                    payload_weight = payload_weight.saturating_add(weight);
+                    waiters.push(item.response);
+                }
+                Err(error @ KvDcRelayError::Build(_)) => {
+                    let error = error.to_string();
+                    let _ = item.response.send(Err(error.clone()));
+                    batch_error = Some(error);
+                }
+                Err(error) => {
+                    let _ = item.response.send(Err(error.to_string()));
+                }
+            }
+        }
+        if let Some(error) = batch_error {
+            for item in pending {
+                let _ = item.response.send(Err(error.clone()));
+            }
+            for response_tx in waiters {
+                let _ = response_tx.send(Err(error.clone()));
+            }
+            return;
+        }
+        if states.is_empty() {
+            return;
+        }
         let batch_result = match self.rebuild_permit.acquire().await {
             Ok(_permit) => self
                 .handle
-                .replace_ranks(replacements)
+                .replace_rank_states(states, payload_weight)
                 .await
                 .map_err(|error| error.to_string()),
             Err(_) => Err(KvDcRelayError::ShuttingDown.to_string()),
         };
-        for response_tx in responses {
+        for response_tx in waiters {
             let response = match &batch_result {
                 Ok(()) => Ok(()),
                 Err(error) => Err(error.clone()),
@@ -835,7 +903,7 @@ enum ActorCommand {
         _payload_permit: OwnedSemaphorePermit,
     },
     ReplaceRanks {
-        replacements: Vec<RankReplacement>,
+        states: HashMap<WorkerWithDpRank, DcCkfRankReplacement>,
         _payload_permit: OwnedSemaphorePermit,
         response: oneshot::Sender<Result<(), KvDcRelayError>>,
     },
@@ -1053,26 +1121,38 @@ async fn run_actor(
                 }
             }
             ActorCommand::ReplaceRanks {
-                replacements,
+                states,
                 _payload_permit: _,
                 response,
             } => {
                 #[cfg(feature = "ckf-diagnostics")]
                 let rebuild_started = Instant::now();
-                let result = replacement_batch_states(replacements)
-                    .and_then(|states| state.replace_ranks(states).map_err(Into::into))
-                    .and_then(|publication| {
-                        if let Some(batch) = publication {
-                            publish_batch(batch, &mut publisher, &diagnostics)?;
-                        } else {
-                            diagnostics.record_no_publication();
-                        }
-                        Ok(())
-                    });
+                let omissions_before = state.lifetime_capacity_omissions();
+                let result =
+                    state
+                        .replace_ranks(states)
+                        .map_err(Into::into)
+                        .and_then(|publication| {
+                            if let Some(batch) = publication {
+                                publish_batch(batch, &mut publisher, &diagnostics)?;
+                            } else {
+                                diagnostics.record_no_publication();
+                            }
+                            Ok(())
+                        });
                 #[cfg(feature = "ckf-diagnostics")]
                 diagnostics.record_rebuild(rebuild_started);
                 // The whole cold-start batch is built off-side. A pre-swap failure leaves every
                 // prior rank unchanged; the strong responses all observe the same atomic result.
+                let replacement_omissions = state
+                    .lifetime_capacity_omissions()
+                    .saturating_sub(omissions_before);
+                if replacement_omissions > 0 {
+                    tracing::warn!(
+                        replacement_omissions,
+                        "KV DC Relay omitted capacity-exhausted blocks while installing rank replacements; service continues"
+                    );
+                }
                 let _ = response.send(result);
             }
             ActorCommand::ResetRank {
@@ -1206,39 +1286,6 @@ fn replacement_state(
         })?;
     }
     Ok(replacement)
-}
-
-fn replacement_batch_states(
-    replacements: Vec<RankReplacement>,
-) -> Result<HashMap<WorkerWithDpRank, DcCkfRankReplacement>, KvDcRelayError> {
-    let mut states_by_rank = HashMap::new();
-    states_by_rank
-        .try_reserve(replacements.len())
-        .map_err(|_| {
-            KvDcRelayError::Build(
-                dynamo_kv_router::indexer::cuckoo::CkfBuildError::AllocationFailed,
-            )
-        })?;
-    for replacement in replacements {
-        let member = WorkerWithDpRank::new(replacement.worker_id, replacement.dp_rank);
-        if states_by_rank.contains_key(&member) {
-            return Err(KvDcRelayError::InvalidTreeDump {
-                worker_id: replacement.worker_id,
-                dp_rank: replacement.dp_rank,
-                message: format!(
-                    "replacement batch contains the same rank more than once (publisher {})",
-                    replacement.publisher_id
-                ),
-            });
-        }
-        let state = replacement_state(
-            replacement.worker_id,
-            replacement.dp_rank,
-            replacement.events,
-        )?;
-        states_by_rank.insert(member, state);
-    }
-    Ok(states_by_rank)
 }
 
 fn publish_batch(
@@ -1797,7 +1844,10 @@ mod tests {
         let capacity = event_failure_point(KvCacheEventError::CapacityExhausted).disposition();
         assert_eq!(capacity.action, CkfFailureAction::ContinueCapacityOmission);
         assert_eq!(capacity.domain, CkfFailureDomain::ProducerCore);
-        assert_eq!(capacity.commit, CkfCommitState::KnownUnchanged);
+        assert_eq!(
+            capacity.commit,
+            CkfCommitState::ExactCommittedPhysicalOmitted
+        );
         assert_eq!(capacity.recovery_domain, None);
 
         let allocation = event_failure_point(KvCacheEventError::AllocationFailed).disposition();

--- a/lib/llm/src/kv_dc_relay/actor.rs
+++ b/lib/llm/src/kv_dc_relay/actor.rs
@@ -1797,7 +1797,7 @@ mod tests {
             tokio::time::timeout(Duration::from_millis(20), faults.recv())
                 .await
                 .is_err(),
-            "a pre-commit capacity omission must not enter lifecycle fault handling"
+            "a capacity omission commits exact state and must not enter lifecycle fault handling"
         );
 
         handle

--- a/lib/llm/src/kv_dc_relay/host.rs
+++ b/lib/llm/src/kv_dc_relay/host.rs
@@ -172,6 +172,7 @@ pub struct KvDcRelayAggregationStats {
     pub contribution_count: usize,
     pub unique_block_count: usize,
     pub unknown_removals: u64,
+    pub parent_not_found: u64,
     pub capacity_failures: u64,
     pub occupied_bucket_count: usize,
     pub occupied_slot_count: usize,
@@ -213,8 +214,8 @@ pub struct KvDcRelayRecoveryStats {
 pub struct KvDcRelayMemoryStats {
     pub filter_bytes: usize,
     pub dirty_tracking_bytes: usize,
-    pub member_set_capacity: usize,
-    pub refcount_capacity: usize,
+    pub source_lineage_capacity: usize,
+    pub canonical_owner_capacity: usize,
     pub insertion_scratch_capacity: usize,
 }
 
@@ -1484,6 +1485,7 @@ async fn endpoint_stats(
                 contribution_count: aggregation.contribution_count(),
                 unique_block_count: aggregation.unique_block_count(),
                 unknown_removals: aggregation.unknown_removals(),
+                parent_not_found: aggregation.parent_not_found(),
                 capacity_failures: aggregation.capacity_failures(),
                 occupied_bucket_count: aggregation.occupied_bucket_count(),
                 occupied_slot_count: aggregation.occupied_slot_count(),
@@ -1512,8 +1514,8 @@ async fn endpoint_stats(
             Some(KvDcRelayMemoryStats {
                 filter_bytes: memory.filter_bytes(),
                 dirty_tracking_bytes: memory.dirty_tracking_bytes(),
-                member_set_capacity: memory.member_set_capacity(),
-                refcount_capacity: memory.refcount_capacity(),
+                source_lineage_capacity: memory.source_lineage_capacity(),
+                canonical_owner_capacity: memory.canonical_owner_capacity(),
                 insertion_scratch_capacity: memory.insertion_scratch_capacity(),
             }),
         )


### PR DESCRIPTION
## Overview:

  The DC CKF (the exact-state cuckoo filter behind the KV DC Relay pool producer) indexed
  engine-specific external block hashes, while its consumer side (`GlobalCkf::prepared_probes`)
  probes canonical Dynamo sequence hashes derived from `tokens_hash` chains. Real vLLM/SGLang
  backends therefore produced zero prefix matches: only mock producers that happen to emit
  Dynamo-computed external hashes appeared to work, and the parity fixtures masked the bug by
  assigning canonical hashes to the external field.

  This PR indexes and refcounts canonical hashes instead, and confines the engine vocabulary to
  a per-source ingest boundary. Both sides of the contract live in this repository today; the
  fix aligns the producer with the consumer that already probes canonically.

  ## Details:

  - `CanonicalSequenceBlockHash` newtype with `root()`/`child()` as the only constructors; the
    CKF mutator API no longer accepts external hashes, so this class of regression is a compile
    error rather than a silent zero-match deployment. `root()` is the block's own `tokens_hash`
    and `child()` delegates to `compute_next_seq_hash` — exactly what the consumer computes via
    `compute_seq_hash_for_block`.
  - **Exact state.** Per-source lineage (`external -> canonical`) is needed for parent lookup,
    removals, and recovery, because `Removed` events carry only external ids. Canonical
    ownership carries the owner count together with a residency flag — the padding in a
    `(hash, u32)` map entry already pays for the flag — so dropping the last owner clears
    residency by construction instead of through a second removal that has to stay
    synchronized. Fingerprints are cleared only when the last owner is removed and the hash is
    resident.
  - **Re-admission after a capacity omission.** A block usually has exactly one owner, so
    waiting for a *new* owner would leave an omitted block non-resident indefinitely. Any
    repeat from the same source re-offers it on a deliberately relocation-free path
    (`max_kicks = 0`: two bucket loads, no kick search) since omissions only happen on a
    saturated filter, where a full kick search would burn up to 500 relocations and a rollback
    per repeat. A failed re-offer is silent and commits no new capacity failure, because the
    first store already reported that omission.
  - **Two-phase batch ingest.** The whole `Stored` event is validated (unknown parent,
    conflicting external remap) before any state is written. `CapacityExhausted` commits
    lineage and ownership but not residency, and does not abort sibling blocks.
  - **Recovery** rebuilds lineage, ownership, and admission off-side from replay-ordered tree
    dumps and swaps atomically. Dumps that violate parent-before-child order, or start
    mid-sequence without a known parent, are rejected instead of being guessed as roots.
  - **Residency domains.** Only primary-GPU residency reaches this Device CKF: cache-owner
    events are ignored and unknown residency encodings fail closed before any state is written,
    both live and during recovery replay.
  - **Store-path scratch reuse.** The new validation phase would otherwise rent seven transient
    containers from the allocator per `Stored` event, which serializes ingest actors on the
    allocator at saturation. The store path now wipes and reuses per-state scratch buffers
    (mirroring the existing `remove_scratch` pattern); `try_reserve` on a reused container
    still reserves only the shortfall, so the fail-closed `AllocationFailed` contract is
    unchanged.
  - **Fixtures.** All producer test fixtures now derive external ids distinct from canonical
    hashes so this conflation cannot pass tests again; captured live vLLM/SGLang/Dynamo hash
    triples are pinned as a regression test.

  ### Compatibility
  
  `FORMAT_VERSION` of the CKF identity intentionally stays 1: the contract has not shipped to
  production, and pre-release schema changes are clean breaks with lockstep producer/consumer
  deployment.

  ### Tree-dump contract

  Recovery replays tree dumps in parent-addressed order: every store either names its
  parent or starts a sequence at position 0, and anything else is rejected instead of
  being guessed at. This requirement is documented on `WorkerKvQueryResponse::TreeDump`.
  The one in-tree producer of a different shape, `PositionalIndexer::dump_events`, is not
  wired into relay recovery (benches only); a future positional backend would need to
  convert its dumps before serving them to the relay.

  ### Validation

  - `cargo test -p dynamo-kv-router --lib` — 899 passed.
  - `cargo test -p dynamo-llm --lib kv_dc_relay` — 66 passed; 67 with `ckf-diagnostics`.
  - `cargo clippy --no-deps -p dynamo-kv-router -p dynamo-llm -p dynamo-bench --all-targets
    --features dc-ckf-relay -- -D warnings` clean; `cargo fmt --all -- --check` clean.
  - New in-tree regression tests cover the canonicalization contract (root and batched chains,
    parent-addressed chains, captured live engine hash triples), rejection paths (unknown
    parent, conflicting external remap, child-before-parent and orphan-position dumps),
    capacity omission and re-admission, alias handling, residency-domain gating, and the
    rank-replacement publication diff.
  - `dc_ckf_relay_bench` (qwen-200k Mooncake replay, 25,809 Stored events, 4 DCs x 64 logical
    workers), scratch reuse against the same fix without it:

    | issuer threads | without scratch reuse | with | admission p50 |
    |---|---|---|---|
    | 1 | 682k ev/s | 1.12M ev/s | 864ns -> 553ns |
    | 4 | 2.56M ev/s | 5.05M ev/s | 1321ns -> 594ns |
    | 16 | 1.80M ev/s | 3.67M ev/s | 4307ns -> 1820ns |

  ## Where should the reviewer start?
  
  1. `lib/kv-router/src/indexer/cuckoo/canonical.rs` — 48 lines, defines the whole contract.
     Worth checking against `compute_seq_hash_for_block` and `GlobalCkf::prepared_probes` in
     `global.rs`, since producer/consumer agreement is the entire point of the fix.
  2. `lib/kv-router/src/indexer/cuckoo/dc.rs` — the substance. In order: `prepare_store`
     (canonicalization and pre-write validation), `store_batch_with_scratch` (every fallible
     reserve happens before the first mutation; then admission, then the re-offer pass),
     `remove` (last-owner residency clearing), and `replace_ranks` (off-side rebuild plus the
     publication diff taken against the last *published* bucket values).
  3. `lib/llm/src/kv_dc_relay/actor.rs` — `replacement_state`: tree dump to rank replacement
     and the error mapping that turns a non-canonical dump into a non-retryable rebuild error.
  4. `lib/kv-router/src/indexer/cuckoo/mutator.rs` — the signature change that makes external
     hashes unrepresentable in the filter API.
  5. Fixture changes in `adapter.rs`, `publication.rs`, and the benches — confirm every
     producer fixture now derives external ids distinct from canonical hashes.

  ## Related Issues
  
  **🔗 This PR is linked to an issue:**

  - Relates to #11225

  Note: this commit is currently also the first commit of #12102 (the KV DC Relay WAN
  transport), which depends on it; #12102 will be rebased to drop it once this PR lands.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved cache block tracking with canonical sequence identities and lineage-aware ownership.
  - Added stronger validation for parent relationships, ordering, residency, and format compatibility.
  - Added support for transactional rank replacement and optional publication materialization.
  - Expanded diagnostics with parent-missing, lineage, ownership, residency, and materialized-batch metrics.

- **Bug Fixes**
  - Improved handling of capacity omissions, aliases, recovery events, removals, and conflicting mappings.
  - Clarified replay ordering and failure behavior for missing parent entries.

- **Documentation**
  - Updated capacity and replay guidance to reflect the revised indexing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->