### PR TITLE
fix(docs-ci): probe the benchmark page at its published slug in the styles check

### DIFF
--- a/docs/fern/scripts/check_published_styles.py
+++ b/docs/fern/scripts/check_published_styles.py
@@ -44,6 +44,7 @@ Usage:
 
 Exits 1 with the failing page/selector pairs listed.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -68,8 +69,10 @@ CHECKS: list[tuple[str, str, str]] = [
     ("community", ".dynamo-community-page", "LandingStyles"),
     ("digest", ".dynamo-blog-art__grid", "BlogStyles"),
     ("reference/compatibility", ".dynref-panel", "ReferenceStyles"),
+    # URL from the nav's explicit slugs (section `benchmarks`, page
+    # `llama-3-70b-topology`), not the page's file path.
     (
-        "recipes/feature-benchmarks/llama-3-3-70b-topology",
+        "recipes/benchmarks/llama-3-70b-topology",
         ".dynamo-benchmark-grid",
         "RecipeStyles",
     ),
@@ -103,7 +106,7 @@ def url_from_base(base: str, path: str) -> str:
     origin = f"{parsed.scheme}://{parsed.netloc}"
     if origin not in ALLOWED_ORIGINS:
         raise SystemExit(
-            f"{origin} is not an allowed docs origin: " f"{sorted(ALLOWED_ORIGINS)}"
+            f"{origin} is not an allowed docs origin: {sorted(ALLOWED_ORIGINS)}"
         )
     return url
 


### PR DESCRIPTION
## Summary

Every main-publish run of the Fern Docs workflow has failed its final step, "Verify published pages carry their component CSS", since the RecipeStyles probe was added on Aug 4 (#12339). The probe derived its URL from the page's file path (`recipes/feature-benchmarks/llama-3-3-70b-topology`), but the nav publishes the section under `slug: benchmarks` and the page under an explicit `slug: llama-3-70b-topology`, so the probe 404ed on every execution. Runs that looked green had merely skipped the docs job (non-docs pushes). The failure was masked for two weeks because the step runs after the sync and publish already succeeded.

One-line fix: probe `recipes/benchmarks/llama-3-70b-topology`, with a comment noting the URL comes from the nav's explicit slugs, not the file path.

## Validation

Ran `check_published_styles.py` against the live site: all six probes pass, including `.dynamo-benchmark-grid` (6 rules, RecipeStyles) at the corrected URL. The first main publish after this merges should go fully green end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the benchmark recipe reference to the current location.
  * Improved the formatting of an allowed-origin error message.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->