### PR TITLE
docs(build): enable pre-releases when installing from source

### DIFF
--- a/docs/fern/pages/developer-guide/advanced-customizations/building-from-source.md
+++ b/docs/fern/pages/developer-guide/advanced-customizations/building-from-source.md
@@ -78,8 +78,15 @@ Install Dynamo with a backend extra to pull the inference engine and its CUDA de
 
 ```bash
 # Use .[vllm] or .[sglang] instead to install the relevant framework dependencies
-uv pip install -e .
+uv pip install -e . --prerelease=allow
 ```
+
+`--prerelease=allow` is required on Python < 3.13. The base dependency
+`aisimulate==0.1.0.dev1` is a pre-release, and it in turn pins the pre-releases
+`aiconfigurator==0.11.0.dev20260728` and `tfp-nightly==0.26.0.dev20260626`.
+`uv` refuses those transitive pre-releases even though the direct pin is
+explicit, so without the flag the install fails with `we can conclude that your
+requirements are unsatisfiable`.
 
 > [!NOTE]
 > The base `uv pip install -e .` installs only the Dynamo runtime and frontend. A backend extra (`[vllm]`, or `[sglang]`) will install the relevant framework dependencies to run an inference worker. For the TensorRT-LLM backend, use the `tensorrtllm-runtime` container instead of installing via `uv pip` to ensure the right dependencies are installed. See [Local Installation](../../cli/installation/install-dynamo.mdx) for more details.


### PR DESCRIPTION
Step 7 of the build-from-source guide documents `uv pip install -e .`, but ai-dynamo depends on a pre-release of aiconfigurator and uv rejects pre-releases by default, so the documented command cannot succeed:

    error: ... we can conclude that your requirements are unsatisfiable.
    hint: `aiconfigurator` was requested with a pre-release marker
          (e.g., aiconfigurator==0.11.0.dev20260728), but pre-releases
          weren't enabled (try: `--prerelease=allow`)

Add `--prerelease=allow` to the command and note why it is needed.

Verified on Ubuntu 24.04 / Python 3.12: the documented command exits 1, the same command with `--prerelease=allow` exits 0, after which `python3 -m dynamo.frontend --help` (step 8) succeeds.

This is my first contribution to Dynamo. I hit this while bringing up a source build on Blackwell (B300) for disaggregated-serving work, and I would like to continue development here. I'm happy to rework the fix or wording if maintainers prefer a different approach.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions for editable setups.
  * Clarified that allowing pre-release dependencies is required for successful installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->