### PR TITLE
fix(test): cap DeepEP smoke payloads at 128 output tokens

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -138,7 +138,6 @@ jobs:
       - vllm-dev-build
       - vllm-test
       - vllm-multi-gpu-test
-      - vllm-h100-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-dev-build
@@ -775,26 +774,6 @@ jobs:
       gpu_parallel_max_vram_gib: '24'
     secrets: inherit
 
-  # TEMPORARY (#13482): H100 lane on PR CI to validate the DeepEP timeout fix.
-  # Remove this job after test_serve_deployment[deepep-2] passes on the PR head.
-  vllm-h100-test:
-    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [changed-files, vllm-build]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: vllm
-      test_type: H100 Test
-      # 2x 80 GiB H100: DeepEP uses two data-parallel ranks on one node.
-      amd_runner: aws-dev-02-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
-      cuda_version: '["13.0"]'
-      platform: '["amd64"]'
-      run_sanity_check: false
-      gpu_test_markers: pre_merge and vllm and h100 and gpu_2
-      gpu_test_timeout_minutes: 60
-    secrets: inherit
-
   vllm-multi-gpu-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files, vllm-build]
@@ -812,8 +791,7 @@ jobs:
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      # H100-only cases run on the temporary vllm-h100-test lane above.
-      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4) and not h100
+      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -1944,7 +1922,6 @@ jobs:
       - planner-copy-to-acr
       - vllm-copy-to-acr
       - vllm-multi-gpu-test
-      - vllm-h100-test
       - vllm-efa-build
       - sglang-copy-to-acr
       - sglang-multi-gpu-test
@@ -1983,7 +1960,6 @@ jobs:
       - vllm-build
       - vllm-test
       - vllm-multi-gpu-test
-      - vllm-h100-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -138,6 +138,7 @@ jobs:
       - vllm-dev-build
       - vllm-test
       - vllm-multi-gpu-test
+      - vllm-h100-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-dev-build
@@ -774,6 +775,26 @@ jobs:
       gpu_parallel_max_vram_gib: '24'
     secrets: inherit
 
+  # TEMPORARY (#13482): H100 lane on PR CI to validate the DeepEP timeout fix.
+  # Remove this job after test_serve_deployment[deepep-2] passes on the PR head.
+  vllm-h100-test:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: H100 Test
+      # 2x 80 GiB H100: DeepEP uses two data-parallel ranks on one node.
+      amd_runner: aws-dev-02-tester-amd-gpu-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]'
+      run_sanity_check: false
+      gpu_test_markers: pre_merge and vllm and h100 and gpu_2
+      gpu_test_timeout_minutes: 60
+    secrets: inherit
+
   vllm-multi-gpu-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files, vllm-build]
@@ -791,7 +812,8 @@ jobs:
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4)
+      # H100-only cases run on the temporary vllm-h100-test lane above.
+      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4) and not h100
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -1922,6 +1944,7 @@ jobs:
       - planner-copy-to-acr
       - vllm-copy-to-acr
       - vllm-multi-gpu-test
+      - vllm-h100-test
       - vllm-efa-build
       - sglang-copy-to-acr
       - sglang-multi-gpu-test
@@ -1960,6 +1983,7 @@ jobs:
       - vllm-build
       - vllm-test
       - vllm-multi-gpu-test
+      - vllm-h100-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-test

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -451,9 +451,7 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.vllm,
             pytest.mark.h100,
-            # TEMPORARY (#13482): pre_merge so PR CI validates the timeout fix
-            # on the H100 lane in pr.yaml; revert to nightly after it passes.
-            pytest.mark.pre_merge,
+            pytest.mark.nightly,
             # TODO: profile to get max_vram and timeout
         ],
         model="deepseek-ai/DeepSeek-V2-Lite",

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -451,7 +451,9 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.vllm,
             pytest.mark.h100,
-            pytest.mark.nightly,
+            # TEMPORARY (#13482): pre_merge so PR CI validates the timeout fix
+            # on the H100 lane in pr.yaml; revert to nightly after it passes.
+            pytest.mark.pre_merge,
             # TODO: profile to get max_vram and timeout
         ],
         model="deepseek-ai/DeepSeek-V2-Lite",

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -466,9 +466,15 @@ vllm_configs = {
             "2",
         ],
         timeout=700,
+        # Each request is bounded by BasePayload.timeout (60s, tests/utils/
+        # payloads.py), not by the readiness budget above. This deployment
+        # decodes at ~15.5 tok/s, so the 1000-token payload default needs ~65s
+        # and cannot fit; 128 tokens finishes in ~8s and leaves ~7x headroom.
+        # Keep the cap small here — a longer decode turns the read timeout back
+        # into an accidental throughput assertion.
         request_payloads=[
-            chat_payload_default(),
-            completion_payload_default(),
+            chat_payload_default(max_tokens=128),
+            completion_payload_default(max_tokens=128),
         ],
     ),
     "aggregated_toolcalling": VLLMConfig(


### PR DESCRIPTION
## Overview:

The nightly H100 job `test_serve_deployment[deepep-2]` times out. The DeepEP smoke
case asks the deployment for the shared 1000-token payload default while every
request is bounded by a 60-second read timeout, and the deployment decodes at
roughly 15.5 tok/s — about 65 s of generation against a 60 s budget, so the
request cannot finish. This caps the two DeepEP payloads at 128 output tokens so
the smoke check finishes well inside the budget, instead of widening the deadline.

## Details:

In the `"deepep"` entry of `vllm_configs` (`tests/serve/test_vllm.py`), the chat
and completion payloads now pass an explicit `max_tokens=128` rather than calling
`chat_payload_default()` / `completion_payload_default()` bare and inheriting
`max_tokens=1000`. At ~15.5 tok/s, 128 tokens completes in ~8 s, leaving roughly
7x headroom. A comment above the payload list records the budget arithmetic so
the next reader does not have to re-derive it.

Deliberately unchanged:

- The shared defaults in `tests/utils/payload_builder.py` still declare
  `max_tokens: int = 1000`, so the other bare call sites across the vLLM, SGLang,
  TensorRT-LLM, XPU, and sample suites are unaffected.
- `timeout=700` on the config stays. That is the deployment readiness budget
  (`EngineConfig.timeout`), not the per-request deadline being missed.
- `repeat_count=3` stays — each iteration gets its own 60 s budget, so reducing it
  would weaken the health signal without buying deadline relief.
- `expected_response` stays on the default six-keyword list. Narrowing it would
  reintroduce the flake that #4704 removed.

The test still proves the same thing: a DeepEP deployment comes up healthy and
returns valid generated text. Raising the timeout instead would also mask a
genuine server slowdown the next time one appears.

## Where should the reviewer start?

`tests/serve/test_vllm.py`, the `"deepep"` entry of `vllm_configs` — the whole
change is the two payload calls and the comment above them. The one behavioral
question worth a second look is whether the keyword match still holds at 128
tokens rather than 1000: the prompt is "Tell me a knock knock joke about AI."
and the assertion is a case-insensitive OR over six common substrings of the
full response, so a 128-token answer has ample room to contain one.

## Validation

- `python -m py_compile tests/serve/test_vllm.py` — clean.
- `pre-commit run --files tests/serve/test_vllm.py` — all applicable hooks pass
  (isort, black, flake8, ruff, codespell, file hygiene, pytest-marker report).
- `pytest tests/serve/test_vllm.py --collect-only -q -k deepep` collects exactly
  `test_serve_deployment[deepep-2]`; the module still collects 53 tests, before
  and after, so the `pytest.param` generation is undisturbed. The nightly lane's
  marker expression (`vllm and (gpu_1 or gpu_2)`) still selects the case.
- Resolved-config readback: both DeepEP payloads report `max_tokens=128`,
  `repeat_count=3`, per-payload `timeout=60`, `EngineConfig.timeout=700`, and the
  full six-keyword `expected_response`. The untouched `aggregated` entry still
  resolves to `max_tokens=1000` — the negative control that the shared default did
  not move.
- `pytest tests/utils/ -m "unit and not gpu" -q` — 69 passed, 1 deselected.

Not reproducible in the development environment used here: the failing scenario
needs two H100s running a DeepEP deployment of DeepSeek-V2-Lite. The end-to-end
claim rests on tracing the budget through source (`BasePayload.timeout` →
`send_request` → `requests.post(..., timeout=...)`, with both payloads
non-streaming so the bound covers the whole generation) plus the
tokens-over-throughput arithmetic. The definitive confirmation is the next nightly
run of `test_serve_deployment[deepep-2]`.

## Related Issues

- Linear: [DYN-4015 — Fix H100 nightly `test_serve_deployment[deepep-2]` 60s timeout](https://linear.app/nvidia/issue/DYN-4015)
- No public GitHub issue; tracked internally in Linear.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated vLLM validation requests to generate no more than 128 tokens.
  * Added documentation clarifying expected decoding performance and request timeout limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->