### PR TITLE
fix(mocker): use named msgpack encoding for ZMQ KV events

### DIFF
--- a/lib/mocker/src/services/zmq_events.rs
+++ b/lib/mocker/src/services/zmq_events.rs
@@ -267,7 +267,7 @@ pub(crate) fn encode_event_batch(
         .unwrap_or_default()
         .as_secs_f64();
     let batch: (f64, Vec<ZmqRawKvEvent>, Option<i32>) = (timestamp, events, Some(dp_rank as i32));
-    rmp_serde::to_vec(&batch).map(|payload| Some(payload.into()))
+    rmp_serde::to_vec_named(&batch).map(|payload| Some(payload.into()))
 }
 
 fn convert_to_zmq_events(
@@ -432,5 +432,95 @@ mod tests {
             panic!("expected one BlockStored event");
         };
         assert_eq!(*medium, None);
+    }
+
+    #[test]
+    fn encoded_batch_decodes_through_router_zmq_wire() {
+        use dynamo_kv_router::protocols::KvCacheRemoveData;
+        use dynamo_kv_router::zmq_wire::{KvEventBatch, RawKvEvent as WireKvEvent};
+
+        let stored = RawKvEvent {
+            event: stored_event(),
+            block_token_ids: Some(vec![vec![1, 2, 3, 4]]),
+            storage_tier: StorageTier::Device,
+        };
+        // Device tier omits `medium`: under positional (unnamed) encoding the
+        // required `group_idx` shifts into `medium`'s slot and BlockRemoved
+        // fails to decode at the consumer.
+        let removed = RawKvEvent {
+            event: KvCacheEvent {
+                event_id: 2,
+                data: KvCacheEventData::Removed(KvCacheRemoveData {
+                    block_hashes: vec![ExternalSequenceBlockHash(10)],
+                }),
+                dp_rank: 0,
+            },
+            block_token_ids: None,
+            storage_tier: StorageTier::Device,
+        };
+
+        // Host-pinned stored events also mis-decode positionally: the medium
+        // string lands in a numeric legacy slot at the consumer.
+        let stored_pinned = RawKvEvent {
+            event: stored_event(),
+            block_token_ids: Some(vec![vec![5, 6, 7, 8]]),
+            storage_tier: StorageTier::HostPinned,
+        };
+
+        let payload = encode_event_batch(&[stored, removed, stored_pinned], 4, 3)
+            .expect("encoding must succeed")
+            .expect("non-empty batch must produce a payload");
+
+        let batch: KvEventBatch =
+            rmp_serde::from_slice(&payload).expect("router zmq_wire must decode the payload");
+        assert_eq!(batch.data_parallel_rank, Some(3));
+
+        let [
+            WireKvEvent::BlockStored {
+                block_hashes,
+                token_ids,
+                medium,
+                group_idx,
+                ..
+            },
+            WireKvEvent::BlockRemoved {
+                block_hashes: removed_hashes,
+                medium: removed_medium,
+                group_idx: removed_group_idx,
+                ..
+            },
+            WireKvEvent::BlockStored {
+                medium: pinned_medium,
+                group_idx: pinned_group_idx,
+                ..
+            },
+        ] = batch.events.as_slice()
+        else {
+            panic!(
+                "expected BlockStored + BlockRemoved, got {:?}",
+                batch.events
+            );
+        };
+        assert_eq!(
+            block_hashes
+                .iter()
+                .map(|h| h.into_u64())
+                .collect::<Vec<_>>(),
+            vec![10]
+        );
+        assert_eq!(token_ids, &vec![1, 2, 3, 4]);
+        assert_eq!(*medium, None);
+        assert_eq!(*group_idx, Some(0));
+        assert_eq!(
+            removed_hashes
+                .iter()
+                .map(|h| h.into_u64())
+                .collect::<Vec<_>>(),
+            vec![10]
+        );
+        assert_eq!(*removed_medium, None);
+        assert_eq!(*removed_group_idx, Some(0));
+        assert_eq!(pinned_medium.as_deref(), Some("CPU_PINNED"));
+        assert_eq!(*pinned_group_idx, Some(0));
     }
 }


### PR DESCRIPTION
## What

`encode_event_batch` in the mocker's ZMQ KV-event sink serializes with `rmp_serde::to_vec`, encoding the tagged `ZmqRawKvEvent` variants as positional msgpack arrays. The consumer of this stream — `dynamo_kv_router::zmq_wire` — binds event fields by name (with legacy positional fallbacks), so positional payloads mis-decode. Verified at HEAD `480b77afd` per variant and storage tier:

| Variant | Tier | Decode at HEAD | With this fix |
|---|---|---|---|
| BlockStored | Device | OK, but `group_idx` silently lost into the legacy `lora_id` slot | OK |
| BlockStored | HostPinned / Disk / External | FAIL: `wrong msgpack marker FixStr(..)` | OK |
| BlockRemoved | Device | FAIL: ``invalid type: integer `0`, expected a string`` | OK |
| BlockRemoved | HostPinned / Disk / External | OK (accidental alignment) | OK |

The practical impact: a KV router consuming a mocker's event stream over ZMQ drops every Device-tier eviction event — under KV pressure its view of the mocker's cache monotonically stales, exactly when routing accuracy matters. The failure is invisible under light load (`BlockStored`/Device appears to work), so smoke tests pass.

Mechanism: `ZmqRawKvEvent.medium` is `#[serde(skip_serializing_if)]`; skipping a middle field in a positional encoding shifts every later field, so Device-tier events (`medium: None`) put the required `group_idx` integer where the consumer expects `medium: Option<String>`. Non-Device stored events instead land the medium string in a numeric slot.

## Change

- `encode_event_batch`: `rmp_serde::to_vec` -> `rmp_serde::to_vec_named`. The outer batch tuple remains an array (the `KvEventBatch` consumer expects that); events encode as tagged maps that the consumer binds by name — the same convention the msgspec-based vLLM/TRT producers emit on this wire.
- Regression test `encoded_batch_decodes_through_router_zmq_wire`: round-trips Device-tier `BlockStored` + `BlockRemoved` and a HostPinned `BlockStored` through the production encoder and the real `zmq_wire` consumer. Flipped back to positional encoding it fails with the exact production error.

## Validation

- `cargo test -p dynamo-mocker` — 195 passed at HEAD with the fix, 0 failures
- The new test verified to fail against the unmodified encoder
- `cargo fmt` clean

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event encoding compatibility when optional fields are omitted.
  * Ensured device, removal, and host-pinned events retain their data, mediums, group indices, and rank when transmitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Where to start reviewing

`encode_event_batch` in `lib/mocker/src/services/zmq_events.rs` (the one-line encoding change), then the regression test `encoded_batch_decodes_through_router_zmq_wire` in the same file's tests module.

## Related Issues

No existing issue tracks this; found by consuming the mocker's KV-event stream with a KV router over ZMQ under eviction load. Happy to open a tracking issue if that's preferred.
