### PR TITLE
fix(vllm): keep response reasoning parser active

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -702,6 +702,13 @@ class StreamingPostProcessor:
                 )
             if not self.reasoning_is_done:
                 self.reasoning_parser.adjust_initial_state_from_prompt(prompt_token_ids)
+        # The parser must still consume hidden reasoning so it cannot leak into
+        # content, but neither the parsed reasoning nor its token metadata should
+        # be projected into the response when the caller opted out.
+        self._suppress_reasoning_output = (
+            self.reasoning_parser is not None
+            and not request_for_sampling.include_reasoning
+        )
         self._fast_plain_text = (
             self.tool_parser is None
             and self.reasoning_parser is None
@@ -1033,7 +1040,7 @@ class StreamingPostProcessor:
             "finish_reason": self._remap_finish_reason(
                 output.index, output.finish_reason
             ),
-            "logprobs": output.logprobs,
+            "logprobs": (None if self._suppress_reasoning_output else output.logprobs),
         }
         self.in_progress_tool_calls.clear()
         return choice
@@ -1047,7 +1054,7 @@ class StreamingPostProcessor:
             "finish_reason": self._remap_finish_reason(
                 output.index, output.finish_reason
             ),
-            "logprobs": output.logprobs,
+            "logprobs": (None if self._suppress_reasoning_output else output.logprobs),
         }
 
     def _process_non_streaming_tool_output(self, output: Any) -> dict[str, Any] | None:
@@ -1270,7 +1277,10 @@ class StreamingPostProcessor:
             if delta_message.tool_calls:
                 self._merge_streaming_tool_calls(delta_message.tool_calls)
 
-            if delta_message.content or delta_message.reasoning:
+            reasoning = (
+                None if self._suppress_reasoning_output else delta_message.reasoning
+            )
+            if delta_message.content or reasoning:
                 delta = {"role": "assistant"}
                 content = delta_message.content
                 if self.in_progress_tool_calls and self._is_control_only_content(
@@ -1279,8 +1289,8 @@ class StreamingPostProcessor:
                     content = None
                 if content:
                     delta["content"] = content
-                if delta_message.reasoning:
-                    delta["reasoning_content"] = delta_message.reasoning
+                if reasoning:
+                    delta["reasoning_content"] = reasoning
                 if self.in_progress_tool_calls:
                     delta["tool_calls"] = self._dump_in_progress_tool_calls()
                     self.in_progress_tool_calls.clear()

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -664,7 +664,7 @@ class StreamingPostProcessor:
         tool_parser: ToolParser | None,
         reasoning_parser_class: type[ReasoningParser] | None,
         chat_template_kwargs: dict[str, Any],
-        reasoning_ended: bool | None = None,
+        response_reasoning_ended: bool | None = None,
         stream_response: bool = True,
         uses_dynamo_json_tool_call_fallback: bool = False,
     ) -> None:
@@ -673,7 +673,7 @@ class StreamingPostProcessor:
         self.sampling_params = sampling_params
         self.tool_parser = tool_parser
         self.stream_response = stream_response
-        self.reasoning_is_done = bool(reasoning_ended)
+        self.reasoning_is_done = bool(response_reasoning_ended)
         self._uses_dynamo_json_tool_call_fallback = uses_dynamo_json_tool_call_fallback
         # See https://github.com/ai-dynamo/dynamo/issues/8636 —
         # when the chat template runs with enable_thinking=False,
@@ -692,11 +692,11 @@ class StreamingPostProcessor:
             )
             if reasoning_parser_class
             and not thinking_disabled
-            and reasoning_ended is not True
+            and response_reasoning_ended is not True
             else None
         )
         if self.reasoning_parser is not None:
-            if reasoning_ended is None:
+            if response_reasoning_ended is None:
                 self.reasoning_is_done = self.reasoning_parser.is_reasoning_end(
                     prompt_token_ids
                 )

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -1128,6 +1128,8 @@ async def test_include_reasoning_false_keeps_response_parser_active(
         model_fields = frozenset()
 
     class FakeReasoningParser:
+        engine_based_streaming = False
+
         def __init__(self, tokenizer, *, chat_template_kwargs):
             self.tokenizer = tokenizer
             self.chat_template_kwargs = chat_template_kwargs
@@ -1138,6 +1140,25 @@ async def test_include_reasoning_false_keeps_response_parser_active(
 
         def adjust_initial_state_from_prompt(self, prompt_token_ids):
             self.adjusted_prompt_token_ids = prompt_token_ids
+
+        def extract_reasoning_streaming(
+            self,
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+        ):
+            if "</think>" in delta_text:
+                return prepost_module.DeltaMessage(
+                    reasoning="hidden tail",
+                    content="visible answer",
+                )
+            return prepost_module.DeltaMessage(reasoning="hidden reasoning")
+
+        def is_reasoning_end_streaming(self, current_token_ids, delta_token_ids):
+            return 3 in delta_token_ids
 
     monkeypatch.setattr(
         vllm_processor_module,
@@ -1229,6 +1250,33 @@ async def test_include_reasoning_false_keeps_response_parser_active(
     assert post_processor.reasoning_is_done is False
     assert isinstance(post_processor.reasoning_parser, FakeReasoningParser)
     assert post_processor.reasoning_parser.adjusted_prompt_token_ids == [1]
+
+    reasoning_choice = post_processor.process_output(
+        SimpleNamespace(
+            index=0,
+            text="<think>hidden reasoning",
+            token_ids=[2],
+            finish_reason=None,
+            logprobs={"tokens": ["hidden"]},
+        )
+    )
+    assert reasoning_choice is None
+
+    content_choice = post_processor.process_output(
+        SimpleNamespace(
+            index=0,
+            text="</think>visible answer",
+            token_ids=[3],
+            finish_reason="stop",
+            logprobs={"tokens": ["hidden", "visible"]},
+        )
+    )
+    assert content_choice == {
+        "index": 0,
+        "delta": {"role": "assistant", "content": "visible answer"},
+        "finish_reason": "stop",
+        "logprobs": None,
+    }
 
 
 def _make_processor(module, routed_engine):

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -820,31 +820,42 @@ class TestReasoningParserMetadata:
     def test_no_reasoning_parser_returns_none(self):
         from dynamo.frontend.vllm_processor import _build_reasoning_parser_metadata
 
-        assert _build_reasoning_parser_metadata(
+        metadata = _build_reasoning_parser_metadata(
             None,
             object(),
             {},
             SimpleNamespace(include_reasoning=True),
             [1, 2, 3],
-        ) == (None, None)
+        )
 
-    def test_include_reasoning_false_marks_reasoning_ended(self):
+        assert metadata.engine_reasoning_ended is None
+        assert metadata.response_reasoning_ended is None
+        assert metadata.parser_kwargs is None
+
+    def test_include_reasoning_false_only_marks_engine_reasoning_ended(self):
         from dynamo.frontend.vllm_processor import _build_reasoning_parser_metadata
 
-        class ParserShouldNotBeBuilt:
-            def __init__(self, *args, **kwargs):
-                raise AssertionError("parser should not be constructed")
+        class FakeReasoningParser:
+            def __init__(self, tokenizer, *, chat_template_kwargs):
+                self.tokenizer = tokenizer
+                self.chat_template_kwargs = chat_template_kwargs
 
-        reasoning_ended, parser_kwargs = _build_reasoning_parser_metadata(
-            ParserShouldNotBeBuilt,
+            def is_reasoning_end(self, prompt_token_ids):
+                return prompt_token_ids == [9, 9]
+
+        metadata = _build_reasoning_parser_metadata(
+            FakeReasoningParser,
             object(),
             {"reasoning_effort": "low"},
             SimpleNamespace(include_reasoning=False),
             [1, 2, 3],
         )
 
-        assert reasoning_ended is True
-        assert parser_kwargs == {"chat_template_kwargs": {"reasoning_effort": "low"}}
+        assert metadata.engine_reasoning_ended is True
+        assert metadata.response_reasoning_ended is False
+        assert metadata.parser_kwargs == {
+            "chat_template_kwargs": {"reasoning_effort": "low"}
+        }
 
     def test_parser_receives_chat_template_kwargs(self):
         from dynamo.frontend.vllm_processor import _build_reasoning_parser_metadata
@@ -858,7 +869,7 @@ class TestReasoningParserMetadata:
                 return prompt_token_ids == [9, 9]
 
         tokenizer = object()
-        reasoning_ended, parser_kwargs = _build_reasoning_parser_metadata(
+        metadata = _build_reasoning_parser_metadata(
             FakeReasoningParser,
             tokenizer,
             {"reasoning_effort": "high"},
@@ -866,8 +877,11 @@ class TestReasoningParserMetadata:
             [9, 9],
         )
 
-        assert reasoning_ended is True
-        assert parser_kwargs == {"chat_template_kwargs": {"reasoning_effort": "high"}}
+        assert metadata.engine_reasoning_ended is True
+        assert metadata.response_reasoning_ended is True
+        assert metadata.parser_kwargs == {
+            "chat_template_kwargs": {"reasoning_effort": "high"}
+        }
 
     def test_kv_router_copies_reasoning_metadata_to_extra_args(self):
         from dynamo.frontend.vllm_processor import _inject_routing_metadata
@@ -1103,6 +1117,118 @@ async def test_generator_preserves_zero_top_logprobs(
         "Logprobs requested but not supported in distributed inference mode"
         in caplog.messages
     )
+
+
+@pytest.mark.asyncio
+async def test_include_reasoning_false_keeps_response_parser_active(
+    vllm_processor_module,
+    monkeypatch,
+):
+    class RequestForSampling(SimpleNamespace):
+        model_fields = frozenset()
+
+    class FakeReasoningParser:
+        def __init__(self, tokenizer, *, chat_template_kwargs):
+            self.tokenizer = tokenizer
+            self.chat_template_kwargs = chat_template_kwargs
+            self.adjusted_prompt_token_ids = None
+
+        def is_reasoning_end(self, prompt_token_ids):
+            return False
+
+        def adjust_initial_state_from_prompt(self, prompt_token_ids):
+            self.adjusted_prompt_token_ids = prompt_token_ids
+
+    monkeypatch.setattr(
+        vllm_processor_module,
+        "preprocess_chat_request",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                request_for_sampling=RequestForSampling(
+                    max_completion_tokens=None,
+                    max_tokens=1,
+                    logprobs=None,
+                    top_logprobs=None,
+                    cache_salt=None,
+                    mm_processor_kwargs=None,
+                    include_reasoning=False,
+                ),
+                tool_parser=None,
+                chat_template_kwargs={"reasoning_effort": "low"},
+                engine_prompt={"prompt": "Hello"},
+                prompt_token_ids=[1],
+                guided_decoding=None,
+                uses_dynamo_json_tool_call_fallback=False,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        vllm_processor_module.InputProcessor,
+        "assign_request_id",
+        lambda request: None,
+    )
+
+    def process_inputs(request_id, engine_inputs, sampling_params, supported_tasks):
+        return SimpleNamespace(sampling_params=sampling_params, mm_features=None)
+
+    input_processor = SimpleNamespace(
+        generation_config_fields={},
+        renderer=SimpleNamespace(process_for_engine_async=AsyncMock(return_value={})),
+        process_inputs=process_inputs,
+    )
+    processor = vllm_processor_module.VllmProcessor(
+        tokenizer=SimpleNamespace(eos_token_id=2, all_special_tokens=[]),
+        input_processor=input_processor,
+        output_processor=object(),
+        tool_parser_class=None,
+        reasoning_parser_class=FakeReasoningParser,
+        routed_engine=object(),
+    )
+    monkeypatch.setattr(
+        processor,
+        "_prepare_mm_routing",
+        AsyncMock(return_value=(None, [], False)),
+    )
+
+    captured = {}
+
+    async def capture_generate_and_stream(
+        request_id,
+        request,
+        dynamo_preproc,
+        tokens,
+        vllm_preproc,
+        post_processors,
+        *,
+        mm_routing_info,
+        context,
+    ):
+        captured["dynamo_preproc"] = dynamo_preproc
+        captured["post_processor"] = post_processors[0]
+        yield {"captured": True}
+
+    monkeypatch.setattr(
+        processor,
+        "_generate_and_stream",
+        capture_generate_and_stream,
+    )
+
+    results = [
+        item
+        async for item in processor._generator_inner(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+        )
+    ]
+
+    assert results == [{"captured": True}]
+    assert captured["dynamo_preproc"]["reasoning_ended"] is True
+    post_processor = captured["post_processor"]
+    assert post_processor.reasoning_is_done is False
+    assert isinstance(post_processor.reasoning_parser, FakeReasoningParser)
+    assert post_processor.reasoning_parser.adjusted_prompt_token_ids == [1]
 
 
 def _make_processor(module, routed_engine):

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -12,6 +12,7 @@ import os
 import time
 from argparse import Namespace
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from typing import Any
 
 from msgspec.structs import replace as msgspec_replace
@@ -177,29 +178,49 @@ def _single_transfer_modality(mm_features: list[Any]) -> str | None:
     return next(iter(modalities))
 
 
+@dataclass(frozen=True)
+class _ReasoningParserMetadata:
+    """Keep engine scheduling hints separate from response parser state."""
+
+    engine_reasoning_ended: bool | None
+    response_reasoning_ended: bool | None
+    parser_kwargs: dict[str, Any] | None
+
+
 def _build_reasoning_parser_metadata(
     reasoning_parser_class: type[ReasoningParser] | None,
     tokenizer: TokenizerLike,
     chat_template_kwargs: dict[str, Any],
     request_for_sampling: Any,
     prompt_token_ids: list[int],
-) -> tuple[bool | None, dict[str, Any] | None]:
+) -> _ReasoningParserMetadata:
     if reasoning_parser_class is None:
-        return None, None
+        return _ReasoningParserMetadata(None, None, None)
 
     parser_kwargs = {"chat_template_kwargs": chat_template_kwargs}
     if chat_template_kwargs.get("enable_thinking") is False:
-        return True, parser_kwargs
-    if not getattr(request_for_sampling, "include_reasoning", True):
-        return True, parser_kwargs
+        return _ReasoningParserMetadata(True, True, parser_kwargs)
     if getattr(request_for_sampling, "_grammar_from_tool_parser", False):
-        return True, parser_kwargs
+        return _ReasoningParserMetadata(True, True, parser_kwargs)
 
     reasoning_parser = reasoning_parser_class(
         tokenizer,
         chat_template_kwargs=chat_template_kwargs,
     )
-    return reasoning_parser.is_reasoning_end(prompt_token_ids), parser_kwargs
+    response_reasoning_ended = reasoning_parser.is_reasoning_end(prompt_token_ids)
+    # include_reasoning controls response projection, not whether the model may
+    # emit reasoning tags. The engine still needs its vLLM scheduling hint, while
+    # the response parser must remain active until the generated tags are parsed.
+    engine_reasoning_ended = (
+        True
+        if not getattr(request_for_sampling, "include_reasoning", True)
+        else response_reasoning_ended
+    )
+    return _ReasoningParserMetadata(
+        engine_reasoning_ended,
+        response_reasoning_ended,
+        parser_kwargs,
+    )
 
 
 def _inject_routing_metadata(
@@ -603,7 +624,7 @@ class VllmProcessor:
         # vLLM 0.17.0 removed EngineCoreRequest.eos_token_id. Dynamo now uses
         # tokenizer metadata for EOS ids when constructing the router payload.
 
-        reasoning_ended, reasoning_parser_kwargs = _build_reasoning_parser_metadata(
+        reasoning_metadata = _build_reasoning_parser_metadata(
             self.reasoning_parser_class,
             self.tokenizer,
             chat_template_kwargs,
@@ -646,10 +667,12 @@ class VllmProcessor:
         }
         if guided_decoding is not None:
             dynamo_preproc["sampling_options"]["guided_decoding"] = guided_decoding
-        if reasoning_ended is not None:
-            dynamo_preproc["reasoning_ended"] = reasoning_ended
-        if reasoning_parser_kwargs is not None:
-            dynamo_preproc["reasoning_parser_kwargs"] = reasoning_parser_kwargs
+        if reasoning_metadata.engine_reasoning_ended is not None:
+            dynamo_preproc[
+                "reasoning_ended"
+            ] = reasoning_metadata.engine_reasoning_ended
+        if reasoning_metadata.parser_kwargs is not None:
+            dynamo_preproc["reasoning_parser_kwargs"] = reasoning_metadata.parser_kwargs
 
         # Attach user cache identities before building routing metadata. Opaque
         # UUIDs deliberately suppress multimodal exact routing and frontend
@@ -704,7 +727,9 @@ class VllmProcessor:
                     tool_parser=choice_tool_parser,
                     reasoning_parser_class=self.reasoning_parser_class,
                     chat_template_kwargs=chat_template_kwargs,
-                    reasoning_ended=reasoning_ended,
+                    response_reasoning_ended=(
+                        reasoning_metadata.response_reasoning_ended
+                    ),
                     stream_response=bool(request.get("stream", False)),
                     uses_dynamo_json_tool_call_fallback=(
                         pre.uses_dynamo_json_tool_call_fallback

--- a/docs/fern/pages/reference/api/python/frontend.mdx
+++ b/docs/fern/pages/reference/api/python/frontend.mdx
@@ -353,7 +353,7 @@ process_output(output: Any) -> dict[str, Any] | None
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L1095)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L1102)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-vllm-processor-vllmprocessor" title="VllmProcessor (class)">

--- a/docs/fern/pages/reference/api/python/frontend.mdx
+++ b/docs/fern/pages/reference/api/python/frontend.mdx
@@ -20,7 +20,7 @@ from dynamo.frontend.vllm_processor import EngineFactory
 EngineFactory(config: FrontendConfig, flags: Namespace)
 ```
 
-[`components/src/dynamo/frontend/vllm_processor.py#L958`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L958)
+[`components/src/dynamo/frontend/vllm_processor.py#L983`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L983)
 
 **Public methods**
 
@@ -32,7 +32,7 @@ __init__(config: FrontendConfig, flags: Namespace)
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L959)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L984)
 
 <h4 id="api-dynamo-frontend-vllm-processor-enginefactory-chat-engine-factory">chat_engine_factory</h4>
 
@@ -42,7 +42,7 @@ chat_engine_factory(instance_id: ModelCardInstanceId, mdc: ModelDeploymentCard, 
 
 Called by Rust when a model is discovered.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L978)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L1003)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-frontend-args-frontendarggroup" title="FrontendArgGroup (class)">
@@ -328,7 +328,7 @@ from dynamo.frontend.prepost import StreamingPostProcessor
 ```
 
 ```python
-StreamingPostProcessor(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionRequest, sampling_params: SamplingParams, prompt_token_ids: Sequence[int], tool_parser: ToolParser | None, reasoning_parser_class: type[ReasoningParser] | None, chat_template_kwargs: dict[str, Any], reasoning_ended: bool | None = None, stream_response: bool = True, uses_dynamo_json_tool_call_fallback: bool = False) -> None
+StreamingPostProcessor(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionRequest, sampling_params: SamplingParams, prompt_token_ids: Sequence[int], tool_parser: ToolParser | None, reasoning_parser_class: type[ReasoningParser] | None, chat_template_kwargs: dict[str, Any], response_reasoning_ended: bool | None = None, stream_response: bool = True, uses_dynamo_json_tool_call_fallback: bool = False) -> None
 ```
 
 [`components/src/dynamo/frontend/prepost.py#L656`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/prepost.py#L656)
@@ -338,7 +338,7 @@ StreamingPostProcessor(*, tokenizer: TokenizerLike, request_for_sampling: ChatCo
 <h4 id="api-dynamo-frontend-prepost-streamingpostprocessor-init">__init__</h4>
 
 ```python
-__init__(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionRequest, sampling_params: SamplingParams, prompt_token_ids: Sequence[int], tool_parser: ToolParser | None, reasoning_parser_class: type[ReasoningParser] | None, chat_template_kwargs: dict[str, Any], reasoning_ended: bool | None = None, stream_response: bool = True, uses_dynamo_json_tool_call_fallback: bool = False) -> None
+__init__(*, tokenizer: TokenizerLike, request_for_sampling: ChatCompletionRequest, sampling_params: SamplingParams, prompt_token_ids: Sequence[int], tool_parser: ToolParser | None, reasoning_parser_class: type[ReasoningParser] | None, chat_template_kwargs: dict[str, Any], response_reasoning_ended: bool | None = None, stream_response: bool = True, uses_dynamo_json_tool_call_fallback: bool = False) -> None
 ```
 
 No summary available.
@@ -367,7 +367,7 @@ from dynamo.frontend.vllm_processor import VllmProcessor
 VllmProcessor(tokenizer: TokenizerLike, input_processor: InputProcessor, output_processor: OutputProcessor, tool_parser_class: type[ToolParser] | None, reasoning_parser_class: type[ReasoningParser] | None, routed_engine: RoutedEngine, block_size: int = 16, enable_auto_tool_choice: bool = False, default_chat_template_kwargs: dict[str, Any] | None = None, default_thinking_mode: str | None = None, structural_tag_mode: str = 'off', structural_tag_scope: str = 'auto', structural_tag_schema: str = 'auto')
 ```
 
-[`components/src/dynamo/frontend/vllm_processor.py#L272`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L272)
+[`components/src/dynamo/frontend/vllm_processor.py#L293`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L293)
 
 **Public methods**
 
@@ -379,7 +379,7 @@ __init__(tokenizer: TokenizerLike, input_processor: InputProcessor, output_proce
 
 No summary available.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L273)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L294)
 
 <h4 id="api-dynamo-frontend-vllm-processor-vllmprocessor-generator">generator</h4>
 
@@ -389,7 +389,7 @@ generator(request: dict[str, Any], context: Any | None = None) -> AsyncGenerator
 
 Run a single request through the engine. Does pre and post processing on this machine, delegates model inference to a backend using the router.
 
-[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L472)
+[source](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L493)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-thinking-apply-default-thinking-mode-to-template-kwargs" title="apply_default_thinking_mode_to_template_kwargs (function)">
@@ -654,7 +654,7 @@ from dynamo.frontend.vllm_processor import map_finish_reason
 map_finish_reason(raw_reason: str | None) -> FinishReason | None
 ```
 
-[`components/src/dynamo/frontend/vllm_processor.py#L66`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L66)
+[`components/src/dynamo/frontend/vllm_processor.py#L67`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/frontend/vllm_processor.py#L67)
 </Accordion>
 
 <Accordion id="api-dynamo-frontend-utils-nvext-extra-field-requested" title="nvext_extra_field_requested (function)">


### PR DESCRIPTION
## Summary

- separate engine/scheduler reasoning metadata from frontend response-parser state
- keep response reasoning parsing active when `include_reasoning=false`, preventing model-emitted `<think>...</think>` text from leaking into `content`
- retain parser bypasses for tag-free paths such as `enable_thinking=false` and guided tool grammar
- add processor-to-postprocessor regression coverage

## Root cause

PR #13059 correctly began forwarding vLLM 0.27 reasoning metadata to the engine, but passed the same `reasoning_ended=true` value used for `include_reasoning=false` into `StreamingPostProcessor`. That skipped reasoning-parser construction even though models may still emit reasoning tags. This change gives the engine and response parser independent state derived from their different contracts.

## Validation

- vLLM 0.27.1 focused test group: 6 passed
  - `TestReasoningParserMetadata`
  - `test_include_reasoning_false_keeps_response_parser_active`
  - `test_streaming_parallel_tool_calls_no_think`
- `pre-commit run --files components/src/dynamo/frontend/vllm_processor.py components/src/dynamo/frontend/prepost.py components/src/dynamo/frontend/tests/test_vllm_processor_unit.py` (all hooks passed)

## Related Issues

**This PR is not linked to a GitHub issue:**

- [x] Confirmed — no related GitHub issue
- Internal tracking: [DYN-4045](https://linear.app/nvidia/issue/DYN-4045/fix-vllm-response-parsing-when-include-reasoningfalse)
- Follow-up to #13059 and [review finding](https://github.com/ai-dynamo/dynamo/pull/13059#discussion_r3800309638)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses that use hidden reasoning, ensuring reasoning remains correctly tracked while only the requested response content is delivered.
  * Preserved accurate completion status across engine processing and response parsing.
  * Improved handling of prompt tokens and structured reasoning metadata during streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->