### PR TITLE
ci(nightly): page Ops-Support via PagerDuty on artifact publication f…

### DIFF
--- a/.github/RUNBOOK-nightly-publication.md
+++ b/.github/RUNBOOK-nightly-publication.md
@@ -16,8 +16,9 @@ publish artifacts.
 
 ## What paged you
 
-The nightly (`nightly-ci.yml`, cron `0 8 * * *` UTC = midnight PST) publishes via
-`release.yml`. Incidents come from one of two jobs:
+The nightly (`nightly-ci.yml`, cron `0 8 * * *` — **08:00 UTC**, which is 01:00 PDT in
+summer and 00:00 PST in winter) publishes via `release.yml`. Incidents come from one of
+two jobs:
 
 | `dedup_key` contains | Meaning |
 |---|---|
@@ -58,9 +59,9 @@ frontend, snapshot-agent, EFA variants) are fail-soft and only increment
 `stage-wheels-artifactory` extracts wheels from the runtime image and uploads them. A failure
 means `pip install` of the nightly wheels is broken for consumers.
 
-Usual causes: expired Artifactory token; the upload rejected (non-201); or the wheel-version
-verification tripping the UTC-midnight date-drift check — the nightly runs *at* 00:00 PST, so
-a run straddling UTC midnight can compute a `wheel_version` date that no longer matches.
+Usual causes: expired Artifactory token; the upload rejected (non-201); or the
+wheel-version verification failing because the wheel in the image does not carry the
+version `prepare-release` computed for this run.
 
 ### `GitLab release trigger` (severity: error)
 Artifacts **were** published successfully, but the downstream GitLab release-automation

--- a/.github/RUNBOOK-nightly-publication.md
+++ b/.github/RUNBOOK-nightly-publication.md
@@ -1,0 +1,94 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Runbook — nightly artifact publication failure
+
+Triage guide for the PagerDuty incident raised by
+[`notify-pagerduty.yml`](workflows/notify-pagerduty.yml) when the nightly pipeline fails to
+publish artifacts.
+
+> This repository is public. Registry hostnames, Artifactory paths, credential owners and
+> rotation procedures live in the internal ops-docs runbook — this file covers only what is
+> already visible in the workflow definitions. Follow the internal runbook for anything
+> requiring credentials.
+
+## What paged you
+
+The nightly (`nightly-ci.yml`, cron `0 8 * * *` UTC = midnight PST) publishes via
+`release.yml`. Incidents come from one of two jobs:
+
+| `dedup_key` contains | Meaning |
+|---|---|
+| `nightly-artifact-publication` | The publish ran and a stage failed. |
+| `nightly-not-published` | A build gate failed, so `release` was skipped and **nothing** was published. |
+
+Only unattended cron runs page. RC/GA releases and manual re-runs never do — see the gating
+comment in `release.yml`.
+
+## First: read `custom_details`
+
+The incident body carries `failing_stages`, each stage's job result, `ngc_version_tag`,
+`wheel_version`, `source_commit`, and a direct `run_url` to the failing Actions run attempt.
+Start there — it identifies which system to look at before you open anything.
+
+## Stage-by-stage
+
+### `prepare-release` (severity: error)
+Version/tag computation failed, so nothing downstream ran. Almost always a repo-state problem
+(unexpected version in the source tree) rather than an infrastructure one. Check the job log;
+this rarely needs Ops-Support credentials.
+
+### `NGC publish` (severity: critical)
+`release-publish` crane-copies runtime images ECR → NGC. A failure here means the core runtime
+images did **not** reach NGC, so the floating `:nightly` tags are stale for consumers.
+
+Usual causes, in order of likelihood:
+1. **Expired/rotated NGC publish credentials** — the login step fails. Most common.
+2. **Source image missing in ECR** — post-merge CI did not push images for `source_commit`.
+   Confirm post-merge CI succeeded for that SHA before blaming the release job.
+3. **NGC-side outage or rate limiting.**
+
+Note: only *core runtime* copy failures fail this job. Optional images (operator, planner,
+frontend, snapshot-agent, EFA variants) are fail-soft and only increment
+`skipped_image_copies`, which is reported for correlation but **never pages on its own**.
+
+### `Artifactory wheels` (severity: critical)
+`stage-wheels-artifactory` extracts wheels from the runtime image and uploads them. A failure
+means `pip install` of the nightly wheels is broken for consumers.
+
+Usual causes: expired Artifactory token; the upload rejected (non-201); or the wheel-version
+verification tripping the UTC-midnight date-drift check — the nightly runs *at* 00:00 PST, so
+a run straddling UTC midnight can compute a `wheel_version` date that no longer matches.
+
+### `GitLab release trigger` (severity: error)
+Artifacts **were** published successfully, but the downstream GitLab release-automation
+pipeline (nSpect/security registration and scans) never started. Consumers are unaffected;
+compliance/scan registration for this nightly is missing. Lower urgency than the two above.
+
+A `skipped` result here is *not* a failure — it is the documented `skip_gitlab_pipeline`
+emergency bypass and never pages.
+
+### `nightly-not-published`
+One of the gating builds (vllm / sglang / trtllm / dynamo-pipeline) failed, so the release job
+was skipped by design to avoid publishing a partial release. This is a **development**
+regression, not an Ops-Support infrastructure problem — the fix is in the build, and the
+failure is already reported in the nightly Slack alert. Hand it to the owning team.
+
+## After you fix it
+
+- Incidents do **not** auto-resolve. Close the incident manually once publication succeeds.
+- Re-running the failed jobs in the same Actions run reuses the same `dedup_key`, so it will
+  not open a second incident.
+- To republish without waiting for the next cron, re-run the `release` job from the nightly
+  run, or `workflow_dispatch` `release.yml` with the same `commit_sha`.
+
+## Muting
+
+For a planned NGC or Artifactory maintenance window, set the repository variable
+`PAGERDUTY_ENABLED` to `false`. The notifier then logs a notice and sends nothing. **Set it
+back to `true` afterwards** — there is no automatic re-enable.
+
+If the `PAGERDUTY_OPS_SUPPORT_ROUTING_KEY` secret is unset or empty, the notifier logs a
+warning and exits successfully; paging is disabled but the nightly is unaffected.

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1347,10 +1347,13 @@ jobs:
   # fatiguing, drop this job — that is why it is separate rather than folded in.
   notify-pagerduty-not-published:
     name: Notify PagerDuty — nightly did not publish
-    needs: [compute-release-mode, release]
+    needs: [release]
+    # No `compute-release-mode.outputs.release == 'true'` clause: on `schedule`
+    # that output is unconditionally 'true', so the check was redundant — and it
+    # silently suppressed the page when compute-release-mode ITSELF failed (its
+    # output is then empty), which is precisely a nothing-was-published night.
     if: ${{ !cancelled()
         && github.event_name == 'schedule'
-        && needs.compute-release-mode.outputs.release == 'true'
         && needs.release.result == 'skipped' }}
     permissions:
       contents: read
@@ -1358,8 +1361,9 @@ jobs:
     with:
       pipeline_name: Nightly
       dedup_key: ${{ github.repository }}/nightly-not-published/${{ github.run_id }}
-      # No stage ever ran; prepare_result drives the notifier's error-severity path.
-      prepare_result: skipped
+      # NOT prepare_result: no publication stage ever ran, and naming one would
+      # send the on-call to the wrong system. The real cause is upstream.
+      reason: "the release job was skipped — a gating build (vllm/sglang/trtllm/dynamo-pipeline) or an upstream job failed, so nothing was published"
       runbook_url: https://github.com/${{ github.repository }}/blob/main/.github/RUNBOOK-nightly-publication.md
       # PHASE 1: print the payload, page nobody. See release.yml's note.
       dry_run: true

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1316,9 +1316,16 @@ jobs:
           docker buildx rm ${{ env.BUILDER_NAME }} || true
 
   ############################## SLACK NOTIFICATION ##############################
+  # `release` is in needs so publication failures are actually observed. The
+  # notifier takes a point-in-time snapshot of this run's jobs via the Actions
+  # API; without this dependency it ran while release.yml was still in_progress
+  # (conclusion: null), so NGC/Artifactory failures never matched
+  # `conclusion == "failure"` and were reported to nobody. A called workflow's
+  # jobs belong to the same run, so once `release` is terminal they all are.
+  # Trade-off: the alert for test failures now waits for publication to finish.
   notify-slack:
     if: always()
-    needs: [vllm-test, vllm-multi-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, deploy-cleanup, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, deploy-cleanup, rust-tests, release]
     permissions:
       contents: read
       actions: read   # grant the reusable notifier read access to list this run's jobs
@@ -1326,4 +1333,34 @@ jobs:
     with:
       pipeline_name: Nightly
       runs_on: prod-default-v2
+    secrets: inherit
+
+  ########################### PAGERDUTY: NOTHING PUBLISHED ###########################
+  # The publication-failure page lives in release.yml, next to the per-stage
+  # results. But when a build gate fails, `release` is SKIPPED, release.yml never
+  # runs, and that job never exists — while the consumer-visible symptom is
+  # identical (the :nightly tags are a day stale). This covers that case.
+  #
+  # Distinct dedup_key prefix so it can never collide with the publication
+  # incident. Expect this to be the noisier of the two: it fires on any
+  # build-gate break, which is dev-owned and already loud in Slack. If it proves
+  # fatiguing, drop this job — that is why it is separate rather than folded in.
+  notify-pagerduty-not-published:
+    name: Notify PagerDuty — nightly did not publish
+    needs: [compute-release-mode, release]
+    if: ${{ !cancelled()
+        && github.event_name == 'schedule'
+        && needs.compute-release-mode.outputs.release == 'true'
+        && needs.release.result == 'skipped' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/notify-pagerduty.yml
+    with:
+      pipeline_name: Nightly
+      dedup_key: ${{ github.repository }}/nightly-not-published/${{ github.run_id }}
+      # No stage ever ran; prepare_result drives the notifier's error-severity path.
+      prepare_result: skipped
+      runbook_url: https://github.com/${{ github.repository }}/blob/main/.github/RUNBOOK-nightly-publication.md
+      # PHASE 1: print the payload, page nobody. See release.yml's note.
+      dry_run: true
     secrets: inherit

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1322,7 +1322,14 @@ jobs:
   # (conclusion: null), so NGC/Artifactory failures never matched
   # `conclusion == "failure"` and were reported to nobody. A called workflow's
   # jobs belong to the same run, so once `release` is terminal they all are.
-  # Trade-off: the alert for test failures now waits for publication to finish.
+  # Trade-offs, both accepted: on `schedule` the alert for test failures now
+  # waits for publication to finish (tens of minutes). On `workflow_dispatch`
+  # with release=true it additionally waits on `manual-release-approval`, an
+  # environment-gated job that `release` needs — so the alert is deferred until
+  # a reviewer approves, bounded only by the environment's wait timer. That is
+  # tolerable because a dispatched run has a human watching it; the unattended
+  # cron, which is what this alert exists for, never hits that gate (the
+  # approval job is `skipped` on schedule).
   notify-slack:
     if: always()
     needs: [vllm-test, vllm-multi-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, deploy-cleanup, rust-tests, release]

--- a/.github/workflows/notify-pagerduty.yml
+++ b/.github/workflows/notify-pagerduty.yml
@@ -54,6 +54,15 @@ on:
         type: string
         default: ''
 
+      reason:
+        description: |
+          Human-readable cause, for the case where publication never ran at all
+          (no per-stage results exist). When set it REPLACES stage derivation and
+          switches the incident to the "published nothing" wording.
+        required: false
+        type: string
+        default: ''
+
       # --- context for the incident body ------------------------------------
       commit_sha:
         description: "Source commit the nightly published from."
@@ -113,6 +122,7 @@ jobs:
           PD_ROUTING_KEY:  ${{ secrets.PAGERDUTY_OPS_SUPPORT_ROUTING_KEY }}
           PD_ENABLED:      ${{ vars.PAGERDUTY_ENABLED }}
           PIPELINE:        ${{ inputs.pipeline_name }}
+          REASON:          ${{ inputs.reason }}
           DEDUP_KEY:       ${{ inputs.dedup_key }}
           PREPARE:         ${{ inputs.prepare_result }}
           NGC:             ${{ inputs.ngc_result }}
@@ -156,9 +166,18 @@ jobs:
             esac
           }
 
+          # `reason` short-circuits stage derivation: the caller is reporting that
+          # publication never ran, so there are no per-stage results to map and
+          # naming one would point the on-call at the wrong system.
+          if [ -n "${REASON}" ]; then
+            FAILING+=("${REASON}")
+            bump error
+            CLASS="not-published"
+          fi
+
           # `skipped` counts as failure for the publish stages: they are only
           # skipped when prepare-release failed, which is itself a paging case.
-          if [ -n "${PREPARE}" ] && [ "${PREPARE}" != "success" ]; then
+          if [ -z "${REASON}" ] && [ -n "${PREPARE}" ] && [ "${PREPARE}" != "success" ]; then
             FAILING+=("prepare-release (${PREPARE})"); bump error; CLASS="prepare"
           fi
           # Suppressed when prepare-release already failed — the downstream
@@ -178,14 +197,19 @@ jobs:
             echo "Artifact publication is green — no PagerDuty event sent."
             exit 0
           fi
-          [ "${#FAILING[@]}" -gt 1 ] && CLASS="multi-stage"
+          # Guarded on REASON so the not-published class is never clobbered.
+          if [ -z "${REASON}" ] && [ "${#FAILING[@]}" -gt 1 ]; then CLASS="multi-stage"; fi
 
           # "${FAILING[*]}" would join on IFS's first char only, giving "a,b".
           FAILING_STR=$(printf '%s, ' "${FAILING[@]}"); FAILING_STR="${FAILING_STR%, }"
 
           # --- payload ---------------------------------------------------------
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}"
-          SUMMARY="[${PIPELINE}] Dynamo artifact publication FAILED — ${FAILING_STR} — ${NGC_TAG:-<no tag>}"
+          if [ "${CLASS}" = "not-published" ]; then
+            SUMMARY="[${PIPELINE}] Dynamo nightly published NO artifacts — ${FAILING_STR}"
+          else
+            SUMMARY="[${PIPELINE}] Dynamo artifact publication FAILED — ${FAILING_STR} — ${NGC_TAG:-<no tag>}"
+          fi
           SUMMARY="${SUMMARY:0:1024}"   # PagerDuty truncates summary at 1024 chars
 
           # Destinations are deliberately SYMBOLIC. NGC_PUBLISH_ORG,

--- a/.github/workflows/notify-pagerduty.yml
+++ b/.github/workflows/notify-pagerduty.yml
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable PagerDuty notifier for nightly artifact-publication failures.
+# Maps the publication stages' job results to a PagerDuty Events API v2 trigger
+# routed to the Ops-Support service, so an unattended nightly that fails to push
+# containers to NGC or wheels to Artifactory pages someone instead of dying in a
+# Slack thread. Called via `uses: ./.github/workflows/notify-pagerduty.yml`.
+#
+# Sends `trigger` only — never `resolve`. Callers pass a dedup_key containing
+# github.run_id, so each nightly opens its own incident (closed manually by
+# Ops-Support) while a "Re-run failed jobs" folds into the incident already open.
+name: Notify PagerDuty
+
+on:
+  workflow_call:
+    inputs:
+      pipeline_name:
+        description: "Human-readable pipeline name used in the incident summary (e.g. Nightly)."
+        required: true
+        type: string
+      dedup_key:
+        description: |
+          PagerDuty dedup_key. Include github.run_id so each run opens its own
+          incident but re-runs of the same run fold into it.
+        required: true
+        type: string
+      runs_on:
+        description: "Runner label for the notifier job."
+        required: false
+        type: string
+        default: ubuntu-slim
+
+      # --- publication stage results (pass needs.<job>.result) ---------------
+      # Empty string means "stage not applicable to this caller" and is ignored.
+      prepare_result:
+        description: "Result of prepare-release."
+        required: false
+        type: string
+        default: ''
+      ngc_result:
+        description: "Result of release-publish (NGC container publish)."
+        required: false
+        type: string
+        default: ''
+      artifactory_result:
+        description: "Result of stage-wheels-artifactory."
+        required: false
+        type: string
+        default: ''
+      gitlab_result:
+        description: "Result of trigger-gitlab-release-pipeline. Only 'failure' pages; 'skipped' is the documented emergency bypass."
+        required: false
+        type: string
+        default: ''
+
+      # --- context for the incident body ------------------------------------
+      commit_sha:
+        description: "Source commit the nightly published from."
+        required: false
+        type: string
+        default: ''
+      ngc_version_tag:
+        description: "NGC version tag (YYYYMMDD-<shortsha>)."
+        required: false
+        type: string
+        default: ''
+      wheel_version:
+        description: "Wheel version (X.Y.Z.devYYYYMMDD)."
+        required: false
+        type: string
+        default: ''
+      skipped_image_copies:
+        description: |
+          release-publish's failed_copy_count. Correlation context ONLY — never
+          escalates on its own. On a green release-publish this can only be
+          fail-soft optional-image warn-skips (see release.yml's copy_images
+          step), so paging on it would fire most nights.
+        required: false
+        type: string
+        default: ''
+      runbook_url:
+        description: "Triage runbook surfaced in the incident."
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: "Build and print the payload (routing key redacted) without POSTing."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      # required: false on purpose. With `required: true` GitHub fails the CALLER
+      # when the secret is unset — reddening the whole nightly because an alerting
+      # secret is missing. The guard step below degrades to a warning instead.
+      PAGERDUTY_OPS_SUPPORT_ROUTING_KEY:
+        required: false
+
+jobs:
+  notify-pagerduty:
+    name: Notify PagerDuty
+    runs-on: ${{ inputs.runs_on }}
+    permissions:
+      contents: read
+    steps:
+      - name: Send PagerDuty event
+        # This job is invoked via `uses:`, which cannot set job-level
+        # continue-on-error, so fail-soft lives on the step (same as
+        # notify-slack-staging). A PagerDuty outage must never fail publication.
+        continue-on-error: true
+        shell: bash
+        env:
+          PD_ROUTING_KEY:  ${{ secrets.PAGERDUTY_OPS_SUPPORT_ROUTING_KEY }}
+          PD_ENABLED:      ${{ vars.PAGERDUTY_ENABLED }}
+          PIPELINE:        ${{ inputs.pipeline_name }}
+          DEDUP_KEY:       ${{ inputs.dedup_key }}
+          PREPARE:         ${{ inputs.prepare_result }}
+          NGC:             ${{ inputs.ngc_result }}
+          ART:             ${{ inputs.artifactory_result }}
+          GITLAB:          ${{ inputs.gitlab_result }}
+          COMMIT_SHA:      ${{ inputs.commit_sha }}
+          NGC_TAG:         ${{ inputs.ngc_version_tag }}
+          WHEEL_VERSION:   ${{ inputs.wheel_version }}
+          SKIPPED_COPIES:  ${{ inputs.skipped_image_copies }}
+          RUNBOOK_URL:     ${{ inputs.runbook_url }}
+          DRY_RUN:         ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          # Kill switch: lets Ops-Support mute paging during a planned NGC or
+          # Artifactory maintenance window without reverting code.
+          if [ "${PD_ENABLED:-}" = "false" ]; then
+            echo "::notice::PagerDuty paging disabled via vars.PAGERDUTY_ENABLED."
+            exit 0
+          fi
+
+          if [ -z "${PD_ROUTING_KEY:-}" ]; then
+            echo "::warning::PAGERDUTY_OPS_SUPPORT_ROUTING_KEY is not set — skipping PagerDuty event."
+            echo "Register it as a repository secret to enable Ops-Support paging."
+            exit 0
+          fi
+
+          # --- severity mapping ------------------------------------------------
+          # Aggregate severity is the max over the failing stages. A single
+          # incident enumerates every failing stage rather than paging per stage,
+          # so one root cause (e.g. expired NGC credentials) is one page.
+          FAILING=()
+          SEVERITY="info"
+          CLASS=""
+
+          bump() {
+            case "$1:${SEVERITY}" in
+              critical:*)               SEVERITY=critical ;;
+              error:info|error:warning) SEVERITY=error ;;
+              warning:info)             SEVERITY=warning ;;
+            esac
+          }
+
+          # `skipped` counts as failure for the publish stages: they are only
+          # skipped when prepare-release failed, which is itself a paging case.
+          if [ -n "${PREPARE}" ] && [ "${PREPARE}" != "success" ]; then
+            FAILING+=("prepare-release (${PREPARE})"); bump error; CLASS="prepare"
+          fi
+          # Suppressed when prepare-release already failed — the downstream
+          # `skipped` results are a consequence, not independent findings.
+          if [ -n "${NGC}" ] && [ "${NGC}" != "success" ] && [ "${PREPARE}" = "success" ]; then
+            FAILING+=("NGC publish (${NGC})"); bump critical; CLASS="ngc-publish"
+          fi
+          if [ -n "${ART}" ] && [ "${ART}" != "success" ] && [ "${PREPARE}" = "success" ]; then
+            FAILING+=("Artifactory wheels (${ART})"); bump critical; CLASS="artifactory-wheels"
+          fi
+          # Only 'failure': 'skipped' is the documented skip_gitlab_pipeline bypass.
+          if [ "${GITLAB}" = "failure" ]; then
+            FAILING+=("GitLab release trigger (failure)"); bump error; CLASS="gitlab-trigger"
+          fi
+
+          if [ "${#FAILING[@]}" -eq 0 ]; then
+            echo "Artifact publication is green — no PagerDuty event sent."
+            exit 0
+          fi
+          [ "${#FAILING[@]}" -gt 1 ] && CLASS="multi-stage"
+
+          # "${FAILING[*]}" would join on IFS's first char only, giving "a,b".
+          FAILING_STR=$(printf '%s, ' "${FAILING[@]}"); FAILING_STR="${FAILING_STR%, }"
+
+          # --- payload ---------------------------------------------------------
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}"
+          SUMMARY="[${PIPELINE}] Dynamo artifact publication FAILED — ${FAILING_STR} — ${NGC_TAG:-<no tag>}"
+          SUMMARY="${SUMMARY:0:1024}"   # PagerDuty truncates summary at 1024 chars
+
+          # Destinations are deliberately SYMBOLIC. NGC_PUBLISH_ORG,
+          # ARTIFACTORY_URL and GITLAB_PIPELINE_URL are repo secrets; GitHub masks
+          # secrets in logs but NOT in an outbound HTTP body, so interpolating them
+          # would ship them to PagerDuty. Concrete hostnames live in the runbook.
+          CUSTOM_DETAILS=$(jq -n \
+            --arg repo     "${GITHUB_REPOSITORY}" \
+            --arg workflow "${GITHUB_WORKFLOW}" \
+            --arg run_id   "${GITHUB_RUN_ID}" \
+            --arg attempt  "${GITHUB_RUN_ATTEMPT}" \
+            --arg run_url  "${RUN_URL}" \
+            --arg commit   "${COMMIT_SHA:-unknown}" \
+            --arg ngc_tag  "${NGC_TAG:-unknown}" \
+            --arg wheel    "${WHEEL_VERSION:-unknown}" \
+            --arg failing  "${FAILING_STR}" \
+            --arg prepare  "${PREPARE:-n/a}" \
+            --arg ngc      "${NGC:-n/a}" \
+            --arg art      "${ART:-n/a}" \
+            --arg gitlab   "${GITLAB:-n/a}" \
+            --arg skipped  "${SKIPPED_COPIES:-unknown}" \
+            --arg runbook  "${RUNBOOK_URL:-none}" \
+            '{
+              failing_stages:                     $failing,
+              "result: prepare-release":          $prepare,
+              "result: release-publish (NGC)":    $ngc,
+              "result: stage-wheels-artifactory": $art,
+              "result: trigger-gitlab-pipeline":  $gitlab,
+              repository:           $repo,
+              workflow:             $workflow,
+              run_id:               $run_id,
+              run_attempt:          $attempt,
+              run_url:              $run_url,
+              source_commit:        $commit,
+              ngc_version_tag:      $ngc_tag,
+              wheel_version:        $wheel,
+              skipped_image_copies: $skipped,
+              ngc_targets:          "ai-dynamo/{vllm,sglang,tensorrtllm}-runtime-nightly:<ngc_version_tag> plus the :nightly floating tags",
+              artifactory_target:   "nightly/<run_id>/ (ai_dynamo, ai_dynamo_runtime, kvbm wheels; amd64+arm64)",
+              runbook:              $runbook
+            }')
+
+          PAYLOAD=$(jq -n \
+            --arg routing_key "${PD_ROUTING_KEY}" \
+            --arg dedup_key   "${DEDUP_KEY}" \
+            --arg summary     "${SUMMARY}" \
+            --arg severity    "${SEVERITY}" \
+            --arg class       "${CLASS}" \
+            --arg source      "github.com/${GITHUB_REPOSITORY}/nightly-ci" \
+            --arg ts          "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg run_url     "${RUN_URL}" \
+            --argjson details "${CUSTOM_DETAILS}" \
+            '{
+              routing_key:  $routing_key,
+              event_action: "trigger",
+              dedup_key:    $dedup_key,
+              client:       "GitHub Actions",
+              client_url:   $run_url,
+              payload: {
+                summary:        $summary,
+                severity:       $severity,
+                source:         $source,
+                component:      "nightly-artifact-publication",
+                group:          "dynamo-ci",
+                class:          $class,
+                timestamp:      $ts,
+                custom_details: $details
+              },
+              links: [ { href: $run_url, text: "GitHub Actions run" } ]
+            }')
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "::notice::DRY RUN — payload below, not sent to PagerDuty."
+            printf '%s' "${PAYLOAD}" | jq '.routing_key = "***"'
+            exit 0
+          fi
+
+          # --- send ------------------------------------------------------------
+          # Body goes over stdin so the routing key never lands in argv or a file.
+          RESPONSE_FILE=$(mktemp)
+          trap 'rm -f "${RESPONSE_FILE}"' EXIT
+
+          # No --fail: it discards the response body, and PagerDuty's 400 body is
+          # the only place the validation error appears. Capture the code with -w.
+          HTTP_CODE=$(printf '%s' "${PAYLOAD}" | curl -sS -o "${RESPONSE_FILE}" -w '%{http_code}' \
+            -X POST https://events.pagerduty.com/v2/enqueue \
+            -H 'Content-Type: application/json' \
+            --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-delay 5 --retry-all-errors \
+            --data @-)
+
+          STATUS=$(jq -r '.status // "unknown"' "${RESPONSE_FILE}" 2>/dev/null || echo unknown)
+          if [ "${HTTP_CODE}" != "202" ] || [ "${STATUS}" != "success" ]; then
+            echo "::error::PagerDuty enqueue failed: HTTP ${HTTP_CODE} status=${STATUS}"
+            jq -r '.errors // [] | .[]' "${RESPONSE_FILE}" 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "PagerDuty incident triggered (severity=${SEVERITY}, class=${CLASS})"
+          echo "  dedup_key: $(jq -r '.dedup_key' "${RESPONSE_FILE}")"
+          echo "  stages:    ${FAILING_STR}"

--- a/.github/workflows/notify-pagerduty.yml
+++ b/.github/workflows/notify-pagerduty.yml
@@ -144,12 +144,6 @@ jobs:
             exit 0
           fi
 
-          if [ -z "${PD_ROUTING_KEY:-}" ]; then
-            echo "::warning::PAGERDUTY_OPS_SUPPORT_ROUTING_KEY is not set — skipping PagerDuty event."
-            echo "Register it as a repository secret to enable Ops-Support paging."
-            exit 0
-          fi
-
           # --- severity mapping ------------------------------------------------
           # Aggregate severity is the max over the failing stages. A single
           # incident enumerates every failing stage rather than paging per stage,
@@ -284,6 +278,16 @@ jobs:
           if [ "${DRY_RUN}" = "true" ]; then
             echo "::notice::DRY RUN — payload below, not sent to PagerDuty."
             printf '%s' "${PAYLOAD}" | jq '.routing_key = "***"'
+            exit 0
+          fi
+
+          # Deliberately AFTER the dry-run branch: during phase 1 the secret does
+          # not exist yet, and an early guard would exit before printing anything
+          # — defeating the whole point of running in dry-run first. The dry-run
+          # output redacts the key regardless, so it needs no secret.
+          if [ -z "${PD_ROUTING_KEY:-}" ]; then
+            echo "::warning::PAGERDUTY_OPS_SUPPORT_ROUTING_KEY is not set — skipping PagerDuty event."
+            echo "Register it as a repository secret to enable Ops-Support paging."
             exit 0
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1292,6 +1292,61 @@ jobs:
             exit 1
           fi
           echo "Posted GitLab trigger reply"
+
+  # ============================================================================
+  # PAGERDUTY: nightly artifact-publication failure
+  # ============================================================================
+  # Pages Ops-Support when the unattended (cron) nightly fails to publish
+  # containers to NGC or wheels to Artifactory, or fails to hand off to the
+  # GitLab release-automation pipeline. Without this the only publication signal
+  # is notify-slack-staging — a continue-on-error thread reply that is skipped
+  # outright when slack_thread_ts is empty.
+  #
+  # This job lives here rather than in nightly-ci.yml because release.yml
+  # declares no workflow_call outputs: the caller can only see the single
+  # needs.release.result bit, not which stage broke.
+  #
+  # `!cancelled()` rather than `always()`: both still run when a need FAILED or
+  # was SKIPPED (the coverage we want), but `always()` would also page when a
+  # human cancels the run. Cancellations are not incidents.
+  #
+  # Gated on `inputs.nightly` (not needs.prepare-release.outputs.nightly, which
+  # is unavailable exactly when prepare-release fails — a paging case) and on
+  # event_name == 'schedule', which inside a called workflow resolves to the
+  # caller's event. Together these exclude RC/GA runs and manual re-stages,
+  # where a human is already driving and would otherwise page themselves.
+  #
+  # Deliberately NOT gated on release-publish's failed_copy_count: on a green
+  # release-publish that count only reflects fail-soft optional-image warn-skips
+  # (a core copy failure aborts the copy step under `set -e` and fails the job
+  # outright), so paging on it would fire most nights. It is passed as
+  # correlation context only.
+  notify-pagerduty-publish:
+    name: Notify PagerDuty — publication failure
+    needs: [prepare-release, release-publish, stage-wheels-artifactory, trigger-gitlab-release-pipeline]
+    if: ${{ !cancelled() && inputs.nightly && github.event_name == 'schedule' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/notify-pagerduty.yml
+    with:
+      pipeline_name: Nightly
+      # run_id, so each nightly opens its own incident while a "Re-run failed
+      # jobs" (same run_id) folds into the one already open.
+      dedup_key: ${{ github.repository }}/nightly-artifact-publication/${{ github.run_id }}
+      prepare_result:       ${{ needs.prepare-release.result }}
+      ngc_result:           ${{ needs.release-publish.result }}
+      artifactory_result:   ${{ needs.stage-wheels-artifactory.result }}
+      gitlab_result:        ${{ needs.trigger-gitlab-release-pipeline.result }}
+      commit_sha:           ${{ needs.prepare-release.outputs.commit_sha }}
+      ngc_version_tag:      ${{ needs.prepare-release.outputs.ngc_version_tag }}
+      wheel_version:        ${{ needs.prepare-release.outputs.wheel_version }}
+      skipped_image_copies: ${{ needs.release-publish.outputs.failed_copy_count }}
+      runbook_url: https://github.com/${{ github.repository }}/blob/main/.github/RUNBOOK-nightly-publication.md
+      # PHASE 1: print the payload, page nobody. Flip to false once a few
+      # nightlies have shown the severity mapping behaves against real noise.
+      dry_run: true
+    secrets: inherit
+
   # ============================================================================
   # LINEAR RELEASE SYNC
   # ============================================================================


### PR DESCRIPTION
…ailure

Nightly artifact publication failures currently reach nobody.

Two independent causes. First, nightly-ci.yml's notify-slack job did not depend on `release`, so it took its point-in-time snapshot of the run's jobs via the Actions API while every publication job was still in_progress with conclusion: null -- `conclusion == "failure"` never matched. Second, the only publication signal is notify-slack-staging, a continue-on-error thread reply that is skipped outright when slack_thread_ts is empty and carries no group mention. A consumer pulling :nightly or pip-installing the nightly wheels silently gets day-stale artifacts.

Add notify-pagerduty.yml, a reusable notifier that maps the publication stages' job results to a PagerDuty Events API v2 trigger routed to the Ops-Support service, and call it from two places:

  - release.yml, where the per-stage results are visible (release.yml declares no workflow_call outputs, so the caller can only see the single needs.release.result bit)
  - nightly-ci.yml, for the case where a build gate fails, `release` is skipped, and nothing is published at all

Raw curl + jq rather than a marketplace action, matching the three existing Slack senders in these files and avoiding a third-party action that would receive a credential.

Notes on the design:

  - Only unattended cron runs page. `inputs.nightly` excludes RC/GA runs and `github.event_name == 'schedule'` excludes manual re-stages, where a human is already driving and would otherwise page themselves.
  - `!cancelled()` rather than `always()`: both still run when a need failed or was skipped, but always() would also page on a human cancellation.
  - dedup_key carries github.run_id, so each nightly opens its own incident while a "Re-run failed jobs" folds into the one already open. No resolve event is sent; Ops-Support closes incidents manually.
  - Deliberately does NOT page on release-publish's failed_copy_count. Core runtime copies call copy_image bare, so a failure aborts under set -e and fails the job; only fail-soft optional-image warn-skips increment that count on a green job, so paging on it would fire most nights. It is passed as correlation context only.
  - Destinations in custom_details are symbolic. NGC_PUBLISH_ORG, ARTIFACTORY_URL and GITLAB_PIPELINE_URL are secrets, and GitHub masks secrets in logs but not in an outbound HTTP body.
  - The routing key secret is required: false with a runtime guard, and the only step is continue-on-error, so a missing key or a PagerDuty outage degrades to a warning instead of failing the nightly.

Landed with dry_run: true -- the payload is printed and nobody is paged until the severity mapping has been observed against a few real nightlies.

Requires a new repository secret PAGERDUTY_OPS_SUPPORT_ROUTING_KEY (Events API v2 integration key). Optional repository variable PAGERDUTY_ENABLED=false acts as a kill switch for maintenance windows.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PagerDuty notifications for scheduled nightly publication failures and unpublished releases.
  * Notifications include relevant release context, failure severity, and recovery guidance.
  * Added dry-run support to safely preview notification payloads.

* **Documentation**
  * Added a public runbook covering nightly publication alerts, triage, recovery, republishing, and alert muting behavior.

* **Bug Fixes**
  * Improved nightly status reporting so publication failures are included in Slack notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->