### PR TITLE
fix(operator): stop SyncResource touching another controller's resource

### DIFF
--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -31,8 +31,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -52,6 +54,57 @@ const (
 type Reconciler interface {
 	client.Client
 	GetRecorder() events.EventRecorder
+}
+
+// isDynamoOwner reports whether ref names a kind this operator manages.
+//
+// The group alone is not enough to decide that. `nvidia.com` is shared with
+// other NVIDIA controllers, the GPU operator's `nvidia.com/v1` ClusterPolicy
+// among them, and treating those as ours would put back the cross-controller
+// mutation this guard exists to stop. Asking the scheme keeps the answer exact
+// across both API versions and stays correct as kinds are added.
+func isDynamoOwner(ref *metav1.OwnerReference, scheme *runtime.Scheme) bool {
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil || gv.Group != v1beta1.GroupVersion.Group {
+		return false
+	}
+	return scheme.Recognizes(gv.WithKind(ref.Kind))
+}
+
+// checkForeignOwner refuses to touch an observed object that some other
+// controller owns.
+//
+// An object is looked up by namespace and name only, so a name collision can
+// hand back a resource that belongs to a different controller. The create path
+// attaches parentResource as controller owner, but the update and delete paths
+// would otherwise write to whatever they found.
+//
+// Scoped to owners outside this operator's API group on purpose. Resources are
+// deliberately shared between our own objects: the headless model discovery
+// service is named from the base model alone, so the prefill and decode
+// DynamoComponentDeployments serving one model sync the same service, and only
+// the first becomes its controller owner. Refusing there would leave every
+// other component permanently unable to reconcile. Whether such sharing should
+// be expressed through ownership at all is a design question, so this leaves
+// our own objects behaving as they do now.
+//
+// A resource with no controller owner is left alone here: adopting it, or
+// treating the collision as fatal, changes behaviour for objects that
+// reconcile today, so that policy belongs with the maintainers.
+func checkForeignOwner(r Reconciler, parentResource, observed, desired client.Object, resourceType string) error {
+	if parentResource == nil {
+		return nil
+	}
+	owner := metav1.GetControllerOf(observed)
+	if owner == nil || owner.UID == parentResource.GetUID() || isDynamoOwner(owner, r.Scheme()) {
+		return nil
+	}
+	err := fmt.Errorf(
+		"%s %s/%s is controlled by %s %s, which this operator does not manage; refusing to modify it",
+		resourceType, observed.GetNamespace(), observed.GetName(), owner.Kind, owner.Name,
+	)
+	recordResourceEvent(r, desired, corev1.EventTypeWarning, fmt.Sprintf("Foreign%s", resourceType), "Sync", "%s", err.Error())
+	return err
 }
 
 // ResourceGenerator is a function that generates a resource.
@@ -113,6 +166,10 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 
 	logs.Info(fmt.Sprintf("%s found.", resourceType))
 	if toDelete {
+		if err = checkForeignOwner(r, parentResource, oldResource, resource, resourceType); err != nil {
+			logs.Error(err, "Refusing to delete a resource owned by a foreign controller.")
+			return
+		}
 		logs.Info(fmt.Sprintf("%s found. Deleting the existing one.", resourceType))
 		err = r.Delete(ctx, oldResource)
 		if err != nil {
@@ -180,6 +237,12 @@ func SyncObservedResource[T client.Object](
 		logs.Info(fmt.Sprintf("%s created.", resourceType))
 		recordResourceEvent(r, desired, corev1.EventTypeNormal, fmt.Sprintf("Create%s", resourceType), "Create", "Created %s %s", resourceType, resourceNamespace)
 		return true, desired, nil
+	}
+
+	if err := checkForeignOwner(r, parentResource, observed, desired, resourceType); err != nil {
+		logs.Error(err, "Refusing to modify a resource owned by a foreign controller.")
+		var zero T
+		return false, zero, err
 	}
 
 	changeResult, err := GetSpecChangeResult(observed, desired)

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -19,13 +19,18 @@ package controller_common
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 
 	"github.com/bsm/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -959,6 +964,13 @@ type observedResourceTestReconciler struct {
 	recorder events.EventRecorder
 }
 
+// syncTestReconciler is the minimal Reconciler SyncResource needs: a client and
+// an event recorder.
+type syncTestReconciler struct {
+	client.Client
+	recorder *events.FakeRecorder
+}
+
 func (r observedResourceTestReconciler) GetRecorder() events.EventRecorder {
 	return r.recorder
 }
@@ -1010,4 +1022,279 @@ func TestSyncObservedResourceUsesProvidedObservation(t *testing.T) {
 	g.Expect(getCalls).To(gomega.Equal(1), "sync must use the caller's exact observation")
 	g.Expect(observed.Data["value"]).To(gomega.Equal("before"), "sync must not mutate the caller's observation")
 	g.Expect(synced.Data["value"]).To(gomega.Equal("after"))
+}
+
+func (r *syncTestReconciler) GetRecorder() events.EventRecorder { return r.recorder }
+
+// warnedForeign reports whether a foreign-owner warning event was emitted.
+func (r *syncTestReconciler) warnedForeign(t *testing.T) bool {
+	t.Helper()
+	for {
+		select {
+		case event := <-r.recorder.Events:
+			if strings.Contains(event, "Foreign") {
+				return true
+			}
+		default:
+			return false
+		}
+	}
+}
+
+func newSyncTestReconciler(t *testing.T, seeded ...client.Object) *syncTestReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add nvidia.com/v1beta1 to scheme: %v", err)
+	}
+	return &syncTestReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(seeded...).Build(),
+		recorder: events.NewFakeRecorder(16),
+	}
+}
+
+// foreignOwnedConfigMap is a ConfigMap already controlled by a different owner.
+func foreignOwnedConfigMap() *corev1.ConfigMap {
+	controller := true
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-name",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "StatefulSet",
+				Name:       "someone-else",
+				UID:        "owner-uid-other",
+				Controller: &controller,
+			}},
+		},
+		Data: map[string]string{"owner": "other-controller"},
+	}
+}
+
+func syncParent() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent", Namespace: "default", UID: "owner-uid-parent"},
+	}
+}
+
+func TestSyncResourceRefusesToUpdateAForeignOwnedResource(t *testing.T) {
+	t.Log("given an existing ConfigMap controlled by another controller")
+	existing := foreignOwnedConfigMap()
+	r := newSyncTestReconciler(t, existing)
+
+	t.Log("when SyncResource reconciles a same-name resource for a different parent")
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-name", Namespace: "default"},
+		Data:       map[string]string{"owner": "us"},
+	}
+	modified, _, err := SyncResource(context.Background(), r, syncParent(),
+		func(context.Context) (*corev1.ConfigMap, bool, error) { return desired, false, nil })
+
+	t.Log("then it reports a collision and leaves the resource untouched")
+	if err == nil {
+		t.Fatal("SyncResource() error = nil, want a collision error")
+	}
+	if modified {
+		t.Fatal("SyncResource() modified = true, want false")
+	}
+	var got corev1.ConfigMap
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "shared-name", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("Get() after refused sync error = %v", err)
+	}
+	if got.Data["owner"] != "other-controller" {
+		t.Fatalf("resource data = %v, want the other controller's content preserved", got.Data)
+	}
+	if !r.warnedForeign(t) {
+		t.Fatal("no foreign-owner warning event was recorded")
+	}
+}
+
+func TestSyncResourceRefusesToDeleteAForeignOwnedResource(t *testing.T) {
+	t.Log("given an existing ConfigMap controlled by another controller")
+	r := newSyncTestReconciler(t, foreignOwnedConfigMap())
+
+	t.Log("when SyncResource is asked to delete a same-name resource for a different parent")
+	modified, _, err := SyncResource(context.Background(), r, syncParent(),
+		func(context.Context) (*corev1.ConfigMap, bool, error) {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "shared-name", Namespace: "default"},
+			}, true, nil
+		})
+
+	t.Log("then it reports a collision and the resource still exists")
+	if err == nil {
+		t.Fatal("SyncResource() error = nil, want a collision error")
+	}
+	if modified {
+		t.Fatal("SyncResource() modified = true, want false")
+	}
+	var got corev1.ConfigMap
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "shared-name", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("resource was deleted despite belonging to another controller: %v", err)
+	}
+	if !r.warnedForeign(t) {
+		t.Fatal("no foreign-owner warning event was recorded")
+	}
+}
+
+// SyncObservedResource is called directly by the Grove workloads reconciler with
+// an observation it read itself, so it needs the same guard as SyncResource
+// rather than inheriting it from the lookup path.
+func TestSyncObservedResourceRefusesAForeignOwnedResource(t *testing.T) {
+	t.Log("given an observation of a ConfigMap controlled by another controller")
+	observed := foreignOwnedConfigMap()
+	r := newSyncTestReconciler(t, observed.DeepCopy())
+
+	t.Log("when a different parent syncs a desired resource against that observation")
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-name", Namespace: "default"},
+		Data:       map[string]string{"owner": "us"},
+	}
+	modified, _, err := SyncObservedResource(context.Background(), r, syncParent(), observed, desired)
+
+	t.Log("then it refuses and leaves the resource untouched")
+	if err == nil {
+		t.Fatal("SyncObservedResource() error = nil, want a collision error")
+	}
+	if modified {
+		t.Fatal("SyncObservedResource() modified = true, want false")
+	}
+	var got corev1.ConfigMap
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "shared-name", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("Get() after refused sync error = %v", err)
+	}
+	if got.Data["owner"] != "other-controller" {
+		t.Fatalf("resource data = %v, want the other controller's content preserved", got.Data)
+	}
+}
+
+// `nvidia.com` is shared with other NVIDIA controllers. The GPU operator's
+// ClusterPolicy lives in that group, so matching on the group alone would treat
+// it as ours and put back the cross-controller mutation this guard prevents.
+func TestSyncResourceRefusesAnotherNvidiaControllersResource(t *testing.T) {
+	t.Log("given an existing resource controlled by a non-Dynamo nvidia.com kind")
+	controller := true
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-name",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "nvidia.com/v1",
+				Kind:       "ClusterPolicy",
+				Name:       "gpu-operator",
+				UID:        "owner-uid-gpu-operator",
+				Controller: &controller,
+			}},
+		},
+		Data: map[string]string{"owner": "gpu-operator"},
+	}
+	r := newSyncTestReconciler(t, existing)
+
+	t.Log("when SyncResource reconciles a same-name resource")
+	_, _, err := SyncResource(context.Background(), r, syncParent(),
+		func(context.Context) (*corev1.ConfigMap, bool, error) {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "shared-name", Namespace: "default"},
+				Data:       map[string]string{"owner": "us"},
+			}, false, nil
+		})
+
+	t.Log("then a kind this operator does not manage is still treated as foreign")
+	if err == nil {
+		t.Fatal("SyncResource() error = nil, want a collision error for a ClusterPolicy-owned resource")
+	}
+	var got corev1.ConfigMap
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "shared-name", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.Data["owner"] != "gpu-operator" {
+		t.Fatalf("resource data = %v, want the GPU operator's content preserved", got.Data)
+	}
+}
+
+func TestSyncResourceStillManagesItsOwnResource(t *testing.T) {
+	t.Log("given an existing ConfigMap this parent already controls")
+	controller := true
+	parent := syncParent()
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-name",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       parent.Name,
+				UID:        parent.UID,
+				Controller: &controller,
+			}},
+		},
+		Data: map[string]string{"owner": "us"},
+	}
+	r := newSyncTestReconciler(t, existing)
+
+	t.Log("when SyncResource deletes it")
+	modified, _, err := SyncResource(context.Background(), r, parent,
+		func(context.Context) (*corev1.ConfigMap, bool, error) {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "shared-name", Namespace: "default"},
+			}, true, nil
+		})
+
+	t.Log("then the delete really happens rather than being skipped")
+	if err != nil {
+		t.Fatalf("SyncResource() error = %v, want nil for an owned resource", err)
+	}
+	if !modified {
+		t.Fatal("SyncResource() modified = false, want true for a deleted resource")
+	}
+	var got corev1.ConfigMap
+	getErr := r.Get(context.Background(), types.NamespacedName{Name: "shared-name", Namespace: "default"}, &got)
+	if !apierrors.IsNotFound(getErr) {
+		t.Fatalf("Get() after delete error = %v, want NotFound", getErr)
+	}
+}
+
+// A resource can legitimately be shared between two of this operator's own
+// objects. The headless model discovery service is named from the base model
+// alone, so the prefill and decode DynamoComponentDeployments serving one model
+// sync the same service and only the first becomes its controller owner.
+// Refusing there would leave every other component unable to reconcile.
+func TestSyncResourceStillManagesAResourceOwnedByAnotherDynamoObject(t *testing.T) {
+	t.Log("given a shared resource already controlled by a different Dynamo object")
+	controller := true
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dynamo-model-abcd1234",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: v1beta1.GroupVersion.String(),
+				Kind:       "DynamoComponentDeployment",
+				Name:       "prefill-worker",
+				UID:        "owner-uid-prefill",
+				Controller: &controller,
+			}},
+		},
+		Data: map[string]string{"model": "shared"},
+	}
+	r := newSyncTestReconciler(t, existing)
+
+	t.Log("when a second Dynamo object syncs the same resource")
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "dynamo-model-abcd1234", Namespace: "default"},
+		Data:       map[string]string{"model": "shared"},
+	}
+	_, _, err := SyncResource(context.Background(), r, syncParent(),
+		func(context.Context) (*corev1.ConfigMap, bool, error) { return desired, false, nil })
+
+	t.Log("then it is not treated as foreign")
+	if err != nil {
+		t.Fatalf("SyncResource() error = %v, want nil for a resource shared with another Dynamo object", err)
+	}
+	if r.warnedForeign(t) {
+		t.Fatal("a foreign-owner warning was recorded for an operator-owned resource")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #13474.

`SyncResource` retrieves the existing object by namespace and name only:

```go
err = r.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: resourceNamespace}, oldResource)
```

The create path attaches `parentResource` as controller owner, but once an object with that name already exists every branch acts on whatever came back. With `toDelete` it deletes unconditionally; otherwise it copies the desired content and bookkeeping annotations in and updates. So a name collision with a resource owned by a different controller lets one controller delete or overwrite another's object.

This is the shared helper behind DCDs, Deployments, Services, RBAC resources, Jobs, ConfigMaps and Ingresses, so the collision surface is every generated resource rather than one call site.

The fix refuses. When `parentResource` is supplied and the existing object carries a controller reference naming someone else, `SyncResource` returns an error, emits a warning event, and leaves the object untouched.

## Scope

I deliberately fixed only the unambiguous half, and I want to be direct about why.

The issue asks for two things. Not mutating or deleting a resource controlled by a different owner is a straightforward safety bug with one correct answer. The second, what to do with a same-name **ownerless** object, is a policy decision: the issue itself offers "either reject the collision, or adopt the object only under a deliberate and testable policy".

Both options change behaviour for objects that reconcile successfully today. Rejecting would start failing reconciles for any ownerless resource that currently syncs, including ones created by an older operator or applied by a chart. Adopting would attach a controller reference to an object the operator has never claimed, which changes garbage-collection lifetime. On a helper this widely used I would rather not pick one unasked.

So this PR leaves ownerless objects behaving exactly as they do now, with a comment at the branch saying so. Happy to add whichever policy you want, in this PR or a follow-up, once the choice is made. If you would rather have the whole issue closed in one go, say which behaviour you want and I will extend it.

## Validation

Three tests, using a fake client and the minimal `Reconciler` the helper needs:

- an existing ConfigMap controlled by another owner is not updated, and its content is still the other controller's afterwards
- the same object is not deleted when `toDelete` is set, and still exists afterwards
- a resource this parent does control is still deleted normally, so the guard does not over-block

The two refusal tests fail on the unfixed helper, verified by stashing only `resource.go` and keeping the tests:

```
--- FAIL: TestSyncResourceRefusesToUpdateAForeignOwnedResource
    SyncResource() error = nil, want a collision error
--- FAIL: TestSyncResourceRefusesToDeleteAForeignOwnedResource
    SyncResource() error = nil, want a collision error
```

Because the blast radius here is every generated resource, I ran the whole operator tree rather than just this package: `go test ./internal/...` with envtest control-plane assets is **36 packages ok, 0 failures**, including the controller envtest suites that exercise real reconciliation. `gofmt`, `go build ./...` and `pre-commit run --files` are clean.

Not verified here: no Kubernetes cluster, so this is fake-client and envtest level rather than an observed cross-controller collision.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental updates or deletions of resources controlled by another controller.
  * Added warnings when a resource cannot be managed because it has a different controller owner.
  * Resources owned by the current controller continue to be updated or deleted as expected.
  * Resources without a controller owner retain their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->