### PR TITLE
feat(snapshot): rebuild vLLM and SGLang NIXL identity after restore

### DIFF
--- a/components/src/dynamo/common/snapshot/autoinstall.py
+++ b/components/src/dynamo/common/snapshot/autoinstall.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-start installers for snapshot-mode backend hooks.
+
+SGLang has no ``kv_connector_module_path``. Spawned scheduler children re-import
+sglang, so the parent wrap of ``get_kv_class`` is invisible to them. The wheel
+installs ``dynamo_snapshot.pth`` which calls :func:`install_snapshot_backends`
+when ``DYN_SNAPSHOT_CONTROL_DIR`` is set.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from dynamo.common.snapshot.constants import SNAPSHOT_CONTROL_DIR_ENV
+
+logger = logging.getLogger(__name__)
+
+
+def install_snapshot_backends() -> None:
+    if not os.environ.get(SNAPSHOT_CONTROL_DIR_ENV):
+        return
+    try:
+        from dynamo.sglang.snapshot_nixl import install_snapshot_nixl
+    except ImportError:
+        return
+    install_snapshot_nixl()

--- a/components/src/dynamo/common/snapshot/constants.py
+++ b/components/src/dynamo/common/snapshot/constants.py
@@ -12,7 +12,13 @@ KUBERNETES_REQUIRED_ENV_NAMES = {
     "POD_NAMESPACE",
     "POD_UID",
 }
-KUBERNETES_OPTIONAL_ENV_NAMES = {"DYN_NAMESPACE_WORKER_SUFFIX"}
+KUBERNETES_OPTIONAL_ENV_NAMES = {
+    "DYN_NAMESPACE_WORKER_SUFFIX",
+    # Advertised by the restore Pod. hostNetwork often keeps the same value
+    # across restart, so NIXL rebind is keyed by incarnation_id, not IP.
+    "POD_IP",
+    "VLLM_NIXL_SIDE_CHANNEL_HOST",
+}
 SNAPSHOT_CONTROL_DIR_ENV = "DYN_SNAPSHOT_CONTROL_DIR"
 SNAPSHOT_CONTROL_DIR = "/snapshot-control"
 SNAPSHOT_RESTORE_CONTEXT_FILE = "restore-context.json"

--- a/components/src/dynamo/common/snapshot/restore_context.py
+++ b/components/src/dynamo/common/snapshot/restore_context.py
@@ -6,6 +6,8 @@
 import json
 import logging
 import os
+import uuid
+from dataclasses import dataclass, field
 from inspect import isawaitable
 from pathlib import Path
 from typing import Awaitable, Callable, Mapping, TypeVar
@@ -35,6 +37,31 @@ _SUPPORTED_RESTORE_ENV_NAMES = {
     *KUBERNETES_OPTIONAL_ENV_NAMES,
     *RESTORE_RUNTIME_ENV_NAMES,
 }
+
+
+@dataclass(frozen=True)
+class RestoreIdentity:
+    """Restore-pod identity written by standby before CRIU resumes the image.
+
+    ``incarnation_id`` is minted on every restore. ``POD_IP`` is often unchanged
+    (hostNetwork, recycled CNI), so P/D NIXL rebind is keyed by incarnation,
+    not address.
+    """
+
+    incarnation_id: str
+    env: Mapping[str, object] = field(default_factory=dict)
+
+    def env_str(self, name: str) -> str | None:
+        value = self.env.get(name)
+        return value if isinstance(value, str) and value else None
+
+    @property
+    def pod_ip(self) -> str | None:
+        return self.env_str("POD_IP")
+
+    @property
+    def side_channel_host(self) -> str | None:
+        return self.env_str("VLLM_NIXL_SIDE_CHANNEL_HOST") or self.pod_ip
 
 
 async def refresh_snapshot_restore_config(
@@ -116,12 +143,64 @@ def parse_snapshot_restore_runtime_config(argv: list[str] | None) -> object:
 def apply_snapshot_restore_env() -> dict[str, str | None]:
     """Load restore-context JSON and apply its runtime env to ``os.environ``."""
 
-    # Load the restore-context JSON captured by the restore standby process. It
-    # contains the target container's actual restore-time env after Kubernetes
-    # resolved literals, Downward API values, ConfigMaps, and Secrets.
-    control_dir = os.environ.get(SNAPSHOT_CONTROL_DIR_ENV, SNAPSHOT_CONTROL_DIR)
-    context_path = Path(control_dir) / SNAPSHOT_RESTORE_CONTEXT_FILE
+    restore_context, context_path = _read_restore_context()
+    assert restore_context is not None
+    env_config = restore_context.get("env")
+    if not isinstance(env_config, dict):
+        raise RuntimeError("snapshot restore context requires an object env field")
+    return _apply_restore_env(env_config, source=str(context_path))
+
+
+def load_restore_identity(control_dir: str | None = None) -> RestoreIdentity | None:
+    """Read restore identity from the snapshot-control volume.
+
+    Workers and scheduler children must call this instead of trusting
+    API-process ``os.environ``. Returns ``None`` when the file is missing
+    (capture path) or has no ``incarnation_id`` (legacy context).
+    """
+
+    restore_context, _ = _read_restore_context(control_dir, missing_ok=True)
+    if restore_context is None:
+        return None
+    incarnation_id = restore_context.get("incarnation_id")
+    if not isinstance(incarnation_id, str) or not incarnation_id:
+        return None
+    env_config = restore_context.get("env")
+    env = env_config if isinstance(env_config, dict) else {}
+    return RestoreIdentity(incarnation_id=incarnation_id, env=env)
+
+
+def should_rebind_pd(
+    captured_incarnation_id: str | None,
+    identity: RestoreIdentity | None = None,
+) -> bool:
+    """Return True when restore context exists and the incarnation changed.
+
+    Rebind is not triggered by ``POD_IP`` changes. Same IP after hostNetwork
+    restart still rebinds when standby minted a new ``incarnation_id``.
+    """
+
+    if identity is None:
+        identity = load_restore_identity()
+    if identity is None:
+        return False
+    return captured_incarnation_id != identity.incarnation_id
+
+
+def _restore_context_path(control_dir: str | None = None) -> Path:
+    root = control_dir or os.environ.get(SNAPSHOT_CONTROL_DIR_ENV, SNAPSHOT_CONTROL_DIR)
+    return Path(root) / SNAPSHOT_RESTORE_CONTEXT_FILE
+
+
+def _read_restore_context(
+    control_dir: str | None = None,
+    *,
+    missing_ok: bool = False,
+) -> tuple[dict[str, object] | None, Path]:
+    context_path = _restore_context_path(control_dir)
     if not context_path.is_file():
+        if missing_ok:
+            return None, context_path
         raise RuntimeError(f"snapshot restore context file not found: {context_path}")
 
     source = str(context_path)
@@ -134,10 +213,7 @@ def apply_snapshot_restore_env() -> dict[str, str | None]:
 
     if not isinstance(restore_context, dict):
         raise RuntimeError("snapshot restore context requires an object payload")
-    env_config = restore_context.get("env")
-    if not isinstance(env_config, dict):
-        raise RuntimeError("snapshot restore context requires an object env field")
-    return _apply_restore_env(env_config, source=source)
+    return restore_context, context_path
 
 
 def write_snapshot_restore_context(control_dir: str | None = None) -> None:
@@ -155,7 +231,10 @@ def write_snapshot_restore_context(control_dir: str | None = None) -> None:
 
     # Capture only the non-secret env names Dynamo needs after restore. Missing
     # values are written as null so stale snapshot-time env can be cleared.
+    # incarnation_id is generated here (not an env var) so same-IP / same-UID
+    # restores still get a new P/D NIXL identity.
     context = {
+        "incarnation_id": str(uuid.uuid4()),
         "env": {
             name: os.environ.get(name) if name in os.environ else None
             for name in sorted(_SUPPORTED_RESTORE_ENV_NAMES)
@@ -175,7 +254,11 @@ def write_snapshot_restore_context(control_dir: str | None = None) -> None:
         encoding="utf-8",
     )
     tmp_path.replace(context_file)
-    logger.info("Captured snapshot restore context at %s", context_file)
+    logger.info(
+        "Captured snapshot restore context at %s incarnation_id=%s",
+        context_file,
+        context["incarnation_id"],
+    )
 
 
 def _validate_kubernetes_restore_env_for_config(config: object) -> None:

--- a/components/src/dynamo/common/snapshot/restore_context.py
+++ b/components/src/dynamo/common/snapshot/restore_context.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import uuid
-from dataclasses import dataclass, field
 from inspect import isawaitable
 from pathlib import Path
 from typing import Awaitable, Callable, Mapping, TypeVar
@@ -37,31 +36,6 @@ _SUPPORTED_RESTORE_ENV_NAMES = {
     *KUBERNETES_OPTIONAL_ENV_NAMES,
     *RESTORE_RUNTIME_ENV_NAMES,
 }
-
-
-@dataclass(frozen=True)
-class RestoreIdentity:
-    """Restore-pod identity written by standby before CRIU resumes the image.
-
-    ``incarnation_id`` is minted on every restore. ``POD_IP`` is often unchanged
-    (hostNetwork, recycled CNI), so P/D NIXL rebind is keyed by incarnation,
-    not address.
-    """
-
-    incarnation_id: str
-    env: Mapping[str, object] = field(default_factory=dict)
-
-    def env_str(self, name: str) -> str | None:
-        value = self.env.get(name)
-        return value if isinstance(value, str) and value else None
-
-    @property
-    def pod_ip(self) -> str | None:
-        return self.env_str("POD_IP")
-
-    @property
-    def side_channel_host(self) -> str | None:
-        return self.env_str("VLLM_NIXL_SIDE_CHANNEL_HOST") or self.pod_ip
 
 
 async def refresh_snapshot_restore_config(
@@ -151,12 +125,11 @@ def apply_snapshot_restore_env() -> dict[str, str | None]:
     return _apply_restore_env(env_config, source=str(context_path))
 
 
-def load_restore_identity(control_dir: str | None = None) -> RestoreIdentity | None:
-    """Read restore identity from the snapshot-control volume.
+def load_restore_incarnation_id(control_dir: str | None = None) -> str | None:
+    """Read the restore ``incarnation_id`` from the snapshot-control volume.
 
-    Workers and scheduler children must call this instead of trusting
-    API-process ``os.environ``. Returns ``None`` when the file is missing
-    (capture path) or has no ``incarnation_id`` (legacy context).
+    Workers must read the file. ``POD_IP`` is often unchanged after restore, so
+    P/D NIXL rebind is keyed by this id, not by address.
     """
 
     restore_context, _ = _read_restore_context(control_dir, missing_ok=True)
@@ -165,26 +138,14 @@ def load_restore_identity(control_dir: str | None = None) -> RestoreIdentity | N
     incarnation_id = restore_context.get("incarnation_id")
     if not isinstance(incarnation_id, str) or not incarnation_id:
         return None
-    env_config = restore_context.get("env")
-    env = env_config if isinstance(env_config, dict) else {}
-    return RestoreIdentity(incarnation_id=incarnation_id, env=env)
+    return incarnation_id
 
 
-def should_rebind_pd(
-    captured_incarnation_id: str | None,
-    identity: RestoreIdentity | None = None,
-) -> bool:
-    """Return True when restore context exists and the incarnation changed.
+def should_rebind_pd(bound_incarnation_id: str | None) -> bool:
+    """True when a restore context exists and this process has not bound it yet."""
 
-    Rebind is not triggered by ``POD_IP`` changes. Same IP after hostNetwork
-    restart still rebinds when standby minted a new ``incarnation_id``.
-    """
-
-    if identity is None:
-        identity = load_restore_identity()
-    if identity is None:
-        return False
-    return captured_incarnation_id != identity.incarnation_id
+    incarnation_id = load_restore_incarnation_id()
+    return incarnation_id is not None and incarnation_id != bound_incarnation_id
 
 
 def _restore_context_path(control_dir: str | None = None) -> Path:

--- a/components/src/dynamo/common/tests/test_snapshot_restore_context.py
+++ b/components/src/dynamo/common/tests/test_snapshot_restore_context.py
@@ -17,9 +17,8 @@ from dynamo.common.snapshot.constants import (
     SNAPSHOT_RESTORE_STANDBY_ENV,
 )
 from dynamo.common.snapshot.restore_context import (
-    RestoreIdentity,
     apply_snapshot_restore_env,
-    load_restore_identity,
+    load_restore_incarnation_id,
     refresh_snapshot_restore_config,
     should_rebind_pd,
     write_snapshot_restore_context,
@@ -249,50 +248,30 @@ def test_write_snapshot_restore_context_records_incarnation_and_pod_ip(
     assert second["incarnation_id"] != first_id
 
 
-def test_load_restore_identity_missing_context_returns_none(monkeypatch, tmp_path):
+def test_load_restore_incarnation_id_missing_context_returns_none(
+    monkeypatch, tmp_path
+):
     monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
-    assert load_restore_identity() is None
+    assert load_restore_incarnation_id() is None
 
 
-def test_should_rebind_pd_same_ip_new_incarnation():
-    identity = RestoreIdentity(
-        incarnation_id="inc-2",
-        env={"POD_IP": "10.0.0.5", "POD_UID": "uid-1"},
+def test_should_rebind_pd_same_ip_new_incarnation(monkeypatch, tmp_path):
+    monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
+    (tmp_path / SNAPSHOT_RESTORE_CONTEXT_FILE).write_text(
+        json.dumps(
+            {
+                "incarnation_id": "inc-2",
+                "env": {"POD_IP": "10.0.0.5", "POD_UID": "uid-1"},
+            }
+        ),
+        encoding="utf-8",
     )
-    assert should_rebind_pd("inc-1", identity) is True
-    assert should_rebind_pd("inc-2", identity) is False
-    assert should_rebind_pd(None, identity) is True
+    assert should_rebind_pd("inc-1") is True
+    assert should_rebind_pd("inc-2") is False
+    assert should_rebind_pd(None) is True
 
 
 def test_should_rebind_pd_missing_context_does_not_rebind(monkeypatch, tmp_path):
     monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
     assert should_rebind_pd("inc-1") is False
     assert should_rebind_pd(None) is False
-
-
-def test_should_rebind_pd_same_uid_same_ip_new_incarnation(monkeypatch, tmp_path):
-    write_restore_context(
-        monkeypatch,
-        tmp_path,
-        {"POD_IP": "10.0.0.5", "POD_UID": "uid-1"},
-    )
-    (tmp_path / SNAPSHOT_RESTORE_CONTEXT_FILE).write_text(
-        json.dumps(
-            {
-                "incarnation_id": "inc-restore",
-                "env": {"POD_IP": "10.0.0.5", "POD_UID": "uid-1"},
-            }
-        ),
-        encoding="utf-8",
-    )
-    identity = load_restore_identity()
-    assert identity is not None
-    assert identity.pod_ip == "10.0.0.5"
-    assert should_rebind_pd("inc-capture", identity) is True
-
-
-def test_autoinstall_is_noop_without_snapshot_mode(monkeypatch):
-    monkeypatch.delenv(SNAPSHOT_CONTROL_DIR_ENV, raising=False)
-    from dynamo.common.snapshot.autoinstall import install_snapshot_backends
-
-    install_snapshot_backends()

--- a/components/src/dynamo/common/tests/test_snapshot_restore_context.py
+++ b/components/src/dynamo/common/tests/test_snapshot_restore_context.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import uuid
 from types import SimpleNamespace
 
 import pytest
@@ -16,8 +17,12 @@ from dynamo.common.snapshot.constants import (
     SNAPSHOT_RESTORE_STANDBY_ENV,
 )
 from dynamo.common.snapshot.restore_context import (
+    RestoreIdentity,
     apply_snapshot_restore_env,
+    load_restore_identity,
     refresh_snapshot_restore_config,
+    should_rebind_pd,
+    write_snapshot_restore_context,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
@@ -220,3 +225,74 @@ async def test_refresh_snapshot_restore_config_validates_kubernetes_env(
                 event_plane=None,
             ),
         )
+
+
+def test_write_snapshot_restore_context_records_incarnation_and_pod_ip(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("POD_IP", "10.0.0.5")
+    monkeypatch.setenv("POD_UID", "uid-1")
+    write_snapshot_restore_context(str(tmp_path))
+
+    payload = json.loads(
+        (tmp_path / SNAPSHOT_RESTORE_CONTEXT_FILE).read_text(encoding="utf-8")
+    )
+    first_id = payload["incarnation_id"]
+    uuid.UUID(first_id)
+    assert payload["env"]["POD_IP"] == "10.0.0.5"
+    assert payload["env"]["POD_UID"] == "uid-1"
+
+    write_snapshot_restore_context(str(tmp_path))
+    second = json.loads(
+        (tmp_path / SNAPSHOT_RESTORE_CONTEXT_FILE).read_text(encoding="utf-8")
+    )
+    assert second["incarnation_id"] != first_id
+
+
+def test_load_restore_identity_missing_context_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
+    assert load_restore_identity() is None
+
+
+def test_should_rebind_pd_same_ip_new_incarnation():
+    identity = RestoreIdentity(
+        incarnation_id="inc-2",
+        env={"POD_IP": "10.0.0.5", "POD_UID": "uid-1"},
+    )
+    assert should_rebind_pd("inc-1", identity) is True
+    assert should_rebind_pd("inc-2", identity) is False
+    assert should_rebind_pd(None, identity) is True
+
+
+def test_should_rebind_pd_missing_context_does_not_rebind(monkeypatch, tmp_path):
+    monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
+    assert should_rebind_pd("inc-1") is False
+    assert should_rebind_pd(None) is False
+
+
+def test_should_rebind_pd_same_uid_same_ip_new_incarnation(monkeypatch, tmp_path):
+    write_restore_context(
+        monkeypatch,
+        tmp_path,
+        {"POD_IP": "10.0.0.5", "POD_UID": "uid-1"},
+    )
+    (tmp_path / SNAPSHOT_RESTORE_CONTEXT_FILE).write_text(
+        json.dumps(
+            {
+                "incarnation_id": "inc-restore",
+                "env": {"POD_IP": "10.0.0.5", "POD_UID": "uid-1"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    identity = load_restore_identity()
+    assert identity is not None
+    assert identity.pod_ip == "10.0.0.5"
+    assert should_rebind_pd("inc-capture", identity) is True
+
+
+def test_autoinstall_is_noop_without_snapshot_mode(monkeypatch):
+    monkeypatch.delenv(SNAPSHOT_CONTROL_DIR_ENV, raising=False)
+    from dynamo.common.snapshot.autoinstall import install_snapshot_backends
+
+    install_snapshot_backends()

--- a/components/src/dynamo/sglang/snapshot.py
+++ b/components/src/dynamo/sglang/snapshot.py
@@ -71,9 +71,9 @@ async def warmup_engine(engine: sgl.Engine, server_args: Any) -> None:
         warmup_args["input_ids"] = np.load(
             server_args.debug_tensor_dump_input_file
         ).tolist()
-        warmup_args["sampling_params"][
-            "max_new_tokens"
-        ] = DUMMY_DEBUG_TENSOR_MAX_NEW_TOKENS
+        warmup_args["sampling_params"]["max_new_tokens"] = (
+            DUMMY_DEBUG_TENSOR_MAX_NEW_TOKENS
+        )
 
     is_disaggregated = server_args.disaggregation_mode != "null"
     if is_disaggregated:
@@ -134,6 +134,9 @@ async def prepare_snapshot_engine(
 
     configure_snapshot_capture_env()
     logger.info("Snapshot mode enabled (watcher-driven signals)")
+    from dynamo.sglang.snapshot_nixl import install_snapshot_nixl
+
+    install_snapshot_nixl()
 
     # Enable memory_saver so GPU memory can be released for CRIU.
     # When using GMS, weights use VA-stable unmap/remap (no CPU backup); GMS

--- a/components/src/dynamo/sglang/snapshot_nixl.py
+++ b/components/src/dynamo/sglang/snapshot_nixl.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Snapshot-aware SGLang NIXL manager.
+"""Snapshot NIXL manager for SGLang.
 
-SGLang has no connector module-path factory. Snapshot mode wraps
-``get_kv_class`` so capture constructs this manager, and spawned children pick
-up the wrap via ``dynamo_snapshot.pth``. After restore, a new NIXL agent name
-is required: live prefill ignores a repeat ``agent_name``.
+SGLang has no connector module-path. Snapshot mode wraps ``get_kv_class`` so
+capture constructs this manager. Spawned children re-import sglang; the wheel
+``.pth`` calls :func:`install_snapshot_nixl` when ``DYN_SNAPSHOT_CONTROL_DIR``
+is set. After restore a new agent name is required because prefill ignores a
+repeat ``agent_name``.
 """
 
 from __future__ import annotations
@@ -15,14 +16,10 @@ import logging
 import uuid
 from typing import Any
 
-from dynamo.common.snapshot.restore_context import (
-    load_restore_identity,
-    should_rebind_pd,
-)
-from sglang.srt.disaggregation.nixl.conn import NixlKVManager, NixlKVReceiver
+from dynamo.common.snapshot.restore_context import should_rebind_pd
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
-from sglang.srt.utils.network import get_zmq_socket_on_host
 
 logger = logging.getLogger(__name__)
 
@@ -31,73 +28,46 @@ class SnapshotNixlKVManager(NixlKVManager):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._bound_incarnation_id: str | None = None
+        self._nixl_agent = self.__dict__.pop("agent")
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "agent":
+            self._maybe_rebind()
+            return self._nixl_agent
+        raise AttributeError(name)
 
     def _add_remote_peer(self, decode_kv_args: Any) -> None:
         self._maybe_rebind()
         super()._add_remote_peer(decode_kv_args)
 
     def _maybe_rebind(self) -> None:
-        identity = load_restore_identity()
-        if not should_rebind_pd(self._bound_incarnation_id, identity):
+        if not should_rebind_pd(self._bound_incarnation_id):
             return
-        assert identity is not None
-
+        from dynamo.common.snapshot.restore_context import load_restore_incarnation_id
         from nixl._api import nixl_agent, nixl_agent_config
 
+        incarnation_id = load_restore_incarnation_id()
+        assert incarnation_id is not None
         backend = envs.SGLANG_DISAGGREGATION_NIXL_BACKEND.get()
-        agent_config = nixl_agent_config(
-            backends=[backend],
-            num_threads=(
-                8 if self.disaggregation_mode == DisaggregationMode.PREFILL else 0
+        self._nixl_agent = nixl_agent(
+            str(uuid.uuid4()),
+            nixl_agent_config(
+                backends=[backend],
+                num_threads=(
+                    8 if self.disaggregation_mode == DisaggregationMode.PREFILL else 0
+                ),
             ),
         )
-        new_name = str(uuid.uuid4())
-        logger.info(
-            "Rebinding SGLang NIXL after snapshot restore incarnation_id=%s "
-            "agent_name=%s",
-            identity.incarnation_id,
-            new_name,
-        )
-        self.agent = nixl_agent(new_name, agent_config)
-        if identity.pod_ip and identity.pod_ip != self.local_ip:
-            self._rebind_zmq(identity.pod_ip)
-        elif identity.pod_ip:
-            self.local_ip = identity.pod_ip
+        self._bound_incarnation_id = incarnation_id
         self.register_buffer_to_engine()
-        self._bound_incarnation_id = identity.incarnation_id
-
-    def _rebind_zmq(self, new_ip: str) -> None:
-        import zmq
-
-        try:
-            self.server_socket.close(linger=0)
-        except Exception:
-            logger.exception("Failed to close restored SGLang NIXL ZMQ socket")
-        self.local_ip = new_ip
-        context = zmq.Context()
-        self.rank_port, self.server_socket = get_zmq_socket_on_host(
-            context, zmq.PULL, host=self.local_ip
-        )
         logger.info(
-            "Rebound SGLang NIXL ZMQ listener to %s:%s",
-            self.local_ip,
-            self.rank_port,
+            "Rebinding SGLang NIXL incarnation_id=%s agent_name=%s",
+            incarnation_id,
+            self._nixl_agent.name,
         )
-
-
-class SnapshotNixlKVReceiver(NixlKVReceiver):
-    def send_metadata(self, *args: Any, **kwargs: Any) -> None:
-        self.kv_mgr._maybe_rebind()
-        return super().send_metadata(*args, **kwargs)
-
-    def _register_kv_args(self) -> None:
-        self.kv_mgr._maybe_rebind()
-        return super()._register_kv_args()
 
 
 def install_snapshot_nixl() -> None:
-    """Register snapshot NIXL classes with SGLang's ``get_kv_class``."""
-
     from sglang.srt.disaggregation import utils as disagg_utils
     from sglang.srt.disaggregation.utils import KVClassType, TransferBackend
 
@@ -107,14 +77,12 @@ def install_snapshot_nixl() -> None:
 
     def get_kv_class(transfer_backend: Any, class_type: Any) -> Any:
         cls = original(transfer_backend, class_type)
-        if transfer_backend != TransferBackend.NIXL:
-            return cls
-        if class_type == KVClassType.MANAGER:
+        if (
+            transfer_backend == TransferBackend.NIXL
+            and class_type == KVClassType.MANAGER
+        ):
             return SnapshotNixlKVManager
-        if class_type == KVClassType.RECEIVER:
-            return SnapshotNixlKVReceiver
         return cls
 
     get_kv_class._dyn_snapshot_nixl = True  # type: ignore[attr-defined]
     disagg_utils.get_kv_class = get_kv_class
-    logger.info("Installed snapshot SGLang NIXL manager/receiver")

--- a/components/src/dynamo/sglang/snapshot_nixl.py
+++ b/components/src/dynamo/sglang/snapshot_nixl.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Snapshot-aware SGLang NIXL manager.
+
+SGLang has no connector module-path factory. Snapshot mode wraps
+``get_kv_class`` so capture constructs this manager, and spawned children pick
+up the wrap via ``dynamo_snapshot.pth``. After restore, a new NIXL agent name
+is required: live prefill ignores a repeat ``agent_name``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from dynamo.common.snapshot.restore_context import (
+    load_restore_identity,
+    should_rebind_pd,
+)
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager, NixlKVReceiver
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.environ import envs
+from sglang.srt.utils.network import get_zmq_socket_on_host
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotNixlKVManager(NixlKVManager):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._bound_incarnation_id: str | None = None
+
+    def _add_remote_peer(self, decode_kv_args: Any) -> None:
+        self._maybe_rebind()
+        super()._add_remote_peer(decode_kv_args)
+
+    def _maybe_rebind(self) -> None:
+        identity = load_restore_identity()
+        if not should_rebind_pd(self._bound_incarnation_id, identity):
+            return
+        assert identity is not None
+
+        from nixl._api import nixl_agent, nixl_agent_config
+
+        backend = envs.SGLANG_DISAGGREGATION_NIXL_BACKEND.get()
+        agent_config = nixl_agent_config(
+            backends=[backend],
+            num_threads=(
+                8 if self.disaggregation_mode == DisaggregationMode.PREFILL else 0
+            ),
+        )
+        new_name = str(uuid.uuid4())
+        logger.info(
+            "Rebinding SGLang NIXL after snapshot restore incarnation_id=%s "
+            "agent_name=%s",
+            identity.incarnation_id,
+            new_name,
+        )
+        self.agent = nixl_agent(new_name, agent_config)
+        if identity.pod_ip and identity.pod_ip != self.local_ip:
+            self._rebind_zmq(identity.pod_ip)
+        elif identity.pod_ip:
+            self.local_ip = identity.pod_ip
+        self.register_buffer_to_engine()
+        self._bound_incarnation_id = identity.incarnation_id
+
+    def _rebind_zmq(self, new_ip: str) -> None:
+        import zmq
+
+        try:
+            self.server_socket.close(linger=0)
+        except Exception:
+            logger.exception("Failed to close restored SGLang NIXL ZMQ socket")
+        self.local_ip = new_ip
+        context = zmq.Context()
+        self.rank_port, self.server_socket = get_zmq_socket_on_host(
+            context, zmq.PULL, host=self.local_ip
+        )
+        logger.info(
+            "Rebound SGLang NIXL ZMQ listener to %s:%s",
+            self.local_ip,
+            self.rank_port,
+        )
+
+
+class SnapshotNixlKVReceiver(NixlKVReceiver):
+    def send_metadata(self, *args: Any, **kwargs: Any) -> None:
+        self.kv_mgr._maybe_rebind()
+        return super().send_metadata(*args, **kwargs)
+
+    def _register_kv_args(self) -> None:
+        self.kv_mgr._maybe_rebind()
+        return super()._register_kv_args()
+
+
+def install_snapshot_nixl() -> None:
+    """Register snapshot NIXL classes with SGLang's ``get_kv_class``."""
+
+    from sglang.srt.disaggregation import utils as disagg_utils
+    from sglang.srt.disaggregation.utils import KVClassType, TransferBackend
+
+    original = disagg_utils.get_kv_class
+    if getattr(original, "_dyn_snapshot_nixl", False):
+        return
+
+    def get_kv_class(transfer_backend: Any, class_type: Any) -> Any:
+        cls = original(transfer_backend, class_type)
+        if transfer_backend != TransferBackend.NIXL:
+            return cls
+        if class_type == KVClassType.MANAGER:
+            return SnapshotNixlKVManager
+        if class_type == KVClassType.RECEIVER:
+            return SnapshotNixlKVReceiver
+        return cls
+
+    get_kv_class._dyn_snapshot_nixl = True  # type: ignore[attr-defined]
+    disagg_utils.get_kv_class = get_kv_class
+    logger.info("Installed snapshot SGLang NIXL manager/receiver")

--- a/components/src/dynamo/sglang/tests/test_sglang_snapshot_nixl.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_snapshot_nixl.py
@@ -11,12 +11,7 @@ from sglang.srt.disaggregation.utils import (
     TransferBackend,
 )
 
-from dynamo.common.snapshot.restore_context import RestoreIdentity
-from dynamo.sglang.snapshot_nixl import (
-    SnapshotNixlKVManager,
-    SnapshotNixlKVReceiver,
-    install_snapshot_nixl,
-)
+from dynamo.sglang.snapshot_nixl import SnapshotNixlKVManager, install_snapshot_nixl
 
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
@@ -25,11 +20,8 @@ class _DummyAgent:
     def __init__(self, name):
         self.name = name
 
-    def get_agent_metadata(self):
-        return f"meta-{self.name}".encode()
 
-
-def test_install_snapshot_nixl_returns_snapshot_classes():
+def test_install_snapshot_nixl_returns_manager():
     install_snapshot_nixl()
     from sglang.srt.disaggregation import utils as disagg_utils
 
@@ -37,15 +29,11 @@ def test_install_snapshot_nixl_returns_snapshot_classes():
         disagg_utils.get_kv_class(TransferBackend.NIXL, KVClassType.MANAGER)
         is SnapshotNixlKVManager
     )
-    assert (
-        disagg_utils.get_kv_class(TransferBackend.NIXL, KVClassType.RECEIVER)
-        is SnapshotNixlKVReceiver
-    )
     install_snapshot_nixl()
     assert getattr(disagg_utils.get_kv_class, "_dyn_snapshot_nixl") is True
 
 
-def test_maybe_rebind_mints_new_agent_name(monkeypatch):
+def test_maybe_rebind_mints_new_agent_name(monkeypatch, tmp_path):
     created = []
 
     def fake_agent(name, _config):
@@ -53,38 +41,31 @@ def test_maybe_rebind_mints_new_agent_name(monkeypatch):
         created.append(agent)
         return agent
 
+    monkeypatch.setenv("DYN_SNAPSHOT_CONTROL_DIR", str(tmp_path))
+    (tmp_path / "restore-context.json").write_text(
+        '{"incarnation_id":"inc-restore","env":{}}\n'
+    )
     monkeypatch.setattr(
         "dynamo.sglang.snapshot_nixl.envs.SGLANG_DISAGGREGATION_NIXL_BACKEND",
         SimpleNamespace(get=lambda: "UCX"),
     )
-    fake_nixl = SimpleNamespace(
-        nixl_agent=fake_agent, nixl_agent_config=lambda **_kw: {}
-    )
-    monkeypatch.setitem(sys.modules, "nixl._api", fake_nixl)
-
-    identity = RestoreIdentity(incarnation_id="inc-restore", env={"POD_IP": "10.0.0.5"})
-    monkeypatch.setattr(
-        "dynamo.sglang.snapshot_nixl.load_restore_identity", lambda: identity
+    monkeypatch.setitem(
+        sys.modules,
+        "nixl._api",
+        SimpleNamespace(nixl_agent=fake_agent, nixl_agent_config=lambda **_kw: {}),
     )
 
     manager = SnapshotNixlKVManager.__new__(SnapshotNixlKVManager)
-    manager.agent = _DummyAgent("old-agent")
-    manager.local_ip = "10.0.0.5"
+    manager._nixl_agent = _DummyAgent("old-agent")
     manager._bound_incarnation_id = None
     manager.registered = False
     manager.disaggregation_mode = DisaggregationMode.DECODE
-
-    def register():
-        manager.registered = True
-
-    manager.register_buffer_to_engine = register
+    manager.register_buffer_to_engine = lambda: setattr(manager, "registered", True)
 
     SnapshotNixlKVManager._maybe_rebind(manager)
 
     assert manager.registered is True
     assert manager.agent.name != "old-agent"
     assert manager._bound_incarnation_id == "inc-restore"
-    assert created and created[0].name == manager.agent.name
-
     SnapshotNixlKVManager._maybe_rebind(manager)
     assert len(created) == 1

--- a/components/src/dynamo/sglang/tests/test_sglang_snapshot_nixl.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_snapshot_nixl.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+from sglang.srt.disaggregation.utils import (
+    DisaggregationMode,
+    KVClassType,
+    TransferBackend,
+)
+
+from dynamo.common.snapshot.restore_context import RestoreIdentity
+from dynamo.sglang.snapshot_nixl import (
+    SnapshotNixlKVManager,
+    SnapshotNixlKVReceiver,
+    install_snapshot_nixl,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+
+
+class _DummyAgent:
+    def __init__(self, name):
+        self.name = name
+
+    def get_agent_metadata(self):
+        return f"meta-{self.name}".encode()
+
+
+def test_install_snapshot_nixl_returns_snapshot_classes():
+    install_snapshot_nixl()
+    from sglang.srt.disaggregation import utils as disagg_utils
+
+    assert (
+        disagg_utils.get_kv_class(TransferBackend.NIXL, KVClassType.MANAGER)
+        is SnapshotNixlKVManager
+    )
+    assert (
+        disagg_utils.get_kv_class(TransferBackend.NIXL, KVClassType.RECEIVER)
+        is SnapshotNixlKVReceiver
+    )
+    install_snapshot_nixl()
+    assert getattr(disagg_utils.get_kv_class, "_dyn_snapshot_nixl") is True
+
+
+def test_maybe_rebind_mints_new_agent_name(monkeypatch):
+    created = []
+
+    def fake_agent(name, _config):
+        agent = _DummyAgent(name)
+        created.append(agent)
+        return agent
+
+    monkeypatch.setattr(
+        "dynamo.sglang.snapshot_nixl.envs.SGLANG_DISAGGREGATION_NIXL_BACKEND",
+        SimpleNamespace(get=lambda: "UCX"),
+    )
+    fake_nixl = SimpleNamespace(
+        nixl_agent=fake_agent, nixl_agent_config=lambda **_kw: {}
+    )
+    monkeypatch.setitem(sys.modules, "nixl._api", fake_nixl)
+
+    identity = RestoreIdentity(incarnation_id="inc-restore", env={"POD_IP": "10.0.0.5"})
+    monkeypatch.setattr(
+        "dynamo.sglang.snapshot_nixl.load_restore_identity", lambda: identity
+    )
+
+    manager = SnapshotNixlKVManager.__new__(SnapshotNixlKVManager)
+    manager.agent = _DummyAgent("old-agent")
+    manager.local_ip = "10.0.0.5"
+    manager._bound_incarnation_id = None
+    manager.registered = False
+    manager.disaggregation_mode = DisaggregationMode.DECODE
+
+    def register():
+        manager.registered = True
+
+    manager.register_buffer_to_engine = register
+
+    SnapshotNixlKVManager._maybe_rebind(manager)
+
+    assert manager.registered is True
+    assert manager.agent.name != "old-agent"
+    assert manager._bound_incarnation_id == "inc-restore"
+    assert created and created[0].name == manager.agent.name
+
+    SnapshotNixlKVManager._maybe_rebind(manager)
+    assert len(created) == 1

--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -37,6 +37,9 @@ async def prepare_snapshot_engine(
     configure_snapshot_capture_env()
     logger.info("Snapshot mode enabled (watcher-driven signals)")
     config.engine_args.enable_sleep_mode = True
+    from .snapshot_nixl import configure_snapshot_nixl_connector
+
+    configure_snapshot_nixl_connector(config.engine_args.kv_transfer_config)
 
     engine = setup_vllm_engine(config)
     gc.collect()
@@ -49,5 +52,11 @@ async def prepare_snapshot_engine(
     if not await snapshot_controller.wait_for_restore():
         logger.info("vLLM snapshot captured successfully")
         os._exit(0)
+
+    from .args import _uses_nixl_connector
+    from .snapshot_nixl import rebind_vllm_nixl_after_restore
+
+    if _uses_nixl_connector(config.engine_args):
+        await rebind_vllm_nixl_after_restore(engine[0])
 
     return snapshot_controller

--- a/components/src/dynamo/vllm/snapshot_nixl.py
+++ b/components/src/dynamo/vllm/snapshot_nixl.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Snapshot-aware vLLM NIXL connector loaded via ``kv_connector_module_path``.
+
+CRIU cannot restore IB/UCX QPs. After restore, live prefill still caches the
+old ``engine_id``. This connector shuts down the restored NIXL agent and side
+channel, mints ``engine_id`` from the restore ``incarnation_id``, re-registers
+KV tensors, and republishes handshake metadata so prefill treats decode as new.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+import time
+from pathlib import Path
+from typing import Any
+
+from dynamo.common.snapshot.constants import (
+    SNAPSHOT_CONTROL_DIR,
+    SNAPSHOT_CONTROL_DIR_ENV,
+)
+from dynamo.common.snapshot.restore_context import (
+    RestoreIdentity,
+    load_restore_identity,
+    should_rebind_pd,
+)
+
+logger = logging.getLogger(__name__)
+
+SNAPSHOT_NIXL_MODULE = "dynamo.vllm.snapshot_nixl"
+NIXL_CONNECTOR_NAMES = frozenset(
+    {"NixlConnector", "NixlPullConnector", "NixlPushConnector"}
+)
+MULTI_CONNECTOR_NAMES = frozenset({"MultiConnector", "PdConnector"})
+_HANDSHAKE_DIR = "nixl-handshake"
+_HANDSHAKE_WAIT_SEC = 30.0
+_HANDSHAKE_POLL_SEC = 0.05
+
+
+def configure_snapshot_nixl_connector(kv_cfg: Any) -> bool:
+    """Point NixlConnector entries at this module. Keep the public class name."""
+
+    if kv_cfg is None:
+        return False
+    rewritten = False
+    connector_name = getattr(kv_cfg, "kv_connector", None)
+    if connector_name in NIXL_CONNECTOR_NAMES:
+        kv_cfg.kv_connector_module_path = SNAPSHOT_NIXL_MODULE
+        rewritten = True
+    elif connector_name in MULTI_CONNECTOR_NAMES:
+        extra = getattr(kv_cfg, "kv_connector_extra_config", None) or {}
+        for entry in extra.get("connectors", []):
+            if (
+                isinstance(entry, dict)
+                and entry.get("kv_connector") in NIXL_CONNECTOR_NAMES
+            ):
+                entry["kv_connector_module_path"] = SNAPSHOT_NIXL_MODULE
+                rewritten = True
+    if rewritten:
+        logger.info(
+            "Snapshot mode: loading NIXL connector from %s", SNAPSHOT_NIXL_MODULE
+        )
+    return rewritten
+
+
+def engine_id_for_restore(old_engine_id: str | None, incarnation_id: str) -> str:
+    """Keep a trailing ``_dpN`` suffix so data-parallel ranks stay distinct."""
+
+    if old_engine_id and "_dp" in old_engine_id:
+        suffix = old_engine_id[old_engine_id.rfind("_dp") :]
+        return f"{incarnation_id}{suffix}"
+    return incarnation_id
+
+
+def handshake_path(
+    incarnation_id: str,
+    pp_rank: int,
+    tp_rank: int,
+    control_dir: str | None = None,
+) -> Path:
+    root = control_dir or os.environ.get(SNAPSHOT_CONTROL_DIR_ENV, SNAPSHOT_CONTROL_DIR)
+    return Path(root) / _HANDSHAKE_DIR / incarnation_id / f"{pp_rank}-{tp_rank}.msgpack"
+
+
+def write_handshake_metadata(
+    incarnation_id: str,
+    pp_rank: int,
+    tp_rank: int,
+    metadata: object,
+    control_dir: str | None = None,
+) -> Path:
+    path = handshake_path(incarnation_id, pp_rank, tp_rank, control_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.tmp")
+    tmp_path.write_bytes(pickle.dumps(metadata))
+    tmp_path.replace(path)
+    return path
+
+
+def read_handshake_metadata(
+    incarnation_id: str,
+    pp_size: int,
+    tp_size: int,
+    control_dir: str | None = None,
+    timeout: float = _HANDSHAKE_WAIT_SEC,
+) -> dict[tuple[int, int], object]:
+    expected = {(pp, tp) for pp in range(pp_size) for tp in range(tp_size)}
+    deadline = time.monotonic() + timeout
+    while True:
+        found: dict[tuple[int, int], object] = {}
+        for key in expected:
+            path = handshake_path(incarnation_id, key[0], key[1], control_dir)
+            if path.is_file():
+                found[key] = pickle.loads(path.read_bytes())
+        if found.keys() == expected:
+            return found
+        if time.monotonic() >= deadline:
+            missing = expected - found.keys()
+            raise RuntimeError(
+                "timed out waiting for NIXL handshake metadata after snapshot "
+                f"restore; missing ranks {sorted(missing)}"
+            )
+        time.sleep(_HANDSHAKE_POLL_SEC)
+
+
+def apply_restore_side_channel_host(identity: RestoreIdentity) -> None:
+    host = identity.side_channel_host
+    if host:
+        os.environ["VLLM_NIXL_SIDE_CHANNEL_HOST"] = host
+
+
+class SnapshotNixlMixin:
+    """Rebuild the NIXL worker/scheduler after CRIU restore."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._bound_incarnation_id: str | None = None
+        self._registered_kv_caches: dict[str, Any] | None = None
+        self._registered_cross_layer_kv: tuple[Any, Any] | None = None
+
+    def register_kv_caches(self, kv_caches: dict[str, Any]) -> None:
+        self._registered_kv_caches = kv_caches
+        super().register_kv_caches(kv_caches)  # type: ignore[misc]
+
+    def register_cross_layers_kv_cache(self, kv_cache: Any, attn_backend: Any) -> None:
+        self._registered_cross_layer_kv = (kv_cache, attn_backend)
+        super().register_cross_layers_kv_cache(kv_cache, attn_backend)  # type: ignore[misc]
+
+    def get_handshake_metadata(self) -> Any:
+        self._maybe_rebind()
+        return super().get_handshake_metadata()  # type: ignore[misc]
+
+    def reset_cache(self) -> bool | None:
+        self._maybe_rebind()
+        result = super().reset_cache()  # type: ignore[misc]
+        return True if result is None else result
+
+    def start_load_kv(self, *args: Any, **kwargs: Any) -> None:
+        self._maybe_rebind()
+        return super().start_load_kv(*args, **kwargs)  # type: ignore[misc]
+
+    def build_connector_meta(self, scheduler_output: Any) -> Any:
+        self._maybe_rebind()
+        return super().build_connector_meta(scheduler_output)  # type: ignore[misc]
+
+    def _maybe_rebind(self) -> None:
+        identity = load_restore_identity()
+        if not should_rebind_pd(self._bound_incarnation_id, identity):
+            return
+        assert identity is not None
+        logger.info(
+            "Rebinding vLLM NIXL after snapshot restore incarnation_id=%s",
+            identity.incarnation_id,
+        )
+        apply_restore_side_channel_host(identity)
+        new_engine_id = engine_id_for_restore(self.engine_id, identity.incarnation_id)
+        self._vllm_config.kv_transfer_config.engine_id = new_engine_id
+        if self.connector_worker is not None:
+            self._rebind_worker(identity, new_engine_id)
+        if self.connector_scheduler is not None:
+            self._rebind_scheduler(identity, new_engine_id)
+        self.engine_id = new_engine_id
+        self._bound_incarnation_id = identity.incarnation_id
+
+    def _rebind_worker(self, identity: RestoreIdentity, new_engine_id: str) -> None:
+        worker_cls = type(self.connector_worker)
+        self.shutdown()
+        self.connector_worker = worker_cls(
+            self._vllm_config, new_engine_id, self.kv_cache_config
+        )
+        if self._registered_kv_caches is not None:
+            self.connector_worker.register_kv_caches(self._registered_kv_caches)
+        if self._registered_cross_layer_kv is not None:
+            kv_cache, _attn_backend = self._registered_cross_layer_kv
+            self.connector_worker.register_cross_layers_kv_caches(kv_cache)
+        metadata = self.connector_worker.xfer_handshake_metadata
+        pp_rank, tp_rank = _local_rank_key(self)
+        write_handshake_metadata(identity.incarnation_id, pp_rank, tp_rank, metadata)
+        logger.info(
+            "Wrote NIXL handshake metadata incarnation_id=%s pp=%s tp=%s engine_id=%s",
+            identity.incarnation_id,
+            pp_rank,
+            tp_rank,
+            new_engine_id,
+        )
+
+    def _rebind_scheduler(self, identity: RestoreIdentity, new_engine_id: str) -> None:
+        scheduler_cls = type(self.connector_scheduler)
+        self.shutdown()
+        self.connector_scheduler = scheduler_cls(
+            self._vllm_config, new_engine_id, self.kv_cache_config
+        )
+        parallel = self._vllm_config.parallel_config
+        metadata = read_handshake_metadata(
+            identity.incarnation_id,
+            getattr(parallel, "pipeline_parallel_size", 1) or 1,
+            getattr(parallel, "tensor_parallel_size", 1) or 1,
+        )
+        self.connector_scheduler.set_xfer_handshake_metadata(metadata)
+        logger.info(
+            "Scheduler NIXL listener rebound incarnation_id=%s engine_id=%s host=%s",
+            identity.incarnation_id,
+            new_engine_id,
+            identity.side_channel_host,
+        )
+
+
+def _local_rank_key(connector: Any) -> tuple[int, int]:
+    worker = getattr(connector, "connector_worker", None)
+    tp_rank = getattr(worker, "tp_rank", None)
+    if tp_rank is None:
+        tp_rank = getattr(connector._vllm_config.parallel_config, "rank", 0) or 0
+    try:
+        from vllm.distributed.parallel_state import get_pp_group
+
+        pp_rank = get_pp_group().rank_in_group
+    except Exception:
+        pp_rank = (
+            getattr(connector._vllm_config.parallel_config, "pipeline_parallel_rank", 0)
+            or 0
+        )
+    return int(pp_rank), int(tp_rank)
+
+
+def __getattr__(name: str) -> Any:
+    # vLLM's factory does getattr(module, kv_connector). Keep the stock names
+    # and import the bases only when the engine actually constructs them.
+    if name not in {
+        "NixlConnector",
+        "NixlPullConnector",
+        "NixlPushConnector",
+        "SnapshotNixlPullConnector",
+        "SnapshotNixlPushConnector",
+    }:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.connector import (
+        NixlPullConnector as _NixlPullConnector,
+        NixlPushConnector as _NixlPushConnector,
+    )
+
+    class SnapshotNixlPullConnector(SnapshotNixlMixin, _NixlPullConnector):
+        pass
+
+    class SnapshotNixlPushConnector(SnapshotNixlMixin, _NixlPushConnector):
+        pass
+
+    exported = {
+        "SnapshotNixlPullConnector": SnapshotNixlPullConnector,
+        "SnapshotNixlPushConnector": SnapshotNixlPushConnector,
+        "NixlPullConnector": SnapshotNixlPullConnector,
+        "NixlPushConnector": SnapshotNixlPushConnector,
+        "NixlConnector": SnapshotNixlPullConnector,
+    }
+    globals().update(exported)
+    return exported[name]
+
+
+async def rebind_vllm_nixl_after_restore(engine: Any) -> None:
+    """Eager worker-then-scheduler rebind after CRIU resume and wake."""
+
+    if not should_rebind_pd(None):
+        return
+    identity = load_restore_identity()
+    assert identity is not None
+    logger.info(
+        "Triggering vLLM NIXL rebind after snapshot restore incarnation_id=%s",
+        identity.incarnation_id,
+    )
+    await engine.collective_rpc("get_kv_connector_handshake_metadata")
+    await engine.reset_prefix_cache(reset_connector=True)

--- a/components/src/dynamo/vllm/snapshot_nixl.py
+++ b/components/src/dynamo/vllm/snapshot_nixl.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Snapshot-aware vLLM NIXL connector loaded via ``kv_connector_module_path``.
+"""Snapshot NIXL connector for vLLM, loaded via ``kv_connector_module_path``.
 
-CRIU cannot restore IB/UCX QPs. After restore, live prefill still caches the
-old ``engine_id``. This connector shuts down the restored NIXL agent and side
-channel, mints ``engine_id`` from the restore ``incarnation_id``, re-registers
-KV tensors, and republishes handshake metadata so prefill treats decode as new.
+After restore, workers rebuild the NIXL agent and write handshake metadata under
+the snapshot-control dir. The scheduler then shuts down the old side channel
+and serves those new blobs. Prefill keys peers by ``engine_id``, so the
+incarnation becomes the new id.
 """
 
 from __future__ import annotations
@@ -14,7 +14,6 @@ from __future__ import annotations
 import logging
 import os
 import pickle
-import time
 from pathlib import Path
 from typing import Any
 
@@ -23,66 +22,34 @@ from dynamo.common.snapshot.constants import (
     SNAPSHOT_CONTROL_DIR_ENV,
 )
 from dynamo.common.snapshot.restore_context import (
-    RestoreIdentity,
-    load_restore_identity,
+    apply_snapshot_restore_env,
+    load_restore_incarnation_id,
     should_rebind_pd,
 )
 
 logger = logging.getLogger(__name__)
 
 SNAPSHOT_NIXL_MODULE = "dynamo.vllm.snapshot_nixl"
-NIXL_CONNECTOR_NAMES = frozenset(
-    {"NixlConnector", "NixlPullConnector", "NixlPushConnector"}
-)
-MULTI_CONNECTOR_NAMES = frozenset({"MultiConnector", "PdConnector"})
-_HANDSHAKE_DIR = "nixl-handshake"
-_HANDSHAKE_WAIT_SEC = 30.0
-_HANDSHAKE_POLL_SEC = 0.05
+_NIXL_NAMES = frozenset({"NixlConnector", "NixlPullConnector", "NixlPushConnector"})
+_WRAPPER_NAMES = frozenset({"MultiConnector", "PdConnector"})
 
 
-def configure_snapshot_nixl_connector(kv_cfg: Any) -> bool:
+def configure_snapshot_nixl_connector(kv_cfg: Any) -> None:
     """Point NixlConnector entries at this module. Keep the public class name."""
 
     if kv_cfg is None:
-        return False
-    rewritten = False
-    connector_name = getattr(kv_cfg, "kv_connector", None)
-    if connector_name in NIXL_CONNECTOR_NAMES:
+        return
+    if kv_cfg.kv_connector in _NIXL_NAMES:
         kv_cfg.kv_connector_module_path = SNAPSHOT_NIXL_MODULE
-        rewritten = True
-    elif connector_name in MULTI_CONNECTOR_NAMES:
-        extra = getattr(kv_cfg, "kv_connector_extra_config", None) or {}
-        for entry in extra.get("connectors", []):
-            if (
-                isinstance(entry, dict)
-                and entry.get("kv_connector") in NIXL_CONNECTOR_NAMES
-            ):
+    elif kv_cfg.kv_connector in _WRAPPER_NAMES:
+        for entry in (kv_cfg.kv_connector_extra_config or {}).get("connectors", []):
+            if isinstance(entry, dict) and entry.get("kv_connector") in _NIXL_NAMES:
                 entry["kv_connector_module_path"] = SNAPSHOT_NIXL_MODULE
-                rewritten = True
-    if rewritten:
-        logger.info(
-            "Snapshot mode: loading NIXL connector from %s", SNAPSHOT_NIXL_MODULE
-        )
-    return rewritten
 
 
-def engine_id_for_restore(old_engine_id: str | None, incarnation_id: str) -> str:
-    """Keep a trailing ``_dpN`` suffix so data-parallel ranks stay distinct."""
-
-    if old_engine_id and "_dp" in old_engine_id:
-        suffix = old_engine_id[old_engine_id.rfind("_dp") :]
-        return f"{incarnation_id}{suffix}"
-    return incarnation_id
-
-
-def handshake_path(
-    incarnation_id: str,
-    pp_rank: int,
-    tp_rank: int,
-    control_dir: str | None = None,
-) -> Path:
+def _handshake_dir(incarnation_id: str, control_dir: str | None = None) -> Path:
     root = control_dir or os.environ.get(SNAPSHOT_CONTROL_DIR_ENV, SNAPSHOT_CONTROL_DIR)
-    return Path(root) / _HANDSHAKE_DIR / incarnation_id / f"{pp_rank}-{tp_rank}.msgpack"
+    return Path(root) / "nixl-handshake" / incarnation_id
 
 
 def write_handshake_metadata(
@@ -91,63 +58,42 @@ def write_handshake_metadata(
     tp_rank: int,
     metadata: object,
     control_dir: str | None = None,
-) -> Path:
-    path = handshake_path(incarnation_id, pp_rank, tp_rank, control_dir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_name(f".{path.name}.tmp")
-    tmp_path.write_bytes(pickle.dumps(metadata))
-    tmp_path.replace(path)
-    return path
+) -> None:
+    directory = _handshake_dir(incarnation_id, control_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{pp_rank}-{tp_rank}"
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_bytes(pickle.dumps(metadata))
+    tmp.replace(path)
 
 
 def read_handshake_metadata(
-    incarnation_id: str,
-    pp_size: int,
-    tp_size: int,
-    control_dir: str | None = None,
-    timeout: float = _HANDSHAKE_WAIT_SEC,
+    incarnation_id: str, control_dir: str | None = None
 ) -> dict[tuple[int, int], object]:
-    expected = {(pp, tp) for pp in range(pp_size) for tp in range(tp_size)}
-    deadline = time.monotonic() + timeout
-    while True:
-        found: dict[tuple[int, int], object] = {}
-        for key in expected:
-            path = handshake_path(incarnation_id, key[0], key[1], control_dir)
-            if path.is_file():
-                found[key] = pickle.loads(path.read_bytes())
-        if found.keys() == expected:
-            return found
-        if time.monotonic() >= deadline:
-            missing = expected - found.keys()
-            raise RuntimeError(
-                "timed out waiting for NIXL handshake metadata after snapshot "
-                f"restore; missing ranks {sorted(missing)}"
-            )
-        time.sleep(_HANDSHAKE_POLL_SEC)
-
-
-def apply_restore_side_channel_host(identity: RestoreIdentity) -> None:
-    host = identity.side_channel_host
-    if host:
-        os.environ["VLLM_NIXL_SIDE_CHANNEL_HOST"] = host
+    directory = _handshake_dir(incarnation_id, control_dir)
+    found = {
+        tuple(int(part) for part in path.name.split("-")): pickle.loads(
+            path.read_bytes()
+        )
+        for path in directory.glob("*-*")
+        if path.is_file()
+    }
+    if not found:
+        raise RuntimeError(
+            f"no NIXL handshake metadata for incarnation {incarnation_id}"
+        )
+    return found  # type: ignore[return-value]
 
 
 class SnapshotNixlMixin:
-    """Rebuild the NIXL worker/scheduler after CRIU restore."""
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._bound_incarnation_id: str | None = None
-        self._registered_kv_caches: dict[str, Any] | None = None
-        self._registered_cross_layer_kv: tuple[Any, Any] | None = None
+        self._kv_caches: dict[str, Any] | None = None
 
     def register_kv_caches(self, kv_caches: dict[str, Any]) -> None:
-        self._registered_kv_caches = kv_caches
+        self._kv_caches = kv_caches
         super().register_kv_caches(kv_caches)  # type: ignore[misc]
-
-    def register_cross_layers_kv_cache(self, kv_cache: Any, attn_backend: Any) -> None:
-        self._registered_cross_layer_kv = (kv_cache, attn_backend)
-        super().register_cross_layers_kv_cache(kv_cache, attn_backend)  # type: ignore[misc]
 
     def get_handshake_metadata(self) -> Any:
         self._maybe_rebind()
@@ -158,137 +104,73 @@ class SnapshotNixlMixin:
         result = super().reset_cache()  # type: ignore[misc]
         return True if result is None else result
 
-    def start_load_kv(self, *args: Any, **kwargs: Any) -> None:
-        self._maybe_rebind()
-        return super().start_load_kv(*args, **kwargs)  # type: ignore[misc]
-
-    def build_connector_meta(self, scheduler_output: Any) -> Any:
-        self._maybe_rebind()
-        return super().build_connector_meta(scheduler_output)  # type: ignore[misc]
-
     def _maybe_rebind(self) -> None:
-        identity = load_restore_identity()
-        if not should_rebind_pd(self._bound_incarnation_id, identity):
+        if not should_rebind_pd(self._bound_incarnation_id):
             return
-        assert identity is not None
+        incarnation_id = load_restore_incarnation_id()
+        assert incarnation_id is not None
+        apply_snapshot_restore_env()
+        dp = getattr(self._vllm_config.parallel_config, "data_parallel_index", 0) or 0
+        engine_id = f"{incarnation_id}_dp{dp}"
+        self._vllm_config.kv_transfer_config.engine_id = engine_id
         logger.info(
-            "Rebinding vLLM NIXL after snapshot restore incarnation_id=%s",
-            identity.incarnation_id,
+            "Rebinding vLLM NIXL incarnation_id=%s engine_id=%s",
+            incarnation_id,
+            engine_id,
         )
-        apply_restore_side_channel_host(identity)
-        new_engine_id = engine_id_for_restore(self.engine_id, identity.incarnation_id)
-        self._vllm_config.kv_transfer_config.engine_id = new_engine_id
         if self.connector_worker is not None:
-            self._rebind_worker(identity, new_engine_id)
+            worker_cls = type(self.connector_worker)
+            self.shutdown()
+            self.connector_worker = worker_cls(
+                self._vllm_config, engine_id, self.kv_cache_config
+            )
+            if self._kv_caches is not None:
+                self.connector_worker.register_kv_caches(self._kv_caches)
+            tp = getattr(self.connector_worker, "tp_rank", 0) or 0
+            write_handshake_metadata(
+                incarnation_id,
+                0,
+                int(tp),
+                self.connector_worker.xfer_handshake_metadata,
+            )
         if self.connector_scheduler is not None:
-            self._rebind_scheduler(identity, new_engine_id)
-        self.engine_id = new_engine_id
-        self._bound_incarnation_id = identity.incarnation_id
-
-    def _rebind_worker(self, identity: RestoreIdentity, new_engine_id: str) -> None:
-        worker_cls = type(self.connector_worker)
-        self.shutdown()
-        self.connector_worker = worker_cls(
-            self._vllm_config, new_engine_id, self.kv_cache_config
-        )
-        if self._registered_kv_caches is not None:
-            self.connector_worker.register_kv_caches(self._registered_kv_caches)
-        if self._registered_cross_layer_kv is not None:
-            kv_cache, _attn_backend = self._registered_cross_layer_kv
-            self.connector_worker.register_cross_layers_kv_caches(kv_cache)
-        metadata = self.connector_worker.xfer_handshake_metadata
-        pp_rank, tp_rank = _local_rank_key(self)
-        write_handshake_metadata(identity.incarnation_id, pp_rank, tp_rank, metadata)
-        logger.info(
-            "Wrote NIXL handshake metadata incarnation_id=%s pp=%s tp=%s engine_id=%s",
-            identity.incarnation_id,
-            pp_rank,
-            tp_rank,
-            new_engine_id,
-        )
-
-    def _rebind_scheduler(self, identity: RestoreIdentity, new_engine_id: str) -> None:
-        scheduler_cls = type(self.connector_scheduler)
-        self.shutdown()
-        self.connector_scheduler = scheduler_cls(
-            self._vllm_config, new_engine_id, self.kv_cache_config
-        )
-        parallel = self._vllm_config.parallel_config
-        metadata = read_handshake_metadata(
-            identity.incarnation_id,
-            getattr(parallel, "pipeline_parallel_size", 1) or 1,
-            getattr(parallel, "tensor_parallel_size", 1) or 1,
-        )
-        self.connector_scheduler.set_xfer_handshake_metadata(metadata)
-        logger.info(
-            "Scheduler NIXL listener rebound incarnation_id=%s engine_id=%s host=%s",
-            identity.incarnation_id,
-            new_engine_id,
-            identity.side_channel_host,
-        )
-
-
-def _local_rank_key(connector: Any) -> tuple[int, int]:
-    worker = getattr(connector, "connector_worker", None)
-    tp_rank = getattr(worker, "tp_rank", None)
-    if tp_rank is None:
-        tp_rank = getattr(connector._vllm_config.parallel_config, "rank", 0) or 0
-    try:
-        from vllm.distributed.parallel_state import get_pp_group
-
-        pp_rank = get_pp_group().rank_in_group
-    except Exception:
-        pp_rank = (
-            getattr(connector._vllm_config.parallel_config, "pipeline_parallel_rank", 0)
-            or 0
-        )
-    return int(pp_rank), int(tp_rank)
+            scheduler_cls = type(self.connector_scheduler)
+            self.shutdown()
+            self.connector_scheduler = scheduler_cls(
+                self._vllm_config, engine_id, self.kv_cache_config
+            )
+            self.connector_scheduler.set_xfer_handshake_metadata(
+                read_handshake_metadata(incarnation_id)
+            )
+        self.engine_id = engine_id
+        self._bound_incarnation_id = incarnation_id
 
 
 def __getattr__(name: str) -> Any:
-    # vLLM's factory does getattr(module, kv_connector). Keep the stock names
-    # and import the bases only when the engine actually constructs them.
-    if name not in {
-        "NixlConnector",
-        "NixlPullConnector",
-        "NixlPushConnector",
-        "SnapshotNixlPullConnector",
-        "SnapshotNixlPushConnector",
-    }:
+    if name not in {"NixlConnector", "NixlPullConnector", "NixlPushConnector"}:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.connector import (
-        NixlPullConnector as _NixlPullConnector,
-        NixlPushConnector as _NixlPushConnector,
+        NixlPullConnector as _Pull,
+        NixlPushConnector as _Push,
     )
 
-    class SnapshotNixlPullConnector(SnapshotNixlMixin, _NixlPullConnector):
+    class NixlPullConnector(SnapshotNixlMixin, _Pull):
         pass
 
-    class SnapshotNixlPushConnector(SnapshotNixlMixin, _NixlPushConnector):
+    class NixlPushConnector(SnapshotNixlMixin, _Push):
         pass
 
     exported = {
-        "SnapshotNixlPullConnector": SnapshotNixlPullConnector,
-        "SnapshotNixlPushConnector": SnapshotNixlPushConnector,
-        "NixlPullConnector": SnapshotNixlPullConnector,
-        "NixlPushConnector": SnapshotNixlPushConnector,
-        "NixlConnector": SnapshotNixlPullConnector,
+        "NixlPullConnector": NixlPullConnector,
+        "NixlPushConnector": NixlPushConnector,
+        "NixlConnector": NixlPullConnector,
     }
     globals().update(exported)
     return exported[name]
 
 
 async def rebind_vllm_nixl_after_restore(engine: Any) -> None:
-    """Eager worker-then-scheduler rebind after CRIU resume and wake."""
-
     if not should_rebind_pd(None):
         return
-    identity = load_restore_identity()
-    assert identity is not None
-    logger.info(
-        "Triggering vLLM NIXL rebind after snapshot restore incarnation_id=%s",
-        identity.incarnation_id,
-    )
     await engine.collective_rpc("get_kv_connector_handshake_metadata")
     await engine.reset_prefix_cache(reset_connector=True)

--- a/components/src/dynamo/vllm/tests/test_vllm_snapshot_nixl.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_snapshot_nixl.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.common.snapshot.constants import SNAPSHOT_CONTROL_DIR_ENV
+from dynamo.common.snapshot.restore_context import RestoreIdentity
+from dynamo.vllm.snapshot_nixl import (
+    SNAPSHOT_NIXL_MODULE,
+    SnapshotNixlMixin,
+    configure_snapshot_nixl_connector,
+    engine_id_for_restore,
+    read_handshake_metadata,
+    write_handshake_metadata,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+
+
+def test_configure_snapshot_nixl_connector_direct():
+    kv_cfg = SimpleNamespace(
+        kv_connector="NixlConnector", kv_connector_module_path=None
+    )
+    assert configure_snapshot_nixl_connector(kv_cfg) is True
+    assert kv_cfg.kv_connector == "NixlConnector"
+    assert kv_cfg.kv_connector_module_path == SNAPSHOT_NIXL_MODULE
+
+
+def test_configure_snapshot_nixl_connector_nested_pd():
+    nixl_child = {"kv_connector": "NixlConnector", "kv_role": "kv_both"}
+    kv_cfg = SimpleNamespace(
+        kv_connector="PdConnector",
+        kv_connector_extra_config={
+            "connectors": [
+                {"kv_connector": "DynamoConnector", "kv_role": "kv_both"},
+                nixl_child,
+            ]
+        },
+    )
+    assert configure_snapshot_nixl_connector(kv_cfg) is True
+    assert nixl_child["kv_connector_module_path"] == SNAPSHOT_NIXL_MODULE
+    assert (
+        "kv_connector_module_path"
+        not in kv_cfg.kv_connector_extra_config["connectors"][0]
+    )
+
+
+def test_engine_id_for_restore_preserves_dp_suffix():
+    assert engine_id_for_restore("old_dp1", "inc-9") == "inc-9_dp1"
+    assert engine_id_for_restore("old", "inc-9") == "inc-9"
+
+
+def test_handshake_round_trip(tmp_path):
+    payload = {"engine_id": "inc-9", "agent": b"new-agent"}
+    write_handshake_metadata("inc-9", 0, 0, payload, control_dir=str(tmp_path))
+    found = read_handshake_metadata(
+        "inc-9", 1, 1, control_dir=str(tmp_path), timeout=0.2
+    )
+    assert found[(0, 0)] == payload
+
+
+class _FakeWorker:
+    tp_rank = 0
+
+    def __init__(self, vllm_config=None, engine_id="old", kv_cache_config=None):
+        self.engine_id = engine_id
+        self.xfer_handshake_metadata = {
+            "engine_id": engine_id,
+            "agent": b"agent-" + engine_id.encode(),
+        }
+        self.registered = None
+
+    def register_kv_caches(self, caches):
+        self.registered = caches
+
+    def register_cross_layers_kv_caches(self, kv_cache):
+        return None
+
+
+class _FakeScheduler:
+    def __init__(self, vllm_config=None, engine_id="old", kv_cache_config=None):
+        self.engine_id = engine_id
+        self.handshake = None
+
+    def set_xfer_handshake_metadata(self, metadata):
+        self.handshake = metadata
+
+
+class _FakeConnector(SnapshotNixlMixin):
+    def __init__(self, role):
+        self._bound_incarnation_id = None
+        self._registered_kv_caches = {"layer": object()}
+        self._registered_cross_layer_kv = None
+        self.engine_id = "old-engine_dp0"
+        self.connector_worker = _FakeWorker() if role == "worker" else None
+        self.connector_scheduler = _FakeScheduler() if role == "scheduler" else None
+        self.kv_cache_config = object()
+        self.shut_down = False
+        self._vllm_config = SimpleNamespace(
+            kv_transfer_config=SimpleNamespace(engine_id="old-engine_dp0"),
+            parallel_config=SimpleNamespace(
+                pipeline_parallel_size=1,
+                tensor_parallel_size=1,
+                rank=0,
+                pipeline_parallel_rank=0,
+            ),
+        )
+
+    def shutdown(self):
+        self.shut_down = True
+
+
+def test_worker_rebind_changes_engine_id_and_handshake(monkeypatch, tmp_path):
+    monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
+    identity = RestoreIdentity(
+        incarnation_id="inc-restore",
+        env={"POD_IP": "10.0.0.5", "VLLM_NIXL_SIDE_CHANNEL_HOST": "10.0.0.5"},
+    )
+    connector = _FakeConnector("worker")
+    monkeypatch.setattr(
+        "dynamo.vllm.snapshot_nixl.load_restore_identity", lambda: identity
+    )
+
+    SnapshotNixlMixin._maybe_rebind(connector)
+
+    assert connector.shut_down is True
+    assert connector.engine_id == "inc-restore_dp0"
+    assert connector.connector_worker.engine_id == "inc-restore_dp0"
+    assert connector.connector_worker.registered is connector._registered_kv_caches
+    assert os.environ["VLLM_NIXL_SIDE_CHANNEL_HOST"] == "10.0.0.5"
+    found = read_handshake_metadata(
+        "inc-restore", 1, 1, control_dir=str(tmp_path), timeout=0.2
+    )
+    assert found[(0, 0)]["engine_id"] == "inc-restore_dp0"
+
+    SnapshotNixlMixin._maybe_rebind(connector)
+    assert connector._bound_incarnation_id == "inc-restore"
+
+
+def test_scheduler_rebind_reads_handshake_and_restarts_listener(monkeypatch, tmp_path):
+    monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
+    identity = RestoreIdentity(incarnation_id="inc-restore", env={"POD_IP": "10.0.0.5"})
+    write_handshake_metadata(
+        "inc-restore",
+        0,
+        0,
+        {"engine_id": "inc-restore", "agent": b"new-agent"},
+        control_dir=str(tmp_path),
+    )
+    connector = _FakeConnector("scheduler")
+    monkeypatch.setattr(
+        "dynamo.vllm.snapshot_nixl.load_restore_identity", lambda: identity
+    )
+
+    SnapshotNixlMixin._maybe_rebind(connector)
+
+    assert connector.shut_down is True
+    assert connector.engine_id == "inc-restore_dp0"
+    assert connector.connector_scheduler.handshake[(0, 0)]["engine_id"] == "inc-restore"

--- a/components/src/dynamo/vllm/tests/test_vllm_snapshot_nixl.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_snapshot_nixl.py
@@ -1,18 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from types import SimpleNamespace
 
 import pytest
 
-from dynamo.common.snapshot.constants import SNAPSHOT_CONTROL_DIR_ENV
-from dynamo.common.snapshot.restore_context import RestoreIdentity
+from dynamo.common.snapshot.constants import (
+    SNAPSHOT_CONTROL_DIR_ENV,
+    SNAPSHOT_RESTORE_CONTEXT_FILE,
+)
 from dynamo.vllm.snapshot_nixl import (
     SNAPSHOT_NIXL_MODULE,
     SnapshotNixlMixin,
     configure_snapshot_nixl_connector,
-    engine_id_for_restore,
     read_handshake_metadata,
     write_handshake_metadata,
 )
@@ -20,46 +20,33 @@ from dynamo.vllm.snapshot_nixl import (
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
 
-def test_configure_snapshot_nixl_connector_direct():
-    kv_cfg = SimpleNamespace(
+def test_configure_snapshot_nixl_connector_direct_and_nested():
+    direct = SimpleNamespace(
         kv_connector="NixlConnector", kv_connector_module_path=None
     )
-    assert configure_snapshot_nixl_connector(kv_cfg) is True
-    assert kv_cfg.kv_connector == "NixlConnector"
-    assert kv_cfg.kv_connector_module_path == SNAPSHOT_NIXL_MODULE
+    configure_snapshot_nixl_connector(direct)
+    assert direct.kv_connector_module_path == SNAPSHOT_NIXL_MODULE
 
-
-def test_configure_snapshot_nixl_connector_nested_pd():
     nixl_child = {"kv_connector": "NixlConnector", "kv_role": "kv_both"}
-    kv_cfg = SimpleNamespace(
+    wrapped = SimpleNamespace(
         kv_connector="PdConnector",
         kv_connector_extra_config={
             "connectors": [
-                {"kv_connector": "DynamoConnector", "kv_role": "kv_both"},
+                {"kv_connector": "DynamoConnector"},
                 nixl_child,
             ]
         },
     )
-    assert configure_snapshot_nixl_connector(kv_cfg) is True
+    configure_snapshot_nixl_connector(wrapped)
     assert nixl_child["kv_connector_module_path"] == SNAPSHOT_NIXL_MODULE
-    assert (
-        "kv_connector_module_path"
-        not in kv_cfg.kv_connector_extra_config["connectors"][0]
-    )
-
-
-def test_engine_id_for_restore_preserves_dp_suffix():
-    assert engine_id_for_restore("old_dp1", "inc-9") == "inc-9_dp1"
-    assert engine_id_for_restore("old", "inc-9") == "inc-9"
 
 
 def test_handshake_round_trip(tmp_path):
     payload = {"engine_id": "inc-9", "agent": b"new-agent"}
     write_handshake_metadata("inc-9", 0, 0, payload, control_dir=str(tmp_path))
-    found = read_handshake_metadata(
-        "inc-9", 1, 1, control_dir=str(tmp_path), timeout=0.2
+    assert (
+        read_handshake_metadata("inc-9", control_dir=str(tmp_path))[(0, 0)] == payload
     )
-    assert found[(0, 0)] == payload
 
 
 class _FakeWorker:
@@ -67,22 +54,15 @@ class _FakeWorker:
 
     def __init__(self, vllm_config=None, engine_id="old", kv_cache_config=None):
         self.engine_id = engine_id
-        self.xfer_handshake_metadata = {
-            "engine_id": engine_id,
-            "agent": b"agent-" + engine_id.encode(),
-        }
+        self.xfer_handshake_metadata = {"engine_id": engine_id, "agent": b"meta"}
         self.registered = None
 
     def register_kv_caches(self, caches):
         self.registered = caches
 
-    def register_cross_layers_kv_caches(self, kv_cache):
-        return None
-
 
 class _FakeScheduler:
     def __init__(self, vllm_config=None, engine_id="old", kv_cache_config=None):
-        self.engine_id = engine_id
         self.handshake = None
 
     def set_xfer_handshake_metadata(self, metadata):
@@ -92,71 +72,57 @@ class _FakeScheduler:
 class _FakeConnector(SnapshotNixlMixin):
     def __init__(self, role):
         self._bound_incarnation_id = None
-        self._registered_kv_caches = {"layer": object()}
-        self._registered_cross_layer_kv = None
-        self.engine_id = "old-engine_dp0"
+        self._kv_caches = {"layer": object()}
+        self.engine_id = "old-engine"
         self.connector_worker = _FakeWorker() if role == "worker" else None
         self.connector_scheduler = _FakeScheduler() if role == "scheduler" else None
         self.kv_cache_config = object()
         self.shut_down = False
         self._vllm_config = SimpleNamespace(
-            kv_transfer_config=SimpleNamespace(engine_id="old-engine_dp0"),
-            parallel_config=SimpleNamespace(
-                pipeline_parallel_size=1,
-                tensor_parallel_size=1,
-                rank=0,
-                pipeline_parallel_rank=0,
-            ),
+            kv_transfer_config=SimpleNamespace(engine_id="old-engine"),
+            parallel_config=SimpleNamespace(data_parallel_index=0),
         )
 
     def shutdown(self):
         self.shut_down = True
 
 
-def test_worker_rebind_changes_engine_id_and_handshake(monkeypatch, tmp_path):
+def test_worker_rebind_writes_new_engine_handshake(monkeypatch, tmp_path):
     monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
-    identity = RestoreIdentity(
-        incarnation_id="inc-restore",
-        env={"POD_IP": "10.0.0.5", "VLLM_NIXL_SIDE_CHANNEL_HOST": "10.0.0.5"},
+    (tmp_path / SNAPSHOT_RESTORE_CONTEXT_FILE).write_text(
+        '{"incarnation_id":"inc-restore","env":{}}\n'
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.snapshot_nixl.apply_snapshot_restore_env", lambda: {}
     )
     connector = _FakeConnector("worker")
-    monkeypatch.setattr(
-        "dynamo.vllm.snapshot_nixl.load_restore_identity", lambda: identity
-    )
-
     SnapshotNixlMixin._maybe_rebind(connector)
 
-    assert connector.shut_down is True
     assert connector.engine_id == "inc-restore_dp0"
-    assert connector.connector_worker.engine_id == "inc-restore_dp0"
-    assert connector.connector_worker.registered is connector._registered_kv_caches
-    assert os.environ["VLLM_NIXL_SIDE_CHANNEL_HOST"] == "10.0.0.5"
-    found = read_handshake_metadata(
-        "inc-restore", 1, 1, control_dir=str(tmp_path), timeout=0.2
+    assert connector.connector_worker.registered is connector._kv_caches
+    assert (
+        read_handshake_metadata("inc-restore", control_dir=str(tmp_path))[(0, 0)][
+            "engine_id"
+        ]
+        == "inc-restore_dp0"
     )
-    assert found[(0, 0)]["engine_id"] == "inc-restore_dp0"
-
     SnapshotNixlMixin._maybe_rebind(connector)
     assert connector._bound_incarnation_id == "inc-restore"
 
 
-def test_scheduler_rebind_reads_handshake_and_restarts_listener(monkeypatch, tmp_path):
+def test_scheduler_rebind_reads_handshake(monkeypatch, tmp_path):
     monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
-    identity = RestoreIdentity(incarnation_id="inc-restore", env={"POD_IP": "10.0.0.5"})
+    (tmp_path / SNAPSHOT_RESTORE_CONTEXT_FILE).write_text(
+        '{"incarnation_id":"inc-restore","env":{}}\n'
+    )
     write_handshake_metadata(
-        "inc-restore",
-        0,
-        0,
-        {"engine_id": "inc-restore", "agent": b"new-agent"},
-        control_dir=str(tmp_path),
+        "inc-restore", 0, 0, {"engine_id": "inc-restore_dp0"}, control_dir=str(tmp_path)
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.snapshot_nixl.apply_snapshot_restore_env", lambda: {}
     )
     connector = _FakeConnector("scheduler")
-    monkeypatch.setattr(
-        "dynamo.vllm.snapshot_nixl.load_restore_identity", lambda: identity
-    )
-
     SnapshotNixlMixin._maybe_rebind(connector)
-
-    assert connector.shut_down is True
-    assert connector.engine_id == "inc-restore_dp0"
-    assert connector.connector_scheduler.handshake[(0, 0)]["engine_id"] == "inc-restore"
+    assert connector.connector_scheduler.handshake[(0, 0)]["engine_id"] == (
+        "inc-restore_dp0"
+    )

--- a/components/src/dynamo_snapshot.pth
+++ b/components/src/dynamo_snapshot.pth
@@ -1,0 +1,1 @@
+import dynamo.common.snapshot.autoinstall; dynamo.common.snapshot.autoinstall.install_snapshot_backends()

--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/snapshot.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/snapshot.md
@@ -572,6 +572,7 @@ status:
 - **Admission is create-only**: with DGD `startupPolicy: Immediate`, only Pods created after a checkpoint is `Ready` are restore-shaped. Existing Pods cold-started before checkpoint readiness keep running as-is.
 - **Restore admission must be installed**: DGD restores rely on the snapshot Pod mutating webhook, so upgrade the snapshot chart/webhook configuration along with the operator and CRDs when enabling these features.
 - **Network state is sensitive**: restore is sensitive to live TCP socket state. Loopback bootstrap/control sockets are the most reliable path today.
+- **P/D disagg NIXL is rebuilt on restore**: CRIU cannot restore IB/UCX queue pairs. vLLM and SGLang workers mint a new NIXL identity from the restore `incarnation_id` so a restored decode worker can reconnect to a live prefill worker. TensorRT-LLM P/D rebind is not implemented. In-flight KV transfers at dump time are not recovered.
 - **Privileged DaemonSet required**: `snapshot-agent` must run privileged to execute CRIU and `cuda-checkpoint`. Workload pods do not need to be privileged.
 
 ## Troubleshooting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,11 @@ path = "hatch_build.py"
 packages = [
     "components/src/dynamo",
 ]
+# Spawned SGLang scheduler children re-import sglang and never run Dynamo
+# entrypoints. This site .pth installs the snapshot NIXL manager when
+# DYN_SNAPSHOT_CONTROL_DIR is set.
+[tool.hatch.build.targets.wheel.force-include]
+"components/src/dynamo_snapshot.pth" = "dynamo_snapshot.pth"
 
 [tool.codespell]
 # note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -


### PR DESCRIPTION
## Summary
- CRIU cannot restore IB/UCX queue pairs. Live prefill caches NIXL peers by vLLM `engine_id` or SGLang `agent_name`, so a restored decode worker with the same `POD_IP` (common on `hostNetwork`) is ignored.
- Standby now writes a new `incarnation_id` into `restore-context.json` on every restore. Rebind is keyed by that id, not by IP change.
- vLLM: snapshot mode sets `kv_connector_module_path=dynamo.vllm.snapshot_nixl`. After restore the connector shuts down the old agent/side channel, mints `engine_id` from the incarnation, re-registers KV tensors, and republishes handshake metadata.
- SGLang: snapshot mode installs a `NixlKVManager`/`NixlKVReceiver` via `get_kv_class` (spawn children pick this up through `dynamo_snapshot.pth`). After restore it creates a new NIXL agent name and re-registers buffers so live prefill accepts the peer.
- TensorRT-LLM P/D rebind and in-flight KV at dump time are out of scope.

## Test plan
- [ ] `pytest components/src/dynamo/common/tests/test_snapshot_restore_context.py` — same IP + new incarnation rebinds; missing context does not
- [ ] `pytest components/src/dynamo/vllm/tests/test_vllm_snapshot_nixl.py` — connector rewrite, handshake files, worker/scheduler rebind
- [ ] `pytest components/src/dynamo/sglang/tests/test_sglang_snapshot_nixl.py` — install wrap + new agent name on rebind
- [ ] Snapshot restore a vLLM P/D decode worker while prefill stays up; next request should handshake with the new `engine_id`
- [ ] Snapshot restore an SGLang P/D decode worker while prefill stays up; prefill should register the new `agent_name` (not ignore a reused name)
- [ ] Same-IP / `hostNetwork` restore still rebinds (incarnation changes even when `POD_IP` does not)