### PR TITLE
fix(operator): respect controller ownership in SyncResource

### DIFF
--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -353,9 +353,13 @@ func (r *dgdCheckpointsReconciler) syncCheckpointGMSResourceClaimTemplate(
 	gpuCount int,
 	deviceClassName string,
 ) error {
+	// This template changes controller deliberately: the DGD creates it here, and
+	// adoptCheckpointGMSResourceClaimTemplate hands it to the DynamoCheckpoint later in the same
+	// pass. Every reconcile after the first therefore re-enters this sync with the DGD as parent
+	// against an object the checkpoint now controls, which the ownership guard would refuse.
 	_, _, err := commoncontroller.SyncResource(ctx, r, dgd, func(ctx context.Context) (*resourcev1.ResourceClaimTemplate, bool, error) {
 		return dra.GenerateResourceClaimTemplate(ctx, r.Client, claimTemplateName, dgd.Namespace, gpuCount, deviceClassName)
-	})
+	}, commoncontroller.WithSharedOwnership())
 	if err != nil {
 		return fmt.Errorf("failed to sync checkpoint GMS ResourceClaimTemplate %s/%s: %w", dgd.Namespace, claimTemplateName, err)
 	}

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -353,10 +353,7 @@ func (r *dgdCheckpointsReconciler) syncCheckpointGMSResourceClaimTemplate(
 	gpuCount int,
 	deviceClassName string,
 ) error {
-	// This template changes controller deliberately: the DGD creates it here, and
-	// adoptCheckpointGMSResourceClaimTemplate hands it to the DynamoCheckpoint later in the same
-	// pass. Every reconcile after the first therefore re-enters this sync with the DGD as parent
-	// against an object the checkpoint now controls, which the ownership guard would refuse.
+	// The DynamoCheckpoint adopts this template after the DGD creates it.
 	_, _, err := commoncontroller.SyncResource(ctx, r, dgd, func(ctx context.Context) (*resourcev1.ResourceClaimTemplate, bool, error) {
 		return dra.GenerateResourceClaimTemplate(ctx, r.Client, claimTemplateName, dgd.Namespace, gpuCount, deviceClassName)
 	}, commoncontroller.WithSharedOwnership())

--- a/deploy/operator/internal/controller_common/errors.go
+++ b/deploy/operator/internal/controller_common/errors.go
@@ -18,18 +18,16 @@
 package controller_common
 
 import (
+	"errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// IgnoreIntermediateError returns err for a real (terminal) Kubernetes API error that will not
-// resolve on retry — Invalid, BadRequest, or Forbidden — and nil for an intermediate
-// (transient, retryable) error. It mirrors client.IgnoreNotFound, so callers can write:
-//
-//	if controller_common.IgnoreIntermediateError(err) != nil { /* terminal: handle */ }
-//
-// to act only on terminal failures while letting transient ones requeue.
+// IgnoreIntermediateError returns terminal reconciliation errors and ignores transient failures.
 func IgnoreIntermediateError(err error) error {
-	if apierrors.IsInvalid(err) || apierrors.IsBadRequest(err) || apierrors.IsForbidden(err) {
+	var alreadyOwned *controllerutil.AlreadyOwnedError
+	if errors.As(err, &alreadyOwned) || apierrors.IsInvalid(err) || apierrors.IsBadRequest(err) || apierrors.IsForbidden(err) {
 		return err
 	}
 	return nil

--- a/deploy/operator/internal/controller_common/errors_test.go
+++ b/deploy/operator/internal/controller_common/errors_test.go
@@ -22,17 +22,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func TestIgnoreIntermediateError(t *testing.T) {
 	gr := schema.GroupResource{Group: "nvidia.com", Resource: "podsnapshots"}
 
 	terminal := map[string]error{
-		"invalid":    apierrors.NewInvalid(schema.GroupKind{Group: "nvidia.com", Kind: "PodSnapshot"}, "x", nil),
-		"badRequest": apierrors.NewBadRequest("bad"),
-		"forbidden":  apierrors.NewForbidden(gr, "x", errors.New("not owned")),
+		"invalid":      apierrors.NewInvalid(schema.GroupKind{Group: "nvidia.com", Kind: "PodSnapshot"}, "x", nil),
+		"badRequest":   apierrors.NewBadRequest("bad"),
+		"forbidden":    apierrors.NewForbidden(gr, "x", errors.New("not owned")),
+		"alreadyOwned": &controllerutil.AlreadyOwnedError{Object: &corev1.ConfigMap{}, Owner: metav1.OwnerReference{Name: "other-controller"}},
 	}
 	for name, err := range terminal {
 		t.Run("terminal/"+name, func(t *testing.T) {

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -80,6 +80,7 @@ func WithSharedOwnership() SyncOption {
 	}
 }
 
+// checkControllerOwnership treats a nil parent as an explicit request to leave ownership unchanged.
 func checkControllerOwnership(existing client.Object, parentResource client.Object, scheme *runtime.Scheme) (adopt bool, err error) {
 	if parentResource == nil {
 		return false, nil

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -31,13 +31,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -47,6 +50,9 @@ const (
 	// NvidiaAnnotationGenerationKey indicates annotation name for last applied generation by the operator
 	// This is used to detect manual changes to resources
 	NvidiaAnnotationGenerationKey = "nvidia.com/last-applied-generation"
+	// EventReasonOwnershipConflict is the event reason emitted when SyncResource refuses to act on an
+	// existing object because another controller owns it.
+	EventReasonOwnershipConflict = "OwnershipConflict"
 )
 
 type Reconciler interface {
@@ -59,9 +65,84 @@ type Reconciler interface {
 // if the resource should be deleted, the returned resource must contain the necessary information to delete it (name and namespace)
 type ResourceGenerator[T client.Object] func(ctx context.Context) (T, bool, error)
 
+// SyncOption tunes the behavior of SyncResource. Options are variadic so that callers
+// which need the default behavior stay unchanged.
+type SyncOption func(*syncOptions)
+
+type syncOptions struct {
+	sharedOwnership bool
+}
+
+// WithSharedOwnership disables the controller-ownership guard for a resource that is
+// deliberately shared between several owners. Without it, SyncResource refuses to touch an
+// existing object controlled by somebody else; with it, a foreign controller reference is
+// tolerated and owner references are left alone.
+//
+// Use it only for objects whose name is derived from shared state rather than from a single
+// owner, where a second owner legitimately converges on the object the first one created.
+func WithSharedOwnership() SyncOption {
+	return func(o *syncOptions) {
+		o.sharedOwnership = true
+	}
+}
+
+// checkControllerOwnership decides whether an existing object may be managed on behalf of
+// parentResource. It reports adopt=true when the object carries no controller reference and
+// should have parentResource installed as its controller, and returns an
+// *controllerutil.AlreadyOwnedError when another controller owns it.
+//
+// A nil parentResource means the caller asked for an independent lifecycle: nothing to check
+// and nothing to adopt.
+func checkControllerOwnership(existing client.Object, parentResource client.Object, scheme *runtime.Scheme) (adopt bool, err error) {
+	if parentResource == nil {
+		return false, nil
+	}
+	// Only owner references with Controller=true participate, matching upstream semantics:
+	// a plain (non-controller) owner reference does not block adoption.
+	existingRef := metav1.GetControllerOf(existing)
+	if existingRef == nil {
+		return true, nil
+	}
+	parentGVK, err := apiutil.GVKForObject(parentResource, scheme)
+	if err != nil {
+		return false, err
+	}
+	if ownerRefIsParent(*existingRef, parentResource, parentGVK) {
+		return false, nil
+	}
+	return false, &controllerutil.AlreadyOwnedError{Object: existing, Owner: *existingRef}
+}
+
+// ownerRefIsParent reports whether ref designates parent as controller.
+//
+// controllerutil.SetControllerReference cannot be used for this decision: its referSameObject
+// helper compares group, kind and name only, so a foreign owner that happens to share the
+// parent's kind and name would be accepted as the same object. The UID comparison below is
+// what distinguishes a recreated or unrelated owner from ours.
+func ownerRefIsParent(ref metav1.OwnerReference, parent client.Object, parentGVK schema.GroupVersionKind) bool {
+	refGV, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return false
+	}
+	if refGV.Group != parentGVK.Group || ref.Kind != parentGVK.Kind || ref.Name != parent.GetName() {
+		return false
+	}
+	// UIDs are compared only when both sides carry one; owner references written by hand and
+	// objects built in tests may legitimately omit it.
+	if ref.UID != "" && parent.GetUID() != "" && ref.UID != parent.GetUID() {
+		return false
+	}
+	return true
+}
+
 //nolint:nakedret
-func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentResource client.Object, generateResource ResourceGenerator[T]) (modified bool, res T, err error) {
+func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentResource client.Object, generateResource ResourceGenerator[T], opts ...SyncOption) (modified bool, res T, err error) {
 	logs := log.FromContext(ctx)
+
+	options := syncOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
 
 	resource, toDelete, err := generateResource(ctx)
 	if err != nil {
@@ -145,6 +226,19 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 		res = resource
 	} else {
 		logs.Info(fmt.Sprintf("%s found.", resourceType))
+
+		// The lookup above matched on namespace and name only, so the object found here may belong
+		// to a different controller. Check that once, before any branch that deletes or writes.
+		var adopt bool
+		if !options.sharedOwnership {
+			adopt, err = checkControllerOwnership(oldResource, parentResource, r.Scheme())
+			if err != nil {
+				logs.Error(err, fmt.Sprintf("Refusing to reconcile %s owned by another controller.", resourceType))
+				r.GetRecorder().Eventf(oldResource, nil, corev1.EventTypeWarning, EventReasonOwnershipConflict, "Sync", "Refusing to reconcile %s %s: %s", resourceType, resourceNamespace, err)
+				return
+			}
+		}
+
 		if toDelete {
 			logs.Info(fmt.Sprintf("%s found. Deleting the existing one.", resourceType))
 			err = r.Delete(ctx, oldResource)
@@ -168,6 +262,29 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 		}
 
 		if !changeResult.NeedsUpdate {
+			if adopt {
+				// The content already matches but the object is not yet owned by the parent, so
+				// returning success here would leave it outside the parent's garbage-collection
+				// and owner-watch lifecycle. Write the ownership change on its own: this branch
+				// has changeResult.NewHash == nil, so it must not go through updateAnnotations.
+				logs.Info(fmt.Sprintf("%s spec is the same. Adopting the existing resource.", resourceType))
+				err = ctrl.SetControllerReference(parentResource, oldResource, r.Scheme())
+				if err != nil {
+					logs.Error(err, "Failed to set controller reference.")
+					r.GetRecorder().Eventf(oldResource, nil, corev1.EventTypeWarning, "SetControllerReference", "Update", "Failed to set controller reference for %s %s: %s", resourceType, resourceNamespace, err)
+					return
+				}
+				err = r.Update(ctx, oldResource)
+				if err != nil {
+					logs.Error(err, fmt.Sprintf("Failed to adopt %s.", resourceType))
+					r.GetRecorder().Eventf(oldResource, nil, corev1.EventTypeWarning, fmt.Sprintf("Adopt%s", resourceType), "Update", "Failed to adopt %s %s: %s", resourceType, resourceNamespace, err)
+					return
+				}
+				r.GetRecorder().Eventf(oldResource, nil, corev1.EventTypeNormal, fmt.Sprintf("Adopt%s", resourceType), "Update", "Adopted %s %s", resourceType, resourceNamespace)
+				modified = true
+				res = oldResource
+				return
+			}
 			logs.Info(fmt.Sprintf("%s spec is the same. Skipping update.", resourceType))
 			r.GetRecorder().Eventf(oldResource, nil, corev1.EventTypeNormal, fmt.Sprintf("Update%s", resourceType), "Update", "Skipping update %s %s", resourceType, resourceNamespace)
 			res = oldResource
@@ -201,7 +318,21 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 			logs.Info(fmt.Sprintf("%s spec is equivalent. Updating bookkeeping annotations only.", resourceType))
 		}
 
-		updateAnnotations(oldResource, *changeResult.NewHash, changeResult.NewGeneration)
+		if adopt {
+			// Ownerless object with content to update: carry the ownership change in the same write.
+			err = ctrl.SetControllerReference(parentResource, oldResource, r.Scheme())
+			if err != nil {
+				logs.Error(err, "Failed to set controller reference.")
+				r.GetRecorder().Eventf(oldResource, nil, corev1.EventTypeWarning, "SetControllerReference", "Update", "Failed to set controller reference for %s %s: %s", resourceType, resourceNamespace, err)
+				return
+			}
+		}
+
+		// NewHash is nil exactly when NeedsUpdate is false, which the branch above already
+		// returned on; the guard keeps a future caller from dereferencing nil here.
+		if changeResult.NewHash != nil {
+			updateAnnotations(oldResource, *changeResult.NewHash, changeResult.NewGeneration)
+		}
 
 		err = r.Update(ctx, oldResource)
 		if err != nil {

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -228,8 +228,9 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 		logs.Error(err, "Failed to get resource.")
 		return
 	}
-	err = nil
 
+	// Past this point err is either nil or the NotFound the branch below consumes, so it never
+	// leaks into a naked return.
 	if oldResourceIsNotFound {
 		return createResource(ctx, logs, r, parentResource, resource, toDelete, resourceType)
 	} else {

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -135,6 +137,52 @@ func ownerRefIsParent(ref metav1.OwnerReference, parent client.Object, parentGVK
 	return true
 }
 
+// createResource handles the branch of SyncResource where the Get found nothing, either by
+// creating the desired object or, when the caller asked for deletion, by doing nothing. It
+// carries no ownership check: there is no existing object to conflict with.
+func createResource[T client.Object](ctx context.Context, logs logr.Logger, r Reconciler, parentResource client.Object, resource T, toDelete bool, resourceType string) (bool, T, error) {
+	var zero T
+	resourceNamespace := resource.GetNamespace()
+
+	if toDelete {
+		logs.Info("Resource not found. Nothing to do.")
+		return false, zero, nil
+	}
+	logs.Info("Resource not found. Creating a new one.")
+
+	// Only set controller reference if parentResource is provided
+	// Passing nil as parentResource creates an independent resource (no owner reference)
+	if parentResource != nil {
+		if err := ctrl.SetControllerReference(parentResource, resource, r.Scheme()); err != nil {
+			logs.Error(err, "Failed to set controller reference.")
+			r.GetRecorder().Eventf(resource, nil, corev1.EventTypeWarning, "SetControllerReference", "Update", "Failed to set controller reference for %s %s: %s", resourceType, resourceNamespace, err)
+			return false, zero, err
+		}
+	} else {
+		logs.Info("No parent resource provided, creating resource without owner reference (independent lifecycle)")
+	}
+
+	hash, err := GetSpecHash(resource)
+	if err != nil {
+		logs.Error(err, "Failed to get spec hash.")
+		r.GetRecorder().Eventf(resource, nil, corev1.EventTypeWarning, "GetSpecHash", "Get", "Failed to get spec hash for %s %s: %s", resourceType, resourceNamespace, err)
+		return false, zero, err
+	}
+
+	// On create, set generation to 1 (new resources start at generation 1)
+	updateAnnotations(resource, hash, 1)
+
+	r.GetRecorder().Eventf(resource, nil, corev1.EventTypeNormal, fmt.Sprintf("Create%s", resourceType), "Create", "Creating a new %s %s", resourceType, resourceNamespace)
+	if err := r.Create(ctx, resource); err != nil {
+		logs.Error(err, "Failed to create Resource.")
+		r.GetRecorder().Eventf(resource, nil, corev1.EventTypeWarning, fmt.Sprintf("Create%s", resourceType), "Create", "Failed to create %s %s: %s", resourceType, resourceNamespace, err)
+		return false, zero, err
+	}
+	logs.Info(fmt.Sprintf("%s created.", resourceType))
+	r.GetRecorder().Eventf(resource, nil, corev1.EventTypeNormal, fmt.Sprintf("Create%s", resourceType), "Create", "Created %s %s", resourceType, resourceNamespace)
+	return true, resource, nil
+}
+
 //nolint:nakedret
 func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentResource client.Object, generateResource ResourceGenerator[T], opts ...SyncOption) (modified bool, res T, err error) {
 	logs := log.FromContext(ctx)
@@ -183,47 +231,7 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 	err = nil
 
 	if oldResourceIsNotFound {
-		if toDelete {
-			logs.Info("Resource not found. Nothing to do.")
-			return
-		}
-		logs.Info("Resource not found. Creating a new one.")
-
-		// Only set controller reference if parentResource is provided
-		// Passing nil as parentResource creates an independent resource (no owner reference)
-		if parentResource != nil {
-			err = ctrl.SetControllerReference(parentResource, resource, r.Scheme())
-			if err != nil {
-				logs.Error(err, "Failed to set controller reference.")
-				r.GetRecorder().Eventf(resource, nil, corev1.EventTypeWarning, "SetControllerReference", "Update", "Failed to set controller reference for %s %s: %s", resourceType, resourceNamespace, err)
-				return
-			}
-		} else {
-			logs.Info("No parent resource provided, creating resource without owner reference (independent lifecycle)")
-		}
-
-		var hash string
-		hash, err = GetSpecHash(resource)
-		if err != nil {
-			logs.Error(err, "Failed to get spec hash.")
-			r.GetRecorder().Eventf(resource, nil, corev1.EventTypeWarning, "GetSpecHash", "Get", "Failed to get spec hash for %s %s: %s", resourceType, resourceNamespace, err)
-			return
-		}
-
-		// On create, set generation to 1 (new resources start at generation 1)
-		updateAnnotations(resource, hash, 1)
-
-		r.GetRecorder().Eventf(resource, nil, corev1.EventTypeNormal, fmt.Sprintf("Create%s", resourceType), "Create", "Creating a new %s %s", resourceType, resourceNamespace)
-		err = r.Create(ctx, resource)
-		if err != nil {
-			logs.Error(err, "Failed to create Resource.")
-			r.GetRecorder().Eventf(resource, nil, corev1.EventTypeWarning, fmt.Sprintf("Create%s", resourceType), "Create", "Failed to create %s %s: %s", resourceType, resourceNamespace, err)
-			return
-		}
-		logs.Info(fmt.Sprintf("%s created.", resourceType))
-		r.GetRecorder().Eventf(resource, nil, corev1.EventTypeNormal, fmt.Sprintf("Create%s", resourceType), "Create", "Created %s %s", resourceType, resourceNamespace)
-		modified = true
-		res = resource
+		return createResource(ctx, logs, r, parentResource, resource, toDelete, resourceType)
 	} else {
 		logs.Info(fmt.Sprintf("%s found.", resourceType))
 
@@ -241,7 +249,14 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 
 		if toDelete {
 			logs.Info(fmt.Sprintf("%s found. Deleting the existing one.", resourceType))
-			err = r.Delete(ctx, oldResource)
+			// The ownership check above read the object at a point in time; another controller
+			// may adopt or recreate a same-name object before this Delete lands. Sending the
+			// fetched UID and resourceVersion as preconditions makes the API server reject the
+			// delete rather than destroying an object the check never saw.
+			err = r.Delete(ctx, oldResource, client.Preconditions{
+				UID:             ptr.To(oldResource.GetUID()),
+				ResourceVersion: ptr.To(oldResource.GetResourceVersion()),
+			})
 			if err != nil {
 				logs.Error(err, fmt.Sprintf("Failed to delete %s.", resourceType))
 				r.GetRecorder().Eventf(oldResource, nil, corev1.EventTypeWarning, fmt.Sprintf("Delete%s", resourceType), "Delete", "Failed to delete %s %s: %s", resourceType, resourceNamespace, err)

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -52,8 +52,7 @@ const (
 	// NvidiaAnnotationGenerationKey indicates annotation name for last applied generation by the operator
 	// This is used to detect manual changes to resources
 	NvidiaAnnotationGenerationKey = "nvidia.com/last-applied-generation"
-	// EventReasonOwnershipConflict is the event reason emitted when SyncResource refuses to act on an
-	// existing object because another controller owns it.
+	// EventReasonOwnershipConflict identifies controller ownership conflicts.
 	EventReasonOwnershipConflict = "OwnershipConflict"
 )
 
@@ -67,40 +66,25 @@ type Reconciler interface {
 // if the resource should be deleted, the returned resource must contain the necessary information to delete it (name and namespace)
 type ResourceGenerator[T client.Object] func(ctx context.Context) (T, bool, error)
 
-// SyncOption tunes the behavior of SyncResource. Options are variadic so that callers
-// which need the default behavior stay unchanged.
+// SyncOption configures SyncResource.
 type SyncOption func(*syncOptions)
 
 type syncOptions struct {
 	sharedOwnership bool
 }
 
-// WithSharedOwnership disables the controller-ownership guard for a resource that is
-// deliberately shared between several owners. Without it, SyncResource refuses to touch an
-// existing object controlled by somebody else; with it, a foreign controller reference is
-// tolerated and owner references are left alone.
-//
-// Use it only for objects whose name is derived from shared state rather than from a single
-// owner, where a second owner legitimately converges on the object the first one created.
+// WithSharedOwnership permits a foreign controller reference without rewriting it.
 func WithSharedOwnership() SyncOption {
 	return func(o *syncOptions) {
 		o.sharedOwnership = true
 	}
 }
 
-// checkControllerOwnership decides whether an existing object may be managed on behalf of
-// parentResource. It reports adopt=true when the object carries no controller reference and
-// should have parentResource installed as its controller, and returns an
-// *controllerutil.AlreadyOwnedError when another controller owns it.
-//
-// A nil parentResource means the caller asked for an independent lifecycle: nothing to check
-// and nothing to adopt.
 func checkControllerOwnership(existing client.Object, parentResource client.Object, scheme *runtime.Scheme) (adopt bool, err error) {
 	if parentResource == nil {
 		return false, nil
 	}
-	// Only owner references with Controller=true participate, matching upstream semantics:
-	// a plain (non-controller) owner reference does not block adoption.
+	// Non-controller owner references do not block adoption.
 	existingRef := metav1.GetControllerOf(existing)
 	if existingRef == nil {
 		return true, nil
@@ -115,12 +99,7 @@ func checkControllerOwnership(existing client.Object, parentResource client.Obje
 	return false, &controllerutil.AlreadyOwnedError{Object: existing, Owner: *existingRef}
 }
 
-// ownerRefIsParent reports whether ref designates parent as controller.
-//
-// controllerutil.SetControllerReference cannot be used for this decision: its referSameObject
-// helper compares group, kind and name only, so a foreign owner that happens to share the
-// parent's kind and name would be accepted as the same object. The UID comparison below is
-// what distinguishes a recreated or unrelated owner from ours.
+// ownerRefIsParent compares UID when available, unlike controllerutil's same-object check.
 func ownerRefIsParent(ref metav1.OwnerReference, parent client.Object, parentGVK schema.GroupVersionKind) bool {
 	refGV, err := schema.ParseGroupVersion(ref.APIVersion)
 	if err != nil {
@@ -129,17 +108,13 @@ func ownerRefIsParent(ref metav1.OwnerReference, parent client.Object, parentGVK
 	if refGV.Group != parentGVK.Group || ref.Kind != parentGVK.Kind || ref.Name != parent.GetName() {
 		return false
 	}
-	// UIDs are compared only when both sides carry one; owner references written by hand and
-	// objects built in tests may legitimately omit it.
+	// Hand-written references and test objects may omit UIDs.
 	if ref.UID != "" && parent.GetUID() != "" && ref.UID != parent.GetUID() {
 		return false
 	}
 	return true
 }
 
-// createResource handles the branch of SyncResource where the Get found nothing, either by
-// creating the desired object or, when the caller asked for deletion, by doing nothing. It
-// carries no ownership check: there is no existing object to conflict with.
 func createResource[T client.Object](ctx context.Context, logs logr.Logger, r Reconciler, parentResource client.Object, resource T, toDelete bool, resourceType string) (bool, T, error) {
 	var zero T
 	resourceNamespace := resource.GetNamespace()
@@ -150,8 +125,7 @@ func createResource[T client.Object](ctx context.Context, logs logr.Logger, r Re
 	}
 	logs.Info("Resource not found. Creating a new one.")
 
-	// Only set controller reference if parentResource is provided
-	// Passing nil as parentResource creates an independent resource (no owner reference)
+	// A nil parent creates an independently owned resource.
 	if parentResource != nil {
 		if err := ctrl.SetControllerReference(parentResource, resource, r.Scheme()); err != nil {
 			logs.Error(err, "Failed to set controller reference.")
@@ -169,7 +143,6 @@ func createResource[T client.Object](ctx context.Context, logs logr.Logger, r Re
 		return false, zero, err
 	}
 
-	// On create, set generation to 1 (new resources start at generation 1)
 	updateAnnotations(resource, hash, 1)
 
 	r.GetRecorder().Eventf(resource, nil, corev1.EventTypeNormal, fmt.Sprintf("Create%s", resourceType), "Create", "Creating a new %s %s", resourceType, resourceNamespace)
@@ -229,15 +202,12 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 		return
 	}
 
-	// Past this point err is either nil or the NotFound the branch below consumes, so it never
-	// leaks into a naked return.
 	if oldResourceIsNotFound {
 		return createResource(ctx, logs, r, parentResource, resource, toDelete, resourceType)
 	} else {
 		logs.Info(fmt.Sprintf("%s found.", resourceType))
 
-		// The lookup above matched on namespace and name only, so the object found here may belong
-		// to a different controller. Check that once, before any branch that deletes or writes.
+		// Name lookup does not establish controller ownership.
 		var adopt bool
 		if !options.sharedOwnership {
 			adopt, err = checkControllerOwnership(oldResource, parentResource, r.Scheme())
@@ -250,10 +220,7 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 
 		if toDelete {
 			logs.Info(fmt.Sprintf("%s found. Deleting the existing one.", resourceType))
-			// The ownership check above read the object at a point in time; another controller
-			// may adopt or recreate a same-name object before this Delete lands. Sending the
-			// fetched UID and resourceVersion as preconditions makes the API server reject the
-			// delete rather than destroying an object the check never saw.
+			// Preconditions reject adoption or replacement after the ownership check.
 			err = r.Delete(ctx, oldResource, client.Preconditions{
 				UID:             ptr.To(oldResource.GetUID()),
 				ResourceVersion: ptr.To(oldResource.GetResourceVersion()),
@@ -279,10 +246,7 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 
 		if !changeResult.NeedsUpdate {
 			if adopt {
-				// The content already matches but the object is not yet owned by the parent, so
-				// returning success here would leave it outside the parent's garbage-collection
-				// and owner-watch lifecycle. Write the ownership change on its own: this branch
-				// has changeResult.NewHash == nil, so it must not go through updateAnnotations.
+				// Matching content still needs an ownership-only update.
 				logs.Info(fmt.Sprintf("%s spec is the same. Adopting the existing resource.", resourceType))
 				err = ctrl.SetControllerReference(parentResource, oldResource, r.Scheme())
 				if err != nil {
@@ -344,8 +308,7 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 			}
 		}
 
-		// NewHash is nil exactly when NeedsUpdate is false, which the branch above already
-		// returned on; the guard keeps a future caller from dereferencing nil here.
+		// NewHash is nil only when NeedsUpdate is false.
 		if changeResult.NewHash != nil {
 			updateAnnotations(oldResource, *changeResult.NewHash, changeResult.NewGeneration)
 		}

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -1048,151 +1048,129 @@ func requireOwnershipConflict(t *testing.T, err error) {
 	assert.Equal(t, ownershipTestForeignUID, alreadyOwned.Owner.UID)
 }
 
-func TestSyncResource_ForeignControllerBlocksUpdate(t *testing.T) {
-	ctx := context.Background()
-	s := newOwnershipTestScheme(t)
+// TestSyncResource_ForeignControllerBlocksMutation covers the three paths that write or delete
+// once an object already exists. Each must refuse a foreign owner before touching anything: the
+// content-differs update, the delete, and the content-matches path that previously reported
+// success without ever attaching an owner reference.
+func TestSyncResource_ForeignControllerBlocksMutation(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingPort int32
+		desiredPort  int32
+		toDelete     bool
+	}{
+		{name: "differing content is not overwritten", existingPort: 9090, desiredPort: 8080},
+		{name: "existing object is not deleted", existingPort: 9090, desiredPort: 9090, toDelete: true},
+		{name: "matching content does not rewrite owner references", existingPort: 8080, desiredPort: 8080},
+	}
 
-	existing := seedService(t, ownershipTestService(9090))
-	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
-	r, c := newOwnershipTestReconciler(t, s, existing)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("seed an object held by a foreign controller that shares the parent's kind and name")
+			s := newOwnershipTestScheme(t)
+			existing := seedService(t, ownershipTestService(tt.existingPort))
+			existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
+			r, c := newOwnershipTestReconciler(t, s, existing)
 
-	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(ownershipTestService(8080), false))
+			t.Log("sync on behalf of a different parent")
+			modified, _, err := SyncResource(context.Background(), r, newOwnershipTestParent(),
+				serviceGenerator(ownershipTestService(tt.desiredPort), tt.toDelete))
 
-	requireOwnershipConflict(t, err)
-	assert.False(t, modified)
-
-	stored := storedService(t, c)
-	assert.Equal(t, int32(9090), stored.Spec.Ports[0].Port, "spec of a foreign-owned object must not be overwritten")
-	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences)
-	assert.Equal(t, existing.Annotations, stored.Annotations, "bookkeeping annotations must not be written either")
+			t.Log("the sync is refused and the stored object is left exactly as it was")
+			requireOwnershipConflict(t, err)
+			assert.False(t, modified)
+			stored := storedService(t, c)
+			assert.Equal(t, tt.existingPort, stored.Spec.Ports[0].Port, "spec of a foreign-owned object must not be overwritten")
+			assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences)
+			assert.Equal(t, existing.Annotations, stored.Annotations, "bookkeeping annotations must not be written either")
+		})
+	}
 }
 
-func TestSyncResource_ForeignControllerBlocksDelete(t *testing.T) {
-	ctx := context.Background()
-	s := newOwnershipTestScheme(t)
+// TestSyncResource_SyncProceeds covers the cases the guard must let through: adoption of an
+// ownerless object, the controller that already owns the object, an opted-out nil parent, and the
+// shared-ownership opt-out. Every case also asserts that a second sync settles, since a write that
+// repeated on each pass would requeue the controller forever without ever converging.
+func TestSyncResource_SyncProceeds(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingOwner []metav1.OwnerReference
+		existingPort  int32
+		desiredPort   int32
+		parent        client.Object
+		opts          []SyncOption
+		wantModified  bool
+		wantOwner     []metav1.OwnerReference
+		wantPort      int32
+		reason        string
+	}{
+		{
+			name:         "ownerless object with matching content is adopted",
+			existingPort: 8080, desiredPort: 8080,
+			parent: newOwnershipTestParent(), wantModified: true,
+			wantOwner: []metav1.OwnerReference{parentControllerRef()}, wantPort: 8080,
+			reason: "adoption must attach the owner reference without changing the content",
+		},
+		{
+			name:         "ownerless object with differing content is adopted and updated",
+			existingPort: 9090, desiredPort: 8080,
+			parent: newOwnershipTestParent(), wantModified: true,
+			wantOwner: []metav1.OwnerReference{parentControllerRef()}, wantPort: 8080,
+			reason: "adoption rides along with the content update in one write",
+		},
+		{
+			name:          "the controller that already owns the object reconciles normally",
+			existingOwner: []metav1.OwnerReference{parentControllerRef()},
+			existingPort:  9090, desiredPort: 8080,
+			parent: newOwnershipTestParent(), wantModified: true,
+			wantOwner: []metav1.OwnerReference{parentControllerRef()}, wantPort: 8080,
+			reason: "the guard must not disturb the ordinary same-owner path",
+		},
+		{
+			name:          "a nil parent asks for an independent lifecycle",
+			existingOwner: []metav1.OwnerReference{foreignControllerRef()},
+			existingPort:  9090, desiredPort: 8080,
+			parent: nil, wantModified: true,
+			wantOwner: []metav1.OwnerReference{foreignControllerRef()}, wantPort: 8080,
+			reason: "a nil parent means no ownership opinion, so behavior is unchanged from before the guard",
+		},
+		{
+			name:          "the shared-ownership opt-out tolerates a foreign controller",
+			existingOwner: []metav1.OwnerReference{foreignControllerRef()},
+			existingPort:  8080, desiredPort: 8080,
+			parent: newOwnershipTestParent(), opts: []SyncOption{WithSharedOwnership()},
+			wantModified: false,
+			wantOwner:    []metav1.OwnerReference{foreignControllerRef()}, wantPort: 8080,
+			reason: "an object legitimately shared between owners must neither fail nor be re-owned",
+		},
+	}
 
-	existing := seedService(t, ownershipTestService(9090))
-	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
-	r, c := newOwnershipTestReconciler(t, s, existing)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("seed the existing object with the owner references under test")
+			ctx := context.Background()
+			s := newOwnershipTestScheme(t)
+			existing := seedService(t, ownershipTestService(tt.existingPort))
+			existing.OwnerReferences = tt.existingOwner
+			r, c := newOwnershipTestReconciler(t, s, existing)
 
-	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(ownershipTestService(9090), true))
+			t.Log("sync once")
+			modified, res, err := SyncResource(ctx, r, tt.parent,
+				serviceGenerator(ownershipTestService(tt.desiredPort), false), tt.opts...)
 
-	requireOwnershipConflict(t, err)
-	assert.False(t, modified)
+			t.Log("the sync is allowed and leaves the expected content and ownership")
+			require.NoError(t, err, tt.reason)
+			assert.Equal(t, tt.wantModified, modified, tt.reason)
+			require.NotNil(t, res)
+			stored := storedService(t, c)
+			assert.Equal(t, tt.wantPort, stored.Spec.Ports[0].Port)
+			assert.Equal(t, tt.wantOwner, stored.OwnerReferences)
 
-	stored := storedService(t, c)
-	assert.Equal(t, int32(9090), stored.Spec.Ports[0].Port)
-	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences)
-}
-
-func TestSyncResource_ForeignControllerBlocksMatchingContentSuccess(t *testing.T) {
-	ctx := context.Background()
-	s := newOwnershipTestScheme(t)
-
-	desired := ownershipTestService(8080)
-	existing := seedService(t, desired)
-	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
-	r, c := newOwnershipTestReconciler(t, s, existing)
-
-	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(desired, false))
-
-	requireOwnershipConflict(t, err)
-	assert.False(t, modified)
-
-	stored := storedService(t, c)
-	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences,
-		"a matching-content sync must not rewrite the owner references of a foreign-owned object")
-}
-
-func TestSyncResource_AdoptsOwnerlessObjectWithMatchingContent(t *testing.T) {
-	ctx := context.Background()
-	s := newOwnershipTestScheme(t)
-
-	desired := ownershipTestService(8080)
-	existing := seedService(t, desired)
-	r, c := newOwnershipTestReconciler(t, s, existing)
-
-	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(desired, false))
-
-	require.NoError(t, err)
-	assert.True(t, modified)
-
-	stored := storedService(t, c)
-	require.Len(t, stored.OwnerReferences, 1)
-	assert.Equal(t, parentControllerRef(), stored.OwnerReferences[0])
-	assert.Equal(t, int32(8080), stored.Spec.Ports[0].Port, "adoption must not change the content")
-}
-
-func TestSyncResource_AdoptsOwnerlessObjectWithDifferingContent(t *testing.T) {
-	ctx := context.Background()
-	s := newOwnershipTestScheme(t)
-
-	existing := seedService(t, ownershipTestService(9090))
-	r, c := newOwnershipTestReconciler(t, s, existing)
-
-	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(ownershipTestService(8080), false))
-
-	require.NoError(t, err)
-	assert.True(t, modified)
-
-	stored := storedService(t, c)
-	require.Len(t, stored.OwnerReferences, 1)
-	assert.Equal(t, parentControllerRef(), stored.OwnerReferences[0])
-	assert.Equal(t, int32(8080), stored.Spec.Ports[0].Port)
-}
-
-func TestSyncResource_SameControllerReconcilesNormally(t *testing.T) {
-	ctx := context.Background()
-	s := newOwnershipTestScheme(t)
-
-	existing := seedService(t, ownershipTestService(9090))
-	existing.OwnerReferences = []metav1.OwnerReference{parentControllerRef()}
-	r, c := newOwnershipTestReconciler(t, s, existing)
-
-	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(ownershipTestService(8080), false))
-
-	require.NoError(t, err)
-	assert.True(t, modified)
-
-	stored := storedService(t, c)
-	assert.Equal(t, int32(8080), stored.Spec.Ports[0].Port)
-	assert.Equal(t, []metav1.OwnerReference{parentControllerRef()}, stored.OwnerReferences)
-}
-
-func TestSyncResource_NilParentIgnoresOwnership(t *testing.T) {
-	ctx := context.Background()
-	s := newOwnershipTestScheme(t)
-
-	existing := seedService(t, ownershipTestService(9090))
-	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
-	r, c := newOwnershipTestReconciler(t, s, existing)
-
-	modified, _, err := SyncResource(ctx, r, nil, serviceGenerator(ownershipTestService(8080), false))
-
-	require.NoError(t, err, "a nil parent asks for an independent lifecycle and must behave as before")
-	assert.True(t, modified)
-
-	stored := storedService(t, c)
-	assert.Equal(t, int32(8080), stored.Spec.Ports[0].Port)
-	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences)
-}
-
-func TestSyncResource_SharedOwnershipToleratesForeignController(t *testing.T) {
-	ctx := context.Background()
-	s := newOwnershipTestScheme(t)
-
-	desired := ownershipTestService(8080)
-	existing := seedService(t, desired)
-	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
-	r, c := newOwnershipTestReconciler(t, s, existing)
-
-	modified, res, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(desired, false), WithSharedOwnership())
-
-	require.NoError(t, err, "the shared-ownership opt-out must keep a second owner from failing")
-	assert.False(t, modified)
-	require.NotNil(t, res)
-
-	stored := storedService(t, c)
-	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences,
-		"shared ownership must leave owner references alone")
+			t.Log("a second sync over the settled object writes nothing further")
+			modified, _, err = SyncResource(ctx, r, tt.parent,
+				serviceGenerator(ownershipTestService(tt.desiredPort), false), tt.opts...)
+			require.NoError(t, err)
+			assert.False(t, modified, "reconciliation must converge rather than write on every pass")
+		})
+	}
 }

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -18,15 +18,26 @@
 package controller_common
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/bsm/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func TestGetSpecChangeResult(t *testing.T) {
@@ -914,4 +925,274 @@ func TestGetSpecChangeResult_ConfigMap(t *testing.T) {
 			g.Expect(result.NeedsUpdate).To(gomega.Equal(tt.needsUpdate))
 		})
 	}
+}
+
+// The tests below cover the controller-ownership guard in SyncResource. They drive the helper
+// against a controller-runtime fake client so that every assertion about what was written can be
+// made by re-reading the stored object rather than by inspecting the in-memory copy SyncResource
+// returned.
+
+const (
+	ownershipTestNamespace   = "default"
+	ownershipTestServiceName = "shared-service"
+	ownershipTestParentName  = "test-dgd"
+	ownershipTestParentUID   = types.UID("parent-dgd-uid")
+	ownershipTestForeignUID  = types.UID("foreign-dgd-uid")
+)
+
+type ownershipTestReconciler struct {
+	client.Client
+	recorder events.EventRecorder
+}
+
+func (r *ownershipTestReconciler) GetRecorder() events.EventRecorder {
+	return r.recorder
+}
+
+func newOwnershipTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, appsv1.AddToScheme(s))
+	require.NoError(t, v1beta1.AddToScheme(s))
+	return s
+}
+
+func newOwnershipTestParent() *v1beta1.DynamoGraphDeployment {
+	return &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ownershipTestParentName,
+			Namespace: ownershipTestNamespace,
+			UID:       ownershipTestParentUID,
+		},
+	}
+}
+
+// foreignControllerRef deliberately carries the parent's kind and name and differs only in UID,
+// which is the collision upstream referSameObject cannot detect.
+func foreignControllerRef() metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion:         v1beta1.GroupVersion.String(),
+		Kind:               "DynamoGraphDeployment",
+		Name:               ownershipTestParentName,
+		UID:                ownershipTestForeignUID,
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}
+}
+
+func parentControllerRef() metav1.OwnerReference {
+	ref := foreignControllerRef()
+	ref.UID = ownershipTestParentUID
+	return ref
+}
+
+func ownershipTestService(port int32) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ownershipTestServiceName,
+			Namespace: ownershipTestNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
+			Selector:  map[string]string{"app": "dynamo"},
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: port, Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+}
+
+// seedService returns a copy of svc annotated as if the operator had last applied exactly this
+// content, so that GetSpecChangeResult reports no update needed when svc is also the desired object.
+func seedService(t *testing.T, svc *corev1.Service) *corev1.Service {
+	t.Helper()
+	existing := svc.DeepCopy()
+	hash, err := GetSpecHash(svc)
+	require.NoError(t, err)
+	existing.Annotations = map[string]string{
+		NvidiaAnnotationHashKey:       hash,
+		NvidiaAnnotationGenerationKey: "1",
+	}
+	existing.Generation = 1
+	return existing
+}
+
+func newOwnershipTestReconciler(t *testing.T, s *runtime.Scheme, objects ...client.Object) (*ownershipTestReconciler, client.Client) {
+	t.Helper()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
+	return &ownershipTestReconciler{Client: c, recorder: events.NewFakeRecorder(100)}, c
+}
+
+func storedService(t *testing.T, c client.Client) *corev1.Service {
+	t.Helper()
+	stored := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+		Name:      ownershipTestServiceName,
+		Namespace: ownershipTestNamespace,
+	}, stored))
+	return stored
+}
+
+func serviceGenerator(svc *corev1.Service, toDelete bool) ResourceGenerator[*corev1.Service] {
+	return func(_ context.Context) (*corev1.Service, bool, error) {
+		return svc, toDelete, nil
+	}
+}
+
+func requireOwnershipConflict(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var alreadyOwned *controllerutil.AlreadyOwnedError
+	require.True(t, errors.As(err, &alreadyOwned), "expected an *controllerutil.AlreadyOwnedError, got %v", err)
+	assert.Equal(t, ownershipTestForeignUID, alreadyOwned.Owner.UID)
+}
+
+func TestSyncResource_ForeignControllerBlocksUpdate(t *testing.T) {
+	ctx := context.Background()
+	s := newOwnershipTestScheme(t)
+
+	existing := seedService(t, ownershipTestService(9090))
+	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
+	r, c := newOwnershipTestReconciler(t, s, existing)
+
+	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(ownershipTestService(8080), false))
+
+	requireOwnershipConflict(t, err)
+	assert.False(t, modified)
+
+	stored := storedService(t, c)
+	assert.Equal(t, int32(9090), stored.Spec.Ports[0].Port, "spec of a foreign-owned object must not be overwritten")
+	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences)
+	assert.Equal(t, existing.Annotations, stored.Annotations, "bookkeeping annotations must not be written either")
+}
+
+func TestSyncResource_ForeignControllerBlocksDelete(t *testing.T) {
+	ctx := context.Background()
+	s := newOwnershipTestScheme(t)
+
+	existing := seedService(t, ownershipTestService(9090))
+	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
+	r, c := newOwnershipTestReconciler(t, s, existing)
+
+	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(ownershipTestService(9090), true))
+
+	requireOwnershipConflict(t, err)
+	assert.False(t, modified)
+
+	stored := storedService(t, c)
+	assert.Equal(t, int32(9090), stored.Spec.Ports[0].Port)
+	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences)
+}
+
+func TestSyncResource_ForeignControllerBlocksMatchingContentSuccess(t *testing.T) {
+	ctx := context.Background()
+	s := newOwnershipTestScheme(t)
+
+	desired := ownershipTestService(8080)
+	existing := seedService(t, desired)
+	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
+	r, c := newOwnershipTestReconciler(t, s, existing)
+
+	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(desired, false))
+
+	requireOwnershipConflict(t, err)
+	assert.False(t, modified)
+
+	stored := storedService(t, c)
+	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences,
+		"a matching-content sync must not rewrite the owner references of a foreign-owned object")
+}
+
+func TestSyncResource_AdoptsOwnerlessObjectWithMatchingContent(t *testing.T) {
+	ctx := context.Background()
+	s := newOwnershipTestScheme(t)
+
+	desired := ownershipTestService(8080)
+	existing := seedService(t, desired)
+	r, c := newOwnershipTestReconciler(t, s, existing)
+
+	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(desired, false))
+
+	require.NoError(t, err)
+	assert.True(t, modified)
+
+	stored := storedService(t, c)
+	require.Len(t, stored.OwnerReferences, 1)
+	assert.Equal(t, parentControllerRef(), stored.OwnerReferences[0])
+	assert.Equal(t, int32(8080), stored.Spec.Ports[0].Port, "adoption must not change the content")
+}
+
+func TestSyncResource_AdoptsOwnerlessObjectWithDifferingContent(t *testing.T) {
+	ctx := context.Background()
+	s := newOwnershipTestScheme(t)
+
+	existing := seedService(t, ownershipTestService(9090))
+	r, c := newOwnershipTestReconciler(t, s, existing)
+
+	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(ownershipTestService(8080), false))
+
+	require.NoError(t, err)
+	assert.True(t, modified)
+
+	stored := storedService(t, c)
+	require.Len(t, stored.OwnerReferences, 1)
+	assert.Equal(t, parentControllerRef(), stored.OwnerReferences[0])
+	assert.Equal(t, int32(8080), stored.Spec.Ports[0].Port)
+}
+
+func TestSyncResource_SameControllerReconcilesNormally(t *testing.T) {
+	ctx := context.Background()
+	s := newOwnershipTestScheme(t)
+
+	existing := seedService(t, ownershipTestService(9090))
+	existing.OwnerReferences = []metav1.OwnerReference{parentControllerRef()}
+	r, c := newOwnershipTestReconciler(t, s, existing)
+
+	modified, _, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(ownershipTestService(8080), false))
+
+	require.NoError(t, err)
+	assert.True(t, modified)
+
+	stored := storedService(t, c)
+	assert.Equal(t, int32(8080), stored.Spec.Ports[0].Port)
+	assert.Equal(t, []metav1.OwnerReference{parentControllerRef()}, stored.OwnerReferences)
+}
+
+func TestSyncResource_NilParentIgnoresOwnership(t *testing.T) {
+	ctx := context.Background()
+	s := newOwnershipTestScheme(t)
+
+	existing := seedService(t, ownershipTestService(9090))
+	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
+	r, c := newOwnershipTestReconciler(t, s, existing)
+
+	modified, _, err := SyncResource(ctx, r, nil, serviceGenerator(ownershipTestService(8080), false))
+
+	require.NoError(t, err, "a nil parent asks for an independent lifecycle and must behave as before")
+	assert.True(t, modified)
+
+	stored := storedService(t, c)
+	assert.Equal(t, int32(8080), stored.Spec.Ports[0].Port)
+	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences)
+}
+
+func TestSyncResource_SharedOwnershipToleratesForeignController(t *testing.T) {
+	ctx := context.Background()
+	s := newOwnershipTestScheme(t)
+
+	desired := ownershipTestService(8080)
+	existing := seedService(t, desired)
+	existing.OwnerReferences = []metav1.OwnerReference{foreignControllerRef()}
+	r, c := newOwnershipTestReconciler(t, s, existing)
+
+	modified, res, err := SyncResource(ctx, r, newOwnershipTestParent(), serviceGenerator(desired, false), WithSharedOwnership())
+
+	require.NoError(t, err, "the shared-ownership opt-out must keep a second owner from failing")
+	assert.False(t, modified)
+	require.NotNil(t, res)
+
+	stored := storedService(t, c)
+	assert.Equal(t, []metav1.OwnerReference{foreignControllerRef()}, stored.OwnerReferences,
+		"shared ownership must leave owner references alone")
 }

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -927,11 +927,6 @@ func TestGetSpecChangeResult_ConfigMap(t *testing.T) {
 	}
 }
 
-// The tests below cover the controller-ownership guard in SyncResource. They drive the helper
-// against a controller-runtime fake client so that every assertion about what was written can be
-// made by re-reading the stored object rather than by inspecting the in-memory copy SyncResource
-// returned.
-
 const (
 	ownershipTestNamespace   = "default"
 	ownershipTestServiceName = "shared-service"
@@ -968,8 +963,7 @@ func newOwnershipTestParent() *v1beta1.DynamoGraphDeployment {
 	}
 }
 
-// foreignControllerRef deliberately carries the parent's kind and name and differs only in UID,
-// which is the collision upstream referSameObject cannot detect.
+// foreignControllerRef differs from the parent only by UID.
 func foreignControllerRef() metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion:         v1beta1.GroupVersion.String(),
@@ -1003,8 +997,7 @@ func ownershipTestService(port int32) *corev1.Service {
 	}
 }
 
-// seedService returns a copy of svc annotated as if the operator had last applied exactly this
-// content, so that GetSpecChangeResult reports no update needed when svc is also the desired object.
+// seedService marks svc as the last applied content.
 func seedService(t *testing.T, svc *corev1.Service) *corev1.Service {
 	t.Helper()
 	existing := svc.DeepCopy()
@@ -1048,10 +1041,6 @@ func requireOwnershipConflict(t *testing.T, err error) {
 	assert.Equal(t, ownershipTestForeignUID, alreadyOwned.Owner.UID)
 }
 
-// TestSyncResource_ForeignControllerBlocksMutation covers the three paths that write or delete
-// once an object already exists. Each must refuse a foreign owner before touching anything: the
-// content-differs update, the delete, and the content-matches path that previously reported
-// success without ever attaching an owner reference.
 func TestSyncResource_ForeignControllerBlocksMutation(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -1087,10 +1076,6 @@ func TestSyncResource_ForeignControllerBlocksMutation(t *testing.T) {
 	}
 }
 
-// TestSyncResource_SyncProceeds covers the cases the guard must let through: adoption of an
-// ownerless object, the controller that already owns the object, an opted-out nil parent, and the
-// shared-ownership opt-out. Every case also asserts that a second sync settles, since a write that
-// repeated on each pass would requeue the controller forever without ever converging.
 func TestSyncResource_SyncProceeds(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/deploy/operator/internal/dynamo/model_service.go
+++ b/deploy/operator/internal/dynamo/model_service.go
@@ -88,10 +88,7 @@ func ReconcileModelServicesForComponents(
 			func(ctx context.Context) (*corev1.Service, bool, error) {
 				return headlessService, false, nil
 			},
-			// dynamo-model-{hash} is named after the base model, not after its owner, so every
-			// deployment serving the same base model in this namespace converges on the same
-			// Service and each passes a different owner. The ownership guard must not treat the
-			// second and later owners as a collision.
+			// Deployments that serve the same base model share this Service.
 			commonController.WithSharedOwnership(),
 		)
 		if err != nil {

--- a/deploy/operator/internal/dynamo/model_service.go
+++ b/deploy/operator/internal/dynamo/model_service.go
@@ -88,6 +88,11 @@ func ReconcileModelServicesForComponents(
 			func(ctx context.Context) (*corev1.Service, bool, error) {
 				return headlessService, false, nil
 			},
+			// dynamo-model-{hash} is named after the base model, not after its owner, so every
+			// deployment serving the same base model in this namespace converges on the same
+			// Service and each passes a different owner. The ownership guard must not treat the
+			// second and later owners as a collision.
+			commonController.WithSharedOwnership(),
 		)
 		if err != nil {
 			logger.Error(err, "Failed to sync headless service for model",


### PR DESCRIPTION
## Summary

`SyncResource` could update or delete an object owned by another controller. It could also accept a matching ownerless object without attaching the controller reference supplied by the caller.

This change checks the existing controller owner before updates and deletes. A foreign controller produces `AlreadyOwnedError` and an `OwnershipConflict` event. The checkpoint reconciler treats that ownership collision as terminal instead of retrying it as a transient API failure. Ownerless objects are adopted, while a nil parent explicitly leaves ownership unchanged. Deletes include UID and resource-version preconditions so stale reconciliation cannot delete a replacement object.

`WithSharedOwnership()` keeps the previous behavior for resources that are intentionally reconciled by several owners. The model-service and checkpoint `ResourceClaimTemplate` call sites use that option. Existing owner references on shared resources are left unchanged.

Closes #13474

## Validation

- `gofmt -d deploy/operator/internal/controller_common/resource.go` produced no diff.
- `git diff --check`

No tests were run.
