### PR TITLE
fix(operator): recover the current worker hash from existing DCDs when annotations are missing

### DIFF
--- a/deploy/operator/internal/controller/dgd_worker_rollout_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_worker_rollout_reconciler.go
@@ -244,6 +244,9 @@ func (r *dgdWorkerRolloutReconciler) shouldTriggerRollingUpdate(
 // managed rolling updates may already have worker DCDs without a hash label; in
 // that case we label those DCDs with the legacy sentinel and let the normal
 // rolling update path migrate from that sentinel to the desired compatibility hash.
+// A DGD whose annotations are missing but which already owns hash-labelled worker
+// DCDs is not a first deploy: its active generation is recovered from those DCDs so
+// that a pending spec change still rolls through the managed lifecycle.
 func (r *dgdWorkerRolloutReconciler) initializeWorkerHashIfNeeded(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
@@ -292,11 +295,38 @@ func (r *dgdWorkerRolloutReconciler) initializeWorkerHashIfNeeded(
 		return nil
 	}
 
-	// Normal first deploy — set the canonical v2 hash.
 	hashes, err := desiredWorkerHashes(dgd)
 	if err != nil {
 		return err
 	}
+
+	// Hash-labelled worker DCDs without annotations mean the annotations were lost
+	// (for example the DGD was replaced instead of patched). Recover the active
+	// generation from the observed DCDs; assuming the desired generation here would
+	// leave the running one outside the rolling update lifecycle for good.
+	existingDCDs, err := r.listOldWorkerDCDs(ctx, dgd, "") // every hash-labelled worker DCD; legacy ones were handled above
+	if err != nil {
+		return fmt.Errorf("failed to list worker DCDs for hash recovery: %w", err)
+	}
+	legacyHash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
+	if err != nil {
+		return fmt.Errorf("failed to compute v1 worker hash for hash recovery: %w", err)
+	}
+	if recovered, found := recoverWorkerHashes(existingDCDs, hashes, legacyHash); found {
+		r.setCurrentWorkerHashes(dgd, recovered)
+		if err := r.Update(ctx, dgd); err != nil {
+			return fmt.Errorf("failed to recover worker hash: %w", err)
+		}
+		logger.Info("Recovered current worker hashes from existing worker DCDs",
+			"v1Hash", recovered.v1, "v2Hash", recovered.v2, "dcdCount", len(existingDCDs))
+		if r.recorder != nil {
+			r.recorder.Eventf(dgd, nil, corev1.EventTypeNormal, "WorkerHashRecovered", "Update",
+				"Recovered current worker hash from %d existing worker DCDs", len(existingDCDs))
+		}
+		return nil
+	}
+
+	// Normal first deploy — set the canonical v2 hash.
 	r.setCurrentWorkerHashes(dgd, workerHashesForCompletedGeneration(hashes.v2, hashes))
 
 	if err := r.Update(ctx, dgd); err != nil {
@@ -306,6 +336,83 @@ func (r *dgdWorkerRolloutReconciler) initializeWorkerHashIfNeeded(
 	logger.Info("Initialized current worker hashes", "v1Hash", hashes.v1, "v2Hash", hashes.v2)
 
 	return nil
+}
+
+// recoverWorkerHashes derives the active worker generation of a DGD from its existing
+// hash-labelled worker DCDs. It reports found=false when there are none, which is a
+// genuine first deploy.
+//
+// A generation counts as current when its label is one of the desired hashes or the
+// legacy alpha hash of the same spec (workers created by a pre-dual operator). When only
+// current generations exist the DGD has converged and the annotations are recorded the
+// way the annotation path would leave them: v2 only for a canonical generation, the
+// legacy alpha hash in v1 next to the canonical v2 for a pre-dual one, so nothing rolls.
+// Otherwise the non-desired generation with the most available replicas (the newest on
+// ties, the hash as the last tie-break) is recorded as current, so the next reconcile
+// starts a rolling update from it and the coordinator drains and removes it. A generation
+// still labelled with the legacy sentinel is recorded as that sentinel in v1 so the
+// existing legacy migration handles it.
+func recoverWorkerHashes(
+	dcds []nvidiacomv1beta1.DynamoComponentDeployment,
+	desired workerGenerationHashes,
+	legacyHash string,
+) (workerGenerationHashes, bool) {
+	// Group the DCDs by generation hash, summing availability and keeping the latest
+	// creation time per generation.
+	type generation struct {
+		hash      string
+		available int32
+		createdAt metav1.Time
+	}
+	generations := make(map[string]*generation)
+	for i := range dcds {
+		hash := dcds[i].Labels[consts.KubeLabelDynamoWorkerHash]
+		if hash == "" {
+			continue
+		}
+		state := dcdComponentStateFromDCD(&dcds[i])
+		g, ok := generations[hash]
+		if !ok {
+			g = &generation{hash: hash, createdAt: dcds[i].CreationTimestamp}
+			generations[hash] = g
+		}
+		g.available += state.Available
+		if dcds[i].CreationTimestamp.After(g.createdAt.Time) {
+			g.createdAt = dcds[i].CreationTimestamp
+		}
+	}
+	if len(generations) == 0 {
+		return workerGenerationHashes{}, false
+	}
+
+	// Pick the serving generation among those that are neither desired nor the legacy
+	// alpha form of the desired spec; the hash breaks full ties so the choice does not
+	// depend on map order.
+	var active *generation
+	for _, g := range generations {
+		if desired.contains(g.hash) || g.hash == legacyHash {
+			continue
+		}
+		if active == nil ||
+			g.available > active.available ||
+			(g.available == active.available && g.createdAt.After(active.createdAt.Time)) ||
+			(g.available == active.available && g.createdAt.Equal(&active.createdAt) && g.hash < active.hash) {
+			active = g
+		}
+	}
+	switch {
+	case active != nil && active.hash == consts.LegacyWorkerHash:
+		return workerGenerationHashes{v1: consts.LegacyWorkerHash}, true
+	case active != nil:
+		return workerGenerationHashes{v2: active.hash}, true
+	}
+	if _, ok := generations[desired.v2]; ok {
+		return workerGenerationHashes{v2: desired.v2}, true
+	}
+	if _, ok := generations[legacyHash]; ok && desired.v1 == desired.v2 {
+		return workerGenerationHashes{v1: legacyHash, v2: desired.v2}, true
+	}
+	return desired, true
 }
 
 // migrateCurrentWorkerHashIfNeeded fills in additive v2 worker-hash state while

--- a/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -389,6 +390,289 @@ func TestInitializeWorkerHashIfNeeded_AlreadyInitialized(t *testing.T) {
 	// Verify the hash was NOT changed
 	hash := r.getCurrentWorkerHash(dgd)
 	assert.Equal(t, existingHash, hash, "Hash should not change when already initialized")
+}
+
+// hashRecoveryWorkerDCD builds a worker DCD carrying only what recoverWorkerHashes reads:
+// the generation label, the available replica count and the creation time.
+func hashRecoveryWorkerDCD(name, hash string, available int32, createdAt metav1.Time) nvidiacomv1beta1.DynamoComponentDeployment {
+	return nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "default",
+			CreationTimestamp: createdAt,
+			Labels:            map[string]string{consts.KubeLabelDynamoWorkerHash: hash},
+		},
+		Status: nvidiacomv1beta1.DynamoComponentDeploymentStatus{
+			Component: &nvidiacomv1beta1.ComponentReplicaStatus{
+				Replicas:          1,
+				AvailableReplicas: ptr.To(available),
+			},
+		},
+	}
+}
+
+func TestRecoverWorkerHashes(t *testing.T) {
+	desired := workerGenerationHashes{v1: "desired-v1", v2: "desired-v2"}
+	// The recovery path only runs when the annotations are empty, and desiredWorkerHashes
+	// then reports the canonical hash in both slots.
+	canonical := workerGenerationHashes{v1: "canonical", v2: "canonical"}
+	const legacyHash = "legacy-alpha"
+	base := metav1.NewTime(metav1.Now().Add(-time.Hour))
+	dcd := hashRecoveryWorkerDCD
+
+	tests := []struct {
+		name      string
+		dcds      []nvidiacomv1beta1.DynamoComponentDeployment
+		desired   workerGenerationHashes
+		want      workerGenerationHashes
+		wantFound bool
+	}{
+		{
+			name:      "no worker DCDs is a first deploy",
+			wantFound: false,
+		},
+		{
+			name:      "a pre-dual generation labelled with the legacy alpha hash is current, recorded as v1 beside the canonical v2",
+			dcds:      []nvidiacomv1beta1.DynamoComponentDeployment{dcd("cur", legacyHash, 1, base)},
+			desired:   canonical,
+			want:      workerGenerationHashes{v1: legacyHash, v2: "canonical"},
+			wantFound: true,
+		},
+		{
+			name:      "a generation still labelled with the legacy sentinel is recorded as the sentinel",
+			dcds:      []nvidiacomv1beta1.DynamoComponentDeployment{dcd("cur", consts.LegacyWorkerHash, 1, base)},
+			desired:   canonical,
+			want:      workerGenerationHashes{v1: consts.LegacyWorkerHash},
+			wantFound: true,
+		},
+		{
+			name: "a serving old generation beside the legacy alpha generation is the active one",
+			dcds: []nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("old", "old-hash", 1, base),
+				dcd("alpha", legacyHash, 0, metav1.NewTime(base.Add(time.Minute))),
+			},
+			desired:   canonical,
+			want:      workerGenerationHashes{v2: "old-hash"},
+			wantFound: true,
+		},
+		{
+			name:      "unlabelled DCDs do not count",
+			dcds:      []nvidiacomv1beta1.DynamoComponentDeployment{dcd("legacy", "", 1, base)},
+			wantFound: false,
+		},
+		{
+			name:      "only the desired v2 generation exists",
+			dcds:      []nvidiacomv1beta1.DynamoComponentDeployment{dcd("cur", "desired-v2", 1, base)},
+			want:      workerGenerationHashes{v2: "desired-v2"},
+			wantFound: true,
+		},
+		{
+			name:      "only the desired v1 generation exists",
+			dcds:      []nvidiacomv1beta1.DynamoComponentDeployment{dcd("cur", "desired-v1", 1, base)},
+			want:      desired,
+			wantFound: true,
+		},
+		{
+			name: "a serving old generation beside a pending desired one is the active generation",
+			dcds: []nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("old", "old-hash", 1, base),
+				dcd("new", "desired-v2", 0, metav1.NewTime(base.Add(time.Minute))),
+			},
+			want:      workerGenerationHashes{v2: "old-hash"},
+			wantFound: true,
+		},
+		{
+			name: "among old generations the one with available replicas wins",
+			dcds: []nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("serving", "serving-hash", 1, base),
+				dcd("superseded", "superseded-hash", 0, metav1.NewTime(base.Add(time.Minute))),
+			},
+			want:      workerGenerationHashes{v2: "serving-hash"},
+			wantFound: true,
+		},
+		{
+			name: "on equal availability the newest old generation wins",
+			dcds: []nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("older", "older-hash", 0, base),
+				dcd("newer", "newer-hash", 0, metav1.NewTime(base.Add(time.Minute))),
+			},
+			want:      workerGenerationHashes{v2: "newer-hash"},
+			wantFound: true,
+		},
+		{
+			name: "availability is summed per generation across its DCDs",
+			dcds: []nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("a-prefill", "a-hash", 1, base),
+				dcd("a-decode", "a-hash", 1, base),
+				dcd("b-prefill", "b-hash", 1, metav1.NewTime(base.Add(time.Minute))),
+			},
+			want:      workerGenerationHashes{v2: "a-hash"},
+			wantFound: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := tt.desired
+			if d.empty() {
+				d = desired
+			}
+
+			t.Log("recover the active generation from the observed DCDs")
+			got, found := recoverWorkerHashes(tt.dcds, d, legacyHash)
+
+			t.Log("check the recovered generation and whether any DCD was found")
+			assert.Equal(t, tt.wantFound, found)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInitializeWorkerHashIfNeeded_RecoversFromExistingWorkerDCDs(t *testing.T) {
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Envs:          []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+		},
+	})
+	desiredV2Hash := betaDGDWorkersSpecHash(t, dgd)
+
+	t.Log("a serving worker DCD from an older generation exists, but the DGD carries no hash annotations")
+	servingDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd-worker-oldhash",
+			Namespace: "default",
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoWorkerHash:          testOldWorkerHash,
+			},
+		},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Replicas:      ptr.To(int32(1)),
+			},
+		},
+	})
+	servingDCD.Status.Component = &nvidiacomv1beta1.ComponentReplicaStatus{
+		Replicas:          1,
+		ReadyReplicas:     ptr.To(int32(1)),
+		AvailableReplicas: ptr.To(int32(1)),
+	}
+
+	r := createTestReconcilerWithStatus(dgd, withObjects(servingDCD))
+	ctx := context.Background()
+
+	t.Log("initialize the missing annotations from the existing DCD")
+	require.NoError(t, r.initializeWorkerHashIfNeeded(ctx, dgd))
+
+	t.Log("the running generation is recorded as current, not the desired one")
+	assert.Equal(t, testOldWorkerHash, r.getCurrentWorkerHashV2(dgd))
+	assert.NotContains(t, dgd.Annotations, consts.AnnotationCurrentWorkerHash)
+
+	persisted := &nvidiacomv1beta1.DynamoGraphDeployment{}
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "test-dgd", Namespace: "default"}, persisted))
+	assert.Equal(t, testOldWorkerHash, persisted.Annotations[consts.AnnotationCurrentWorkerHashV2])
+
+	t.Log("the pending spec change rolls from the recovered generation to the desired one")
+	trigger, err := r.shouldTriggerRollingUpdate(dgd)
+	require.NoError(t, err)
+	assert.True(t, trigger)
+
+	rollingCtx, err := r.buildRollingUpdateContext(ctx, dgd)
+	require.NoError(t, err)
+	assert.Equal(t, desiredV2Hash, rollingCtx.NewWorkerHash)
+
+	oldDCDs, err := r.listOldWorkerDCDs(ctx, dgd, rollingCtx.NewWorkerHash)
+	require.NoError(t, err)
+	require.Len(t, oldDCDs, 1)
+	assert.Equal(t, "test-dgd-worker-oldhash", oldDCDs[0].Name)
+}
+
+func TestInitializeWorkerHashIfNeeded_RecoversLegacyAlphaGenerationWithoutRolling(t *testing.T) {
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Envs:          []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+			Resources: &nvidiacomv1alpha1.Resources{
+				Requests: &nvidiacomv1alpha1.ResourceItem{CPU: "1"},
+			},
+		},
+	})
+	legacyHash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
+	require.NoError(t, err)
+	v2Hash := betaDGDWorkersSpecHash(t, dgd)
+	require.NotEqual(t, legacyHash, v2Hash)
+
+	t.Log("workers created by a pre-dual operator carry the legacy alpha hash; the annotations are gone")
+	alphaDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd-worker-alpha",
+			Namespace: "default",
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoWorkerHash:          legacyHash,
+			},
+		},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+			},
+		},
+	})
+
+	r := createTestReconcilerWithStatus(dgd, withObjects(alphaDCD))
+
+	t.Log("initialize the missing annotations from the existing DCD")
+	require.NoError(t, r.initializeWorkerHashIfNeeded(context.Background(), dgd))
+
+	t.Log("recorded like the annotation path leaves a pre-dual generation, and nothing rolls")
+	assert.Equal(t, legacyHash, r.getCurrentWorkerHash(dgd))
+	assert.Equal(t, v2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
+	trigger, err := r.shouldTriggerRollingUpdate(dgd)
+	require.NoError(t, err)
+	assert.False(t, trigger)
+	rollingCtx, err := r.buildRollingUpdateContext(context.Background(), dgd)
+	require.NoError(t, err)
+	assert.Equal(t, legacyHash, rollingCtx.NewWorkerHash)
+	assert.False(t, rollingCtx.InProgress())
+}
+
+func TestInitializeWorkerHashIfNeeded_ExistingDesiredGenerationDoesNotRoll(t *testing.T) {
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Envs:          []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+		},
+	})
+	desiredV2Hash := betaDGDWorkersSpecHash(t, dgd)
+
+	t.Log("the only worker DCD already carries the desired hash")
+	currentDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd-worker-current",
+			Namespace: "default",
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoWorkerHash:          desiredV2Hash,
+			},
+		},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+			},
+		},
+	})
+
+	r := createTestReconcilerWithStatus(dgd, withObjects(currentDCD))
+
+	t.Log("initialize the missing annotations from the existing DCD")
+	require.NoError(t, r.initializeWorkerHashIfNeeded(context.Background(), dgd))
+
+	t.Log("the desired generation is recorded and no rollout is triggered")
+	assert.Equal(t, desiredV2Hash, r.getCurrentWorkerHashV2(dgd))
+	trigger, err := r.shouldTriggerRollingUpdate(dgd)
+	require.NoError(t, err)
+	assert.False(t, trigger)
 }
 
 func TestInitializeWorkerHashIfNeeded_PreservesLegacyAlphaHash(t *testing.T) {


### PR DESCRIPTION
## Overview:

When a DynamoGraphDeployment has lost its `nvidia.com/current-worker-hash*` annotations but already owns hash-labelled worker DynamoComponentDeployments, `initializeWorkerHashIfNeeded` treats it as a first deploy and records the desired hash as current. A spec change applied in that state never starts a rolling update: the new-generation DCD is created next to the running one, and the previous generation is never scaled down, drained or deleted. Each further spec change adds one more DCD.

The annotations disappear whenever the DGD object is replaced rather than patched (`kubectl replace`, `helm upgrade --force`, re-creating it from a stored manifest). The operator has no other record of the active generation, and it does not consult the DCDs it created.

## Details:

`initializeWorkerHashIfNeeded` now lists the DGD's hash-labelled worker DCDs before falling through to the first-deploy branch. If any exist, `recoverWorkerHashes` derives the active generation from them:

- if every existing generation is the desired one, the DGD has already converged and the desired hashes are recorded;
- otherwise the non-desired generation with the most available replicas (newest on ties, hash as the final tie-break) is recorded as current, so the next reconcile starts a managed rolling update from it and the coordinator drains and removes it as usual.

An event (`WorkerHashRecovered`) and a log line record that this happened. Legacy DCDs without a hash label keep taking the existing migration path; the unsupported (Grove/multinode) path is unchanged.

Tests: a table test for `recoverWorkerHashes` (first deploy, unlabelled DCDs, converged v1/v2, serving old generation beside a pending desired one, availability and creation-time tie-breaks, availability summed across a generation's DCDs) and two fake-client tests for `initializeWorkerHashIfNeeded`: recovery followed by a rollout that treats the recovered generation as old, and no rollout when the only existing DCD already carries the desired hash. `make test` (unit + envtest) and `golangci-lint` pass.

Reproduced on a 1.3.0 cluster before the change with a throwaway DGD: `kubectl replace` after a template edit produces a second `Initialized current worker hashes` in the operator log, two DCDs at full replicas and no `status.rollingUpdate`; the same edit via `kubectl apply` starts a rolling update. Details in the linked issue.

## Where should the reviewer start?

`deploy/operator/internal/controller/dgd_worker_rollout_reconciler.go`: `initializeWorkerHashIfNeeded` and the new `recoverWorkerHashes`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #13495

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rolling-update recovery when deployment metadata is missing by detecting active worker generations from existing workloads.
  * Prevented unnecessary first-deployment behavior and resumed updates from the correct serving generation.
  * Avoided triggering a rollout when the existing worker generation already matches the desired state.
  * Added event recording when generation information is successfully recovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->