### PR TITLE
fix(runtime): release endpoint state on rollback and shutdown

### DIFF
--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -130,6 +130,25 @@ impl EndpointConfigBuilder {
     }
 
     /// Start an endpoint and return once its exact discovery instance is callable.
+    /// Release the endpoint-scoped state that startup installs before any fallible
+    /// registration: the local engine and, if one was registered, the health check
+    /// target with its notifier and status.
+    ///
+    /// Safe to call when neither was installed; both removals are no-ops for an
+    /// unknown endpoint name.
+    fn release_endpoint_local_state(
+        endpoint: &Endpoint,
+        system_health: &Arc<parking_lot::Mutex<crate::system_health::SystemHealth>>,
+    ) {
+        endpoint
+            .drt()
+            .local_endpoint_registry()
+            .remove(&endpoint.name);
+        system_health
+            .lock()
+            .unregister_health_check_target(&endpoint.name);
+    }
+
     pub async fn start_with_registration(self) -> Result<StartedEndpoint> {
         let (endpoint, handler, metrics_labels, graceful_shutdown, health_check_payload) =
             self.build_internal()?.dissolve();
@@ -204,7 +223,7 @@ impl EndpointConfigBuilder {
         );
 
         // Register endpoint with the server (unified interface)
-        server
+        if let Err(error) = server
             .register_endpoint(
                 endpoint_name_for_task.clone(),
                 handler,
@@ -213,7 +232,15 @@ impl EndpointConfigBuilder {
                 component_name_for_task.clone(),
                 system_health.clone(),
             )
-            .await?;
+            .await
+        {
+            // The local engine and the health check target were installed before
+            // this point. Returning without releasing them leaves the endpoint
+            // callable and its canary target in place for an endpoint that never
+            // started.
+            Self::release_endpoint_local_state(&endpoint, &system_health);
+            return Err(error);
+        }
 
         let tracker_clone = if graceful_shutdown {
             tracing::debug!(
@@ -254,6 +281,7 @@ impl EndpointConfigBuilder {
                 if let Some(tracker) = tracker_clone {
                     tracker.unregister_endpoint();
                 }
+                Self::release_endpoint_local_state(&endpoint, &system_health);
                 anyhow::bail!(
                     "Unable to register service for discovery. Check discovery service status"
                 );
@@ -266,6 +294,8 @@ impl EndpointConfigBuilder {
 
         // Create cleanup task that unregisters on cancellation.
         let endpoint_name_for_cleanup = endpoint_name_for_task;
+        let local_registry_for_cleanup = endpoint.drt().local_endpoint_registry().clone();
+        let system_health_for_cleanup = system_health.clone();
         let server_for_cleanup = server;
         let cancel_token_for_cleanup = endpoint_shutdown_token.clone();
         let discovery_for_cleanup = discovery;
@@ -297,6 +327,14 @@ impl EndpointConfigBuilder {
                 tracing::debug!("Unregister endpoint from graceful shutdown tracker");
                 tracker.unregister_endpoint();
             }
+
+            // Release the state installed before startup too, so restarting this
+            // endpoint name picks up the new engine and canary target instead of
+            // the previous instance's.
+            local_registry_for_cleanup.remove(&endpoint_name_for_cleanup);
+            system_health_for_cleanup
+                .lock()
+                .unregister_health_check_target(&endpoint_name_for_cleanup);
 
             anyhow::Ok(())
         });

--- a/lib/runtime/src/local_endpoint_registry.rs
+++ b/lib/runtime/src/local_endpoint_registry.rs
@@ -55,4 +55,16 @@ impl LocalEndpointRegistry {
     pub fn get(&self, endpoint_name: &str) -> Option<LocalAsyncEngine> {
         self.engines.get(endpoint_name).map(|e| e.clone())
     }
+
+    /// Remove a registered local endpoint.
+    ///
+    /// Registration happens before endpoint startup, so a start that fails part
+    /// way through, or an endpoint that is shut down, has to give the engine
+    /// back. Leaving it behind keeps the endpoint callable and lets a canary go
+    /// on reporting a torn-down endpoint as ready.
+    pub fn remove(&self, endpoint_name: &str) {
+        if self.engines.remove(endpoint_name).is_some() {
+            tracing::debug!("Removed local endpoint: {endpoint_name}");
+        }
+    }
 }

--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -248,6 +248,35 @@ impl SystemHealth {
         endpoint_health.get(endpoint).cloned()
     }
 
+    /// Remove an endpoint's health check target, notifier and status.
+    ///
+    /// `register_health_check_target` refuses a second registration under the
+    /// same name, so an endpoint that goes away without clearing its entries
+    /// leaves a restarted endpoint of that name monitoring the previous
+    /// instance's target and payload.
+    pub fn unregister_health_check_target(&self, endpoint_subject: &str) {
+        let removed = self
+            .health_check_targets
+            .write()
+            .unwrap()
+            .remove(endpoint_subject)
+            .is_some();
+        self.health_check_notifiers
+            .write()
+            .unwrap()
+            .remove(endpoint_subject);
+        self.endpoint_health
+            .write()
+            .unwrap()
+            .remove(endpoint_subject);
+        if removed {
+            tracing::debug!(
+                endpoint = %endpoint_subject,
+                "Removed endpoint health check target"
+            );
+        }
+    }
+
     /// Get the endpoint-specific health check notifier
     pub fn get_endpoint_health_check_notifier(
         &self,
@@ -328,6 +357,49 @@ mod tests {
             device_type: None,
             request_plane_codec: None,
         }
+    }
+
+    /// `register_health_check_target` refuses a second registration under the
+    /// same name, so an endpoint that goes away without clearing its entries
+    /// leaves a restarted endpoint of that name monitoring the previous
+    /// instance's target and payload.
+    #[test]
+    fn unregistering_lets_the_same_endpoint_name_register_again() {
+        let health = system_health(true);
+        health.register_health_check_target(ENDPOINT, instance(), serde_json::json!({"gen": 1}));
+        assert!(
+            health
+                .get_endpoint_health_check_notifier(ENDPOINT)
+                .is_some()
+        );
+
+        health.unregister_health_check_target(ENDPOINT);
+
+        assert!(
+            health.get_health_check_target(ENDPOINT).is_none(),
+            "target survived unregistration"
+        );
+        assert!(
+            health
+                .get_endpoint_health_check_notifier(ENDPOINT)
+                .is_none(),
+            "notifier survived unregistration"
+        );
+        assert!(
+            health.get_endpoint_health_status(ENDPOINT).is_none(),
+            "endpoint health status survived unregistration"
+        );
+
+        // The point of removing it: a restart of this endpoint name installs its
+        // own target rather than inheriting the previous instance's payload.
+        let mut restarted = instance();
+        restarted.instance_id = 2;
+        health.register_health_check_target(ENDPOINT, restarted, serde_json::json!({"gen": 2}));
+        let target = health
+            .get_health_check_target(ENDPOINT)
+            .expect("restarted endpoint should own the target");
+        assert_eq!(target.instance.instance_id, 2);
+        assert_eq!(target.payload, serde_json::json!({"gen": 2}));
     }
 
     /// A worker that registers a health-check payload reports ready once its


### PR DESCRIPTION
## Summary

Fixes #13475.

Endpoint startup installs two pieces of process-wide state before anything fallible runs. `register_local_engine` puts the engine in `LocalEndpointRegistry`, and `start_with_registration` installs the canary target, its notifier and a `NotReady` status. Neither had a removal path, so:

- a request-plane registration failure returned immediately and left both behind;
- a discovery registration failure rolled back the request-plane and graceful-shutdown entries but not these;
- a successful `StartedEndpoint::shutdown` unregistered discovery and the request-plane endpoint and also left them.

The consequence is the part worth fixing. `register_health_check_target` refuses a second registration under the same name, so an endpoint restarted under that name kept monitoring the previous instance's `Instance` and payload. The local engine staying callable is worse, because the canary can go on marking the stale record `Ready` after its request-plane and discovery registrations are gone.

The change adds `LocalEndpointRegistry::remove` and `SystemHealth::unregister_health_check_target`, and calls them on all three paths through one small helper. The unregister clears all three maps the registration writes: target, notifier and endpoint status. Leaving the notifier or status behind would reproduce the same staleness in a quieter form.

One assumption worth stating, since removing state on shutdown is only safe if nothing depends on it outliving the endpoint. Engines are registered through the builder (`builder.register_local_engine(...)` in `lib/backend-common/src/worker.rs` and the Python bindings), so a restart constructs a new builder and re-registers. I checked the callers rather than assuming it.

## Validation

`cargo test -p dynamo-runtime --lib` — **590 passed, 0 failed**. `cargo build -p dynamo-runtime` and `cargo clippy -p dynamo-runtime` are clean.

`unregistering_lets_the_same_endpoint_name_register_again` covers the behaviour that actually bites: after unregistering, the target, notifier and status are all gone, and re-registering the same endpoint name yields the *new* instance and payload rather than the previous one. It fails without the unregister call, verified by commenting out that single line:

```
test system_health::tests::unregistering_lets_the_same_endpoint_name_register_again ... FAILED
panicked at lib/runtime/src/system_health.rs:378
```

I did not add a unit test for `LocalEndpointRegistry::remove`. It is a one-line `DashMap` removal, and exercising it needs a full `AsyncEngine` implementation, so a test there would be about forty lines of mock to assert a map delete. The behaviour that matters is covered above and by the call sites.

Not verified here: the issue also asks for coverage that forces request-plane and discovery registration failures after setup and asserts no endpoint-scoped state remains. Reaching those two branches needs a live request-plane server and discovery backend, which this crate's unit tests do not stand up, so I have wired the rollback rather than proved it end to end. If you would rather that land as an integration test under the `integration` feature, I am happy to add it.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint startup failure handling to ensure temporary engine and health-check state is removed.
  * Prevented stale endpoint registrations from remaining after shutdown, cancellation, or registration errors.
  * Ensured health-check information is fully cleared so endpoint names can be safely reused.
  * Improved cleanup when endpoint discovery or request registration fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->