### PR TITLE
feat(gms): first-fit client slabs for V1 mappings

### DIFF
--- a/lib/gpu_memory_service/tests/test_v1_memory_manager.py
+++ b/lib/gpu_memory_service/tests/test_v1_memory_manager.py
@@ -159,3 +159,73 @@ def test_latched_failure_raises_fresh_exceptions(monkeypatch) -> None:
         manager.connect(RequestedLockType.RO)
     assert first.value is not second.value
     assert str(first.value) == str(second.value)
+
+
+def _connected_client(tmp_path, monkeypatch, *, slab_size: int):
+    path = str(tmp_path / "weights.sock")
+    vmm = FakeVMM(granularity=64)
+    server_manager = GMSServerMemoryManager("GPU-0", vmm, 0)
+    server = GMSRPCServer(path, server_manager)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setattr(device_identity, "invalidate_device_uuid_cache", lambda: None)
+    monkeypatch.setattr(device_identity, "get_device_uuid", lambda _device: "GPU-0")
+    client = GMSClientMemoryManager(path, vmm, 0, slab_size=slab_size)
+    client.connect(RequestedLockType.RW)
+    return client, vmm, server, thread
+
+
+def _stop_client(client, server, thread) -> None:
+    client.close()
+    _stop(server, thread)
+
+
+@pytest.mark.timeout(10)
+def test_small_mappings_share_one_slab_and_reuse_freed_holes(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    client, vmm, server, thread = _connected_client(tmp_path, monkeypatch, slab_size=256)
+    try:
+        first = client.create_mapping(65)
+        second = client.create_mapping(65)
+        assert second == first + 128
+        assert len(client.mappings) == 1
+        assert client.owns(first)
+        assert client.owns(second)
+        assert set(vmm.reservations) == {client.mappings[0].base}
+
+        client.destroy_mapping(first, 65)
+        reused = client.create_mapping(65)
+        assert reused == first
+        assert len(client.mappings) == 1
+
+        client.unmap_all_vas()
+        client.disconnect()
+        client.connect(RequestedLockType.RW)
+        client.reallocate_all_handles()
+        client.remap_all_vas()
+        assert len(client.mappings) == 1
+        assert client.owns(reused)
+        assert client.owns(second)
+    finally:
+        _stop_client(client, server, thread)
+
+
+@pytest.mark.timeout(10)
+def test_mapping_larger_than_slab_gets_its_own_reservation(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    client, vmm, server, thread = _connected_client(tmp_path, monkeypatch, slab_size=256)
+    try:
+        small = client.create_mapping(65)
+        large = client.create_mapping(320)
+        assert len(client.mappings) == 2
+        assert large != small
+        assert set(vmm.reservations) == {mapping.base for mapping in client.mappings}
+        client.destroy_mapping(large, 320)
+        assert len(client.mappings) == 1
+        assert client.owns(small)
+    finally:
+        _stop_client(client, server, thread)

--- a/lib/gpu_memory_service/tests/test_v1_memory_manager.py
+++ b/lib/gpu_memory_service/tests/test_v1_memory_manager.py
@@ -215,8 +215,12 @@ def test_client_slabs_pack_reuse_coalesce_and_remap(tmp_path, monkeypatch) -> No
         assert client.owns(small)
 
         client.unmap_all_vas()
+        with pytest.raises(RuntimeError, match="slabs are unmapped"):
+            client.create_mapping(65)
         client.disconnect()
         client.connect(RequestedLockType.RW)
+        with pytest.raises(RuntimeError, match="slabs are unmapped"):
+            client.create_mapping(65)
         client.reallocate_all_handles()
         client.remap_all_vas()
         assert len(client.mappings) == 1

--- a/lib/gpu_memory_service/tests/test_v1_memory_manager.py
+++ b/lib/gpu_memory_service/tests/test_v1_memory_manager.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import threading
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 
 import pytest
 from _deps import HAS_GMS
@@ -161,44 +161,58 @@ def test_latched_failure_raises_fresh_exceptions(monkeypatch) -> None:
     assert str(first.value) == str(second.value)
 
 
+@contextmanager
 def _connected_client(tmp_path, monkeypatch, *, slab_size: int):
     path = str(tmp_path / "weights.sock")
     vmm = FakeVMM(granularity=64)
-    server_manager = GMSServerMemoryManager("GPU-0", vmm, 0)
-    server = GMSRPCServer(path, server_manager)
+    server = GMSRPCServer(path, GMSServerMemoryManager("GPU-0", vmm, 0))
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     monkeypatch.setattr(device_identity, "invalidate_device_uuid_cache", lambda: None)
     monkeypatch.setattr(device_identity, "get_device_uuid", lambda _device: "GPU-0")
     client = GMSClientMemoryManager(path, vmm, 0, slab_size=slab_size)
-    client.connect(RequestedLockType.RW)
-    return client, vmm, server, thread
-
-
-def _stop_client(client, server, thread) -> None:
-    client.close()
-    _stop(server, thread)
+    try:
+        client.connect(RequestedLockType.RW)
+        try:
+            yield client, vmm
+        finally:
+            client.close()
+    finally:
+        _stop(server, thread)
 
 
 @pytest.mark.timeout(10)
-def test_small_mappings_share_one_slab_and_reuse_freed_holes(
-    tmp_path,
-    monkeypatch,
-) -> None:
-    client, vmm, server, thread = _connected_client(tmp_path, monkeypatch, slab_size=256)
-    try:
+def test_client_slabs_pack_reuse_coalesce_and_remap(tmp_path, monkeypatch) -> None:
+    with _connected_client(tmp_path, monkeypatch, slab_size=384) as (client, vmm):
         first = client.create_mapping(65)
         second = client.create_mapping(65)
+        third = client.create_mapping(65)
         assert second == first + 128
+        assert third == first + 256
         assert len(client.mappings) == 1
-        assert client.owns(first)
-        assert client.owns(second)
-        assert set(vmm.reservations) == {client.mappings[0].base}
+        assert set(vmm.reservations) == {first}
 
         client.destroy_mapping(first, 65)
-        reused = client.create_mapping(65)
-        assert reused == first
+        assert client.create_mapping(65) == first
+
+        client.destroy_mapping(first, 65)
+        client.destroy_mapping(second, 65)
+        coalesced = client.create_mapping(200)
+        assert coalesced == first
         assert len(client.mappings) == 1
+        assert client.owns(third)
+
+        client.destroy_mapping(coalesced, 200)
+        client.destroy_mapping(third, 65)
+        assert len(client.mappings) == 0
+
+        small = client.create_mapping(65)
+        large = client.create_mapping(400)
+        assert len(client.mappings) == 2
+        assert set(vmm.reservations) == {mapping.base for mapping in client.mappings}
+        client.destroy_mapping(large, 400)
+        assert len(client.mappings) == 1
+        assert client.owns(small)
 
         client.unmap_all_vas()
         client.disconnect()
@@ -206,26 +220,4 @@ def test_small_mappings_share_one_slab_and_reuse_freed_holes(
         client.reallocate_all_handles()
         client.remap_all_vas()
         assert len(client.mappings) == 1
-        assert client.owns(reused)
-        assert client.owns(second)
-    finally:
-        _stop_client(client, server, thread)
-
-
-@pytest.mark.timeout(10)
-def test_mapping_larger_than_slab_gets_its_own_reservation(
-    tmp_path,
-    monkeypatch,
-) -> None:
-    client, vmm, server, thread = _connected_client(tmp_path, monkeypatch, slab_size=256)
-    try:
-        small = client.create_mapping(65)
-        large = client.create_mapping(320)
-        assert len(client.mappings) == 2
-        assert large != small
-        assert set(vmm.reservations) == {mapping.base for mapping in client.mappings}
-        client.destroy_mapping(large, 320)
-        assert len(client.mappings) == 1
         assert client.owns(small)
-    finally:
-        _stop_client(client, server, thread)

--- a/lib/gpu_memory_service/v1/client/memory_manager.py
+++ b/lib/gpu_memory_service/v1/client/memory_manager.py
@@ -24,6 +24,8 @@ from gpu_memory_service.v1.client.session import _GMSClientSession
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SLAB_SIZE = 2 * 1024 * 1024 * 1024
+
 _SessionFactory = Callable[
     [str, RequestedLockType],
     _GMSClientSession,
@@ -47,6 +49,7 @@ class GMSClientMemoryManager:
         device: int,
         *,
         session_factory: _SessionFactory = _GMSClientSession,
+        slab_size: int = DEFAULT_SLAB_SIZE,
     ):
         self._socket_path = socket_path
         self._vmm = vmm
@@ -54,12 +57,17 @@ class GMSClientMemoryManager:
         self._session_factory = session_factory
         self._session: _GMSClientSession | None = None
         self._mappings: dict[int, _InstalledMapping] = {}
+        self._regions: dict[int, tuple[int, int]] = {}
+        self._free: dict[int, list[tuple[int, int]]] = {}
         self._lock = threading.RLock()
         self._failure: str | None = None
         self._vmm.ensure_initialized()
         self._granularity = int(self._vmm.get_allocation_granularity(device))
         if self._granularity <= 0:
             raise ValueError("allocation granularity must be positive")
+        self._slab_size = self._align(slab_size)
+        if self._slab_size <= 0:
+            raise ValueError("slab size must be positive")
 
     @property
     def mappings(self) -> tuple[LocalMapping, ...]:
@@ -68,7 +76,7 @@ class GMSClientMemoryManager:
 
     def owns(self, va: int) -> bool:
         with self._lock:
-            return va in self._mappings
+            return va in self._regions
 
     def connect(self, lock_type: RequestedLockType) -> None:
         with self._lock:
@@ -92,35 +100,19 @@ class GMSClientMemoryManager:
     def create_mapping(self, size: int) -> int:
         with self._lock:
             self._check()
-            session = self._require_rw()
+            self._require_rw()
             if size <= 0:
                 raise ValueError("allocation size must be positive")
             aligned_size = self._align(size)
-            allocation_id = f"allocation-{uuid4()}"
             try:
-                session.allocate(allocation_id, aligned_size)
-                self._select_device()
-                mapping, handle = reserve_and_install_mapping(
-                    self._vmm,
-                    session.export(allocation_id),
-                    allocation_id,
-                    size,
-                    aligned_size,
-                    aligned_size,
-                    self._granularity,
-                    self._device,
-                    GrantedLockType.RW,
-                )
-                installed = _InstalledMapping(
-                    mapping.allocation_id,
-                    mapping.requested_size,
-                    mapping.aligned_size,
-                    mapping.base,
-                    mapping.reservation_size,
-                    handle,
-                )
-                self._mappings[mapping.base] = installed
-                return mapping.base
+                for mapping in self._ordered_mappings():
+                    offset = self._take_free(mapping.base, aligned_size)
+                    if offset is None:
+                        continue
+                    va = mapping.base + offset
+                    self._regions[va] = (mapping.base, size)
+                    return va
+                return self._add_slab(size, aligned_size)
             except Exception as exc:
                 raise self._latch("GMS mapping creation failed", exc) from exc
 
@@ -128,21 +120,17 @@ class GMSClientMemoryManager:
         with self._lock:
             self._check()
             try:
-                mapping = self._mappings[va]
+                slab_base, requested_size = self._regions[va]
             except KeyError:
                 raise RuntimeError(f"GMS does not own VA 0x{va:x}") from None
-            if size is not None and size != mapping.requested_size:
+            if size is not None and size != requested_size:
                 raise RuntimeError("allocator free does not match the GMS mapping")
             try:
-                self._select_device()
-                if mapping.handle:
-                    self._unmap(mapping)
-                if self._session is not None and (
-                    self._session.lock_type is GrantedLockType.RW
-                ):
-                    self._session.free(mapping.allocation_id)
-                self._vmm.address_free(mapping.base, mapping.reservation_size)
-                del self._mappings[va]
+                mapping = self._mappings[slab_base]
+                del self._regions[va]
+                self._put_free(slab_base, va - slab_base, self._align(requested_size))
+                if self._free[slab_base] == [(0, mapping.aligned_size)]:
+                    self._destroy_slab(mapping)
             except Exception as exc:
                 raise self._latch("GMS mapping destruction failed", exc) from exc
 
@@ -223,8 +211,8 @@ class GMSClientMemoryManager:
         """Release local mappings and VAs, then disconnect the socket lease."""
         with self._lock:
             self._check()
-            for mapping in reversed(self._ordered_mappings()):
-                self.destroy_mapping(mapping.base)
+            for va in reversed(sorted(self._regions)):
+                self.destroy_mapping(va)
             self.disconnect()
 
     def _ordered_mappings(self) -> tuple[_InstalledMapping, ...]:
@@ -250,6 +238,79 @@ class GMSClientMemoryManager:
 
     def _align(self, size: int) -> int:
         return (size + self._granularity - 1) // self._granularity * self._granularity
+
+    def _add_slab(self, size: int, aligned_size: int) -> int:
+        slab_bytes = max(self._slab_size, aligned_size)
+        session = self._require_rw()
+        allocation_id = f"allocation-{uuid4()}"
+        session.allocate(allocation_id, slab_bytes)
+        self._select_device()
+        mapping, handle = reserve_and_install_mapping(
+            self._vmm,
+            session.export(allocation_id),
+            allocation_id,
+            slab_bytes,
+            slab_bytes,
+            slab_bytes,
+            self._granularity,
+            self._device,
+            GrantedLockType.RW,
+        )
+        installed = _InstalledMapping(
+            mapping.allocation_id,
+            mapping.requested_size,
+            mapping.aligned_size,
+            mapping.base,
+            mapping.reservation_size,
+            handle,
+        )
+        self._mappings[mapping.base] = installed
+        leftover = slab_bytes - aligned_size
+        self._free[mapping.base] = [(aligned_size, leftover)] if leftover else []
+        self._regions[mapping.base] = (mapping.base, size)
+        return mapping.base
+
+    def _destroy_slab(self, mapping: _InstalledMapping) -> None:
+        self._select_device()
+        if mapping.handle:
+            self._unmap(mapping)
+        if self._session is not None and self._session.lock_type is GrantedLockType.RW:
+            self._session.free(mapping.allocation_id)
+        self._vmm.address_free(mapping.base, mapping.reservation_size)
+        del self._mappings[mapping.base]
+        del self._free[mapping.base]
+
+    def _take_free(self, slab_base: int, aligned_size: int) -> int | None:
+        holes = self._free[slab_base]
+        for index, (offset, length) in enumerate(holes):
+            if length < aligned_size:
+                continue
+            leftover = length - aligned_size
+            if leftover:
+                holes[index] = (offset + aligned_size, leftover)
+            else:
+                del holes[index]
+            return offset
+        return None
+
+    def _put_free(self, slab_base: int, offset: int, length: int) -> None:
+        holes = self._free[slab_base]
+        index = 0
+        while index < len(holes) and holes[index][0] < offset:
+            index += 1
+        holes.insert(index, (offset, length))
+        merged: list[tuple[int, int]] = []
+        for hole_offset, hole_length in holes:
+            if merged and hole_offset <= merged[-1][0] + merged[-1][1]:
+                prev_offset, prev_length = merged[-1]
+                merged[-1] = (
+                    prev_offset,
+                    max(prev_offset + prev_length, hole_offset + hole_length)
+                    - prev_offset,
+                )
+                continue
+            merged.append((hole_offset, hole_length))
+        self._free[slab_base] = merged
 
     def _check(self) -> None:
         if self._failure is not None:

--- a/lib/gpu_memory_service/v1/client/memory_manager.py
+++ b/lib/gpu_memory_service/v1/client/memory_manager.py
@@ -106,13 +106,14 @@ class GMSClientMemoryManager:
             aligned_size = self._align(size)
             try:
                 for mapping in self._ordered_mappings():
-                    offset = self._take_free(mapping.base, aligned_size)
-                    if offset is None:
-                        continue
-                    va = mapping.base + offset
-                    self._regions[va] = (mapping.base, size)
-                    return va
-                return self._add_slab(size, aligned_size)
+                    va = self._carve(mapping.base, size, aligned_size)
+                    if va is not None:
+                        return va
+                slab = self._add_slab(aligned_size)
+                va = self._carve(slab.base, size, aligned_size)
+                if va is None:
+                    raise RuntimeError("new GMS slab has no room for the allocation")
+                return va
             except Exception as exc:
                 raise self._latch("GMS mapping creation failed", exc) from exc
 
@@ -239,7 +240,7 @@ class GMSClientMemoryManager:
     def _align(self, size: int) -> int:
         return (size + self._granularity - 1) // self._granularity * self._granularity
 
-    def _add_slab(self, size: int, aligned_size: int) -> int:
+    def _add_slab(self, aligned_size: int) -> _InstalledMapping:
         slab_bytes = max(self._slab_size, aligned_size)
         session = self._require_rw()
         allocation_id = f"allocation-{uuid4()}"
@@ -265,10 +266,8 @@ class GMSClientMemoryManager:
             handle,
         )
         self._mappings[mapping.base] = installed
-        leftover = slab_bytes - aligned_size
-        self._free[mapping.base] = [(aligned_size, leftover)] if leftover else []
-        self._regions[mapping.base] = (mapping.base, size)
-        return mapping.base
+        self._free[mapping.base] = [(0, slab_bytes)]
+        return installed
 
     def _destroy_slab(self, mapping: _InstalledMapping) -> None:
         self._select_device()
@@ -279,6 +278,14 @@ class GMSClientMemoryManager:
         self._vmm.address_free(mapping.base, mapping.reservation_size)
         del self._mappings[mapping.base]
         del self._free[mapping.base]
+
+    def _carve(self, slab_base: int, size: int, aligned_size: int) -> int | None:
+        offset = self._take_free(slab_base, aligned_size)
+        if offset is None:
+            return None
+        va = slab_base + offset
+        self._regions[va] = (slab_base, size)
+        return va
 
     def _take_free(self, slab_base: int, aligned_size: int) -> int | None:
         holes = self._free[slab_base]
@@ -295,21 +302,17 @@ class GMSClientMemoryManager:
 
     def _put_free(self, slab_base: int, offset: int, length: int) -> None:
         holes = self._free[slab_base]
-        index = 0
-        while index < len(holes) and holes[index][0] < offset:
-            index += 1
-        holes.insert(index, (offset, length))
-        merged: list[tuple[int, int]] = []
-        for hole_offset, hole_length in holes:
-            if merged and hole_offset <= merged[-1][0] + merged[-1][1]:
-                prev_offset, prev_length = merged[-1]
-                merged[-1] = (
-                    prev_offset,
-                    max(prev_offset + prev_length, hole_offset + hole_length)
-                    - prev_offset,
-                )
-                continue
-            merged.append((hole_offset, hole_length))
+        holes.append((offset, length))
+        holes.sort()
+        merged: list[tuple[int, int]] = [holes[0]]
+        for hole_offset, hole_length in holes[1:]:
+            prev_offset, prev_length = merged[-1]
+            prev_end = prev_offset + prev_length
+            hole_end = hole_offset + hole_length
+            if hole_offset <= prev_end:
+                merged[-1] = (prev_offset, max(prev_end, hole_end) - prev_offset)
+            else:
+                merged.append((hole_offset, hole_length))
         self._free[slab_base] = merged
 
     def _check(self) -> None:

--- a/lib/gpu_memory_service/v1/client/memory_manager.py
+++ b/lib/gpu_memory_service/v1/client/memory_manager.py
@@ -103,6 +103,8 @@ class GMSClientMemoryManager:
             self._require_rw()
             if size <= 0:
                 raise ValueError("allocation size must be positive")
+            if any(not mapping.handle for mapping in self._ordered_mappings()):
+                raise RuntimeError("cannot create a mapping while GMS slabs are unmapped")
             aligned_size = self._align(size)
             try:
                 for mapping in self._ordered_mappings():

--- a/lib/gpu_memory_service/v1/client/memory_manager.py
+++ b/lib/gpu_memory_service/v1/client/memory_manager.py
@@ -104,7 +104,9 @@ class GMSClientMemoryManager:
             if size <= 0:
                 raise ValueError("allocation size must be positive")
             if any(not mapping.handle for mapping in self._ordered_mappings()):
-                raise RuntimeError("cannot create a mapping while GMS slabs are unmapped")
+                raise RuntimeError(
+                    "cannot create a mapping while GMS slabs are unmapped"
+                )
             aligned_size = self._align(size)
             try:
                 for mapping in self._ordered_mappings():


### PR DESCRIPTION
## Summary
- GMS V1 `create_mapping` now carves first-fit regions out of 2 GiB (or larger) client slabs instead of one server allocation per Torch caching-allocator segment.
- Freed regions go back on a coalescing free list so intermediate load segments can be reused.
- `remap_all_vas` is unchanged and now remaps O(slabs) handles. No huge physical allocation is created up front.

## Test plan
- [x] `pytest lib/gpu_memory_service/tests/test_v1_memory_manager.py` (existing + pack/reuse/oversize slab cases)
- [ ] Re-run DSV4 dest restore and confirm `weights_remap` / `kv_remap` drop with fewer `GMS V1 wake` mappings
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GPU memory allocation by grouping smaller mappings into shared memory slabs.
  * Reuses freed memory and combines adjacent available regions to reduce wasted space.
  * Allocates larger mappings separately when they exceed the slab capacity.
  * Preserves mappings across client disconnects and reconnects.
  * Added configurable slab sizing with validation for safer memory manager configuration.

* **Bug Fixes**
  * Improved cleanup and ownership handling for partially allocated memory regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->