### PR TITLE
refactor(router): migrate simple policies into RoutingHost

### DIFF
--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -16,16 +16,13 @@ use crate::{
     kv_router::{
         EncoderRouter, KvRouter, PrefillRouter, RoutingHost, metrics::RouterRequestMetrics,
     },
-    lora::LoraFilteredRouter,
     migration::Migration,
     model_card::ModelDeploymentCard,
     namespace::NamespaceFilter,
     preprocessor::{OpenAIPreprocessor, prompt::prompt_formatter_from_mdc},
     protocols::common::llm_backend::{BackendOutput, LLMEngineOutput, PreprocessedRequest},
     request_template::RequestTemplate,
-    session_affinity::{
-        AffinityCoordinator, SessionAffinityPushRouter, create_affinity_coordinator,
-    },
+    session_affinity::{AffinityCoordinator, create_affinity_coordinator},
     types::{
         Annotated,
         openai::chat_completions::{
@@ -181,40 +178,19 @@ where
     )?;
 
     let engine: ServiceEngine<_, _> = match router_mode {
-        RouterMode::Direct => Arc::new(SessionAffinityPushRouter::new_with_coordinator(
-            router, affinity, true,
-        )),
-        RouterMode::Random | RouterMode::RoundRobin => {
-            match model_manager.lora_filter_for(endpoint_id) {
-                Some(lora_filter) => Arc::new(LoraFilteredRouter::new(
-                    router,
-                    lora_filter,
-                    model_manager.lora_load_estimator_for(endpoint_id),
-                    router_mode,
-                )),
-                None if affinity.is_none() => Arc::new(RoutingHost::<Sel>::new_builtin(router)?),
-                None => Arc::new(SessionAffinityPushRouter::new_with_coordinator(
-                    router, affinity, false,
-                )),
-            }
-        }
-        RouterMode::PowerOfTwoChoices | RouterMode::LeastLoaded if affinity.is_none() => {
-            Arc::new(RoutingHost::<Sel>::new_builtin(router)?)
-        }
-        RouterMode::PowerOfTwoChoices
-        | RouterMode::LeastLoaded
-        | RouterMode::DeviceAwareWeighted => {
-            Arc::new(SessionAffinityPushRouter::new_with_coordinator(
-                router,
-                affinity,
-                router_mode.is_direct_routing(),
-            ))
-        }
         RouterMode::KV => {
             let Some(chooser) = chooser else {
                 anyhow::bail!("RouterMode::KV requires KVRouter to not be null");
             };
             Arc::new(RoutingHost::new_with_coordinator(router, chooser, affinity))
+        }
+        _ => {
+            let lora = model_manager
+                .lora_filter_for(endpoint_id)
+                .map(|filter| (filter, model_manager.lora_load_estimator_for(endpoint_id)));
+            Arc::new(RoutingHost::<Sel>::new_builtin_with_capabilities(
+                router, affinity, lora,
+            )?)
         }
     };
 
@@ -306,10 +282,9 @@ where
     )
     .await?;
 
-    // Eagerly register router request metrics so they appear as zeros even in
-    // non-KV modes (Direct, Random, RoundRobin) where RoutingHost is never created.
-    // In KV mode, RoutingHost::new() also calls from_component() (idempotent via
-    // OnceLock), which covers the standalone router path as well.
+    // Eagerly register router request metrics so they appear as zeros before
+    // RoutingHost is constructed. The host repeats this idempotently so the
+    // standalone router path is covered as well.
     RouterRequestMetrics::from_component(client.endpoint.component());
 
     let prefill_router = prefill_chooser.unwrap_or_else(|| {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -73,7 +73,6 @@ pub use dynamo_kv_router::scheduling::{
 pub use encoder_router::EncoderRouter;
 pub use indexer::{Indexer, ServedIndexerHandle, ServedIndexerMode, ensure_served_indexer_service};
 pub use prefill_router::PrefillRouter;
-pub(crate) use push_router::is_builtin_router_mode;
 pub use push_router::{DirectRoutingRouter, KvPushRouter, RoutingHost};
 
 use crate::{

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -26,7 +26,7 @@ use super::{
 };
 use crate::{
     discovery::ModelManager,
-    kv_router::{KvRouter, RoutingHost, WorkerSelectorFactory, is_builtin_router_mode},
+    kv_router::{KvRouter, RoutingHost, WorkerSelectorFactory},
     local_model::runtime_config::ModelRuntimeConfig,
     model_card::ModelDeploymentCard,
     protocols::common::{
@@ -404,19 +404,9 @@ where
             )
             .await?;
 
-            let router = if affinity.is_none() && is_builtin_router_mode(prefill_router_mode) {
-                InnerPrefillRouter::RoutingHost(Arc::new(RoutingHost::<Sel>::new_builtin(
-                    push_router,
-                )?))
-            } else {
-                InnerPrefillRouter::SimpleRouter(Arc::new(
-                    crate::session_affinity::SessionAffinityPushRouter::new_with_coordinator(
-                        push_router,
-                        affinity,
-                        prefill_router_mode.is_direct_routing(),
-                    ),
-                ))
-            };
+            let router = InnerPrefillRouter::RoutingHost(Arc::new(
+                RoutingHost::<Sel>::new_builtin_with_coordinator(push_router, affinity)?,
+            ));
             (router, prefill_client)
         };
 

--- a/lib/llm/src/kv_router/prefill_router/admission.rs
+++ b/lib/llm/src/kv_router/prefill_router/admission.rs
@@ -31,6 +31,8 @@ where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
     RoutingHost(Arc<RoutingHost<Sel>>),
+    // Kept for the deletion-only cleanup PR; production activation no longer constructs it.
+    #[allow(dead_code)]
     SimpleRouter(Arc<SessionAffinityPushRouter>),
 }
 

--- a/lib/llm/src/kv_router/prefill_router/conditional_bypass.rs
+++ b/lib/llm/src/kv_router/prefill_router/conditional_bypass.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use anyhow::Result;
 use dynamo_kv_router::conditional_disagg::ConditionalDisaggDecisionInput;
 use dynamo_kv_router::protocols::WorkerWithDpRank;
@@ -335,7 +337,7 @@ where
             .routing
             .as_ref()
             .and_then(|routing| routing.expected_output_tokens);
-        let allowed_worker_ids = req
+        let mut allowed_worker_ids = req
             .routing
             .as_ref()
             .and_then(|routing| routing.allowed_worker_ids.clone());
@@ -349,10 +351,25 @@ where
         if let Some(session_affinity) = session_affinity {
             probe_context.insert(SESSION_AFFINITY_CONTEXT_KEY, session_affinity.clone());
         }
-        let pinned_worker = router
-            .query_affinity_worker(&probe_context, RequestPhase::Prefill)
+        let affinity_target = router
+            .query_affinity_target(&probe_context, RequestPhase::Prefill)
             .ok()
             .flatten();
+        if let Some(AffinityTarget {
+            worker_id,
+            dp_rank: None,
+        }) = affinity_target
+        {
+            match &mut allowed_worker_ids {
+                Some(allowed_workers) => allowed_workers.retain(|id| *id == worker_id),
+                None => allowed_worker_ids = Some(HashSet::from([worker_id])),
+            }
+        }
+        let pinned_worker = affinity_target.and_then(|target| {
+            target
+                .dp_rank
+                .map(|dp_rank| WorkerWithDpRank::new(target.worker_id, dp_rank))
+        });
 
         let outcome = kv_router
             .find_best_match_details_without_admission(

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -1,10 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::HashSet,
+    future::{Future, ready},
+    sync::Arc,
+    time::Duration,
+};
 
 use dynamo_kv_router::{
-    protocols::{TokensWithHashes, WorkerWithDpRank},
+    protocols::{TokensWithHashes, WorkerConfigLike, WorkerWithDpRank},
     selector::{WorkerInputs, WorkerSelector},
 };
 use dynamo_runtime::{
@@ -25,6 +30,7 @@ use crate::{
         to_worker_selection_session_context,
     },
     local_model::runtime_config::ModelRuntimeConfig,
+    lora::{LoadEstimator, LoraFilter},
     preprocessor::PreprocessedRequest,
     protocols::common::{
         FinishReason,
@@ -33,6 +39,7 @@ use crate::{
     },
     session_affinity::{
         AffinityAcquire, AffinityCoordinator, AffinityTarget, affinity_id, explicit_target,
+        invalid_argument,
     },
 };
 
@@ -45,7 +52,7 @@ mod selection;
 use builtin::BuiltinWorkerSelector;
 use cancellation::cancel_on_stop;
 use occupancy::HostedOccupancy;
-use request_guard::RequestGuard;
+use request_guard::{LoraLoadGuard, RequestGuard};
 use selection::{RoutingRequestParts, SelectionOptions, WorkerSelection};
 
 const OUTPUT_REPLAY_ID_ANNOTATION_KEY: &str = "output_replay_id";
@@ -135,22 +142,41 @@ where
     ResponseStream::new(wrapped_stream, stream_context)
 }
 
-pub(crate) fn is_builtin_router_mode(mode: RouterMode) -> bool {
-    matches!(
-        mode,
-        RouterMode::RoundRobin
-            | RouterMode::Random
-            | RouterMode::PowerOfTwoChoices
-            | RouterMode::LeastLoaded
-    )
-}
-
 enum RoutingPolicy<Sel>
 where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
     Kv(Arc<KvRouter<Sel>>),
     Builtin(BuiltinWorkerSelector),
+    Direct,
+    DeviceAwareWeighted,
+}
+
+struct LoraRouting {
+    filter: Arc<LoraFilter>,
+    load_estimator: Arc<LoadEstimator>,
+    selector: BuiltinWorkerSelector,
+}
+
+struct LoraSelection {
+    target: u64,
+    allowed_fallback: HashSet<u64>,
+    load_guard: LoraLoadGuard,
+}
+
+struct HostedSelection {
+    initial_worker: u64,
+    target_constraint: Option<AffinityTarget>,
+    occupancy_reservation: Option<dynamo_runtime::pipeline::OccupancyReservation>,
+    candidate_count: usize,
+    selected_occupancy: Option<u64>,
+    device_aware_telemetry: Option<DeviceAwareTelemetry>,
+}
+
+struct DeviceAwareTelemetry {
+    is_cpu: bool,
+    embedding_cache_hit: bool,
+    request_cache_keys: usize,
 }
 
 /// Owns request routing from worker selection through response cleanup.
@@ -167,6 +193,7 @@ where
     request_metrics: Arc<RouterRequestMetrics>,
     affinity: Option<AffinityCoordinator>,
     hosted_occupancy: Option<HostedOccupancy>,
+    lora: Option<LoraRouting>,
 }
 
 /// Compatibility name for the KV-only host used by existing callers.
@@ -208,31 +235,82 @@ where
             request_metrics,
             affinity,
             hosted_occupancy: None,
+            lora: None,
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn new_builtin(
         inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     ) -> Result<Self, Error> {
-        let selector = BuiltinWorkerSelector::new(inner.router_mode()).ok_or_else(|| {
-            anyhow::anyhow!(
-                "{:?} routing is not a first-party builtin policy",
-                inner.router_mode()
-            )
-        })?;
-        let hosted_occupancy = selector
-            .required_worker_inputs()
-            .contains(WorkerInputs::OCCUPANCY)
+        Self::new_builtin_with_capabilities(inner, None, None)
+    }
+
+    pub(crate) fn new_builtin_with_coordinator(
+        inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
+        affinity: Option<AffinityCoordinator>,
+    ) -> Result<Self, Error> {
+        Self::new_builtin_with_capabilities(inner, affinity, None)
+    }
+
+    pub(crate) fn new_builtin_with_capabilities(
+        inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
+        affinity: Option<AffinityCoordinator>,
+        lora: Option<(Arc<LoraFilter>, Arc<LoadEstimator>)>,
+    ) -> Result<Self, Error> {
+        if affinity.is_some() && lora.is_some() {
+            anyhow::bail!("session affinity and LoRA filtering cannot both be enabled");
+        }
+        let policy = match inner.router_mode() {
+            RouterMode::Direct => RoutingPolicy::Direct,
+            RouterMode::DeviceAwareWeighted => RoutingPolicy::DeviceAwareWeighted,
+            mode => {
+                RoutingPolicy::Builtin(BuiltinWorkerSelector::new(mode).ok_or_else(|| {
+                    anyhow::anyhow!("{mode:?} routing is not a first-party policy")
+                })?)
+            }
+        };
+        let required_worker_inputs = match &policy {
+            RoutingPolicy::Builtin(selector) => selector.required_worker_inputs(),
+            RoutingPolicy::DeviceAwareWeighted => WorkerInputs::OCCUPANCY,
+            RoutingPolicy::Direct => WorkerInputs::NONE,
+            RoutingPolicy::Kv(_) => unreachable!(),
+        };
+        let hosted_occupancy = matches!(&policy, RoutingPolicy::Builtin(_))
+            .then_some(required_worker_inputs.contains(WorkerInputs::OCCUPANCY))
+            .unwrap_or(false)
             .then(|| HostedOccupancy::new(&inner))
             .transpose()?;
+        if lora.is_some()
+            && !matches!(
+                inner.router_mode(),
+                RouterMode::RoundRobin | RouterMode::Random
+            )
+        {
+            anyhow::bail!(
+                "LoRA filtering is unsupported with {:?} routing",
+                inner.router_mode()
+            );
+        }
+        let lora_selector = lora.as_ref().map(|_| {
+            BuiltinWorkerSelector::new(inner.router_mode())
+                .expect("LoRA routing mode was validated above")
+        });
         let request_metrics =
             RouterRequestMetrics::from_component(inner.client.endpoint.component());
         Ok(Self {
             inner,
-            policy: RoutingPolicy::Builtin(selector),
+            policy,
             request_metrics,
-            affinity: None,
+            affinity,
             hosted_occupancy,
+            lora: lora
+                .zip(lora_selector)
+                .map(|((filter, load_estimator), selector)| LoraRouting {
+                    filter,
+                    load_estimator,
+                    selector,
+                }),
         })
     }
 
@@ -240,6 +318,8 @@ where
         match &self.policy {
             RoutingPolicy::Kv(chooser) => chooser.required_worker_inputs(),
             RoutingPolicy::Builtin(selector) => selector.required_worker_inputs(),
+            RoutingPolicy::Direct => WorkerInputs::NONE,
+            RoutingPolicy::DeviceAwareWeighted => WorkerInputs::OCCUPANCY,
         }
     }
 
@@ -252,7 +332,9 @@ where
     pub(crate) fn kv_router_if_enabled(&self) -> Option<&Arc<KvRouter<Sel>>> {
         match &self.policy {
             RoutingPolicy::Kv(chooser) => Some(chooser),
-            RoutingPolicy::Builtin(_) => None,
+            RoutingPolicy::Builtin(_)
+            | RoutingPolicy::Direct
+            | RoutingPolicy::DeviceAwareWeighted => None,
         }
     }
 
@@ -270,15 +352,17 @@ where
                     .ok()
                     .and_then(Result::ok),
             },
+            RoutingPolicy::DeviceAwareWeighted => self.inner.peek_next_worker(),
+            RoutingPolicy::Direct => None,
             RoutingPolicy::Kv(_) => None,
         }
     }
 
-    pub(crate) fn query_affinity_worker(
+    pub(crate) fn query_affinity_target(
         &self,
         request: &SingleIn<PreprocessedRequest>,
         phase: RequestPhase,
-    ) -> Result<Option<WorkerWithDpRank>, Error> {
+    ) -> Result<Option<AffinityTarget>, Error> {
         let Some(affinity) = self.affinity.as_ref() else {
             return Ok(None);
         };
@@ -286,8 +370,42 @@ where
             return Ok(None);
         };
         let explicit = explicit_target(request, phase)?;
-        let target = affinity.query_target(&session_id, explicit)?;
-        Ok(target.and_then(affinity_worker))
+        affinity.query_target(&session_id, explicit)
+    }
+
+    fn affinity_target_requires_rebind(
+        &self,
+        request: &PreprocessedRequest,
+        target: AffinityTarget,
+    ) -> bool {
+        if request
+            .migration_state
+            .as_ref()
+            .is_some_and(|state| state.excluded_worker_ids().contains(&target.worker_id))
+        {
+            return true;
+        }
+        if !self
+            .inner
+            .client
+            .instance_ids_avail()
+            .contains(&target.worker_id)
+        {
+            return true;
+        }
+        let Some(kv_router) = self.kv_router_if_enabled() else {
+            return false;
+        };
+        let workers = kv_router.workers_with_configs.borrow();
+        let Some(config) = workers.get(&target.worker_id) else {
+            return true;
+        };
+        let Some(dp_rank) = target.dp_rank else {
+            return false;
+        };
+        let start = config.data_parallel_start_rank();
+        let end = start.saturating_add(config.data_parallel_size());
+        !(start..end).contains(&dp_rank)
     }
 
     async fn select_request(
@@ -295,7 +413,7 @@ where
         request: &SingleIn<PreprocessedRequest>,
         phase: RequestPhase,
         is_query_only: bool,
-        affinity_worker: Option<WorkerWithDpRank>,
+        affinity_target: Option<AffinityTarget>,
     ) -> Result<WorkerSelection, Error> {
         let context_id = request.context().id().to_string();
         let policy_class = request.metadata().get("policy-class").cloned();
@@ -313,7 +431,7 @@ where
                 phase,
                 is_query_only,
                 SelectionOptions {
-                    affinity_worker,
+                    affinity_target,
                     policy_class,
                     session_context,
                 },
@@ -323,66 +441,66 @@ where
         cancel_on_stop(request_context.as_ref(), selection_future).await?
     }
 
-    async fn select_with_affinity(
+    async fn select_with_session_affinity<T, Select, SelectionFuture>(
         &self,
         request: &SingleIn<PreprocessedRequest>,
         phase: RequestPhase,
         is_query_only: bool,
-    ) -> Result<(WorkerSelection, Option<AffinityAcquire>), Error> {
+        mut select: Select,
+    ) -> Result<(T, Option<AffinityAcquire>), Error>
+    where
+        Select: FnMut(Option<AffinityTarget>) -> SelectionFuture,
+        SelectionFuture: Future<Output = Result<T, Error>>,
+    {
         let Some(affinity) = self.affinity.as_ref() else {
-            return Ok((
-                self.select_request(request, phase, is_query_only, None)
-                    .await?,
-                None,
-            ));
+            return Ok((select(None).await?, None));
         };
         let Some(session_id) = affinity_id(request)? else {
-            return Ok((
-                self.select_request(request, phase, is_query_only, None)
-                    .await?,
-                None,
-            ));
+            return Ok((select(None).await?, None));
         };
         let explicit = explicit_target(request, phase)?;
         if is_query_only {
             let target = affinity.query_target(&session_id, explicit)?;
-            let worker = target.and_then(affinity_worker);
-            return Ok((
-                self.select_request(request, phase, true, worker).await?,
-                None,
-            ));
+            return Ok((select(target).await?, None));
         }
 
         let request_context = request.context();
         let operation = affinity
             .acquire_with_context(&session_id, explicit, request_context.as_ref())
             .await?;
-        let worker = operation.target().and_then(affinity_worker);
-        match self.select_request(request, phase, false, worker).await {
+        let target = operation.target();
+        match select(target).await {
             Ok(selection) => Ok((selection, Some(operation))),
             Err(error) if is_cancelled(&error) => Err(error),
-            Err(_) if operation.target().is_some() && explicit.is_none() => {
+            Err(_)
+                if explicit.is_none()
+                    && target.is_some_and(|target| {
+                        self.affinity_target_requires_rebind(request.content(), target)
+                    }) =>
+            {
                 operation.invalidate();
                 let retry = affinity
                     .acquire_with_context(&session_id, None, request_context.as_ref())
                     .await?;
-                let retry_worker = retry.target().and_then(affinity_worker);
-                match self
-                    .select_request(request, phase, false, retry_worker)
-                    .await
-                {
+                match select(retry.target()).await {
                     Ok(selection) => Ok((selection, Some(retry))),
-                    Err(retry_error) => {
-                        retry.invalidate();
-                        Err(retry_error)
-                    }
+                    Err(retry_error) => Err(retry_error),
                 }
             }
-            Err(error) => {
-                operation.invalidate();
-                Err(error)
-            }
+            Err(error) => Err(error),
         }
+    }
+
+    async fn select_with_affinity(
+        &self,
+        request: &SingleIn<PreprocessedRequest>,
+        phase: RequestPhase,
+        is_query_only: bool,
+    ) -> Result<(WorkerSelection, Option<AffinityAcquire>), Error> {
+        self.select_with_session_affinity(request, phase, is_query_only, |target| {
+            self.select_request(request, phase, is_query_only, target)
+        })
+        .await
     }
 
     async fn track_selection(
@@ -600,6 +718,167 @@ where
         );
     }
 
+    fn select_lora_target(
+        &self,
+        request: &PreprocessedRequest,
+    ) -> Result<Option<LoraSelection>, Error> {
+        let Some(lora) = self.lora.as_ref() else {
+            return Ok(None);
+        };
+        let Some(lora_name) = request
+            .routing
+            .as_ref()
+            .and_then(|routing| routing.lora_name.clone())
+        else {
+            return Ok(None);
+        };
+        let load_guard = LoraLoadGuard::new(Arc::clone(&lora.load_estimator), lora_name.clone());
+        let routable = self.inner.client.instance_ids_avail();
+        let candidates = lora
+            .filter
+            .filter_worker_ids_for_lora(Some(&lora_name), &routable);
+        if candidates.is_empty() {
+            anyhow::bail!("No workers available after LoRA filtering (lora={lora_name})");
+        }
+
+        let free = self
+            .inner
+            .client
+            .instance_ids_free()
+            .into_iter()
+            .collect::<HashSet<_>>();
+        let candidates = candidates
+            .into_iter()
+            .filter(|worker_id| free.contains(worker_id))
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            return Err(anyhow::anyhow!(
+                DynamoError::builder()
+                    .error_type(ErrorType::ResourceExhausted)
+                    .message(format!(
+                        "All eligible LoRA workers are overloaded (lora={lora_name})"
+                    ))
+                    .build()
+            ));
+        }
+        let target = lora
+            .selector
+            .select_worker(dynamo_kv_router::selector::WorkerSelectionInput::hosted(
+                &candidates,
+                None,
+            ))?
+            .worker
+            .worker_id;
+        tracing::debug!(
+            lora = %lora_name,
+            worker_id = target,
+            candidates = candidates.len(),
+            routable = routable.len(),
+            free = free.len(),
+            "LoRA-filtered router selected worker"
+        );
+        Ok(Some(LoraSelection {
+            target,
+            allowed_fallback: candidates.into_iter().collect(),
+            load_guard,
+        }))
+    }
+
+    fn select_hosted_worker(
+        &self,
+        request: &SingleIn<PreprocessedRequest>,
+        target_constraint: Option<AffinityTarget>,
+    ) -> Result<HostedSelection, Error> {
+        match &self.policy {
+            RoutingPolicy::Kv(_) => unreachable!("hosted selection called for KV routing"),
+            RoutingPolicy::Direct => {
+                let target = target_constraint
+                    .ok_or_else(|| anyhow::anyhow!("Direct routing requires an exact target"))?;
+                Ok(HostedSelection {
+                    initial_worker: target.worker_id,
+                    target_constraint: Some(target),
+                    occupancy_reservation: None,
+                    candidate_count: 1,
+                    selected_occupancy: None,
+                    device_aware_telemetry: None,
+                })
+            }
+            RoutingPolicy::Builtin(selector) => {
+                if selector
+                    .required_worker_inputs()
+                    .contains(WorkerInputs::OCCUPANCY)
+                {
+                    let occupancy = self
+                        .hosted_occupancy
+                        .as_ref()
+                        .expect("OCCUPANCY policy must have hosted occupancy state");
+                    let selection = occupancy.select_and_reserve(
+                        &self.inner,
+                        selector,
+                        target_constraint.map(|target| target.worker_id),
+                    )?;
+                    Ok(HostedSelection {
+                        initial_worker: selection.worker_id,
+                        target_constraint,
+                        occupancy_reservation: Some(selection.reservation),
+                        candidate_count: selection.candidate_count,
+                        selected_occupancy: Some(selection.occupancy),
+                        device_aware_telemetry: None,
+                    })
+                } else {
+                    let worker_id = match target_constraint {
+                        Some(target) => {
+                            self.inner.ensure_routable(target.worker_id)?;
+                            target.worker_id
+                        }
+                        None => {
+                            self.inner
+                                .with_selectable_worker_ids(|ids| {
+                                    selector.select_worker(
+                                        dynamo_kv_router::selector::WorkerSelectionInput::hosted(
+                                            ids, None,
+                                        ),
+                                    )
+                                })??
+                                .worker
+                                .worker_id
+                        }
+                    };
+                    Ok(HostedSelection {
+                        initial_worker: worker_id,
+                        target_constraint,
+                        occupancy_reservation: None,
+                        candidate_count: 0,
+                        selected_occupancy: None,
+                        device_aware_telemetry: None,
+                    })
+                }
+            }
+            RoutingPolicy::DeviceAwareWeighted => {
+                let selection = self.inner.select_device_aware_and_reserve(
+                    request.content(),
+                    target_constraint.map(|target| target.worker_id),
+                )?;
+                let initial_worker = selection.worker_id();
+                let candidate_count = selection.candidate_count();
+                let selected_occupancy = Some(selection.load());
+                let device_aware_telemetry = Some(DeviceAwareTelemetry {
+                    is_cpu: selection.is_cpu(),
+                    embedding_cache_hit: selection.embedding_cache_hit(),
+                    request_cache_keys: selection.request_cache_keys(),
+                });
+                Ok(HostedSelection {
+                    initial_worker,
+                    target_constraint,
+                    occupancy_reservation: selection.into_reservation(),
+                    candidate_count,
+                    selected_occupancy,
+                    device_aware_telemetry,
+                })
+            }
+        }
+    }
+
     async fn select_and_dispatch_builtin<M, F>(
         &self,
         mut request: SingleIn<PreprocessedRequest>,
@@ -609,62 +888,60 @@ where
     where
         F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error>,
     {
-        let RoutingPolicy::Builtin(selector) = &self.policy else {
-            unreachable!("builtin dispatch called for KV routing")
-        };
-
         let phase_label = phase.to_string();
         let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
         let explicit = explicit_target(&request, phase)?;
-        let uses_occupancy = selector
-            .required_worker_inputs()
-            .contains(WorkerInputs::OCCUPANCY);
-        let (
+        let is_direct = matches!(&self.policy, RoutingPolicy::Direct);
+        if is_direct && explicit.is_none() {
+            return Err(invalid_argument(format!(
+                "worker ID required for {phase} request in Direct routing mode"
+            )));
+        }
+        let has_affinity_session = self.affinity.is_some() && affinity_id(&request)?.is_some();
+        let is_query_only = request.get_annotation_value("query_instance_id").is_some();
+        let (lora_target, lora_fallback, lora_load) =
+            match self.select_lora_target(request.content())? {
+                Some(selection) => (
+                    Some(selection.target),
+                    Some(selection.allowed_fallback),
+                    Some(selection.load_guard),
+                ),
+                None => (None, None, None),
+            };
+        let (selection, mut operation) = if let Some(target) = lora_target {
+            (
+                HostedSelection {
+                    initial_worker: target,
+                    target_constraint: None,
+                    occupancy_reservation: None,
+                    candidate_count: 0,
+                    selected_occupancy: None,
+                    device_aware_telemetry: None,
+                },
+                None,
+            )
+        } else {
+            self.select_with_session_affinity(&request, phase, is_query_only, |target| {
+                ready(self.select_hosted_worker(&request, target.or(explicit)))
+            })
+            .await?
+        };
+        let HostedSelection {
             initial_worker,
-            reserved_target,
+            target_constraint,
             occupancy_reservation,
             candidate_count,
             selected_occupancy,
-        ) = if uses_occupancy {
-            let occupancy = self
-                .hosted_occupancy
-                .as_ref()
-                .expect("OCCUPANCY policy must have hosted occupancy state");
-            let selection = occupancy.select_and_reserve(
-                &self.inner,
-                selector,
-                explicit.map(|target| target.worker_id),
-            )?;
-            (
-                selection.worker_id,
-                explicit,
-                Some(selection.reservation),
-                selection.candidate_count,
-                Some(selection.occupancy),
-            )
-        } else {
-            let worker_id = match explicit {
-                Some(target) => {
-                    self.inner.ensure_routable(target.worker_id)?;
-                    target.worker_id
-                }
-                None => {
-                    self.inner
-                        .with_selectable_worker_ids(|ids| {
-                            selector.select_worker(
-                                dynamo_kv_router::selector::WorkerSelectionInput::hosted(ids, None),
-                            )
-                        })??
-                        .worker
-                        .worker_id
-                }
-            };
-            (worker_id, None, None, 0, None)
-        };
+            device_aware_telemetry,
+        } = selection;
+        let uses_occupancy = self
+            .required_worker_inputs()
+            .contains(WorkerInputs::OCCUPANCY);
         let mut guard: RequestGuard<Sel> = RequestGuard::new_builtin(
             self.request_metrics.clone(),
             initial_worker,
             occupancy_reservation,
+            lora_load,
             &request,
         );
         let tracker = request.tracker.clone();
@@ -676,13 +953,35 @@ where
 
         guard.start_dispatch(&phase_label);
         guard.record_prefill_start();
-        let dispatch_result = if let Some(target) = explicit {
-            let target = reserved_target.unwrap_or(target);
+        let dispatch_result = if is_direct && !has_affinity_session {
+            let target = target_constraint.expect("Direct routing requires an explicit target");
+            cancel_on_stop(
+                request_context.as_ref(),
+                self.inner.direct_within_prepared(
+                    request,
+                    target.worker_id,
+                    None,
+                    |request, worker_id| {
+                        let occupancy = guard.retarget_worker(worker_id);
+                        let target = AffinityTarget::new(
+                            worker_id,
+                            target.dp_rank.filter(|_| worker_id == target.worker_id),
+                        );
+                        request.routing_mut().dp_rank = target.dp_rank;
+                        prepare(request, target).map(|metadata| (metadata, target, occupancy))
+                    },
+                ),
+            )
+            .await
+            .and_then(|result| result)
+            .map(|((metadata, target, occupancy), stream)| (metadata, target, occupancy, stream))
+        } else if let Some(target) = target_constraint {
             request.routing_mut().dp_rank = target.dp_rank;
             let metadata = match prepare(&mut request, target) {
                 Ok(metadata) => metadata,
                 Err(error) => {
                     guard.abort().await;
+                    invalidate_on_non_cancellation(&mut operation, &error);
                     return Err(error);
                 }
             };
@@ -700,9 +999,7 @@ where
                     request,
                     initial_worker,
                     |request, worker_id| {
-                        let occupancy = guard.retarget_worker(worker_id).ok_or_else(|| {
-                            anyhow::anyhow!("occupancy-aware request lost its reservation")
-                        })?;
+                        let occupancy = guard.retarget_worker(worker_id);
                         let target = AffinityTarget::worker(worker_id);
                         request.routing_mut().dp_rank = None;
                         prepare(request, target).map(|metadata| (metadata, target, occupancy))
@@ -711,26 +1008,25 @@ where
             )
             .await
             .and_then(|result| result)
-            .map(|((metadata, target, occupancy), stream)| {
-                (metadata, target, Some(occupancy), stream)
-            })
+            .map(|((metadata, target, occupancy), stream)| (metadata, target, occupancy, stream))
         } else {
-            let target = AffinityTarget::new(initial_worker, None);
-            request.routing_mut().dp_rank = None;
-            let metadata = match prepare(&mut request, target) {
-                Ok(metadata) => metadata,
-                Err(error) => {
-                    guard.abort().await;
-                    return Err(error);
-                }
-            };
             cancel_on_stop(
                 request_context.as_ref(),
-                self.inner.dispatch_exact(request, target.worker_id),
+                self.inner.direct_within_prepared(
+                    request,
+                    initial_worker,
+                    lora_fallback.as_ref(),
+                    |request, worker_id| {
+                        let occupancy = guard.retarget_worker(worker_id);
+                        let target = AffinityTarget::worker(worker_id);
+                        request.routing_mut().dp_rank = None;
+                        prepare(request, target).map(|metadata| (metadata, target, occupancy))
+                    },
+                ),
             )
             .await
             .and_then(|result| result)
-            .map(|stream| (metadata, target, None, stream))
+            .map(|((metadata, target, occupancy), stream)| (metadata, target, occupancy, stream))
         };
 
         let (metadata, target, final_occupancy, response_stream) = match dispatch_result {
@@ -741,17 +1037,32 @@ where
                     .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned());
                 guard.record_migration_failure(typed_error);
                 guard.abort().await;
+                invalidate_on_non_cancellation(&mut operation, &error);
                 return Err(error);
             }
         };
         guard.retarget_worker(target.worker_id);
-        if uses_occupancy {
+        if let Some(telemetry) = device_aware_telemetry {
+            let selection_survived_transport = target.worker_id == initial_worker;
             tracing::info!(
-                router_mode = selector.telemetry_name(),
+                router_mode = "device-aware-weighted",
                 worker_id = target.worker_id,
                 candidate_count,
-                occupancy =
-                    final_occupancy.expect("OCCUPANCY dispatch must retain its reservation"),
+                occupancy = ?final_occupancy,
+                endpoint = %self.inner.client.endpoint.id(),
+                is_cpu = ?selection_survived_transport.then_some(telemetry.is_cpu),
+                embedding_cache_hit = ?selection_survived_transport
+                    .then_some(telemetry.embedding_cache_hit),
+                request_cache_keys = telemetry.request_cache_keys,
+                transport_fallback = !selection_survived_transport,
+                "Selected worker"
+            );
+        } else if uses_occupancy {
+            tracing::info!(
+                router_mode = self.inner.router_mode().telemetry_label(),
+                worker_id = target.worker_id,
+                candidate_count,
+                occupancy = ?final_occupancy,
                 transport_fallback = target.worker_id != initial_worker,
                 "Selected worker"
             );
@@ -765,7 +1076,11 @@ where
             tracker.record_worker(target.worker_id, target.dp_rank, worker_type);
         }
         guard.mark_dispatched();
-        Ok((metadata, into_monitored_response(response_stream, guard)))
+        let stream = into_monitored_response(response_stream, guard);
+        match operation {
+            Some(operation) => Ok((metadata, operation.into_stream(target, stream)?)),
+            None => Ok((metadata, stream)),
+        }
     }
 
     async fn select_and_dispatch_kv_prefill<M, F>(
@@ -829,7 +1144,9 @@ where
     {
         match &self.policy {
             RoutingPolicy::Kv(_) => self.select_and_dispatch_kv_prefill(request, prepare).await,
-            RoutingPolicy::Builtin(_) => {
+            RoutingPolicy::Builtin(_)
+            | RoutingPolicy::Direct
+            | RoutingPolicy::DeviceAwareWeighted => {
                 self.select_and_dispatch_builtin(request, RequestPhase::Prefill, prepare)
                     .await
             }
@@ -870,7 +1187,7 @@ where
         &self,
         request: SingleIn<PreprocessedRequest>,
     ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
-        if matches!(&self.policy, RoutingPolicy::Builtin(_)) {
+        if !matches!(&self.policy, RoutingPolicy::Kv(_)) {
             let phase = request
                 .tracker
                 .as_ref()
@@ -964,12 +1281,6 @@ where
     }
 }
 
-fn affinity_worker(target: AffinityTarget) -> Option<WorkerWithDpRank> {
-    target
-        .dp_rank
-        .map(|rank| WorkerWithDpRank::new(target.worker_id, rank))
-}
-
 /// A direct routing wrapper for `RouterMode::Direct`.
 ///
 /// This wraps a `PushRouter` and reads worker IDs from each request's routing hints,
@@ -1035,7 +1346,7 @@ mod tests {
             Arc, Mutex,
             atomic::{AtomicBool, Ordering},
         },
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use dynamo_kv_router::{
@@ -1060,6 +1371,7 @@ mod tests {
     use crate::{
         http::service::metrics::Metrics,
         local_model::runtime_config::ModelRuntimeConfig,
+        lora::{LoraReplicaConfig, LoraRoutingTable, LoraStateTracker},
         migration::Migration,
         protocols::common::extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
     };
@@ -1157,6 +1469,7 @@ mod tests {
             Arc::clone(&host.request_metrics),
             selection.worker_id,
             Some(selection.reservation),
+            None,
             &request(),
         );
         assert_eq!(guard.retarget_worker(1), Some(1));
@@ -1205,6 +1518,336 @@ mod tests {
 
         drop(second);
         drop(first);
+        drop(host);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn builtin_direct_without_worker_is_invalid_argument() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("builtin-direct-invalid-argument".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate".to_string());
+        let client = endpoint.client().await.unwrap();
+        let inner = PushRouter::from_client(client, RouterMode::Direct)
+            .await
+            .unwrap();
+        let host = RoutingHost::<DefaultWorkerSelector>::new_builtin_with_coordinator(inner, None)
+            .unwrap();
+
+        let error = host.generate(Context::new(request())).await.unwrap_err();
+        assert!(match_error_chain(
+            error.as_ref(),
+            &[ErrorType::InvalidArgument],
+            &[]
+        ));
+
+        drop(host);
+        runtime.shutdown();
+    }
+
+    #[derive(Default)]
+    struct CompletedBuiltinDispatch {
+        worker_ids: Mutex<Vec<u64>>,
+    }
+
+    #[async_trait]
+    impl StreamingDispatch<PreprocessedRequest, Annotated<LLMEngineOutput>>
+        for CompletedBuiltinDispatch
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<AddressedRequest<PreprocessedRequest>>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            let (addressed, context) = request.transfer(());
+            let (_, _, instance) = addressed.into_parts();
+            self.worker_ids
+                .lock()
+                .unwrap()
+                .push(instance.expect("selected worker instance").id());
+            let output = Annotated::from_data(LLMEngineOutput {
+                finish_reason: Some(FinishReason::Stop),
+                ..Default::default()
+            });
+            Ok(ResponseStream::new(
+                Box::pin(stream::once(async move { output })),
+                context.context(),
+            ))
+        }
+
+        async fn generate_bidirectional(
+            &self,
+            _instance: Instance,
+            _address: String,
+            _input: ManyIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            unreachable!("the routing host dispatches unary requests")
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn builtin_direct_dispatch_ignores_local_inhibition() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("builtin-direct-local-inhibition".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+        let dispatch = Arc::new(CompletedBuiltinDispatch::default());
+        let inner = PushRouter::from_client_with_dispatch(
+            client.clone(),
+            RouterMode::Direct,
+            Arc::clone(&dispatch) as Arc<dyn StreamingDispatch<_, _>>,
+        )
+        .await
+        .unwrap();
+        let host = RoutingHost::<DefaultWorkerSelector>::new_builtin_with_coordinator(inner, None)
+            .unwrap();
+
+        client.report_instance_down(worker_id);
+        assert!(client.instance_ids().contains(&worker_id));
+        assert!(!client.instance_ids_avail().contains(&worker_id));
+
+        let mut direct_request = request();
+        direct_request.routing_mut().backend_instance_id = Some(worker_id);
+        let mut stream = host.generate(Context::new(direct_request)).await.unwrap();
+        while stream.next().await.is_some() {}
+        assert_eq!(dispatch.worker_ids.lock().unwrap().as_slice(), &[worker_id]);
+
+        drop(host);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn builtin_lora_keeps_separate_selection_and_cleanup() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("builtin-lora-capability".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+        let stale_worker = worker_id.wrapping_add(1);
+        client.override_instance_avail(vec![stale_worker, worker_id]);
+        let dispatch = Arc::new(CompletedBuiltinDispatch::default());
+        let inner = PushRouter::from_client_with_dispatch(
+            client,
+            RouterMode::RoundRobin,
+            Arc::clone(&dispatch) as Arc<dyn StreamingDispatch<_, _>>,
+        )
+        .await
+        .unwrap();
+        let routing_table = LoraRoutingTable::new();
+        routing_table.update_allocation(
+            "adapter".to_string(),
+            LoraReplicaConfig {
+                lora_name: "adapter".to_string(),
+                replica_factor: 1,
+                replica_set: vec![WorkerWithDpRank::new(worker_id, 0)],
+                updated_at: Instant::now(),
+                is_active: true,
+            },
+        );
+        let filter = Arc::new(LoraFilter::new(routing_table, LoraStateTracker::new()));
+        let estimator = Arc::new(LoadEstimator::new());
+        let host = RoutingHost::<DefaultWorkerSelector>::new_builtin_with_capabilities(
+            inner,
+            None,
+            Some((filter, Arc::clone(&estimator))),
+        )
+        .unwrap();
+
+        let mut base_stream = host.generate(Context::new(request())).await.unwrap();
+        while base_stream.next().await.is_some() {}
+
+        let mut adapter_request = request();
+        adapter_request.routing_mut().lora_name = Some("adapter".to_string());
+        let mut adapter_stream = host.generate(Context::new(adapter_request)).await.unwrap();
+        assert_eq!(estimator.get_inflight_counts().get("adapter"), Some(&1));
+        while adapter_stream.next().await.is_some() {}
+
+        assert_eq!(dispatch.worker_ids.lock().unwrap().len(), 2);
+        assert_eq!(dispatch.worker_ids.lock().unwrap()[1], worker_id);
+        assert!(!estimator.get_inflight_counts().contains_key("adapter"));
+
+        drop(host);
+        runtime.shutdown();
+    }
+
+    fn affinity_request(
+        session_id: &str,
+        explicit_worker: Option<u64>,
+    ) -> SingleIn<PreprocessedRequest> {
+        let mut content = request();
+        content.routing_mut().backend_instance_id = explicit_worker;
+        let mut request = Context::new(content);
+        request.insert(
+            SESSION_AFFINITY_CONTEXT_KEY,
+            SessionAffinityId::new(session_id),
+        );
+        request
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn builtin_affinity_uses_common_host_for_every_policy() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let component = distributed
+            .namespace("builtin-affinity-lifecycle".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap();
+
+        for (index, mode) in [
+            RouterMode::RoundRobin,
+            RouterMode::Random,
+            RouterMode::PowerOfTwoChoices,
+            RouterMode::LeastLoaded,
+            RouterMode::DeviceAwareWeighted,
+            RouterMode::Direct,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let endpoint = component.endpoint(format!("mode-{index}"));
+            let client = endpoint.client().await.unwrap();
+            endpoint.register_endpoint_instance().await.unwrap();
+            let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+            let dispatch = Arc::new(CompletedBuiltinDispatch::default());
+            let inner = PushRouter::from_client_with_dispatch(
+                client,
+                mode,
+                Arc::clone(&dispatch) as Arc<dyn StreamingDispatch<_, _>>,
+            )
+            .await
+            .unwrap();
+            let affinity = AffinityCoordinator::new(Duration::from_secs(10)).unwrap();
+            let host = RoutingHost::<DefaultWorkerSelector>::new_builtin_with_coordinator(
+                inner,
+                Some(affinity.clone()),
+            )
+            .unwrap();
+            let session_id = format!("session-{index}");
+            let affinity_id = SessionAffinityId::new(session_id.clone());
+            let explicit_worker = (mode == RouterMode::Direct).then_some(worker_id);
+
+            let mut first = host
+                .generate(affinity_request(&session_id, explicit_worker))
+                .await
+                .unwrap();
+            while first.next().await.is_some() {}
+            assert_eq!(
+                affinity.query_target(&affinity_id, None).unwrap(),
+                Some(AffinityTarget::worker(worker_id))
+            );
+
+            let mut second = host
+                .generate(affinity_request(&session_id, explicit_worker))
+                .await
+                .unwrap();
+            while second.next().await.is_some() {}
+            assert_eq!(
+                dispatch.worker_ids.lock().unwrap().as_slice(),
+                &[worker_id; 2]
+            );
+        }
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn builtin_direct_fallback_stays_disabled_for_affinity() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("builtin-direct-worker-loss".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let real_worker = client.wait_for_instances().await.unwrap()[0].id();
+        let stale_worker = real_worker.wrapping_add(1);
+        client.override_instance_avail(vec![stale_worker, real_worker]);
+        let dispatch = Arc::new(CompletedBuiltinDispatch::default());
+        let inner = PushRouter::from_client_with_dispatch(
+            client,
+            RouterMode::Direct,
+            Arc::clone(&dispatch) as Arc<dyn StreamingDispatch<_, _>>,
+        )
+        .await
+        .unwrap();
+        let affinity = AffinityCoordinator::new(Duration::from_secs(10)).unwrap();
+        let host = RoutingHost::<DefaultWorkerSelector>::new_builtin_with_coordinator(
+            inner,
+            Some(affinity.clone()),
+        )
+        .unwrap();
+
+        let mut standalone = request();
+        standalone.routing_mut().backend_instance_id = Some(stale_worker);
+        let mut stream = host.generate(Context::new(standalone)).await.unwrap();
+        while stream.next().await.is_some() {}
+        assert_eq!(
+            dispatch.worker_ids.lock().unwrap().as_slice(),
+            &[real_worker]
+        );
+
+        let session_id = SessionAffinityId::new("direct-affinity");
+        let AffinityAcquire::Initialize(initializer) =
+            affinity.acquire(&session_id, None).await.unwrap()
+        else {
+            panic!("new affinity session must initialize");
+        };
+        drop(
+            initializer
+                .commit(AffinityTarget::worker(stale_worker))
+                .unwrap(),
+        );
+        assert!(
+            host.generate(affinity_request("direct-affinity", Some(stale_worker)))
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            dispatch.worker_ids.lock().unwrap().as_slice(),
+            &[real_worker]
+        );
+        assert_eq!(affinity.query_target(&session_id, None).unwrap(), None);
+
         drop(host);
         runtime.shutdown();
     }
@@ -1339,6 +1982,7 @@ mod tests {
             .unwrap();
         let endpoint = component.endpoint("generate");
         let client = endpoint.client().await.unwrap();
+        let worker_ids = workers.keys().copied().collect::<Vec<_>>();
         let (_tx, workers) = watch::channel(workers);
         let config = KvRouterConfig {
             skip_initial_worker_wait: true,
@@ -1367,6 +2011,11 @@ mod tests {
             .await
             .unwrap();
         let router = RoutingHost::new(inner, Arc::new(chooser), session_affinity_ttl).unwrap();
+        router
+            .inner
+            .client
+            .override_discovered_instances(worker_ids.clone());
+        router.inner.client.override_instance_avail(worker_ids);
         (router, runtime)
     }
 
@@ -1469,6 +2118,7 @@ mod tests {
         let mut builtin_guard = RequestGuard::<DefaultWorkerSelector>::new_builtin(
             Arc::clone(&metrics),
             7,
+            None,
             None,
             &request(),
         );
@@ -1581,7 +2231,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn query_affinity_worker_returns_existing_binding_without_reserving() {
+    async fn query_affinity_target_returns_existing_binding_without_reserving() {
         let (router, runtime) = router(Some(Duration::from_secs(10))).await;
         let session_id = SessionAffinityId::new("query-existing-binding");
         let target = AffinityTarget {
@@ -1605,9 +2255,9 @@ mod tests {
 
         assert_eq!(
             router
-                .query_affinity_worker(&request, RequestPhase::Prefill)
+                .query_affinity_target(&request, RequestPhase::Prefill)
                 .unwrap(),
-            Some(WorkerWithDpRank::new(7, 0))
+            Some(target)
         );
         assert_eq!(
             router
@@ -1619,6 +2269,105 @@ mod tests {
             Some(target)
         );
 
+        drop(router);
+        runtime.shutdown();
+    }
+
+    async fn bind_affinity_target(
+        router: &RoutingHost,
+        session_id: &SessionAffinityId,
+        target: AffinityTarget,
+    ) {
+        let AffinityAcquire::Initialize(initializer) = router
+            .affinity
+            .as_ref()
+            .unwrap()
+            .acquire(session_id, None)
+            .await
+            .unwrap()
+        else {
+            panic!("first request must initialize");
+        };
+        drop(initializer.commit(target).unwrap());
+    }
+
+    #[tokio::test]
+    async fn request_constraints_preserve_worker_only_affinity() {
+        let mut request_worker = ModelRuntimeConfig::default();
+        request_worker.taints.insert("request-pool".to_string());
+        let workers = HashMap::from([(7, ModelRuntimeConfig::default()), (8, request_worker)]);
+        let (router, runtime) =
+            router_with_worker_configs(Some(Duration::from_secs(10)), workers).await;
+        let target = AffinityTarget::worker(7);
+
+        let allowlist_session = SessionAffinityId::new("affinity-allowlist-conflict");
+        bind_affinity_target(&router, &allowlist_session, target).await;
+        let mut allowlist_input = request();
+        allowlist_input.routing_mut().allowed_worker_ids = Some(HashSet::from([8]));
+        let mut allowlist_request = Context::new(allowlist_input);
+        allowlist_request.insert(SESSION_AFFINITY_CONTEXT_KEY, allowlist_session.clone());
+        assert!(
+            router
+                .select_with_affinity(&allowlist_request, RequestPhase::Aggregated, false)
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            router
+                .affinity
+                .as_ref()
+                .unwrap()
+                .query_target(&allowlist_session, None)
+                .unwrap(),
+            Some(target)
+        );
+
+        let taint_session = SessionAffinityId::new("affinity-taint-conflict");
+        bind_affinity_target(&router, &taint_session, target).await;
+        let mut taint_input = request();
+        taint_input.routing_mut().routing_constraints = Some(RoutingConstraints {
+            required_taints: HashSet::from(["request-pool".to_string()]),
+            ..Default::default()
+        });
+        let mut taint_request = Context::new(taint_input);
+        taint_request.insert(SESSION_AFFINITY_CONTEXT_KEY, taint_session.clone());
+        assert!(
+            router
+                .select_with_affinity(&taint_request, RequestPhase::Aggregated, false)
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            router
+                .affinity
+                .as_ref()
+                .unwrap()
+                .query_target(&taint_session, None)
+                .unwrap(),
+            Some(target)
+        );
+
+        drop(router);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn stale_affinity_rank_rebinds_once() {
+        let (router, runtime) = router(Some(Duration::from_secs(10))).await;
+        let session_id = SessionAffinityId::new("stale-affinity-rank");
+        bind_affinity_target(&router, &session_id, AffinityTarget::new(7, Some(1))).await;
+        let mut request = Context::new(request());
+        request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_id);
+
+        let (selection, operation) = router
+            .select_with_affinity(&request, RequestPhase::Aggregated, false)
+            .await
+            .unwrap();
+        assert_eq!(selection.worker, WorkerWithDpRank::new(7, 0));
+        assert!(matches!(operation, Some(AffinityAcquire::Initialize(_))));
+        router.kv_router().free(request.id()).await.unwrap();
+
+        drop(operation);
         drop(router);
         runtime.shutdown();
     }

--- a/lib/llm/src/kv_router/push_router/builtin.rs
+++ b/lib/llm/src/kv_router/push_router/builtin.rs
@@ -28,16 +28,6 @@ impl BuiltinWorkerSelector {
         Some(Self { mode, picker })
     }
 
-    pub(super) fn telemetry_name(&self) -> &'static str {
-        match self.mode {
-            RouterMode::RoundRobin => "round-robin",
-            RouterMode::Random => "random",
-            RouterMode::PowerOfTwoChoices => "power-of-two-choices",
-            RouterMode::LeastLoaded => "least-loaded",
-            _ => unreachable!("builtin selector cannot contain a non-builtin mode"),
-        }
-    }
-
     pub(super) fn peek_worker(
         &self,
         input: WorkerSelectionInput<'_, ModelRuntimeConfig>,

--- a/lib/llm/src/kv_router/push_router/request_guard.rs
+++ b/lib/llm/src/kv_router/push_router/request_guard.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 use crate::{
     kv_router::{KvRouter, metrics::RouterRequestMetrics, scheduler::DefaultWorkerSelector},
     local_model::runtime_config::ModelRuntimeConfig,
+    lora::LoadEstimator,
     preprocessor::PreprocessedRequest,
     protocols::common::{
         llm_backend::LLMEngineOutput,
@@ -29,6 +30,27 @@ use dynamo_runtime::{
     pipeline::OccupancyReservation,
     protocols::annotated::Annotated,
 };
+
+pub(super) struct LoraLoadGuard {
+    estimator: Arc<LoadEstimator>,
+    lora_name: String,
+}
+
+impl LoraLoadGuard {
+    pub(super) fn new(estimator: Arc<LoadEstimator>, lora_name: String) -> Self {
+        estimator.increment_load(&lora_name);
+        Self {
+            estimator,
+            lora_name,
+        }
+    }
+}
+
+impl Drop for LoraLoadGuard {
+    fn drop(&mut self) {
+        self.estimator.decrement_load(&self.lora_name);
+    }
+}
 
 #[derive(Clone)]
 struct OutputHashBranch {
@@ -553,6 +575,7 @@ where
     record_itl_at_completion: bool,
     prefill_marked: bool,
     migration_state: Option<MigrationState>,
+    _lora_load: Option<LoraLoadGuard>,
 }
 
 impl<Sel> RequestGuard<Sel>
@@ -612,6 +635,7 @@ where
             record_itl_at_completion: false,
             prefill_marked: false,
             migration_state: request.migration_state.clone(),
+            _lora_load: None,
         }
     }
 
@@ -619,6 +643,7 @@ where
         request_metrics: Arc<RouterRequestMetrics>,
         worker_id: u64,
         occupancy_reservation: Option<OccupancyReservation>,
+        lora_load: Option<LoraLoadGuard>,
         request: &PreprocessedRequest,
     ) -> Self {
         request_metrics.requests_started_total().inc();
@@ -639,6 +664,7 @@ where
             record_itl_at_completion: true,
             prefill_marked: false,
             migration_state: request.migration_state.clone(),
+            _lora_load: lora_load,
         }
     }
 

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -24,6 +24,7 @@ use crate::{
         TokenIdType,
         common::{preprocessor::RoutingHints, timing::RequestPhase},
     },
+    session_affinity::AffinityTarget,
 };
 
 pub(super) struct WorkerSelection {
@@ -52,7 +53,7 @@ impl<'a> RoutingRequestParts<'a> {
 }
 
 pub(super) struct SelectionOptions {
-    pub(super) affinity_worker: Option<WorkerWithDpRank>,
+    pub(super) affinity_target: Option<AffinityTarget>,
     pub(super) policy_class: Option<String>,
     pub(super) session_context: Option<dynamo_kv_router::SessionContext>,
 }
@@ -183,11 +184,37 @@ where
         let return_routing_hashes =
             !is_query_only && self.kv_router().indexer().records_routing_decisions();
         let SelectionOptions {
-            affinity_worker,
+            affinity_target,
             policy_class,
             session_context,
         } = options;
-        let affinity_pin = affinity_worker.map(|worker| (worker.worker_id, Some(worker.dp_rank)));
+        let worker_only_affinity = affinity_target.filter(|target| target.dp_rank.is_none());
+        if let Some(target) = worker_only_affinity {
+            match &mut allowed_worker_ids {
+                Some(allowed_workers) => {
+                    allowed_workers.retain(|worker_id| *worker_id == target.worker_id);
+                }
+                None => {
+                    allowed_worker_ids = Some(HashSet::from([target.worker_id]));
+                }
+            }
+        }
+        let explicit_pin = match (explicit_pin, worker_only_affinity) {
+            (Some((worker_id, None)), Some(affinity_target))
+                if worker_id == affinity_target.worker_id =>
+            {
+                // A worker-only session binding allows the KV scheduler to select this
+                // request's rank, so do not turn a matching worker-only request hint into an
+                // exact-rank pin.
+                None
+            }
+            (explicit_pin, _) => explicit_pin,
+        };
+        let affinity_pin = affinity_target.and_then(|target| {
+            target
+                .dp_rank
+                .map(|dp_rank| (target.worker_id, Some(dp_rank)))
+        });
         let Some((pinned_worker_id, requested_dp_rank)) =
             merge_affinity_pin(explicit_pin, affinity_pin)
         else {

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -555,9 +555,9 @@ impl AffinityAcquire {
                     lease.invalidate();
                     return Err(error);
                 }
-                // TODO: Revisit this split with the DP-rank-routing design. A worker-only
-                // binding deliberately permits per-request rank selection, so scheduling must
-                // not silently narrow the persisted affinity to the selected rank.
+                // TODO: Revisit this split with the DP-rank-routing design. Decide whether a
+                // session binds at worker or rank scope; changing persisted scope requires an
+                // ordered replica-migration protocol, not conversion of a dispatch target.
                 lease.publish(target);
                 Ok(lease.into_stream(stream))
             }

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -541,21 +541,23 @@ impl AffinityAcquire {
 
     pub(crate) fn into_stream(
         self,
-        selected_target: AffinityTarget,
+        dispatched_target: AffinityTarget,
         stream: ManyOut<LlmResponse>,
     ) -> Result<ManyOut<LlmResponse>, Error> {
         match self {
             Self::Initialize(initialization) => {
-                let lease = initialization.commit(selected_target)?;
-                lease.publish(selected_target);
+                let lease = initialization.commit(dispatched_target)?;
+                lease.publish(dispatched_target);
                 Ok(lease.into_stream(stream))
             }
             Self::Bound { target, mut lease } => {
-                if let Err(error) = validate_bound_target("session", target, Some(selected_target))
-                {
+                if let Err(error) = validate_dispatch_target("session", target, dispatched_target) {
                     lease.invalidate();
                     return Err(error);
                 }
+                // TODO: Revisit this split with the DP-rank-routing design. A worker-only
+                // binding deliberately permits per-request rank selection, so scheduling must
+                // not silently narrow the persisted affinity to the selected rank.
                 lease.publish(target);
                 Ok(lease.into_stream(stream))
             }
@@ -796,6 +798,39 @@ fn validate_bound_target(
         ))),
         _ => Ok(()),
     }
+}
+
+/// Validates that a request was dispatched within an existing session binding.
+///
+/// Unlike an explicit requested target, a dispatch target may add a DP rank to a worker-only
+/// binding because load-aware scheduling chooses that rank for this request only.
+fn validate_dispatch_target(
+    session_id: &str,
+    bound: AffinityTarget,
+    dispatched: AffinityTarget,
+) -> Result<(), Error> {
+    if bound.worker_id != dispatched.worker_id {
+        return Err(invalid_argument(format!(
+            "session {session_id} is bound to worker {}, not {}",
+            bound.worker_id, dispatched.worker_id
+        )));
+    }
+    if let Some(bound_rank) = bound.dp_rank {
+        match dispatched.dp_rank {
+            Some(dispatched_rank) if dispatched_rank == bound_rank => {}
+            Some(dispatched_rank) => {
+                return Err(invalid_argument(format!(
+                    "session {session_id} is bound to DP rank {bound_rank}, not {dispatched_rank}"
+                )));
+            }
+            None => {
+                return Err(invalid_argument(format!(
+                    "session {session_id} is bound to DP rank {bound_rank}, but dispatch did not select a DP rank"
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn invalid_argument(message: impl Into<String>) -> Error {

--- a/lib/llm/src/session_affinity/mod.rs
+++ b/lib/llm/src/session_affinity/mod.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use dynamo_runtime::{component::Client, pipeline::Error};
 
-pub(crate) use coordinator::{AffinityAcquire, affinity_id};
+pub(crate) use coordinator::{AffinityAcquire, affinity_id, invalid_argument};
 pub use coordinator::{AffinityCoordinator, AffinityTarget, explicit_target};
 pub use push_router::SessionAffinityPushRouter;
 

--- a/lib/llm/src/session_affinity/tests.rs
+++ b/lib/llm/src/session_affinity/tests.rs
@@ -614,6 +614,51 @@ async fn session_affinity_publishes_after_dispatch_and_lease_completion() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn session_affinity_worker_only_binding_allows_ranked_dispatch_without_narrowing() {
+    let coordinator = coordinator();
+    let worker_binding = target(7, None);
+
+    let initialization = coordinator.acquire(&session_id(), None).await.unwrap();
+    drop(
+        initialization
+            .into_stream(worker_binding, response_stream(1))
+            .unwrap(),
+    );
+
+    let continuation = coordinator.acquire(&session_id(), None).await.unwrap();
+    let stream = continuation
+        .into_stream(target(7, Some(3)), response_stream(1))
+        .expect("worker-only affinity must allow the scheduler to select a DP rank");
+
+    assert_eq!(
+        coordinator.query_target(&session_id(), None).unwrap(),
+        Some(worker_binding)
+    );
+    drop(stream);
+}
+
+#[tokio::test(start_paused = true)]
+async fn session_affinity_ranked_binding_rejects_mismatched_rank_dispatch() {
+    let coordinator = coordinator();
+    let binding = target(7, Some(2));
+
+    let initialization = coordinator.acquire(&session_id(), None).await.unwrap();
+    drop(
+        initialization
+            .into_stream(binding, response_stream(1))
+            .unwrap(),
+    );
+
+    let continuation = coordinator.acquire(&session_id(), None).await.unwrap();
+    assert!(
+        continuation
+            .into_stream(target(7, Some(3)), response_stream(1))
+            .is_err()
+    );
+    assert_eq!(coordinator.query_target(&session_id(), None).unwrap(), None);
+}
+
+#[tokio::test(start_paused = true)]
 async fn session_affinity_completion_restores_expired_remote_binding() {
     let origin = coordinator();
     let mut updates = origin.enable_test_replica(99, 4);

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -212,7 +212,61 @@ struct DeviceAwareCandidates {
     request_cache_keys: usize,
 }
 
+/// A DeviceAware policy decision whose optional occupancy booking is owned by
+/// the caller's request lifecycle.
+pub struct DeviceAwareSelection {
+    worker_id: u64,
+    candidate_count: usize,
+    load: u64,
+    is_cpu: bool,
+    embedding_cache_hit: bool,
+    request_cache_keys: usize,
+    reservation: Option<OccupancyReservation>,
+}
+
+impl DeviceAwareSelection {
+    pub fn worker_id(&self) -> u64 {
+        self.worker_id
+    }
+
+    pub fn candidate_count(&self) -> usize {
+        self.candidate_count
+    }
+
+    pub fn load(&self) -> u64 {
+        self.load
+    }
+
+    pub fn is_cpu(&self) -> bool {
+        self.is_cpu
+    }
+
+    pub fn embedding_cache_hit(&self) -> bool {
+        self.embedding_cache_hit
+    }
+
+    pub fn request_cache_keys(&self) -> usize {
+        self.request_cache_keys
+    }
+
+    pub fn into_reservation(self) -> Option<OccupancyReservation> {
+        self.reservation
+    }
+}
+
 impl RouterMode {
+    pub const fn telemetry_label(self) -> &'static str {
+        match self {
+            Self::RoundRobin => "round-robin",
+            Self::Random => "random",
+            Self::PowerOfTwoChoices => "power-of-two-choices",
+            Self::KV => "kv",
+            Self::Direct => "direct",
+            Self::LeastLoaded => "least-loaded",
+            Self::DeviceAwareWeighted => "device-aware-weighted",
+        }
+    }
+
     pub fn is_kv_routing(&self) -> bool {
         *self == RouterMode::KV
     }
@@ -737,6 +791,72 @@ where
         self.occupancy_state.clone()
     }
 
+    /// Select a DeviceAware worker while leaving request-lifecycle cleanup to
+    /// the routing host. Request and device metadata is prepared before the
+    /// occupancy admission lock is acquired.
+    pub fn select_device_aware_and_reserve(
+        &self,
+        request: &T,
+        pinned_worker: Option<u64>,
+    ) -> anyhow::Result<DeviceAwareSelection> {
+        anyhow::ensure!(
+            self.router_mode == RouterMode::DeviceAwareWeighted,
+            "{:?} routing is not DeviceAwareWeighted",
+            self.router_mode
+        );
+
+        let state = self.occupancy_state()?;
+        if let Some(worker_id) = pinned_worker {
+            self.ensure_routable(worker_id)?;
+            let selection = self.device_aware_candidates(request, &[worker_id]);
+            let is_cpu = selection
+                .candidates
+                .first()
+                .is_some_and(|candidate| candidate.device == RouteDevice::Cpu);
+            let reservation = state.reserve(worker_id);
+            let load = reservation.load();
+            return Ok(DeviceAwareSelection {
+                worker_id,
+                candidate_count: 1,
+                load,
+                is_cpu,
+                embedding_cache_hit: selection.embedding_cache_hit,
+                request_cache_keys: selection.request_cache_keys,
+                reservation: Some(reservation),
+            });
+        }
+
+        let routing_instances = self.client.routing_instances();
+        let instance_ids = routing_instances.free_ids();
+        if instance_ids.is_empty() {
+            return Err(self.empty_free_pool_error(&routing_instances));
+        }
+        let selection = self.device_aware_candidates(request, instance_ids);
+        let (decision, counter) = state
+            .select_and_admit(
+                self.picker()?,
+                CandidateView::DeviceAware(&selection.candidates),
+                selection.context,
+            )
+            .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
+        let worker_id = decision.target.worker_id;
+        let is_cpu = selection.candidates.iter().any(|candidate| {
+            candidate.target.worker_id == worker_id && candidate.device == RouteDevice::Cpu
+        });
+        let reservation = counter
+            .map(|counter| OccupancyReservation::from_counter(state.clone(), worker_id, counter));
+
+        Ok(DeviceAwareSelection {
+            worker_id,
+            candidate_count: selection.candidates.len(),
+            load: state.load(worker_id),
+            is_cpu,
+            embedding_cache_hit: selection.embedding_cache_hit,
+            request_cache_keys: selection.request_cache_keys,
+            reservation,
+        })
+    }
+
     /// Reject an exact target that local fault detection has removed from routing.
     pub fn ensure_routable(&self, instance_id: u64) -> anyhow::Result<()> {
         if self
@@ -952,14 +1072,50 @@ where
     where
         F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
     {
-        self.ensure_discovered_for_dispatch(instance_id)?;
+        // Fallback resolution owns the unavailable-target decision. Allowing it
+        // to see a worker already absent from discovery preserves Direct's
+        // historical standalone fallback; `Deny` remains exact-target behavior.
+        let selected_is_discovered = self
+            .client
+            .instances()
+            .iter()
+            .any(|instance| instance.instance_id == instance_id);
+        if !selected_is_discovered {
+            let fallback_is_available = self
+                .client
+                .routing_instances()
+                .free_ids()
+                .iter()
+                .copied()
+                .any(|candidate| {
+                    candidate != instance_id
+                        && match fallback {
+                            TransportFallback::Allow => true,
+                            TransportFallback::Deny => false,
+                            TransportFallback::Within(allowed) => allowed.contains(&candidate),
+                        }
+                });
+            if !fallback_is_available {
+                self.ensure_discovered_for_dispatch(instance_id)?;
+            }
+        }
+        let ((metadata, resolved_instance_id), response_stream) = self
+            .generate_with_fault_detection_prepared(
+                instance_id,
+                request,
+                fallback,
+                |request, resolved_instance_id| {
+                    prepare(request, resolved_instance_id)
+                        .map(|metadata| (metadata, resolved_instance_id))
+                },
+            )
+            .await?;
         tracing::info!(
-            router_mode = "direct",
-            worker_id = instance_id,
+            router_mode = self.router_mode.telemetry_label(),
+            worker_id = resolved_instance_id,
             "Selected worker"
         );
-        self.generate_with_fault_detection_prepared(instance_id, request, fallback, prepare)
-            .await
+        Ok((metadata, response_stream))
     }
 
     async fn dispatch_preselected_with_fallback<M, F>(
@@ -1975,6 +2131,23 @@ mod tests {
     }
 
     #[test]
+    fn router_mode_telemetry_labels_are_stable() {
+        assert_eq!(RouterMode::RoundRobin.telemetry_label(), "round-robin");
+        assert_eq!(RouterMode::Random.telemetry_label(), "random");
+        assert_eq!(
+            RouterMode::PowerOfTwoChoices.telemetry_label(),
+            "power-of-two-choices"
+        );
+        assert_eq!(RouterMode::KV.telemetry_label(), "kv");
+        assert_eq!(RouterMode::Direct.telemetry_label(), "direct");
+        assert_eq!(RouterMode::LeastLoaded.telemetry_label(), "least-loaded");
+        assert_eq!(
+            RouterMode::DeviceAwareWeighted.telemetry_label(),
+            "device-aware-weighted"
+        );
+    }
+
+    #[test]
     fn p2c_selects_lower_load_worker() {
         let state = RoutingOccupancyState::default();
         for _ in 0..10 {
@@ -2748,10 +2921,10 @@ mod tests {
         .await
         .unwrap();
 
-        let (worker_id, permit) = router.select_exact_target(&42, None).await.unwrap();
-        assert_eq!(worker_id, cache_worker);
+        let selection = router.select_device_aware_and_reserve(&42, None).unwrap();
+        assert_eq!(selection.worker_id(), cache_worker);
         assert!(
-            permit.is_none(),
+            selection.into_reservation().is_none(),
             "full cache hits bypass occupancy charging"
         );
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This moves the remaining non-KV modes—Direct, hard-affinity, LoRA-filtered, and DeviceAware routing—into the existing `RoutingHost` orchestration path. It matters because every production routing mode now shares selection-to-dispatch bookkeeping and request cleanup without reviving a separate `SimpleRouter` host.

PART OF: DYNO-128

### How This Was Implemented

- Extend #13513's `RoutingHost` construction to Direct and DeviceAwareWeighted; RoundRobin, Random, PowerOfTwoChoices, and LeastLoaded remain on the same host.
- Keep RoundRobin and Random on `WorkerInputs::NONE`, and keep P2C and least-loaded on #13513's shared O(1) `WorkerInputs::OCCUPANCY` path.
- Reuse the hard session-affinity coordinator around the common policy-selection and dispatch lifecycle.
- Host RR/random LoRA eligibility and load lifetime in `RoutingHost`, with an independent selector cursor and candidate-bounded fallback.
- Give DeviceAware selection an optional guard-owned occupancy reservation so full cache hits retain their no-admission behavior.

<details>
<summary>Walkthrough</summary>

#### Mental model

`RoutingHost` is the common request-orchestration entry point. Each policy still owns its specialized selection inputs, but the selected worker returns to the same transport, telemetry, and request-guard lifecycle.

```mermaid
flowchart LR
    E["Frontend / prefill"] --> H["RoutingHost"]
    H --> K["KV selector"]
    H --> S["RR / Random selector"]
    H --> O["P2C / LeastLoaded occupancy selector"]
    H --> D["Direct / DeviceAware selection"]
    S --> L["Optional LoRA eligibility"]
    K --> P["PushRouter transport"]
    L --> P
    O --> P
    D --> P
    P --> G["RequestGuard cleanup"]
```

#### State and ordering

An explicit request target is the hard constraint. Otherwise, a live session-affinity binding constrains policy selection; request-level allow-list or taint conflicts do not silently replace that binding, and rebinding happens only when migration excludes the worker or the bound worker/rank disappears. A worker-only affinity binding may select a DP rank for one request without changing the persisted binding. RR and Random need no hosted signals, P2C and least-loaded select and reserve against the shared O(1) request-occupancy counters, and DeviceAware combines request/device/cache metadata with the same occupancy state. Only a full DeviceAware cache hit skips occupancy admission.

LoRA is supported only for RR and Random. Adapter requests filter the live worker set before selection, use a selector cursor separate from base-model traffic, constrain transport fallback to that replica set, and hold the LoRA load lease until the response lifecycle ends.

#### Request lifecycle

Policy selection happens before dispatch. Transport fallback reports the final worker back to `RoutingHost`, which retargets any occupancy reservation before recording selected-worker telemetry. `RequestGuard` releases scheduler, occupancy, LoRA, metrics, and cancellation state on success, failure, or stream drop; the affinity acquire/lease remains separate and commits only after dispatch succeeds.

#### Boundaries and limitations

KV cache/load scoring remains specialized policy state inside the same host lifecycle. The legacy wrapper types remain source-compatible for now, but production construction no longer selects them; deleting that dead surface is intentionally separate from this stack. Soft-affinity configuration and broader coordinator convergence remain in #13163.

</details>

### Validation

- `cargo test -p dynamo-llm 'kv_router::push_router::tests' --lib` — 41 passed.
- `cargo test -p dynamo-llm session_affinity --lib` — 54 passed.
- `cargo test -p dynamo-llm 'kv_router::prefill_router' --lib` — 36 passed.
- `cargo test -p dynamo-llm 'entrypoint::input::common::tests' --lib` — 1 passed.
- `cargo test -p dynamo-runtime 'pipeline::network::egress::push_router::tests' --lib` — 37 passed.
- `cargo clippy -p dynamo-runtime -p dynamo-llm --lib --tests -- -D warnings`.
- `cargo fmt --all -- --check`.
- `git diff --check`.
- Post-rebase `cargo check -p dynamo-runtime -p dynamo-kv-router -p dynamo-llm --lib` on the final stack.
<!-- codex-pr-description:end -->
## Summary

- route every non-KV mode through `RoutingHost`: Direct, RoundRobin, Random, PowerOfTwoChoices, LeastLoaded, and DeviceAwareWeighted
- reuse the existing hard session-affinity coordinator inside the common selection/dispatch/cleanup lifecycle
- move RR/random LoRA eligibility and LoRA load lifetime into `RoutingHost` while preserving candidate-bounded transport fallback
- reuse `PushRouter`'s existing policy pickers, device-aware selection, occupancy reservations, discovery, and transport behavior
- stop constructing `SessionAffinityPushRouter`, `LoraFilteredRouter`, or the prefill `SimpleRouter` variant in production paths

PART OF: DYNO-128

Stacked on #13513.

## Boundaries

Stacked cleanup [#13558](https://github.com/ai-dynamo/dynamo/pull/13558) deletes the now-dead `SimpleRouter`, `SessionAffinityPushRouter`, `LoraFilteredRouter`, `DirectRoutingRouter`, and their legacy-only tests.

#13163 remains the home for soft-affinity configuration and its broader coordinator convergence fixes. It should rebase onto this stack and adapt those semantics to `RoutingHost`; this PR only migrates the existing hard-affinity behavior.

## Validation

- `cargo test -p dynamo-llm 'kv_router::push_router::tests' --lib` — 15 passed
- `cargo test -p dynamo-llm session_affinity --lib` — 43 passed
- `cargo test -p dynamo-llm 'kv_router::prefill_router' --lib` — 30 passed
- `cargo test -p dynamo-llm 'entrypoint::input::common::tests' --lib` — 1 passed
- `cargo test -p dynamo-runtime 'pipeline::network::egress::push_router::tests' --lib` — 38 passed
- `cargo clippy -p dynamo-llm --lib --tests -- -D warnings`
- `cargo clippy -p dynamo-runtime --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
