### PR TITLE
fix(sglang): route post-resolution ServerArgs mutation through override()

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -173,8 +173,34 @@ def require_reasoning_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[st
     return kwargs
 
 
+def set_resolved_server_args(server_args: Any, source: str, **fields: Any) -> None:
+    """Mutate an already-resolved ``ServerArgs`` the way SGLang sanctions.
+
+    Configuration known before resolution belongs on ``parsed_args``, ahead of
+    ``ServerArgs.from_cli_args`` -- see ``args.py``. This is for the values that
+    only exist afterwards: an endpoint identity, a temp IPC path, a weight
+    version from a live request.
+
+    SGLang >= 0.5.16 provides ``ServerArgs.override(source, **fields)`` for that
+    and rejects bare assignment on a resolved instance, opt-in via
+    ``SGLANG_STRICT_CONFIG_MUTATION`` in 0.5.16 and unconditionally from 0.5.17:
+
+        AttributeError: server_args.<field> assigned after resolution
+
+    Fallback covers 0.5.15, which has neither the guard nor ``override``, and is
+    removable once 0.5.15 leaves the N/N-1 support window.
+    """
+    override = getattr(server_args, "override", None)
+    if callable(override):
+        override(source, **fields)
+        return
+    for name, value in fields.items():
+        setattr(server_args, name, value)
+
+
 __all__ = [
     "ensure_sglang_tensor_image_size",
+    "set_resolved_server_args",
     "ensure_sglang_top_level_exports",
     "filter_supported_async_generate_kwargs",
     "require_reasoning_kwargs",

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -14,6 +14,7 @@ from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.llm import ModelInput, ModelType, WorkerType
 from dynamo.runtime import DistributedRuntime
+from dynamo.sglang._compat import set_resolved_server_args
 from dynamo.sglang.args import Config
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
@@ -71,7 +72,11 @@ async def init_decode(
                 "created before the endpoint existed, so its FPM publisher bound "
                 "a different IPC path than the relay would subscribe to."
             )
-            server_args.enable_forward_pass_metrics = False
+            set_resolved_server_args(
+                server_args,
+                "dynamo_snapshot_mode",
+                enable_forward_pass_metrics=False,
+            )
     else:
         set_forward_pass_metrics_worker_id(server_args, generate_endpoint)
         start_time = time.time()
@@ -227,7 +232,11 @@ async def init_prefill(
                 "created before the endpoint existed, so its FPM publisher bound "
                 "a different IPC path than the relay would subscribe to."
             )
-            server_args.enable_forward_pass_metrics = False
+            set_resolved_server_args(
+                server_args,
+                "dynamo_snapshot_mode",
+                enable_forward_pass_metrics=False,
+            )
     else:
         set_forward_pass_metrics_worker_id(server_args, generate_endpoint)
         start_time = time.time()

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -15,6 +15,7 @@ from dynamo.common.snapshot.restore_context import (
 )
 from dynamo.common.utils.runtime import create_runtime
 from dynamo.runtime.logging import configure_dynamo_logging
+from dynamo.sglang._compat import set_resolved_server_args
 from dynamo.sglang.args import parse_args
 from dynamo.sglang.init_diffusion import (
     init_image_diffusion,
@@ -44,7 +45,12 @@ async def worker(argv: list[str] | None = None):
     if config.server_args.load_format == "gms":
         from gpu_memory_service.integrations.sglang import setup_gms
 
-        config.server_args.load_format = setup_gms(config.server_args)
+        set_resolved_server_args(
+            config.server_args,
+            "dynamo_gms_load_format",
+            load_format=setup_gms(config.server_args),
+            enable_memory_saver=True,
+        )
 
     # Snapshot mode: engine must be created before runtime so CRIU captures no
     # NATS/etcd connections.

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -49,7 +49,6 @@ async def worker(argv: list[str] | None = None):
             config.server_args,
             "dynamo_gms_load_format",
             load_format=setup_gms(config.server_args),
-            enable_memory_saver=True,
         )
 
     # Snapshot mode: engine must be created before runtime so CRIU captures no

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -24,6 +24,7 @@ from dynamo.common.utils.prometheus import (
 )
 from dynamo.llm import KvEventPublisher, WorkerMetricsPublisher
 from dynamo.runtime import Endpoint
+from dynamo.sglang._compat import set_resolved_server_args
 from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_group_id
 from dynamo.sglang.args import Config
 from dynamo.sglang.capacity import (
@@ -49,9 +50,13 @@ def set_forward_pass_metrics_worker_id(
 
     import tempfile
 
-    server_args.forward_pass_metrics_worker_id = str(generate_endpoint.connection_id())
     ipc_path = tempfile.NamedTemporaryFile(delete=False).name
-    server_args.forward_pass_metrics_ipc_name = f"ipc://{ipc_path}"
+    set_resolved_server_args(
+        server_args,
+        "dynamo_forward_pass_metrics",
+        forward_pass_metrics_worker_id=str(generate_endpoint.connection_id()),
+        forward_pass_metrics_ipc_name=f"ipc://{ipc_path}",
+    )
 
 
 async def _resolve_multinode_leader_worker_id(

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -45,6 +45,7 @@ from dynamo.llm import (
 )
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.runtime import DistributedRuntime
+from dynamo.sglang._compat import set_resolved_server_args
 from dynamo.sglang.args import Config
 from dynamo.sglang.capacity import kv_event_block_size
 from dynamo.sglang.engine_routes import resolve_configured_engine_routes
@@ -871,7 +872,11 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         if req.abort_all_requests:
             self.engine.tokenizer_manager.abort_request(abort_all=True)
 
-        self.engine.tokenizer_manager.server_args.weight_version = req.new_version
+        set_resolved_server_args(
+            self.engine.tokenizer_manager.server_args,
+            "dynamo_update_weight_version",
+            weight_version=req.new_version,
+        )
         return {
             "success": True,
             "message": f"Weight version updated to {req.new_version}",

--- a/components/src/dynamo/sglang/snapshot.py
+++ b/components/src/dynamo/sglang/snapshot.py
@@ -16,8 +16,14 @@ from dynamo.common.snapshot.lifecycle import (
     SnapshotConfig,
     configure_snapshot_capture_env,
 )
+from dynamo.sglang._compat import set_resolved_server_args
 
 from .pause import SGLangEnginePauseController
+
+try:
+    from gpu_memory_service.integrations.sglang import is_gms_active
+except ImportError:  # GMS is an optional dependency.
+    is_gms_active = None
 
 logger = logging.getLogger(__name__)
 
@@ -138,15 +144,16 @@ async def prepare_snapshot_engine(
     # Enable memory_saver so GPU memory can be released for CRIU.
     # When using GMS, weights use VA-stable unmap/remap (no CPU backup); GMS
     # forbids enable_weights_cpu_backup. Otherwise use CPU backup for weights.
-    server_args.enable_memory_saver = True
-    try:
-        from gpu_memory_service.integrations.sglang import is_gms_active
-
-        _using_gms = is_gms_active()
-    except ImportError:
-        _using_gms = False
+    set_resolved_server_args(
+        server_args, "dynamo_snapshot_memory_saver", enable_memory_saver=True
+    )
+    _using_gms = is_gms_active() if is_gms_active is not None else False
     if not _using_gms:
-        server_args.enable_weights_cpu_backup = True
+        set_resolved_server_args(
+            server_args,
+            "dynamo_snapshot_weights_cpu_backup",
+            enable_weights_cpu_backup=True,
+        )
 
     start_time = time.time()
     engine = sgl.Engine(server_args=server_args)

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -1588,15 +1588,15 @@ def test_real_server_args_rejects_bare_assignment(tmp_path, monkeypatch):
         server_args.enable_memory_saver = True
 
 
-def test_set_resolved_server_args_applies_gms_fields_on_real_server_args(tmp_path):
-    """The ``--load-format gms`` pair, applied the way ``main.py`` applies it."""
+def test_set_resolved_server_args_applies_fields_on_real_server_args(tmp_path):
+    """A multi-field override on a real resolved instance, as publisher.py does."""
     server_args = _resolved_server_args(tmp_path)
     if not hasattr(server_args, "override"):
         pytest.skip("SGLang < 0.5.16 has no ServerArgs.override")
 
     set_resolved_server_args(
         server_args,
-        "dynamo_gms_load_format",
+        "dynamo_test",
         load_format="dummy",
         enable_memory_saver=True,
     )

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -3,6 +3,7 @@
 
 """Unit tests for SGLang backend components."""
 
+import json
 import logging
 import os
 import re
@@ -25,6 +26,7 @@ from dynamo.sglang._compat import (
     ensure_sglang_top_level_exports,
     filter_supported_async_generate_kwargs,
     require_reasoning_kwargs,
+    set_resolved_server_args,
 )
 from dynamo.sglang.args import (
     _forward_pass_metrics_source,
@@ -38,6 +40,7 @@ from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
 )
+from dynamo.sglang.publisher import set_forward_pass_metrics_worker_id
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
@@ -1424,3 +1427,170 @@ async def test_lora_registration_model_type_gate(
     assert captured["kv_cache_block_size"] == 32
     assert captured["runtime_config"] is lora_runtime_config
     assert "token_budget" in captured["runtime_config"].runtime_data
+
+
+class _ResolvedServerArgs:
+    """Stands in for SGLang >= 0.5.17's frozen ``ServerArgs``.
+
+    Mirrors the upstream guard: any bare assignment after resolution raises,
+    and ``override`` is the sanctioned entry point, recording the source it was
+    given.
+    """
+
+    def __init__(self, **fields):
+        object.__setattr__(self, "_overrides", [])
+        for name, value in fields.items():
+            object.__setattr__(self, name, value)
+
+    def __setattr__(self, name, value):
+        raise AttributeError(
+            f"server_args.{name} assigned after resolution; server_args is "
+            "read-only -- use get_context().override(source, ...) to change "
+            "resolved config."
+        )
+
+    def override(self, source, **fields):
+        self._overrides.append((source, dict(fields)))
+        for name, value in fields.items():
+            object.__setattr__(self, name, value)
+
+
+def test_resolved_server_args_rejects_bare_assignment():
+    """Guards the premise: without the helper these call sites would raise."""
+    server_args = _ResolvedServerArgs(enable_memory_saver=False)
+
+    with pytest.raises(AttributeError, match="assigned after resolution"):
+        server_args.enable_memory_saver = True
+
+
+def test_set_resolved_server_args_uses_override_when_available():
+    server_args = _ResolvedServerArgs(
+        forward_pass_metrics_worker_id=None, forward_pass_metrics_ipc_name=None
+    )
+
+    set_resolved_server_args(
+        server_args,
+        "dynamo_forward_pass_metrics",
+        forward_pass_metrics_worker_id="worker-1",
+        forward_pass_metrics_ipc_name="ipc:///tmp/fpm",
+    )
+
+    assert server_args.forward_pass_metrics_worker_id == "worker-1"
+    assert server_args.forward_pass_metrics_ipc_name == "ipc:///tmp/fpm"
+    assert server_args._overrides == [
+        (
+            "dynamo_forward_pass_metrics",
+            {
+                "forward_pass_metrics_worker_id": "worker-1",
+                "forward_pass_metrics_ipc_name": "ipc:///tmp/fpm",
+            },
+        )
+    ]
+
+
+def test_set_resolved_server_args_falls_back_without_override():
+    """SGLang 0.5.15 has neither the guard nor ``override``."""
+    server_args = SimpleNamespace(enable_memory_saver=False)
+
+    set_resolved_server_args(
+        server_args, "dynamo_snapshot_memory_saver", enable_memory_saver=True
+    )
+
+    assert server_args.enable_memory_saver is True
+
+
+def test_set_resolved_server_args_repeats_a_source_across_call_sites():
+    """The source string is provenance, not a key: reuse must not be rejected."""
+    server_args = _ResolvedServerArgs(enable_forward_pass_metrics=True)
+
+    set_resolved_server_args(
+        server_args, "dynamo_forward_pass_metrics", enable_forward_pass_metrics=False
+    )
+    set_resolved_server_args(
+        server_args, "dynamo_forward_pass_metrics", enable_forward_pass_metrics=True
+    )
+
+    assert server_args.enable_forward_pass_metrics is True
+    assert [source for source, _ in server_args._overrides] == [
+        "dynamo_forward_pass_metrics",
+        "dynamo_forward_pass_metrics",
+    ]
+
+
+def test_set_forward_pass_metrics_worker_id_on_resolved_server_args():
+    """The publisher path end to end against a frozen ``ServerArgs``."""
+    server_args = _ResolvedServerArgs(
+        enable_forward_pass_metrics=True,
+        forward_pass_metrics_worker_id=None,
+        forward_pass_metrics_ipc_name=None,
+    )
+    endpoint = SimpleNamespace(connection_id=lambda: 4242)
+
+    set_forward_pass_metrics_worker_id(server_args, endpoint)
+
+    try:
+        assert server_args.forward_pass_metrics_worker_id == "4242"
+        assert server_args.forward_pass_metrics_ipc_name.startswith("ipc://")
+    finally:
+        # NamedTemporaryFile(delete=False) leaves the placeholder behind.
+        Path(server_args.forward_pass_metrics_ipc_name[len("ipc://") :]).unlink(
+            missing_ok=True
+        )
+
+
+def _resolved_server_args(tmp_path):
+    """A real, resolved ``ServerArgs`` from the installed SGLang."""
+    from sglang.srt.server_args import ServerArgs
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["LlamaForCausalLM"],
+                "model_type": "llama",
+                "hidden_size": 64,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 4,
+                "num_hidden_layers": 2,
+                "max_position_embeddings": 128,
+                "vocab_size": 32,
+                "torch_dtype": "float16",
+            }
+        )
+    )
+    try:
+        return ServerArgs(
+            model_path=str(tmp_path),
+            tokenizer_path=str(tmp_path),
+            device="cpu",
+            skip_tokenizer_init=True,
+        )
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"cannot resolve ServerArgs here: {exc}")
+
+
+def test_real_server_args_rejects_bare_assignment(tmp_path):
+    """The regression itself, against the installed SGLang rather than a double."""
+    server_args = _resolved_server_args(tmp_path)
+    if not hasattr(server_args, "override"):
+        pytest.skip("SGLang < 0.5.16 has no ServerArgs.override")
+
+    with pytest.raises(AttributeError, match="read-only"):
+        server_args.enable_memory_saver = True
+
+
+def test_set_resolved_server_args_applies_gms_fields_on_real_server_args(tmp_path):
+    """The ``--load-format gms`` pair, applied the way ``main.py`` applies it."""
+    server_args = _resolved_server_args(tmp_path)
+    if not hasattr(server_args, "override"):
+        pytest.skip("SGLang < 0.5.16 has no ServerArgs.override")
+
+    set_resolved_server_args(
+        server_args,
+        "dynamo_gms_load_format",
+        load_format="dummy",
+        enable_memory_saver=True,
+    )
+
+    assert server_args.load_format == "dummy"
+    assert server_args.enable_memory_saver is True

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -1569,13 +1569,22 @@ def _resolved_server_args(tmp_path):
         pytest.skip(f"cannot resolve ServerArgs here: {exc}")
 
 
-def test_real_server_args_rejects_bare_assignment(tmp_path):
-    """The regression itself, against the installed SGLang rather than a double."""
+def test_real_server_args_rejects_bare_assignment(tmp_path, monkeypatch):
+    """The regression itself, against the installed SGLang rather than a double.
+
+    0.5.16 -- the version pinned here -- reads SGLANG_STRICT_CONFIG_MUTATION on
+    every assignment and only guards when it is set; 0.5.17 guards
+    unconditionally and ignores the variable. Setting it covers both.
+    """
     server_args = _resolved_server_args(tmp_path)
     if not hasattr(server_args, "override"):
         pytest.skip("SGLang < 0.5.16 has no ServerArgs.override")
+    monkeypatch.setenv("SGLANG_STRICT_CONFIG_MUTATION", "1")
 
-    with pytest.raises(AttributeError, match="read-only"):
+    # Match only the wording common to both: 0.5.16 says "use
+    # server_args.override(source, ...) instead", 0.5.17 says "server_args is
+    # read-only -- use get_context().override(source, ...)".
+    with pytest.raises(AttributeError, match="assigned after resolution"):
         server_args.enable_memory_saver = True
 
 

--- a/lib/gpu_memory_service/integrations/sglang/__init__.py
+++ b/lib/gpu_memory_service/integrations/sglang/__init__.py
@@ -7,7 +7,9 @@ Usage:
     from gpu_memory_service.integrations.sglang import setup_gms
 
     if server_args.load_format == "gms":
-        server_args.load_format = setup_gms(server_args)
+        server_args.override(
+            "gms", load_format=setup_gms(server_args), enable_memory_saver=True
+        )
 """
 
 from __future__ import annotations
@@ -41,6 +43,11 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
     Args:
         server_args: SGLang ServerArgs instance.
 
+    The caller applies the result, and must also enable memory saver: GMS
+    releases GPU memory through SGLang's memory-saver path. This function does
+    not touch ``server_args`` because SGLang freezes it once resolved, and this
+    package deliberately does not depend on Dynamo's SGLang compatibility layer.
+
     Returns:
         GMSModelLoader class to use as load_format.
 
@@ -57,7 +64,6 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
             "Cannot use --enable-draft-weights-cpu-backup with --load-format gms."
         )
 
-    server_args.enable_memory_saver = True
     # Resolve lock mode and RO reconnect timeout from model_loader_extra_config
     # before patches fire.
     global _gms_lock_mode

--- a/lib/gpu_memory_service/integrations/sglang/__init__.py
+++ b/lib/gpu_memory_service/integrations/sglang/__init__.py
@@ -7,9 +7,7 @@ Usage:
     from gpu_memory_service.integrations.sglang import setup_gms
 
     if server_args.load_format == "gms":
-        server_args.override(
-            "gms", load_format=setup_gms(server_args), enable_memory_saver=True
-        )
+        server_args.override("gms", load_format=setup_gms(server_args))
 """
 
 from __future__ import annotations
@@ -43,10 +41,9 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
     Args:
         server_args: SGLang ServerArgs instance.
 
-    The caller applies the result, and must also enable memory saver: GMS
-    releases GPU memory through SGLang's memory-saver path. This function does
-    not touch ``server_args`` because SGLang freezes it once resolved, and this
-    package deliberately does not depend on Dynamo's SGLang compatibility layer.
+    Enables the memory saver on ``server_args`` -- GMS releases GPU memory
+    through SGLang's memory-saver path -- and leaves ``load_format`` to the
+    caller, which is the value this returns.
 
     Returns:
         GMSModelLoader class to use as load_format.
@@ -63,6 +60,16 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
         raise ValueError(
             "Cannot use --enable-draft-weights-cpu-backup with --load-format gms."
         )
+
+    # SGLang >= 0.5.16 freezes ServerArgs once resolved and offers override()
+    # as the mutation point; the guard is opt-in there and unconditional from
+    # 0.5.17. This package cannot import Dynamo's SGLang compat helper, so it
+    # repeats the same two-line check.
+    override = getattr(server_args, "override", None)
+    if callable(override):
+        override("gms", enable_memory_saver=True)
+    else:  # SGLang < 0.5.16 has neither override() nor the guard.
+        server_args.enable_memory_saver = True
 
     # Resolve lock mode and RO reconnect timeout from model_loader_extra_config
     # before patches fire.

--- a/lib/gpu_memory_service/tests/test_sglang_patches.py
+++ b/lib/gpu_memory_service/tests/test_sglang_patches.py
@@ -82,19 +82,25 @@ def test_patch_model_runner_leaves_baseline_unchanged_without_preload(monkeypatc
 
 
 class _FrozenServerArgs(SimpleNamespace):
-    """SGLang >= 0.5.17 rejects assignment on a resolved ``ServerArgs``."""
+    """SGLang >= 0.5.17 rejects bare assignment on a resolved ``ServerArgs``."""
 
     def __setattr__(self, name, value):
         raise AttributeError(
             f"server_args.{name} assigned after resolution; server_args is read-only"
         )
 
+    def override(self, source, **fields):
+        self.overrides.append((source, dict(fields)))
+        for name, value in fields.items():
+            object.__setattr__(self, name, value)
 
-def test_setup_gms_does_not_write_to_resolved_server_args():
-    """``--load-format gms`` runs after resolution, so setup must not assign."""
+
+def test_setup_gms_enables_memory_saver_through_override():
+    """``--load-format gms`` runs after resolution, so this cannot bare-assign."""
     from gpu_memory_service.integrations.sglang import setup_gms
 
     server_args = _FrozenServerArgs(
+        overrides=[],
         enable_weights_cpu_backup=False,
         enable_draft_weights_cpu_backup=False,
         model_loader_extra_config=None,
@@ -105,5 +111,23 @@ def test_setup_gms_does_not_write_to_resolved_server_args():
     loader = setup_gms(server_args)
 
     assert loader is not None
-    assert server_args.enable_memory_saver is False
+    assert server_args.enable_memory_saver is True
+    assert server_args.overrides == [("gms", {"enable_memory_saver": True})]
+    # load_format stays the caller's to apply.
     assert server_args.load_format == "gms"
+
+
+def test_setup_gms_falls_back_to_assignment_without_override():
+    """SGLang < 0.5.16 has neither ``override`` nor the guard."""
+    from gpu_memory_service.integrations.sglang import setup_gms
+
+    server_args = SimpleNamespace(
+        enable_weights_cpu_backup=False,
+        enable_draft_weights_cpu_backup=False,
+        model_loader_extra_config=None,
+        enable_memory_saver=False,
+        load_format="gms",
+    )
+
+    assert setup_gms(server_args) is not None
+    assert server_args.enable_memory_saver is True

--- a/lib/gpu_memory_service/tests/test_sglang_patches.py
+++ b/lib/gpu_memory_service/tests/test_sglang_patches.py
@@ -79,3 +79,31 @@ def test_patch_model_runner_leaves_baseline_unchanged_without_preload(monkeypatc
 
     assert runner.alloc_memory_pool() == 10.0
     assert runner.pre_model_load_memory == 10.0
+
+
+class _FrozenServerArgs(SimpleNamespace):
+    """SGLang >= 0.5.17 rejects assignment on a resolved ``ServerArgs``."""
+
+    def __setattr__(self, name, value):
+        raise AttributeError(
+            f"server_args.{name} assigned after resolution; server_args is read-only"
+        )
+
+
+def test_setup_gms_does_not_write_to_resolved_server_args():
+    """``--load-format gms`` runs after resolution, so setup must not assign."""
+    from gpu_memory_service.integrations.sglang import setup_gms
+
+    server_args = _FrozenServerArgs(
+        enable_weights_cpu_backup=False,
+        enable_draft_weights_cpu_backup=False,
+        model_loader_extra_config=None,
+        enable_memory_saver=False,
+        load_format="gms",
+    )
+
+    loader = setup_gms(server_args)
+
+    assert loader is not None
+    assert server_args.enable_memory_saver is False
+    assert server_args.load_format == "gms"


### PR DESCRIPTION
SGLang makes `ServerArgs` read-only once `__post_init__` resolves it — `override()` is opt-in behind `SGLANG_STRICT_CONFIG_MUTATION` in 0.5.16 and mandatory from 0.5.17. Seven call sites in the SGLang component still assign fields directly afterwards, so on 0.5.17 the worker dies at startup with `AttributeError: server_args.<field> assigned after resolution`. `args.py` already fixed its own site by moving the value onto `parsed_args` before `from_cli_args`; these sites can't, because the values don't exist until after resolution (endpoint identity, a temp IPC path, a weight version from a live request).

The fix adds `set_resolved_server_args(server_args, source, **fields)` to `_compat.py`, which calls `ServerArgs.override(...)` when present and falls back to assignment for 0.5.15 — the N-1 release, which has neither the guard nor `override`. Fallback is removable when 0.5.15 leaves the support window. All seven sites now go through it: `init_llm.py` (×2), `publisher.py`, `snapshot.py` (×2), `main.py`, `request_handlers/handler_base.py`.

`--load-format gms` was broken the same way: `setup_gms()` set `enable_memory_saver` on a resolved `ServerArgs`. Since `gpu-memory-service` ships as its own distribution, it keeps that responsibility and now goes through `override()` when available — the same check, repeated because the package cannot import from `dynamo.sglang`.

Coverage in `test_sglang_unit.py`: a double reproducing the guard, plus two tests against a real resolved `ServerArgs` from the installed SGLang — one asserting bare assignment raises (setting `SGLANG_STRICT_CONFIG_MUTATION`, since 0.5.16 is opt-in and 0.5.17 ignores it), one applying a multi-field override. `test_sglang_patches.py` covers both `setup_gms()` branches. The `SimpleNamespace` stub the image/video diffusion workers build in `args.py` is untouched; it never reaches these sites.