### PR TITLE
fix(llm): project native Generate controls

### DIFF
--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -763,6 +763,8 @@ mod tests {
             r#"{"token_ids":[1],"sampling_params":{"logprobs":-2}}"#,
             r#"{"token_ids":[1],"sampling_params":{"prompt_logprobs":-2}}"#,
             r#"{"token_ids":[1],"sampling_params":{"min_tokens":3,"max_tokens":2}}"#,
+            r#"{"token_ids":[1],"sampling_params":{"stop":""}}"#,
+            r#"{"token_ids":[1],"sampling_params":{"stop":["done",""]}}"#,
         ];
 
         for body in invalid {
@@ -981,6 +983,34 @@ mod tests {
         assert_eq!(preprocessed.stop_conditions.ignore_eos, Some(true));
         assert_eq!(preprocessed.output_options.logprobs, Some(3));
         assert_eq!(preprocessed.output_options.prompt_logprobs, Some(4));
+    }
+
+    #[test]
+    fn generate_projects_python_vllm_text_output_controls() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2],
+            "sampling_params": {
+                "stop": ["done", "halt"],
+                "include_stop_str_in_output": true,
+                "skip_special_tokens": false
+            },
+            "model": "test-model"
+        }))
+        .expect("deserialize request");
+
+        let preprocessed =
+            preprocessed_from_generate(request, "test-model", None, "resolved-request")
+                .expect("build request");
+
+        assert_eq!(
+            preprocessed.stop_conditions.stop.as_deref(),
+            Some(&["done".to_string(), "halt".to_string()][..])
+        );
+        assert_eq!(
+            preprocessed.sampling_options.include_stop_str_in_output,
+            Some(true)
+        );
+        assert_eq!(preprocessed.output_options.skip_special_tokens, Some(false));
     }
 
     #[test]

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -33,7 +33,6 @@ use super::openai::{
 use super::{RouteDoc, service_v2};
 use crate::local_model::runtime_config::VLLM_INFERENCE_V1_GENERATE_CAPABILITY;
 use crate::protocols::common::preprocessor::PreprocessedRequest;
-use crate::protocols::common::{SamplingOptions, StopConditions};
 use crate::protocols::openai::generate::{
     GenerateRequest, GenerateResponse, GenerateResponseOptions, SamplingParams, StreamOptions,
 };
@@ -216,8 +215,13 @@ fn preprocessed_from_generate(
 ) -> anyhow::Result<PreprocessedRequest> {
     let sampling = &request.sampling_params;
     let max_tokens = sampling.max_tokens();
-    let min_tokens = sampling.min_tokens();
-    let ignore_eos = sampling.ignore_eos();
+    let stop_conditions = sampling.project_stop_conditions();
+    let sampling_options = sampling
+        .project_sampling_options()
+        .map_err(anyhow::Error::msg)?;
+    let output_options = sampling
+        .project_output_options()
+        .map_err(anyhow::Error::msg)?;
     let routing_priority = dynamo_routing_priority(request.priority);
     let vllm_tito = serde_json::to_value(VllmTitoEnvelope::new(&request, request_id))?;
     let GenerateRequest {
@@ -229,17 +233,9 @@ fn preprocessed_from_generate(
     PreprocessedRequest::builder()
         .model(model.to_string())
         .token_ids(token_ids)
-        .stop_conditions(StopConditions {
-            max_tokens,
-            min_tokens,
-            ignore_eos: Some(ignore_eos),
-            ..Default::default()
-        })
-        .sampling_options(SamplingOptions {
-            n: Some(1),
-            ..Default::default()
-        })
-        .output_options(Default::default())
+        .stop_conditions(stop_conditions)
+        .sampling_options(sampling_options)
+        .output_options(output_options)
         .routing(Some(crate::protocols::common::preprocessor::RoutingHints {
             dp_rank: data_parallel_rank,
             expected_output_tokens: max_tokens,
@@ -764,6 +760,7 @@ mod tests {
         let invalid = [
             r#"{"token_ids":[1],"sampling_params":{},"stream_options":{"include_usage":true}}"#,
             r#"{"token_ids":[1],"sampling_params":{"max_tokens":0}}"#,
+            r#"{"token_ids":[1],"sampling_params":{"logprobs":-2}}"#,
             r#"{"token_ids":[1],"sampling_params":{"prompt_logprobs":-2}}"#,
             r#"{"token_ids":[1],"sampling_params":{"min_tokens":3,"max_tokens":2}}"#,
         ];
@@ -937,6 +934,91 @@ mod tests {
             preprocessed_from_generate(request, "test-model", None, "resolved-request")
                 .expect("build request");
         assert_eq!(preprocessed.stop_conditions.min_tokens, Some(0));
+    }
+
+    #[test]
+    fn generate_projects_vllm_sampling_and_output_controls() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2],
+            "sampling_params": {
+                "temperature": 0.25,
+                "top_p": 0.9,
+                "top_k": 17,
+                "min_p": 0.05,
+                "seed": 23,
+                "max_tokens": 8,
+                "min_tokens": 2,
+                "presence_penalty": 0.1,
+                "frequency_penalty": 0.2,
+                "repetition_penalty": 1.1,
+                "stop_token_ids": [7, 8],
+                "ignore_eos": true,
+                "logprobs": 3,
+                "prompt_logprobs": 4
+            },
+            "model": "test-model"
+        }))
+        .expect("deserialize request");
+
+        let preprocessed =
+            preprocessed_from_generate(request, "test-model", None, "resolved-request")
+                .expect("build request");
+
+        assert_eq!(preprocessed.sampling_options.temperature, Some(0.25));
+        assert_eq!(preprocessed.sampling_options.top_p, Some(0.9));
+        assert_eq!(preprocessed.sampling_options.top_k, Some(17));
+        assert_eq!(preprocessed.sampling_options.min_p, Some(0.05));
+        assert_eq!(preprocessed.sampling_options.seed, Some(23));
+        assert_eq!(preprocessed.sampling_options.presence_penalty, Some(0.1));
+        assert_eq!(preprocessed.sampling_options.frequency_penalty, Some(0.2));
+        assert_eq!(preprocessed.sampling_options.repetition_penalty, Some(1.1));
+        assert_eq!(preprocessed.stop_conditions.max_tokens, Some(8));
+        assert_eq!(preprocessed.stop_conditions.min_tokens, Some(2));
+        assert_eq!(
+            preprocessed.stop_conditions.stop_token_ids.as_deref(),
+            Some(&[7, 8][..])
+        );
+        assert_eq!(preprocessed.stop_conditions.ignore_eos, Some(true));
+        assert_eq!(preprocessed.output_options.logprobs, Some(3));
+        assert_eq!(preprocessed.output_options.prompt_logprobs, Some(4));
+    }
+
+    #[test]
+    fn generate_projects_all_logprobs() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2],
+            "sampling_params": {
+                "logprobs": -1,
+                "prompt_logprobs": -1
+            },
+            "model": "test-model"
+        }))
+        .expect("deserialize request");
+
+        let preprocessed =
+            preprocessed_from_generate(request, "test-model", None, "resolved-request")
+                .expect("build request");
+
+        assert_eq!(preprocessed.output_options.logprobs, Some(u32::MAX));
+        assert_eq!(preprocessed.output_options.prompt_logprobs, Some(u32::MAX));
+    }
+
+    #[test]
+    fn generate_rejects_top_k_outside_dynamo_range() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2],
+            "sampling_params": {"top_k": u32::MAX},
+            "model": "test-model"
+        }))
+        .expect("deserialize request");
+
+        let error = preprocessed_from_generate(request, "test-model", None, "resolved-request")
+            .expect_err("reject unsupported top_k range");
+
+        assert_eq!(
+            error.to_string(),
+            "sampling_params.top_k exceeds Dynamo's supported range: 4294967295"
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -93,6 +93,15 @@ impl GenerateRequest {
             return Err("sampling_params.max_tokens must be greater than 0.".to_string());
         }
 
+        if self
+            .sampling_params
+            .stop
+            .as_ref()
+            .is_some_and(StopStrings::has_empty)
+        {
+            return Err("sampling_params.stop cannot contain an empty string.".to_string());
+        }
+
         if let Some(logprobs) = self.sampling_params.logprobs()
             && logprobs < 0
             && logprobs != -1
@@ -170,8 +179,11 @@ pub struct SamplingParams {
     frequency_penalty: Option<f32>,
     presence_penalty: Option<f32>,
     repetition_penalty: Option<f32>,
+    stop: Option<StopStrings>,
     stop_token_ids: Option<Vec<u32>>,
     ignore_eos: bool,
+    include_stop_str_in_output: Option<bool>,
+    skip_special_tokens: Option<bool>,
     logit_bias: Option<HashMap<u32, f32>>,
     allowed_token_ids: Option<Vec<u32>>,
     bad_words: Option<Vec<String>>,
@@ -227,6 +239,7 @@ impl SamplingParams {
             top_k,
             min_p: self.min_p,
             seed: self.seed,
+            include_stop_str_in_output: self.include_stop_str_in_output,
             ..Default::default()
         })
     }
@@ -234,6 +247,7 @@ impl SamplingParams {
     pub(crate) fn project_stop_conditions(&self) -> StopConditions {
         StopConditions {
             max_tokens: self.max_tokens,
+            stop: self.stop.as_ref().map(StopStrings::to_vec),
             stop_token_ids: self.stop_token_ids.clone(),
             min_tokens: self.min_tokens,
             ignore_eos: Some(self.ignore_eos),
@@ -245,8 +259,32 @@ impl SamplingParams {
         Ok(OutputOptions {
             logprobs: project_logprob_count(self.logprobs, "logprobs")?,
             prompt_logprobs: project_logprob_count(self.prompt_logprobs, "prompt_logprobs")?,
+            skip_special_tokens: self.skip_special_tokens,
             ..Default::default()
         })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum StopStrings {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl StopStrings {
+    fn has_empty(&self) -> bool {
+        match self {
+            Self::One(value) => value.is_empty(),
+            Self::Many(values) => values.iter().any(String::is_empty),
+        }
+    }
+
+    fn to_vec(&self) -> Vec<String> {
+        match self {
+            Self::One(value) => vec![value.clone()],
+            Self::Many(values) => values.clone(),
+        }
     }
 }
 
@@ -305,9 +343,12 @@ impl<'de> Deserialize<'de> for SamplingParams {
             frequency_penalty: field!(frequency_penalty),
             presence_penalty: field!(presence_penalty),
             repetition_penalty: field!(repetition_penalty),
+            stop: field!(stop),
             stop_token_ids: field!(stop_token_ids),
             ignore_eos: sampling_field_or_default(object, "ignore_eos")
                 .map_err(serde::de::Error::custom)?,
+            include_stop_str_in_output: field!(include_stop_str_in_output),
+            skip_special_tokens: field!(skip_special_tokens),
             logit_bias: field!(logit_bias),
             allowed_token_ids: field!(allowed_token_ids),
             bad_words: field!(bad_words),

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -22,6 +22,7 @@ use serde_json::{Map, Value};
 use super::{convert_backend_top_logprobs, token_to_utf8_bytes};
 use crate::protocols::Annotated;
 use crate::protocols::common::llm_backend::{LLMEngineOutput, PromptLogprobs};
+use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
 
 /// Token-in/token-out generation request.
 ///
@@ -90,6 +91,13 @@ impl GenerateRequest {
 
         if self.sampling_params.max_tokens() == Some(0) {
             return Err("sampling_params.max_tokens must be greater than 0.".to_string());
+        }
+
+        if let Some(logprobs) = self.sampling_params.logprobs()
+            && logprobs < 0
+            && logprobs != -1
+        {
+            return Err("sampling_params.logprobs must be non-negative or -1.".to_string());
         }
 
         if let Some(prompt_logprobs) = self.sampling_params.prompt_logprobs() {
@@ -198,6 +206,58 @@ impl SamplingParams {
 
     pub fn as_value(&self) -> &Value {
         &self.raw
+    }
+
+    pub(crate) fn project_sampling_options(&self) -> Result<SamplingOptions, String> {
+        let top_k = self
+            .top_k
+            .map(|value| {
+                i32::try_from(value).map_err(|_| {
+                    format!("sampling_params.top_k exceeds Dynamo's supported range: {value}")
+                })
+            })
+            .transpose()?;
+        Ok(SamplingOptions {
+            n: Some(1),
+            presence_penalty: self.presence_penalty,
+            frequency_penalty: self.frequency_penalty,
+            repetition_penalty: self.repetition_penalty,
+            temperature: self.temperature,
+            top_p: self.top_p,
+            top_k,
+            min_p: self.min_p,
+            seed: self.seed,
+            ..Default::default()
+        })
+    }
+
+    pub(crate) fn project_stop_conditions(&self) -> StopConditions {
+        StopConditions {
+            max_tokens: self.max_tokens,
+            stop_token_ids: self.stop_token_ids.clone(),
+            min_tokens: self.min_tokens,
+            ignore_eos: Some(self.ignore_eos),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn project_output_options(&self) -> Result<OutputOptions, String> {
+        Ok(OutputOptions {
+            logprobs: project_logprob_count(self.logprobs, "logprobs")?,
+            prompt_logprobs: project_logprob_count(self.prompt_logprobs, "prompt_logprobs")?,
+            ..Default::default()
+        })
+    }
+}
+
+fn project_logprob_count(value: Option<i32>, field: &str) -> Result<Option<u32>, String> {
+    match value {
+        None => Ok(None),
+        Some(-1) => Ok(Some(u32::MAX)),
+        Some(value) if value >= 0 => Ok(Some(value as u32)),
+        Some(value) => Err(format!(
+            "sampling_params.{field} must be non-negative or -1, got {value}"
+        )),
     }
 }
 
@@ -762,6 +822,13 @@ mod tests {
                     "sampling_params": {"max_tokens": 0}
                 }),
                 "max_tokens",
+            ),
+            (
+                json!({
+                    "token_ids": [1],
+                    "sampling_params": {"logprobs": -2}
+                }),
+                "logprobs",
             ),
             (
                 json!({


### PR DESCRIPTION
## Summary

- Project native vLLM Generate sampling fields into Dynamo sampling options.
- Preserve stop-token, token-limit, and ignore-EOS controls in the preprocessed request.
- Project output and prompt logprob counts, including the native all-logprobs sentinel.
- Reject values that cannot be represented by the current Dynamo control types.

This is an independent extraction from the Prime-RL integration branch. Exact multimodal routing is intentionally left to #11588.

## Validation

- cargo fmt --all
- cargo clippy -p dynamo-llm --all-targets -- -D warnings
- cargo test -p dynamo-llm --lib generate (70 passed)
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for more sampling, stopping, and output controls when generating text.
  - Added handling for unlimited log probability output using the `-1` setting.
  - Added safer conversion and validation for sampling options such as `top_k`.

- **Bug Fixes**
  - Requests with invalid negative log probability values are now rejected with validation errors.
  - Unsupported sampling configurations are reported instead of being silently replaced with defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->