### PR TITLE
feat(vllm): sync routed expert output protocol

### DIFF
--- a/lib/mocker/servers/vllm/src/server_request.rs
+++ b/lib/mocker/servers/vllm/src/server_request.rs
@@ -293,6 +293,7 @@ impl PreparedRequest {
                 kv_transfer_params: (self.mode == ServerMode::Prefill).then(|| self.handoff()),
                 ec_transfer_params: None,
             }),
+            routed_experts: None,
         }
     }
 

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Inference source: [`rust/proto/inference.proto`](https://github.com/vllm-project/vllm/blob/3d1f5cee1552b8208f3009c75f8bc856f27e0eff/rust/proto/inference.proto) at `3d1f5cee1552b8208f3009c75f8bc856f27e0eff`
+- Inference source: [`rust/proto/inference.proto`](https://github.com/biswapanda/vllm/blob/100f970b4ee45036a6015f4fa852cf0610556633/rust/proto/inference.proto) at `100f970b4ee45036a6015f4fa852cf0610556633`
 - RL Control source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/76ebe5a217d7536a5661272c680f0b1e3a62f5be/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) at `76ebe5a217d7536a5661272c680f0b1e3a62f5be`
-- `inference.proto` SHA-256: `6152c306583166ecd691c9c715cab950523e8d1ed2db3dc2bcb538f6ca90e56f`
+- `inference.proto` SHA-256: `bad6c9101f81ab8b8b78bf3e7d70992796d859dbe81219fa6de119caf9a6d94a`
 - `control.proto` SHA-256: `db72b0782142054293b07fd48247cc821c048213b9c95dbc37fb0d81dde8f46f`
 
 The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Inference source: [`rust/proto/inference.proto`](https://github.com/biswapanda/vllm/blob/100f970b4ee45036a6015f4fa852cf0610556633/rust/proto/inference.proto) at `100f970b4ee45036a6015f4fa852cf0610556633`
+- Inference source: [`rust/proto/inference.proto`](https://github.com/biswapanda/vllm/blob/6eb8d5b352a50933177a639cc06f55d1c24f6f20/rust/proto/inference.proto) at `6eb8d5b352a50933177a639cc06f55d1c24f6f20`
 - RL Control source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/76ebe5a217d7536a5661272c680f0b1e3a62f5be/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) at `76ebe5a217d7536a5661272c680f0b1e3a62f5be`
-- `inference.proto` SHA-256: `bad6c9101f81ab8b8b78bf3e7d70992796d859dbe81219fa6de119caf9a6d94a`
+- `inference.proto` SHA-256: `608e4677a678bd2faeb97eb2145414db863a713b8df8c9164dd6b2fd04acc803`
 - `control.proto` SHA-256: `db72b0782142054293b07fd48247cc821c048213b9c95dbc37fb0d81dde8f46f`
 
 The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -164,7 +164,6 @@ message RoutedExperts {
   bytes data = 1;
   repeated uint32 shape = 2;
   string dtype = 3;
-  uint32 start = 4;
 }
 
 // Prompt info, returned in the first response
@@ -236,19 +235,7 @@ message MediaItem {
     string url = 2;       // http:// or https://
     string data_uri = 3;  // data:
     bytes raw_bytes = 4;
-    PreprocessedMediaFeatures features = 7;
   }
   string mime_type = 5;
   string uuid = 6;
-}
-
-// Engine-ready multimodal features produced by a version-compatible frontend.
-// `kwargs` is the MessagePack wire representation of one MmKwargsItem.
-message PreprocessedMediaFeatures {
-  optional bytes kwargs = 1;
-  string identifier = 2;
-  uint64 offset = 3;
-  uint64 length = 4;
-  optional string mm_hash = 5;
-  repeated bool is_embed = 6;
 }

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -107,6 +107,10 @@ message ResponseOptions {
   bool output_token_ids = 5;
   bool output_logprobs = 6;
   optional CandidateTokens output_candidates = 7;
+  // Defaults to true when omitted.
+  optional bool skip_special_tokens = 8;
+  // Skip routing rows for this already-returned prompt prefix.
+  optional uint32 routed_experts_prompt_start = 9;
 }
 
 message KVCacheParameters {
@@ -152,6 +156,15 @@ message SequenceOutput {
 
   // Only present in final output for this sequence
   optional FinishInfo finish_info = 8;
+  // Only present in final output when routed-experts capture is enabled.
+  optional RoutedExperts routed_experts = 9;
+}
+
+message RoutedExperts {
+  bytes data = 1;
+  repeated uint32 shape = 2;
+  string dtype = 3;
+  uint32 start = 4;
 }
 
 // Prompt info, returned in the first response
@@ -223,7 +236,19 @@ message MediaItem {
     string url = 2;       // http:// or https://
     string data_uri = 3;  // data:
     bytes raw_bytes = 4;
+    PreprocessedMediaFeatures features = 7;
   }
   string mime_type = 5;
   string uuid = 6;
+}
+
+// Engine-ready multimodal features produced by a version-compatible frontend.
+// `kwargs` is the MessagePack wire representation of one MmKwargsItem.
+message PreprocessedMediaFeatures {
+  optional bytes kwargs = 1;
+  string identifier = 2;
+  uint64 offset = 3;
+  uint64 length = 4;
+  optional string mm_hash = 5;
+  repeated bool is_embed = 6;
 }

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -117,6 +117,8 @@ pub(crate) fn build_generate_request(
             output_token_ids: true,
             output_logprobs: output_logprobs.is_some(),
             output_candidates: output_logprobs.map(top_n_candidates).transpose()?,
+            skip_special_tokens: None,
+            routed_experts_prompt_start: None,
         }),
         kv: Some(kv),
         truncate_prompt_tokens: 0,

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -489,6 +489,7 @@ fn sequence_response(
                 kv_transfer_params,
                 ec_transfer_params: None,
             }),
+            routed_experts: None,
         }),
     }
 }


### PR DESCRIPTION
## Summary

- vendor the exact vLLM Rust inference protocol needed for native routed-expert output
- preserve the typed `{data, shape, dtype}` tensor over gRPC without adding Prime-RL trajectory metadata
- initialize the new optional routed tensor field so current sidecar behavior remains unchanged
- record the exact vLLM source revision and SHA-256 checksum

This protocol-only extraction is wire-compatible and leaves behavior unchanged. Preprocessed multimodal features remain in the independent #13533 train and are not part of this leaf.

The vendored source is `biswapanda/vllm@6eb8d5b352a50933177a639cc06f55d1c24f6f20`; the corresponding upstream runtime train is vllm-project/vllm#52721 followed by #52723. The draft remains blocked until those runtime changes land and the source pin can move to upstream main.

## Validation

- `cargo test -p dynamo-vllm-sidecar`: 21 library tests and 1 executable test passed
- `cargo fmt --all -- --check`
- vendored `inference.proto` SHA-256 verified as `608e4677a678bd2faeb97eb2145414db863a713b8df8c9164dd6b2fd04acc803`
- vendored protocol is byte-for-byte identical to the pinned vLLM source
- `cargo check -p dynamo-vllm-mocker` passed after the mock server initialized the new optional routed tensor to `None`
- `git diff --check`
