### PR TITLE
feat(runtime): add mutual TLS (mTLS) support for TCP and NATS transports

### DIFF
--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -64,8 +64,13 @@ class DynamoRuntimeConfig(ConfigBase):
     tcp_tls_insecure: bool = False
     tcp_tls_server_name: Optional[str] = None
     tcp_tls_handshake_timeout_secs: Optional[int] = None
+    tcp_tls_client_cert_path: Optional[str] = None
+    tcp_tls_client_key_path: Optional[str] = None
+    tcp_tls_client_ca_cert_path: Optional[str] = None
     nats_tls_ca_cert_path: Optional[str] = None
     nats_tls_insecure: bool = False
+    nats_tls_client_cert_path: Optional[str] = None
+    nats_tls_client_key_path: Optional[str] = None
 
     def validate(self) -> None:
         self.namespace = get_worker_namespace(self.namespace)
@@ -121,6 +126,16 @@ class DynamoRuntimeConfig(ConfigBase):
             os.environ["DYN_TCP_TLS_HANDSHAKE_TIMEOUT_SECS"] = str(
                 self.tcp_tls_handshake_timeout_secs
             )
+        # TCP mTLS: client identity presented to the server, and the CA the
+        # server uses to verify client certificates.
+        if self.tcp_tls_client_cert_path:
+            os.environ["DYN_TCP_TLS_CLIENT_CERT_PATH"] = self.tcp_tls_client_cert_path
+        if self.tcp_tls_client_key_path:
+            os.environ["DYN_TCP_TLS_CLIENT_KEY_PATH"] = self.tcp_tls_client_key_path
+        if self.tcp_tls_client_ca_cert_path:
+            os.environ[
+                "DYN_TCP_TLS_CLIENT_CA_CERT_PATH"
+            ] = self.tcp_tls_client_ca_cert_path
 
         # Propagate NATS TLS CLI flags.
         if self.nats_tls_ca_cert_path:
@@ -129,6 +144,11 @@ class DynamoRuntimeConfig(ConfigBase):
             os.environ["NATS_TLS_INSECURE"] = "1"
         else:
             os.environ.pop("NATS_TLS_INSECURE", None)
+        # NATS mTLS: client identity presented to the NATS server.
+        if self.nats_tls_client_cert_path:
+            os.environ["NATS_TLS_CLIENT_CERT_PATH"] = self.nats_tls_client_cert_path
+        if self.nats_tls_client_key_path:
+            os.environ["NATS_TLS_CLIENT_KEY_PATH"] = self.nats_tls_client_key_path
 
     def _validate_output_modalities(self) -> None:
         """Validate --output-modalities values."""
@@ -441,6 +461,31 @@ class DynamoRuntimeArgGroup(ArgGroup):
 
         add_argument(
             g,
+            flag_name="--tcp-tls-client-cert-path",
+            env_var="DYN_TCP_TLS_CLIENT_CERT_PATH",
+            default=None,
+            help="Path to PEM client certificate presented to the TCP server for mTLS.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--tcp-tls-client-key-path",
+            env_var="DYN_TCP_TLS_CLIENT_KEY_PATH",
+            default=None,
+            help="Path to PEM private key for the TCP client certificate (mTLS).",
+        )
+
+        add_argument(
+            g,
+            flag_name="--tcp-tls-client-ca-cert-path",
+            env_var="DYN_TCP_TLS_CLIENT_CA_CERT_PATH",
+            default=None,
+            help="Path to PEM CA certificate the TCP server uses to verify client "
+            "certificates. When set, clients must present a trusted certificate (mTLS enforced).",
+        )
+
+        add_argument(
+            g,
             flag_name="--nats-tls-ca-cert-path",
             env_var="NATS_TLS_CA_CERT_PATH",
             default=None,
@@ -453,4 +498,20 @@ class DynamoRuntimeArgGroup(ArgGroup):
             env_var="NATS_TLS_INSECURE",
             default=False,
             help="Disable NATS TLS certificate verification. For local development only.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--nats-tls-client-cert-path",
+            env_var="NATS_TLS_CLIENT_CERT_PATH",
+            default=None,
+            help="Path to PEM client certificate presented to the NATS server for mTLS.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--nats-tls-client-key-path",
+            env_var="NATS_TLS_CLIENT_KEY_PATH",
+            default=None,
+            help="Path to PEM private key for the NATS client certificate (mTLS).",
         )

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -64,8 +64,13 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     tcp_tls_cert_path: Optional[str] = None
     tcp_tls_key_path: Optional[str] = None
     tcp_tls_ca_cert_path: Optional[str] = None
+    tcp_tls_client_cert_path: Optional[str] = None
+    tcp_tls_client_key_path: Optional[str] = None
+    tcp_tls_client_ca_cert_path: Optional[str] = None
     nats_tls_ca_cert_path: Optional[str] = None
     nats_tls_insecure: bool = False
+    nats_tls_client_cert_path: Optional[str] = None
+    nats_tls_client_key_path: Optional[str] = None
 
     namespace: Optional[str] = None
     namespace_prefix: Optional[str] = None
@@ -317,6 +322,31 @@ class FrontendArgGroup(ArgGroup):
 
         add_argument(
             g,
+            flag_name="--tcp-tls-client-cert-path",
+            env_var="DYN_TCP_TLS_CLIENT_CERT_PATH",
+            default=None,
+            help="Path to PEM client certificate presented to the TCP server for mTLS.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--tcp-tls-client-key-path",
+            env_var="DYN_TCP_TLS_CLIENT_KEY_PATH",
+            default=None,
+            help="Path to PEM private key for the TCP client certificate (mTLS).",
+        )
+
+        add_argument(
+            g,
+            flag_name="--tcp-tls-client-ca-cert-path",
+            env_var="DYN_TCP_TLS_CLIENT_CA_CERT_PATH",
+            default=None,
+            help="Path to PEM CA certificate the TCP server uses to verify client "
+            "certificates. When set, clients must present a trusted certificate (mTLS enforced).",
+        )
+
+        add_argument(
+            g,
             flag_name="--nats-tls-ca-cert-path",
             env_var="NATS_TLS_CA_CERT_PATH",
             default=None,
@@ -329,6 +359,22 @@ class FrontendArgGroup(ArgGroup):
             env_var="NATS_TLS_INSECURE",
             default=False,
             help="Disable NATS TLS certificate verification. For local development only.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--nats-tls-client-cert-path",
+            env_var="NATS_TLS_CLIENT_CERT_PATH",
+            default=None,
+            help="Path to PEM client certificate presented to the NATS server for mTLS.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--nats-tls-client-key-path",
+            env_var="NATS_TLS_CLIENT_KEY_PATH",
+            default=None,
+            help="Path to PEM private key for the NATS client certificate (mTLS).",
         )
 
         # Router options (shared with dynamo.router)

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -317,6 +317,41 @@ def parse_args() -> tuple[FrontendConfig, Optional[Namespace], Optional[Namespac
     return config, vllm_flags, sglang_flags
 
 
+def _export_transport_tls_env(config: FrontendConfig) -> None:
+    """Propagate transport TLS/mTLS CLI flags to the env vars the Rust runtime
+    reads. Must run before ``DistributedRuntime`` is constructed: it connects to
+    NATS eagerly, so NATS settings applied afterwards are ignored. The TCP
+    request/response planes dial lazily, so they only need the vars set before
+    the first connection, but exporting everything up front keeps it consistent.
+    """
+    if config.tcp_tls_cert_path:
+        os.environ["DYN_TCP_TLS_CERT_PATH"] = config.tcp_tls_cert_path
+    if config.tcp_tls_key_path:
+        os.environ["DYN_TCP_TLS_KEY_PATH"] = config.tcp_tls_key_path
+    if config.tcp_tls_ca_cert_path:
+        os.environ["DYN_TCP_TLS_CA_CERT_PATH"] = config.tcp_tls_ca_cert_path
+    if config.tcp_tls_client_cert_path:
+        os.environ["DYN_TCP_TLS_CLIENT_CERT_PATH"] = config.tcp_tls_client_cert_path
+    if config.tcp_tls_client_key_path:
+        os.environ["DYN_TCP_TLS_CLIENT_KEY_PATH"] = config.tcp_tls_client_key_path
+    if config.tcp_tls_client_ca_cert_path:
+        os.environ[
+            "DYN_TCP_TLS_CLIENT_CA_CERT_PATH"
+        ] = config.tcp_tls_client_ca_cert_path
+    if config.nats_tls_ca_cert_path:
+        os.environ["NATS_TLS_CA_CERT_PATH"] = config.nats_tls_ca_cert_path
+    if config.nats_tls_insecure:
+        os.environ["NATS_TLS_INSECURE"] = "1"
+    else:
+        # Clear any inherited NATS_TLS_INSECURE so --no-nats-tls-insecure can
+        # override it before the Rust runtime reads the env var.
+        os.environ.pop("NATS_TLS_INSECURE", None)
+    if config.nats_tls_client_cert_path:
+        os.environ["NATS_TLS_CLIENT_CERT_PATH"] = config.nats_tls_client_cert_path
+    if config.nats_tls_client_key_path:
+        os.environ["NATS_TLS_CLIENT_KEY_PATH"] = config.nats_tls_client_key_path
+
+
 async def async_main():
     """Main async entry point for the Dynamo frontend.
 
@@ -352,6 +387,10 @@ async def async_main():
         )
 
     loop = asyncio.get_running_loop()
+    # Export transport TLS/mTLS settings BEFORE constructing DistributedRuntime:
+    # it connects to NATS eagerly, so NATS (m)TLS env vars must already be set or
+    # the CLI flags are silently ignored (unlike the lazily-dialed TCP planes).
+    _export_transport_tls_env(config)
     runtime = DistributedRuntime(
         loop,
         config.discovery_backend,
@@ -402,20 +441,6 @@ async def async_main():
         kwargs["tls_cert_path"] = config.tls_cert_path
     if config.tls_key_path:
         kwargs["tls_key_path"] = config.tls_key_path
-    if config.tcp_tls_cert_path:
-        os.environ["DYN_TCP_TLS_CERT_PATH"] = config.tcp_tls_cert_path
-    if config.tcp_tls_key_path:
-        os.environ["DYN_TCP_TLS_KEY_PATH"] = config.tcp_tls_key_path
-    if config.tcp_tls_ca_cert_path:
-        os.environ["DYN_TCP_TLS_CA_CERT_PATH"] = config.tcp_tls_ca_cert_path
-    if config.nats_tls_ca_cert_path:
-        os.environ["NATS_TLS_CA_CERT_PATH"] = config.nats_tls_ca_cert_path
-    if config.nats_tls_insecure:
-        os.environ["NATS_TLS_INSECURE"] = "1"
-    else:
-        # Clear any inherited NATS_TLS_INSECURE so --no-nats-tls-insecure can
-        # override it before the Rust runtime reads the env var.
-        os.environ.pop("NATS_TLS_INSECURE", None)
     if config.namespace:
         kwargs["namespace"] = config.namespace
     if config.namespace_prefix:

--- a/docs/fern/pages/reference/components/tls-configuration.mdx
+++ b/docs/fern/pages/reference/components/tls-configuration.mdx
@@ -156,7 +156,9 @@ distribution. TLS is configured separately from TCP:
 When only the `tls://` URL scheme is used without explicit TLS env vars,
 async-nats handles TLS natively with system roots.
 
-The `NATS_SERVER` URL accepts both `nats://` and `tls://` schemes.
+The `NATS_SERVER` URL accepts both `nats://` and `tls://` schemes, but setting
+any explicit NATS TLS variable (`NATS_TLS_*`) requires the `tls://` scheme —
+startup fails with a clear error otherwise.
 
 CLI flags (all backends via `DynamoRuntimeArgGroup`):
 
@@ -167,6 +169,68 @@ CLI flags (all backends via `DynamoRuntimeArgGroup`):
 
 The frontend (`dynamo.frontend`) also accepts `--nats-tls-ca-cert-path` and
 `--nats-tls-insecure`.
+
+## Mutual TLS (mTLS)
+
+By default only the server is authenticated (the client verifies the server's
+certificate). Mutual TLS additionally makes the **client present a certificate**
+that the **server verifies**, so both ends of a connection prove their identity.
+mTLS is opt-in and layered on top of the TLS configuration above.
+
+For the **TCP** transports (request plane + response stream) Dynamo owns both
+ends, so configure two things and — since every component is both TCP client and
+server — set both on every pod:
+
+- **On the client:** a client certificate/key to present.
+- **On the server:** a CA certificate (`DYN_TCP_TLS_CLIENT_CA_CERT_PATH`) to
+  verify the presented client certificate. When set, the server **requires** a
+  trusted client certificate and rejects the handshake otherwise.
+
+For **NATS** the broker is external, so Dynamo only presents a client identity —
+there is no Dynamo-side "server" half. Whether client certificates are actually
+required is enforced by the **NATS server** configuration (e.g.
+`tls { ca_file: ...; verify: true }`), not by Dynamo.
+
+### TCP request/response streams
+
+| Variable | Role | Description |
+|---|---|---|
+| `DYN_TCP_TLS_CLIENT_CERT_PATH` | Client | PEM client certificate presented to the server. Set with `DYN_TCP_TLS_CLIENT_KEY_PATH`. |
+| `DYN_TCP_TLS_CLIENT_KEY_PATH` | Client | PEM private key for the client certificate. |
+| `DYN_TCP_TLS_CLIENT_CA_CERT_PATH` | Server | PEM CA used to verify client certificates. When set, clients **must** present a certificate signed by this CA. |
+
+### NATS
+
+| Variable | Role | Description |
+|---|---|---|
+| `NATS_TLS_CLIENT_CERT_PATH` | Client | PEM client certificate presented to the NATS server. Set with `NATS_TLS_CLIENT_KEY_PATH`. |
+| `NATS_TLS_CLIENT_KEY_PATH` | Client | PEM private key for the NATS client certificate. |
+
+> **Note:** Dynamo cannot detect whether the NATS broker actually requests a
+> client certificate. If you set `NATS_TLS_CLIENT_CERT_PATH`/`_KEY_PATH` but the
+> broker is not configured to verify client certs, the connection silently
+> falls back to ordinary one-way TLS. Enable verification on the NATS server
+> (`verify: true`) to make NATS mTLS effective.
+
+Client certificate and key must be set **together**, and a client identity
+requires a server CA (`*_CA_CERT_PATH`) — or insecure mode for development — so
+the server can still be verified. The TCP **servers** and the **NATS** client
+validate this at startup and fail closed. The TCP **client** connectors,
+however, initialize lazily on the first outbound connection, so an incomplete
+TCP client config surfaces as a per-connection handshake failure rather than a
+startup crash. The client certificate/key hot-reload from disk on rotation,
+exactly like the server certificate (see Design notes).
+
+The same options are available as CLI flags on all backends (via
+`DynamoRuntimeArgGroup`) and the frontend (`dynamo.frontend`):
+
+```text
+--tcp-tls-client-cert-path PATH      Client certificate presented for TCP mTLS (PEM)
+--tcp-tls-client-key-path PATH       Client private key for TCP mTLS (PEM)
+--tcp-tls-client-ca-cert-path PATH   CA to verify client certs; enforces TCP mTLS (PEM)
+--nats-tls-client-cert-path PATH     Client certificate presented for NATS mTLS (PEM)
+--nats-tls-client-key-path PATH      Client private key for NATS mTLS (PEM)
+```
 
 ## Encrypted paths
 
@@ -190,6 +254,10 @@ plane is not covered):
   once every 30s, sooner after a failed reload) and never blocks a handshake; a
   failed reload keeps serving the last valid certificate. Client trust anchors
   (the CA) are still loaded once, so rotating the CA itself requires a restart.
+- mTLS **client identity** certificates hot-reload through the same resolver, so
+  a rotated client cert/key is picked up without a restart. The CA used by the
+  server to verify client certificates is loaded once (rotating it needs a
+  restart).
 - Client TLS connectors are built once and cached via `OnceCell` on the first
   outbound connection.
 - The TLS handshake is spawned per-connection on both the request plane and

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -183,6 +183,14 @@ pub mod nats {
         /// When set, a custom TLS config with this CA is applied to the NATS connection.
         pub const NATS_TLS_CA_CERT_PATH: &str = "NATS_TLS_CA_CERT_PATH";
 
+        /// Path to the PEM client certificate presented to the NATS server for
+        /// mutual TLS (mTLS). Must be set together with `NATS_TLS_CLIENT_KEY_PATH`.
+        pub const NATS_TLS_CLIENT_CERT_PATH: &str = "NATS_TLS_CLIENT_CERT_PATH";
+
+        /// Path to the PEM client private key for NATS mutual TLS (mTLS).
+        /// Must be set together with `NATS_TLS_CLIENT_CERT_PATH`.
+        pub const NATS_TLS_CLIENT_KEY_PATH: &str = "NATS_TLS_CLIENT_KEY_PATH";
+
         /// Disable TLS certificate verification. Set to a truthy value to skip.
         /// WARNING: Only for local development. Never use in production.
         pub const NATS_TLS_INSECURE: &str = "NATS_TLS_INSECURE";
@@ -723,6 +731,19 @@ pub mod tcp_response_stream {
         /// uses a DNS SAN.
         pub const DYN_TCP_TLS_SERVER_NAME: &str = "DYN_TCP_TLS_SERVER_NAME";
 
+        /// Path to the PEM client certificate presented by TCP clients to the
+        /// server for mutual TLS (mTLS). Must be set together with
+        /// `DYN_TCP_TLS_CLIENT_KEY_PATH`.
+        pub const DYN_TCP_TLS_CLIENT_CERT_PATH: &str = "DYN_TCP_TLS_CLIENT_CERT_PATH";
+
+        /// Path to the PEM private key for the TCP client certificate (mTLS).
+        pub const DYN_TCP_TLS_CLIENT_KEY_PATH: &str = "DYN_TCP_TLS_CLIENT_KEY_PATH";
+
+        /// Path to the PEM CA certificate the TCP server uses to verify client
+        /// certificates. When set, the server requires clients to present a
+        /// certificate signed by this CA (mTLS is enforced).
+        pub const DYN_TCP_TLS_CLIENT_CA_CERT_PATH: &str = "DYN_TCP_TLS_CLIENT_CA_CERT_PATH";
+
         /// TLS handshake timeout in seconds (default: 3).
         pub const DYN_TCP_TLS_HANDSHAKE_TIMEOUT_SECS: &str = "DYN_TCP_TLS_HANDSHAKE_TIMEOUT_SECS";
     }
@@ -879,6 +900,8 @@ mod tests {
             nats::auth::NATS_AUTH_CREDENTIALS_FILE,
             nats::stream::DYN_NATS_STREAM_MAX_AGE,
             nats::tls::NATS_TLS_CA_CERT_PATH,
+            nats::tls::NATS_TLS_CLIENT_CERT_PATH,
+            nats::tls::NATS_TLS_CLIENT_KEY_PATH,
             nats::tls::NATS_TLS_INSECURE,
             // ETCD
             etcd::ETCD_ENDPOINTS,
@@ -986,6 +1009,9 @@ mod tests {
             tcp_response_stream::tls::DYN_TCP_TLS_CA_CERT_PATH,
             tcp_response_stream::tls::DYN_TCP_TLS_INSECURE,
             tcp_response_stream::tls::DYN_TCP_TLS_SERVER_NAME,
+            tcp_response_stream::tls::DYN_TCP_TLS_CLIENT_CERT_PATH,
+            tcp_response_stream::tls::DYN_TCP_TLS_CLIENT_KEY_PATH,
+            tcp_response_stream::tls::DYN_TCP_TLS_CLIENT_CA_CERT_PATH,
             tcp_response_stream::tls::DYN_TCP_TLS_HANDSHAKE_TIMEOUT_SECS,
             // Event Plane
             event_plane::DYN_EVENT_PLANE,

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -389,21 +389,57 @@ fn get_request_plane_tls_connector() -> anyhow::Result<&'static Option<TlsConnec
 }
 
 /// Build the request-plane client TLS connector from the `DYN_TCP_TLS_*`
-/// environment. Returns `None` when no TLS is requested (no CA and not
-/// insecure). Split out from the `OnceCell` init so the env parsing can be
-/// unit-tested directly.
+/// environment. Returns `None` when no TLS is requested (no CA, not insecure,
+/// no client identity). Split out from the `OnceCell` init so the env parsing
+/// can be unit-tested directly.
 fn build_request_plane_tls_connector_from_env() -> anyhow::Result<Option<TlsConnector>> {
     use crate::config::environment_names::tcp_response_stream::tls as env;
     let ca_cert_path = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).ok();
     let insecure = crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
-    let tls_requested = ca_cert_path.is_some() || insecure;
+    let client_cert = std::env::var(env::DYN_TCP_TLS_CLIENT_CERT_PATH).ok();
+    let client_key = std::env::var(env::DYN_TCP_TLS_CLIENT_KEY_PATH).ok();
+    build_request_plane_tls_connector(
+        ca_cert_path.as_deref().map(std::path::Path::new),
+        insecure,
+        client_cert.as_deref().map(std::path::Path::new),
+        client_key.as_deref().map(std::path::Path::new),
+    )
+}
+
+/// Build the request-plane client TLS connector from explicit paths. Presents
+/// the client certificate/key for mTLS and fails closed on incomplete TLS
+/// settings. Returns `None` when no TLS is requested.
+fn build_request_plane_tls_connector(
+    ca_cert_path: Option<&std::path::Path>,
+    insecure: bool,
+    client_cert: Option<&std::path::Path>,
+    client_key: Option<&std::path::Path>,
+) -> anyhow::Result<Option<TlsConnector>> {
+    let tls_requested =
+        ca_cert_path.is_some() || insecure || client_cert.is_some() || client_key.is_some();
     if !tls_requested {
         return Ok(None);
     }
-    let tls_config = crate::tls_utils::client_tls_config(
-        ca_cert_path.as_deref().map(std::path::Path::new),
-        insecure,
-    )?;
+    use crate::config::environment_names::tcp_response_stream::tls as env;
+    // Validate the client identity pair before the CA check so a lone cert/key
+    // produces the accurate "set both" error rather than a misleading CA error.
+    if client_cert.is_some() != client_key.is_some() {
+        anyhow::bail!(
+            "both {} and {} must be set together to present a client identity",
+            env::DYN_TCP_TLS_CLIENT_CERT_PATH,
+            env::DYN_TCP_TLS_CLIENT_KEY_PATH,
+        );
+    }
+    if !insecure && ca_cert_path.is_none() {
+        anyhow::bail!(
+            "Request plane TLS is enabled but {} is not set and {} is not true; \
+             provide a CA cert or set insecure mode for development",
+            env::DYN_TCP_TLS_CA_CERT_PATH,
+            env::DYN_TCP_TLS_INSECURE,
+        );
+    }
+    let tls_config =
+        crate::tls_utils::client_tls_config(ca_cert_path, insecure, client_cert, client_key)?;
     Ok(Some(TlsConnector::from(std::sync::Arc::new(tls_config))))
 }
 
@@ -1720,6 +1756,123 @@ mod tests {
         (cert_file, key_file)
     }
 
+    // CA + server leaf (SAN=localhost) + client leaf, both signed by the CA.
+    // Returns PEM temp files: (ca, server_cert, server_key, client_cert, client_key).
+    fn make_mtls_cert_files() -> (
+        tempfile::NamedTempFile,
+        tempfile::NamedTempFile,
+        tempfile::NamedTempFile,
+        tempfile::NamedTempFile,
+        tempfile::NamedTempFile,
+    ) {
+        use std::io::Write as _;
+        fn write_pem(contents: &str) -> tempfile::NamedTempFile {
+            let mut f = tempfile::NamedTempFile::new().unwrap();
+            f.write_all(contents.as_bytes()).unwrap();
+            f
+        }
+
+        // Certificate Authority (self-signed, CA:TRUE).
+        let ca_key = rcgen::KeyPair::generate().unwrap();
+        let mut ca_params = rcgen::CertificateParams::new(Vec::new()).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        ca_params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, "Dynamo Test CA");
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        // Server leaf (SAN=localhost) signed by the CA, with serverAuth EKU.
+        let server_key = rcgen::KeyPair::generate().unwrap();
+        let mut server_params =
+            rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+        server_params
+            .extended_key_usages
+            .push(rcgen::ExtendedKeyUsagePurpose::ServerAuth);
+        let server_cert = server_params
+            .signed_by(&server_key, &ca_cert, &ca_key)
+            .unwrap();
+
+        // Client leaf signed by the CA, with clientAuth EKU.
+        let client_key = rcgen::KeyPair::generate().unwrap();
+        let mut client_params =
+            rcgen::CertificateParams::new(vec!["dynamo-client".to_string()]).unwrap();
+        client_params
+            .extended_key_usages
+            .push(rcgen::ExtendedKeyUsagePurpose::ClientAuth);
+        let client_cert = client_params
+            .signed_by(&client_key, &ca_cert, &ca_key)
+            .unwrap();
+
+        (
+            write_pem(&ca_cert.pem()),
+            write_pem(&server_cert.pem()),
+            write_pem(&server_key.serialize_pem()),
+            write_pem(&client_cert.pem()),
+            write_pem(&client_key.serialize_pem()),
+        )
+    }
+
+    // mTLS enforcement: a server built with a client CA must reject a client
+    // that presents no certificate and one whose certificate is signed by an
+    // untrusted CA. The accepted case is covered by `request_plane_mtls_end_to_end`.
+    // Assertions are made server-side because a TLS 1.3 client may finish its
+    // flight before observing the server's rejection.
+    #[tokio::test]
+    async fn request_plane_mtls_rejects_untrusted_clients() {
+        let (ca, server_cert, server_key, _client_cert, _client_key) = make_mtls_cert_files();
+        let server_config = crate::tls_utils::server_tls_config(
+            server_cert.path(),
+            server_key.path(),
+            Some(ca.path()),
+        )
+        .unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(std::sync::Arc::new(server_config));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (no_cert, _) = listener.accept().await.unwrap();
+            let no_cert_ok = acceptor.accept(no_cert).await.is_ok();
+            let (wrong_ca, _) = listener.accept().await.unwrap();
+            let wrong_ca_ok = acceptor.accept(wrong_ca).await.is_ok();
+            (no_cert_ok, wrong_ca_ok)
+        });
+
+        let sni = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+
+        // No client identity presented.
+        let no_identity =
+            crate::tls_utils::client_tls_config(Some(ca.path()), false, None, None).unwrap();
+        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let _ = tokio_rustls::TlsConnector::from(std::sync::Arc::new(no_identity))
+            .connect(sni.clone(), stream)
+            .await;
+
+        // Client cert signed by an untrusted (self-signed) CA, not the server's.
+        let (wrong_cert, wrong_key) = make_cert_files();
+        let untrusted = crate::tls_utils::client_tls_config(
+            Some(ca.path()),
+            false,
+            Some(wrong_cert.path()),
+            Some(wrong_key.path()),
+        )
+        .unwrap();
+        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let _ = tokio_rustls::TlsConnector::from(std::sync::Arc::new(untrusted))
+            .connect(sni, stream)
+            .await;
+
+        let (no_cert_ok, wrong_ca_ok) = server.await.unwrap();
+        assert!(
+            !no_cert_ok,
+            "server must reject a client that presents no cert"
+        );
+        assert!(
+            !wrong_ca_ok,
+            "server must reject a client cert signed by an untrusted CA"
+        );
+    }
+
     #[test]
     fn test_tcp_config_default() {
         let config = TcpRequestConfig::default();
@@ -1911,14 +2064,25 @@ mod tests {
     /// connector built.
     #[test]
     fn request_plane_tls_connector_from_env_parses() {
-        let (cert, _key) = make_cert_files();
-        temp_env::with_vars_unset(["DYN_TCP_TLS_CA_CERT_PATH", "DYN_TCP_TLS_INSECURE"], || {
-            assert!(
-                build_request_plane_tls_connector_from_env()
-                    .unwrap()
-                    .is_none()
-            );
-        });
+        let (cert, key) = make_cert_files();
+        // Clear every var the builder reads (incl. the client-identity vars) so
+        // ambient mTLS settings can't flip the "no TLS -> plaintext" assertion.
+        temp_env::with_vars_unset(
+            [
+                "DYN_TCP_TLS_CA_CERT_PATH",
+                "DYN_TCP_TLS_INSECURE",
+                "DYN_TCP_TLS_CLIENT_CERT_PATH",
+                "DYN_TCP_TLS_CLIENT_KEY_PATH",
+            ],
+            || {
+                assert!(
+                    build_request_plane_tls_connector_from_env()
+                        .unwrap()
+                        .is_none()
+                );
+            },
+        );
+        // CA only -> TLS.
         temp_env::with_vars(
             [
                 (
@@ -1926,6 +2090,8 @@ mod tests {
                     Some(cert.path().to_str().unwrap()),
                 ),
                 ("DYN_TCP_TLS_INSECURE", None),
+                ("DYN_TCP_TLS_CLIENT_CERT_PATH", None),
+                ("DYN_TCP_TLS_CLIENT_KEY_PATH", None),
             ],
             || {
                 assert!(
@@ -1935,10 +2101,38 @@ mod tests {
                 );
             },
         );
+        // Insecure only -> TLS.
         temp_env::with_vars(
             [
                 ("DYN_TCP_TLS_CA_CERT_PATH", None),
                 ("DYN_TCP_TLS_INSECURE", Some("1")),
+                ("DYN_TCP_TLS_CLIENT_CERT_PATH", None),
+                ("DYN_TCP_TLS_CLIENT_KEY_PATH", None),
+            ],
+            || {
+                assert!(
+                    build_request_plane_tls_connector_from_env()
+                        .unwrap()
+                        .is_some()
+                );
+            },
+        );
+        // CA + client identity -> mTLS connector.
+        temp_env::with_vars(
+            [
+                (
+                    "DYN_TCP_TLS_CA_CERT_PATH",
+                    Some(cert.path().to_str().unwrap()),
+                ),
+                ("DYN_TCP_TLS_INSECURE", None),
+                (
+                    "DYN_TCP_TLS_CLIENT_CERT_PATH",
+                    Some(cert.path().to_str().unwrap()),
+                ),
+                (
+                    "DYN_TCP_TLS_CLIENT_KEY_PATH",
+                    Some(key.path().to_str().unwrap()),
+                ),
             ],
             || {
                 assert!(
@@ -1950,52 +2144,67 @@ mod tests {
         );
     }
 
+    #[test]
+    fn request_plane_tls_connector_rejects_client_identity_without_ca() {
+        let (cert, key) = make_cert_files();
+        // A client identity without a server CA (and not insecure) must fail closed.
+        let error =
+            build_request_plane_tls_connector(None, false, Some(cert.path()), Some(key.path()))
+                .err()
+                .expect("a client identity without a server CA must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("DYN_TCP_TLS_CA_CERT_PATH is not set")
+        );
+    }
+
+    // Accept one TLS connection, read a single request-plane frame, and echo its
+    // payload back as a response frame. Shared by the TLS and mTLS e2e tests.
+    async fn tls_echo_one_request(listener: TcpListener, acceptor: tokio_rustls::TlsAcceptor) {
+        use crate::pipeline::network::codec::TcpResponseMessage;
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+        let (tcp, _) = listener.accept().await.unwrap();
+        let tls = acceptor.accept(tcp).await.expect("server TLS handshake");
+        let (mut r, mut w) = tokio::io::split(tls);
+        let mut path_len = [0u8; 2];
+        r.read_exact(&mut path_len).await.unwrap();
+        let mut path = vec![0u8; u16::from_be_bytes(path_len) as usize];
+        r.read_exact(&mut path).await.unwrap();
+        let mut headers_len = [0u8; 2];
+        r.read_exact(&mut headers_len).await.unwrap();
+        let mut headers = vec![0u8; u16::from_be_bytes(headers_len) as usize];
+        r.read_exact(&mut headers).await.unwrap();
+        let mut payload_len = [0u8; 4];
+        r.read_exact(&mut payload_len).await.unwrap();
+        let mut payload = vec![0u8; u32::from_be_bytes(payload_len) as usize];
+        r.read_exact(&mut payload).await.unwrap();
+        let resp = TcpResponseMessage::new(Bytes::from(payload));
+        w.write_all(&resp.encode().unwrap()).await.unwrap();
+        w.flush().await.unwrap();
+    }
+
     /// End-to-end encrypted request through the **real** request-plane client
     /// path: `TcpConnection::connect_with_connector` performs the TLS handshake
     /// (SNI from `DYN_TCP_TLS_SERVER_NAME`), spawns the reader/writer tasks over
     /// boxed TLS I/O, and `send_request` frames a request that a TLS-wrapped echo
-    /// server (built from the production `server_tls_config`) reads and replies
-    /// to. This exercises handshake + SNI + boxed I/O + reader/writer + framing,
-    /// not just a `tls_utils` round-trip.
+    /// server reads and replies to. Exercises handshake + SNI + boxed I/O +
+    /// reader/writer + framing, not just a `tls_utils` round-trip.
     #[tokio::test]
     async fn request_plane_tls_end_to_end() {
-        use crate::pipeline::network::codec::TcpResponseMessage;
-        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
-
         // Self-signed cert (SAN=localhost), trusted as the CA by the client.
         let (cert, key) = make_cert_files();
-        let server_config = crate::tls_utils::server_tls_config(cert.path(), key.path()).unwrap();
+        let server_config =
+            crate::tls_utils::server_tls_config(cert.path(), key.path(), None).unwrap();
         let acceptor = tokio_rustls::TlsAcceptor::from(std::sync::Arc::new(server_config));
-        let client_config = crate::tls_utils::client_tls_config(Some(cert.path()), false).unwrap();
+        let client_config =
+            crate::tls_utils::client_tls_config(Some(cert.path()), false, None, None).unwrap();
         let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(client_config));
 
         // TLS-wrapped echo server speaking the request-plane wire framing.
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            let (tcp, _) = listener.accept().await.unwrap();
-            let tls = acceptor.accept(tcp).await.expect("server TLS handshake");
-            let (mut r, mut w) = tokio::io::split(tls);
-            // path
-            let mut l2 = [0u8; 2];
-            r.read_exact(&mut l2).await.unwrap();
-            let mut path = vec![0u8; u16::from_be_bytes(l2) as usize];
-            r.read_exact(&mut path).await.unwrap();
-            // headers
-            let mut hl = [0u8; 2];
-            r.read_exact(&mut hl).await.unwrap();
-            let mut headers = vec![0u8; u16::from_be_bytes(hl) as usize];
-            r.read_exact(&mut headers).await.unwrap();
-            // payload
-            let mut l4 = [0u8; 4];
-            r.read_exact(&mut l4).await.unwrap();
-            let mut payload = vec![0u8; u32::from_be_bytes(l4) as usize];
-            r.read_exact(&mut payload).await.unwrap();
-            // echo the payload back as a response frame
-            let resp = TcpResponseMessage::new(Bytes::from(payload));
-            w.write_all(&resp.encode().unwrap()).await.unwrap();
-            w.flush().await.unwrap();
-        });
+        tokio::spawn(tls_echo_one_request(listener, acceptor));
 
         // Drive the real client path with an explicit connector (no OnceCell) and
         // SNI supplied via env so it matches the cert's `localhost` SAN.
@@ -2024,6 +2233,62 @@ mod tests {
         assert_eq!(
             response, expected,
             "payload should round-trip through the encrypted request plane"
+        );
+    }
+
+    /// Same production path as `request_plane_tls_end_to_end`, but mutually
+    /// authenticated: the server requires a client certificate (built with a
+    /// client CA) and the real client path presents a CA-signed identity. Proves
+    /// `TcpConnection::connect_with_connector` + `send_request` work end-to-end
+    /// when the server enforces mTLS.
+    #[tokio::test]
+    async fn request_plane_mtls_end_to_end() {
+        let (ca, server_cert, server_key, client_cert, client_key) = make_mtls_cert_files();
+        let server_config = crate::tls_utils::server_tls_config(
+            server_cert.path(),
+            server_key.path(),
+            Some(ca.path()),
+        )
+        .unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(std::sync::Arc::new(server_config));
+        let client_config = crate::tls_utils::client_tls_config(
+            Some(ca.path()),
+            false,
+            Some(client_cert.path()),
+            Some(client_key.path()),
+        )
+        .unwrap();
+        let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(client_config));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(tls_echo_one_request(listener, acceptor));
+
+        let payload = Bytes::from_static(b"encrypted-mtls-request-plane-payload");
+        let expected = payload.clone();
+        let response = temp_env::async_with_vars(
+            [("DYN_TCP_TLS_SERVER_NAME", Some("localhost"))],
+            async move {
+                let conn = TcpConnection::connect_with_connector(
+                    addr,
+                    Duration::from_secs(5),
+                    10,
+                    Some(&connector),
+                )
+                .await
+                .expect("client connect + mTLS handshake");
+                let mut headers = Headers::new();
+                headers.insert("x-endpoint-path".to_string(), "test".to_string());
+                conn.send_request(payload, &headers)
+                    .await
+                    .expect("send_request over mTLS")
+            },
+        )
+        .await;
+
+        assert_eq!(
+            response, expected,
+            "payload should round-trip through the mutually-authenticated request plane"
         );
     }
 

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -209,54 +209,12 @@ impl SharedTcpServer {
             use crate::config::environment_names::tcp_response_stream::tls as env;
             let cert = std::env::var(env::DYN_TCP_TLS_CERT_PATH).ok();
             let key = std::env::var(env::DYN_TCP_TLS_KEY_PATH).ok();
-            match (cert, key) {
-                (Some(c), Some(k)) => {
-                    let config = crate::tls_utils::server_tls_config(c.as_ref(), k.as_ref())
-                        .context(
-                            "Failed to build TCP request plane TLS config — check cert/key paths",
-                        )?;
-                    tracing::info!("TCP request plane: TLS enabled");
-                    // Warn if the client side is not configured for TLS — peers
-                    // dialing this server without a CA (or insecure) will fail the
-                    // handshake with no obvious diagnostic.
-                    let client_tls_set = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).is_ok()
-                        || crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
-                    if !client_tls_set {
-                        tracing::warn!(
-                            "TCP request plane server has TLS enabled but client TLS env vars are \
-                             not set. Set {} (or {}) so clients can connect, or unset {}/{}.",
-                            env::DYN_TCP_TLS_CA_CERT_PATH,
-                            env::DYN_TCP_TLS_INSECURE,
-                            env::DYN_TCP_TLS_CERT_PATH,
-                            env::DYN_TCP_TLS_KEY_PATH,
-                        );
-                    }
-                    Some(TlsAcceptor::from(Arc::new(config)))
-                }
-                (Some(_), None) | (None, Some(_)) => {
-                    anyhow::bail!(
-                        "Both {} and {} must be set to enable TCP request plane TLS",
-                        env::DYN_TCP_TLS_CERT_PATH,
-                        env::DYN_TCP_TLS_KEY_PATH,
-                    );
-                }
-                (None, None) => {
-                    // Warn on the reverse mismatch: server plaintext but client TLS
-                    // env is set (mirrors the call-home server warning).
-                    let client_tls_set = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).is_ok()
-                        || crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
-                    if client_tls_set {
-                        tracing::warn!(
-                            "TCP request plane server is running in plaintext mode but client TLS \
-                             env vars are set. Set {} and {} to enable server-side TLS, or unset \
-                             client TLS vars.",
-                            env::DYN_TCP_TLS_CERT_PATH,
-                            env::DYN_TCP_TLS_KEY_PATH,
-                        );
-                    }
-                    None
-                }
-            }
+            let client_ca = std::env::var(env::DYN_TCP_TLS_CLIENT_CA_CERT_PATH).ok();
+            Self::request_plane_tls_acceptor(
+                cert.as_deref().map(std::path::Path::new),
+                key.as_deref().map(std::path::Path::new),
+                client_ca.as_deref().map(std::path::Path::new),
+            )?
         };
 
         Ok(Arc::new(Self {
@@ -269,6 +227,26 @@ impl SharedTcpServer {
             queue_capacity: work_queue_size,
             tls_acceptor,
         }))
+    }
+
+    /// Build the request-plane TLS acceptor from cert/key/client-CA paths.
+    /// Validation and diagnostics are shared with the response-stream server via
+    /// [`crate::tls_utils::server_tls_acceptor_config`]; when a client CA is
+    /// provided, mTLS is enforced (clients must present a trusted certificate).
+    fn request_plane_tls_acceptor(
+        cert: Option<&std::path::Path>,
+        key: Option<&std::path::Path>,
+        client_ca: Option<&std::path::Path>,
+    ) -> Result<Option<TlsAcceptor>> {
+        Ok(
+            crate::tls_utils::server_tls_acceptor_config(
+                "TCP request plane",
+                cert,
+                key,
+                client_ca,
+            )?
+            .map(|config| TlsAcceptor::from(Arc::new(config))),
+        )
     }
 
     /// Start the worker pool dispatcher that processes requests with bounded concurrency
@@ -1370,5 +1348,48 @@ mod tests {
             },
         );
         token.cancel();
+    }
+
+    #[test]
+    fn request_plane_tls_acceptor_enables_mtls() {
+        let (cert, key) = make_cert_files();
+        // cert + key + client CA -> mTLS acceptor built.
+        assert!(
+            SharedTcpServer::request_plane_tls_acceptor(
+                Some(cert.path()),
+                Some(key.path()),
+                Some(cert.path()),
+            )
+            .unwrap()
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn request_plane_tls_rejects_client_ca_without_server_identity() {
+        let (client_ca, _) = make_cert_files();
+        let error = SharedTcpServer::request_plane_tls_acceptor(None, None, Some(client_ca.path()))
+            .err()
+            .expect("a client CA without a server certificate/key must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("DYN_TCP_TLS_CLIENT_CA_CERT_PATH requires")
+        );
+    }
+
+    #[test]
+    fn request_plane_tls_reads_client_ca_path() {
+        let (cert, key) = make_cert_files();
+        let error = SharedTcpServer::request_plane_tls_acceptor(
+            Some(cert.path()),
+            Some(key.path()),
+            Some(std::path::Path::new(
+                "/nonexistent/request-plane-client-ca.pem",
+            )),
+        )
+        .err()
+        .expect("an invalid client CA path must fail mTLS configuration");
+        assert!(format!("{error:#}").contains("reading client CA cert"));
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -67,10 +67,23 @@ impl TcpClient {
     }
 
     /// Connect to `address` and return split, boxed read/write halves.
-    /// When any TCP TLS env var is configured the connection is upgraded to TLS.
+    /// When any TCP TLS env var is configured the connection is upgraded to TLS,
+    /// using the process-global connector (built once from the environment).
     async fn connect_and_split(address: &str) -> anyhow::Result<(BoxRead, BoxWrite)> {
+        Self::connect_and_split_with_connector(address, get_tls_connector()?.as_ref()).await
+    }
+
+    /// Like [`connect_and_split`], but with an explicitly supplied TLS connector
+    /// instead of the process-global `OnceCell`. Lets tests drive the real client
+    /// handshake + boxed-I/O path deterministically (the `OnceCell` can only be
+    /// initialized once per process). Mirrors the request-plane client's
+    /// `connect_with_connector`.
+    async fn connect_and_split_with_connector(
+        address: &str,
+        connector: Option<&TlsConnector>,
+    ) -> anyhow::Result<(BoxRead, BoxWrite)> {
         let stream = TcpClient::connect(address).await?;
-        if let Some(connector) = get_tls_connector()? {
+        if let Some(connector) = connector {
             let server_name = tls_server_name(address)?;
             let tls_stream = tokio::time::timeout(
                 crate::tls_utils::handshake_timeout(),
@@ -263,9 +276,10 @@ impl TcpClient {
 /// Cached TCP TLS connector — built once from env vars on first TCP connection, reused for every
 /// subsequent connection. `None` means plaintext; `Some(connector)` means TLS.
 ///
-/// The config is intentionally immutable after the first build: `rustls::ClientConfig` is
-/// cheaply `Arc`-cloned per-connection, so sharing it is free. Cert rotation requires a process
-/// restart; this is consistent with how most services handle TLS credential updates.
+/// The connector itself is immutable after the first build (`rustls::ClientConfig` is cheaply
+/// `Arc`-cloned per-connection). The client *identity* it presents still hot-reloads from disk via
+/// `ReloadingCertifiedKey`, so rotating the client cert/key needs no restart; only the trust
+/// anchors (CA / insecure flag) are fixed at first build and require a restart to change.
 static TCP_TLS_CONNECTOR: once_cell::sync::OnceCell<Option<TlsConnector>> =
     once_cell::sync::OnceCell::new();
 
@@ -281,8 +295,11 @@ fn build_tls_connector_from_env() -> anyhow::Result<Option<TlsConnector>> {
     use crate::config::environment_names::tcp_response_stream::tls as env;
     let ca_cert_path = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).ok();
     let insecure = crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
+    let client_cert = std::env::var(env::DYN_TCP_TLS_CLIENT_CERT_PATH).ok();
+    let client_key = std::env::var(env::DYN_TCP_TLS_CLIENT_KEY_PATH).ok();
 
-    let tls_requested = ca_cert_path.is_some() || insecure;
+    let tls_requested =
+        ca_cert_path.is_some() || insecure || client_cert.is_some() || client_key.is_some();
     if !tls_requested {
         // Warn if the server side has TLS configured — a plaintext client connecting to a
         // TLS server will fail with an opaque framing error rather than a clear TLS error.
@@ -298,6 +315,15 @@ fn build_tls_connector_from_env() -> anyhow::Result<Option<TlsConnector>> {
         }
         return Ok(None);
     }
+    // Validate the client identity pair before the CA check so a lone cert/key
+    // produces the accurate "set both" error rather than a misleading CA error.
+    if client_cert.is_some() != client_key.is_some() {
+        anyhow::bail!(
+            "both {} and {} must be set together to present a client identity",
+            env::DYN_TCP_TLS_CLIENT_CERT_PATH,
+            env::DYN_TCP_TLS_CLIENT_KEY_PATH,
+        );
+    }
     if !insecure && ca_cert_path.is_none() {
         anyhow::bail!(
             "TCP TLS is enabled but {} is not set and {} is not true; \
@@ -310,6 +336,8 @@ fn build_tls_connector_from_env() -> anyhow::Result<Option<TlsConnector>> {
     let tls_config = crate::tls_utils::client_tls_config(
         ca_cert_path.as_deref().map(std::path::Path::new),
         insecure,
+        client_cert.as_deref().map(std::path::Path::new),
+        client_key.as_deref().map(std::path::Path::new),
     )?;
     Ok(Some(TlsConnector::from(Arc::new(tls_config))))
 }
@@ -1944,9 +1972,19 @@ mod tests {
 
     #[test]
     fn connector_no_env_vars_is_plaintext() {
-        temp_env::with_vars_unset(["DYN_TCP_TLS_CA_CERT_PATH", "DYN_TCP_TLS_INSECURE"], || {
-            assert!(build_tls_connector_from_env().unwrap().is_none());
-        });
+        // Clear every var the builder reads, incl. the client-identity vars, so
+        // ambient mTLS settings can't flip this to "TLS requested".
+        temp_env::with_vars_unset(
+            [
+                "DYN_TCP_TLS_CA_CERT_PATH",
+                "DYN_TCP_TLS_INSECURE",
+                "DYN_TCP_TLS_CLIENT_CERT_PATH",
+                "DYN_TCP_TLS_CLIENT_KEY_PATH",
+            ],
+            || {
+                assert!(build_tls_connector_from_env().unwrap().is_none());
+            },
+        );
     }
 
     #[test]
@@ -1969,6 +2007,152 @@ mod tests {
                 Some(ca.path().to_str().unwrap()),
             )],
             || assert!(build_tls_connector_from_env().unwrap().is_some()),
+        );
+    }
+
+    // Self-signed cert + matching key, for use as a client identity.
+    fn make_identity_files() -> (tempfile::NamedTempFile, tempfile::NamedTempFile) {
+        use std::io::Write;
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
+            .unwrap()
+            .self_signed(&key_pair)
+            .unwrap();
+        let mut cert_file = tempfile::NamedTempFile::new().unwrap();
+        cert_file.write_all(cert.pem().as_bytes()).unwrap();
+        let mut key_file = tempfile::NamedTempFile::new().unwrap();
+        key_file
+            .write_all(key_pair.serialize_pem().as_bytes())
+            .unwrap();
+        (cert_file, key_file)
+    }
+
+    // CA + server leaf (SAN=localhost, serverAuth) + client leaf (clientAuth),
+    // both signed by the CA. Returns (ca, server_cert, server_key, client_cert,
+    // client_key) PEM temp files.
+    #[allow(clippy::type_complexity)]
+    fn make_mtls_chain() -> (
+        tempfile::NamedTempFile,
+        tempfile::NamedTempFile,
+        tempfile::NamedTempFile,
+        tempfile::NamedTempFile,
+        tempfile::NamedTempFile,
+    ) {
+        use std::io::Write;
+        fn write_pem(contents: &str) -> tempfile::NamedTempFile {
+            let mut f = tempfile::NamedTempFile::new().unwrap();
+            f.write_all(contents.as_bytes()).unwrap();
+            f
+        }
+        let ca_key = rcgen::KeyPair::generate().unwrap();
+        let mut ca_params = rcgen::CertificateParams::new(Vec::new()).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        let server_key = rcgen::KeyPair::generate().unwrap();
+        let mut server_params =
+            rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+        server_params
+            .extended_key_usages
+            .push(rcgen::ExtendedKeyUsagePurpose::ServerAuth);
+        let server_cert = server_params
+            .signed_by(&server_key, &ca_cert, &ca_key)
+            .unwrap();
+
+        let client_key = rcgen::KeyPair::generate().unwrap();
+        let mut client_params =
+            rcgen::CertificateParams::new(vec!["dynamo-client".to_string()]).unwrap();
+        client_params
+            .extended_key_usages
+            .push(rcgen::ExtendedKeyUsagePurpose::ClientAuth);
+        let client_cert = client_params
+            .signed_by(&client_key, &ca_cert, &ca_key)
+            .unwrap();
+
+        (
+            write_pem(&ca_cert.pem()),
+            write_pem(&server_cert.pem()),
+            write_pem(&server_key.serialize_pem()),
+            write_pem(&client_cert.pem()),
+            write_pem(&client_key.serialize_pem()),
+        )
+    }
+
+    /// Live mTLS handshake over the **real** response-stream client path:
+    /// `TcpClient::connect_and_split` (via an injected connector) performs the
+    /// handshake against a server that requires a client certificate, then a
+    /// payload round-trips over the boxed split halves. Exercises the client
+    /// handshake + boxed I/O with mutual authentication, not a builder round-trip.
+    #[tokio::test]
+    async fn response_stream_client_mtls_handshake() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let (ca, server_cert, server_key, client_cert, client_key) = make_mtls_chain();
+
+        // mTLS server acceptor: requires a client cert signed by the CA.
+        let server_config = crate::tls_utils::server_tls_config(
+            server_cert.path(),
+            server_key.path(),
+            Some(ca.path()),
+        )
+        .unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(std::sync::Arc::new(server_config));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut tls = acceptor.accept(tcp).await.expect("server mTLS handshake");
+            let mut buf = [0u8; 5];
+            tls.read_exact(&mut buf).await.unwrap();
+            tls.write_all(&buf).await.unwrap();
+            tls.flush().await.unwrap();
+        });
+
+        // Real client path with an injected connector (bypasses the OnceCell);
+        // dial by "localhost" so SNI matches the server cert's DNS SAN.
+        let client_config = crate::tls_utils::client_tls_config(
+            Some(ca.path()),
+            false,
+            Some(client_cert.path()),
+            Some(client_key.path()),
+        )
+        .unwrap();
+        let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(client_config));
+        let (mut reader, mut writer) = TcpClient::connect_and_split_with_connector(
+            &format!("localhost:{port}"),
+            Some(&connector),
+        )
+        .await
+        .expect("client mTLS connect + handshake");
+
+        writer.write_all(b"hello").await.unwrap();
+        writer.flush().await.unwrap();
+        let mut got = [0u8; 5];
+        reader.read_exact(&mut got).await.unwrap();
+        assert_eq!(
+            &got, b"hello",
+            "payload should round-trip over the mutually-authenticated response-stream client path"
+        );
+    }
+
+    #[test]
+    fn connector_partial_client_identity_errors() {
+        // A client cert without its key must fail closed (pair validation).
+        let ca = make_ca_file();
+        let (client_cert, _client_key) = make_identity_files();
+        temp_env::with_vars(
+            [
+                (
+                    "DYN_TCP_TLS_CA_CERT_PATH",
+                    Some(ca.path().to_str().unwrap()),
+                ),
+                (
+                    "DYN_TCP_TLS_CLIENT_CERT_PATH",
+                    Some(client_cert.path().to_str().unwrap()),
+                ),
+                ("DYN_TCP_TLS_CLIENT_KEY_PATH", None),
+            ],
+            || assert!(build_tls_connector_from_env().is_err()),
         );
     }
 

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -369,46 +369,28 @@ impl TcpStreamServer {
     }
 
     /// Build a TLS acceptor from env vars if `DYN_TCP_TLS_CERT_PATH` and
-    /// `DYN_TCP_TLS_KEY_PATH` are set.
-    fn build_tls_acceptor() -> anyhow::Result<Option<Arc<TlsAcceptor>>> {
+    /// `DYN_TCP_TLS_KEY_PATH` are set. Validation and diagnostics are shared with
+    /// the request-plane server via
+    /// [`crate::tls_utils::server_tls_acceptor_config`]; a client CA enables mTLS.
+    fn build_tls_acceptor() -> anyhow::Result<Option<TlsAcceptor>> {
         use crate::config::environment_names::tcp_response_stream::tls as env;
         let cert_path = std::env::var(env::DYN_TCP_TLS_CERT_PATH).ok();
         let key_path = std::env::var(env::DYN_TCP_TLS_KEY_PATH).ok();
-        match (cert_path, key_path) {
-            (Some(cert), Some(key)) => {
-                let server_config =
-                    crate::tls_utils::server_tls_config(cert.as_ref(), key.as_ref())?;
-                tracing::info!("TCP server: TLS enabled");
-                Ok(Some(Arc::new(TlsAcceptor::from(Arc::new(server_config)))))
-            }
-            (None, None) => {
-                // Warn if the client side has TLS configured — mixing plaintext server with
-                // TLS client (or vice versa) results in failed connections that are hard to debug.
-                let client_tls_set = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).is_ok()
-                    || crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
-                if client_tls_set {
-                    tracing::warn!(
-                        "TCP server is running in plaintext mode but client TLS env vars are set. \
-                         Set {} and {} to enable server-side TLS, or unset client TLS vars.",
-                        env::DYN_TCP_TLS_CERT_PATH,
-                        env::DYN_TCP_TLS_KEY_PATH,
-                    );
-                }
-                Ok(None)
-            }
-            _ => anyhow::bail!(
-                "Both {} and {} must be set to enable TCP TLS",
-                env::DYN_TCP_TLS_CERT_PATH,
-                env::DYN_TCP_TLS_KEY_PATH
-            ),
-        }
+        let client_ca = std::env::var(env::DYN_TCP_TLS_CLIENT_CA_CERT_PATH).ok();
+        Ok(crate::tls_utils::server_tls_acceptor_config(
+            "TCP server",
+            cert_path.as_deref().map(std::path::Path::new),
+            key_path.as_deref().map(std::path::Path::new),
+            client_ca.as_deref().map(std::path::Path::new),
+        )?
+        .map(|config| TlsAcceptor::from(Arc::new(config))))
     }
 
     async fn start(
         local_ip: String,
         local_port: u16,
         state: Arc<Mutex<State>>,
-        tls_acceptor: Option<Arc<TlsAcceptor>>,
+        tls_acceptor: Option<TlsAcceptor>,
     ) -> Result<u16> {
         let addr = format!("{}:{}", local_ip, local_port);
         let state_clone = state.clone();
@@ -789,7 +771,7 @@ type BoxWrite = Box<dyn tokio::io::AsyncWrite + Unpin + Send>;
 async fn tcp_listener(
     addr: String,
     state: Arc<Mutex<State>>,
-    tls_acceptor: Option<Arc<TlsAcceptor>>,
+    tls_acceptor: Option<TlsAcceptor>,
     read_tx: tokio::sync::oneshot::Sender<Result<u16>>,
 ) -> Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr)
@@ -1363,9 +1345,18 @@ mod tests {
 
     #[test]
     fn build_tls_acceptor_no_env_vars_is_plaintext() {
-        temp_env::with_vars_unset(["DYN_TCP_TLS_CERT_PATH", "DYN_TCP_TLS_KEY_PATH"], || {
-            assert!(TcpStreamServer::build_tls_acceptor().unwrap().is_none());
-        });
+        // Also clear the client-CA var: ambient it would turn this into an error
+        // (client CA without a server cert/key) instead of plaintext.
+        temp_env::with_vars_unset(
+            [
+                "DYN_TCP_TLS_CERT_PATH",
+                "DYN_TCP_TLS_KEY_PATH",
+                "DYN_TCP_TLS_CLIENT_CA_CERT_PATH",
+            ],
+            || {
+                assert!(TcpStreamServer::build_tls_acceptor().unwrap().is_none());
+            },
+        );
     }
 
     #[test]
@@ -1400,6 +1391,39 @@ mod tests {
                 ("DYN_TCP_TLS_KEY_PATH", Some(key.path().to_str().unwrap())),
             ],
             || assert!(TcpStreamServer::build_tls_acceptor().unwrap().is_some()),
+        );
+    }
+
+    #[test]
+    fn build_tls_acceptor_with_client_ca_is_mtls() {
+        // A client CA turns the response-stream server into an mTLS acceptor.
+        let (cert, key) = make_cert_files();
+        temp_env::with_vars(
+            [
+                ("DYN_TCP_TLS_CERT_PATH", Some(cert.path().to_str().unwrap())),
+                ("DYN_TCP_TLS_KEY_PATH", Some(key.path().to_str().unwrap())),
+                (
+                    "DYN_TCP_TLS_CLIENT_CA_CERT_PATH",
+                    Some(cert.path().to_str().unwrap()),
+                ),
+            ],
+            || assert!(TcpStreamServer::build_tls_acceptor().unwrap().is_some()),
+        );
+    }
+
+    #[test]
+    fn build_tls_acceptor_client_ca_without_server_identity_errors() {
+        let (cert, _key) = make_cert_files();
+        temp_env::with_vars(
+            [
+                ("DYN_TCP_TLS_CERT_PATH", None),
+                ("DYN_TCP_TLS_KEY_PATH", None),
+                (
+                    "DYN_TCP_TLS_CLIENT_CA_CERT_PATH",
+                    Some(cert.path().to_str().unwrap()),
+                ),
+            ],
+            || assert!(TcpStreamServer::build_tls_acceptor().is_err()),
         );
     }
 

--- a/lib/runtime/src/tls_utils.rs
+++ b/lib/runtime/src/tls_utils.rs
@@ -9,8 +9,8 @@
 use std::{
     fmt,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, TryLockError},
-    time::{Duration, Instant},
+    sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use anyhow::{Context, Result};
@@ -37,17 +37,139 @@ pub fn handshake_timeout() -> std::time::Duration {
 /// automatically on the next handshake without restarting the process. The
 /// initial load is validated eagerly: an invalid cert/key path
 /// fails here rather than starting a server that cannot serve TLS.
-pub fn server_tls_config(cert_path: &Path, key_path: &Path) -> Result<ServerConfig> {
+///
+/// When `client_ca_cert_path` is `Some`, the server requires clients to present
+/// a certificate signed by that CA (mutual TLS); an unauthenticated client is
+/// rejected at the handshake. When `None`, client certificates are not
+/// requested.
+pub fn server_tls_config(
+    cert_path: &Path,
+    key_path: &Path,
+    client_ca_cert_path: Option<&Path>,
+) -> Result<ServerConfig> {
     let resolver = Arc::new(ReloadingCertifiedKey::new(cert_path, key_path)?);
 
     let provider = Arc::new(rustls::crypto::ring::default_provider());
-    let config = ServerConfig::builder_with_provider(provider)
+    let builder = ServerConfig::builder_with_provider(provider.clone())
         .with_safe_default_protocol_versions()
-        .context("configuring TLS protocol versions")?
-        .with_no_client_auth()
-        .with_cert_resolver(resolver);
+        .context("configuring TLS protocol versions")?;
+
+    let config = if let Some(ca_path) = client_ca_cert_path {
+        let ca_pem = std::fs::read(ca_path)
+            .with_context(|| format!("reading client CA cert: {}", ca_path.display()))?;
+        let ca_certs = certs(&mut ca_pem.as_slice())
+            .collect::<Result<Vec<_>, _>>()
+            .context("parsing client CA certificate PEM")?;
+        let mut client_roots = RootCertStore::empty();
+        for cert in ca_certs {
+            client_roots
+                .add(cert)
+                .context("adding client CA certificate to root store")?;
+        }
+        if client_roots.is_empty() {
+            anyhow::bail!(
+                "client CA certificate store is empty after parsing {}; \
+                 ensure the file contains at least one valid PEM certificate",
+                ca_path.display()
+            );
+        }
+        let verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
+            Arc::new(client_roots),
+            provider,
+        )
+        .build()
+        .context("building client certificate verifier")?;
+        builder
+            .with_client_cert_verifier(verifier)
+            .with_cert_resolver(resolver)
+    } else {
+        builder.with_no_client_auth().with_cert_resolver(resolver)
+    };
 
     Ok(config)
+}
+
+/// Build a server `ServerConfig` for a TCP plane from optional cert/key/client-CA
+/// paths, with the validation and misconfiguration diagnostics shared by the
+/// request-plane and response-stream servers. `plane` labels the log lines
+/// (e.g. `"TCP request plane"` / `"TCP server"`).
+///
+/// Returns `Ok(None)` for the plaintext case and fails closed on partial or
+/// invalid configuration (cert without key, a client CA without a server
+/// cert/key). When a client CA is supplied, the resulting config enforces mTLS.
+pub fn server_tls_acceptor_config(
+    plane: &str,
+    cert: Option<&Path>,
+    key: Option<&Path>,
+    client_ca: Option<&Path>,
+) -> Result<Option<ServerConfig>> {
+    use crate::config::environment_names::tcp_response_stream::tls as env;
+    match (cert, key) {
+        (Some(cert), Some(key)) => {
+            let config = server_tls_config(cert, key, client_ca)
+                .with_context(|| format!("building {plane} TLS config from cert/key/client CA"))?;
+            if client_ca.is_some() {
+                tracing::info!(
+                    plane,
+                    "TLS enabled with mutual authentication (client certificates required)"
+                );
+                // Every component also dials peers as a client. Enforcing client
+                // certs here while presenting no identity of our own means our
+                // outbound handshakes to other mTLS peers would fail.
+                let has_client_identity = std::env::var(env::DYN_TCP_TLS_CLIENT_CERT_PATH).is_ok()
+                    && std::env::var(env::DYN_TCP_TLS_CLIENT_KEY_PATH).is_ok();
+                if !has_client_identity {
+                    tracing::warn!(
+                        plane,
+                        client_ca_var = env::DYN_TCP_TLS_CLIENT_CA_CERT_PATH,
+                        client_cert_var = env::DYN_TCP_TLS_CLIENT_CERT_PATH,
+                        client_key_var = env::DYN_TCP_TLS_CLIENT_KEY_PATH,
+                        "server enforces client certificates but no client identity is configured; outbound connections to peers that also enforce mTLS will fail the handshake",
+                    );
+                }
+            } else {
+                tracing::info!(plane, "TLS enabled");
+            }
+            // Applies to both TLS and mTLS: if the client side has no way to
+            // verify this server, peers dialing it fail the handshake with an
+            // opaque error.
+            let client_trust_set = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).is_ok()
+                || crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
+            if !client_trust_set {
+                tracing::warn!(
+                    plane,
+                    ca_var = env::DYN_TCP_TLS_CA_CERT_PATH,
+                    insecure_var = env::DYN_TCP_TLS_INSECURE,
+                    "server has TLS enabled but no client trust is configured; peers cannot verify this server",
+                );
+            }
+            Ok(Some(config))
+        }
+        (Some(_), None) | (None, Some(_)) => anyhow::bail!(
+            "both {} and {} must be set to enable {plane} TLS",
+            env::DYN_TCP_TLS_CERT_PATH,
+            env::DYN_TCP_TLS_KEY_PATH,
+        ),
+        (None, None) if client_ca.is_some() => anyhow::bail!(
+            "{} requires {} and {} to also be set",
+            env::DYN_TCP_TLS_CLIENT_CA_CERT_PATH,
+            env::DYN_TCP_TLS_CERT_PATH,
+            env::DYN_TCP_TLS_KEY_PATH,
+        ),
+        (None, None) => {
+            let client_trust_set = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).is_ok()
+                || crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
+            if client_trust_set {
+                tracing::warn!(
+                    plane,
+                    cert_var = env::DYN_TCP_TLS_CERT_PATH,
+                    key_var = env::DYN_TCP_TLS_KEY_PATH,
+                    "server is running in plaintext but client TLS env vars are set; set the server cert/key to enable TLS, or unset the client vars",
+                );
+            }
+            Ok(None)
+        }
+    }
 }
 
 /// Build a rustls `ClientConfig` for outbound TLS connections.
@@ -55,17 +177,35 @@ pub fn server_tls_config(cert_path: &Path, key_path: &Path) -> Result<ServerConf
 /// - `ca_cert_path`: trust this CA for verifying the server certificate.
 ///   When `None`, the root store is empty — supply a CA cert or use `insecure`.
 /// - `insecure`: skip certificate verification entirely. **Dev/test only.**
-pub fn client_tls_config(ca_cert_path: Option<&Path>, insecure: bool) -> Result<ClientConfig> {
+/// - `client_cert_path` + `client_key_path`: when both are `Some`, the client
+///   presents this certificate to the server (mutual TLS). The identity is
+///   served through a `ReloadingCertifiedKey`, so a rotated client cert/key on
+///   disk is picked up without a process restart. Both must be set together.
+pub fn client_tls_config(
+    ca_cert_path: Option<&Path>,
+    insecure: bool,
+    client_cert_path: Option<&Path>,
+    client_key_path: Option<&Path>,
+) -> Result<ClientConfig> {
+    if client_cert_path.is_some() != client_key_path.is_some() {
+        anyhow::bail!("client cert and key paths must both be set or both be unset");
+    }
+
     let provider = Arc::new(rustls::crypto::ring::default_provider());
 
     if insecure {
-        tracing::info!("TCP TLS: certificate verification disabled (insecure mode)");
-        let config = ClientConfig::builder_with_provider(provider)
+        tracing::info!("TLS: certificate verification disabled (insecure mode)");
+        let builder = ClientConfig::builder_with_provider(provider)
             .with_safe_default_protocol_versions()
             .context("configuring TLS protocol versions")?
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(NoVerifier))
-            .with_no_client_auth();
+            .with_custom_certificate_verifier(Arc::new(NoVerifier));
+        let config = match (client_cert_path, client_key_path) {
+            (Some(cp), Some(kp)) => {
+                builder.with_client_cert_resolver(Arc::new(ReloadingCertifiedKey::new(cp, kp)?))
+            }
+            _ => builder.with_no_client_auth(),
+        };
         return Ok(config);
     }
 
@@ -94,11 +234,16 @@ pub fn client_tls_config(ca_cert_path: Option<&Path>, insecure: bool) -> Result<
     // cluster deployments, certs are issued by an internal CA and system roots
     // are not relevant.
 
-    let config = ClientConfig::builder_with_provider(provider)
+    let builder = ClientConfig::builder_with_provider(provider)
         .with_safe_default_protocol_versions()
         .context("configuring TLS protocol versions")?
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
+        .with_root_certificates(root_store);
+    let config = match (client_cert_path, client_key_path) {
+        (Some(cp), Some(kp)) => {
+            builder.with_client_cert_resolver(Arc::new(ReloadingCertifiedKey::new(cp, kp)?))
+        }
+        _ => builder.with_no_client_auth(),
+    };
 
     Ok(config)
 }
@@ -153,63 +298,19 @@ struct LoadedIdentity {
     certified_key: Arc<CertifiedKey>,
 }
 
-struct ReloadState {
-    /// Fingerprint of the last successfully loaded identity.
-    fingerprint: IdentityFingerprint,
-    last_checked: Instant,
-    /// Minimum time between filesystem checks: the full interval after a
-    /// successful check, a short backoff after a failed one so an in-progress
-    /// rotation is picked up promptly.
-    min_check_interval: Duration,
-}
-
-/// A rustls certificate resolver that reloads the leaf certificate and private
-/// key from disk when their contents change, so certificate rotation takes
-/// effect without a process restart.
-///
-/// Handshakes read the current identity from an [`ArcSwap`] without locking.
-/// One caller at a time performs the rate-limited filesystem check (`try_lock`);
-/// others keep serving the current identity, so a reload never blocks a
-/// handshake. A failed reload keeps the last valid identity and retries soon.
-///
-/// The same type serves as both a [`ResolvesServerCert`] (server leaf cert) and
-/// a [`rustls::client::ResolvesClientCert`] (mTLS client identity).
-pub(crate) struct ReloadingCertifiedKey {
+/// Shared reloadable identity. The current identity lives in an [`ArcSwap`]
+/// read lock-free on the handshake path; a background thread owns the filesystem
+/// reads and swaps in a new identity when the on-disk contents change.
+struct ReloadingState {
     cert_path: PathBuf,
     key_path: PathBuf,
     current: ArcSwap<CertifiedKey>,
-    reload_state: Mutex<ReloadState>,
+    /// Fingerprint of the last successfully loaded identity. Only the background
+    /// reloader (and tests) touch this, so it never contends with handshakes.
+    fingerprint: Mutex<IdentityFingerprint>,
 }
 
-impl fmt::Debug for ReloadingCertifiedKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ReloadingCertifiedKey")
-            .field("cert_path", &self.cert_path)
-            .field("key_path", &self.key_path)
-            .finish_non_exhaustive()
-    }
-}
-
-impl ReloadingCertifiedKey {
-    const RELOAD_CHECK_INTERVAL: Duration = Duration::from_secs(30);
-    const FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
-
-    fn new(cert_path: &Path, key_path: &Path) -> Result<Self> {
-        let cert_path = cert_path.to_path_buf();
-        let key_path = key_path.to_path_buf();
-        let loaded = Self::load(&cert_path, &key_path)?;
-        Ok(Self {
-            cert_path,
-            key_path,
-            current: ArcSwap::from(loaded.certified_key),
-            reload_state: Mutex::new(ReloadState {
-                fingerprint: loaded.fingerprint,
-                last_checked: Instant::now(),
-                min_check_interval: Self::RELOAD_CHECK_INTERVAL,
-            }),
-        })
-    }
-
+impl ReloadingState {
     fn load(cert_path: &Path, key_path: &Path) -> Result<LoadedIdentity> {
         let cert_pem = std::fs::read(cert_path)
             .with_context(|| format!("reading cert: {}", cert_path.display()))?;
@@ -223,55 +324,144 @@ impl ReloadingCertifiedKey {
         })
     }
 
-    fn resolve_key(&self) -> Arc<CertifiedKey> {
-        // Never make a handshake wait on another handshake's filesystem check;
-        // the current identity stays available via ArcSwap while one caller
-        // performs the rate-limited reload.
-        let mut state = match self.reload_state.try_lock() {
-            Ok(state) => state,
-            Err(TryLockError::WouldBlock) => return self.current.load_full(),
-            Err(TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
-        };
-        if state.last_checked.elapsed() < state.min_check_interval {
-            return self.current.load_full();
-        }
-
-        match Self::load(&self.cert_path, &self.key_path) {
-            Ok(reloaded) => {
-                if state.fingerprint != reloaded.fingerprint {
-                    let cert_count = reloaded.certified_key.cert.len();
-                    self.current.store(reloaded.certified_key);
-                    tracing::info!(
-                        cert_path = %self.cert_path.display(),
-                        cert_count,
-                        "Reloaded rotated TLS certificate and key from disk"
-                    );
-                }
-                state.fingerprint = reloaded.fingerprint;
-                state.last_checked = Instant::now();
-                state.min_check_interval = Self::RELOAD_CHECK_INTERVAL;
-            }
-            Err(error) => {
-                state.last_checked = Instant::now();
-                state.min_check_interval = Self::FAILURE_RETRY_INTERVAL;
-                tracing::warn!(
-                    cert_path = %self.cert_path.display(),
-                    error = %format!("{error:#}"),
-                    "Failed to reload rotated TLS certificate; keeping the last valid identity"
-                );
-            }
-        }
-        self.current.load_full()
-    }
-
-    #[cfg(test)]
-    fn mark_reload_due(&self) {
-        let mut state = self
-            .reload_state
+    /// Re-read the identity from disk and swap it in if the contents changed.
+    /// Runs off the handshake path (background thread / tests). A failed read
+    /// leaves the last valid identity in place and propagates the error so the
+    /// caller can back off.
+    fn refresh(&self) -> Result<()> {
+        let reloaded = Self::load(&self.cert_path, &self.key_path)?;
+        let mut fingerprint = self
+            .fingerprint
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        state.min_check_interval = Duration::ZERO;
-        state.last_checked = Instant::now() - Duration::from_secs(1);
+        if *fingerprint != reloaded.fingerprint {
+            let cert_count = reloaded.certified_key.cert.len();
+            self.current.store(reloaded.certified_key);
+            *fingerprint = reloaded.fingerprint;
+            tracing::info!(
+                cert_path = %self.cert_path.display(),
+                cert_count,
+                "Reloaded rotated TLS certificate and key from disk"
+            );
+        }
+        Ok(())
+    }
+
+    /// Spawn a background thread that periodically refreshes the identity. It
+    /// holds only a `Weak` reference, so it exits once the resolver is dropped.
+    /// A plain OS thread (not a Tokio task) keeps the filesystem reads off every
+    /// async runtime worker and avoids depending on a runtime being present when
+    /// the resolver is built.
+    fn spawn_reloader(state: &Arc<Self>) {
+        let weak = Arc::downgrade(state);
+        let spawned = std::thread::Builder::new()
+            .name("tls-cert-reloader".to_string())
+            .spawn(move || {
+                let mut interval = ReloadingCertifiedKey::RELOAD_CHECK_INTERVAL;
+                let mut consecutive_failures: u32 = 0;
+                loop {
+                    std::thread::sleep(interval);
+                    let Some(state) = weak.upgrade() else {
+                        break; // resolver dropped; stop reloading
+                    };
+                    match state.refresh() {
+                        Ok(()) => {
+                            if consecutive_failures > 0 {
+                                tracing::info!(
+                                    cert_path = %state.cert_path.display(),
+                                    failed_attempts = consecutive_failures,
+                                    "Recovered: reloaded TLS certificate after earlier failures"
+                                );
+                            }
+                            consecutive_failures = 0;
+                            interval = ReloadingCertifiedKey::RELOAD_CHECK_INTERVAL;
+                        }
+                        Err(error) => {
+                            consecutive_failures = consecutive_failures.saturating_add(1);
+                            // Exponential backoff from FAILURE_RETRY_INTERVAL, capped
+                            // at the normal check interval, so a persistently broken
+                            // file doesn't hammer the filesystem or the logs.
+                            let backoff = 2u32.saturating_pow((consecutive_failures - 1).min(16));
+                            interval = (ReloadingCertifiedKey::FAILURE_RETRY_INTERVAL * backoff)
+                                .min(ReloadingCertifiedKey::RELOAD_CHECK_INTERVAL);
+                            // Warn once when the failure begins; drop to debug while
+                            // it persists so a permanently broken file isn't logged
+                            // on every retry.
+                            if consecutive_failures == 1 {
+                                tracing::warn!(
+                                    cert_path = %state.cert_path.display(),
+                                    error = %format!("{error:#}"),
+                                    "Failed to reload rotated TLS certificate; keeping the last valid identity"
+                                );
+                            } else {
+                                tracing::debug!(
+                                    cert_path = %state.cert_path.display(),
+                                    error = %format!("{error:#}"),
+                                    attempt = consecutive_failures,
+                                    "TLS certificate reload still failing; retrying with backoff"
+                                );
+                            }
+                        }
+                    }
+                }
+            });
+        if let Err(error) = spawned {
+            tracing::warn!(
+                error = %error,
+                "Failed to spawn TLS certificate reloader thread; certificate hot-reload is disabled for this identity"
+            );
+        }
+    }
+}
+
+/// A rustls certificate resolver whose served identity is refreshed from disk by
+/// a background thread, so a rotated cert/key (in-place rewrite or atomic
+/// symlink swap) is picked up without a process restart.
+///
+/// `resolve()` only reads the current identity from an [`ArcSwap`] — it performs
+/// no filesystem I/O and never blocks, so it is safe to call from the
+/// `tokio-rustls` handshake poll. A failed reload keeps the last valid identity.
+///
+/// The same type serves as both a [`ResolvesServerCert`] (server leaf cert) and
+/// a [`rustls::client::ResolvesClientCert`] (mTLS client identity).
+pub(crate) struct ReloadingCertifiedKey {
+    state: Arc<ReloadingState>,
+}
+
+impl fmt::Debug for ReloadingCertifiedKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReloadingCertifiedKey")
+            .field("cert_path", &self.state.cert_path)
+            .field("key_path", &self.state.key_path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ReloadingCertifiedKey {
+    const RELOAD_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+    const FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+    fn new(cert_path: &Path, key_path: &Path) -> Result<Self> {
+        let loaded = ReloadingState::load(cert_path, key_path)?;
+        let state = Arc::new(ReloadingState {
+            cert_path: cert_path.to_path_buf(),
+            key_path: key_path.to_path_buf(),
+            current: ArcSwap::from(loaded.certified_key),
+            fingerprint: Mutex::new(loaded.fingerprint),
+        });
+        ReloadingState::spawn_reloader(&state);
+        Ok(Self { state })
+    }
+
+    fn resolve_key(&self) -> Arc<CertifiedKey> {
+        self.state.current.load_full()
+    }
+
+    /// Test-only: perform one synchronous reload cycle (what the background
+    /// thread does on each tick) so tests can drive rotation deterministically.
+    #[cfg(test)]
+    fn reload_now(&self) -> Result<()> {
+        self.state.refresh()
     }
 }
 
@@ -361,21 +551,40 @@ mod tests {
     #[test]
     fn server_config_roundtrip() {
         let (cert, key) = make_cert_files();
-        server_tls_config(cert.path(), key.path()).unwrap();
+        server_tls_config(cert.path(), key.path(), None).unwrap();
+    }
+
+    #[test]
+    fn server_config_with_mtls() {
+        // A client CA turns on client-certificate verification (mTLS).
+        let (cert, key) = make_cert_files();
+        server_tls_config(cert.path(), key.path(), Some(cert.path())).unwrap();
+    }
+
+    #[test]
+    fn server_config_mtls_empty_client_ca_errors() {
+        let (cert, key) = make_cert_files();
+        let empty = NamedTempFile::new().unwrap();
+        assert!(
+            server_tls_config(cert.path(), key.path(), Some(empty.path()))
+                .unwrap_err()
+                .to_string()
+                .contains("client CA certificate store is empty")
+        );
     }
 
     #[test]
     fn server_config_bad_paths() {
         let missing = std::path::Path::new("/nonexistent/x.pem");
         assert!(
-            server_tls_config(missing, missing)
+            server_tls_config(missing, missing, None)
                 .unwrap_err()
                 .to_string()
                 .contains("reading cert")
         );
         let (cert, _) = make_cert_files();
         assert!(
-            server_tls_config(cert.path(), missing)
+            server_tls_config(cert.path(), missing, None)
                 .unwrap_err()
                 .to_string()
                 .contains("reading key")
@@ -406,7 +615,7 @@ mod tests {
         let (cert2, key2) = make_cert_pem();
         std::fs::write(cert_file.path(), &cert2).unwrap();
         std::fs::write(key_file.path(), &key2).unwrap();
-        resolver.mark_reload_due();
+        resolver.reload_now().unwrap();
 
         let after = resolver.resolve_key().cert[0].clone();
         assert_ne!(
@@ -449,7 +658,7 @@ mod tests {
         symlink(gen2.join("tls.key"), &key_tmp).unwrap();
         std::fs::rename(&cert_tmp, &cert_link).unwrap();
         std::fs::rename(&key_tmp, &key_link).unwrap();
-        resolver.mark_reload_due();
+        resolver.reload_now().unwrap();
 
         let after = resolver.resolve_key().cert[0].clone();
         assert_ne!(
@@ -470,36 +679,62 @@ mod tests {
 
         // Simulate a partial write mid-rotation.
         std::fs::write(cert_file.path(), b"not a valid pem").unwrap();
-        resolver.mark_reload_due();
+        let reload_result = resolver.reload_now();
 
+        assert!(
+            reload_result.is_err(),
+            "a corrupt reload should surface an error to the caller"
+        );
         let after = resolver.resolve_key().cert[0].clone();
         assert_eq!(
             before, after,
             "a failed reload must keep serving the previously loaded certificate"
         );
-        assert_eq!(
-            resolver.reload_state.lock().unwrap().min_check_interval,
-            ReloadingCertifiedKey::FAILURE_RETRY_INTERVAL,
-            "a failed reload should schedule a short retry"
-        );
     }
 
     #[test]
     fn client_config_insecure() {
-        client_tls_config(None, true).unwrap();
+        client_tls_config(None, true, None, None).unwrap();
     }
 
     #[test]
     fn client_config_with_ca() {
         let (cert, _) = make_cert_files();
-        client_tls_config(Some(cert.path()), false).unwrap();
+        client_tls_config(Some(cert.path()), false, None, None).unwrap();
+    }
+
+    #[test]
+    fn client_config_with_mtls() {
+        // A client cert/key pair is presented as the client identity (mTLS).
+        let (cert, key) = make_cert_files();
+        client_tls_config(
+            Some(cert.path()),
+            false,
+            Some(cert.path()),
+            Some(key.path()),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn client_config_mtls_insecure() {
+        // Client identity is also honored in insecure (no server verification) mode.
+        let (cert, key) = make_cert_files();
+        client_tls_config(None, true, Some(cert.path()), Some(key.path())).unwrap();
+    }
+
+    #[test]
+    fn client_config_partial_mtls_errors() {
+        // Cert without key (or vice versa) is rejected.
+        let (cert, _) = make_cert_files();
+        assert!(client_tls_config(Some(cert.path()), false, Some(cert.path()), None).is_err());
     }
 
     #[test]
     fn client_config_empty_ca_errors() {
         let empty = NamedTempFile::new().unwrap();
         assert!(
-            client_tls_config(Some(empty.path()), false)
+            client_tls_config(Some(empty.path()), false, None, None)
                 .unwrap_err()
                 .to_string()
                 .contains("CA certificate store is empty")
@@ -509,10 +744,15 @@ mod tests {
     #[test]
     fn client_config_missing_ca_errors() {
         assert!(
-            client_tls_config(Some(std::path::Path::new("/nonexistent/ca.pem")), false)
-                .unwrap_err()
-                .to_string()
-                .contains("reading CA cert")
+            client_tls_config(
+                Some(std::path::Path::new("/nonexistent/ca.pem")),
+                false,
+                None,
+                None
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("reading CA cert")
         );
     }
 }

--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -19,12 +19,14 @@
 //!
 //! ## TLS
 //!
-//! A custom TLS config is applied when `NATS_TLS_CA_CERT_PATH` is set or
-//! `NATS_TLS_INSECURE` is truthy. When only the `tls://` URL scheme is used
-//! without explicit TLS env vars, async-nats handles TLS natively with system
-//! roots.
+//! A custom TLS config is applied when `NATS_TLS_CA_CERT_PATH` is set,
+//! `NATS_TLS_INSECURE` is truthy, or a client certificate is configured. When
+//! only the `tls://` URL scheme is used without explicit TLS env vars,
+//! async-nats handles TLS natively with system roots.
 //!
 //! - `NATS_TLS_CA_CERT_PATH`: path to the CA cert PEM used to verify the server
+//! - `NATS_TLS_CLIENT_CERT_PATH`: client cert PEM for mutual TLS (optional)
+//! - `NATS_TLS_CLIENT_KEY_PATH`: client key PEM for mutual TLS (optional)
 //! - `NATS_TLS_INSECURE`: set to a truthy value to skip certificate verification (dev only)
 use crate::metrics::MetricsHierarchy;
 use crate::protocols::EndpointId;
@@ -296,6 +298,15 @@ pub struct ClientOptions {
     #[builder(default = "default_nats_tls_ca_cert_path()")]
     tls_ca_cert_path: Option<PathBuf>,
 
+    /// Path to PEM client certificate presented to the NATS server for mutual
+    /// TLS (mTLS). Must be set together with `tls_client_key_path`.
+    #[builder(default = "default_nats_tls_client_cert_path()")]
+    tls_client_cert_path: Option<PathBuf>,
+
+    /// Path to PEM client private key for mutual TLS (mTLS).
+    #[builder(default = "default_nats_tls_client_key_path()")]
+    tls_client_key_path: Option<PathBuf>,
+
     /// Skip TLS certificate verification. For development only.
     #[builder(default = "default_nats_tls_insecure()")]
     tls_insecure: bool,
@@ -325,6 +336,18 @@ fn default_nats_tls_ca_cert_path() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+fn default_nats_tls_client_cert_path() -> Option<PathBuf> {
+    std::env::var(env_nats::tls::NATS_TLS_CLIENT_CERT_PATH)
+        .ok()
+        .map(PathBuf::from)
+}
+
+fn default_nats_tls_client_key_path() -> Option<PathBuf> {
+    std::env::var(env_nats::tls::NATS_TLS_CLIENT_KEY_PATH)
+        .ok()
+        .map(PathBuf::from)
+}
+
 fn default_nats_tls_insecure() -> bool {
     crate::config::env_is_truthy(env_nats::tls::NATS_TLS_INSECURE)
 }
@@ -342,7 +365,33 @@ impl ClientOptions {
     pub async fn connect(self) -> Result<Client> {
         self.validate()?;
 
-        let custom_tls = self.tls_ca_cert_path.is_some() || self.tls_insecure;
+        // Client cert and key must be set together to present a client identity.
+        if self.tls_client_cert_path.is_some() != self.tls_client_key_path.is_some() {
+            anyhow::bail!(
+                "Both {} and {} must be set together to enable NATS mTLS",
+                env_nats::tls::NATS_TLS_CLIENT_CERT_PATH,
+                env_nats::tls::NATS_TLS_CLIENT_KEY_PATH,
+            );
+        }
+
+        // A client identity requires a CA (or insecure) so the server can still
+        // be verified; otherwise the root store would be empty and verification
+        // would fail with an opaque error.
+        if self.tls_client_cert_path.is_some()
+            && self.tls_ca_cert_path.is_none()
+            && !self.tls_insecure
+        {
+            anyhow::bail!(
+                "{} requires {} (or {}) to also be set",
+                env_nats::tls::NATS_TLS_CLIENT_CERT_PATH,
+                env_nats::tls::NATS_TLS_CA_CERT_PATH,
+                env_nats::tls::NATS_TLS_INSECURE,
+            );
+        }
+
+        let custom_tls = self.tls_ca_cert_path.is_some()
+            || self.tls_insecure
+            || self.tls_client_cert_path.is_some();
         let tls_url = self.server.starts_with("tls://");
 
         // Custom TLS settings imply an encrypted connection, so the server URL
@@ -350,8 +399,8 @@ impl ClientOptions {
         // error instead of silently forcing TLS onto a nats:// URL.
         if custom_tls && !tls_url {
             anyhow::bail!(
-                "NATS TLS is configured (NATS_TLS_CA_CERT_PATH or NATS_TLS_INSECURE) but \
-                 NATS_SERVER does not use the 'tls://' scheme: {}",
+                "NATS TLS is configured (NATS_TLS_CA_CERT_PATH, NATS_TLS_INSECURE, or a client \
+                 certificate) but NATS_SERVER does not use the 'tls://' scheme: {}",
                 self.server
             );
         }
@@ -387,6 +436,8 @@ impl ClientOptions {
             let tls_config = crate::tls_utils::client_tls_config(
                 self.tls_ca_cert_path.as_deref(),
                 self.tls_insecure,
+                self.tls_client_cert_path.as_deref(),
+                self.tls_client_key_path.as_deref(),
             )?;
             options = options.tls_client_config(tls_config).require_tls(true);
         } else if tls_url {
@@ -429,6 +480,8 @@ impl Default for ClientOptions {
             server: default_server(),
             auth: NatsAuth::default(),
             tls_ca_cert_path: default_nats_tls_ca_cert_path(),
+            tls_client_cert_path: default_nats_tls_client_cert_path(),
+            tls_client_key_path: default_nats_tls_client_key_path(),
             tls_insecure: default_nats_tls_insecure(),
         }
     }
@@ -1106,6 +1159,69 @@ mod tests {
             .build()
             .unwrap();
         assert_scheme_error(opts.connect().await, "nats:// + insecure");
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn test_nats_mtls_client_cert_from_env() {
+        Jail::expect_with(|jail| {
+            jail.set_env(env_nats::NATS_SERVER, "tls://localhost:4222");
+            jail.set_env(env_nats::tls::NATS_TLS_CA_CERT_PATH, "/etc/certs/ca.pem");
+            jail.set_env(
+                env_nats::tls::NATS_TLS_CLIENT_CERT_PATH,
+                "/etc/certs/client.pem",
+            );
+            jail.set_env(
+                env_nats::tls::NATS_TLS_CLIENT_KEY_PATH,
+                "/etc/certs/client-key.pem",
+            );
+            let opts = ClientOptions::builder().build().unwrap();
+            assert_eq!(
+                opts.tls_client_cert_path,
+                Some(PathBuf::from("/etc/certs/client.pem"))
+            );
+            assert_eq!(
+                opts.tls_client_key_path,
+                Some(PathBuf::from("/etc/certs/client-key.pem"))
+            );
+            Ok(())
+        });
+    }
+
+    #[tokio::test]
+    async fn test_nats_mtls_client_cert_requires_ca() {
+        // Client cert/key set, tls:// URL, but no CA and not insecure → rejected.
+        let opts = ClientOptions::builder()
+            .server("tls://localhost:4222".to_string())
+            .tls_client_cert_path(Some(PathBuf::from("/tmp/client.pem")))
+            .tls_client_key_path(Some(PathBuf::from("/tmp/client-key.pem")))
+            .build()
+            .unwrap();
+        match opts.connect().await {
+            Err(e) => assert!(
+                e.to_string().contains("requires"),
+                "expected CA-requirement error, got: {e}"
+            ),
+            Ok(_) => panic!("expected error when client cert set without CA"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_nats_mtls_partial_client_identity_errors() {
+        // Client cert without key → rejected before connecting.
+        let opts = ClientOptions::builder()
+            .server("tls://localhost:4222".to_string())
+            .tls_ca_cert_path(Some(PathBuf::from("/tmp/ca.pem")))
+            .tls_client_cert_path(Some(PathBuf::from("/tmp/client.pem")))
+            .build()
+            .unwrap();
+        match opts.connect().await {
+            Err(e) => assert!(
+                e.to_string().contains("must be set together"),
+                "expected both-or-neither error, got: {e}"
+            ),
+            Ok(_) => panic!("expected error when client cert set without key"),
+        }
     }
 
     // Integration test for object store data operations using bincode


### PR DESCRIPTION
> **Tracking issue:** #10809 — [CONTRIBUTION]: Add opt-in TLS and mTLS support to NATS and TCP transports.
> Part of the TLS stack: #10921 (TCP streams, merged) → #12533 (TCP request plane, merged) → #13096 (NATS, merged) → **this PR** (mTLS) → operator injection.

## What

Adds opt-in **mutual TLS (mTLS)** for Dynamo's TCP and NATS transports, layered on the existing TLS support and off by default. With mTLS the client presents a certificate that the server verifies, so both ends of a connection authenticate.

- **Server side** (`DYN_TCP_TLS_CLIENT_CA_CERT_PATH`): the request-plane and response-stream servers require and verify client certificates via a `WebPkiClientVerifier`. When set, an unauthenticated client is rejected at the handshake — mTLS is enforced.
- **Client side** (`DYN_TCP_TLS_CLIENT_CERT_PATH`/`_KEY_PATH`, and `NATS_TLS_CLIENT_CERT_PATH`/`_KEY_PATH`): the client presents an identity. It is served through the existing `ReloadingCertifiedKey` resolver, so a **rotated client cert/key hot-reloads without a process restart** (same as the server cert).
- **NATS**: the client identity is applied to the NATS connection with the same both-or-neither / requires-CA validation.
- **Fail closed** on incomplete config: cert and key must be set together; a client identity requires a server CA (or insecure); a client CA on the server requires a server cert/key.
- **CLI flags** for parity with the existing TLS flags, on all backends (`DynamoRuntimeArgGroup`) and the frontend (`FrontendArgGroup`): `--tcp-tls-client-cert-path` / `--tcp-tls-client-key-path` / `--tcp-tls-client-ca-cert-path` and `--nats-tls-client-cert-path` / `--nats-tls-client-key-path`.
- **Docs**: new mTLS section (env vars + CLI flags + validation rules + reload note).

## Testing

`cargo test -p dynamo-runtime` — 47 pass across tls / nats / request-plane / env-name registration, including a **real loopback mTLS handshake test** (`request_plane_mtls_enforced_end_to_end`) that builds a CA-signed server+client chain and verifies the server **accepts** a client presenting a valid cert and **rejects** a client that presents none (enforcement). `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the generated-API-reference freshness check are clean.

Part of #10809.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added mutual TLS (mTLS) support for TCP and NATS connections.
  - Added configuration options for client certificates, private keys, and certificate authorities.
  - Added validation for incomplete or incompatible TLS settings.
  - Client TLS identities can be refreshed without restarting; server verification CA changes require restart.
- **Documentation**
  - Expanded TLS configuration guidance, including CLI options, validation, and reload behavior.
- **Bug Fixes**
  - Improved handling of invalid TLS credentials and incomplete configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->