### PR TITLE
feat(vllm): publish RL worker metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,6 +3171,7 @@ dependencies = [
  "tonic-build 0.13.1",
  "tonic-health",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/lib/backend-common/src/lib.rs
+++ b/lib/backend-common/src/lib.rs
@@ -42,6 +42,7 @@ pub use engine::{
 };
 pub use error::{BackendError, DynamoError, ErrorType};
 pub use metrics::{ComponentGauges, EngineMetrics, LifecycleGauges};
+pub use rl::RlWorkerMetadata;
 pub use run::{run, run_raw};
 pub use snapshot_publisher::SnapshotPublisher;
 pub use worker::{RuntimeConfig, Worker, WorkerConfig};

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{num::NonZeroU32, sync::Arc};
 
 use async_trait::async_trait;
 use dynamo_runtime::component::{Endpoint, StartedEndpoint};
@@ -24,6 +24,48 @@ pub(crate) struct RlServeEndpoint {
 pub(crate) struct RlEndpointConfig {
     endpoint_name: String,
     system_url: String,
+    metadata: Option<RlWorkerMetadata>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RlWorkerMetadata {
+    world_size: NonZeroU32,
+    weight_transfer_backend: Option<String>,
+    admin_base_url: Option<String>,
+}
+
+impl RlWorkerMetadata {
+    pub fn new(
+        world_size: u32,
+        weight_transfer_backend: Option<String>,
+        admin_base_url: Option<String>,
+    ) -> anyhow::Result<Self> {
+        let world_size = NonZeroU32::new(world_size)
+            .ok_or_else(|| anyhow::anyhow!("RL worker world size must be positive"))?;
+        let weight_transfer_backend = normalized_optional(
+            weight_transfer_backend,
+            "RL weight-transfer backend must not be blank",
+        )?;
+        let admin_base_url =
+            normalized_optional(admin_base_url, "RL admin base URL must not be blank")?;
+        Ok(Self {
+            world_size,
+            weight_transfer_backend,
+            admin_base_url,
+        })
+    }
+}
+
+fn normalized_optional(value: Option<String>, error: &str) -> anyhow::Result<Option<String>> {
+    value
+        .map(|value| {
+            let value = value.trim();
+            if value.is_empty() {
+                anyhow::bail!(error.to_string());
+            }
+            Ok(value.to_string())
+        })
+        .transpose()
 }
 
 impl RlServeEndpoint {
@@ -32,7 +74,10 @@ impl RlServeEndpoint {
     }
 }
 
-pub(crate) fn prepare_endpoint(primary: &Endpoint) -> anyhow::Result<RlEndpointConfig> {
+pub(crate) fn prepare_endpoint(
+    primary: &Endpoint,
+    metadata: Option<RlWorkerMetadata>,
+) -> anyhow::Result<RlEndpointConfig> {
     let endpoint_name = resolve_endpoint_name(&primary.id().name)?;
     let system_url = self_host_base_url(primary.drt()).ok_or_else(|| {
         anyhow::anyhow!(
@@ -42,6 +87,7 @@ pub(crate) fn prepare_endpoint(primary: &Endpoint) -> anyhow::Result<RlEndpointC
     Ok(RlEndpointConfig {
         endpoint_name,
         system_url,
+        metadata,
     })
 }
 
@@ -53,6 +99,7 @@ pub(crate) async fn serve_endpoint(
     let handler = Arc::new(RlRouteHandler {
         routes: primary.drt().engine_routes().clone(),
         system_url: config.system_url,
+        metadata: config.metadata,
     });
     let ingress = Ingress::for_engine(handler)?;
     let started = endpoint
@@ -100,6 +147,7 @@ fn validate_endpoint_name(endpoint_name: &str, primary_name: &str) -> anyhow::Re
 struct RlRouteHandler {
     routes: EngineRouteRegistry,
     system_url: String,
+    metadata: Option<RlWorkerMetadata>,
 }
 
 impl RlRouteHandler {
@@ -122,11 +170,21 @@ impl RlRouteHandler {
         let mut routes = self.routes.routes().into_iter().collect::<Vec<_>>();
         routes.sort();
         routes.dedup();
-        json!({
+        let mut response = json!({
             "status": "ok",
             "routes": routes,
             "system_url": self.system_url,
-        })
+        });
+        if let Some(metadata) = &self.metadata {
+            response["world_size"] = json!(metadata.world_size.get());
+            if let Some(backend) = &metadata.weight_transfer_backend {
+                response["weight_transfer_backend"] = json!(backend);
+            }
+            if let Some(url) = &metadata.admin_base_url {
+                response["admin_base_url"] = json!(url);
+            }
+        }
+        response
     }
 }
 
@@ -156,6 +214,14 @@ mod tests {
         let handler = RlRouteHandler {
             routes,
             system_url: "http://worker:8080".to_string(),
+            metadata: Some(
+                RlWorkerMetadata::new(
+                    4,
+                    Some(" nccl ".to_string()),
+                    Some(" http://worker:8120 ".to_string()),
+                )
+                .expect("valid metadata"),
+            ),
         };
 
         assert_eq!(
@@ -164,11 +230,21 @@ mod tests {
                 "status": "ok",
                 "routes": ["control/pause_generation"],
                 "system_url": "http://worker:8080",
+                "admin_base_url": "http://worker:8120",
+                "world_size": 4,
+                "weight_transfer_backend": "nccl",
             })
         );
         assert_eq!(
             handler.dispatch(&json!({"method": "control/pause_generation"}))["status"],
             "error"
         );
+    }
+
+    #[test]
+    fn rl_worker_metadata_rejects_invalid_values() {
+        assert!(RlWorkerMetadata::new(0, None, None).is_err());
+        assert!(RlWorkerMetadata::new(1, Some("   ".to_string()), None).is_err());
+        assert!(RlWorkerMetadata::new(1, None, Some("   ".to_string())).is_err());
     }
 }

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -30,27 +30,17 @@ pub(crate) struct RlEndpointConfig {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RlWorkerMetadata {
     world_size: NonZeroU32,
-    weight_transfer_backend: Option<String>,
     admin_base_url: Option<String>,
 }
 
 impl RlWorkerMetadata {
-    pub fn new(
-        world_size: u32,
-        weight_transfer_backend: Option<String>,
-        admin_base_url: Option<String>,
-    ) -> anyhow::Result<Self> {
+    pub fn new(world_size: u32, admin_base_url: Option<String>) -> anyhow::Result<Self> {
         let world_size = NonZeroU32::new(world_size)
             .ok_or_else(|| anyhow::anyhow!("RL worker world size must be positive"))?;
-        let weight_transfer_backend = normalized_optional(
-            weight_transfer_backend,
-            "RL weight-transfer backend must not be blank",
-        )?;
         let admin_base_url =
             normalized_optional(admin_base_url, "RL admin base URL must not be blank")?;
         Ok(Self {
             world_size,
-            weight_transfer_backend,
             admin_base_url,
         })
     }
@@ -177,9 +167,6 @@ impl RlRouteHandler {
         });
         if let Some(metadata) = &self.metadata {
             response["world_size"] = json!(metadata.world_size.get());
-            if let Some(backend) = &metadata.weight_transfer_backend {
-                response["weight_transfer_backend"] = json!(backend);
-            }
             if let Some(url) = &metadata.admin_base_url {
                 response["admin_base_url"] = json!(url);
             }
@@ -215,12 +202,8 @@ mod tests {
             routes,
             system_url: "http://worker:8080".to_string(),
             metadata: Some(
-                RlWorkerMetadata::new(
-                    4,
-                    Some(" nccl ".to_string()),
-                    Some(" http://worker:8120 ".to_string()),
-                )
-                .expect("valid metadata"),
+                RlWorkerMetadata::new(4, Some(" http://worker:8120 ".to_string()))
+                    .expect("valid metadata"),
             ),
         };
 
@@ -242,8 +225,7 @@ mod tests {
 
     #[test]
     fn rl_worker_metadata_rejects_invalid_values() {
-        assert!(RlWorkerMetadata::new(0, None, None).is_err());
-        assert!(RlWorkerMetadata::new(1, Some("   ".to_string()), None).is_err());
-        assert!(RlWorkerMetadata::new(1, None, Some("   ".to_string())).is_err());
+        assert!(RlWorkerMetadata::new(0, None).is_err());
+        assert!(RlWorkerMetadata::new(1, Some("   ".to_string())).is_err());
     }
 }

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -232,7 +232,6 @@ mod tests {
                 "system_url": "http://worker:8080",
                 "admin_base_url": "http://worker:8120",
                 "world_size": 4,
-                "weight_transfer_backend": "nccl",
             })
         );
         assert_eq!(

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -193,6 +193,8 @@ pub struct WorkerConfig {
     pub route_to_encoder: bool,
     /// Publish the worker's engine routes through an auxiliary RL discovery endpoint.
     pub enable_rl: bool,
+    /// Optional RL topology and weight-transfer metadata published by the worker.
+    pub rl_metadata: Option<crate::RlWorkerMetadata>,
     /// Optional frontend media decoding and fetch policy advertised on the
     /// model deployment card.
     pub media_decoder: Option<MediaDecoder>,
@@ -238,6 +240,7 @@ impl Default for WorkerConfig {
             runtime: RuntimeConfig::default(),
             route_to_encoder: false,
             enable_rl: false,
+            rl_metadata: None,
             media_decoder: None,
             media_fetcher: None,
             default_thinking_mode: None,
@@ -926,12 +929,16 @@ impl Worker {
         let model_type = resolve_model_type(&self.config)?;
         let (worker_type, needs) = resolve_worker_type_and_needs(&self.config);
         let rl_config = if self.config.enable_rl {
-            Some(crate::rl::prepare_endpoint(&endpoint).map_err(|error| {
-                err(
-                    ErrorType::Backend(BackendError::InvalidArgument),
-                    format!("RL endpoint configuration: {error}"),
-                )
-            })?)
+            Some(
+                crate::rl::prepare_endpoint(&endpoint, self.config.rl_metadata.clone()).map_err(
+                    |error| {
+                        err(
+                            ErrorType::Backend(BackendError::InvalidArgument),
+                            format!("RL endpoint configuration: {error}"),
+                        )
+                    },
+                )?,
+            )
         } else {
             None
         };

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -469,6 +469,7 @@ impl WorkerConfig {
                 // Python vLLM owns and serves its existing `.rl` endpoint.
                 // The shared Rust endpoint is opt-in for Rust sidecars only.
                 enable_rl: false,
+                rl_metadata: None,
                 media_decoder: media_decoder.map(|decoder| decoder.inner),
                 media_fetcher: media_fetcher.map(|fetcher| fetcher.inner),
             },

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -112,8 +112,6 @@ pub struct RlWorkerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub world_size: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub weight_transfer_backend: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
@@ -355,7 +353,6 @@ struct WorkerRoutes {
     system_url: Option<String>,
     admin_base_url: Option<String>,
     world_size: Option<u32>,
-    weight_transfer_backend: Option<String>,
 }
 
 async fn call_worker_routes(
@@ -481,26 +478,11 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
                 .ok_or_else(|| anyhow::anyhow!("worker routes response has invalid 'world_size'"))
         })
         .transpose()?;
-    let weight_transfer_backend = value
-        .get("weight_transfer_backend")
-        .map(|value| {
-            let value = value.as_str().ok_or_else(|| {
-                anyhow::anyhow!("worker routes response has invalid 'weight_transfer_backend'")
-            })?;
-            let value = value.trim();
-            if value.is_empty() {
-                anyhow::bail!("worker routes response has invalid 'weight_transfer_backend'");
-            }
-            Ok(value.to_string())
-        })
-        .transpose()?;
-
     Ok(WorkerRoutes {
         routes,
         system_url,
         admin_base_url,
         world_size,
-        weight_transfer_backend,
     })
 }
 
@@ -525,7 +507,6 @@ fn worker_info(
         model,
         routes: discovered.routes,
         world_size: discovered.world_size,
-        weight_transfer_backend: discovered.weight_transfer_backend,
         error,
     }
 }
@@ -611,7 +592,6 @@ mod tests {
         assert_eq!(parsed.system_url.as_deref(), Some("http://worker:8080"));
         assert_eq!(parsed.admin_base_url.as_deref(), Some("http://worker:8120"));
         assert_eq!(parsed.world_size, Some(4));
-        assert_eq!(parsed.weight_transfer_backend.as_deref(), Some("nccl"));
     }
 
     #[test]
@@ -645,12 +625,6 @@ mod tests {
     fn parse_worker_routes_rejects_invalid_rl_metadata() {
         let zero = parse_worker_routes(json!({ "routes": [], "world_size": 0 })).unwrap_err();
         assert!(zero.to_string().contains("world_size"));
-        let blank = parse_worker_routes(json!({
-            "routes": [],
-            "weight_transfer_backend": "  ",
-        }))
-        .unwrap_err();
-        assert!(blank.to_string().contains("weight_transfer_backend"));
     }
 
     #[test]

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -40,6 +40,7 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
 /// Global cap on concurrent per-worker probes (across all in-flight discovery
 /// requests), so a large fleet or many concurrent callers can't fan out without bound.
 const DEFAULT_MAX_CONCURRENT_PROBES: usize = 32;
+const RL_WORKERS_PROTOCOL_VERSION: u32 = 1;
 
 type ModelKey = (String, String, u64);
 
@@ -104,14 +105,21 @@ pub struct RlWorkerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub admin_base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     pub routes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub world_size: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weight_transfer_backend: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RlWorkersResponse {
+    pub protocol_version: u32,
     pub namespace: String,
     pub workers: Vec<RlWorkerInfo>,
 }
@@ -195,6 +203,7 @@ pub fn rl_router(state: RlDiscoveryState) -> Router {
 async fn workers_handler(State(state): State<RlDiscoveryState>) -> impl IntoResponse {
     match list_workers(&state).await {
         Ok(workers) => Json(RlWorkersResponse {
+            protocol_version: RL_WORKERS_PROTOCOL_VERSION,
             namespace: state.config.namespace.clone(),
             workers,
         })
@@ -229,8 +238,7 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
         .list(DiscoveryQuery::NamespacedModels {
             namespace: config.namespace.clone(),
         })
-        .await
-        .unwrap_or_default();
+        .await?;
 
     let models = model_map(model_instances);
     let rl_endpoints = endpoint_instances
@@ -246,6 +254,13 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
                 .as_ref()
                 .map(|components| components.iter().any(|c| c == &endpoint.component))
                 .unwrap_or(true)
+        })
+        .filter(|endpoint| {
+            models.contains_key(&(
+                endpoint.namespace.clone(),
+                endpoint.component.clone(),
+                endpoint.instance_id,
+            ))
         })
         .collect::<Vec<_>>();
 
@@ -315,13 +330,17 @@ async fn describe_worker(
         call_worker_routes(state, &endpoint, timeout).await
     };
     match tokio::time::timeout(timeout, probe).await {
-        Ok(Ok(routes)) => worker_info(endpoint, model, routes.routes, routes.system_url, None),
-        Ok(Err(err)) => worker_info(endpoint, model, Vec::new(), None, Some(err.to_string())),
+        Ok(Ok(routes)) => worker_info(endpoint, model, routes, None),
+        Ok(Err(err)) => worker_info(
+            endpoint,
+            model,
+            WorkerRoutes::default(),
+            Some(err.to_string()),
+        ),
         Err(_) => worker_info(
             endpoint,
             model,
-            Vec::new(),
-            None,
+            WorkerRoutes::default(),
             Some(format!(
                 "worker discovery timed out after {}s",
                 timeout.as_secs()
@@ -334,6 +353,9 @@ async fn describe_worker(
 struct WorkerRoutes {
     routes: Vec<String>,
     system_url: Option<String>,
+    admin_base_url: Option<String>,
+    world_size: Option<u32>,
+    weight_transfer_backend: Option<String>,
 }
 
 async fn call_worker_routes(
@@ -440,18 +462,56 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
         .filter(|url| !url.is_empty())
         .map(ToString::to_string);
 
-    Ok(WorkerRoutes { routes, system_url })
+    let admin_base_url = value
+        .get("admin_base_url")
+        .and_then(|url| url.as_str())
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(ToString::to_string);
+
+    let world_size = value
+        .get("world_size")
+        .map(|value| {
+            let value = value.as_u64().ok_or_else(|| {
+                anyhow::anyhow!("worker routes response has invalid 'world_size'")
+            })?;
+            u32::try_from(value)
+                .ok()
+                .filter(|value| *value > 0)
+                .ok_or_else(|| anyhow::anyhow!("worker routes response has invalid 'world_size'"))
+        })
+        .transpose()?;
+    let weight_transfer_backend = value
+        .get("weight_transfer_backend")
+        .map(|value| {
+            let value = value.as_str().ok_or_else(|| {
+                anyhow::anyhow!("worker routes response has invalid 'weight_transfer_backend'")
+            })?;
+            let value = value.trim();
+            if value.is_empty() {
+                anyhow::bail!("worker routes response has invalid 'weight_transfer_backend'");
+            }
+            Ok(value.to_string())
+        })
+        .transpose()?;
+
+    Ok(WorkerRoutes {
+        routes,
+        system_url,
+        admin_base_url,
+        world_size,
+        weight_transfer_backend,
+    })
 }
 
 fn worker_info(
     endpoint: Instance,
     model: Option<String>,
-    mut routes: Vec<String>,
-    system_url: Option<String>,
+    mut discovered: WorkerRoutes,
     error: Option<String>,
 ) -> RlWorkerInfo {
-    routes.sort();
-    routes.dedup();
+    discovered.routes.sort();
+    discovered.routes.dedup();
 
     RlWorkerInfo {
         request_plane_url: request_plane_url(&endpoint),
@@ -460,9 +520,12 @@ fn worker_info(
         endpoint: endpoint.endpoint,
         instance_id: endpoint.instance_id,
         transport: endpoint.transport,
-        system_url,
+        system_url: discovered.system_url,
+        admin_base_url: discovered.admin_base_url,
         model,
-        routes,
+        routes: discovered.routes,
+        world_size: discovered.world_size,
+        weight_transfer_backend: discovered.weight_transfer_backend,
         error,
     }
 }
@@ -537,12 +600,18 @@ mod tests {
         let parsed = parse_worker_routes(json!({
             "routes": ["pause_generation", "resume_generation"],
             "system_url": "  http://worker:8080  ",
+            "admin_base_url": "  http://worker:8120  ",
+            "world_size": 4,
+            "weight_transfer_backend": "nccl",
         }))
         .expect("valid payload");
         let routes: Vec<&str> = parsed.routes.iter().map(String::as_str).collect();
         assert_eq!(routes, ["pause_generation", "resume_generation"]);
         // system_url is trimmed.
         assert_eq!(parsed.system_url.as_deref(), Some("http://worker:8080"));
+        assert_eq!(parsed.admin_base_url.as_deref(), Some("http://worker:8120"));
+        assert_eq!(parsed.world_size, Some(4));
+        assert_eq!(parsed.weight_transfer_backend.as_deref(), Some("nccl"));
     }
 
     #[test]
@@ -570,6 +639,18 @@ mod tests {
     fn parse_worker_routes_rejects_empty_entry() {
         let err = parse_worker_routes(json!({ "routes": ["pause", ""] })).unwrap_err();
         assert!(err.to_string().contains("empty route entry"));
+    }
+
+    #[test]
+    fn parse_worker_routes_rejects_invalid_rl_metadata() {
+        let zero = parse_worker_routes(json!({ "routes": [], "world_size": 0 })).unwrap_err();
+        assert!(zero.to_string().contains("world_size"));
+        let blank = parse_worker_routes(json!({
+            "routes": [],
+            "weight_transfer_backend": "  ",
+        }))
+        .unwrap_err();
+        assert!(blank.to_string().contains("weight_transfer_backend"));
     }
 
     #[test]

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -236,31 +236,15 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
         .list(DiscoveryQuery::NamespacedModels {
             namespace: config.namespace.clone(),
         })
-        .await?;
+        .await
+        .unwrap_or_default();
 
     let models = model_map(model_instances);
-    let rl_endpoints = endpoint_instances
-        .into_iter()
-        .filter_map(|instance| match instance {
-            DiscoveryInstance::Endpoint(endpoint) => Some(endpoint),
-            _ => None,
-        })
-        .filter(|endpoint| endpoint.endpoint == config.rl_endpoint)
-        .filter(|endpoint| {
-            config
-                .component_filter
-                .as_ref()
-                .map(|components| components.iter().any(|c| c == &endpoint.component))
-                .unwrap_or(true)
-        })
-        .filter(|endpoint| {
-            models.contains_key(&(
-                endpoint.namespace.clone(),
-                endpoint.component.clone(),
-                endpoint.instance_id,
-            ))
-        })
-        .collect::<Vec<_>>();
+    let rl_endpoints = rl_endpoint_instances(
+        endpoint_instances,
+        &config.rl_endpoint,
+        config.component_filter.as_deref(),
+    );
 
     // Bound the client cache (N2): drop clients for endpoints that are no longer
     // present. Live endpoints are retained, so the fan-out below still reuses their
@@ -308,6 +292,26 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
     });
 
     Ok(workers)
+}
+
+fn rl_endpoint_instances(
+    instances: Vec<DiscoveryInstance>,
+    rl_endpoint: &str,
+    component_filter: Option<&[String]>,
+) -> Vec<Instance> {
+    instances
+        .into_iter()
+        .filter_map(|instance| match instance {
+            DiscoveryInstance::Endpoint(endpoint) => Some(endpoint),
+            _ => None,
+        })
+        .filter(|endpoint| endpoint.endpoint == rl_endpoint)
+        .filter(|endpoint| {
+            component_filter
+                .map(|components| components.iter().any(|c| c == &endpoint.component))
+                .unwrap_or(true)
+        })
+        .collect()
 }
 
 async fn describe_worker(
@@ -461,10 +465,17 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
 
     let admin_base_url = value
         .get("admin_base_url")
-        .and_then(|url| url.as_str())
-        .map(str::trim)
-        .filter(|url| !url.is_empty())
-        .map(ToString::to_string);
+        .map(|value| {
+            let url = value.as_str().ok_or_else(|| {
+                anyhow::anyhow!("worker routes response has invalid 'admin_base_url'")
+            })?;
+            let url = url.trim();
+            if url.is_empty() {
+                anyhow::bail!("worker routes response has invalid 'admin_base_url'");
+            }
+            Ok(url.to_string())
+        })
+        .transpose()?;
 
     let world_size = value
         .get("world_size")

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -558,6 +558,23 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn endpoint_instance(
+        namespace: &str,
+        component: &str,
+        endpoint: &str,
+        instance_id: u64,
+    ) -> DiscoveryInstance {
+        DiscoveryInstance::Endpoint(Instance {
+            namespace: namespace.to_string(),
+            component: component.to_string(),
+            endpoint: endpoint.to_string(),
+            instance_id,
+            transport: TransportType::Nats("nats://127.0.0.1:4222".to_string()),
+            device_type: None,
+            request_plane_codec: None,
+        })
+    }
+
     fn model_instance(
         namespace: &str,
         component: &str,
@@ -628,6 +645,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_worker_routes_rejects_invalid_admin_base_url() {
+        for value in [json!("   "), json!(42)] {
+            let err = parse_worker_routes(json!({
+                "routes": [],
+                "admin_base_url": value,
+            }))
+            .unwrap_err();
+            assert!(err.to_string().contains("admin_base_url"));
+        }
+    }
+
+    #[test]
     fn parse_worker_routes_propagates_worker_error_status() {
         let err = parse_worker_routes(json!({ "status": "error", "message": "engine is dead" }))
             .unwrap_err();
@@ -693,5 +722,17 @@ mod tests {
             Some("lora-1"),
         )]);
         assert!(map.is_empty());
+    }
+
+    #[test]
+    fn rl_endpoint_instances_do_not_require_model_metadata() {
+        let endpoints = rl_endpoint_instances(
+            vec![endpoint_instance("dynamo", "backend", "rl", 1)],
+            "rl",
+            None,
+        );
+
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].instance_id, 1);
     }
 }

--- a/lib/sidecar/vllm/Cargo.toml
+++ b/lib/sidecar/vllm/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/lib/sidecar/vllm/src/args.rs
+++ b/lib/sidecar/vllm/src/args.rs
@@ -15,4 +15,8 @@ pub(crate) struct Args {
     /// vLLM gRPC endpoint as host:port or an http:// URL.
     #[arg(long, env = "VLLM_GRPC_ENDPOINT")]
     pub vllm_endpoint: String,
+
+    /// Optional vLLM HTTP admin endpoint advertised for RL weight-transfer control.
+    #[arg(long, env = "VLLM_HTTP_ENDPOINT")]
+    pub vllm_http_endpoint: Option<String>,
 }

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -36,6 +36,25 @@ fn cancelled(state: &ResponseState) -> LLMEngineOutput {
     ))
 }
 
+pub(crate) fn validate_http_endpoint(value: &str) -> Result<String, DynamoError> {
+    let value = value.trim();
+    let parsed = url::Url::parse(value).map_err(|error| {
+        client::invalid_argument(format!("invalid --vllm-http-endpoint: {error}"))
+    })?;
+    let has_valid_authority = value
+        .split_once("://")
+        .is_some_and(|(_, authority)| !authority.is_empty() && !authority.starts_with('/'));
+    if !matches!(parsed.scheme(), "http" | "https")
+        || parsed.host_str().is_none()
+        || !has_valid_authority
+    {
+        return Err(client::invalid_argument(
+            "invalid --vllm-http-endpoint: expected an http:// or https:// URL with a host",
+        ));
+    }
+    Ok(value.to_string())
+}
+
 impl VllmSidecarEngine {
     pub(crate) fn new(
         endpoint: GrpcEndpoint,
@@ -102,15 +121,11 @@ impl VllmSidecarEngine {
 
         let endpoint = GrpcEndpoint::parse(&args.vllm_endpoint, "--vllm-endpoint")?;
         let enable_rl = args.sidecar.common.enable_rl;
-        let vllm_http_url = if enable_rl {
-            args.vllm_http_endpoint
-                .as_deref()
-                .map(|value| GrpcEndpoint::parse(value, "--vllm-http-endpoint"))
-                .transpose()?
-                .map(|endpoint| endpoint.to_string())
-        } else {
-            None
-        };
+        let vllm_http_url = args
+            .vllm_http_endpoint
+            .as_deref()
+            .map(validate_http_endpoint)
+            .transpose()?;
         let transport = args.sidecar.grpc.config();
         let bootstrap_deadline = client::startup_deadline(transport.startup_deadline)?;
         eprintln!(

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -101,6 +101,16 @@ impl VllmSidecarEngine {
         }
 
         let endpoint = GrpcEndpoint::parse(&args.vllm_endpoint, "--vllm-endpoint")?;
+        let enable_rl = args.sidecar.common.enable_rl;
+        let vllm_http_url = if enable_rl {
+            args.vllm_http_endpoint
+                .as_deref()
+                .map(|value| GrpcEndpoint::parse(value, "--vllm-http-endpoint"))
+                .transpose()?
+                .map(|endpoint| endpoint.to_string())
+        } else {
+            None
+        };
         let transport = args.sidecar.grpc.config();
         let bootstrap_deadline = client::startup_deadline(transport.startup_deadline)?;
         eprintln!(
@@ -109,6 +119,9 @@ impl VllmSidecarEngine {
         );
         let model = bootstrap_discover(&endpoint, transport, bootstrap_deadline)?;
         let mode = args.sidecar.common.disaggregation_mode;
+        let rl_metadata = enable_rl
+            .then(|| model.rl_worker_metadata(vllm_http_url))
+            .transpose()?;
         let engine = Self::new(endpoint, model.clone(), mode, transport);
         let config = WorkerConfig {
             namespace: args.sidecar.common.namespace,
@@ -134,7 +147,8 @@ impl VllmSidecarEngine {
             enable_kv_routing: true,
             disaggregation_mode: mode,
             route_to_encoder: false,
-            enable_rl: args.sidecar.common.enable_rl,
+            enable_rl,
+            rl_metadata,
             ..Default::default()
         };
         Ok((engine, config))

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_backend_common::{DynamoError, EngineConfig, LlmRegistration};
+use dynamo_backend_common::{DynamoError, EngineConfig, LlmRegistration, RlWorkerMetadata};
 
 use crate::client;
 use crate::proto as pb;
@@ -82,11 +82,10 @@ impl DiscoveredModel {
                 self.identity, observed.identity
             )));
         }
-        let expected_dp_size = self.data_parallel_size();
-        let observed_dp_size = observed.data_parallel_size();
-        if expected_dp_size != observed_dp_size {
+        if self.server.parallelism != observed.server.parallelism {
             return Err(client::protocol_error(format!(
-                "data-parallel size changed between bootstrap and startup: expected {expected_dp_size}, observed {observed_dp_size}"
+                "parallelism changed between bootstrap and startup: expected {:?}, observed {:?}",
+                self.server.parallelism, observed.server.parallelism
             )));
         }
         if self.server.rl_capabilities != observed.server.rl_capabilities {
@@ -100,6 +99,32 @@ impl DiscoveredModel {
 
     pub(crate) fn rl_capabilities(&self) -> Option<&pb::RlCapabilities> {
         self.server.rl_capabilities.as_ref()
+    }
+
+    pub(crate) fn rl_worker_metadata(
+        &self,
+        admin_base_url: Option<String>,
+    ) -> Result<RlWorkerMetadata, DynamoError> {
+        let parallelism = self.server.parallelism.as_ref().ok_or_else(|| {
+            client::protocol_error("RL discovery requires vLLM parallelism metadata")
+        })?;
+        let world_size = parallelism
+            .tensor_parallel_size
+            .checked_mul(parallelism.pipeline_parallel_size)
+            .and_then(|size| size.checked_mul(parallelism.data_parallel_size))
+            .filter(|size| *size > 0)
+            .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
+        let backend = self
+            .server
+            .rl_capabilities
+            .as_ref()
+            .and_then(|capabilities| {
+                capabilities
+                    .weight_transfer_enabled
+                    .then(|| capabilities.weight_transfer_backend.clone())
+            });
+        RlWorkerMetadata::new(world_size, backend, admin_base_url)
+            .map_err(|error| client::protocol_error(error.to_string()))
     }
 
     pub(crate) fn engine_config(&self) -> EngineConfig {

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -114,16 +114,7 @@ impl DiscoveredModel {
             .and_then(|size| size.checked_mul(parallelism.data_parallel_size))
             .filter(|size| *size > 0)
             .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
-        let backend = self
-            .server
-            .rl_capabilities
-            .as_ref()
-            .and_then(|capabilities| {
-                capabilities
-                    .weight_transfer_enabled
-                    .then(|| capabilities.weight_transfer_backend.clone())
-            });
-        RlWorkerMetadata::new(world_size, backend, admin_base_url)
+        RlWorkerMetadata::new(world_size, admin_base_url)
             .map_err(|error| client::protocol_error(error.to_string()))
     }
 

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -108,11 +108,15 @@ impl DiscoveredModel {
         let parallelism = self.server.parallelism.as_ref().ok_or_else(|| {
             client::protocol_error("RL discovery requires vLLM parallelism metadata")
         })?;
-        let world_size = parallelism
-            .tensor_parallel_size
-            .checked_mul(parallelism.pipeline_parallel_size)
+        let tensor_parallel_size = nonzero(parallelism.tensor_parallel_size)
+            .ok_or_else(|| client::protocol_error("vLLM reports a tensor-parallel size of zero"))?;
+        let pipeline_parallel_size =
+            nonzero(parallelism.pipeline_parallel_size).ok_or_else(|| {
+                client::protocol_error("vLLM reports a pipeline-parallel size of zero")
+            })?;
+        let world_size = tensor_parallel_size
+            .checked_mul(pipeline_parallel_size)
             .and_then(|size| size.checked_mul(parallelism.data_parallel_size))
-            .filter(|size| *size > 0)
             .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
         RlWorkerMetadata::new(world_size, admin_base_url)
             .map_err(|error| client::protocol_error(error.to_string()))

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use dynamo_backend_common::engine::RoutingHints;
 use dynamo_backend_common::{
     DisaggregationMode, FinishReason, GenerateContext, LLMEngine, MultimodalData, OutputOptions,
-    PrefillResult, PreprocessedRequest, SamplingOptions, StopConditions,
+    PrefillResult, PreprocessedRequest, RlWorkerMetadata, SamplingOptions, StopConditions,
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::{Stream, StreamExt};
@@ -459,6 +459,48 @@ fn server_info() -> pb::ServerInfo {
     }
 }
 
+#[test]
+fn discovered_model_reports_rl_worker_metadata() {
+    let model = DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery");
+    assert_eq!(
+        model
+            .rl_worker_metadata(Some("http://worker:8120".to_string()))
+            .expect("valid RL metadata"),
+        RlWorkerMetadata::new(
+            4,
+            Some("nccl".to_string()),
+            Some("http://worker:8120".to_string()),
+        )
+        .expect("valid expected metadata")
+    );
+}
+
+#[test]
+fn startup_compatibility_rejects_tensor_or_pipeline_parallelism_change() {
+    let bootstrap = DiscoveredModel::from_proto(model_info(), server_info())
+        .expect("valid bootstrap discovery");
+
+    for dimension in ["tensor", "pipeline"] {
+        let mut changed_server = server_info();
+        let parallelism = changed_server
+            .parallelism
+            .as_mut()
+            .expect("parallelism metadata");
+        match dimension {
+            "tensor" => parallelism.tensor_parallel_size += 1,
+            "pipeline" => parallelism.pipeline_parallel_size += 1,
+            _ => unreachable!(),
+        }
+        let observed = DiscoveredModel::from_proto(model_info(), changed_server)
+            .expect("valid startup discovery");
+
+        assert!(
+            bootstrap.ensure_startup_compatible(&observed).is_err(),
+            "{dimension} parallelism change should be rejected"
+        );
+    }
+}
+
 fn sequence_response(
     terminal: bool,
     logprobs: bool,
@@ -761,6 +803,9 @@ async fn engine_from_args(
         "dynamo-vllm-sidecar".to_string(),
         "--vllm-endpoint".to_string(),
         endpoint.to_string(),
+        "--vllm-http-endpoint".to_string(),
+        "http://worker:8120".to_string(),
+        "--enable-rl".to_string(),
         "--grpc-connections".to_string(),
         "2".to_string(),
         "--grpc-startup-deadline-secs".to_string(),
@@ -835,6 +880,17 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
     assert_eq!(worker.served_model_name.as_deref(), Some("served-model"));
     assert!(worker.reasoning_parser.is_none());
     assert!(worker.tool_call_parser.is_none());
+    assert_eq!(
+        worker.rl_metadata,
+        Some(
+            RlWorkerMetadata::new(
+                4,
+                Some("nccl".to_string()),
+                Some("http://worker:8120".to_string()),
+            )
+            .expect("valid RL metadata")
+        )
+    );
     let config = engine.start(0).await.expect("start");
     assert_eq!(config.model, "model-source");
     assert_eq!(config.served_model_name.as_deref(), Some("served-model"));

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -24,7 +24,7 @@ use tonic_health::ServingStatus as HealthServingStatus;
 
 use crate::client::{CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
 use crate::convert::{ResponseState, build_generate_request};
-use crate::engine::VllmSidecarEngine;
+use crate::engine::{VllmSidecarEngine, validate_http_endpoint};
 use crate::json::{json_to_struct, struct_to_json};
 use crate::model::DiscoveredModel;
 use crate::proto as pb;
@@ -469,6 +469,28 @@ fn discovered_model_reports_rl_worker_metadata() {
         RlWorkerMetadata::new(4, Some("http://worker:8120".to_string()))
             .expect("valid expected metadata")
     );
+}
+
+#[test]
+fn http_admin_endpoint_accepts_http_https_and_path_prefixes() {
+    for endpoint in [
+        "http://worker:8120",
+        "https://worker.example.com",
+        "https://worker.example.com/admin/v1",
+    ] {
+        assert_eq!(
+            validate_http_endpoint(endpoint).expect("valid HTTP admin endpoint"),
+            endpoint
+        );
+    }
+}
+
+#[test]
+fn http_admin_endpoint_rejects_invalid_values() {
+    for endpoint in ["", "worker:8120", "grpc://worker:8120", "https:///admin"] {
+        let error = validate_http_endpoint(endpoint).unwrap_err();
+        assert!(error.to_string().contains("--vllm-http-endpoint"));
+    }
 }
 
 #[test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -472,6 +472,25 @@ fn discovered_model_reports_rl_worker_metadata() {
 }
 
 #[test]
+fn rl_worker_metadata_identifies_zero_parallelism_dimensions() {
+    for (dimension, expected) in [
+        ("tensor", "tensor-parallel size of zero"),
+        ("pipeline", "pipeline-parallel size of zero"),
+    ] {
+        let mut server = server_info();
+        let parallelism = server.parallelism.as_mut().expect("parallelism metadata");
+        match dimension {
+            "tensor" => parallelism.tensor_parallel_size = 0,
+            "pipeline" => parallelism.pipeline_parallel_size = 0,
+            _ => unreachable!(),
+        }
+        let model = DiscoveredModel::from_proto(model_info(), server).expect("valid discovery");
+        let error = model.rl_worker_metadata(None).unwrap_err();
+        assert!(error.to_string().contains(expected));
+    }
+}
+
+#[test]
 fn http_admin_endpoint_accepts_http_https_and_path_prefixes() {
     for endpoint in [
         "http://worker:8120",

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -466,12 +466,8 @@ fn discovered_model_reports_rl_worker_metadata() {
         model
             .rl_worker_metadata(Some("http://worker:8120".to_string()))
             .expect("valid RL metadata"),
-        RlWorkerMetadata::new(
-            4,
-            Some("nccl".to_string()),
-            Some("http://worker:8120".to_string()),
-        )
-        .expect("valid expected metadata")
+        RlWorkerMetadata::new(4, Some("http://worker:8120".to_string()))
+            .expect("valid expected metadata")
     );
 }
 
@@ -883,12 +879,8 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
     assert_eq!(
         worker.rl_metadata,
         Some(
-            RlWorkerMetadata::new(
-                4,
-                Some("nccl".to_string()),
-                Some("http://worker:8120".to_string()),
-            )
-            .expect("valid RL metadata")
+            RlWorkerMetadata::new(4, Some("http://worker:8120".to_string()))
+                .expect("valid RL metadata")
         )
     );
     let config = engine.start(0).await.expect("start");


### PR DESCRIPTION
## Summary

- publish vLLM sidecar RL worker metadata through Dynamo discovery
- compute the inference world size from tensor, pipeline, and data parallelism
- advertise the optional vLLM HTTP admin endpoint for weight-transfer control
- reject topology or RL-capability drift between bootstrap and startup

## Dependency

Stacked on #13524, which defines the shared worker metadata contract. Once #13524 merges, this PR reduces to the four vLLM sidecar files.

## Validation

- cargo test -p dynamo-vllm-sidecar: 23 library tests and 1 executable test passed
- cargo clippy -p dynamo-vllm-sidecar --all-targets -- -D warnings
- cargo fmt --all
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RL worker metadata, including world size and optional administrative endpoint details.
  * RL discovery responses now include a protocol version and richer worker information.
  * vLLM workers can advertise an HTTP administrative endpoint for RL weight-transfer control.
* **Bug Fixes**
  * Improved validation for invalid metadata and blank endpoint values.
  * Startup checks now detect incompatible parallelism changes and handle model discovery failures more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up validation

- RED: HTTP endpoint tests failed before the dedicated validator existed; topology tests failed against the generic world-size error
- GREEN: `cargo test -p dynamo-vllm-sidecar --lib` (26 passed)
- GREEN: `cargo clippy -p dynamo-vllm-sidecar --all-targets -- -D warnings`
