### PR TITLE
feat(vllm): forward routed expert prompt offset

### DIFF
--- a/lib/mocker/servers/vllm/src/server_request.rs
+++ b/lib/mocker/servers/vllm/src/server_request.rs
@@ -293,6 +293,7 @@ impl PreparedRequest {
                 kv_transfer_params: (self.mode == ServerMode::Prefill).then(|| self.handoff()),
                 ec_transfer_params: None,
             }),
+            routed_experts: None,
         }
     }
 

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Inference source: [`rust/proto/inference.proto`](https://github.com/vllm-project/vllm/blob/3d1f5cee1552b8208f3009c75f8bc856f27e0eff/rust/proto/inference.proto) at `3d1f5cee1552b8208f3009c75f8bc856f27e0eff`
+- Inference source: [`rust/proto/inference.proto`](https://github.com/biswapanda/vllm/blob/100f970b4ee45036a6015f4fa852cf0610556633/rust/proto/inference.proto) at `100f970b4ee45036a6015f4fa852cf0610556633`
 - RL Control source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/76ebe5a217d7536a5661272c680f0b1e3a62f5be/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) at `76ebe5a217d7536a5661272c680f0b1e3a62f5be`
-- `inference.proto` SHA-256: `6152c306583166ecd691c9c715cab950523e8d1ed2db3dc2bcb538f6ca90e56f`
+- `inference.proto` SHA-256: `bad6c9101f81ab8b8b78bf3e7d70992796d859dbe81219fa6de119caf9a6d94a`
 - `control.proto` SHA-256: `db72b0782142054293b07fd48247cc821c048213b9c95dbc37fb0d81dde8f46f`
 
 The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Inference source: [`rust/proto/inference.proto`](https://github.com/biswapanda/vllm/blob/100f970b4ee45036a6015f4fa852cf0610556633/rust/proto/inference.proto) at `100f970b4ee45036a6015f4fa852cf0610556633`
+- Inference source: [`rust/proto/inference.proto`](https://github.com/biswapanda/vllm/blob/6eb8d5b352a50933177a639cc06f55d1c24f6f20/rust/proto/inference.proto) at `6eb8d5b352a50933177a639cc06f55d1c24f6f20`
 - RL Control source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/76ebe5a217d7536a5661272c680f0b1e3a62f5be/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) at `76ebe5a217d7536a5661272c680f0b1e3a62f5be`
-- `inference.proto` SHA-256: `bad6c9101f81ab8b8b78bf3e7d70992796d859dbe81219fa6de119caf9a6d94a`
+- `inference.proto` SHA-256: `608e4677a678bd2faeb97eb2145414db863a713b8df8c9164dd6b2fd04acc803`
 - `control.proto` SHA-256: `db72b0782142054293b07fd48247cc821c048213b9c95dbc37fb0d81dde8f46f`
 
 The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -164,7 +164,6 @@ message RoutedExperts {
   bytes data = 1;
   repeated uint32 shape = 2;
   string dtype = 3;
-  uint32 start = 4;
 }
 
 // Prompt info, returned in the first response
@@ -236,19 +235,7 @@ message MediaItem {
     string url = 2;       // http:// or https://
     string data_uri = 3;  // data:
     bytes raw_bytes = 4;
-    PreprocessedMediaFeatures features = 7;
   }
   string mime_type = 5;
   string uuid = 6;
-}
-
-// Engine-ready multimodal features produced by a version-compatible frontend.
-// `kwargs` is the MessagePack wire representation of one MmKwargsItem.
-message PreprocessedMediaFeatures {
-  optional bytes kwargs = 1;
-  string identifier = 2;
-  uint64 offset = 3;
-  uint64 length = 4;
-  optional string mm_hash = 5;
-  repeated bool is_embed = 6;
 }

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -107,6 +107,10 @@ message ResponseOptions {
   bool output_token_ids = 5;
   bool output_logprobs = 6;
   optional CandidateTokens output_candidates = 7;
+  // Defaults to true when omitted.
+  optional bool skip_special_tokens = 8;
+  // Skip routing rows for this already-returned prompt prefix.
+  optional uint32 routed_experts_prompt_start = 9;
 }
 
 message KVCacheParameters {
@@ -152,6 +156,15 @@ message SequenceOutput {
 
   // Only present in final output for this sequence
   optional FinishInfo finish_info = 8;
+  // Only present in final output when routed-experts capture is enabled.
+  optional RoutedExperts routed_experts = 9;
+}
+
+message RoutedExperts {
+  bytes data = 1;
+  repeated uint32 shape = 2;
+  string dtype = 3;
+  uint32 start = 4;
 }
 
 // Prompt info, returned in the first response
@@ -223,7 +236,19 @@ message MediaItem {
     string url = 2;       // http:// or https://
     string data_uri = 3;  // data:
     bytes raw_bytes = 4;
+    PreprocessedMediaFeatures features = 7;
   }
   string mime_type = 5;
   string uuid = 6;
+}
+
+// Engine-ready multimodal features produced by a version-compatible frontend.
+// `kwargs` is the MessagePack wire representation of one MmKwargsItem.
+message PreprocessedMediaFeatures {
+  optional bytes kwargs = 1;
+  string identifier = 2;
+  uint64 offset = 3;
+  uint64 length = 4;
+  optional string mm_hash = 5;
+  repeated bool is_embed = 6;
 }

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -19,6 +19,7 @@ const DYNAMO_CACHE_SALT_PREFIX: &str = "dynamo-cache-salt:";
 #[derive(Default)]
 struct VllmTitoProjection {
     priority: Option<i32>,
+    routed_experts_prompt_start: Option<u32>,
 }
 
 pub(crate) fn build_generate_request(
@@ -132,7 +133,7 @@ pub(crate) fn build_generate_request(
             output_logprobs: output_logprobs.is_some(),
             output_candidates: output_logprobs.map(top_n_candidates).transpose()?,
             skip_special_tokens: request.output_options.skip_special_tokens,
-            routed_experts_prompt_start: None,
+            routed_experts_prompt_start: vllm_tito.routed_experts_prompt_start,
         }),
         kv: Some(kv),
         truncate_prompt_tokens: 0,
@@ -252,6 +253,7 @@ fn validate_and_remove_vllm_tito(
                 | "skip_special_tokens"
                 | "include_stop_str_in_output"
                 | "return_token_ids"
+                | "routed_experts_prompt_start"
         ) {
             return Err(client::invalid_argument(format!(
                 "extra_args.vllm_tito.sampling_params.{key} is not supported by vLLM gRPC"
@@ -266,6 +268,20 @@ fn validate_and_remove_vllm_tito(
             "extra_args.vllm_tito.sampling_params.skip_special_tokens must be a boolean",
         ));
     }
+    let routed_experts_prompt_start = sampling
+        .get("routed_experts_prompt_start")
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            value
+                .as_u64()
+                .and_then(|value| u32::try_from(value).ok())
+                .ok_or_else(|| {
+                    client::invalid_argument(
+                        "extra_args.vllm_tito.sampling_params.routed_experts_prompt_start must be an unsigned 32-bit integer",
+                    )
+                })
+        })
+        .transpose()?;
     if sampling
         .get("return_token_ids")
         .is_some_and(|value| value != &serde_json::Value::Bool(true))
@@ -340,6 +356,7 @@ fn validate_and_remove_vllm_tito(
     }
     Ok(VllmTitoProjection {
         priority: Some(priority),
+        routed_experts_prompt_start,
     })
 }
 

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -117,6 +117,8 @@ pub(crate) fn build_generate_request(
             output_token_ids: true,
             output_logprobs: output_logprobs.is_some(),
             output_candidates: output_logprobs.map(top_n_candidates).transpose()?,
+            skip_special_tokens: None,
+            routed_experts_prompt_start: None,
         }),
         kv: Some(kv),
         truncate_prompt_tokens: 0,

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -16,6 +16,11 @@ const MM_HASHES_KEY: &str = "mm_hashes";
 // Must match DYNAMO_CACHE_SALT_PREFIX in lib/kv-router/src/zmq_wire/extra_keys.rs.
 const DYNAMO_CACHE_SALT_PREFIX: &str = "dynamo-cache-salt:";
 
+#[derive(Default)]
+struct VllmTitoProjection {
+    priority: Option<i32>,
+}
+
 pub(crate) fn build_generate_request(
     request: PreprocessedRequest,
     request_id: String,
@@ -56,7 +61,7 @@ pub(crate) fn build_generate_request(
         request.stop_conditions.min_tokens.unwrap_or(0)
     };
     let mut routing = request.routing;
-    let priority = routing
+    let mut priority = routing
         .as_ref()
         .and_then(|routing| routing.priority)
         .unwrap_or(0);
@@ -67,6 +72,15 @@ pub(crate) fn build_generate_request(
     let sampling = request.sampling_options;
     let stop_conditions = request.stop_conditions;
     let mut extra_args = request.extra_args;
+    let vllm_tito = validate_and_remove_vllm_tito(
+        &mut extra_args,
+        cache_salt.as_deref(),
+        priority,
+        &request_id,
+    )?;
+    if let Some(vllm_priority) = vllm_tito.priority {
+        priority = vllm_priority;
+    }
     consume_redundant_nvext(&mut extra_args, cache_salt.as_deref())?;
     if has_media && let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() {
         // These fields are already represented by token_ids and media.
@@ -117,7 +131,7 @@ pub(crate) fn build_generate_request(
             output_token_ids: true,
             output_logprobs: output_logprobs.is_some(),
             output_candidates: output_logprobs.map(top_n_candidates).transpose()?,
-            skip_special_tokens: None,
+            skip_special_tokens: request.output_options.skip_special_tokens,
             routed_experts_prompt_start: None,
         }),
         kv: Some(kv),
@@ -126,6 +140,246 @@ pub(crate) fn build_generate_request(
         session_id: None,
         media,
     })
+}
+
+fn validate_and_remove_vllm_tito(
+    extra_args: &mut Option<serde_json::Value>,
+    canonical_cache_salt: Option<&str>,
+    canonical_priority: i32,
+    canonical_request_id: &str,
+) -> Result<VllmTitoProjection, DynamoError> {
+    let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() else {
+        return Ok(VllmTitoProjection::default());
+    };
+    let Some(envelope) = extra.remove("vllm_tito") else {
+        return Ok(VllmTitoProjection::default());
+    };
+    let serde_json::Value::Object(envelope) = envelope else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito must be a JSON object",
+        ));
+    };
+
+    for key in envelope.keys() {
+        if !matches!(
+            key.as_str(),
+            "request_id"
+                | "sampling_params"
+                | "model"
+                | "stream"
+                | "stream_options"
+                | "cache_salt"
+                | "priority"
+                | "kv_transfer_params"
+                | "features"
+        ) {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.{key} is not supported by vLLM gRPC"
+            )));
+        }
+    }
+
+    if envelope
+        .get("request_id")
+        .and_then(serde_json::Value::as_str)
+        .is_none_or(|request_id| request_id != canonical_request_id)
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.request_id must match the canonical request ID",
+        ));
+    }
+    if envelope
+        .get("features")
+        .is_some_and(|features| !features.is_null())
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.features requires preprocessed multimodal gRPC support",
+        ));
+    }
+    if envelope
+        .get("model")
+        .is_some_and(|model| !model.is_null() && !model.is_string())
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.model must be a string",
+        ));
+    }
+    if envelope
+        .get("stream")
+        .is_some_and(|stream| stream != &serde_json::Value::Bool(false))
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.stream must be false",
+        ));
+    }
+    if envelope
+        .get("stream_options")
+        .is_some_and(|options| !options.is_null())
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.stream_options is not supported by vLLM gRPC",
+        ));
+    }
+
+    let sampling = envelope.get("sampling_params").ok_or_else(|| {
+        client::invalid_argument("extra_args.vllm_tito.sampling_params is required")
+    })?;
+    let serde_json::Value::Object(sampling) = sampling else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params must be a JSON object",
+        ));
+    };
+    for key in sampling.keys() {
+        if !matches!(
+            key.as_str(),
+            "temperature"
+                | "top_p"
+                | "top_k"
+                | "min_p"
+                | "seed"
+                | "max_tokens"
+                | "min_tokens"
+                | "presence_penalty"
+                | "frequency_penalty"
+                | "repetition_penalty"
+                | "stop"
+                | "stop_token_ids"
+                | "ignore_eos"
+                | "logprobs"
+                | "prompt_logprobs"
+                | "cache_salt"
+                | "skip_reading_prefix_cache"
+                | "skip_special_tokens"
+                | "include_stop_str_in_output"
+                | "return_token_ids"
+        ) {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.sampling_params.{key} is not supported by vLLM gRPC"
+            )));
+        }
+    }
+    if sampling
+        .get("skip_special_tokens")
+        .is_some_and(|value| !value.is_null() && !value.is_boolean())
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params.skip_special_tokens must be a boolean",
+        ));
+    }
+    if sampling
+        .get("return_token_ids")
+        .is_some_and(|value| value != &serde_json::Value::Bool(true))
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params.return_token_ids must be true",
+        ));
+    }
+    validate_compat_cache_salt(
+        sampling.get("cache_salt"),
+        canonical_cache_salt,
+        "sampling_params.cache_salt",
+    )?;
+    validate_compat_cache_salt(
+        envelope.get("cache_salt"),
+        canonical_cache_salt,
+        "cache_salt",
+    )?;
+
+    if let Some(skip_reading_prefix_cache) = sampling
+        .get("skip_reading_prefix_cache")
+        .filter(|value| !value.is_null())
+    {
+        if !skip_reading_prefix_cache.is_boolean() {
+            return Err(client::invalid_argument(
+                "extra_args.vllm_tito.sampling_params.skip_reading_prefix_cache must be a boolean",
+            ));
+        }
+        if let Some(bypass_prefix_cache) = extra.get("bypass_prefix_cache")
+            && bypass_prefix_cache != skip_reading_prefix_cache
+        {
+            return Err(client::invalid_argument(
+                "extra_args.vllm_tito.sampling_params.skip_reading_prefix_cache conflicts with extra_args.bypass_prefix_cache",
+            ));
+        }
+        insert_compatible_projection(
+            extra,
+            "skip_reading_prefix_cache",
+            skip_reading_prefix_cache.clone(),
+            "sampling_params.skip_reading_prefix_cache",
+        )?;
+    }
+    if let Some(kv_transfer_params) = envelope.get("kv_transfer_params")
+        && !kv_transfer_params.is_null()
+    {
+        if !kv_transfer_params.is_object() {
+            return Err(client::invalid_argument(
+                "extra_args.vllm_tito.kv_transfer_params must be a JSON object",
+            ));
+        }
+        insert_compatible_projection(
+            extra,
+            "kv_transfer_params",
+            kv_transfer_params.clone(),
+            "kv_transfer_params",
+        )?;
+    }
+
+    let priority = envelope
+        .get("priority")
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|priority| i32::try_from(priority).ok())
+        .ok_or_else(|| {
+            client::invalid_argument(
+                "extra_args.vllm_tito.priority must be a signed 32-bit integer",
+            )
+        })?;
+    if priority.saturating_neg() != canonical_priority {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.priority does not match the canonical Dynamo routing priority",
+        ));
+    }
+    Ok(VllmTitoProjection {
+        priority: Some(priority),
+    })
+}
+
+fn insert_compatible_projection(
+    extra: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    value: serde_json::Value,
+    envelope_path: &str,
+) -> Result<(), DynamoError> {
+    if let Some(existing) = extra.get(key) {
+        if existing != &value {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.{envelope_path} conflicts with extra_args.{key}"
+            )));
+        }
+    } else {
+        extra.insert(key.to_string(), value);
+    }
+    Ok(())
+}
+
+fn validate_compat_cache_salt(
+    value: Option<&serde_json::Value>,
+    canonical: Option<&str>,
+    path: &str,
+) -> Result<(), DynamoError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let Some(value) = value.as_str() else {
+        return Err(client::invalid_argument(format!(
+            "extra_args.vllm_tito.{path} must be a string"
+        )));
+    };
+    if Some(value) != canonical {
+        return Err(client::invalid_argument(format!(
+            "extra_args.vllm_tito.{path} must match the canonical cache_salt"
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn data_parallel_rank(
@@ -361,6 +615,11 @@ fn build_media(
 }
 
 fn top_n_candidates(count: u32) -> Result<pb::CandidateTokens, DynamoError> {
+    if count == u32::MAX {
+        return Ok(pb::CandidateTokens {
+            select: Some(pb::candidate_tokens::Select::All(true)),
+        });
+    }
     i32::try_from(count).map_err(|_| {
         client::invalid_argument(format!(
             "vLLM logprobs request must fit in i32; got {count}"
@@ -605,11 +864,6 @@ fn validate_request(
     if request.stop_conditions.max_thinking_tokens.is_some() {
         return Err(client::invalid_argument(
             "max_thinking_tokens is not supported by vLLM gRPC v0.25.1",
-        ));
-    }
-    if request.output_options.skip_special_tokens == Some(false) {
-        return Err(client::invalid_argument(
-            "skip_special_tokens=false is not supported by vLLM gRPC v0.25.1",
         ));
     }
     let sampling = &request.sampling_options;

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -7,6 +7,7 @@ use crate::client;
 use crate::proto as pb;
 
 const SUPPORTED_API_VERSION: &str = "vllm";
+const VLLM_INFERENCE_V1_GENERATE_CAPABILITY: &str = "vllm_inference_v1_generate";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ModelIdentity {
@@ -108,7 +109,11 @@ impl DiscoveredModel {
             model: self.source.clone(),
             served_model_name: Some(self.served_name.clone()),
             model_aliases: self.identity.aliases.clone(),
-            runtime_data: Default::default(),
+            runtime_data: [(
+                VLLM_INFERENCE_V1_GENERATE_CAPABILITY.to_string(),
+                serde_json::Value::Bool(true),
+            )]
+            .into(),
             llm: Some(LlmRegistration {
                 context_length: nonzero(self.server.max_model_len),
                 kv_cache_block_size: nonzero(self.server.kv_block_size),

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -489,6 +489,7 @@ fn sequence_response(
                 kv_transfer_params,
                 ec_transfer_params: None,
             }),
+            routed_experts: None,
         }),
     }
 }

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -713,6 +713,65 @@ fn token_native_compatibility_envelope_is_accepted_when_fields_are_projected() {
 }
 
 #[test]
+fn routed_expert_prompt_offset_is_forwarded() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {"routed_experts_prompt_start": 2},
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("valid routed-expert prompt offset");
+
+    assert_eq!(
+        wire.response
+            .expect("response options")
+            .routed_experts_prompt_start,
+        Some(2)
+    );
+}
+
+#[test]
+fn routed_expert_prompt_offset_rejects_invalid_values() {
+    for value in [
+        json!(-1),
+        json!(u64::from(u32::MAX) + 1),
+        json!(1.5),
+        json!("2"),
+    ] {
+        let mut request = request();
+        request.extra_args = Some(json!({
+            "vllm_tito": {
+                "request_id": "request-1",
+                "sampling_params": {"routed_experts_prompt_start": value},
+                "stream": false,
+                "priority": 0
+            }
+        }));
+
+        let error = build_generate_request(
+            request,
+            "request-1".to_string(),
+            DisaggregationMode::Aggregated,
+        )
+        .expect_err("invalid routed-expert prompt offset must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("routed_experts_prompt_start must be an unsigned 32-bit integer")
+        );
+    }
+}
+
+#[test]
 fn token_native_compatibility_envelope_rejects_disabled_token_ids() {
     let mut request = request();
     request.extra_args = Some(json!({

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -459,6 +459,18 @@ fn server_info() -> pb::ServerInfo {
     }
 }
 
+#[test]
+fn discovered_model_advertises_token_native_generate() {
+    let model = DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery");
+    assert_eq!(
+        model
+            .engine_config()
+            .runtime_data
+            .get("vllm_inference_v1_generate"),
+        Some(&serde_json::Value::Bool(true))
+    );
+}
+
 fn sequence_response(
     terminal: bool,
     logprobs: bool,
@@ -587,6 +599,30 @@ fn zero_output_logprobs_omits_top_logprobs() {
 }
 
 #[test]
+fn all_logprobs_use_the_proto_all_selector() {
+    let mut request = request();
+    request.output_options.logprobs = Some(u32::MAX);
+    request.output_options.prompt_logprobs = Some(u32::MAX);
+
+    let wire = build_generate_request(
+        request,
+        "all-logprobs".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("build request");
+    let response = wire.response.expect("response options");
+
+    assert!(matches!(
+        response.output_candidates.and_then(|value| value.select),
+        Some(pb::candidate_tokens::Select::All(true))
+    ));
+    assert!(matches!(
+        response.prompt_candidates.and_then(|value| value.select),
+        Some(pb::candidate_tokens::Select::All(true))
+    ));
+}
+
+#[test]
 fn oversized_logprob_counts_are_rejected() {
     let oversized = i32::MAX as u32 + 1;
 
@@ -609,6 +645,248 @@ fn oversized_logprob_counts_are_rejected() {
     )
     .expect_err("oversized prompt logprobs must fail");
     assert!(prompt_error.to_string().contains("must fit in i32"));
+}
+
+#[test]
+fn token_native_compatibility_envelope_is_accepted_when_fields_are_projected() {
+    let mut request = request();
+    request.output_options.skip_special_tokens = Some(false);
+    request.routing.as_mut().unwrap().priority = Some(-7);
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "top_k": 4,
+                "min_p": 0.1,
+                "seed": 123,
+                "max_tokens": 1,
+                "min_tokens": 1,
+                "presence_penalty": 0.3,
+                "frequency_penalty": 0.4,
+                "repetition_penalty": 1.1,
+                "stop": ["done"],
+                "stop_token_ids": [2],
+                "ignore_eos": true,
+                "logprobs": 1,
+                "prompt_logprobs": 1,
+                "cache_salt": "cache-salt",
+                "skip_reading_prefix_cache": true,
+                "skip_special_tokens": false,
+                "include_stop_str_in_output": true,
+                "return_token_ids": true
+            },
+            "model": "served-model",
+            "stream": false,
+            "cache_salt": "cache-salt",
+            "priority": 7,
+            "kv_transfer_params": {
+                "connector_data": {"values": [1, true, null]}
+            }
+        }
+    }));
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("projected compatibility envelope");
+
+    assert_eq!(wire.temperature, Some(0.2));
+    assert_eq!(wire.stopping.as_ref().unwrap().stop_token_ids, [2]);
+    assert_eq!(wire.stopping.as_ref().unwrap().stop_strings, ["done"]);
+    assert!(wire.stopping.as_ref().unwrap().include_stop_strings);
+    assert_eq!(
+        wire.response.as_ref().unwrap().skip_special_tokens,
+        Some(false)
+    );
+    assert!(wire.response.as_ref().unwrap().output_logprobs);
+    assert_eq!(
+        wire.kv.as_ref().unwrap().cache_salt,
+        "dynamo-cache-salt:cache-salt"
+    );
+    assert!(wire.kv.as_ref().unwrap().bypass_prefix_cache);
+    assert!(wire.kv.as_ref().unwrap().kv_transfer_params.is_some());
+    assert_eq!(wire.priority, 7);
+}
+
+#[test]
+fn token_native_compatibility_envelope_rejects_disabled_token_ids() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {"max_tokens": 1, "return_token_ids": false},
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("the token-native sidecar always returns token IDs");
+
+    assert!(
+        error
+            .to_string()
+            .contains("sampling_params.return_token_ids must be true")
+    );
+}
+
+#[test]
+fn token_native_compatibility_envelope_rejects_conflicting_cache_salt() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {"max_tokens": 1, "cache_salt": "different-policy-version"},
+            "cache_salt": "cache-salt",
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("duplicate cache salts must match the canonical routing salt");
+
+    assert!(
+        error
+            .to_string()
+            .contains("sampling_params.cache_salt must match the canonical cache_salt")
+    );
+}
+
+#[test]
+fn token_native_compatibility_envelope_rejects_conflicting_prefix_cache_aliases() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "bypass_prefix_cache": true,
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {"skip_reading_prefix_cache": false},
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("prefix-cache aliases must agree");
+
+    assert!(
+        error
+            .to_string()
+            .contains("conflicts with extra_args.bypass_prefix_cache")
+    );
+}
+
+#[test]
+fn token_native_compatibility_envelope_treats_optional_nulls_as_omitted() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {
+                "skip_reading_prefix_cache": null,
+                "skip_special_tokens": null
+            },
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("optional nulls should be omitted");
+}
+
+#[test]
+fn token_native_compatibility_envelope_rejects_unprojected_fields() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {"max_tokens": 1, "future_sampling_field": true},
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("unprojected compatibility fields must fail closed");
+
+    assert!(
+        error
+            .to_string()
+            .contains("extra_args.vllm_tito.sampling_params.future_sampling_field")
+    );
+}
+
+#[test]
+fn token_native_compatibility_envelope_rejects_multimodal_features_without_support() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {},
+            "stream": false,
+            "priority": 0,
+            "features": {"mm_hashes": {"image": ["untrusted"]}}
+        }
+    }));
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("preprocessed features must fail until their transport is enabled");
+
+    assert!(
+        error
+            .to_string()
+            .contains("requires preprocessed multimodal")
+    );
+}
+
+#[test]
+fn skip_special_tokens_false_is_forwarded_to_vllm() {
+    let mut request = request();
+    request.output_options.skip_special_tokens = Some(false);
+
+    let mapped = build_generate_request(
+        request,
+        "skip-special-tokens".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("skip_special_tokens=false should be supported");
+
+    assert_eq!(
+        mapped
+            .response
+            .expect("response options")
+            .skip_special_tokens,
+        Some(false)
+    );
 }
 
 struct FakeServer {

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -740,6 +740,43 @@ fn routed_expert_prompt_offset_is_forwarded() {
 }
 
 #[test]
+fn routed_expert_prompt_offset_preserves_optional_and_boundary_values() {
+    for (sampling_params, expected) in [
+        (json!({}), None),
+        (json!({"routed_experts_prompt_start": null}), None),
+        (json!({"routed_experts_prompt_start": 0}), Some(0)),
+        (
+            json!({"routed_experts_prompt_start": u32::MAX}),
+            Some(u32::MAX),
+        ),
+    ] {
+        let mut request = request();
+        request.extra_args = Some(json!({
+            "vllm_tito": {
+                "request_id": "request-1",
+                "sampling_params": sampling_params,
+                "stream": false,
+                "priority": 0
+            }
+        }));
+
+        let wire = build_generate_request(
+            request,
+            "request-1".to_string(),
+            DisaggregationMode::Aggregated,
+        )
+        .expect("valid routed-expert prompt offset boundary");
+
+        assert_eq!(
+            wire.response
+                .expect("response options")
+                .routed_experts_prompt_start,
+            expected
+        );
+    }
+}
+
+#[test]
 fn routed_expert_prompt_offset_rejects_invalid_values() {
     for value in [
         json!(-1),


### PR DESCRIPTION
## Summary

- forward the optional native `routed_experts_prompt_start` Generate control into vLLM gRPC response options
- preserve absent and null values as unset while accepting the full `uint32` wire range
- reject negative, fractional, string, and overflowing values at the Dynamo boundary

The offset is a generic vLLM request-side capture control. It is not embedded in or echoed with the native routed-expert tensor. Prime-RL retains its requested offset locally and associates it in the Verifiers response adapter.

## Stack

- #13527 supplies the synchronized optional protobuf field
- #13532 supplies native Generate request validation and projection
- #13531 is the independent native response-output slice and does not require this request-control leaf
- vllm-project/vllm#52703 is the merged runtime counterpart for the request field

## Validation

- `cargo test -p dynamo-vllm-sidecar routed_expert_prompt_offset --lib`
- combined integration suite: 49 sidecar library tests and 1 executable test passed
- live Dynamo generation forwarded a nonzero prompt start, while the Prime adapter associated `start=1` from request context
- `cargo fmt --all -- --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing routed-expert data, including its format and shape metadata.
  * Added generation options for skipping special tokens and selecting routed-expert prompt offsets.
  * Added vLLM compatibility support for request priorities, cache settings, KV transfer, and related configuration.
  * Added runtime metadata indicating support for vLLM generation.
  * Candidate-token requests can now select all available candidates.

* **Bug Fixes**
  * Improved validation and error reporting for unsupported, conflicting, or invalid generation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->