### PR TITLE
fix(replay): apply the aic speculation flags to the engine args

### DIFF
--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -657,10 +657,29 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser.error(
                 "--max-sim-time-seconds is not supported with --planner-config"
             )
+    if args.aic_nextn_accept_rates is not None and args.aic_nextn is None:
+        # The engine args validator rejects this pair, but it raises from
+        # MockEngineArgs.from_json below, which is outside the error handling
+        # that turns a bad value into a usage message.
+        parser.error("--aic-nextn-accept-rates requires --aic-nextn")
+
     # Speculation is a decode-side concept, so the flags are defaulted into the
-    # aggregated and decode engine args only. Prefill does not speculate, and
-    # modelling it there would change prefill timing.
-    extra_raw = _with_aic_speculation(base_config.extra_engine_args, args)
+    # aggregated or the decode engine args, never prefill: prefill does not
+    # speculate and modelling it there would change prefill timing.
+    #
+    # The aggregated slot has to stay empty for a disaggregated run.
+    # validate_replay_args_mode rejects extra_engine_args combined with
+    # prefill/decode args, so inventing aggregated args here would abort the run
+    # rather than simulate it.
+    disagg_engine_args = (
+        base_config.prefill_engine_args is not None
+        or base_config.decode_engine_args is not None
+    )
+    extra_raw = (
+        base_config.extra_engine_args
+        if disagg_engine_args
+        else _with_aic_speculation(base_config.extra_engine_args, args)
+    )
     extra_engine_args = _load_engine_args(
         json.dumps(extra_raw) if extra_raw is not None else None
     )
@@ -669,7 +688,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         if base_config.prefill_engine_args is not None
         else None
     )
-    decode_raw = _with_aic_speculation(base_config.decode_engine_args, args)
+    # Only when decode args already exist. Creating them from the flags alone
+    # would turn "prefill and decode must be provided together" into a
+    # different failure.
+    decode_raw = (
+        _with_aic_speculation(base_config.decode_engine_args, args)
+        if base_config.decode_engine_args is not None
+        else None
+    )
     decode_engine_args = _load_engine_args(
         json.dumps(decode_raw) if decode_raw is not None else None
     )

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -102,8 +102,8 @@ def _with_aic_speculation(raw: dict | None, args) -> dict | None:
     per worker type. Returns ``raw`` untouched when neither flag was given, so
     a run with no engine args and no speculation keeps passing ``None``.
     """
-    nextn = getattr(args, "aic_nextn", None)
-    accept_rates = getattr(args, "aic_nextn_accept_rates", None)
+    nextn = args.aic_nextn
+    accept_rates = args.aic_nextn_accept_rates
     if nextn is None and accept_rates is None:
         return raw
 
@@ -148,7 +148,15 @@ def _load_engine_args(raw_args: str | None):
             else:
                 del raw["planner_profile_data"]
     _resolve_aic_num_gpu_blocks(raw)
-    return MockEngineArgs.from_json(json.dumps(raw))
+    try:
+        return MockEngineArgs.from_json(json.dumps(raw))
+    except Exception as exc:
+        # The engine validators live in Rust and reach Python through PyO3 as a
+        # bare `Exception`, so there is no narrower type to catch. Convert here,
+        # at the one call that produces them, rather than widening the caller's
+        # handler: everything this function raises is then a bad-input error and
+        # the caller can keep reporting exactly that as a usage error.
+        raise ValueError(str(exc)) from exc
 
 
 def _load_aic_perf_config(args: argparse.Namespace):

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -89,6 +89,32 @@ def _resolve_aic_num_gpu_blocks(raw: dict) -> None:
     raw.update(lowered)
 
 
+def _with_aic_speculation(raw: dict | None, args) -> dict | None:
+    """Default the speculative-decoding engine args from the ``--aic-*`` flags.
+
+    ``--aic-nextn`` and ``--aic-nextn-accept-rates`` are routed into
+    ``AicPerfConfig``, which only feeds the router's prefill-load estimator. The
+    engine timing and the speculative burst sampler read them off the engine
+    args instead, which is why the same values passed through
+    ``--extra-engine-args`` take effect while the dedicated flags did not.
+
+    An explicit value in the engine args wins, so a caller can still override
+    per worker type. Returns ``raw`` untouched when neither flag was given, so
+    a run with no engine args and no speculation keeps passing ``None``.
+    """
+    nextn = getattr(args, "aic_nextn", None)
+    accept_rates = getattr(args, "aic_nextn_accept_rates", None)
+    if nextn is None and accept_rates is None:
+        return raw
+
+    merged = dict(raw or {})
+    if nextn is not None:
+        merged.setdefault("aic_nextn", nextn)
+    if accept_rates is not None:
+        merged.setdefault("aic_nextn_accept_rates", accept_rates)
+    return merged
+
+
 def _load_engine_args(raw_args: str | None):
     if raw_args is None:
         return None
@@ -631,20 +657,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser.error(
                 "--max-sim-time-seconds is not supported with --planner-config"
             )
+    # Speculation is a decode-side concept, so the flags are defaulted into the
+    # aggregated and decode engine args only. Prefill does not speculate, and
+    # modelling it there would change prefill timing.
+    extra_raw = _with_aic_speculation(base_config.extra_engine_args, args)
     extra_engine_args = _load_engine_args(
-        json.dumps(base_config.extra_engine_args)
-        if base_config.extra_engine_args is not None
-        else None
+        json.dumps(extra_raw) if extra_raw is not None else None
     )
     prefill_engine_args = _load_engine_args(
         json.dumps(base_config.prefill_engine_args)
         if base_config.prefill_engine_args is not None
         else None
     )
+    decode_raw = _with_aic_speculation(base_config.decode_engine_args, args)
     decode_engine_args = _load_engine_args(
-        json.dumps(base_config.decode_engine_args)
-        if base_config.decode_engine_args is not None
-        else None
+        json.dumps(decode_raw) if decode_raw is not None else None
     )
     router_config = _load_router_config(
         args.router_config,

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -657,16 +657,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser.error(
                 "--max-sim-time-seconds is not supported with --planner-config"
             )
-    # These two checks exist because defaulting the flags into the engine args
-    # moves their validation earlier. Both conditions are already rejected, by
-    # normalize_conditional_accept_rates, but that now raises from
-    # MockEngineArgs.from_json below, which is outside the error handling that
-    # turns a bad value into a usage message.
-    if args.aic_nextn_accept_rates is not None and args.aic_nextn is None:
-        parser.error("--aic-nextn-accept-rates requires --aic-nextn")
-    if args.aic_nextn is not None and not 1 <= args.aic_nextn <= 5:
-        parser.error(f"--aic-nextn must be in 1..=5, got {args.aic_nextn}")
-
     # Speculation is a decode-side concept, so the flags are defaulted into the
     # aggregated or the decode engine args, never prefill: prefill does not
     # speculate and modelling it there would change prefill timing.
@@ -684,14 +674,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         if disagg_engine_args
         else _with_aic_speculation(base_config.extra_engine_args, args)
     )
-    extra_engine_args = _load_engine_args(
-        json.dumps(extra_raw) if extra_raw is not None else None
-    )
-    prefill_engine_args = _load_engine_args(
-        json.dumps(base_config.prefill_engine_args)
-        if base_config.prefill_engine_args is not None
-        else None
-    )
     # Only when decode args already exist. Creating them from the flags alone
     # would turn "prefill and decode must be provided together" into a
     # different failure.
@@ -700,9 +682,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         if base_config.decode_engine_args is not None
         else None
     )
-    decode_engine_args = _load_engine_args(
-        json.dumps(decode_raw) if decode_raw is not None else None
-    )
+    # The engine-args validators live in the simulation engine and raise out of
+    # MockEngineArgs.from_json. Report them as usage errors, the way the
+    # neighbouring config loads in this function already do, so a bad flag or a
+    # bad --extra-engine-args key gives a usage message instead of a traceback.
+    try:
+        extra_engine_args = _load_engine_args(
+            json.dumps(extra_raw) if extra_raw is not None else None
+        )
+        prefill_engine_args = _load_engine_args(
+            json.dumps(base_config.prefill_engine_args)
+            if base_config.prefill_engine_args is not None
+            else None
+        )
+        decode_engine_args = _load_engine_args(
+            json.dumps(decode_raw) if decode_raw is not None else None
+        )
+    except (ValueError, RuntimeError) as exc:
+        parser.error(str(exc))
     router_config = _load_router_config(
         args.router_config,
         args.router_policy_config,

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -657,11 +657,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser.error(
                 "--max-sim-time-seconds is not supported with --planner-config"
             )
+    # These two checks exist because defaulting the flags into the engine args
+    # moves their validation earlier. Both conditions are already rejected, by
+    # normalize_conditional_accept_rates, but that now raises from
+    # MockEngineArgs.from_json below, which is outside the error handling that
+    # turns a bad value into a usage message.
     if args.aic_nextn_accept_rates is not None and args.aic_nextn is None:
-        # The engine args validator rejects this pair, but it raises from
-        # MockEngineArgs.from_json below, which is outside the error handling
-        # that turns a bad value into a usage message.
         parser.error("--aic-nextn-accept-rates requires --aic-nextn")
+    if args.aic_nextn is not None and not 1 <= args.aic_nextn <= 5:
+        parser.error(f"--aic-nextn must be in 1..=5, got {args.aic_nextn}")
 
     # Speculation is a decode-side concept, so the flags are defaulted into the
     # aggregated or the decode engine args, never prefill: prefill does not

--- a/components/src/dynamo/replay/tests/test_main.py
+++ b/components/src/dynamo/replay/tests/test_main.py
@@ -369,3 +369,51 @@ def test_engine_and_dynamo_mains_apply_identical_aic_capacity_lowering(
     assert engine_blocks == dynamo_blocks == 444
     assert len(estimator_calls) == 2
     assert all("nextn" not in call for call in estimator_calls)
+
+
+class _AicSpecArgs:
+    """Only the two attributes `_with_aic_speculation` reads."""
+
+    def __init__(self, aic_nextn=None, aic_nextn_accept_rates=None) -> None:
+        self.aic_nextn = aic_nextn
+        self.aic_nextn_accept_rates = aic_nextn_accept_rates
+
+
+def test_aic_speculation_flags_reach_the_engine_args() -> None:
+    # The flags are routed into AicPerfConfig, which only feeds the router's
+    # prefill-load estimator. The burst sampler reads them off the engine args,
+    # so without this the simulation modelled no speculation at all.
+    merged = replay_main._with_aic_speculation(
+        None, _AicSpecArgs(aic_nextn=5, aic_nextn_accept_rates="1,1,1,1,1")
+    )
+
+    assert merged == {"aic_nextn": 5, "aic_nextn_accept_rates": "1,1,1,1,1"}
+
+
+def test_aic_speculation_does_not_invent_engine_args() -> None:
+    # A run with no engine args and no speculation must keep passing None
+    # rather than an empty dict.
+    assert replay_main._with_aic_speculation(None, _AicSpecArgs()) is None
+
+
+def test_explicit_engine_args_win_over_the_aic_flags() -> None:
+    # --extra-engine-args is the documented per-worker override, so a value
+    # already present there is not overwritten by the CLI default.
+    merged = replay_main._with_aic_speculation(
+        {"aic_nextn": 2, "block_size": 16},
+        _AicSpecArgs(aic_nextn=5, aic_nextn_accept_rates="1,1,1,1,1"),
+    )
+
+    assert merged["aic_nextn"] == 2
+    assert merged["block_size"] == 16
+    assert merged["aic_nextn_accept_rates"] == "1,1,1,1,1"
+
+
+def test_zero_accept_rate_is_not_treated_as_unset() -> None:
+    # "--aic-nextn 1 --aic-nextn-accept-rates 0" is a meaningful configuration
+    # (draft never accepted); a falsy check would silently drop it.
+    merged = replay_main._with_aic_speculation(
+        None, _AicSpecArgs(aic_nextn=1, aic_nextn_accept_rates="0")
+    )
+
+    assert merged == {"aic_nextn": 1, "aic_nextn_accept_rates": "0"}

--- a/components/src/dynamo/replay/tests/test_main.py
+++ b/components/src/dynamo/replay/tests/test_main.py
@@ -32,8 +32,15 @@ pytestmark = [
 ]
 
 
-def _stub_cli_dependencies(monkeypatch, seen: dict) -> None:
-    monkeypatch.setattr(replay_main, "_load_engine_args", lambda value: value)
+def _stub_cli_dependencies(
+    monkeypatch, seen: dict, *, stub_engine_args: bool = True
+) -> None:
+    # `stub_engine_args=False` lets the real MockEngineArgs validators run, which
+    # is the point for the tests that assert a bad flag becomes a usage error:
+    # with the pass-through stub nothing validates, so such a test would only be
+    # exercising a CLI-side duplicate of the engine's own check.
+    if stub_engine_args:
+        monkeypatch.setattr(replay_main, "_load_engine_args", lambda value: value)
     monkeypatch.setattr(
         replay_main,
         "_load_router_config",
@@ -471,7 +478,7 @@ def test_accept_rates_without_nextn_is_a_usage_error(monkeypatch) -> None:
     # MockEngineArgs.from_json, outside the handling that produces a usage
     # message, so the user would see a traceback instead.
     seen: dict = {}
-    _stub_cli_dependencies(monkeypatch, seen)
+    _stub_cli_dependencies(monkeypatch, seen, stub_engine_args=False)
 
     with pytest.raises(SystemExit):
         replay_main.main(
@@ -492,11 +499,11 @@ def test_accept_rates_without_nextn_is_a_usage_error(monkeypatch) -> None:
 
 @pytest.mark.parametrize("nextn", ["0", "6"])
 def test_out_of_range_nextn_is_a_usage_error(monkeypatch, nextn) -> None:
-    # normalize_conditional_accept_rates already rejects anything outside
-    # 1..=5, but defaulting the flag into the engine args moves that error
-    # ahead of the handling that turns it into a usage message.
+    # The engine rejects anything outside 1..=5. This asserts the CLI turns that
+    # into a usage error rather than a traceback, so the real validator has to
+    # run here.
     seen: dict = {}
-    _stub_cli_dependencies(monkeypatch, seen)
+    _stub_cli_dependencies(monkeypatch, seen, stub_engine_args=False)
 
     with pytest.raises(SystemExit):
         replay_main.main(

--- a/components/src/dynamo/replay/tests/test_main.py
+++ b/components/src/dynamo/replay/tests/test_main.py
@@ -488,3 +488,28 @@ def test_accept_rates_without_nextn_is_a_usage_error(monkeypatch) -> None:
                 "1,1",
             ]
         )
+
+
+@pytest.mark.parametrize("nextn", ["0", "6"])
+def test_out_of_range_nextn_is_a_usage_error(monkeypatch, nextn) -> None:
+    # normalize_conditional_accept_rates already rejects anything outside
+    # 1..=5, but defaulting the flag into the engine args moves that error
+    # ahead of the handling that turns it into a usage message.
+    seen: dict = {}
+    _stub_cli_dependencies(monkeypatch, seen)
+
+    with pytest.raises(SystemExit):
+        replay_main.main(
+            [
+                "--input-tokens",
+                "8",
+                "--output-tokens",
+                "4",
+                "--request-count",
+                "1",
+                "--replay-concurrency",
+                "1",
+                "--aic-nextn",
+                nextn,
+            ]
+        )

--- a/components/src/dynamo/replay/tests/test_main.py
+++ b/components/src/dynamo/replay/tests/test_main.py
@@ -473,6 +473,50 @@ def test_disagg_run_keeps_the_aggregated_engine_args_empty(
     assert "aic_nextn" not in seen["native_kwargs"]["prefill_engine_args"]
 
 
+def test_aggregated_run_wires_the_speculation_flags_into_the_engine_args(
+    monkeypatch,
+) -> None:
+    # The helper-level cases call _with_aic_speculation directly, so a break
+    # between the parser and the merge would leave the flags dropped again,
+    # which is the bug this change exists to fix. This drives the same path the
+    # disaggregated case above covers, for the aggregated slot.
+    seen: dict = {}
+    _stub_cli_dependencies(monkeypatch, seen)
+
+    def run_synthetic(*args, **kwargs):
+        seen["native_kwargs"] = kwargs
+        return ReplayReport(
+            summary={"completed_requests": 1}, per_request=[], coverage={}, planner=None
+        )
+
+    monkeypatch.setattr(replay_main, "run_synthetic_trace_replay", run_synthetic)
+
+    assert (
+        replay_main.main(
+            [
+                "--input-tokens",
+                "8",
+                "--output-tokens",
+                "4",
+                "--request-count",
+                "1",
+                "--replay-concurrency",
+                "1",
+                "--aic-nextn",
+                "5",
+                "--aic-nextn-accept-rates",
+                "1,1,1,1,1",
+            ]
+        )
+        == 0
+    )
+
+    # No --extra-engine-args, so the aggregated slot is created from the flags.
+    extra = seen["native_kwargs"]["extra_engine_args"]
+    assert '"aic_nextn": 5' in extra
+    assert '"aic_nextn_accept_rates": "1,1,1,1,1"' in extra
+
+
 def test_accept_rates_without_nextn_is_a_usage_error(monkeypatch) -> None:
     # The engine args validator rejects the pair, but it raises from
     # MockEngineArgs.from_json, outside the handling that produces a usage

--- a/components/src/dynamo/replay/tests/test_main.py
+++ b/components/src/dynamo/replay/tests/test_main.py
@@ -417,3 +417,74 @@ def test_zero_accept_rate_is_not_treated_as_unset() -> None:
     )
 
     assert merged == {"aic_nextn": 1, "aic_nextn_accept_rates": "0"}
+
+
+def test_disagg_run_keeps_the_aggregated_engine_args_empty(
+    monkeypatch, tmp_path
+) -> None:
+    # validate_replay_args_mode rejects extra_engine_args combined with
+    # prefill/decode args, so defaulting the speculation flags into the
+    # aggregated slot would abort a disaggregated run instead of simulating it.
+    seen: dict = {}
+    _stub_cli_dependencies(monkeypatch, seen)
+
+    def run_synthetic(*args, **kwargs):
+        seen["native_kwargs"] = kwargs
+        return ReplayReport(
+            summary={"completed_requests": 1}, per_request=[], coverage={}, planner=None
+        )
+
+    monkeypatch.setattr(replay_main, "run_synthetic_trace_replay", run_synthetic)
+
+    assert (
+        replay_main.main(
+            [
+                "--input-tokens",
+                "8",
+                "--output-tokens",
+                "4",
+                "--request-count",
+                "1",
+                "--replay-concurrency",
+                "1",
+                "--prefill-engine-args",
+                json.dumps({"engine_type": "vllm"}),
+                "--decode-engine-args",
+                json.dumps({"engine_type": "vllm"}),
+                "--aic-nextn",
+                "5",
+                "--aic-nextn-accept-rates",
+                "1,1,1,1,1",
+            ]
+        )
+        == 0
+    )
+
+    assert seen["native_kwargs"]["extra_engine_args"] is None
+    # The decode worker is where the burst sampler reads them.
+    assert '"aic_nextn": 5' in seen["native_kwargs"]["decode_engine_args"]
+    assert "aic_nextn" not in seen["native_kwargs"]["prefill_engine_args"]
+
+
+def test_accept_rates_without_nextn_is_a_usage_error(monkeypatch) -> None:
+    # The engine args validator rejects the pair, but it raises from
+    # MockEngineArgs.from_json, outside the handling that produces a usage
+    # message, so the user would see a traceback instead.
+    seen: dict = {}
+    _stub_cli_dependencies(monkeypatch, seen)
+
+    with pytest.raises(SystemExit):
+        replay_main.main(
+            [
+                "--input-tokens",
+                "8",
+                "--output-tokens",
+                "4",
+                "--request-count",
+                "1",
+                "--replay-concurrency",
+                "1",
+                "--aic-nextn-accept-rates",
+                "1,1",
+            ]
+        )


### PR DESCRIPTION
## Summary

Fixes #13517.

`--aic-nextn` and `--aic-nextn-accept-rates` are parsed and validated by `dynamo.replay` and then have no effect on the simulation, so speculative decoding is silently not modelled. @yeyu-nvidia measured three runs that differ only in those flags and got byte-identical output, including one with a perfect five-token accept vector that should have emitted about six tokens per decode step.

The wiring gap is confirmed on `main`:

- `_build_aic_perf_config` routes the `--aic-*` flags into `AicPerfConfig`, which is consumed only to build the router's prefill-load estimator.
- Engine timing and the speculative burst sampler read `aic_nextn` and the accept rates off the engine args, which is why passing the same values through `--extra-engine-args` takes effect.
- `dynamo.mocker` does the equivalent already: `build_mocker_engine_args` sets `aic_nextn` and `aic_nextn_accept_rates` on `MockEngineArgs` (`components/src/dynamo/mocker/config.py:292-293`).

So the flags are defaulted into the engine args, reusing the path that demonstrably works rather than adding a second one. Two deliberate details:

**An explicit engine-args value wins.** `--extra-engine-args` is the documented per-worker override, so `setdefault` is used rather than overwriting. That also keeps the reporter's existing workaround working unchanged.

**Aggregated and decode only, not prefill.** Speculation is a decode-side concept, and defaulting it onto the prefill worker would change prefill timing. In disaggregated runs the burst sampler comes from the decode engine args, which is where it now lands.

Also worth noting the fix has to create an engine-args dict when none was supplied, since `_load_engine_args(None)` returns `None` and the reported case passes no `--extra-engine-args` at all. The helper still returns `None` when neither flag is given, so a run with no speculation is unchanged.

## Validation

`pytest components/src/dynamo/replay/tests/test_main.py` — 12 passed.

Running these needed `aisimulate` built locally (`maturin develop --uv` in `aisimulate/`); the module is otherwise skipped as an optional dependency, which is why the existing coverage did not catch this.

Four tests, three of which fail on the unfixed wiring. Verified by making the helper a pass-through, which is exactly the pre-fix behaviour of the flags never reaching the engine args:

```
FAILED test_main.py::test_aic_speculation_flags_reach_the_engine_args
FAILED test_main.py::test_explicit_engine_args_win_over_the_aic_flags
FAILED test_main.py::test_zero_accept_rate_is_not_treated_as_unset
```

The fourth pins that a run with neither flag still passes `None` rather than an empty dict. The zero-rate case is there because `--aic-nextn 1 --aic-nextn-accept-rates 0` is meaningful (draft never accepted) and a truthiness check would drop it silently.

`pre-commit run --files` is clean on both changed files.

Not verified here: I did not reproduce the ITL numbers from the issue. Three tests in `test_simulation_integration.py` fail in my environment both with and without this change, with `AIC perf model requires the 'aic-forward-pass' feature; rebuild the dynamo bindings with --features aic-forward-pass`, so the end-to-end AIC timing path is not something I can exercise locally.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replay configurations now correctly forward AIC speculation settings to aggregated and decoding engines.
  * Explicit engine settings take precedence, while zero-valued and unset options are preserved correctly.

* **Tests**
  * Added coverage for speculation flag forwarding, precedence handling, absent values, and zero-valued acceptance rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->