### PR TITLE
fix: install frontend NIXL from PyPI and put it on the loader path

### DIFF
--- a/container/README.md
+++ b/container/README.md
@@ -285,7 +285,7 @@ EPP_IMAGE="dynamo/dynamo-epp:${EPP_GIT_TAG}"
 container/render.py --framework=dynamo --target=frontend --output-short-filename
 docker build -t dynamo:frontend --build-arg EPP_IMAGE=${EPP_IMAGE} -f container/rendered.Dockerfile .
 
-# NIXL comes from PyPI; override the release with --build-arg NIXL_VERSION=1.4.0
+# NIXL comes from PyPI; override the release with --build-arg NIXL_REF=v1.4.0
 ```
 
 The build process automatically:

--- a/container/README.md
+++ b/container/README.md
@@ -284,6 +284,8 @@ EPP_IMAGE="dynamo/dynamo-epp:${EPP_GIT_TAG}"
 # Build the frontend image (automatically builds EPP image as a dependency)
 container/render.py --framework=dynamo --target=frontend --output-short-filename
 docker build -t dynamo:frontend --build-arg EPP_IMAGE=${EPP_IMAGE} -f container/rendered.Dockerfile .
+
+# NIXL comes from PyPI; override the release with --build-arg NIXL_VERSION=1.4.0
 ```
 
 The build process automatically:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -25,6 +25,9 @@ dynamo:
     # The frontend installs NIXL from PyPI (the tag minus its leading "v")
     # rather than building it in wheel_builder, so it moves independently of
     # the framework-level ref the runtime target's nixl-sys links against.
+    # Those refs differing assumes the NIXL C API stays ABI-compatible between
+    # them: nixl-sys resolves it at runtime, so a break surfaces as a missing
+    # symbol in the running frontend rather than as a build failure.
     nixl_ref: v1.3.2
   epp_image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v1.5.0-rc.2
   frontend_image: nvcr.io/nvidia/base/ubuntu:noble-20250619

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -42,6 +42,9 @@ dynamo:
   etcd_version: v3.5.33
 
   nixl_ref: v1.0.1
+  # NIXL release the frontend image installs from PyPI; independent of nixl_ref,
+  # which drives the from-source build used by the runtime target.
+  nixl_version: "1.3.2"
   nixl_ucx_ref: v1.21.0
   nixl_gdrcopy_ref: v2.5.2
   nixl_libfabric_repo: https://github.com/ofiwg/libfabric.git

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -21,6 +21,11 @@ dynamo:
     # is a STEM; the licenses stage appends -${TARGETARCH}.cdx.json so each arch
     # of a multi-arch build subtracts its own-arch floor (the @<digest8> is the
     # shared multi-arch index digest).
+  frontend:
+    # The frontend installs NIXL from PyPI instead of the wheel_builder source
+    # build; scoped here so it can move independently of nixl_ref, which pins
+    # the C++ SDK the runtime target's nixl-sys links against.
+    nixl_version: "1.3.2"
   epp_image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v1.5.0-rc.2
   frontend_image: nvcr.io/nvidia/base/ubuntu:noble-20250619
   # Self-baseline of the ubuntu frontend base; the licenses stage subtracts it so
@@ -42,9 +47,6 @@ dynamo:
   etcd_version: v3.5.33
 
   nixl_ref: v1.0.1
-  # NIXL release the frontend image installs from PyPI; independent of nixl_ref,
-  # which drives the from-source build used by the runtime target.
-  nixl_version: "1.3.2"
   nixl_ucx_ref: v1.21.0
   nixl_gdrcopy_ref: v2.5.2
   nixl_libfabric_repo: https://github.com/ofiwg/libfabric.git

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -25,9 +25,6 @@ dynamo:
     # The frontend installs NIXL from PyPI (the tag minus its leading "v")
     # rather than building it in wheel_builder, so it moves independently of
     # the framework-level ref the runtime target's nixl-sys links against.
-    # Those refs differing assumes the NIXL C API stays ABI-compatible between
-    # them: nixl-sys resolves it at runtime, so a break surfaces as a missing
-    # symbol in the running frontend rather than as a build failure.
     nixl_ref: v1.3.2
   epp_image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v1.5.0-rc.2
   frontend_image: nvcr.io/nvidia/base/ubuntu:noble-20250619

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -22,10 +22,10 @@ dynamo:
     # of a multi-arch build subtracts its own-arch floor (the @<digest8> is the
     # shared multi-arch index digest).
   frontend:
-    # The frontend installs NIXL from PyPI instead of the wheel_builder source
-    # build; scoped here so it can move independently of nixl_ref, which pins
-    # the C++ SDK the runtime target's nixl-sys links against.
-    nixl_version: "1.3.2"
+    # The frontend installs NIXL from PyPI (the tag minus its leading "v")
+    # rather than building it in wheel_builder, so it moves independently of
+    # the framework-level ref the runtime target's nixl-sys links against.
+    nixl_ref: v1.3.2
   epp_image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v1.5.0-rc.2
   frontend_image: nvcr.io/nvidia/base/ubuntu:noble-20250619
   # Self-baseline of the ubuntu frontend base; the licenses stage subtracts it so

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -70,6 +70,13 @@ ARG NIXL_REF={{ context[framework][device_key].nixl_ref }}
 {% elif "nixl_ref" in context[framework] -%}
 ARG NIXL_REF={{ context[framework].nixl_ref }}
 {% endif -%}
+{# NIXL installed from PyPI rather than built from source; target-scoped so a
+   target opts in by declaring nixl_version, e.g. dynamo.frontend. #}
+{% if "nixl_version" in context[framework].get(target, {}) -%}
+ARG NIXL_VERSION={{ context[framework][target].nixl_version }}
+{% elif "nixl_version" in context[framework] -%}
+ARG NIXL_VERSION={{ context[framework].nixl_version }}
+{% endif -%}
 {% if device == "cuda" %}
 ARG NIXL_GDRCOPY_REF={{ context.dynamo.nixl_gdrcopy_ref }}
 ARG NIXL_LIBFABRIC_REPO={{ context.dynamo.nixl_libfabric_repo }}
@@ -84,7 +91,6 @@ ARG FRAMEWORK={{ framework }}
 {% if target == "frontend" %}
 ARG EPP_IMAGE={{ context.dynamo.epp_image }}
 ARG FRONTEND_IMAGE={{ context.dynamo.frontend_image }}
-ARG NIXL_VERSION={{ context.dynamo.nixl_version }}
 {% endif %}
 
 {% if target == "planner" %}

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -84,6 +84,7 @@ ARG FRAMEWORK={{ framework }}
 {% if target == "frontend" %}
 ARG EPP_IMAGE={{ context.dynamo.epp_image }}
 ARG FRONTEND_IMAGE={{ context.dynamo.frontend_image }}
+ARG NIXL_VERSION={{ context.dynamo.nixl_version }}
 {% endif %}
 
 {% if target == "planner" %}

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -65,17 +65,13 @@ ARG SCCACHE_REGION=""
 
 # NIXL configuration
 ARG NIXL_UCX_REF={{ context.dynamo.nixl_ucx_ref }}
-{% if "nixl_ref" in context[framework].get(device_key, {}) -%}
+{# Resolved most-specific first: per-target, then per-device, then framework. #}
+{% if "nixl_ref" in context[framework].get(target, {}) -%}
+ARG NIXL_REF={{ context[framework][target].nixl_ref }}
+{% elif "nixl_ref" in context[framework].get(device_key, {}) -%}
 ARG NIXL_REF={{ context[framework][device_key].nixl_ref }}
 {% elif "nixl_ref" in context[framework] -%}
 ARG NIXL_REF={{ context[framework].nixl_ref }}
-{% endif -%}
-{# NIXL installed from PyPI rather than built from source; target-scoped so a
-   target opts in by declaring nixl_version, e.g. dynamo.frontend. #}
-{% if "nixl_version" in context[framework].get(target, {}) -%}
-ARG NIXL_VERSION={{ context[framework][target].nixl_version }}
-{% elif "nixl_version" in context[framework] -%}
-ARG NIXL_VERSION={{ context[framework].nixl_version }}
 {% endif -%}
 {% if device == "cuda" %}
 ARG NIXL_GDRCOPY_REF={{ context.dynamo.nixl_gdrcopy_ref }}

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -149,7 +149,7 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
         --requirement /tmp/requirements.frontend.txt
 
 ARG ENABLE_GPU_MEMORY_SERVICE
-ARG NIXL_VERSION
+ARG NIXL_REF
 # In an ideal world, we'd use a mirror of PyPI for much more reliable downloads.
 # UV_FIND_LINKS points at the crick wheel pre-built in the crick_builder stage;
 # uv prefers it over the sdist on arm64 where no manylinux aarch64 wheel exists.
@@ -158,7 +158,8 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
     uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl && \
-    uv pip install "nixl[cu13]==${NIXL_VERSION}" && \
+    echo "${NIXL_REF}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || { echo "NIXL_REF must be a vX.Y.Z release tag; got '${NIXL_REF}'" >&2; exit 1; } && \
+    uv pip install "nixl[cu13]==${NIXL_REF#v}" && \
     uv pip show nixl nixl-cu13 | grep -E '^(Name|Version)' | tee /opt/dynamo/nixl-versions.txt && \
     if [ "$ENABLE_GPU_MEMORY_SERVICE" = "true" ]; then \
         GMS_WHEEL=$(ls /opt/dynamo/wheelhouse/gpu_memory_service*.whl 2>/dev/null | head -1); \

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -127,8 +127,6 @@ ENV PATH="/opt/dynamo/venv/bin:$PATH"
 COPY --chown=dynamo: --from=dynamo_base /opt/uv/bin/uv /opt/uv/bin/uvx /opt/uv/bin/
 ENV PATH=/opt/uv/bin:${PATH}
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
-COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
-COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
 # crick wheel pre-built in the crick_builder stage; see comment near the top.
 COPY --chown=dynamo: --from=crick_builder /wheels/ /opt/dynamo/wheelhouse/extra/
 
@@ -150,8 +148,8 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.frontend.txt
 
-ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
+ARG NIXL_VERSION
 # In an ideal world, we'd use a mirror of PyPI for much more reliable downloads.
 # UV_FIND_LINKS points at the crick wheel pre-built in the crick_builder stage;
 # uv prefers it over the sdist on arm64 where no manylinux aarch64 wheel exists.
@@ -159,8 +157,9 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra && \
     uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
-    /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
-    /opt/dynamo/wheelhouse/nixl/nixl*.whl && \
+    /opt/dynamo/wheelhouse/ai_dynamo*any.whl && \
+    uv pip install "nixl[cu13]==${NIXL_VERSION}" && \
+    uv pip show nixl nixl-cu13 | grep -E '^(Name|Version)' | tee /opt/dynamo/nixl-versions.txt && \
     if [ "$ENABLE_GPU_MEMORY_SERVICE" = "true" ]; then \
         GMS_WHEEL=$(ls /opt/dynamo/wheelhouse/gpu_memory_service*.whl 2>/dev/null | head -1); \
         if [ -z "$GMS_WHEEL" ]; then \
@@ -168,14 +167,6 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
             exit 1; \
         fi; \
         uv pip install "$GMS_WHEEL"; \
-    fi && \
-    if [ "$ENABLE_KVBM" = "true" ]; then \
-        KVBM_WHEEL=$(ls /opt/dynamo/wheelhouse/kvbm*.whl 2>/dev/null | head -1); \
-        if [ -z "$KVBM_WHEEL" ]; then \
-            echo "ERROR: ENABLE_KVBM is true but no KVBM wheel found in wheelhouse" >&2; \
-            exit 1; \
-        fi; \
-        uv pip install "$KVBM_WHEEL"; \
     fi && \
     cd /workspace/benchmarks && \
     export UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -154,11 +154,11 @@ ARG NIXL_REF
 # UV_FIND_LINKS points at the crick wheel pre-built in the crick_builder stage;
 # uv prefers it over the sdist on arm64 where no manylinux aarch64 wheel exists.
 RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+    echo "${NIXL_REF}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || { echo "NIXL_REF must be a vX.Y.Z release tag; got '${NIXL_REF}'" >&2; exit 1; } && \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra && \
     uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl && \
-    echo "${NIXL_REF}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || { echo "NIXL_REF must be a vX.Y.Z release tag; got '${NIXL_REF}'" >&2; exit 1; } && \
     # The meta package requires both backends unconditionally (its cu12/cu13
     # extras are vestigial), so install the backend first and the meta module
     # --no-deps to keep a single CUDA build and one libnixl_capi.so.
@@ -182,9 +182,14 @@ USER root
 # nixl-sys resolves the C API with a bare dlopen("libnixl_capi.so"), and
 # dynamo/_core.abi3.so carries no RPATH, so without this the Rust bindings
 # silently fall back to stub mode while the Python ones work. The wheel keeps
-# its libraries in a private directory; put that on the loader path.
+# its libraries in a private directory; put that on the loader path and point
+# NIXL at the backend plugins beside them. The RUN below fails the build if
+# either path drifts from the wheel layout.
+ENV NIXL_PLUGIN_DIR=/opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/.nixl_cu13.mesonpy.libs/plugins
 RUN NIXL_LIB_DIR="$(/opt/dynamo/venv/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/.nixl_cu13.mesonpy.libs" && \
     [ -f "${NIXL_LIB_DIR}/libnixl_capi.so" ] || { echo "missing ${NIXL_LIB_DIR}/libnixl_capi.so; NIXL wheel layout changed" >&2; exit 1; } && \
+    [ -d "${NIXL_LIB_DIR}/plugins" ] || { echo "missing ${NIXL_LIB_DIR}/plugins; NIXL wheel layout changed" >&2; exit 1; } && \
+    [ "${NIXL_LIB_DIR}" = "${NIXL_PLUGIN_DIR%/plugins}" ] || { echo "NIXL_PLUGIN_DIR ${NIXL_PLUGIN_DIR} does not match ${NIXL_LIB_DIR}/plugins" >&2; exit 1; } && \
     echo "${NIXL_LIB_DIR}" > /etc/ld.so.conf.d/nixl.conf && \
     ldconfig && \
     chmod 755 /opt/dynamo/.launch_screen && \

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -159,7 +159,11 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl && \
     echo "${NIXL_REF}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || { echo "NIXL_REF must be a vX.Y.Z release tag; got '${NIXL_REF}'" >&2; exit 1; } && \
-    uv pip install "nixl[cu13]==${NIXL_REF#v}" && \
+    # The meta package requires both backends unconditionally (its cu12/cu13
+    # extras are vestigial), so install the backend first and the meta module
+    # --no-deps to keep a single CUDA build and one libnixl_capi.so.
+    uv pip install "nixl-cu13==${NIXL_REF#v}" && \
+    uv pip install --no-deps "nixl==${NIXL_REF#v}" && \
     uv pip show nixl nixl-cu13 | grep -E '^(Name|Version)' | tee /opt/dynamo/nixl-versions.txt && \
     if [ "$ENABLE_GPU_MEMORY_SERVICE" = "true" ]; then \
         GMS_WHEEL=$(ls /opt/dynamo/wheelhouse/gpu_memory_service*.whl 2>/dev/null | head -1); \
@@ -175,7 +179,15 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
 
 # Setup environment for all users
 USER root
-RUN chmod 755 /opt/dynamo/.launch_screen && \
+# nixl-sys resolves the C API with a bare dlopen("libnixl_capi.so"), and
+# dynamo/_core.abi3.so carries no RPATH, so without this the Rust bindings
+# silently fall back to stub mode while the Python ones work. The wheel keeps
+# its libraries in a private directory; put that on the loader path.
+RUN NIXL_LIB_DIR="$(/opt/dynamo/venv/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/.nixl_cu13.mesonpy.libs" && \
+    [ -f "${NIXL_LIB_DIR}/libnixl_capi.so" ] || { echo "missing ${NIXL_LIB_DIR}/libnixl_capi.so; NIXL wheel layout changed" >&2; exit 1; } && \
+    echo "${NIXL_LIB_DIR}" > /etc/ld.so.conf.d/nixl.conf && \
+    ldconfig && \
+    chmod 755 /opt/dynamo/.launch_screen && \
     echo 'source /opt/dynamo/venv/bin/activate' >> /etc/bash.bashrc && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc
 

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -182,14 +182,12 @@ USER root
 # nixl-sys resolves the C API with a bare dlopen("libnixl_capi.so"), and
 # dynamo/_core.abi3.so carries no RPATH, so without this the Rust bindings
 # silently fall back to stub mode while the Python ones work. The wheel keeps
-# its libraries in a private directory; put that on the loader path and point
-# NIXL at the backend plugins beside them. The RUN below fails the build if
-# either path drifts from the wheel layout.
-ENV NIXL_PLUGIN_DIR=/opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/.nixl_cu13.mesonpy.libs/plugins
+# its libraries in a private directory; put that on the loader path. NIXL finds
+# the backend plugins beside them on its own (nixl_plugin_manager.cpp's
+# getPluginDir dladdr fallback), so NIXL_PLUGIN_DIR is deliberately left unset.
 RUN NIXL_LIB_DIR="$(/opt/dynamo/venv/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/.nixl_cu13.mesonpy.libs" && \
     [ -f "${NIXL_LIB_DIR}/libnixl_capi.so" ] || { echo "missing ${NIXL_LIB_DIR}/libnixl_capi.so; NIXL wheel layout changed" >&2; exit 1; } && \
     [ -d "${NIXL_LIB_DIR}/plugins" ] || { echo "missing ${NIXL_LIB_DIR}/plugins; NIXL wheel layout changed" >&2; exit 1; } && \
-    [ "${NIXL_LIB_DIR}" = "${NIXL_PLUGIN_DIR%/plugins}" ] || { echo "NIXL_PLUGIN_DIR ${NIXL_PLUGIN_DIR} does not match ${NIXL_LIB_DIR}/plugins" >&2; exit 1; } && \
     echo "${NIXL_LIB_DIR}" > /etc/ld.so.conf.d/nixl.conf && \
     ldconfig && \
     chmod 755 /opt/dynamo/.launch_screen && \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -716,7 +716,7 @@ RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.
 # Runtime templates COPY from this stage.
 # Note: XPU triggers this path even when the framework section lacks nixl_ref,
 # because no upstream XPU runtime image ships pre-built NIXL.
-# Note: frontend is excluded — it installs NIXL from PyPI (NIXL_VERSION) and does
+# Note: frontend is excluded — it installs NIXL from PyPI at NIXL_REF and does
 # not install KVBM, so nothing in that image consumes a from-source NIXL build.
 
 FROM wheel_builder_base AS wheel_builder

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -710,12 +710,14 @@ RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.
 ##################################
 ##### wheel_builder ##############
 ##################################
-{% if "nixl_ref" in context[framework] or device == "xpu" %}
+{% if ("nixl_ref" in context[framework] or device == "xpu") and target != "frontend" %}
 # Builds NIXL (native + Python wheel) and NIXL-linked extension wheels, then
 # consolidates all wheels.
 # Runtime templates COPY from this stage.
 # Note: XPU triggers this path even when the framework section lacks nixl_ref,
 # because no upstream XPU runtime image ships pre-built NIXL.
+# Note: frontend is excluded — it installs NIXL from PyPI (NIXL_VERSION) and does
+# not install KVBM, so nothing in that image consumes a from-source NIXL build.
 
 FROM wheel_builder_base AS wheel_builder
 
@@ -876,9 +878,10 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=shared \
     echo "kvbm wheel NOTICES step done"
 
 {% else %}
-# SGLang CUDA uses NIXL from the upstream lmsysorg/sglang runtime image and
-# does not build Dynamo KVBM. Keep this alias so downstream stages can still
-# COPY Dynamo wheels and build tools from a common wheel_builder stage name.
+# SGLang CUDA uses NIXL from the upstream lmsysorg/sglang runtime image and the
+# frontend installs it from PyPI; neither builds Dynamo KVBM. Keep this alias so
+# downstream stages can still COPY Dynamo wheels and build tools from a common
+# wheel_builder stage name.
 # SGLang dev/source builds may link nixl-sys against stubs when native NIXL is
 # absent; block-manager/KVBM runtime work should use vllm/trtllm/none images.
 FROM runtime_wheel_builder AS wheel_builder


### PR DESCRIPTION
The frontend image took its NIXL wheels from the `wheel_builder` stage, pinning it to whatever `nixl_ref` compiles, and left the library somewhere the dynamic loader could not find it. `nixl-sys` resolves the C API with a bare `dlopen("libnixl_capi.so")` (`nixl-sys-1.0.1/stubs.cpp:49`) and `dynamo/_core.abi3.so` carries no RPATH, so Rust NIXL silently ran in stub mode while the Python bindings worked in the same interpreter.

This installs NIXL from PyPI at a target-scoped `nixl_ref` and registers the wheel's library directory with `ldconfig`.

## Details

- **PyPI install, target-scoped ref.** `dynamo.frontend.nixl_ref` overrides the framework  ref the same way `sglang.xpu.nixl_ref` already does; `args.Dockerfile` resolves target →  device → framework. The frontend moves to `v1.3.2` (matching the vLLM and SGLang workers  it talks NIXL to); `dynamo.nixl_ref` stays `v1.0.1` for the runtime target's `nixl-sys`  link. The install strips the leading `v` and validates the tag shape, as  `trtllm_runtime.Dockerfile` and `vllm_runtime.Dockerfile` do.
- **Loader path.** The wheel keeps its libraries in a private  `.nixl_cu13.mesonpy.libs` directory reachable only through `_bindings*.so`'s `$ORIGIN`  RPATH. Writing that directory to `/etc/ld.so.conf.d/nixl.conf` + `ldconfig` makes the  bare `dlopen` resolve. The path is derived from the venv rather than hardcoded, and the  build fails if `libnixl_capi.so` is not where expected, so a wheel-layout change breaks  the build instead of silently shipping an image that hangs at startup.
- **One CUDA build.** `nixl`'s meta package requires *both* backends unconditionally — its  `cu12`/`cu13` extras are vestigial — so `nixl[cu13]` installed a cu12 build the image  never used and left two `libnixl_capi.so` for the loader to choose between. Installing  `nixl-cu13` and then the meta package `--no-deps` keeps exactly one.
- **No kvbm, no from-source NIXL.** Nothing in `dynamo.frontend` imports `kvbm` (the only  `import kvbm` sites are `dynamo/vllm/main.py` and `dynamo/trtllm/workers/llm_worker.py`),  and its `nixl[cu13]==1.0.1` pin would have overridden the selected ref. With kvbm gone,  nothing in the image consumes a from-source NIXL build, so the frontend routes to the  existing `runtime_wheel_builder` alias in `wheel_builder.Dockerfile` and skips the  meson/ninja NIXL build and the kvbm maturin build entirely.

closes: OPS-8297 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the NIXL release used by frontend container builds.
  * Configured the CUDA 13 frontend to use NIXL v1.3.2 by default.
  * Improved runtime discovery and loading of NIXL libraries.

* **Bug Fixes**
  * Improved NIXL installation validation and version tracking.
  * Added target-specific release selection with appropriate fallback behavior.

* **Documentation**
  * Clarified that NIXL is installed from PyPI and can be overridden during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->