### PR TITLE
docs: document Python test dependency setup, fix marker-report hook deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,13 @@ uv pip install -e .
 python3 -m dynamo.frontend --help   # verify
 ```
 
+The runtime wheel does not carry pytest or its plugins. Install the test dependencies
+separately before running the Python suite:
+
+```bash
+uv pip install -r container/deps/requirements.test.txt
+```
+
 Rust-only:
 
 ```bash
@@ -112,8 +119,28 @@ cargo build -p dynamo-llm   # one crate
 ## Test
 
 ```bash
-cargo test                  # Rust
-pytest -m unit tests/       # Python unit tests
+cargo test                                             # Rust
+python3 -m pytest -m "unit and not post_merge" tests/  # Python unit tests
+```
+
+Invoke pytest as `python3 -m pytest` so it resolves against the active venv, and install
+`container/deps/requirements.test.txt` first (see [Build](#build)). Pytest runs with
+`--strict-config` and `--strict-markers`, so a missing plugin is a collection error, not a
+warning — `Unknown config option: asyncio_mode` means `pytest-asyncio` is absent, and
+`'order' not found in markers` means `pytest-order` is.
+
+`not post_merge` drops `tests/dependencies/test_kvbm_imports.py`, which asserts on the
+in-container path `/opt/dynamo/wheelhouse/kvbm*.whl` and cannot pass on a host checkout.
+
+A base `uv pip install -e .` has no `torch`, and a few backend test modules import it at
+module scope, so they fail during *collection* even though `-m unit` deselects every test
+in them. Either install a backend extra (`uv pip install -e '.[vllm]'`) or skip those
+modules:
+
+```bash
+python3 -m pytest -m "unit and not post_merge" tests/ \
+  --ignore=tests/serve/test_vllm.py --ignore=tests/serve/test_sglang.py \
+  --ignore=tests/serve/test_trtllm.py --ignore=tests/fault_tolerance/test_canary_rank_pause.py
 ```
 
 Markers are strict (`--strict-markers`); the full marker list lives in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,9 @@ modules:
 ```bash
 python3 -m pytest -m "unit and not post_merge" tests/ \
   --ignore=tests/serve/test_vllm.py --ignore=tests/serve/test_sglang.py \
-  --ignore=tests/serve/test_trtllm.py --ignore=tests/fault_tolerance/test_canary_rank_pause.py
+  --ignore=tests/serve/test_trtllm.py --ignore=tests/serve/test_trtllm_mm_hashes_protocol.py \
+  --ignore=tests/frontend/test_prompt_embeds.py \
+  --ignore=tests/fault_tolerance/test_canary_rank_pause.py
 ```
 
 Markers are strict (`--strict-markers`); the full marker list lives in

--- a/docs/fern/pages/community/contributing/code-quality.md
+++ b/docs/fern/pages/community/contributing/code-quality.md
@@ -76,13 +76,27 @@ review. The correct command depends on the component.
 Common starting points include:
 
 ```bash
-pytest tests/
+python3 -m pytest -m "unit and not post_merge" tests/
 cargo test --locked --all-targets
 cd deploy/operator && go test ./... -v
 ```
 
-Use package-specific test instructions when a component provides them. Include the exact commands
-and results in the pull request's **Validation** section.
+The Python suite needs test-only dependencies that the Dynamo wheel does not carry. Install them
+once per environment:
+
+```bash
+uv pip install -r container/deps/requirements.test.txt
+```
+
+Without them, pytest fails during collection rather than warning, because it runs with
+`--strict-config` and `--strict-markers`. See
+[Building from Source](../../developer-guide/advanced-customizations/building-from-source.md#9-install-test-dependencies)
+for the full setup and for the `torch` collection errors you hit on a runtime-only install.
+
+Use package-specific test instructions when a component provides them, and see
+[Pytest Guidelines](https://github.com/ai-dynamo/dynamo/blob/main/.ai/pytest-guidelines.md) for
+marker filtering and test conventions. Include the exact commands and results in the pull
+request's **Validation** section.
 
 ## Quality Checklist
 

--- a/docs/fern/pages/developer-guide/advanced-customizations/building-from-source.md
+++ b/docs/fern/pages/developer-guide/advanced-customizations/building-from-source.md
@@ -92,6 +92,39 @@ python3 -m dynamo.frontend --help
 
 You should see the frontend command help output.
 
+## 9. Install Test Dependencies
+
+The Dynamo wheel carries runtime dependencies only. Pytest and its plugins live in a separate
+manifest that the test and dev containers install:
+
+```bash
+uv pip install -r container/deps/requirements.test.txt
+```
+
+Install it before running the Python suite. Pytest is configured with `--strict-config` and
+`--strict-markers`, so a missing plugin becomes a collection error rather than a warning --
+`Unknown config option: asyncio_mode` means `pytest-asyncio` is absent, and
+`'order' not found in markers` means `pytest-order` is.
+
+## 10. Run the Tests
+
+```bash
+cargo test --locked --all-targets
+python3 -m pytest -m "unit and not post_merge" tests/
+```
+
+Invoke pytest as `python3 -m pytest` so it resolves against the active virtual environment.
+A bare `pytest` on your `PATH` may come from outside the environment and will not see the
+editable `dynamo` install.
+
+> [!NOTE]
+> `not post_merge` excludes `tests/dependencies/test_kvbm_imports.py`. That module asserts on
+> `/opt/dynamo/wheelhouse/kvbm*.whl`, a path that exists only inside a CI container image, so it
+> cannot pass on a host checkout.
+
+See [Pytest Guidelines](https://github.com/ai-dynamo/dynamo/blob/main/.ai/pytest-guidelines.md)
+for marker filtering, `--models-dir`, and the conventions that apply when you add tests.
+
 ## DevContainer
 
 VSCode and Cursor users can skip manual setup using pre-configured development containers. The DevContainer installs all toolchains, builds the project, and sets up the Python environment automatically.
@@ -129,6 +162,25 @@ Maturin builds against the active Python interpreter. If you see errors about Py
 
 ```bash
 source .venv/bin/activate
+```
+
+**Test collection fails with `No module named 'torch'`**
+
+A base `uv pip install -e .` does not install `torch`; it arrives with a backend extra. A few
+backend test modules import it at module scope, so they fail during collection even when the
+marker expression deselects every test inside them. Either install the backend extra you work
+against:
+
+```bash
+uv pip install -e '.[vllm]'
+```
+
+Or skip the affected modules for a runtime-only test run:
+
+```bash
+python3 -m pytest -m "unit and not post_merge" tests/ \
+  --ignore=tests/serve/test_vllm.py --ignore=tests/serve/test_sglang.py \
+  --ignore=tests/serve/test_trtllm.py --ignore=tests/fault_tolerance/test_canary_rank_pause.py
 ```
 
 **Disk space**

--- a/docs/fern/pages/developer-guide/advanced-customizations/building-from-source.md
+++ b/docs/fern/pages/developer-guide/advanced-customizations/building-from-source.md
@@ -180,7 +180,9 @@ Or skip the affected modules for a runtime-only test run:
 ```bash
 python3 -m pytest -m "unit and not post_merge" tests/ \
   --ignore=tests/serve/test_vllm.py --ignore=tests/serve/test_sglang.py \
-  --ignore=tests/serve/test_trtllm.py --ignore=tests/fault_tolerance/test_canary_rank_pause.py
+  --ignore=tests/serve/test_trtllm.py --ignore=tests/serve/test_trtllm_mm_hashes_protocol.py \
+  --ignore=tests/frontend/test_prompt_embeds.py \
+  --ignore=tests/fault_tolerance/test_canary_rank_pause.py
 ```
 
 **Disk space**

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -294,6 +294,12 @@ STUB_MODULES = [
     "zmq",
     "zmq.asyncio",
     "blake3",
+    # tqdm -- imported at module scope by aisimulate.sweeper.search, which
+    # planner/replay/sweeper test modules pull in transitively. The report
+    # only needs the import to resolve during --collect-only, and the hook
+    # env is built from additional_dependencies alone, so stub it rather
+    # than grow that env.
+    "tqdm",
 ]
 
 # These APIs define the AIC 0.11 upper/core contract. The marker-report


### PR DESCRIPTION
## Summary

Two independent fixes for the host-checkout developer experience.

**Docs** — running the Python suite after a plain `uv pip install -e .` fails in ways the docs did not explain. Pytest runs with `--strict-config` and `--strict-markers`, so a missing plugin is a *collection error*, not a warning, and the runtime wheel does not carry pytest or its plugins. Documented across `AGENTS.md`, the contributing code-quality page, and building-from-source:

- installing `container/deps/requirements.test.txt`
- invoking `python3 -m pytest` so it resolves against the active venv
- why `not post_merge` is needed — `tests/dependencies/test_kvbm_imports.py` asserts on `/opt/dynamo/wheelhouse/kvbm*.whl`, a path that exists only inside a CI container
- the `No module named 'torch'` collection failure, with both fixes (backend extra or `--ignore`). All five modules that import `torch` at module scope are listed: `tests/serve/test_vllm.py`, `test_sglang.py`, `test_trtllm.py`, `test_trtllm_mm_hashes_protocol.py`, `tests/frontend/test_prompt_embeds.py`, `tests/fault_tolerance/test_canary_rank_pause.py`

**CI** — the `pytest-marker-report` pre-commit hook fails on a clean checkout. It uses `language: python`, so pre-commit builds it an isolated environment from `additional_dependencies` alone. `tqdm` is a real project dependency (`pyproject.toml`, `aisimulate/pyproject.toml`) that seven test modules import transitively, so collection died with `ModuleNotFoundError: No module named 'tqdm'` and pytest returned exit code 2. The marker check itself was already passing (`Missing sets: 0`) — only collection was broken.

Fixed by adding `tqdm` to `STUB_MODULES` in `tests/report_pytest_markers.py` rather than to the hook's `additional_dependencies`. The script never calls `tqdm`; it only needs the import to resolve during `--collect-only`, which is exactly what `STUB_MODULES` exists for and how `grpc`, `msgspec`, `numpy`, `requests` and the rest are already handled. Installing it would grow the isolated hook env for no benefit. (Changed from `additional_dependencies` after review feedback — both work; this one matches the existing convention.)

## Validation

Reproduced the hook failure on unmodified `main` in a clean worktree — 7 collection errors, exit code 2:

```
ERROR components/src/dynamo/planner/tests/unit/test_planner_sweep_config_provider.py
ERROR components/src/dynamo/planner/tests/unit/test_simulation_load_predictor.py
ERROR components/src/dynamo/planner/tests/unit/test_simulation_presets.py
ERROR components/src/dynamo/replay/tests/test_simulation.py
ERROR components/src/dynamo/replay/tests/test_simulation_integration.py
ERROR aisimulate/tests/sweeper/test_search.py
ERROR aisimulate/tests/sweeper/test_search_providers.py
!!!!!!!!!!!!!!!!!!! Interrupted: 7 errors during collection !!!!!!!!!!!!!!!!!!!!
```

After the fix, on this branch:

```
$ pre-commit run pytest-marker-report --all-files
Report pytest markers (static + inherited)...............................Passed
```

Full pre-commit over all changed files — every applicable hook passes (codespell, check yaml, Fern docs asset paths, canonical AI Simulate docs sync, marker report, skills validation, DCO).

Verified the documented runtime-only command against a simulated install with `torch` absent (shadowed by a
module raising `ModuleNotFoundError`). Before the skip-list correction it aborted with
`ERROR tests/frontend/test_prompt_embeds.py`; after, it is `164 passed, 19 skipped, 1703 deselected`,
no collection errors.

All commits are DCO-signed and GPG-signed.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded contributor guidance for setting up Python test dependencies and running Rust and Python test suites.
  - Clarified test selection, marker usage, virtual-environment requirements, and handling tests that need optional backends such as `torch`.
  - Added troubleshooting guidance and links to testing conventions.

- **Chores**
  - Updated test tooling dependencies to support improved test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
