### PR TITLE
ci: run EFA CPU tests on CPU runners

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -455,7 +455,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: vllm-efa
       test_type: CPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      amd_runner: prod-tester-amd-v2 # EFA image validation runs gpu_0 tests only
       target_tag_plain: ${{ needs.vllm-efa-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]'
@@ -576,7 +576,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: trtllm-efa
       test_type: CPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      amd_runner: prod-tester-amd-v2 # EFA image validation runs gpu_0 tests only
       target_tag_plain: ${{ needs.trtllm-efa-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64", "arm64"]'


### PR DESCRIPTION
## Summary

- move the AMD64 vLLM EFA image-validation job from the four-GPU runner to `prod-tester-amd-v2`
- move the AMD64 TensorRT-LLM EFA image-validation job from the four-GPU runner to `prod-tester-amd-v2`
- keep both jobs CPU-only with their existing `gpu_0` selectors and `run_gpu_tests: false`

## Validation

- `pre-commit run --files .github/workflows/post-merge-ci.yml`
- parsed the workflow and asserted both EFA jobs target `prod-tester-amd-v2`, retain `gpu_0`, and keep GPU tests disabled
- live Actions validation: https://github.com/ai-dynamo/dynamo/actions/runs/32290700554
  - vLLM: 1,269 passed, 11 skipped, 0 failed
  - TensorRT-LLM: 248 passed, 24 skipped, 0 failed
  - both jobs ran on `prod-tester-amd-v2` using `m6id.xlarge` nodes in `tester-v2`
  - workflow pods requested no GPU resources; the nodes exposed no `nvidia.com/gpu` capacity or allocatable GPUs