### PR TITLE
fix(thunderagent): restore state after cancelled admission

### DIFF
--- a/components/src/dynamo/thunderagent_router/README.md
+++ b/components/src/dynamo/thunderagent_router/README.md
@@ -75,6 +75,12 @@ Requests without session identity are passed through as one-off (no program
 admission, no pause/resume). This is the safe fallback for non-agentic traffic
 sharing the same workers.
 
+Admission is a transaction. A request cancelled while it is queued for capacity
+— a client disconnect, for instance — leaves the program table as it found it:
+a program the admission attempt created is removed, and one that already existed
+keeps the session history of its previous turn. Cancelled requests therefore do
+not hold capacity, and do not queue other programs behind them.
+
 ### SGLang HiCache retention budget
 
 `dynamo.sglang` publishes the authoritative GPU KV and HiCache host capacities in each worker's model deployment card. The scheduler automatically uses their sum as its retention budget, so `--pause-threshold 0.95` means 95% of the combined GPU + host pool; there is no ThunderAgent HiCache flag to set. This lets SGLang spill from GPU to its native host tier before ThunderAgent starts holding programs at tool boundaries.

--- a/components/src/dynamo/thunderagent_router/program_state.py
+++ b/components/src/dynamo/thunderagent_router/program_state.py
@@ -47,7 +47,7 @@ class Program:
     # monotonic seconds; used to compute resume-side decay
     acting_since: float = 0.0
 
-    # Distinguishes concurrent admissions that share a Program object.
+    # Distinguishes successive admissions that share a Program object.
     admission_epoch: int = 0
 
 
@@ -133,7 +133,7 @@ class ProgramTable:
         program.soft_demoted_until = snapshot.soft_demoted_until
         program.acting_since = snapshot.acting_since
         program.admission_epoch = snapshot.admission_epoch
-        # Do not replace an event installed by a concurrent admission.
+        # Do not replace an event installed after this snapshot was captured.
         if program.waiting is None or program.waiting is snapshot.waiting:
             program.waiting = snapshot.waiting
         if program.lifecycle == ProgramLifecycle.PAUSED and program.waiting is not None:

--- a/components/src/dynamo/thunderagent_router/program_state.py
+++ b/components/src/dynamo/thunderagent_router/program_state.py
@@ -47,6 +47,11 @@ class Program:
     # monotonic seconds; used to compute resume-side decay
     acting_since: float = 0.0
 
+    # Bumped by every `begin_request`. Two concurrent requests for one session
+    # share this object, so object identity alone cannot tell a rollback whether
+    # the mutations it is about to undo are still its own.
+    admission_epoch: int = 0
+
 
 @dataclass(frozen=True)
 class RequestSnapshot:
@@ -54,7 +59,9 @@ class RequestSnapshot:
 
     ``program`` is captured so a rollback can tell "the program I mutated" from
     "a program with the same id that a later request created": the two are
-    different objects and only the first may be restored.
+    different objects and only the first may be restored. ``admission_epoch``
+    extends that to the case where the object is the same but a later request
+    has admitted its own turn on it since.
     """
 
     program: Program
@@ -68,6 +75,7 @@ class RequestSnapshot:
     waiting: Optional[asyncio.Event]
     acting_since: float
     was_paused: bool
+    admission_epoch: int
 
 
 @dataclass
@@ -85,6 +93,7 @@ class ProgramTable:
             program = Program(program_id=program_id)
             self.programs[program_id] = program
         program.step_count += 1
+        program.admission_epoch += 1
         if estimated_prompt_tokens > 0:
             program.token_total = estimated_prompt_tokens
         program.status = ProgramStatus.REASONING
@@ -113,6 +122,7 @@ class ProgramTable:
             waiting=program.waiting,
             acting_since=program.acting_since,
             was_paused=program_id in self.paused,
+            admission_epoch=program.admission_epoch,
         )
 
     def rollback_request(
@@ -128,6 +138,10 @@ class ProgramTable:
 
         Restoration is skipped when a different Program object now holds the id:
         the recorded one was released meanwhile and a newer request owns it.
+
+        The caller is responsible for the matching ``admission_epoch`` check --
+        the same object can be shared by a later request whose mutations must
+        not be undone. See ``ThunderAgentScheduler._rollback_admission``.
         """
         if snapshot is None:
             self.paused.pop(program_id, None)
@@ -146,10 +160,17 @@ class ProgramTable:
         program.marked_for_pause = snapshot.marked_for_pause
         program.soft_demoted_until = snapshot.soft_demoted_until
         program.acting_since = snapshot.acting_since
+        program.admission_epoch = snapshot.admission_epoch
         # A concurrent admission for the same program may have installed its own
         # Event; leave that one in place rather than stranding its waiter.
         if program.waiting is None or program.waiting is snapshot.waiting:
             program.waiting = snapshot.waiting
+        if program.lifecycle == ProgramLifecycle.PAUSED and program.waiting is not None:
+            # The Event may have been set by the resume this rollback is undoing.
+            # A paused program has to make its next waiter wait, and clearing
+            # cannot un-wake anyone: `set` completes every waiter already parked
+            # on the Event, and `clear` only affects `wait` calls made after it.
+            program.waiting.clear()
         if snapshot.was_paused:
             self.paused[program_id] = None
         else:

--- a/components/src/dynamo/thunderagent_router/program_state.py
+++ b/components/src/dynamo/thunderagent_router/program_state.py
@@ -48,6 +48,28 @@ class Program:
     acting_since: float = 0.0
 
 
+@dataclass(frozen=True)
+class RequestSnapshot:
+    """State of a Program immediately before ``begin_request`` mutates it.
+
+    ``program`` is captured so a rollback can tell "the program I mutated" from
+    "a program with the same id that a later request created": the two are
+    different objects and only the first may be restored.
+    """
+
+    program: Program
+    status: ProgramStatus
+    lifecycle: ProgramLifecycle
+    assigned_worker_id: Optional[int]
+    token_total: int
+    step_count: int
+    marked_for_pause: bool
+    soft_demoted_until: float
+    waiting: Optional[asyncio.Event]
+    acting_since: float
+    was_paused: bool
+
+
 @dataclass
 class ProgramTable:
     programs: dict[str, Program] = field(default_factory=dict)
@@ -68,6 +90,70 @@ class ProgramTable:
         program.status = ProgramStatus.REASONING
         program.acting_since = 0.0
         return program
+
+    def snapshot_request(self, program_id: str) -> Optional[RequestSnapshot]:
+        """Record what a following ``begin_request``/admission attempt will change.
+
+        Returns None when the program does not exist yet: that is the signal to
+        ``rollback_request`` that the attempt is what created it, so undoing the
+        attempt means removing it rather than restoring fields.
+        """
+        program = self.programs.get(program_id)
+        if program is None:
+            return None
+        return RequestSnapshot(
+            program=program,
+            status=program.status,
+            lifecycle=program.lifecycle,
+            assigned_worker_id=program.assigned_worker_id,
+            token_total=program.token_total,
+            step_count=program.step_count,
+            marked_for_pause=program.marked_for_pause,
+            soft_demoted_until=program.soft_demoted_until,
+            waiting=program.waiting,
+            acting_since=program.acting_since,
+            was_paused=program_id in self.paused,
+        )
+
+    def rollback_request(
+        self, program_id: str, snapshot: Optional[RequestSnapshot]
+    ) -> None:
+        """Undo one abandoned request's mutations, given its pre-request snapshot.
+
+        With ``snapshot`` None the program did not exist before the attempt, so
+        it is dropped from both tables; dropping it from ``programs`` is what
+        releases the capacity the scheduler had accounted to it. Otherwise the
+        recorded fields — including ``paused`` membership — are put back, which
+        preserves a live session's history that ``release`` would discard.
+
+        Restoration is skipped when a different Program object now holds the id:
+        the recorded one was released meanwhile and a newer request owns it.
+        """
+        if snapshot is None:
+            self.paused.pop(program_id, None)
+            self.programs.pop(program_id, None)
+            return
+
+        program = self.programs.get(program_id)
+        if program is not snapshot.program:
+            return
+
+        program.status = snapshot.status
+        program.lifecycle = snapshot.lifecycle
+        program.assigned_worker_id = snapshot.assigned_worker_id
+        program.token_total = snapshot.token_total
+        program.step_count = snapshot.step_count
+        program.marked_for_pause = snapshot.marked_for_pause
+        program.soft_demoted_until = snapshot.soft_demoted_until
+        program.acting_since = snapshot.acting_since
+        # A concurrent admission for the same program may have installed its own
+        # Event; leave that one in place rather than stranding its waiter.
+        if program.waiting is None or program.waiting is snapshot.waiting:
+            program.waiting = snapshot.waiting
+        if snapshot.was_paused:
+            self.paused[program_id] = None
+        else:
+            self.paused.pop(program_id, None)
 
     def end_request(
         self, program_id: str, prompt_tokens: int, completion_tokens: int

--- a/components/src/dynamo/thunderagent_router/program_state.py
+++ b/components/src/dynamo/thunderagent_router/program_state.py
@@ -47,22 +47,13 @@ class Program:
     # monotonic seconds; used to compute resume-side decay
     acting_since: float = 0.0
 
-    # Bumped by every `begin_request`. Two concurrent requests for one session
-    # share this object, so object identity alone cannot tell a rollback whether
-    # the mutations it is about to undo are still its own.
+    # Distinguishes concurrent admissions that share a Program object.
     admission_epoch: int = 0
 
 
 @dataclass(frozen=True)
 class RequestSnapshot:
-    """State of a Program immediately before ``begin_request`` mutates it.
-
-    ``program`` is captured so a rollback can tell "the program I mutated" from
-    "a program with the same id that a later request created": the two are
-    different objects and only the first may be restored. ``admission_epoch``
-    extends that to the case where the object is the same but a later request
-    has admitted its own turn on it since.
-    """
+    """Program state captured before admission."""
 
     program: Program
     status: ProgramStatus
@@ -101,12 +92,7 @@ class ProgramTable:
         return program
 
     def snapshot_request(self, program_id: str) -> Optional[RequestSnapshot]:
-        """Record what a following ``begin_request``/admission attempt will change.
-
-        Returns None when the program does not exist yet: that is the signal to
-        ``rollback_request`` that the attempt is what created it, so undoing the
-        attempt means removing it rather than restoring fields.
-        """
+        """Capture state before admission; None means admission creates it."""
         program = self.programs.get(program_id)
         if program is None:
             return None
@@ -128,21 +114,7 @@ class ProgramTable:
     def rollback_request(
         self, program_id: str, snapshot: Optional[RequestSnapshot]
     ) -> None:
-        """Undo one abandoned request's mutations, given its pre-request snapshot.
-
-        With ``snapshot`` None the program did not exist before the attempt, so
-        it is dropped from both tables; dropping it from ``programs`` is what
-        releases the capacity the scheduler had accounted to it. Otherwise the
-        recorded fields — including ``paused`` membership — are put back, which
-        preserves a live session's history that ``release`` would discard.
-
-        Restoration is skipped when a different Program object now holds the id:
-        the recorded one was released meanwhile and a newer request owns it.
-
-        The caller is responsible for the matching ``admission_epoch`` check --
-        the same object can be shared by a later request whose mutations must
-        not be undone. See ``ThunderAgentScheduler._rollback_admission``.
-        """
+        """Restore state only if the snapshot still names the current program."""
         if snapshot is None:
             self.paused.pop(program_id, None)
             self.programs.pop(program_id, None)
@@ -161,15 +133,11 @@ class ProgramTable:
         program.soft_demoted_until = snapshot.soft_demoted_until
         program.acting_since = snapshot.acting_since
         program.admission_epoch = snapshot.admission_epoch
-        # A concurrent admission for the same program may have installed its own
-        # Event; leave that one in place rather than stranding its waiter.
+        # Do not replace an event installed by a concurrent admission.
         if program.waiting is None or program.waiting is snapshot.waiting:
             program.waiting = snapshot.waiting
         if program.lifecycle == ProgramLifecycle.PAUSED and program.waiting is not None:
-            # The Event may have been set by the resume this rollback is undoing.
-            # A paused program has to make its next waiter wait, and clearing
-            # cannot un-wake anyone: `set` completes every waiter already parked
-            # on the Event, and `clear` only affects `wait` calls made after it.
+            # A set event would admit the next paused turn without a capacity check.
             program.waiting.clear()
         if snapshot.was_paused:
             self.paused[program_id] = None

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -111,6 +111,7 @@ class ThunderAgentScheduler:
             # between _admit_locked returning and the end of this block, so the
             # handle to what it mutated cannot be lost.
             admitted = self._table.programs.get(program_id)
+            admitted_epoch = admitted.admission_epoch if admitted is not None else None
 
         try:
             if wait_event is not None:
@@ -167,24 +168,56 @@ class ThunderAgentScheduler:
             # keeps consuming worker capacity, holds unrelated new programs
             # behind the fairness rule, and a later tick can resume and assign
             # a worker to a request nobody is waiting for.
-            await self._rollback_admission(program_id, snapshot, admitted)
+            await self._rollback_admission_shielded(
+                program_id, snapshot, admitted, admitted_epoch
+            )
             raise
+
+    async def _rollback_admission_shielded(
+        self,
+        program_id: str,
+        snapshot: Optional[RequestSnapshot],
+        admitted: Optional[Program],
+        admitted_epoch: Optional[int],
+    ) -> None:
+        """Run the rollback to completion even if cancellation is re-delivered.
+
+        The rollback has to take the lock, and a scheduler tick holds that lock
+        across awaits (``_pause_until_safe``, ``_greedy_resume``), so the
+        acquisition really can block. A second ``cancel()`` landing on it would
+        abandon the cleanup and leave behind exactly the state this path exists
+        to remove, so repeated cancellation is absorbed here; ``before_request``
+        re-raises ``CancelledError`` either way.
+
+        Post-cancellation state stays observable to whoever awaits the cancelled
+        task: this returns only once the rollback has finished.
+        """
+        rollback = asyncio.ensure_future(
+            self._rollback_admission(program_id, snapshot, admitted, admitted_epoch)
+        )
+        while not rollback.done():
+            try:
+                await asyncio.shield(rollback)
+            except asyncio.CancelledError:
+                if rollback.cancelled():
+                    break
+        if not rollback.cancelled():
+            # Surface a rollback failure the way a direct await would, instead
+            # of leaving it as an unretrieved task exception.
+            rollback.result()
 
     async def _rollback_admission(
         self,
         program_id: str,
         snapshot: Optional[RequestSnapshot],
         admitted: Optional[Program],
+        admitted_epoch: Optional[int],
     ) -> None:
         """Undo a cancelled admission attempt's mutations under the lock.
 
         A scheduler tick can run between cancellation being requested and this
         acquisition, so nothing here assumes the program is still paused: a
-        resumed program is rolled back just the same. Deliberately a plain
-        await rather than a shielded one — every critical section in this class
-        is synchronous, so the acquisition normally completes without yielding,
-        which keeps the post-cancellation state observable to the caller that
-        awaits the cancelled task.
+        resumed program is rolled back just the same.
         """
         if admitted is None:
             return
@@ -192,6 +225,14 @@ class ThunderAgentScheduler:
             if self._table.programs.get(program_id) is not admitted:
                 # Released meanwhile, and possibly recreated by a newer request.
                 # Neither case is ours to undo.
+                return
+            if admitted.admission_epoch != admitted_epoch:
+                # A later request for the same session has admitted its own turn
+                # on this same object. Its mutations are live and the snapshot
+                # predates them, so restoring would undo that request's work,
+                # and dropping a program it is parked on would strand it until
+                # the resume timeout. Leaving the program to its new owner costs
+                # only this attempt's step_count.
                 return
             self._table.rollback_request(program_id, snapshot)
             self._stat_admissions_cancelled += 1

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -53,6 +53,14 @@ class ThunderAgentConfig:
     buffer_per_program: int = 100
 
 
+@dataclass
+class _AdmissionGate:
+    """Serialize admission transactions for one program."""
+
+    lock: asyncio.Lock
+    users: int = 0
+
+
 class ThunderAgentScheduler:
     def __init__(
         self,
@@ -63,6 +71,7 @@ class ThunderAgentScheduler:
         self._cfg = config
         self._table = ProgramTable()
         self._lock = asyncio.Lock()
+        self._admission_gates: dict[str, _AdmissionGate] = {}
         self._scheduler_task: Optional[asyncio.Task] = None
         self._stat_forced_resumes = 0
         self._stat_programs_created = 0
@@ -100,6 +109,24 @@ class ThunderAgentScheduler:
         self,
         program_id: str,
         estimated_prompt_tokens: int = 0,
+    ) -> PauseDecision:
+        gate = self._admission_gates.get(program_id)
+        if gate is None:
+            gate = _AdmissionGate(lock=asyncio.Lock())
+            self._admission_gates[program_id] = gate
+        gate.users += 1
+        try:
+            async with gate.lock:
+                return await self._admit_request(program_id, estimated_prompt_tokens)
+        finally:
+            gate.users -= 1
+            if gate.users == 0 and self._admission_gates.get(program_id) is gate:
+                self._admission_gates.pop(program_id)
+
+    async def _admit_request(
+        self,
+        program_id: str,
+        estimated_prompt_tokens: int,
     ) -> PauseDecision:
         wait_started = time.monotonic()
         async with self._lock:

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -107,9 +107,7 @@ class ThunderAgentScheduler:
             wait_event, was_paused = self._admit_locked(
                 program_id, estimated_prompt_tokens
             )
-            # Cancellation is only delivered at an await, and there is none
-            # between _admit_locked returning and the end of this block, so the
-            # handle to what it mutated cannot be lost.
+            # No await can replace this program before its identity is captured.
             admitted = self._table.programs.get(program_id)
             admitted_epoch = admitted.admission_epoch if admitted is not None else None
 
@@ -162,12 +160,7 @@ class ThunderAgentScheduler:
                     assigned_worker_hint=program.assigned_worker_id,
                 )
         except asyncio.CancelledError:
-            # The caller is gone (client disconnect, request cancellation) but
-            # _admit_locked already wrote this attempt into the program table.
-            # Undo it before re-raising, or the entry outlives the request: it
-            # keeps consuming worker capacity, holds unrelated new programs
-            # behind the fairness rule, and a later tick can resume and assign
-            # a worker to a request nobody is waiting for.
+            # Admission mutates shared state before the first cancellable wait.
             await self._rollback_admission_shielded(
                 program_id, snapshot, admitted, admitted_epoch
             )
@@ -180,18 +173,7 @@ class ThunderAgentScheduler:
         admitted: Optional[Program],
         admitted_epoch: Optional[int],
     ) -> None:
-        """Run the rollback to completion even if cancellation is re-delivered.
-
-        The rollback has to take the lock, and a scheduler tick holds that lock
-        across awaits (``_pause_until_safe``, ``_greedy_resume``), so the
-        acquisition really can block. A second ``cancel()`` landing on it would
-        abandon the cleanup and leave behind exactly the state this path exists
-        to remove, so repeated cancellation is absorbed here; ``before_request``
-        re-raises ``CancelledError`` either way.
-
-        Post-cancellation state stays observable to whoever awaits the cancelled
-        task: this returns only once the rollback has finished.
-        """
+        """Finish rollback even if request cancellation is delivered again."""
         rollback = asyncio.ensure_future(
             self._rollback_admission(program_id, snapshot, admitted, admitted_epoch)
         )
@@ -202,8 +184,6 @@ class ThunderAgentScheduler:
                 if rollback.cancelled():
                     break
         if not rollback.cancelled():
-            # Surface a rollback failure the way a direct await would, instead
-            # of leaving it as an unretrieved task exception.
             rollback.result()
 
     async def _rollback_admission(
@@ -213,26 +193,13 @@ class ThunderAgentScheduler:
         admitted: Optional[Program],
         admitted_epoch: Optional[int],
     ) -> None:
-        """Undo a cancelled admission attempt's mutations under the lock.
-
-        A scheduler tick can run between cancellation being requested and this
-        acquisition, so nothing here assumes the program is still paused: a
-        resumed program is rolled back just the same.
-        """
         if admitted is None:
             return
         async with self._lock:
             if self._table.programs.get(program_id) is not admitted:
-                # Released meanwhile, and possibly recreated by a newer request.
-                # Neither case is ours to undo.
                 return
             if admitted.admission_epoch != admitted_epoch:
-                # A later request for the same session has admitted its own turn
-                # on this same object. Its mutations are live and the snapshot
-                # predates them, so restoring would undo that request's work,
-                # and dropping a program it is parked on would strand it until
-                # the resume timeout. Leaving the program to its new owner costs
-                # only this attempt's step_count.
+                # A later admission owns the shared Program state.
                 return
             self._table.rollback_request(program_id, snapshot)
             self._stat_admissions_cancelled += 1

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -22,6 +22,7 @@ from dynamo.thunderagent_router.program_state import (
     ProgramLifecycle,
     ProgramStatus,
     ProgramTable,
+    RequestSnapshot,
 )
 
 logger = logging.getLogger(__name__)
@@ -72,6 +73,7 @@ class ThunderAgentScheduler:
         self._stat_resumes = 0
         self._stat_marked_for_pause = 0
         self._stat_worker_assignments = 0
+        self._stat_admissions_cancelled = 0
 
     def start(self) -> None:
         if self._scheduler_task is not None:
@@ -101,56 +103,105 @@ class ThunderAgentScheduler:
     ) -> PauseDecision:
         wait_started = time.monotonic()
         async with self._lock:
+            snapshot = self._table.snapshot_request(program_id)
             wait_event, was_paused = self._admit_locked(
                 program_id, estimated_prompt_tokens
             )
+            # Cancellation is only delivered at an await, and there is none
+            # between _admit_locked returning and the end of this block, so the
+            # handle to what it mutated cannot be lost.
+            admitted = self._table.programs.get(program_id)
 
-        if wait_event is not None:
-            try:
-                await asyncio.wait_for(
-                    wait_event.wait(), timeout=self._cfg.resume_timeout_seconds
+        try:
+            if wait_event is not None:
+                try:
+                    await asyncio.wait_for(
+                        wait_event.wait(), timeout=self._cfg.resume_timeout_seconds
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Forced resume for %s after %.1fs",
+                        program_id,
+                        self._cfg.resume_timeout_seconds,
+                    )
+                    async with self._lock:
+                        program = self._table.programs.get(program_id)
+                        if (
+                            program is not None
+                            and program.lifecycle == ProgramLifecycle.PAUSED
+                        ):
+                            worker_id = self._least_loaded_worker_locked(
+                                self._capacity.snapshot()
+                            )
+                            self._resume_program(program, worker_id)
+                            self._stat_forced_resumes += 1
+
+            waited = time.monotonic() - wait_started
+
+            async with self._lock:
+                program = self._table.programs.get(program_id)
+                if program is None:
+                    return PauseDecision(program_id=program_id, waited_seconds=waited)
+
+                self._stat_requests_admitted += 1
+                if was_paused:
+                    self._stat_requests_paused += 1
+
+                priority_jump = self._cfg.resume_priority_boost if was_paused else 0.0
+                soft_demoted = program.soft_demoted_until > time.monotonic()
+                if soft_demoted:
+                    priority_jump += self._cfg.soft_demote_priority_jump
+
+                return PauseDecision(
+                    program_id=program_id,
+                    priority_jump=priority_jump,
+                    waited_seconds=waited,
+                    was_paused=was_paused,
+                    was_soft_demoted=soft_demoted,
+                    assigned_worker_hint=program.assigned_worker_id,
                 )
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "Forced resume for %s after %.1fs",
-                    program_id,
-                    self._cfg.resume_timeout_seconds,
-                )
-                async with self._lock:
-                    program = self._table.programs.get(program_id)
-                    if (
-                        program is not None
-                        and program.lifecycle == ProgramLifecycle.PAUSED
-                    ):
-                        worker_id = self._least_loaded_worker_locked(
-                            self._capacity.snapshot()
-                        )
-                        self._resume_program(program, worker_id)
-                        self._stat_forced_resumes += 1
+        except asyncio.CancelledError:
+            # The caller is gone (client disconnect, request cancellation) but
+            # _admit_locked already wrote this attempt into the program table.
+            # Undo it before re-raising, or the entry outlives the request: it
+            # keeps consuming worker capacity, holds unrelated new programs
+            # behind the fairness rule, and a later tick can resume and assign
+            # a worker to a request nobody is waiting for.
+            await self._rollback_admission(program_id, snapshot, admitted)
+            raise
 
-        waited = time.monotonic() - wait_started
+    async def _rollback_admission(
+        self,
+        program_id: str,
+        snapshot: Optional[RequestSnapshot],
+        admitted: Optional[Program],
+    ) -> None:
+        """Undo a cancelled admission attempt's mutations under the lock.
 
+        A scheduler tick can run between cancellation being requested and this
+        acquisition, so nothing here assumes the program is still paused: a
+        resumed program is rolled back just the same. Deliberately a plain
+        await rather than a shielded one — every critical section in this class
+        is synchronous, so the acquisition normally completes without yielding,
+        which keeps the post-cancellation state observable to the caller that
+        awaits the cancelled task.
+        """
+        if admitted is None:
+            return
         async with self._lock:
-            program = self._table.programs.get(program_id)
-            if program is None:
-                return PauseDecision(program_id=program_id, waited_seconds=waited)
-
-            self._stat_requests_admitted += 1
-            if was_paused:
-                self._stat_requests_paused += 1
-
-            priority_jump = self._cfg.resume_priority_boost if was_paused else 0.0
-            soft_demoted = program.soft_demoted_until > time.monotonic()
-            if soft_demoted:
-                priority_jump += self._cfg.soft_demote_priority_jump
-
-            return PauseDecision(
-                program_id=program_id,
-                priority_jump=priority_jump,
-                waited_seconds=waited,
-                was_paused=was_paused,
-                was_soft_demoted=soft_demoted,
-                assigned_worker_hint=program.assigned_worker_id,
+            if self._table.programs.get(program_id) is not admitted:
+                # Released meanwhile, and possibly recreated by a newer request.
+                # Neither case is ours to undo.
+                return
+            self._table.rollback_request(program_id, snapshot)
+            self._stat_admissions_cancelled += 1
+            logger.info(
+                "thunderagent.program admission_cancelled program=%s "
+                "retained=%s active=%d paused=%d",
+                program_id,
+                snapshot is not None,
+                len(self._table.programs),
+                len(self._table.paused),
             )
 
     def _admit_locked(
@@ -687,6 +738,7 @@ class ThunderAgentScheduler:
                     "program_resumes_total": self._stat_resumes,
                     "programs_marked_for_pause_total": self._stat_marked_for_pause,
                     "forced_resumes_total": self._stat_forced_resumes,
+                    "admissions_cancelled_total": self._stat_admissions_cancelled,
                     "worker_assignments_total": self._stat_worker_assignments,
                 },
                 "gauges": {

--- a/components/src/dynamo/thunderagent_router/tests/test_program_state.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_program_state.py
@@ -112,8 +112,6 @@ def test_snapshot_and_rollback_track_the_admission_epoch():
 
 
 def test_rollback_clears_a_wait_event_the_resume_had_set():
-    """Restoring PAUSED alongside an already-set Event would let the session's
-    next turn through with no capacity check."""
     table = ProgramTable()
     table.begin_request("p1")
     table.end_request("p1", prompt_tokens=100, completion_tokens=10)
@@ -126,7 +124,6 @@ def test_rollback_clears_a_wait_event_the_resume_had_set():
     assert snapshot is not None
     table.begin_request("p1", estimated_prompt_tokens=500)
 
-    # A tick resumes the program the instant the turn is cancelled.
     resumed_event = program.waiting
     assert resumed_event is not None
     program.lifecycle = ProgramLifecycle.ACTIVE

--- a/components/src/dynamo/thunderagent_router/tests/test_program_state.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_program_state.py
@@ -43,3 +43,53 @@ def test_end_request_records_real_token_total():
     assert p is not None
     assert p.token_total == 150
     assert p.status == ProgramStatus.ACTING
+
+
+def test_rollback_drops_a_program_the_attempt_created():
+    table = ProgramTable()
+    snapshot = table.snapshot_request("p1")
+    assert snapshot is None
+    table.begin_request("p1", estimated_prompt_tokens=64)
+    table.paused["p1"] = None
+
+    table.rollback_request("p1", snapshot)
+
+    assert "p1" not in table.programs
+    assert "p1" not in table.paused
+
+
+def test_rollback_restores_a_pre_existing_program_instead_of_dropping_it():
+    table = ProgramTable()
+    table.begin_request("p1")
+    table.end_request("p1", prompt_tokens=100, completion_tokens=10)
+    program = table.programs["p1"]
+    program.lifecycle = ProgramLifecycle.PAUSED
+    table.paused["p1"] = None
+    acting_since = program.acting_since
+
+    snapshot = table.snapshot_request("p1")
+    table.begin_request("p1", estimated_prompt_tokens=500)
+
+    table.rollback_request("p1", snapshot)
+
+    assert table.programs["p1"] is program
+    assert program.step_count == 1
+    assert program.token_total == 110
+    assert program.status == ProgramStatus.ACTING
+    assert program.lifecycle == ProgramLifecycle.PAUSED
+    assert program.acting_since == acting_since
+    assert "p1" in table.paused
+
+
+def test_rollback_leaves_a_replacement_program_alone():
+    table = ProgramTable()
+    table.begin_request("p1", estimated_prompt_tokens=10)
+    snapshot = table.snapshot_request("p1")
+    table.release("p1")
+    replacement = table.begin_request("p1", estimated_prompt_tokens=42)
+
+    table.rollback_request("p1", snapshot)
+
+    assert table.programs["p1"] is replacement
+    assert replacement.token_total == 42
+    assert replacement.step_count == 1

--- a/components/src/dynamo/thunderagent_router/tests/test_program_state.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_program_state.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from dynamo.thunderagent_router.program_state import (
@@ -93,3 +95,48 @@ def test_rollback_leaves_a_replacement_program_alone():
     assert table.programs["p1"] is replacement
     assert replacement.token_total == 42
     assert replacement.step_count == 1
+
+
+def test_snapshot_and_rollback_track_the_admission_epoch():
+    table = ProgramTable()
+    program = table.begin_request("p1")
+    assert program.admission_epoch == 1
+
+    snapshot = table.snapshot_request("p1")
+    table.begin_request("p1")
+    assert program.admission_epoch == 2
+
+    table.rollback_request("p1", snapshot)
+
+    assert program.admission_epoch == 1
+
+
+def test_rollback_clears_a_wait_event_the_resume_had_set():
+    """Restoring PAUSED alongside an already-set Event would let the session's
+    next turn through with no capacity check."""
+    table = ProgramTable()
+    table.begin_request("p1")
+    table.end_request("p1", prompt_tokens=100, completion_tokens=10)
+    program = table.programs["p1"]
+    program.lifecycle = ProgramLifecycle.PAUSED
+    program.waiting = asyncio.Event()
+    table.paused["p1"] = None
+
+    snapshot = table.snapshot_request("p1")
+    assert snapshot is not None
+    table.begin_request("p1", estimated_prompt_tokens=500)
+
+    # A tick resumes the program the instant the turn is cancelled.
+    resumed_event = program.waiting
+    assert resumed_event is not None
+    program.lifecycle = ProgramLifecycle.ACTIVE
+    program.waiting = None
+    table.paused.pop("p1")
+    resumed_event.set()
+
+    table.rollback_request("p1", snapshot)
+
+    assert program.lifecycle == ProgramLifecycle.PAUSED
+    assert "p1" in table.paused
+    assert program.waiting is resumed_event
+    assert not resumed_event.is_set()

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -535,21 +535,24 @@ async def test_cancelled_admission_does_not_strand_a_concurrent_waiter():
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(asyncio.shield(first), timeout=0.05)
     assert "shared" in router._table.paused
+    first_program = router._table.programs["shared"]
 
     second = asyncio.create_task(
         router.before_request("shared", estimated_prompt_tokens=50)
     )
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(asyncio.shield(second), timeout=0.05)
-    wait_event = router._table.programs["shared"].waiting
+    assert router._table.programs["shared"] is first_program
 
     first.cancel()
     with pytest.raises(asyncio.CancelledError):
         await first
+    await asyncio.sleep(0)
 
     assert "shared" in router._table.programs
     assert "shared" in router._table.paused
-    assert router._table.programs["shared"].waiting is wait_event
+    assert router._table.programs["shared"] is not first_program
+    assert router._table.programs["shared"].step_count == 1
 
     assert await router.end_program("existing") is True
     await router._scheduler_tick()
@@ -561,7 +564,7 @@ async def test_cancelled_admission_does_not_strand_a_concurrent_waiter():
 
 @pytest.mark.fault_tolerance
 @pytest.mark.asyncio
-async def test_cancelled_admission_does_not_undo_a_later_turn():
+async def test_cancelled_admission_serializes_a_later_turn():
     cfg = ThunderAgentConfig(
         scheduler_interval_seconds=1000.0,
         resume_timeout_seconds=5.0,
@@ -585,21 +588,66 @@ async def test_cancelled_admission_does_not_undo_a_later_turn():
     )
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(asyncio.shield(later), timeout=0.05)
-    assert program.token_total == 777
-    assert program.step_count == 3
+    assert program.token_total == 500
+    assert program.step_count == 2
 
     cancelled.cancel()
     with pytest.raises(asyncio.CancelledError):
         await cancelled
+    await asyncio.sleep(0)
 
     assert router._table.programs["p1"] is program
     assert program.token_total == 777
-    assert program.step_count == 3
+    assert program.step_count == 2
     assert program.lifecycle == ProgramLifecycle.PAUSED
 
     later.cancel()
     with pytest.raises(asyncio.CancelledError):
         await later
+
+    assert router._table.programs["p1"] is program
+    assert program.token_total == 110
+    assert program.step_count == 1
+    assert program.lifecycle == ProgramLifecycle.PAUSED
+
+
+@pytest.mark.fault_tolerance
+@pytest.mark.asyncio
+async def test_two_cancelled_admissions_of_new_program_leave_no_trace():
+    cfg = ThunderAgentConfig(
+        scheduler_interval_seconds=1000.0,
+        resume_timeout_seconds=5.0,
+        pause_threshold=1.0,
+        pause_target=1.0,
+        resume_hysteresis=0.0,
+    )
+    router, _ = make_router(capacity_workers={1: 1000}, config=cfg)
+
+    await router.before_request("existing", estimated_prompt_tokens=850)
+
+    first = asyncio.create_task(
+        router.before_request("shared", estimated_prompt_tokens=50)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(first), timeout=0.05)
+
+    second = asyncio.create_task(
+        router.before_request("shared", estimated_prompt_tokens=75)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(second), timeout=0.05)
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    second.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await second
+
+    assert "shared" not in router._table.programs
+    assert "shared" not in router._table.paused
+    assert "shared" not in router._admission_gates
 
 
 @pytest.mark.fault_tolerance

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -419,3 +419,102 @@ async def test_scheduler_tick_resumes_before_pausing_new_overload():
         if p.lifecycle == ProgramLifecycle.PAUSED
     )
     assert paused == 6
+
+
+@pytest.mark.asyncio
+async def test_cancelled_admission_of_new_program_leaves_no_trace():
+    """A cancelled first-turn admission must not outlive the request.
+
+    The parked program is small and the program holding the worker is large, so
+    a tick after the blocker is released has room to resume the phantom -- which
+    is what makes the phantom's absence, rather than a lucky capacity shortage,
+    the reason nothing is assigned to it.
+    """
+    cfg = ThunderAgentConfig(
+        scheduler_interval_seconds=1000.0,
+        resume_timeout_seconds=0.5,
+        pause_threshold=1.0,
+        pause_target=1.0,
+        resume_hysteresis=0.0,
+    )
+    router, _ = make_router(capacity_workers={1: 1000}, config=cfg)
+
+    decision = await router.before_request("existing", estimated_prompt_tokens=850)
+    assert decision.assigned_worker_hint == 1
+    assert router._worker_used(1) == 950
+
+    waiter = asyncio.create_task(
+        router.before_request("new", estimated_prompt_tokens=50)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(waiter), timeout=0.05)
+    assert "new" in router._table.paused
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert "new" not in router._table.programs
+    assert "new" not in router._table.paused
+
+    assert await router.end_program("existing") is True
+    decision = await asyncio.wait_for(
+        router.before_request("other", estimated_prompt_tokens=50), timeout=1.5
+    )
+    assert decision.was_paused is False
+    assert decision.assigned_worker_hint == 1
+
+    assignments_before_tick = router._stat_worker_assignments
+    await router._scheduler_tick()
+
+    assert "new" not in router._table.programs
+    assert router._worker_used(1) == 150
+    assert router._stat_worker_assignments == assignments_before_tick
+
+
+@pytest.mark.asyncio
+async def test_cancelled_admission_of_existing_program_restores_prior_turn():
+    cfg = ThunderAgentConfig(
+        scheduler_interval_seconds=1000.0,
+        resume_timeout_seconds=2.0,
+    )
+    router, _ = make_router(config=cfg)
+
+    await router.before_request("p1")
+    await router.assign_worker("p1", 1)
+    await router.after_request("p1", prompt_tokens=100, completion_tokens=10)
+    await router._pause_acting("p1")
+
+    program = router._table.programs["p1"]
+    assert program.lifecycle == ProgramLifecycle.PAUSED
+    assert program.status == ProgramStatus.ACTING
+    assert program.step_count == 1
+    assert program.token_total == 110
+    assert program.assigned_worker_id is None
+    assert "p1" in router._table.paused
+    waiting_before = program.waiting
+    acting_since_before = program.acting_since
+    assert waiting_before is not None
+    assert not waiting_before.is_set()
+
+    waiter = asyncio.create_task(
+        router.before_request("p1", estimated_prompt_tokens=500)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(waiter), timeout=0.05)
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    # Session history survives: the cancelled turn is undone, not the program.
+    assert router._table.programs["p1"] is program
+    assert program.lifecycle == ProgramLifecycle.PAUSED
+    assert program.status == ProgramStatus.ACTING
+    assert program.step_count == 1
+    assert program.token_total == 110
+    assert program.assigned_worker_id is None
+    assert program.acting_since == acting_since_before
+    assert "p1" in router._table.paused
+    assert program.waiting is waiting_before
+    assert not program.waiting.is_set()

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -424,13 +424,6 @@ async def test_scheduler_tick_resumes_before_pausing_new_overload():
 @pytest.mark.fault_tolerance
 @pytest.mark.asyncio
 async def test_cancelled_admission_of_new_program_leaves_no_trace():
-    """A cancelled first-turn admission must not outlive the request.
-
-    The parked program is small and the program holding the worker is large, so
-    a tick after the blocker is released has room to resume the phantom -- which
-    is what makes the phantom's absence, rather than a lucky capacity shortage,
-    the reason nothing is assigned to it.
-    """
     cfg = ThunderAgentConfig(
         scheduler_interval_seconds=1000.0,
         resume_timeout_seconds=0.5,
@@ -509,7 +502,6 @@ async def test_cancelled_admission_of_existing_program_restores_prior_turn():
     with pytest.raises(asyncio.CancelledError):
         await waiter
 
-    # Session history survives: the cancelled turn is undone, not the program.
     assert router._table.programs["p1"] is program
     assert program.lifecycle == ProgramLifecycle.PAUSED
     assert program.status == ProgramStatus.ACTING
@@ -525,9 +517,6 @@ async def test_cancelled_admission_of_existing_program_restores_prior_turn():
 @pytest.mark.fault_tolerance
 @pytest.mark.asyncio
 async def test_cancelled_admission_does_not_strand_a_concurrent_waiter():
-    """Two turns of one session share a program, so one cancelling must not
-    delete it out from under the other: the survivor is parked on the program's
-    Event and only a resume of that program can wake it."""
     cfg = ThunderAgentConfig(
         scheduler_interval_seconds=1000.0,
         resume_timeout_seconds=5.0,
@@ -573,8 +562,6 @@ async def test_cancelled_admission_does_not_strand_a_concurrent_waiter():
 @pytest.mark.fault_tolerance
 @pytest.mark.asyncio
 async def test_cancelled_admission_does_not_undo_a_later_turn():
-    """Both turns mutate the same Program object, so object identity alone
-    cannot tell the cancelled turn's mutations from the live turn's."""
     cfg = ThunderAgentConfig(
         scheduler_interval_seconds=1000.0,
         resume_timeout_seconds=5.0,
@@ -605,8 +592,6 @@ async def test_cancelled_admission_does_not_undo_a_later_turn():
     with pytest.raises(asyncio.CancelledError):
         await cancelled
 
-    # The later turn's admission is still in force; restoring the cancelled
-    # turn's snapshot would have put token_total back to 110 and step_count to 1.
     assert router._table.programs["p1"] is program
     assert program.token_total == 777
     assert program.step_count == 3
@@ -620,8 +605,6 @@ async def test_cancelled_admission_does_not_undo_a_later_turn():
 @pytest.mark.fault_tolerance
 @pytest.mark.asyncio
 async def test_rollback_completes_when_cancellation_is_redelivered():
-    """A scheduler tick holds the lock across awaits, so the rollback's
-    acquisition can block long enough to be cancelled a second time."""
     cfg = ThunderAgentConfig(
         scheduler_interval_seconds=1000.0,
         resume_timeout_seconds=5.0,

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -421,6 +421,7 @@ async def test_scheduler_tick_resumes_before_pausing_new_overload():
     assert paused == 6
 
 
+@pytest.mark.fault_tolerance
 @pytest.mark.asyncio
 async def test_cancelled_admission_of_new_program_leaves_no_trace():
     """A cancelled first-turn admission must not outlive the request.
@@ -472,6 +473,7 @@ async def test_cancelled_admission_of_new_program_leaves_no_trace():
     assert router._stat_worker_assignments == assignments_before_tick
 
 
+@pytest.mark.fault_tolerance
 @pytest.mark.asyncio
 async def test_cancelled_admission_of_existing_program_restores_prior_turn():
     cfg = ThunderAgentConfig(
@@ -518,3 +520,140 @@ async def test_cancelled_admission_of_existing_program_restores_prior_turn():
     assert "p1" in router._table.paused
     assert program.waiting is waiting_before
     assert not program.waiting.is_set()
+
+
+@pytest.mark.fault_tolerance
+@pytest.mark.asyncio
+async def test_cancelled_admission_does_not_strand_a_concurrent_waiter():
+    """Two turns of one session share a program, so one cancelling must not
+    delete it out from under the other: the survivor is parked on the program's
+    Event and only a resume of that program can wake it."""
+    cfg = ThunderAgentConfig(
+        scheduler_interval_seconds=1000.0,
+        resume_timeout_seconds=5.0,
+        pause_threshold=1.0,
+        pause_target=1.0,
+        resume_hysteresis=0.0,
+    )
+    router, _ = make_router(capacity_workers={1: 1000}, config=cfg)
+
+    decision = await router.before_request("existing", estimated_prompt_tokens=850)
+    assert decision.assigned_worker_hint == 1
+
+    first = asyncio.create_task(
+        router.before_request("shared", estimated_prompt_tokens=50)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(first), timeout=0.05)
+    assert "shared" in router._table.paused
+
+    second = asyncio.create_task(
+        router.before_request("shared", estimated_prompt_tokens=50)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(second), timeout=0.05)
+    wait_event = router._table.programs["shared"].waiting
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    assert "shared" in router._table.programs
+    assert "shared" in router._table.paused
+    assert router._table.programs["shared"].waiting is wait_event
+
+    assert await router.end_program("existing") is True
+    await router._scheduler_tick()
+
+    decision = await asyncio.wait_for(second, timeout=1.5)
+    assert decision.was_paused is True
+    assert decision.assigned_worker_hint == 1
+
+
+@pytest.mark.fault_tolerance
+@pytest.mark.asyncio
+async def test_cancelled_admission_does_not_undo_a_later_turn():
+    """Both turns mutate the same Program object, so object identity alone
+    cannot tell the cancelled turn's mutations from the live turn's."""
+    cfg = ThunderAgentConfig(
+        scheduler_interval_seconds=1000.0,
+        resume_timeout_seconds=5.0,
+    )
+    router, _ = make_router(config=cfg)
+
+    await router.before_request("p1")
+    await router.assign_worker("p1", 1)
+    await router.after_request("p1", prompt_tokens=100, completion_tokens=10)
+    await router._pause_acting("p1")
+    program = router._table.programs["p1"]
+
+    cancelled = asyncio.create_task(
+        router.before_request("p1", estimated_prompt_tokens=500)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(cancelled), timeout=0.05)
+
+    later = asyncio.create_task(
+        router.before_request("p1", estimated_prompt_tokens=777)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(later), timeout=0.05)
+    assert program.token_total == 777
+    assert program.step_count == 3
+
+    cancelled.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled
+
+    # The later turn's admission is still in force; restoring the cancelled
+    # turn's snapshot would have put token_total back to 110 and step_count to 1.
+    assert router._table.programs["p1"] is program
+    assert program.token_total == 777
+    assert program.step_count == 3
+    assert program.lifecycle == ProgramLifecycle.PAUSED
+
+    later.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await later
+
+
+@pytest.mark.fault_tolerance
+@pytest.mark.asyncio
+async def test_rollback_completes_when_cancellation_is_redelivered():
+    """A scheduler tick holds the lock across awaits, so the rollback's
+    acquisition can block long enough to be cancelled a second time."""
+    cfg = ThunderAgentConfig(
+        scheduler_interval_seconds=1000.0,
+        resume_timeout_seconds=5.0,
+        pause_threshold=1.0,
+        pause_target=1.0,
+        resume_hysteresis=0.0,
+    )
+    router, _ = make_router(capacity_workers={1: 1000}, config=cfg)
+
+    decision = await router.before_request("existing", estimated_prompt_tokens=850)
+    assert decision.assigned_worker_hint == 1
+
+    waiter = asyncio.create_task(
+        router.before_request("new", estimated_prompt_tokens=50)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(waiter), timeout=0.05)
+    assert "new" in router._table.paused
+
+    await router._lock.acquire()
+    try:
+        waiter.cancel()
+        await asyncio.sleep(0.01)
+        assert "new" in router._table.programs, "rollback should be parked on the lock"
+        waiter.cancel()
+        await asyncio.sleep(0.01)
+        assert "new" in router._table.programs
+    finally:
+        router._lock.release()
+
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert "new" not in router._table.programs
+    assert "new" not in router._table.paused


### PR DESCRIPTION
## Summary

ThunderAgent updates a session's program state before a request may have to wait for capacity. If that request was cancelled, the abandoned admission could retain capacity, leave stale wait state, or overwrite a later admission for the same session.

Each session now serializes its admission transactions. Before changing a program, the router records its state and admission epoch. Cancellation restores that state only while the same admission still owns the program; a program created by the cancelled request is removed, while an existing program keeps the history from its previous turn. Rollback is shielded from repeated cancellation and clears stale wait events before another turn can proceed.

Per-session admission locks are removed when their final user exits. The router also reports cancelled admissions through `admissions_cancelled_total`, and the README documents the behavior.

Closes #13549

## Validation

The diff includes focused coverage for new and existing programs, overlapping admissions, repeated cancellation, stale wait events, and admission-lock cleanup. No tests were run locally at the current head.
