### PR TITLE
fix(kvbm): bound the recorder queue and account for dropped actions

### DIFF
--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/recorder.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/recorder.rs
@@ -4,6 +4,19 @@
 use super::*;
 use anyhow;
 use dynamo_llm::block_manager::kv_consolidator::EventSource;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::task::JoinHandle;
+
+/// Capacity of the staging queue between the synchronous connector hooks and
+/// the [`Recorder`]'s own event channel. Mirrors that channel's 2,048-event
+/// bound, so total retained actions are bounded by ingress + downstream + the
+/// single action the forwarding task holds in flight.
+const RECORD_INGRESS_CAPACITY: usize = 2048;
+
+/// Drops between overload warnings after the first one. Overload is by
+/// definition high-frequency, so an unthrottled warning would become the
+/// unbounded thing the queue no longer is.
+const DROP_WARN_INTERVAL: u64 = 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Action {
@@ -87,10 +100,109 @@ pub struct ResetCacheOutput {
     result: bool,
 }
 
+/// Bounded, explicitly lossy staging queue in front of a [`Recorder`]'s event
+/// channel.
+///
+/// The producers are synchronous vLLM scheduler callbacks reached through
+/// pyo3, so they cannot wait for capacity: applying real backpressure here
+/// would turn a stall on the recorder's output file into a stall of the
+/// serving path. `record` therefore never blocks and never fails — when the
+/// queue is full it discards the action and counts it.
+///
+/// Recording is consequently **lossy under overload**: the JSONL output can
+/// contain a gap. The gap is announced rather than silent, through
+/// [`Self::dropped_count`], a throttled warning, and the total logged when the
+/// ingress is dropped.
+///
+/// The *newest* action is discarded, not the oldest. That keeps whatever is
+/// retained a FIFO prefix of the action stream instead of a shuffled window,
+/// and it means an action that was accepted is never later evicted.
+#[derive(Debug)]
+struct ActionRecorderIngress<T: Send + 'static> {
+    tx: mpsc::Sender<T>,
+    dropped: Arc<AtomicU64>,
+    capacity: usize,
+    // Held rather than detached so the forwarding task's lifetime is tied to
+    // this value. It is never aborted: dropping `tx` ends the loop only after
+    // it has drained the actions it already accepted.
+    _forwarder: JoinHandle<()>,
+}
+
+impl<T: Send + 'static> ActionRecorderIngress<T> {
+    /// The runtime handle and the capacity are parameters rather than a global
+    /// lookup and a private constant so that the queue can be constructed —
+    /// and its overload behavior exercised — from a plain `cargo test`, with
+    /// no GPU, no pyo3 state, and no leader/worker barrier.
+    fn new(rt: &Handle, downstream: mpsc::Sender<T>, capacity: usize) -> Self {
+        let (tx, rx) = mpsc::channel(capacity);
+        let forwarder = rt.spawn(Self::forward_to_downstream(rx, downstream));
+
+        Self {
+            tx,
+            dropped: Arc::new(AtomicU64::new(0)),
+            capacity,
+            _forwarder: forwarder,
+        }
+    }
+
+    /// Enqueue an action, discarding it if the queue is full or the recorder
+    /// has already shut down. Callable from a synchronous thread that may or
+    /// may not be inside a runtime.
+    fn record(&self, item: T) {
+        let closed = match self.tx.try_send(item) {
+            Ok(()) => return,
+            Err(mpsc::error::TrySendError::Full(_)) => false,
+            Err(mpsc::error::TrySendError::Closed(_)) => true,
+        };
+
+        let dropped = self.dropped.fetch_add(1, Ordering::Relaxed) + 1;
+        if dropped == 1 || dropped.is_multiple_of(DROP_WARN_INTERVAL) {
+            if closed {
+                tracing::warn!(
+                    dropped,
+                    capacity = self.capacity,
+                    "kvbm recorder ingress is closed; dropping action"
+                );
+            } else {
+                tracing::warn!(
+                    dropped,
+                    capacity = self.capacity,
+                    "kvbm recorder ingress is full; dropping newest action"
+                );
+            }
+        }
+    }
+
+    fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    async fn forward_to_downstream(mut rx: mpsc::Receiver<T>, downstream: mpsc::Sender<T>) {
+        while let Some(msg) = rx.recv().await {
+            if downstream.send(msg).await.is_err() {
+                tracing::error!("Failed to send message to bounded channel");
+            }
+        }
+    }
+}
+
+impl<T: Send + 'static> Drop for ActionRecorderIngress<T> {
+    fn drop(&mut self) {
+        let dropped = self.dropped_count();
+        if dropped > 0 {
+            tracing::warn!(
+                dropped,
+                capacity = self.capacity,
+                "kvbm recorder dropped actions under overload; the recorded trace has a gap"
+            );
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct KvConnectorLeaderRecorder {
     _recorder: Recorder<Action>, // Keep recorder alive
-    unbounded_tx: mpsc::UnboundedSender<Action>,
+    ingress: ActionRecorderIngress<Action>,
     connector_leader: Box<dyn Leader>,
 }
 
@@ -126,12 +238,16 @@ impl KvConnectorLeaderRecorder {
             .block_on(async { Recorder::new(token, &output_path, None, None, None).await })
             .unwrap();
 
-        let (unbounded_tx, unbounded_rx) = mpsc::unbounded_channel();
-        let recorder_tx = recorder.event_sender();
-
         // todo(kvbm): make this a critical task
-        get_current_tokio_handle()
-            .spawn(Self::forward_unbounded_to_sender(unbounded_rx, recorder_tx));
+        // The queue in front of the writer is bounded, so if writes to
+        // `output_path` cannot keep pace the trace loses actions rather than
+        // accumulating them: expect gaps in that file, counted and logged by
+        // `ActionRecorderIngress`.
+        let ingress = ActionRecorderIngress::new(
+            &get_current_tokio_handle(),
+            recorder.event_sender(),
+            RECORD_INGRESS_CAPACITY,
+        );
 
         let slot_manager_cell = Arc::new(OnceLock::new());
         let (leader_ready_tx, leader_ready_rx) = oneshot::channel::<String>();
@@ -215,19 +331,8 @@ impl KvConnectorLeaderRecorder {
 
         Self {
             _recorder: recorder,
-            unbounded_tx,
+            ingress,
             connector_leader: Box::new(connector_leader),
-        }
-    }
-
-    async fn forward_unbounded_to_sender<T: Send + 'static>(
-        mut unbounded_rx: mpsc::UnboundedReceiver<T>,
-        bounded_tx: mpsc::Sender<T>,
-    ) {
-        while let Some(msg) = unbounded_rx.recv().await {
-            if bounded_tx.send(msg).await.is_err() {
-                tracing::error!("Failed to send message to bounded channel");
-            }
         }
     }
 }
@@ -259,7 +364,7 @@ impl Leader for KvConnectorLeaderRecorder {
             request_num_tokens,
             num_computed_tokens,
         )?;
-        let _ = self.unbounded_tx.send(Action::GetNumNewMatchedTokens(
+        self.ingress.record(Action::GetNumNewMatchedTokens(
             input_copy,
             GetNumNewMatchedTokensOutput {
                 num_new_matched_tokens: output.0,
@@ -290,7 +395,7 @@ impl Leader for KvConnectorLeaderRecorder {
             block_ids,
             num_external_tokens,
         )?;
-        let _ = self.unbounded_tx.send(Action::UpdateStateAfterAlloc(
+        self.ingress.record(Action::UpdateStateAfterAlloc(
             input_copy,
             UpdateStateAfterAllocOutput {},
         ));
@@ -307,7 +412,7 @@ impl Leader for KvConnectorLeaderRecorder {
         let output = self
             .connector_leader
             .build_connector_metadata(scheduler_output)?;
-        let _ = self.unbounded_tx.send(Action::BuildConnectorMeta(
+        self.ingress.record(Action::BuildConnectorMeta(
             input_copy,
             BuildConnectorMetaOutput {
                 metadata: serde_json::from_slice(&output)?,
@@ -328,7 +433,7 @@ impl Leader for KvConnectorLeaderRecorder {
         let output = self
             .connector_leader
             .request_finished(request_id, block_ids)?;
-        let _ = self.unbounded_tx.send(Action::RequestFinished(
+        self.ingress.record(Action::RequestFinished(
             input_copy,
             RequestFinishedOutput {
                 is_finished: output,
@@ -342,7 +447,7 @@ impl Leader for KvConnectorLeaderRecorder {
             request_id: request_id.clone(),
         };
         let output = self.connector_leader.has_slot(request_id);
-        let _ = self.unbounded_tx.send(Action::HasSlot(
+        self.ingress.record(Action::HasSlot(
             input_copy,
             HasSlotOutput { result: output },
         ));
@@ -357,18 +462,154 @@ impl Leader for KvConnectorLeaderRecorder {
             tokens: tokens.clone(),
         };
         let _ = self.connector_leader.create_slot(request, tokens);
-        let _ = self
-            .unbounded_tx
-            .send(Action::CreateSlot(input_copy, CreateSlotOutput {}));
+        self.ingress
+            .record(Action::CreateSlot(input_copy, CreateSlotOutput {}));
         Ok(())
     }
 
     fn reset_cache(&mut self) -> anyhow::Result<bool> {
         let output = self.connector_leader.reset_cache()?;
-        let _ = self.unbounded_tx.send(Action::ResetCache(
+        self.ingress.record(Action::ResetCache(
             ResetCacheInput {},
             ResetCacheOutput { result: output },
         ));
         Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build the production `Action` the cheapest hook records, tagged with a
+    /// monotone id so ordering and loss are both readable off the drained
+    /// stream.
+    fn has_slot_action(id: usize) -> Action {
+        Action::HasSlot(
+            HasSlotInput {
+                request_id: id.to_string(),
+            },
+            HasSlotOutput { result: true },
+        )
+    }
+
+    /// Drain everything the forwarding task will ever deliver.
+    ///
+    /// The ingress must already have been dropped: that is what closes the
+    /// forwarding loop once it has flushed the actions it accepted, which in
+    /// turn drops the last downstream sender and terminates this loop. Without
+    /// it a stalled-sink test would hang instead of failing.
+    async fn drain<T>(rx: &mut mpsc::Receiver<T>) -> Vec<T> {
+        let mut drained = Vec::new();
+        while let Some(item) = rx.recv().await {
+            drained.push(item);
+        }
+        drained
+    }
+
+    /// T1: with a sink that never drains, retention is capped near the
+    /// configured capacity instead of growing with the number of pushes, and
+    /// the loss is counted rather than silent.
+    #[tokio::test]
+    async fn stalled_sink_bounds_retention_and_counts_the_loss() {
+        const CAPACITY: usize = 4;
+        const PUSHED: usize = 100;
+
+        let (downstream_tx, mut downstream_rx) = mpsc::channel::<usize>(1);
+        let ingress = ActionRecorderIngress::new(&Handle::current(), downstream_tx, CAPACITY);
+
+        for i in 0..PUSHED {
+            ingress.record(i);
+        }
+
+        let dropped = ingress.dropped_count();
+        assert!(
+            dropped > 0,
+            "overload against a stalled sink must be counted, got {dropped} drops after {PUSHED} pushes"
+        );
+
+        drop(ingress);
+        let retained = drain(&mut downstream_rx).await;
+
+        // Ceiling: the ingress queue, plus the one action the forwarding task
+        // holds while parked on the downstream `send`, plus the one the
+        // downstream channel itself buffers. Deliberately an inequality --
+        // whether the forwarder had already parked is a scheduling detail.
+        assert!(
+            retained.len() <= CAPACITY + 2,
+            "retained {} actions, which exceeds the {} the queue can hold",
+            retained.len(),
+            CAPACITY + 2
+        );
+        assert_eq!(
+            retained.len() as u64 + dropped,
+            PUSHED as u64,
+            "every action must be either retained or counted as dropped"
+        );
+    }
+
+    /// T2: the actions that were accepted come out in the order they went in,
+    /// and they are a prefix of the pushed stream -- the drop-newest policy,
+    /// observed on real `Action` values rather than on the generic parameter.
+    #[tokio::test]
+    async fn accepted_actions_drain_in_fifo_order_after_the_sink_is_released() {
+        const CAPACITY: usize = 4;
+        const PUSHED: usize = 32;
+
+        let (downstream_tx, mut downstream_rx) = mpsc::channel::<Action>(1);
+        let ingress = ActionRecorderIngress::new(&Handle::current(), downstream_tx, CAPACITY);
+
+        for i in 0..PUSHED {
+            ingress.record(has_slot_action(i));
+        }
+        assert!(
+            ingress.dropped_count() > 0,
+            "pushing {PUSHED} actions through a capacity-{CAPACITY} queue with a stalled sink must overflow it"
+        );
+
+        drop(ingress);
+        let ids: Vec<usize> = drain(&mut downstream_rx)
+            .await
+            .into_iter()
+            .map(|action| match action {
+                Action::HasSlot(input, _) => input.request_id.parse().unwrap(),
+                other => panic!("recorded a different action than the one pushed: {other:?}"),
+            })
+            .collect();
+
+        assert!(!ids.is_empty(), "the queue must retain what it accepted");
+        assert!(
+            ids.windows(2).all(|pair| pair[0] < pair[1]),
+            "accepted actions must drain in FIFO order, got {ids:?}"
+        );
+        assert_eq!(
+            ids,
+            (0..ids.len()).collect::<Vec<_>>(),
+            "dropping the newest action must leave a prefix of the pushed stream"
+        );
+    }
+
+    /// T3: the negative control. A bound that simply threw actions away would
+    /// pass T1; this is the test it would fail.
+    #[tokio::test]
+    async fn a_sink_that_keeps_up_loses_nothing() {
+        const CAPACITY: usize = 8;
+        const PUSHED: usize = 5;
+
+        let (downstream_tx, mut downstream_rx) = mpsc::channel::<usize>(1);
+        let ingress = ActionRecorderIngress::new(&Handle::current(), downstream_tx, CAPACITY);
+
+        let mut received = Vec::new();
+        for i in 0..PUSHED {
+            ingress.record(i);
+            received.push(downstream_rx.recv().await.expect("sink closed early"));
+        }
+
+        assert_eq!(
+            ingress.dropped_count(),
+            0,
+            "a sink that keeps up, fed fewer actions than the queue holds, must lose nothing"
+        );
+        assert_eq!(received, (0..PUSHED).collect::<Vec<_>>());
     }
 }

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/recorder.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/recorder.rs
@@ -124,10 +124,8 @@ struct ActionRecorderIngress<T: Send + 'static> {
     tx: mpsc::Sender<T>,
     dropped: Arc<AtomicU64>,
     capacity: usize,
-    // Held rather than detached so the forwarding task's lifetime is tied to
-    // this value. It is never aborted: dropping `tx` ends the loop only after
-    // it has drained the actions it already accepted. The loop can also end
-    // on its own, when the recorder's channel closes under it.
+    // Held rather than detached: dropping `tx` ties the forwarding task's
+    // lifetime to this value, which drains before exiting rather than aborting.
     _forwarder: JoinHandle<()>,
 }
 
@@ -273,10 +271,8 @@ impl KvConnectorLeaderRecorder {
             .unwrap();
 
         // todo(kvbm): make this a critical task
-        // The queue in front of the writer is bounded, so if writes to
-        // `output_path` cannot keep pace the trace loses actions rather than
-        // accumulating them: expect gaps in that file, counted and logged by
-        // `ActionRecorderIngress`.
+        // The queue in front of the writer is bounded: a slow `output_path` write
+        // drops actions instead of buffering unbounded, counted by `ActionRecorderIngress`.
         let ingress = ActionRecorderIngress::new(
             &get_current_tokio_handle(),
             recorder.event_sender(),
@@ -565,10 +561,8 @@ mod tests {
         drop(ingress);
         let retained = drain(&mut downstream_rx).await;
 
-        // Ceiling: the ingress queue, plus the one action the forwarding task
-        // holds while parked on the downstream `send`, plus the one the
-        // downstream channel itself buffers. Deliberately an inequality --
-        // whether the forwarder had already parked is a scheduling detail.
+        // Ceiling: queue capacity, plus one in-flight action held by the forwarder,
+        // plus one buffered downstream -- an inequality since parking timing varies.
         assert!(
             retained.len() <= CAPACITY + 2,
             "retained {} actions, which exceeds the {} the queue can hold",
@@ -667,10 +661,8 @@ mod tests {
             ingress.record(i);
         }
 
-        // The forwarding task has to be polled before it can notice the
-        // closure, so the accounting settles asynchronously. The timeout is a
-        // failure bound, not a delay -- it is reached only if some action was
-        // neither delivered nor counted.
+        // Accounting settles asynchronously once the forwarding task is polled;
+        // the timeout is a failure bound, reached only if an action goes uncounted.
         let settled = tokio::time::timeout(std::time::Duration::from_secs(10), async {
             while ingress.dropped_count() != PUSHED as u64 {
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/recorder.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/recorder.rs
@@ -112,7 +112,9 @@ pub struct ResetCacheOutput {
 /// Recording is consequently **lossy under overload**: the JSONL output can
 /// contain a gap. The gap is announced rather than silent, through
 /// [`Self::dropped_count`], a throttled warning, and the total logged when the
-/// ingress is dropped.
+/// ingress is dropped. The same counter covers the other way an action can go
+/// missing — the recorder shutting down while producers are still calling —
+/// so an action is always either written or counted.
 ///
 /// The *newest* action is discarded, not the oldest. That keeps whatever is
 /// retained a FIFO prefix of the action stream instead of a shuffled window,
@@ -124,7 +126,8 @@ struct ActionRecorderIngress<T: Send + 'static> {
     capacity: usize,
     // Held rather than detached so the forwarding task's lifetime is tied to
     // this value. It is never aborted: dropping `tx` ends the loop only after
-    // it has drained the actions it already accepted.
+    // it has drained the actions it already accepted. The loop can also end
+    // on its own, when the recorder's channel closes under it.
     _forwarder: JoinHandle<()>,
 }
 
@@ -135,11 +138,12 @@ impl<T: Send + 'static> ActionRecorderIngress<T> {
     /// no GPU, no pyo3 state, and no leader/worker barrier.
     fn new(rt: &Handle, downstream: mpsc::Sender<T>, capacity: usize) -> Self {
         let (tx, rx) = mpsc::channel(capacity);
-        let forwarder = rt.spawn(Self::forward_to_downstream(rx, downstream));
+        let dropped = Arc::new(AtomicU64::new(0));
+        let forwarder = rt.spawn(Self::forward_to_downstream(rx, downstream, dropped.clone()));
 
         Self {
             tx,
-            dropped: Arc::new(AtomicU64::new(0)),
+            dropped,
             capacity,
             _forwarder: forwarder,
         }
@@ -177,10 +181,40 @@ impl<T: Send + 'static> ActionRecorderIngress<T> {
         self.dropped.load(Ordering::Relaxed)
     }
 
-    async fn forward_to_downstream(mut rx: mpsc::Receiver<T>, downstream: mpsc::Sender<T>) {
+    /// Move accepted actions to the recorder's own channel until either the
+    /// ingress or the recorder goes away.
+    ///
+    /// A failed `send` means the recorder's receiver has been dropped — after
+    /// cancellation, or once a `max_count`/`max_time` limit ends its writer
+    /// task. That is terminal, never transient, so the loop stops there
+    /// instead of continuing to receive actions it could only throw away: a
+    /// forwarder that kept draining would leave `tx` open, so producers would
+    /// go on succeeding while every action vanished uncounted, which is the
+    /// silent gap the drop counter exists to rule out.
+    ///
+    /// Closing `rx` on the way out converts that into the accounted case. The
+    /// action in flight and everything still buffered are added to `dropped`,
+    /// and later `record` calls see `Closed` and count themselves.
+    async fn forward_to_downstream(
+        mut rx: mpsc::Receiver<T>,
+        downstream: mpsc::Sender<T>,
+        dropped: Arc<AtomicU64>,
+    ) {
         while let Some(msg) = rx.recv().await {
             if downstream.send(msg).await.is_err() {
-                tracing::error!("Failed to send message to bounded channel");
+                rx.close();
+                let mut lost: u64 = 1;
+                while rx.try_recv().is_ok() {
+                    lost += 1;
+                }
+                let total = dropped.fetch_add(lost, Ordering::Relaxed) + lost;
+                tracing::error!(
+                    lost,
+                    dropped = total,
+                    "kvbm recorder channel is closed; discarding buffered actions and \
+                     stopping the forwarder"
+                );
+                return;
             }
         }
     }
@@ -611,5 +645,43 @@ mod tests {
             "a sink that keeps up, fed fewer actions than the queue holds, must lose nothing"
         );
         assert_eq!(received, (0..PUSHED).collect::<Vec<_>>());
+    }
+
+    /// T4: the other way an action can go missing. When the recorder's own
+    /// receiver is gone, nothing downstream can be delivered any more, so
+    /// every push must show up in the drop count -- none of it may be
+    /// discarded quietly inside the forwarding task.
+    #[tokio::test]
+    async fn a_departed_recorder_counts_the_actions_it_can_no_longer_take() {
+        const CAPACITY: usize = 4;
+        const PUSHED: usize = 64;
+
+        let (downstream_tx, downstream_rx) = mpsc::channel::<usize>(1);
+        let ingress = ActionRecorderIngress::new(&Handle::current(), downstream_tx, CAPACITY);
+
+        // What `Recorder`'s writer task does when it is cancelled or hits a
+        // `max_count`/`max_time` limit: its `event_rx` is dropped.
+        drop(downstream_rx);
+
+        for i in 0..PUSHED {
+            ingress.record(i);
+        }
+
+        // The forwarding task has to be polled before it can notice the
+        // closure, so the accounting settles asynchronously. The timeout is a
+        // failure bound, not a delay -- it is reached only if some action was
+        // neither delivered nor counted.
+        let settled = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while ingress.dropped_count() != PUSHED as u64 {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            settled.is_ok(),
+            "with the recorder gone, all {PUSHED} actions must be counted as dropped, got {}",
+            ingress.dropped_count()
+        );
     }
 }


### PR DESCRIPTION
## Summary

When KVBM recording is enabled, synchronous connector hooks previously sent actions through an unbounded staging channel before the bounded recorder channel. If recorder output stalled, cloned recording payloads could accumulate without a memory bound.

This change replaces that staging channel with a bounded ingress that holds up to 2,048 actions. The hooks remain non-blocking: when the ingress is full, it drops the newest action, increments a shared counter, and emits throttled warnings. Accepted actions retain FIFO ordering.

If the downstream recorder channel closes, the forwarding task closes the ingress, counts the action in flight and any buffered actions, and exits. Later submissions are also counted as closed-channel drops. JSONL traces can therefore contain gaps during overload or recorder shutdown, but losses detected at the ingress are counted and reported.

All seven leader hooks now use the bounded ingress.

Closes #13548

## Validation

- `cargo check --workspace --all-targets` in `lib/bindings/kvbm`
- `cargo test recorder` in `lib/bindings/kvbm` — 4 tests passed, covering bounded retention, FIFO delivery, a sink that keeps pace, and downstream closure
- `rustfmt --edition 2024 --check` on the changed Rust file
- GitHub CI: `rust-clippy (lib/bindings/kvbm)` passed

No end-to-end KVBM engine test ran. The unit tests exercise the ingress directly rather than the composed recorder, and they do not assert the warning text.