### PR TITLE
feat: [cherry-pick 1.4.1] classify and pooling stack (#12140, #12139, #12142, #12141)

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -229,6 +229,8 @@ def _unsupported_fpm_trace_role(dynamo_config: Config) -> Optional[str]:
     """Return the worker role when trace-based FPM activation is unsupported."""
     if dynamo_config.embedding_worker:
         return "embedding"
+    if dynamo_config.classify_worker:
+        return "classify"
     if dynamo_config.headless:
         return "headless"
     if dynamo_config.disaggregation_mode == DisaggregationMode.ENCODE:
@@ -261,11 +263,23 @@ def update_engine_config_with_dynamo(
 ) -> None:
     """Update engine config based on Dynamo config."""
     if engine_config.enable_prefix_caching is None:
-        logger.debug(
-            "--enable-prefix-caching or --no-enable-prefix-caching not specified. "
-            "Defaulting to True (vLLM v1 default behavior)"
-        )
-        engine_config.enable_prefix_caching = True
+        if dynamo_config.embedding_worker or dynamo_config.classify_worker:
+            # Pooling engines never decode, so prefix caching buys nothing —
+            # and force-enabling it crashes models vLLM itself would leave it
+            # off for (e.g. ModernBERT's hybrid local/global attention dies
+            # with "HybridKVCacheCoordinator requires at least two attention
+            # groups"). Match bare `vllm serve`, which does not enable prefix
+            # caching for pooling runners.
+            logger.debug(
+                "Pooling-family worker: defaulting --enable-prefix-caching to False"
+            )
+            engine_config.enable_prefix_caching = False
+        else:
+            logger.debug(
+                "--enable-prefix-caching or --no-enable-prefix-caching not specified. "
+                "Defaulting to True (vLLM v1 default behavior)"
+            )
+            engine_config.enable_prefix_caching = True
 
     if getattr(engine_config, "block_size", None) is None:
         logger.debug(

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -177,6 +177,16 @@ class DynamoVllmArgGroup(ArgGroup):
             "and InstrumentedScheduler injection (none apply to pooling models).",
         )
 
+        add_negatable_bool_argument(
+            g,
+            flag_name="--classify-worker",
+            env_var="DYN_VLLM_CLASSIFY_WORKER",
+            default=False,
+            help="Run as a sequence-classification worker, exposing /v1/classify and "
+            "/v1/pooling endpoints. Engine must be started with vLLM's --runner pooling. "
+            "Skips KV events, KV router registration, and InstrumentedScheduler injection.",
+        )
+
         # Headless mode for multi-node TP/PP
         add_negatable_bool_argument(
             g,
@@ -431,6 +441,7 @@ class DynamoVllmConfig(ConfigBase):
         str, EmbeddingTransferMode
     ]  # resolved to enum in validate()
     embedding_worker: bool = False
+    classify_worker: bool = False
 
     # CustomEncoder (image-only embeddings; worker assembles mixed prompt)
     custom_encoder_class: Optional[str] = None
@@ -477,6 +488,7 @@ class DynamoVllmConfig(ConfigBase):
         self._resolve_disaggregation_mode()
         self._resolve_embedding_transfer_mode()
         self._validate_embedding_worker_exclusivity()
+        self._validate_classify_worker_exclusivity()
         self._validate_custom_encoder()
         self._load_explicit_benchmark_points()
         self._resolve_legacy_benchmark_sampling()
@@ -661,4 +673,45 @@ class DynamoVllmConfig(ConfigBase):
                 "generation scheduler and not compatible with pooling engines. "
                 "Embedding workers do not run generation, so prefill/decode "
                 "benchmark sweeps are not meaningful."
+            )
+
+    def _validate_classify_worker_exclusivity(self) -> None:
+        """Classify worker is aggregated-only and exclusive of multimodal /
+        embedding roles. Mirrors the embedding-worker constraints — both are
+        pooling roles with no prefill/decode phases."""
+        if not self.classify_worker:
+            return
+        if self.embedding_worker:
+            raise ValueError(
+                "--classify-worker and --embedding-worker are mutually exclusive; "
+                "a worker registers exactly one pooling model type."
+            )
+        if self.disaggregation_mode != DisaggregationMode.AGGREGATED:
+            raise ValueError(
+                "--classify-worker is only valid with --disaggregation-mode=agg "
+                f"(got {self.disaggregation_mode.value if isinstance(self.disaggregation_mode, DisaggregationMode) else self.disaggregation_mode}). "
+                "Pooling models do not have prefill/decode phases."
+            )
+        if self.enable_multimodal:
+            raise ValueError(
+                "--classify-worker cannot be combined with multimodal flags."
+            )
+        if self.benchmark_mode is not None:
+            raise ValueError(
+                "--classify-worker cannot be combined with --benchmark-mode. "
+                "Benchmark mode injects InstrumentedScheduler, which is a "
+                "generation scheduler and not compatible with pooling engines."
+            )
+        if self.headless:
+            raise ValueError(
+                "--classify-worker cannot be combined with --headless. "
+                "Headless mode returns before WorkerFactory.create(), so the "
+                "classify/pooling endpoint would never be registered."
+            )
+        if getattr(getattr(self, "engine_args", None), "enable_lora", False):
+            raise ValueError(
+                "--classify-worker cannot be combined with --enable-lora. "
+                "The pooling-family handler does not forward lora_request to "
+                "engine_client.encode(), so an adapter-targeted request would "
+                "silently run against the base model."
             )

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -757,7 +757,7 @@ async def register_vllm_model(
         model_aliases=config.served_model_aliases or None,
         # Advertise LoRA capacity on the BASE card so the frontend can place the first
         # adapter onto an idle worker. Decode, aggregated, and prefill workers all serve
-        # lifecycle registration; embeddings still do not.
+        # lifecycle registration; embeddings and classify still do not.
         max_gpu_lora_count=_base_model_lora_capacity(config, model_type),
     )
 
@@ -765,7 +765,15 @@ async def register_vllm_model(
 def _base_model_lora_capacity(config: Config, model_type: ModelType) -> int | None:
     if not getattr(config.engine_args, "enable_lora", False):
         return None
-    if model_type == ModelType.Embedding:
+    # Pooling-family workers (embedding, classify|pooling) do not serve the
+    # LoRA load endpoints, so they must not advertise adapter capacity. Use
+    # capability checks, not identity: the classify worker registers the
+    # combined ModelType.Classify | ModelType.Pooling bits.
+    if (
+        model_type.supports_embedding()
+        or model_type.supports_classify()
+        or model_type.supports_pooling()
+    ):
         return None
     return config.engine_args.max_loras
 

--- a/components/src/dynamo/vllm/pooling_handlers.py
+++ b/components/src/dynamo/vllm/pooling_handlers.py
@@ -1,0 +1,535 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""vLLM worker handling for the ``/classify`` and ``/pooling`` APIs.
+
+This module is intentionally separate from the generation and embeddings
+handlers. Pooling-family models use vLLM's pooling runner and do not need the
+KV-cache, disaggregation, or multimodal generation setup used by those paths.
+"""
+
+import asyncio
+import base64
+import importlib
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, AsyncIterator, Final, Optional, cast
+
+import torch
+from vllm import PoolingParams
+from vllm.config import ModelConfig
+from vllm.inputs import TextPrompt, TokensPrompt
+
+from dynamo._core import Context
+
+from .args import Config
+from .handlers import EmbeddingWorkerHandler
+
+logger = logging.getLogger(__name__)
+
+_POOLING_BATCH_CONCURRENCY_FALLBACK: Final = 256
+_POOLING_EMBED_DTYPES: Final = frozenset(
+    ("float32", "float16", "bfloat16", "fp8_e4m3", "fp8_e5m2")
+)
+_POOLING_ENDIANNESS: Final = frozenset(("native", "big", "little"))
+
+
+class ClassifyWorkerHandler(EmbeddingWorkerHandler):
+    """Handle ``/classify`` and ``/pooling`` on a vLLM pooling engine.
+
+    The handler reuses the embeddings worker's engine lifecycle and abort
+    monitoring, but supplies the request-specific pooling task and response
+    shape. The Rust pooling wire request always contains ``encoding_format``;
+    the classify wire request does not, which provides an unambiguous internal
+    dispatch key.
+    """
+
+    def __init__(
+        self,
+        runtime: Any,
+        engine: Any,
+        config: Config,
+        model_config: ModelConfig | None = None,
+        shutdown_event: Optional[asyncio.Event] = None,
+    ) -> None:
+        super().__init__(
+            runtime=runtime,
+            engine=engine,
+            config=config,
+            shutdown_event=shutdown_event,
+        )
+        self.model_config = model_config
+        self._default_pooling_task: str | None = None
+        logger.info("Classify worker handler initialized")
+
+    def _id2label(self) -> dict[int, str]:
+        """Return the model's Hugging Face label map with integer keys."""
+        hf_config = getattr(self.model_config, "hf_config", None)
+        raw = getattr(hf_config, "id2label", None) or {}
+        normalized: dict[int, str] = {}
+        for key, value in raw.items():
+            try:
+                normalized[int(key)] = str(value)
+            except (TypeError, ValueError):
+                continue
+        return normalized
+
+    async def _resolve_pooling_task(self, requested_task: str | None) -> str:
+        if requested_task is not None:
+            return requested_task
+        if self._default_pooling_task is not None:
+            return self._default_pooling_task
+        if self.model_config is None:
+            raise RuntimeError("Model config is required to resolve the pooling task")
+
+        supported_tasks = await self.engine_client.get_supported_tasks()
+        pooling_task = self.model_config.get_pooling_task(supported_tasks)
+        if pooling_task is None:
+            raise ValueError(
+                f"No default pooling task is available; supported tasks: {supported_tasks}"
+            )
+        self._default_pooling_task = pooling_task
+        return pooling_task
+
+    async def _run_pooling_batch(
+        self,
+        prompts: list[Any],
+        encode_one: Callable[[int, Any], Awaitable[Any]],
+    ) -> list[Any]:
+        """Run a request batch without exceeding vLLM scheduler capacity."""
+        scheduler_config = getattr(
+            getattr(self.engine_client, "vllm_config", None),
+            "scheduler_config",
+            None,
+        )
+        max_num_seqs = getattr(scheduler_config, "max_num_seqs", None)
+        if (
+            not isinstance(max_num_seqs, int)
+            or isinstance(max_num_seqs, bool)
+            or max_num_seqs < 1
+        ):
+            max_num_seqs = _POOLING_BATCH_CONCURRENCY_FALLBACK
+
+        outputs: list[Any | None] = [None] * len(prompts)
+        indices = iter(range(len(prompts)))
+
+        async def _worker() -> None:
+            for idx in indices:
+                outputs[idx] = await encode_one(idx, prompts[idx])
+
+        tasks = [
+            asyncio.create_task(_worker())
+            for _ in range(min(len(prompts), max_num_seqs))
+        ]
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            pending = [task for task in tasks if not task.done()]
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        if any(output is None for output in outputs):
+            raise RuntimeError("vLLM engine.encode did not return every batch item")
+        return cast(list[Any], outputs)
+
+    async def _encode_batch(
+        self,
+        request: dict[str, Any],
+        context: Context,
+        prompts: list[Any],
+        pooling_params: PoolingParams,
+    ) -> list[Any]:
+        """Encode all inputs with common request controls and preprocessing."""
+        tokenization_kwargs = _build_tokenization_kwargs(request)
+        tokenize_params = _build_pooling_tokenize_params(
+            self.engine_client, tokenization_kwargs
+        )
+        tokenizer = getattr(self.engine_client.renderer, "tokenizer", None)
+        engine_request_id = context.id()
+        priority = request.get("priority", 0)
+
+        async def _encode_one(idx: int, prompt: Any) -> Any:
+            request_id = f"{engine_request_id}-{idx}"
+            encode_arg = _prepare_pooling_prompt(
+                prompt,
+                request,
+                tokenize_params,
+                tokenizer,
+            )
+            final_output = None
+            async with self._abort_monitor(context, request_id):
+                encode_kwargs: dict[str, Any] = {
+                    "prompt": encode_arg,
+                    "pooling_params": pooling_params,
+                    "request_id": request_id,
+                }
+                if priority != 0:
+                    encode_kwargs["priority"] = priority
+                # Token-ID prompts have already been passed through vLLM's
+                # TokenizeParams. Text prompts are tokenized inside AsyncLLM.
+                if tokenization_kwargs is not None and isinstance(prompt, str):
+                    encode_kwargs["tokenization_kwargs"] = tokenization_kwargs
+
+                async for output in self.engine_client.encode(**encode_kwargs):
+                    final_output = output
+
+            if final_output is None:
+                raise RuntimeError(
+                    f"vLLM engine.encode produced no output for input index {idx}"
+                )
+            return final_output
+
+        return await self._run_pooling_batch(prompts, _encode_one)
+
+    async def generate(
+        self, request: dict, context: Context
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Handle one internal classify or pooling wire request."""
+        if "encoding_format" in request:
+            async for response in self._generate_pooling(request, context):
+                yield response
+            return
+
+        model_name = request.get("model") or self.config.served_model_name or ""
+        input_field = request.get("input")
+        if input_field is None:
+            raise ValueError("Classify request missing required 'input' field")
+        prompts = _classify_pooling_input(input_field)
+
+        pooling_kwargs: dict[str, Any] = {"task": "classify"}
+        use_activation = request.get("use_activation")
+        if use_activation is not None:
+            pooling_kwargs["use_activation"] = use_activation
+        pooling_params = PoolingParams(**pooling_kwargs)
+        outputs = await self._encode_batch(request, context, prompts, pooling_params)
+
+        id2label = self._id2label()
+        data: list[dict[str, Any]] = []
+        prompt_tokens = 0
+        for idx, final_output in enumerate(outputs):
+            probs = _classification_output_to_list(final_output.outputs.data)
+            predicted_index = (
+                max(range(len(probs)), key=probs.__getitem__) if probs else None
+            )
+            data.append(
+                {
+                    "index": idx,
+                    "label": (
+                        id2label.get(predicted_index)
+                        if predicted_index is not None
+                        else None
+                    ),
+                    "probs": probs,
+                    "num_classes": len(probs),
+                }
+            )
+            token_ids = getattr(final_output, "prompt_token_ids", None) or []
+            prompt_tokens += len(token_ids)
+
+        response_request_id = request.get("request_id") or context.id()
+        yield {
+            "id": f"classify-{response_request_id}",
+            "object": "list",
+            "created": int(time.time()),
+            "model": model_name,
+            "data": data,
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "total_tokens": prompt_tokens,
+                "completion_tokens": 0,
+            },
+        }
+
+    async def _generate_pooling(
+        self, request: dict[str, Any], context: Context
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Handle one internal pooling wire request."""
+        model_name = request.get("model") or self.config.served_model_name or ""
+        input_field = request.get("input")
+        if input_field is None:
+            raise ValueError("Pooling request missing required 'input' field")
+        prompts = _classify_pooling_input(input_field)
+
+        if request.get("dimensions") is not None:
+            raise ValueError("dimensions is currently not supported")
+
+        encoding_format = request.get("encoding_format", "float")
+        if encoding_format not in ("float", "base64", "bytes", "bytes_only"):
+            raise ValueError(
+                f"Invalid 'encoding_format' value {encoding_format!r}; "
+                "expected 'float', 'base64', 'bytes', or 'bytes_only'"
+            )
+
+        embed_dtype = request.get("embed_dtype", "float32")
+        if not isinstance(embed_dtype, str) or embed_dtype not in _POOLING_EMBED_DTYPES:
+            raise ValueError(f"Invalid 'embed_dtype' value {embed_dtype!r}")
+
+        endianness = request.get("endianness", "native")
+        if not isinstance(endianness, str) or endianness not in _POOLING_ENDIANNESS:
+            raise ValueError(f"Invalid 'endianness' value {endianness!r}")
+
+        pooling_task = await self._resolve_pooling_task(request.get("task"))
+        pooling_kwargs: dict[str, Any] = {"task": pooling_task}
+        use_activation = request.get("use_activation")
+        if use_activation is not None:
+            pooling_kwargs["use_activation"] = use_activation
+        pooling_params = PoolingParams(**pooling_kwargs)
+        outputs = await self._encode_batch(request, context, prompts, pooling_params)
+
+        data: list[dict[str, Any]] = []
+        prompt_tokens = 0
+        for idx, final_output in enumerate(outputs):
+            item: dict[str, Any] = {
+                "index": idx,
+                "object": "pooling",
+            }
+            if encoding_format == "float":
+                item["data"] = _pooling_output_to_nested(final_output.outputs.data)
+            else:
+                encoded, shape = _encode_pooling_output(
+                    final_output.outputs.data,
+                    embed_dtype,
+                    endianness,
+                )
+                item["data"] = encoded
+                if encoding_format == "bytes":
+                    item["shape"] = shape
+            data.append(item)
+            token_ids = getattr(final_output, "prompt_token_ids", None) or []
+            prompt_tokens += len(token_ids)
+
+        response_request_id = request.get("request_id") or context.id()
+        yield {
+            "id": f"pool-{response_request_id}",
+            "object": "list",
+            "created": int(time.time()),
+            "model": model_name,
+            "data": data,
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "total_tokens": prompt_tokens,
+                "completion_tokens": 0,
+            },
+        }
+
+
+def _build_pooling_tokenize_params(
+    engine_client: Any, tokenization_kwargs: dict[str, Any] | None
+) -> Any:
+    """Resolve the TokenizeParams applied to pre-tokenized inputs.
+
+    With no caller overrides this returns the renderer's defaults rather than
+    ``None``: upstream vLLM runs every pooling/classify input through
+    ``apply_post_tokenization``, which is also where default truncation to
+    ``max_model_len`` happens. Returning ``None`` here would skip that for
+    token-ID inputs, so an over-long pre-tokenized prompt would reach the engine
+    untruncated instead of being truncated the way native vLLM truncates it.
+    """
+    defaults = engine_client.renderer.default_cmpl_tok_params
+    if tokenization_kwargs is None:
+        return defaults
+    return defaults.with_kwargs(**tokenization_kwargs)
+
+
+def _prepare_pooling_prompt(
+    prompt: Any,
+    request: dict[str, Any],
+    tokenize_params: Any,
+    tokenizer: Any,
+) -> Any:
+    """Build a vLLM prompt and preprocess token-ID inputs with its renderer."""
+    mm_processor_kwargs = request.get("mm_processor_kwargs")
+    cache_salt = request.get("cache_salt")
+    if isinstance(prompt, str):
+        if mm_processor_kwargs is None and cache_salt is None:
+            return prompt
+        encode_arg: Any = TextPrompt(prompt=prompt)
+    else:
+        encode_arg = TokensPrompt(prompt_token_ids=prompt)
+
+    if mm_processor_kwargs is not None:
+        encode_arg["mm_processor_kwargs"] = mm_processor_kwargs
+    if cache_salt is not None:
+        encode_arg["cache_salt"] = cache_salt
+
+    # AsyncLLM's compatibility preprocessor does not apply tokenization kwargs
+    # to TokensPrompt. Run the same vLLM TokenizeParams post-tokenization path
+    # explicitly, including the tokenizer's configured default truncation side.
+    if tokenize_params is not None and not isinstance(prompt, str):
+        encode_arg = tokenize_params.apply_post_tokenization(tokenizer, encode_arg)
+    return encode_arg
+
+
+def _build_tokenization_kwargs(request: dict[str, Any]) -> dict[str, Any] | None:
+    """Validate and collect vLLM completion tokenization controls."""
+    kwargs: dict[str, Any] = {}
+
+    truncate_prompt_tokens = request.get("truncate_prompt_tokens")
+    if truncate_prompt_tokens is not None:
+        if not isinstance(truncate_prompt_tokens, int) or isinstance(
+            truncate_prompt_tokens, bool
+        ):
+            raise TypeError(
+                "Invalid 'truncate_prompt_tokens' type "
+                f"{type(truncate_prompt_tokens).__name__}; expected int"
+            )
+        if truncate_prompt_tokens < -1:
+            raise ValueError(
+                f"truncate_prompt_tokens must be >= -1, got {truncate_prompt_tokens}"
+            )
+        kwargs["truncate_prompt_tokens"] = truncate_prompt_tokens
+
+    truncation_side = request.get("truncation_side")
+    if truncation_side is not None:
+        if truncation_side not in ("left", "right"):
+            raise ValueError(
+                f"Invalid 'truncation_side' value {truncation_side!r}; "
+                "expected 'left' or 'right'"
+            )
+        kwargs["truncation_side"] = truncation_side
+
+    add_special_tokens = request.get("add_special_tokens")
+    if add_special_tokens is not None:
+        if not isinstance(add_special_tokens, bool):
+            raise TypeError(
+                "Invalid 'add_special_tokens' type "
+                f"{type(add_special_tokens).__name__}; expected bool"
+            )
+        kwargs["add_special_tokens"] = add_special_tokens
+
+    return kwargs or None
+
+
+def _is_token_id(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _classify_pooling_input(input_field: Any) -> list[Any]:
+    """Normalize the four vLLM completion input forms without coercion."""
+    if isinstance(input_field, str):
+        return [input_field]
+    if not isinstance(input_field, list):
+        raise TypeError(
+            f"Invalid 'input' type {type(input_field).__name__}; "
+            "expected str, list[str], list[int], or list[list[int]]"
+        )
+    if not input_field:
+        raise ValueError("Request 'input' must be non-empty")
+
+    first = input_field[0]
+    if isinstance(first, str):
+        texts: list[str] = []
+        for item in input_field:
+            if not isinstance(item, str):
+                raise TypeError(
+                    "'input' list mixes str and non-str entries; pass either "
+                    "all strings or all token-ID arrays"
+                )
+            texts.append(item)
+        return texts
+
+    if _is_token_id(first):
+        token_ids: list[int] = []
+        for item in input_field:
+            if not _is_token_id(item):
+                raise TypeError(
+                    "'input' list mixes int and non-int entries; for tokenized "
+                    "input pass all integers or list[list[int]]"
+                )
+            token_ids.append(item)
+        return [token_ids]
+
+    if isinstance(first, list):
+        prompts: list[list[int]] = []
+        for idx, item in enumerate(input_field):
+            if not isinstance(item, list) or not all(
+                _is_token_id(token_id) for token_id in item
+            ):
+                raise TypeError(
+                    f"'input' list element at index {idx} must be a list of "
+                    "ints (token IDs); mixed batches are not supported"
+                )
+            prompts.append(item)
+        return prompts
+
+    raise TypeError(
+        f"Unsupported 'input' element type {type(first).__name__}; "
+        "expected str, int, or list[int]"
+    )
+
+
+def _classification_output_to_list(data: Any) -> list[float]:
+    """Convert sequence-level classification output to one probability vector.
+
+    ``/classify`` reports a single vector of shape ``[num_classes]``. vLLM's
+    pooling pipeline may wrap it in a singleton batch dim (``[1, num_classes]``),
+    which is unwrapped here. Any other multi-row shape means the model or pooler
+    produced token-level output: flattening it would report ``num_classes`` as
+    ``rows * classes`` and pick an ``argmax`` outside the label range, yielding a
+    200 with a null label instead of a visible failure. Native vLLM rejects
+    classification output with ``ndim != 1``; so does this.
+    """
+    if isinstance(data, torch.Tensor):
+        tensor = data.detach().cpu()
+        if tensor.ndim == 2 and tensor.shape[0] == 1:
+            tensor = tensor[0]
+        if tensor.ndim != 1:
+            raise ValueError(
+                "Classification output must be one probability vector of shape "
+                f"[num_classes]; got tensor of shape {tuple(tensor.shape)}. "
+                "This usually means the model or pooler emits token-level output."
+            )
+        return tensor.tolist()
+    if isinstance(data, (list, tuple)):
+        if data and isinstance(data[0], (list, tuple)):
+            if len(data) != 1:
+                raise ValueError(
+                    "Classification output must be one probability vector of "
+                    f"shape [num_classes]; got {len(data)} rows. This usually "
+                    "means the model or pooler emits token-level output."
+                )
+            return [float(value) for value in data[0]]
+        return [float(value) for value in data]
+    raise TypeError(
+        f"Unsupported PoolingOutput.data type {type(data).__name__}; "
+        "expected torch.Tensor or list"
+    )
+
+
+def _pooling_output_to_nested(data: Any) -> Any:
+    """Convert pooling output to JSON values while preserving tensor shape."""
+    if isinstance(data, torch.Tensor):
+        return data.detach().cpu().tolist()
+    if isinstance(data, (list, tuple)):
+        return [
+            _pooling_output_to_nested(value)
+            if isinstance(value, (list, tuple))
+            else float(value)
+            for value in data
+        ]
+    raise TypeError(
+        f"Unsupported PoolingOutput.data type {type(data).__name__}; "
+        "expected torch.Tensor or list"
+    )
+
+
+def _encode_pooling_output(
+    data: Any, embed_dtype: str, endianness: str
+) -> tuple[str, list[int]]:
+    """Encode a pooling tensor with vLLM's binary response implementation."""
+    if isinstance(data, torch.Tensor):
+        tensor = data.detach().cpu()
+    elif isinstance(data, (list, tuple)):
+        tensor = torch.tensor(data)
+    else:
+        raise TypeError(
+            f"Unsupported PoolingOutput.data type {type(data).__name__}; "
+            "expected torch.Tensor or list"
+        )
+
+    serial_utils = importlib.import_module("vllm.utils.serial_utils")
+    binary = serial_utils.tensor2binary(tensor, embed_dtype, endianness)
+    return base64.b64encode(binary).decode("ascii"), list(tensor.shape)

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -10,6 +10,7 @@ need to add more tests to cover different code paths of DynamoVllmConfig.
 
 import argparse
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -209,6 +210,87 @@ class TestEmbeddingWorkerExclusivity:
         config.embedding_worker = False
         config.benchmark_mode = "agg"
         config._validate_embedding_worker_exclusivity()
+
+
+class TestClassifyWorkerExclusivity:
+    """--classify-worker mirrors the embedding-worker constraints (both are
+    pooling roles) and is additionally exclusive with --embedding-worker.
+    """
+
+    def test_baseline_aggregated_is_accepted(self):
+        config = create_config()
+        config.classify_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        # Must not raise.
+        config._validate_classify_worker_exclusivity()
+
+    def test_embedding_worker_combination_rejected(self):
+        config = create_config()
+        config.classify_worker = True
+        config.embedding_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            config._validate_classify_worker_exclusivity()
+
+    @pytest.mark.parametrize(
+        "mode",
+        [
+            DisaggregationMode.PREFILL,
+            DisaggregationMode.DECODE,
+            DisaggregationMode.ENCODE,
+        ],
+    )
+    def test_non_aggregated_disagg_rejected(self, mode):
+        config = create_config()
+        config.classify_worker = True
+        config.disaggregation_mode = mode
+        with pytest.raises(ValueError, match="disaggregation-mode=agg"):
+            config._validate_classify_worker_exclusivity()
+
+    def test_multimodal_combination_rejected(self):
+        config = create_config()
+        config.classify_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        config.enable_multimodal = True
+        with pytest.raises(ValueError, match="multimodal"):
+            config._validate_classify_worker_exclusivity()
+
+    def test_benchmark_mode_rejected(self):
+        config = create_config()
+        config.classify_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        config.benchmark_mode = "agg"
+        with pytest.raises(ValueError, match="benchmark-mode"):
+            config._validate_classify_worker_exclusivity()
+
+    def test_headless_combination_rejected(self):
+        """Headless returns from main.worker() before WorkerFactory.create(),
+        so the classify/pooling endpoint would never register — the process
+        would come up healthy and serve nothing."""
+        config = create_config()
+        config.classify_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        config.headless = True
+        with pytest.raises(ValueError, match="headless"):
+            config._validate_classify_worker_exclusivity()
+
+    def test_enable_lora_combination_rejected(self):
+        """The pooling-family handler never forwards lora_request to
+        engine_client.encode(), so an adapter-targeted request would silently
+        run against the base model."""
+        config = create_config()
+        config.classify_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        config.engine_args = SimpleNamespace(enable_lora=True)
+        with pytest.raises(ValueError, match="enable-lora"):
+            config._validate_classify_worker_exclusivity()
+
+    def test_no_op_when_classify_worker_disabled(self):
+        config = create_config()
+        config.classify_worker = False
+        config.benchmark_mode = "agg"
+        config.headless = True
+        config._validate_classify_worker_exclusivity()
 
 
 class TestValidateCustomEncoder:

--- a/components/src/dynamo/vllm/tests/test_vllm_pooling_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_pooling_handlers.py
@@ -1,0 +1,551 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import base64
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import torch
+
+import dynamo.vllm.handlers as base_handlers
+import dynamo.vllm.pooling_handlers as mod
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+]
+
+
+def _make_handler(
+    id2label: dict[int, str] | None = None,
+) -> mod.ClassifyWorkerHandler:
+    model_config = MagicMock()
+    model_config.hf_config = SimpleNamespace(id2label=id2label or {})
+    model_config.get_pooling_task.return_value = "classify"
+    with patch.object(base_handlers, "VllmEngineMonitor"):
+        handler = mod.ClassifyWorkerHandler(
+            runtime=MagicMock(),
+            engine=MagicMock(),
+            config=MagicMock(served_model_name="test-model"),
+            model_config=model_config,
+            shutdown_event=None,
+        )
+    handler.engine_client = MagicMock()
+    handler.engine_client.abort = AsyncMock()
+    handler.engine_client.get_supported_tasks = AsyncMock(
+        return_value=("classify", "token_classify")
+    )
+    return handler
+
+
+def _make_context() -> MagicMock:
+    context = MagicMock()
+    context.id.return_value = "engine-request"
+    context.async_killed_or_stopped.side_effect = (
+        lambda: asyncio.get_running_loop().create_future()
+    )
+    return context
+
+
+def _pooling_output(data: Any, prompt_token_ids: list[int]) -> MagicMock:
+    output = MagicMock()
+    output.outputs.data = torch.tensor(data)
+    output.prompt_token_ids = prompt_token_ids
+    return output
+
+
+class TestInputNormalization:
+    @pytest.mark.parametrize(
+        ("input_field", "expected"),
+        [
+            ("hello", ["hello"]),
+            (["a", "b"], ["a", "b"]),
+            ([1, 2, 3], [[1, 2, 3]]),
+            ([[1, 2], [3, 4]], [[1, 2], [3, 4]]),
+        ],
+    )
+    def test_supported_input_shapes(self, input_field, expected):
+        assert mod._classify_pooling_input(input_field) == expected
+
+    @pytest.mark.parametrize(
+        "input_field",
+        [
+            ["hello", 42],
+            [1, "two"],
+            [[1, 2], "three"],
+            [[1, 2], [3.5, 4]],
+            [True, False],
+        ],
+    )
+    def test_mixed_or_non_token_inputs_are_rejected(self, input_field):
+        with pytest.raises(TypeError):
+            mod._classify_pooling_input(input_field)
+
+    def test_empty_input_is_rejected(self):
+        with pytest.raises(ValueError, match="must be non-empty"):
+            mod._classify_pooling_input([])
+
+
+class TestClassifyWorkerHandler:
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_classify_response_uses_model_labels(self):
+        handler = _make_handler({0: "contradiction", 1: "entailment", 2: "neutral"})
+        captured: dict = {}
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            captured["task"] = pooling_params.task
+            yield _pooling_output([0.1, 0.7, 0.2], [1, 2, 3, 4])
+
+        handler.engine_client.encode = fake_encode
+        [response] = [
+            item
+            async for item in handler.generate(
+                {
+                    "input": "premise entails hypothesis",
+                    "model": "test-model",
+                    "request_id": "client-request",
+                },
+                _make_context(),
+            )
+        ]
+
+        assert captured["task"] == "classify"
+        assert response["id"] == "classify-client-request"
+        assert response["object"] == "list"
+        assert response["data"][0] == {
+            "index": 0,
+            "label": "entailment",
+            "probs": pytest.approx([0.1, 0.7, 0.2]),
+            "num_classes": 3,
+        }
+        assert response["usage"] == {
+            "prompt_tokens": 4,
+            "total_tokens": 4,
+            "completion_tokens": 0,
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_classify_forwards_activation_and_text_tokenization(self):
+        handler = _make_handler()
+        captured: dict = {}
+
+        async def fake_encode(prompt, pooling_params, request_id, **kwargs):
+            captured["use_activation"] = pooling_params.use_activation
+            captured["tokenization_kwargs"] = kwargs["tokenization_kwargs"]
+            yield _pooling_output([0.4, 0.6], [1, 2])
+
+        handler.engine_client.encode = fake_encode
+        [_] = [
+            item
+            async for item in handler.generate(
+                {
+                    "input": "text",
+                    "model": "test-model",
+                    "use_activation": False,
+                    "truncate_prompt_tokens": 64,
+                    "truncation_side": "right",
+                    "add_special_tokens": False,
+                },
+                _make_context(),
+            )
+        ]
+
+        assert captured == {
+            "use_activation": False,
+            "tokenization_kwargs": {
+                "truncate_prompt_tokens": 64,
+                "truncation_side": "right",
+                "add_special_tokens": False,
+            },
+        }
+
+    @pytest.mark.parametrize(
+        ("input_field", "is_pooling", "expected_token_ids"),
+        [
+            ([101, 102, 103, 104], False, [[103, 104]]),
+            (
+                [[101, 102, 103, 104], [201, 202, 203, 204]],
+                True,
+                [[103, 104], [203, 204]],
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_pretokenized_input_uses_vllm_truncation(
+        self, input_field, is_pooling, expected_token_ids
+    ):
+        from vllm.renderers import TokenizeParams
+
+        handler = _make_handler()
+        handler.engine_client.renderer.default_cmpl_tok_params = TokenizeParams(
+            max_total_tokens=8
+        )
+        handler.engine_client.renderer.tokenizer = SimpleNamespace(
+            truncation_side="left"
+        )
+        seen_prompts: list[dict] = []
+        seen_kwargs: list[dict] = []
+
+        async def fake_encode(prompt, pooling_params, request_id, **kwargs):
+            seen_prompts.append(prompt)
+            seen_kwargs.append(kwargs)
+            yield _pooling_output([0.5, 0.5], prompt["prompt_token_ids"])
+
+        handler.engine_client.encode = fake_encode
+        request = {
+            "input": input_field,
+            "model": "test-model",
+            "truncate_prompt_tokens": 2,
+        }
+        if is_pooling:
+            request["encoding_format"] = "float"
+
+        [response] = [item async for item in handler.generate(request, _make_context())]
+
+        assert [prompt["prompt_token_ids"] for prompt in seen_prompts] == (
+            expected_token_ids
+        )
+        assert all("tokenization_kwargs" not in kwargs for kwargs in seen_kwargs)
+        assert response["usage"]["prompt_tokens"] == 2 * len(expected_token_ids)
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_explicit_right_truncation_keeps_first_tokens(self):
+        from vllm.renderers import TokenizeParams
+
+        handler = _make_handler()
+        handler.engine_client.renderer.default_cmpl_tok_params = TokenizeParams(
+            max_total_tokens=8
+        )
+        handler.engine_client.renderer.tokenizer = SimpleNamespace(
+            truncation_side="left"
+        )
+        seen_prompt: dict = {}
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            seen_prompt.update(prompt)
+            yield _pooling_output([0.5, 0.5], prompt["prompt_token_ids"])
+
+        handler.engine_client.encode = fake_encode
+        [_] = [
+            item
+            async for item in handler.generate(
+                {
+                    "input": [101, 102, 103, 104],
+                    "model": "test-model",
+                    "truncate_prompt_tokens": 2,
+                    "truncation_side": "right",
+                },
+                _make_context(),
+            )
+        ]
+
+        assert seen_prompt["prompt_token_ids"] == [101, 102]
+
+
+class TestPoolingWorkerHandler:
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_default_task_and_output_shape(self):
+        handler = _make_handler()
+        captured: dict = {}
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            captured["task"] = pooling_params.task
+            yield _pooling_output([[1.0, 2.0], [3.0, 4.0]], [1, 2])
+
+        handler.engine_client.encode = fake_encode
+        [response] = [
+            item
+            async for item in handler.generate(
+                {
+                    "input": "some text",
+                    "model": "test-model",
+                    "encoding_format": "float",
+                },
+                _make_context(),
+            )
+        ]
+
+        assert captured["task"] == "classify"
+        handler.model_config.get_pooling_task.assert_called_once_with(
+            ("classify", "token_classify")
+        )
+        assert response["id"] == "pool-engine-request"
+        assert response["data"][0] == {
+            "index": 0,
+            "object": "pooling",
+            "data": [[1.0, 2.0], [3.0, 4.0]],
+        }
+        assert response["usage"] == {
+            "prompt_tokens": 2,
+            "total_tokens": 2,
+            "completion_tokens": 0,
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_requested_token_task_and_request_controls_are_forwarded(self):
+        handler = _make_handler()
+        captured: dict = {}
+
+        async def fake_encode(prompt, pooling_params, request_id, **kwargs):
+            captured.update(
+                task=pooling_params.task,
+                use_activation=pooling_params.use_activation,
+                prompt=prompt,
+                request_id=request_id,
+                priority=kwargs["priority"],
+            )
+            yield _pooling_output([[0.1], [0.2]], [1, 2])
+
+        handler.engine_client.encode = fake_encode
+        [response] = [
+            item
+            async for item in handler.generate(
+                {
+                    "input": "text",
+                    "model": "test-model",
+                    "encoding_format": "float",
+                    "task": "token_classify",
+                    "use_activation": False,
+                    "request_id": "client-request",
+                    "priority": -3,
+                    "cache_salt": "secret",
+                    "mm_processor_kwargs": {"do_resize": False},
+                },
+                _make_context(),
+            )
+        ]
+
+        assert captured["task"] == "token_classify"
+        assert captured["use_activation"] is False
+        assert captured["request_id"] == "engine-request-0"
+        assert captured["priority"] == -3
+        assert captured["prompt"]["prompt"] == "text"
+        assert captured["prompt"]["cache_salt"] == "secret"
+        assert captured["prompt"]["mm_processor_kwargs"] == {"do_resize": False}
+        assert response["id"] == "pool-client-request"
+
+    @pytest.mark.parametrize("encoding_format", ["base64", "bytes", "bytes_only"])
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_encoded_formats_use_vllm_tensor_encoding(self, encoding_format):
+        handler = _make_handler()
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            yield _pooling_output([[1.0, 2.0], [3.0, 4.0]], [1, 2])
+
+        handler.engine_client.encode = fake_encode
+        [response] = [
+            item
+            async for item in handler.generate(
+                {
+                    "input": "text",
+                    "model": "test-model",
+                    "encoding_format": encoding_format,
+                    "embed_dtype": "float16",
+                    "endianness": "big",
+                },
+                _make_context(),
+            )
+        ]
+
+        expected = base64.b64encode(bytes.fromhex("3c00400042004400")).decode("ascii")
+        item = response["data"][0]
+        assert item["data"] == expected
+        if encoding_format == "bytes":
+            assert item["shape"] == [2, 2]
+        else:
+            assert "shape" not in item
+
+    @pytest.mark.parametrize(
+        ("request_field", "value", "message"),
+        [
+            ("dimensions", 128, "dimensions is currently not supported"),
+            ("encoding_format", "hex", "Invalid 'encoding_format'"),
+            ("embed_dtype", "int8", "Invalid 'embed_dtype'"),
+            ("endianness", "middle", "Invalid 'endianness'"),
+        ],
+    )
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_unsupported_response_controls_are_rejected(
+        self, request_field, value, message
+    ):
+        handler = _make_handler()
+        request = {
+            "input": "text",
+            "model": "test-model",
+            "encoding_format": "float",
+            request_field: value,
+        }
+
+        with pytest.raises(ValueError, match=message):
+            async for _ in handler.generate(request, _make_context()):
+                pass
+
+
+class TestPoolingBatchExecution:
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_partial_failure_cancels_in_flight_encodes(self):
+        handler = _make_handler()
+        cancelled: set[int] = set()
+        started = {idx: asyncio.Event() for idx in range(4)}
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            idx = int(request_id.rsplit("-", 1)[-1])
+            started[idx].set()
+            if idx == 1:
+                raise RuntimeError("boom")
+            try:
+                await asyncio.sleep(60)
+                yield MagicMock()
+            except asyncio.CancelledError:
+                cancelled.add(idx)
+                raise
+
+        handler.engine_client.encode = fake_encode
+        with pytest.raises(RuntimeError, match="boom"):
+            async for _ in handler.generate(
+                {"input": ["a", "b", "c", "d"], "model": "test-model"},
+                _make_context(),
+            ):
+                pass
+
+        assert all(event.is_set() for event in started.values())
+        assert cancelled == {0, 2, 3}
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_fanout_is_bounded_by_scheduler_capacity(self):
+        handler = _make_handler()
+        handler.engine_client.vllm_config = SimpleNamespace(
+            scheduler_config=SimpleNamespace(max_num_seqs=2)
+        )
+        active = 0
+        max_active = 0
+        first_pair_started = asyncio.Event()
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            if active == 2:
+                first_pair_started.set()
+            try:
+                await first_pair_started.wait()
+                yield _pooling_output([0.1, 0.2], [1])
+            finally:
+                active -= 1
+
+        handler.engine_client.encode = fake_encode
+        [response] = [
+            item
+            async for item in handler.generate(
+                {
+                    "input": [str(idx) for idx in range(8)],
+                    "model": "test-model",
+                },
+                _make_context(),
+            )
+        ]
+
+        assert len(response["data"]) == 8
+        assert max_active == 2
+
+
+class TestClassificationOutputShape:
+    """`/classify` reports one probability vector of shape [num_classes].
+
+    Flattening a token-level result instead would report num_classes as
+    rows*classes and pick an argmax outside the label range, so the client
+    would get a 200 carrying a null label and a nonsense class count. Native
+    vLLM rejects classification output with ndim != 1.
+    """
+
+    def test_accepts_flat_vector(self):
+        assert mod._classification_output_to_list(
+            torch.tensor([0.1, 0.7, 0.2])
+        ) == pytest.approx([0.1, 0.7, 0.2])
+
+    def test_unwraps_singleton_batch_dim(self):
+        """vLLM's pooling pipeline may return shape [1, num_classes]."""
+        assert mod._classification_output_to_list(
+            torch.tensor([[0.1, 0.7, 0.2]])
+        ) == pytest.approx([0.1, 0.7, 0.2])
+        assert mod._classification_output_to_list([[0.1, 0.7, 0.2]]) == pytest.approx(
+            [0.1, 0.7, 0.2]
+        )
+
+    def test_rejects_token_level_tensor(self):
+        token_level = torch.tensor(
+            [[0.1, 0.2, 0.7], [0.1, 0.8, 0.1], [0.2, 0.7, 0.1], [0.05, 0.9, 0.05]]
+        )
+        with pytest.raises(ValueError, match=r"one probability vector"):
+            mod._classification_output_to_list(token_level)
+
+    def test_rejects_token_level_list(self):
+        with pytest.raises(ValueError, match=r"4 rows"):
+            mod._classification_output_to_list(
+                [[0.1, 0.2, 0.7], [0.1, 0.8, 0.1], [0.2, 0.7, 0.1], [0.05, 0.9, 0.05]]
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_classify_surfaces_token_level_output_as_error(self):
+        """End-to-end through the handler: a pooler emitting token-level output
+        must fail visibly rather than return a mislabelled 200."""
+        handler = _make_handler({0: "contradiction", 1: "entailment", 2: "neutral"})
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            yield _pooling_output([[0.1, 0.2, 0.7], [0.1, 0.8, 0.1]], [1, 2])
+
+        handler.engine_client.encode = fake_encode
+        with pytest.raises(ValueError, match=r"one probability vector"):
+            [
+                item
+                async for item in handler.generate(
+                    {"input": "premise", "model": "test-model"},
+                    _make_context(),
+                )
+            ]
+
+
+class TestDefaultTokenizeParams:
+    """Upstream vLLM runs every pooling/classify input through
+    apply_post_tokenization, which is also where default truncation to
+    max_model_len happens. Returning None with no caller overrides would skip
+    that for token-ID inputs.
+    """
+
+    def test_defaults_used_when_no_overrides(self):
+        defaults = object()
+        engine_client = SimpleNamespace(
+            renderer=SimpleNamespace(default_cmpl_tok_params=defaults)
+        )
+        assert mod._build_pooling_tokenize_params(engine_client, None) is defaults
+
+    def test_overrides_layer_onto_defaults(self):
+        sentinel = object()
+        default_params = MagicMock()
+        default_params.with_kwargs.return_value = sentinel
+        engine_client = SimpleNamespace(
+            renderer=SimpleNamespace(default_cmpl_tok_params=default_params)
+        )
+
+        result = mod._build_pooling_tokenize_params(
+            engine_client, {"truncate_prompt_tokens": 8}
+        )
+
+        assert result is sentinel
+        default_params.with_kwargs.assert_called_once_with(truncate_prompt_tokens=8)

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -78,6 +78,11 @@ def _load_vllm_main() -> ModuleType:
         (True, dynamo_llm.ModelType.Prefill, 3),
         (True, dynamo_llm.ModelType.Chat, 3),
         (True, dynamo_llm.ModelType.Embedding, None),
+        (
+            True,
+            dynamo_llm.ModelType.Classify | dynamo_llm.ModelType.Pooling,
+            None,
+        ),
         (False, dynamo_llm.ModelType.Prefill, None),
     ],
 )
@@ -1306,6 +1311,7 @@ def _make_dynamo_config(**overrides):
         "use_kv_events": False,
         "enable_local_indexer": True,
         "embedding_worker": False,
+        "classify_worker": False,
         "headless": False,
         "enable_multimodal": False,
         "fpm_trace": False,
@@ -1338,6 +1344,44 @@ def _make_engine_config_with_runner(runner="auto", **overrides):
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
+
+
+class TestPoolingWorkerPrefixCachingDefault:
+    """Pooling-family workers must not default prefix caching on: pooling
+    engines never decode, and force-enabling it crashes hybrid-attention
+    models (e.g. ModernBERT: "HybridKVCacheCoordinator requires at least two
+    attention groups") that bare `vllm serve` runs fine.
+    """
+
+    @pytest.mark.parametrize("role", ["embedding_worker", "classify_worker"])
+    def test_pooling_family_defaults_to_disabled(self, role):
+        dynamo_cfg = _make_dynamo_config(**{role: True})
+        engine_cfg = _make_engine_config_with_runner(
+            runner="pooling", enable_prefix_caching=None
+        )
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.enable_prefix_caching is False
+
+    @pytest.mark.parametrize("role", ["embedding_worker", "classify_worker"])
+    def test_explicit_enable_is_preserved(self, role):
+        dynamo_cfg = _make_dynamo_config(**{role: True})
+        engine_cfg = _make_engine_config_with_runner(
+            runner="pooling", enable_prefix_caching=True
+        )
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.enable_prefix_caching is True
+
+    def test_generative_worker_still_defaults_to_enabled(self):
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner(enable_prefix_caching=None)
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.enable_prefix_caching is True
 
 
 class TestRunnerPreservation:
@@ -1505,6 +1549,7 @@ class TestForwardPassMetricsActivation:
         ("overrides", "role"),
         [
             ({"embedding_worker": True}, "embedding"),
+            ({"classify_worker": True}, "classify"),
             ({"headless": True}, "headless"),
             (
                 {"disaggregation_mode": DisaggregationMode.ENCODE},

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -45,6 +45,7 @@ def _make_config(**overrides) -> Mock:
         # optional gpu_memory_service package (absent in some test images).
         "gms_shadow_mode": False,
         "realtime": False,
+        "classify_worker": False,
     }
     defaults.update(overrides)
     return Mock(**defaults)
@@ -669,6 +670,7 @@ class TestCreate:
         factory._create_prefill_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_decode_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_embedding_worker = AsyncMock()  # type: ignore[assignment]
+        factory._create_classify_worker = AsyncMock()  # type: ignore[assignment]
         return factory
 
     # Tests for non-legacy worker config, 'route_to_encode' is worker internal config
@@ -734,6 +736,17 @@ class TestCreate:
         factory._create_prefill_worker.assert_not_called()  # type: ignore[union-attr]
         factory._create_multimodal_encode_worker.assert_not_called()  # type: ignore[union-attr]
 
+    async def test_classify_worker_takes_priority(self, factory: WorkerFactory) -> None:
+        config = _make_config(classify_worker=True)
+        shutdown_event = asyncio.Event()
+
+        await factory.create(Mock(), config, shutdown_event, [])
+
+        factory._create_classify_worker.assert_called_once()  # type: ignore[union-attr]
+        factory._create_decode_worker.assert_not_called()  # type: ignore[union-attr]
+        factory._create_prefill_worker.assert_not_called()  # type: ignore[union-attr]
+        factory._create_multimodal_encode_worker.assert_not_called()  # type: ignore[union-attr]
+
     async def test_passes_snapshot_engine(self, factory: WorkerFactory) -> None:
         config = _make_config(enable_multimodal=True)
         runtime = Mock()
@@ -762,6 +775,81 @@ class TestCreate:
             shutdown_endpoints,
             snapshot_engine=snapshot_engine,
         )
+
+
+@pytest.mark.asyncio
+async def test_classify_worker_registers_classify_and_pooling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint = Mock()
+    endpoint.connection_id.return_value = "worker-1"
+    endpoint.serve_endpoint = AsyncMock()
+    runtime = Mock()
+    runtime.endpoint.return_value = endpoint
+
+    engine_client = Mock()
+    vllm_config = Mock(model_config=Mock())
+    engine_tuple: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        "/tmp/prom",
+        None,
+    )
+    register_model = AsyncMock()
+    handler = Mock()
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.ClassifyWorkerHandler",
+        Mock(return_value=handler),
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.StatLoggerFactory",
+        Mock(return_value=Mock()),
+    )
+
+    factory = WorkerFactory(
+        setup_vllm_engine_fn=Mock(return_value=engine_tuple),
+        setup_kv_event_publisher_fn=Mock(),
+        register_vllm_model_fn=register_model,
+        setup_fpm_relay_fn=Mock(),
+        setup_metrics_collection_fn=Mock(),
+    )
+    config = _make_config(
+        classify_worker=True,
+        namespace="dynamo",
+        component="worker",
+        endpoint="generate",
+        served_model_name="model",
+        model="model",
+    )
+    shutdown_endpoints: list = []
+
+    await factory._create_classify_worker(
+        runtime,
+        config,
+        asyncio.Event(),
+        shutdown_endpoints,
+    )
+
+    register_model.assert_awaited_once()
+    register_args = register_model.await_args.args
+    registered_model_type = register_args[1]
+    assert register_args[0] == ModelInput.Text
+    assert registered_model_type.supports_classify()
+    assert registered_model_type.supports_pooling()
+    assert not registered_model_type.supports_embedding()
+    assert register_args[2:] == (
+        endpoint,
+        config,
+        engine_client,
+        vllm_config,
+    )
+    assert register_model.await_args.kwargs == {
+        "worker_type": WorkerType.Aggregated,
+        "needs": [],
+    }
+    assert shutdown_endpoints == [endpoint]
+    handler.cleanup.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -47,6 +47,7 @@ from .health_check import (
 )
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
 from .multimodal_handlers import EncodeWorkerHandler
+from .pooling_handlers import ClassifyWorkerHandler
 from .publisher import StatLoggerFactory
 
 logger = logging.getLogger(__name__)
@@ -613,6 +614,12 @@ class WorkerFactory:
             )
             return
 
+        if config.classify_worker:
+            await self._create_classify_worker(
+                runtime, config, shutdown_event, shutdown_endpoints
+            )
+            return
+
         # NOTE: --benchmark-mode is only supported for prefill/decode workers.
         # The encode worker path does not wire benchmark waiting or
         # the get_perf_metrics endpoint.
@@ -791,6 +798,74 @@ class WorkerFactory:
             )
         except Exception as e:
             logger.error(f"Failed to serve embedding worker endpoint: {e}")
+            raise
+        finally:
+            handler.cleanup()
+
+    async def _create_classify_worker(
+        self,
+        runtime: DistributedRuntime,
+        config: Config,
+        shutdown_event: asyncio.Event,
+        shutdown_endpoints: list,  # mutated in place
+    ) -> None:
+        """Initialize an aggregated sequence-classification worker.
+
+        Like the embeddings worker, this uses a pooling ``AsyncLLM`` and skips
+        the generation-only KV-cache and scheduler machinery. The combined
+        model type advertises both pooling-family endpoints.
+        """
+        generate_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.{config.endpoint}"
+        )
+        shutdown_endpoints[:] = [generate_endpoint]
+
+        fpm_worker_id = str(generate_endpoint.connection_id())
+        factory = StatLoggerFactory(
+            endpoint=generate_endpoint,
+            embedding_worker=True,
+        )
+        (
+            engine_client,
+            vllm_config,
+            _default_sampling_params,
+            _prometheus_temp_dir,
+            _component_gauges,
+        ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
+
+        handler = ClassifyWorkerHandler(
+            runtime=runtime,
+            engine=engine_client,
+            config=config,
+            model_config=getattr(vllm_config, "model_config", None),
+            shutdown_event=shutdown_event,
+        )
+
+        classify_health_check_payload = VllmEmbeddingHealthCheckPayload(
+            model_name=config.served_model_name or config.model
+        ).to_dict()
+
+        logger.info("Starting to serve the classify worker endpoint...")
+        try:
+            await asyncio.gather(
+                generate_endpoint.serve_endpoint(
+                    handler.generate,
+                    metrics_labels=[("model", config.model)],
+                    health_check_payload=classify_health_check_payload,
+                ),
+                self.register_vllm_model(
+                    ModelInput.Text,
+                    ModelType.Classify | ModelType.Pooling,
+                    generate_endpoint,
+                    config,
+                    engine_client,
+                    vllm_config,
+                    worker_type=WorkerType.Aggregated,
+                    needs=[],
+                ),
+            )
+        except Exception as e:
+            logger.error(f"Failed to serve classify worker endpoint: {e}")
             raise
         finally:
             handler.cleanup()

--- a/deploy/helm/charts/platform/templates/NOTES.txt
+++ b/deploy/helm/charts/platform/templates/NOTES.txt
@@ -27,7 +27,7 @@
   This release must use dynamo-operator.upgradeCRD=false and use CRDs managed
   by the cluster-wide operator. Use cluster-wide mode for production deployments.
 
-  See: https://docs.nvidia.com/dynamo/latest/kubernetes-deployment/start-here/installation-guide
+  See: https://docs.nvidia.com/dynamo/latest/kubernetes/installation/install-dynamo
 ================================================================================
 
 {{- end }}

--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/snapshot.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/snapshot.md
@@ -450,7 +450,7 @@ Failover restore is not yet available. The current Snapshot flow does not suppor
 
 It is possible to checkpoint and restore pods without the Dynamo operator via the lower-level `snapshotctl` utility. However, the snapshot helm chart must be installed, with a running `snapshot-agent` DaemonSet in the namespace with the checkpoint PVC mounted.
 
-`snapshotctl` is intended for lower-level debugging and validation workflows, not as the primary user-facing checkpoint interface. For command details and manifest requirements, see [deploy/snapshot/cmd/snapshotctl/README.md](https://github.com/ai-dynamo/dynamo/blob/main/deploy/snapshot/cmd/snapshotctl/README.md).
+`snapshotctl` is intended for lower-level debugging and validation workflows, not as the primary user-facing checkpoint interface. For command details and manifest requirements, see [deploy/snapshot/cmd/snapshotctl/README.md](https://github.com/ai-dynamo/dynamo/blob/release/1.4.1/deploy/snapshot/cmd/snapshotctl/README.md).
 
 ### Checkpoint from a worker pod manifest
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md
@@ -28,7 +28,7 @@ When resources become constrained, the mocker simulates the engine's real recove
 
 ## KV Block Manager
 
-The mocker's KV block manager is built on [`kvbm-logical::BlockManager<G1>`](https://github.com/ai-dynamo/dynamo/tree/main/lib/kvbm-logical), the same logical block manager the real Dynamo runtime uses. The mocker wraps it in [`lib/mocker/src/kv_manager/kvbm_backend.rs`](https://github.com/ai-dynamo/dynamo/blob/main/lib/mocker/src/kv_manager/kvbm_backend.rs) and translates its own `MoveBlock` protocol onto kvbm-logical's RAII lifecycle (`allocate → stage → register → drop`).
+The mocker's KV block manager is built on [`kvbm-logical::BlockManager<G1>`](https://github.com/ai-dynamo/dynamo/tree/main/lib/kvbm-logical), the same logical block manager the real Dynamo runtime uses. The mocker wraps it in [`lib/mocker/src/kv_manager/kvbm_backend.rs`](https://github.com/ai-dynamo/dynamo/blob/release/1.4.1/lib/mocker/src/kv_manager/kvbm_backend.rs) and translates its own `MoveBlock` protocol onto kvbm-logical's RAII lifecycle (`allocate → stage → register → drop`).
 
 Blocks conceptually live in one of two pools:
 

--- a/examples/backends/vllm/launch/agg_classify.sh
+++ b/examples/backends/vllm/launch/agg_classify.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated sequence-classification and pooling model serving.
+# One --classify-worker registers both pooling-family model types, so the
+# frontend mounts POST /v1/classify and POST /v1/pooling.
+# GPUs: 1
+
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"     # build_vllm_gpu_mem_args
+source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+
+# Small three-class NLI cross-encoder (contradiction / entailment / neutral).
+MODEL="cross-encoder/nli-MiniLM2-L6-H768"
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        -h | --help)
+            echo "Usage: $0 [OPTIONS]"
+            echo "Options:"
+            echo "  --model <name>  Specify classification model (default: $MODEL)"
+            echo "  -h, --help      Show this help message"
+            echo ""
+            echo "Any additional options are passed through to dynamo.vllm."
+            echo "Note: --runner pooling is set here and required for pooling models."
+            trap - EXIT
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+print_launch_banner --no-curl "Launching Classify Worker (1 GPU)" "$MODEL" "$HTTP_PORT"
+
+print_curl_footer <<CURL
+  curl http://localhost:${HTTP_PORT}/v1/classify \\
+    -H 'Content-Type: application/json' \\
+    -d '{
+      "model": "${MODEL}",
+      "input": "A man is playing a sport. Some men are playing a sport."
+    }'
+CURL
+
+# Run ingress.
+python3 -m dynamo.frontend &
+
+# Classification models have varied native context lengths. Leave the model's
+# own value unchanged unless the caller explicitly supplies a safe override.
+MAX_MODEL_LEN_ARGS=()
+if [[ -n "${MAX_MODEL_LEN:-}" ]]; then
+    MAX_MODEL_LEN_ARGS=(--max-model-len "$MAX_MODEL_LEN")
+fi
+
+# Run a pooling AsyncLLM worker. Prefix caching remains disabled by the
+# pooling-family worker default because pooling requests have no decode phase.
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+    python3 -m dynamo.vllm \
+    --classify-worker \
+    --model "$MODEL" \
+    --runner pooling \
+    --trust-remote-code \
+    "${MAX_MODEL_LEN_ARGS[@]}" \
+    $GPU_MEM_ARGS \
+    "${EXTRA_ARGS[@]}" &
+
+# Exit on the first process failure; the EXIT trap tears down the remainder.
+wait_any_exit

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -897,9 +897,29 @@ impl ModelType {
     const Realtime: Self = ModelType {
         inner: llm_rs::model_type::ModelType::Realtime,
     };
+    #[classattr]
+    const Classify: Self = ModelType {
+        inner: llm_rs::model_type::ModelType::Classify,
+    };
+    #[classattr]
+    const Pooling: Self = ModelType {
+        inner: llm_rs::model_type::ModelType::Pooling,
+    };
 
     fn supports_chat(&self) -> bool {
         self.inner.supports_chat()
+    }
+
+    fn supports_embedding(&self) -> bool {
+        self.inner.supports_embedding()
+    }
+
+    fn supports_classify(&self) -> bool {
+        self.inner.supports_classify()
+    }
+
+    fn supports_pooling(&self) -> bool {
+        self.inner.supports_pooling()
     }
 
     fn __or__(&self, other: &Self) -> Self {

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1633,7 +1633,11 @@ class ModelInput:
 
 
 class ModelType:
-    """What type of request this model supports: Chat, Completions, Embedding, Tensor, Images, Videos, Realtime, or Empty (no OpenAI surface)"""
+    """OpenAI-style surfaces supported by a model.
+
+    Values are Chat, Completions, Embedding, Classify, Pooling, TensorBased,
+    Images, Audios, Videos, Realtime, and Empty (no OpenAI surface).
+    """
     # No OpenAI surface — used by prefill / encode workers whose role is
     # carried by WorkerType. Symmetric with the other ModelType.Foo members.
     Empty: ModelType
@@ -1649,12 +1653,29 @@ class ModelType:
     Audios: ModelType
     Videos: ModelType
     Realtime: ModelType
+    # Sequence-classification / cross-encoder pooling models served on /v1/classify.
+    Classify: ModelType
+    # Raw pooler output served on /v1/pooling (token embeddings, logits, rewards).
+    # Usually combined with Classify or Embedding: ModelType.Classify | ModelType.Pooling.
+    Pooling: ModelType
 
     def __or__(self, other: ModelType) -> ModelType:
         ...
 
     def supports_chat(self) -> bool:
         """Return True if this model type supports chat."""
+        ...
+
+    def supports_embedding(self) -> bool:
+        """Return True if this model type supports /v1/embeddings."""
+        ...
+
+    def supports_classify(self) -> bool:
+        """Return True if this model type supports /v1/classify."""
+        ...
+
+    def supports_pooling(self) -> bool:
+        """Return True if this model type supports /v1/pooling."""
         ...
 
 class RouterMode:

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -23,8 +23,9 @@ use crate::types::{
     openai::{
         audios::OpenAIAudiosStreamingEngine,
         chat_completions::OpenAIChatCompletionsStreamingEngine,
-        completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
-        generate::GenerateStreamingEngine, images::OpenAIImagesStreamingEngine,
+        classify::OpenAIClassifyStreamingEngine, completions::OpenAICompletionsStreamingEngine,
+        embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
+        images::OpenAIImagesStreamingEngine, pooling::OpenAIPoolingStreamingEngine,
         videos::OpenAIVideosStreamingEngine,
     },
 };
@@ -328,6 +329,20 @@ impl Model {
         self.worker_sets
             .iter()
             .any(|entry| entry.value().has_embeddings_engine())
+    }
+
+    /// Check if any WorkerSet has a classify engine.
+    pub fn has_classify_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_classify_engine())
+    }
+
+    /// Check if any WorkerSet has a pooling engine.
+    pub fn has_pooling_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_pooling_engine())
     }
 
     /// Check if any WorkerSet has a tensor engine.
@@ -686,6 +701,16 @@ impl Model {
     ) -> Result<OpenAIEmbeddingsStreamingEngine, ModelManagerError> {
         self.select_worker_set_with(|ws| ws.embeddings_engine.clone())
             .ok_or_else(|| self.engine_error(self.has_embeddings_engine()))
+    }
+
+    pub fn get_classify_engine(&self) -> Result<OpenAIClassifyStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.classify_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_classify_engine()))
+    }
+
+    pub fn get_pooling_engine(&self) -> Result<OpenAIPoolingStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.pooling_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_pooling_engine()))
     }
 
     pub fn get_images_engine(&self) -> Result<OpenAIImagesStreamingEngine, ModelManagerError> {

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -45,9 +45,10 @@ use crate::{
         openai::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
-            completions::OpenAICompletionsStreamingEngine,
+            classify::OpenAIClassifyStreamingEngine, completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
-            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
+            images::OpenAIImagesStreamingEngine, pooling::OpenAIPoolingStreamingEngine,
+            videos::OpenAIVideosStreamingEngine,
         },
     },
     worker_type::WorkerType,
@@ -597,6 +598,22 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_classify_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_classify_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    pub fn list_pooling_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_pooling_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_tensor_models(&self) -> Vec<String> {
         self.models
             .iter()
@@ -661,6 +678,26 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_embeddings_engine()
+    }
+
+    pub fn get_classify_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIClassifyStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_classify_engine()
+    }
+
+    pub fn get_pooling_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIPoolingStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_pooling_engine()
     }
 
     pub fn get_completions_engine(
@@ -874,6 +911,48 @@ impl ModelManager {
         Ok(())
     }
 
+    pub fn add_classify_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIClassifyStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_classify_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_classify_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            Self::aggregated_local_card(),
+        );
+        ws.classify_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    pub fn add_pooling_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIPoolingStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_pooling_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_pooling_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            Self::aggregated_local_card(),
+        );
+        ws.pooling_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
     pub fn add_tensor_model(
         &self,
         model: &str,
@@ -1052,6 +1131,20 @@ impl ModelManager {
 
     pub fn remove_embeddings_model(&self, model: &str) -> Result<(), ModelManagerError> {
         let namespace = format!("__local_embeddings_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_classify_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_classify_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_pooling_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_pooling_{}", model);
         self.remove_worker_set(model, &namespace)
             .map(|_| ())
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -2275,6 +2275,8 @@ fn seed_lora_state_from_card(
 mod tests {
     use super::*;
     use crate::model_card::ModelDeploymentCard;
+    use dynamo_runtime::engine::AsyncEngine;
+    use dynamo_runtime::pipeline::Error;
 
     fn test_endpoint_id(name: &str) -> EndpointId {
         EndpointId {
@@ -2690,6 +2692,84 @@ mod tests {
         let engine = std::sync::Arc::new(crate::engines::EchoBidirectionalEngine);
         mm.add_realtime_model("rt-echo", "0", engine).unwrap();
         assert!(!is_model_type_list_empty(&mm, ModelType::Realtime));
+    }
+
+    /// Stand-in engine for registration-only tests; never invoked.
+    struct UncalledEngine;
+
+    #[async_trait::async_trait]
+    impl
+        AsyncEngine<
+            SingleIn<NvCreatePoolingRequest>,
+            ManyOut<Annotated<NvCreatePoolingResponse>>,
+            Error,
+        > for UncalledEngine
+    {
+        async fn generate(
+            &self,
+            _request: SingleIn<NvCreatePoolingRequest>,
+        ) -> Result<ManyOut<Annotated<NvCreatePoolingResponse>>, Error> {
+            anyhow::bail!("engine is never invoked by this test")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl
+        AsyncEngine<
+            SingleIn<NvCreateClassifyRequest>,
+            ManyOut<Annotated<NvCreateClassifyResponse>>,
+            Error,
+        > for UncalledEngine
+    {
+        async fn generate(
+            &self,
+            _request: SingleIn<NvCreateClassifyRequest>,
+        ) -> Result<ManyOut<Annotated<NvCreateClassifyResponse>>, Error> {
+            anyhow::bail!("engine is never invoked by this test")
+        }
+    }
+
+    /// Removing one model of a type must not retract the endpoint for the
+    /// models of that type that are still registered: the frontend maps a
+    /// `ModelUpdate::Removed` card onto process-wide endpoint flags, so an
+    /// over-eager removal card would 404 the surviving models' endpoint.
+    #[test]
+    fn removing_one_model_keeps_the_endpoint_for_surviving_models() {
+        let mm = ModelManager::new();
+        mm.add_pooling_model("model-a", "ck-a", std::sync::Arc::new(UncalledEngine))
+            .unwrap();
+        mm.add_pooling_model("model-b", "ck-b", std::sync::Arc::new(UncalledEngine))
+            .unwrap();
+        mm.add_classify_model("model-a", "ck-a", std::sync::Arc::new(UncalledEngine))
+            .unwrap();
+        mm.add_classify_model("model-b", "ck-b", std::sync::Arc::new(UncalledEngine))
+            .unwrap();
+
+        let mut card = ModelDeploymentCard::with_name_only("model-a");
+        card.model_type = ModelType::Classify | ModelType::Pooling;
+
+        // Mirrors `handle_delete`, which drops the model from the manager
+        // before computing the removal cards.
+        mm.remove_model("model-a");
+        assert!(
+            removed_model_cards(&mm, &card).is_empty(),
+            "removing model-a must emit no removal card while model-b is still registered"
+        );
+
+        // The last model of each type going away must still retract both.
+        mm.remove_model("model-b");
+        let removed = removed_model_cards(&mm, &card);
+        assert_eq!(removed.len(), 2);
+        assert!(
+            removed
+                .iter()
+                .any(|card| card.model_type == ModelType::Classify)
+        );
+        assert!(
+            removed
+                .iter()
+                .any(|card| card.model_type == ModelType::Pooling)
+        );
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -50,9 +50,11 @@ use crate::{
             chat_completions::{
                 NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
             },
+            classify::{NvCreateClassifyRequest, NvCreateClassifyResponse},
             completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
             embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
             images::{NvCreateImageRequest, NvImagesResponse},
+            pooling::{NvCreatePoolingRequest, NvCreatePoolingResponse},
             videos::{NvCreateVideoRequest, NvVideosResponse},
         },
         tensor::{NvCreateTensorRequest, NvCreateTensorResponse},
@@ -262,6 +264,8 @@ const ALL_MODEL_TYPES: &[ModelType] = &[
     ModelType::Videos,
     ModelType::TensorBased,
     ModelType::Realtime,
+    ModelType::Classify,
+    ModelType::Pooling,
 ];
 
 /// Returns true if no models in the manager support the given model type.
@@ -282,9 +286,33 @@ fn is_model_type_list_empty(manager: &ModelManager, model_type: ModelType) -> bo
         manager.list_tensor_models().is_empty()
     } else if model_type == ModelType::Realtime {
         manager.list_realtime_models().is_empty()
+    } else if model_type == ModelType::Classify {
+        manager.list_classify_models().is_empty()
+    } else if model_type == ModelType::Pooling {
+        manager.list_pooling_models().is_empty()
     } else {
         true
     }
+}
+
+fn removed_model_cards(
+    manager: &ModelManager,
+    card: &ModelDeploymentCard,
+) -> Vec<ModelDeploymentCard> {
+    ALL_MODEL_TYPES
+        .iter()
+        .filter_map(|model_type| {
+            if card.model_type.intersects(*model_type)
+                && is_model_type_list_empty(manager, *model_type)
+            {
+                let mut removed_card = card.clone();
+                removed_card.model_type = *model_type;
+                Some(removed_card)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// RAII guard that removes a key from a `DashSet` on drop and wakes any tasks
@@ -1181,12 +1209,8 @@ impl ModelWatcher {
         }
 
         if let Some(tx) = &self.model_update_tx {
-            for model_type in ALL_MODEL_TYPES {
-                if card.model_type.intersects(*model_type)
-                    && is_model_type_list_empty(&self.manager, *model_type)
-                {
-                    tx.send(ModelUpdate::Removed(card.clone())).await.ok();
-                }
+            for removed_card in removed_model_cards(&self.manager, &card) {
+                tx.send(ModelUpdate::Removed(removed_card)).await.ok();
             }
         }
 
@@ -1893,27 +1917,44 @@ impl ModelWatcher {
                     card.name()
                 );
             }
-        } else if card.model_input == ModelInput::Text && card.model_type.supports_embedding() {
-            // Case: Text + Embeddings
-            let push_router = PushRouter::<
-                NvCreateEmbeddingRequest,
-                Annotated<NvCreateEmbeddingResponse>,
-            >::from_client_with_monitor(
-                client, router_config.router_mode, None
-            )
-            .await?;
-            worker_set.embeddings_engine = Some(Arc::new(push_router));
-        }
-        // Case: Text + (Images, Audio, Videos)
-        // Must come before the plain Text+Chat / Text+Completions branches because
-        // diffusion models often set both Images and Chat flags. The branch below
-        // handles the chat registration internally when supports_chat() is true.
-        else if card.model_input == ModelInput::Text
-            && (card.model_type.supports_images()
-                || card.model_type.supports_audios()
-                || card.model_type.supports_videos())
-        {
-            // Image/Audio/Video models can also support chat completions (vLLM omni way)
+        } else if card.model_input == ModelInput::Text {
+            // Text workers tokenize in the backend and can advertise multiple
+            // OpenAI surfaces. Build each declared surface independently:
+            // ModelType is a bitflag, so choosing one mutually-exclusive branch
+            // would silently omit engines for mixed-capability cards.
+            if card.model_type.supports_embedding() {
+                let push_router = PushRouter::<
+                    NvCreateEmbeddingRequest,
+                    Annotated<NvCreateEmbeddingResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.embeddings_engine = Some(Arc::new(push_router));
+            }
+
+            if card.model_type.supports_classify() {
+                let push_router = PushRouter::<
+                    NvCreateClassifyRequest,
+                    Annotated<NvCreateClassifyResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.classify_engine = Some(Arc::new(push_router));
+            }
+
+            if card.model_type.supports_pooling() {
+                let push_router = PushRouter::<
+                    NvCreatePoolingRequest,
+                    Annotated<NvCreatePoolingResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.pooling_engine = Some(Arc::new(push_router));
+            }
+
             if card.model_type.supports_chat() {
                 let chat_router = PushRouter::<
                     NvCreateChatCompletionRequest,
@@ -1923,6 +1964,17 @@ impl ModelWatcher {
                 )
                 .await?;
                 worker_set.chat_engine = Some(Arc::new(chat_router));
+            }
+
+            if card.model_type.supports_completions() {
+                let completions_router = PushRouter::<
+                    NvCreateCompletionRequest,
+                    Annotated<NvCreateCompletionResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.completions_engine = Some(Arc::new(completions_router));
             }
 
             if card.model_type.supports_images() {
@@ -1953,25 +2005,30 @@ impl ModelWatcher {
                 .await?;
                 worker_set.audios_engine = Some(Arc::new(audios_router));
             }
-        } else if card.model_input == ModelInput::Text && card.model_type.supports_chat() {
-            // Case: Text + Chat (pure text-to-text, no diffusion)
-            let push_router =
-                PushRouter::<
-                    NvCreateChatCompletionRequest,
-                    Annotated<NvCreateChatCompletionStreamResponse>,
-                >::from_client_with_monitor(client, router_config.router_mode, None)
+
+            if card.model_type.supports_realtime() {
+                // `Text` is overloaded for Realtime; its I/O passes through.
+                let realtime_router = PushRouter::<
+                    RealtimeClientEvent,
+                    Annotated<RealtimeServerEvent>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
                 .await?;
-            worker_set.chat_engine = Some(Arc::new(push_router));
-        } else if card.model_input == ModelInput::Text && card.model_type.supports_completions() {
-            // Case: Text + Completions
-            let push_router = PushRouter::<
-                NvCreateCompletionRequest,
-                Annotated<NvCreateCompletionResponse>,
-            >::from_client_with_monitor(
-                client, router_config.router_mode, None
-            )
-            .await?;
-            worker_set.completions_engine = Some(Arc::new(push_router));
+                worker_set.realtime_engine = Some(Arc::new(realtime_router));
+            }
+
+            if card.model_type.is_empty() {
+                tracing::info!(
+                    model_name = card.name(),
+                    "Topology-only worker (empty model_type), registering for serving readiness only"
+                );
+            } else if !worker_set.has_any_serving_engine() {
+                anyhow::bail!(
+                    "Unsupported model configuration: {} with Text input",
+                    card.model_type
+                );
+            }
         } else if card.model_input == ModelInput::Tokens && card.model_type.supports_embedding() {
             // Case 4: Tokens + Embeddings
             // Create preprocessing pipeline similar to Backend
@@ -2015,17 +2072,6 @@ impl ModelWatcher {
             )
             .await?;
             worker_set.tensor_engine = Some(Arc::new(push_router));
-        } else if card.model_input == ModelInput::Text && card.model_type.supports_realtime() {
-            // Case 7: Text + Realtime
-            // 'Text' is being overloaded here, it simply means the I/O will be passed through
-            let realtime_router = PushRouter::<
-                RealtimeClientEvent,
-                Annotated<RealtimeServerEvent>,
-            >::from_client_with_monitor(
-                client, router_config.router_mode, None
-            )
-            .await?;
-            worker_set.realtime_engine = Some(Arc::new(realtime_router));
         } else if card.model_type.is_empty() {
             // No OpenAI surface declared: a topology-only worker that exists
             // purely for serving-readiness accounting — e.g. a surface-less
@@ -2044,7 +2090,7 @@ impl ModelWatcher {
             // prefill is routed off `worker_type`.)
             anyhow::bail!(
                 "Unsupported model configuration: {} with {} input. Supported combinations: \
-                Tokens+(Chat|Completions), Text+(Chat|Completions|Images|Audios|Videos|Embeddings|Realtime), \
+                Tokens+(Chat|Completions), Text+(Chat|Completions|Images|Audios|Videos|Embeddings|Classify|Pooling|Realtime), \
                 Tokens+Embeddings, Tensor+TensorBased",
                 card.model_type,
                 card.model_input.as_str()
@@ -2400,6 +2446,50 @@ mod tests {
         assert_eq!(released_base_engine.strong_count(), 0);
         runtime.shutdown();
     }
+
+    #[tokio::test]
+    async fn text_pooling_family_preserves_chat_engine() {
+        use dynamo_runtime::{Runtime, distributed::DistributedConfig};
+
+        let runtime = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(runtime, DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let manager = Arc::new(ModelManager::new());
+        let watcher = ModelWatcher::new(
+            drt,
+            manager.clone(),
+            RouterConfig::default(),
+            0,
+            None,
+            None,
+            None,
+            Arc::new(Metrics::new_with_prefix(Some(
+                "watcher_mixed_text_test".to_string(),
+            ))),
+        );
+        let mcid = ModelCardInstanceId {
+            namespace: "mixed-text-ns".to_string(),
+            component: "workers".to_string(),
+            endpoint: "generate".to_string(),
+            instance_id: 1,
+            model_suffix: None,
+        };
+        let mut card = ModelDeploymentCard::with_name_only("mixed-text-model");
+        card.model_input = ModelInput::Text;
+        card.model_type = ModelType::Chat | ModelType::Classify | ModelType::Pooling;
+        card.worker_type = Some(WorkerType::Aggregated);
+
+        watcher
+            .do_worker_set_registration(&mcid, &mut card)
+            .await
+            .unwrap();
+
+        let model = manager.get_model(card.name()).unwrap();
+        assert!(model.has_chat_engine());
+        assert!(model.has_classify_engine());
+        assert!(model.has_pooling_engine());
+    }
     #[test]
     fn base_card_with_capacity_seeds_idle_lora_capable_worker() {
         // jh-nv (watcher base-card seeding): a base worker card (lora=None) carrying
@@ -2565,6 +2655,33 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Videos));
         assert!(is_model_type_list_empty(&mm, ModelType::TensorBased));
         assert!(is_model_type_list_empty(&mm, ModelType::Realtime));
+        assert!(is_model_type_list_empty(&mm, ModelType::Classify));
+        assert!(is_model_type_list_empty(&mm, ModelType::Pooling));
+    }
+
+    #[test]
+    fn removal_cards_contain_only_the_empty_model_type() {
+        let mm = ModelManager::new();
+        let mut card = ModelDeploymentCard::with_name_only("model");
+        card.model_type = ModelType::Classify | ModelType::Pooling;
+
+        let removed_cards = removed_model_cards(&mm, &card);
+        assert_eq!(removed_cards.len(), 2);
+        assert!(
+            removed_cards
+                .iter()
+                .any(|card| card.model_type == ModelType::Classify)
+        );
+        assert!(
+            removed_cards
+                .iter()
+                .any(|card| card.model_type == ModelType::Pooling)
+        );
+        assert!(
+            removed_cards
+                .iter()
+                .all(|card| card.model_type.bits().count_ones() == 1)
+        );
     }
 
     #[test]

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -23,9 +23,10 @@ use crate::{
         openai::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
-            completions::OpenAICompletionsStreamingEngine,
+            classify::OpenAIClassifyStreamingEngine, completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
-            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
+            images::OpenAIImagesStreamingEngine, pooling::OpenAIPoolingStreamingEngine,
+            videos::OpenAIVideosStreamingEngine,
         },
     },
 };
@@ -145,6 +146,8 @@ pub struct WorkerSet {
     pub(crate) chat_engine: Option<OpenAIChatCompletionsStreamingEngine>,
     pub(crate) completions_engine: Option<OpenAICompletionsStreamingEngine>,
     pub(crate) embeddings_engine: Option<OpenAIEmbeddingsStreamingEngine>,
+    pub(crate) classify_engine: Option<OpenAIClassifyStreamingEngine>,
+    pub(crate) pooling_engine: Option<OpenAIPoolingStreamingEngine>,
     pub(crate) images_engine: Option<OpenAIImagesStreamingEngine>,
     pub(crate) videos_engine: Option<OpenAIVideosStreamingEngine>,
     pub(crate) audios_engine: Option<OpenAIAudiosStreamingEngine>,
@@ -185,6 +188,8 @@ impl WorkerSet {
             chat_engine: None,
             completions_engine: None,
             embeddings_engine: None,
+            classify_engine: None,
+            pooling_engine: None,
             images_engine: None,
             videos_engine: None,
             audios_engine: None,
@@ -233,6 +238,14 @@ impl WorkerSet {
         self.embeddings_engine.is_some()
     }
 
+    pub fn has_classify_engine(&self) -> bool {
+        self.classify_engine.is_some()
+    }
+
+    pub fn has_pooling_engine(&self) -> bool {
+        self.pooling_engine.is_some()
+    }
+
     pub fn has_images_engine(&self) -> bool {
         self.images_engine.is_some()
     }
@@ -270,6 +283,8 @@ impl WorkerSet {
         self.has_chat_engine()
             || self.has_completions_engine()
             || self.has_embeddings_engine()
+            || self.has_classify_engine()
+            || self.has_pooling_engine()
             || self.has_images_engine()
             || self.has_tensor_engine()
             || self.has_videos_engine()
@@ -383,6 +398,8 @@ impl WorkerSet {
             videos_engine: lora_context_engine(&self.videos_engine, &lora_name),
             audios_engine: lora_context_engine(&self.audios_engine, &lora_name),
             tensor_engine: lora_context_engine(&self.tensor_engine, &lora_name),
+            classify_engine: lora_context_engine(&self.classify_engine, &lora_name),
+            pooling_engine: lora_context_engine(&self.pooling_engine, &lora_name),
             // The bidirectional realtime engine cannot carry the server-streaming context
             // wrapper. Do not expose the base weights through an adapter model name.
             realtime_engine: None,
@@ -414,11 +431,13 @@ mod tests {
     use crate::types::openai::chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
     };
+    use crate::types::openai::classify::{NvCreateClassifyRequest, NvCreateClassifyResponse};
     use crate::types::openai::completions::{
         NvCreateCompletionRequest, NvCreateCompletionResponse,
     };
     use crate::types::openai::embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse};
     use crate::types::openai::images::{NvCreateImageRequest, NvImagesResponse};
+    use crate::types::openai::pooling::{NvCreatePoolingRequest, NvCreatePoolingResponse};
     use crate::types::openai::videos::{NvCreateVideoRequest, NvVideosResponse};
     use async_trait::async_trait;
     use dynamo_runtime::engine::AsyncEngine;
@@ -526,6 +545,8 @@ mod tests {
         assert!(!ws.has_chat_engine());
         assert!(!ws.has_completions_engine());
         assert!(!ws.has_embeddings_engine());
+        assert!(!ws.has_classify_engine());
+        assert!(!ws.has_pooling_engine());
         assert!(!ws.has_images_engine());
         assert!(!ws.has_videos_engine());
         assert!(!ws.has_audios_engine());
@@ -573,6 +594,18 @@ mod tests {
             has_embeddings_engine,
             StubEngine::<NvCreateEmbeddingRequest, NvCreateEmbeddingResponse>::new(),
             "embeddings"
+        );
+        check!(
+            classify_engine,
+            has_classify_engine,
+            StubEngine::<NvCreateClassifyRequest, NvCreateClassifyResponse>::new(),
+            "classify"
+        );
+        check!(
+            pooling_engine,
+            has_pooling_engine,
+            StubEngine::<NvCreatePoolingRequest, NvCreatePoolingResponse>::new(),
+            "pooling"
         );
         check!(
             images_engine,

--- a/lib/llm/src/endpoint_type.rs
+++ b/lib/llm/src/endpoint_type.rs
@@ -20,6 +20,10 @@ pub enum EndpointType {
     Videos,
     /// Realtime API (bidirectional streaming over WebSocket)
     Realtime,
+    /// Classification API (sequence classification / cross-encoder pooling)
+    Classify,
+    /// Pooling API (raw pooler output: token embeddings, logits, rewards)
+    Pooling,
     /// Responses API
     Responses,
     /// Anthropic Messages API
@@ -40,6 +44,8 @@ impl EndpointType {
             Self::Audios => "audios",
             Self::Videos => "videos",
             Self::Realtime => "realtime",
+            Self::Classify => "classify",
+            Self::Pooling => "pooling",
             Self::Responses => "responses",
             Self::AnthropicMessages => "anthropic_messages",
             Self::Generate => "generate",
@@ -56,6 +62,8 @@ impl EndpointType {
             Self::Audios,
             Self::Videos,
             Self::Realtime,
+            Self::Classify,
+            Self::Pooling,
             Self::Responses,
             Self::AnthropicMessages,
             Self::Generate,

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -458,6 +458,12 @@ pub enum Endpoint {
     /// OAI Embeddings
     Embeddings,
 
+    /// Classification (sequence classification / cross-encoder pooling)
+    Classify,
+
+    /// Pooling (raw pooler output)
+    Pooling,
+
     /// OAI Images
     Images,
 
@@ -1498,6 +1504,8 @@ impl std::fmt::Display for Endpoint {
             Endpoint::Completions => write!(f, "completions"),
             Endpoint::ChatCompletions => write!(f, "chat_completions"),
             Endpoint::Embeddings => write!(f, "embeddings"),
+            Endpoint::Classify => write!(f, "classify"),
+            Endpoint::Pooling => write!(f, "pooling"),
             Endpoint::Images => write!(f, "images"),
             Endpoint::Videos => write!(f, "videos"),
             Endpoint::Audios => write!(f, "audios"),
@@ -1515,6 +1523,8 @@ impl Endpoint {
             Endpoint::Completions => "completions",
             Endpoint::ChatCompletions => "chat_completions",
             Endpoint::Embeddings => "embeddings",
+            Endpoint::Classify => "classify",
+            Endpoint::Pooling => "pooling",
             Endpoint::Images => "images",
             Endpoint::Videos => "videos",
             Endpoint::Audios => "audios",

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -58,10 +58,15 @@ use crate::protocols::openai::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
         NvCreateChatCompletionStreamResponse,
     },
+    classify::{NvCreateClassifyRequest, NvCreateClassifyResponse},
     completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
     delta_common,
     embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
     images::{NvCreateImageRequest, NvImagesResponse},
+    pooling::{
+        NvCreatePoolingRequest, NvCreatePoolingResponse, PoolingEmbedDType, PoolingEncodingFormat,
+        PoolingEndianness, PoolingOutput,
+    },
     responses::{
         NvCreateResponse, NvResponse, ResponseParams, ResponsesConversionError,
         chat_completion_to_response,
@@ -1361,6 +1366,410 @@ fn decode_base64_embedding_to_floats(s: &str) -> Result<Vec<f32>, anyhow::Error>
         floats.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
     }
     Ok(floats)
+}
+
+#[tracing::instrument(skip_all)]
+async fn classify(
+    State(state): State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    Json(mut request): Json<NvCreateClassifyRequest>,
+) -> Result<Response, ErrorResponse> {
+    // return a 503 if the service or model is not ready
+    check_ready(&state)?;
+    check_model_serving_ready(&state, &request.model)?;
+
+    if !state.nvext_enabled() {
+        warn_nvext_disabled("classify", request.nvext.is_some(), &headers);
+        request.nvext = None;
+    }
+
+    // Resolve alias → primary served name before wrapping the request, so
+    // engine routing, metrics, and the response model all use the canonical
+    // primary (mirrors `embeddings` / `completions_single`).
+    let canonical = state.manager().resolve_canonical_name(&request.model);
+    if canonical != request.model {
+        request.model = canonical;
+    }
+    let request_id = get_or_create_request_id(&headers);
+    let request = context_from_headers(request, request_id, &headers)?;
+    let request_id = request.id().to_string();
+
+    // Classification, like embeddings, is a pooling task returned as a single
+    // (non-streaming) response.
+    let streaming = false;
+
+    let model = &request.model;
+    let metric_model = state.manager().metric_model_for(model).to_string();
+
+    // Create inflight_guard early to ensure all errors (including validation)
+    // are counted. Request validation runs after this point so a rejected
+    // request still lands in `requests_total` with error_type=validation
+    // (mirrors `chat_completions`).
+    let mut inflight = state.metrics_clone().create_inflight_guard(
+        &metric_model,
+        Endpoint::Classify,
+        streaming,
+        &request_id,
+    );
+
+    // Marked as `Validation` explicitly rather than through
+    // `extract_error_type_from_response`: that helper infers the type from the
+    // message, and only a `VALIDATION_PREFIX`-prefixed 400 maps to
+    // `Validation` (anything else falls back to `Internal`). These messages
+    // stay verbatim vLLM-compatible, so the prefix is not an option here.
+    if let Err(err_response) = validate_pooling_cache_salt(request.cache_salt.as_deref()) {
+        inflight.mark_error(ErrorType::Validation);
+        return Err(err_response);
+    }
+
+    // Create http_queue_guard early - tracks time waiting to be processed
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
+
+    let engine = state.manager().get_classify_engine(model).map_err(|e| {
+        let err_response = ErrorMessage::from_model_error(&e);
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    let mut response_collector = state
+        .metrics_clone()
+        .create_response_collector(&metric_model);
+    let model_name = model.to_string();
+
+    // issue the generate call on the engine
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model_name, super::metrics::Endpoint::Classify);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to generate classification");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    // Process stream to collect metrics and drop http_queue_guard on first token
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
+    });
+
+    // Fold the (single-response) stream into one classification response.
+    let response = NvCreateClassifyResponse::from_annotated_stream(stream)
+        .await
+        .map_err(|e| {
+            let err_response = ErrorMessage::from_anyhow(
+                anyhow::Error::new(e),
+                "Failed to fold classification stream",
+            );
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
+        })?;
+
+    inflight.mark_ok();
+    Ok(Json(response).into_response())
+}
+
+fn pooling_or_classify_bad_request(message: String) -> ErrorResponse {
+    let code = StatusCode::BAD_REQUEST;
+    (
+        code,
+        Json(ErrorMessage {
+            message,
+            error_type: map_error_code_to_error_type(code),
+            code: code.as_u16(),
+            details: None,
+        }),
+    )
+}
+
+fn validate_pooling_cache_salt(cache_salt: Option<&str>) -> Result<(), ErrorResponse> {
+    if cache_salt == Some("") {
+        return Err(pooling_or_classify_bad_request(
+            "Parameter 'cache_salt' must be a non-empty string if provided.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct PoolingBinaryMetadataItem {
+    index: u32,
+    embed_dtype: &'static str,
+    endianness: &'static str,
+    start: usize,
+    end: usize,
+    shape: Vec<u64>,
+}
+
+#[derive(Serialize)]
+struct PoolingBinaryUsage {
+    prompt_tokens: u32,
+    total_tokens: u32,
+}
+
+#[derive(Serialize)]
+struct PoolingBinaryMetadata {
+    id: String,
+    created: u64,
+    model: String,
+    data: Vec<PoolingBinaryMetadataItem>,
+    usage: PoolingBinaryUsage,
+}
+
+fn build_pooling_binary_response(
+    response: NvCreatePoolingResponse,
+    include_metadata: bool,
+    embed_dtype: PoolingEmbedDType,
+    endianness: PoolingEndianness,
+) -> anyhow::Result<Response> {
+    let NvCreatePoolingResponse {
+        id,
+        created,
+        model,
+        data,
+        usage,
+        ..
+    } = response;
+
+    let mut chunks = Vec::with_capacity(data.len());
+    let mut metadata_items = Vec::with_capacity(if include_metadata { data.len() } else { 0 });
+    let mut offset = 0usize;
+
+    for item in data {
+        let encoded = match item.data {
+            PoolingOutput::Base64(encoded) => encoded,
+            _ => anyhow::bail!(
+                "binary pooling output at index {} was not base64 encoded",
+                item.index
+            ),
+        };
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "invalid base64 in binary pooling output at index {}: {e}",
+                    item.index
+                )
+            })?;
+        let end = offset.checked_add(bytes.len()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "binary pooling response size overflow at index {}",
+                item.index
+            )
+        })?;
+
+        if include_metadata {
+            let shape = item.shape.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "binary pooling output at index {} is missing its tensor shape",
+                    item.index
+                )
+            })?;
+            let expected_len =
+                shape
+                    .iter()
+                    .try_fold(embed_dtype.byte_width(), |size, &dimension| {
+                        let dimension = usize::try_from(dimension).map_err(|_| {
+                            anyhow::anyhow!(
+                                "binary pooling tensor dimension overflow at index {}",
+                                item.index
+                            )
+                        })?;
+                        size.checked_mul(dimension).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "binary pooling tensor size overflow at index {}",
+                                item.index
+                            )
+                        })
+                    })?;
+            anyhow::ensure!(
+                bytes.len() == expected_len,
+                "binary pooling output at index {} has {} bytes, but shape {:?} with dtype {} requires {}",
+                item.index,
+                bytes.len(),
+                shape,
+                embed_dtype.as_str(),
+                expected_len
+            );
+            metadata_items.push(PoolingBinaryMetadataItem {
+                index: item.index,
+                embed_dtype: embed_dtype.as_str(),
+                endianness: endianness.as_str(),
+                start: offset,
+                end,
+                shape,
+            });
+        }
+
+        chunks.push(Bytes::from(bytes));
+        offset = end;
+    }
+
+    let metadata = if include_metadata {
+        Some(serde_json::to_string(&PoolingBinaryMetadata {
+            id,
+            created,
+            model,
+            data: metadata_items,
+            usage: PoolingBinaryUsage {
+                prompt_tokens: usage.prompt_tokens,
+                total_tokens: usage.total_tokens,
+            },
+        })?)
+    } else {
+        None
+    };
+
+    let body = Body::from_stream(stream::iter(
+        chunks
+            .into_iter()
+            .map(Ok::<Bytes, std::convert::Infallible>),
+    ));
+    let mut builder =
+        Response::builder().header(axum::http::header::CONTENT_TYPE, "application/octet-stream");
+    if let Some(metadata) = metadata {
+        builder = builder.header("metadata", metadata);
+    }
+    Ok(builder.body(body)?)
+}
+
+#[tracing::instrument(skip_all)]
+async fn pooling(
+    State(state): State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    Json(mut request): Json<NvCreatePoolingRequest>,
+) -> Result<Response, ErrorResponse> {
+    // return a 503 if the service or model is not ready
+    check_ready(&state)?;
+    check_model_serving_ready(&state, &request.model)?;
+
+    if !state.nvext_enabled() {
+        warn_nvext_disabled("pooling", request.nvext.is_some(), &headers);
+        request.nvext = None;
+    }
+    let response_encoding = request.encoding_format;
+    let response_dtype = request.embed_dtype.unwrap_or_default();
+    let response_endianness = request.endianness.unwrap_or_default();
+
+    // Resolve alias → primary served name before wrapping the request, so
+    // engine routing, metrics, and the response model all use the canonical
+    // primary (mirrors `embeddings` / `completions_single`).
+    let canonical = state.manager().resolve_canonical_name(&request.model);
+    if canonical != request.model {
+        request.model = canonical;
+    }
+    let request_id = get_or_create_request_id(&headers);
+    let request = context_from_headers(request, request_id, &headers)?;
+    let request_id = request.id().to_string();
+
+    // Pooling, like embeddings, is a single (non-streaming) response.
+    let streaming = false;
+
+    let model = &request.model;
+    let metric_model = state.manager().metric_model_for(model).to_string();
+
+    // Create inflight_guard early to ensure all errors (including validation)
+    // are counted. Request validation runs after this point so a rejected
+    // request still lands in `requests_total` with error_type=validation
+    // (mirrors `chat_completions`).
+    let mut inflight = state.metrics_clone().create_inflight_guard(
+        &metric_model,
+        Endpoint::Pooling,
+        streaming,
+        &request_id,
+    );
+
+    // Marked as `Validation` explicitly rather than through
+    // `extract_error_type_from_response`: that helper infers the type from the
+    // message, and only a `VALIDATION_PREFIX`-prefixed 400 maps to
+    // `Validation` (anything else falls back to `Internal`). These messages
+    // stay verbatim vLLM-compatible, so the prefix is not an option here.
+    if let Err(err_response) = validate_pooling_cache_salt(request.cache_salt.as_deref()) {
+        inflight.mark_error(ErrorType::Validation);
+        return Err(err_response);
+    }
+
+    // vLLM currently rejects dimensionality reduction on `/pooling`.
+    if request.dimensions.is_some() {
+        inflight.mark_error(ErrorType::Validation);
+        return Err(pooling_or_classify_bad_request(
+            "dimensions is currently not supported".to_string(),
+        ));
+    }
+
+    // Create http_queue_guard early - tracks time waiting to be processed
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
+
+    let engine = state.manager().get_pooling_engine(model).map_err(|e| {
+        let err_response = ErrorMessage::from_model_error(&e);
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    let mut response_collector = state
+        .metrics_clone()
+        .create_response_collector(&metric_model);
+    let model_name = model.to_string();
+
+    // issue the generate call on the engine
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model_name, super::metrics::Endpoint::Pooling);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to generate pooling output");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    // Process stream to collect metrics and drop http_queue_guard on first token
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
+    });
+
+    // Fold the (single-response) stream into one pooling response.
+    let response = NvCreatePoolingResponse::from_annotated_stream(stream)
+        .await
+        .map_err(|e| {
+            let err_response =
+                ErrorMessage::from_anyhow(anyhow::Error::new(e), "Failed to fold pooling stream");
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
+        })?;
+
+    let response = match response_encoding {
+        PoolingEncodingFormat::Float | PoolingEncodingFormat::Base64 => {
+            Json(response).into_response()
+        }
+        PoolingEncodingFormat::Bytes | PoolingEncodingFormat::BytesOnly => {
+            build_pooling_binary_response(
+                response,
+                response_encoding == PoolingEncodingFormat::Bytes,
+                response_dtype,
+                response_endianness,
+            )
+            .map_err(|e| {
+                let err_response =
+                    ErrorMessage::from_anyhow(e, "Failed to build pooling binary response");
+                inflight.mark_error(extract_error_type_from_response(&err_response));
+                err_response
+            })?
+        }
+    };
+
+    inflight.mark_ok();
+    Ok(response)
 }
 
 async fn handler_chat_completions(
@@ -2965,6 +3374,44 @@ pub fn embeddings_router(
     (vec![doc], router)
 }
 
+/// Create an Axum [`Router`] for the `/v1/classify` endpoint (sequence
+/// classification / cross-encoder pooling). If no path is provided, the
+/// default path is `/v1/classify`. Deployments migrating clients from native
+/// `vllm-serve` (which mounts a bare `/classify`) can set the path via
+/// `DYN_HTTP_SVC_CLASSIFY_PATH`.
+pub fn classify_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let path = path.unwrap_or("/v1/classify".to_string());
+    let doc = RouteDoc::new(axum::http::Method::POST, &path);
+    let router = Router::new()
+        .route(&path, post(classify))
+        .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
+        .with_state(state);
+    (vec![doc], router)
+}
+
+/// Create an Axum [`Router`] for the `/v1/pooling` endpoint (raw pooler output
+/// from pooling-runner models). If no path is provided, the default path is
+/// `/v1/pooling`. Deployments migrating clients from native `vllm-serve`
+/// (which mounts a bare `/pooling`) can set the path via
+/// `DYN_HTTP_SVC_POOLING_PATH`.
+pub fn pooling_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let path = path.unwrap_or("/v1/pooling".to_string());
+    let doc = RouteDoc::new(axum::http::Method::POST, &path);
+    let router = Router::new()
+        .route(&path, post(pooling))
+        .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
+        .with_state(state);
+    (vec![doc], router)
+}
+
 /// Create an Axum [`Router`] for the OpenAI Batch API skeleton.
 ///
 /// The first slice exposes the route and protocol shape. Durable file storage,
@@ -3738,6 +4185,7 @@ mod tests {
     use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
     use crate::protocols::openai::common_ext::CommonExt;
     use crate::protocols::openai::completions::NvCreateCompletionRequest;
+    use crate::protocols::openai::pooling::{PoolingData, PoolingUsage};
     use crate::protocols::openai::responses::NvCreateResponse;
     use dynamo_protocols::types::responses::{CreateResponse, Input, PromptConfig};
     use dynamo_protocols::types::{
@@ -3747,6 +4195,139 @@ mod tests {
     };
 
     const BACKUP_ERROR_MESSAGE: &str = "Failed to generate completions";
+
+    fn binary_pooling_response() -> NvCreatePoolingResponse {
+        NvCreatePoolingResponse {
+            id: "pool-request".to_string(),
+            object: "list".to_string(),
+            created: 123,
+            model: "test-model".to_string(),
+            data: vec![
+                PoolingData {
+                    index: 0,
+                    object: "pooling".to_string(),
+                    data: PoolingOutput::Base64(
+                        base64::engine::general_purpose::STANDARD.encode([1, 2, 3, 4]),
+                    ),
+                    shape: Some(vec![2]),
+                },
+                PoolingData {
+                    index: 1,
+                    object: "pooling".to_string(),
+                    data: PoolingOutput::Base64(
+                        base64::engine::general_purpose::STANDARD.encode([5, 6, 7, 8]),
+                    ),
+                    shape: Some(vec![1, 2]),
+                },
+            ],
+            usage: PoolingUsage {
+                prompt_tokens: 7,
+                total_tokens: 7,
+                completion_tokens: 0,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn pooling_bytes_response_has_vllm_metadata_and_chunked_body() {
+        let response = build_pooling_binary_response(
+            binary_pooling_response(),
+            true,
+            PoolingEmbedDType::Float16,
+            PoolingEndianness::Big,
+        )
+        .unwrap();
+
+        assert_eq!(
+            response.headers()[axum::http::header::CONTENT_TYPE],
+            "application/octet-stream"
+        );
+        let metadata: serde_json::Value =
+            serde_json::from_str(response.headers()["metadata"].to_str().unwrap()).unwrap();
+        assert_eq!(
+            metadata,
+            serde_json::json!({
+                "id": "pool-request",
+                "created": 123,
+                "model": "test-model",
+                "data": [
+                    {
+                        "index": 0,
+                        "embed_dtype": "float16",
+                        "endianness": "big",
+                        "start": 0,
+                        "end": 4,
+                        "shape": [2]
+                    },
+                    {
+                        "index": 1,
+                        "embed_dtype": "float16",
+                        "endianness": "big",
+                        "start": 4,
+                        "end": 8,
+                        "shape": [1, 2]
+                    }
+                ],
+                "usage": {"prompt_tokens": 7, "total_tokens": 7}
+            })
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], &[1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[tokio::test]
+    async fn pooling_bytes_only_response_omits_metadata() {
+        let mut source = binary_pooling_response();
+        for item in &mut source.data {
+            item.shape = None;
+        }
+        let response = build_pooling_binary_response(
+            source,
+            false,
+            PoolingEmbedDType::Float32,
+            PoolingEndianness::Native,
+        )
+        .unwrap();
+
+        assert!(response.headers().get("metadata").is_none());
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], &[1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn pooling_bytes_metadata_requires_tensor_shape() {
+        let mut response = binary_pooling_response();
+        response.data[0].shape = None;
+
+        let error = build_pooling_binary_response(
+            response,
+            true,
+            PoolingEmbedDType::Float32,
+            PoolingEndianness::Native,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("missing its tensor shape"));
+    }
+
+    #[test]
+    fn pooling_bytes_metadata_validates_tensor_size() {
+        let mut response = binary_pooling_response();
+        response.data[0].shape = Some(vec![3]);
+
+        let error = build_pooling_binary_response(
+            response,
+            true,
+            PoolingEmbedDType::Float16,
+            PoolingEndianness::Native,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("requires 6"));
+    }
 
     #[test]
     fn test_is_json_content_type() {
@@ -4002,6 +4583,19 @@ mod tests {
         let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
         assert_eq!(response.0, StatusCode::BAD_REQUEST);
         assert_eq!(response.1.message, "custom error message");
+    }
+
+    #[test]
+    fn empty_pooling_cache_salt_is_rejected() {
+        assert!(validate_pooling_cache_salt(None).is_ok());
+        assert!(validate_pooling_cache_salt(Some("salt")).is_ok());
+
+        let response = validate_pooling_cache_salt(Some("")).unwrap_err();
+        assert_eq!(response.0, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.1.message,
+            "Parameter 'cache_salt' must be a non-empty string if provided."
+        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -285,6 +285,8 @@ struct StateFlags {
     chat_endpoints_enabled: AtomicBool,
     cmpl_endpoints_enabled: AtomicBool,
     embeddings_endpoints_enabled: AtomicBool,
+    classify_endpoints_enabled: AtomicBool,
+    pooling_endpoints_enabled: AtomicBool,
     images_endpoints_enabled: AtomicBool,
     videos_endpoints_enabled: AtomicBool,
     audios_endpoints_enabled: AtomicBool,
@@ -301,6 +303,8 @@ impl StateFlags {
             EndpointType::Chat => self.chat_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Completion => self.cmpl_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Embedding => self.embeddings_endpoints_enabled.load(Ordering::Relaxed),
+            EndpointType::Classify => self.classify_endpoints_enabled.load(Ordering::Relaxed),
+            EndpointType::Pooling => self.pooling_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Images => self.images_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Videos => self.videos_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Audios => self.audios_endpoints_enabled.load(Ordering::Relaxed),
@@ -324,6 +328,12 @@ impl StateFlags {
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Embedding => self
                 .embeddings_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
+            EndpointType::Classify => self
+                .classify_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
+            EndpointType::Pooling => self
+                .pooling_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Images => self
                 .images_endpoints_enabled
@@ -370,6 +380,8 @@ impl State {
                 chat_endpoints_enabled: AtomicBool::new(false),
                 cmpl_endpoints_enabled: AtomicBool::new(false),
                 embeddings_endpoints_enabled: AtomicBool::new(false),
+                classify_endpoints_enabled: AtomicBool::new(false),
+                pooling_endpoints_enabled: AtomicBool::new(false),
                 images_endpoints_enabled: AtomicBool::new(false),
                 videos_endpoints_enabled: AtomicBool::new(false),
                 audios_endpoints_enabled: AtomicBool::new(false),
@@ -905,6 +917,10 @@ static HTTP_SVC_CHAT_PATH_ENV: &str = "DYN_HTTP_SVC_CHAT_PATH";
 static HTTP_SVC_CMP_PATH_ENV: &str = "DYN_HTTP_SVC_CMP_PATH";
 /// Environment variable to set the embeddings endpoint path (default: `/v1/embeddings`)
 static HTTP_SVC_EMB_PATH_ENV: &str = "DYN_HTTP_SVC_EMB_PATH";
+/// Environment variable to set the classify endpoint path (default: `/v1/classify`)
+static HTTP_SVC_CLASSIFY_PATH_ENV: &str = "DYN_HTTP_SVC_CLASSIFY_PATH";
+/// Environment variable to set the pooling endpoint path (default: `/v1/pooling`)
+static HTTP_SVC_POOLING_PATH_ENV: &str = "DYN_HTTP_SVC_POOLING_PATH";
 /// Environment variable to set the responses endpoint path (default: `/v1/responses`)
 static HTTP_SVC_RESPONSES_PATH_ENV: &str = "DYN_HTTP_SVC_RESPONSES_PATH";
 /// Environment variable to set the batch files endpoint path (default: `/v1/files`)
@@ -1246,6 +1262,10 @@ impl HttpServiceConfigBuilder {
             super::openai::completions_router(state.clone(), var(HTTP_SVC_CMP_PATH_ENV).ok());
         let (embed_docs, embed_route) =
             super::openai::embeddings_router(state.clone(), var(HTTP_SVC_EMB_PATH_ENV).ok());
+        let (classify_docs, classify_route) =
+            super::openai::classify_router(state.clone(), var(HTTP_SVC_CLASSIFY_PATH_ENV).ok());
+        let (pooling_docs, pooling_route) =
+            super::openai::pooling_router(state.clone(), var(HTTP_SVC_POOLING_PATH_ENV).ok());
         let (images_docs, images_route) = super::openai::images_router(state.clone(), None);
         let (videos_docs, videos_route) = super::openai::videos_router(state.clone(), None);
         let (audios_docs, audios_route) = super::openai::audios_router(state.clone(), None);
@@ -1259,6 +1279,8 @@ impl HttpServiceConfigBuilder {
         endpoint_routes.insert(EndpointType::Chat, (chat_docs, chat_route));
         endpoint_routes.insert(EndpointType::Completion, (cmpl_docs, cmpl_route));
         endpoint_routes.insert(EndpointType::Embedding, (embed_docs, embed_route));
+        endpoint_routes.insert(EndpointType::Classify, (classify_docs, classify_route));
+        endpoint_routes.insert(EndpointType::Pooling, (pooling_docs, pooling_route));
         endpoint_routes.insert(EndpointType::Images, (images_docs, images_route));
         endpoint_routes.insert(EndpointType::Videos, (videos_docs, videos_route));
         endpoint_routes.insert(EndpointType::Audios, (audios_docs, audios_route));

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -227,6 +227,12 @@ impl ModelType {
         if self.contains(Self::Realtime) {
             endpoint_types.push(crate::endpoint_type::EndpointType::Realtime);
         }
+        if self.contains(Self::Classify) {
+            endpoint_types.push(crate::endpoint_type::EndpointType::Classify);
+        }
+        if self.contains(Self::Pooling) {
+            endpoint_types.push(crate::endpoint_type::EndpointType::Pooling);
+        }
         // [gluo NOTE] ModelType::Tensor doesn't map to any endpoint type,
         // current use of endpoint type is LLM specific and so does the HTTP
         // server that uses it.
@@ -368,6 +374,14 @@ mod tests {
     }
 
     #[test]
+    fn classify_endpoint_mapping() {
+        assert_eq!(
+            ModelType::Classify.as_endpoint_types(),
+            vec![EndpointType::Classify]
+        );
+    }
+
+    #[test]
     fn pooling_bit_position() {
         assert_eq!(ModelType::Pooling.bits(), 1 << 10);
     }
@@ -393,6 +407,10 @@ mod tests {
         assert_eq!(
             combined.units(),
             vec![ModelType::Classify, ModelType::Pooling]
+        );
+        assert_eq!(
+            combined.as_endpoint_types(),
+            vec![EndpointType::Classify, EndpointType::Pooling]
         );
     }
 

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -52,6 +52,16 @@ bitflags! {
         const Audios = 1 << 6;
         const Videos = 1 << 7;
         const Realtime = 1 << 8;
+        /// Sequence-classification / cross-encoder pooling models served on
+        /// the `/v1/classify` endpoint (e.g. NLI, sentiment). Like `Embedding`,
+        /// this is a pooling capability, not a token-generating surface.
+        const Classify = 1 << 9;
+        /// Raw pooler output served on the `/v1/pooling` endpoint (token-level
+        /// embeddings, per-token classification logits, reward scores, …).
+        /// Usually combined with `Classify` or `Embedding`: native vLLM
+        /// mounts its `/pooling` alongside those surfaces for every
+        /// pooling-runner model.
+        const Pooling = 1 << 10;
     }
 }
 
@@ -91,6 +101,12 @@ impl ModelType {
     pub fn supports_realtime(&self) -> bool {
         self.contains(ModelType::Realtime)
     }
+    pub fn supports_classify(&self) -> bool {
+        self.contains(ModelType::Classify)
+    }
+    pub fn supports_pooling(&self) -> bool {
+        self.contains(ModelType::Pooling)
+    }
 
     pub fn as_vec(&self) -> Vec<&'static str> {
         let mut result = Vec::new();
@@ -120,6 +136,12 @@ impl ModelType {
         }
         if self.supports_realtime() {
             result.push("realtime");
+        }
+        if self.supports_classify() {
+            result.push("classify");
+        }
+        if self.supports_pooling() {
+            result.push("pooling");
         }
         result
     }
@@ -154,6 +176,12 @@ impl ModelType {
         }
         if self.supports_realtime() {
             result.push(ModelType::Realtime);
+        }
+        if self.supports_classify() {
+            result.push(ModelType::Classify);
+        }
+        if self.supports_pooling() {
+            result.push(ModelType::Pooling);
         }
         result
     }
@@ -319,6 +347,53 @@ mod tests {
         let endpoints = (ModelType::Chat | ModelType::Realtime).as_endpoint_types();
         assert!(endpoints.contains(&EndpointType::Chat));
         assert!(endpoints.contains(&EndpointType::Realtime));
+    }
+
+    #[test]
+    fn classify_bit_position() {
+        assert_eq!(ModelType::Classify.bits(), 1 << 9);
+    }
+
+    #[test]
+    fn classify_supports_classify() {
+        assert!(ModelType::Classify.supports_classify());
+        assert!(!ModelType::Chat.supports_classify());
+        assert!(!ModelType::Embedding.supports_classify());
+    }
+
+    #[test]
+    fn classify_in_as_vec_and_units() {
+        assert_eq!(ModelType::Classify.as_vec(), vec!["classify"]);
+        assert_eq!(ModelType::Classify.units(), vec![ModelType::Classify]);
+    }
+
+    #[test]
+    fn pooling_bit_position() {
+        assert_eq!(ModelType::Pooling.bits(), 1 << 10);
+    }
+
+    #[test]
+    fn pooling_supports_pooling() {
+        assert!(ModelType::Pooling.supports_pooling());
+        assert!(!ModelType::Classify.supports_pooling());
+        assert!(!ModelType::Embedding.supports_pooling());
+    }
+
+    #[test]
+    fn pooling_in_as_vec_and_units() {
+        assert_eq!(ModelType::Pooling.as_vec(), vec!["pooling"]);
+        assert_eq!(ModelType::Pooling.units(), vec![ModelType::Pooling]);
+    }
+
+    #[test]
+    fn classify_pooling_combination_decomposes() {
+        let combined = ModelType::Classify | ModelType::Pooling;
+        assert!(combined.supports_classify());
+        assert!(combined.supports_pooling());
+        assert_eq!(
+            combined.units(),
+            vec![ModelType::Classify, ModelType::Pooling]
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::{
     ContentProvider,
@@ -15,6 +16,7 @@ use crate::types::TokenIdType;
 pub mod audios;
 pub mod batches;
 pub mod chat_completions;
+pub mod classify;
 pub mod common_ext;
 pub mod completions;
 pub(crate) mod delta_common;
@@ -22,6 +24,7 @@ pub mod embeddings;
 pub mod generate;
 pub mod images;
 pub mod models;
+pub mod pooling;
 pub mod responses;
 pub mod stream_aggregator;
 pub mod tools;
@@ -32,6 +35,14 @@ use validate::{
     BEST_OF_RANGE, FREQUENCY_PENALTY_RANGE, MIN_P_RANGE, N_RANGE, PRESENCE_PENALTY_RANGE,
     TEMPERATURE_RANGE, TOP_P_RANGE, validate_range,
 };
+
+/// Side from which prompt tokens are truncated.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptTruncationSide {
+    Left,
+    Right,
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AnnotatedDelta<R> {

--- a/lib/llm/src/protocols/openai/classify.rs
+++ b/lib/llm/src/protocols/openai/classify.rs
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol types for the `/v1/classify` endpoint (sequence-classification /
+//! cross-encoder pooling models, e.g. NLI or sentiment).
+//!
+//! There is no OpenAI-native classification schema, so — unlike embeddings,
+//! which wraps `dynamo_protocols::types::CreateEmbeddingRequest` — these types
+//! are defined fully in-repo. The wire shape mirrors vLLM's `/classify`
+//! endpoint (`vllm/entrypoints/pooling/classify/protocol.py`, vLLM 0.25.1):
+//! request `{model, input, ...}` → response
+//! `{id, object, created, model, data:[{index, label, probs, num_classes}], usage}`.
+//!
+//! Only the **completion-style** request (`input`) is supported. vLLM also
+//! accepts a chat-style variant (`messages`) that renders a chat template;
+//! that is out of scope here. Pooling controls such as `priority`,
+//! `cache_salt`, `mm_processor_kwargs`, `use_activation`,
+//! `add_special_tokens`, `truncate_prompt_tokens`, and `truncation_side` are
+//! forwarded.
+
+use std::collections::HashMap;
+
+use dynamo_runtime::protocols::annotated::AnnotationsProvider;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::Validate;
+
+mod aggregator;
+
+use super::PromptTruncationSide;
+pub use super::embeddings::{NvExt, NvExtProvider};
+
+/// Classification input — text or pre-tokenized prompts, single or batched.
+/// Mirrors the `input` field of vLLM's `ClassificationCompletionRequest`
+/// (`CompletionRequestMixin`: `list[int] | list[list[int]] | str | list[str]`),
+/// so upstream-tokenized clients migrate unchanged.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum ClassificationInput {
+    /// A single text to classify.
+    Single(String),
+    /// A batch of texts to classify.
+    Batch(Vec<String>),
+    /// A single pre-tokenized prompt (token IDs).
+    Tokens(Vec<u32>),
+    /// A batch of pre-tokenized prompts.
+    TokenBatch(Vec<Vec<u32>>),
+}
+
+/// Request for the `/classify` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateClassifyRequest {
+    /// The model to use for classification.
+    pub model: String,
+
+    /// The text (or texts) to classify.
+    pub input: ClassificationInput,
+
+    /// A unique identifier representing the end user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+
+    /// Optional caller-provided identifier used in the response ID. Internal
+    /// engine request IDs remain server-generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+
+    /// Scheduling priority. Lower values are scheduled first.
+    #[serde(default)]
+    pub priority: i64,
+
+    /// Additional keyword arguments forwarded to the Hugging Face processor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mm_processor_kwargs: Option<HashMap<String, serde_json::Value>>,
+
+    /// Salt applied to prefix-cache keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_salt: Option<String>,
+
+    /// Whether to apply the classification pooler's activation
+    /// (sigmoid/softmax). `None` uses the pooler's default. Forwarded verbatim
+    /// to `PoolingParams`, mirroring vLLM's `ClassifyRequestMixin`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_activation: Option<bool>,
+
+    /// Whether to add the tokenizer's special tokens (BOS/CLS/SEP). `None`
+    /// uses the tokenizer default (`true`). Forwarded to the worker's
+    /// tokenization, mirroring vLLM's `CompletionRequestMixin.add_special_tokens`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub add_special_tokens: Option<bool>,
+
+    /// Truncate the tokenized prompt to this many tokens (`-1` = model max).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncate_prompt_tokens: Option<i64>,
+
+    /// Which side to truncate from. When omitted, the tokenizer default is
+    /// used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncation_side: Option<PromptTruncationSide>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<NvExt>,
+}
+
+/// One classification result within a [`NvCreateClassifyResponse`].
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+pub struct ClassificationData {
+    /// Index of this item within the request batch.
+    pub index: u32,
+
+    /// Predicted label (from the model's `id2label`), if available.
+    #[serde(default)]
+    pub label: Option<String>,
+
+    /// Per-class probability vector.
+    pub probs: Vec<f32>,
+
+    /// Number of classes (== `probs.len()`).
+    pub num_classes: u32,
+}
+
+/// Usage information for a classification response. `completion_tokens` is
+/// always 0 (a classification pass generates nothing) but is kept for parity
+/// with vLLM's `UsageInfo`, which serializes it.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Default)]
+pub struct ClassificationUsage {
+    pub prompt_tokens: u32,
+    pub total_tokens: u32,
+    #[serde(default)]
+    pub completion_tokens: u32,
+}
+
+/// Response for the `/classify` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateClassifyResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub data: Vec<ClassificationData>,
+    pub usage: ClassificationUsage,
+}
+
+impl NvCreateClassifyResponse {
+    pub fn empty() -> Self {
+        Self {
+            id: String::new(),
+            object: "list".to_string(),
+            created: 0,
+            model: "classify".to_string(),
+            data: vec![],
+            usage: ClassificationUsage::default(),
+        }
+    }
+}
+
+/// Implements `NvExtProvider` for `NvCreateClassifyRequest`,
+/// providing access to NVIDIA-specific extensions.
+impl NvExtProvider for NvCreateClassifyRequest {
+    fn nvext(&self) -> Option<&NvExt> {
+        self.nvext.as_ref()
+    }
+}
+
+/// Implements `AnnotationsProvider` for `NvCreateClassifyRequest`,
+/// enabling retrieval and management of request annotations.
+impl AnnotationsProvider for NvCreateClassifyRequest {
+    fn annotations(&self) -> Option<Vec<String>> {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.clone())
+    }
+
+    fn has_annotation(&self, annotation: &str) -> bool {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .map(|annotations| annotations.contains(&annotation.to_string()))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn single_input_round_trips() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello world"
+        }))
+        .unwrap();
+        assert!(matches!(request.input, ClassificationInput::Single(_)));
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["input"], "hello world");
+    }
+
+    #[test]
+    fn batch_input_round_trips() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": ["a", "b"]
+        }))
+        .unwrap();
+        match &request.input {
+            ClassificationInput::Batch(v) => assert_eq!(v.len(), 2),
+            _ => panic!("expected batch input"),
+        }
+    }
+
+    #[test]
+    fn token_inputs_parse_as_token_variants() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [101, 2023, 102]
+        }))
+        .unwrap();
+        assert!(matches!(request.input, ClassificationInput::Tokens(_)));
+
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [[101, 102], [101, 103]]
+        }))
+        .unwrap();
+        match &request.input {
+            ClassificationInput::TokenBatch(v) => assert_eq!(v.len(), 2),
+            other => panic!("expected token batch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn use_activation_round_trips_and_defaults_to_none() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        assert!(request.use_activation.is_none());
+        // Omitted → not serialized onto the wire to the worker.
+        assert!(
+            serde_json::to_value(&request)
+                .unwrap()
+                .get("use_activation")
+                .is_none()
+        );
+
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "use_activation": false
+        }))
+        .unwrap();
+        assert_eq!(request.use_activation, Some(false));
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["use_activation"],
+            serde_json::json!(false)
+        );
+    }
+
+    #[test]
+    fn tokenization_options_round_trip() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "add_special_tokens": false,
+            "truncate_prompt_tokens": 128,
+            "truncation_side": "left"
+        }))
+        .unwrap();
+        assert_eq!(request.add_special_tokens, Some(false));
+        assert_eq!(request.truncate_prompt_tokens, Some(128));
+        assert_eq!(request.truncation_side, Some(PromptTruncationSide::Left));
+
+        // All omitted → None, none serialized onto the worker wire.
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        let value = serde_json::to_value(&request).unwrap();
+        assert!(value.get("add_special_tokens").is_none());
+        assert!(value.get("truncate_prompt_tokens").is_none());
+        assert!(value.get("truncation_side").is_none());
+    }
+
+    #[test]
+    fn classify_request_controls_round_trip() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "user": "user-1",
+            "request_id": "request-1",
+            "priority": -2,
+            "mm_processor_kwargs": {"do_resize": false},
+            "cache_salt": "salt"
+        }))
+        .unwrap();
+
+        assert_eq!(request.user.as_deref(), Some("user-1"));
+        assert_eq!(request.request_id.as_deref(), Some("request-1"));
+        assert_eq!(request.priority, -2);
+        assert_eq!(request.cache_salt.as_deref(), Some("salt"));
+
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["mm_processor_kwargs"]["do_resize"], false);
+        assert_eq!(value["priority"], -2);
+    }
+
+    #[test]
+    fn usage_mirrors_vllm_usage_info() {
+        // vLLM's `ClassificationResponse.usage` is the shared `UsageInfo`,
+        // dumped without exclusions — so `completion_tokens` is always on the
+        // wire even though a classification pass generates nothing. A worker
+        // that omits it still parses, defaulting to 0.
+        let response: NvCreateClassifyResponse = serde_json::from_value(json!({
+            "id": "classify-1",
+            "object": "list",
+            "created": 1,
+            "model": "m",
+            "data": [{"index": 0, "label": "entailment", "probs": [0.9, 0.1], "num_classes": 2}],
+            "usage": {"prompt_tokens": 3, "total_tokens": 3}
+        }))
+        .unwrap();
+        assert_eq!(response.usage.completion_tokens, 0);
+
+        let value = serde_json::to_value(&response).unwrap();
+        assert_eq!(value["usage"]["completion_tokens"], 0);
+    }
+
+    #[test]
+    fn omitted_nvext_is_not_serialized() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        assert!(request.nvext.is_none());
+        let value = serde_json::to_value(request).unwrap();
+        assert!(value.get("nvext").is_none());
+    }
+}

--- a/lib/llm/src/protocols/openai/classify/aggregator.rs
+++ b/lib/llm/src/protocols/openai/classify/aggregator.rs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::NvCreateClassifyResponse;
+use crate::protocols::{
+    Annotated,
+    codec::{Message, SseCodecError},
+    convert_sse_stream,
+    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
+};
+
+use dynamo_runtime::{engine::DataStream, error::DynamoError};
+use futures::Stream;
+
+impl StreamAggregable for NvCreateClassifyResponse {
+    fn empty() -> Self {
+        Self::empty()
+    }
+
+    fn merge(&mut self, next: Self) {
+        // Preserve identity/model from the first non-empty response.
+        if self.id.is_empty() {
+            self.id = next.id;
+        }
+        if self.created == 0 {
+            self.created = next.created;
+        }
+        if self.model == "classify" && next.model != "classify" {
+            self.model = next.model;
+        }
+        self.data.extend(next.data);
+        self.usage.prompt_tokens += next.usage.prompt_tokens;
+        self.usage.total_tokens += next.usage.total_tokens;
+        self.usage.completion_tokens += next.usage.completion_tokens;
+    }
+}
+
+impl NvCreateClassifyResponse {
+    /// Converts an SSE stream into a [`NvCreateClassifyResponse`].
+    pub async fn from_sse_stream(
+        stream: DataStream<Result<Message, SseCodecError>>,
+    ) -> Result<NvCreateClassifyResponse, DynamoError> {
+        let stream = convert_sse_stream::<NvCreateClassifyResponse>(stream);
+        NvCreateClassifyResponse::from_annotated_stream(stream).await
+    }
+
+    /// Aggregates an annotated stream of classification responses into a final response.
+    pub async fn from_annotated_stream(
+        stream: impl Stream<Item = Annotated<NvCreateClassifyResponse>>,
+    ) -> Result<NvCreateClassifyResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::openai::classify::ClassificationData;
+    use futures::stream;
+
+    fn make_response(
+        index: u32,
+        label: &str,
+        probs: Vec<f32>,
+        prompt_tokens: u32,
+    ) -> Annotated<NvCreateClassifyResponse> {
+        let response = NvCreateClassifyResponse {
+            id: "classify-test".to_string(),
+            object: "list".to_string(),
+            created: 1,
+            model: "test-model".to_string(),
+            data: vec![ClassificationData {
+                index,
+                label: Some(label.to_string()),
+                num_classes: probs.len() as u32,
+                probs,
+            }],
+            usage: super::super::ClassificationUsage {
+                prompt_tokens,
+                total_tokens: prompt_tokens,
+                completion_tokens: 0,
+            },
+        };
+        Annotated::from_data(response)
+    }
+
+    #[tokio::test]
+    async fn test_empty_stream() {
+        let stream = stream::empty();
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 0);
+        assert_eq!(response.object, "list");
+    }
+
+    #[tokio::test]
+    async fn test_single_classification() {
+        let annotated = make_response(0, "entailment", vec![0.1, 0.7, 0.2], 5);
+        let stream = stream::iter(vec![annotated]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].label.as_deref(), Some("entailment"));
+        assert_eq!(response.data[0].num_classes, 3);
+        assert_eq!(response.usage.prompt_tokens, 5);
+        assert_eq!(response.model, "test-model");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_classifications() {
+        let a = make_response(0, "entailment", vec![0.8, 0.2], 4);
+        let b = make_response(1, "contradiction", vec![0.3, 0.7], 6);
+        let stream = stream::iter(vec![a, b]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].index, 0);
+        assert_eq!(response.data[1].index, 1);
+        assert_eq!(response.usage.total_tokens, 10);
+        assert_eq!(response.usage.completion_tokens, 0);
+    }
+
+    #[tokio::test]
+    async fn test_error_in_stream() {
+        let error_annotated =
+            Annotated::<NvCreateClassifyResponse>::from_error("Test error".to_string());
+        let stream = stream::iter(vec![error_annotated]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Test error"));
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_stream_errors() {
+        use dynamo_runtime::{
+            error::{BackendError, ErrorType},
+            protocols::maybe_error::MaybeError,
+        };
+
+        let backend_error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid classify input")
+            .build();
+        let stream = stream::iter(vec![Annotated::<NvCreateClassifyResponse>::from_err(
+            backend_error,
+        )]);
+
+        let error = NvCreateClassifyResponse::from_annotated_stream(stream)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid classify input");
+    }
+}

--- a/lib/llm/src/protocols/openai/pooling.rs
+++ b/lib/llm/src/protocols/openai/pooling.rs
@@ -1,0 +1,447 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol types for the `/v1/pooling` endpoint (raw pooler output from
+//! pooling-runner models: token-level embeddings, per-token classification
+//! logits, reward-model scores, …).
+//!
+//! Like `/classify`, there is no OpenAI-native schema; the wire shape mirrors
+//! vLLM's `/pooling` endpoint (`vllm/entrypoints/pooling/pooling/protocol.py`):
+//! request `{model, input, task?, encoding_format?, use_activation?, …}` →
+//! response `{id, object, created, model,
+//! data:[{index, object: "pooling", data}], usage}`.
+//!
+//! The completion-style request (`input`) is supported; vLLM's chat-messages
+//! and IOProcessor-plugin request variants are not. Pooling controls such as
+//! `task`, `priority`, `cache_salt`, `mm_processor_kwargs`, `use_activation`,
+//! `encoding_format`, `add_special_tokens`, and `truncate_prompt_tokens` are
+//! forwarded; `dimensions` is rejected with a 400.
+//!
+//! `task` is forwarded verbatim when set. When omitted, the worker resolves
+//! the model's configured/default task using vLLM's `ModelConfig`.
+
+use std::collections::HashMap;
+
+use dynamo_runtime::protocols::annotated::AnnotationsProvider;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::Validate;
+
+mod aggregator;
+
+use super::PromptTruncationSide;
+pub use super::embeddings::{NvExt, NvExtProvider};
+
+/// Pooling input — raw text or pre-tokenized prompts, single or batched.
+/// Mirrors the `input` field of vLLM's pooling request
+/// (`list[int] | list[list[int]] | str | list[str]`).
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum PoolingInput {
+    /// A single text prompt.
+    Single(String),
+    /// A batch of text prompts.
+    Batch(Vec<String>),
+    /// A single pre-tokenized prompt (token IDs).
+    Tokens(Vec<u32>),
+    /// A batch of pre-tokenized prompts.
+    TokenBatch(Vec<Vec<u32>>),
+}
+
+/// Client-visible pooling response representation.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolingEncodingFormat {
+    #[default]
+    Float,
+    Base64,
+    Bytes,
+    BytesOnly,
+}
+
+/// Element type used for base64 and binary pooling responses.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PoolingEmbedDType {
+    #[default]
+    #[serde(rename = "float32")]
+    Float32,
+    #[serde(rename = "float16")]
+    Float16,
+    #[serde(rename = "bfloat16")]
+    Bfloat16,
+    #[serde(rename = "fp8_e4m3")]
+    Fp8E4m3,
+    #[serde(rename = "fp8_e5m2")]
+    Fp8E5m2,
+}
+
+impl PoolingEmbedDType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Float32 => "float32",
+            Self::Float16 => "float16",
+            Self::Bfloat16 => "bfloat16",
+            Self::Fp8E4m3 => "fp8_e4m3",
+            Self::Fp8E5m2 => "fp8_e5m2",
+        }
+    }
+}
+
+/// Byte order used for base64 and binary pooling responses.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolingEndianness {
+    #[default]
+    Native,
+    Big,
+    Little,
+}
+
+impl PoolingEndianness {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Big => "big",
+            Self::Little => "little",
+        }
+    }
+}
+
+/// Request for the `/v1/pooling` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreatePoolingRequest {
+    /// The model to run the pooling pass on.
+    pub model: String,
+
+    /// The prompt(s) to pool.
+    pub input: PoolingInput,
+
+    /// A unique identifier representing the end user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+
+    /// Optional caller-provided identifier used in the response ID. Internal
+    /// engine request IDs remain server-generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+
+    /// Scheduling priority. Lower values are scheduled first.
+    #[serde(default)]
+    pub priority: i64,
+
+    /// Additional keyword arguments forwarded to the Hugging Face processor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mm_processor_kwargs: Option<HashMap<String, serde_json::Value>>,
+
+    /// Salt applied to prefix-cache keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_salt: Option<String>,
+
+    /// vLLM pooling task (`embed`, `classify`, `token_embed`,
+    /// `token_classify`, …). Forwarded verbatim when set; `None` lets the
+    /// worker resolve the model's configured/default task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+
+    /// `"float"` (default), `"base64"`, `"bytes"`, or `"bytes_only"`. Always
+    /// serialized: the classify and pooling engines push to the same worker
+    /// endpoint, and the worker dispatches on this key's presence.
+    #[serde(default)]
+    pub encoding_format: PoolingEncodingFormat,
+
+    /// Whether to apply the pooler's activation (sigmoid/softmax) to the
+    /// output. `None` uses the pooler's default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_activation: Option<bool>,
+
+    /// Whether to add the tokenizer's special tokens (BOS/CLS/SEP). `None`
+    /// uses the tokenizer default (`true`). Forwarded to the worker's
+    /// tokenization, mirroring vLLM's `CompletionRequestMixin.add_special_tokens`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub add_special_tokens: Option<bool>,
+
+    /// Which side to truncate from. When omitted, the tokenizer default is
+    /// used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncation_side: Option<PromptTruncationSide>,
+
+    /// Matryoshka dimensionality reduction. vLLM's `/pooling` rejects this
+    /// parameter ("dimensions is currently not supported"); accepted here so
+    /// the same 400 can be returned instead of silently ignoring it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dimensions: Option<u32>,
+
+    /// Element dtype for base64 and binary responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embed_dtype: Option<PoolingEmbedDType>,
+
+    /// Byte order for base64 and binary responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endianness: Option<PoolingEndianness>,
+
+    /// Truncate the tokenized prompt to this many tokens (`-1` = model max).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncate_prompt_tokens: Option<i64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<NvExt>,
+}
+
+/// One pooled output within a [`NvCreatePoolingResponse`]. The payload shape
+/// depends on the resolved task: a matrix for token-level tasks
+/// (`token_embed` / `token_classify`), a vector for sequence-level tasks
+/// (`embed` / `classify`), or a base64 string of packed tensor bytes for an
+/// encoded response. Binary responses are decoded at the HTTP boundary.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum PoolingOutput {
+    /// Base64-encoded packed tensor bytes.
+    Base64(String),
+    /// Sequence-level pooled vector.
+    Vector(Vec<f32>),
+    /// Token-level output: one row per input token.
+    Matrix(Vec<Vec<f32>>),
+}
+
+fn default_pooling_object() -> String {
+    "pooling".to_string()
+}
+
+/// One result item within a [`NvCreatePoolingResponse`].
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+pub struct PoolingData {
+    /// Index of this item within the request batch.
+    pub index: u32,
+
+    /// Always `"pooling"`.
+    #[serde(default = "default_pooling_object")]
+    pub object: String,
+
+    /// The raw pooler output for this input.
+    pub data: PoolingOutput,
+
+    /// Tensor shape carried on Dynamo's internal wire for binary responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(ignore)]
+    pub shape: Option<Vec<u64>>,
+}
+
+/// Usage information for a pooling response. `completion_tokens` is always 0
+/// (a pooling pass generates nothing) but is kept for parity with vLLM's
+/// `UsageInfo`, which serializes it.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Default)]
+pub struct PoolingUsage {
+    pub prompt_tokens: u32,
+    pub total_tokens: u32,
+    #[serde(default)]
+    pub completion_tokens: u32,
+}
+
+/// Response for the `/v1/pooling` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreatePoolingResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub data: Vec<PoolingData>,
+    pub usage: PoolingUsage,
+}
+
+impl NvCreatePoolingResponse {
+    pub fn empty() -> Self {
+        Self {
+            id: String::new(),
+            object: "list".to_string(),
+            created: 0,
+            model: "pooling".to_string(),
+            data: vec![],
+            usage: PoolingUsage::default(),
+        }
+    }
+}
+
+/// Implements `NvExtProvider` for `NvCreatePoolingRequest`,
+/// providing access to NVIDIA-specific extensions.
+impl NvExtProvider for NvCreatePoolingRequest {
+    fn nvext(&self) -> Option<&NvExt> {
+        self.nvext.as_ref()
+    }
+}
+
+/// Implements `AnnotationsProvider` for `NvCreatePoolingRequest`,
+/// enabling retrieval and management of request annotations.
+impl AnnotationsProvider for NvCreatePoolingRequest {
+    fn annotations(&self) -> Option<Vec<String>> {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.clone())
+    }
+
+    fn has_annotation(&self, annotation: &str) -> bool {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .map(|annotations| annotations.contains(&annotation.to_string()))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn single_input_round_trips_and_wire_carries_encoding_format() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello world"
+        }))
+        .unwrap();
+        assert!(matches!(request.input, PoolingInput::Single(_)));
+        assert_eq!(request.encoding_format, PoolingEncodingFormat::Float);
+        assert!(request.task.is_none());
+
+        // The wire discriminator must survive serialization even when the
+        // client omitted it (see ClassifyWorkerHandler dispatch).
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["encoding_format"], "float");
+        assert!(value.get("task").is_none());
+    }
+
+    #[test]
+    fn token_inputs_parse_as_token_variants() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [101, 2023, 102]
+        }))
+        .unwrap();
+        assert!(matches!(request.input, PoolingInput::Tokens(_)));
+
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [[101, 102], [101, 103]]
+        }))
+        .unwrap();
+        match &request.input {
+            PoolingInput::TokenBatch(v) => assert_eq!(v.len(), 2),
+            other => panic!("expected token batch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task_and_options_round_trip() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": ["a", "b"],
+            "task": "token_classify",
+            "encoding_format": "base64",
+            "use_activation": false
+        }))
+        .unwrap();
+        assert_eq!(request.task.as_deref(), Some("token_classify"));
+        assert_eq!(request.encoding_format, PoolingEncodingFormat::Base64);
+        assert_eq!(request.use_activation, Some(false));
+    }
+
+    #[test]
+    fn binary_encoding_options_round_trip() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hi",
+            "encoding_format": "bytes",
+            "embed_dtype": "float16",
+            "endianness": "big"
+        }))
+        .unwrap();
+        assert_eq!(request.encoding_format, PoolingEncodingFormat::Bytes);
+        assert_eq!(request.embed_dtype, Some(PoolingEmbedDType::Float16));
+        assert_eq!(request.endianness, Some(PoolingEndianness::Big));
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["encoding_format"], "bytes");
+        assert_eq!(value["embed_dtype"], "float16");
+        assert_eq!(value["endianness"], "big");
+
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hi",
+            "encoding_format": "bytes_only",
+            "embed_dtype": "fp8_e4m3",
+            "endianness": "little"
+        }))
+        .unwrap();
+        assert_eq!(request.encoding_format, PoolingEncodingFormat::BytesOnly);
+        assert_eq!(request.embed_dtype, Some(PoolingEmbedDType::Fp8E4m3));
+        assert_eq!(request.endianness, Some(PoolingEndianness::Little));
+
+        // Omitted → None, and not serialized onto the worker wire.
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hi"
+        }))
+        .unwrap();
+        assert!(request.embed_dtype.is_none() && request.endianness.is_none());
+        let value = serde_json::to_value(&request).unwrap();
+        assert!(value.get("embed_dtype").is_none() && value.get("endianness").is_none());
+    }
+
+    #[test]
+    fn tokenization_options_round_trip() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hi",
+            "add_special_tokens": false,
+            "truncate_prompt_tokens": 64,
+            "truncation_side": "left"
+        }))
+        .unwrap();
+        assert_eq!(request.add_special_tokens, Some(false));
+        assert_eq!(request.truncate_prompt_tokens, Some(64));
+        assert_eq!(request.truncation_side, Some(PromptTruncationSide::Left));
+    }
+
+    #[test]
+    fn pooling_request_controls_round_trip() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "user": "user-1",
+            "request_id": "request-1",
+            "priority": -2,
+            "mm_processor_kwargs": {"do_resize": false},
+            "cache_salt": "salt"
+        }))
+        .unwrap();
+
+        assert_eq!(request.user.as_deref(), Some("user-1"));
+        assert_eq!(request.request_id.as_deref(), Some("request-1"));
+        assert_eq!(request.priority, -2);
+        assert_eq!(request.cache_salt.as_deref(), Some("salt"));
+
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["mm_processor_kwargs"]["do_resize"], false);
+        assert_eq!(value["priority"], -2);
+    }
+
+    #[test]
+    fn response_data_accepts_vector_matrix_and_base64() {
+        let response: NvCreatePoolingResponse = serde_json::from_value(json!({
+            "id": "pool-1",
+            "object": "list",
+            "created": 1,
+            "model": "m",
+            "data": [
+                {"index": 0, "object": "pooling", "data": [0.1, 0.2]},
+                {"index": 1, "object": "pooling", "data": [[0.1], [0.2]]},
+                {"index": 2, "object": "pooling", "data": "AAAA"}
+            ],
+            "usage": {"prompt_tokens": 3, "total_tokens": 3}
+        }))
+        .unwrap();
+        assert!(matches!(response.data[0].data, PoolingOutput::Vector(_)));
+        assert!(matches!(response.data[1].data, PoolingOutput::Matrix(_)));
+        assert!(matches!(response.data[2].data, PoolingOutput::Base64(_)));
+        assert_eq!(response.usage.completion_tokens, 0);
+    }
+}

--- a/lib/llm/src/protocols/openai/pooling.rs
+++ b/lib/llm/src/protocols/openai/pooling.rs
@@ -85,6 +85,14 @@ impl PoolingEmbedDType {
             Self::Fp8E5m2 => "fp8_e5m2",
         }
     }
+
+    pub(crate) const fn byte_width(self) -> usize {
+        match self {
+            Self::Float32 => 4,
+            Self::Float16 | Self::Bfloat16 => 2,
+            Self::Fp8E4m3 | Self::Fp8E5m2 => 1,
+        }
+    }
 }
 
 /// Byte order used for base64 and binary pooling responses.

--- a/lib/llm/src/protocols/openai/pooling/aggregator.rs
+++ b/lib/llm/src/protocols/openai/pooling/aggregator.rs
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::NvCreatePoolingResponse;
+use crate::protocols::{
+    Annotated,
+    codec::{Message, SseCodecError},
+    convert_sse_stream,
+    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
+};
+
+use dynamo_runtime::{engine::DataStream, error::DynamoError};
+use futures::Stream;
+
+impl StreamAggregable for NvCreatePoolingResponse {
+    fn empty() -> Self {
+        Self::empty()
+    }
+
+    fn merge(&mut self, next: Self) {
+        // Preserve identity/model from the first non-empty response.
+        if self.id.is_empty() {
+            self.id = next.id;
+        }
+        if self.created == 0 {
+            self.created = next.created;
+        }
+        if self.model == "pooling" && next.model != "pooling" {
+            self.model = next.model;
+        }
+        self.data.extend(next.data);
+        self.usage.prompt_tokens += next.usage.prompt_tokens;
+        self.usage.total_tokens += next.usage.total_tokens;
+        self.usage.completion_tokens += next.usage.completion_tokens;
+    }
+}
+
+impl NvCreatePoolingResponse {
+    /// Converts an SSE stream into a [`NvCreatePoolingResponse`].
+    pub async fn from_sse_stream(
+        stream: DataStream<Result<Message, SseCodecError>>,
+    ) -> Result<NvCreatePoolingResponse, DynamoError> {
+        let stream = convert_sse_stream::<NvCreatePoolingResponse>(stream);
+        NvCreatePoolingResponse::from_annotated_stream(stream).await
+    }
+
+    /// Aggregates an annotated stream of pooling responses into a final response.
+    pub async fn from_annotated_stream(
+        stream: impl Stream<Item = Annotated<NvCreatePoolingResponse>>,
+    ) -> Result<NvCreatePoolingResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::openai::pooling::{PoolingData, PoolingOutput, PoolingUsage};
+    use futures::stream;
+
+    fn make_response(
+        index: u32,
+        data: PoolingOutput,
+        prompt_tokens: u32,
+    ) -> Annotated<NvCreatePoolingResponse> {
+        let response = NvCreatePoolingResponse {
+            id: "pool-test".to_string(),
+            object: "list".to_string(),
+            created: 1,
+            model: "test-model".to_string(),
+            data: vec![PoolingData {
+                index,
+                object: "pooling".to_string(),
+                data,
+                shape: None,
+            }],
+            usage: PoolingUsage {
+                prompt_tokens,
+                total_tokens: prompt_tokens,
+                completion_tokens: 0,
+            },
+        };
+        Annotated::from_data(response)
+    }
+
+    #[tokio::test]
+    async fn test_empty_stream() {
+        let stream = stream::empty();
+        let result = NvCreatePoolingResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 0);
+        assert_eq!(response.object, "list");
+    }
+
+    #[tokio::test]
+    async fn test_single_pooling_output() {
+        let annotated = make_response(
+            0,
+            PoolingOutput::Matrix(vec![vec![0.1, 0.7], vec![0.2, 0.3]]),
+            5,
+        );
+        let stream = stream::iter(vec![annotated]);
+        let result = NvCreatePoolingResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 1);
+        assert!(matches!(response.data[0].data, PoolingOutput::Matrix(_)));
+        assert_eq!(response.usage.prompt_tokens, 5);
+        assert_eq!(response.model, "test-model");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_pooling_outputs() {
+        let a = make_response(0, PoolingOutput::Vector(vec![0.8, 0.2]), 4);
+        let b = make_response(1, PoolingOutput::Vector(vec![0.3, 0.7]), 6);
+        let stream = stream::iter(vec![a, b]);
+        let result = NvCreatePoolingResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].index, 0);
+        assert_eq!(response.data[1].index, 1);
+        assert_eq!(response.usage.total_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn test_error_in_stream() {
+        let error_annotated =
+            Annotated::<NvCreatePoolingResponse>::from_error("Test error".to_string());
+        let stream = stream::iter(vec![error_annotated]);
+        let result = NvCreatePoolingResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Test error"));
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_stream_errors() {
+        use dynamo_runtime::{
+            error::{BackendError, ErrorType},
+            protocols::maybe_error::MaybeError,
+        };
+
+        let backend_error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid pooling input")
+            .build();
+        let stream = stream::iter(vec![Annotated::<NvCreatePoolingResponse>::from_err(
+            backend_error,
+        )]);
+
+        let error = NvCreatePoolingResponse::from_annotated_stream(stream)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid pooling input");
+    }
+}

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -39,6 +39,39 @@ where
     Ok(response.unwrap_or_else(T::empty))
 }
 
+/// Aggregate a stream of [`Annotated<T>`] while preserving structured backend
+/// errors. Existing callers that expose string errors can continue to use
+/// [`aggregate_stream`].
+pub async fn aggregate_typed_stream<T, S>(stream: S) -> Result<T, DynamoError>
+where
+    T: StreamAggregable,
+    S: Stream<Item = Annotated<T>>,
+{
+    let mut stream = std::pin::pin!(stream);
+    let mut response: Option<T> = None;
+
+    while let Some(delta) = stream.next().await {
+        if delta.is_error() {
+            return Err(delta.error.unwrap_or_else(|| {
+                DynamoError::msg(
+                    delta
+                        .comment
+                        .map(|comments| comments.join(", "))
+                        .unwrap_or_else(|| "unknown error".to_string()),
+                )
+            }));
+        }
+        if let Some(data) = delta.data {
+            match response.as_mut() {
+                Some(existing) => existing.merge(data),
+                None => response = Some(data),
+            }
+        }
+    }
+
+    Ok(response.unwrap_or_else(T::empty))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -78,6 +78,34 @@ pub mod openai {
             ServerStreamingEngine<NvCreateEmbeddingRequest, Annotated<NvCreateEmbeddingResponse>>;
     }
 
+    pub mod classify {
+        use super::*;
+
+        pub use protocols::openai::classify::{NvCreateClassifyRequest, NvCreateClassifyResponse};
+
+        /// A [`UnaryEngine`] implementation for the `/classify` API
+        pub type OpenAIClassifyUnaryEngine =
+            UnaryEngine<NvCreateClassifyRequest, NvCreateClassifyResponse>;
+
+        /// A [`ServerStreamingEngine`] implementation for the `/classify` API
+        pub type OpenAIClassifyStreamingEngine =
+            ServerStreamingEngine<NvCreateClassifyRequest, Annotated<NvCreateClassifyResponse>>;
+    }
+
+    pub mod pooling {
+        use super::*;
+
+        pub use protocols::openai::pooling::{NvCreatePoolingRequest, NvCreatePoolingResponse};
+
+        /// A [`UnaryEngine`] implementation for the `/pooling` API
+        pub type OpenAIPoolingUnaryEngine =
+            UnaryEngine<NvCreatePoolingRequest, NvCreatePoolingResponse>;
+
+        /// A [`ServerStreamingEngine`] implementation for the `/pooling` API
+        pub type OpenAIPoolingStreamingEngine =
+            ServerStreamingEngine<NvCreatePoolingRequest, Annotated<NvCreatePoolingResponse>>;
+    }
+
     pub mod images {
         use super::*;
 

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -1560,8 +1560,12 @@ impl
 async fn test_classify_and_pooling_validation_errors_are_metered() {
     let (listener, port) = bind_random_port().await;
     let service = HttpService::builder().port(port).build().unwrap();
-    service.enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Classify, true);
-    service.enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Pooling, true);
+    service
+        .enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Classify, true)
+        .unwrap();
+    service
+        .enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Pooling, true)
+        .unwrap();
 
     let state = service.state_clone();
     let manager = state.manager();

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -210,6 +210,8 @@ fn compute_index(endpoint: &Endpoint, request_type: &RequestType, status: &Statu
         Endpoint::Completions => 0,
         Endpoint::ChatCompletions => 1,
         Endpoint::Embeddings => todo!(),
+        Endpoint::Classify => todo!(),
+        Endpoint::Pooling => todo!(),
         Endpoint::Responses => todo!(),
         Endpoint::AnthropicMessages => todo!(),
         Endpoint::Tensor => todo!(),
@@ -1502,6 +1504,141 @@ async fn test_audio_speech_failed_status_meters_as_client_error() {
         &Status::Error,
         &ErrorType::Validation,
         1,
+    );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}
+
+/// Engine registered only so the classify/pooling routes resolve a model; the
+/// validation errors under test are rejected before the engine is reached.
+struct UncalledPoolingFamilyEngine {}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<dynamo_llm::protocols::openai::classify::NvCreateClassifyRequest>,
+        ManyOut<Annotated<dynamo_llm::protocols::openai::classify::NvCreateClassifyResponse>>,
+        Error,
+    > for UncalledPoolingFamilyEngine
+{
+    async fn generate(
+        &self,
+        _request: SingleIn<dynamo_llm::protocols::openai::classify::NvCreateClassifyRequest>,
+    ) -> Result<
+        ManyOut<Annotated<dynamo_llm::protocols::openai::classify::NvCreateClassifyResponse>>,
+        Error,
+    > {
+        anyhow::bail!("engine must not be reached by a rejected request")
+    }
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<dynamo_llm::protocols::openai::pooling::NvCreatePoolingRequest>,
+        ManyOut<Annotated<dynamo_llm::protocols::openai::pooling::NvCreatePoolingResponse>>,
+        Error,
+    > for UncalledPoolingFamilyEngine
+{
+    async fn generate(
+        &self,
+        _request: SingleIn<dynamo_llm::protocols::openai::pooling::NvCreatePoolingRequest>,
+    ) -> Result<
+        ManyOut<Annotated<dynamo_llm::protocols::openai::pooling::NvCreatePoolingResponse>>,
+        Error,
+    > {
+        anyhow::bail!("engine must not be reached by a rejected request")
+    }
+}
+
+/// A request rejected by handler-local validation must still be counted in
+/// `requests_total` with `error_type=validation`, like `chat_completions`.
+/// Validating before the inflight guard would drop these 400s from metrics
+/// (and from the "request completed" log the guard emits on drop).
+#[tokio::test]
+async fn test_classify_and_pooling_validation_errors_are_metered() {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder().port(port).build().unwrap();
+    service.enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Classify, true);
+    service.enable_model_endpoint(dynamo_llm::endpoint_type::EndpointType::Pooling, true);
+
+    let state = service.state_clone();
+    let manager = state.manager();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task =
+        tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+    wait_for_service_ready(port).await;
+
+    let registry = Registry::new();
+    let card = ModelDeploymentCard::with_name_only("foo");
+    let engine = Arc::new(UncalledPoolingFamilyEngine {});
+    manager
+        .add_classify_model("foo", card.mdcsum(), engine.clone())
+        .unwrap();
+    manager
+        .add_pooling_model("foo", card.mdcsum(), engine)
+        .unwrap();
+
+    let metrics = state.metrics_clone();
+    metrics.register(&registry).unwrap();
+
+    let client = reqwest::Client::new();
+
+    // ==== /v1/classify: empty cache_salt ====
+    let response = client
+        .post(format!("http://localhost:{port}/v1/classify"))
+        .json(&serde_json::json!({"model": "foo", "input": "hi", "cache_salt": ""}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    compare_counter(
+        &metrics,
+        "foo",
+        &Endpoint::Classify,
+        &RequestType::Unary,
+        &Status::Error,
+        &ErrorType::Validation,
+        1,
+    );
+
+    // ==== /v1/pooling: empty cache_salt ====
+    let response = client
+        .post(format!("http://localhost:{port}/v1/pooling"))
+        .json(&serde_json::json!({"model": "foo", "input": "hi", "cache_salt": ""}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    compare_counter(
+        &metrics,
+        "foo",
+        &Endpoint::Pooling,
+        &RequestType::Unary,
+        &Status::Error,
+        &ErrorType::Validation,
+        1,
+    );
+
+    // ==== /v1/pooling: unsupported dimensions ====
+    let response = client
+        .post(format!("http://localhost:{port}/v1/pooling"))
+        .json(&serde_json::json!({"model": "foo", "input": "hi", "dimensions": 8}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    compare_counter(
+        &metrics,
+        "foo",
+        &Endpoint::Pooling,
+        &RequestType::Unary,
+        &Status::Error,
+        &ErrorType::Validation,
+        2,
     );
 
     cancel_token.cancel();

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -29,12 +29,14 @@ from tests.utils.payload_builder import (
     chat_payload,
     chat_payload_default,
     chat_payload_with_logprobs,
+    classify_payload,
     completion_payload_default,
     completion_payload_with_logprobs,
     embedding_payload,
     embedding_payload_default,
     kv_events_metrics_payload,
     metric_payload_default,
+    pooling_payload,
     router_cached_tokens_chat_payload,
     router_selection_chat_payload_default,
 )
@@ -730,6 +732,90 @@ vllm_configs = {
                 repeat_count=1,
                 expected_log=[],
                 expected_response=["Generated 1 embeddings with dimension 128"],
+            ),
+        ],
+    ),
+    "classify_agg": VLLMConfig(
+        name="classify_agg",
+        directory=vllm_dir,
+        script_name="agg_classify.sh",
+        marks=[
+            pytest.mark.core,
+            pytest.mark.gpu_1,
+            # Small RoBERTa NLI classifier plus vLLM pooling overhead.
+            pytest.mark.profiled_vram_gib(3.0),
+            # Pooling models do not use a KV cache, but the harness requires
+            # a non-zero allocation budget.
+            pytest.mark.requested_vllm_kv_cache_bytes(559_693_824),
+            pytest.mark.timeout(360),
+            pytest.mark.pre_merge,
+        ],
+        model="cross-encoder/nli-MiniLM2-L6-H768",
+        request_payloads=[
+            classify_payload(
+                input_data=("A man is playing a sport. Some men are playing a sport."),
+            ),
+            classify_payload(
+                input_data=[
+                    "A soccer game is underway. Some men are playing a sport.",
+                    "A cat sleeps on a mat. A dog is swimming in the ocean.",
+                ],
+            ),
+            # A single token-ID prompt must be truncated through vLLM's
+            # renderer rather than bypassing truncate_prompt_tokens.
+            classify_payload(
+                input_data=[0, 101, 102, 2],
+                expected_prompt_tokens=2,
+                extra_body={"truncate_prompt_tokens": 2},
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="classify",
+            ),
+            # Token-level classification preserves the token-by-class matrix.
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="token_classify",
+            ),
+            # A batch of token-ID prompts covers the second pre-tokenized
+            # request shape from the vLLM completion-input contract.
+            pooling_payload(
+                input_data=[[0, 101, 102, 2], [0, 201, 202, 2]],
+                task="classify",
+                expected_prompt_tokens=4,
+                extra_body={"truncate_prompt_tokens": 2},
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="classify",
+                extra_body={
+                    "encoding_format": "base64",
+                    "embed_dtype": "float16",
+                    "endianness": "big",
+                },
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="classify",
+                expected_response=["Pooled 1 binary tensors"],
+                extra_body={
+                    "encoding_format": "bytes",
+                    "embed_dtype": "float16",
+                    "endianness": "big",
+                },
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="classify",
+                expected_response=["Pooled bytes_only response"],
+                extra_body={
+                    "encoding_format": "bytes_only",
+                    "embed_dtype": "float16",
+                    "endianness": "big",
+                },
             ),
         ],
     ),

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -11,6 +11,7 @@ from tests.utils.payloads import (
     CachedTokensChatPayload,
     ChatPayload,
     ChatPayloadWithLogprobs,
+    ClassifyPayload,
     ClearKVBlocksPayload,
     CompletionPayload,
     CompletionPayloadWithLogprobs,
@@ -22,6 +23,7 @@ from tests.utils.payloads import (
     KvEventMetricsPayload,
     LMCacheMetricsPayload,
     MetricsPayload,
+    PoolingPayload,
     ResponsesPayload,
     ResponsesStreamPayload,
     RouterNvextChatPayload,
@@ -526,6 +528,64 @@ def embedding_payload(
         expected_log=expected_log or [],
         expected_response=expected_response
         or [f"Generated {expected_count} embeddings with dimension"],
+    )
+
+
+PoolingInput = Union[str, List[str], List[int], List[List[int]]]
+
+
+def _pooling_input_count(input_data: PoolingInput) -> int:
+    if isinstance(input_data, str):
+        return 1
+    if input_data and isinstance(input_data[0], int):
+        return 1
+    return len(input_data)
+
+
+def classify_payload(
+    input_data: PoolingInput,
+    repeat_count: int = 1,
+    expected_response: Optional[List[str]] = None,
+    expected_log: Optional[List[str]] = None,
+    expected_prompt_tokens: Optional[int] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+) -> ClassifyPayload:
+    body: Dict[str, Any] = {"input": input_data}
+    if extra_body:
+        body.update(extra_body)
+    expected_count = _pooling_input_count(input_data)
+
+    return ClassifyPayload(
+        body=body,
+        repeat_count=repeat_count,
+        expected_log=expected_log or [],
+        expected_response=expected_response or [f"Classified {expected_count} inputs"],
+        expected_prompt_tokens=expected_prompt_tokens,
+    )
+
+
+def pooling_payload(
+    input_data: PoolingInput,
+    task: Optional[str] = None,
+    repeat_count: int = 1,
+    expected_response: Optional[List[str]] = None,
+    expected_log: Optional[List[str]] = None,
+    expected_prompt_tokens: Optional[int] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+) -> PoolingPayload:
+    body: Dict[str, Any] = {"input": input_data}
+    if task is not None:
+        body["task"] = task
+    if extra_body:
+        body.update(extra_body)
+    expected_count = _pooling_input_count(input_data)
+
+    return PoolingPayload(
+        body=body,
+        repeat_count=repeat_count,
+        expected_log=expected_log or [],
+        expected_response=expected_response or [f"Pooled {expected_count} inputs"],
+        expected_prompt_tokens=expected_prompt_tokens,
     )
 
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -1284,6 +1284,211 @@ class EmbeddingPayload(BasePayload):
 
 
 @dataclass
+class ClassifyPayload(BasePayload):
+    """Payload for the ``/v1/classify`` endpoint."""
+
+    endpoint: str = "/v1/classify"
+    expected_prompt_tokens: Optional[int] = None
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        result = response.json()
+        assert (
+            result.get("object") == "list"
+        ), f"Expected object='list', got {result.get('object')}"
+        assert result.get("data"), "Empty classification data"
+
+        for index, item in enumerate(result["data"]):
+            assert item.get("index") == index
+            probs = item.get("probs")
+            assert isinstance(probs, list) and probs, "probs must be a non-empty list"
+            assert item.get("num_classes") == len(probs)
+            assert all(isinstance(prob, (int, float)) for prob in probs)
+            assert item.get("label") is None or isinstance(item["label"], str)
+
+        usage = result.get("usage")
+        assert isinstance(usage, dict), "Missing usage in classification response"
+        assert usage.get("prompt_tokens") == usage.get("total_tokens")
+        assert usage.get("completion_tokens") == 0
+        if self.expected_prompt_tokens is not None:
+            assert usage.get("prompt_tokens") == self.expected_prompt_tokens
+
+        return f"Classified {len(result['data'])} inputs"
+
+
+@dataclass
+class PoolingPayload(BasePayload):
+    """Payload for JSON and binary ``/v1/pooling`` responses."""
+
+    endpoint: str = "/v1/pooling"
+    expected_prompt_tokens: Optional[int] = None
+
+    # Tasks whose output is one vector per token, so the response must stay a
+    # matrix. Validating only ``data[0]`` would accept a flattened vector here,
+    # which is the exact regression these cases exist to catch.
+    _TOKEN_WISE_TASKS = frozenset(("token_embed", "token_classify"))
+
+    _DTYPE_WIDTHS = {
+        "float32": 4,
+        "float16": 2,
+        "bfloat16": 2,
+        "fp8_e4m3": 1,
+        "fp8_e5m2": 1,
+    }
+
+    def _validate_json_data(self, data: Any) -> None:
+        assert isinstance(data, list) and data, "pooling data must be non-empty"
+
+        if self.body.get("task") in self._TOKEN_WISE_TASKS:
+            self._validate_token_wise_data(data)
+            return
+
+        self._validate_sequence_wise_data(data)
+
+    @staticmethod
+    def _validate_sequence_wise_data(data: Any) -> None:
+        """Require a flat numeric vector: exactly one vector per input.
+
+        Sequence-level tasks (``embed``, ``classify``) return one vector per
+        input, which the worker enforces itself. Accepting a matrix here and
+        validating only ``data[0]`` would let a rank regression pass while
+        clients can no longer read the result as a vector.
+        """
+        assert all(
+            isinstance(value, (int, float)) and not isinstance(value, bool)
+            for value in data
+        ), f"sequence-level output must be a flat numeric vector, got {data!r}"
+
+    @staticmethod
+    def _validate_token_wise_data(data: Any) -> None:
+        """Require a non-empty matrix of numeric rows with a consistent width.
+
+        Rejects a flattened vector, ragged rows, empty rows, and non-numeric
+        values — every row is checked, not just the first.
+        """
+        assert all(
+            isinstance(row, list) for row in data
+        ), f"token-wise output must be a list of rows, got {data!r}"
+
+        width = len(data[0])
+        assert width, "token-wise rows must be non-empty"
+        for position, row in enumerate(data):
+            assert len(row) == width, (
+                f"token-wise rows must have a consistent width; row {position} "
+                f"has {len(row)}, expected {width}"
+            )
+            assert all(
+                isinstance(value, (int, float)) and not isinstance(value, bool)
+                for value in row
+            ), f"token-wise row {position} has non-numeric values: {row!r}"
+
+    def _handle_json_response(self, response: Any) -> str:
+        result = response.json()
+        assert (
+            result.get("object") == "list"
+        ), f"Expected object='list', got {result.get('object')}"
+        assert result.get("data"), "Empty pooling data"
+
+        encoding_format = self.body.get("encoding_format", "float")
+        dtype_width = self._DTYPE_WIDTHS[self.body.get("embed_dtype", "float32")]
+        for index, item in enumerate(result["data"]):
+            assert item.get("index") == index
+            assert item.get("object") == "pooling"
+            data = item.get("data")
+            if encoding_format == "base64":
+                assert isinstance(data, str)
+                decoded = base64.b64decode(data, validate=True)
+                assert decoded and len(decoded) % dtype_width == 0
+            else:
+                self._validate_json_data(data)
+
+        usage = result.get("usage")
+        assert isinstance(usage, dict), "Missing usage in pooling response"
+        assert usage.get("prompt_tokens") == usage.get("total_tokens")
+        assert usage.get("completion_tokens") == 0
+        if self.expected_prompt_tokens is not None:
+            assert usage.get("prompt_tokens") == self.expected_prompt_tokens
+
+        return f"Pooled {len(result['data'])} inputs as {encoding_format}"
+
+    def _handle_binary_response(self, response: Any) -> str:
+        assert response.headers.get("content-type") == "application/octet-stream"
+        assert response.content, "Empty binary pooling response"
+
+        encoding_format = self.body["encoding_format"]
+        metadata_header = response.headers.get("metadata")
+        if encoding_format == "bytes_only":
+            assert metadata_header is None
+            return f"Pooled bytes_only response with {len(response.content)} bytes"
+
+        assert metadata_header is not None, "bytes response is missing metadata"
+        metadata = json.loads(metadata_header)
+        assert metadata.get("data"), "bytes metadata has no tensor entries"
+
+        # A client reconstructs each tensor from (start, end, shape, dtype,
+        # endianness) alone, so metadata that merely stays in bounds is not
+        # enough — it must agree with the body byte-for-byte. Checking only
+        # bounds lets an offset/shape serialization regression pass here while
+        # clients cannot reconstruct anything.
+        dtype_width = self._DTYPE_WIDTHS[self.body.get("embed_dtype", "float32")]
+        expected_start = 0
+        for index, item in enumerate(metadata["data"]):
+            assert item.get("index") == index
+            assert item.get("embed_dtype") == self.body.get("embed_dtype", "float32")
+            assert item.get("endianness") == self.body.get("endianness", "native")
+            assert item["start"] < item["end"] <= len(response.content)
+
+            shape = item.get("shape")
+            assert shape, "bytes metadata entry is missing shape"
+            assert all(
+                isinstance(dim, int) and dim > 0 for dim in shape
+            ), f"tensor {index} has a non-positive shape: {shape!r}"
+
+            # Rank matters as much as the byte count: [2, 2] and [4] cover the
+            # same span, but only one is the shape the task promises.
+            expected_rank = 2 if self.body.get("task") in self._TOKEN_WISE_TASKS else 1
+            assert len(shape) == expected_rank, (
+                f"tensor {index} has rank {len(shape)} (shape {shape!r}), "
+                f"expected rank {expected_rank} for task "
+                f"{self.body.get('task', 'embed')!r}"
+            )
+
+            element_count = math.prod(shape)
+            expected_bytes = element_count * dtype_width
+            actual_bytes = item["end"] - item["start"]
+            assert actual_bytes == expected_bytes, (
+                f"tensor {index} span is {actual_bytes} bytes but shape {shape} "
+                f"at {dtype_width} bytes/element needs {expected_bytes}"
+            )
+
+            # Spans must tile the body in order: contiguous and non-overlapping.
+            assert item["start"] == expected_start, (
+                f"tensor {index} starts at {item['start']}, expected "
+                f"{expected_start} (spans must be contiguous and non-overlapping)"
+            )
+            expected_start = item["end"]
+
+        assert expected_start == len(response.content), (
+            f"metadata spans cover {expected_start} bytes but the body is "
+            f"{len(response.content)} bytes"
+        )
+
+        usage = metadata.get("usage")
+        assert isinstance(usage, dict), "bytes metadata is missing usage"
+        assert usage.get("prompt_tokens") == usage.get("total_tokens")
+        if self.expected_prompt_tokens is not None:
+            assert usage.get("prompt_tokens") == self.expected_prompt_tokens
+
+        return f"Pooled {len(metadata['data'])} binary tensors"
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        if self.body.get("encoding_format") in ("bytes", "bytes_only"):
+            return self._handle_binary_response(response)
+        return self._handle_json_response(response)
+
+
+@dataclass
 class EmbeddingMultiWorkerDispatchPayload(BasePayload):
     """Send ``repeat_count`` embedding requests to the frontend, capturing a
     per-worker ``/metrics`` snapshot on the FIRST iteration and on the LAST

--- a/tests/utils/test_pooling_payload.py
+++ b/tests/utils/test_pooling_payload.py
@@ -1,0 +1,358 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.utils.payload_builder import classify_payload, pooling_payload
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+def _response(
+    *,
+    json_body: dict | None = None,
+    content: bytes = b"",
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = json_body
+    response.content = content
+    response.headers = headers or {}
+    return response
+
+
+def test_classify_payload_validates_truncated_usage():
+    payload = classify_payload(
+        input_data=[0, 1, 2, 3],
+        expected_prompt_tokens=2,
+        extra_body={"truncate_prompt_tokens": 2},
+    )
+    response = _response(
+        json_body={
+            "object": "list",
+            "data": [
+                {
+                    "index": 0,
+                    "label": "entailment",
+                    "probs": [0.1, 0.8, 0.1],
+                    "num_classes": 3,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 2,
+                "total_tokens": 2,
+                "completion_tokens": 0,
+            },
+        }
+    )
+
+    assert payload.process_response(response) == "Classified 1 inputs"
+
+
+def test_pooling_payload_validates_flat_float_output():
+    """A batch of pre-tokenized prompts returns one flat vector per input."""
+    payload = pooling_payload(
+        input_data=[[0, 1, 2], [3, 4, 5]],
+        expected_prompt_tokens=4,
+        extra_body={"truncate_prompt_tokens": 2},
+    )
+    response = _response(
+        json_body={
+            "object": "list",
+            "data": [
+                {"index": 0, "object": "pooling", "data": [0.1, 0.2]},
+                {"index": 1, "object": "pooling", "data": [0.3, 0.4]},
+            ],
+            "usage": {
+                "prompt_tokens": 4,
+                "total_tokens": 4,
+                "completion_tokens": 0,
+            },
+        }
+    )
+
+    assert payload.process_response(response) == "Pooled 2 inputs as float"
+
+
+def test_pooling_payload_validates_base64_dtype_width():
+    payload = pooling_payload(
+        input_data="text",
+        extra_body={"encoding_format": "base64", "embed_dtype": "float16"},
+    )
+    response = _response(
+        json_body={
+            "object": "list",
+            "data": [
+                {
+                    "index": 0,
+                    "object": "pooling",
+                    "data": base64.b64encode(b"\x00\x01\x02\x03").decode(),
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 1,
+                "total_tokens": 1,
+                "completion_tokens": 0,
+            },
+        }
+    )
+
+    assert payload.process_response(response) == "Pooled 1 inputs as base64"
+
+
+def test_pooling_payload_validates_bytes_metadata():
+    payload = pooling_payload(
+        input_data="text",
+        expected_response=["Pooled 1 binary tensors"],
+        expected_prompt_tokens=3,
+        extra_body={
+            "encoding_format": "bytes",
+            "embed_dtype": "float16",
+            "endianness": "big",
+        },
+    )
+    metadata = {
+        "data": [
+            {
+                "index": 0,
+                "embed_dtype": "float16",
+                "endianness": "big",
+                "start": 0,
+                "end": 6,
+                "shape": [3],
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "total_tokens": 3},
+    }
+    response = _response(
+        content=b"\x00\x01\x02\x03\x04\x05",
+        headers={
+            "content-type": "application/octet-stream",
+            "metadata": json.dumps(metadata),
+        },
+    )
+
+    assert payload.process_response(response) == "Pooled 1 binary tensors"
+
+
+def test_pooling_payload_validates_bytes_only_without_metadata():
+    payload = pooling_payload(
+        input_data="text",
+        expected_response=["Pooled bytes_only response"],
+        extra_body={"encoding_format": "bytes_only"},
+    )
+    response = _response(
+        content=b"\x00\x01\x02\x03",
+        headers={"content-type": "application/octet-stream"},
+    )
+
+    assert payload.process_response(response) == (
+        "Pooled bytes_only response with 4 bytes"
+    )
+
+
+def _token_wise_response(data, prompt_tokens: int = 2):
+    return _response(
+        json_body={
+            "object": "list",
+            "data": [{"index": 0, "object": "pooling", "data": data}],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "total_tokens": prompt_tokens,
+                "completion_tokens": 0,
+            },
+        }
+    )
+
+
+def _token_wise_payload():
+    return pooling_payload(input_data="text", task="token_classify")
+
+
+def test_pooling_payload_accepts_token_wise_matrix():
+    payload = _token_wise_payload()
+    response = _token_wise_response([[0.1, 0.2, 0.7], [0.3, 0.4, 0.3]])
+
+    assert payload.process_response(response) == "Pooled 1 inputs as float"
+
+
+def test_pooling_payload_rejects_flattened_token_wise_output():
+    """A flattened vector loses the token-by-class structure this case exists
+    to prove; validating only data[0] used to accept it."""
+    payload = _token_wise_payload()
+    response = _token_wise_response([0.1, 0.2, 0.7, 0.3, 0.4, 0.3])
+
+    with pytest.raises(AssertionError, match="must be a list of rows"):
+        payload.process_response(response)
+
+
+def test_pooling_payload_rejects_ragged_token_wise_rows():
+    payload = _token_wise_payload()
+    response = _token_wise_response([[0.1, 0.2, 0.7], [0.3, 0.4]])
+
+    with pytest.raises(AssertionError, match="consistent width"):
+        payload.process_response(response)
+
+
+def test_pooling_payload_rejects_empty_token_wise_rows():
+    payload = _token_wise_payload()
+    response = _token_wise_response([[], []])
+
+    with pytest.raises(AssertionError, match="non-empty"):
+        payload.process_response(response)
+
+
+def test_pooling_payload_rejects_nonnumeric_token_wise_rows():
+    payload = _token_wise_payload()
+    response = _token_wise_response([[0.1, 0.2], [0.3, "oops"]])
+
+    with pytest.raises(AssertionError, match="non-numeric"):
+        payload.process_response(response)
+
+
+def _sequence_wise_payload():
+    return pooling_payload(input_data="text", task="classify")
+
+
+def test_pooling_payload_rejects_nested_sequence_wise_output():
+    """Sequence classification returns one vector per input, which the worker
+    enforces. A matrix used to pass because only data[0] was validated, so a
+    rank regression stayed invisible here."""
+    payload = _sequence_wise_payload()
+    response = _token_wise_response([[0.1, 0.2, 0.7], [0.3, 0.4, 0.3]])
+
+    with pytest.raises(AssertionError, match="flat numeric vector"):
+        payload.process_response(response)
+
+
+def test_pooling_payload_rejects_nonnumeric_sequence_wise_values():
+    """Every element is checked, not only the first."""
+    payload = _sequence_wise_payload()
+    response = _token_wise_response([0.1, 0.2, "oops"])
+
+    with pytest.raises(AssertionError, match="flat numeric vector"):
+        payload.process_response(response)
+
+
+def _bytes_payload():
+    return pooling_payload(
+        input_data="text",
+        expected_response=["Pooled 1 binary tensors"],
+        extra_body={
+            "encoding_format": "bytes",
+            "embed_dtype": "float16",
+            "endianness": "big",
+        },
+    )
+
+
+def _bytes_response(entries, content: bytes):
+    return _response(
+        content=content,
+        headers={
+            "content-type": "application/octet-stream",
+            "metadata": json.dumps(
+                {"data": entries, "usage": {"prompt_tokens": 3, "total_tokens": 3}}
+            ),
+        },
+    )
+
+
+def test_pooling_payload_rejects_shape_span_mismatch():
+    """float16 with shape=[999] and a 2-byte span used to pass on bounds alone,
+    leaving clients unable to reconstruct the tensor."""
+    payload = _bytes_payload()
+    response = _bytes_response(
+        [
+            {
+                "index": 0,
+                "embed_dtype": "float16",
+                "endianness": "big",
+                "start": 0,
+                "end": 2,
+                "shape": [999],
+            }
+        ],
+        content=b"\x00\x01",
+    )
+
+    with pytest.raises(AssertionError, match="needs 1998"):
+        payload.process_response(response)
+
+
+def test_pooling_payload_rejects_overlapping_spans():
+    payload = _bytes_payload()
+    response = _bytes_response(
+        [
+            {
+                "index": 0,
+                "embed_dtype": "float16",
+                "endianness": "big",
+                "start": 0,
+                "end": 4,
+                "shape": [2],
+            },
+            {
+                "index": 1,
+                "embed_dtype": "float16",
+                "endianness": "big",
+                "start": 2,
+                "end": 6,
+                "shape": [2],
+            },
+        ],
+        content=b"\x00\x01\x02\x03\x04\x05",
+    )
+
+    with pytest.raises(AssertionError, match="contiguous and non-overlapping"):
+        payload.process_response(response)
+
+
+def test_pooling_payload_rejects_incomplete_body_coverage():
+    payload = _bytes_payload()
+    response = _bytes_response(
+        [
+            {
+                "index": 0,
+                "embed_dtype": "float16",
+                "endianness": "big",
+                "start": 0,
+                "end": 4,
+                "shape": [2],
+            }
+        ],
+        content=b"\x00\x01\x02\x03\x04\x05",
+    )
+
+    with pytest.raises(AssertionError, match="cover 4 bytes but the body is 6"):
+        payload.process_response(response)
+
+
+def test_pooling_payload_rejects_wrong_rank_binary_shape():
+    """shape=[2, 2] and shape=[4] span the same bytes, so the byte-count check
+    alone cannot tell them apart; sequence classification must stay rank 1."""
+    payload = _bytes_payload()
+    response = _bytes_response(
+        [
+            {
+                "index": 0,
+                "embed_dtype": "float16",
+                "endianness": "big",
+                "start": 0,
+                "end": 8,
+                "shape": [2, 2],
+            }
+        ],
+        content=b"\x00\x01\x02\x03\x04\x05\x06\x07",
+    )
+
+    with pytest.raises(AssertionError, match="has rank 2"):
+        payload.process_response(response)


### PR DESCRIPTION
## Overview

Cherry-pick of the classify/pooling stack onto `release/1.4.1`, in original merge order:

- #12140 feat(llm): add classify and pooling model support
- #12139 feat(http): serve classify and pooling requests
- #12142 feat(vllm): enable classify and pooling workers
- #12141 test(vllm): validate classify and pooling endpoints

## Conflict resolutions

- `lib/llm/src/discovery/watcher.rs`: both branches added test functions at the same location; kept both (release-branch LoRA lifecycle test + incoming pooling test).
- `lib/llm/src/protocols/openai/stream_aggregator.rs`: additive collision between the incoming aggregate helper and the release-branch test module; kept both.
- `lib/llm/src/http/service/openai.rs`: merged imports (kept `ResponsesConversionError` from the release branch plus the incoming `pooling` imports).
- `components/src/dynamo/vllm/`: dropped realtime-worker hunks that are main-only context (the realtime feature is not on this branch); kept all classify additions. Added the `SimpleNamespace` import the trimmed hunk carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->