### PR TITLE
fix: [cherry-pick 1.4.1] forward logprob_token_ids through the OpenAI frontend (#12277)

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -791,7 +791,14 @@ def build_sampling_params(
     # Apply output_options (logprobs, prompt_logprobs, etc.)
     output_options = request.get("output_options", {}) or {}
     logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(output_options)
-    if logprobs is not None:
+    # Explicit `logprob_token_ids` replace vLLM's natural top-k selection, so the
+    # requested width no longer applies. vLLM's own OpenAI adapters null `logprobs`
+    # in this case and let `num_logprobs` derive the width from the id list; mirror
+    # that here, otherwise `SamplingParams.verify()` rejects the pair unless the
+    # caller happens to set `top_logprobs == len(logprob_token_ids)`.
+    if getattr(sampling_params, "logprob_token_ids", None):
+        sampling_params.logprobs = None
+    elif logprobs is not None:
         sampling_params.logprobs = logprobs
     if prompt_logprobs is not None:
         sampling_params.prompt_logprobs = prompt_logprobs

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -211,6 +211,41 @@ class TestTokenInSamplingDefaults:
         assert sp.top_p == pytest.approx(1.0)
 
 
+class TestLogprobTokenIds:
+    """Explicit `logprob_token_ids` must null the top-k width, as vLLM's own
+    OpenAI adapters do, so `SamplingParams.verify()` accepts the pair."""
+
+    @staticmethod
+    def _build(output_options, sampling_options=None):
+        from dynamo.vllm.handlers import build_sampling_params
+
+        return build_sampling_params(
+            {
+                "token_ids": [1, 2, 3],
+                "sampling_options": sampling_options or {},
+                "stop_conditions": {},
+                "output_options": output_options,
+            },
+            {},
+        )
+
+    def test_explicit_ids_null_requested_width(self):
+        sp = self._build(
+            {"logprobs": 5}, sampling_options={"logprob_token_ids": [5000]}
+        )
+        assert sp.logprob_token_ids == [5000]
+        assert sp.logprobs is None
+        assert sp.num_logprobs == 1
+
+    def test_requested_width_kept_without_explicit_ids(self):
+        sp = self._build({"logprobs": 5})
+        assert sp.logprobs == 5
+
+    def test_empty_id_list_falls_through_to_top_k(self):
+        sp = self._build({"logprobs": 5}, sampling_options={"logprob_token_ids": []})
+        assert sp.logprobs == 5
+
+
 class TestFlattenLogprobs:
     def test_nested_lists_are_fully_flattened(self):
         from dynamo.vllm.handlers import _flatten_logprobs

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -527,7 +527,12 @@ impl OpenAIPreprocessor {
         let mut sampling_passthrough = serde_json::Map::new();
 
         if let Some(fields) = request.unsupported_fields() {
-            for key in ["detokenize", "allowed_token_ids", "bad_words_token_ids"] {
+            for key in [
+                "detokenize",
+                "allowed_token_ids",
+                "bad_words_token_ids",
+                "logprob_token_ids",
+            ] {
                 if let Some(value) = fields.get(key) {
                     sampling_passthrough.insert(key.to_string(), value.clone());
                 }
@@ -4654,6 +4659,7 @@ mod tests {
             "detokenize": false,
             "allowed_token_ids": [10, 11],
             "bad_words_token_ids": [[12, 13]],
+            "logprob_token_ids": [14, 15],
             "nvext": {
                 "cache_salt": "step_7",
                 "extra_fields": ["completion_token_ids"],
@@ -4685,6 +4691,10 @@ mod tests {
         assert_eq!(
             extra_args["sampling_options"]["bad_words_token_ids"],
             serde_json::json!([[12, 13]])
+        );
+        assert_eq!(
+            extra_args["sampling_options"]["logprob_token_ids"],
+            serde_json::json!([14, 15])
         );
     }
 

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -108,6 +108,7 @@ pub const PASSTHROUGH_EXTRA_FIELDS: &[&str] = &[
     "detokenize",
     "allowed_token_ids",
     "bad_words_token_ids",
+    "logprob_token_ids",
 ];
 
 static IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS: LazyLock<bool> =
@@ -161,6 +162,10 @@ fn validate_no_unsupported_fields_with_ignore(
         serde_json::from_value::<Vec<Vec<crate::types::TokenIdType>>>(value.clone()).map_err(
             |_| anyhow::anyhow!("`bad_words_token_ids` must be an array of token ID arrays"),
         )?;
+    }
+    if let Some(value) = unsupported_fields.get("logprob_token_ids") {
+        serde_json::from_value::<Vec<crate::types::TokenIdType>>(value.clone())
+            .map_err(|_| anyhow::anyhow!("`logprob_token_ids` must be an array of token IDs"))?;
     }
     Ok(())
 }
@@ -866,6 +871,21 @@ mod tests {
         let args = HashMap::from([("enable_thinking".to_string(), json!(false))]);
         validate_chat_template_args(Some(&args)).unwrap();
         validate_chat_template_args(None).unwrap();
+    }
+
+    #[test]
+    fn validate_no_unsupported_fields_accepts_logprob_token_ids() {
+        let fields = HashMap::from([("logprob_token_ids".to_string(), json!([14, 15]))]);
+        validate_no_unsupported_fields_with_ignore(&fields, false).unwrap();
+    }
+
+    #[test]
+    fn validate_no_unsupported_fields_rejects_malformed_logprob_token_ids() {
+        for bad in [json!(["notanint"]), json!(7), json!([[1, 2]]), json!([-1])] {
+            let fields = HashMap::from([("logprob_token_ids".to_string(), bad)]);
+            let err = validate_no_unsupported_fields_with_ignore(&fields, false).unwrap_err();
+            assert!(err.to_string().contains("must be an array of token IDs"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Cherry-pick of #12277 onto `release/1.4.1`.

## Conflict resolution

- `lib/llm/src/protocols/openai/validate.rs`: kept the two incoming logprob_token_ids validation tests; dropped an adjacent main-only test (null json_schema rejection) whose subject code is not on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->