### PR TITLE
fix(ci): strip trailing separators from the truncated namespace suffix

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -135,6 +135,11 @@ runs:
           BRANCH_SANITIZED="${BRANCH_SANITIZED/pull-request/pr}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED//./-}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED:0:10}"
+          # k8s label values must end alphanumeric; truncation can leave a
+          # trailing separator (release/1.4.1 -> release-1-)
+          while [[ "${BRANCH_SANITIZED}" == *[-.] ]]; do
+            BRANCH_SANITIZED="${BRANCH_SANITIZED%[-.]}"
+          done
           while [[ "${BRANCH_SANITIZED}" =~ [^[:alnum:]]$ ]]; do
             BRANCH_SANITIZED="${BRANCH_SANITIZED%?}"
           done


### PR DESCRIPTION
## Overview

The deploy-test namespace suffix is the branch name sanitized and truncated to 10 characters. For `release/1.4.1` that yields `release-1-`, which ends in a hyphen — an invalid Kubernetes label value — so `Setup vCluster and operator` fails at namespace labeling before the vCluster exists, and every dependent deploy test rolls up red. Observed deterministically on run 32187249598 (`release/1.4.1`).

## Details

Strip trailing `-` / `.` after the 10-char truncation so the suffix always ends alphanumeric. `release/1.4.1` now sanitizes to `release-1`.

Any branch whose 10-char sanitized prefix ends in a separator hits this; release branches especially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated Kubernetes label values by removing trailing hyphens and periods after namespace suffix truncation.
  * Ensured generated values end with a valid alphanumeric character.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->