### PR TITLE
test(sglang): cover disaggregated DP attention

### DIFF
--- a/examples/backends/sglang/launch/disagg_dp_attn.sh
+++ b/examples/backends/sglang/launch/disagg_dp_attn.sh
@@ -55,6 +55,13 @@ GPU_MEM_ARGS=$(build_sglang_gpu_mem_args)
 DISAGG_BOOTSTRAP_PORT="${DYN_DISAGG_BOOTSTRAP_PORT:-12345}"
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 
+# SGLang derives a contiguous port block from --dist-init-addr: the supplied
+# port plus the next six. Keep the prefill and decode bases at least seven
+# apart so the two blocks stay disjoint. The serve test overrides both with
+# separately allocated blocks; these defaults keep the script runnable by hand.
+PREFILL_DIST_INIT_ADDR="${SGLANG_PREFILL_DIST_INIT_ADDR:-127.0.0.1:29500}"
+DECODE_DIST_INIT_ADDR="${SGLANG_DECODE_DIST_INIT_ADDR:-127.0.0.1:29510}"
+
 print_launch_banner "Launching Disaggregated DP Attention (2 shared GPUs)" "$MODEL" "$HTTP_PORT"
 
 python3 -m dynamo.frontend &
@@ -71,7 +78,7 @@ python3 -m dynamo.sglang \
   --tp 2 \
   --dp-size 2 \
   --enable-dp-attention \
-  --dist-init-addr "${SGLANG_PREFILL_DIST_INIT_ADDR:?SGLANG_PREFILL_DIST_INIT_ADDR must be set}" \
+  --dist-init-addr "$PREFILL_DIST_INIT_ADDR" \
   --trust-remote-code \
   --disaggregation-mode prefill \
   --disaggregation-bootstrap-port "$DISAGG_BOOTSTRAP_PORT" \
@@ -97,7 +104,7 @@ python3 -m dynamo.sglang \
   --tp 2 \
   --dp-size 2 \
   --enable-dp-attention \
-  --dist-init-addr "${SGLANG_DECODE_DIST_INIT_ADDR:?SGLANG_DECODE_DIST_INIT_ADDR must be set}" \
+  --dist-init-addr "$DECODE_DIST_INIT_ADDR" \
   --trust-remote-code \
   --disaggregation-mode decode \
   --disaggregation-bootstrap-port "$DISAGG_BOOTSTRAP_PORT" \

--- a/examples/backends/sglang/launch/disagg_dp_attn.sh
+++ b/examples/backends/sglang/launch/disagg_dp_attn.sh
@@ -71,6 +71,7 @@ python3 -m dynamo.sglang \
   --tp 2 \
   --dp-size 2 \
   --enable-dp-attention \
+  --dist-init-addr "${SGLANG_PREFILL_DIST_INIT_ADDR:?SGLANG_PREFILL_DIST_INIT_ADDR must be set}" \
   --trust-remote-code \
   --disaggregation-mode prefill \
   --disaggregation-bootstrap-port "$DISAGG_BOOTSTRAP_PORT" \
@@ -96,6 +97,7 @@ python3 -m dynamo.sglang \
   --tp 2 \
   --dp-size 2 \
   --enable-dp-attention \
+  --dist-init-addr "${SGLANG_DECODE_DIST_INIT_ADDR:?SGLANG_DECODE_DIST_INIT_ADDR must be set}" \
   --trust-remote-code \
   --disaggregation-mode decode \
   --disaggregation-bootstrap-port "$DISAGG_BOOTSTRAP_PORT" \

--- a/examples/backends/sglang/launch/disagg_dp_attn.sh
+++ b/examples/backends/sglang/launch/disagg_dp_attn.sh
@@ -49,6 +49,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Parse arguments before installing the process-group cleanup trap so --help or
+# an invalid option cannot tear down the caller via kill 0.
 trap 'echo Cleaning up...; kill 0' EXIT
 
 GPU_MEM_ARGS=$(build_sglang_gpu_mem_args)
@@ -92,9 +94,8 @@ python3 -m dynamo.sglang \
   $GPU_MEM_ARGS &
 
 # Serialize model loading so the two shared-GPU workers do not race for peak
-# initialization memory. Continue after the bounded wait so normal deployment
-# readiness remains the authoritative failure signal.
-wait_for_ready "http://localhost:${DYN_SYSTEM_PORT1:-8081}/health" 120 || true
+# initialization memory. Decode must not start if prefill never becomes ready.
+wait_for_ready "http://localhost:${DYN_SYSTEM_PORT1:-8081}/health" 120
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 python3 -m dynamo.sglang \

--- a/examples/backends/sglang/launch/disagg_dp_attn.sh
+++ b/examples/backends/sglang/launch/disagg_dp_attn.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Disaggregated DP-attention serving on two shared GPUs. Each prefill/decode
+# worker owns two DP ranks over the same GPU pair, which keeps this smoke test
+# representative without requiring a separate two-GPU pair for each role.
+# GPUs: 2
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+MODEL="silence09/DeepSeek-R1-Small-2layers"
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "Missing value for --model"
+                exit 1
+            fi
+            MODEL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--model <name>]"
+            echo "  --model <name>  MoE model to serve (default: $MODEL)"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+trap 'echo Cleaning up...; kill 0' EXIT
+
+GPU_MEM_ARGS=$(build_sglang_gpu_mem_args)
+DISAGG_BOOTSTRAP_PORT="${DYN_DISAGG_BOOTSTRAP_PORT:-12345}"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+
+print_launch_banner "Launching Disaggregated DP Attention (2 shared GPUs)" "$MODEL" "$HTTP_PORT"
+
+python3 -m dynamo.frontend &
+
+# SGLang DP attention uses tp_size == dp_size: the attention replicas occupy
+# the visible GPU pair while MoE weights are tensor-parallel across that pair.
+# Both P/D workers intentionally share the pair; the tiny two-layer model keeps
+# the combined footprint suitable for CI.
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
+python3 -m dynamo.sglang \
+  --model-path "$MODEL" \
+  --served-model-name "$MODEL" \
+  --page-size 64 \
+  --tp 2 \
+  --dp-size 2 \
+  --enable-dp-attention \
+  --trust-remote-code \
+  --disaggregation-mode prefill \
+  --disaggregation-bootstrap-port "$DISAGG_BOOTSTRAP_PORT" \
+  --disaggregation-transfer-backend nixl \
+  --load-balance-method round_robin \
+  --nccl-port "${DYN_SYSTEM_PORT3:-8083}" \
+  --context-length 1024 \
+  --disable-cuda-graph \
+  --disable-piecewise-cuda-graph \
+  --enable-metrics \
+  $GPU_MEM_ARGS &
+
+# Serialize model loading so the two shared-GPU workers do not race for peak
+# initialization memory. Continue after the bounded wait so normal deployment
+# readiness remains the authoritative failure signal.
+wait_for_ready "http://localhost:${DYN_SYSTEM_PORT1:-8081}/health" 120 || true
+
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
+python3 -m dynamo.sglang \
+  --model-path "$MODEL" \
+  --served-model-name "$MODEL" \
+  --page-size 64 \
+  --tp 2 \
+  --dp-size 2 \
+  --enable-dp-attention \
+  --trust-remote-code \
+  --disaggregation-mode decode \
+  --disaggregation-bootstrap-port "$DISAGG_BOOTSTRAP_PORT" \
+  --disaggregation-transfer-backend nixl \
+  --prefill-round-robin-balance \
+  --nccl-port "${DYN_SYSTEM_PORT4:-8084}" \
+  --context-length 1024 \
+  --disable-cuda-graph \
+  --disable-piecewise-cuda-graph \
+  --enable-metrics \
+  $GPU_MEM_ARGS &
+
+wait_any_exit

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -50,6 +50,7 @@ from tests.utils.payload_builder import (
     router_selection_chat_payload_default,
 )
 from tests.utils.payloads import (
+    ChatPayload,
     ImageGenerationPayload,
     LoraTestChatPayload,
     ResponsesPayload,
@@ -166,6 +167,45 @@ sglang_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+        ],
+    ),
+    "disaggregated_dp_attention": SGLangConfig(
+        # Prefill and decode each run two DP-attention ranks over the same
+        # two-GPU pair. PR #13464 excludes h100 tests from non-H100 multi-GPU
+        # lanes; leaving this unprofiled routes it through sequential H100 CI.
+        name="disaggregated_dp_attention",
+        directory=sglang_dir,
+        script_name="disagg_dp_attn.sh",
+        marks=[
+            pytest.mark.core,
+            pytest.mark.gpu_2,
+            pytest.mark.h100,
+            pytest.mark.requested_sglang_kv_tokens(2048),
+            pytest.mark.timeout(600),
+            pytest.mark.nightly,
+        ],
+        model="silence09/DeepSeek-R1-Small-2layers",
+        script_args=["--model", "silence09/DeepSeek-R1-Small-2layers"],
+        timeout=480,
+        env={},
+        frontend_port=DefaultPort.FRONTEND.value,
+        request_payloads=[
+            ChatPayload(
+                body={
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "What is a mixture-of-experts model?",
+                        }
+                    ],
+                    "max_tokens": 32,
+                    "temperature": 0.0,
+                    "stream": False,
+                },
+                repeat_count=2,
+                expected_response=[],
+                expected_log=[],
+            )
         ],
     ),
     "disaggregated_router": SGLangConfig(
@@ -1004,8 +1044,8 @@ def sglang_config_test(request):
 
 @pytest.mark.e2e
 @pytest.mark.sglang
-# Allocate 4 system ports: disaggregated_router runs 4 workers each needing a
-# unique DYN_SYSTEM_PORT; other configs use <=2 (extra ports are harmless).
+# Allocate 4 system ports: disaggregated_router runs 4 workers, while the
+# two-GPU DP-attention config uses ports 1/2 for metrics and 3/4 for NCCL.
 @pytest.mark.parametrize("num_system_ports", [4], indirect=True)
 def test_sglang_deployment(
     sglang_config_test,
@@ -1024,22 +1064,6 @@ def test_sglang_deployment(
         sglang_config_test, frontend_port=dynamo_dynamic_ports.frontend_port
     )
     run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
-
-
-@pytest.mark.e2e
-@pytest.mark.sglang
-@pytest.mark.core
-@pytest.mark.gpu_2
-@pytest.mark.nightly
-@pytest.mark.skip(
-    reason="Requires 4 GPUs - enable when hardware is consistently available"
-)
-def test_sglang_disagg_dp_attention(
-    request, runtime_services_dynamic_ports, dynamo_dynamic_ports, predownload_models
-):
-    """Test sglang disaggregated with DP attention (requires 4 GPUs)"""
-
-    # Kept for reference; this test uses a different launch path and is skipped
 
 
 # ── LoRA Tests ──────────────────────────────────────────────────────────────

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -30,7 +30,7 @@ from tests.serve.multimodal_profiles.sglang import (
     SGLANG_MULTIMODAL_PROFILES,
     SGLANG_TOPOLOGY_SCRIPTS,
 )
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import DefaultPort, DynamoPortRange
 from tests.utils.engine_process import EngineConfig
 from tests.utils.multimodal import make_image_payload_b64, make_multimodal_configs
 from tests.utils.payload_builder import (
@@ -57,6 +57,7 @@ from tests.utils.payloads import (
     ResponsesStreamPayload,
     VideoGenerationPayload,
 )
+from tests.utils.port_utils import allocate_contiguous_ports, deallocate_ports
 
 logger = logging.getLogger(__name__)
 
@@ -1042,13 +1043,40 @@ def sglang_config_test(request):
     return sglang_configs[request.param]
 
 
+@pytest.fixture
+def sglang_config_with_dist_ports(sglang_config_test):
+    """Give each DP-attention process a disjoint SGLang port block."""
+    if sglang_config_test.name != "disaggregated_dp_attention":
+        yield sglang_config_test
+        return
+
+    # SGLang PortArgs consumes the supplied distributed-init port and the next
+    # six ports, so reserve two independently contiguous seven-port blocks.
+    ports = allocate_contiguous_ports(
+        count=2,
+        block_size=7,
+        start_port=DynamoPortRange.SERVE.value,
+    )
+    try:
+        yield dataclasses.replace(
+            sglang_config_test,
+            env={
+                **sglang_config_test.env,
+                "SGLANG_PREFILL_DIST_INIT_ADDR": f"127.0.0.1:{ports[0]}",
+                "SGLANG_DECODE_DIST_INIT_ADDR": f"127.0.0.1:{ports[7]}",
+            },
+        )
+    finally:
+        deallocate_ports(ports)
+
+
 @pytest.mark.e2e
 @pytest.mark.sglang
 # Allocate 4 system ports: disaggregated_router runs 4 workers, while the
 # two-GPU DP-attention config uses ports 1/2 for metrics and 3/4 for NCCL.
 @pytest.mark.parametrize("num_system_ports", [4], indirect=True)
 def test_sglang_deployment(
-    sglang_config_test,
+    sglang_config_with_dist_ports,
     request,
     runtime_services_dynamic_ports,
     dynamo_dynamic_ports,
@@ -1061,7 +1089,8 @@ def test_sglang_deployment(
         num_system_ports >= 2
     ), "serve tests require at least SYSTEM_PORT1 + SYSTEM_PORT2"
     config = dataclasses.replace(
-        sglang_config_test, frontend_port=dynamo_dynamic_ports.frontend_port
+        sglang_config_with_dist_ports,
+        frontend_port=dynamo_dynamic_ports.frontend_port,
     )
     run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
 


### PR DESCRIPTION
## Summary

- Replace the empty skipped DP-attention placeholder with a runnable two-H100 nightly configuration.
- Add a disaggregated SGLang launch script where prefill and decode each use DP and TP size 2 over the same GPU pair.
- Reserve separate contiguous SGLang process-port blocks for prefill and decode while keeping metrics and NCCL on the existing dynamic system ports.
- Rely on the H100 sequential lane from merged PR #13464 to avoid parallel GPU contention.

Linear: https://linear.app/nvidia/issue/DYN-4057

## Validation

- `python3 -m py_compile tests/serve/test_sglang.py`
- Black, isort, flake8, codespell, and Ruff on `tests/serve/test_sglang.py`
- `bash -n examples/backends/sglang/launch/disagg_dp_attn.sh`
- Relevant documentation and example pre-commit checks
- `git diff --check`
- The [combined H100 nightly run](https://github.com/ai-dynamo/dynamo/actions/runs/32305698693) reached both DP-attention process launches and exposed that their default `ServerArgs.port=30000` values derived the same `dist_init_port=30233` and `port_base=30234`; it was not a complete test pass
- The follow-up fixture reserves two disjoint contiguous seven-port blocks and passes their base ports as the prefill and decode `--dist-init-addr` values
- The repository-wide marker reporter found zero missing marker sets, then local collection was blocked by unrelated exhausted test-port registrations in `tests/serve/conftest.py`
- The [follow-up H100 nightly validation](https://github.com/ai-dynamo/dynamo/actions/runs/32320415313/job/96282898034) passed `test_sglang_deployment[disaggregated_dp_attention-4]`; the sequential H100 phase completed with 77 passed and 9 skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for launching SGLang with disaggregated data-parallel attention across two GPUs.
  * Added configurable model selection and coordinated prefill/decode worker startup.
  * Added distributed port allocation for reliable SGLang deployment testing.

* **Tests**
  * Added coverage for disaggregated data-parallel attention configurations and chat requests.
  * Updated deployment tests to validate distributed worker communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->