### PR TITLE
test(sglang): restore request cancellation coverage

### DIFF
--- a/tests/fault_tolerance/README.md
+++ b/tests/fault_tolerance/README.md
@@ -95,7 +95,7 @@ pytest tests/fault_tolerance/cancellation/test_trtllm.py::test_request_cancellat
 
 | Test | Mode | Cancellation Phase | Request Type | Setup | Notes |
 |------|------|-------------------|--------------|-------|-------|
-| `test_request_cancellation_sglang_aggregated` | Aggregated | During generation | 3 scenarios: completion, chat, streaming chat (1 response read) | 1 worker | ⚠️ Flaky: SGLang prefill cancellation issues |
+| `test_request_cancellation_sglang_aggregated` | Aggregated | During generation | 3 scenarios: completion, chat, streaming chat (1 response read) | 1 worker | Nightly NATS and TCP coverage; cancellation occurs after request-ID assignment |
 | `test_request_cancellation_sglang_decode_cancel` | Disaggregated | Remote decode | Streaming chat (1 response read) | Decode + Prefill workers | Requires 2 GPUs |
 
 **Run examples:**

--- a/tests/fault_tolerance/cancellation/sglang_devices.py
+++ b/tests/fault_tolerance/cancellation/sglang_devices.py
@@ -5,7 +5,7 @@
 def resolve_sglang_disaggregated_devices(
     cuda_visible_devices: str | None,
 ) -> tuple[str, str]:
-    """Return the decode and prefill tokens for a two-GPU SGLang deployment."""
+    """Return scheduler device tokens in established prefill, decode order."""
     if cuda_visible_devices is None:
         devices = ("0", "1")
     else:

--- a/tests/fault_tolerance/cancellation/sglang_devices.py
+++ b/tests/fault_tolerance/cancellation/sglang_devices.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def resolve_sglang_disaggregated_devices(
+    cuda_visible_devices: str | None,
+) -> tuple[str, str]:
+    """Return the decode and prefill tokens for a two-GPU SGLang deployment."""
+    if cuda_visible_devices is None:
+        devices = ("0", "1")
+    else:
+        devices = tuple(
+            device.strip()
+            for device in cuda_visible_devices.split(",")
+            if device.strip()
+        )
+
+    if len(devices) < 2:
+        configured = cuda_visible_devices if cuda_visible_devices is not None else "0,1"
+        raise ValueError(
+            "SGLang disaggregated cancellation requires at least two entries in "
+            f"CUDA_VISIBLE_DEVICES; got {configured!r}"
+        )
+
+    return devices[0], devices[1]

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -137,9 +137,10 @@ class DynamoWorkerProcess(ManagedProcess):
         request.addfinalizer(lambda port=self.fpm_port: deallocate_port(port))
         env["DYN_FORWARDPASS_METRIC_PORT"] = str(self.fpm_port)
 
-        # Preserve scheduler-assigned device tokens (including GPU/MIG UUIDs).
+        # Preserve scheduler-assigned device tokens (including GPU/MIG UUIDs)
+        # while retaining the established prefill-first, decode-second topology.
         if mode in ("prefill", "decode"):
-            decode_device, prefill_device = resolve_sglang_disaggregated_devices(
+            prefill_device, decode_device = resolve_sglang_disaggregated_devices(
                 env.get("CUDA_VISIBLE_DEVICES")
             )
             env["CUDA_VISIBLE_DEVICES"] = (

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -10,11 +10,13 @@ Test Execution Times (Last Run: 2025-12-09):
 
 import logging
 import os
-import shutil
 import time
 
 import pytest
 
+from tests.fault_tolerance.cancellation.sglang_devices import (
+    resolve_sglang_disaggregated_devices,
+)
 from tests.fault_tolerance.cancellation.utils import (
     DynamoFrontendProcess,
     poll_for_pattern,
@@ -48,6 +50,7 @@ class DynamoWorkerProcess(ManagedProcess):
         system_port: int,
         frontend_port: int,
         mode: str = "agg",
+        bootstrap_port: int | None = None,
     ):
         """
         Initialize SGLang worker process.
@@ -57,6 +60,8 @@ class DynamoWorkerProcess(ManagedProcess):
             system_port: Port for system metrics server
             frontend_port: Port where frontend is running
             mode: One of "agg", "prefill", "decode"
+            bootstrap_port: Shared disaggregation bootstrap port. Required for
+                prefill and decode workers; unused by aggregated workers.
         """
         command = [
             "python3",
@@ -72,19 +77,25 @@ class DynamoWorkerProcess(ManagedProcess):
             "1",
             "--trust-remote-code",
         ]
-
+        # The test owns this shared rendezvous port and releases it once after
+        # both disaggregated workers stop.
+        self.bootstrap_port = bootstrap_port
         # Add mode-specific arguments
         if mode == "agg":
             # Aggregated mode - add skip-tokenizer-init like the serve test
             command.append("--skip-tokenizer-init")
         else:
             # Disaggregated mode - add disaggregation arguments like disagg.sh
+            if bootstrap_port is None:
+                raise ValueError(
+                    "bootstrap_port is required for disaggregated SGLang workers"
+                )
             command.extend(
                 [
                     "--disaggregation-mode",
                     mode,
                     "--disaggregation-bootstrap-port",
-                    "12345",  # TODO: use dynamic port allocation
+                    str(bootstrap_port),
                     "--host",
                     "0.0.0.0",
                     "--disaggregation-transfer-backend",
@@ -126,23 +137,17 @@ class DynamoWorkerProcess(ManagedProcess):
         request.addfinalizer(lambda port=self.fpm_port: deallocate_port(port))
         env["DYN_FORWARDPASS_METRIC_PORT"] = str(self.fpm_port)
 
-        # Set GPU assignment for disaggregated mode (like disagg.sh)
-        if mode == "decode":
-            env["CUDA_VISIBLE_DEVICES"] = "1"  # Use GPU 1 for decode worker
-        elif mode == "prefill":
-            env["CUDA_VISIBLE_DEVICES"] = "0"  # Use GPU 0 for prefill worker
-        # For agg (aggregated) mode, use default GPU assignment
+        # Preserve scheduler-assigned device tokens (including GPU/MIG UUIDs).
+        if mode in ("prefill", "decode"):
+            decode_device, prefill_device = resolve_sglang_disaggregated_devices(
+                env.get("CUDA_VISIBLE_DEVICES")
+            )
+            env["CUDA_VISIBLE_DEVICES"] = (
+                prefill_device if mode == "prefill" else decode_device
+            )
+        # Aggregated mode inherits the scheduler assignment unchanged.
 
-        # Set log directory based on worker type
-        log_dir = f"{request.node.name}_{mode}_worker"
-
-        # Clean up any existing log directory from previous runs
-        try:
-            shutil.rmtree(log_dir)
-            logger.info(f"Cleaned up existing log directory: {log_dir}")
-        except FileNotFoundError:
-            # Directory doesn't exist, which is fine
-            pass
+        log_dir = request.getfixturevalue("tmp_path") / f"{mode}_worker"
 
         super().__init__(
             command=command,
@@ -158,7 +163,7 @@ class DynamoWorkerProcess(ManagedProcess):
             straggler_commands=[
                 "-m dynamo.sglang",
             ],
-            log_dir=log_dir,
+            log_dir=str(log_dir),
         )
 
         self.mode = mode
@@ -166,12 +171,13 @@ class DynamoWorkerProcess(ManagedProcess):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Release allocated port when worker exits."""
-        try:
-            # system_port is a required parameter, always set in __init__
-            deallocate_port(self.system_port)
-            deallocate_port(self.fpm_port)
-        except Exception as e:
-            logging.warning(f"Failed to release SGLang worker port: {e}")
+        for port in (self.system_port, self.fpm_port):
+            if port is None:
+                continue
+            try:
+                deallocate_port(port)
+            except Exception as e:
+                logging.warning(f"Failed to release SGLang worker port {port}: {e}")
 
         return super().__exit__(exc_type, exc_val, exc_tb)
 
@@ -194,7 +200,6 @@ class DynamoWorkerProcess(ManagedProcess):
 
 @pytest.mark.timeout(160)  # 3x average
 @pytest.mark.gpu_1
-@pytest.mark.skip(reason="DYN-2265")
 @pytest.mark.nightly
 def test_request_cancellation_sglang_aggregated(
     request, runtime_services_dynamic_ports, predownload_models
@@ -216,8 +221,8 @@ def test_request_cancellation_sglang_aggregated(
     - Testing 3 scenarios: ~30s (~10s each)
     - Teardown: ~2s
 
-    TODO: Test is currently flaky/failing due to SGLang limitations with prefill cancellation.
-    See: https://github.com/sgl-project/sglang/issues/11139
+    The upstream SGLang prefill-cancellation limitation does not apply here: this
+    test waits for SGLang to assign a request ID before cancelling generation.
     """
     logger.info("Sanity check if latest test is getting executed")
 
@@ -339,6 +344,8 @@ def test_request_cancellation_sglang_decode_cancel(
     request.addfinalizer(lambda port=decode_system_port: deallocate_port(port))
     prefill_system_port = allocate_port(DynamoPortRange.SERVE.value)
     request.addfinalizer(lambda port=prefill_system_port: deallocate_port(port))
+    bootstrap_port = allocate_port(DynamoPortRange.BOOTSTRAP.value)
+    request.addfinalizer(lambda port=bootstrap_port: deallocate_port(port))
 
     # Step 1: Start the frontend (allocates its own port)
     with DynamoFrontendProcess(request) as frontend:
@@ -350,6 +357,7 @@ def test_request_cancellation_sglang_decode_cancel(
             system_port=decode_system_port,
             frontend_port=frontend.frontend_port,
             mode="decode",
+            bootstrap_port=bootstrap_port,
         ) as decode_worker:
             logger.info(f"Decode Worker PID: {decode_worker.get_pid()}")
 
@@ -359,8 +367,12 @@ def test_request_cancellation_sglang_decode_cancel(
                 system_port=prefill_system_port,
                 frontend_port=frontend.frontend_port,
                 mode="prefill",
+                bootstrap_port=bootstrap_port,
             ) as prefill_worker:
                 logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
+                assert (
+                    decode_worker.bootstrap_port == prefill_worker.bootstrap_port
+                ), "Prefill and decode workers must share a bootstrap port"
 
                 # TODO: Why wait after worker ready fixes frontend 404 / 500 flakiness?
                 time.sleep(2)

--- a/tests/fault_tolerance/cancellation/test_sglang_cuda_devices.py
+++ b/tests/fault_tolerance/cancellation/test_sglang_cuda_devices.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from tests.fault_tolerance.cancellation.sglang_devices import (
+    resolve_sglang_disaggregated_devices,
+)
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.fault_tolerance,
+]
+
+
+@pytest.mark.parametrize(
+    "visible_devices,expected",
+    [
+        pytest.param(None, ("0", "1"), id="unset-default"),
+        pytest.param("3,5", ("3", "5"), id="numeric-scheduler-assignment"),
+        pytest.param(
+            "GPU-decode,GPU-prefill,GPU-spare",
+            ("GPU-decode", "GPU-prefill"),
+            id="uuid-scheduler-assignment",
+        ),
+        pytest.param(" MIG-decode , MIG-prefill ", ("MIG-decode", "MIG-prefill")),
+    ],
+)
+def test_resolve_sglang_disaggregated_devices(visible_devices, expected):
+    assert resolve_sglang_disaggregated_devices(visible_devices) == expected
+
+
+@pytest.mark.parametrize("visible_devices", ["", "7", " , "])
+def test_resolve_sglang_disaggregated_devices_requires_two_entries(visible_devices):
+    with pytest.raises(ValueError, match="requires at least two entries"):
+        resolve_sglang_disaggregated_devices(visible_devices)

--- a/tests/fault_tolerance/cancellation/test_sglang_cuda_devices.py
+++ b/tests/fault_tolerance/cancellation/test_sglang_cuda_devices.py
@@ -20,13 +20,17 @@ pytestmark = [
     "visible_devices,expected",
     [
         pytest.param(None, ("0", "1"), id="unset-default"),
-        pytest.param("3,5", ("3", "5"), id="numeric-scheduler-assignment"),
+        pytest.param("3,5", ("3", "5"), id="prefill-then-decode-numeric"),
         pytest.param(
-            "GPU-decode,GPU-prefill,GPU-spare",
-            ("GPU-decode", "GPU-prefill"),
-            id="uuid-scheduler-assignment",
+            "GPU-prefill,GPU-decode,GPU-spare",
+            ("GPU-prefill", "GPU-decode"),
+            id="prefill-then-decode-uuid",
         ),
-        pytest.param(" MIG-decode , MIG-prefill ", ("MIG-decode", "MIG-prefill")),
+        pytest.param(
+            " MIG-prefill , MIG-decode ",
+            ("MIG-prefill", "MIG-decode"),
+            id="prefill-then-decode-mig",
+        ),
     ],
 )
 def test_resolve_sglang_disaggregated_devices(visible_devices, expected):


### PR DESCRIPTION
## Summary

- Re-enable SGLang aggregated request cancellation coverage for NATS and TCP.
- Allocate a dynamic bootstrap port shared by disaggregated prefill and decode workers.
- Preserve scheduler-provided CUDA device identifiers, including GPU and MIG UUID forms.
- Move worker logs to pytest-managed temporary directories.
- Add CPU unit coverage for disaggregated device assignment.

Linear: https://linear.app/nvidia/issue/DYN-4060

## Validation

- 7 device-assignment unit tests passed
- `python3 -m py_compile` on the changed Python files
- `black --check` on the changed Python files
- `git diff --check`
- Normal repository pytest startup is blocked because the local environment does not include `pytest_benchmark`
- Aggregated and disaggregated cancellation cases require H100 validation