### PR TITLE
ci: move trusted PR jobs to self-hosted runners

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   codeowners:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   codeowners:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   codeql:
     name: Analyze Codebase
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read
@@ -31,4 +31,3 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
             category: "/language:${{matrix.language}}"
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   codeql:
     name: Analyze Codebase
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/compliance-base-drift.yml
+++ b/.github/workflows/compliance-base-drift.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   check-drift:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1

--- a/.github/workflows/compliance-base-drift.yml
+++ b/.github/workflows/compliance-base-drift.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   check-drift:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1

--- a/.github/workflows/dco_comment.yml
+++ b/.github/workflows/dco_comment.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dco-comment:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - name: Get DCO status
         id: dco

--- a/.github/workflows/dco_comment.yml
+++ b/.github/workflows/dco_comment.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dco-comment:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - name: Get DCO status
         id: dco

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lychee:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
 
       - name: Check out repository
@@ -96,7 +96,7 @@ jobs:
 
   broken-links-check:
     name: Check for broken markdown links
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *internal_pr_runner
 
     steps:
       - name: Check out repository

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lychee:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
 
       - name: Check out repository
@@ -96,7 +96,7 @@ jobs:
 
   broken-links-check:
     name: Check for broken markdown links
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -72,7 +72,7 @@ permissions:
 jobs:
   # Detect changed files for conditional job execution
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/') && 'prod-default-small-v2' || 'ubuntu-latest' }}
     # Skip for tag pushes - version release doesn't need changed-files check
     if: github.ref_type != 'tag'
     outputs:
@@ -101,7 +101,7 @@ jobs:
       github.ref_type != 'tag' &&
       (needs.changed-files.outputs.docs == 'true' || github.event_name == 'workflow_dispatch') &&
       (github.event.inputs.tag == '' || github.event.inputs.tag == null)
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/') && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - name: Determine context
         id: ctx

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -72,7 +72,7 @@ permissions:
 jobs:
   # Detect changed files for conditional job execution
   changed-files:
-    runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/') && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &trusted_pr_branch_runner ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/') && 'prod-default-small-v2' || 'ubuntu-latest' }}
     # Skip for tag pushes - version release doesn't need changed-files check
     if: github.ref_type != 'tag'
     outputs:
@@ -101,7 +101,7 @@ jobs:
       github.ref_type != 'tag' &&
       (needs.changed-files.outputs.docs == 'true' || github.event_name == 'workflow_dispatch') &&
       (github.event.inputs.tag == '' || github.event.inputs.tag == null)
-    runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/') && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *trusted_pr_branch_runner
     steps:
       - name: Determine context
         id: ctx

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   label:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   conventional-commits:
     name: Validate PR title and add label
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - uses:  ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98
         with:

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   conventional-commits:
     name: Validate PR title and add label
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - uses:  ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98
         with:

--- a/.github/workflows/pr-xpu.yaml
+++ b/.github/workflows/pr-xpu.yaml
@@ -21,7 +21,7 @@ jobs:
   # ============================================================================
 
   guard:
-    runs-on: ubuntu-latest
+    runs-on: prod-default-small-v2
     outputs:
       has_xpu_label: ${{ steps.pr-info.outputs.has_xpu_label }}
     steps:
@@ -49,7 +49,7 @@ jobs:
   changed-files:
     needs: [guard]
     if: needs.guard.outputs.has_xpu_label == 'true'
-    runs-on: ubuntu-latest
+    runs-on: prod-default-small-v2
     outputs:
       core: ${{ steps.changes.outputs.core }}
       vllm: ${{ steps.changes.outputs.vllm }}
@@ -84,7 +84,7 @@ jobs:
   # ============================================================================
 
   xpu-status-check:
-    runs-on: ubuntu-latest
+    runs-on: prod-default-small-v2
     needs: [guard, changed-files, xpu-ci-vllm]
     if: always() && needs.guard.outputs.has_xpu_label == 'true'
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,7 +21,7 @@ jobs:
   # SETUP & DETECTION JOBS
   # ============================================================================
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: prod-default-small-v2
     outputs:
       core: ${{ steps.changes.outputs.core }}
       dev_images: ${{ steps.changes.outputs.dev_images }}
@@ -121,7 +121,7 @@ jobs:
           echo "builder_name=${{ env.BUILDER_NAME }}" >> $GITHUB_OUTPUT
 
   backend-status-check:
-    runs-on: ubuntu-latest
+    runs-on: prod-default-small-v2
     needs:
       - changed-files
       - operator
@@ -165,7 +165,7 @@ jobs:
           echo '${{ toJson(needs) }}' | jq -e 'to_entries | map(.value.result) | all(. as $result | ["success", "skipped"] | any($result == .))'
 
   deploy-status-check:
-    runs-on: ubuntu-latest
+    runs-on: prod-default-small-v2
     needs:
       - changed-files
       - deploy-operator
@@ -271,7 +271,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.operator == 'true'
     name: Helm Chart Tests
-    runs-on: ubuntu-latest
+    runs-on: prod-default-small-v2
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - name: Check for trusted contributor
         id: contributor_check

--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - name: Check for trusted contributor
         id: contributor_check

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   changed-files:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     outputs:
       docs: ${{ steps.changes.outputs.docs }}
       examples: ${{ steps.changes.outputs.examples }}
@@ -49,7 +49,7 @@ jobs:
           gh_token: ${{ github.token }}
 
   pre-merge-status-check:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *internal_pr_runner
     needs: [changed-files, pre-commit, recipe-check, api-docs, fern-check, fern-broken-links, operator, rust-tests, rust-clippy, docs-website-composition]
     if: always()
     steps:
@@ -58,7 +58,7 @@ jobs:
           echo '${{ toJson(needs) }}' | jq -e 'to_entries | map(.value.result) | all(. as $result | ["success", "skipped"] | any($result == .))'
 
   pre-commit:
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *internal_pr_runner
     permissions:
       contents: read
     steps:
@@ -71,7 +71,7 @@ jobs:
     name: Recipe Check
     needs: changed-files
     if: needs.changed-files.outputs.examples == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *internal_pr_runner
     timeout-minutes: 5
     permissions:
       contents: read
@@ -100,7 +100,7 @@ jobs:
     name: Generated API References
     needs: changed-files
     if: needs.changed-files.outputs.api_docs == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *internal_pr_runner
     permissions:
       contents: read
     steps:
@@ -172,7 +172,7 @@ jobs:
     name: Fern Configuration Check
     needs: changed-files
     if: needs.changed-files.outputs.docs == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *internal_pr_runner
     permissions:
       contents: read
     steps:
@@ -245,7 +245,7 @@ jobs:
     name: Docs Website Composition Check
     needs: changed-files
     if: needs.changed-files.outputs.docs == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *internal_pr_runner
     permissions:
       contents: read
     steps:
@@ -281,7 +281,7 @@ jobs:
     name: Fern Broken Links Check
     needs: changed-files
     if: needs.changed-files.outputs.docs == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *internal_pr_runner
     permissions:
       contents: read
     steps:
@@ -298,7 +298,7 @@ jobs:
   operator:
     needs: changed-files
     if: needs.changed-files.outputs.operator == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: *internal_pr_runner
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     outputs:
       docs: ${{ steps.changes.outputs.docs }}
       examples: ${{ steps.changes.outputs.examples }}
@@ -49,7 +49,7 @@ jobs:
           gh_token: ${{ github.token }}
 
   pre-merge-status-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     needs: [changed-files, pre-commit, recipe-check, api-docs, fern-check, fern-broken-links, operator, rust-tests, rust-clippy, docs-website-composition]
     if: always()
     steps:
@@ -58,7 +58,7 @@ jobs:
           echo '${{ toJson(needs) }}' | jq -e 'to_entries | map(.value.result) | all(. as $result | ["success", "skipped"] | any($result == .))'
 
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:
@@ -71,7 +71,7 @@ jobs:
     name: Recipe Check
     needs: changed-files
     if: needs.changed-files.outputs.examples == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     timeout-minutes: 5
     permissions:
       contents: read
@@ -100,7 +100,7 @@ jobs:
     name: Generated API References
     needs: changed-files
     if: needs.changed-files.outputs.api_docs == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:
@@ -172,7 +172,7 @@ jobs:
     name: Fern Configuration Check
     needs: changed-files
     if: needs.changed-files.outputs.docs == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:
@@ -245,7 +245,7 @@ jobs:
     name: Docs Website Composition Check
     needs: changed-files
     if: needs.changed-files.outputs.docs == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:
@@ -281,7 +281,7 @@ jobs:
     name: Fern Broken Links Check
     needs: changed-files
     if: needs.changed-files.outputs.docs == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:
@@ -298,7 +298,7 @@ jobs:
   operator:
     needs: changed-files
     if: needs.changed-files.outputs.operator == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/trigger-ci-approval-flow.yml
+++ b/.github/workflows/trigger-ci-approval-flow.yml
@@ -66,7 +66,7 @@ permissions:
 jobs:
   ok-to-test:
     if: github.event.pull_request.head.repo.fork
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     environment: external_collaborator
     steps:
       - name: Validate approved contributor

--- a/.github/workflows/trigger-ci-approval-flow.yml
+++ b/.github/workflows/trigger-ci-approval-flow.yml
@@ -66,7 +66,7 @@ permissions:
 jobs:
   ok-to-test:
     if: github.event.pull_request.head.repo.fork
-    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
+    runs-on: &internal_pr_runner ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     environment: external_collaborator
     steps:
       - name: Validate approved contributor


### PR DESCRIPTION
## Summary

- move the trusted `pull-request/N` setup, status, and documentation jobs from `ubuntu-latest` to `prod-default-small-v2`
- move the equivalent guard, change-detection, and status jobs in the PR-XPU workflow
- route all 19 jobs in workflows that directly handle PR events to `prod-default-small-v2` for same-repository branch PRs
- keep fork PRs and non-PR executions of mixed-event workflows on `ubuntu-latest`

This reduces exposure to GitHub-hosted runner queue delays while preserving the fork security boundary. It reuses the existing small CPU runner scale set; no new runner infrastructure is required.

## Validation

- `git diff --check origin/main...HEAD`
- `pre-commit run --files <all modified workflow files>`
- parsed all modified workflow files as YAML

## Dependency

The Velonix admission change must merge and deploy before this PR: [ai-dynamo/velonix#597](https://github.com/ai-dynamo/velonix/pull/597). Do not merge this PR until the updated admission policy is live in `dynamo-aws-ci-prod`.

Related: [OPS-8307](https://linear.app/nvidia/issue/OPS-8307/identify-ubuntu-latest-jobs-to-move-to-own-runners)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks to run on the standardized build environment.
  * Applied the environment update across pull request validation, backend, deployment, and Helm chart checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
