### PR TITLE
ci: route trusted PR title checks internally

### DIFF
--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   conventional-commits:
     name: Validate PR title and add label
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'prod-default-small-v2' || 'ubuntu-latest' }}
     steps:
       - uses:  ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98
         with:


### PR DESCRIPTION
## Summary

- route the `pull_request_target` PR-title validation job to `prod-default-small-v2` when the PR head belongs to `ai-dynamo/dynamo`
- keep fork PR title validation on `ubuntu-latest`
- rely on the Velonix admission hook as a second fail-closed check of the PR head repository

GitHub evaluates the runner expression before assigning the job. A same-repository PR selects the Velonix pool; a fork selects a GitHub-hosted runner.

## Validation

- `git diff --check origin/codex/ops-8307-own-runners...HEAD`
- `pre-commit run --files .github/workflows/lint-pr-title.yaml`
- parsed `.github/workflows/lint-pr-title.yaml` as YAML

## Dependencies

- Velonix admission support must merge and deploy first: [ai-dynamo/velonix#597](https://github.com/ai-dynamo/velonix/pull/597)
- stacked on the existing runner migration: [ai-dynamo/dynamo#13573](https://github.com/ai-dynamo/dynamo/pull/13573)

After #13573 merges, retarget this PR to `main`. Do not merge until the Velonix policy is live in `dynamo-aws-ci-prod`.

Related: [OPS-8307](https://linear.app/nvidia/issue/OPS-8307/identify-ubuntu-latest-jobs-to-move-to-own-runners)
