### PR TITLE
fix(operator): stop writing unrecognized gpu models into gpusku

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1772,7 +1772,16 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 		case inferred != "":
 			hw.GPUSKU = inferred
 		default:
-			hw.GPUSKU = nvidiacomv1beta1.GPUSKUType(gpuInfo.Model)
+			// Neither the discovery backend nor InferHardwareSystem could classify this
+			// GPU. Writing gpuInfo.Model here would violate the GPUSKUType CRD enum and
+			// fail the Update below with a confusing "Unsupported value" error that looks
+			// like the user supplied it, when the operator did. Fail fast with a message
+			// that names the actual problem instead.
+			return changed, fmt.Errorf(
+				"could not infer spec.hardware.gpuSku from discovered GPU model %q on node %q: "+
+					"no known hardware matches this product; set spec.hardware.gpuSku explicitly "+
+					"to one of the supported values %v",
+				gpuInfo.Model, gpuInfo.NodeName, gpu.SupportedGPUSKUs())
 		}
 		changed = true
 	}

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1772,15 +1772,15 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 		case inferred != "":
 			hw.GPUSKU = inferred
 		default:
-			// Neither the discovery backend nor InferHardwareSystem could classify this
-			// GPU. Writing gpuInfo.Model here would violate the GPUSKUType CRD enum and
-			// fail the Update below with a confusing "Unsupported value" error that looks
-			// like the user supplied it, when the operator did. Fail fast with a message
-			// that names the actual problem instead.
+			// Neither the discovery backend nor InferHardwareSystem could classify this GPU.
+			// Writing gpuInfo.Model would violate the GPUSKUType CRD enum; fail fast with an
+			// actionable error instead.
 			return changed, fmt.Errorf(
 				"could not infer spec.hardware.gpuSku from discovered GPU model %q on node %q: "+
-					"no known hardware matches this product; set spec.hardware.gpuSku explicitly "+
-					"to one of the supported values %v",
+					"no known hardware matches this product; discovery cannot verify an "+
+					"unrecognized model, so set all required hardware fields explicitly "+
+					"(gpuSku, vramMb, numGpusPerNode, totalGpus) to bypass discovery, "+
+					"using one of the supported gpuSku values %v",
 				gpuInfo.Model, gpuInfo.NodeName, gpu.SupportedGPUSKUs())
 		}
 		changed = true

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1778,8 +1778,9 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 			return changed, fmt.Errorf(
 				"could not infer spec.hardware.gpuSku from discovered GPU model %q on node %q: "+
 					"no known hardware matches this product; discovery cannot verify an "+
-					"unrecognized model, so set all required hardware fields explicitly "+
-					"(gpuSku, vramMb, numGpusPerNode, totalGpus) to bypass discovery, "+
+					"unrecognized model, so create a new DGDR with all required hardware fields "+
+					"set explicitly (gpuSku, vramMb, numGpusPerNode, totalGpus) to bypass discovery "+
+					"(editing this DGDR will not retry it, since Failed is terminal), "+
 					"using one of the supported gpuSku values %v",
 				gpuInfo.Model, gpuInfo.NodeName, gpu.SupportedGPUSKUs())
 		}

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -586,3 +586,44 @@ func TestEnrichHardwareFromDiscovery_UnknownGPUReturnsActionableError(t *testing
 	require.ErrorContains(t, err, unknownProduct)
 	assert.Empty(t, dgdr.Spec.Hardware.GPUSKU)
 }
+
+// TestEnrichHardwareFromDiscovery_GPUSKUAloneDoesNotUnblockUnknownGPU verifies that setting
+// gpuSku alone does not recover an unrecognized GPU: the remaining required fields keep
+// discovery active, and filtering by gpuSku can't match a model discovery already failed to
+// classify, so reconciliation fails again with a different error.
+func TestEnrichHardwareFromDiscovery_GPUSKUAloneDoesNotUnblockUnknownGPU(t *testing.T) {
+	r := newFakeReconciler(gpuNode("gpu-node-1", "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition", 4, 98304))
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Hardware: &nvidiacomv1beta1.HardwareSpec{
+				GPUSKU: nvidiacomv1beta1.GPUSKUTypeH100SXM,
+			},
+		},
+	}
+
+	_, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.ErrorContains(t, err, "no nodes with NVIDIA GPU Feature Discovery labels matching SKU")
+}
+
+// TestEnrichHardwareFromDiscovery_AllRequiredFieldsBypassDiscoveryForUnknownGPU verifies that
+// supplying all four required hardware fields bypasses discovery, so an unrecognized GPU no
+// longer blocks reconciliation.
+func TestEnrichHardwareFromDiscovery_AllRequiredFieldsBypassDiscoveryForUnknownGPU(t *testing.T) {
+	r := newFakeReconciler(gpuNode("gpu-node-1", "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition", 8, 98304))
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Hardware: &nvidiacomv1beta1.HardwareSpec{
+				GPUSKU:         nvidiacomv1beta1.GPUSKUTypeH100SXM,
+				VRAMMB:         ptr.To(float64(98304)),
+				NumGPUsPerNode: ptr.To(int32(8)),
+				TotalGPUs:      ptr.To(int32(8)),
+			},
+		},
+	}
+
+	_, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.NoError(t, err)
+	assert.Equal(t, nvidiacomv1beta1.GPUSKUTypeH100SXM, dgdr.Spec.Hardware.GPUSKU)
+}

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -190,9 +190,9 @@ func TestEnrichHardwareFromDiscovery(t *testing.T) {
 			wantGPUSKU:    "v100_sxm", wantVRAM: 16384, wantGPUsNode: 8, wantTotalGPUs: 8, wantChanged: true,
 		},
 		{
-			name:          "nothing set, unknown GPU falls back to model name",
+			name:          "nothing set, unknown GPU returns actionable error instead of raw model name",
 			discoveredGPU: &gpupkg.GPUInfo{NodeName: "n1", GPUsPerNode: 4, Model: "FutureGPU-X1000", VRAMPerGPU: 65536},
-			wantGPUSKU:    "FutureGPU-X1000", wantVRAM: 65536, wantGPUsNode: 4, wantTotalGPUs: 4, wantChanged: true,
+			wantErr:       `could not infer spec.hardware.gpuSku from discovered GPU model "FutureGPU-X1000"`,
 		},
 		{
 			name: "only totalGpus missing, discovery fills it",
@@ -549,9 +549,10 @@ func TestEnrichHardwareFromDiscovery_NormalizesBareModelFromDCGM(t *testing.T) {
 	}
 }
 
-// TestEnrichHardwareFromDiscovery_FallsBackToModelForUnknownGPU verifies that for GPUs
-// not in the AIC support matrix, the raw GFD product name is used as a fallback.
-func TestEnrichHardwareFromDiscovery_FallsBackToModelForUnknownGPU(t *testing.T) {
+// TestEnrichHardwareFromDiscovery_PreservesUserSuppliedGPUSKUEvenIfInvalid verifies that
+// discovery never overwrites a user-supplied gpuSku, even a value that wouldn't itself pass
+// enum validation (e.g. an already-broken DGDR being re-reconciled).
+func TestEnrichHardwareFromDiscovery_PreservesUserSuppliedGPUSKUEvenIfInvalid(t *testing.T) {
 	r := newFakeReconciler(gpuNode("gpu-node-1", "Tesla-V100-SXM2-16GB", 8, 16384))
 
 	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
@@ -567,7 +568,21 @@ func TestEnrichHardwareFromDiscovery_FallsBackToModelForUnknownGPU(t *testing.T)
 
 	_, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
 	require.NoError(t, err)
-	require.NotNil(t, dgdr.Spec.Hardware)
-	assert.Equal(t, "Tesla-V100-SXM2-16GB", string(dgdr.Spec.Hardware.GPUSKU),
-		"Unknown GPU should fall back to raw model name")
+	assert.Equal(t, "Tesla-V100-SXM2-16GB", string(dgdr.Spec.Hardware.GPUSKU))
+}
+
+// TestEnrichHardwareFromDiscovery_UnknownGPUReturnsActionableError is the regression test for
+// https://github.com/ai-dynamo/dynamo/issues/13239: an unrecognized GPU must not have its raw
+// product string written into hw.GPUSKU (which the CRD enum would then reject).
+func TestEnrichHardwareFromDiscovery_UnknownGPUReturnsActionableError(t *testing.T) {
+	const unknownProduct = "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition"
+	r := newFakeReconciler(gpuNode("gpu-node-1", unknownProduct, 8, 98304))
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{},
+	}
+
+	_, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.ErrorContains(t, err, unknownProduct)
+	assert.Empty(t, dgdr.Spec.Hardware.GPUSKU)
 }

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -977,6 +978,30 @@ func InferHardwareSystem(gpuProduct string) nvidiacomv1beta1.GPUSKUType {
 	}
 
 	return ""
+}
+
+// SupportedGPUSKUs returns the sorted, deduplicated set of GPUSKU values that
+// InferHardwareSystem can produce from a node's nvidia.com/gpu.product label.
+// It is derived from gpuRules so it can never drift from the actual matching
+// logic; callers use it to build actionable errors when a product string
+// matches no known GPU.
+func SupportedGPUSKUs() []nvidiacomv1beta1.GPUSKUType {
+	seen := make(map[nvidiacomv1beta1.GPUSKUType]struct{})
+	var out []nvidiacomv1beta1.GPUSKUType
+	for _, rule := range gpuRules {
+		for _, sku := range []nvidiacomv1beta1.GPUSKUType{rule.singleSKU, rule.sxmSKU, rule.pcieSKU} {
+			if sku == "" {
+				continue
+			}
+			if _, ok := seen[sku]; ok {
+				continue
+			}
+			seen[sku] = struct{}{}
+			out = append(out, sku)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
 }
 
 // normalize standardizes a GPU product string to simplify matching.

--- a/deploy/operator/internal/gpu/discovery_test.go
+++ b/deploy/operator/internal/gpu/discovery_test.go
@@ -1641,3 +1641,29 @@ func TestDetectRDMAFromNode(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportedGPUSKUs(t *testing.T) {
+	skus := SupportedGPUSKUs()
+
+	require.NotEmpty(t, skus)
+
+	seen := make(map[nvidiacomv1beta1.GPUSKUType]struct{}, len(skus))
+	for i, sku := range skus {
+		assert.NotEmpty(t, sku)
+		if _, dup := seen[sku]; dup {
+			t.Errorf("SupportedGPUSKUs returned duplicate entry %q", sku)
+		}
+		seen[sku] = struct{}{}
+		if i > 0 {
+			assert.Less(t, skus[i-1], sku, "SupportedGPUSKUs must be sorted")
+		}
+	}
+
+	// Every SKU InferHardwareSystem can actually return must be listed, so the
+	// error message built from this list is never missing a real answer.
+	for _, product := range []string{"H100-SXM", "H100", "A100-PCIe", "V100-SXM", "L40S", "MI300"} {
+		inferred := InferHardwareSystem(product)
+		require.NotEmpty(t, inferred, "test fixture product %q should be recognized", product)
+		assert.Contains(t, skus, inferred)
+	}
+}


### PR DESCRIPTION
## Overview:

DGDR hardware auto-discovery wrote an unrecognized GPU's raw product string into `spec.hardware.gpuSku`, a field the CRD enum then rejects, failing reconciliation with a confusing error. This PR stops that write and returns an actionable error instead.

## Details:

- `internal/controller/dynamographdeploymentrequest_controller.go`: removed the `default:` branch that wrote `gpuInfo.Model` into `hw.GPUSKU`; now returns an error naming the unmatched GPU model, node, and supported SKUs
- `internal/gpu/discovery.go`: added `SupportedGPUSKUs()`, derived from the existing `gpuRules` table, so the error's supported-values list can't drift from the actual matching logic
- updated/added tests in `enrich_hardware_test.go` and `discovery_test.go` covering the new error path

## Where should the reviewer start?

`enrichHardwareFromDiscovery` in `internal/controller/dynamographdeploymentrequest_controller.go` is the actual fix. `SupportedGPUSKUs()` in `internal/gpu/discovery.go` is the small supporting helper.

## Related Issues

**This PR is linked to an issue:**
- Relates to #13239

This fixes the fallback-write bug reported in the issue, not its secondary ask to sync the `gpuSku` enum with AIConfigurator's systems list (a larger, separate follow-up).

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown GPU models no longer populate the hardware SKU with unsupported values.
  * GPU discovery now reports a clear error with the detected model and supported SKU options.
  * User-provided GPU SKUs are preserved, even when they are not recognized.

* **Tests**
  * Added coverage for unknown GPU models and supported SKU listing.
  * Verified supported GPU SKUs are complete, unique, and consistently ordered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->