### PR TITLE
feat(sglang): add sidecar KV routing

### DIFF
--- a/lib/sidecar/sglang/launch/agg_kv_router.sh
+++ b/lib/sidecar/sglang/launch/agg_kv_router.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Two aggregated SGLang native-gRPC sidecars behind Dynamo's KV-aware router.
+# Requires two GPUs and an SGLang build that exposes KV-event discovery over GetServerInfo.
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+export DYNAMO_HOME="${DYNAMO_HOME:-$(readlink -f "$SCRIPT_DIR/../../../..")}"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$DYNAMO_HOME/examples/common/gpu_utils.sh"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$DYNAMO_HOME/examples/common/launch_utils.sh"
+
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model|--model-path)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "Missing value for $1"
+                echo "Use --help for usage information"
+                exit 1
+            fi
+            MODEL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--model|--model-path <name>] [SGLang engine options...]"
+            echo
+            echo "Additional options are passed to both SGLang engines."
+            echo
+            echo "Environment overrides:"
+            echo "  MODEL                         Model to serve (default: Qwen/Qwen3-0.6B)"
+            echo "  SGLANG_PYTHON                 Python with SGLang installed (default: python3)"
+            echo "  SGLANG_WORKER1_GPU            First GPU assignment (default: 0)"
+            echo "  SGLANG_WORKER2_GPU            Second GPU assignment (default: 1)"
+            echo "  DYN_HTTP_PORT                 Dynamo frontend port (default: 8000)"
+            echo "  DYN_SYSTEM_PORT1              First sidecar system port (default: 8081)"
+            echo "  DYN_SYSTEM_PORT2              Second sidecar system port (default: 8082)"
+            echo "  SGLANG_WORKER1_HTTP_PORT      First SGLang HTTP port (default: 30000)"
+            echo "  SGLANG_WORKER1_GRPC_PORT      First SGLang gRPC port (default: 30001)"
+            echo "  SGLANG_WORKER1_KV_EVENT_PORT  First SGLang KV-event port (default: 5557)"
+            echo "  SGLANG_WORKER2_HTTP_PORT      Second SGLang HTTP port (default: 30010)"
+            echo "  SGLANG_WORKER2_GRPC_PORT      Second SGLang gRPC port (default: 30011)"
+            echo "  SGLANG_WORKER2_KV_EVENT_PORT  Second SGLang KV-event port (default: 5567)"
+            echo "  SGLANG_PAGE_SIZE              KV-event block size (default: 16)"
+            echo "  MAX_MODEL_LEN                 Maximum model length (default: 4096)"
+            echo "  MAX_CONCURRENT_SEQS           Maximum concurrent sequences per engine (default: 2)"
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+trap dynamo_exit_trap EXIT
+
+SGLANG_PYTHON="${SGLANG_PYTHON:-python3}"
+SGLANG_HOST="127.0.0.1"
+SGLANG_WORKER1_GPU="${SGLANG_WORKER1_GPU:-0}"
+SGLANG_WORKER2_GPU="${SGLANG_WORKER2_GPU:-1}"
+SGLANG_WORKER1_HTTP_PORT="${SGLANG_WORKER1_HTTP_PORT:-30000}"
+SGLANG_WORKER1_GRPC_PORT="${SGLANG_WORKER1_GRPC_PORT:-30001}"
+SGLANG_WORKER1_KV_EVENT_PORT="${SGLANG_WORKER1_KV_EVENT_PORT:-5557}"
+SGLANG_WORKER2_HTTP_PORT="${SGLANG_WORKER2_HTTP_PORT:-30010}"
+SGLANG_WORKER2_GRPC_PORT="${SGLANG_WORKER2_GRPC_PORT:-30011}"
+SGLANG_WORKER2_KV_EVENT_PORT="${SGLANG_WORKER2_KV_EVENT_PORT:-5567}"
+SGLANG_PAGE_SIZE="${SGLANG_PAGE_SIZE:-16}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_CONCURRENT_SEQS="${MAX_CONCURRENT_SEQS:-2}"
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+GPU_MEM_ARGS=$(build_sglang_gpu_mem_args)
+
+KV_EVENTS_CONFIG_1="{\"publisher\":\"zmq\",\"endpoint\":\"tcp://*:${SGLANG_WORKER1_KV_EVENT_PORT}\",\"topic\":\"\"}"
+KV_EVENTS_CONFIG_2="{\"publisher\":\"zmq\",\"endpoint\":\"tcp://*:${SGLANG_WORKER2_KV_EVENT_PORT}\",\"topic\":\"\"}"
+
+print_launch_banner "Launching SGLang Native-gRPC Sidecars with KV Routing (2 GPUs)" "$MODEL" "$HTTP_PORT" \
+    "Worker 1: GPU ${SGLANG_WORKER1_GPU}, gRPC ${SGLANG_HOST}:${SGLANG_WORKER1_GRPC_PORT}, KV events tcp://*:${SGLANG_WORKER1_KV_EVENT_PORT}" \
+    "Worker 2: GPU ${SGLANG_WORKER2_GPU}, gRPC ${SGLANG_HOST}:${SGLANG_WORKER2_GRPC_PORT}, KV events tcp://*:${SGLANG_WORKER2_KV_EVENT_PORT}"
+
+python3 -m dynamo.frontend --router-mode kv &
+
+# shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
+CUDA_VISIBLE_DEVICES="$SGLANG_WORKER1_GPU" \
+"$SGLANG_PYTHON" -m sglang.launch_server \
+    --model-path "$MODEL" \
+    --host "$SGLANG_HOST" \
+    --port "$SGLANG_WORKER1_HTTP_PORT" \
+    --grpc-port "$SGLANG_WORKER1_GRPC_PORT" \
+    --kv-events-config "$KV_EVENTS_CONFIG_1" \
+    --page-size "$SGLANG_PAGE_SIZE" \
+    --context-length "$MAX_MODEL_LEN" \
+    --max-running-requests "$MAX_CONCURRENT_SEQS" \
+    $GPU_MEM_ARGS \
+    "${EXTRA_ARGS[@]}" &
+
+# shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
+CUDA_VISIBLE_DEVICES="$SGLANG_WORKER2_GPU" \
+"$SGLANG_PYTHON" -m sglang.launch_server \
+    --model-path "$MODEL" \
+    --host "$SGLANG_HOST" \
+    --port "$SGLANG_WORKER2_HTTP_PORT" \
+    --grpc-port "$SGLANG_WORKER2_GRPC_PORT" \
+    --kv-events-config "$KV_EVENTS_CONFIG_2" \
+    --page-size "$SGLANG_PAGE_SIZE" \
+    --context-length "$MAX_MODEL_LEN" \
+    --max-running-requests "$MAX_CONCURRENT_SEQS" \
+    $GPU_MEM_ARGS \
+    "${EXTRA_ARGS[@]}" &
+
+OTEL_SERVICE_NAME=dynamo-worker-1 \
+DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT1:-8081}" \
+    dynamo-sglang-sidecar \
+    --sglang-endpoint "${SGLANG_HOST}:${SGLANG_WORKER1_GRPC_PORT}" &
+
+OTEL_SERVICE_NAME=dynamo-worker-2 \
+DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT2:-8082}" \
+    dynamo-sglang-sidecar \
+    --sglang-endpoint "${SGLANG_HOST}:${SGLANG_WORKER2_GRPC_PORT}" &
+
+wait_any_exit

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use dynamo_backend_common::{
-    AsyncEngineContext, DisaggregationMode, DynamoError, EngineConfig, GenerateContext, LLMEngine,
-    LLMEngineOutput, LLMEngineOutputExt, LlmRegistration, ModelInput, PreprocessedRequest,
-    WorkerConfig, usage,
+    AsyncEngineContext, DisaggregationMode, DynamoError, EngineConfig, GenerateContext,
+    KvEventSource, LLMEngine, LLMEngineOutput, LLMEngineOutputExt, LlmRegistration, ModelInput,
+    PreprocessedRequest, WorkerConfig, usage,
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::stream::BoxStream;
@@ -34,8 +34,20 @@ pub struct SglangSidecarEngine {
     disaggregation_mode: DisaggregationMode,
     bootstrap_host: Option<String>,
     bootstrap_port: Option<u16>,
-    pool: OnceCell<Pool>,
+    state: OnceCell<StartedState>,
     cancel: CancellationToken,
+}
+
+struct StartedState {
+    pool: Pool,
+    kv_event_sources: Vec<DiscoveredKvEventSource>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DiscoveredKvEventSource {
+    endpoint: String,
+    topic: String,
+    dp_rank: u32,
 }
 
 impl SglangSidecarEngine {
@@ -52,7 +64,7 @@ impl SglangSidecarEngine {
             disaggregation_mode,
             bootstrap_host,
             bootstrap_port,
-            pool: OnceCell::new(),
+            state: OnceCell::new(),
             cancel: CancellationToken::new(),
         }
     }
@@ -163,7 +175,7 @@ impl SglangSidecarEngine {
 #[async_trait]
 impl LLMEngine for SglangSidecarEngine {
     async fn start(&self, _worker_id: u64) -> Result<EngineConfig, DynamoError> {
-        if self.pool.initialized() {
+        if self.state.initialized() {
             return Err(client::engine_shutdown("sglang sidecar already started"));
         }
 
@@ -186,14 +198,20 @@ impl LLMEngine for SglangSidecarEngine {
             self.bootstrap_host.clone(),
             self.bootstrap_port,
         )?;
+        let kv_event_sources = discover_kv_event_sources(&discovery, &config, &self.endpoint)?;
         let connection_count = pool.len();
-        self.pool
-            .set(pool)
+        let kv_event_source_count = kv_event_sources.len();
+        self.state
+            .set(StartedState {
+                pool,
+                kv_event_sources,
+            })
             .map_err(|_| client::engine_shutdown("sglang sidecar already started"))?;
         tracing::info!(
             model = %config.model,
             mode = ?self.disaggregation_mode,
             connections = connection_count,
+            kv_event_sources = kv_event_source_count,
             "sglang sidecar started"
         );
         Ok(config)
@@ -205,9 +223,9 @@ impl LLMEngine for SglangSidecarEngine {
         ctx: GenerateContext,
     ) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
         let mut grpc_client = self
-            .pool
+            .state
             .get()
-            .map(Pool::stream_client)
+            .map(|state| state.pool.stream_client())
             .ok_or_else(|| client::engine_shutdown("generate called before start"))?;
 
         let prompt_tokens = request.token_ids.len() as u32;
@@ -394,7 +412,8 @@ impl LLMEngine for SglangSidecarEngine {
     }
 
     async fn abort(&self, ctx: Arc<dyn AsyncEngineContext>) {
-        let Some(mut grpc_client) = self.pool.get().map(Pool::control_client) else {
+        let Some(mut grpc_client) = self.state.get().map(|state| state.pool.control_client())
+        else {
             return;
         };
         let request = pb::AbortRequest {
@@ -420,6 +439,22 @@ impl LLMEngine for SglangSidecarEngine {
         self.cancel.cancel();
         tracing::info!("sglang sidecar shutdown complete");
         Ok(())
+    }
+
+    async fn kv_event_sources(&self) -> Result<Vec<KvEventSource>, DynamoError> {
+        let state = self
+            .state
+            .get()
+            .ok_or_else(|| client::engine_shutdown("sglang sidecar is not started"))?;
+        Ok(state
+            .kv_event_sources
+            .iter()
+            .map(|source| KvEventSource::Zmq {
+                endpoint: source.endpoint.clone(),
+                topic: source.topic.clone(),
+                dp_rank: source.dp_rank,
+            })
+            .collect())
     }
 }
 
@@ -557,6 +592,162 @@ fn is_routable_host(host: &str) -> bool {
         .unwrap_or(true)
 }
 
+fn discover_kv_event_sources(
+    discovery: &Discovery,
+    engine_config: &EngineConfig,
+    grpc_endpoint: &GrpcEndpoint,
+) -> Result<Vec<DiscoveredKvEventSource>, DynamoError> {
+    let Some(descriptor) = discovery.server_info.get("kv_events") else {
+        return Ok(Vec::new());
+    };
+    if descriptor.is_null() {
+        return Ok(Vec::new());
+    }
+    let descriptor = descriptor.as_object().ok_or_else(|| {
+        client::protocol_error("SGLang GetServerInfo.kv_events must be an object or null")
+    })?;
+
+    let publisher = descriptor
+        .get("publisher")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            client::protocol_error("SGLang GetServerInfo.kv_events.publisher must be a string")
+        })?;
+    if publisher != "zmq" {
+        return Err(client::protocol_error(format!(
+            "unsupported SGLang KV-event publisher `{publisher}`; expected `zmq`"
+        )));
+    }
+    let endpoint_host = descriptor
+        .get("endpoint_host")
+        .and_then(Value::as_str)
+        .filter(|host| !host.trim().is_empty())
+        .ok_or_else(|| {
+            client::protocol_error(
+                "SGLang GetServerInfo.kv_events.endpoint_host must be a non-empty string",
+            )
+        })?;
+    let base_port = descriptor
+        .get("endpoint_port_base")
+        .and_then(Value::as_u64)
+        .and_then(|port| u16::try_from(port).ok())
+        .filter(|port| *port != 0)
+        .ok_or_else(|| {
+            client::protocol_error(
+                "SGLang GetServerInfo.kv_events.endpoint_port_base must be in 1..=65535",
+            )
+        })?;
+    let topic = descriptor
+        .get("topic")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            client::protocol_error("SGLang GetServerInfo.kv_events.topic must be a string")
+        })?;
+    let block_size = descriptor
+        .get("block_size")
+        .and_then(Value::as_u64)
+        .and_then(|size| u32::try_from(size).ok())
+        .filter(|size| *size != 0)
+        .ok_or_else(|| {
+            client::protocol_error(
+                "SGLang GetServerInfo.kv_events.block_size must be a positive uint32",
+            )
+        })?;
+    let reported_dp_size = descriptor
+        .get("dp_size")
+        .and_then(Value::as_u64)
+        .and_then(|size| u32::try_from(size).ok())
+        .filter(|size| *size != 0)
+        .ok_or_else(|| {
+            client::protocol_error(
+                "SGLang GetServerInfo.kv_events.dp_size must be a positive uint32",
+            )
+        })?;
+
+    let llm = engine_config.llm.as_ref().ok_or_else(|| {
+        client::protocol_error("SGLang KV events require an LLM engine registration")
+    })?;
+    if llm.kv_cache_block_size != Some(block_size) {
+        return Err(client::protocol_error(format!(
+            "SGLang KV-event block size {block_size} does not match the registered engine block size {:?}",
+            llm.kv_cache_block_size
+        )));
+    }
+    let dp_start = llm.data_parallel_start_rank.unwrap_or(0);
+    let dp_size = llm.data_parallel_size.unwrap_or(1);
+    if reported_dp_size != dp_size {
+        return Err(client::protocol_error(format!(
+            "SGLang KV-event discovery reports {reported_dp_size} DP ranks but this sidecar registered {dp_size}"
+        )));
+    }
+    let dp_end = dp_start.checked_add(dp_size).ok_or_else(|| {
+        client::protocol_error("SGLang data-parallel rank range overflows uint32")
+    })?;
+    if dp_end > reported_dp_size {
+        return Err(client::protocol_error(format!(
+            "SGLang KV-event discovery does not cover registered DP rank range {dp_start}..{dp_end}"
+        )));
+    }
+    let nnodes = client::json_u32(&discovery.server_info, "nnodes")
+        .unwrap_or(1)
+        .max(1);
+    if nnodes > 1 && dp_size > 1 {
+        return Err(client::protocol_error(format!(
+            "SGLang KV events for multi-node DP are unsupported because GetServerInfo does not map DP ranks to publisher hosts (nnodes={nnodes}, dp_size={dp_size})"
+        )));
+    }
+
+    let connect_host = kv_event_connect_host(endpoint_host, grpc_endpoint)?;
+    let mut sources = Vec::with_capacity(dp_size as usize);
+    for dp_rank in dp_start..dp_end {
+        let port = u32::from(base_port)
+            .checked_add(dp_rank)
+            .filter(|port| *port <= u32::from(u16::MAX))
+            .ok_or_else(|| {
+                client::protocol_error(format!(
+                    "SGLang KV-event port overflows 65535 for base port {base_port} and DP rank {dp_rank}"
+                ))
+            })?;
+        sources.push(DiscoveredKvEventSource {
+            endpoint: format!("tcp://{connect_host}:{port}"),
+            topic: topic.to_string(),
+            dp_rank,
+        });
+    }
+
+    tracing::info!(
+        sources = sources.len(),
+        block_size,
+        base_port,
+        topic,
+        "discovered SGLang ZMQ KV-event sources"
+    );
+    Ok(sources)
+}
+
+fn kv_event_connect_host(
+    endpoint_host: &str,
+    grpc_endpoint: &GrpcEndpoint,
+) -> Result<String, DynamoError> {
+    let endpoint_host = endpoint_host.trim();
+    let bare_host = endpoint_host.trim_matches(&['[', ']'][..]);
+    if matches!(bare_host, "*" | "0.0.0.0" | "::") {
+        return Ok(grpc_endpoint.authority_host().to_string());
+    }
+    if let Ok(address) = bare_host.parse::<IpAddr>() {
+        return Ok(match address {
+            IpAddr::V4(address) => address.to_string(),
+            IpAddr::V6(address) => format!("[{address}]"),
+        });
+    }
+    if bare_host.contains([':', '/', '\\']) || bare_host.chars().any(char::is_whitespace) {
+        return Err(client::protocol_error(format!(
+            "invalid SGLang KV-event endpoint host `{endpoint_host}`"
+        )));
+    }
+    Ok(bare_host.to_string())
+}
+
 fn build_engine_config(
     discovery: &Discovery,
     mode: DisaggregationMode,
@@ -635,10 +826,12 @@ fn build_engine_config(
 
 #[cfg(test)]
 mod tests {
+    use dynamo_sidecar_common::GrpcEndpoint;
     use serde_json::json;
 
     use super::{
-        DisaggregationMode, Discovery, build_engine_config, resolve_bootstrap_host_with_local,
+        DisaggregationMode, DiscoveredKvEventSource, Discovery, build_engine_config,
+        discover_kv_event_sources, resolve_bootstrap_host_with_local,
     };
 
     fn discovery(server_info: serde_json::Value) -> Discovery {
@@ -755,5 +948,44 @@ mod tests {
 
         assert_eq!(registration.kv_cache_block_size, Some(512));
         assert_eq!(registration.total_kv_blocks, Some(16));
+    }
+
+    #[test]
+    fn discovers_ranked_kv_event_sources_from_server_info() {
+        let discovery = discovery(json!({
+            "page_size": 64,
+            "dcp_size": 2,
+            "dp_size": 2,
+            "enable_dp_attention": true,
+            "kv_events": {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "kv",
+                "block_size": 128,
+                "dp_size": 2
+            }
+        }));
+        let config =
+            build_engine_config(&discovery, DisaggregationMode::Aggregated, None, None).unwrap();
+        let endpoint = GrpcEndpoint::parse("http://worker.example:30001", "test").unwrap();
+
+        let sources = discover_kv_event_sources(&discovery, &config, &endpoint).unwrap();
+
+        assert_eq!(
+            sources,
+            [
+                DiscoveredKvEventSource {
+                    endpoint: "tcp://worker.example:5557".to_string(),
+                    topic: "kv".to_string(),
+                    dp_rank: 0,
+                },
+                DiscoveredKvEventSource {
+                    endpoint: "tcp://worker.example:5558".to_string(),
+                    topic: "kv".to_string(),
+                    dp_rank: 1,
+                },
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Overview:

Enable event-driven KV routing for the native SGLang sidecar by consuming the structured `kv_events` discovery information exposed through SGLang's existing `GetServerInfo.json_info` response.

SGLang support landed in [sgl-project/sglang#35714](https://github.com/sgl-project/sglang/pull/35714) (merge commit `61fa64ae7e4975d27c275e30739e1bd9fa4372dd`). No protobuf changes are required: gRPC carries only the low-volume publisher descriptor, while SGLang continues to publish cache events over ZMQ.

## Details:

- Parse and validate SGLang's KV-event publisher descriptor during sidecar startup.
- Normalize wildcard publisher hosts to the native gRPC endpoint host.
- Validate publisher type, block size, DP topology, rank coverage, and port arithmetic before worker registration.
- Expose one `KvEventSource::Zmq` per registered DP rank through Dynamo's existing publisher and KV-router infrastructure.
- Preserve approximate routing when SGLang reports KV events as disabled.
- Reject unsupported multi-node DP discovery rather than constructing incorrect follower endpoints.
- Add a two-worker `agg_kv_router.sh` example that launches SGLang KV publishers, native gRPC sidecars, and a Dynamo frontend in `--router-mode kv`.

Validation:

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-sglang-sidecar`
- `cargo clippy -p dynamo-sglang-sidecar --all-targets -- -D warnings`
- `bash -n lib/sidecar/sglang/launch/agg_kv_router.sh`
- Two-H100 Computelab smoke with `Qwen/Qwen3-0.6B` and SGLang fork commit `adb48e81d5`:
  - Both sidecars discovered and connected one SGLang KV-event source.
  - Initial 242-token request selected worker `7587896987540183562` with `overlap_blocks=0`.
  - The identical repeated request selected the same worker with `overlap_blocks=15`.
  - Both requests completed successfully.

## Where should the reviewer start?

- `lib/sidecar/sglang/src/engine.rs`: discovery validation and `kv_event_sources()` implementation.
- `lib/sidecar/sglang/launch/agg_kv_router.sh`: runnable two-worker KV-routing example.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a launcher for running two SGLang workers behind a KV-aware routing frontend.
  - Supports model configuration, GPU assignment, ports, context length, concurrency, and engine argument passthrough.
  - Added help output and environment-based configuration overrides.
  - Automatically coordinates worker, routing, and sidecar startup.

- **Bug Fixes**
  - Improved startup validation and reporting for KV-event configuration.
  - Added support for discovering ranked KV-event sources and constructing their endpoints reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->