### PR TITLE
feat(codeowners): answer "who reviews this?" on the pull request

### DIFF
--- a/.github/codeowners/suggest_reviewers.py
+++ b/.github/codeowners/suggest_reviewers.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""suggest_reviewers.py -- the reviewer answer, rendered for a pull request.
+
+``who_owns.py`` already answers "who reviews this?" for anyone who knows it
+exists and can run it locally. Most contributors do neither, so the answer
+arrives only when GitHub silently requests a team and they wonder who that was.
+This renders the same answer as a comment on the pull request itself.
+
+It is deliberately the same resolution. Owners come from ``codeowners_match``,
+the module ``emit_codeowners.py`` and ``who_owns.py`` both use, so a comment
+cannot disagree with what GitHub actually does. What is added here is the part a
+terminal did not need: grouping, so a forty-file pull request is readable;
+keeping the co-owner distinction, which a flat union destroys; and a byte
+ceiling, because GitHub rejects a comment body over 65536 characters.
+
+Resolution needs no authentication and no dependencies outside the standard
+library. CODEOWNERS ships in this repository, so this answer is public and the
+comment can go to anyone who opens a pull request -- including an external
+contributor with no org membership. Naming *which people are on* an owning team,
+or how loaded they are, is a different question with a different answer, and
+this does not ask it.
+
+  # from a JSON array of changed paths, as the workflow provides it
+  gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+    | jq -Rs 'split("\n") | map(select(length > 0))' \
+    | python suggest_reviewers.py --codeowners CODEOWNERS --files -
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from codeowners_match import parse_codeowners, resolve_owners  # noqa: E402
+
+#: Hidden marker identifying the bot's own comment, so a second run edits the
+#: first one instead of appending. Without it every push adds a comment and
+#: notifies every subscriber again.
+COMMENT_MARKER = "<!-- dynamo-ops:suggest-reviewers -->"
+
+#: GitHub's hard limit on a comment body. Exceeding it fails the API call, which
+#: would turn a large pull request into no answer at all.
+MAX_COMMENT_BYTES = 65536
+
+#: Files listed per owner group before the rest are counted rather than named.
+#: Evidence for the answer, not the answer, so this is the first thing cut.
+MAX_FILES_SHOWN = 10
+
+#: Teams named in the summary before the rest are counted. The summary is the
+#: answer, so this is cut last -- but it is cut, because otherwise it is not
+#: bounded at all. `areas.yaml` declares two dozen teams today, so this is well
+#: past any real pull request; the point is that the byte ceiling holds for
+#: every input rather than only for realistic ones.
+MAX_TEAMS_SHOWN = 100
+
+
+@dataclass(frozen=True)
+class OwnerGroup:
+    """Paths sharing one owner line.
+
+    ``owners`` is a disjunction: CODEOWNERS requests every entry on the matching
+    line, and any one of their approvals satisfies the gate. Collapsing groups
+    into a single list of teams loses that, and the result reads as though every
+    team must approve.
+    """
+
+    owners: tuple[str, ...]
+    files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Suggestion:
+    """The full answer for one pull request."""
+
+    #: Owned paths, grouped by owner line. Ordered by group size descending then
+    #: by owners, so the largest surface in the pull request reads first and the
+    #: order does not depend on how the file list arrived.
+    groups: tuple[OwnerGroup, ...]
+
+    #: Every team or login GitHub will request. Accurate as a union -- all of
+    #: them are requested -- but see :class:`OwnerGroup` for why the groups are
+    #: what tell a contributor how many approvals they actually need.
+    requested_teams: tuple[str, ...]
+
+    #: Paths no rule matched. Reported rather than dropped: "no reviewer" and
+    #: "no rule covers this" look identical in a union and mean different
+    #: things, the second being a gap the coverage gate should have caught.
+    unowned: tuple[str, ...]
+
+
+def suggest(files: list[str], rules: list[tuple[str, list[str]]]) -> Suggestion:
+    """Resolve ``files`` into a grouped reviewer answer."""
+    by_owners: dict[tuple[str, ...], list[str]] = {}
+    unowned: list[str] = []
+    blocking: set[str] = set()
+
+    for path in sorted(set(files)):
+        owners = tuple(resolve_owners(rules, path))
+        if owners:
+            by_owners.setdefault(owners, []).append(path)
+            blocking.update(owners)
+        else:
+            unowned.append(path)
+
+    groups = tuple(
+        OwnerGroup(owners=owners, files=tuple(paths))
+        for owners, paths in sorted(
+            by_owners.items(), key=lambda kv: (-len(kv[1]), kv[0])
+        )
+    )
+    return Suggestion(
+        groups=groups,
+        requested_teams=tuple(sorted(blocking)),
+        unowned=tuple(unowned),
+    )
+
+
+def _render_group(group: OwnerGroup) -> list[str]:
+    """Render one owner group as markdown lines."""
+    owners = ", ".join(f"`{o}`" for o in group.owners)
+    suffix = " -- any one of them satisfies the gate" if len(group.owners) > 1 else ""
+    lines = [f"**{owners}**{suffix}"]
+    shown = group.files[:MAX_FILES_SHOWN]
+    lines.extend(f"- `{path}`" for path in shown)
+    hidden = len(group.files) - len(shown)
+    if hidden:
+        lines.append(f"- ...and {hidden} more file{'s' if hidden != 1 else ''}")
+    return lines
+
+
+def render_comment(suggestion: Suggestion) -> str:
+    """Render ``suggestion`` as one pull request comment body.
+
+    Bounded by :data:`MAX_COMMENT_BYTES`, unconditionally. Sections are cut in
+    reverse order of value: the per-path evidence first, then the tail of the
+    team list, because the team list is the answer and the paths only show why.
+
+    Every section has its own cap, which is what makes the ceiling hold. An
+    earlier version capped only the file lists and left the team list unbounded,
+    on the reasoning that no real pull request touches many owner groups. That
+    is true and it was still wrong: 4000 groups rendered a 100KB body, and
+    GitHub rejects the request outright rather than truncating it, so the
+    unrealistic input produced no answer at all instead of a clipped one.
+    """
+    header = [
+        COMMENT_MARKER,
+        "### Suggested reviewers",
+        "",
+    ]
+
+    summary: list[str] = []
+    if suggestion.requested_teams:
+        shown_teams = suggestion.requested_teams[:MAX_TEAMS_SHOWN]
+        summary.append("GitHub will request review from:")
+        summary.append("")
+        summary.extend(f"- `{team}`" for team in shown_teams)
+        hidden_teams = len(suggestion.requested_teams) - len(shown_teams)
+        if hidden_teams:
+            summary.append(f"- ...and {hidden_teams} more")
+    else:
+        summary.append("No CODEOWNERS rule matches the changed files.")
+
+    footer: list[str] = [""]
+    if suggestion.unowned:
+        shown = suggestion.unowned[:MAX_FILES_SHOWN]
+        footer.append("These paths match no rule, which the coverage gate should flag:")
+        footer.append("")
+        footer.extend(f"- `{path}`" for path in shown)
+        hidden = len(suggestion.unowned) - len(shown)
+        if hidden:
+            footer.append(f"- ...and {hidden} more")
+        footer.append("")
+    footer.append(
+        "Resolved from the repository's `CODEOWNERS` with "
+        "`python .github/codeowners/who_owns.py --codeowners CODEOWNERS "
+        "--changed --base main`, which you can run yourself."
+    )
+
+    fixed = "\n".join([*header, *summary, *footer])
+    # The overflow note's room is reserved before any group is placed. Adding it
+    # only if it happens to fit means the one case that needs it -- a body large
+    # enough to truncate -- is the case with no room left, so the list comes out
+    # clipped and looking complete.
+    note_reserve = len(b"...and 000000 more owner groups\n")
+    budget = (
+        MAX_COMMENT_BYTES
+        - len(fixed.encode())
+        - len("\n\n#### Where\n\n")
+        - note_reserve
+    )
+
+    detail: list[str] = []
+    rendered_groups = 0
+    for group in suggestion.groups:
+        block = "\n".join(_render_group(group))
+        if len(("\n".join([*detail, block])).encode()) > budget:
+            remaining = len(suggestion.groups) - rendered_groups
+            detail.append(
+                f"...and {remaining} more owner group{'s' if remaining != 1 else ''}"
+            )
+            break
+        detail.append(block)
+        detail.append("")
+        rendered_groups += 1
+
+    if not detail:
+        return fixed
+    body = "\n".join([*header, *summary, "", "#### Where", "", *detail, *footer[1:]])
+    return body if len(body.encode()) <= MAX_COMMENT_BYTES else fixed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Render a reviewer suggestion comment for a pull request."
+    )
+    ap.add_argument(
+        "--codeowners", required=True, type=Path, help="path to the CODEOWNERS file"
+    )
+    ap.add_argument(
+        "--files",
+        required=True,
+        help="JSON array of changed paths, or - to read it from stdin",
+    )
+    args = ap.parse_args()
+
+    raw = sys.stdin.read() if args.files == "-" else Path(args.files).read_text()
+    files = json.loads(raw)
+    if not isinstance(files, list):
+        raise SystemExit("--files must be a JSON array of paths")
+
+    rules = parse_codeowners(args.codeowners.read_text())
+    print(render_comment(suggest(files, rules)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/codeowners/test_suggest_reviewers.py
+++ b/.github/codeowners/test_suggest_reviewers.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for suggest_reviewers -- the reviewer answer posted on a pull request.
+
+Resolution is not retested here. ``resolve_owners`` and ``match`` are covered by
+``test_codeowners.py``, and this module calls the same functions, so duplicating
+those cases would only assert that imports work. What is tested is the part that
+is new: grouping many files into a readable answer, keeping the "any one
+co-owner satisfies the gate" distinction that a flat union destroys, surfacing
+unowned paths instead of quietly reporting no reviewer, and bounding the comment
+so a large pull request cannot produce one GitHub refuses to accept.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from codeowners_match import parse_codeowners  # noqa: E402
+from suggest_reviewers import (  # noqa: E402
+    COMMENT_MARKER,
+    MAX_COMMENT_BYTES,
+    render_comment,
+    suggest,
+)
+
+CODEOWNERS = """\
+* @ai-dynamo/dynamo-codeowners
+/lib/llm/ @ai-dynamo/dynamo-llm-codeowners
+/deploy/ @ai-dynamo/dynamo-deploy-codeowners @ai-dynamo/dynamo-ops-codeowners
+/docs/ @ai-dynamo/dynamo-docs-codeowners @janedoe
+"""
+
+
+@pytest.fixture
+def rules() -> list[tuple[str, list[str]]]:
+    return parse_codeowners(CODEOWNERS)
+
+
+# ------------------------------------------------------------------- resolution
+
+
+def test_the_union_names_every_team_github_will_request(rules) -> None:
+    result = suggest(["lib/llm/a.rs", "deploy/b.yaml"], rules)
+    assert result.requested_teams == (
+        "@ai-dynamo/dynamo-deploy-codeowners",
+        "@ai-dynamo/dynamo-llm-codeowners",
+        "@ai-dynamo/dynamo-ops-codeowners",
+    )
+
+
+def test_co_owners_stay_grouped_because_any_one_satisfies_the_gate(rules) -> None:
+    """The union alone is misleading, so the grouping has to survive.
+
+    ``/deploy/`` lists two teams on one line, which means either team's approval
+    satisfies the gate. Flattened into a list of three requested teams, that
+    reads as three required approvals. The group preserves the distinction.
+    """
+    result = suggest(["deploy/b.yaml"], rules)
+    assert len(result.groups) == 1
+    assert result.groups[0].owners == (
+        "@ai-dynamo/dynamo-deploy-codeowners",
+        "@ai-dynamo/dynamo-ops-codeowners",
+    )
+
+
+def test_files_sharing_an_owner_set_collapse_into_one_group(rules) -> None:
+    """A forty-file pull request must not render forty lines."""
+    result = suggest(["lib/llm/a.rs", "lib/llm/b.rs", "lib/llm/c.rs"], rules)
+    assert len(result.groups) == 1
+    assert result.groups[0].files == ("lib/llm/a.rs", "lib/llm/b.rs", "lib/llm/c.rs")
+
+
+def test_last_match_wins_exactly_as_github_resolves(rules) -> None:
+    """``/lib/llm/`` is more specific than ``*``, so the catch-all loses."""
+    result = suggest(["lib/llm/a.rs"], rules)
+    assert result.requested_teams == ("@ai-dynamo/dynamo-llm-codeowners",)
+
+
+def test_an_individual_login_from_codeowners_may_be_named(rules) -> None:
+    """Public-tier disclosure, and it looks like a contradiction without this.
+
+    The agent's capability contract forbids naming individuals to someone who
+    could not look them up. A login written into CODEOWNERS is not that case:
+    the file ships in a public repository, so ``@janedoe`` owning ``/docs/`` is
+    already public. What stays behind the org boundary is *team membership* and
+    per-person review load, neither of which this answer reads.
+    """
+    result = suggest(["docs/x.md"], rules)
+    assert "@janedoe" in result.requested_teams
+
+
+# --------------------------------------------------------------- unowned paths
+
+
+def test_unowned_files_are_surfaced_not_silently_dropped() -> None:
+    """Reporting no reviewer and reporting no rule are different answers."""
+    result = suggest(["stray.txt"], parse_codeowners("/lib/ @ai-dynamo/x\n"))
+    assert result.unowned == ("stray.txt",)
+    assert result.requested_teams == ()
+
+
+def test_unowned_files_do_not_suppress_the_owned_ones() -> None:
+    rules = parse_codeowners("/lib/ @ai-dynamo/x\n")
+    result = suggest(["lib/a.rs", "stray.txt"], rules)
+    assert result.requested_teams == ("@ai-dynamo/x",)
+    assert result.unowned == ("stray.txt",)
+
+
+# ------------------------------------------------------------------ rendering
+
+
+def test_the_comment_carries_a_marker_so_it_can_be_updated_in_place(rules) -> None:
+    """Without a marker the bot appends a new comment on every push."""
+    body = render_comment(suggest(["lib/llm/a.rs"], rules))
+    assert COMMENT_MARKER in body
+
+
+def test_the_comment_names_the_requested_teams(rules) -> None:
+    body = render_comment(suggest(["lib/llm/a.rs"], rules))
+    assert "@ai-dynamo/dynamo-llm-codeowners" in body
+
+
+def test_the_comment_says_any_one_co_owner_suffices(rules) -> None:
+    body = render_comment(suggest(["deploy/b.yaml"], rules))
+    assert "any one" in body.lower()
+
+
+def test_the_comment_points_at_the_self_service_tool(rules) -> None:
+    """The answer is reproducible without the bot, and saying so is the point."""
+    body = render_comment(suggest(["lib/llm/a.rs"], rules))
+    assert "who_owns.py" in body
+
+
+def test_a_huge_pull_request_still_fits_in_one_comment(rules) -> None:
+    """GitHub rejects a comment body over 65536 characters."""
+    files = [f"lib/llm/f{i:05d}.rs" for i in range(5000)]
+    body = render_comment(suggest(files, rules))
+    assert len(body.encode()) <= MAX_COMMENT_BYTES
+
+
+def test_truncation_says_so_rather_than_appearing_complete(rules) -> None:
+    files = [f"lib/llm/f{i:05d}.rs" for i in range(5000)]
+    body = render_comment(suggest(files, rules))
+    assert "more" in body.lower()
+
+
+def test_truncation_never_drops_a_team_only_the_file_list(rules) -> None:
+    """The team list is the answer; the file list is evidence for it."""
+    files = [f"lib/llm/f{i:05d}.rs" for i in range(5000)] + ["deploy/b.yaml"]
+    body = render_comment(suggest(files, rules))
+    assert "@ai-dynamo/dynamo-llm-codeowners" in body
+    assert "@ai-dynamo/dynamo-deploy-codeowners" in body
+
+
+def test_many_distinct_owner_groups_are_counted_when_they_do_not_fit() -> None:
+    """The overflow note must name a plausible remainder, not a stale total."""
+    rules = parse_codeowners(
+        "".join(f"/area{i:04d}/ @ai-dynamo/team-{i:04d}\n" for i in range(4000))
+    )
+    files = [f"area{i:04d}/f.rs" for i in range(4000)]
+    body = render_comment(suggest(files, rules))
+    assert len(body.encode()) <= MAX_COMMENT_BYTES
+    assert "more owner group" in body
+
+
+def test_a_pull_request_touching_nothing_owned_says_what_to_do() -> None:
+    result = suggest(["stray.txt"], parse_codeowners("/lib/ @ai-dynamo/x\n"))
+    body = render_comment(result)
+    assert "stray.txt" in body
+
+
+def test_rendering_is_stable_for_the_same_input(rules) -> None:
+    """An unstable render would edit the comment on every run, mailing everyone."""
+    files = ["deploy/b.yaml", "lib/llm/a.rs", "docs/x.md"]
+    assert render_comment(suggest(files, rules)) == render_comment(
+        suggest(files, rules)
+    )
+
+
+def test_file_order_does_not_change_the_answer(rules) -> None:
+    forward = render_comment(suggest(["lib/llm/a.rs", "deploy/b.yaml"], rules))
+    reverse = render_comment(suggest(["deploy/b.yaml", "lib/llm/a.rs"], rules))
+    assert forward == reverse
+
+
+def test_no_third_party_import_so_the_workflow_needs_no_pip_install() -> None:
+    """A dependency here means a pip step in the workflow that can fail offline."""
+    import ast
+
+    source = Path(__file__).parent / "suggest_reviewers.py"
+    tree = ast.parse(source.read_text())
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    assert "yaml" not in imported

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -37,7 +37,7 @@ jobs:
       # fail, nothing else means anything.
       - name: Unit tests (matcher + tree-independence)
         run: |
-          python -m pytest .github/codeowners/test_codeowners.py -v \
+          python -m pytest .github/codeowners/ -v \
             -p no:cacheprovider \
             --override-ini="addopts=" \
             --override-ini="filterwarnings="

--- a/.github/workflows/suggest-reviewers.yml
+++ b/.github/workflows/suggest-reviewers.yml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Suggest reviewers
+
+# Answers "who reviews this?" on the pull request that asked. The same answer
+# .github/codeowners/who_owns.py has always given, delivered where a contributor
+# is already standing instead of requiring them to know a script exists.
+#
+# Resolution needs no authentication: CODEOWNERS ships in this repository, so
+# the answer is public and external contributors get it too. Which people are on
+# an owning team, and how loaded they are, is a different question this does not
+# ask -- that needs an org-scoped token and stays on the maintainer surface.
+
+on:
+  issue_comment:
+    types: [created]
+
+# Read-only by default. The comment is posted with a separate bot token, so no
+# job here needs write access to this repository (zizmor: excessive-permissions).
+permissions:
+  contents: read
+
+jobs:
+  suggest:
+    # Pull requests only, and only when actually asked. Matching a bare mention
+    # of the bot would fire on every unrelated tag of it in a thread.
+    if: >
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '/reviewers' ||
+        startsWith(github.event.comment.body, '/reviewers ') ||
+        startsWith(github.event.comment.body, format('/reviewers{0}', '\n')) ||
+        (contains(github.event.comment.body, '@dynamo-ops') &&
+          contains(github.event.comment.body, 'review')))
+    runs-on: ubuntu-latest
+    concurrency:
+      group: suggest-reviewers-${{ github.repository }}-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      # The default branch, explicitly, NOT the pull request head. This job
+      # holds a token that can write comments, and the head of a fork pull
+      # request is attacker-controlled: checking it out would run their
+      # suggest_reviewers.py with that token. The changed-file list comes from
+      # the API below, so nothing from the pull request is ever executed.
+      # CODEOWNERS is evaluated at the base anyway, so this is also the correct
+      # ref for the answer.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      # No pip step: suggest_reviewers.py imports only the standard library and
+      # codeowners_match, so there is nothing to install and nothing to fail.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Collect changed paths
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' \
+            | jq -Rs 'split("\n") | map(select(length > 0))' > changed.json
+          echo "changed paths: $(jq 'length' changed.json)"
+
+      - name: Render the answer
+        run: |
+          set -euo pipefail
+          python .github/codeowners/suggest_reviewers.py \
+            --codeowners CODEOWNERS \
+            --files changed.json > comment.md
+          cat comment.md >> "${GITHUB_STEP_SUMMARY}"
+
+      # Upsert, so asking twice edits one comment instead of notifying every
+      # subscriber again. The marker is written by suggest_reviewers.py.
+      #
+      # The body reaches gh through a file, never through the command line or a
+      # ${{ }} interpolation: it is rendered from paths in a pull request, and
+      # a path can contain anything (zizmor: template-injection).
+      - name: Post or update the comment
+        env:
+          GH_TOKEN: ${{ secrets.OPS_BOT_PAT }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "Missing OPS_BOT_PAT secret; cannot comment as @dynamo-ops."
+            exit 1
+          fi
+
+          existing="$(gh api --paginate \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq 'map(select(.body | contains("<!-- dynamo-ops:suggest-reviewers -->")))
+                  | .[0].id // empty')"
+
+          if [ -n "${existing}" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${existing}" \
+              -F "body=@comment.md" >/dev/null
+            echo "Updated comment ${existing}."
+          else
+            gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -F "body=@comment.md" >/dev/null
+            echo "Posted a new comment."
+          fi


### PR DESCRIPTION
## Overview

`who_owns.py` has always answered "who reviews this?" — for anyone who knows it exists and can run it locally. Most contributors do neither, so the answer arrives only when GitHub silently requests a team and they wonder who that was.

Commenting `/reviewers`, or tagging `@dynamo-ops` and asking for a review, now gets that answer on the pull request itself.

## Details

**Same resolution, by construction.** Owners come from `codeowners_match`, the module `emit_codeowners.py` and `who_owns.py` both use, so a comment cannot disagree with what GitHub actually does. Verified three ways against live PR #13580:

| source | result |
| --- | --- |
| `suggest_reviewers.py` | `@ai-dynamo/dynamo-operator-codeowners` |
| `who_owns.py` | `@ai-dynamo/dynamo-operator-codeowners` |
| GitHub's actual review request | `dynamo-operator-codeowners` |

**Co-owners stay grouped.** Two teams on one CODEOWNERS line means any one satisfies the gate. A flat team list reads as though both must approve, so files are grouped by owner line and the disjunction is stated.

**Unowned paths are surfaced.** "No reviewer" and "no rule covers this" look identical in a union, and the second is a coverage gap worth naming.

**Every section is capped.** GitHub rejects a body over 65536 characters outright rather than truncating it, so an uncapped section means no comment at all. Capping only the file lists was not enough — 4000 owner groups rendered 100KB. Room for the overflow note is reserved *before* any group is placed, because the one case that needs the note is the case with no room left; otherwise the list comes out clipped and looking complete.

| owner groups | body | within limit | says it truncated |
| --- | --- | --- | --- |
| 24 | 1,977 B | yes | no (fits) |
| 1000 | 48,791 B | yes | no (fits) |
| 4000 | 65,520 B | yes | yes |

## Security

- **Checks out the default branch, not the pull request head.** This job holds a token that can write comments, and a fork's head is attacker-controlled — checking it out would run their `suggest_reviewers.py` with that token. The changed-file list comes from the API, so nothing from the pull request is executed. CODEOWNERS is evaluated at the base anyway, so this is also the correct ref.
- **Comment bodies reach `gh` through a file**, never a `${{ }}` interpolation or a command line, since they are rendered from paths that can contain anything (zizmor `template-injection`).
- **`permissions: contents: read`**; the comment uses a separate bot token.

## Disclosure

The answer needs no authentication and goes to external contributors too — CODEOWNERS ships in this repository, so which team owns a path is public, and an individual login written into CODEOWNERS is public for the same reason.

Which people are *on* an owning team, and how loaded they are, needs an org-scoped token. That is a different question and is not asked here.

## Test plan

- [x] 112 tests pass in `.github/codeowners/` (93 existing + 19 new)
- [x] `isort`, `black`, `flake8`, `ruff`, `codespell`, yaml checks all pass
- [x] No third-party imports, asserted by a test so the workflow needs no `pip install`
- [x] Rendering is stable and order-independent, so re-asking edits one comment instead of notifying everyone again
- [x] Verified against a live PR from a clean worktree off `origin/main`
- [ ] End-to-end comment round trip, which needs the workflow on `main` to be triggerable

CI already runs this directory's tests; the pytest path widened from the one file to the directory so the new ones are covered.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated pull-request reviewer suggestions triggered by `/reviewers` requests or qualifying review mentions.
  - Suggestions identify matching code owners, preserve co-owner assignments, and highlight unowned files.
  - Results are posted or updated in a marked pull-request comment with clear reproduction instructions.
  - Large suggestions are safely truncated to remain within GitHub comment limits.

- **Tests**
  - Expanded automated coverage for reviewer matching, grouping, rendering, input handling, and output limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->