### PR TITLE
feat(replay): deprecate engine-only Dynamo entry points

### DIFF
--- a/components/src/dynamo/replay/api.py
+++ b/components/src/dynamo/replay/api.py
@@ -13,6 +13,7 @@ from dynamo._core import (
     run_mocker_synthetic_trace_replay as _run_mocker_synthetic_trace_replay,
 )
 from dynamo._core import run_mocker_trace_replay as _run_mocker_trace_replay
+from dynamo.replay.deprecation import uses_dynamo_integration, warn_engine_only_replay
 from dynamo.replay.report import PlannerReplayDetails, ReplayReport
 
 
@@ -90,8 +91,7 @@ def run_trace_replay(
     *,
     replay_mode: Literal["offline"] = "offline",
     **kwargs: Unpack[_TraceReplayOptions],
-) -> ReplayReport:
-    ...
+) -> ReplayReport: ...
 
 
 @overload
@@ -100,8 +100,7 @@ def run_trace_replay(
     *,
     replay_mode: Literal["online"],
     **kwargs: Unpack[_TraceReplayOptions],
-) -> dict[str, Any]:
-    ...
+) -> dict[str, Any]: ...
 
 
 @overload
@@ -110,8 +109,7 @@ def run_trace_replay(
     *,
     replay_mode: str,
     **kwargs: Unpack[_TraceReplayOptions],
-) -> ReplayReport | dict[str, Any]:
-    ...
+) -> ReplayReport | dict[str, Any]: ...
 
 
 def run_trace_replay(
@@ -149,6 +147,18 @@ def run_trace_replay(
     ``wall_time_ms`` and derived throughput measure Rust runtime construction
     and execution. Planner creation and bootstrap happen before that boundary.
     """
+    if not uses_dynamo_integration(
+        replay_mode=replay_mode,
+        router_mode=router_mode,
+        router_config=router_config,
+        aic_perf_config=aic_perf_config,
+        planner_config=planner_config,
+        model_name=model_name,
+    ):
+        warn_engine_only_replay(
+            "dynamo.replay.run_trace_replay()",
+            "aisimulate.EngineReplayRunnerFactory with aisimulate.ReplaySpec",
+        )
     trace_files = _normalize_trace_files(trace_files)
     replay_kwargs = {
         "extra_engine_args": extra_engine_args,
@@ -243,8 +253,7 @@ def run_synthetic_trace_replay(
     *,
     replay_mode: Literal["offline"] = "offline",
     **kwargs: Unpack[_SyntheticReplayOptions],
-) -> ReplayReport:
-    ...
+) -> ReplayReport: ...
 
 
 @overload
@@ -255,8 +264,7 @@ def run_synthetic_trace_replay(
     *,
     replay_mode: Literal["online"],
     **kwargs: Unpack[_SyntheticReplayOptions],
-) -> dict[str, Any]:
-    ...
+) -> dict[str, Any]: ...
 
 
 @overload
@@ -267,8 +275,7 @@ def run_synthetic_trace_replay(
     *,
     replay_mode: str,
     **kwargs: Unpack[_SyntheticReplayOptions],
-) -> ReplayReport | dict[str, Any]:
-    ...
+) -> ReplayReport | dict[str, Any]: ...
 
 
 def run_synthetic_trace_replay(
@@ -305,6 +312,18 @@ def run_synthetic_trace_replay(
     capture_planner_details=True,
 ) -> ReplayReport | dict[str, Any]:
     """Run synthetic replay with the same timing boundary as trace replay."""
+    if not uses_dynamo_integration(
+        replay_mode=replay_mode,
+        router_mode=router_mode,
+        router_config=router_config,
+        aic_perf_config=aic_perf_config,
+        planner_config=planner_config,
+        model_name=model_name,
+    ):
+        warn_engine_only_replay(
+            "dynamo.replay.run_synthetic_trace_replay()",
+            "aisimulate.EngineReplayRunnerFactory with aisimulate.ReplaySpec",
+        )
     replay_kwargs = {
         "extra_engine_args": extra_engine_args,
         "prefill_engine_args": prefill_engine_args,

--- a/components/src/dynamo/replay/api.py
+++ b/components/src/dynamo/replay/api.py
@@ -91,7 +91,8 @@ def run_trace_replay(
     *,
     replay_mode: Literal["offline"] = "offline",
     **kwargs: Unpack[_TraceReplayOptions],
-) -> ReplayReport: ...
+) -> ReplayReport:
+    ...
 
 
 @overload
@@ -100,7 +101,8 @@ def run_trace_replay(
     *,
     replay_mode: Literal["online"],
     **kwargs: Unpack[_TraceReplayOptions],
-) -> dict[str, Any]: ...
+) -> dict[str, Any]:
+    ...
 
 
 @overload
@@ -109,7 +111,8 @@ def run_trace_replay(
     *,
     replay_mode: str,
     **kwargs: Unpack[_TraceReplayOptions],
-) -> ReplayReport | dict[str, Any]: ...
+) -> ReplayReport | dict[str, Any]:
+    ...
 
 
 def run_trace_replay(
@@ -151,9 +154,7 @@ def run_trace_replay(
         replay_mode=replay_mode,
         router_mode=router_mode,
         router_config=router_config,
-        aic_perf_config=aic_perf_config,
         planner_config=planner_config,
-        model_name=model_name,
     ):
         warn_engine_only_replay(
             "dynamo.replay.run_trace_replay()",
@@ -253,7 +254,8 @@ def run_synthetic_trace_replay(
     *,
     replay_mode: Literal["offline"] = "offline",
     **kwargs: Unpack[_SyntheticReplayOptions],
-) -> ReplayReport: ...
+) -> ReplayReport:
+    ...
 
 
 @overload
@@ -264,7 +266,8 @@ def run_synthetic_trace_replay(
     *,
     replay_mode: Literal["online"],
     **kwargs: Unpack[_SyntheticReplayOptions],
-) -> dict[str, Any]: ...
+) -> dict[str, Any]:
+    ...
 
 
 @overload
@@ -275,7 +278,8 @@ def run_synthetic_trace_replay(
     *,
     replay_mode: str,
     **kwargs: Unpack[_SyntheticReplayOptions],
-) -> ReplayReport | dict[str, Any]: ...
+) -> ReplayReport | dict[str, Any]:
+    ...
 
 
 def run_synthetic_trace_replay(
@@ -316,9 +320,7 @@ def run_synthetic_trace_replay(
         replay_mode=replay_mode,
         router_mode=router_mode,
         router_config=router_config,
-        aic_perf_config=aic_perf_config,
         planner_config=planner_config,
-        model_name=model_name,
     ):
         warn_engine_only_replay(
             "dynamo.replay.run_synthetic_trace_replay()",

--- a/components/src/dynamo/replay/deprecation.py
+++ b/components/src/dynamo/replay/deprecation.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-import logging
 import warnings
 from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import lru_cache
 from typing import Iterator
-
-logger = logging.getLogger(__name__)
 
 _MIGRATION_GUIDE = (
     "https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/"
@@ -30,9 +27,7 @@ def uses_dynamo_integration(
     replay_mode: str,
     router_mode: str,
     router_config: object | None,
-    aic_perf_config: object | None,
     planner_config: object | None,
-    model_name: str | None,
 ) -> bool:
     """Return whether a replay selects a Dynamo-owned integration."""
 
@@ -40,42 +35,34 @@ def uses_dynamo_integration(
         replay_mode == "online"
         or router_mode != "round_robin"
         or router_config is not None
-        or aic_perf_config is not None
         or planner_config is not None
-        or model_name is not None
     )
 
 
 def warn_engine_only_replay(
     entry_point: str,
     replacement: str,
-    *,
-    log: bool = False,
 ) -> None:
     """Warn once per legacy entry point and replacement pair."""
 
     if _suppress_api_warning.get():
         return
-    _warn_engine_only_replay_once(entry_point, replacement, log=log)
+    _warn_engine_only_replay_once(entry_point, replacement)
 
 
 @lru_cache(maxsize=None)
 def _warn_engine_only_replay_once(
     entry_point: str,
     replacement: str,
-    *,
-    log: bool,
 ) -> None:
     message = (
         f"Dynamo engine-only offline replay via `{entry_point}` is deprecated "
-        "and will be removed in Dynamo 1.6.0. Use "
+        "and is planned for removal in Dynamo 1.6.0. Use "
         f"`{replacement}` instead. Dynamo 1.5.0 retains this compatibility "
         "path; Router, Planner, and online replay remain Dynamo-owned and are "
         f"not deprecated. Migration guide: {_MIGRATION_GUIDE}"
     )
     warnings.warn(message, FutureWarning, stacklevel=4)
-    if log:
-        logger.warning("%s", message)
 
 
 @contextmanager

--- a/components/src/dynamo/replay/deprecation.py
+++ b/components/src/dynamo/replay/deprecation.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deprecation policy for engine-only replay through Dynamo entry points."""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import lru_cache
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+_MIGRATION_GUIDE = (
+    "https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/"
+    "developer-guide/knowledge-base/modular-components/"
+    "ai-simulate-experimental/overview.md"
+)
+_suppress_api_warning: ContextVar[bool] = ContextVar(
+    "dynamo_replay_suppress_api_deprecation_warning",
+    default=False,
+)
+
+
+def uses_dynamo_integration(
+    *,
+    replay_mode: str,
+    router_mode: str,
+    router_config: object | None,
+    aic_perf_config: object | None,
+    planner_config: object | None,
+    model_name: str | None,
+) -> bool:
+    """Return whether a replay selects a Dynamo-owned integration."""
+
+    return (
+        replay_mode == "online"
+        or router_mode != "round_robin"
+        or router_config is not None
+        or aic_perf_config is not None
+        or planner_config is not None
+        or model_name is not None
+    )
+
+
+def warn_engine_only_replay(
+    entry_point: str,
+    replacement: str,
+    *,
+    log: bool = False,
+) -> None:
+    """Warn once per legacy entry point and replacement pair."""
+
+    if _suppress_api_warning.get():
+        return
+    _warn_engine_only_replay_once(entry_point, replacement, log=log)
+
+
+@lru_cache(maxsize=None)
+def _warn_engine_only_replay_once(
+    entry_point: str,
+    replacement: str,
+    *,
+    log: bool,
+) -> None:
+    message = (
+        f"Dynamo engine-only offline replay via `{entry_point}` is deprecated "
+        "and will be removed in Dynamo 1.6.0. Use "
+        f"`{replacement}` instead. Dynamo 1.5.0 retains this compatibility "
+        "path; Router, Planner, and online replay remain Dynamo-owned and are "
+        f"not deprecated. Migration guide: {_MIGRATION_GUIDE}"
+    )
+    warnings.warn(message, FutureWarning, stacklevel=4)
+    if log:
+        logger.warning("%s", message)
+
+
+@contextmanager
+def suppress_engine_only_api_warning() -> Iterator[None]:
+    """Avoid a second API warning after a CLI or adapter boundary warned."""
+
+    token = _suppress_api_warning.set(True)
+    try:
+        yield
+    finally:
+        _suppress_api_warning.reset(token)

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -37,6 +37,11 @@ from dynamo.common.forward_pass_metrics import (
 from dynamo.llm import AicPerfConfig, KvRouterConfig
 from dynamo.mocker import MockEngineArgs
 from dynamo.replay import run_synthetic_trace_replay, run_trace_replay
+from dynamo.replay.deprecation import (
+    suppress_engine_only_api_warning,
+    uses_dynamo_integration,
+    warn_engine_only_replay,
+)
 from dynamo.replay.reporting import format_report_table, write_report_json
 
 
@@ -654,6 +659,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ValueError as exc:
         parser.error(str(exc))
 
+    if not uses_dynamo_integration(
+        replay_mode=base_config.replay_mode,
+        router_mode=args.router_mode,
+        router_config=router_config,
+        aic_perf_config=aic_perf_config,
+        planner_config=args.planner_config,
+        model_name=args.model_name,
+    ):
+        warn_engine_only_replay(
+            "python -m dynamo.replay",
+            "python -m aisimulate.replay with the same base arguments",
+            log=True,
+        )
+
     if args.planner_config is not None:
         if args.replay_mode != "offline":
             parser.error("--planner-config only supports --replay-mode=offline")
@@ -687,31 +706,34 @@ def main(argv: Sequence[str] | None = None) -> int:
         "capture_per_request": capture_per_request,
     }
 
-    if using_trace_file:
-        report = run_trace_replay(
-            list(base_config.trace_files),
-            trace_block_size=workload.get("trace_block_size"),
-            trace_format=workload.get("trace_format", "mooncake"),
-            trace_shared_prefix_ratio=workload.get("trace_shared_prefix_ratio", 0.0),
-            trace_num_prefix_groups=workload.get("trace_num_prefix_groups", 0),
-            report_jsonl_path=per_request_jsonl,
-            max_sim_time_ms=workload.get("max_sim_time_ms"),
-            **replay_options,
-        )
-    else:
-        report = run_synthetic_trace_replay(
-            workload["isl"],
-            workload["osl"],
-            workload["request_count"],
-            request_rate=workload.get("request_rate"),
-            arrival_interval_ms=workload.get("arrival_interval_ms"),
-            arrival_seed=workload.get("arrival_seed", 42),
-            turns_per_session=workload.get("turns_per_session", 1),
-            shared_prefix_ratio=workload.get("shared_prefix_ratio", 0.0),
-            num_prefix_groups=workload.get("num_prefix_groups", 0),
-            inter_turn_delay_ms=workload.get("inter_turn_delay_ms", 0.0),
-            **replay_options,
-        )
+    with suppress_engine_only_api_warning():
+        if using_trace_file:
+            report = run_trace_replay(
+                list(base_config.trace_files),
+                trace_block_size=workload.get("trace_block_size"),
+                trace_format=workload.get("trace_format", "mooncake"),
+                trace_shared_prefix_ratio=workload.get(
+                    "trace_shared_prefix_ratio", 0.0
+                ),
+                trace_num_prefix_groups=workload.get("trace_num_prefix_groups", 0),
+                report_jsonl_path=per_request_jsonl,
+                max_sim_time_ms=workload.get("max_sim_time_ms"),
+                **replay_options,
+            )
+        else:
+            report = run_synthetic_trace_replay(
+                workload["isl"],
+                workload["osl"],
+                workload["request_count"],
+                request_rate=workload.get("request_rate"),
+                arrival_interval_ms=workload.get("arrival_interval_ms"),
+                arrival_seed=workload.get("arrival_seed", 42),
+                turns_per_session=workload.get("turns_per_session", 1),
+                shared_prefix_ratio=workload.get("shared_prefix_ratio", 0.0),
+                num_prefix_groups=workload.get("num_prefix_groups", 0),
+                inter_turn_delay_ms=workload.get("inter_turn_delay_ms", 0.0),
+                **replay_options,
+            )
 
     if base_config.replay_mode == "online":
         summary = report

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -663,14 +663,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         replay_mode=base_config.replay_mode,
         router_mode=args.router_mode,
         router_config=router_config,
-        aic_perf_config=aic_perf_config,
         planner_config=args.planner_config,
-        model_name=args.model_name,
     ):
         warn_engine_only_replay(
             "python -m dynamo.replay",
-            "python -m aisimulate.replay with the same base arguments",
-            log=True,
+            "python -m aisimulate.replay",
         )
 
     if args.planner_config is not None:

--- a/components/src/dynamo/replay/simulation.py
+++ b/components/src/dynamo/replay/simulation.py
@@ -29,6 +29,7 @@ from aisimulate.sweeper.replay import (
 from dynamo.llm import KvRouterConfig
 from dynamo.mocker import MockEngineArgs
 from dynamo.replay.api import run_synthetic_trace_replay, run_trace_replay
+from dynamo.replay.deprecation import suppress_engine_only_api_warning
 
 _PLANNER_HOOK = HookCapability(
     provider="dynamo.planner",
@@ -116,12 +117,13 @@ class DynamoReplayRunner:
             **self._goodput_sla_kwargs(spec),
         }
 
-        if self._is_trace(spec):
-            common["trace_block_size"] = self.trace_block_size
-            report = self._run_trace(spec, common)
-        else:
-            common.update(self._synthetic_kwargs(spec))
-            report = self._run_synthetic(spec, common)
+        with suppress_engine_only_api_warning():
+            if self._is_trace(spec):
+                common["trace_block_size"] = self.trace_block_size
+                report = self._run_trace(spec, common)
+            else:
+                common.update(self._synthetic_kwargs(spec))
+                report = self._run_synthetic(spec, common)
 
         metrics, metadata = self._normalize_report(report, output_requirements)
         self._require_goodput_metric(metrics, spec)

--- a/components/src/dynamo/replay/tests/test_deprecation.py
+++ b/components/src/dynamo/replay/tests/test_deprecation.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deprecation contracts for Dynamo's engine-only replay compatibility path."""
+
+import warnings
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.replay import api as replay_api
+from dynamo.replay import deprecation
+from dynamo.replay import main as replay_main
+from dynamo.replay import ReplayReport
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.planner,
+]
+
+
+@pytest.fixture(autouse=True)
+def _fresh_warning_state():
+    deprecation._warn_engine_only_replay_once.cache_clear()
+    try:
+        yield
+    finally:
+        deprecation._warn_engine_only_replay_once.cache_clear()
+
+
+def _native_report():
+    return SimpleNamespace(summary={}, per_request=None, coverage={})
+
+
+def _stub_cli_dependencies(monkeypatch, seen: dict) -> None:
+    monkeypatch.setattr(replay_main, "_load_engine_args", lambda value: value)
+    monkeypatch.setattr(replay_main, "_load_router_config", lambda config, policy: None)
+    monkeypatch.setattr(replay_main, "_load_aic_perf_config", lambda args: None)
+    monkeypatch.setattr(
+        replay_main,
+        "run_synthetic_trace_replay",
+        lambda *args, **kwargs: ReplayReport(
+            summary={}, per_request=None, coverage={}, planner=None
+        ),
+    )
+    monkeypatch.setattr(
+        replay_main,
+        "write_report_json",
+        lambda payload, path: seen.setdefault("report", path or "report.json"),
+    )
+    monkeypatch.setattr(replay_main, "format_report_table", lambda summary: "table")
+
+
+def test_engine_only_cli_warns_once_at_the_caller(monkeypatch) -> None:
+    seen: dict = {}
+    _stub_cli_dependencies(monkeypatch, seen)
+    argv = [
+        "--input-tokens",
+        "8",
+        "--output-tokens",
+        "4",
+        "--request-count",
+        "1",
+        "--replay-concurrency",
+        "1",
+    ]
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        assert replay_main.main(argv) == 0
+        assert replay_main.main(argv) == 0
+
+    assert len(captured) == 1
+    warning = captured[0]
+    assert warning.category is FutureWarning
+    assert "`python -m dynamo.replay`" in str(warning.message)
+    assert "`python -m aisimulate.replay with the same base arguments`" in str(
+        warning.message
+    )
+    assert "Dynamo 1.6.0" in str(warning.message)
+    assert "Dynamo 1.5.0 retains this compatibility path" in str(warning.message)
+    assert warning.filename == __file__
+
+
+def test_engine_only_python_api_warns_with_sdk_replacement(monkeypatch) -> None:
+    monkeypatch.setattr(
+        replay_api,
+        "_run_mocker_synthetic_trace_replay",
+        lambda *args, **kwargs: _native_report(),
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        replay_api.run_synthetic_trace_replay(
+            8,
+            4,
+            1,
+            replay_concurrency=1,
+        )
+
+    assert len(captured) == 1
+    warning = captured[0]
+    assert "dynamo.replay.run_synthetic_trace_replay()" in str(warning.message)
+    assert "aisimulate.EngineReplayRunnerFactory" in str(warning.message)
+    assert warning.filename == __file__
+
+
+def test_engine_only_trace_api_warns_with_sdk_replacement(monkeypatch) -> None:
+    monkeypatch.setattr(
+        replay_api,
+        "_run_mocker_trace_replay",
+        lambda *args, **kwargs: _native_report(),
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        replay_api.run_trace_replay(
+            "trace.jsonl",
+            replay_concurrency=1,
+        )
+
+    assert len(captured) == 1
+    warning = captured[0]
+    assert "dynamo.replay.run_trace_replay()" in str(warning.message)
+    assert "aisimulate.EngineReplayRunnerFactory" in str(warning.message)
+    assert warning.filename == __file__
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"replay_mode": "online"},
+        {"router_mode": "kv_router"},
+        {"router_config": object()},
+        {"aic_perf_config": object()},
+        {"planner_config": object()},
+        {"model_name": "test-model"},
+    ],
+)
+def test_dynamo_owned_paths_do_not_warn(overrides) -> None:
+    values = {
+        "replay_mode": "offline",
+        "router_mode": "round_robin",
+        "router_config": None,
+        "aic_perf_config": None,
+        "planner_config": None,
+        "model_name": None,
+        **overrides,
+    }
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        assert deprecation.uses_dynamo_integration(**values)
+
+    assert captured == []

--- a/components/src/dynamo/replay/tests/test_deprecation.py
+++ b/components/src/dynamo/replay/tests/test_deprecation.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Optional-dependency preflight must run before replay CLI imports.
+# ruff: noqa: E402
 
 """Deprecation contracts for Dynamo's engine-only replay compatibility path."""
 
@@ -8,10 +10,15 @@ from types import SimpleNamespace
 
 import pytest
 
+pytest.importorskip(
+    "aisimulate.replay",
+    reason="AI Simulate is an optional Dynamo simulation dependency",
+)
+
+from dynamo.replay import ReplayReport
 from dynamo.replay import api as replay_api
 from dynamo.replay import deprecation
 from dynamo.replay import main as replay_main
-from dynamo.replay import ReplayReport
 
 pytestmark = [
     pytest.mark.pre_merge,
@@ -76,10 +83,8 @@ def test_engine_only_cli_warns_once_at_the_caller(monkeypatch) -> None:
     warning = captured[0]
     assert warning.category is FutureWarning
     assert "`python -m dynamo.replay`" in str(warning.message)
-    assert "`python -m aisimulate.replay with the same base arguments`" in str(
-        warning.message
-    )
-    assert "Dynamo 1.6.0" in str(warning.message)
+    assert "`python -m aisimulate.replay`" in str(warning.message)
+    assert "planned for removal in Dynamo 1.6.0" in str(warning.message)
     assert "Dynamo 1.5.0 retains this compatibility path" in str(warning.message)
     assert warning.filename == __file__
 
@@ -128,15 +133,34 @@ def test_engine_only_trace_api_warns_with_sdk_replacement(monkeypatch) -> None:
     assert warning.filename == __file__
 
 
+def test_model_name_without_router_still_warns(monkeypatch) -> None:
+    monkeypatch.setattr(
+        replay_api,
+        "_run_mocker_synthetic_trace_replay",
+        lambda *args, **kwargs: _native_report(),
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        replay_api.run_synthetic_trace_replay(
+            8,
+            4,
+            1,
+            replay_concurrency=1,
+            model_name="ignored-without-router-config",
+        )
+
+    assert len(captured) == 1
+    assert "engine-only offline replay" in str(captured[0].message)
+
+
 @pytest.mark.parametrize(
     "overrides",
     [
         {"replay_mode": "online"},
         {"router_mode": "kv_router"},
         {"router_config": object()},
-        {"aic_perf_config": object()},
         {"planner_config": object()},
-        {"model_name": "test-model"},
     ],
 )
 def test_dynamo_owned_paths_do_not_warn(overrides) -> None:
@@ -144,9 +168,7 @@ def test_dynamo_owned_paths_do_not_warn(overrides) -> None:
         "replay_mode": "offline",
         "router_mode": "round_robin",
         "router_config": None,
-        "aic_perf_config": None,
         "planner_config": None,
-        "model_name": None,
         **overrides,
     }
 

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
@@ -27,7 +27,6 @@ bindings if they are not already available:
 ```bash
 .venv/bin/maturin develop --release -m lib/bindings/python/Cargo.toml --features aic-forward-pass
 uv pip install -e .
-DYNOSIM_ENGINE_ARGS='{"block_size":512,"num_gpu_blocks":100000,"aic_backend":"vllm","aic_system":"h200_sxm","aic_backend_version":"0.19.0","aic_tp_size":1,"aic_model_path":"Qwen/Qwen3-32B"}'
 ```
 
 The release build is recommended because the simulation is CPU-bound.
@@ -37,6 +36,8 @@ The release build is recommended because the simulation is CPU-bound.
 Start with a small aggregated simulation:
 
 ```bash
+DYNOSIM_ENGINE_ARGS='{"block_size":512,"num_gpu_blocks":100000,"aic_backend":"vllm","aic_system":"h200_sxm","aic_backend_version":"0.19.0","aic_tp_size":1,"aic_model_path":"Qwen/Qwen3-32B"}'
+
 .venv/bin/python -m aisimulate.replay \
   --input-tokens 2048 \
   --output-tokens 128 \
@@ -56,6 +57,8 @@ The command prints a latency and throughput table. Confirm that all requests com
 Run a second synthetic workload with shared prefixes and three turns per session:
 
 ```bash
+DYNOSIM_ENGINE_ARGS='{"block_size":512,"num_gpu_blocks":100000,"aic_backend":"vllm","aic_system":"h200_sxm","aic_backend_version":"0.19.0","aic_tp_size":1,"aic_model_path":"Qwen/Qwen3-32B"}'
+
 .venv/bin/python -m aisimulate.replay \
   --input-tokens 5000 \
   --output-tokens 500 \
@@ -87,6 +90,8 @@ curl -sL \
 Replay it with the trace block size used by the dataset:
 
 ```bash
+DYNOSIM_ENGINE_ARGS='{"block_size":512,"num_gpu_blocks":100000,"aic_backend":"vllm","aic_system":"h200_sxm","aic_backend_version":"0.19.0","aic_tp_size":1,"aic_model_path":"Qwen/Qwen3-32B"}'
+
 .venv/bin/python -m aisimulate.replay /tmp/toolagent_trace.jsonl \
   --trace-block-size 512 \
   --replay-mode offline \
@@ -100,9 +105,12 @@ the simulated KV-cache block size, so the two values do not need to match.
 
 </Step>
 <Step title="Compare routing modes" id="compare-routing-modes">
-Run the same trace through the KV router. Change only the routing settings:
+Run the same trace through the Dynamo-owned KV router. Keep the engine configuration and worker
+count fixed; the Dynamo entry point is required for this routing mode:
 
 ```bash
+DYNOSIM_ENGINE_ARGS='{"block_size":512,"num_gpu_blocks":100000,"aic_backend":"vllm","aic_system":"h200_sxm","aic_backend_version":"0.19.0","aic_tp_size":1,"aic_model_path":"Qwen/Qwen3-32B"}'
+
 .venv/bin/python -m dynamo.replay /tmp/toolagent_trace.jsonl \
   --trace-block-size 512 \
   --replay-mode offline \

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
@@ -36,7 +36,7 @@ The release build is recommended because the simulation is CPU-bound.
 Start with a small aggregated simulation:
 
 ```bash
-.venv/bin/python -m dynamo.replay \
+.venv/bin/python -m aisimulate.replay \
   --input-tokens 2048 \
   --output-tokens 128 \
   --request-count 100 \
@@ -55,7 +55,7 @@ The command prints a latency and throughput table. Confirm that all requests com
 Run a second synthetic workload with shared prefixes and three turns per session:
 
 ```bash
-.venv/bin/python -m dynamo.replay \
+.venv/bin/python -m aisimulate.replay \
   --input-tokens 5000 \
   --output-tokens 500 \
   --request-count 200 \
@@ -86,10 +86,9 @@ curl -sL \
 Replay it with the trace block size used by the dataset:
 
 ```bash
-.venv/bin/python -m dynamo.replay /tmp/toolagent_trace.jsonl \
+.venv/bin/python -m aisimulate.replay /tmp/toolagent_trace.jsonl \
   --trace-block-size 512 \
   --replay-mode offline \
-  --router-mode round_robin \
   --num-workers 4 \
   --extra-engine-args '{"block_size":64}' \
   --report-json /tmp/dynosim-trace.json

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
@@ -25,8 +25,9 @@ Run the commands from the repository root. Use the project virtual environment a
 bindings if they are not already available:
 
 ```bash
-.venv/bin/maturin develop --release -m lib/bindings/python/Cargo.toml
+.venv/bin/maturin develop --release -m lib/bindings/python/Cargo.toml --features aic-forward-pass
 uv pip install -e .
+DYNOSIM_ENGINE_ARGS='{"block_size":512,"num_gpu_blocks":100000,"aic_backend":"vllm","aic_system":"h200_sxm","aic_backend_version":"0.19.0","aic_tp_size":1,"aic_model_path":"Qwen/Qwen3-32B"}'
 ```
 
 The release build is recommended because the simulation is CPU-bound.
@@ -43,7 +44,7 @@ Start with a small aggregated simulation:
   --replay-mode offline \
   --replay-concurrency 16 \
   --num-workers 2 \
-  --extra-engine-args '{"block_size":64}' \
+  --extra-engine-args "$DYNOSIM_ENGINE_ARGS" \
   --report-json /tmp/dynosim-synthetic.json
 ```
 
@@ -66,7 +67,7 @@ Run a second synthetic workload with shared prefixes and three turns per session
   --replay-mode offline \
   --replay-concurrency 32 \
   --num-workers 2 \
-  --extra-engine-args '{"block_size":64}' \
+  --extra-engine-args "$DYNOSIM_ENGINE_ARGS" \
   --report-json /tmp/dynosim-prefix.json
 ```
 
@@ -90,7 +91,7 @@ Replay it with the trace block size used by the dataset:
   --trace-block-size 512 \
   --replay-mode offline \
   --num-workers 4 \
-  --extra-engine-args '{"block_size":64}' \
+  --extra-engine-args "$DYNOSIM_ENGINE_ARGS" \
   --report-json /tmp/dynosim-trace.json
 ```
 
@@ -107,7 +108,7 @@ Run the same trace through the KV router. Change only the routing settings:
   --replay-mode offline \
   --router-mode kv_router \
   --num-workers 4 \
-  --extra-engine-args '{"block_size":64}' \
+  --extra-engine-args "$DYNOSIM_ENGINE_ARGS" \
   --router-config '{"router_queue_policy":"fcfs"}' \
   --report-json /tmp/dynosim-kv-router.json
 ```
@@ -127,8 +128,8 @@ Use separate prefill and decode worker pools and engine arguments:
   --router-mode kv_router \
   --num-prefill-workers 2 \
   --num-decode-workers 2 \
-  --prefill-engine-args '{"block_size":64,"worker_type":"prefill"}' \
-  --decode-engine-args '{"block_size":64,"worker_type":"decode"}' \
+  --prefill-engine-args '{"block_size":512,"num_gpu_blocks":100000,"aic_backend":"vllm","aic_system":"h200_sxm","aic_backend_version":"0.19.0","aic_tp_size":1,"aic_model_path":"Qwen/Qwen3-32B","worker_type":"prefill"}' \
+  --decode-engine-args '{"block_size":512,"num_gpu_blocks":100000,"aic_backend":"vllm","aic_system":"h200_sxm","aic_backend_version":"0.19.0","aic_tp_size":1,"aic_model_path":"Qwen/Qwen3-32B","worker_type":"decode"}' \
   --report-json /tmp/dynosim-disagg.json
 ```
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/overview.md
@@ -19,6 +19,38 @@ replay configuration; Dynamo extends it with adapter options. The selected runti
 `--*-engine-args` JSON payload, so runtime-specific fields can differ. For configuration search, call
 `Sweeper(runner_factory=...).run(config)`.
 
+## Migrate engine-only replay from Dynamo 1.5
+
+Engine-only offline use of the Dynamo CLI and the `dynamo.replay.run_trace_replay` /
+`run_synthetic_trace_replay` Python functions is deprecated in Dynamo 1.5.0 and is planned for
+removal in Dynamo 1.6.0. The compatibility path still runs in 1.5.0. Dynamo Router, Planner, and
+online replay entry points remain supported and do not emit this warning.
+
+For the CLI, keep the shared base arguments and change the module:
+
+```bash
+# Before: deprecated engine-only Dynamo path
+python -m dynamo.replay \
+  --input-tokens 1024 --output-tokens 128 --request-count 16 \
+  --replay-concurrency 4 --extra-engine-args '{"block_size":64}'
+
+# Standalone replacement
+python -m aisimulate.replay \
+  --input-tokens 1024 --output-tokens 128 --request-count 16 \
+  --replay-concurrency 4 --extra-engine-args '{"block_size":64}'
+```
+
+For Python integrations, build an `aisimulate.ReplaySpec` and run it with the standalone factory:
+
+```python
+from aisimulate import EngineReplayRunnerFactory
+
+report = EngineReplayRunnerFactory().create(worker_id=0).run(spec)
+```
+
+Keep using `DynamoReplayRunnerFactory` or `python -m dynamo.replay` when the replay selects Dynamo
+Router or Planner adapters. Keep using the Dynamo command for `--replay-mode online`.
+
 ## Sweeper
 
 [Sweeper](sweeper-experimental/overview.md) searches backend deployment settings against an injected replay runner.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/overview.md
@@ -26,26 +26,56 @@ Engine-only offline use of the Dynamo CLI and the `dynamo.replay.run_trace_repla
 removal in Dynamo 1.6.0. The compatibility path still runs in 1.5.0. Dynamo Router, Planner, and
 online replay entry points remain supported and do not emit this warning.
 
-For the CLI, keep the shared base arguments and change the module:
+For the CLI, keep the shared base arguments and change the module. This example pins one
+engine configuration that both runtimes accept, so the command is directly comparable:
 
 ```bash
+ENGINE_ARGS='{"block_size":512,"num_gpu_blocks":100000,"aic_backend":"vllm","aic_system":"h200_sxm","aic_backend_version":"0.19.0","aic_tp_size":1,"aic_model_path":"Qwen/Qwen3-32B"}'
+
 # Before: deprecated engine-only Dynamo path
 python -m dynamo.replay \
   --input-tokens 1024 --output-tokens 128 --request-count 16 \
-  --replay-concurrency 4 --extra-engine-args '{"block_size":64}'
+  --replay-concurrency 4 --extra-engine-args "$ENGINE_ARGS"
 
 # Standalone replacement
 python -m aisimulate.replay \
   --input-tokens 1024 --output-tokens 128 --request-count 16 \
-  --replay-concurrency 4 --extra-engine-args '{"block_size":64}'
+  --replay-concurrency 4 --extra-engine-args "$ENGINE_ARGS"
 ```
 
 For Python integrations, build an `aisimulate.ReplaySpec` and run it with the standalone factory:
 
 ```python
-from aisimulate import EngineReplayRunnerFactory
+from aisimulate import (
+    BackendDeploymentSpec,
+    EngineReplayRunnerFactory,
+    ReplaySpec,
+)
+
+engine_args = {
+    "block_size": 512,
+    "num_gpu_blocks": 100_000,
+    "aic_backend": "vllm",
+    "aic_system": "h200_sxm",
+    "aic_backend_version": "0.19.0",
+    "aic_tp_size": 1,
+    "aic_model_path": "Qwen/Qwen3-32B",
+}
+spec = ReplaySpec(
+    backend_deployment=BackendDeploymentSpec(
+        deployment_mode="agg",
+        backend="vllm",
+        backend_version="0.19.0",
+        agg_engine_args=engine_args,
+        num_workers=2,
+    ),
+    workload={"isl": 1024, "osl": 128, "request_count": 16},
+    goal={"target": "throughput"},
+    concurrency=4,
+)
 
 report = EngineReplayRunnerFactory().create(worker_id=0).run(spec)
+print(report.metrics)
 ```
 
 Keep using `DynamoReplayRunnerFactory` or `python -m dynamo.replay` when the replay selects Dynamo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,6 +268,8 @@ filterwarnings = [
     "ignore:The pynvml package is deprecated.*:FutureWarning",
     # Dynamo's own KV events deprecation warning
     "ignore:Automatic KV events configuration is deprecated.*:FutureWarning",
+    # Direct warning behavior is asserted in focused replay deprecation tests.
+    "ignore:Dynamo engine-only offline replay via .* is deprecated.*:FutureWarning",
     # Python 3.12 SWIG extension warning from third-party tokenizer deps
     "ignore:builtin type (SwigPyPacked|SwigPyObject|swigvarlink) has no __module__ attribute:DeprecationWarning",
     # Pydantic V2 deprecation warnings from TRTLLM dependencies


### PR DESCRIPTION
## Overview:

Deprecate only Dynamo's engine-only offline Replay compatibility entry points now that AISimulate owns standalone simulation.

## Details:

- Warn once for engine-only offline use of `python -m dynamo.replay`, `run_trace_replay`, and `run_synthetic_trace_replay`.
- Point CLI users to `python -m aisimulate.replay` and Python users to the AISimulate runner API.
- Preserve supported Dynamo Router, Planner, online Replay, and `DynamoReplayRunnerFactory` paths without warnings.
- Document copy-paste migration steps, the Dynamo 1.5 compatibility window, and the planned Dynamo 1.6 removal.
- Add focused tests for warning text, frequency, caller attribution, and supported-path exclusions.

## Where should the reviewer start?

Start with `components/src/dynamo/replay/deprecation.py`, then review the call sites in `api.py`, `main.py`, and `simulation.py` alongside `test_deprecation.py`.

## Validation:

- `pre-commit run --files ...` across all eight PR-touched files (all hooks passed)
- `python -m pytest --confcutdir=components/src/dynamo/replay/tests -q components/src/dynamo/replay/tests/test_deprecation.py components/src/dynamo/replay/tests/test_main.py components/src/dynamo/replay/tests/test_simulation.py` (25 passed)
- Built and installed the native `ai-dynamo-runtime` binding with `--features aic-forward-pass`
- Ran the documented standalone AISimulate and deprecated Dynamo CLI commands with the same engine configuration; both succeeded with matching metrics, and Dynamo emitted one deprecation warning
- Ran the documented AISimulate Python migration example successfully

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #13583
- Internal NVIDIA tracking: [AIC-1653](https://linear.app/nvidia/issue/AIC-1653)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation**
  * Added warnings for deprecated engine-only replay entry points, including guidance on replacement workflows.
  * Dynamo-integrated replay paths continue without these warnings.

* **Documentation**
  * Updated replay examples and engine configuration guidance.
  * Added migration instructions for moving engine-only replay workflows to standalone AI Simulate.

* **Tests**
  * Added coverage for warning behavior across command-line, synthetic, and trace replay workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->