### PR TITLE
feat(gms): first-fit client slabs for V1 mappings

### DIFF
--- a/lib/gpu_memory_service/tests/test_v1_memory_manager.py
+++ b/lib/gpu_memory_service/tests/test_v1_memory_manager.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import threading
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 
 import pytest
 from _deps import HAS_GMS
@@ -159,3 +159,65 @@ def test_latched_failure_raises_fresh_exceptions(monkeypatch) -> None:
         manager.connect(RequestedLockType.RO)
     assert first.value is not second.value
     assert str(first.value) == str(second.value)
+
+
+@contextmanager
+def _connected_client(tmp_path, monkeypatch, *, slab_size: int):
+    path = str(tmp_path / "weights.sock")
+    vmm = FakeVMM(granularity=64)
+    server = GMSRPCServer(path, GMSServerMemoryManager("GPU-0", vmm, 0))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setattr(device_identity, "invalidate_device_uuid_cache", lambda: None)
+    monkeypatch.setattr(device_identity, "get_device_uuid", lambda _device: "GPU-0")
+    client = GMSClientMemoryManager(path, vmm, 0, slab_size=slab_size)
+    try:
+        client.connect(RequestedLockType.RW)
+        try:
+            yield client, vmm
+        finally:
+            client.close()
+    finally:
+        _stop(server, thread)
+
+
+@pytest.mark.timeout(10)
+def test_client_slabs_pack_reuse_coalesce_and_remap(tmp_path, monkeypatch) -> None:
+    with _connected_client(tmp_path, monkeypatch, slab_size=384) as (client, vmm):
+        first = client.create_mapping(65)
+        second = client.create_mapping(65)
+        third = client.create_mapping(65)
+        assert second == first + 128
+        assert third == first + 256
+        assert len(client.mappings) == 1
+        assert set(vmm.reservations) == {first}
+
+        client.destroy_mapping(first, 65)
+        assert client.create_mapping(65) == first
+
+        client.destroy_mapping(first, 65)
+        client.destroy_mapping(second, 65)
+        coalesced = client.create_mapping(200)
+        assert coalesced == first
+        assert len(client.mappings) == 1
+        assert client.owns(third)
+
+        client.destroy_mapping(coalesced, 200)
+        client.destroy_mapping(third, 65)
+        assert len(client.mappings) == 0
+
+        small = client.create_mapping(65)
+        large = client.create_mapping(400)
+        assert len(client.mappings) == 2
+        assert set(vmm.reservations) == {mapping.base for mapping in client.mappings}
+        client.destroy_mapping(large, 400)
+        assert len(client.mappings) == 1
+        assert client.owns(small)
+
+        client.unmap_all_vas()
+        client.disconnect()
+        client.connect(RequestedLockType.RW)
+        client.reallocate_all_handles()
+        client.remap_all_vas()
+        assert len(client.mappings) == 1
+        assert client.owns(small)

--- a/lib/gpu_memory_service/v1/client/memory_manager.py
+++ b/lib/gpu_memory_service/v1/client/memory_manager.py
@@ -24,6 +24,8 @@ from gpu_memory_service.v1.client.session import _GMSClientSession
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SLAB_SIZE = 2 * 1024 * 1024 * 1024
+
 _SessionFactory = Callable[
     [str, RequestedLockType],
     _GMSClientSession,
@@ -47,6 +49,7 @@ class GMSClientMemoryManager:
         device: int,
         *,
         session_factory: _SessionFactory = _GMSClientSession,
+        slab_size: int = DEFAULT_SLAB_SIZE,
     ):
         self._socket_path = socket_path
         self._vmm = vmm
@@ -54,12 +57,17 @@ class GMSClientMemoryManager:
         self._session_factory = session_factory
         self._session: _GMSClientSession | None = None
         self._mappings: dict[int, _InstalledMapping] = {}
+        self._regions: dict[int, tuple[int, int]] = {}
+        self._free: dict[int, list[tuple[int, int]]] = {}
         self._lock = threading.RLock()
         self._failure: str | None = None
         self._vmm.ensure_initialized()
         self._granularity = int(self._vmm.get_allocation_granularity(device))
         if self._granularity <= 0:
             raise ValueError("allocation granularity must be positive")
+        self._slab_size = self._align(slab_size)
+        if self._slab_size <= 0:
+            raise ValueError("slab size must be positive")
 
     @property
     def mappings(self) -> tuple[LocalMapping, ...]:
@@ -68,7 +76,7 @@ class GMSClientMemoryManager:
 
     def owns(self, va: int) -> bool:
         with self._lock:
-            return va in self._mappings
+            return va in self._regions
 
     def connect(self, lock_type: RequestedLockType) -> None:
         with self._lock:
@@ -92,35 +100,20 @@ class GMSClientMemoryManager:
     def create_mapping(self, size: int) -> int:
         with self._lock:
             self._check()
-            session = self._require_rw()
+            self._require_rw()
             if size <= 0:
                 raise ValueError("allocation size must be positive")
             aligned_size = self._align(size)
-            allocation_id = f"allocation-{uuid4()}"
             try:
-                session.allocate(allocation_id, aligned_size)
-                self._select_device()
-                mapping, handle = reserve_and_install_mapping(
-                    self._vmm,
-                    session.export(allocation_id),
-                    allocation_id,
-                    size,
-                    aligned_size,
-                    aligned_size,
-                    self._granularity,
-                    self._device,
-                    GrantedLockType.RW,
-                )
-                installed = _InstalledMapping(
-                    mapping.allocation_id,
-                    mapping.requested_size,
-                    mapping.aligned_size,
-                    mapping.base,
-                    mapping.reservation_size,
-                    handle,
-                )
-                self._mappings[mapping.base] = installed
-                return mapping.base
+                for mapping in self._ordered_mappings():
+                    va = self._carve(mapping.base, size, aligned_size)
+                    if va is not None:
+                        return va
+                slab = self._add_slab(aligned_size)
+                va = self._carve(slab.base, size, aligned_size)
+                if va is None:
+                    raise RuntimeError("new GMS slab has no room for the allocation")
+                return va
             except Exception as exc:
                 raise self._latch("GMS mapping creation failed", exc) from exc
 
@@ -128,21 +121,17 @@ class GMSClientMemoryManager:
         with self._lock:
             self._check()
             try:
-                mapping = self._mappings[va]
+                slab_base, requested_size = self._regions[va]
             except KeyError:
                 raise RuntimeError(f"GMS does not own VA 0x{va:x}") from None
-            if size is not None and size != mapping.requested_size:
+            if size is not None and size != requested_size:
                 raise RuntimeError("allocator free does not match the GMS mapping")
             try:
-                self._select_device()
-                if mapping.handle:
-                    self._unmap(mapping)
-                if self._session is not None and (
-                    self._session.lock_type is GrantedLockType.RW
-                ):
-                    self._session.free(mapping.allocation_id)
-                self._vmm.address_free(mapping.base, mapping.reservation_size)
-                del self._mappings[va]
+                mapping = self._mappings[slab_base]
+                del self._regions[va]
+                self._put_free(slab_base, va - slab_base, self._align(requested_size))
+                if self._free[slab_base] == [(0, mapping.aligned_size)]:
+                    self._destroy_slab(mapping)
             except Exception as exc:
                 raise self._latch("GMS mapping destruction failed", exc) from exc
 
@@ -223,8 +212,8 @@ class GMSClientMemoryManager:
         """Release local mappings and VAs, then disconnect the socket lease."""
         with self._lock:
             self._check()
-            for mapping in reversed(self._ordered_mappings()):
-                self.destroy_mapping(mapping.base)
+            for va in reversed(sorted(self._regions)):
+                self.destroy_mapping(va)
             self.disconnect()
 
     def _ordered_mappings(self) -> tuple[_InstalledMapping, ...]:
@@ -250,6 +239,81 @@ class GMSClientMemoryManager:
 
     def _align(self, size: int) -> int:
         return (size + self._granularity - 1) // self._granularity * self._granularity
+
+    def _add_slab(self, aligned_size: int) -> _InstalledMapping:
+        slab_bytes = max(self._slab_size, aligned_size)
+        session = self._require_rw()
+        allocation_id = f"allocation-{uuid4()}"
+        session.allocate(allocation_id, slab_bytes)
+        self._select_device()
+        mapping, handle = reserve_and_install_mapping(
+            self._vmm,
+            session.export(allocation_id),
+            allocation_id,
+            slab_bytes,
+            slab_bytes,
+            slab_bytes,
+            self._granularity,
+            self._device,
+            GrantedLockType.RW,
+        )
+        installed = _InstalledMapping(
+            mapping.allocation_id,
+            mapping.requested_size,
+            mapping.aligned_size,
+            mapping.base,
+            mapping.reservation_size,
+            handle,
+        )
+        self._mappings[mapping.base] = installed
+        self._free[mapping.base] = [(0, slab_bytes)]
+        return installed
+
+    def _destroy_slab(self, mapping: _InstalledMapping) -> None:
+        self._select_device()
+        if mapping.handle:
+            self._unmap(mapping)
+        if self._session is not None and self._session.lock_type is GrantedLockType.RW:
+            self._session.free(mapping.allocation_id)
+        self._vmm.address_free(mapping.base, mapping.reservation_size)
+        del self._mappings[mapping.base]
+        del self._free[mapping.base]
+
+    def _carve(self, slab_base: int, size: int, aligned_size: int) -> int | None:
+        offset = self._take_free(slab_base, aligned_size)
+        if offset is None:
+            return None
+        va = slab_base + offset
+        self._regions[va] = (slab_base, size)
+        return va
+
+    def _take_free(self, slab_base: int, aligned_size: int) -> int | None:
+        holes = self._free[slab_base]
+        for index, (offset, length) in enumerate(holes):
+            if length < aligned_size:
+                continue
+            leftover = length - aligned_size
+            if leftover:
+                holes[index] = (offset + aligned_size, leftover)
+            else:
+                del holes[index]
+            return offset
+        return None
+
+    def _put_free(self, slab_base: int, offset: int, length: int) -> None:
+        holes = self._free[slab_base]
+        holes.append((offset, length))
+        holes.sort()
+        merged: list[tuple[int, int]] = [holes[0]]
+        for hole_offset, hole_length in holes[1:]:
+            prev_offset, prev_length = merged[-1]
+            prev_end = prev_offset + prev_length
+            hole_end = hole_offset + hole_length
+            if hole_offset <= prev_end:
+                merged[-1] = (prev_offset, max(prev_end, hole_end) - prev_offset)
+            else:
+                merged.append((hole_offset, hole_length))
+        self._free[slab_base] = merged
 
     def _check(self) -> None:
         if self._failure is not None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Simplified version of #13516. GMS V1 `create_mapping` packs Torch segment mallocs into shared 2 GiB (or larger) client slabs so `remap_all_vas` walks O(slabs) handles instead of one handle per caching-allocator segment. No huge physical allocation is created up front.

## Details

- New slabs start fully free; every mapping goes through one first-fit `_carve` path.
- Freed regions return to a coalescing free list. A slab is destroyed only when it is completely empty.
- Mappings larger than the slab size get their own reservation.
- `remap_all_vas` is unchanged and now remaps the packed slabs.

**Agent review comments on #13516 — none are production correctness bugs:**

- **CodeRabbit (mutate `holes` while iterating):** false positive. `_take_free` mutates the chosen hole and immediately returns, so it never continues the `enumerate` loop.
- **Devin (2 GiB slabs can overshoot remaining GPU memory / hang):** design tradeoff of slab packing, not an allocator logic bug. The sidecar's infinite `cuMemCreate` OOM retry already existed for exact-size allocations. A fallback-to-exact-size path would add complexity this change does not need.
- **Devin (`empty_cache` no longer releases physical memory):** inherent to packing. Fully empty slabs *are* destroyed; only partially occupied slabs keep their backing. That is the point of sharing a handle across segments.
- **dynamo-review-agent (`create_mapping` after `unmap_all_vas` can return an unmapped VA):** theoretically true on the raw API if you allocate after unmap and before remap while still RW-connected. The vLLM V1 backend never does that (`suspend` disconnects immediately; `resume` remaps before returning to RUNNING). Skipping handle-less slabs and adding a *new* slab would actually break later `remap_all_vas` (the new slab already has a handle). Left as-is.

## Where should the reviewer start?

- `lib/gpu_memory_service/v1/client/memory_manager.py` — slab carve / free-list
- `lib/gpu_memory_service/tests/test_v1_memory_manager.py` — one test covering pack, hole reuse, coalescing, empty-slab destroy, oversize, and remap

## Related Issues

- Relates to #13516 (original first-fit slabs PR; this is the simplified take)
- [ ] Confirmed — no related GitHub issue beyond #13516

## Validation

- [x] `PYTHONPATH=lib python3 -m pytest -c /dev/null --timeout=10 lib/gpu_memory_service/tests/test_v1_memory_manager.py` — 4 passed
- [ ] Re-run DSV4 dest restore and confirm `weights_remap` / `kv_remap` drop with fewer `GMS V1 wake` mappings

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85821593-c793-4d19-8d71-5e0df77cddf1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85821593-c793-4d19-8d71-5e0df77cddf1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

