### PR TITLE
fix(sglang): release multimodal embeddings on build failure

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -67,6 +67,9 @@ class EmbeddingsProcessorLike(Protocol):
     ) -> dict[str, Any]:
         ...
 
+    def release_embeddings(self, tensor_id: int) -> None:
+        ...
+
 
 class SglangUtils:
     """General SGLang utilities (not multimodal-specific)"""
@@ -347,63 +350,79 @@ async def _build_mm_items(
     if encoded_groups:
         embeddings, tensor_id = await embeddings_processor.process_embeddings(request)
 
-        grouped_grids: dict[str, list[Any]] = {"IMAGE": [], "VIDEO": []}
-        grouped_embeds: dict[str, list[torch.Tensor]] = {"IMAGE": [], "VIDEO": []}
-        video_second_per_grid_ts: list[float] = []
-        # SGLang expects one timestamp list per video in the grouped item.
-        video_timestamps: list[list[float]] = []
+        try:
+            grouped_grids: dict[str, list[Any]] = {"IMAGE": [], "VIDEO": []}
+            grouped_embeds: dict[str, list[torch.Tensor]] = {
+                "IMAGE": [],
+                "VIDEO": [],
+            }
+            video_second_per_grid_ts: list[float] = []
+            # SGLang expects one timestamp list per video in the grouped item.
+            video_timestamps: list[list[float]] = []
 
-        offset = 0
-        for (
-            modality,
-            grid_item,
-            token_count,
-            second_per_grid_ts,
-            timestamps,
-        ) in encoded_groups:
-            next_offset = offset + int(token_count)
-            if next_offset > embeddings.shape[0]:
-                raise ValueError("Encoded token counts exceed received embedding rows")
-            grouped_grids[modality].append(grid_item)
-            grouped_embeds[modality].append(embeddings[offset:next_offset])
-            if modality == "VIDEO":
-                if second_per_grid_ts is not None:
-                    video_second_per_grid_ts.append(second_per_grid_ts)
-                if timestamps is not None:
-                    video_timestamps.append(timestamps)
-            offset = next_offset
+            offset = 0
+            for (
+                modality,
+                grid_item,
+                token_count,
+                second_per_grid_ts,
+                timestamps,
+            ) in encoded_groups:
+                next_offset = offset + int(token_count)
+                if next_offset > embeddings.shape[0]:
+                    raise ValueError(
+                        "Encoded token counts exceed received embedding rows"
+                    )
+                grouped_grids[modality].append(grid_item)
+                grouped_embeds[modality].append(embeddings[offset:next_offset])
+                if modality == "VIDEO":
+                    if second_per_grid_ts is not None:
+                        video_second_per_grid_ts.append(second_per_grid_ts)
+                    if timestamps is not None:
+                        video_timestamps.append(timestamps)
+                offset = next_offset
 
-        if offset != embeddings.shape[0]:
-            raise ValueError("Encoded token counts do not match received embeddings")
-
-        if grouped_embeds["IMAGE"]:
-            image_mm_items.append(
-                embeddings_processor.create_multimodal_image_item(
-                    torch.cat(grouped_embeds["IMAGE"], dim=0),
-                    grouped_grids["IMAGE"],
-                )
-            )
-        if grouped_embeds["VIDEO"]:
-            video_group_count = len(grouped_grids["VIDEO"])
-            if (
-                video_second_per_grid_ts
-                and len(video_second_per_grid_ts) != video_group_count
-            ):
+            if offset != embeddings.shape[0]:
                 raise ValueError(
-                    "second_per_grid_ts must be present for every video group"
+                    "Encoded token counts do not match received embeddings"
                 )
-            if video_timestamps and len(video_timestamps) != video_group_count:
-                raise ValueError(
-                    "video_timestamps must be present for every video group"
+
+            if grouped_embeds["IMAGE"]:
+                image_mm_items.append(
+                    embeddings_processor.create_multimodal_image_item(
+                        torch.cat(grouped_embeds["IMAGE"], dim=0),
+                        grouped_grids["IMAGE"],
+                    )
                 )
-            video_data_items.append(
-                embeddings_processor.create_multimodal_video_item(
-                    torch.cat(grouped_embeds["VIDEO"], dim=0),
-                    grouped_grids["VIDEO"],
-                    second_per_grid_ts=video_second_per_grid_ts or None,
-                    video_timestamps=video_timestamps or None,
+            if grouped_embeds["VIDEO"]:
+                video_group_count = len(grouped_grids["VIDEO"])
+                if (
+                    video_second_per_grid_ts
+                    and len(video_second_per_grid_ts) != video_group_count
+                ):
+                    raise ValueError(
+                        "second_per_grid_ts must be present for every video group"
+                    )
+                if video_timestamps and len(video_timestamps) != video_group_count:
+                    raise ValueError(
+                        "video_timestamps must be present for every video group"
+                    )
+                video_data_items.append(
+                    embeddings_processor.create_multimodal_video_item(
+                        torch.cat(grouped_embeds["VIDEO"], dim=0),
+                        grouped_grids["VIDEO"],
+                        second_per_grid_ts=video_second_per_grid_ts or None,
+                        video_timestamps=video_timestamps or None,
+                    )
                 )
-            )
+        except BaseException:
+            try:
+                embeddings_processor.release_embeddings(tensor_id)
+            except BaseException:
+                logger.exception(
+                    "Failed to release multimodal embeddings allocation %s", tensor_id
+                )
+            raise
 
     return image_mm_items, video_data_items, embeddings, tensor_id
 

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
@@ -124,6 +124,10 @@ async def test_build_mm_items_routes_video_to_video_data():
             return embeddings, 17
 
         @staticmethod
+        def release_embeddings(tensor_id):
+            raise AssertionError("successful construction transfers tensor ownership")
+
+        @staticmethod
         def create_multimodal_image_item(
             embeddings,
             image_grid_thw,
@@ -413,6 +417,104 @@ async def test_multimodal_prefill_cleanup_awaits_consumers_before_engine_shutdow
 
     assert events == ["consumer stopped", "engine shutdown"]
     assert not handler._consume_tasks
+
+
+@pytest.mark.asyncio
+async def test_build_mm_items_releases_embeddings_when_validation_fails():
+    embeddings = torch.zeros((1, 4), dtype=torch.float16)
+    released_tensor_ids = []
+
+    class _FakeEmbeddingsProcessor:
+        async def process_embeddings(self, request):
+            return embeddings, 17
+
+        @staticmethod
+        def create_multimodal_image_item(embeddings, image_grid_thw):
+            raise AssertionError("validation should fail before item construction")
+
+        @staticmethod
+        def create_multimodal_video_item(
+            embeddings,
+            video_grid_thw,
+            second_per_grid_ts=None,
+            video_timestamps=None,
+        ):
+            raise AssertionError("validation should fail before item construction")
+
+        @staticmethod
+        def release_embeddings(tensor_id):
+            released_tensor_ids.append(tensor_id)
+            raise RuntimeError("release failed")
+
+    request = SglangMultimodalRequest(
+        request=PreprocessedRequest(
+            token_ids=[151652, 151656, 151653],
+            stop_conditions=StopConditions(max_tokens=32),
+            sampling_options=SamplingOptions(temperature=0.0),
+        ),
+        multimodal_inputs=[
+            MultiModalGroup(
+                multimodal_input=MultiModalInput(),
+                image_grid_thw=[1, 1, 1],
+                num_mm_tokens=2,
+            )
+        ],
+    )
+
+    with pytest.raises(
+        ValueError, match="Encoded token counts exceed received embedding rows"
+    ):
+        await _build_mm_items(request, _FakeEmbeddingsProcessor())
+
+    assert released_tensor_ids == [17]
+
+
+@pytest.mark.asyncio
+async def test_build_mm_items_releases_embeddings_when_item_construction_fails():
+    embeddings = torch.zeros((1, 4), dtype=torch.float16)
+    released_tensor_ids = []
+
+    class _FakeEmbeddingsProcessor:
+        async def process_embeddings(self, request):
+            return embeddings, 17
+
+        @staticmethod
+        def create_multimodal_image_item(embeddings, image_grid_thw):
+            raise ValueError("image item construction failed")
+
+        @staticmethod
+        def create_multimodal_video_item(
+            embeddings,
+            video_grid_thw,
+            second_per_grid_ts=None,
+            video_timestamps=None,
+        ):
+            raise AssertionError("image item construction should run")
+
+        @staticmethod
+        def release_embeddings(tensor_id):
+            released_tensor_ids.append(tensor_id)
+            raise RuntimeError("release failed")
+
+    request = SglangMultimodalRequest(
+        request=PreprocessedRequest(
+            token_ids=[151652, 151656, 151653],
+            stop_conditions=StopConditions(max_tokens=32),
+            sampling_options=SamplingOptions(temperature=0.0),
+        ),
+        multimodal_inputs=[
+            MultiModalGroup(
+                multimodal_input=MultiModalInput(),
+                image_grid_thw=[1, 1, 1],
+                num_mm_tokens=1,
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="image item construction failed"):
+        await _build_mm_items(request, _FakeEmbeddingsProcessor())
+
+    assert released_tensor_ids == [17]
 
 
 async def test_nvdec_video_metadata_shim_stamps_valid_metadata():


### PR DESCRIPTION
## Overview:

Release received multimodal embedding allocations when SGLang item construction fails, preventing receiver allocations from leaking on validation errors or cancellation.

## Details:

- Extend the multimodal embeddings processor protocol with the existing `release_embeddings()` ownership operation.
- Keep ownership inside `_build_mm_items()` until image/video items are constructed successfully.
- Release the received tensor ID on any post-receipt `BaseException`, then re-raise the original failure.
- Add focused regression coverage for a token-count mismatch and guard the successful ownership-transfer path against premature release.

## Validation:

- Reproduced current `main` in the official `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0` image on AKS: post-receipt validation raised with allocation ID `41`, and no release occurred.
- Re-ran the same validation with this patch: validation failure and cancellation each released allocation ID `41` exactly once.
- Validated the concrete local embedding receiver: its allocation tracking map was emptied and the backing safetensors file was removed after failure.
- Ran the two focused `_build_mm_items()` tests through pytest in the same SGLang runtime: 2 passed.
- `pre-commit run --files components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py`
- `python3 -m py_compile components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py`

## Where should the reviewer start?

`components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py`, in `_build_mm_items()` immediately after `process_embeddings()` returns.

## Related Issues

**This PR is linked to an issue:**

- Closes #13515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multimodal request handling to safely release embedding data when validation or item construction fails.
  * Prevented retained embedding resources after unsuccessful image or video processing.

* **Tests**
  * Added coverage confirming embeddings are released when token-count validation fails.
  * Verified successful multimodal processing transfers ownership without unnecessary cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->