### PR TITLE
fix(llm): populate KV cache metrics in context-free request trace rows

### DIFF
--- a/docs/fern/pages/reference/observability/request-traces.mdx
+++ b/docs/fern/pages/reference/observability/request-traces.mdx
@@ -74,8 +74,7 @@ feature. Shipped Dynamo Python wheels enable it; local source builds pass
 
 ### `request_end`
 
-Contains compact replay metadata. Session headers can enrich the row with session identity, request
-metrics, finish metadata, and tool-call metadata. Session identity does not enable sticky routing.
+Contains compact replay metadata and, when available, per-request timing and KV-cache metrics. Session headers add session identity, finish metadata, and tool-call metadata. Session identity does not enable sticky routing.
 
 ### `request_payload`
 
@@ -94,9 +93,7 @@ before fan-out to the configured sinks.
 
 ## Record Schema
 
-All rows use `schema: dynamo.request.trace.v1` and an `event_type`. A context-free replay row
-contains request timing, output length, KV block size, input length, and rolling input-sequence
-hashes:
+All rows use `schema: dynamo.request.trace.v1` and an `event_type`. A context-free replay row always contains the replay hashes, KV block size, input length, and output length. It also includes request timing, token counts, KV-cache hit metrics, and worker information when the tracker has recorded them:
 
 ```json
 {

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -55,13 +55,12 @@ pub(crate) fn emit_request_end(
     tracker: &RequestTracker,
     replay: RequestReplayMetrics,
 ) {
-    let request_received_ms = tracker.request_received_epoch_ms();
-    let event_time_unix_ms = tracker
-        .total_time_ms()
-        .map_or_else(unix_time_ms, |elapsed| {
-            request_received_ms.saturating_add(elapsed.max(0.0).round() as u64)
-        });
     let timing = tracker.get_timing_info();
+    let event_time_unix_ms = timing.total_time_ms.map_or_else(unix_time_ms, |elapsed| {
+        timing
+            .request_received_ms
+            .saturating_add(elapsed.max(0.0).round() as u64)
+    });
     let worker = tracker
         .get_worker_info()
         .map(|worker| RequestTraceWorkerInfo {

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -56,11 +56,12 @@ pub(crate) fn emit_request_end(
     replay: RequestReplayMetrics,
 ) {
     let timing = tracker.get_timing_info();
-    let event_time_unix_ms = timing.total_time_ms.map_or_else(unix_time_ms, |elapsed| {
-        timing
-            .request_received_ms
-            .saturating_add(elapsed.max(0.0).round() as u64)
-    });
+    let event_time_unix_ms =
+        sanitize_finite(timing.total_time_ms).map_or_else(unix_time_ms, |elapsed| {
+            timing
+                .request_received_ms
+                .saturating_add(elapsed.max(0.0).round() as u64)
+        });
     let worker = tracker
         .get_worker_info()
         .map(|worker| RequestTraceWorkerInfo {

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -56,6 +56,11 @@ pub(crate) fn emit_request_end(
     replay: RequestReplayMetrics,
 ) {
     let timing = tracker.get_timing_info();
+    let event_time_unix_ms = timing.total_time_ms.map_or_else(unix_time_ms, |elapsed| {
+        timing
+            .request_received_ms
+            .saturating_add(elapsed.max(0.0).round() as u64)
+    });
     let worker = tracker
         .get_worker_info()
         .map(|worker| RequestTraceWorkerInfo {
@@ -86,12 +91,6 @@ pub(crate) fn emit_request_end(
         finish_reason_metadata: None,
     };
     sanitize_request(&mut request);
-    let event_time_unix_ms = match (request.request_received_ms, request.total_time_ms) {
-        (Some(received_ms), Some(elapsed_ms)) => {
-            received_ms.saturating_add(elapsed_ms.max(0.0).round() as u64)
-        }
-        _ => unix_time_ms(),
-    };
 
     publish(RequestTraceRecord {
         schema: RequestTraceSchema::V1,

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -56,12 +56,6 @@ pub(crate) fn emit_request_end(
     replay: RequestReplayMetrics,
 ) {
     let timing = tracker.get_timing_info();
-    let event_time_unix_ms =
-        sanitize_finite(timing.total_time_ms).map_or_else(unix_time_ms, |elapsed| {
-            timing
-                .request_received_ms
-                .saturating_add(elapsed.max(0.0).round() as u64)
-        });
     let worker = tracker
         .get_worker_info()
         .map(|worker| RequestTraceWorkerInfo {
@@ -92,6 +86,12 @@ pub(crate) fn emit_request_end(
         finish_reason_metadata: None,
     };
     sanitize_request(&mut request);
+    let event_time_unix_ms = match (request.request_received_ms, request.total_time_ms) {
+        (Some(received_ms), Some(elapsed_ms)) => {
+            received_ms.saturating_add(elapsed_ms.max(0.0).round() as u64)
+        }
+        _ => unix_time_ms(),
+    };
 
     publish(RequestTraceRecord {
         schema: RequestTraceSchema::V1,

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -14,6 +14,7 @@ use super::RequestTraceEventType;
 use super::RequestTraceMetrics;
 use super::RequestTraceRecord;
 use super::RequestTraceSchema;
+use super::RequestTraceWorkerInfo;
 use super::publish;
 
 fn unix_time_ms() -> u64 {
@@ -60,27 +61,37 @@ pub(crate) fn emit_request_end(
         .map_or_else(unix_time_ms, |elapsed| {
             request_received_ms.saturating_add(elapsed.max(0.0).round() as u64)
         });
+    let timing = tracker.get_timing_info();
+    let worker = tracker
+        .get_worker_info()
+        .map(|worker| RequestTraceWorkerInfo {
+            prefill_worker_id: worker.prefill_worker_id,
+            prefill_dp_rank: worker.prefill_dp_rank,
+            decode_worker_id: worker.decode_worker_id,
+            decode_dp_rank: worker.decode_dp_rank,
+        });
 
-    let request = RequestTraceMetrics {
+    let mut request = RequestTraceMetrics {
         request_id,
         x_request_id: None,
         model: None,
-        input_tokens: None,
+        input_tokens: tracker.isl_tokens().map(|v| v as u64),
         output_tokens: Some(tracker.osl_tokens()),
-        cached_tokens: None,
-        request_received_ms: Some(request_received_ms),
-        prefill_wait_time_ms: None,
-        prefill_time_ms: None,
-        ttft_ms: None,
-        total_time_ms: None,
-        avg_itl_ms: None,
-        kv_hit_rate: None,
-        kv_transfer_estimated_latency_ms: None,
-        queue_depth: None,
-        worker: None,
+        cached_tokens: tracker.cached_tokens().map(|v| v as u64),
+        request_received_ms: Some(timing.request_received_ms),
+        prefill_wait_time_ms: timing.prefill_wait_time_ms,
+        prefill_time_ms: timing.prefill_time_ms,
+        ttft_ms: timing.ttft_ms,
+        total_time_ms: timing.total_time_ms,
+        avg_itl_ms: tracker.avg_itl_ms(),
+        kv_hit_rate: timing.kv_hit_rate,
+        kv_transfer_estimated_latency_ms: timing.kv_transfer_estimated_latency_ms,
+        queue_depth: timing.router_queue_depth.map(|v| v as u64),
+        worker,
         replay: Some(replay),
         finish_reason_metadata: None,
     };
+    sanitize_request(&mut request);
 
     publish(RequestTraceRecord {
         schema: RequestTraceSchema::V1,
@@ -183,6 +194,8 @@ mod tests {
         BUS.init(16);
         let mut rx = BUS.subscribe();
         let tracker = RequestTracker::new();
+        tracker.record_isl(8, Some(4));
+        tracker.record_kv_hit(2.0, 4);
         tracker.record_osl(7);
         tracker.record_finish();
 
@@ -208,7 +221,10 @@ mod tests {
         };
         let request = record.request.as_ref().expect("request payload");
         assert_eq!(request.request_id, "req-1");
+        assert_eq!(request.input_tokens, Some(8));
         assert_eq!(request.output_tokens, Some(7));
+        assert_eq!(request.cached_tokens, Some(4));
+        assert_eq!(request.kv_hit_rate, Some(0.5));
         assert_eq!(
             request.request_received_ms,
             Some(tracker.request_received_epoch_ms())


### PR DESCRIPTION
## Summary
- Context-free `request_end` trace rows were intentionally minimal, but the `RequestTracker` already records KV-cache hit metrics, timing, worker info, and queue depth for every routed request.
- Update `emit_request_end` to populate `input_tokens`, `cached_tokens`, `kv_hit_rate`, `prefill_*`, `ttft_ms`, `total_time_ms`, `avg_itl_ms`, `kv_transfer_estimated_latency_ms`, `queue_depth`, and `worker` from the tracker instead of leaving them `None`.
- This makes `DYN_REQUEST_TRACE` useful for KV-routing observability without requiring session headers.
- Updated `request-traces.mdx` to reflect that context-free rows now include timing and KV-cache metrics when available.

## Validation
- `cargo fmt --check`
- `cargo check -p dynamo-llm --lib --no-default-features`
- `cargo clippy -p dynamo-llm --lib --no-default-features`
- `cargo test -p dynamo-llm --lib request_trace::record --no-default-features` (2 passed)
- `cargo test -p dynamo-llm --lib request_trace::integration --no-default-features` (6 passed)
- Full `cargo test -p dynamo-llm --lib request_trace --no-default-features` shows 3 unrelated `tool_relay` ZMQ deadline failures; the record and integration tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Request traces now include additional per-request metrics when available, including timing, token usage, KV-cache activity, queue depth, and worker details.
  - Context-free replay data now includes replay hashes, token counts, cache-hit metrics, and worker information where applicable.

- **Documentation**
  - Updated observability documentation to describe the expanded request trace and replay data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->