### PR TITLE
fix(sglang): support pre-tokenized embedding inputs

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncGenerator
 from typing import Any, Dict, List, Optional
 
 import sglang as sgl
+from sglang.srt.managers.io_struct import EmbeddingReqInput
 
 from dynamo._core import Context
 from dynamo.sglang.args import Config
@@ -49,6 +50,41 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
         super().cleanup()
         self.engine.shutdown()
         logging.info("Engine shutdown")
+
+    async def _encode_input(
+        self,
+        embedding_input: str | list[Any],
+        *,
+        trace_header: dict[str, str] | None,
+        trace_id: str | None,
+    ) -> Any:
+        """Dispatch text and pre-tokenized inputs through their native paths."""
+        if isinstance(embedding_input, list) and (
+            not embedding_input or not isinstance(embedding_input[0], str)
+        ):
+            request_id: str | list[str] | None = trace_id
+            if (
+                embedding_input
+                and isinstance(embedding_input[0], list)
+                and trace_id is not None
+            ):
+                request_id = [
+                    f"{trace_id}-{index}" for index in range(len(embedding_input))
+                ]
+
+            request = EmbeddingReqInput(
+                input_ids=embedding_input,
+                external_trace_header=trace_header,
+                rid=request_id,
+            )
+            responses = self.engine.tokenizer_manager.generate_request(request, None)
+            return await anext(responses)
+
+        return await self.engine.async_encode(
+            prompt=embedding_input,
+            external_trace_header=trace_header,
+            rid=trace_id,
+        )
 
     async def generate(
         self, request: dict, context: Context
@@ -105,10 +141,10 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
         trace_header = context.trace_headers() if self.enable_trace else None
         trace_id = context.trace_id
 
-        result = await self.engine.async_encode(
-            prompt=prompt,
-            external_trace_header=trace_header,
-            rid=trace_id,
+        result = await self._encode_input(
+            prompt,
+            trace_header=trace_header,
+            trace_id=trace_id,
         )
 
         # Transform the response to OpenAI format

--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -59,19 +59,20 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
         trace_id: str | None,
     ) -> Any:
         """Dispatch text and pre-tokenized inputs through their native paths."""
+        request_id: str | list[str] | None = trace_id
+        if (
+            isinstance(embedding_input, list)
+            and embedding_input
+            and isinstance(embedding_input[0], (str, list))
+            and trace_id is not None
+        ):
+            request_id = [
+                f"{trace_id}-{index}" for index in range(len(embedding_input))
+            ]
+
         if isinstance(embedding_input, list) and (
             not embedding_input or not isinstance(embedding_input[0], str)
         ):
-            request_id: str | list[str] | None = trace_id
-            if (
-                embedding_input
-                and isinstance(embedding_input[0], list)
-                and trace_id is not None
-            ):
-                request_id = [
-                    f"{trace_id}-{index}" for index in range(len(embedding_input))
-                ]
-
             request = EmbeddingReqInput(
                 input_ids=embedding_input,
                 external_trace_header=trace_header,
@@ -83,7 +84,7 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
         return await self.engine.async_encode(
             prompt=embedding_input,
             external_trace_header=trace_header,
-            rid=trace_id,
+            rid=request_id,
         )
 
     async def generate(

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
@@ -6,9 +6,16 @@
 from typing import Any
 
 import pytest
-from sglang.srt.managers.io_struct import EmbeddingReqInput
 
-from dynamo.sglang.request_handlers.embedding import embedding_handler as eh
+pytest.importorskip(
+    "sglang.srt.managers.io_struct", reason="sglang not installed in this container"
+)
+
+from sglang.srt.managers.io_struct import EmbeddingReqInput  # noqa: E402
+
+from dynamo.sglang.request_handlers.embedding import (  # noqa: E402
+    embedding_handler as eh,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -25,6 +32,7 @@ class _TokenizerManager:
         self.requests: list[tuple[EmbeddingReqInput, Any]] = []
 
     async def generate_request(self, request: EmbeddingReqInput, context: Any):
+        request.normalize_batch_and_arguments()
         self.requests.append((request, context))
         yield {"embedding": [0.1, 0.2], "meta_info": {"prompt_tokens": 2}}
 
@@ -54,8 +62,14 @@ def _handler(*, enable_trace: bool = True) -> eh.EmbeddingWorkerHandler:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("embedding_input", ["hello", ["hello", "world"]])
-async def test_text_inputs_use_async_encode(embedding_input):
+@pytest.mark.parametrize(
+    ("embedding_input", "expected_request_id"),
+    [
+        ("hello", "embedding-trace"),
+        (["hello", "world"], ["embedding-trace-0", "embedding-trace-1"]),
+    ],
+)
+async def test_text_inputs_use_async_encode(embedding_input, expected_request_id):
     handler = _handler()
 
     outputs = [
@@ -70,7 +84,7 @@ async def test_text_inputs_use_async_encode(embedding_input):
         {
             "prompt": embedding_input,
             "external_trace_header": {"traceparent": "00-test"},
-            "rid": "embedding-trace",
+            "rid": expected_request_id,
         }
     ]
     assert handler.engine.tokenizer_manager.requests == []

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for SGLang embedding input dispatch."""
+
+from typing import Any
+
+import pytest
+from sglang.srt.managers.io_struct import EmbeddingReqInput
+
+from dynamo.sglang.request_handlers.embedding import embedding_handler as eh
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.pre_merge,
+]
+
+
+class _TokenizerManager:
+    def __init__(self) -> None:
+        self.requests: list[tuple[EmbeddingReqInput, Any]] = []
+
+    async def generate_request(self, request: EmbeddingReqInput, context: Any):
+        self.requests.append((request, context))
+        yield {"embedding": [0.1, 0.2], "meta_info": {"prompt_tokens": 2}}
+
+
+class _Engine:
+    def __init__(self) -> None:
+        self.tokenizer_manager = _TokenizerManager()
+        self.async_encode_calls: list[dict[str, Any]] = []
+
+    async def async_encode(self, **kwargs: Any):
+        self.async_encode_calls.append(kwargs)
+        return {"embedding": [0.1, 0.2], "meta_info": {"prompt_tokens": 2}}
+
+
+class _Context:
+    trace_id = "embedding-trace"
+
+    def trace_headers(self) -> dict[str, str]:
+        return {"traceparent": "00-test"}
+
+
+def _handler(*, enable_trace: bool = True) -> eh.EmbeddingWorkerHandler:
+    handler = eh.EmbeddingWorkerHandler.__new__(eh.EmbeddingWorkerHandler)
+    handler.engine = _Engine()
+    handler.enable_trace = enable_trace
+    return handler
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("embedding_input", ["hello", ["hello", "world"]])
+async def test_text_inputs_use_async_encode(embedding_input):
+    handler = _handler()
+
+    outputs = [
+        output
+        async for output in handler.generate(
+            {"model": "embedding-model", "input": embedding_input}, _Context()
+        )
+    ]
+
+    assert len(outputs) == 1
+    assert handler.engine.async_encode_calls == [
+        {
+            "prompt": embedding_input,
+            "external_trace_header": {"traceparent": "00-test"},
+            "rid": "embedding-trace",
+        }
+    ]
+    assert handler.engine.tokenizer_manager.requests == []
+
+
+@pytest.mark.asyncio
+async def test_single_tokenized_input_uses_native_input_ids():
+    handler = _handler()
+
+    outputs = [
+        output
+        async for output in handler.generate(
+            {"model": "embedding-model", "input": [11, 22, 33]}, _Context()
+        )
+    ]
+
+    assert len(outputs) == 1
+    assert handler.engine.async_encode_calls == []
+    [(request, context)] = handler.engine.tokenizer_manager.requests
+    assert context is None
+    assert request.text is None
+    assert request.input_ids == [11, 22, 33]
+    assert request.rid == "embedding-trace"
+    assert request.external_trace_header == {"traceparent": "00-test"}
+
+
+@pytest.mark.asyncio
+async def test_batched_tokenized_input_gets_unique_request_ids():
+    handler = _handler(enable_trace=False)
+    token_ids = [[11, 22], [33, 44]]
+
+    outputs = [
+        output
+        async for output in handler.generate(
+            {"model": "embedding-model", "input": token_ids}, _Context()
+        )
+    ]
+
+    assert len(outputs) == 1
+    [(request, context)] = handler.engine.tokenizer_manager.requests
+    assert context is None
+    assert request.text is None
+    assert request.input_ids == token_ids
+    assert request.rid == ["embedding-trace-0", "embedding-trace-1"]
+    assert request.external_trace_header is None


### PR DESCRIPTION
## Summary

- route pre-tokenized SGLang embedding inputs through `EmbeddingReqInput(input_ids=...)`
- preserve the existing `async_encode()` path for text and text-batch inputs
- propagate tracing metadata and assign unique request IDs to text and token-ID batches
- add focused unit coverage for text, single token-ID, and batched token-ID dispatch

## Related Issues

None.

## Reviewer Guide

Start with `EmbeddingWorkerHandler._encode_input`, then review
`test_sglang_embedding_inputs.py` for the input-shape and request-ID contract.

## Validation

- `uvx pre-commit run isort --files components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py`
- `uvx pre-commit run ruff --files components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py`
- `python -m py_compile components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py`
- isolated async dispatch smoke test covering text and token-ID batch request IDs
- focused pytest collection without project configuration: 1 skipped when SGLang is unavailable

The focused pytest test was not run locally because the available environment does not include SGLang. The repository-wide pytest marker report also cannot collect against the local stale `_core.abi3.so`, which is missing `FrontendExtensionContext`.
