### PR TITLE
fix(epp): propagate scheduling metadata to SelectionService

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -27,6 +27,7 @@ use anyhow::Result;
 use tokio::sync::Semaphore;
 
 use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
+use dynamo_llm::http::service::metadata::extract_metadata_from_header_pairs;
 use dynamo_llm::protocols::common::extensions::{
     AgentHints, HEADER_REQUEST_PRIORITY, HEADER_REQUEST_STRICT_PRIORITY, resolve_request_priority,
 };
@@ -38,6 +39,17 @@ use crate::pod_discovery::PodDiscovery;
 use crate::selector::{SelectRequest, Selector};
 use crate::topology_adapter::{RegistrationDefaults, TopologyAdapter};
 use crate::vllm_render_client::{VllmRenderClient, VllmRenderError};
+
+/// Resolve the request's scheduling policy class from the Dynamo metadata
+/// headers. Goes through the frontend's metadata extractor (rather than a
+/// hardcoded header name) so custom `DYN_METADATA_HEADER` prefixes, trimming,
+/// and duplicate handling stay aligned with the integrated router.
+fn requested_policy_class(headers: &[(String, String)]) -> Result<Option<String>, PickError> {
+    let metadata =
+        extract_metadata_from_header_pairs(headers.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+            .map_err(|e| PickError::MetadataHeadersInvalid(e.to_string()))?;
+    Ok(metadata.get("policy-class").cloned())
+}
 
 /// Standalone endpoint picker backed by the standalone selection service.
 pub struct EppRouter {
@@ -96,14 +108,14 @@ impl EppRouter {
     }
 
     /// Tokenize a chat body for routing → `(token_ids, priority_jump,
-    /// strict_priority)`. Priority uses header-over-body precedence via
-    /// [`resolve_request_priority`].
+    /// strict_priority, expected_output_tokens)`. Priority uses header-over-body
+    /// precedence via [`resolve_request_priority`]
     async fn tokenize(
         &self,
         request_body: bytes::Bytes,
         priority_header: Option<String>,
         strict_priority_header: Option<String>,
-    ) -> Result<(Vec<u32>, Option<f64>, Option<u32>), TokenizeError> {
+    ) -> Result<(Vec<u32>, Option<f64>, Option<u32>, Option<u32>), TokenizeError> {
         // Parse only `nvext.agent_hints` for priority — the worker re-parses the
         // full body anyway, so we skip allocating the large `messages`/tools
         // fields. Malformed JSON still fails here (→ 400); a well-formed body that
@@ -115,13 +127,23 @@ impl EppRouter {
             priority_header.as_deref(),
             strict_priority_header.as_deref(),
         );
+        let expected_output_tokens = hints
+            .nvext
+            .as_ref()
+            .and_then(|n| n.agent_hints.as_ref())
+            .and_then(|h| h.osl);
         // Moves the `Bytes` into reqwest (zero-copy) rather than copying.
         let token_ids = self
             .renderer
             .render_chat(request_body)
             .await
             .map_err(TokenizeError::Render)?;
-        Ok((token_ids, resolved.priority_jump, resolved.strict_priority))
+        Ok((
+            token_ids,
+            resolved.priority_jump,
+            resolved.strict_priority,
+            expected_output_tokens,
+        ))
     }
 
     /// Ready workers inside an Envoy `candidate_subset`, resolved in a single index
@@ -262,10 +284,11 @@ impl EndpointPicker for EppRouter {
             first_header(&req.headers, HEADER_REQUEST_PRIORITY).map(str::to_owned);
         let strict_priority_header =
             first_header(&req.headers, HEADER_REQUEST_STRICT_PRIORITY).map(str::to_owned);
-        let (tokens, priority_jump, strict_priority) = self
+        let (tokens, priority_jump, strict_priority, expected_output_tokens) = self
             .tokenize(req.body.clone(), priority_header, strict_priority_header)
             .await
             .map_err(|e| e.into_pick_error(&req.request_id))?;
+        let policy_class = requested_policy_class(&req.headers)?;
 
         // EPP-minted booking key (not the reused `x-request-id`): stays
         // EPP-known/releasable and rides back on `PickResult::reservation_id`,
@@ -290,9 +313,12 @@ impl EndpointPicker for EppRouter {
             // Effective header-over-body values; `None` only when unset everywhere.
             priority_jump,
             strict_priority,
+            expected_output_tokens,
+            policy_class,
         };
 
         // On either error return below the guard (still armed) frees the booking.
+
         let resp = match self.selector.select_and_reserve(select_req).await {
             Ok(resp) => resp,
             Err(e) => return Err(PickError::RoutingFailed(e.to_string())),
@@ -446,6 +472,41 @@ impl TokenizeError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn requested_policy_class_uses_frontend_metadata_extraction() {
+        // The class rides a Dynamo metadata header; the extractor strips the
+        // prefix, trims, and honors the first of repeated headers.
+        let headers: Vec<(String, String)> = vec![
+            (
+                "x-dynamo-meta-policy-class".to_string(),
+                " latency ".to_string(),
+            ),
+            (
+                "x-dynamo-meta-policy-class".to_string(),
+                "throughput".to_string(),
+            ),
+            ("x-request-id".to_string(), "irrelevant".to_string()),
+        ];
+        assert_eq!(
+            requested_policy_class(&headers).unwrap().as_deref(),
+            Some("latency")
+        );
+
+        // Mixed-case header names match as well.
+        let headers: Vec<(String, String)> = vec![(
+            "X-Dynamo-Meta-Policy-Class".to_string(),
+            "express".to_string(),
+        )];
+        assert_eq!(
+            requested_policy_class(&headers).unwrap().as_deref(),
+            Some("express")
+        );
+
+        // No metadata header → no policy class.
+        let headers: Vec<(String, String)> = vec![("x-request-id".to_string(), "r1".to_string())];
+        assert_eq!(requested_policy_class(&headers).unwrap(), None);
+    }
 
     #[test]
     fn render_upstream_status_maps_to_correct_pick_error() {

--- a/deploy/inference-gateway/ext-proc/src/picker.rs
+++ b/deploy/inference-gateway/ext-proc/src/picker.rs
@@ -137,6 +137,11 @@ pub enum PickError {
     /// Malformed client input (unparseable body, or a 4xx from the tokenizer) → 400.
     #[error("tokenization failed: {0}")]
     TokenizationFailed(String),
+    /// Metadata headers exceeded the frontend's entry/size limits → 400. The
+    /// frontend rejects these requests too; the EPP surfaces the same client
+    /// error rather than silently dropping the metadata.
+    #[error("metadata headers invalid: {0}")]
+    MetadataHeadersInvalid(String),
     /// The upstream tokenization service could not be reached → 503.
     #[error("tokenization service unavailable")]
     TokenizerUnavailable,

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -52,6 +52,8 @@ pub struct SelectRequest {
     pub allowed_worker_ids: Option<HashSet<u64>>,
     pub priority_jump: Option<f64>,
     pub strict_priority: Option<u32>,
+    pub expected_output_tokens: Option<u32>,
+    pub policy_class: Option<String>,
 }
 
 /// Observability overlap summary (matched token counts).
@@ -145,7 +147,6 @@ impl Selector {
                 .await
                 .map_err(|e| anyhow!("building embedded selection service: {e}"))?,
         );
-
         let cancel = CancellationToken::new();
         if let (Some(peer_client), Some(peer_replication)) = (peer_client, peer_replication) {
             crate::peer_discovery::spawn(
@@ -288,7 +289,7 @@ impl Selector {
                 ..Default::default()
             },
             router_config_override: None,
-            expected_output_tokens: None,
+            expected_output_tokens: req.expected_output_tokens,
             session_id: None,
             priority_jump: req.priority_jump,
             strict_priority: req.strict_priority,
@@ -298,7 +299,7 @@ impl Selector {
         };
         let resp = self
             .service
-            .select_and_reserve(core_req)
+            .select_and_reserve_with_policy_class(core_req, req.policy_class)
             .await
             .map_err(|e| anyhow!("select_and_reserve failed: {e}"))?;
         Ok(SelectResponse {
@@ -354,6 +355,7 @@ impl Drop for Selector {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use dynamo_kv_router::services::selection::WorkerSelectionPolicyParameters;
@@ -363,6 +365,31 @@ mod tests {
     };
 
     use super::*;
+
+    /// Custom picker that records the expected output length observed in the
+    /// worker-selection context so tests can assert the value propagated from
+    /// the EPP request into the scheduling policy.
+    #[derive(Clone)]
+    struct ExpectedOutputRecorder(Arc<Mutex<Option<u32>>>);
+
+    impl ExpectedOutputRecorder {
+        fn new() -> (Self, Arc<Mutex<Option<u32>>>) {
+            let inner = Arc::new(Mutex::new(None));
+            (Self(inner.clone()), inner)
+        }
+    }
+
+    impl WorkerPicker for ExpectedOutputRecorder {
+        fn pick(
+            &mut self,
+            context: &WorkerSelectionContext<'_>,
+            input: WorkerInputView<'_>,
+        ) -> Result<usize, WorkerSelectionPolicyError> {
+            *self.0.lock().unwrap() = context.expected_output_tokens();
+            assert!(!input.candidates().is_empty());
+            Ok(0)
+        }
+    }
 
     fn model_policy_file() -> tempfile::NamedTempFile {
         let policy_file = tempfile::NamedTempFile::new().expect("create policy file");
@@ -390,6 +417,8 @@ models:
       - name: direct
         policy_family: standard
         cache_bucket: all
+        quantum: 1
+      - name: express
         quantum: 1
 "#,
         )
@@ -477,6 +506,8 @@ models:
             allowed_worker_ids: None,
             priority_jump: None,
             strict_priority: None,
+            expected_output_tokens: None,
+            policy_class: None,
         }
     }
 
@@ -868,5 +899,160 @@ worker_selection:
             .expect_err("duplicate IDs must be rejected");
         assert!(error.to_string().contains("duplicate worker_id 1"));
         assert!(selector.service.list_workers(None, None).is_empty());
+    }
+
+    /// Regression test for the scheduling-metadata propagation gap: a request
+    /// that carries `expected_output_tokens` must forward the value all the way
+    /// into the worker-selection context, not silently drop it to `None`.
+    #[tokio::test]
+    async fn expected_output_tokens_reaches_worker_selection_context() {
+        let (picker, recorded) = ExpectedOutputRecorder::new();
+        let policy_file = tempfile::NamedTempFile::new().expect("create policy file");
+        std::fs::write(
+            policy_file.path(),
+            r#"
+worker_selection:
+  aggregated: expected-output-recorder
+  instances:
+    - name: expected-output-recorder
+      type: expected-output-recorder
+      parameters: {}
+"#,
+        )
+        .expect("write policy file");
+
+        let mut registry = WorkerSelectionPolicyRegistry::default();
+        registry
+            .register(
+                "expected-output-recorder",
+                Arc::new({
+                    let picker = picker.clone();
+                    move |_parameters: &WorkerSelectionPolicyParameters| {
+                        let picker = picker.clone();
+                        let factory: WorkerSelectionPolicyFactory =
+                            Arc::new(move |config, worker_type, _partition| {
+                                WorkerSelectionPolicy::new(
+                                    config.clone(),
+                                    worker_type.as_str(),
+                                    Vec::new(),
+                                    Box::new(picker.clone()),
+                                )
+                            });
+                        Ok(factory)
+                    }
+                }),
+            )
+            .expect("register policy provider");
+
+        let selector = Selector::new_with_kv_router_config(
+            &test_config(),
+            KvRouterConfig {
+                router_policy_config: Some(policy_file.path().display().to_string()),
+                ..Default::default()
+            },
+            registry,
+        )
+        .await
+        .expect("selector should build");
+        selector
+            .reconcile(&[schedulable_registration(1)])
+            .await
+            .expect("worker should register");
+
+        let mut req = select_request("res-eot");
+        req.expected_output_tokens = Some(128);
+        selector
+            .select_and_reserve(req)
+            .await
+            .expect("reserve should succeed");
+
+        let observed = *recorded.lock().unwrap();
+        assert_eq!(
+            observed,
+            Some(128),
+            "expected_output_tokens must reach the worker-selection policy; got {observed:?}"
+        );
+    }
+
+    /// Fallback parity with the integrated router: `policy_class` is passed
+    /// through to the core's `PolicyProfile::resolve_class_index`, which never
+    /// rejects. Family names and explicit class names resolve normally;
+    /// physical (matrix) class names and unknown names silently fall back to
+    /// the default policy family and still schedule.
+    #[tokio::test]
+    async fn policy_class_falls_back_instead_of_rejecting() {
+        let policy_file = model_policy_file();
+        let mut cfg = test_config();
+        cfg.model_name = "threshold-free-model".to_string();
+
+        let selector = Selector::new_with_kv_router_config(
+            &cfg,
+            router_config_with_policy(&policy_file),
+            WorkerSelectionPolicyRegistry::default(),
+        )
+        .await
+        .expect("selector should build");
+        let mut reg = schedulable_registration(1);
+        reg.model_name = "threshold-free-model".to_string();
+        selector
+            .reconcile(&[reg])
+            .await
+            .expect("worker should register");
+
+        // A policy-family name resolves to that family's bucketed class.
+        let mut family_req = select_request("res-family");
+        family_req.model_name = "threshold-free-model".to_string();
+        family_req.policy_class = Some("standard".to_string());
+        selector
+            .select_and_reserve(family_req)
+            .await
+            .expect("policy_family 'standard' should schedule");
+
+        // An explicit class name is honored.
+        let mut explicit_req = select_request("res-explicit");
+        explicit_req.model_name = "threshold-free-model".to_string();
+        explicit_req.policy_class = Some("express".to_string());
+        selector
+            .select_and_reserve(explicit_req)
+            .await
+            .expect("explicit class 'express' should schedule");
+
+        // A physical FamilyBucket class name is not client-requestable; the
+        // core falls back to the default family instead of rejecting — the
+        // integrated router schedules this value normally, so standalone EPP
+        // must not 400 it either.
+        let mut physical_req = select_request("res-physical");
+        physical_req.model_name = "threshold-free-model".to_string();
+        physical_req.policy_class = Some("direct".to_string());
+        selector
+            .select_and_reserve(physical_req)
+            .await
+            .expect("physical class name 'direct' should fall back and schedule");
+
+        // A completely unknown name (e.g. a stale header after a config
+        // change) falls back the same way instead of erroring.
+        let mut unknown_req = select_request("res-unknown");
+        unknown_req.model_name = "threshold-free-model".to_string();
+        unknown_req.policy_class = Some("unknown".to_string());
+        selector
+            .select_and_reserve(unknown_req)
+            .await
+            .expect("unknown policy_class should fall back and schedule");
+
+        // Under the synthetic profile (no policy file configured) any value is
+        // ignored and the request schedules, matching the integrated router.
+        let selector = Selector::new(&test_config(), WorkerSelectionPolicyRegistry::default())
+            .await
+            .expect("selector should build");
+        selector
+            .reconcile(&[schedulable_registration(1)])
+            .await
+            .expect("worker should register");
+        let mut synthetic_req = select_request("res-synthetic");
+        synthetic_req.policy_class = Some("anything".to_string());
+        selector
+            .select_and_reserve(synthetic_req)
+            .await
+            .expect("synthetic profile must ignore any policy_class value");
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/server.rs
+++ b/deploy/inference-gateway/ext-proc/src/server.rs
@@ -949,6 +949,10 @@ impl ExtProcError {
                 status_code: StatusCode::BadRequest,
                 message: msg,
             },
+            PickError::MetadataHeadersInvalid(msg) => Self {
+                status_code: StatusCode::BadRequest,
+                message: msg,
+            },
             // Upstream tokenizer failures are not client errors: preserve their
             // semantics so clients retry appropriately. `e.to_string()` is the
             // client-safe variant message; the detailed cause is logged upstream.
@@ -1591,5 +1595,15 @@ mod tests {
     fn overloaded_pick_error_maps_to_503() {
         let err = ExtProcError::from_pick_error(PickError::Overloaded);
         assert_eq!(err.status_code, StatusCode::ServiceUnavailable);
+    }
+
+    /// Metadata headers over the frontend's limits map to a client 400, not a
+    /// retryable 503: the frontend rejects these requests too.
+    #[test]
+    fn metadata_headers_invalid_maps_to_400() {
+        let err = ExtProcError::from_pick_error(PickError::MetadataHeadersInvalid(
+            "metadata headers exceed the limit of 64 entries".to_string(),
+        ));
+        assert_eq!(err.status_code, StatusCode::BadRequest);
     }
 }

--- a/lib/llm/src/http/service/metadata.rs
+++ b/lib/llm/src/http/service/metadata.rs
@@ -87,18 +87,19 @@ fn insert_metadata_entry(
     Ok(())
 }
 
-fn extract_metadata_from_pairs<'a>(
-    pairs: impl IntoIterator<Item = (&'a str, &'a str)>,
+fn extract_metadata_from_pairs(
+    pairs: impl IntoIterator<Item = (impl AsRef<str>, impl AsRef<str>)>,
     prefix: &str,
 ) -> Result<BTreeMap<String, String>, MetadataHeaderError> {
     let mut out = BTreeMap::new();
     let mut total_bytes = 0;
 
     for (name, value) in pairs {
+        let name = name.as_ref();
         let Some(raw_key) = name.strip_prefix(prefix) else {
             continue;
         };
-        insert_metadata_entry(&mut out, &mut total_bytes, raw_key, value)?;
+        insert_metadata_entry(&mut out, &mut total_bytes, raw_key, value.as_ref())?;
     }
 
     Ok(out)
@@ -118,6 +119,21 @@ pub fn extract_metadata_from_http(
             .iter()
             .filter_map(|(name, value)| value.to_str().ok().map(|value| (name.as_str(), value))),
         prefix,
+    )
+}
+
+/// Extract metadata from raw `(name, value)` header pairs.
+///
+/// If a header is repeated, the first value wins; values are trimmed.
+/// Requests exceeding 64 entries or 64 KiB of key/value payload are rejected.
+pub fn extract_metadata_from_header_pairs(
+    pairs: impl IntoIterator<Item = (impl AsRef<str>, impl AsRef<str>)>,
+) -> Result<BTreeMap<String, String>, MetadataHeaderError> {
+    extract_metadata_from_pairs(
+        pairs
+            .into_iter()
+            .map(|(name, value)| (name.as_ref().to_ascii_lowercase(), value)),
+        metadata_header_prefix(),
     )
 }
 
@@ -265,5 +281,59 @@ mod tests {
         let meta = extract_metadata_from_grpc(&metadata).unwrap();
         assert_eq!(meta.get("tenant").map(String::as_str), Some("acme"));
         assert_eq!(meta.len(), 1);
+    }
+
+    #[test]
+    fn test_extract_metadata_from_header_pairs_matches_frontend_semantics() {
+        // EPP receives headers as ordered (name, value) pairs from Envoy: the
+        // extractor must apply the same prefix, trimming, first-wins, and
+        // case-insensitive name matching as the frontend's HeaderMap path.
+        let headers: Vec<(String, String)> = vec![
+            (
+                format!("{}policy-class", DYNAMO_METADATA_HEADER_PREFIX_DEFAULT),
+                " latency ".to_string(),
+            ),
+            // Mixed-case names (possible from HTTP/1.1 upstreams) must match.
+            ("X-Dynamo-Meta-Tenant".to_string(), "acme".to_string()),
+            // Repeated header: the first value wins.
+            (
+                format!("{}policy-class", DYNAMO_METADATA_HEADER_PREFIX_DEFAULT),
+                "throughput".to_string(),
+            ),
+            ("x-request-id".to_string(), "irrelevant".to_string()),
+        ];
+
+        let meta = extract_metadata_from_header_pairs(
+            headers.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+        )
+        .unwrap();
+        assert_eq!(
+            meta.get("policy-class").map(String::as_str),
+            Some("latency")
+        );
+        assert_eq!(meta.get("tenant").map(String::as_str), Some("acme"));
+        assert!(!meta.contains_key("x-request-id"));
+    }
+
+    #[test]
+    fn test_extract_metadata_from_header_pairs_applies_limits() {
+        let headers: Vec<(String, String)> = (0..DYNAMO_METADATA_MAX_ENTRIES_DEFAULT + 1)
+            .map(|i| {
+                (
+                    format!("{}{i}", DYNAMO_METADATA_HEADER_PREFIX_DEFAULT),
+                    "v".to_string(),
+                )
+            })
+            .collect();
+
+        let err = extract_metadata_from_header_pairs(
+            headers.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, MetadataHeaderError::TooManyEntries { .. }),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Overview:

Standalone EPP was dropping two scheduling metadata fields before they reached the embedded SelectionService：
`expected_output_tokens` and `policy_class`.

Because of this, configured scheduling policies always saw the default values, even though the underlying `SelectionService` already supported both fields.

This change threads both fields through the standalone routing path and validates `policy_class` against the configured class set before scheduling. 

## Details:

- Defines trusted EPP inputs for `expected_output_tokens` and `policy_class`.
- Extends the embedded selection path to carry `expected_output_tokens` to `select_and_reserve`.
- Invokes the SelectionService policy-class-aware selection API.
- Validates and rejects unsupported/malformed `policy_class` values before they affect scheduling.

### Validation results

- `cargo test -p dynamo-ext-proc `→ 123 passed, 0 failed

- `cargo test -p dynamo-kv-router `→ 901 passed; 0 failed; 2 ignored


## Where should the reviewer start?

- `deploy/inference-gateway/ext-proc/src/epp_router.rs` — see how metadata is extracted from the request body and headers.

- `deploy/inference-gateway/ext-proc/src/selector.rs` — see the SelectRequest expansion, policy-class validation, and the call into SelectionService, and `SelectorError`

- `lib/kv-router/src/services/selection/core/mod.rs` and `service.rs`

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #13427 

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved request routing by accounting for expected output token counts.
  * Added support for selecting configured scheduling policy classes.
  * Requests can now specify a policy class to influence workload scheduling.

* **Bug Fixes**
  * Invalid or unsupported policy classes are rejected before scheduling.
  * Expected output token information is consistently forwarded to worker selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->