### PR TITLE
feat(recipes): add GKE A4 DRANET disaggregation overlay

### DIFF
--- a/recipes/kustomize/components/vllm-disagg/nixl-default/patch-dgd.yaml
+++ b/recipes/kustomize/components/vllm-disagg/nixl-default/patch-dgd.yaml
@@ -10,6 +10,11 @@ spec:
       extraPodSpec:
         mainContainer:
           env: &nixlEnvironment
+            # Use the Pod IP because hostname lookup can prefer an unreachable IPv6 address in dual-stack clusters.
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: KV_TRANSFER_CONFIG
               value: '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
     DecodeWorker:

--- a/recipes/kustomize/templates/gke-a4-dranet/dgd-worker-a4-dranet-patch.yaml.j2
+++ b/recipes/kustomize/templates/gke-a4-dranet/dgd-worker-a4-dranet-patch.yaml.j2
@@ -37,12 +37,6 @@ spec:
               value: "{{ gpu_count }}"
             - name: UCX_RNDV_SCHEME
               value: get_zcopy
-            - name: UCX_PROTO_INFO
-              value: "y"
-            - name: UCX_LOG_LEVEL
-              value: info
-            - name: NIXL_LOG_LEVEL
-              value: INFO
           resources:
             claims:
               - name: devices

--- a/recipes/kustomize/templates/gke-a4-dranet/dgd-worker-a4-dranet-patch.yaml.j2
+++ b/recipes/kustomize/templates/gke-a4-dranet/dgd-worker-a4-dranet-patch.yaml.j2
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+{% set dgd = base.dynamographdeployment | only %}
+apiVersion: {{ dgd.apiVersion }}
+kind: DynamoGraphDeployment
+metadata:
+  name: {{ dgd.metadata.name }}
+spec:
+  services:
+  {% for name, service in dgd.spec.services.items() if service.componentType == "worker" %}
+  {% set gpu_count = service.resources.limits.gpu | int %}
+  {% set claim_name = dgd.metadata.name ~ '-' ~ (name | lower | replace('_', '-')) ~ '-a4-devices' %}
+    {{ name }}:
+      resources:
+        limits:
+          gpu: null
+        requests:
+          gpu: null
+      extraPodSpec:
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-b200
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        resourceClaims:
+          - name: devices
+            resourceClaimTemplateName: {{ claim_name }}
+        mainContainer:
+          env:
+            # Require reliable-connected RoCE and CUDA memory support; do not fall back to TCP or CUDA IPC.
+            - name: UCX_TLS
+              value: rc_x,rc,cuda_copy
+            - name: UCX_IB_GPU_DIRECT_RDMA
+              value: "yes"
+            - name: UCX_MAX_RNDV_RAILS
+              value: "{{ gpu_count }}"
+            - name: UCX_RNDV_SCHEME
+              value: get_zcopy
+            - name: UCX_PROTO_INFO
+              value: "y"
+            - name: UCX_LOG_LEVEL
+              value: info
+            - name: NIXL_LOG_LEVEL
+              value: INFO
+          resources:
+            claims:
+              - name: devices
+          securityContext:
+            $patch: replace
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+  {% endfor %}

--- a/recipes/kustomize/templates/gke-a4-dranet/kustomization.yaml.j2
+++ b/recipes/kustomize/templates/gke-a4-dranet/kustomization.yaml.j2
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - worker-device-claims.yaml
+patches:
+  - target:
+      group: nvidia.com
+      kind: DynamoGraphDeployment
+    path: dgd-worker-a4-dranet-patch.yaml

--- a/recipes/kustomize/templates/gke-a4-dranet/worker-device-claims.yaml.j2
+++ b/recipes/kustomize/templates/gke-a4-dranet/worker-device-claims.yaml.j2
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+{% set dgd = base.dynamographdeployment | only %}
+{% for name, service in dgd.spec.services.items() if service.componentType == "worker" %}
+{% set gpu_count = service.resources.limits.gpu | int %}
+{% set claim_name = dgd.metadata.name ~ '-' ~ (name | lower | replace('_', '-')) ~ '-a4-devices' %}
+{% if not loop.first %}
+---
+{% endif %}
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: {{ claim_name }}
+spec:
+  spec:
+    devices:
+      constraints:
+      {% for index in range(gpu_count) %}
+        - matchAttribute: resource.kubernetes.io/pcieRoot
+          requests:
+            - gpu-{{ index }}
+            - rdma-{{ index }}
+      {% endfor %}
+      requests:
+      {% for index in range(gpu_count) %}
+        - name: gpu-{{ index }}
+          exactly:
+            deviceClassName: gpu.nvidia.com
+            allocationMode: ExactCount
+            count: 1
+        - name: rdma-{{ index }}
+          exactly:
+            deviceClassName: mrdma.google.com
+            allocationMode: ExactCount
+            count: 1
+      {% endfor %}
+{% endfor %}

--- a/recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
@@ -20,6 +20,13 @@ matrix:
         - ../../../kustomize/components/disagg-workers/gke-roce
         - ../../../kustomize/components/vllm-disagg/nixl-default
         - kustomize/components/gke-image-pull-secret
+    - name: gke-a4-dranet
+      components:
+        - ../../../kustomize/components/vllm-disagg/nixl-default
+        - kustomize/components/gke-image-pull-secret
+      templates:
+        - source: ../../../kustomize/templates/gke-a4-dranet
+          path: components/dranet
     - name: nebius-ib
       components:
         - ../../../kustomize/components/disagg-workers/nebius-ib

--- a/recipes/qwen3-32b/vllm/cloud-providers/README.md
+++ b/recipes/qwen3-32b/vllm/cloud-providers/README.md
@@ -49,35 +49,9 @@ Neither path requires regeneration.
 | `deploy-nebius-ib.yaml` | Nebius InfiniBand | `kustomize/overlays/nebius-ib/` |
 | `deploy-nscale-ib.yaml` | Nscale InfiniBand | `kustomize/overlays/nscale-ib/` |
 
-The `gke-a4-dranet` variant targets an `a4-highgpu-8g` node. It requires GKE
-Standard 1.34.1-gke.1829001 or later, Dataplane V2, and a node pool with
-[GKE managed Dynamic Resource Allocation for Networking
-(DRANET)](https://cloud.google.com/kubernetes-engine/docs/how-to/allocate-network-resources-dra)
-enabled. In this 4-GPU-per-worker recipe, each worker Pod creates a claim for
-four of the node's eight `gpu.nvidia.com` GPUs and four `mrdma.google.com` RDMA
-NICs. The shared A4 template derives both quantities and the claim name from
-each worker in the base deployment. It groups GPU and RDMA requests by
-`resource.kubernetes.io/pcieRoot` for GPUDirect RDMA locality. Its UCX transport
-allowlist omits TCP and CUDA IPC so a missing RDMA path fails instead of
-silently using a slower transport.
-
-Verify both DeviceClasses before applying the variant:
-
-```bash
-kubectl get deviceclass gpu.nvidia.com mrdma.google.com
-```
-
-When a custom scheduler binds the Pods, its binder must be authorized to update
-the `resourceclaims/binding` subresource. The default Kubernetes scheduler has
-this permission; custom scheduler installations might require an RBAC update.
-
-Apply the GKE A4 DRANET composition directly from its checked-in
-Kustomization:
-
-```bash
-kubectl apply -k recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet \
-  -n ${NAMESPACE}
-```
+GKE A4 requires GKE Standard 1.34.1-gke.1829001 or later, Dataplane V2, and
+[managed DRANET](https://cloud.google.com/kubernetes-engine/docs/how-to/allocate-network-resources-dra).
+Custom-scheduler binders also need access to `resourceclaims/binding`.
 
 To make a local, uncommitted composition, create your own `kustomization.yaml` in
 the repository checkout or use `compose` from the repository root:

--- a/recipes/qwen3-32b/vllm/cloud-providers/README.md
+++ b/recipes/qwen3-32b/vllm/cloud-providers/README.md
@@ -44,15 +44,39 @@ Neither path requires regeneration.
 |-------------------|-----------------|---------|
 | `deploy-aks-ib.yaml` | Azure AKS InfiniBand | `kustomize/overlays/aks-ib/` |
 | `deploy-aws-p5.48xlarge.yaml` | AWS EFA + libfabric on `p5.48xlarge`, derived from each worker's GPU count | `kustomize/overlays/aws-p5.48xlarge/` |
+| `deploy-gke-a4-dranet.yaml` | GKE A4 DRANET; GPU-aligned RDMA derived from each worker's GPU count | `kustomize/overlays/gke-a4-dranet/` |
 | `deploy-gke-roce.yaml` | GKE RoCE | `kustomize/overlays/gke-roce/` |
 | `deploy-nebius-ib.yaml` | Nebius InfiniBand | `kustomize/overlays/nebius-ib/` |
 | `deploy-nscale-ib.yaml` | Nscale InfiniBand | `kustomize/overlays/nscale-ib/` |
 
-For example, apply the GKE RoCE composition directly from its checked-in
+The `gke-a4-dranet` variant targets an `a4-highgpu-8g` node. It requires GKE
+Standard 1.34.1-gke.1829001 or later, Dataplane V2, and a node pool with
+[GKE managed Dynamic Resource Allocation for Networking
+(DRANET)](https://cloud.google.com/kubernetes-engine/docs/how-to/allocate-network-resources-dra)
+enabled. In this 4-GPU-per-worker recipe, each worker Pod creates a claim for
+four of the node's eight `gpu.nvidia.com` GPUs and four `mrdma.google.com` RDMA
+NICs. The shared A4 template derives both quantities and the claim name from
+each worker in the base deployment. It groups GPU and RDMA requests by
+`resource.kubernetes.io/pcieRoot` for GPUDirect RDMA locality. Its UCX transport
+allowlist omits TCP and CUDA IPC so a missing RDMA path fails instead of
+silently using a slower transport.
+
+Verify both DeviceClasses before applying the variant:
+
+```bash
+kubectl get deviceclass gpu.nvidia.com mrdma.google.com
+```
+
+When a custom scheduler binds the Pods, its binder must be authorized to update
+the `resourceclaims/binding` subresource. The default Kubernetes scheduler has
+this permission; custom scheduler installations might require an RBAC update.
+
+Apply the GKE A4 DRANET composition directly from its checked-in
 Kustomization:
 
 ```bash
-kubectl apply -k kustomize/overlays/gke-roce -n ${NAMESPACE}
+kubectl apply -k recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet \
+  -n ${NAMESPACE}
 ```
 
 To make a local, uncommitted composition, create your own `kustomization.yaml` in

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-aks-ib.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-aks-ib.yaml
@@ -84,7 +84,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           securityContext:
             capabilities:
               add:
@@ -128,7 +128,7 @@ spec:
         value: /model-cache
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.5.0
           securityContext:
             runAsUser: 0
           volumeMounts:
@@ -213,7 +213,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           securityContext:
             capabilities:
               add:

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-aws-p5.48xlarge.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-aws-p5.48xlarge.yaml
@@ -113,7 +113,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1-efa-amd64
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-efa
           securityContext:
             capabilities:
               add:
@@ -148,7 +148,7 @@ spec:
         value: /model-cache
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.5.0
           securityContext:
             runAsUser: 0
           volumeMounts:
@@ -260,7 +260,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1-efa-amd64
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-efa
           securityContext:
             capabilities:
               add:

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-a4-dranet.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-a4-dranet.yaml
@@ -93,7 +93,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           resources:
             claims:
             - name: devices
@@ -137,7 +137,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-pull-secret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.5.0
           securityContext:
             runAsUser: 0
           volumeMounts:
@@ -230,7 +230,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           resources:
             claims:
             - name: devices

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-a4-dranet.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-a4-dranet.yaml
@@ -61,12 +61,6 @@ spec:
             value: "4"
           - name: UCX_RNDV_SCHEME
             value: get_zcopy
-          - name: UCX_PROTO_INFO
-            value: "y"
-          - name: UCX_LOG_LEVEL
-            value: info
-          - name: NIXL_LOG_LEVEL
-            value: INFO
           - name: NIXL_TELEMETRY_ENABLE
             value: "y"
           - name: NIXL_TELEMETRY_EXPORTER
@@ -199,12 +193,6 @@ spec:
             value: "4"
           - name: UCX_RNDV_SCHEME
             value: get_zcopy
-          - name: UCX_PROTO_INFO
-            value: "y"
-          - name: UCX_LOG_LEVEL
-            value: info
-          - name: NIXL_LOG_LEVEL
-            value: INFO
           - name: NIXL_TELEMETRY_ENABLE
             value: "y"
           - name: NIXL_TELEMETRY_EXPORTER

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-a4-dranet.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-a4-dranet.yaml
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generated file. For repository contributors, do not edit this checked-in copy.
+# Regenerate every public overlay and rendered manifest of this matrix (from the repository root):
+#   scripts/kustomize-matrix.py unfold recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
+#   scripts/kustomize-matrix.py render recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
+# Inspect only this Kustomize overlay (from the repository root):
+#   kustomize build recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet
+# You may edit a copy before applying it.
+
+# Qwen3-32B BF16 disagg, 1 prefill + 1 decode, with provider-specific RDMA in overlays.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: q32b-1p1d-cloud-provider
+spec:
+  pvcs:
+  - create: false
+    name: model-cache
+  services:
+    DecodeWorker:
+      componentType: worker
+      envFromSecret: hf-token-secret
+      extraPodMetadata:
+        annotations:
+          prometheus.io/path: /metrics
+          prometheus.io/port: "19090"
+          prometheus.io/scrape: "true"
+      extraPodSpec:
+        imagePullSecrets:
+        - name: nvcr-pull-secret
+        mainContainer:
+          args:
+          - |
+            exec python3 -m dynamo.vllm \
+              --model "${MODEL_NAME}" \
+              --served-model-name "${SERVED_MODEL_NAME}" \
+              --disaggregation-mode decode \
+              --kv-transfer-config "${KV_TRANSFER_CONFIG}" \
+              --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \
+              --no-enable-log-requests \
+              --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+              --no-enable-prefix-caching \
+              --async-scheduling \
+              --block-size "${BLOCK_SIZE}" \
+              --hf-overrides "${HF_OVERRIDES}" \
+              --max-model-len "${MAX_MODEL_LEN}"
+          command:
+          - /bin/sh
+          - -lc
+          env:
+          - name: KV_TRANSFER_CONFIG
+            value: '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          # Require reliable-connected RoCE and CUDA memory support; do not fall back to TCP or CUDA IPC.
+          - name: UCX_TLS
+            value: rc_x,rc,cuda_copy
+          - name: UCX_IB_GPU_DIRECT_RDMA
+            value: "yes"
+          - name: UCX_MAX_RNDV_RAILS
+            value: "4"
+          - name: UCX_RNDV_SCHEME
+            value: get_zcopy
+          - name: UCX_PROTO_INFO
+            value: "y"
+          - name: UCX_LOG_LEVEL
+            value: info
+          - name: NIXL_LOG_LEVEL
+            value: INFO
+          - name: NIXL_TELEMETRY_ENABLE
+            value: "y"
+          - name: NIXL_TELEMETRY_EXPORTER
+            value: prometheus
+          - name: NIXL_TELEMETRY_PROMETHEUS_PORT
+            value: "19090"
+          - name: NCCL_DEBUG
+            value: WARN
+          - name: MODEL_NAME
+            value: Qwen/Qwen3-32B
+          - name: SERVED_MODEL_NAME
+            value: Qwen/Qwen3-32B
+          - name: TENSOR_PARALLEL_SIZE
+            value: "4"
+          - name: GPU_MEMORY_UTILIZATION
+            value: "0.90"
+          - name: BLOCK_SIZE
+            value: "64"
+          - name: HF_OVERRIDES
+            value: '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768},"max_position_embeddings":131072}'
+          - name: MAX_MODEL_LEN
+            value: "131072"
+          - name: DYN_HEALTH_CHECK_ENABLED
+            value: "false"
+          - name: HF_HOME
+            value: /model-cache
+          - name: VLLM_LOGGING_LEVEL
+            value: INFO
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          resources:
+            claims:
+            - name: devices
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+          workingDir: /workspace
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-b200
+        resourceClaims:
+        - name: devices
+          resourceClaimTemplateName: q32b-1p1d-cloud-provider-decodeworker-a4-devices
+        tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+      replicas: 1
+      resources:
+        limits: {}
+        requests:
+          custom:
+            ephemeral-storage: 2Gi
+      subComponentType: decode
+    Frontend:
+      componentType: frontend
+      envs:
+      - name: HF_HOME
+        value: /model-cache
+      extraPodSpec:
+        imagePullSecrets:
+        - name: nvcr-pull-secret
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+          workingDir: /workspace
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+      replicas: 1
+      resources:
+        limits:
+          cpu: "8"
+        requests:
+          cpu: "4"
+      subComponentType: null
+    # Provider Components target backend-neutral worker service keys.
+    PrefillWorker:
+      componentType: worker
+      envFromSecret: hf-token-secret
+      extraPodMetadata:
+        annotations:
+          prometheus.io/path: /metrics
+          prometheus.io/port: "19090"
+          prometheus.io/scrape: "true"
+      extraPodSpec:
+        imagePullSecrets:
+        - name: nvcr-pull-secret
+        mainContainer:
+          args:
+          - |
+            exec python3 -m dynamo.vllm \
+              --model "${MODEL_NAME}" \
+              --served-model-name "${SERVED_MODEL_NAME}" \
+              --disaggregation-mode prefill \
+              --kv-transfer-config "${KV_TRANSFER_CONFIG}" \
+              --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \
+              --no-enable-log-requests \
+              --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+              --async-scheduling \
+              --block-size "${BLOCK_SIZE}" \
+              --hf-overrides "${HF_OVERRIDES}" \
+              --max-model-len "${MAX_MODEL_LEN}"
+          command:
+          - /bin/sh
+          - -lc
+          env:
+          - name: KV_TRANSFER_CONFIG
+            value: '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          # Require reliable-connected RoCE and CUDA memory support; do not fall back to TCP or CUDA IPC.
+          - name: UCX_TLS
+            value: rc_x,rc,cuda_copy
+          - name: UCX_IB_GPU_DIRECT_RDMA
+            value: "yes"
+          - name: UCX_MAX_RNDV_RAILS
+            value: "4"
+          - name: UCX_RNDV_SCHEME
+            value: get_zcopy
+          - name: UCX_PROTO_INFO
+            value: "y"
+          - name: UCX_LOG_LEVEL
+            value: info
+          - name: NIXL_LOG_LEVEL
+            value: INFO
+          - name: NIXL_TELEMETRY_ENABLE
+            value: "y"
+          - name: NIXL_TELEMETRY_EXPORTER
+            value: prometheus
+          - name: NIXL_TELEMETRY_PROMETHEUS_PORT
+            value: "19090"
+          - name: NCCL_DEBUG
+            value: WARN
+          - name: MODEL_NAME
+            value: Qwen/Qwen3-32B
+          - name: SERVED_MODEL_NAME
+            value: Qwen/Qwen3-32B
+          - name: TENSOR_PARALLEL_SIZE
+            value: "4"
+          - name: GPU_MEMORY_UTILIZATION
+            value: "0.90"
+          - name: BLOCK_SIZE
+            value: "64"
+          - name: HF_OVERRIDES
+            value: '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768},"max_position_embeddings":131072}'
+          - name: MAX_MODEL_LEN
+            value: "131072"
+          - name: DYN_HEALTH_CHECK_ENABLED
+            value: "false"
+          - name: HF_HOME
+            value: /model-cache
+          - name: VLLM_LOGGING_LEVEL
+            value: INFO
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          resources:
+            claims:
+            - name: devices
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+          workingDir: /workspace
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-b200
+        resourceClaims:
+        - name: devices
+          resourceClaimTemplateName: q32b-1p1d-cloud-provider-prefillworker-a4-devices
+        tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+      replicas: 1
+      resources:
+        limits: {}
+        requests:
+          custom:
+            ephemeral-storage: 2Gi
+      subComponentType: prefill
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: q32b-1p1d-cloud-provider-decodeworker-a4-devices
+spec:
+  spec:
+    devices:
+      constraints:
+      - matchAttribute: resource.kubernetes.io/pcieRoot
+        requests:
+        - gpu-0
+        - rdma-0
+      - matchAttribute: resource.kubernetes.io/pcieRoot
+        requests:
+        - gpu-1
+        - rdma-1
+      - matchAttribute: resource.kubernetes.io/pcieRoot
+        requests:
+        - gpu-2
+        - rdma-2
+      - matchAttribute: resource.kubernetes.io/pcieRoot
+        requests:
+        - gpu-3
+        - rdma-3
+      requests:
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: gpu.nvidia.com
+        name: gpu-0
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: mrdma.google.com
+        name: rdma-0
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: gpu.nvidia.com
+        name: gpu-1
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: mrdma.google.com
+        name: rdma-1
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: gpu.nvidia.com
+        name: gpu-2
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: mrdma.google.com
+        name: rdma-2
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: gpu.nvidia.com
+        name: gpu-3
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: mrdma.google.com
+        name: rdma-3
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: q32b-1p1d-cloud-provider-prefillworker-a4-devices
+spec:
+  spec:
+    devices:
+      constraints:
+      - matchAttribute: resource.kubernetes.io/pcieRoot
+        requests:
+        - gpu-0
+        - rdma-0
+      - matchAttribute: resource.kubernetes.io/pcieRoot
+        requests:
+        - gpu-1
+        - rdma-1
+      - matchAttribute: resource.kubernetes.io/pcieRoot
+        requests:
+        - gpu-2
+        - rdma-2
+      - matchAttribute: resource.kubernetes.io/pcieRoot
+        requests:
+        - gpu-3
+        - rdma-3
+      requests:
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: gpu.nvidia.com
+        name: gpu-0
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: mrdma.google.com
+        name: rdma-0
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: gpu.nvidia.com
+        name: gpu-1
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: mrdma.google.com
+        name: rdma-1
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: gpu.nvidia.com
+        name: gpu-2
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: mrdma.google.com
+        name: rdma-2
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: gpu.nvidia.com
+        name: gpu-3
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: mrdma.google.com
+        name: rdma-3

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-a4-dranet.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-a4-dranet.yaml
@@ -50,6 +50,10 @@ spec:
           - /bin/sh
           - -lc
           env:
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: KV_TRANSFER_CONFIG
             value: '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
           # Require reliable-connected RoCE and CUDA memory support; do not fall back to TCP or CUDA IPC.
@@ -182,6 +186,11 @@ spec:
           - /bin/sh
           - -lc
           env:
+          # Use the Pod IP because hostname lookup can prefer an unreachable IPv6 address in dual-stack clusters.
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: KV_TRANSFER_CONFIG
             value: '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
           # Require reliable-connected RoCE and CUDA memory support; do not fall back to TCP or CUDA IPC.

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-roce.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-roce.yaml
@@ -57,6 +57,10 @@ spec:
           - /bin/sh
           - -lc
           env:
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: KV_TRANSFER_CONFIG
             value: '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
           - name: NCCL_SOCKET_IFNAME
@@ -216,6 +220,11 @@ spec:
           - /bin/sh
           - -lc
           env:
+          # Use the Pod IP because hostname lookup can prefer an unreachable IPv6 address in dual-stack clusters.
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: KV_TRANSFER_CONFIG
             value: '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
           - name: NCCL_SOCKET_IFNAME

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-roce.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-roce.yaml
@@ -95,7 +95,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           securityContext:
             capabilities:
               add:
@@ -164,7 +164,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-pull-secret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.5.0
           securityContext:
             runAsUser: 0
           volumeMounts:
@@ -259,7 +259,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           securityContext:
             capabilities:
               add:

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-nebius-ib.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-nebius-ib.yaml
@@ -48,6 +48,10 @@ spec:
           - /bin/sh
           - -lc
           env:
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: KV_TRANSFER_CONFIG
             value: '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
           - name: UCX_RNDV_THRESH
@@ -175,6 +179,11 @@ spec:
           - /bin/sh
           - -lc
           env:
+          # Use the Pod IP because hostname lookup can prefer an unreachable IPv6 address in dual-stack clusters.
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: KV_TRANSFER_CONFIG
             value: '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
           - name: NCCL_SOCKET_IFNAME

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-nebius-ib.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-nebius-ib.yaml
@@ -86,7 +86,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           securityContext:
             capabilities:
               add:
@@ -132,7 +132,7 @@ spec:
         value: /model-cache
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.5.0
           securityContext:
             runAsUser: 0
           volumeMounts:
@@ -216,7 +216,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           securityContext:
             capabilities:
               add:

--- a/recipes/qwen3-32b/vllm/cloud-providers/deploy-nscale-ib.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/deploy-nscale-ib.yaml
@@ -82,7 +82,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           securityContext:
             capabilities:
               add:
@@ -132,7 +132,7 @@ spec:
         value: /model-cache
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.5.0
           securityContext:
             runAsUser: 0
           volumeMounts:
@@ -214,7 +214,7 @@ spec:
             value: /model-cache
           - name: VLLM_LOGGING_LEVEL
             value: INFO
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           securityContext:
             capabilities:
               add:

--- a/recipes/qwen3-32b/vllm/cloud-providers/kustomize/base/deploy.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/kustomize/base/deploy.yaml
@@ -17,7 +17,7 @@ spec:
           value: /model-cache
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.5.0
           workingDir: /workspace
           securityContext:
             runAsUser: 0
@@ -73,7 +73,7 @@ spec:
                 --block-size "${BLOCK_SIZE}" \
                 --hf-overrides "${HF_OVERRIDES}" \
                 --max-model-len "${MAX_MODEL_LEN}"
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           workingDir: /workspace
           env: &vllmEnvironment
             - name: MODEL_NAME
@@ -143,7 +143,7 @@ spec:
                 --block-size "${BLOCK_SIZE}" \
                 --hf-overrides "${HF_OVERRIDES}" \
                 --max-model-len "${MAX_MODEL_LEN}"
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0
           workingDir: /workspace
           env: *vllmEnvironment
           volumeMounts:

--- a/recipes/qwen3-32b/vllm/cloud-providers/kustomize/components/vllm-efa-runtime/patch-dgd.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/kustomize/components/vllm-efa-runtime/patch-dgd.yaml
@@ -9,7 +9,7 @@ spec:
     PrefillWorker:
       extraPodSpec:
         mainContainer:
-          image: &vllmEfaImage nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1-efa-amd64
+          image: &vllmEfaImage nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-efa
     DecodeWorker:
       extraPodSpec:
         mainContainer:

--- a/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/components/dranet/dgd-worker-a4-dranet-patch.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/components/dranet/dgd-worker-a4-dranet-patch.yaml
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generated file. For repository contributors, do not edit this checked-in copy.
+# Regenerate this matrix's public overlays and template Components from the repository root:
+# Regenerate: scripts/kustomize-matrix.py unfold recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
+# Template source: recipes/kustomize/templates/gke-a4-dranet
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: q32b-1p1d-cloud-provider
+spec:
+  services:
+    DecodeWorker:
+      resources:
+        limits:
+          gpu: null
+        requests:
+          gpu: null
+      extraPodSpec:
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-b200
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        resourceClaims:
+          - name: devices
+            resourceClaimTemplateName: q32b-1p1d-cloud-provider-decodeworker-a4-devices
+        mainContainer:
+          env:
+            # Require reliable-connected RoCE and CUDA memory support; do not fall back to TCP or CUDA IPC.
+            - name: UCX_TLS
+              value: rc_x,rc,cuda_copy
+            - name: UCX_IB_GPU_DIRECT_RDMA
+              value: "yes"
+            - name: UCX_MAX_RNDV_RAILS
+              value: "4"
+            - name: UCX_RNDV_SCHEME
+              value: get_zcopy
+            - name: UCX_PROTO_INFO
+              value: "y"
+            - name: UCX_LOG_LEVEL
+              value: info
+            - name: NIXL_LOG_LEVEL
+              value: INFO
+          resources:
+            claims:
+              - name: devices
+          securityContext:
+            $patch: replace
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+    PrefillWorker:
+      resources:
+        limits:
+          gpu: null
+        requests:
+          gpu: null
+      extraPodSpec:
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-b200
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        resourceClaims:
+          - name: devices
+            resourceClaimTemplateName: q32b-1p1d-cloud-provider-prefillworker-a4-devices
+        mainContainer:
+          env:
+            # Require reliable-connected RoCE and CUDA memory support; do not fall back to TCP or CUDA IPC.
+            - name: UCX_TLS
+              value: rc_x,rc,cuda_copy
+            - name: UCX_IB_GPU_DIRECT_RDMA
+              value: "yes"
+            - name: UCX_MAX_RNDV_RAILS
+              value: "4"
+            - name: UCX_RNDV_SCHEME
+              value: get_zcopy
+            - name: UCX_PROTO_INFO
+              value: "y"
+            - name: UCX_LOG_LEVEL
+              value: info
+            - name: NIXL_LOG_LEVEL
+              value: INFO
+          resources:
+            claims:
+              - name: devices
+          securityContext:
+            $patch: replace
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE

--- a/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/components/dranet/dgd-worker-a4-dranet-patch.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/components/dranet/dgd-worker-a4-dranet-patch.yaml
@@ -39,12 +39,6 @@ spec:
               value: "4"
             - name: UCX_RNDV_SCHEME
               value: get_zcopy
-            - name: UCX_PROTO_INFO
-              value: "y"
-            - name: UCX_LOG_LEVEL
-              value: info
-            - name: NIXL_LOG_LEVEL
-              value: INFO
           resources:
             claims:
               - name: devices
@@ -83,12 +77,6 @@ spec:
               value: "4"
             - name: UCX_RNDV_SCHEME
               value: get_zcopy
-            - name: UCX_PROTO_INFO
-              value: "y"
-            - name: UCX_LOG_LEVEL
-              value: info
-            - name: NIXL_LOG_LEVEL
-              value: INFO
           resources:
             claims:
               - name: devices

--- a/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/components/dranet/kustomization.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/components/dranet/kustomization.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generated file. For repository contributors, do not edit this checked-in copy.
+# Regenerate this matrix's public overlays and template Components from the repository root:
+# Regenerate: scripts/kustomize-matrix.py unfold recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
+# Template source: recipes/kustomize/templates/gke-a4-dranet
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - worker-device-claims.yaml
+patches:
+  - target:
+      group: nvidia.com
+      kind: DynamoGraphDeployment
+    path: dgd-worker-a4-dranet-patch.yaml

--- a/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/components/dranet/worker-device-claims.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/components/dranet/worker-device-claims.yaml
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generated file. For repository contributors, do not edit this checked-in copy.
+# Regenerate this matrix's public overlays and template Components from the repository root:
+# Regenerate: scripts/kustomize-matrix.py unfold recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
+# Template source: recipes/kustomize/templates/gke-a4-dranet
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: q32b-1p1d-cloud-provider-decodeworker-a4-devices
+spec:
+  spec:
+    devices:
+      constraints:
+        - matchAttribute: resource.kubernetes.io/pcieRoot
+          requests:
+            - gpu-0
+            - rdma-0
+        - matchAttribute: resource.kubernetes.io/pcieRoot
+          requests:
+            - gpu-1
+            - rdma-1
+        - matchAttribute: resource.kubernetes.io/pcieRoot
+          requests:
+            - gpu-2
+            - rdma-2
+        - matchAttribute: resource.kubernetes.io/pcieRoot
+          requests:
+            - gpu-3
+            - rdma-3
+      requests:
+        - name: gpu-0
+          exactly:
+            deviceClassName: gpu.nvidia.com
+            allocationMode: ExactCount
+            count: 1
+        - name: rdma-0
+          exactly:
+            deviceClassName: mrdma.google.com
+            allocationMode: ExactCount
+            count: 1
+        - name: gpu-1
+          exactly:
+            deviceClassName: gpu.nvidia.com
+            allocationMode: ExactCount
+            count: 1
+        - name: rdma-1
+          exactly:
+            deviceClassName: mrdma.google.com
+            allocationMode: ExactCount
+            count: 1
+        - name: gpu-2
+          exactly:
+            deviceClassName: gpu.nvidia.com
+            allocationMode: ExactCount
+            count: 1
+        - name: rdma-2
+          exactly:
+            deviceClassName: mrdma.google.com
+            allocationMode: ExactCount
+            count: 1
+        - name: gpu-3
+          exactly:
+            deviceClassName: gpu.nvidia.com
+            allocationMode: ExactCount
+            count: 1
+        - name: rdma-3
+          exactly:
+            deviceClassName: mrdma.google.com
+            allocationMode: ExactCount
+            count: 1
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: q32b-1p1d-cloud-provider-prefillworker-a4-devices
+spec:
+  spec:
+    devices:
+      constraints:
+        - matchAttribute: resource.kubernetes.io/pcieRoot
+          requests:
+            - gpu-0
+            - rdma-0
+        - matchAttribute: resource.kubernetes.io/pcieRoot
+          requests:
+            - gpu-1
+            - rdma-1
+        - matchAttribute: resource.kubernetes.io/pcieRoot
+          requests:
+            - gpu-2
+            - rdma-2
+        - matchAttribute: resource.kubernetes.io/pcieRoot
+          requests:
+            - gpu-3
+            - rdma-3
+      requests:
+        - name: gpu-0
+          exactly:
+            deviceClassName: gpu.nvidia.com
+            allocationMode: ExactCount
+            count: 1
+        - name: rdma-0
+          exactly:
+            deviceClassName: mrdma.google.com
+            allocationMode: ExactCount
+            count: 1
+        - name: gpu-1
+          exactly:
+            deviceClassName: gpu.nvidia.com
+            allocationMode: ExactCount
+            count: 1
+        - name: rdma-1
+          exactly:
+            deviceClassName: mrdma.google.com
+            allocationMode: ExactCount
+            count: 1
+        - name: gpu-2
+          exactly:
+            deviceClassName: gpu.nvidia.com
+            allocationMode: ExactCount
+            count: 1
+        - name: rdma-2
+          exactly:
+            deviceClassName: mrdma.google.com
+            allocationMode: ExactCount
+            count: 1
+        - name: gpu-3
+          exactly:
+            deviceClassName: gpu.nvidia.com
+            allocationMode: ExactCount
+            count: 1
+        - name: rdma-3
+          exactly:
+            deviceClassName: mrdma.google.com
+            allocationMode: ExactCount
+            count: 1

--- a/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/kustomization.yaml
+++ b/recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet/kustomization.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generated file. For repository contributors, do not edit this checked-in copy.
+# Regenerate this matrix's public overlays and template Components from the repository root:
+# Regenerate: scripts/kustomize-matrix.py unfold recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+sortOptions:
+  order: fifo
+resources:
+  - "../../base"
+components:
+  - "components/dranet"
+  - "../../../../../../kustomize/components/vllm-disagg/nixl-default"
+  - "../../components/gke-image-pull-secret"


### PR DESCRIPTION
## Summary

- add a reusable `recipes/kustomize/templates/gke-a4-dranet` template and select it from the Qwen3-32B cloud-provider matrix
- derive each worker ResourceClaimTemplate name and GPU/RDMA device count from the base DynamoGraphDeployment instead of hard-coding `q32b-a4-rdma-4`
- request `gpu.nvidia.com` GPUs and `mrdma.google.com` NICs together through DRA, pairing every GPU with an RDMA device by `resource.kubernetes.io/pcieRoot`
- remove legacy GPU resource requests and the hard Prefill/Decode pod affinity; the latter deadlocks atomic gang scheduling
- require the UCX RoCE/CUDA-memory path without TCP or CUDA IPC fallback, and document GKE, DeviceClass, and custom-scheduler RBAC prerequisites
- commit the generated public overlay and flattened manifest for direct inspection and application

## Usage

Users can apply the checked-in manifest directly:

```bash
kubectl apply -f recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-a4-dranet.yaml \
  -n ${NAMESPACE}
```

Or apply the checked-in Kustomization:

```bash
kubectl apply -k recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet \
  -n ${NAMESPACE}
```

Contributors edit the matrix, base, local Components, or shared template source, then regenerate from the repository root:

```bash
scripts/kustomize-matrix.py unfold recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
scripts/kustomize-matrix.py render recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
```

Start review with:

- `recipes/kustomize/templates/gke-a4-dranet/`
- `recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml`
- `recipes/qwen3-32b/vllm/cloud-providers/README.md`

## Validation

- `uv run --no-project --with pyyaml --with jinja2==3.1.6 python3 scripts/kustomize-matrix.py check`
- `kustomize build recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-a4-dranet`
- semantic assertions verify two worker claims, no legacy worker GPU resources, and four GPU plus four RDMA devices per worker in this recipe
- `uv run --no-project --with pyyaml --with jinja2==3.1.6 --with pytest --with pydantic --with pytest-asyncio --with pytest-benchmark python3 -m pytest --noconftest tests/test_kustomize_matrix.py tests/test_generate_kustomize_openapi.py` (17 passed)
- `npm --prefix .github/scripts test` (37 passed)
- pre-commit hooks on all changed files
- not yet validated end-to-end on a GKE A4 cluster; the latest cluster attempt reported an external image-pull authorization blocker

## Related

- builds on the value-aware Kustomize template support merged in #13125
