### PR TITLE
fix(llm): harden migration retry state

### DIFF
--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -206,6 +206,10 @@ where
         request: SingleIn<PreprocessedRequest>,
         next: ServerStreamingEngine<PreprocessedRequest, Annotated<Resp>>,
     ) -> Result<ManyOut<Annotated<Resp>>> {
+        if self.migration_limit == 0 {
+            return next.generate(request).await;
+        }
+
         let (preprocessed_request, context) = request.transfer(());
         let engine_ctx = context.context();
         let engine_ctx_ = engine_ctx.clone();
@@ -260,7 +264,7 @@ where
     session_affinity: Option<SessionAffinityId>,
     next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<Resp>>,
     next_stream: Option<ManyOut<Annotated<Resp>>>,
-    retries_left: u32,
+    retries_left: u64,
     max_seq_len: Option<u32>,
     model_name: Arc<String>,
     metrics: Arc<Metrics>,
@@ -285,6 +289,13 @@ where
         metrics: Arc<Metrics>,
         session_affinity: Option<SessionAffinityId>,
     ) -> Result<Self> {
+        // TODO: prompt_embeds take precedence over replayed token_ids. Disable migration for
+        // embedding prompts until a retry can represent an embedding-based continuation.
+
+        // TODO: Define a replay-capability contract for attempt-local decoder and sampler state.
+        // Stop-string matching, generated-token penalties, and thinking-token budgets are not
+        // currently checkpointed across workers.
+
         // Disable migration for structured-output (guided-decoding) requests.
         // Inference backends initialize the guided-decoding FSM (finite state machine) fresh
         // for every new request and only advance it on newly-generated tokens, not on
@@ -323,7 +334,7 @@ where
             session_affinity,
             next_generate: next,
             next_stream: None,
-            retries_left: retries_left + 1, // +1 to account for the initial attempt
+            retries_left: u64::from(retries_left) + 1, // +1 to account for the initial attempt
             max_seq_len,
             model_name,
             metrics,
@@ -352,10 +363,30 @@ where
                     self.metrics.inc_migration_ongoing_request(&self.model_name);
                     let migration_event =
                         MigrationEvent::new(frontend_service::migration_type::ONGOING_REQUEST);
-                    if let Err(err) = self.new_stream(Some(migration_event)).await {
-                        tracing::warn!(error = ?err, "Cannot recreate stream");
-                    } else {
-                        continue;
+                    if self.retries_left == 0 {
+                        self.record_migration_outcome(
+                            Some(&migration_event),
+                            frontend_service::migration_outcome::FAILURE,
+                        );
+                        self.track_response(&response);
+                        return Some(response);
+                    }
+                    match self.new_stream(Some(migration_event)).await {
+                        Ok(()) => continue,
+                        Err(err) => {
+                            tracing::warn!(error = ?err, "Cannot recreate stream");
+                            let terminal_error = err
+                                .chain()
+                                .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned())
+                                .unwrap_or_else(|| DynamoError::from(err.as_ref()));
+                            return Some(Annotated {
+                                data: None,
+                                id: None,
+                                event: Some("error".to_string()),
+                                comment: None,
+                                error: Some(terminal_error),
+                            });
+                        }
                     }
                 }
                 self.track_response(&response);
@@ -433,7 +464,7 @@ where
                         frontend_service::migration_outcome::FAILURE
                     };
                 self.record_migration_outcome(migration_event.as_ref(), outcome);
-                Err(err) // should propagate original error if any
+                Err(err)
             }
             None => {
                 self.record_migration_outcome(
@@ -472,12 +503,19 @@ where
             self.last_worker_link = Some(link.clone());
         }
         let token_ids = llm_engine_output.token_ids();
-        if self.exceed_max_seq_len(token_ids.len() as u32) {
+        let output_len = u32::try_from(token_ids.len()).unwrap_or(u32::MAX);
+        if self.exceed_max_seq_len(output_len) {
             return;
         }
         if let Some(max_tokens) = self.request.stop_conditions.max_tokens {
-            self.request.stop_conditions.max_tokens =
-                Some(max_tokens.saturating_sub(token_ids.len() as u32));
+            let remaining = max_tokens.saturating_sub(output_len);
+            self.request.stop_conditions.max_tokens = Some(remaining);
+            if remaining == 0 {
+                self.retries_left = 0;
+            }
+        }
+        if let Some(min_tokens) = self.request.stop_conditions.min_tokens {
+            self.request.stop_conditions.min_tokens = Some(min_tokens.saturating_sub(output_len));
         }
         for token_id in token_ids.iter() {
             self.request.token_ids.push(*token_id);
@@ -734,6 +772,7 @@ mod tests {
         token_offset: u32,
         call_count: Arc<AtomicU32>,
         context_id: String,
+        initial_min_tokens: Option<u32>,
     }
 
     impl MockEngine {
@@ -749,7 +788,13 @@ mod tests {
                 token_offset,
                 call_count: Arc::new(AtomicU32::new(0)),
                 context_id,
+                initial_min_tokens: None,
             }
+        }
+
+        fn with_min_tokens(mut self, min_tokens: u32) -> Self {
+            self.initial_min_tokens = Some(min_tokens);
+            self
         }
     }
 
@@ -797,6 +842,15 @@ mod tests {
                 expected_max_tokens,
                 preprocessed_request.stop_conditions.max_tokens
             );
+            if let Some(initial_min_tokens) = self.initial_min_tokens {
+                let expected_min_tokens =
+                    initial_min_tokens.saturating_sub(responses_already_generated as u32);
+                assert_eq!(
+                    preprocessed_request.stop_conditions.min_tokens,
+                    Some(expected_min_tokens),
+                    "min_tokens should be rebased for each replacement request"
+                );
+            }
 
             match &self.behavior {
                 MockBehavior::Success => {
@@ -1126,6 +1180,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn zero_migration_limit_passes_the_original_context_through() {
+        struct ContextIdentityEngine {
+            expected: Arc<dyn AsyncEngineContext>,
+        }
+
+        #[async_trait]
+        impl
+            AsyncEngine<
+                SingleIn<PreprocessedRequest>,
+                ManyOut<Annotated<BackendOutput>>,
+                anyhow::Error,
+            > for ContextIdentityEngine
+        {
+            async fn generate(
+                &self,
+                request: SingleIn<PreprocessedRequest>,
+            ) -> Result<ManyOut<Annotated<BackendOutput>>> {
+                let context = request.context();
+                assert!(Arc::ptr_eq(&context, &self.expected));
+                Ok(ResponseStream::new(
+                    Box::pin(stream::empty::<Annotated<BackendOutput>>()),
+                    context,
+                ))
+            }
+        }
+
+        let context_id = uuid::Uuid::new_v4().to_string();
+        let request =
+            Context::with_id_and_metadata(create_mock_request(1), context_id, BTreeMap::new());
+        let expected = request.context();
+        let engine = Arc::new(ContextIdentityEngine { expected });
+        let migration = Migration::new(0, None, TEST_MODEL.to_string(), Arc::new(Metrics::new()));
+
+        let mut responses = migration.generate(request, engine).await.unwrap();
+        assert!(responses.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn maximum_migration_limit_does_not_overflow() {
+        let context_id = uuid::Uuid::new_v4().to_string();
+        let mock_engine = Arc::new(MockEngine::new(
+            MockBehavior::Success,
+            1,
+            100,
+            context_id.clone(),
+        ));
+        let calls = mock_engine.call_count.clone();
+        let request =
+            Context::with_id_and_metadata(create_mock_request(1), context_id, BTreeMap::new());
+        let migration = Migration::new(
+            u32::MAX,
+            None,
+            TEST_MODEL.to_string(),
+            Arc::new(Metrics::new()),
+        );
+
+        let responses = migration
+            .generate(request, mock_engine)
+            .await
+            .unwrap()
+            .collect::<Vec<_>>()
+            .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(responses.len(), 1);
+        assert!(responses[0].error.is_none());
+    }
+
+    #[tokio::test]
     async fn test_migration_preserves_session_affinity_across_retry() {
         let context_id = uuid::Uuid::new_v4().to_string();
         let mock_engine = Arc::new(MockEngine::new(
@@ -1323,6 +1446,70 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn retry_rebases_min_tokens_from_the_delivered_prefix() {
+        let context_id = uuid::Uuid::new_v4().to_string();
+        let mut request = create_mock_request(10);
+        request.stop_conditions.min_tokens = Some(7);
+        let mock_engine = Arc::new(
+            MockEngine::new(
+                MockBehavior::MidStreamFail { fail_after: 3 },
+                10,
+                100,
+                context_id.clone(),
+            )
+            .with_min_tokens(7),
+        );
+        let calls = mock_engine.call_count.clone();
+        let request = Context::with_id_and_metadata(request, context_id, BTreeMap::new());
+        let migration = Migration::new(1, None, TEST_MODEL.to_string(), Arc::new(Metrics::new()));
+
+        let responses = migration
+            .generate(request, mock_engine)
+            .await
+            .unwrap()
+            .collect::<Vec<_>>()
+            .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(responses.len(), 10);
+        assert!(responses.iter().all(|response| response.error.is_none()));
+    }
+
+    #[tokio::test]
+    async fn exhausted_token_budget_does_not_dispatch_a_replacement() {
+        let context_id = uuid::Uuid::new_v4().to_string();
+        let mock_engine = Arc::new(MockEngine::new(
+            MockBehavior::MidStreamFail { fail_after: 3 },
+            3,
+            100,
+            context_id.clone(),
+        ));
+        let calls = mock_engine.call_count.clone();
+        let request =
+            Context::with_id_and_metadata(create_mock_request(3), context_id, BTreeMap::new());
+        let migration = Migration::new(1, None, TEST_MODEL.to_string(), Arc::new(Metrics::new()));
+
+        let responses = migration
+            .generate(request, mock_engine)
+            .await
+            .unwrap()
+            .collect::<Vec<_>>()
+            .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(responses.len(), 4);
+        assert!(
+            responses[..3]
+                .iter()
+                .all(|response| response.error.is_none())
+        );
+        assert_eq!(
+            responses[3].err().unwrap().error_type(),
+            ErrorType::Disconnected
+        );
+    }
+
     /// Test case 4: New request migration - indefinite failure
     /// Tests the scenario where a worker becomes unreachable for new requests indefinitely.
     /// The RetryManager should exhaust all retries and return the original error from the first attempt.
@@ -1376,8 +1563,9 @@ mod tests {
 
     /// Test case 5: Ongoing request migration - indefinite failure
     /// Tests the scenario where a worker fails mid-stream indefinitely during ongoing requests.
-    /// The RetryManager should exhaust all retries and return the original stream disconnection error.
-    /// Expected behavior: Should receive some responses from first stream, then error after retries exhausted.
+    /// The RetryManager should exhaust all retries and return the final replacement error.
+    /// Expected behavior: Should receive some responses from the first stream, then the authoritative
+    /// error from the last failed replacement attempt.
     #[tokio::test]
     async fn test_retry_manager_ongoing_request_migration_indefinite_failure() {
         dynamo_runtime::logging::init();
@@ -1426,10 +1614,12 @@ mod tests {
             }
         }
 
-        // 4th response should be a Disconnected error after retries are exhausted
+        // The replacement attempts fail before producing a stream, so their CannotConnect
+        // result supersedes the original stream's Disconnected error.
         let error_response = &responses[3];
         let err = error_response.err().expect("expected error response");
-        assert_eq!(err.error_type(), ErrorType::Disconnected);
+        assert_eq!(err.error_type(), ErrorType::CannotConnect);
+        assert_eq!(err.message(), "no responders");
 
         assert_eq!(metrics.get_migration_new_request_count(TEST_MODEL), 3);
         assert_eq!(metrics.get_migration_ongoing_request_count(TEST_MODEL), 1);

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -206,10 +206,8 @@ where
         request: SingleIn<PreprocessedRequest>,
         next: ServerStreamingEngine<PreprocessedRequest, Annotated<Resp>>,
     ) -> Result<ManyOut<Annotated<Resp>>> {
-        if self.migration_limit == 0 {
-            return next.generate(request).await;
-        }
-
+        // NOTE: Keep the migration operator in the request path at limit zero. The limit controls
+        // replacement attempts; RetryManager continues to own the initial attempt uniformly.
         let (preprocessed_request, context) = request.transfer(());
         let engine_ctx = context.context();
         let engine_ctx_ = engine_ctx.clone();
@@ -363,30 +361,12 @@ where
                     self.metrics.inc_migration_ongoing_request(&self.model_name);
                     let migration_event =
                         MigrationEvent::new(frontend_service::migration_type::ONGOING_REQUEST);
-                    if self.retries_left == 0 {
-                        self.record_migration_outcome(
-                            Some(&migration_event),
-                            frontend_service::migration_outcome::FAILURE,
-                        );
-                        self.track_response(&response);
-                        return Some(response);
-                    }
-                    match self.new_stream(Some(migration_event)).await {
-                        Ok(()) => continue,
-                        Err(err) => {
-                            tracing::warn!(error = ?err, "Cannot recreate stream");
-                            let terminal_error = err
-                                .chain()
-                                .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned())
-                                .unwrap_or_else(|| DynamoError::from(err.as_ref()));
-                            return Some(Annotated {
-                                data: None,
-                                id: None,
-                                event: Some("error".to_string()),
-                                comment: None,
-                                error: Some(terminal_error),
-                            });
-                        }
+                    // NOTE: Delegate exhaustion to new_stream so retry accounting has one owner.
+                    // When no replacement is established, preserve the triggering stream error.
+                    if let Err(err) = self.new_stream(Some(migration_event)).await {
+                        tracing::warn!(error = ?err, "Cannot recreate stream");
+                    } else {
+                        continue;
                     }
                 }
                 self.track_response(&response);
@@ -464,7 +444,7 @@ where
                         frontend_service::migration_outcome::FAILURE
                     };
                 self.record_migration_outcome(migration_event.as_ref(), outcome);
-                Err(err)
+                Err(err) // should propagate original error if any
             }
             None => {
                 self.record_migration_outcome(
@@ -507,12 +487,10 @@ where
         if self.exceed_max_seq_len(output_len) {
             return;
         }
+        // NOTE: A zero remaining token budget is not retry-budget exhaustion. Backends remain
+        // authoritative for deciding how generation terminates at max_tokens.
         if let Some(max_tokens) = self.request.stop_conditions.max_tokens {
-            let remaining = max_tokens.saturating_sub(output_len);
-            self.request.stop_conditions.max_tokens = Some(remaining);
-            if remaining == 0 {
-                self.retries_left = 0;
-            }
+            self.request.stop_conditions.max_tokens = Some(max_tokens.saturating_sub(output_len));
         }
         if let Some(min_tokens) = self.request.stop_conditions.min_tokens {
             self.request.stop_conditions.min_tokens = Some(min_tokens.saturating_sub(output_len));
@@ -1180,44 +1158,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zero_migration_limit_passes_the_original_context_through() {
-        struct ContextIdentityEngine {
-            expected: Arc<dyn AsyncEngineContext>,
-        }
-
-        #[async_trait]
-        impl
-            AsyncEngine<
-                SingleIn<PreprocessedRequest>,
-                ManyOut<Annotated<BackendOutput>>,
-                anyhow::Error,
-            > for ContextIdentityEngine
-        {
-            async fn generate(
-                &self,
-                request: SingleIn<PreprocessedRequest>,
-            ) -> Result<ManyOut<Annotated<BackendOutput>>> {
-                let context = request.context();
-                assert!(Arc::ptr_eq(&context, &self.expected));
-                Ok(ResponseStream::new(
-                    Box::pin(stream::empty::<Annotated<BackendOutput>>()),
-                    context,
-                ))
-            }
-        }
-
-        let context_id = uuid::Uuid::new_v4().to_string();
-        let request =
-            Context::with_id_and_metadata(create_mock_request(1), context_id, BTreeMap::new());
-        let expected = request.context();
-        let engine = Arc::new(ContextIdentityEngine { expected });
-        let migration = Migration::new(0, None, TEST_MODEL.to_string(), Arc::new(Metrics::new()));
-
-        let mut responses = migration.generate(request, engine).await.unwrap();
-        assert!(responses.next().await.is_none());
-    }
-
-    #[tokio::test]
     async fn maximum_migration_limit_does_not_overflow() {
         let context_id = uuid::Uuid::new_v4().to_string();
         let mock_engine = Arc::new(MockEngine::new(
@@ -1476,40 +1416,6 @@ mod tests {
         assert!(responses.iter().all(|response| response.error.is_none()));
     }
 
-    #[tokio::test]
-    async fn exhausted_token_budget_does_not_dispatch_a_replacement() {
-        let context_id = uuid::Uuid::new_v4().to_string();
-        let mock_engine = Arc::new(MockEngine::new(
-            MockBehavior::MidStreamFail { fail_after: 3 },
-            3,
-            100,
-            context_id.clone(),
-        ));
-        let calls = mock_engine.call_count.clone();
-        let request =
-            Context::with_id_and_metadata(create_mock_request(3), context_id, BTreeMap::new());
-        let migration = Migration::new(1, None, TEST_MODEL.to_string(), Arc::new(Metrics::new()));
-
-        let responses = migration
-            .generate(request, mock_engine)
-            .await
-            .unwrap()
-            .collect::<Vec<_>>()
-            .await;
-
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-        assert_eq!(responses.len(), 4);
-        assert!(
-            responses[..3]
-                .iter()
-                .all(|response| response.error.is_none())
-        );
-        assert_eq!(
-            responses[3].err().unwrap().error_type(),
-            ErrorType::Disconnected
-        );
-    }
-
     /// Test case 4: New request migration - indefinite failure
     /// Tests the scenario where a worker becomes unreachable for new requests indefinitely.
     /// The RetryManager should exhaust all retries and return the original error from the first attempt.
@@ -1563,9 +1469,8 @@ mod tests {
 
     /// Test case 5: Ongoing request migration - indefinite failure
     /// Tests the scenario where a worker fails mid-stream indefinitely during ongoing requests.
-    /// The RetryManager should exhaust all retries and return the final replacement error.
-    /// Expected behavior: Should receive some responses from the first stream, then the authoritative
-    /// error from the last failed replacement attempt.
+    /// The RetryManager should exhaust all retries and return the original stream disconnection error.
+    /// Expected behavior: Should receive some responses from first stream, then error after retries exhausted.
     #[tokio::test]
     async fn test_retry_manager_ongoing_request_migration_indefinite_failure() {
         dynamo_runtime::logging::init();
@@ -1614,12 +1519,10 @@ mod tests {
             }
         }
 
-        // The replacement attempts fail before producing a stream, so their CannotConnect
-        // result supersedes the original stream's Disconnected error.
+        // 4th response should be a Disconnected error after retries are exhausted
         let error_response = &responses[3];
         let err = error_response.err().expect("expected error response");
-        assert_eq!(err.error_type(), ErrorType::CannotConnect);
-        assert_eq!(err.message(), "no responders");
+        assert_eq!(err.error_type(), ErrorType::Disconnected);
 
         assert_eq!(metrics.get_migration_new_request_count(TEST_MODEL), 3);
         assert_eq!(metrics.get_migration_ongoing_request_count(TEST_MODEL), 1);


### PR DESCRIPTION
## Summary

Harden request migration bookkeeping in the LLM retry manager:

- represent the initial attempt plus `u32::MAX` retries without overflowing
- rebase `min_tokens` alongside `max_tokens` after delivering a partial response
- document unsupported replay state for prompt embeddings, stop-string matching, generated-token penalties, and thinking-token budgets
- document the existing ownership boundaries for the zero migration limit, retry exhaustion, and backend token-budget termination

This intentionally preserves the existing retry path and terminal-error behavior; broader replay-state support remains deferred until Dynamo has an explicit replay-capability contract.

## Validation

- `cargo test -p dynamo-llm --no-default-features migration::tests` — 26 passed, 0 failed
- `(cd lib/llm && cargo fmt --check)`
